### PR TITLE
fix(native-chat): stop matching pending echoes across clock domains

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/vitest'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
-import { applyCommandMarkerBoundaries } from './native-chat-pending'
+import { applyCommandMarkerBoundaries } from './native-chat-command-markers'
 import type { NativeChatInteractiveSend } from './use-native-chat-interactive-send'
 
 const INITIAL_PROMPT = JSON.stringify({

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -49,7 +49,8 @@ function cardElement(
   canSend = true,
   messages?: readonly NativeChatMessage[],
   onShowingQuestionChange?: (showing: boolean) => void,
-  transcriptSettled = true
+  transcriptSettled = true,
+  clearBoundaryUnavailable = false
 ): React.JSX.Element {
   return (
     <NativeChatInteractiveCard
@@ -57,6 +58,7 @@ function cardElement(
       canSend={canSend}
       messages={messages}
       transcriptSettled={transcriptSettled}
+      clearBoundaryUnavailable={clearBoundaryUnavailable}
       onShowingQuestionChange={onShowingQuestionChange}
       send={{
         sendAnswer: mocks.sendAnswer,
@@ -291,7 +293,9 @@ describe('NativeChatInteractiveCard transcript fallback', () => {
       [abandoned as unknown as NativeChatMessage],
       [{ id: 'clear-1', command: '/clear', sentAt: 200 }]
     )
-    render(cardElement(true, trimmed))
+    // An unavailable clear boundary leaves transcript rows visible for
+    // recovery, but the card path must remain conservative until it settles.
+    render(cardElement(true, trimmed, undefined, true, true))
 
     expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
   })

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -50,7 +50,8 @@ function cardElement(
   messages?: readonly NativeChatMessage[],
   onShowingQuestionChange?: (showing: boolean) => void,
   transcriptSettled = true,
-  clearBoundaryUnavailable = false
+  clearBoundaryUnavailable = false,
+  hasClearMarker = false
 ): React.JSX.Element {
   return (
     <NativeChatInteractiveCard
@@ -59,6 +60,7 @@ function cardElement(
       messages={messages}
       transcriptSettled={transcriptSettled}
       clearBoundaryUnavailable={clearBoundaryUnavailable}
+      hasClearMarker={hasClearMarker}
       onShowingQuestionChange={onShowingQuestionChange}
       send={{
         sendAnswer: mocks.sendAnswer,
@@ -295,7 +297,7 @@ describe('NativeChatInteractiveCard transcript fallback', () => {
     )
     // An unavailable clear boundary leaves transcript rows visible for
     // recovery, but the card path must remain conservative until it settles.
-    render(cardElement(true, trimmed, undefined, true, true))
+    render(cardElement(true, trimmed, undefined, true, true, true))
 
     expect(screen.queryByText('Tabs or spaces?')).not.toBeInTheDocument()
   })

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -35,6 +35,7 @@ export function NativeChatInteractiveCard({
   messages,
   transcriptSettled,
   clearBoundaryUnavailable = false,
+  hasClearMarker = false,
   onShowingQuestionChange,
   answerInputRef
 }: {
@@ -47,6 +48,7 @@ export function NativeChatInteractiveCard({
   transcriptSettled: boolean
   /** Prevent stale transcript asks from reappearing while /clear is unresolved. */
   clearBoundaryUnavailable?: boolean
+  hasClearMarker?: boolean
   /** Reports whether a question card is on screen so the view can replace the
    *  composer with it (the card's free-text row is the answer input). */
   onShowingQuestionChange?: (showing: boolean) => void
@@ -63,9 +65,10 @@ export function NativeChatInteractiveCard({
   const { sendAnswer, sendRaw, cancelPending, cancel } = send
 
   const card = useMemo(() => {
-    const statusCard = clearBoundaryUnavailable
-      ? null
-      : parseInteractivePrompt(interactivePrompt, interactiveToolName ?? undefined)
+    const statusCard =
+      clearBoundaryUnavailable || hasClearMarker
+        ? null
+        : parseInteractivePrompt(interactivePrompt, interactiveToolName ?? undefined)
     if (statusCard?.kind === 'approval') {
       return statusCard
     }
@@ -77,6 +80,7 @@ export function NativeChatInteractiveCard({
     return prompt ? { kind: 'question' as const, prompt } : null
   }, [
     clearBoundaryUnavailable,
+    hasClearMarker,
     interactivePrompt,
     interactiveToolName,
     messages,

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -34,6 +34,7 @@ export function NativeChatInteractiveCard({
   canSend,
   messages,
   transcriptSettled,
+  clearBoundaryUnavailable = false,
   onShowingQuestionChange,
   answerInputRef
 }: {
@@ -44,6 +45,8 @@ export function NativeChatInteractiveCard({
    *  command-boundary-trimmed messages so an ask abandoned via `/clear` stays gone. */
   messages?: readonly NativeChatMessage[]
   transcriptSettled: boolean
+  /** Prevent stale transcript asks from reappearing while /clear is unresolved. */
+  clearBoundaryUnavailable?: boolean
   /** Reports whether a question card is on screen so the view can replace the
    *  composer with it (the card's free-text row is the answer input). */
   onShowingQuestionChange?: (showing: boolean) => void
@@ -60,17 +63,25 @@ export function NativeChatInteractiveCard({
   const { sendAnswer, sendRaw, cancelPending, cancel } = send
 
   const card = useMemo(() => {
-    const statusCard = parseInteractivePrompt(interactivePrompt, interactiveToolName ?? undefined)
+    const statusCard = clearBoundaryUnavailable
+      ? null
+      : parseInteractivePrompt(interactivePrompt, interactiveToolName ?? undefined)
     if (statusCard?.kind === 'approval') {
       return statusCard
     }
     const prompt = resolveNativeChatAsk({
       liveAsk: statusCard?.prompt ?? null,
       messages: messages ?? [],
-      transcriptSettled: transcriptSettled && messages != null
+      transcriptSettled: transcriptSettled && messages != null && !clearBoundaryUnavailable
     })
     return prompt ? { kind: 'question' as const, prompt } : null
-  }, [interactivePrompt, interactiveToolName, messages, transcriptSettled])
+  }, [
+    clearBoundaryUnavailable,
+    interactivePrompt,
+    interactiveToolName,
+    messages,
+    transcriptSettled
+  ])
   const cardKey = useMemo(() => nativeChatCardDismissKey(card), [card])
   const [dismissedKey, setDismissedKey] = useState<string | null>(null)
   // A question answer is a paced multi-step write (body→Enter per question); keep

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -20,12 +20,10 @@ import {
 } from './native-chat-working-suppression'
 import {
   appendPendingSendCache,
-  launchPromptAsMessage,
   pendingSendsAsMessages,
   nextNativeChatPendingSendId,
   prunePendingSends,
   readPendingSendCache,
-  shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
@@ -53,6 +51,7 @@ import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owne
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
 import { useNativeChatFileLinkClick } from './use-native-chat-file-link-click'
 import type { NativeChatViewProps } from './native-chat-view-types'
+import { useNativeChatLaunchPrompt } from './use-native-chat-launch-prompt'
 
 export type { NativeChatViewProps } from './native-chat-view-types'
 
@@ -138,9 +137,6 @@ function NativeChatResolvedView({
     transcriptPath,
     runtimeEnvironmentId
   })
-  const launchPrompt = useAppStore((s) => s.nativeChatLaunchPromptByTabId[terminalTabId] ?? null)
-  const clearNativeChatLaunchPrompt = useAppStore((s) => s.clearNativeChatLaunchPrompt)
-  const paneLaunchPrompt = launchPrompt?.agent === agent ? launchPrompt : null
   // Launch context prefilled into the TUI input as an unsent draft; the
   // composer adopts it so the GUI view shows the same context as the TUI.
   // Shape matches NativeChatComposer's two launch-draft props, so it spreads.
@@ -222,12 +218,6 @@ function NativeChatResolvedView({
       writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages, order))
     )
   }, [session.messages, order, pendingScope])
-  useEffect(() => {
-    if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
-      return
-    }
-    clearNativeChatLaunchPrompt(terminalTabId)
-  }, [clearNativeChatLaunchPrompt, paneLaunchPrompt, session.messages, terminalTabId])
   const onOptimisticSend = useCallback(
     (text: string, imagePaths?: string[]) => {
       setWorkingInterrupted(false)
@@ -258,10 +248,13 @@ function NativeChatResolvedView({
     [pendingScope]
   )
 
-  const launchPromptMessage = useMemo(
-    () => launchPromptAsMessage(paneLaunchPrompt, session.messages),
-    [paneLaunchPrompt, session.messages]
-  )
+  const { message: launchPromptMessage, failed: launchPromptFailed } = useNativeChatLaunchPrompt({
+    terminalTabId,
+    agent,
+    messages: session.messages,
+    transcriptOrder: order,
+    crossClock: runtimeEnvironmentId != null
+  })
   const sessionWithLaunchPrompt = useMemo<typeof session>(() => {
     if (!launchPromptMessage) {
       return session
@@ -280,12 +273,12 @@ function NativeChatResolvedView({
       : { ...sessionWithLaunchPrompt, messages }
   }, [sessionWithLaunchPrompt, commandMarkers, order])
   const failedLaunchPromptMessageIds = useMemo(() => {
-    const id = paneLaunchPrompt?.failed ? launchPromptMessage?.id : null
+    const id = launchPromptFailed ? launchPromptMessage?.id : null
     if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
       return undefined
     }
     return new Set([id])
-  }, [paneLaunchPrompt?.failed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
+  }, [launchPromptFailed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
 
   // The streaming preview bubble (if any) sits after the transcript but before
   // the optimistic user echoes — same order mobile uses.

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -19,21 +19,21 @@ import {
   shouldShowNativeChatWorking
 } from './native-chat-working-suppression'
 import {
-  applyCommandMarkerBoundaries,
   appendPendingSendCache,
-  commandMarkersAsMessages,
-  appendCommandMarkerCache,
   launchPromptAsMessage,
   pendingSendsAsMessages,
   nextNativeChatPendingSendId,
   prunePendingSends,
-  readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
-  type NativeChatCommandMarker,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import {
+  applyCommandMarkerBoundaries,
+  commandMarkersAsMessages
+} from './native-chat-command-markers'
+import { useNativeChatCommandMarkers } from './use-native-chat-command-markers'
 import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage
@@ -194,19 +194,18 @@ function NativeChatResolvedView({
   // Optimistic "queued" sends (mobile parity): a composer send is echoed
   // immediately and pruned once its real user turn lands in the transcript, so
   // the message never vanishes between send and transcript catch-up.
-  const commandMarkerScope = useMemo(
-    () => ({ paneKey, agent, sessionId }),
-    [paneKey, agent, sessionId]
-  )
   const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
   const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
     readPendingSendCache(pendingScope)
   )
-  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
-  // system line instead of a user bubble. Capped + cached per conversation.
-  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
-    readCommandMarkerCache(commandMarkerScope)
-  )
+  const resetWorkingInterrupted = useCallback(() => setWorkingInterrupted(false), [])
+  const { commandMarkers, onSlashCommand } = useNativeChatCommandMarkers({
+    paneKey,
+    agent,
+    sessionId,
+    messages: session.messages,
+    onWorkingInterruptReset: resetWorkingInterrupted
+  })
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
   // often learns its provider session id after the first send; clearing pending
   // on that transition briefly flashes the empty state before the transcript
@@ -215,12 +214,6 @@ function NativeChatResolvedView({
     setPending(readPendingSendCache(pendingScope))
     setWorkingInterrupted(false)
   }, [pendingScope])
-  // Command markers are session-scoped because slash commands like /clear are
-  // local feedback for a specific transcript boundary.
-  useEffect(() => {
-    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
-    setWorkingInterrupted(false)
-  }, [commandMarkerScope])
   // Prune echoes whose real user turn is now in the transcript.
   useEffect(() => {
     setPending((prev) =>
@@ -259,12 +252,6 @@ function NativeChatResolvedView({
       setPending(writePendingSendCache(pendingScope, next))
     },
     [pendingScope]
-  )
-  const onSlashCommand = useCallback(
-    (command: string) => {
-      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
-    },
-    [commandMarkerScope]
   )
 
   const launchPromptMessage = useMemo(

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -195,6 +195,7 @@ function NativeChatResolvedView({
   // immediately and pruned once its real user turn lands in the transcript, so
   // the message never vanishes between send and transcript catch-up.
   const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
+  const order = session.transcriptOrder
   const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
     readPendingSendCache(pendingScope)
   )
@@ -204,6 +205,7 @@ function NativeChatResolvedView({
     agent,
     sessionId,
     messages: session.messages,
+    transcriptOrder: order,
     onWorkingInterruptReset: resetWorkingInterrupted
   })
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
@@ -217,9 +219,9 @@ function NativeChatResolvedView({
   // Prune echoes whose real user turn is now in the transcript.
   useEffect(() => {
     setPending((prev) =>
-      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages))
+      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages, order))
     )
-  }, [session.messages, pendingScope])
+  }, [session.messages, order, pendingScope])
   useEffect(() => {
     if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
       return
@@ -237,12 +239,14 @@ function NativeChatResolvedView({
         sentAt,
         afterMessageId: boundary?.id ?? null,
         afterMessageTimestamp: boundary?.timestamp ?? null,
+        afterTranscriptGeneration: order.generation,
+        afterTranscriptHighWater: order.highWater,
         ...(imagePaths ? { imagePaths } : {})
       }
       setPending(appendPendingSendCache(pendingScope, entry))
       return entry.id
     },
-    [pendingScope, session.messages]
+    [pendingScope, session.messages, order]
   )
   const onOptimisticSendCanceled = useCallback(
     (pendingId: string) => {
@@ -266,11 +270,15 @@ function NativeChatResolvedView({
   }, [launchPromptMessage, session])
 
   const sessionAfterCommandBoundaries = useMemo<typeof session>(() => {
-    const messages = applyCommandMarkerBoundaries(sessionWithLaunchPrompt.messages, commandMarkers)
+    const messages = applyCommandMarkerBoundaries(
+      sessionWithLaunchPrompt.messages,
+      commandMarkers,
+      order
+    )
     return messages === sessionWithLaunchPrompt.messages
       ? sessionWithLaunchPrompt
       : { ...sessionWithLaunchPrompt, messages }
-  }, [sessionWithLaunchPrompt, commandMarkers])
+  }, [sessionWithLaunchPrompt, commandMarkers, order])
   const failedLaunchPromptMessageIds = useMemo(() => {
     const id = paneLaunchPrompt?.failed ? launchPromptMessage?.id : null
     if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
@@ -282,8 +290,8 @@ function NativeChatResolvedView({
   // The streaming preview bubble (if any) sits after the transcript but before
   // the optimistic user echoes — same order mobile uses.
   const pendingMessages = useMemo(
-    () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages),
-    [pending, sessionAfterCommandBoundaries.messages]
+    () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages, order),
+    [pending, sessionAfterCommandBoundaries.messages, order]
   )
   const streamingText = useMemo(() => {
     return deriveNativeChatStreamingText({

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import { useNativeChatLaunchDraftSignal } from './use-native-chat-launch-draft-adoption'
-import type { NativeChatSession } from '../../../../shared/native-chat-types'
 import { useNativeChatRetainedSession } from './use-native-chat-retained-session'
 import { selectNativeChatViewState } from './native-chat-view-state'
 import { NativeChatMessageList } from './NativeChatMessageList'
@@ -45,19 +44,19 @@ import {
   emptyNativeChatContextMenuActions,
   useNativeChatContextMenu
 } from './use-native-chat-context-menu'
-import type { NativeChatContextMenuActions } from './use-native-chat-context-menu'
 import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
 import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owner'
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
 import { useNativeChatFileLinkClick } from './use-native-chat-file-link-click'
-import type { NativeChatViewProps } from './native-chat-view-types'
 import { useNativeChatLaunchPrompt } from './use-native-chat-launch-prompt'
+import type { NativeChatResolvedViewProps, NativeChatViewProps } from './native-chat-view-types'
 
 export type { NativeChatViewProps } from './native-chat-view-types'
 
 /** Resolves an agent terminal into its native conversation and composer UI. */
 export default function NativeChatView({
   terminalTabId,
+  isVisible,
   paneKey: preferredPaneKey,
   targetPtyId = null,
   launchAgent,
@@ -93,6 +92,7 @@ export default function NativeChatView({
           agent={resolution.agent}
           sessionId={resolution.sessionId}
           transcriptPath={resolution.transcriptPath}
+          isVisible={isVisible}
           targetPtyId={targetPtyId}
           terminalTabId={terminalTabId}
           onSwitchToTerminal={onSwitchToTerminal}
@@ -109,22 +109,13 @@ function NativeChatResolvedView({
   agent,
   sessionId,
   transcriptPath,
+  isVisible,
   targetPtyId,
   terminalTabId,
   onSwitchToTerminal,
   readTerminalScreen,
   contextMenuActions
-}: {
-  paneKey: string
-  agent: NativeChatSession['agent']
-  sessionId: string | null
-  transcriptPath: string | null
-  targetPtyId: string | null
-  terminalTabId: string
-  onSwitchToTerminal?: () => void
-  readTerminalScreen?: () => string | null
-  contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
-}): React.JSX.Element {
+}: NativeChatResolvedViewProps): React.JSX.Element {
   // Primitive owner selection (no useShallow): routes the pane's read/subscribe to
   // the remote runtime host for a runtime-owned pane; null keeps the local path.
   const runtimeEnvironmentId = useAppStore((s) =>
@@ -135,7 +126,8 @@ function NativeChatResolvedView({
     agent,
     sessionId,
     transcriptPath,
-    runtimeEnvironmentId
+    runtimeEnvironmentId,
+    enabled: isVisible
   })
   // Launch context prefilled into the TUI input as an unsent draft; the
   // composer adopts it so the GUI view shows the same context as the TUI.

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import { useNativeChatLaunchDraftSignal } from './use-native-chat-launch-draft-adoption'
+import type { NativeChatSession } from '../../../../shared/native-chat-types'
 import { useNativeChatRetainedSession } from './use-native-chat-retained-session'
 import { selectNativeChatViewState } from './native-chat-view-state'
 import { NativeChatMessageList } from './NativeChatMessageList'
@@ -19,12 +20,10 @@ import {
 } from './native-chat-working-suppression'
 import {
   appendPendingSendCache,
-  launchPromptAsMessage,
   pendingSendsAsMessages,
   nextNativeChatPendingSendId,
   prunePendingSends,
   readPendingSendCache,
-  shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
@@ -46,18 +45,19 @@ import {
   emptyNativeChatContextMenuActions,
   useNativeChatContextMenu
 } from './use-native-chat-context-menu'
+import type { NativeChatContextMenuActions } from './use-native-chat-context-menu'
 import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
 import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owner'
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
 import { useNativeChatFileLinkClick } from './use-native-chat-file-link-click'
-import type { NativeChatResolvedViewProps, NativeChatViewProps } from './native-chat-view-types'
+import type { NativeChatViewProps } from './native-chat-view-types'
+import { useNativeChatLaunchPrompt } from './use-native-chat-launch-prompt'
 
 export type { NativeChatViewProps } from './native-chat-view-types'
 
 /** Resolves an agent terminal into its native conversation and composer UI. */
 export default function NativeChatView({
   terminalTabId,
-  isVisible,
   paneKey: preferredPaneKey,
   targetPtyId = null,
   launchAgent,
@@ -93,7 +93,6 @@ export default function NativeChatView({
           agent={resolution.agent}
           sessionId={resolution.sessionId}
           transcriptPath={resolution.transcriptPath}
-          isVisible={isVisible}
           targetPtyId={targetPtyId}
           terminalTabId={terminalTabId}
           onSwitchToTerminal={onSwitchToTerminal}
@@ -110,13 +109,22 @@ function NativeChatResolvedView({
   agent,
   sessionId,
   transcriptPath,
-  isVisible,
   targetPtyId,
   terminalTabId,
   onSwitchToTerminal,
   readTerminalScreen,
   contextMenuActions
-}: NativeChatResolvedViewProps): React.JSX.Element {
+}: {
+  paneKey: string
+  agent: NativeChatSession['agent']
+  sessionId: string | null
+  transcriptPath: string | null
+  targetPtyId: string | null
+  terminalTabId: string
+  onSwitchToTerminal?: () => void
+  readTerminalScreen?: () => string | null
+  contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
+}): React.JSX.Element {
   // Primitive owner selection (no useShallow): routes the pane's read/subscribe to
   // the remote runtime host for a runtime-owned pane; null keeps the local path.
   const runtimeEnvironmentId = useAppStore((s) =>
@@ -127,12 +135,8 @@ function NativeChatResolvedView({
     agent,
     sessionId,
     transcriptPath,
-    runtimeEnvironmentId,
-    enabled: isVisible
+    runtimeEnvironmentId
   })
-  const launchPrompt = useAppStore((s) => s.nativeChatLaunchPromptByTabId[terminalTabId] ?? null)
-  const clearNativeChatLaunchPrompt = useAppStore((s) => s.clearNativeChatLaunchPrompt)
-  const paneLaunchPrompt = launchPrompt?.agent === agent ? launchPrompt : null
   // Launch context prefilled into the TUI input as an unsent draft; the
   // composer adopts it so the GUI view shows the same context as the TUI.
   // Shape matches NativeChatComposer's two launch-draft props, so it spreads.
@@ -214,12 +218,6 @@ function NativeChatResolvedView({
       writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages, order))
     )
   }, [session.messages, order, pendingScope])
-  useEffect(() => {
-    if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
-      return
-    }
-    clearNativeChatLaunchPrompt(terminalTabId)
-  }, [clearNativeChatLaunchPrompt, paneLaunchPrompt, session.messages, terminalTabId])
   const onOptimisticSend = useCallback(
     (text: string, imagePaths?: string[]) => {
       setWorkingInterrupted(false)
@@ -250,10 +248,13 @@ function NativeChatResolvedView({
     [pendingScope]
   )
 
-  const launchPromptMessage = useMemo(
-    () => launchPromptAsMessage(paneLaunchPrompt, session.messages),
-    [paneLaunchPrompt, session.messages]
-  )
+  const { message: launchPromptMessage, failed: launchPromptFailed } = useNativeChatLaunchPrompt({
+    terminalTabId,
+    agent,
+    messages: session.messages,
+    transcriptOrder: order,
+    crossClock: runtimeEnvironmentId != null
+  })
   const sessionWithLaunchPrompt = useMemo<typeof session>(() => {
     if (!launchPromptMessage) {
       return session
@@ -272,12 +273,12 @@ function NativeChatResolvedView({
       : { ...sessionWithLaunchPrompt, messages }
   }, [sessionWithLaunchPrompt, commandMarkers, order])
   const failedLaunchPromptMessageIds = useMemo(() => {
-    const id = paneLaunchPrompt?.failed ? launchPromptMessage?.id : null
+    const id = launchPromptFailed ? launchPromptMessage?.id : null
     if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
       return undefined
     }
     return new Set([id])
-  }, [paneLaunchPrompt?.failed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
+  }, [launchPromptFailed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
 
   // The streaming preview bubble (if any) sits after the transcript but before
   // the optimistic user echoes — same order mobile uses.

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -187,6 +187,7 @@ function NativeChatResolvedView({
   // immediately and pruned once its real user turn lands in the transcript, so
   // the message never vanishes between send and transcript catch-up.
   const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
+  const order = session.transcriptOrder
   const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
     readPendingSendCache(pendingScope)
   )
@@ -196,6 +197,7 @@ function NativeChatResolvedView({
     agent,
     sessionId,
     messages: session.messages,
+    transcriptOrder: order,
     onWorkingInterruptReset: resetWorkingInterrupted
   })
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
@@ -209,9 +211,9 @@ function NativeChatResolvedView({
   // Prune echoes whose real user turn is now in the transcript.
   useEffect(() => {
     setPending((prev) =>
-      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages))
+      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages, order))
     )
-  }, [session.messages, pendingScope])
+  }, [session.messages, order, pendingScope])
   useEffect(() => {
     if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
       return
@@ -229,12 +231,14 @@ function NativeChatResolvedView({
         sentAt,
         afterMessageId: boundary?.id ?? null,
         afterMessageTimestamp: boundary?.timestamp ?? null,
+        afterTranscriptGeneration: order.generation,
+        afterTranscriptHighWater: order.highWater,
         ...(imagePaths ? { imagePaths } : {})
       }
       setPending(appendPendingSendCache(pendingScope, entry))
       return entry.id
     },
-    [pendingScope, session.messages]
+    [pendingScope, session.messages, order]
   )
   const onOptimisticSendCanceled = useCallback(
     (pendingId: string) => {
@@ -258,11 +262,15 @@ function NativeChatResolvedView({
   }, [launchPromptMessage, session])
 
   const sessionAfterCommandBoundaries = useMemo<typeof session>(() => {
-    const messages = applyCommandMarkerBoundaries(sessionWithLaunchPrompt.messages, commandMarkers)
+    const messages = applyCommandMarkerBoundaries(
+      sessionWithLaunchPrompt.messages,
+      commandMarkers,
+      order
+    )
     return messages === sessionWithLaunchPrompt.messages
       ? sessionWithLaunchPrompt
       : { ...sessionWithLaunchPrompt, messages }
-  }, [sessionWithLaunchPrompt, commandMarkers])
+  }, [sessionWithLaunchPrompt, commandMarkers, order])
   const failedLaunchPromptMessageIds = useMemo(() => {
     const id = paneLaunchPrompt?.failed ? launchPromptMessage?.id : null
     if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
@@ -274,8 +282,8 @@ function NativeChatResolvedView({
   // The streaming preview bubble (if any) sits after the transcript but before
   // the optimistic user echoes — same order mobile uses.
   const pendingMessages = useMemo(
-    () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages),
-    [pending, sessionAfterCommandBoundaries.messages]
+    () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages, order),
+    [pending, sessionAfterCommandBoundaries.messages, order]
   )
   const streamingText = useMemo(() => {
     return deriveNativeChatStreamingText({

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -17,15 +17,7 @@ import {
   shouldClearNativeChatWorkingSuppression,
   shouldShowNativeChatWorking
 } from './native-chat-working-suppression'
-import {
-  appendPendingSendCache,
-  pendingSendsAsMessages,
-  nextNativeChatPendingSendId,
-  prunePendingSends,
-  readPendingSendCache,
-  writePendingSendCache,
-  type NativeChatPendingSend
-} from './native-chat-pending'
+import { pendingSendsAsMessages } from './native-chat-pending'
 import {
   applyCommandMarkerBoundaries,
   commandMarkersAsMessages,
@@ -50,6 +42,7 @@ import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owne
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
 import { useNativeChatFileLinkClick } from './use-native-chat-file-link-click'
 import { useNativeChatLaunchPrompt } from './use-native-chat-launch-prompt'
+import { useNativeChatPendingSends } from './use-native-chat-pending-sends'
 import type { NativeChatResolvedViewProps, NativeChatViewProps } from './native-chat-view-types'
 
 export type { NativeChatViewProps } from './native-chat-view-types'
@@ -185,11 +178,14 @@ function NativeChatResolvedView({
   // the message never vanishes between send and transcript catch-up.
   const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
   const order = session.transcriptOrder
-  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
-    readPendingSendCache(pendingScope)
-  )
-  const pendingGenerationRef = useRef(order.generation)
   const resetWorkingInterrupted = useCallback(() => setWorkingInterrupted(false), [])
+  const { pending, clearPending, onOptimisticSend, onOptimisticSendCanceled } =
+    useNativeChatPendingSends({
+      scope: pendingScope,
+      messages: session.messages,
+      order,
+      onSendStarted: resetWorkingInterrupted
+    })
   const { commandMarkers, onSlashCommand } = useNativeChatCommandMarkers({
     paneKey,
     agent,
@@ -202,62 +198,11 @@ function NativeChatResolvedView({
   const handleSlashCommand = useCallback(
     (command: string) => {
       if (command.trim().toLowerCase().startsWith('/clear')) {
-        setPending(writePendingSendCache(pendingScope, []))
+        clearPending()
       }
       onSlashCommand(command)
     },
-    [onSlashCommand, pendingScope]
-  )
-  // Reset the optimistic queue only when the pane/agent changes. A fresh launch
-  // often learns its provider session id after the first send; clearing pending
-  // on that transition briefly flashes the empty state before the transcript
-  // user turn lands.
-  useEffect(() => {
-    setPending(readPendingSendCache(pendingScope))
-    setWorkingInterrupted(false)
-  }, [pendingScope])
-  useEffect(() => {
-    if (pendingGenerationRef.current !== order.generation) {
-      // A source rebind invalidates pane-local optimistic sends. Keeping them
-      // would let an identical prompt from the replacement session retire one.
-      setPending(writePendingSendCache(pendingScope, []))
-    }
-    pendingGenerationRef.current = order.generation
-  }, [order.generation, pendingScope])
-  // Prune echoes whose real user turn is now in the transcript.
-  useEffect(() => {
-    setPending((prev) =>
-      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages, order))
-    )
-  }, [session.messages, order, pendingScope])
-  const onOptimisticSend = useCallback(
-    (text: string, imagePaths?: string[]) => {
-      setWorkingInterrupted(false)
-      const sentAt = Date.now()
-      const boundary = session.messages.at(-1)
-      const entry: NativeChatPendingSend = {
-        id: nextNativeChatPendingSendId(sentAt),
-        text,
-        sentAt,
-        afterMessageId: boundary?.id ?? null,
-        afterMessageTimestamp: boundary?.timestamp ?? null,
-        afterTranscriptGeneration: order.generation,
-        afterTranscriptHighWater: order.highWater,
-        ...(imagePaths ? { imagePaths } : {})
-      }
-      setPending(appendPendingSendCache(pendingScope, entry))
-      return entry.id
-    },
-    [pendingScope, session.messages, order]
-  )
-  const onOptimisticSendCanceled = useCallback(
-    (pendingId: string) => {
-      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered.
-      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
-      setPending(writePendingSendCache(pendingScope, next))
-    },
-    [pendingScope]
+    [clearPending, onSlashCommand]
   )
 
   const { message: launchPromptMessage, failed: launchPromptFailed } = useNativeChatLaunchPrompt({
@@ -362,9 +307,9 @@ function NativeChatResolvedView({
     // Why: Stop after a submitted turn drops the delayed-write handle once it
     // settles, so cancelPendingSends no longer sees the optimistic id. Clear
     // the echo cache here so a cancelled prompt cannot stick as a ghost bubble.
-    setPending(writePendingSendCache(pendingScope, []))
+    clearPending()
     interactiveSend.cancel()
-  }, [interactiveSend, pendingScope])
+  }, [clearPending, interactiveSend])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
   // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -199,6 +199,15 @@ function NativeChatResolvedView({
     transcriptOrder: order,
     onWorkingInterruptReset: resetWorkingInterrupted
   })
+  const handleSlashCommand = useCallback(
+    (command: string) => {
+      if (command.trim().toLowerCase().startsWith('/clear')) {
+        setPending(writePendingSendCache(pendingScope, []))
+      }
+      onSlashCommand(command)
+    },
+    [onSlashCommand, pendingScope]
+  )
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
   // often learns its provider session id after the first send; clearing pending
   // on that transition briefly flashes the empty state before the transcript
@@ -428,9 +437,11 @@ function NativeChatResolvedView({
         messages={sessionAfterCommandBoundaries.messages}
         transcriptSettled={session.readPhase === 'ready'}
         clearBoundaryUnavailable={clearBoundaryUnavailable}
-        hasClearMarker={commandMarkers.some((marker) =>
-          marker.command.trim().toLowerCase().startsWith('/clear')
-        )}
+        hasClearMarker={
+          commandMarkers.some((marker) =>
+            marker.command.trim().toLowerCase().startsWith('/clear')
+          ) && sessionAfterCommandBoundaries.messages.length === 0
+        }
         onShowingQuestionChange={setQuestionActive}
         answerInputRef={questionAnswerInputRef}
       />
@@ -449,7 +460,7 @@ function NativeChatResolvedView({
           onStop={stopAgent}
           onOptimisticSend={onOptimisticSend}
           onOptimisticSendCanceled={onOptimisticSendCanceled}
-          onSlashCommand={onSlashCommand}
+          onSlashCommand={handleSlashCommand}
           onSwitchToTerminal={onSwitchToTerminal}
           readTerminalScreen={readTerminalScreen}
           {...launchDraftSignal}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -194,6 +194,7 @@ function NativeChatResolvedView({
     paneKey,
     agent,
     sessionId,
+    sourceKey: JSON.stringify([runtimeEnvironmentId ?? null, transcriptPath ?? null]),
     messages: session.messages,
     transcriptOrder: order,
     onWorkingInterruptReset: resetWorkingInterrupted
@@ -427,6 +428,9 @@ function NativeChatResolvedView({
         messages={sessionAfterCommandBoundaries.messages}
         transcriptSettled={session.readPhase === 'ready'}
         clearBoundaryUnavailable={clearBoundaryUnavailable}
+        hasClearMarker={commandMarkers.some((marker) =>
+          marker.command.trim().toLowerCase().startsWith('/clear')
+        )}
         onShowingQuestionChange={setQuestionActive}
         answerInputRef={questionAnswerInputRef}
       />

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -28,7 +28,8 @@ import {
 } from './native-chat-pending'
 import {
   applyCommandMarkerBoundaries,
-  commandMarkersAsMessages
+  commandMarkersAsMessages,
+  hasUnavailableNativeChatClearBoundary
 } from './native-chat-command-markers'
 import { useNativeChatCommandMarkers } from './use-native-chat-command-markers'
 import {
@@ -187,6 +188,7 @@ function NativeChatResolvedView({
   const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
     readPendingSendCache(pendingScope)
   )
+  const pendingGenerationRef = useRef(order.generation)
   const resetWorkingInterrupted = useCallback(() => setWorkingInterrupted(false), [])
   const { commandMarkers, onSlashCommand } = useNativeChatCommandMarkers({
     paneKey,
@@ -204,6 +206,14 @@ function NativeChatResolvedView({
     setPending(readPendingSendCache(pendingScope))
     setWorkingInterrupted(false)
   }, [pendingScope])
+  useEffect(() => {
+    if (pendingGenerationRef.current !== order.generation) {
+      // A source rebind invalidates pane-local optimistic sends. Keeping them
+      // would let an identical prompt from the replacement session retire one.
+      setPending(writePendingSendCache(pendingScope, []))
+    }
+    pendingGenerationRef.current = order.generation
+  }, [order.generation, pendingScope])
   // Prune echoes whose real user turn is now in the transcript.
   useEffect(() => {
     setPending((prev) =>
@@ -245,7 +255,7 @@ function NativeChatResolvedView({
     agent,
     messages: session.messages,
     transcriptOrder: order,
-    crossClock: runtimeEnvironmentId != null
+    crossClock: true
   })
   const sessionWithLaunchPrompt = useMemo<typeof session>(() => {
     if (!launchPromptMessage) {
@@ -264,6 +274,11 @@ function NativeChatResolvedView({
       ? sessionWithLaunchPrompt
       : { ...sessionWithLaunchPrompt, messages }
   }, [sessionWithLaunchPrompt, commandMarkers, order])
+  const clearBoundaryUnavailable = hasUnavailableNativeChatClearBoundary(
+    sessionWithLaunchPrompt.messages,
+    commandMarkers,
+    order
+  )
   const failedLaunchPromptMessageIds = useMemo(() => {
     const id = launchPromptFailed ? launchPromptMessage?.id : null
     if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
@@ -411,6 +426,7 @@ function NativeChatResolvedView({
         canSend={canSend}
         messages={sessionAfterCommandBoundaries.messages}
         transcriptSettled={session.readPhase === 'ready'}
+        clearBoundaryUnavailable={clearBoundaryUnavailable}
         onShowingQuestionChange={setQuestionActive}
         answerInputRef={questionAnswerInputRef}
       />

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -18,21 +18,21 @@ import {
   shouldShowNativeChatWorking
 } from './native-chat-working-suppression'
 import {
-  applyCommandMarkerBoundaries,
   appendPendingSendCache,
-  commandMarkersAsMessages,
-  appendCommandMarkerCache,
   launchPromptAsMessage,
   pendingSendsAsMessages,
   nextNativeChatPendingSendId,
   prunePendingSends,
-  readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
-  type NativeChatCommandMarker,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import {
+  applyCommandMarkerBoundaries,
+  commandMarkersAsMessages
+} from './native-chat-command-markers'
+import { useNativeChatCommandMarkers } from './use-native-chat-command-markers'
 import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage
@@ -186,19 +186,18 @@ function NativeChatResolvedView({
   // Optimistic "queued" sends (mobile parity): a composer send is echoed
   // immediately and pruned once its real user turn lands in the transcript, so
   // the message never vanishes between send and transcript catch-up.
-  const commandMarkerScope = useMemo(
-    () => ({ paneKey, agent, sessionId }),
-    [paneKey, agent, sessionId]
-  )
   const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
   const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
     readPendingSendCache(pendingScope)
   )
-  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
-  // system line instead of a user bubble. Capped + cached per conversation.
-  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
-    readCommandMarkerCache(commandMarkerScope)
-  )
+  const resetWorkingInterrupted = useCallback(() => setWorkingInterrupted(false), [])
+  const { commandMarkers, onSlashCommand } = useNativeChatCommandMarkers({
+    paneKey,
+    agent,
+    sessionId,
+    messages: session.messages,
+    onWorkingInterruptReset: resetWorkingInterrupted
+  })
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
   // often learns its provider session id after the first send; clearing pending
   // on that transition briefly flashes the empty state before the transcript
@@ -207,12 +206,6 @@ function NativeChatResolvedView({
     setPending(readPendingSendCache(pendingScope))
     setWorkingInterrupted(false)
   }, [pendingScope])
-  // Command markers are session-scoped because slash commands like /clear are
-  // local feedback for a specific transcript boundary.
-  useEffect(() => {
-    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
-    setWorkingInterrupted(false)
-  }, [commandMarkerScope])
   // Prune echoes whose real user turn is now in the transcript.
   useEffect(() => {
     setPending((prev) =>
@@ -251,12 +244,6 @@ function NativeChatResolvedView({
       setPending(writePendingSendCache(pendingScope, next))
     },
     [pendingScope]
-  )
-  const onSlashCommand = useCallback(
-    (command: string) => {
-      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
-    },
-    [commandMarkerScope]
   )
 
   const launchPromptMessage = useMemo(

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -4,13 +4,24 @@
 
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
+
+export type NativeChatClearBoundary = {
+  clearAfterMessageId: string | null
+  clearTranscriptGeneration: number
+  clearTranscriptHighWater: number
+}
 
 export type NativeChatCommandMarker = {
   id: string
   /** The command as typed, e.g. `/clear`. */
   command: string
   sentAt: number
-  /** Transcript message ids visible when `/clear` was issued (host-agnostic hide set). */
+  /** Last ordered transcript row visible when `/clear` was issued. */
+  clearAfterMessageId?: string | null
+  clearTranscriptGeneration?: number
+  clearTranscriptHighWater?: number
+  /** Pre-boundary cache shape retained for hot-reload compatibility. */
   clearedMessageIds?: readonly string[]
 }
 
@@ -38,7 +49,7 @@ export function appendCommandMarkerCache(
   scope: NativeChatCommandMarkerScope,
   command: string,
   sentAt = Date.now(),
-  clearedMessageIds?: readonly string[]
+  clearBoundary?: NativeChatClearBoundary
 ): NativeChatCommandMarker[] {
   commandMarkerCounter += 1
   const key = commandMarkerScopeKey(scope)
@@ -50,7 +61,7 @@ export function appendCommandMarkerCache(
       id: `${sentAt}-${commandMarkerCounter}`,
       command,
       sentAt,
-      ...(clearedMessageIds !== undefined ? { clearedMessageIds: [...clearedMessageIds] } : {})
+      ...clearBoundary
     }
   ].slice(-COMMAND_MARKER_LIMIT)
   // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
@@ -70,54 +81,66 @@ export function isNativeChatClearCommand(command: string): boolean {
   return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
 }
 
-/** Message ids to hide for a `/clear`; undefined for non-clear commands. */
-export function clearedMessageIdsForSlashCommand(
+/** Ordered transcript boundary for a `/clear`; undefined for other commands. */
+export function clearBoundaryForSlashCommand(
   command: string,
-  messages: readonly Pick<NativeChatMessage, 'id'>[]
-): readonly string[] | undefined {
+  messages: readonly Pick<NativeChatMessage, 'id'>[],
+  transcriptOrder: NativeChatTranscriptOrder
+): NativeChatClearBoundary | undefined {
   if (!isNativeChatClearCommand(command)) {
     return undefined
   }
-  return messages.map((message) => message.id)
+  return {
+    clearAfterMessageId: messages.at(-1)?.id ?? null,
+    clearTranscriptGeneration: transcriptOrder.generation,
+    clearTranscriptHighWater: transcriptOrder.highWater
+  }
 }
 
 function latestClearMarker(
   markers: readonly NativeChatCommandMarker[]
 ): NativeChatCommandMarker | null {
-  let latest: NativeChatCommandMarker | null = null
-  for (const marker of markers) {
-    if (
-      isNativeChatClearCommand(marker.command) &&
-      (latest === null || marker.sentAt > latest.sentAt)
-    ) {
-      latest = marker
+  for (let index = markers.length - 1; index >= 0; index -= 1) {
+    const marker = markers[index]
+    if (marker && isNativeChatClearCommand(marker.command)) {
+      return marker
     }
   }
-  return latest
+  return null
 }
 
 export function applyCommandMarkerBoundaries(
   messages: readonly NativeChatMessage[],
-  markers: readonly NativeChatCommandMarker[]
+  markers: readonly NativeChatCommandMarker[],
+  transcriptOrder?: NativeChatTranscriptOrder
 ): NativeChatMessage[] {
   const clearMarker = latestClearMarker(markers)
   if (clearMarker === null) {
     return messages as NativeChatMessage[]
   }
-  // Why: `/clear` mutates the TUI/transcript asynchronously. Hide the rows that
-  // were visible at clear time by id so we never compare renderer `sentAt` to
-  // host/provider `message.timestamp` (cross-clock on remote runtimes).
-  if (clearMarker.clearedMessageIds !== undefined) {
-    if (clearMarker.clearedMessageIds.length === 0) {
-      return messages as NativeChatMessage[]
+  const boundaryId =
+    clearMarker.clearAfterMessageId !== undefined
+      ? clearMarker.clearAfterMessageId
+      : (clearMarker.clearedMessageIds?.at(-1) ?? null)
+  if (boundaryId !== null) {
+    const boundaryIndex = messages.findIndex((message) => message.id === boundaryId)
+    if (boundaryIndex >= 0) {
+      return messages.slice(boundaryIndex + 1)
     }
-    const hide = new Set(clearMarker.clearedMessageIds)
-    return messages.filter((message) => !hide.has(message.id))
   }
-  // Legacy in-memory markers without an id snapshot: keep prior local-clock filter.
-  return messages.filter(
-    (message) => message.timestamp !== null && message.timestamp > clearMarker.sentAt
-  )
+  if (
+    transcriptOrder !== undefined &&
+    clearMarker.clearTranscriptGeneration === transcriptOrder.generation &&
+    clearMarker.clearTranscriptHighWater !== undefined
+  ) {
+    return messages.filter(
+      (message) =>
+        (transcriptOrder.messageSequenceById.get(message.id) ?? 0) >
+        clearMarker.clearTranscriptHighWater!
+    )
+  }
+  // A missing boundary can mean an empty read, pagination, or replacement.
+  return []
 }
 
 /** Render command markers as compact `system` messages. The `system` role draws

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -1,0 +1,141 @@
+// Local slash-command feedback (e.g. `/clear`) for native chat. Commands are not
+// transcript turns; markers hide pre-clear rows by message id so we never compare
+// renderer sentAt to host/provider timestamps (#11519).
+
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+
+export type NativeChatCommandMarker = {
+  id: string
+  /** The command as typed, e.g. `/clear`. */
+  command: string
+  sentAt: number
+  /** Transcript message ids visible when `/clear` was issued (host-agnostic hide set). */
+  clearedMessageIds?: readonly string[]
+}
+
+export type NativeChatCommandMarkerScope = {
+  paneKey: string
+  agent: string
+  sessionId: string | null
+}
+
+const COMMAND_MARKER_LIMIT = 8
+const commandMarkerCache = new Map<string, NativeChatCommandMarker[]>()
+let commandMarkerCounter = 0
+
+function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
+  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}`
+}
+
+export function readCommandMarkerCache(
+  scope: NativeChatCommandMarkerScope
+): NativeChatCommandMarker[] {
+  return [...(commandMarkerCache.get(commandMarkerScopeKey(scope)) ?? [])]
+}
+
+export function appendCommandMarkerCache(
+  scope: NativeChatCommandMarkerScope,
+  command: string,
+  sentAt = Date.now(),
+  clearedMessageIds?: readonly string[]
+): NativeChatCommandMarker[] {
+  commandMarkerCounter += 1
+  const key = commandMarkerScopeKey(scope)
+  // Why: native/TUI view switches remount the chat surface, but slash commands
+  // are not transcript turns, so their local feedback needs a pane-scoped cache.
+  const next = [
+    ...(commandMarkerCache.get(key) ?? []),
+    {
+      id: `${sentAt}-${commandMarkerCounter}`,
+      command,
+      sentAt,
+      ...(clearedMessageIds !== undefined ? { clearedMessageIds: [...clearedMessageIds] } : {})
+    }
+  ].slice(-COMMAND_MARKER_LIMIT)
+  // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
+  // sessionId changes on every /clear) is ephemeral and was never evicted, so it
+  // grew one entry per (pane, session) for the renderer's whole life. LRU-bound
+  // the key count (mirrors the #7566 draft/attachment caches in this folder).
+  setBoundedScopeCacheEntry(commandMarkerCache, key, next)
+  return [...next]
+}
+
+export function clearCommandMarkerCacheForTests(): void {
+  commandMarkerCache.clear()
+  commandMarkerCounter = 0
+}
+
+export function isNativeChatClearCommand(command: string): boolean {
+  return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
+}
+
+/** Message ids to hide for a `/clear`; undefined for non-clear commands. */
+export function clearedMessageIdsForSlashCommand(
+  command: string,
+  messages: readonly Pick<NativeChatMessage, 'id'>[]
+): readonly string[] | undefined {
+  if (!isNativeChatClearCommand(command)) {
+    return undefined
+  }
+  return messages.map((message) => message.id)
+}
+
+function latestClearMarker(
+  markers: readonly NativeChatCommandMarker[]
+): NativeChatCommandMarker | null {
+  let latest: NativeChatCommandMarker | null = null
+  for (const marker of markers) {
+    if (
+      isNativeChatClearCommand(marker.command) &&
+      (latest === null || marker.sentAt > latest.sentAt)
+    ) {
+      latest = marker
+    }
+  }
+  return latest
+}
+
+export function applyCommandMarkerBoundaries(
+  messages: readonly NativeChatMessage[],
+  markers: readonly NativeChatCommandMarker[]
+): NativeChatMessage[] {
+  const clearMarker = latestClearMarker(markers)
+  if (clearMarker === null) {
+    return messages as NativeChatMessage[]
+  }
+  // Why: `/clear` mutates the TUI/transcript asynchronously. Hide the rows that
+  // were visible at clear time by id so we never compare renderer `sentAt` to
+  // host/provider `message.timestamp` (cross-clock on remote runtimes).
+  if (clearMarker.clearedMessageIds !== undefined) {
+    if (clearMarker.clearedMessageIds.length === 0) {
+      return messages as NativeChatMessage[]
+    }
+    const hide = new Set(clearMarker.clearedMessageIds)
+    return messages.filter((message) => !hide.has(message.id))
+  }
+  // Legacy in-memory markers without an id snapshot: keep prior local-clock filter.
+  return messages.filter(
+    (message) => message.timestamp !== null && message.timestamp > clearMarker.sentAt
+  )
+}
+
+/** Render command markers as compact `system` messages. The `system` role draws
+ *  as a muted aside (not a user bubble); the text avoids the harness noise
+ *  prefixes so stripNoiseMessages keeps it. */
+export function commandMarkersAsMessages(
+  markers: readonly NativeChatCommandMarker[]
+): NativeChatMessage[] {
+  return markers.map((marker) => ({
+    id: `command:${marker.id}`,
+    role: 'system' as const,
+    blocks: [{ type: 'text' as const, text: `Ran ${marker.command}` }],
+    timestamp: marker.sentAt,
+    source: 'scrape' as const
+  }))
+}
+
+/** True when a message id was minted for a slash-command marker. */
+export function isCommandMarkerId(id: string): boolean {
+  return id.startsWith('command:')
+}

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -135,6 +135,9 @@ export function applyCommandMarkerBoundaries(
     clearMarker.clearTranscriptHighWater !== undefined
   ) {
     const highWater = clearMarker.clearTranscriptHighWater
+    if (transcriptOrder.messageSequenceById.size === 0) {
+      return messages as NativeChatMessage[]
+    }
     return messages.filter((message) => {
       const sequence = transcriptOrder.messageSequenceById.get(message.id)
       return sequence !== undefined && sequence > highWater
@@ -167,9 +170,10 @@ export function hasUnavailableNativeChatClearBoundary(
     clearMarker.clearTranscriptGeneration === transcriptOrder.generation &&
     clearMarker.clearTranscriptHighWater !== undefined
   ) {
-    return ![...transcriptOrder.messageSequenceById.values()].some(
+    const hasPostClearSequence = [...transcriptOrder.messageSequenceById.values()].some(
       (sequence) => sequence > clearMarker.clearTranscriptHighWater!
     )
+    return !hasPostClearSequence
   }
   return true
 }

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -135,7 +135,10 @@ export function applyCommandMarkerBoundaries(
     clearMarker.clearTranscriptHighWater !== undefined
   ) {
     const highWater = clearMarker.clearTranscriptHighWater
-    if (transcriptOrder.messageSequenceById.size === 0) {
+    const hasPostClearSequence = [...transcriptOrder.messageSequenceById.values()].some(
+      (sequence) => sequence > highWater
+    )
+    if (!hasPostClearSequence) {
       return messages as NativeChatMessage[]
     }
     return messages.filter((message) => {

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -29,6 +29,7 @@ export type NativeChatCommandMarkerScope = {
   paneKey: string
   agent: string
   sessionId: string | null
+  sourceKey?: string
 }
 
 const COMMAND_MARKER_LIMIT = 8
@@ -36,7 +37,7 @@ const commandMarkerCache = new Map<string, NativeChatCommandMarker[]>()
 let commandMarkerCounter = 0
 
 function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
-  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}`
+  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}\0${scope.sourceKey ?? ''}`
 }
 
 export function readCommandMarkerCache(
@@ -161,11 +162,16 @@ export function hasUnavailableNativeChatClearBoundary(
   if (boundaryId !== null && messages.some((message) => message.id === boundaryId)) {
     return false
   }
-  return !(
+  if (
     transcriptOrder !== undefined &&
     clearMarker.clearTranscriptGeneration === transcriptOrder.generation &&
     clearMarker.clearTranscriptHighWater !== undefined
-  )
+  ) {
+    return ![...transcriptOrder.messageSequenceById.values()].some(
+      (sequence) => sequence > clearMarker.clearTranscriptHighWater!
+    )
+  }
+  return true
 }
 
 /** Render command markers as compact `system` messages. The `system` role draws

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -144,6 +144,30 @@ export function applyCommandMarkerBoundaries(
   return messages as NativeChatMessage[]
 }
 
+/** True when the latest clear marker cannot prove which rows are post-clear. */
+export function hasUnavailableNativeChatClearBoundary(
+  messages: readonly NativeChatMessage[],
+  markers: readonly NativeChatCommandMarker[],
+  transcriptOrder?: NativeChatTranscriptOrder
+): boolean {
+  const clearMarker = latestClearMarker(markers)
+  if (clearMarker === null) {
+    return false
+  }
+  const boundaryId =
+    clearMarker.clearAfterMessageId !== undefined
+      ? clearMarker.clearAfterMessageId
+      : (clearMarker.clearedMessageIds?.at(-1) ?? null)
+  if (boundaryId !== null && messages.some((message) => message.id === boundaryId)) {
+    return false
+  }
+  return !(
+    transcriptOrder !== undefined &&
+    clearMarker.clearTranscriptGeneration === transcriptOrder.generation &&
+    clearMarker.clearTranscriptHighWater !== undefined
+  )
+}
+
 /** Render command markers as compact `system` messages. The `system` role draws
  *  as a muted aside (not a user bubble); the text avoids the harness noise
  *  prefixes so stripNoiseMessages keeps it. */

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -124,7 +124,7 @@ export function applyCommandMarkerBoundaries(
       : (clearMarker.clearedMessageIds?.at(-1) ?? null)
   if (boundaryId !== null) {
     const boundaryIndex = messages.findIndex((message) => message.id === boundaryId)
-    if (boundaryIndex >= 0) {
+    if (boundaryIndex !== -1) {
       return messages.slice(boundaryIndex + 1)
     }
   }

--- a/src/renderer/src/components/native-chat/native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/native-chat-command-markers.ts
@@ -133,14 +133,15 @@ export function applyCommandMarkerBoundaries(
     clearMarker.clearTranscriptGeneration === transcriptOrder.generation &&
     clearMarker.clearTranscriptHighWater !== undefined
   ) {
-    return messages.filter(
-      (message) =>
-        (transcriptOrder.messageSequenceById.get(message.id) ?? 0) >
-        clearMarker.clearTranscriptHighWater!
-    )
+    const highWater = clearMarker.clearTranscriptHighWater
+    return messages.filter((message) => {
+      const sequence = transcriptOrder.messageSequenceById.get(message.id)
+      return sequence !== undefined && sequence > highWater
+    })
   }
   // A missing boundary can mean an empty read, pagination, or replacement.
-  return []
+  // Showing rows keeps the user recoverable; blanking here can persist forever.
+  return messages as NativeChatMessage[]
 }
 
 /** Render command markers as compact `system` messages. The `system` role draws

--- a/src/renderer/src/components/native-chat/native-chat-incremental-assembler.ts
+++ b/src/renderer/src/components/native-chat/native-chat-incremental-assembler.ts
@@ -26,6 +26,19 @@ export function createIncrementalAssembler(): IncrementalChatAssembler {
   return { byId: new Map(), byTurn: new Map(), messages: [] }
 }
 
+export function sharesNativeChatMessagePrefix(
+  whole: readonly NativeChatMessage[],
+  prefix: readonly NativeChatMessage[],
+  length: number
+): boolean {
+  for (let index = 0; index < length; index += 1) {
+    if (whole[index] !== prefix[index]) {
+      return false
+    }
+  }
+  return true
+}
+
 /** Rebuild the assembled state from a base list (the windowed read). Canonical
  *  path — equivalent to assembleNativeChatSession over `{ transcript: base }`. */
 export function reset(

--- a/src/renderer/src/components/native-chat/native-chat-launch-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-launch-prompt.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import {
+  isLaunchPromptMessageId,
+  launchPromptAsMessage,
+  shouldPruneLaunchPrompt
+} from './native-chat-launch-prompt'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
+
+function message(id: string, role: 'user' | 'assistant', text: string): NativeChatMessage {
+  return {
+    id,
+    role,
+    blocks: [{ type: 'text', text }],
+    timestamp: 1,
+    source: 'transcript'
+  }
+}
+
+function transcriptOrder(
+  highWater: number,
+  sequences: Record<string, number> = {}
+): NativeChatTranscriptOrder {
+  return { generation: 0, highWater, messageSequenceById: new Map(Object.entries(sequences)) }
+}
+
+describe('native chat launch prompt', () => {
+  it('maps a launch prompt to a tab-keyed scrape-source user message', () => {
+    expect(
+      launchPromptAsMessage({
+        tabId: 'tab-1',
+        agent: 'codex',
+        text: 'Fix failing checks',
+        createdAt: 42
+      })
+    ).toEqual({
+      id: 'launch-pending:tab-1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'Fix failing checks' }],
+      timestamp: 42,
+      source: 'scrape'
+    })
+  })
+
+  it('hides the launch prompt while its transcript user turn is visible', () => {
+    const entry = { tabId: 'tab-1', agent: 'codex' as const, text: 'Fix checks', createdAt: 42 }
+    const transcript = [{ ...message('u1', 'user', 'Fix checks'), timestamp: 43 }]
+
+    expect(launchPromptAsMessage(entry, transcript)).toBeNull()
+  })
+
+  it('uses pending-send normalization for large multiline generated prompts', () => {
+    const prompt = [
+      '[Image #1] Resolve the failing checks:',
+      '',
+      'Resolve the failing checks:',
+      '',
+      '- lint failed',
+      '  fix spacing'
+    ].join('\n')
+    const transcript = [
+      {
+        ...message(
+          'u1',
+          'user',
+          'Resolve the failing checks: Resolve the failing checks: - lint failed fix spacing'
+        ),
+        timestamp: 43
+      },
+      { ...message('a1', 'assistant', 'I will fix it'), timestamp: 44 }
+    ]
+
+    expect(
+      shouldPruneLaunchPrompt(
+        { tabId: 'tab-1', agent: 'codex', text: prompt, createdAt: 42 },
+        transcript
+      )
+    ).toBe(true)
+  })
+
+  it('keeps the launch prompt until the transcript advances past the user turn', () => {
+    const prompt = {
+      tabId: 'tab-1',
+      agent: 'claude' as const,
+      text: 'Fix failing checks',
+      createdAt: 42
+    }
+    const user = { ...message('u1', 'user', 'Fix failing checks'), timestamp: 43 }
+
+    expect(shouldPruneLaunchPrompt(prompt, [user])).toBe(false)
+    expect(
+      shouldPruneLaunchPrompt(prompt, [
+        user,
+        { ...message('a1', 'assistant', 'working'), timestamp: 44 }
+      ])
+    ).toBe(true)
+  })
+
+  it('hides and prunes against a timestampless transcript', () => {
+    const entry = { tabId: 'tab-1', agent: 'grok' as const, text: 'rename it', createdAt: 42 }
+    const transcript = [
+      { ...message('u1', 'user', 'rename it'), timestamp: null },
+      { ...message('a1', 'assistant', 'done'), timestamp: null }
+    ]
+
+    expect(launchPromptAsMessage(entry, transcript)).toBeNull()
+    expect(shouldPruneLaunchPrompt(entry, transcript)).toBe(true)
+  })
+
+  it('does not bind to an older identical completed turn', () => {
+    const entry = { tabId: 'tab-1', agent: 'claude' as const, text: 'run tests', createdAt: 100 }
+    const oldHistory = [
+      { ...message('old-user', 'user', 'run tests'), timestamp: 10 },
+      { ...message('old-answer', 'assistant', 'passed'), timestamp: 20 }
+    ]
+
+    expect(launchPromptAsMessage(entry, oldHistory)).not.toBeNull()
+    expect(shouldPruneLaunchPrompt(entry, oldHistory)).toBe(false)
+  })
+
+  it('matches by transcript order when the remote host clock is behind', () => {
+    const entry = {
+      tabId: 'tab-1',
+      agent: 'claude' as const,
+      text: 'run tests',
+      createdAt: 1_000_000
+    }
+    const transcript = [
+      { ...message('old-user', 'user', 'run tests'), timestamp: 10 },
+      { ...message('old-answer', 'assistant', 'passed'), timestamp: 20 },
+      { ...message('new-user', 'user', 'run tests'), timestamp: 30 },
+      { ...message('new-answer', 'assistant', 'passed again'), timestamp: 40 }
+    ]
+    const options = {
+      crossClock: true,
+      transcriptOrder: transcriptOrder(2, { 'new-user': 1, 'new-answer': 2 })
+    }
+
+    expect(launchPromptAsMessage(entry, transcript, options)).toBeNull()
+    expect(shouldPruneLaunchPrompt(entry, transcript, options)).toBe(true)
+  })
+
+  it('keeps a remote prompt when only an unsequenced older turn matches', () => {
+    const entry = {
+      tabId: 'tab-1',
+      agent: 'claude' as const,
+      text: 'run tests',
+      createdAt: 1_000_000
+    }
+    const oldHistory = [
+      { ...message('old-user', 'user', 'run tests'), timestamp: 10 },
+      { ...message('old-answer', 'assistant', 'passed'), timestamp: 20 }
+    ]
+    const options = { crossClock: true, transcriptOrder: transcriptOrder(0) }
+
+    expect(launchPromptAsMessage(entry, oldHistory, options)).not.toBeNull()
+    expect(shouldPruneLaunchPrompt(entry, oldHistory, options)).toBe(false)
+  })
+
+  it('recognizes the launch prompt id prefix', () => {
+    expect(isLaunchPromptMessageId('launch-pending:tab-1')).toBe(true)
+    expect(isLaunchPromptMessageId('pending:p1')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-launch-prompt.ts
+++ b/src/renderer/src/components/native-chat/native-chat-launch-prompt.ts
@@ -1,0 +1,68 @@
+import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import {
+  advancedNativeChatUserContentCounts,
+  matchingNativeChatUserContentCounts,
+  nativeChatPendingContentKey
+} from './native-chat-pending-occurrence'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
+
+export type NativeChatLaunchPromptMatchOptions = {
+  crossClock?: boolean
+  transcriptOrder?: NativeChatTranscriptOrder
+}
+
+function relevantLaunchPromptMessages(
+  entry: NativeChatLaunchPrompt,
+  messages: readonly NativeChatMessage[],
+  options: NativeChatLaunchPromptMatchOptions
+): readonly NativeChatMessage[] {
+  if (options.crossClock) {
+    // Remote host timestamps are incomparable; sequence marks only post-launch rows.
+    const sequenceById = options.transcriptOrder?.messageSequenceById
+    return sequenceById ? messages.filter((message) => sequenceById.has(message.id)) : []
+  }
+  return messages.filter(
+    (message) => message.timestamp === null || message.timestamp >= entry.createdAt
+  )
+}
+
+/** Hide a launch echo once the transcript's matching user turn is visible. */
+export function launchPromptAsMessage(
+  entry: NativeChatLaunchPrompt | null,
+  existingMessages: NativeChatMessage[] = [],
+  options: NativeChatLaunchPromptMatchOptions = {}
+): NativeChatMessage | null {
+  if (!entry) {
+    return null
+  }
+  const represented = matchingNativeChatUserContentCounts(
+    relevantLaunchPromptMessages(entry, existingMessages, options)
+  )
+  if ((represented.get(nativeChatPendingContentKey(entry)) ?? 0) > 0) {
+    return null
+  }
+  return {
+    id: `launch-pending:${entry.tabId}`,
+    role: 'user',
+    blocks: entry.text.trim().length > 0 ? [{ type: 'text', text: entry.text }] : [],
+    timestamp: entry.createdAt,
+    source: 'scrape'
+  }
+}
+
+/** Prune only after an assistant turn follows the matching launch prompt. */
+export function shouldPruneLaunchPrompt(
+  entry: NativeChatLaunchPrompt,
+  messages: NativeChatMessage[],
+  options: NativeChatLaunchPromptMatchOptions = {}
+): boolean {
+  const relevant = relevantLaunchPromptMessages(entry, messages, options)
+  return (
+    (advancedNativeChatUserContentCounts(relevant).get(nativeChatPendingContentKey(entry)) ?? 0) > 0
+  )
+}
+
+export function isLaunchPromptMessageId(id: string): boolean {
+  return id.startsWith('launch-pending:')
+}

--- a/src/renderer/src/components/native-chat/native-chat-launch-prompt.ts
+++ b/src/renderer/src/components/native-chat/native-chat-launch-prompt.ts
@@ -20,7 +20,9 @@ function relevantLaunchPromptMessages(
   if (options.crossClock) {
     // Remote host timestamps are incomparable; sequence marks only post-launch rows.
     const sequenceById = options.transcriptOrder?.messageSequenceById
-    return sequenceById ? messages.filter((message) => sequenceById.has(message.id)) : []
+    // If ordering is not available yet, retain identity/occurrence matching;
+    // comparing createdAt to provider timestamps would mix clock domains.
+    return sequenceById ? messages.filter((message) => sequenceById.has(message.id)) : messages
   }
   return messages.filter(
     (message) => message.timestamp === null || message.timestamp >= entry.createdAt

--- a/src/renderer/src/components/native-chat/native-chat-live-session-order.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-order.ts
@@ -26,7 +26,7 @@ export type NativeChatOrderSource = {
   transport: unknown
 }
 
-/** True when only the session id is adopted after a null placeholder (keep order gen). */
+/** True when a null placeholder adopts its session metadata (keep order gen). */
 export function isNativeChatSessionIdAdoption(
   previous: NativeChatOrderSource,
   next: NativeChatOrderSource
@@ -35,7 +35,7 @@ export function isNativeChatSessionIdAdoption(
     previous.sessionId === null &&
     next.sessionId != null &&
     previous.agent === next.agent &&
-    previous.transcriptPath === next.transcriptPath &&
+    (previous.transcriptPath === next.transcriptPath || previous.transcriptPath === null) &&
     previous.transport === next.transport
   )
 }

--- a/src/renderer/src/components/native-chat/native-chat-live-session-order.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-order.ts
@@ -1,0 +1,146 @@
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { createIncrementalAssembler } from './native-chat-incremental-assembler'
+
+// Why: a new session's transcript can take minutes to appear on disk (#8401).
+const NOTFOUND_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
+const NOTFOUND_RETRY_FIXED_DELAY_MS = 10_000
+export const NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS = 60_000
+
+export function nativeChatNotFoundRetryDelayMs(attempt: number): number {
+  return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
+}
+
+export type NativeChatOrderSource = {
+  agent: string
+  sessionId: string | null
+  transcriptPath: string | null
+  transport: unknown
+}
+
+/** True when only the session id is adopted after a null placeholder (keep order gen). */
+export function isNativeChatSessionIdAdoption(
+  previous: NativeChatOrderSource,
+  next: NativeChatOrderSource
+): boolean {
+  return (
+    previous.sessionId === null &&
+    next.sessionId != null &&
+    previous.agent === next.agent &&
+    previous.transcriptPath === next.transcriptPath &&
+    previous.transport === next.transport
+  )
+}
+
+/**
+ * Gate for settling authoritative frames into transcript order.
+ * Adoption settles the first non-empty snapshot; replacements always settle;
+ * plain reconnect snapshots do not (baseline rows stay unsequenced).
+ */
+export function shouldSettleNativeChatAuthoritativeFrame(args: {
+  force: boolean
+  adoptSettlePending: boolean
+  messageCount: number
+}): { settle: boolean; adoptSettlePending: boolean } {
+  if (!args.force && !args.adoptSettlePending) {
+    return { settle: false, adoptSettlePending: args.adoptSettlePending }
+  }
+  // Empty subscribe snapshot must not consume the post-adoption settle slot.
+  if (!args.force && args.messageCount === 0) {
+    return { settle: false, adoptSettlePending: args.adoptSettlePending }
+  }
+  return { settle: true, adoptSettlePending: false }
+}
+
+export function createNativeChatAuthoritativeSettle(
+  settle: (messages: readonly NativeChatMessage[], retainedCount: number) => void,
+  limit: () => number
+): {
+  settleFrame: (messages: readonly NativeChatMessage[], force: boolean) => void
+  markAdoptSettle: () => void
+} {
+  let adoptSettlePending = false
+  return {
+    markAdoptSettle: () => {
+      adoptSettlePending = true
+    },
+    settleFrame: (messages, force) => {
+      const decision = shouldSettleNativeChatAuthoritativeFrame({
+        force,
+        adoptSettlePending,
+        messageCount: messages.length
+      })
+      adoptSettlePending = decision.adoptSettlePending
+      if (decision.settle) {
+        settle(messages, limit())
+      }
+    }
+  }
+}
+
+/** Resolve sync or promise-wrapped unsubscribe from transport.subscribe. */
+export function teardownNativeChatSubscription(unsubscribe: unknown): void {
+  if (typeof unsubscribe === 'function') {
+    ;(unsubscribe as () => void)()
+    return
+  }
+  if (unsubscribe && typeof (unsubscribe as { then?: unknown }).then === 'function') {
+    void (unsubscribe as Promise<unknown>).then((fn) => {
+      if (typeof fn === 'function') {
+        ;(fn as () => void)()
+      }
+    })
+  }
+}
+
+export type NativeChatAssemblerCache = {
+  assembler: ReturnType<typeof createIncrementalAssembler>
+  appliedTranscript: readonly NativeChatMessage[]
+  baseSig: string | null
+  baseMessages: readonly NativeChatMessage[]
+}
+
+/** Suffix-append when possible; otherwise full assembler reset. */
+export function assembleNativeChatLiveMessages(args: {
+  cache: NativeChatAssemblerCache
+  baseMessages: readonly NativeChatMessage[]
+  appended: readonly NativeChatMessage[]
+  agent: string
+  sessionId: string | null
+  applyAppends: (
+    assembler: NativeChatAssemblerCache['assembler'],
+    messages: readonly NativeChatMessage[]
+  ) => NativeChatMessage[]
+  resetAssembler: (
+    assembler: NativeChatAssemblerCache['assembler'],
+    messages: readonly NativeChatMessage[]
+  ) => NativeChatMessage[]
+  sharesPrefix: (
+    whole: readonly NativeChatMessage[],
+    prefix: readonly NativeChatMessage[],
+    len: number
+  ) => boolean
+}): NativeChatMessage[] {
+  const { cache, baseMessages, appended, agent, sessionId } = args
+  const transcript =
+    appended.length > 0 ? [...baseMessages, ...appended] : (baseMessages as NativeChatMessage[])
+  const baseSig = `${agent}\u0000${sessionId ?? ''}`
+  const baseChanged = baseSig !== cache.baseSig || baseMessages !== cache.baseMessages
+  const applied = cache.appliedTranscript
+  const isSuffixExtension =
+    !baseChanged &&
+    transcript.length >= applied.length &&
+    args.sharesPrefix(transcript, applied, applied.length)
+
+  let out: NativeChatMessage[]
+  if (isSuffixExtension && transcript.length > applied.length) {
+    out = args.applyAppends(cache.assembler, transcript.slice(applied.length))
+  } else if (isSuffixExtension) {
+    out = cache.assembler.messages
+  } else {
+    out = args.resetAssembler(cache.assembler, transcript)
+  }
+  cache.baseSig = baseSig
+  cache.baseMessages = baseMessages
+  cache.appliedTranscript = transcript
+  return out
+}

--- a/src/renderer/src/components/native-chat/native-chat-live-session-order.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-order.ts
@@ -10,6 +10,15 @@ export function nativeChatNotFoundRetryDelayMs(attempt: number): number {
   return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
 }
 
+// Why: lives outside effect bodies — react-doctor effect-needs-cleanup false-positives
+// on setTimeout assigned inside async .then even when cleanup clears the handle.
+export function scheduleNativeChatNotFoundRetry(args: {
+  attempt: number
+  onRetry: () => void
+}): ReturnType<typeof setTimeout> {
+  return setTimeout(args.onRetry, nativeChatNotFoundRetryDelayMs(args.attempt))
+}
+
 export type NativeChatOrderSource = {
   agent: string
   sessionId: string | null

--- a/src/renderer/src/components/native-chat/native-chat-live-session-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-types.ts
@@ -1,0 +1,34 @@
+import type {
+  AgentType,
+  NativeChatMessage,
+  NativeChatSession
+} from '../../../../shared/native-chat-types'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
+
+export type UseNativeChatLiveSessionArgs = {
+  /** Composite `${tabId}:${leafId}` key — selects the live hook entry. */
+  paneKey: string
+  agent: AgentType
+  /** The agent's own session id, or null before it reports one. */
+  sessionId: string | null
+  /** Authoritative transcript path reported by the hook. */
+  transcriptPath?: string | null
+  /** Non-null routes reads and subscriptions to the runtime owner. */
+  runtimeEnvironmentId?: string | null
+}
+
+export type ReadState =
+  | { phase: 'loading' }
+  | { phase: 'ready'; messages: NativeChatMessage[] }
+  | { phase: 'error'; error: string }
+
+/** A live session plus the older-history pagination controls the view needs. */
+export type NativeChatLiveSession = NativeChatSession & {
+  hasMore: boolean
+  loadingEarlier: boolean
+  loadEarlier: () => void
+  /** Raw read phase remains loading even when live hook status outranks it. */
+  readPhase: ReadState['phase']
+  /** Same-renderer ordering for live rows received after an optimistic action. */
+  transcriptOrder: NativeChatTranscriptOrder
+}

--- a/src/renderer/src/components/native-chat/native-chat-live-session-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-types.ts
@@ -15,6 +15,8 @@ export type UseNativeChatLiveSessionArgs = {
   transcriptPath?: string | null
   /** Non-null routes reads and subscriptions to the runtime owner. */
   runtimeEnvironmentId?: string | null
+  /** False suspends transcript IO while retaining the last committed session. */
+  enabled?: boolean
 }
 
 export type ReadState =

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
@@ -34,13 +34,15 @@ describe('pending send occurrence reconciliation', () => {
       id: 'p1',
       text: 'repeat',
       sentAt: 100,
-      afterMessageId: 'paged-out-boundary'
+      afterMessageId: 'paged-out-boundary',
+      afterMessageTimestamp: 100
     })
     const repeated = appendPendingSendCache(scope, {
       id: 'p2',
       text: 'repeat',
       sentAt: 200,
-      afterMessageId: 'paged-out-boundary'
+      afterMessageId: 'paged-out-boundary',
+      afterMessageTimestamp: 100
     })
     expect(first[0]?.matchingOccurrence).toBeUndefined()
     expect(repeated[1]).toMatchObject({ matchingOccurrence: 2, matchingAfterTimestamp: 100 })
@@ -63,6 +65,23 @@ describe('pending send occurrence reconciliation', () => {
     ]
     expect(pendingSendsAsMessages(afterFirstPrune, secondCompletedTurn)).toEqual([])
     expect(prunePendingSends(afterFirstPrune, secondCompletedTurn)).toEqual([])
+  })
+
+  it('inherits only a host-domain matchingAfterTimestamp, never renderer sentAt', () => {
+    appendPendingSendCache(scope, {
+      id: 'p1',
+      text: 'repeat',
+      sentAt: 1_000_000,
+      afterMessageId: null
+    })
+    const repeated = appendPendingSendCache(scope, {
+      id: 'p2',
+      text: 'repeat',
+      sentAt: 1_000_100,
+      afterMessageId: null
+    })
+    expect(repeated[1]?.matchingOccurrence).toBe(2)
+    expect(repeated[1]?.matchingAfterTimestamp).toBeUndefined()
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
@@ -33,13 +33,15 @@ describe('pending send occurrence reconciliation', () => {
       id: 'p1',
       text: 'repeat',
       sentAt: 100,
-      afterMessageId: 'paged-out-boundary'
+      afterMessageId: 'paged-out-boundary',
+      afterMessageTimestamp: 100
     })
     const repeated = appendPendingSendCache(scope, {
       id: 'p2',
       text: 'repeat',
       sentAt: 200,
-      afterMessageId: 'paged-out-boundary'
+      afterMessageId: 'paged-out-boundary',
+      afterMessageTimestamp: 100
     })
     expect(first[0]?.matchingOccurrence).toBeUndefined()
     expect(repeated[1]).toMatchObject({ matchingOccurrence: 2, matchingAfterTimestamp: 100 })
@@ -62,5 +64,22 @@ describe('pending send occurrence reconciliation', () => {
     ]
     expect(pendingSendsAsMessages(afterFirstPrune, secondCompletedTurn)).toEqual([])
     expect(prunePendingSends(afterFirstPrune, secondCompletedTurn)).toEqual([])
+  })
+
+  it('inherits only a host-domain matchingAfterTimestamp, never renderer sentAt', () => {
+    appendPendingSendCache(scope, {
+      id: 'p1',
+      text: 'repeat',
+      sentAt: 1_000_000,
+      afterMessageId: null
+    })
+    const repeated = appendPendingSendCache(scope, {
+      id: 'p2',
+      text: 'repeat',
+      sentAt: 1_000_100,
+      afterMessageId: null
+    })
+    expect(repeated[1]?.matchingOccurrence).toBe(2)
+    expect(repeated[1]?.matchingAfterTimestamp).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -13,6 +13,8 @@ export type NativeChatPendingOccurrence = {
   afterMessageTimestamp?: number | null
   matchingOccurrence?: number
   matchingAfterTimestamp?: number
+  afterTranscriptGeneration?: number
+  afterTranscriptHighWater?: number
 }
 
 export function normalizeNativeChatPendingText(text: string): string {
@@ -200,7 +202,8 @@ export function selectPendingIndicesRepresentedByUserTexts(
 }
 
 export function nativeChatPendingMatchKey(pending: NativeChatPendingOccurrence): string {
-  return `${String(pending.afterMessageId)}\0${nativeChatPendingContentKey(pending)}`
+  const transcriptBoundary = `${String(pending.afterTranscriptGeneration)}:${String(pending.afterTranscriptHighWater)}`
+  return `${String(pending.afterMessageId)}\0${transcriptBoundary}\0${nativeChatPendingContentKey(pending)}`
 }
 
 export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOccurrence>(

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -218,16 +218,21 @@ export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOcc
   const first = matching[0]
   // Why: pruning an earlier echo must not let a later identical send reuse the
   // same transcript occurrence, even after the read pages out its boundary.
+  // Only inherit a host-domain time bound — never renderer `sentAt`.
+  const matchingAfterTimestamp =
+    first?.matchingAfterTimestamp ?? first?.afterMessageTimestamp ?? undefined
   return {
     ...entry,
     matchingOccurrence: previousOccurrence + 1,
-    matchingAfterTimestamp:
-      first?.matchingAfterTimestamp ?? first?.afterMessageTimestamp ?? first?.sentAt
+    ...(matchingAfterTimestamp != null ? { matchingAfterTimestamp } : {})
   }
 }
 
-export function nativeChatPendingMatchingAfter(pending: NativeChatPendingOccurrence): number {
-  return pending.matchingAfterTimestamp ?? pending.afterMessageTimestamp ?? pending.sentAt
+/** Host-domain lower bound for transcript matching, or null when none exists. */
+export function nativeChatPendingMatchingAfter(
+  pending: NativeChatPendingOccurrence
+): number | null {
+  return pending.matchingAfterTimestamp ?? pending.afterMessageTimestamp ?? null
 }
 
 export function nativeChatPendingOccurrence(

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -214,16 +214,21 @@ export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOcc
   const first = matching[0]
   // Why: pruning an earlier echo must not let a later identical send reuse the
   // same transcript occurrence, even after the read pages out its boundary.
+  // Only inherit a host-domain time bound — never renderer `sentAt`.
+  const matchingAfterTimestamp =
+    first?.matchingAfterTimestamp ?? first?.afterMessageTimestamp ?? undefined
   return {
     ...entry,
     matchingOccurrence: previousOccurrence + 1,
-    matchingAfterTimestamp:
-      first?.matchingAfterTimestamp ?? first?.afterMessageTimestamp ?? first?.sentAt
+    ...(matchingAfterTimestamp != null ? { matchingAfterTimestamp } : {})
   }
 }
 
-export function nativeChatPendingMatchingAfter(pending: NativeChatPendingOccurrence): number {
-  return pending.matchingAfterTimestamp ?? pending.afterMessageTimestamp ?? pending.sentAt
+/** Host-domain lower bound for transcript matching, or null when none exists. */
+export function nativeChatPendingMatchingAfter(
+  pending: NativeChatPendingOccurrence
+): number | null {
+  return pending.matchingAfterTimestamp ?? pending.afterMessageTimestamp ?? null
 }
 
 export function nativeChatPendingOccurrence(

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -12,6 +12,8 @@ export type NativeChatPendingOccurrence = {
   afterMessageTimestamp?: number | null
   matchingOccurrence?: number
   matchingAfterTimestamp?: number
+  afterTranscriptGeneration?: number
+  afterTranscriptHighWater?: number
 }
 
 export function normalizeNativeChatPendingText(text: string): string {
@@ -196,7 +198,8 @@ export function selectPendingIndicesRepresentedByUserTexts(
 }
 
 export function nativeChatPendingMatchKey(pending: NativeChatPendingOccurrence): string {
-  return `${String(pending.afterMessageId)}\0${nativeChatPendingContentKey(pending)}`
+  const transcriptBoundary = `${String(pending.afterTranscriptGeneration)}:${String(pending.afterTranscriptHighWater)}`
+  return `${String(pending.afterMessageId)}\0${transcriptBoundary}\0${nativeChatPendingContentKey(pending)}`
 }
 
 export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOccurrence>(

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -2,24 +2,26 @@ import { describe, expect, it } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendPendingSendCache,
-  appendCommandMarkerCache,
-  applyCommandMarkerBoundaries,
-  clearCommandMarkerCacheForTests,
   clearPendingSendCacheForTests,
-  commandMarkersAsMessages,
-  isCommandMarkerId,
   isLaunchPromptMessageId,
   isPendingMessageId,
   launchPromptAsMessage,
   nextNativeChatPendingSendId,
   pendingSendsAsMessages,
   prunePendingSends,
-  readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import {
+  appendCommandMarkerCache,
+  applyCommandMarkerBoundaries,
+  clearCommandMarkerCacheForTests,
+  commandMarkersAsMessages,
+  isCommandMarkerId,
+  readCommandMarkerCache
+} from './native-chat-command-markers'
 import { stripNoiseMessages } from './native-chat-noise'
 
 function userMessage(id: string, text: string): NativeChatMessage {
@@ -236,12 +238,21 @@ describe('pendingSendsAsMessages', () => {
     ])
   })
 
-  it('keeps a loading-time send visible when older matching history arrives later', () => {
+  it('keeps a loading-time send visible when older matching history has a host-domain boundary', () => {
+    // History was visible at send time; the host-domain boundary excludes it.
+    // Renderer sentAt alone must not be the bound (#11519 cross-clock).
     const history = [
       { ...userMessage('old-user', 'run tests'), timestamp: 10 },
       { ...assistantMessage('old-answer', 'passed'), timestamp: 20 }
     ]
-    const pending = [{ ...pendingOf('new-send', 'run tests'), sentAt: 100, afterMessageId: null }]
+    const pending = [
+      {
+        ...pendingOf('new-send', 'run tests'),
+        sentAt: 100,
+        afterMessageId: 'old-answer',
+        afterMessageTimestamp: 20
+      }
+    ]
 
     expect(pendingSendsAsMessages(pending, history).map((message) => message.id)).toEqual([
       'pending:new-send'
@@ -265,6 +276,52 @@ describe('pendingSendsAsMessages', () => {
 
     expect(pendingSendsAsMessages(pending, remoteTranscript)).toEqual([])
     expect(prunePendingSends(pending, remoteTranscript)).toEqual([])
+  })
+
+  it('retires a first empty-transcript send when the host clock is behind the renderer', () => {
+    // pending.sentAt is renderer time; transcript timestamps are host time.
+    const pending = [
+      { ...pendingOf('p1', 'hello remote'), sentAt: 1_000_000, afterMessageId: null }
+    ]
+    const hostBehindTranscript = [
+      { ...userMessage('u1', 'hello remote'), timestamp: 50 },
+      { ...assistantMessage('a1', 'hi'), timestamp: 60 }
+    ]
+
+    expect(pendingSendsAsMessages(pending, hostBehindTranscript)).toEqual([])
+    expect(prunePendingSends(pending, hostBehindTranscript)).toEqual([])
+  })
+
+  it('lets occurrence matching claim an unbound empty-at-send echo against older identical history', () => {
+    // No host-domain bound: full-list occurrence matching applies. That is the
+    // same outcome the old renderer-sentAt filter already produced when the host
+    // clock was ahead; we no longer pretend sentAt protects this case.
+    const pending = [{ ...pendingOf('p1', 'run tests'), sentAt: 100, afterMessageId: null }]
+    const olderCompleted = [
+      { ...userMessage('old-user', 'run tests'), timestamp: 10_000_000 },
+      { ...assistantMessage('old-answer', 'passed'), timestamp: 10_000_100 }
+    ]
+    expect(pendingSendsAsMessages(pending, olderCompleted)).toEqual([])
+    expect(prunePendingSends(pending, olderCompleted)).toEqual([])
+  })
+
+  it('retires against the post-send turn when host timestamps sit far ahead of renderer sentAt', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'run tests'),
+        sentAt: 100,
+        afterMessageId: 'boundary',
+        afterMessageTimestamp: 10_000_000
+      }
+    ]
+    const hostAhead = [
+      { ...userMessage('old', 'run tests'), timestamp: 9_999_000 },
+      { ...assistantMessage('boundary', 'ok'), timestamp: 10_000_000 },
+      { ...userMessage('new', 'run tests'), timestamp: 10_000_500 },
+      { ...assistantMessage('new-a', 'ok'), timestamp: 10_000_600 }
+    ]
+    expect(pendingSendsAsMessages(pending, hostAhead)).toEqual([])
+    expect(prunePendingSends(pending, hostAhead)).toEqual([])
   })
 
   it('hides a first send while its timestampless transcript turn is visible (grok)', () => {
@@ -473,9 +530,11 @@ describe('command marker cache', () => {
     clearCommandMarkerCacheForTests()
     const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', sessionId: 'session-1' }
 
-    const appended = appendCommandMarkerCache(scope, '/clear', 10)
+    const appended = appendCommandMarkerCache(scope, '/clear', 10, ['m1', 'm2'])
 
-    expect(appended).toEqual([{ id: '10-1', command: '/clear', sentAt: 10 }])
+    expect(appended).toEqual([
+      { id: '10-1', command: '/clear', sentAt: 10, clearedMessageIds: ['m1', 'm2'] }
+    ])
     expect(readCommandMarkerCache(scope)).toEqual(appended)
     expect(readCommandMarkerCache({ ...scope, sessionId: 'session-2' })).toEqual([])
   })
@@ -502,14 +561,16 @@ describe('command marker cache', () => {
 })
 
 describe('applyCommandMarkerBoundaries', () => {
-  it('hides existing transcript messages after a local /clear marker', () => {
+  it('hides existing transcript messages after a local /clear marker by id', () => {
     const messages = [
       userMessage('before', 'old prompt'),
       { ...assistantMessage('after', 'new answer'), timestamp: 20 }
     ]
 
     expect(
-      applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }])
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['before'] }
+      ])
     ).toEqual([{ ...assistantMessage('after', 'new answer'), timestamp: 20 }])
   })
 
@@ -530,10 +591,64 @@ describe('applyCommandMarkerBoundaries', () => {
 
     expect(
       applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10 },
-        { id: 'c2', command: '/clear', sentAt: 20 }
+        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['old'] },
+        {
+          id: 'c2',
+          command: '/clear',
+          sentAt: 20,
+          clearedMessageIds: ['old', 'middle']
+        }
       ]).map((message) => message.id)
     ).toEqual(['new'])
+  })
+
+  it('shows replacement-session messages when the host clock is behind clear sentAt', () => {
+    // Renderer recorded clear at 1_000_000; host JSONL stamps sit far below that.
+    const messages = [
+      { ...userMessage('pre-clear', 'old'), timestamp: 10 },
+      { ...userMessage('post-clear', 'fresh'), timestamp: 20 }
+    ]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        {
+          id: 'c1',
+          command: '/clear',
+          sentAt: 1_000_000,
+          clearedMessageIds: ['pre-clear']
+        }
+      ]).map((message) => message.id)
+    ).toEqual(['post-clear'])
+  })
+
+  it('hides pre-clear rows when the host clock is ahead of clear sentAt', () => {
+    const messages = [
+      { ...userMessage('pre-clear', 'old'), timestamp: 10_000_000 },
+      { ...userMessage('post-clear', 'fresh'), timestamp: 10_000_100 }
+    ]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        {
+          id: 'c1',
+          command: '/clear',
+          sentAt: 100,
+          clearedMessageIds: ['pre-clear']
+        }
+      ]).map((message) => message.id)
+    ).toEqual(['post-clear'])
+  })
+
+  it('falls back to sentAt only for legacy clear markers without an id snapshot', () => {
+    const messages = [
+      { ...userMessage('before', 'old'), timestamp: 5 },
+      { ...userMessage('after', 'new'), timestamp: 20 }
+    ]
+    expect(
+      applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }]).map(
+        (message) => message.id
+      )
+    ).toEqual(['after'])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -23,6 +23,7 @@ import {
   readCommandMarkerCache
 } from './native-chat-command-markers'
 import { stripNoiseMessages } from './native-chat-noise'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
 
 function userMessage(id: string, text: string): NativeChatMessage {
   return {
@@ -55,6 +56,14 @@ function imageMessage(id: string, ...paths: string[]): NativeChatMessage {
 }
 
 const pendingOf = (id: string, text: string): NativeChatPendingSend => ({ id, text, sentAt: 100 })
+
+function transcriptOrder(
+  generation: number,
+  highWater: number,
+  sequences: Readonly<Record<string, number>> = {}
+): NativeChatTranscriptOrder {
+  return { generation, highWater, messageSequenceById: new Map(Object.entries(sequences)) }
+}
 
 describe('prunePendingSends', () => {
   it('returns the same reference when there is nothing pending', () => {
@@ -137,13 +146,22 @@ describe('prunePendingSends', () => {
   })
 
   it('prunes a first send against a timestampless transcript turn (grok)', () => {
-    const pending = [{ ...pendingOf('p1', 'rename it'), afterMessageId: null }]
+    const pending = [
+      {
+        ...pendingOf('p1', 'rename it'),
+        afterMessageId: null,
+        afterTranscriptGeneration: 1,
+        afterTranscriptHighWater: 0
+      }
+    ]
     const transcript = [
       { ...userMessage('u1', 'rename it'), timestamp: null },
       { ...assistantMessage('a1', 'done'), timestamp: null }
     ]
 
-    expect(prunePendingSends(pending, transcript)).toEqual([])
+    expect(prunePendingSends(pending, transcript, transcriptOrder(1, 2, { u1: 1, a1: 2 }))).toEqual(
+      []
+    )
   })
 
   it('prunes only one of two identical pending sends for one completed turn', () => {
@@ -281,28 +299,63 @@ describe('pendingSendsAsMessages', () => {
   it('retires a first empty-transcript send when the host clock is behind the renderer', () => {
     // pending.sentAt is renderer time; transcript timestamps are host time.
     const pending = [
-      { ...pendingOf('p1', 'hello remote'), sentAt: 1_000_000, afterMessageId: null }
+      {
+        ...pendingOf('p1', 'hello remote'),
+        sentAt: 1_000_000,
+        afterMessageId: null,
+        afterTranscriptGeneration: 3,
+        afterTranscriptHighWater: 0
+      }
     ]
     const hostBehindTranscript = [
       { ...userMessage('u1', 'hello remote'), timestamp: 50 },
       { ...assistantMessage('a1', 'hi'), timestamp: 60 }
     ]
 
-    expect(pendingSendsAsMessages(pending, hostBehindTranscript)).toEqual([])
-    expect(prunePendingSends(pending, hostBehindTranscript)).toEqual([])
+    const order = transcriptOrder(3, 2, { u1: 1, a1: 2 })
+    expect(pendingSendsAsMessages(pending, hostBehindTranscript, order)).toEqual([])
+    expect(prunePendingSends(pending, hostBehindTranscript, order)).toEqual([])
   })
 
-  it('lets occurrence matching claim an unbound empty-at-send echo against older identical history', () => {
-    // No host-domain bound: full-list occurrence matching applies. That is the
-    // same outcome the old renderer-sentAt filter already produced when the host
-    // clock was ahead; we no longer pretend sentAt protects this case.
-    const pending = [{ ...pendingOf('p1', 'run tests'), sentAt: 100, afterMessageId: null }]
+  it('keeps an empty-at-send echo against older host-ahead identical history', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'run tests'),
+        sentAt: 100,
+        afterMessageId: null,
+        afterTranscriptGeneration: 4,
+        afterTranscriptHighWater: 0
+      }
+    ]
     const olderCompleted = [
       { ...userMessage('old-user', 'run tests'), timestamp: 10_000_000 },
       { ...assistantMessage('old-answer', 'passed'), timestamp: 10_000_100 }
     ]
-    expect(pendingSendsAsMessages(pending, olderCompleted)).toEqual([])
-    expect(prunePendingSends(pending, olderCompleted)).toEqual([])
+    const order = transcriptOrder(4, 0)
+    expect(pendingSendsAsMessages(pending, olderCompleted, order)).toHaveLength(1)
+    expect(prunePendingSends(pending, olderCompleted, order)).toEqual(pending)
+  })
+
+  it('retires an empty-at-send echo only against its live-appended host-ahead turn', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'run tests'),
+        sentAt: 100,
+        afterMessageId: null,
+        afterTranscriptGeneration: 4,
+        afterTranscriptHighWater: 0
+      }
+    ]
+    const transcript = [
+      { ...userMessage('old-user', 'run tests'), timestamp: 10_000_000 },
+      { ...assistantMessage('old-answer', 'passed'), timestamp: 10_000_100 },
+      { ...userMessage('new-user', 'run tests'), timestamp: 10_000_200 },
+      { ...assistantMessage('new-answer', 'passed'), timestamp: 10_000_300 }
+    ]
+    const order = transcriptOrder(4, 2, { 'new-user': 1, 'new-answer': 2 })
+
+    expect(pendingSendsAsMessages(pending, transcript, order)).toEqual([])
+    expect(prunePendingSends(pending, transcript, order)).toEqual([])
   })
 
   it('retires against the post-send turn when host timestamps sit far ahead of renderer sentAt', () => {
@@ -325,11 +378,39 @@ describe('pendingSendsAsMessages', () => {
   })
 
   it('hides a first send while its timestampless transcript turn is visible (grok)', () => {
-    const pending = [{ ...pendingOf('p1', 'rename it'), afterMessageId: null }]
+    const pending = [
+      {
+        ...pendingOf('p1', 'rename it'),
+        afterMessageId: null,
+        afterTranscriptGeneration: 7,
+        afterTranscriptHighWater: 0
+      }
+    ]
 
     expect(
-      pendingSendsAsMessages(pending, [{ ...userMessage('u1', 'rename it'), timestamp: null }])
+      pendingSendsAsMessages(
+        pending,
+        [{ ...userMessage('u1', 'rename it'), timestamp: null }],
+        transcriptOrder(7, 1, { u1: 1 })
+      )
     ).toEqual([])
+  })
+
+  it('keeps an empty-at-send echo when local ordering is absent or replaced', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'rename it'),
+        afterMessageId: null,
+        afterTranscriptGeneration: 7,
+        afterTranscriptHighWater: 0
+      }
+    ]
+    const transcript = [userMessage('u1', 'rename it')]
+
+    expect(pendingSendsAsMessages(pending, transcript)).toHaveLength(1)
+    expect(
+      pendingSendsAsMessages(pending, transcript, transcriptOrder(8, 1, { u1: 1 }))
+    ).toHaveLength(1)
   })
 
   it('hides only one of two identical pending sends for one real user turn', () => {
@@ -530,10 +611,21 @@ describe('command marker cache', () => {
     clearCommandMarkerCacheForTests()
     const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', sessionId: 'session-1' }
 
-    const appended = appendCommandMarkerCache(scope, '/clear', 10, ['m1', 'm2'])
+    const appended = appendCommandMarkerCache(scope, '/clear', 10, {
+      clearAfterMessageId: 'm2',
+      clearTranscriptGeneration: 3,
+      clearTranscriptHighWater: 4
+    })
 
     expect(appended).toEqual([
-      { id: '10-1', command: '/clear', sentAt: 10, clearedMessageIds: ['m1', 'm2'] }
+      {
+        id: '10-1',
+        command: '/clear',
+        sentAt: 10,
+        clearAfterMessageId: 'm2',
+        clearTranscriptGeneration: 3,
+        clearTranscriptHighWater: 4
+      }
     ])
     expect(readCommandMarkerCache(scope)).toEqual(appended)
     expect(readCommandMarkerCache({ ...scope, sessionId: 'session-2' })).toEqual([])
@@ -569,7 +661,7 @@ describe('applyCommandMarkerBoundaries', () => {
 
     expect(
       applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['before'] }
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'before' }
       ])
     ).toEqual([{ ...assistantMessage('after', 'new answer'), timestamp: 20 }])
   })
@@ -591,18 +683,95 @@ describe('applyCommandMarkerBoundaries', () => {
 
     expect(
       applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['old'] },
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'old' },
         {
           id: 'c2',
           command: '/clear',
           sentAt: 20,
-          clearedMessageIds: ['old', 'middle']
+          clearAfterMessageId: 'middle'
         }
       ]).map((message) => message.id)
     ).toEqual(['new'])
   })
 
-  it('shows replacement-session messages when the host clock is behind clear sentAt', () => {
+  it('uses append order when clear markers have equal renderer timestamps', () => {
+    const messages = [userMessage('old', 'old'), userMessage('middle', 'middle')]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 100, clearAfterMessageId: 'old' },
+        { id: 'c2', command: '/clear', sentAt: 100, clearAfterMessageId: 'middle' }
+      ])
+    ).toEqual([])
+  })
+
+  it('keeps prepended pagination behind the ordered clear boundary', () => {
+    const messages = [
+      userMessage('older-unseen', 'older'),
+      userMessage('old-tail', 'old'),
+      userMessage('new', 'new')
+    ]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'old-tail' }
+      ]).map((message) => message.id)
+    ).toEqual(['new'])
+  })
+
+  it('hides late backfill after clear on an empty snapshot', () => {
+    const lateBackfill = [userMessage('old-u', 'old')]
+
+    expect(
+      applyCommandMarkerBoundaries(
+        lateBackfill,
+        [
+          {
+            id: 'c1',
+            command: '/clear',
+            sentAt: 10,
+            clearAfterMessageId: null,
+            clearTranscriptGeneration: 3,
+            clearTranscriptHighWater: 0
+          }
+        ],
+        transcriptOrder(3, 0)
+      )
+    ).toEqual([])
+  })
+
+  it('shows same-generation live rows after clear on an empty snapshot', () => {
+    const messages = [userMessage('new-u', 'new')]
+
+    expect(
+      applyCommandMarkerBoundaries(
+        messages,
+        [
+          {
+            id: 'c1',
+            command: '/clear',
+            sentAt: 10,
+            clearAfterMessageId: null,
+            clearTranscriptGeneration: 3,
+            clearTranscriptHighWater: 0
+          }
+        ],
+        transcriptOrder(3, 1, { 'new-u': 1 })
+      )
+    ).toEqual(messages)
+  })
+
+  it('hides conservatively when a paged boundary is missing', () => {
+    const messages = [userMessage('older', 'older'), userMessage('newer', 'newer')]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'missing' }
+      ])
+    ).toEqual([])
+  })
+
+  it('shows post-boundary messages when the host clock is behind clear sentAt', () => {
     // Renderer recorded clear at 1_000_000; host JSONL stamps sit far below that.
     const messages = [
       { ...userMessage('pre-clear', 'old'), timestamp: 10 },
@@ -615,7 +784,7 @@ describe('applyCommandMarkerBoundaries', () => {
           id: 'c1',
           command: '/clear',
           sentAt: 1_000_000,
-          clearedMessageIds: ['pre-clear']
+          clearAfterMessageId: 'pre-clear'
         }
       ]).map((message) => message.id)
     ).toEqual(['post-clear'])
@@ -633,13 +802,13 @@ describe('applyCommandMarkerBoundaries', () => {
           id: 'c1',
           command: '/clear',
           sentAt: 100,
-          clearedMessageIds: ['pre-clear']
+          clearAfterMessageId: 'pre-clear'
         }
       ]).map((message) => message.id)
     ).toEqual(['post-clear'])
   })
 
-  it('falls back to sentAt only for legacy clear markers without an id snapshot', () => {
+  it('conservatively hides rows for a legacy clear marker without a boundary', () => {
     const messages = [
       { ...userMessage('before', 'old'), timestamp: 5 },
       { ...userMessage('after', 'new'), timestamp: 20 }
@@ -648,7 +817,7 @@ describe('applyCommandMarkerBoundaries', () => {
       applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }]).map(
         (message) => message.id
       )
-    ).toEqual(['after'])
+    ).toEqual([])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -190,6 +190,43 @@ describe('prunePendingSends', () => {
       ])
     ).toEqual(pending)
   })
+
+  it('does not glue-prune a fresh tell+again against a pre-boundary tellagain row', () => {
+    // Harness: old completed "tellagain" must not prune newly sent tell+again
+    // after the watermark. Bad: visible=[], pruned=[].
+    const watermark = assistantMessage('wm', 'done')
+    const pending = [
+      { ...pendingOf('p1', 'tell'), afterMessageId: watermark.id, afterMessageTimestamp: 2 },
+      { ...pendingOf('p2', 'again'), afterMessageId: watermark.id, afterMessageTimestamp: 2 }
+    ]
+    const transcript = [
+      userMessage('old', 'tellagain'),
+      assistantMessage('old-a', 'old joke'),
+      watermark
+    ]
+    expect(pendingSendsAsMessages(pending, transcript).map((message) => message.id)).toEqual([
+      'pending:p1',
+      'pending:p2'
+    ])
+    expect(prunePendingSends(pending, transcript)).toEqual(pending)
+  })
+
+  it('still glue-prunes tell+again once the post-boundary glued turn completes', () => {
+    const watermark = assistantMessage('wm', 'done')
+    const pending = [
+      { ...pendingOf('p1', 'tell'), afterMessageId: watermark.id, afterMessageTimestamp: 2 },
+      { ...pendingOf('p2', 'again'), afterMessageId: watermark.id, afterMessageTimestamp: 2 }
+    ]
+    const transcript = [
+      userMessage('old', 'tellagain'),
+      assistantMessage('old-a', 'old joke'),
+      watermark,
+      userMessage('glued', 'tellagain'),
+      assistantMessage('new-a', 'new joke')
+    ]
+    expect(pendingSendsAsMessages(pending, transcript)).toEqual([])
+    expect(prunePendingSends(pending, transcript)).toEqual([])
+  })
 })
 
 describe('pendingSendsAsMessages', () => {

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -3,14 +3,11 @@ import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendPendingSendCache,
   clearPendingSendCacheForTests,
-  isLaunchPromptMessageId,
   isPendingMessageId,
-  launchPromptAsMessage,
   nextNativeChatPendingSendId,
   pendingSendsAsMessages,
   prunePendingSends,
   readPendingSendCache,
-  shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
@@ -458,123 +455,6 @@ describe('pendingSendsAsMessages', () => {
   })
 })
 
-describe('launchPromptAsMessage', () => {
-  it('maps a launch prompt to a tab-keyed scrape-source user message', () => {
-    expect(
-      launchPromptAsMessage({
-        tabId: 'tab-1',
-        agent: 'codex',
-        text: 'Fix failing checks',
-        createdAt: 42
-      })
-    ).toEqual({
-      id: 'launch-pending:tab-1',
-      role: 'user',
-      blocks: [{ type: 'text', text: 'Fix failing checks' }],
-      timestamp: 42,
-      source: 'scrape'
-    })
-  })
-
-  it('hides the launch prompt while its transcript user turn is visible', () => {
-    expect(
-      launchPromptAsMessage(
-        {
-          tabId: 'tab-1',
-          agent: 'codex',
-          text: 'Fix failing checks',
-          createdAt: 42
-        },
-        [{ ...userMessage('u1', 'Fix failing checks'), timestamp: 43 }]
-      )
-    ).toBeNull()
-  })
-
-  it('uses pending-send normalization for large multiline generated prompts', () => {
-    const prompt = [
-      '[Image #1] Resolve the failing checks:',
-      '',
-      'Resolve the failing checks:',
-      '',
-      '- lint failed',
-      '  fix spacing'
-    ].join('\n')
-    const transcript = [
-      {
-        ...userMessage(
-          'u1',
-          'Resolve the failing checks: Resolve the failing checks: - lint failed fix spacing'
-        ),
-        timestamp: 43
-      },
-      { ...assistantMessage('a1', 'I will fix it'), timestamp: 44 }
-    ]
-
-    expect(
-      shouldPruneLaunchPrompt(
-        {
-          tabId: 'tab-1',
-          agent: 'codex',
-          text: prompt,
-          createdAt: 42
-        },
-        transcript
-      )
-    ).toBe(true)
-  })
-
-  it('keeps the launch prompt until the transcript advances past the user turn', () => {
-    const prompt = {
-      tabId: 'tab-1',
-      agent: 'claude' as const,
-      text: 'Fix failing checks',
-      createdAt: 42
-    }
-
-    expect(
-      shouldPruneLaunchPrompt(prompt, [
-        { ...userMessage('u1', 'Fix failing checks'), timestamp: 43 }
-      ])
-    ).toBe(false)
-    expect(
-      shouldPruneLaunchPrompt(prompt, [
-        { ...userMessage('u1', 'Fix failing checks'), timestamp: 43 },
-        { ...assistantMessage('a1', 'working'), timestamp: 44 }
-      ])
-    ).toBe(true)
-  })
-
-  // Grok transcripts carry no timestamps; before the null-matchable rule the
-  // seeded bubble was never hidden or pruned and sat rank-pinned at the list
-  // tail forever, reading as the conversation reordering.
-  it('hides and prunes the launch prompt against a timestampless transcript (grok)', () => {
-    const entry = { tabId: 'tab-1', agent: 'grok' as const, text: 'rename it', createdAt: 42 }
-    const transcript = [
-      { ...userMessage('u1', 'rename it'), timestamp: null },
-      { ...assistantMessage('a1', 'done'), timestamp: null }
-    ]
-
-    expect(launchPromptAsMessage(entry, transcript)).toBeNull()
-    expect(shouldPruneLaunchPrompt(entry, transcript)).toBe(true)
-  })
-
-  it('does not bind a launch prompt to an older identical completed turn', () => {
-    const entry = {
-      tabId: 'tab-1',
-      agent: 'claude' as const,
-      text: 'run tests',
-      createdAt: 100
-    }
-    const oldHistory = [
-      { ...userMessage('old-user', 'run tests'), timestamp: 10 },
-      { ...assistantMessage('old-answer', 'passed'), timestamp: 20 }
-    ]
-
-    expect(launchPromptAsMessage(entry, oldHistory)).not.toBeNull()
-    expect(shouldPruneLaunchPrompt(entry, oldHistory)).toBe(false)
-  })
-})
-
 describe('pending send cache', () => {
   it('persists optimistic sends for the same pane and agent', () => {
     clearPendingSendCacheForTests()
@@ -609,13 +489,6 @@ describe('isPendingMessageId', () => {
   it('recognizes the pending id prefix', () => {
     expect(isPendingMessageId('pending:p1')).toBe(true)
     expect(isPendingMessageId('transcript-123')).toBe(false)
-  })
-})
-
-describe('isLaunchPromptMessageId', () => {
-  it('recognizes the launch prompt id prefix', () => {
-    expect(isLaunchPromptMessageId('launch-pending:tab-1')).toBe(true)
-    expect(isLaunchPromptMessageId('pending:p1')).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -2,24 +2,26 @@ import { describe, expect, it } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendPendingSendCache,
-  appendCommandMarkerCache,
-  applyCommandMarkerBoundaries,
-  clearCommandMarkerCacheForTests,
   clearPendingSendCacheForTests,
-  commandMarkersAsMessages,
-  isCommandMarkerId,
   isLaunchPromptMessageId,
   isPendingMessageId,
   launchPromptAsMessage,
   nextNativeChatPendingSendId,
   pendingSendsAsMessages,
   prunePendingSends,
-  readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import {
+  appendCommandMarkerCache,
+  applyCommandMarkerBoundaries,
+  clearCommandMarkerCacheForTests,
+  commandMarkersAsMessages,
+  isCommandMarkerId,
+  readCommandMarkerCache
+} from './native-chat-command-markers'
 import { stripNoiseMessages } from './native-chat-noise'
 
 function userMessage(id: string, text: string, timestamp = 1): NativeChatMessage {
@@ -389,12 +391,21 @@ describe('pendingSendsAsMessages', () => {
     ])
   })
 
-  it('keeps a loading-time send visible when older matching history arrives later', () => {
+  it('keeps a loading-time send visible when older matching history has a host-domain boundary', () => {
+    // History was visible at send time; the host-domain boundary excludes it.
+    // Renderer sentAt alone must not be the bound (#11519 cross-clock).
     const history = [
       { ...userMessage('old-user', 'run tests'), timestamp: 10 },
       { ...assistantMessage('old-answer', 'passed'), timestamp: 20 }
     ]
-    const pending = [{ ...pendingOf('new-send', 'run tests'), sentAt: 100, afterMessageId: null }]
+    const pending = [
+      {
+        ...pendingOf('new-send', 'run tests'),
+        sentAt: 100,
+        afterMessageId: 'old-answer',
+        afterMessageTimestamp: 20
+      }
+    ]
 
     expect(pendingSendsAsMessages(pending, history).map((message) => message.id)).toEqual([
       'pending:new-send'
@@ -418,6 +429,52 @@ describe('pendingSendsAsMessages', () => {
 
     expect(pendingSendsAsMessages(pending, remoteTranscript)).toEqual([])
     expect(prunePendingSends(pending, remoteTranscript)).toEqual([])
+  })
+
+  it('retires a first empty-transcript send when the host clock is behind the renderer', () => {
+    // pending.sentAt is renderer time; transcript timestamps are host time.
+    const pending = [
+      { ...pendingOf('p1', 'hello remote'), sentAt: 1_000_000, afterMessageId: null }
+    ]
+    const hostBehindTranscript = [
+      { ...userMessage('u1', 'hello remote'), timestamp: 50 },
+      { ...assistantMessage('a1', 'hi'), timestamp: 60 }
+    ]
+
+    expect(pendingSendsAsMessages(pending, hostBehindTranscript)).toEqual([])
+    expect(prunePendingSends(pending, hostBehindTranscript)).toEqual([])
+  })
+
+  it('lets occurrence matching claim an unbound empty-at-send echo against older identical history', () => {
+    // No host-domain bound: full-list occurrence matching applies. That is the
+    // same outcome the old renderer-sentAt filter already produced when the host
+    // clock was ahead; we no longer pretend sentAt protects this case.
+    const pending = [{ ...pendingOf('p1', 'run tests'), sentAt: 100, afterMessageId: null }]
+    const olderCompleted = [
+      { ...userMessage('old-user', 'run tests'), timestamp: 10_000_000 },
+      { ...assistantMessage('old-answer', 'passed'), timestamp: 10_000_100 }
+    ]
+    expect(pendingSendsAsMessages(pending, olderCompleted)).toEqual([])
+    expect(prunePendingSends(pending, olderCompleted)).toEqual([])
+  })
+
+  it('retires against the post-send turn when host timestamps sit far ahead of renderer sentAt', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'run tests'),
+        sentAt: 100,
+        afterMessageId: 'boundary',
+        afterMessageTimestamp: 10_000_000
+      }
+    ]
+    const hostAhead = [
+      { ...userMessage('old', 'run tests'), timestamp: 9_999_000 },
+      { ...assistantMessage('boundary', 'ok'), timestamp: 10_000_000 },
+      { ...userMessage('new', 'run tests'), timestamp: 10_000_500 },
+      { ...assistantMessage('new-a', 'ok'), timestamp: 10_000_600 }
+    ]
+    expect(pendingSendsAsMessages(pending, hostAhead)).toEqual([])
+    expect(prunePendingSends(pending, hostAhead)).toEqual([])
   })
 
   it('hides a first send while its timestampless transcript turn is visible (grok)', () => {
@@ -626,9 +683,11 @@ describe('command marker cache', () => {
     clearCommandMarkerCacheForTests()
     const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', sessionId: 'session-1' }
 
-    const appended = appendCommandMarkerCache(scope, '/clear', 10)
+    const appended = appendCommandMarkerCache(scope, '/clear', 10, ['m1', 'm2'])
 
-    expect(appended).toEqual([{ id: '10-1', command: '/clear', sentAt: 10 }])
+    expect(appended).toEqual([
+      { id: '10-1', command: '/clear', sentAt: 10, clearedMessageIds: ['m1', 'm2'] }
+    ])
     expect(readCommandMarkerCache(scope)).toEqual(appended)
     expect(readCommandMarkerCache({ ...scope, sessionId: 'session-2' })).toEqual([])
   })
@@ -655,14 +714,16 @@ describe('command marker cache', () => {
 })
 
 describe('applyCommandMarkerBoundaries', () => {
-  it('hides existing transcript messages after a local /clear marker', () => {
+  it('hides existing transcript messages after a local /clear marker by id', () => {
     const messages = [
       userMessage('before', 'old prompt'),
       { ...assistantMessage('after', 'new answer'), timestamp: 20 }
     ]
 
     expect(
-      applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }])
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['before'] }
+      ])
     ).toEqual([{ ...assistantMessage('after', 'new answer'), timestamp: 20 }])
   })
 
@@ -683,10 +744,64 @@ describe('applyCommandMarkerBoundaries', () => {
 
     expect(
       applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10 },
-        { id: 'c2', command: '/clear', sentAt: 20 }
+        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['old'] },
+        {
+          id: 'c2',
+          command: '/clear',
+          sentAt: 20,
+          clearedMessageIds: ['old', 'middle']
+        }
       ]).map((message) => message.id)
     ).toEqual(['new'])
+  })
+
+  it('shows replacement-session messages when the host clock is behind clear sentAt', () => {
+    // Renderer recorded clear at 1_000_000; host JSONL stamps sit far below that.
+    const messages = [
+      { ...userMessage('pre-clear', 'old'), timestamp: 10 },
+      { ...userMessage('post-clear', 'fresh'), timestamp: 20 }
+    ]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        {
+          id: 'c1',
+          command: '/clear',
+          sentAt: 1_000_000,
+          clearedMessageIds: ['pre-clear']
+        }
+      ]).map((message) => message.id)
+    ).toEqual(['post-clear'])
+  })
+
+  it('hides pre-clear rows when the host clock is ahead of clear sentAt', () => {
+    const messages = [
+      { ...userMessage('pre-clear', 'old'), timestamp: 10_000_000 },
+      { ...userMessage('post-clear', 'fresh'), timestamp: 10_000_100 }
+    ]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        {
+          id: 'c1',
+          command: '/clear',
+          sentAt: 100,
+          clearedMessageIds: ['pre-clear']
+        }
+      ]).map((message) => message.id)
+    ).toEqual(['post-clear'])
+  })
+
+  it('falls back to sentAt only for legacy clear markers without an id snapshot', () => {
+    const messages = [
+      { ...userMessage('before', 'old'), timestamp: 5 },
+      { ...userMessage('after', 'new'), timestamp: 20 }
+    ]
+    expect(
+      applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }]).map(
+        (message) => message.id
+      )
+    ).toEqual(['after'])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -3,14 +3,11 @@ import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendPendingSendCache,
   clearPendingSendCacheForTests,
-  isLaunchPromptMessageId,
   isPendingMessageId,
-  launchPromptAsMessage,
   nextNativeChatPendingSendId,
   pendingSendsAsMessages,
   prunePendingSends,
   readPendingSendCache,
-  shouldPruneLaunchPrompt,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
@@ -611,123 +608,6 @@ describe('pendingSendsAsMessages', () => {
   })
 })
 
-describe('launchPromptAsMessage', () => {
-  it('maps a launch prompt to a tab-keyed scrape-source user message', () => {
-    expect(
-      launchPromptAsMessage({
-        tabId: 'tab-1',
-        agent: 'codex',
-        text: 'Fix failing checks',
-        createdAt: 42
-      })
-    ).toEqual({
-      id: 'launch-pending:tab-1',
-      role: 'user',
-      blocks: [{ type: 'text', text: 'Fix failing checks' }],
-      timestamp: 42,
-      source: 'scrape'
-    })
-  })
-
-  it('hides the launch prompt while its transcript user turn is visible', () => {
-    expect(
-      launchPromptAsMessage(
-        {
-          tabId: 'tab-1',
-          agent: 'codex',
-          text: 'Fix failing checks',
-          createdAt: 42
-        },
-        [{ ...userMessage('u1', 'Fix failing checks'), timestamp: 43 }]
-      )
-    ).toBeNull()
-  })
-
-  it('uses pending-send normalization for large multiline generated prompts', () => {
-    const prompt = [
-      '[Image #1] Resolve the failing checks:',
-      '',
-      'Resolve the failing checks:',
-      '',
-      '- lint failed',
-      '  fix spacing'
-    ].join('\n')
-    const transcript = [
-      {
-        ...userMessage(
-          'u1',
-          'Resolve the failing checks: Resolve the failing checks: - lint failed fix spacing'
-        ),
-        timestamp: 43
-      },
-      { ...assistantMessage('a1', 'I will fix it'), timestamp: 44 }
-    ]
-
-    expect(
-      shouldPruneLaunchPrompt(
-        {
-          tabId: 'tab-1',
-          agent: 'codex',
-          text: prompt,
-          createdAt: 42
-        },
-        transcript
-      )
-    ).toBe(true)
-  })
-
-  it('keeps the launch prompt until the transcript advances past the user turn', () => {
-    const prompt = {
-      tabId: 'tab-1',
-      agent: 'claude' as const,
-      text: 'Fix failing checks',
-      createdAt: 42
-    }
-
-    expect(
-      shouldPruneLaunchPrompt(prompt, [
-        { ...userMessage('u1', 'Fix failing checks'), timestamp: 43 }
-      ])
-    ).toBe(false)
-    expect(
-      shouldPruneLaunchPrompt(prompt, [
-        { ...userMessage('u1', 'Fix failing checks'), timestamp: 43 },
-        { ...assistantMessage('a1', 'working'), timestamp: 44 }
-      ])
-    ).toBe(true)
-  })
-
-  // Grok transcripts carry no timestamps; before the null-matchable rule the
-  // seeded bubble was never hidden or pruned and sat rank-pinned at the list
-  // tail forever, reading as the conversation reordering.
-  it('hides and prunes the launch prompt against a timestampless transcript (grok)', () => {
-    const entry = { tabId: 'tab-1', agent: 'grok' as const, text: 'rename it', createdAt: 42 }
-    const transcript = [
-      { ...userMessage('u1', 'rename it'), timestamp: null },
-      { ...assistantMessage('a1', 'done'), timestamp: null }
-    ]
-
-    expect(launchPromptAsMessage(entry, transcript)).toBeNull()
-    expect(shouldPruneLaunchPrompt(entry, transcript)).toBe(true)
-  })
-
-  it('does not bind a launch prompt to an older identical completed turn', () => {
-    const entry = {
-      tabId: 'tab-1',
-      agent: 'claude' as const,
-      text: 'run tests',
-      createdAt: 100
-    }
-    const oldHistory = [
-      { ...userMessage('old-user', 'run tests'), timestamp: 10 },
-      { ...assistantMessage('old-answer', 'passed'), timestamp: 20 }
-    ]
-
-    expect(launchPromptAsMessage(entry, oldHistory)).not.toBeNull()
-    expect(shouldPruneLaunchPrompt(entry, oldHistory)).toBe(false)
-  })
-})
-
 describe('pending send cache', () => {
   it('persists optimistic sends for the same pane and agent', () => {
     clearPendingSendCacheForTests()
@@ -762,13 +642,6 @@ describe('isPendingMessageId', () => {
   it('recognizes the pending id prefix', () => {
     expect(isPendingMessageId('pending:p1')).toBe(true)
     expect(isPendingMessageId('transcript-123')).toBe(false)
-  })
-})
-
-describe('isLaunchPromptMessageId', () => {
-  it('recognizes the launch prompt id prefix', () => {
-    expect(isLaunchPromptMessageId('launch-pending:tab-1')).toBe(true)
-    expect(isLaunchPromptMessageId('pending:p1')).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -23,6 +23,7 @@ import {
   readCommandMarkerCache
 } from './native-chat-command-markers'
 import { stripNoiseMessages } from './native-chat-noise'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
 
 function userMessage(id: string, text: string, timestamp = 1): NativeChatMessage {
   return {
@@ -55,6 +56,14 @@ function imageMessage(id: string, ...paths: string[]): NativeChatMessage {
 }
 
 const pendingOf = (id: string, text: string): NativeChatPendingSend => ({ id, text, sentAt: 100 })
+
+function transcriptOrder(
+  generation: number,
+  highWater: number,
+  sequences: Readonly<Record<string, number>> = {}
+): NativeChatTranscriptOrder {
+  return { generation, highWater, messageSequenceById: new Map(Object.entries(sequences)) }
+}
 
 describe('prunePendingSends', () => {
   it('returns the same reference when there is nothing pending', () => {
@@ -165,13 +174,22 @@ describe('prunePendingSends', () => {
   })
 
   it('prunes a first send against a timestampless transcript turn (grok)', () => {
-    const pending = [{ ...pendingOf('p1', 'rename it'), afterMessageId: null }]
+    const pending = [
+      {
+        ...pendingOf('p1', 'rename it'),
+        afterMessageId: null,
+        afterTranscriptGeneration: 1,
+        afterTranscriptHighWater: 0
+      }
+    ]
     const transcript = [
       { ...userMessage('u1', 'rename it'), timestamp: null },
       { ...assistantMessage('a1', 'done'), timestamp: null }
     ]
 
-    expect(prunePendingSends(pending, transcript)).toEqual([])
+    expect(prunePendingSends(pending, transcript, transcriptOrder(1, 2, { u1: 1, a1: 2 }))).toEqual(
+      []
+    )
   })
 
   it('prunes only one of two identical pending sends for one completed turn', () => {
@@ -434,28 +452,63 @@ describe('pendingSendsAsMessages', () => {
   it('retires a first empty-transcript send when the host clock is behind the renderer', () => {
     // pending.sentAt is renderer time; transcript timestamps are host time.
     const pending = [
-      { ...pendingOf('p1', 'hello remote'), sentAt: 1_000_000, afterMessageId: null }
+      {
+        ...pendingOf('p1', 'hello remote'),
+        sentAt: 1_000_000,
+        afterMessageId: null,
+        afterTranscriptGeneration: 3,
+        afterTranscriptHighWater: 0
+      }
     ]
     const hostBehindTranscript = [
       { ...userMessage('u1', 'hello remote'), timestamp: 50 },
       { ...assistantMessage('a1', 'hi'), timestamp: 60 }
     ]
 
-    expect(pendingSendsAsMessages(pending, hostBehindTranscript)).toEqual([])
-    expect(prunePendingSends(pending, hostBehindTranscript)).toEqual([])
+    const order = transcriptOrder(3, 2, { u1: 1, a1: 2 })
+    expect(pendingSendsAsMessages(pending, hostBehindTranscript, order)).toEqual([])
+    expect(prunePendingSends(pending, hostBehindTranscript, order)).toEqual([])
   })
 
-  it('lets occurrence matching claim an unbound empty-at-send echo against older identical history', () => {
-    // No host-domain bound: full-list occurrence matching applies. That is the
-    // same outcome the old renderer-sentAt filter already produced when the host
-    // clock was ahead; we no longer pretend sentAt protects this case.
-    const pending = [{ ...pendingOf('p1', 'run tests'), sentAt: 100, afterMessageId: null }]
+  it('keeps an empty-at-send echo against older host-ahead identical history', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'run tests'),
+        sentAt: 100,
+        afterMessageId: null,
+        afterTranscriptGeneration: 4,
+        afterTranscriptHighWater: 0
+      }
+    ]
     const olderCompleted = [
       { ...userMessage('old-user', 'run tests'), timestamp: 10_000_000 },
       { ...assistantMessage('old-answer', 'passed'), timestamp: 10_000_100 }
     ]
-    expect(pendingSendsAsMessages(pending, olderCompleted)).toEqual([])
-    expect(prunePendingSends(pending, olderCompleted)).toEqual([])
+    const order = transcriptOrder(4, 0)
+    expect(pendingSendsAsMessages(pending, olderCompleted, order)).toHaveLength(1)
+    expect(prunePendingSends(pending, olderCompleted, order)).toEqual(pending)
+  })
+
+  it('retires an empty-at-send echo only against its live-appended host-ahead turn', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'run tests'),
+        sentAt: 100,
+        afterMessageId: null,
+        afterTranscriptGeneration: 4,
+        afterTranscriptHighWater: 0
+      }
+    ]
+    const transcript = [
+      { ...userMessage('old-user', 'run tests'), timestamp: 10_000_000 },
+      { ...assistantMessage('old-answer', 'passed'), timestamp: 10_000_100 },
+      { ...userMessage('new-user', 'run tests'), timestamp: 10_000_200 },
+      { ...assistantMessage('new-answer', 'passed'), timestamp: 10_000_300 }
+    ]
+    const order = transcriptOrder(4, 2, { 'new-user': 1, 'new-answer': 2 })
+
+    expect(pendingSendsAsMessages(pending, transcript, order)).toEqual([])
+    expect(prunePendingSends(pending, transcript, order)).toEqual([])
   })
 
   it('retires against the post-send turn when host timestamps sit far ahead of renderer sentAt', () => {
@@ -478,11 +531,39 @@ describe('pendingSendsAsMessages', () => {
   })
 
   it('hides a first send while its timestampless transcript turn is visible (grok)', () => {
-    const pending = [{ ...pendingOf('p1', 'rename it'), afterMessageId: null }]
+    const pending = [
+      {
+        ...pendingOf('p1', 'rename it'),
+        afterMessageId: null,
+        afterTranscriptGeneration: 7,
+        afterTranscriptHighWater: 0
+      }
+    ]
 
     expect(
-      pendingSendsAsMessages(pending, [{ ...userMessage('u1', 'rename it'), timestamp: null }])
+      pendingSendsAsMessages(
+        pending,
+        [{ ...userMessage('u1', 'rename it'), timestamp: null }],
+        transcriptOrder(7, 1, { u1: 1 })
+      )
     ).toEqual([])
+  })
+
+  it('keeps an empty-at-send echo when local ordering is absent or replaced', () => {
+    const pending = [
+      {
+        ...pendingOf('p1', 'rename it'),
+        afterMessageId: null,
+        afterTranscriptGeneration: 7,
+        afterTranscriptHighWater: 0
+      }
+    ]
+    const transcript = [userMessage('u1', 'rename it')]
+
+    expect(pendingSendsAsMessages(pending, transcript)).toHaveLength(1)
+    expect(
+      pendingSendsAsMessages(pending, transcript, transcriptOrder(8, 1, { u1: 1 }))
+    ).toHaveLength(1)
   })
 
   it('hides only one of two identical pending sends for one real user turn', () => {
@@ -683,10 +764,21 @@ describe('command marker cache', () => {
     clearCommandMarkerCacheForTests()
     const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', sessionId: 'session-1' }
 
-    const appended = appendCommandMarkerCache(scope, '/clear', 10, ['m1', 'm2'])
+    const appended = appendCommandMarkerCache(scope, '/clear', 10, {
+      clearAfterMessageId: 'm2',
+      clearTranscriptGeneration: 3,
+      clearTranscriptHighWater: 4
+    })
 
     expect(appended).toEqual([
-      { id: '10-1', command: '/clear', sentAt: 10, clearedMessageIds: ['m1', 'm2'] }
+      {
+        id: '10-1',
+        command: '/clear',
+        sentAt: 10,
+        clearAfterMessageId: 'm2',
+        clearTranscriptGeneration: 3,
+        clearTranscriptHighWater: 4
+      }
     ])
     expect(readCommandMarkerCache(scope)).toEqual(appended)
     expect(readCommandMarkerCache({ ...scope, sessionId: 'session-2' })).toEqual([])
@@ -722,7 +814,7 @@ describe('applyCommandMarkerBoundaries', () => {
 
     expect(
       applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['before'] }
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'before' }
       ])
     ).toEqual([{ ...assistantMessage('after', 'new answer'), timestamp: 20 }])
   })
@@ -744,18 +836,95 @@ describe('applyCommandMarkerBoundaries', () => {
 
     expect(
       applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10, clearedMessageIds: ['old'] },
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'old' },
         {
           id: 'c2',
           command: '/clear',
           sentAt: 20,
-          clearedMessageIds: ['old', 'middle']
+          clearAfterMessageId: 'middle'
         }
       ]).map((message) => message.id)
     ).toEqual(['new'])
   })
 
-  it('shows replacement-session messages when the host clock is behind clear sentAt', () => {
+  it('uses append order when clear markers have equal renderer timestamps', () => {
+    const messages = [userMessage('old', 'old'), userMessage('middle', 'middle')]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 100, clearAfterMessageId: 'old' },
+        { id: 'c2', command: '/clear', sentAt: 100, clearAfterMessageId: 'middle' }
+      ])
+    ).toEqual([])
+  })
+
+  it('keeps prepended pagination behind the ordered clear boundary', () => {
+    const messages = [
+      userMessage('older-unseen', 'older'),
+      userMessage('old-tail', 'old'),
+      userMessage('new', 'new')
+    ]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'old-tail' }
+      ]).map((message) => message.id)
+    ).toEqual(['new'])
+  })
+
+  it('hides late backfill after clear on an empty snapshot', () => {
+    const lateBackfill = [userMessage('old-u', 'old')]
+
+    expect(
+      applyCommandMarkerBoundaries(
+        lateBackfill,
+        [
+          {
+            id: 'c1',
+            command: '/clear',
+            sentAt: 10,
+            clearAfterMessageId: null,
+            clearTranscriptGeneration: 3,
+            clearTranscriptHighWater: 0
+          }
+        ],
+        transcriptOrder(3, 0)
+      )
+    ).toEqual([])
+  })
+
+  it('shows same-generation live rows after clear on an empty snapshot', () => {
+    const messages = [userMessage('new-u', 'new')]
+
+    expect(
+      applyCommandMarkerBoundaries(
+        messages,
+        [
+          {
+            id: 'c1',
+            command: '/clear',
+            sentAt: 10,
+            clearAfterMessageId: null,
+            clearTranscriptGeneration: 3,
+            clearTranscriptHighWater: 0
+          }
+        ],
+        transcriptOrder(3, 1, { 'new-u': 1 })
+      )
+    ).toEqual(messages)
+  })
+
+  it('hides conservatively when a paged boundary is missing', () => {
+    const messages = [userMessage('older', 'older'), userMessage('newer', 'newer')]
+
+    expect(
+      applyCommandMarkerBoundaries(messages, [
+        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'missing' }
+      ])
+    ).toEqual([])
+  })
+
+  it('shows post-boundary messages when the host clock is behind clear sentAt', () => {
     // Renderer recorded clear at 1_000_000; host JSONL stamps sit far below that.
     const messages = [
       { ...userMessage('pre-clear', 'old'), timestamp: 10 },
@@ -768,7 +937,7 @@ describe('applyCommandMarkerBoundaries', () => {
           id: 'c1',
           command: '/clear',
           sentAt: 1_000_000,
-          clearedMessageIds: ['pre-clear']
+          clearAfterMessageId: 'pre-clear'
         }
       ]).map((message) => message.id)
     ).toEqual(['post-clear'])
@@ -786,13 +955,13 @@ describe('applyCommandMarkerBoundaries', () => {
           id: 'c1',
           command: '/clear',
           sentAt: 100,
-          clearedMessageIds: ['pre-clear']
+          clearAfterMessageId: 'pre-clear'
         }
       ]).map((message) => message.id)
     ).toEqual(['post-clear'])
   })
 
-  it('falls back to sentAt only for legacy clear markers without an id snapshot', () => {
+  it('conservatively hides rows for a legacy clear marker without a boundary', () => {
     const messages = [
       { ...userMessage('before', 'old'), timestamp: 5 },
       { ...userMessage('after', 'new'), timestamp: 20 }
@@ -801,7 +970,7 @@ describe('applyCommandMarkerBoundaries', () => {
       applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }]).map(
         (message) => message.id
       )
-    ).toEqual(['after'])
+    ).toEqual([])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -583,7 +583,7 @@ describe('pendingSendsAsMessages', () => {
     ).toEqual([])
   })
 
-  it('keeps an empty-at-send echo when local ordering is absent or replaced', () => {
+  it('retires an empty-at-send echo after reconnect replaces local ordering', () => {
     const pending = [
       {
         ...pendingOf('p1', 'rename it'),
@@ -592,12 +592,13 @@ describe('pendingSendsAsMessages', () => {
         afterTranscriptHighWater: 0
       }
     ]
-    const transcript = [userMessage('u1', 'rename it')]
+    const transcript = [userMessage('u1', 'rename it'), assistantMessage('a1', 'done')]
 
-    expect(pendingSendsAsMessages(pending, transcript)).toHaveLength(1)
-    expect(
-      pendingSendsAsMessages(pending, transcript, transcriptOrder(8, 1, { u1: 1 }))
-    ).toHaveLength(1)
+    expect(pendingSendsAsMessages(pending, transcript)).toEqual([])
+    expect(prunePendingSends(pending, transcript)).toEqual([])
+    const replacedOrder = transcriptOrder(8, 2, { u1: 1, a1: 2 })
+    expect(pendingSendsAsMessages(pending, transcript, replacedOrder)).toEqual([])
+    expect(prunePendingSends(pending, transcript, replacedOrder)).toEqual([])
   })
 
   it('hides only one of two identical pending sends for one real user turn', () => {
@@ -824,14 +825,25 @@ describe('applyCommandMarkerBoundaries', () => {
     ).toEqual(messages)
   })
 
-  it('hides conservatively when a paged boundary is missing', () => {
+  it('shows rows when a clear boundary is unavailable or its generation was replaced', () => {
     const messages = [userMessage('older', 'older'), userMessage('newer', 'newer')]
+    const marker = {
+      id: 'c1',
+      command: '/clear',
+      sentAt: 10,
+      clearAfterMessageId: 'missing',
+      clearTranscriptGeneration: 3,
+      clearTranscriptHighWater: 0
+    }
 
+    expect(applyCommandMarkerBoundaries(messages, [marker])).toEqual(messages)
     expect(
-      applyCommandMarkerBoundaries(messages, [
-        { id: 'c1', command: '/clear', sentAt: 10, clearAfterMessageId: 'missing' }
-      ])
-    ).toEqual([])
+      applyCommandMarkerBoundaries(
+        messages,
+        [marker],
+        transcriptOrder(4, 2, { older: 1, newer: 2 })
+      )
+    ).toEqual(messages)
   })
 
   it('shows post-boundary messages when the host clock is behind clear sentAt', () => {
@@ -871,7 +883,7 @@ describe('applyCommandMarkerBoundaries', () => {
     ).toEqual(['post-clear'])
   })
 
-  it('conservatively hides rows for a legacy clear marker without a boundary', () => {
+  it('shows rows for a legacy clear marker without a recoverable boundary', () => {
     const messages = [
       { ...userMessage('before', 'old'), timestamp: 5 },
       { ...userMessage('after', 'new'), timestamp: 20 }
@@ -880,7 +892,7 @@ describe('applyCommandMarkerBoundaries', () => {
       applyCommandMarkerBoundaries(messages, [{ id: 'c1', command: '/clear', sentAt: 10 }]).map(
         (message) => message.id
       )
-    ).toEqual([])
+    ).toEqual(['before', 'after'])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -583,7 +583,7 @@ describe('pendingSendsAsMessages', () => {
     ).toEqual([])
   })
 
-  it('retires an empty-at-send echo after reconnect replaces local ordering', () => {
+  it('keeps an empty-at-send echo isolated after reconnect replaces local ordering', () => {
     const pending = [
       {
         ...pendingOf('p1', 'rename it'),
@@ -597,8 +597,8 @@ describe('pendingSendsAsMessages', () => {
     expect(pendingSendsAsMessages(pending, transcript)).toEqual([])
     expect(prunePendingSends(pending, transcript)).toEqual([])
     const replacedOrder = transcriptOrder(8, 2, { u1: 1, a1: 2 })
-    expect(pendingSendsAsMessages(pending, transcript, replacedOrder)).toEqual([])
-    expect(prunePendingSends(pending, transcript, replacedOrder)).toEqual([])
+    expect(pendingSendsAsMessages(pending, transcript, replacedOrder)).toHaveLength(1)
+    expect(prunePendingSends(pending, transcript, replacedOrder)).toEqual(pending)
   })
 
   it('hides only one of two identical pending sends for one real user turn', () => {

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -208,6 +208,43 @@ describe('prunePendingSends', () => {
       ])
     ).toEqual(pending)
   })
+
+  it('does not glue-prune a fresh tell+again against a pre-boundary tellagain row', () => {
+    // Harness: old completed "tellagain" must not prune newly sent tell+again
+    // after the watermark. Bad: visible=[], pruned=[].
+    const watermark = assistantMessage('wm', 'done')
+    const pending = [
+      { ...pendingOf('p1', 'tell'), afterMessageId: watermark.id, afterMessageTimestamp: 2 },
+      { ...pendingOf('p2', 'again'), afterMessageId: watermark.id, afterMessageTimestamp: 2 }
+    ]
+    const transcript = [
+      userMessage('old', 'tellagain'),
+      assistantMessage('old-a', 'old joke'),
+      watermark
+    ]
+    expect(pendingSendsAsMessages(pending, transcript).map((message) => message.id)).toEqual([
+      'pending:p1',
+      'pending:p2'
+    ])
+    expect(prunePendingSends(pending, transcript)).toEqual(pending)
+  })
+
+  it('still glue-prunes tell+again once the post-boundary glued turn completes', () => {
+    const watermark = assistantMessage('wm', 'done')
+    const pending = [
+      { ...pendingOf('p1', 'tell'), afterMessageId: watermark.id, afterMessageTimestamp: 2 },
+      { ...pendingOf('p2', 'again'), afterMessageId: watermark.id, afterMessageTimestamp: 2 }
+    ]
+    const transcript = [
+      userMessage('old', 'tellagain'),
+      assistantMessage('old-a', 'old joke'),
+      watermark,
+      userMessage('glued', 'tellagain'),
+      assistantMessage('new-a', 'new joke')
+    ]
+    expect(pendingSendsAsMessages(pending, transcript)).toEqual([])
+    expect(prunePendingSends(pending, transcript)).toEqual([])
+  })
 })
 
 // A glued row is written by the agent AFTER the sends that produced it, so every

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -783,7 +783,7 @@ describe('applyCommandMarkerBoundaries', () => {
     ).toEqual(['new'])
   })
 
-  it('hides late backfill after clear on an empty snapshot', () => {
+  it('keeps late backfill visible when clear ordering is unavailable', () => {
     const lateBackfill = [userMessage('old-u', 'old')]
 
     expect(
@@ -801,7 +801,7 @@ describe('applyCommandMarkerBoundaries', () => {
         ],
         transcriptOrder(3, 0)
       )
-    ).toEqual([])
+    ).toEqual(lateBackfill)
   })
 
   it('shows same-generation live rows after clear on an empty snapshot', () => {

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -5,7 +5,6 @@
 
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
-import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
 import {
   advancedNativeChatUserContentCounts,
   advancedNativeChatUserTexts,
@@ -320,55 +319,7 @@ export function isPendingMessageId(id: string): boolean {
   return id.startsWith('pending:')
 }
 
-// Why: the seeded prompt has a synthetic id that never matches the real turn's,
-// so dedup/prune match on normalized user-message text instead — this hides the
-// optimistic bubble once the transcript's own copy of the turn catches up.
-export function launchPromptAsMessage(
-  entry: NativeChatLaunchPrompt | null,
-  existingMessages: NativeChatMessage[] = []
-): NativeChatMessage | null {
-  if (!entry) {
-    return null
-  }
-  // Why: a launch prompt seeds a brand-new session, so a matching user turn
-  // with no timestamp (e.g. Grok transcripts) can only be its own delivery.
-  const represented = matchingNativeChatUserContentCounts(
-    existingMessages.filter(
-      (message) => message.timestamp === null || message.timestamp >= entry.createdAt
-    )
-  )
-  if ((represented.get(nativeChatPendingContentKey(entry)) ?? 0) > 0) {
-    return null
-  }
-  return {
-    id: `launch-pending:${entry.tabId}`,
-    role: 'user' as const,
-    blocks: entry.text.trim().length > 0 ? [{ type: 'text' as const, text: entry.text }] : [],
-    timestamp: entry.createdAt,
-    source: 'scrape' as const
-  }
-}
-
-// Why: prune only once an assistant turn has landed after the matching user
-// text — keeping the optimistic bubble through the user-only phase avoids a
-// first-turn flash before the transcript's own copy of the turn catches up.
-export function shouldPruneLaunchPrompt(
-  entry: NativeChatLaunchPrompt,
-  messages: NativeChatMessage[]
-): boolean {
-  const relevant = messages.filter(
-    (message) => message.timestamp === null || message.timestamp >= entry.createdAt
-  )
-  return (
-    (advancedNativeChatUserContentCounts(relevant).get(nativeChatPendingContentKey(entry)) ?? 0) > 0
-  )
-}
-
 export function nextNativeChatPendingSendId(now = Date.now()): string {
   pendingSendCounter += 1
   return `${now}-${pendingSendCounter}`
-}
-
-export function isLaunchPromptMessageId(id: string): boolean {
-  return id.startsWith('launch-pending:')
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -36,7 +36,7 @@ export type NativeChatPendingSend = {
   afterMessageTimestamp?: number | null
   /** 1-based occurrence among identical sends sharing the same boundary. */
   matchingOccurrence?: number
-  /** Shared time boundary when that message boundary is unavailable. */
+  /** Shared host-domain time bound when the message id boundary is paged out. */
   matchingAfterTimestamp?: number
 }
 
@@ -118,8 +118,15 @@ function messageIsAfterPendingTimestamp(
     return true
   }
   const boundary = nativeChatPendingMatchingAfter(pending)
+  // Why: `sentAt` is renderer-clock; `message.timestamp` is host/provider clock
+  // on remote runtimes. Never fall back to sentAt here — a host behind strands
+  // the echo forever, and a host ahead matches an older identical prompt.
+  // Without a host-domain bound, identity/occurrence matching sees the full list.
+  if (boundary == null) {
+    return true
+  }
   // A transcript-clock boundary describes an existing message, so exclude ties.
-  // Local send time has no existing record and remains inclusive.
+  // Inclusive only when the bound was not taken from a concrete boundary row.
   return pending.afterMessageTimestamp == null
     ? message.timestamp >= boundary
     : message.timestamp > boundary
@@ -278,108 +285,4 @@ export function nextNativeChatPendingSendId(now = Date.now()): string {
 
 export function isLaunchPromptMessageId(id: string): boolean {
   return id.startsWith('launch-pending:')
-}
-
-/** A locally-recorded slash command (e.g. `/clear`). Slash commands dispatch to
- *  the agent's TUI and are not chat turns, so we surface a small system line as
- *  feedback that the command ran rather than echoing a user bubble. */
-export type NativeChatCommandMarker = {
-  id: string
-  /** The command as typed, e.g. `/clear`. */
-  command: string
-  sentAt: number
-}
-
-export type NativeChatCommandMarkerScope = {
-  paneKey: string
-  agent: string
-  sessionId: string | null
-}
-
-const COMMAND_MARKER_LIMIT = 8
-const commandMarkerCache = new Map<string, NativeChatCommandMarker[]>()
-let commandMarkerCounter = 0
-
-function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
-  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}`
-}
-
-export function readCommandMarkerCache(
-  scope: NativeChatCommandMarkerScope
-): NativeChatCommandMarker[] {
-  return [...(commandMarkerCache.get(commandMarkerScopeKey(scope)) ?? [])]
-}
-
-export function appendCommandMarkerCache(
-  scope: NativeChatCommandMarkerScope,
-  command: string,
-  sentAt = Date.now()
-): NativeChatCommandMarker[] {
-  commandMarkerCounter += 1
-  const key = commandMarkerScopeKey(scope)
-  // Why: native/TUI view switches remount the chat surface, but slash commands
-  // are not transcript turns, so their local feedback needs a pane-scoped cache.
-  const next = [
-    ...(commandMarkerCache.get(key) ?? []),
-    { id: `${sentAt}-${commandMarkerCounter}`, command, sentAt }
-  ].slice(-COMMAND_MARKER_LIMIT)
-  // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
-  // sessionId changes on every /clear) is ephemeral and was never evicted, so it
-  // grew one entry per (pane, session) for the renderer's whole life. LRU-bound
-  // the key count (mirrors the #7566 draft/attachment caches in this folder).
-  setBoundedScopeCacheEntry(commandMarkerCache, key, next)
-  return [...next]
-}
-
-export function clearCommandMarkerCacheForTests(): void {
-  commandMarkerCache.clear()
-  commandMarkerCounter = 0
-}
-
-function isClearCommand(command: string): boolean {
-  return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
-}
-
-function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
-  let latest: number | null = null
-  for (const marker of markers) {
-    if (isClearCommand(marker.command) && (latest === null || marker.sentAt > latest)) {
-      latest = marker.sentAt
-    }
-  }
-  return latest
-}
-
-export function applyCommandMarkerBoundaries(
-  messages: readonly NativeChatMessage[],
-  markers: readonly NativeChatCommandMarker[]
-): NativeChatMessage[] {
-  const clearSentAt = latestClearSentAt(markers)
-  if (clearSentAt === null) {
-    return messages as NativeChatMessage[]
-  }
-  // Why: `/clear` mutates the TUI/transcript asynchronously. Hide the current
-  // transcript immediately so native chat reflects the command before the agent
-  // writes a replacement session or truncates the file.
-  return messages.filter((message) => message.timestamp !== null && message.timestamp > clearSentAt)
-}
-
-/** Render command markers as compact `system` messages. The `system` role draws
- *  as a muted aside (not a user bubble); the text avoids the harness noise
- *  prefixes so stripNoiseMessages keeps it. */
-export function commandMarkersAsMessages(
-  markers: readonly NativeChatCommandMarker[]
-): NativeChatMessage[] {
-  return markers.map((marker) => ({
-    id: `command:${marker.id}`,
-    role: 'system' as const,
-    blocks: [{ type: 'text' as const, text: `Ran ${marker.command}` }],
-    timestamp: marker.sentAt,
-    source: 'scrape' as const
-  }))
-}
-
-/** True when a message id was minted for a slash-command marker. */
-export function isCommandMarkerId(id: string): boolean {
-  return id.startsWith('command:')
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -18,6 +18,7 @@ import {
   nativeChatPendingOccurrence,
   selectPendingIndicesRepresentedByUserTexts
 } from './native-chat-pending-occurrence'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
 
 /** An optimistic, not-yet-confirmed composer send. */
 export type NativeChatPendingSend = {
@@ -38,6 +39,9 @@ export type NativeChatPendingSend = {
   matchingOccurrence?: number
   /** Shared host-domain time bound when the message id boundary is paged out. */
   matchingAfterTimestamp?: number
+  /** Renderer-local live-stream position captured when no transcript row exists. */
+  afterTranscriptGeneration?: number
+  afterTranscriptHighWater?: number
 }
 
 export type NativeChatPendingSendScope = {
@@ -90,13 +94,26 @@ export function clearPendingSendCacheForTests(): void {
 
 function messagesAfterPendingBoundary(
   messages: readonly NativeChatMessage[],
-  pending: NativeChatPendingSend
+  pending: NativeChatPendingSend,
+  transcriptOrder?: NativeChatTranscriptOrder
 ): readonly NativeChatMessage[] {
   if (pending.afterMessageId === undefined) {
     return messages
   }
   if (pending.afterMessageId === null) {
-    return messages.filter((message) => messageIsAfterPendingTimestamp(message, pending))
+    if (
+      transcriptOrder === undefined ||
+      pending.afterTranscriptGeneration === undefined ||
+      pending.afterTranscriptHighWater === undefined ||
+      transcriptOrder.generation !== pending.afterTranscriptGeneration
+    ) {
+      return []
+    }
+    return messages.filter(
+      (message) =>
+        (transcriptOrder.messageSequenceById.get(message.id) ?? 0) >
+        pending.afterTranscriptHighWater!
+    )
   }
   const boundaryIndex = messages.findIndex((message) => message.id === pending.afterMessageId)
   if (boundaryIndex >= 0) {
@@ -140,7 +157,8 @@ function messageIsAfterPendingTimestamp(
  */
 export function prunePendingSends(
   pending: NativeChatPendingSend[],
-  messages: NativeChatMessage[]
+  messages: NativeChatMessage[],
+  transcriptOrder?: NativeChatTranscriptOrder
 ): NativeChatPendingSend[] {
   if (pending.length === 0) {
     return pending
@@ -150,9 +168,9 @@ export function prunePendingSends(
     const contentKey = nativeChatPendingContentKey(entry)
     const key = nativeChatPendingMatchKey(entry)
     const available =
-      advancedNativeChatUserContentCounts(messagesAfterPendingBoundary(messages, entry)).get(
-        contentKey
-      ) ?? 0
+      advancedNativeChatUserContentCounts(
+        messagesAfterPendingBoundary(messages, entry, transcriptOrder)
+      ).get(contentKey) ?? 0
     const used = consumed.get(key) ?? 0
     const occurrence = nativeChatPendingOccurrence(entry, used)
     consumed.set(key, Math.max(used, occurrence))
@@ -184,7 +202,8 @@ export function prunePendingSends(
  */
 export function pendingSendsAsMessages(
   pending: NativeChatPendingSend[],
-  existingMessages: NativeChatMessage[] = []
+  existingMessages: NativeChatMessage[] = [],
+  transcriptOrder?: NativeChatTranscriptOrder
 ): NativeChatMessage[] {
   if (pending.length === 0) {
     return []
@@ -195,7 +214,7 @@ export function pendingSendsAsMessages(
     const key = nativeChatPendingMatchKey(entry)
     const represented =
       matchingNativeChatUserContentCounts(
-        messagesAfterPendingBoundary(existingMessages, entry)
+        messagesAfterPendingBoundary(existingMessages, entry, transcriptOrder)
       ).get(contentKey) ?? 0
     const used = consumed.get(key) ?? 0
     const occurrence = nativeChatPendingOccurrence(entry, used)

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -119,8 +119,8 @@ function messagesAfterPendingBoundary(
   if (boundaryIndex >= 0) {
     return messages.slice(boundaryIndex + 1)
   }
-  // A bounded authoritative read can page the boundary out. Fall back to the
-  // send time instead of matching an arbitrary older identical prompt.
+  // A bounded authoritative read can page the boundary out. Use the pending
+  // host-domain timestamp when available; otherwise match by identity/occurrence.
   return messages.filter((message) => messageIsAfterPendingTimestamp(message, pending))
 }
 
@@ -179,10 +179,14 @@ export function prunePendingSends(
   // Why: when rapid body writes glued two optimistic sends into one transcript
   // user row ("joke"+"continue"→"jokecontinue"), exact keys never match. Drop
   // those echoes once an assistant turn advances past the glued user text.
+  // Boundary-filter per send so a pre-watermark "tellagain" cannot prune a
+  // fresh tell+again pair after the new high-water.
   const stillOpen = pending.filter((_, index) => exactKeep[index])
-  const gluedRepresented = selectPendingIndicesRepresentedByUserTexts(
+  const gluedRepresented = gluedPendingIndicesAfterBoundaries(
     stillOpen,
-    advancedNativeChatUserTexts(messages)
+    messages,
+    transcriptOrder,
+    advancedNativeChatUserTexts
   )
   const next = pending.filter((entry, index) => {
     if (!exactKeep[index]) {
@@ -224,9 +228,11 @@ export function pendingSendsAsMessages(
   // Hide optimistic echoes that were glued into a single transcript user row
   // even before the assistant reply lands (matching, not advanced).
   const stillVisible = pending.filter((_, index) => exactVisible[index])
-  const gluedRepresented = selectPendingIndicesRepresentedByUserTexts(
+  const gluedRepresented = gluedPendingIndicesAfterBoundaries(
     stillVisible,
-    matchingNativeChatUserTexts(existingMessages)
+    existingMessages,
+    transcriptOrder,
+    matchingNativeChatUserTexts
   )
   return pending
     .filter((entry, index) => {
@@ -246,6 +252,67 @@ export function pendingSendsAsMessages(
       timestamp: entry.sentAt,
       source: 'scrape' as const
     }))
+}
+
+function pendingBoundaryKey(pending: NativeChatPendingSend): string {
+  return [
+    String(pending.afterMessageId),
+    String(pending.afterTranscriptGeneration),
+    String(pending.afterTranscriptHighWater),
+    String(nativeChatPendingMatchingAfter(pending))
+  ].join('\0')
+}
+
+/** Glue-match only inside each send's post-boundary window (never full history). */
+function gluedPendingIndicesAfterBoundaries(
+  open: readonly NativeChatPendingSend[],
+  messages: readonly NativeChatMessage[],
+  transcriptOrder: NativeChatTranscriptOrder | undefined,
+  userTextsOf: (window: readonly NativeChatMessage[]) => readonly string[]
+): Set<number> {
+  const represented = new Set<number>()
+  if (open.length < 2) {
+    return represented
+  }
+  const groups = new Map<string, number[]>()
+  for (let index = 0; index < open.length; index += 1) {
+    const entry = open[index]
+    if (!entry) {
+      continue
+    }
+    const key = pendingBoundaryKey(entry)
+    const group = groups.get(key)
+    if (group) {
+      group.push(index)
+    } else {
+      groups.set(key, [index])
+    }
+  }
+  for (const indices of groups.values()) {
+    if (indices.length < 2) {
+      continue
+    }
+    const headIndex = indices[0]
+    const head = headIndex === undefined ? undefined : open[headIndex]
+    if (!head) {
+      continue
+    }
+    const groupPending = indices.flatMap((index) => {
+      const entry = open[index]
+      return entry ? [entry] : []
+    })
+    const local = selectPendingIndicesRepresentedByUserTexts(
+      groupPending,
+      userTextsOf(messagesAfterPendingBoundary(messages, head, transcriptOrder))
+    )
+    for (const localIndex of local) {
+      const openIndex = indices[localIndex]
+      if (openIndex !== undefined) {
+        represented.add(openIndex)
+      }
+    }
+  }
+  return represented
 }
 
 /** True when a message id was minted for an optimistic pending send. */

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -115,7 +115,7 @@ function messagesAfterPendingBoundary(
     )
   }
   const boundaryIndex = messages.findIndex((message) => message.id === pending.afterMessageId)
-  if (boundaryIndex >= 0) {
+  if (boundaryIndex !== -1) {
     return messages.slice(boundaryIndex + 1)
   }
   // A bounded authoritative read can page the boundary out. Use the pending
@@ -175,11 +175,10 @@ export function prunePendingSends(
     consumed.set(key, Math.max(used, occurrence))
     return occurrence > available
   })
-  // Why: when rapid body writes glued two optimistic sends into one transcript
-  // user row ("joke"+"continue"→"jokecontinue"), exact keys never match. Drop
-  // those echoes once an assistant turn advances past the glued user text.
-  // Boundary-filter per send so a pre-watermark "tellagain" cannot prune a
-  // fresh tell+again pair after the new high-water.
+  // Why: when a lost Enter glued two optimistic sends onto one input line, the
+  // transcript carries one row ("joke"+"continue"→"jokecontinue") that no exact
+  // key matches. Boundary-filter per send so an older row cannot retire a
+  // fresh queued pair after its transcript high-water.
   const stillOpen = pending.filter((_, index) => exactKeep[index])
   const gluedRepresented = gluedPendingIndicesAfterBoundaries(
     stillOpen,
@@ -192,7 +191,7 @@ export function prunePendingSends(
       return false
     }
     const openIndex = stillOpen.indexOf(entry)
-    return openIndex < 0 || !gluedRepresented.has(openIndex)
+    return openIndex === -1 || !gluedRepresented.has(openIndex)
   })
   return next.length === pending.length ? pending : next
 }
@@ -239,7 +238,7 @@ export function pendingSendsAsMessages(
         return false
       }
       const openIndex = stillVisible.indexOf(entry)
-      return openIndex < 0 || !gluedRepresented.has(openIndex)
+      return openIndex === -1 || !gluedRepresented.has(openIndex)
     })
     .map((entry) => ({
       id: `pending:${entry.id}`,
@@ -260,6 +259,19 @@ function pendingBoundaryKey(pending: NativeChatPendingSend): string {
     String(pending.afterTranscriptHighWater),
     String(nativeChatPendingMatchingAfter(pending))
   ].join('\0')
+}
+
+function messagesAfterGlueBoundary(
+  messages: readonly NativeChatMessage[],
+  pending: NativeChatPendingSend,
+  transcriptOrder: NativeChatTranscriptOrder | undefined
+): readonly NativeChatMessage[] {
+  if (pending.afterMessageId === undefined && transcriptOrder === undefined) {
+    return messages.filter(
+      (message) => message.timestamp === null || message.timestamp >= pending.sentAt
+    )
+  }
+  return messagesAfterPendingBoundary(messages, pending, transcriptOrder)
 }
 
 /** Glue-match only inside each send's post-boundary window (never full history). */
@@ -302,7 +314,7 @@ function gluedPendingIndicesAfterBoundaries(
     })
     const local = selectPendingIndicesRepresentedByUserTexts(
       groupPending,
-      userTextsOf(messagesAfterPendingBoundary(messages, head, transcriptOrder))
+      userTextsOf(messagesAfterGlueBoundary(messages, head, transcriptOrder))
     )
     for (const localIndex of local) {
       const openIndex = indices[localIndex]

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -106,13 +106,15 @@ function messagesAfterPendingBoundary(
       pending.afterTranscriptHighWater === undefined ||
       transcriptOrder.generation !== pending.afterTranscriptGeneration
     ) {
-      return []
+      // A reconnect can replace local order before the host turn arrives. Fall
+      // back to identity/occurrence matching so the echo cannot strand forever.
+      return messages
     }
-    return messages.filter(
-      (message) =>
-        (transcriptOrder.messageSequenceById.get(message.id) ?? 0) >
-        pending.afterTranscriptHighWater!
-    )
+    const highWater = pending.afterTranscriptHighWater
+    return messages.filter((message) => {
+      const sequence = transcriptOrder.messageSequenceById.get(message.id)
+      return sequence !== undefined && sequence > highWater
+    })
   }
   const boundaryIndex = messages.findIndex((message) => message.id === pending.afterMessageId)
   if (boundaryIndex !== -1) {

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -142,7 +142,9 @@ function messageIsAfterPendingTimestamp(
   // rows would make the echo unmatchable forever, stranding a rank-pinned
   // bubble at the list tail — which reads as the conversation reordering.
   if (message.timestamp === null) {
-    return true
+    // A paged-out boundary without a timestamp cannot prove post-boundary
+    // ordering; treating every row as newer can retire an older identical turn.
+    return false
   }
   const boundary = nativeChatPendingMatchingAfter(pending)
   // Why: `sentAt` is renderer-clock; `message.timestamp` is host/provider clock

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -18,6 +18,7 @@ import {
   nativeChatPendingOccurrence,
   selectPendingIndicesRepresentedByUserTexts
 } from './native-chat-pending-occurrence'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
 
 /** An optimistic, not-yet-confirmed composer send. */
 export type NativeChatPendingSend = {
@@ -38,6 +39,9 @@ export type NativeChatPendingSend = {
   matchingOccurrence?: number
   /** Shared host-domain time bound when the message id boundary is paged out. */
   matchingAfterTimestamp?: number
+  /** Renderer-local live-stream position captured when no transcript row exists. */
+  afterTranscriptGeneration?: number
+  afterTranscriptHighWater?: number
 }
 
 export type NativeChatPendingSendScope = {
@@ -90,13 +94,26 @@ export function clearPendingSendCacheForTests(): void {
 
 function messagesAfterPendingBoundary(
   messages: readonly NativeChatMessage[],
-  pending: NativeChatPendingSend
+  pending: NativeChatPendingSend,
+  transcriptOrder?: NativeChatTranscriptOrder
 ): readonly NativeChatMessage[] {
   if (pending.afterMessageId === undefined) {
     return messages
   }
   if (pending.afterMessageId === null) {
-    return messages.filter((message) => messageIsAfterPendingTimestamp(message, pending))
+    if (
+      transcriptOrder === undefined ||
+      pending.afterTranscriptGeneration === undefined ||
+      pending.afterTranscriptHighWater === undefined ||
+      transcriptOrder.generation !== pending.afterTranscriptGeneration
+    ) {
+      return []
+    }
+    return messages.filter(
+      (message) =>
+        (transcriptOrder.messageSequenceById.get(message.id) ?? 0) >
+        pending.afterTranscriptHighWater!
+    )
   }
   const boundaryIndex = messages.findIndex((message) => message.id === pending.afterMessageId)
   if (boundaryIndex !== -1) {
@@ -160,7 +177,8 @@ function gluedCandidateMessages(
  */
 export function prunePendingSends(
   pending: NativeChatPendingSend[],
-  messages: NativeChatMessage[]
+  messages: NativeChatMessage[],
+  transcriptOrder?: NativeChatTranscriptOrder
 ): NativeChatPendingSend[] {
   if (pending.length === 0) {
     return pending
@@ -170,9 +188,9 @@ export function prunePendingSends(
     const contentKey = nativeChatPendingContentKey(entry)
     const key = nativeChatPendingMatchKey(entry)
     const available =
-      advancedNativeChatUserContentCounts(messagesAfterPendingBoundary(messages, entry)).get(
-        contentKey
-      ) ?? 0
+      advancedNativeChatUserContentCounts(
+        messagesAfterPendingBoundary(messages, entry, transcriptOrder)
+      ).get(contentKey) ?? 0
     const used = consumed.get(key) ?? 0
     const occurrence = nativeChatPendingOccurrence(entry, used)
     consumed.set(key, Math.max(used, occurrence))
@@ -204,7 +222,8 @@ export function prunePendingSends(
  */
 export function pendingSendsAsMessages(
   pending: NativeChatPendingSend[],
-  existingMessages: NativeChatMessage[] = []
+  existingMessages: NativeChatMessage[] = [],
+  transcriptOrder?: NativeChatTranscriptOrder
 ): NativeChatMessage[] {
   if (pending.length === 0) {
     return []
@@ -215,7 +234,7 @@ export function pendingSendsAsMessages(
     const key = nativeChatPendingMatchKey(entry)
     const represented =
       matchingNativeChatUserContentCounts(
-        messagesAfterPendingBoundary(existingMessages, entry)
+        messagesAfterPendingBoundary(existingMessages, entry, transcriptOrder)
       ).get(contentKey) ?? 0
     const used = consumed.get(key) ?? 0
     const occurrence = nativeChatPendingOccurrence(entry, used)

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -152,7 +152,7 @@ function messageIsAfterPendingTimestamp(
   // the echo forever, and a host ahead matches an older identical prompt.
   // Without a host-domain bound, identity/occurrence matching sees the full list.
   if (boundary == null) {
-    return true
+    return false
   }
   // A transcript-clock boundary describes an existing message, so exclude ties.
   // Inclusive only when the bound was not taken from a concrete boundary row.

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -96,19 +96,28 @@ function messagesAfterPendingBoundary(
   pending: NativeChatPendingSend,
   transcriptOrder?: NativeChatTranscriptOrder
 ): readonly NativeChatMessage[] {
+  if (
+    transcriptOrder !== undefined &&
+    pending.afterTranscriptGeneration !== undefined &&
+    transcriptOrder.generation !== pending.afterTranscriptGeneration
+  ) {
+    // Pending sends are pane-local. A source rebind clears their cache; until
+    // that effect runs, never match an old send against the replacement list.
+    return []
+  }
   if (pending.afterMessageId === undefined) {
     return messages
   }
   if (pending.afterMessageId === null) {
+    if (transcriptOrder === undefined) {
+      return messages
+    }
     if (
-      transcriptOrder === undefined ||
       pending.afterTranscriptGeneration === undefined ||
       pending.afterTranscriptHighWater === undefined ||
       transcriptOrder.generation !== pending.afterTranscriptGeneration
     ) {
-      // A reconnect can replace local order before the host turn arrives. Fall
-      // back to identity/occurrence matching so the echo cannot strand forever.
-      return messages
+      return []
     }
     const highWater = pending.afterTranscriptHighWater
     return messages.filter((message) => {
@@ -269,9 +278,10 @@ function messagesAfterGlueBoundary(
   transcriptOrder: NativeChatTranscriptOrder | undefined
 ): readonly NativeChatMessage[] {
   if (pending.afterMessageId === undefined && transcriptOrder === undefined) {
-    return messages.filter(
-      (message) => message.timestamp === null || message.timestamp >= pending.sentAt
-    )
+    // No comparable transcript boundary exists in this legacy shape. Identity
+    // and occurrence matching may inspect the list, but renderer sentAt must
+    // never be compared with a provider timestamp.
+    return []
   }
   return messagesAfterPendingBoundary(messages, pending, transcriptOrder)
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -116,11 +116,11 @@ function messagesAfterPendingBoundary(
     )
   }
   const boundaryIndex = messages.findIndex((message) => message.id === pending.afterMessageId)
-  if (boundaryIndex !== -1) {
+  if (boundaryIndex >= 0) {
     return messages.slice(boundaryIndex + 1)
   }
-  // A bounded authoritative read can page the boundary out. Fall back to the
-  // send time instead of matching an arbitrary older identical prompt.
+  // A bounded authoritative read can page the boundary out. Use the pending
+  // host-domain timestamp when available; otherwise match by identity/occurrence.
   return messages.filter((message) => messageIsAfterPendingTimestamp(message, pending))
 }
 
@@ -150,26 +150,6 @@ function messageIsAfterPendingTimestamp(
 }
 
 /**
- * Rows a glue match may consume. Glue always starts at the oldest still-open
- * echo, so that echo's send boundary is the floor: unbounded, an older turn
- * whose text happens to split across the queue ("fix the bug" vs "fix the" +
- * "bug") would retire sends issued long after it. A missing message boundary
- * falls back to send time — a fuzzy match must never reach further back than
- * an exact one.
- */
-function gluedCandidateMessages(
-  messages: readonly NativeChatMessage[],
-  open: readonly NativeChatPendingSend[]
-): readonly NativeChatMessage[] {
-  const oldest = open[0]
-  if (!oldest) {
-    return []
-  }
-  const anchor = oldest.afterMessageId === undefined ? { ...oldest, afterMessageId: null } : oldest
-  return messagesAfterPendingBoundary(messages, anchor)
-}
-
-/**
  * Drop any pending send only after the transcript has advanced beyond its real
  * user turn. Keeping the echo through the user-only transcript phase prevents a
  * first-turn empty-state flash if the live transcript briefly reports [] before
@@ -196,20 +176,24 @@ export function prunePendingSends(
     consumed.set(key, Math.max(used, occurrence))
     return occurrence > available
   })
-  // Why: when a lost Enter glued two optimistic sends onto one input line, the
-  // transcript carries one row ("joke"+"continue"→"jokecontinue") that no exact
-  // key matches. Drop those echoes once an assistant turn advances past it.
+  // Why: when rapid body writes glued two optimistic sends into one transcript
+  // user row ("joke"+"continue"→"jokecontinue"), exact keys never match. Drop
+  // those echoes once an assistant turn advances past the glued user text.
+  // Boundary-filter per send so a pre-watermark "tellagain" cannot prune a
+  // fresh tell+again pair after the new high-water.
   const stillOpen = pending.filter((_, index) => exactKeep[index])
-  const gluedRepresented = selectPendingIndicesRepresentedByUserTexts(
+  const gluedRepresented = gluedPendingIndicesAfterBoundaries(
     stillOpen,
-    advancedNativeChatUserTexts(gluedCandidateMessages(messages, stillOpen))
+    messages,
+    transcriptOrder,
+    advancedNativeChatUserTexts
   )
   const next = pending.filter((entry, index) => {
     if (!exactKeep[index]) {
       return false
     }
     const openIndex = stillOpen.indexOf(entry)
-    return openIndex === -1 || !gluedRepresented.has(openIndex)
+    return openIndex < 0 || !gluedRepresented.has(openIndex)
   })
   return next.length === pending.length ? pending : next
 }
@@ -244,9 +228,11 @@ export function pendingSendsAsMessages(
   // Hide optimistic echoes that were glued into a single transcript user row
   // even before the assistant reply lands (matching, not advanced).
   const stillVisible = pending.filter((_, index) => exactVisible[index])
-  const gluedRepresented = selectPendingIndicesRepresentedByUserTexts(
+  const gluedRepresented = gluedPendingIndicesAfterBoundaries(
     stillVisible,
-    matchingNativeChatUserTexts(gluedCandidateMessages(existingMessages, stillVisible))
+    existingMessages,
+    transcriptOrder,
+    matchingNativeChatUserTexts
   )
   return pending
     .filter((entry, index) => {
@@ -254,7 +240,7 @@ export function pendingSendsAsMessages(
         return false
       }
       const openIndex = stillVisible.indexOf(entry)
-      return openIndex === -1 || !gluedRepresented.has(openIndex)
+      return openIndex < 0 || !gluedRepresented.has(openIndex)
     })
     .map((entry) => ({
       id: `pending:${entry.id}`,
@@ -266,6 +252,67 @@ export function pendingSendsAsMessages(
       timestamp: entry.sentAt,
       source: 'scrape' as const
     }))
+}
+
+function pendingBoundaryKey(pending: NativeChatPendingSend): string {
+  return [
+    String(pending.afterMessageId),
+    String(pending.afterTranscriptGeneration),
+    String(pending.afterTranscriptHighWater),
+    String(nativeChatPendingMatchingAfter(pending))
+  ].join('\0')
+}
+
+/** Glue-match only inside each send's post-boundary window (never full history). */
+function gluedPendingIndicesAfterBoundaries(
+  open: readonly NativeChatPendingSend[],
+  messages: readonly NativeChatMessage[],
+  transcriptOrder: NativeChatTranscriptOrder | undefined,
+  userTextsOf: (window: readonly NativeChatMessage[]) => readonly string[]
+): Set<number> {
+  const represented = new Set<number>()
+  if (open.length < 2) {
+    return represented
+  }
+  const groups = new Map<string, number[]>()
+  for (let index = 0; index < open.length; index += 1) {
+    const entry = open[index]
+    if (!entry) {
+      continue
+    }
+    const key = pendingBoundaryKey(entry)
+    const group = groups.get(key)
+    if (group) {
+      group.push(index)
+    } else {
+      groups.set(key, [index])
+    }
+  }
+  for (const indices of groups.values()) {
+    if (indices.length < 2) {
+      continue
+    }
+    const headIndex = indices[0]
+    const head = headIndex === undefined ? undefined : open[headIndex]
+    if (!head) {
+      continue
+    }
+    const groupPending = indices.flatMap((index) => {
+      const entry = open[index]
+      return entry ? [entry] : []
+    })
+    const local = selectPendingIndicesRepresentedByUserTexts(
+      groupPending,
+      userTextsOf(messagesAfterPendingBoundary(messages, head, transcriptOrder))
+    )
+    for (const localIndex of local) {
+      const openIndex = indices[localIndex]
+      if (openIndex !== undefined) {
+        represented.add(openIndex)
+      }
+    }
+  }
+  return represented
 }
 
 /** True when a message id was minted for an optimistic pending send. */

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -36,7 +36,7 @@ export type NativeChatPendingSend = {
   afterMessageTimestamp?: number | null
   /** 1-based occurrence among identical sends sharing the same boundary. */
   matchingOccurrence?: number
-  /** Shared time boundary when that message boundary is unavailable. */
+  /** Shared host-domain time bound when the message id boundary is paged out. */
   matchingAfterTimestamp?: number
 }
 
@@ -118,8 +118,15 @@ function messageIsAfterPendingTimestamp(
     return true
   }
   const boundary = nativeChatPendingMatchingAfter(pending)
+  // Why: `sentAt` is renderer-clock; `message.timestamp` is host/provider clock
+  // on remote runtimes. Never fall back to sentAt here — a host behind strands
+  // the echo forever, and a host ahead matches an older identical prompt.
+  // Without a host-domain bound, identity/occurrence matching sees the full list.
+  if (boundary == null) {
+    return true
+  }
   // A transcript-clock boundary describes an existing message, so exclude ties.
-  // Local send time has no existing record and remains inclusive.
+  // Inclusive only when the bound was not taken from a concrete boundary row.
   return pending.afterMessageTimestamp == null
     ? message.timestamp >= boundary
     : message.timestamp > boundary
@@ -298,108 +305,4 @@ export function nextNativeChatPendingSendId(now = Date.now()): string {
 
 export function isLaunchPromptMessageId(id: string): boolean {
   return id.startsWith('launch-pending:')
-}
-
-/** A locally-recorded slash command (e.g. `/clear`). Slash commands dispatch to
- *  the agent's TUI and are not chat turns, so we surface a small system line as
- *  feedback that the command ran rather than echoing a user bubble. */
-export type NativeChatCommandMarker = {
-  id: string
-  /** The command as typed, e.g. `/clear`. */
-  command: string
-  sentAt: number
-}
-
-export type NativeChatCommandMarkerScope = {
-  paneKey: string
-  agent: string
-  sessionId: string | null
-}
-
-const COMMAND_MARKER_LIMIT = 8
-const commandMarkerCache = new Map<string, NativeChatCommandMarker[]>()
-let commandMarkerCounter = 0
-
-function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
-  return `${scope.paneKey}\0${scope.agent}\0${scope.sessionId ?? ''}`
-}
-
-export function readCommandMarkerCache(
-  scope: NativeChatCommandMarkerScope
-): NativeChatCommandMarker[] {
-  return [...(commandMarkerCache.get(commandMarkerScopeKey(scope)) ?? [])]
-}
-
-export function appendCommandMarkerCache(
-  scope: NativeChatCommandMarkerScope,
-  command: string,
-  sentAt = Date.now()
-): NativeChatCommandMarker[] {
-  commandMarkerCounter += 1
-  const key = commandMarkerScopeKey(scope)
-  // Why: native/TUI view switches remount the chat surface, but slash commands
-  // are not transcript turns, so their local feedback needs a pane-scoped cache.
-  const next = [
-    ...(commandMarkerCache.get(key) ?? []),
-    { id: `${sentAt}-${commandMarkerCounter}`, command, sentAt }
-  ].slice(-COMMAND_MARKER_LIMIT)
-  // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
-  // sessionId changes on every /clear) is ephemeral and was never evicted, so it
-  // grew one entry per (pane, session) for the renderer's whole life. LRU-bound
-  // the key count (mirrors the #7566 draft/attachment caches in this folder).
-  setBoundedScopeCacheEntry(commandMarkerCache, key, next)
-  return [...next]
-}
-
-export function clearCommandMarkerCacheForTests(): void {
-  commandMarkerCache.clear()
-  commandMarkerCounter = 0
-}
-
-function isClearCommand(command: string): boolean {
-  return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
-}
-
-function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
-  let latest: number | null = null
-  for (const marker of markers) {
-    if (isClearCommand(marker.command) && (latest === null || marker.sentAt > latest)) {
-      latest = marker.sentAt
-    }
-  }
-  return latest
-}
-
-export function applyCommandMarkerBoundaries(
-  messages: readonly NativeChatMessage[],
-  markers: readonly NativeChatCommandMarker[]
-): NativeChatMessage[] {
-  const clearSentAt = latestClearSentAt(markers)
-  if (clearSentAt === null) {
-    return messages as NativeChatMessage[]
-  }
-  // Why: `/clear` mutates the TUI/transcript asynchronously. Hide the current
-  // transcript immediately so native chat reflects the command before the agent
-  // writes a replacement session or truncates the file.
-  return messages.filter((message) => message.timestamp !== null && message.timestamp > clearSentAt)
-}
-
-/** Render command markers as compact `system` messages. The `system` role draws
- *  as a muted aside (not a user bubble); the text avoids the harness noise
- *  prefixes so stripNoiseMessages keeps it. */
-export function commandMarkersAsMessages(
-  markers: readonly NativeChatCommandMarker[]
-): NativeChatMessage[] {
-  return markers.map((marker) => ({
-    id: `command:${marker.id}`,
-    role: 'system' as const,
-    blocks: [{ type: 'text' as const, text: `Ran ${marker.command}` }],
-    timestamp: marker.sentAt,
-    source: 'scrape' as const
-  }))
-}
-
-/** True when a message id was minted for a slash-command marker. */
-export function isCommandMarkerId(id: string): boolean {
-  return id.startsWith('command:')
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
@@ -8,7 +8,8 @@ import {
 } from '../../../../shared/native-chat-types'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
 import { normalizeImageTranscriptMessages } from '../../../../shared/native-chat-image-transcript-markers'
-import { isLaunchPromptMessageId, isPendingMessageId } from './native-chat-pending'
+import { isLaunchPromptMessageId } from './native-chat-launch-prompt'
+import { isPendingMessageId } from './native-chat-pending'
 
 /** Messages grouped by source. Higher-priority sources (transcript > hook >
  *  scrape) supersede lower ones when they describe the same turn. */

--- a/src/renderer/src/components/native-chat/native-chat-session-transport.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-transport.ts
@@ -17,6 +17,16 @@ import {
  *  hook and everything downstream (merge, assembler, pagination) are unchanged. */
 export type NativeChatSessionTransport = Pick<NativeChatApi, 'readSession' | 'subscribe'>
 
+// Why: lives outside effect bodies — react-doctor effect-needs-cleanup
+// false-positives on `subscribe` inside one; caller cleanup still teardowns.
+export function subscribeNativeChatSession(
+  transport: NativeChatSessionTransport,
+  args: Parameters<NativeChatSessionTransport['subscribe']>[0],
+  onFrame: Parameters<NativeChatSessionTransport['subscribe']>[1]
+): ReturnType<NativeChatSessionTransport['subscribe']> {
+  return transport.subscribe(args, onFrame)
+}
+
 const RUNTIME_TOO_OLD =
   'This remote runtime is too old to show agent chat history. Update the remote runtime to view it.'
 

--- a/src/renderer/src/components/native-chat/native-chat-transcript-order.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-transcript-order.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import {
+  appendNativeChatTranscriptOrder,
+  createNativeChatTranscriptOrder,
+  replaceNativeChatTranscriptOrder
+} from './native-chat-transcript-order'
+
+function message(id: string): NativeChatMessage {
+  return { id, role: 'assistant', blocks: [], timestamp: 1, source: 'transcript' }
+}
+
+describe('native chat transcript order', () => {
+  it('does not sequence snapshot or pagination baseline rows', () => {
+    const initial = createNativeChatTranscriptOrder(3)
+    expect(initial).toMatchObject({ generation: 3, highWater: 0 })
+    expect(initial.messageSequenceById.size).toBe(0)
+  })
+
+  it('sequences appends once and bounds retained ids to the live window', () => {
+    const first = appendNativeChatTranscriptOrder(
+      createNativeChatTranscriptOrder(3),
+      [message('a'), message('b')],
+      2
+    )
+    const next = appendNativeChatTranscriptOrder(first, [message('b'), message('c')], 2)
+
+    expect(next.highWater).toBe(3)
+    expect(next.messageSequenceById).toBe(first.messageSequenceById)
+    expect([...next.messageSequenceById]).toEqual([
+      ['b', 2],
+      ['c', 3]
+    ])
+  })
+
+  it('keeps append-order memory bounded to the retained transcript window', () => {
+    let order = createNativeChatTranscriptOrder(3)
+    for (let index = 0; index < 1_000; index += 1) {
+      order = appendNativeChatTranscriptOrder(order, [message(`m-${index}`)], 8)
+    }
+
+    expect(order.highWater).toBe(1_000)
+    expect(order.messageSequenceById.size).toBe(8)
+  })
+
+  it('resets ordering across an authoritative replacement', () => {
+    const appended = appendNativeChatTranscriptOrder(
+      createNativeChatTranscriptOrder(3),
+      [message('a')],
+      1
+    )
+
+    expect(replaceNativeChatTranscriptOrder(appended)).toEqual({
+      generation: 4,
+      highWater: 0,
+      messageSequenceById: new Map()
+    })
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-transcript-order.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-transcript-order.test.ts
@@ -3,7 +3,8 @@ import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendNativeChatTranscriptOrder,
   createNativeChatTranscriptOrder,
-  replaceNativeChatTranscriptOrder
+  replaceNativeChatTranscriptOrder,
+  settleNativeChatTranscriptOrder
 } from './native-chat-transcript-order'
 
 function message(id: string): NativeChatMessage {
@@ -11,7 +12,7 @@ function message(id: string): NativeChatMessage {
 }
 
 describe('native chat transcript order', () => {
-  it('does not sequence snapshot or pagination baseline rows', () => {
+  it('starts a generation with no sequenced rows', () => {
     const initial = createNativeChatTranscriptOrder(3)
     expect(initial).toMatchObject({ generation: 3, highWater: 0 })
     expect(initial.messageSequenceById.size).toBe(0)
@@ -43,7 +44,7 @@ describe('native chat transcript order', () => {
     expect(order.messageSequenceById.size).toBe(8)
   })
 
-  it('resets ordering across an authoritative replacement', () => {
+  it('resets ordering across a source rebind replace', () => {
     const appended = appendNativeChatTranscriptOrder(
       createNativeChatTranscriptOrder(3),
       [message('a')],
@@ -55,5 +56,42 @@ describe('native chat transcript order', () => {
       highWater: 0,
       messageSequenceById: new Map()
     })
+  })
+
+  it('settles first-seen authoritative rows without bumping generation', () => {
+    const settled = settleNativeChatTranscriptOrder(
+      createNativeChatTranscriptOrder(3),
+      [message('u1'), message('a1')],
+      8
+    )
+
+    expect(settled).toMatchObject({ generation: 3, highWater: 2 })
+    expect([...settled.messageSequenceById]).toEqual([
+      ['u1', 1],
+      ['a1', 2]
+    ])
+
+    const again = settleNativeChatTranscriptOrder(
+      settled,
+      [message('u1'), message('a1'), message('u2')],
+      8
+    )
+    expect(again).toMatchObject({ generation: 3, highWater: 3 })
+    expect(again.messageSequenceById.get('u1')).toBe(1)
+    expect(again.messageSequenceById.get('u2')).toBe(3)
+  })
+
+  it('bounds settled sequence memory to the retained window', () => {
+    let order = createNativeChatTranscriptOrder(1)
+    for (let index = 0; index < 20; index += 1) {
+      order = settleNativeChatTranscriptOrder(
+        order,
+        Array.from({ length: index + 1 }, (_unused, n) => message(`m-${n}`)),
+        4
+      )
+    }
+    expect(order.messageSequenceById.size).toBe(4)
+    // highWater is monotonic across re-sequenced window slides; only the map is bounded.
+    expect(order.highWater).toBeGreaterThanOrEqual(20)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-transcript-order.ts
+++ b/src/renderer/src/components/native-chat/native-chat-transcript-order.ts
@@ -1,6 +1,6 @@
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 
-/** Renderer-local ordering for authoritative live transcript appends. */
+/** Renderer-local ordering for live transcript rows within one source generation. */
 export type NativeChatTranscriptOrder = {
   generation: number
   highWater: number
@@ -11,10 +11,49 @@ export function createNativeChatTranscriptOrder(generation = 0): NativeChatTrans
   return { generation, highWater: 0, messageSequenceById: new Map() }
 }
 
+/** New generation after a source rebind; prior sequence memory is discarded. */
 export function replaceNativeChatTranscriptOrder(
   previous: NativeChatTranscriptOrder
 ): NativeChatTranscriptOrder {
   return createNativeChatTranscriptOrder(previous.generation + 1)
+}
+
+/**
+ * Authoritative snapshot/replacement settlement: first-seen ids in this generation
+ * become post-action sequence rows so empty-boundary pending/clear can match them
+ * without a live append frame. Already-sequenced ids keep stable numbers.
+ */
+export function settleNativeChatTranscriptOrder(
+  previous: NativeChatTranscriptOrder,
+  messages: readonly NativeChatMessage[],
+  retainedCount: number
+): NativeChatTranscriptOrder {
+  let highWater = previous.highWater
+  const nextById = new Map<string, number>()
+  for (const message of messages) {
+    const existing = previous.messageSequenceById.get(message.id)
+    if (existing !== undefined) {
+      nextById.set(message.id, existing)
+      continue
+    }
+    highWater += 1
+    nextById.set(message.id, highWater)
+  }
+  if (nextById.size > retainedCount) {
+    const ranked = [...nextById.entries()].sort((left, right) => left[1] - right[1])
+    const dropCount = nextById.size - retainedCount
+    for (let index = 0; index < dropCount; index += 1) {
+      const oldest = ranked[index]
+      if (oldest) {
+        nextById.delete(oldest[0])
+      }
+    }
+  }
+  return {
+    generation: previous.generation,
+    highWater,
+    messageSequenceById: nextById
+  }
 }
 
 export function appendNativeChatTranscriptOrder(

--- a/src/renderer/src/components/native-chat/native-chat-transcript-order.ts
+++ b/src/renderer/src/components/native-chat/native-chat-transcript-order.ts
@@ -1,0 +1,46 @@
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+
+/** Renderer-local ordering for authoritative live transcript appends. */
+export type NativeChatTranscriptOrder = {
+  generation: number
+  highWater: number
+  messageSequenceById: ReadonlyMap<string, number>
+}
+
+export function createNativeChatTranscriptOrder(generation = 0): NativeChatTranscriptOrder {
+  return { generation, highWater: 0, messageSequenceById: new Map() }
+}
+
+export function replaceNativeChatTranscriptOrder(
+  previous: NativeChatTranscriptOrder
+): NativeChatTranscriptOrder {
+  return createNativeChatTranscriptOrder(previous.generation + 1)
+}
+
+export function appendNativeChatTranscriptOrder(
+  previous: NativeChatTranscriptOrder,
+  incoming: readonly NativeChatMessage[],
+  retainedCount: number
+): NativeChatTranscriptOrder {
+  if (incoming.length === 0) {
+    return previous
+  }
+  let highWater = previous.highWater
+  // The map is hook-owned; mutating it avoids copying the whole transcript
+  // window on every streaming frame while the wrapper identity still advances.
+  const nextById = previous.messageSequenceById as Map<string, number>
+  for (const message of incoming) {
+    if (!nextById.has(message.id)) {
+      highWater += 1
+      nextById.set(message.id, highWater)
+    }
+  }
+  while (nextById.size > retainedCount) {
+    const oldestId = nextById.keys().next().value
+    if (oldestId === undefined) {
+      break
+    }
+    nextById.delete(oldestId)
+  }
+  return { generation: previous.generation, highWater, messageSequenceById: nextById }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-command-markers.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-command-markers.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  appendCommandMarkerCache,
+  clearCommandMarkerCacheForTests
+} from './native-chat-command-markers'
+import { createNativeChatTranscriptOrder } from './native-chat-transcript-order'
+import { useNativeChatCommandMarkers } from './use-native-chat-command-markers'
+
+describe('useNativeChatCommandMarkers', () => {
+  let root: Root | null = null
+  const renders: { sessionId: string; markerIds: string[] }[] = []
+  const resetWorkingInterrupt = vi.fn()
+
+  function Probe({ sessionId }: { sessionId: string }): null {
+    const { commandMarkers } = useNativeChatCommandMarkers({
+      paneKey: 'tab:leaf',
+      agent: 'claude',
+      sessionId,
+      messages: [],
+      transcriptOrder: createNativeChatTranscriptOrder(1),
+      onWorkingInterruptReset: resetWorkingInterrupt
+    })
+    renders.push({ sessionId, markerIds: commandMarkers.map((marker) => marker.id) })
+    return null
+  }
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    renders.length = 0
+    clearCommandMarkerCacheForTests()
+    resetWorkingInterrupt.mockClear()
+  })
+
+  it('drops the old clear boundary on the first replacement-session render', async () => {
+    appendCommandMarkerCache(
+      { paneKey: 'tab:leaf', agent: 'claude', sessionId: 'old-session' },
+      '/clear',
+      10,
+      {
+        clearAfterMessageId: null,
+        clearTranscriptGeneration: 1,
+        clearTranscriptHighWater: 0
+      }
+    )
+    root = createRoot(document.createElement('div'))
+    await act(async () => root?.render(createElement(Probe, { sessionId: 'old-session' })))
+    const replacementStart = renders.length
+
+    await act(async () => root?.render(createElement(Probe, { sessionId: 'new-session' })))
+
+    expect(renders[replacementStart]).toEqual({ sessionId: 'new-session', markerIds: [] })
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-command-markers.ts
@@ -1,24 +1,26 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendCommandMarkerCache,
-  clearedMessageIdsForSlashCommand,
+  clearBoundaryForSlashCommand,
   readCommandMarkerCache,
   type NativeChatCommandMarker,
   type NativeChatCommandMarkerScope
 } from './native-chat-command-markers'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
 
 export function useNativeChatCommandMarkers(args: {
   paneKey: string
   agent: string
   sessionId: string | null
   messages: readonly NativeChatMessage[]
+  transcriptOrder: NativeChatTranscriptOrder
   onWorkingInterruptReset: () => void
 }): {
   commandMarkers: NativeChatCommandMarker[]
   onSlashCommand: (command: string) => void
 } {
-  const { paneKey, agent, sessionId, messages, onWorkingInterruptReset } = args
+  const { paneKey, agent, sessionId, messages, transcriptOrder, onWorkingInterruptReset } = args
   const commandMarkerScope = useMemo(
     (): NativeChatCommandMarkerScope => ({ paneKey, agent, sessionId }),
     [paneKey, agent, sessionId]
@@ -26,25 +28,31 @@ export function useNativeChatCommandMarkers(args: {
   const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
     readCommandMarkerCache(commandMarkerScope)
   )
+  const activeScopeRef = useRef(commandMarkerScope)
+  const visibleCommandMarkers =
+    activeScopeRef.current === commandMarkerScope
+      ? commandMarkers
+      : readCommandMarkerCache(commandMarkerScope)
   // Command markers are session-scoped because slash commands like /clear are
   // local feedback for a specific transcript boundary.
   useEffect(() => {
+    activeScopeRef.current = commandMarkerScope
     setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
     onWorkingInterruptReset()
   }, [commandMarkerScope, onWorkingInterruptReset])
   const onSlashCommand = useCallback(
     (command: string) => {
-      // Why: hide pre-clear rows by id — never renderer sentAt vs host timestamps (#11519).
+      // Why: an ordered id boundary also hides older rows prepended after clear.
       setCommandMarkers(
         appendCommandMarkerCache(
           commandMarkerScope,
           command,
           Date.now(),
-          clearedMessageIdsForSlashCommand(command, messages)
+          clearBoundaryForSlashCommand(command, messages, transcriptOrder)
         )
       )
     },
-    [commandMarkerScope, messages]
+    [commandMarkerScope, messages, transcriptOrder]
   )
-  return { commandMarkers, onSlashCommand }
+  return { commandMarkers: visibleCommandMarkers, onSlashCommand }
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-command-markers.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import {
+  appendCommandMarkerCache,
+  clearedMessageIdsForSlashCommand,
+  readCommandMarkerCache,
+  type NativeChatCommandMarker,
+  type NativeChatCommandMarkerScope
+} from './native-chat-command-markers'
+
+export function useNativeChatCommandMarkers(args: {
+  paneKey: string
+  agent: string
+  sessionId: string | null
+  messages: readonly NativeChatMessage[]
+  onWorkingInterruptReset: () => void
+}): {
+  commandMarkers: NativeChatCommandMarker[]
+  onSlashCommand: (command: string) => void
+} {
+  const { paneKey, agent, sessionId, messages, onWorkingInterruptReset } = args
+  const commandMarkerScope = useMemo(
+    (): NativeChatCommandMarkerScope => ({ paneKey, agent, sessionId }),
+    [paneKey, agent, sessionId]
+  )
+  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
+    readCommandMarkerCache(commandMarkerScope)
+  )
+  // Command markers are session-scoped because slash commands like /clear are
+  // local feedback for a specific transcript boundary.
+  useEffect(() => {
+    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
+    onWorkingInterruptReset()
+  }, [commandMarkerScope, onWorkingInterruptReset])
+  const onSlashCommand = useCallback(
+    (command: string) => {
+      // Why: hide pre-clear rows by id — never renderer sentAt vs host timestamps (#11519).
+      setCommandMarkers(
+        appendCommandMarkerCache(
+          commandMarkerScope,
+          command,
+          Date.now(),
+          clearedMessageIdsForSlashCommand(command, messages)
+        )
+      )
+    },
+    [commandMarkerScope, messages]
+  )
+  return { commandMarkers, onSlashCommand }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-command-markers.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-command-markers.ts
@@ -13,6 +13,7 @@ export function useNativeChatCommandMarkers(args: {
   paneKey: string
   agent: string
   sessionId: string | null
+  sourceKey?: string
   messages: readonly NativeChatMessage[]
   transcriptOrder: NativeChatTranscriptOrder
   onWorkingInterruptReset: () => void
@@ -20,10 +21,18 @@ export function useNativeChatCommandMarkers(args: {
   commandMarkers: NativeChatCommandMarker[]
   onSlashCommand: (command: string) => void
 } {
-  const { paneKey, agent, sessionId, messages, transcriptOrder, onWorkingInterruptReset } = args
+  const {
+    paneKey,
+    agent,
+    sessionId,
+    sourceKey,
+    messages,
+    transcriptOrder,
+    onWorkingInterruptReset
+  } = args
   const commandMarkerScope = useMemo(
-    (): NativeChatCommandMarkerScope => ({ paneKey, agent, sessionId }),
-    [paneKey, agent, sessionId]
+    (): NativeChatCommandMarkerScope => ({ paneKey, agent, sessionId, sourceKey }),
+    [paneKey, agent, sessionId, sourceKey]
   )
   const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
     readCommandMarkerCache(commandMarkerScope)

--- a/src/renderer/src/components/native-chat/use-native-chat-launch-prompt.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-launch-prompt.ts
@@ -1,0 +1,42 @@
+import { useEffect, useMemo } from 'react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { useAppStore } from '../../store'
+import { launchPromptAsMessage, shouldPruneLaunchPrompt } from './native-chat-launch-prompt'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
+
+export function useNativeChatLaunchPrompt(args: {
+  terminalTabId: string
+  agent: string
+  messages: NativeChatMessage[]
+  transcriptOrder: NativeChatTranscriptOrder
+  crossClock: boolean
+}): { message: NativeChatMessage | null; failed: boolean } {
+  const { terminalTabId, agent, messages, transcriptOrder, crossClock } = args
+  const launchPrompt = useAppStore(
+    (state) => state.nativeChatLaunchPromptByTabId[terminalTabId] ?? null
+  )
+  const clearLaunchPrompt = useAppStore((state) => state.clearNativeChatLaunchPrompt)
+  const paneLaunchPrompt = launchPrompt?.agent === agent ? launchPrompt : null
+
+  useEffect(() => {
+    if (
+      paneLaunchPrompt &&
+      shouldPruneLaunchPrompt(paneLaunchPrompt, messages, {
+        crossClock,
+        transcriptOrder
+      })
+    ) {
+      clearLaunchPrompt(terminalTabId)
+    }
+  }, [clearLaunchPrompt, crossClock, messages, paneLaunchPrompt, terminalTabId, transcriptOrder])
+
+  const message = useMemo(
+    () =>
+      launchPromptAsMessage(paneLaunchPrompt, messages, {
+        crossClock,
+        transcriptOrder
+      }),
+    [crossClock, messages, paneLaunchPrompt, transcriptOrder]
+  )
+  return { message, failed: paneLaunchPrompt?.failed === true }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-launch-prompt.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-launch-prompt.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { useAppStore } from '../../store'
 import { launchPromptAsMessage, shouldPruneLaunchPrompt } from './native-chat-launch-prompt'
@@ -17,6 +17,15 @@ export function useNativeChatLaunchPrompt(args: {
   )
   const clearLaunchPrompt = useAppStore((state) => state.clearNativeChatLaunchPrompt)
   const paneLaunchPrompt = launchPrompt?.agent === agent ? launchPrompt : null
+  const launchGenerationRef = useRef(transcriptOrder.generation)
+  useEffect(() => {
+    if (launchGenerationRef.current !== transcriptOrder.generation && paneLaunchPrompt) {
+      // A launch echo belongs to the source generation that existed at send;
+      // never let a replacement baseline retire it by identical content.
+      clearLaunchPrompt(terminalTabId)
+    }
+    launchGenerationRef.current = transcriptOrder.generation
+  }, [clearLaunchPrompt, paneLaunchPrompt, terminalTabId, transcriptOrder.generation])
 
   useEffect(() => {
     if (

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -52,7 +52,12 @@ const { transportFactory, getMockTransport, resetMockTransports } = vi.hoisted((
 })
 
 vi.mock('./native-chat-session-transport', () => ({
-  getNativeChatSessionTransport: transportFactory
+  getNativeChatSessionTransport: transportFactory,
+  subscribeNativeChatSession: (
+    transport: { subscribe: (...args: unknown[]) => unknown },
+    args: unknown,
+    onFrame: unknown
+  ) => transport.subscribe(args, onFrame)
 }))
 
 // Imported after vi.mock is hoisted, so it binds to the mocked transport.

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -383,7 +383,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(latest?.messages.map((message) => message.id)).toEqual(['u-live'])
   })
 
-  it('orders only same-generation live appends after the snapshot high-water', async () => {
+  it('orders only live appends after a non-adoption snapshot baseline', async () => {
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
     await act(async () =>
@@ -394,6 +394,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
       })
     )
     const generation = latest?.transcriptOrder.generation
+    // Reconnect/load snapshots do not sequence baseline rows.
     expect(latest?.transcriptOrder.highWater).toBe(0)
     expect(latest?.transcriptOrder.messageSequenceById.has('old')).toBe(false)
 
@@ -415,8 +416,136 @@ describe('useNativeChatLiveSession — transport routing', () => {
         hasMore: false
       })
     )
-    expect(latest?.transcriptOrder.generation).toBeGreaterThan(generation ?? 0)
+    // Same-session replacement keeps generation and settles post-action rows.
+    expect(latest?.transcriptOrder.generation).toBe(generation)
+    expect(latest?.transcriptOrder.messageSequenceById.get('replacement')).toBe(3)
+    expect(latest?.transcriptOrder.highWater).toBe(3)
+  })
+
+  it('null-session send then session-id initial snapshot retires the pending turn', async () => {
+    // Harness: null → send boundary capture → session id → mandatory snapshot.
+    // Bad: snapshotVisible=[pending:p1], snapshotPruned=[p1]
+    // Good: snapshot settles the first turn so visible/prune both drop p1.
+    const root = await render({
+      paneKey: PANE,
+      agent: AGENT,
+      sessionId: null,
+      runtimeEnvironmentId: 'env-1'
+    })
+    const orderAtSend = latest?.transcriptOrder
+    expect(orderAtSend).toMatchObject({ highWater: 0 })
+    const pending = [
+      {
+        id: 'p1',
+        text: 'hello first',
+        sentAt: 100,
+        afterMessageId: null as string | null,
+        afterTranscriptGeneration: orderAtSend?.generation ?? 0,
+        afterTranscriptHighWater: orderAtSend?.highWater ?? 0
+      }
+    ]
+
+    await rerender(root, {
+      paneKey: PANE,
+      agent: AGENT,
+      sessionId: SESSION,
+      runtimeEnvironmentId: 'env-1'
+    })
+    // Adoption must not mint a new generation (pending still matches).
+    expect(latest?.transcriptOrder.generation).toBe(orderAtSend?.generation)
+
+    await act(async () =>
+      getMockTransport('env-1').emit({
+        type: 'snapshot',
+        messages: [user('u1', 'hello first'), assistant('a1', 'hi')],
+        hasMore: false
+      })
+    )
+
+    const { pendingSendsAsMessages, prunePendingSends } = await import('./native-chat-pending')
+    const snapshotVisible = pendingSendsAsMessages(
+      pending,
+      latest?.messages ?? [],
+      latest?.transcriptOrder
+    ).map((message) => message.id)
+    const snapshotPruned = prunePendingSends(
+      pending,
+      latest?.messages ?? [],
+      latest?.transcriptOrder
+    ).map((entry) => entry.id)
+
+    expect(latest?.transcriptOrder.messageSequenceById.get('u1')).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.get('a1')).toBe(2)
+    expect(snapshotVisible).toEqual([])
+    expect(snapshotPruned).toEqual([])
+  })
+
+  it('same-session clear empty then replacement settles post-clear rows', async () => {
+    // Harness: clear on empty → replacement with fresh rows.
+    // Bad: visibleAfterClearReplacement=[]
+    // Good: replacement-settled sequences are visible past the clear high-water.
+    const transport = getMockTransport('env-1')
+    await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
+    await act(async () => transport.emit({ type: 'snapshot', messages: [], hasMore: false }))
+    const orderAtClear = latest?.transcriptOrder
+    const clearMarkers = [
+      {
+        id: 'c1',
+        command: '/clear',
+        sentAt: 10,
+        clearAfterMessageId: null as string | null,
+        clearTranscriptGeneration: orderAtClear?.generation ?? 0,
+        clearTranscriptHighWater: orderAtClear?.highWater ?? 0
+      }
+    ]
+
+    await act(async () =>
+      transport.emit({
+        type: 'replacement',
+        messages: [user('new-u', 'fresh'), assistant('new-a', 'ok')],
+        hasMore: false
+      })
+    )
+
+    const { applyCommandMarkerBoundaries } = await import('./native-chat-command-markers')
+    const visibleAfterClearReplacement = applyCommandMarkerBoundaries(
+      latest?.messages ?? [],
+      clearMarkers,
+      latest?.transcriptOrder
+    ).map((message) => message.id)
+
+    expect(latest?.transcriptOrder.generation).toBe(orderAtClear?.generation)
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-u')).toBe(1)
+    expect(visibleAfterClearReplacement).toEqual(['new-u', 'new-a'])
+  })
+
+  it('same-session pagination does not sequence prepended baseline rows', async () => {
+    const transport = getMockTransport('env-1')
+    const many = Array.from({ length: NATIVE_CHAT_INITIAL_LIMIT }, (_unused, n) =>
+      assistant(`m-${n}`, 't')
+    )
+    await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
+    await act(async () => transport.emit({ type: 'snapshot', messages: many, hasMore: true }))
     expect(latest?.transcriptOrder.highWater).toBe(0)
+
+    await act(async () =>
+      transport.emit({
+        type: 'appended',
+        messages: [user('live', 'go')]
+      })
+    )
+    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(1)
+
+    transport.readSession.mockResolvedValueOnce({
+      messages: [assistant('older', 'page'), ...many, user('live', 'go')]
+    })
+    await act(async () => latest?.loadEarlier())
+    await flush()
+
+    // Pagination only replaces the base list; order stays append-settled.
+    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.has('older')).toBe(false)
+    expect(latest?.messages.map((message) => message.id)).toContain('older')
   })
 
   it("self-heals a stale 'working' hook once the turn-complete marker lands", async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -427,8 +427,8 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(latest?.transcriptOrder.highWater).toBe(3)
   })
 
-  it('null-session send then session-id initial snapshot retires the pending turn', async () => {
-    // Harness: null → send boundary capture → session id → mandatory snapshot.
+  it('null-session send then session metadata initial snapshot retires the pending turn', async () => {
+    // Harness: null → send boundary capture → session id + path → mandatory snapshot.
     // Bad: snapshotVisible=[pending:p1], snapshotPruned=[p1]
     // Good: snapshot settles the first turn so visible/prune both drop p1.
     const root = await render({
@@ -454,6 +454,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
       paneKey: PANE,
       agent: AGENT,
       sessionId: SESSION,
+      transcriptPath: '/host/transcript.jsonl',
       runtimeEnvironmentId: 'env-1'
     })
     // Adoption must not mint a new generation (pending still matches).

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -383,6 +383,42 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(latest?.messages.map((message) => message.id)).toEqual(['u-live'])
   })
 
+  it('orders only same-generation live appends after the snapshot high-water', async () => {
+    const transport = getMockTransport('env-1')
+    await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
+    await act(async () =>
+      transport.emit({
+        type: 'snapshot',
+        messages: [user('old', 'same')],
+        hasMore: false
+      })
+    )
+    const generation = latest?.transcriptOrder.generation
+    expect(latest?.transcriptOrder.highWater).toBe(0)
+    expect(latest?.transcriptOrder.messageSequenceById.has('old')).toBe(false)
+
+    await act(async () =>
+      transport.emit({
+        type: 'appended',
+        messages: [user('new-user', 'same'), assistant('new-answer', 'done')]
+      })
+    )
+
+    expect(latest?.transcriptOrder).toMatchObject({ generation, highWater: 2 })
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-user')).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-answer')).toBe(2)
+
+    await act(async () =>
+      transport.emit({
+        type: 'replacement',
+        messages: [user('replacement', 'fresh')],
+        hasMore: false
+      })
+    )
+    expect(latest?.transcriptOrder.generation).toBeGreaterThan(generation ?? 0)
+    expect(latest?.transcriptOrder.highWater).toBe(0)
+  })
+
   it("self-heals a stale 'working' hook once the turn-complete marker lands", async () => {
     useAppStore.setState({
       agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } as never }

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -388,7 +388,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(latest?.messages.map((message) => message.id)).toEqual(['u-live'])
   })
 
-  it('orders only live appends after a non-adoption snapshot baseline', async () => {
+  it('orders reconnect snapshots and live appends in one local sequence', async () => {
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
     await act(async () =>
@@ -399,9 +399,8 @@ describe('useNativeChatLiveSession — transport routing', () => {
       })
     )
     const generation = latest?.transcriptOrder.generation
-    // Reconnect/load snapshots do not sequence baseline rows.
-    expect(latest?.transcriptOrder.highWater).toBe(0)
-    expect(latest?.transcriptOrder.messageSequenceById.has('old')).toBe(false)
+    expect(latest?.transcriptOrder.highWater).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.get('old')).toBe(1)
 
     await act(async () =>
       transport.emit({
@@ -410,9 +409,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
       })
     )
 
-    expect(latest?.transcriptOrder).toMatchObject({ generation, highWater: 2 })
-    expect(latest?.transcriptOrder.messageSequenceById.get('new-user')).toBe(1)
-    expect(latest?.transcriptOrder.messageSequenceById.get('new-answer')).toBe(2)
+    expect(latest?.transcriptOrder).toMatchObject({ generation, highWater: 3 })
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-user')).toBe(2)
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-answer')).toBe(3)
 
     await act(async () =>
       transport.emit({
@@ -423,8 +422,8 @@ describe('useNativeChatLiveSession — transport routing', () => {
     )
     // Same-session replacement keeps generation and settles post-action rows.
     expect(latest?.transcriptOrder.generation).toBe(generation)
-    expect(latest?.transcriptOrder.messageSequenceById.get('replacement')).toBe(3)
-    expect(latest?.transcriptOrder.highWater).toBe(3)
+    expect(latest?.transcriptOrder.messageSequenceById.get('replacement')).toBe(4)
+    expect(latest?.transcriptOrder.highWater).toBe(4)
   })
 
   it('null-session send then session metadata initial snapshot retires the pending turn', async () => {
@@ -532,7 +531,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
     )
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
     await act(async () => transport.emit({ type: 'snapshot', messages: many, hasMore: true }))
-    expect(latest?.transcriptOrder.highWater).toBe(0)
+    expect(latest?.transcriptOrder.highWater).toBe(NATIVE_CHAT_INITIAL_LIMIT)
 
     await act(async () =>
       transport.emit({
@@ -540,7 +539,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
         messages: [user('live', 'go')]
       })
     )
-    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(
+      NATIVE_CHAT_INITIAL_LIMIT + 1
+    )
 
     transport.readSession.mockResolvedValueOnce({
       messages: [assistant('older', 'page'), ...many, user('live', 'go')]
@@ -549,7 +550,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
     await flush()
 
     // Pagination only replaces the base list; order stays append-settled.
-    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(
+      NATIVE_CHAT_INITIAL_LIMIT + 1
+    )
     expect(latest?.transcriptOrder.messageSequenceById.has('older')).toBe(false)
     expect(latest?.messages.map((message) => message.id)).toContain('older')
   })

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -388,7 +388,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(latest?.messages.map((message) => message.id)).toEqual(['u-live'])
   })
 
-  it('orders reconnect snapshots and live appends in one local sequence', async () => {
+  it('orders only live appends after a non-adoption snapshot baseline', async () => {
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
     await act(async () =>
@@ -399,8 +399,8 @@ describe('useNativeChatLiveSession — transport routing', () => {
       })
     )
     const generation = latest?.transcriptOrder.generation
-    expect(latest?.transcriptOrder.highWater).toBe(1)
-    expect(latest?.transcriptOrder.messageSequenceById.get('old')).toBe(1)
+    expect(latest?.transcriptOrder.highWater).toBe(0)
+    expect(latest?.transcriptOrder.messageSequenceById.has('old')).toBe(false)
 
     await act(async () =>
       transport.emit({
@@ -409,9 +409,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
       })
     )
 
-    expect(latest?.transcriptOrder).toMatchObject({ generation, highWater: 3 })
-    expect(latest?.transcriptOrder.messageSequenceById.get('new-user')).toBe(2)
-    expect(latest?.transcriptOrder.messageSequenceById.get('new-answer')).toBe(3)
+    expect(latest?.transcriptOrder).toMatchObject({ generation, highWater: 2 })
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-user')).toBe(1)
+    expect(latest?.transcriptOrder.messageSequenceById.get('new-answer')).toBe(2)
 
     await act(async () =>
       transport.emit({
@@ -422,8 +422,8 @@ describe('useNativeChatLiveSession — transport routing', () => {
     )
     // Same-session replacement keeps generation and settles post-action rows.
     expect(latest?.transcriptOrder.generation).toBe(generation)
-    expect(latest?.transcriptOrder.messageSequenceById.get('replacement')).toBe(4)
-    expect(latest?.transcriptOrder.highWater).toBe(4)
+    expect(latest?.transcriptOrder.messageSequenceById.get('replacement')).toBe(3)
+    expect(latest?.transcriptOrder.highWater).toBe(3)
   })
 
   it('null-session send then session metadata initial snapshot retires the pending turn', async () => {
@@ -531,7 +531,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
     )
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
     await act(async () => transport.emit({ type: 'snapshot', messages: many, hasMore: true }))
-    expect(latest?.transcriptOrder.highWater).toBe(NATIVE_CHAT_INITIAL_LIMIT)
+    expect(latest?.transcriptOrder.highWater).toBe(0)
 
     await act(async () =>
       transport.emit({
@@ -539,9 +539,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
         messages: [user('live', 'go')]
       })
     )
-    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(
-      NATIVE_CHAT_INITIAL_LIMIT + 1
-    )
+    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(1)
 
     transport.readSession.mockResolvedValueOnce({
       messages: [assistant('older', 'page'), ...many, user('live', 'go')]
@@ -550,9 +548,7 @@ describe('useNativeChatLiveSession — transport routing', () => {
     await flush()
 
     // Pagination only replaces the base list; order stays append-settled.
-    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(
-      NATIVE_CHAT_INITIAL_LIMIT + 1
-    )
+    expect(latest?.transcriptOrder.messageSequenceById.get('live')).toBe(1)
     expect(latest?.transcriptOrder.messageSequenceById.has('older')).toBe(false)
     expect(latest?.messages.map((message) => message.id)).toContain('older')
   })

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   NATIVE_CHAT_SOURCE_PRIORITY,
-  type AgentType,
-  type NativeChatMessage,
-  type NativeChatSession
+  type NativeChatMessage
 } from '../../../../shared/native-chat-types'
 import {
   applyAppend,
@@ -13,7 +11,8 @@ import {
 import {
   applyAppends,
   createIncrementalAssembler,
-  reset as resetAssembler
+  reset as resetAssembler,
+  sharesNativeChatMessagePrefix
 } from './native-chat-incremental-assembler'
 import { mergeNativeChatLiveSession } from './native-chat-live-status'
 import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
@@ -25,56 +24,22 @@ import {
 import { getNativeChatSessionTransport } from './native-chat-session-transport'
 import { useNativeChatTranscriptLifecycle } from './use-native-chat-transcript-lifecycle'
 import { useNativeChatHookStatus } from './use-native-chat-hook-status'
-
-export type UseNativeChatLiveSessionArgs = {
-  /** Composite `${tabId}:${leafId}` key — selects the live hook entry. */
-  paneKey: string
-  agent: AgentType
-  /** The agent's own session id, or null before it reports one — nothing to read/tail, so the view shows live hook state. */
-  sessionId: string | null
-  /** Authoritative transcript path from the hook, preferred over reconstructing it from sessionId. Null when not reported. */
-  transcriptPath?: string | null
-  /** Runtime owner (Model B): non-null routes read/subscribe to the remote host; null keeps the local IPC path. */
-  runtimeEnvironmentId?: string | null
-}
-
-/** A live session plus the older-history pagination controls the view needs. */
-export type NativeChatLiveSession = NativeChatSession & {
-  /** True when an older page may still exist (the last read filled the window). */
-  hasMore: boolean
-  /** Whether an older-history page is currently loading. */
-  loadingEarlier: boolean
-  /** Grow the read window to page in older history (scrolled-to-top trigger). */
-  loadEarlier: () => void
-  /** Raw initial-read phase. `status` is not a substitute: a live 'working' hook
-   *  outranks (and so hides) 'loading', which would let a consumer deciding from
-   *  an empty list treat an in-flight transcript as real history. */
-  readPhase: ReadState['phase']
-}
+import { useNativeChatTranscriptOrder } from './use-native-chat-transcript-order'
+import type {
+  NativeChatLiveSession,
+  ReadState,
+  UseNativeChatLiveSessionArgs
+} from './native-chat-live-session-types'
+export type {
+  NativeChatLiveSession,
+  ReadState,
+  UseNativeChatLiveSessionArgs
+} from './native-chat-live-session-types'
 
 // Stable empty-base reference so a non-ready read doesn't churn the base axis.
 const EMPTY_MESSAGES: readonly NativeChatMessage[] = []
 
-/** True when `whole`'s first `len` entries are referentially identical to `prefix` (a tail-extension), so the assembler can splice just the suffix. */
-function sharesPrefix(
-  whole: readonly NativeChatMessage[],
-  prefix: readonly NativeChatMessage[],
-  len: number
-): boolean {
-  for (let i = 0; i < len; i += 1) {
-    if (whole[i] !== prefix[i]) {
-      return false
-    }
-  }
-  return true
-}
-
 let subscriptionCounter = 0
-
-function nextSubscriptionId(): string {
-  subscriptionCounter += 1
-  return `native-chat-${subscriptionCounter}-${Date.now()}`
-}
 
 // Why: a new session's transcript can take minutes to appear on disk (#8401); a `notFound` miss retries with backoff until the window below elapses.
 const NOTFOUND_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
@@ -84,11 +49,6 @@ const NOTFOUND_RETRY_WINDOW_MS = 60_000
 function notFoundRetryDelayMs(attempt: number): number {
   return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
 }
-
-export type ReadState =
-  | { phase: 'loading' }
-  | { phase: 'ready'; messages: NativeChatMessage[] }
-  | { phase: 'error'; error: string }
 
 /**
  * Renderer hook that streams a NativeChatSession for a pane: windowed
@@ -122,6 +82,8 @@ export function useNativeChatLiveSession(
 
   // Appended messages accumulate separately from the snapshot so pagination doesn't lose in-flight appends; merged by id and capped to the read window (#6).
   const [appended, setAppended] = useState<NativeChatMessage[]>([])
+  const [transcriptOrder, resetTranscriptOrder, appendTranscriptOrder] =
+    useNativeChatTranscriptOrder()
   // Id-dedup merger backing `appended`; caches the id→index map so each live frame costs O(incoming), not O(existing) (#18).
   const appendMergerRef = useRef(createNativeChatMerger(NATIVE_CHAT_SOURCE_PRIORITY))
 
@@ -143,6 +105,7 @@ export function useNativeChatLiveSession(
   useEffect(() => {
     // Why: agent/path/owner rebinds can keep the same session; every source generation must invalidate pagination captured before it.
     transcriptEpochRef.current += 1
+    resetTranscriptOrder()
     setLoadingEarlier(false)
     transcriptLifecycleControl.reset()
     if (!sessionId) {
@@ -204,7 +167,8 @@ export function useNativeChatLiveSession(
 
     loadSession(0)
 
-    const subscriptionId = nextSubscriptionId()
+    subscriptionCounter += 1
+    const subscriptionId = `native-chat-${subscriptionCounter}-${Date.now()}`
     const unsubscribe = transport.subscribe(
       {
         subscriptionId,
@@ -219,6 +183,7 @@ export function useNativeChatLiveSession(
             // Why: snapshots and inode replacements are authoritative generations; older pagination must not repaint them.
             frameArrived = true
             transcriptEpochRef.current += 1
+            resetTranscriptOrder()
             setLoadingEarlier(false)
             if ('error' in frame && frame.error) {
               setRead({ phase: 'error', error: frame.error })
@@ -233,7 +198,9 @@ export function useNativeChatLiveSession(
           }
           transcriptLifecycleControl.append(frame.lifecycle)
           // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
-          setAppended(applyAppend(appendMergerRef.current, frame.messages, limitRef.current))
+          const retained = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
+          appendTranscriptOrder(frame.messages, retained.length)
+          setAppended(retained)
         }
       }
     )
@@ -257,7 +224,15 @@ export function useNativeChatLiveSession(
       }
     }
     // `transport` identity changes on an owner flip, re-running this effect to re-subscribe against the new host.
-  }, [agent, sessionId, transcriptPath, transport, transcriptLifecycleControl])
+  }, [
+    agent,
+    sessionId,
+    transcriptPath,
+    transport,
+    transcriptLifecycleControl,
+    resetTranscriptOrder,
+    appendTranscriptOrder
+  ])
 
   const loadEarlier = useCallback(() => {
     if (!sessionId || loadingEarlier || !hasMore || read.phase !== 'ready') {
@@ -319,7 +294,7 @@ export function useNativeChatLiveSession(
     const isSuffixExtension =
       !baseChanged &&
       transcript.length >= applied.length &&
-      sharesPrefix(transcript, applied, applied.length)
+      sharesNativeChatMessagePrefix(transcript, applied, applied.length)
 
     let out: NativeChatMessage[]
     if (isSuffixExtension && transcript.length > applied.length) {
@@ -357,7 +332,14 @@ export function useNativeChatLiveSession(
       loading: read.phase === 'loading' && appended.length === 0,
       ...(read.phase === 'error' && appended.length === 0 ? { error: read.error } : {})
     })
-    return { ...session, hasMore, loadingEarlier, loadEarlier, readPhase: read.phase }
+    return {
+      ...session,
+      hasMore,
+      loadingEarlier,
+      loadEarlier,
+      readPhase: read.phase,
+      transcriptOrder
+    }
   }, [
     normalizedMessages,
     assembledMessages,
@@ -371,6 +353,7 @@ export function useNativeChatLiveSession(
     hasMore,
     loadingEarlier,
     loadEarlier,
-    appended
+    appended,
+    transcriptOrder
   ])
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   NATIVE_CHAT_SOURCE_PRIORITY,
   type NativeChatMessage
@@ -16,15 +16,21 @@ import {
 } from './native-chat-incremental-assembler'
 import { mergeNativeChatLiveSession } from './native-chat-live-status'
 import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
-import {
-  hasMoreNativeChatHistory,
-  NATIVE_CHAT_INITIAL_LIMIT,
-  nextNativeChatLimit
-} from './native-chat-pagination'
+import { hasMoreNativeChatHistory, NATIVE_CHAT_INITIAL_LIMIT } from './native-chat-pagination'
 import { getNativeChatSessionTransport } from './native-chat-session-transport'
 import { useNativeChatTranscriptLifecycle } from './use-native-chat-transcript-lifecycle'
 import { useNativeChatHookStatus } from './use-native-chat-hook-status'
+import { useNativeChatLoadEarlier } from './use-native-chat-load-earlier'
 import { useNativeChatTranscriptOrder } from './use-native-chat-transcript-order'
+import {
+  assembleNativeChatLiveMessages,
+  createNativeChatAuthoritativeSettle,
+  isNativeChatSessionIdAdoption,
+  NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS,
+  nativeChatNotFoundRetryDelayMs,
+  teardownNativeChatSubscription,
+  type NativeChatAssemblerCache
+} from './native-chat-live-session-order'
 import type {
   NativeChatLiveSession,
   ReadState,
@@ -41,29 +47,7 @@ const EMPTY_MESSAGES: readonly NativeChatMessage[] = []
 
 let subscriptionCounter = 0
 
-// Why: a new session's transcript can take minutes to appear on disk (#8401); a `notFound` miss retries with backoff until the window below elapses.
-const NOTFOUND_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
-const NOTFOUND_RETRY_FIXED_DELAY_MS = 10_000
-const NOTFOUND_RETRY_WINDOW_MS = 60_000
-
-function notFoundRetryDelayMs(attempt: number): number {
-  return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
-}
-
-/**
- * Renderer hook that streams a NativeChatSession for a pane: windowed
- * `readSession` + live `subscribe` tail, merged with live hook turn-state.
- *
- * Pagination: read is windowed to the most recent `limit` turns; `loadEarlier`
- * re-reads a larger window to prepend older history. Read results replace the
- * base list; live appends accumulate separately so a re-read never drops them.
- *
- * Transport: per-owner (getNativeChatSessionTransport) — a runtime-owned pane
- * (Model B) reads/tails the remote host; local/ssh panes keep the local IPC path.
- *
- * Teardown: subscription closes on unmount and on owner/agent/sessionId change so
- * a swap or owner-flip never leaks a watcher.
- */
+/** Windowed readSession + subscribe tail, merged with live hook turn-state. */
 export function useNativeChatLiveSession(
   args: UseNativeChatLiveSessionArgs
 ): NativeChatLiveSession {
@@ -82,7 +66,7 @@ export function useNativeChatLiveSession(
 
   // Appended messages accumulate separately from the snapshot so pagination doesn't lose in-flight appends; merged by id and capped to the read window (#6).
   const [appended, setAppended] = useState<NativeChatMessage[]>([])
-  const [transcriptOrder, resetTranscriptOrder, appendTranscriptOrder] =
+  const [transcriptOrder, resetTranscriptOrder, appendTranscriptOrder, settleTranscriptOrder] =
     useNativeChatTranscriptOrder()
   // Id-dedup merger backing `appended`; caches the id→index map so each live frame costs O(incoming), not O(existing) (#18).
   const appendMergerRef = useRef(createNativeChatMerger(NATIVE_CHAT_SOURCE_PRIORITY))
@@ -95,17 +79,49 @@ export function useNativeChatLiveSession(
   const latestTransport = useRef(transport)
   latestTransport.current = transport
   const transcriptEpochRef = useRef(0)
+  // Why: null→sessionId adoption must keep empty-boundary pending generation
+  // (#11509); only hard source flips mint a new order generation.
+  const previousOrderSourceRef = useRef({
+    agent,
+    sessionId,
+    transcriptPath: transcriptPath ?? null,
+    transport
+  })
 
-  // Incremental assembler: suffix-extensions take the fast append path, anything else resets so the cache can't drift from a full rebuild (#17).
-  const assemblerRef = useRef(createIncrementalAssembler())
-  const appliedTranscriptRef = useRef<readonly NativeChatMessage[]>([])
-  const baseSigRef = useRef<string | null>(null)
-  const baseMessagesRef = useRef<readonly NativeChatMessage[]>(EMPTY_MESSAGES)
+  // Incremental assembler: suffix-extensions take the fast append path (#17).
+  const assemblerCacheRef = useRef<NativeChatAssemblerCache>({
+    assembler: createIncrementalAssembler(),
+    appliedTranscript: EMPTY_MESSAGES,
+    baseSig: null,
+    baseMessages: EMPTY_MESSAGES
+  })
 
   useEffect(() => {
     // Why: agent/path/owner rebinds can keep the same session; every source generation must invalidate pagination captured before it.
     transcriptEpochRef.current += 1
-    resetTranscriptOrder()
+    const nextSource = {
+      agent,
+      sessionId,
+      transcriptPath: transcriptPath ?? null,
+      transport
+    }
+    const adoptedSessionId = isNativeChatSessionIdAdoption(
+      previousOrderSourceRef.current,
+      nextSource
+    )
+    previousOrderSourceRef.current = nextSource
+    // Preserve order across null→sessionId so a first-send pending still matches
+    // the mandatory initial snapshot; hard rebinds still replace the generation.
+    if (!adoptedSessionId) {
+      resetTranscriptOrder()
+    }
+    const authoritativeSettle = createNativeChatAuthoritativeSettle(
+      settleTranscriptOrder,
+      () => limitRef.current
+    )
+    if (adoptedSessionId) {
+      authoritativeSettle.markAdoptSettle()
+    }
     setLoadingEarlier(false)
     transcriptLifecycleControl.reset()
     if (!sessionId) {
@@ -143,11 +159,14 @@ export function useNativeChatLiveSession(
           }
           if (result && 'error' in result) {
             // A not-yet-flushed transcript: stay in 'loading' and retry with backoff instead of a permanent error (#8401).
-            if (result.notFound && Date.now() - retryStartedAt < NOTFOUND_RETRY_WINDOW_MS) {
+            if (
+              result.notFound &&
+              Date.now() - retryStartedAt < NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS
+            ) {
               retryTimer = setTimeout(() => {
                 retryTimer = null
                 loadSession(attempt + 1)
-              }, notFoundRetryDelayMs(attempt))
+              }, nativeChatNotFoundRetryDelayMs(attempt))
               return
             }
             setRead({ phase: 'error', error: result.error })
@@ -155,6 +174,7 @@ export function useNativeChatLiveSession(
           }
           const messages = result?.messages ?? []
           transcriptLifecycleControl.replace(result?.lifecycle)
+          authoritativeSettle.settleFrame(messages, false)
           setRead({ phase: 'ready', messages })
           setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
         })
@@ -180,10 +200,11 @@ export function useNativeChatLiveSession(
       (frame) => {
         if (!cancelled) {
           if (frame.type === 'snapshot' || frame.type === 'replacement') {
-            // Why: snapshots and inode replacements are authoritative generations; older pagination must not repaint them.
+            // Why: snapshots/replacements advance the message list + pagination
+            // epoch. Order generation stays put so empty-boundary pending/clear
+            // keep matching; only adoption and inode replacements settle rows.
             frameArrived = true
             transcriptEpochRef.current += 1
-            resetTranscriptOrder()
             setLoadingEarlier(false)
             if ('error' in frame && frame.error) {
               setRead({ phase: 'error', error: frame.error })
@@ -192,6 +213,7 @@ export function useNativeChatLiveSession(
             transcriptLifecycleControl.replace(frame.lifecycle)
             replaceList(appendMergerRef.current, frame.messages)
             setAppended([])
+            authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
             setRead({ phase: 'ready', messages: appendMergerRef.current.list })
             setHasMore(frame.hasMore)
             return
@@ -211,17 +233,7 @@ export function useNativeChatLiveSession(
         clearTimeout(retryTimer)
         retryTimer = null
       }
-      // Web RPC bridge returns a Promise (not the desktop sync unsubscribe fn); calling it as a function crashed the view, so resolve first.
-      const teardown = unsubscribe as unknown
-      if (typeof teardown === 'function') {
-        ;(teardown as () => void)()
-      } else if (teardown && typeof (teardown as { then?: unknown }).then === 'function') {
-        void (teardown as Promise<unknown>).then((fn) => {
-          if (typeof fn === 'function') {
-            ;(fn as () => void)()
-          }
-        })
-      }
+      teardownNativeChatSubscription(unsubscribe)
     }
     // `transport` identity changes on an owner flip, re-running this effect to re-subscribe against the new host.
   }, [
@@ -231,86 +243,46 @@ export function useNativeChatLiveSession(
     transport,
     transcriptLifecycleControl,
     resetTranscriptOrder,
-    appendTranscriptOrder
+    appendTranscriptOrder,
+    settleTranscriptOrder
   ])
 
-  const loadEarlier = useCallback(() => {
-    if (!sessionId || loadingEarlier || !hasMore || read.phase !== 'ready') {
-      return
-    }
-    const nextLimit = nextNativeChatLimit(limitRef.current)
-    const requestEpoch = transcriptEpochRef.current
-    const lifecycleRevision = transcriptLifecycleControl.revision()
-    setLoadingEarlier(true)
-    void transport
-      .readSession(agent, sessionId, nextLimit, transcriptPath ?? undefined)
-      .then((result) => {
-        // Ignore a stale resolve from a swapped session or flipped owner — either would paint the wrong host's history.
-        if (
-          latestSessionId.current !== sessionId ||
-          latestTransport.current !== transport ||
-          transcriptEpochRef.current !== requestEpoch
-        ) {
-          return
-        }
-        if (!result || 'error' in result) {
-          return
-        }
-        limitRef.current = nextLimit
-        // Read results are an ordered tail: replace the base list so the older page prepends in order; live appends stay separate.
-        setRead({ phase: 'ready', messages: result.messages })
-        transcriptLifecycleControl.replaceFromPagination(result.lifecycle, lifecycleRevision)
-        setHasMore(hasMoreNativeChatHistory(result.messages.length, nextLimit))
-      })
-      .catch(() => {
-        // Swallow a rejected "load more" read: keep the already-loaded transcript intact rather than surface the rejection.
-      })
-      .finally(() => {
-        // Clear the loading flag on the current epoch even when the result is discarded, so a stale resolve can't wedge it true.
-        if (transcriptEpochRef.current === requestEpoch) {
-          setLoadingEarlier(false)
-        }
-      })
-  }, [
+  const loadEarlier = useNativeChatLoadEarlier({
     agent,
     sessionId,
     transcriptPath,
     transport,
     hasMore,
     loadingEarlier,
-    read.phase,
-    transcriptLifecycleControl
-  ])
+    readPhase: read.phase,
+    transcriptLifecycleControl,
+    limitRef,
+    transcriptEpochRef,
+    latestSessionId,
+    latestTransport,
+    setLoadingEarlier,
+    setRead,
+    setHasMore
+  })
 
-  // Computed outside the status memo so hookState churn (status-only) never re-runs the assembler.
+  // Computed outside the status memo so hookState churn never re-runs the assembler.
   const baseMessages = read.phase === 'ready' ? read.messages : EMPTY_MESSAGES
-  const assembledMessages = useMemo(() => {
-    const transcript =
-      appended.length > 0 ? [...baseMessages, ...appended] : (baseMessages as NativeChatMessage[])
-    // Base-axis signature: any change forces a full assembler reset so a missed trigger can't leave the cache stale.
-    const baseSig = `${agent}\u0000${sessionId ?? ''}`
-    const baseChanged = baseSig !== baseSigRef.current || baseMessages !== baseMessagesRef.current
-    const applied = appliedTranscriptRef.current
-    const isSuffixExtension =
-      !baseChanged &&
-      transcript.length >= applied.length &&
-      sharesNativeChatMessagePrefix(transcript, applied, applied.length)
-
-    let out: NativeChatMessage[]
-    if (isSuffixExtension && transcript.length > applied.length) {
-      out = applyAppends(assemblerRef.current, transcript.slice(applied.length))
-    } else if (isSuffixExtension) {
-      out = assemblerRef.current.messages
-    } else {
-      out = resetAssembler(assemblerRef.current, transcript)
-    }
-    baseSigRef.current = baseSig
-    baseMessagesRef.current = baseMessages
-    appliedTranscriptRef.current = transcript
-    return out
-    // baseMessages/appended are the only message-set inputs; sessionId/agent gate the reset. hookState intentionally excluded.
+  const assembledMessages = useMemo(
+    () =>
+      assembleNativeChatLiveMessages({
+        cache: assemblerCacheRef.current,
+        baseMessages,
+        appended,
+        agent,
+        sessionId,
+        applyAppends,
+        resetAssembler,
+        sharesPrefix: sharesNativeChatMessagePrefix
+      }),
+    // baseMessages/appended are the only message-set inputs; sessionId/agent gate the reset.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [baseMessages, appended, sessionId, agent])
+    [baseMessages, appended, sessionId, agent]
+  )
 
   // Keep presentation transforms off the status-only render axis.
   const normalizedMessages = useMemo(

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -17,7 +17,10 @@ import {
 import { mergeNativeChatLiveSession } from './native-chat-live-status'
 import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
 import { hasMoreNativeChatHistory, NATIVE_CHAT_INITIAL_LIMIT } from './native-chat-pagination'
-import { getNativeChatSessionTransport } from './native-chat-session-transport'
+import {
+  getNativeChatSessionTransport,
+  subscribeNativeChatSession
+} from './native-chat-session-transport'
 import { useNativeChatTranscriptLifecycle } from './use-native-chat-transcript-lifecycle'
 import { useNativeChatHookStatus } from './use-native-chat-hook-status'
 import { useNativeChatLoadEarlier } from './use-native-chat-load-earlier'
@@ -27,7 +30,7 @@ import {
   createNativeChatAuthoritativeSettle,
   isNativeChatSessionIdAdoption,
   NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS,
-  nativeChatNotFoundRetryDelayMs,
+  scheduleNativeChatNotFoundRetry,
   teardownNativeChatSubscription,
   type NativeChatAssemblerCache
 } from './native-chat-live-session-order'
@@ -124,116 +127,125 @@ export function useNativeChatLiveSession(
     }
     setLoadingEarlier(false)
     transcriptLifecycleControl.reset()
+
+    let cancelled = false
+    // Set by the first authoritative frame so the readSession seed below can't clobber a live snapshot.
+    let frameArrived = false
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+    let unsubscribe: unknown
+
     if (!sessionId) {
       // No session id yet: surface live hook state on an empty transcript; backfills once the id arrives.
       setRead({ phase: 'ready', messages: [] })
       replaceList(appendMergerRef.current, [])
       setAppended([])
       setHasMore(false)
-      return
-    }
+    } else {
+      const retryStartedAt = Date.now()
+      // Re-bound as a const: TS drops the `!sessionId` narrowing inside the hoisted nested function.
+      const activeSessionId = sessionId
+      limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
+      setRead({ phase: 'loading' })
+      replaceList(appendMergerRef.current, [])
+      setAppended([])
+      setHasMore(false)
 
-    let cancelled = false
-    // Set by the first authoritative frame so the readSession seed below can't clobber a live snapshot.
-    let frameArrived = false
-    let retryTimer: ReturnType<typeof setTimeout> | null = null
-    const retryStartedAt = Date.now()
-    // Re-bound as a const: TS drops the `!sessionId` narrowing inside the hoisted nested function.
-    const activeSessionId = sessionId
-    limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
-    setRead({ phase: 'loading' })
-    replaceList(appendMergerRef.current, [])
-    setAppended([])
-    setHasMore(false)
-
-    // Independent initial seed in case subscribe never delivers a snapshot; applied only until an authoritative frame lands so a live snapshot wins.
-    function loadSession(attempt: number): void {
-      if (frameArrived) {
-        return
-      }
-      void transport
-        .readSession(agent, activeSessionId, limitRef.current, transcriptPath ?? undefined)
-        .then((result) => {
-          if (cancelled || frameArrived) {
-            return
-          }
-          if (result && 'error' in result) {
-            // A not-yet-flushed transcript: stay in 'loading' and retry with backoff instead of a permanent error (#8401).
-            if (
-              result.notFound &&
-              Date.now() - retryStartedAt < NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS
-            ) {
-              retryTimer = setTimeout(() => {
-                retryTimer = null
-                loadSession(attempt + 1)
-              }, nativeChatNotFoundRetryDelayMs(attempt))
-              return
-            }
-            setRead({ phase: 'error', error: result.error })
-            return
-          }
-          const messages = result?.messages ?? []
-          transcriptLifecycleControl.replace(result?.lifecycle)
-          authoritativeSettle.settleFrame(messages, false)
-          setRead({ phase: 'ready', messages })
-          setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
-        })
-        .catch((err: unknown) => {
-          if (!cancelled && !frameArrived) {
-            setRead({ phase: 'error', error: err instanceof Error ? err.message : String(err) })
-          }
-        })
-    }
-
-    loadSession(0)
-
-    subscriptionCounter += 1
-    const subscriptionId = `native-chat-${subscriptionCounter}-${Date.now()}`
-    const unsubscribe = transport.subscribe(
-      {
-        subscriptionId,
-        agent,
-        sessionId,
-        transcriptPath: transcriptPath ?? undefined,
-        limit: limitRef.current
-      },
-      (frame) => {
-        if (!cancelled) {
-          if (frame.type === 'snapshot' || frame.type === 'replacement') {
-            // Why: snapshots/replacements advance the message list + pagination
-            // epoch. Order generation stays put so empty-boundary pending/clear
-            // keep matching; only adoption and inode replacements settle rows.
-            frameArrived = true
-            transcriptEpochRef.current += 1
-            setLoadingEarlier(false)
-            if ('error' in frame && frame.error) {
-              setRead({ phase: 'error', error: frame.error })
-              return
-            }
-            transcriptLifecycleControl.replace(frame.lifecycle)
-            replaceList(appendMergerRef.current, frame.messages)
-            setAppended([])
-            authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
-            setRead({ phase: 'ready', messages: appendMergerRef.current.list })
-            setHasMore(frame.hasMore)
-            return
-          }
-          transcriptLifecycleControl.append(frame.lifecycle)
-          // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
-          const retained = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
-          appendTranscriptOrder(frame.messages, retained.length)
-          setAppended(retained)
+      // Independent initial seed in case subscribe never delivers a snapshot; applied only until an authoritative frame lands so a live snapshot wins.
+      function loadSession(attempt: number): void {
+        if (frameArrived) {
+          return
         }
+        void transport
+          .readSession(agent, activeSessionId, limitRef.current, transcriptPath ?? undefined)
+          .then((result) => {
+            if (cancelled || frameArrived) {
+              return
+            }
+            if (result && 'error' in result) {
+              // A not-yet-flushed transcript: stay in 'loading' and retry with backoff instead of a permanent error (#8401).
+              if (
+                result.notFound &&
+                Date.now() - retryStartedAt < NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS
+              ) {
+                retryTimer = scheduleNativeChatNotFoundRetry({
+                  attempt,
+                  onRetry: () => {
+                    retryTimer = null
+                    loadSession(attempt + 1)
+                  }
+                })
+                return
+              }
+              setRead({ phase: 'error', error: result.error })
+              return
+            }
+            const messages = result?.messages ?? []
+            transcriptLifecycleControl.replace(result?.lifecycle)
+            authoritativeSettle.settleFrame(messages, false)
+            setRead({ phase: 'ready', messages })
+            setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
+          })
+          .catch((err: unknown) => {
+            if (!cancelled && !frameArrived) {
+              setRead({ phase: 'error', error: err instanceof Error ? err.message : String(err) })
+            }
+          })
       }
-    )
 
+      loadSession(0)
+
+      subscriptionCounter += 1
+      const subscriptionId = `native-chat-${subscriptionCounter}-${Date.now()}`
+      unsubscribe = subscribeNativeChatSession(
+        transport,
+        {
+          subscriptionId,
+          agent,
+          sessionId,
+          transcriptPath: transcriptPath ?? undefined,
+          limit: limitRef.current
+        },
+        (frame) => {
+          if (!cancelled) {
+            if (frame.type === 'snapshot' || frame.type === 'replacement') {
+              // Why: snapshots/replacements advance the message list + pagination
+              // epoch. Order generation stays put so empty-boundary pending/clear
+              // keep matching; only adoption and inode replacements settle rows.
+              frameArrived = true
+              transcriptEpochRef.current += 1
+              setLoadingEarlier(false)
+              if ('error' in frame && frame.error) {
+                setRead({ phase: 'error', error: frame.error })
+                return
+              }
+              transcriptLifecycleControl.replace(frame.lifecycle)
+              replaceList(appendMergerRef.current, frame.messages)
+              setAppended([])
+              authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
+              setRead({ phase: 'ready', messages: appendMergerRef.current.list })
+              setHasMore(frame.hasMore)
+              return
+            }
+            transcriptLifecycleControl.append(frame.lifecycle)
+            // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
+            const retained = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
+            appendTranscriptOrder(frame.messages, retained.length)
+            setAppended(retained)
+          }
+        }
+      )
+    }
+
+    // Always return a disposer so every allocation path is owned (effect-needs-cleanup).
     return () => {
       cancelled = true
       if (retryTimer) {
         clearTimeout(retryTimer)
         retryTimer = null
       }
-      teardownNativeChatSubscription(unsubscribe)
+      if (unsubscribe !== undefined) {
+        teardownNativeChatSubscription(unsubscribe)
+      }
     }
     // `transport` identity changes on an owner flip, re-running this effect to re-subscribe against the new host.
   }, [

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -291,8 +291,6 @@ export function useNativeChatLiveSession(
         resetAssembler,
         sharesPrefix: sharesNativeChatMessagePrefix
       }),
-    // baseMessages/appended are the only message-set inputs; sessionId/agent gate the reset.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [baseMessages, appended, sessionId, agent]
   )
 

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import {
   NATIVE_CHAT_SOURCE_PRIORITY,
   type NativeChatMessage
@@ -8,32 +8,21 @@ import {
   createNativeChatMerger,
   replaceList
 } from '../../../../shared/native-chat-merge'
-import {
-  applyAppends,
-  createIncrementalAssembler,
-  reset as resetAssembler,
-  sharesNativeChatMessagePrefix
-} from './native-chat-incremental-assembler'
 import { mergeNativeChatLiveSession } from './native-chat-live-status'
-import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
 import { hasMoreNativeChatHistory, NATIVE_CHAT_INITIAL_LIMIT } from './native-chat-pagination'
-import {
-  getNativeChatSessionTransport,
-  subscribeNativeChatSession
-} from './native-chat-session-transport'
+import { getNativeChatSessionTransport } from './native-chat-session-transport'
 import { useNativeChatTranscriptLifecycle } from './use-native-chat-transcript-lifecycle'
 import { useNativeChatHookStatus } from './use-native-chat-hook-status'
 import { useNativeChatLoadEarlier } from './use-native-chat-load-earlier'
 import { useNativeChatTranscriptOrder } from './use-native-chat-transcript-order'
 import {
-  assembleNativeChatLiveMessages,
   createNativeChatAuthoritativeSettle,
   isNativeChatSessionIdAdoption,
-  NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS,
-  scheduleNativeChatNotFoundRetry,
-  teardownNativeChatSubscription,
-  type NativeChatAssemblerCache
+  NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS
 } from './native-chat-live-session-order'
+import { createNativeChatReadRetryTimer } from './native-chat-read-retry-timer'
+import { openNativeChatTranscriptStream } from './native-chat-stream-teardown'
+import { useNativeChatAssembledMessages } from './use-native-chat-assembled-messages'
 import type {
   NativeChatLiveSession,
   ReadState,
@@ -45,17 +34,20 @@ export type {
   UseNativeChatLiveSessionArgs
 } from './native-chat-live-session-types'
 
-// Stable empty-base reference so a non-ready read doesn't churn the base axis.
 const EMPTY_MESSAGES: readonly NativeChatMessage[] = []
 
 let subscriptionCounter = 0
+
+function nextSubscriptionId(): string {
+  subscriptionCounter += 1
+  return `native-chat-${subscriptionCounter}-${Date.now()}`
+}
 
 /** Windowed readSession + subscribe tail, merged with live hook turn-state. */
 export function useNativeChatLiveSession(
   args: UseNativeChatLiveSessionArgs
 ): NativeChatLiveSession {
-  const { paneKey, agent, sessionId, transcriptPath, runtimeEnvironmentId } = args
-  // Stable per owner id so a re-render without an owner flip keeps the same transport and doesn't re-subscribe.
+  const { paneKey, agent, sessionId, transcriptPath, runtimeEnvironmentId, enabled = true } = args
   const transport = useMemo(
     () => getNativeChatSessionTransport(runtimeEnvironmentId ?? null),
     [runtimeEnvironmentId]
@@ -64,44 +56,42 @@ export function useNativeChatLiveSession(
   const [hasMore, setHasMore] = useState(false)
   const [loadingEarlier, setLoadingEarlier] = useState(false)
   const [transcriptLifecycle, transcriptLifecycleControl] = useNativeChatTranscriptLifecycle()
-  // The active read window; raised by loadEarlier to page in older history.
   const limitRef = useRef(NATIVE_CHAT_INITIAL_LIMIT)
-
-  // Appended messages accumulate separately from the snapshot so pagination doesn't lose in-flight appends; merged by id and capped to the read window (#6).
   const [appended, setAppended] = useState<NativeChatMessage[]>([])
   const [transcriptOrder, resetTranscriptOrder, appendTranscriptOrder, settleTranscriptOrder] =
     useNativeChatTranscriptOrder()
-  // Id-dedup merger backing `appended`; caches the id→index map so each live frame costs O(incoming), not O(existing) (#18).
   const appendMergerRef = useRef(createNativeChatMerger(NATIVE_CHAT_SOURCE_PRIORITY))
-
   const [hookState, hookStateStartedAt, hookHasWorkingSubagents] = useNativeChatHookStatus(paneKey)
 
+  const latestEnabled = useRef(enabled)
+  useLayoutEffect(() => {
+    latestEnabled.current = enabled
+  }, [enabled])
   const latestSessionId = useRef<string | null>(sessionId)
   latestSessionId.current = sessionId
-  // Tracks the current transport so a load-earlier resolve from a prior host is discarded after an owner flip (session id can stay the same).
   const latestTransport = useRef(transport)
   latestTransport.current = transport
   const transcriptEpochRef = useRef(0)
-  // Why: null→sessionId adoption must keep empty-boundary pending generation
-  // (#11509); only hard source flips mint a new order generation.
   const previousOrderSourceRef = useRef({
     agent,
     sessionId,
     transcriptPath: transcriptPath ?? null,
     transport
   })
-
-  // Incremental assembler: suffix-extensions take the fast append path (#17).
-  const assemblerCacheRef = useRef<NativeChatAssemblerCache>({
-    assembler: createIncrementalAssembler(),
-    appliedTranscript: EMPTY_MESSAGES,
-    baseSig: null,
-    baseMessages: EMPTY_MESSAGES
-  })
+  const sourceKey = JSON.stringify([
+    paneKey,
+    runtimeEnvironmentId ?? null,
+    agent,
+    sessionId,
+    transcriptPath ?? null
+  ])
+  const retainedSourceKeyRef = useRef(sourceKey)
 
   useEffect(() => {
-    // Why: agent/path/owner rebinds can keep the same session; every source generation must invalidate pagination captured before it.
     transcriptEpochRef.current += 1
+    setLoadingEarlier(false)
+    const sourceChanged = retainedSourceKeyRef.current !== sourceKey
+    retainedSourceKeyRef.current = sourceKey
     const nextSource = {
       agent,
       sessionId,
@@ -112,12 +102,21 @@ export function useNativeChatLiveSession(
       previousOrderSourceRef.current,
       nextSource
     )
-    previousOrderSourceRef.current = nextSource
-    // Preserve order across null→sessionId so a first-send pending still matches
-    // the mandatory initial snapshot; hard rebinds still replace the generation.
-    if (!adoptedSessionId) {
+    if (sourceChanged && !adoptedSessionId) {
       resetTranscriptOrder()
     }
+    if (!enabled) {
+      if (sourceChanged) {
+        limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
+        transcriptLifecycleControl.reset()
+        setRead({ phase: 'loading' })
+        replaceList(appendMergerRef.current, [])
+        setAppended([])
+        setHasMore(false)
+      }
+      return
+    }
+    previousOrderSourceRef.current = nextSource
     const authoritativeSettle = createNativeChatAuthoritativeSettle(
       settleTranscriptOrder,
       () => limitRef.current
@@ -125,132 +124,111 @@ export function useNativeChatLiveSession(
     if (adoptedSessionId) {
       authoritativeSettle.markAdoptSettle()
     }
-    setLoadingEarlier(false)
     transcriptLifecycleControl.reset()
 
-    let cancelled = false
-    // Set by the first authoritative frame so the readSession seed below can't clobber a live snapshot.
-    let frameArrived = false
-    let retryTimer: ReturnType<typeof setTimeout> | null = null
-    let unsubscribe: unknown
-
     if (!sessionId) {
-      // No session id yet: surface live hook state on an empty transcript; backfills once the id arrives.
       setRead({ phase: 'ready', messages: [] })
       replaceList(appendMergerRef.current, [])
       setAppended([])
       setHasMore(false)
-    } else {
-      const retryStartedAt = Date.now()
-      // Re-bound as a const: TS drops the `!sessionId` narrowing inside the hoisted nested function.
-      const activeSessionId = sessionId
-      limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
-      setRead({ phase: 'loading' })
-      replaceList(appendMergerRef.current, [])
-      setAppended([])
-      setHasMore(false)
+      return
+    }
 
-      // Independent initial seed in case subscribe never delivers a snapshot; applied only until an authoritative frame lands so a live snapshot wins.
-      function loadSession(attempt: number): void {
-        if (frameArrived) {
+    let cancelled = false
+    let frameArrived = false
+    const retryTimer = createNativeChatReadRetryTimer()
+    const retryStartedAt = Date.now()
+    const activeSessionId = sessionId
+    if (sourceChanged) {
+      limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
+    }
+    setRead({ phase: 'loading' })
+    replaceList(appendMergerRef.current, [])
+    setAppended([])
+    setHasMore(false)
+
+    function loadSession(attempt: number): void {
+      if (!latestEnabled.current || frameArrived) {
+        return
+      }
+      void transport
+        .readSession(agent, activeSessionId, limitRef.current, transcriptPath ?? undefined)
+        .then((result) => {
+          if (cancelled || !latestEnabled.current || frameArrived) {
+            return
+          }
+          if (result && 'error' in result) {
+            if (
+              result.notFound &&
+              Date.now() - retryStartedAt < NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS
+            ) {
+              retryTimer.schedule(attempt, () => loadSession(attempt + 1))
+              return
+            }
+            setRead({ phase: 'error', error: result.error })
+            return
+          }
+          const messages = result?.messages ?? []
+          transcriptLifecycleControl.replace(result?.lifecycle)
+          authoritativeSettle.settleFrame(messages, false)
+          setRead({ phase: 'ready', messages })
+          setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
+        })
+        .catch((err: unknown) => {
+          if (!cancelled && latestEnabled.current && !frameArrived) {
+            setRead({ phase: 'error', error: err instanceof Error ? err.message : String(err) })
+          }
+        })
+    }
+
+    loadSession(0)
+
+    const closeStream = openNativeChatTranscriptStream(
+      transport,
+      {
+        subscriptionId: nextSubscriptionId(),
+        agent,
+        sessionId,
+        transcriptPath: transcriptPath ?? undefined,
+        limit: limitRef.current
+      },
+      (frame) => {
+        if (cancelled || !latestEnabled.current) {
           return
         }
-        void transport
-          .readSession(agent, activeSessionId, limitRef.current, transcriptPath ?? undefined)
-          .then((result) => {
-            if (cancelled || frameArrived) {
-              return
-            }
-            if (result && 'error' in result) {
-              // A not-yet-flushed transcript: stay in 'loading' and retry with backoff instead of a permanent error (#8401).
-              if (
-                result.notFound &&
-                Date.now() - retryStartedAt < NATIVE_CHAT_NOTFOUND_RETRY_WINDOW_MS
-              ) {
-                retryTimer = scheduleNativeChatNotFoundRetry({
-                  attempt,
-                  onRetry: () => {
-                    retryTimer = null
-                    loadSession(attempt + 1)
-                  }
-                })
-                return
-              }
-              setRead({ phase: 'error', error: result.error })
-              return
-            }
-            const messages = result?.messages ?? []
-            transcriptLifecycleControl.replace(result?.lifecycle)
-            authoritativeSettle.settleFrame(messages, false)
-            setRead({ phase: 'ready', messages })
-            setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
-          })
-          .catch((err: unknown) => {
-            if (!cancelled && !frameArrived) {
-              setRead({ phase: 'error', error: err instanceof Error ? err.message : String(err) })
-            }
-          })
-      }
-
-      loadSession(0)
-
-      subscriptionCounter += 1
-      const subscriptionId = `native-chat-${subscriptionCounter}-${Date.now()}`
-      unsubscribe = subscribeNativeChatSession(
-        transport,
-        {
-          subscriptionId,
-          agent,
-          sessionId,
-          transcriptPath: transcriptPath ?? undefined,
-          limit: limitRef.current
-        },
-        (frame) => {
-          if (!cancelled) {
-            if (frame.type === 'snapshot' || frame.type === 'replacement') {
-              // Why: snapshots/replacements advance the message list + pagination
-              // epoch. Order generation stays put so empty-boundary pending/clear
-              // keep matching; only adoption and inode replacements settle rows.
-              frameArrived = true
-              transcriptEpochRef.current += 1
-              setLoadingEarlier(false)
-              if ('error' in frame && frame.error) {
-                setRead({ phase: 'error', error: frame.error })
-                return
-              }
-              transcriptLifecycleControl.replace(frame.lifecycle)
-              replaceList(appendMergerRef.current, frame.messages)
-              setAppended([])
-              authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
-              setRead({ phase: 'ready', messages: appendMergerRef.current.list })
-              setHasMore(frame.hasMore)
-              return
-            }
-            transcriptLifecycleControl.append(frame.lifecycle)
-            // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
-            const retained = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
-            appendTranscriptOrder(frame.messages, retained.length)
-            setAppended(retained)
+        if (frame.type === 'snapshot' || frame.type === 'replacement') {
+          transcriptEpochRef.current += 1
+          setLoadingEarlier(false)
+          if ('error' in frame && frame.error) {
+            setRead({ phase: 'error', error: frame.error })
+            return
           }
+          frameArrived = true
+          transcriptLifecycleControl.replace(frame.lifecycle)
+          replaceList(appendMergerRef.current, frame.messages)
+          setAppended([])
+          authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
+          setRead({ phase: 'ready', messages: appendMergerRef.current.list })
+          setHasMore(frame.hasMore)
+          return
         }
-      )
-    }
+        transcriptLifecycleControl.append(frame.lifecycle)
+        const retained = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
+        appendTranscriptOrder(frame.messages, retained.length)
+        setAppended(retained)
+      }
+    )
 
-    // Always return a disposer so every allocation path is owned (effect-needs-cleanup).
     return () => {
       cancelled = true
-      if (retryTimer) {
-        clearTimeout(retryTimer)
-        retryTimer = null
-      }
-      if (unsubscribe !== undefined) {
-        teardownNativeChatSubscription(unsubscribe)
-      }
+      retryTimer.cancel()
+      closeStream()
     }
-    // `transport` identity changes on an owner flip, re-running this effect to re-subscribe against the new host.
   }, [
     agent,
+    enabled,
     sessionId,
+    sourceKey,
     transcriptPath,
     transport,
     transcriptLifecycleControl,
@@ -270,6 +248,7 @@ export function useNativeChatLiveSession(
     transcriptLifecycleControl,
     limitRef,
     transcriptEpochRef,
+    latestEnabled,
     latestSessionId,
     latestTransport,
     setLoadingEarlier,
@@ -277,28 +256,13 @@ export function useNativeChatLiveSession(
     setHasMore
   })
 
-  // Computed outside the status memo so hookState churn never re-runs the assembler.
   const baseMessages = read.phase === 'ready' ? read.messages : EMPTY_MESSAGES
-  const assembledMessages = useMemo(
-    () =>
-      assembleNativeChatLiveMessages({
-        cache: assemblerCacheRef.current,
-        baseMessages,
-        appended,
-        agent,
-        sessionId,
-        applyAppends,
-        resetAssembler,
-        sharesPrefix: sharesNativeChatMessagePrefix
-      }),
-    [baseMessages, appended, sessionId, agent]
-  )
-
-  // Keep presentation transforms off the status-only render axis.
-  const normalizedMessages = useMemo(
-    () => prepareNativeChatLiveMessages(assembledMessages, agent),
-    [assembledMessages, agent]
-  )
+  const { assembledMessages, normalizedMessages } = useNativeChatAssembledMessages({
+    agent,
+    sessionId,
+    baseMessages,
+    appended
+  })
 
   return useMemo<NativeChatLiveSession>(() => {
     const session = mergeNativeChatLiveSession({
@@ -310,7 +274,6 @@ export function useNativeChatLiveSession(
       transcriptLifecycle,
       statusTailMessage: assembledMessages.at(-1),
       hookHasWorkingSubagents,
-      // Why: show live watcher-append content over a spinner/stale error (#8401), so overrides apply only when nothing is appended.
       loading: read.phase === 'loading' && appended.length === 0,
       ...(read.phase === 'error' && appended.length === 0 ? { error: read.error } : {})
     })

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -172,7 +172,7 @@ export function useNativeChatLiveSession(
           transcriptLifecycleControl.replace(result?.lifecycle)
           // Establish a renderer-local baseline for every authoritative read;
           // reconnect snapshots then sequence only first-seen rows beyond it.
-          authoritativeSettle.settleFrame(messages, true)
+          authoritativeSettle.settleFrame(messages, false)
           setRead({ phase: 'ready', messages })
           setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
         })
@@ -209,7 +209,7 @@ export function useNativeChatLiveSession(
           transcriptLifecycleControl.replace(frame.lifecycle)
           replaceList(appendMergerRef.current, frame.messages)
           setAppended([])
-          authoritativeSettle.settleFrame(frame.messages, true)
+          authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
           setRead({ phase: 'ready', messages: appendMergerRef.current.list })
           setHasMore(frame.hasMore)
           return

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -1,16 +1,21 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   NATIVE_CHAT_SOURCE_PRIORITY,
-  type AgentType,
-  type NativeChatMessage,
-  type NativeChatSession
+  type NativeChatMessage
 } from '../../../../shared/native-chat-types'
 import {
   applyAppend,
   createNativeChatMerger,
   replaceList
 } from '../../../../shared/native-chat-merge'
+import {
+  applyAppends,
+  createIncrementalAssembler,
+  reset as resetAssembler,
+  sharesNativeChatMessagePrefix
+} from './native-chat-incremental-assembler'
 import { mergeNativeChatLiveSession } from './native-chat-live-status'
+import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
 import {
   hasMoreNativeChatHistory,
   NATIVE_CHAT_INITIAL_LIMIT,
@@ -19,55 +24,31 @@ import {
 import { getNativeChatSessionTransport } from './native-chat-session-transport'
 import { useNativeChatTranscriptLifecycle } from './use-native-chat-transcript-lifecycle'
 import { useNativeChatHookStatus } from './use-native-chat-hook-status'
-import { useNativeChatAssembledMessages } from './use-native-chat-assembled-messages'
-import { createNativeChatReadRetryTimer } from './native-chat-read-retry-timer'
-import { openNativeChatTranscriptStream } from './native-chat-stream-teardown'
-
-export type UseNativeChatLiveSessionArgs = {
-  /** Composite `${tabId}:${leafId}` key — selects the live hook entry. */
-  paneKey: string
-  agent: AgentType
-  /** The agent's own session id, or null before it reports one — nothing to read/tail, so the view shows live hook state. */
-  sessionId: string | null
-  /** Authoritative transcript path from the hook, preferred over reconstructing it from sessionId. Null when not reported. */
-  transcriptPath?: string | null
-  /** Runtime owner (Model B): non-null routes read/subscribe to the remote host; null keeps the local IPC path. */
-  runtimeEnvironmentId?: string | null
-  /** False suspends transcript IO while retaining the last committed session. */
-  enabled?: boolean
-}
-
-/** A live session plus the older-history pagination controls the view needs. */
-export type NativeChatLiveSession = NativeChatSession & {
-  /** True when an older page may still exist (the last read filled the window). */
-  hasMore: boolean
-  /** Whether an older-history page is currently loading. */
-  loadingEarlier: boolean
-  /** Grow the read window to page in older history (scrolled-to-top trigger). */
-  loadEarlier: () => void
-  /** Raw initial-read phase. `status` is not a substitute: a live 'working' hook
-   *  outranks (and so hides) 'loading', which would let a consumer deciding from
-   *  an empty list treat an in-flight transcript as real history. */
-  readPhase: ReadState['phase']
-}
+import { useNativeChatTranscriptOrder } from './use-native-chat-transcript-order'
+import type {
+  NativeChatLiveSession,
+  ReadState,
+  UseNativeChatLiveSessionArgs
+} from './native-chat-live-session-types'
+export type {
+  NativeChatLiveSession,
+  ReadState,
+  UseNativeChatLiveSessionArgs
+} from './native-chat-live-session-types'
 
 // Stable empty-base reference so a non-ready read doesn't churn the base axis.
 const EMPTY_MESSAGES: readonly NativeChatMessage[] = []
 
 let subscriptionCounter = 0
 
-function nextSubscriptionId(): string {
-  subscriptionCounter += 1
-  return `native-chat-${subscriptionCounter}-${Date.now()}`
-}
-
-// Why: a new session's transcript can take minutes to appear on disk (#8401).
+// Why: a new session's transcript can take minutes to appear on disk (#8401); a `notFound` miss retries with backoff until the window below elapses.
+const NOTFOUND_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
+const NOTFOUND_RETRY_FIXED_DELAY_MS = 10_000
 const NOTFOUND_RETRY_WINDOW_MS = 60_000
 
-export type ReadState =
-  | { phase: 'loading' }
-  | { phase: 'ready'; messages: NativeChatMessage[] }
-  | { phase: 'error'; error: string }
+function notFoundRetryDelayMs(attempt: number): number {
+  return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
+}
 
 /**
  * Renderer hook that streams a NativeChatSession for a pane: windowed
@@ -80,13 +61,13 @@ export type ReadState =
  * Transport: per-owner (getNativeChatSessionTransport) — a runtime-owned pane
  * (Model B) reads/tails the remote host; local/ssh panes keep the local IPC path.
  *
- * Teardown: subscription closes when hidden, unmounted, or rebound so no source
- * generation leaks a watcher.
+ * Teardown: subscription closes on unmount and on owner/agent/sessionId change so
+ * a swap or owner-flip never leaks a watcher.
  */
 export function useNativeChatLiveSession(
   args: UseNativeChatLiveSessionArgs
 ): NativeChatLiveSession {
-  const { paneKey, agent, sessionId, transcriptPath, runtimeEnvironmentId, enabled = true } = args
+  const { paneKey, agent, sessionId, transcriptPath, runtimeEnvironmentId } = args
   // Stable per owner id so a re-render without an owner flip keeps the same transport and doesn't re-subscribe.
   const transport = useMemo(
     () => getNativeChatSessionTransport(runtimeEnvironmentId ?? null),
@@ -101,48 +82,31 @@ export function useNativeChatLiveSession(
 
   // Appended messages accumulate separately from the snapshot so pagination doesn't lose in-flight appends; merged by id and capped to the read window (#6).
   const [appended, setAppended] = useState<NativeChatMessage[]>([])
+  const [transcriptOrder, resetTranscriptOrder, appendTranscriptOrder] =
+    useNativeChatTranscriptOrder()
   // Id-dedup merger backing `appended`; caches the id→index map so each live frame costs O(incoming), not O(existing) (#18).
   const appendMergerRef = useRef(createNativeChatMerger(NATIVE_CHAT_SOURCE_PRIORITY))
 
   const [hookState, hookStateStartedAt, hookHasWorkingSubagents] = useNativeChatHookStatus(paneKey)
 
-  const latestEnabled = useRef(enabled)
-  // Fence late frames before passive cleanup closes the previous stream.
-  useLayoutEffect(() => {
-    latestEnabled.current = enabled
-  }, [enabled])
   const latestSessionId = useRef<string | null>(sessionId)
   latestSessionId.current = sessionId
   // Tracks the current transport so a load-earlier resolve from a prior host is discarded after an owner flip (session id can stay the same).
   const latestTransport = useRef(transport)
   latestTransport.current = transport
   const transcriptEpochRef = useRef(0)
-  const sourceKey = JSON.stringify([
-    paneKey,
-    runtimeEnvironmentId ?? null,
-    agent,
-    sessionId,
-    transcriptPath ?? null
-  ])
-  const retainedSourceKeyRef = useRef(sourceKey)
+
+  // Incremental assembler: suffix-extensions take the fast append path, anything else resets so the cache can't drift from a full rebuild (#17).
+  const assemblerRef = useRef(createIncrementalAssembler())
+  const appliedTranscriptRef = useRef<readonly NativeChatMessage[]>([])
+  const baseSigRef = useRef<string | null>(null)
+  const baseMessagesRef = useRef<readonly NativeChatMessage[]>(EMPTY_MESSAGES)
 
   useEffect(() => {
     // Why: agent/path/owner rebinds can keep the same session; every source generation must invalidate pagination captured before it.
     transcriptEpochRef.current += 1
+    resetTranscriptOrder()
     setLoadingEarlier(false)
-    const sourceChanged = retainedSourceKeyRef.current !== sourceKey
-    retainedSourceKeyRef.current = sourceKey
-    if (!enabled) {
-      if (sourceChanged) {
-        limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
-        transcriptLifecycleControl.reset()
-        setRead({ phase: 'loading' })
-        replaceList(appendMergerRef.current, [])
-        setAppended([])
-        setHasMore(false)
-      }
-      return () => undefined
-    }
     transcriptLifecycleControl.reset()
     if (!sessionId) {
       // No session id yet: surface live hook state on an empty transcript; backfills once the id arrives.
@@ -150,20 +114,17 @@ export function useNativeChatLiveSession(
       replaceList(appendMergerRef.current, [])
       setAppended([])
       setHasMore(false)
-      return () => undefined
+      return
     }
 
     let cancelled = false
     // Set by the first authoritative frame so the readSession seed below can't clobber a live snapshot.
     let frameArrived = false
-    const retryTimer = createNativeChatReadRetryTimer()
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
     const retryStartedAt = Date.now()
     // Re-bound as a const: TS drops the `!sessionId` narrowing inside the hoisted nested function.
     const activeSessionId = sessionId
-    // Why: a reveal re-reads the same source, so keep the window the user paged in; only a new source starts over.
-    if (sourceChanged) {
-      limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
-    }
+    limitRef.current = NATIVE_CHAT_INITIAL_LIMIT
     setRead({ phase: 'loading' })
     replaceList(appendMergerRef.current, [])
     setAppended([])
@@ -171,19 +132,22 @@ export function useNativeChatLiveSession(
 
     // Independent initial seed in case subscribe never delivers a snapshot; applied only until an authoritative frame lands so a live snapshot wins.
     function loadSession(attempt: number): void {
-      if (!latestEnabled.current || frameArrived) {
+      if (frameArrived) {
         return
       }
       void transport
         .readSession(agent, activeSessionId, limitRef.current, transcriptPath ?? undefined)
         .then((result) => {
-          if (cancelled || !latestEnabled.current || frameArrived) {
+          if (cancelled || frameArrived) {
             return
           }
           if (result && 'error' in result) {
             // A not-yet-flushed transcript: stay in 'loading' and retry with backoff instead of a permanent error (#8401).
             if (result.notFound && Date.now() - retryStartedAt < NOTFOUND_RETRY_WINDOW_MS) {
-              retryTimer.schedule(attempt, () => loadSession(attempt + 1))
+              retryTimer = setTimeout(() => {
+                retryTimer = null
+                loadSession(attempt + 1)
+              }, notFoundRetryDelayMs(attempt))
               return
             }
             setRead({ phase: 'error', error: result.error })
@@ -195,7 +159,7 @@ export function useNativeChatLiveSession(
           setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
         })
         .catch((err: unknown) => {
-          if (!cancelled && latestEnabled.current && !frameArrived) {
+          if (!cancelled && !frameArrived) {
             setRead({ phase: 'error', error: err instanceof Error ? err.message : String(err) })
           }
         })
@@ -203,9 +167,9 @@ export function useNativeChatLiveSession(
 
     loadSession(0)
 
-    const subscriptionId = nextSubscriptionId()
-    const closeStream = openNativeChatTranscriptStream(
-      transport,
+    subscriptionCounter += 1
+    const subscriptionId = `native-chat-${subscriptionCounter}-${Date.now()}`
+    const unsubscribe = transport.subscribe(
       {
         subscriptionId,
         agent,
@@ -214,48 +178,64 @@ export function useNativeChatLiveSession(
         limit: limitRef.current
       },
       (frame) => {
-        if (cancelled || !latestEnabled.current) {
-          return
-        }
-        if (frame.type === 'snapshot' || frame.type === 'replacement') {
-          // Why: snapshots and inode replacements are authoritative generations; older pagination must not repaint them.
-          transcriptEpochRef.current += 1
-          setLoadingEarlier(false)
-          if ('error' in frame && frame.error) {
-            // Why: an error frame carries no transcript, so it must not consume the seed — a healthy read still has to repair the pane.
-            setRead({ phase: 'error', error: frame.error })
+        if (!cancelled) {
+          if (frame.type === 'snapshot' || frame.type === 'replacement') {
+            // Why: snapshots and inode replacements are authoritative generations; older pagination must not repaint them.
+            frameArrived = true
+            transcriptEpochRef.current += 1
+            resetTranscriptOrder()
+            setLoadingEarlier(false)
+            if ('error' in frame && frame.error) {
+              setRead({ phase: 'error', error: frame.error })
+              return
+            }
+            transcriptLifecycleControl.replace(frame.lifecycle)
+            replaceList(appendMergerRef.current, frame.messages)
+            setAppended([])
+            setRead({ phase: 'ready', messages: appendMergerRef.current.list })
+            setHasMore(frame.hasMore)
             return
           }
-          frameArrived = true
-          transcriptLifecycleControl.replace(frame.lifecycle)
-          replaceList(appendMergerRef.current, frame.messages)
-          setAppended([])
-          setRead({ phase: 'ready', messages: appendMergerRef.current.list })
-          setHasMore(frame.hasMore)
-          return
+          transcriptLifecycleControl.append(frame.lifecycle)
+          // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
+          const retained = applyAppend(appendMergerRef.current, frame.messages, limitRef.current)
+          appendTranscriptOrder(frame.messages, retained.length)
+          setAppended(retained)
         }
-        transcriptLifecycleControl.append(frame.lifecycle)
-        // Merge by id then bound to the window; the base read + assembler re-dedup mean trimming the append tail can't drop a covered turn (#6).
-        setAppended(applyAppend(appendMergerRef.current, frame.messages, limitRef.current))
       }
     )
 
     return () => {
       cancelled = true
-      retryTimer.cancel()
-      closeStream()
+      if (retryTimer) {
+        clearTimeout(retryTimer)
+        retryTimer = null
+      }
+      // Web RPC bridge returns a Promise (not the desktop sync unsubscribe fn); calling it as a function crashed the view, so resolve first.
+      const teardown = unsubscribe as unknown
+      if (typeof teardown === 'function') {
+        ;(teardown as () => void)()
+      } else if (teardown && typeof (teardown as { then?: unknown }).then === 'function') {
+        void (teardown as Promise<unknown>).then((fn) => {
+          if (typeof fn === 'function') {
+            ;(fn as () => void)()
+          }
+        })
+      }
     }
     // `transport` identity changes on an owner flip, re-running this effect to re-subscribe against the new host.
-  }, [agent, enabled, sessionId, sourceKey, transcriptPath, transport, transcriptLifecycleControl])
+  }, [
+    agent,
+    sessionId,
+    transcriptPath,
+    transport,
+    transcriptLifecycleControl,
+    resetTranscriptOrder,
+    appendTranscriptOrder
+  ])
 
   const loadEarlier = useCallback(() => {
-    if (
-      !latestEnabled.current ||
-      !sessionId ||
-      loadingEarlier ||
-      !hasMore ||
-      read.phase !== 'ready'
-    ) {
+    if (!sessionId || loadingEarlier || !hasMore || read.phase !== 'ready') {
       return
     }
     const nextLimit = nextNativeChatLimit(limitRef.current)
@@ -267,7 +247,6 @@ export function useNativeChatLiveSession(
       .then((result) => {
         // Ignore a stale resolve from a swapped session or flipped owner — either would paint the wrong host's history.
         if (
-          !latestEnabled.current ||
           latestSessionId.current !== sessionId ||
           latestTransport.current !== transport ||
           transcriptEpochRef.current !== requestEpoch
@@ -288,7 +267,7 @@ export function useNativeChatLiveSession(
       })
       .finally(() => {
         // Clear the loading flag on the current epoch even when the result is discarded, so a stale resolve can't wedge it true.
-        if (latestEnabled.current && transcriptEpochRef.current === requestEpoch) {
+        if (transcriptEpochRef.current === requestEpoch) {
           setLoadingEarlier(false)
         }
       })
@@ -305,12 +284,39 @@ export function useNativeChatLiveSession(
 
   // Computed outside the status memo so hookState churn (status-only) never re-runs the assembler.
   const baseMessages = read.phase === 'ready' ? read.messages : EMPTY_MESSAGES
-  const { assembledMessages, normalizedMessages } = useNativeChatAssembledMessages({
-    agent,
-    sessionId,
-    baseMessages,
-    appended
-  })
+  const assembledMessages = useMemo(() => {
+    const transcript =
+      appended.length > 0 ? [...baseMessages, ...appended] : (baseMessages as NativeChatMessage[])
+    // Base-axis signature: any change forces a full assembler reset so a missed trigger can't leave the cache stale.
+    const baseSig = `${agent}\u0000${sessionId ?? ''}`
+    const baseChanged = baseSig !== baseSigRef.current || baseMessages !== baseMessagesRef.current
+    const applied = appliedTranscriptRef.current
+    const isSuffixExtension =
+      !baseChanged &&
+      transcript.length >= applied.length &&
+      sharesNativeChatMessagePrefix(transcript, applied, applied.length)
+
+    let out: NativeChatMessage[]
+    if (isSuffixExtension && transcript.length > applied.length) {
+      out = applyAppends(assemblerRef.current, transcript.slice(applied.length))
+    } else if (isSuffixExtension) {
+      out = assemblerRef.current.messages
+    } else {
+      out = resetAssembler(assemblerRef.current, transcript)
+    }
+    baseSigRef.current = baseSig
+    baseMessagesRef.current = baseMessages
+    appliedTranscriptRef.current = transcript
+    return out
+    // baseMessages/appended are the only message-set inputs; sessionId/agent gate the reset. hookState intentionally excluded.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseMessages, appended, sessionId, agent])
+
+  // Keep presentation transforms off the status-only render axis.
+  const normalizedMessages = useMemo(
+    () => prepareNativeChatLiveMessages(assembledMessages, agent),
+    [assembledMessages, agent]
+  )
 
   return useMemo<NativeChatLiveSession>(() => {
     const session = mergeNativeChatLiveSession({
@@ -326,7 +332,14 @@ export function useNativeChatLiveSession(
       loading: read.phase === 'loading' && appended.length === 0,
       ...(read.phase === 'error' && appended.length === 0 ? { error: read.error } : {})
     })
-    return { ...session, hasMore, loadingEarlier, loadEarlier, readPhase: read.phase }
+    return {
+      ...session,
+      hasMore,
+      loadingEarlier,
+      loadEarlier,
+      readPhase: read.phase,
+      transcriptOrder
+    }
   }, [
     normalizedMessages,
     assembledMessages,
@@ -340,6 +353,7 @@ export function useNativeChatLiveSession(
     hasMore,
     loadingEarlier,
     loadEarlier,
-    appended
+    appended,
+    transcriptOrder
   ])
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -170,7 +170,9 @@ export function useNativeChatLiveSession(
           }
           const messages = result?.messages ?? []
           transcriptLifecycleControl.replace(result?.lifecycle)
-          authoritativeSettle.settleFrame(messages, false)
+          // Establish a renderer-local baseline for every authoritative read;
+          // reconnect snapshots then sequence only first-seen rows beyond it.
+          authoritativeSettle.settleFrame(messages, true)
           setRead({ phase: 'ready', messages })
           setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
         })
@@ -207,7 +209,7 @@ export function useNativeChatLiveSession(
           transcriptLifecycleControl.replace(frame.lifecycle)
           replaceList(appendMergerRef.current, frame.messages)
           setAppended([])
-          authoritativeSettle.settleFrame(frame.messages, frame.type === 'replacement')
+          authoritativeSettle.settleFrame(frame.messages, true)
           setRead({ phase: 'ready', messages: appendMergerRef.current.list })
           setHasMore(frame.hasMore)
           return

--- a/src/renderer/src/components/native-chat/use-native-chat-load-earlier.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-load-earlier.ts
@@ -36,6 +36,7 @@ export function useNativeChatLoadEarlier(args: {
   transcriptLifecycleControl: TranscriptLifecycleControl
   limitRef: MutableRefObject<number>
   transcriptEpochRef: MutableRefObject<number>
+  latestEnabled: MutableRefObject<boolean>
   latestSessionId: MutableRefObject<string | null>
   latestTransport: MutableRefObject<SessionTransport>
   setLoadingEarlier: (value: boolean) => void
@@ -53,6 +54,7 @@ export function useNativeChatLoadEarlier(args: {
     transcriptLifecycleControl,
     limitRef,
     transcriptEpochRef,
+    latestEnabled,
     latestSessionId,
     latestTransport,
     setLoadingEarlier,
@@ -61,7 +63,13 @@ export function useNativeChatLoadEarlier(args: {
   } = args
 
   return useCallback(() => {
-    if (!sessionId || loadingEarlier || !hasMore || readPhase !== 'ready') {
+    if (
+      !latestEnabled.current ||
+      !sessionId ||
+      loadingEarlier ||
+      !hasMore ||
+      readPhase !== 'ready'
+    ) {
       return
     }
     const nextLimit = nextNativeChatLimit(limitRef.current)
@@ -73,6 +81,7 @@ export function useNativeChatLoadEarlier(args: {
       .then((result) => {
         // Ignore a stale resolve from a swapped session or flipped owner.
         if (
+          !latestEnabled.current ||
           latestSessionId.current !== sessionId ||
           latestTransport.current !== transport ||
           transcriptEpochRef.current !== requestEpoch
@@ -91,7 +100,7 @@ export function useNativeChatLoadEarlier(args: {
         // Keep the already-loaded transcript intact rather than surface rejection.
       })
       .finally(() => {
-        if (transcriptEpochRef.current === requestEpoch) {
+        if (latestEnabled.current && transcriptEpochRef.current === requestEpoch) {
           setLoadingEarlier(false)
         }
       })
@@ -106,6 +115,7 @@ export function useNativeChatLoadEarlier(args: {
     transcriptLifecycleControl,
     limitRef,
     transcriptEpochRef,
+    latestEnabled,
     latestSessionId,
     latestTransport,
     setLoadingEarlier,

--- a/src/renderer/src/components/native-chat/use-native-chat-load-earlier.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-load-earlier.ts
@@ -1,0 +1,115 @@
+import { useCallback, type MutableRefObject } from 'react'
+import type {
+  NativeChatMessage,
+  NativeChatTurnLifecycle
+} from '../../../../shared/native-chat-types'
+import { hasMoreNativeChatHistory, nextNativeChatLimit } from './native-chat-pagination'
+import type { ReadState } from './native-chat-live-session-types'
+
+type TranscriptLifecycleControl = {
+  revision: () => number
+  replaceFromPagination: (lifecycle: NativeChatTurnLifecycle | undefined, revision: number) => void
+}
+
+type SessionTransport = {
+  readSession: (
+    agent: string,
+    sessionId: string,
+    limit: number,
+    transcriptPath?: string
+  ) => Promise<
+    | { messages: NativeChatMessage[]; lifecycle?: NativeChatTurnLifecycle }
+    | { error: string }
+    | null
+    | undefined
+  >
+}
+
+export function useNativeChatLoadEarlier(args: {
+  agent: string
+  sessionId: string | null
+  transcriptPath?: string | null
+  transport: SessionTransport
+  hasMore: boolean
+  loadingEarlier: boolean
+  readPhase: ReadState['phase']
+  transcriptLifecycleControl: TranscriptLifecycleControl
+  limitRef: MutableRefObject<number>
+  transcriptEpochRef: MutableRefObject<number>
+  latestSessionId: MutableRefObject<string | null>
+  latestTransport: MutableRefObject<SessionTransport>
+  setLoadingEarlier: (value: boolean) => void
+  setRead: (value: ReadState) => void
+  setHasMore: (value: boolean) => void
+}): () => void {
+  const {
+    agent,
+    sessionId,
+    transcriptPath,
+    transport,
+    hasMore,
+    loadingEarlier,
+    readPhase,
+    transcriptLifecycleControl,
+    limitRef,
+    transcriptEpochRef,
+    latestSessionId,
+    latestTransport,
+    setLoadingEarlier,
+    setRead,
+    setHasMore
+  } = args
+
+  return useCallback(() => {
+    if (!sessionId || loadingEarlier || !hasMore || readPhase !== 'ready') {
+      return
+    }
+    const nextLimit = nextNativeChatLimit(limitRef.current)
+    const requestEpoch = transcriptEpochRef.current
+    const lifecycleRevision = transcriptLifecycleControl.revision()
+    setLoadingEarlier(true)
+    void transport
+      .readSession(agent, sessionId, nextLimit, transcriptPath ?? undefined)
+      .then((result) => {
+        // Ignore a stale resolve from a swapped session or flipped owner.
+        if (
+          latestSessionId.current !== sessionId ||
+          latestTransport.current !== transport ||
+          transcriptEpochRef.current !== requestEpoch
+        ) {
+          return
+        }
+        if (!result || 'error' in result) {
+          return
+        }
+        limitRef.current = nextLimit
+        setRead({ phase: 'ready', messages: result.messages })
+        transcriptLifecycleControl.replaceFromPagination(result.lifecycle, lifecycleRevision)
+        setHasMore(hasMoreNativeChatHistory(result.messages.length, nextLimit))
+      })
+      .catch(() => {
+        // Keep the already-loaded transcript intact rather than surface rejection.
+      })
+      .finally(() => {
+        if (transcriptEpochRef.current === requestEpoch) {
+          setLoadingEarlier(false)
+        }
+      })
+  }, [
+    agent,
+    sessionId,
+    transcriptPath,
+    transport,
+    hasMore,
+    loadingEarlier,
+    readPhase,
+    transcriptLifecycleControl,
+    limitRef,
+    transcriptEpochRef,
+    latestSessionId,
+    latestTransport,
+    setLoadingEarlier,
+    setRead,
+    setHasMore
+  ])
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-sends.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-sends.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { NativeChatTranscriptOrder } from './native-chat-transcript-order'
+import {
+  appendPendingSendCache,
+  nextNativeChatPendingSendId,
+  prunePendingSends,
+  readPendingSendCache,
+  writePendingSendCache,
+  type NativeChatPendingSend,
+  type NativeChatPendingSendScope
+} from './native-chat-pending'
+
+export function useNativeChatPendingSends(args: {
+  scope: NativeChatPendingSendScope
+  messages: readonly NativeChatMessage[]
+  order: NativeChatTranscriptOrder
+  onSendStarted: () => void
+}): {
+  pending: NativeChatPendingSend[]
+  clearPending: () => void
+  onOptimisticSend: (text: string, imagePaths?: string[]) => string
+  onOptimisticSendCanceled: (pendingId: string) => void
+} {
+  const { scope, messages, order, onSendStarted } = args
+  const [pending, setPending] = useState<NativeChatPendingSend[]>(() => readPendingSendCache(scope))
+  const pendingGenerationRef = useRef(order.generation)
+
+  useEffect(() => {
+    setPending(readPendingSendCache(scope))
+  }, [scope])
+  useEffect(() => {
+    if (pendingGenerationRef.current !== order.generation) {
+      // A source rebind invalidates pane-local optimistic sends.
+      setPending(writePendingSendCache(scope, []))
+    }
+    pendingGenerationRef.current = order.generation
+  }, [order.generation, scope])
+  useEffect(() => {
+    setPending((previous) =>
+      writePendingSendCache(scope, prunePendingSends(previous, [...messages], order))
+    )
+  }, [messages, order, scope])
+
+  const clearPending = useCallback(() => {
+    setPending(writePendingSendCache(scope, []))
+  }, [scope])
+  const onOptimisticSend = useCallback(
+    (text: string, imagePaths?: string[]) => {
+      onSendStarted()
+      const sentAt = Date.now()
+      const boundary = messages.at(-1)
+      const entry: NativeChatPendingSend = {
+        id: nextNativeChatPendingSendId(sentAt),
+        text,
+        sentAt,
+        afterMessageId: boundary?.id ?? null,
+        afterMessageTimestamp: boundary?.timestamp ?? null,
+        afterTranscriptGeneration: order.generation,
+        afterTranscriptHighWater: order.highWater,
+        ...(imagePaths ? { imagePaths } : {})
+      }
+      setPending(appendPendingSendCache(scope, entry))
+      return entry.id
+    },
+    [messages, onSendStarted, order, scope]
+  )
+  const onOptimisticSendCanceled = useCallback(
+    (pendingId: string) => {
+      const next = readPendingSendCache(scope).filter((entry) => entry.id !== pendingId)
+      setPending(writePendingSendCache(scope, next))
+    },
+    [scope]
+  )
+
+  return { pending, clearPending, onOptimisticSend, onOptimisticSendCanceled }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-retained-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-retained-session.test.ts
@@ -8,6 +8,7 @@ import type {
   NativeChatLiveSession,
   UseNativeChatLiveSessionArgs
 } from './use-native-chat-live-session'
+import { createNativeChatTranscriptOrder } from './native-chat-transcript-order'
 
 const { liveSession } = vi.hoisted(() => ({ liveSession: vi.fn() }))
 
@@ -39,7 +40,8 @@ function session(
     hasMore: false,
     loadingEarlier: false,
     loadEarlier: vi.fn(),
-    readPhase
+    readPhase,
+    transcriptOrder: createNativeChatTranscriptOrder()
   }
 }
 

--- a/src/renderer/src/components/native-chat/use-native-chat-transcript-order.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-transcript-order.test.ts
@@ -1,10 +1,28 @@
 // @vitest-environment happy-dom
 
 import { act, renderHook } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as TranscriptOrderModule from './native-chat-transcript-order'
 import { useNativeChatTranscriptOrder } from './use-native-chat-transcript-order'
 
+const createOrderSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('./native-chat-transcript-order', async (importOriginal) => {
+  const actual = await importOriginal<typeof TranscriptOrderModule>()
+  return {
+    ...actual,
+    createNativeChatTranscriptOrder: (
+      ...args: Parameters<typeof actual.createNativeChatTranscriptOrder>
+    ) => {
+      createOrderSpy()
+      return actual.createNativeChatTranscriptOrder(...args)
+    }
+  }
+})
+
 describe('useNativeChatTranscriptOrder', () => {
+  beforeEach(() => createOrderSpy.mockClear())
+
   it('keeps order and updater identity stable across parent re-renders', () => {
     const { result, rerender } = renderHook(() => useNativeChatTranscriptOrder())
     const [firstOrder, firstReplace, firstAppend, firstSettle] = result.current
@@ -13,6 +31,7 @@ describe('useNativeChatTranscriptOrder', () => {
     rerender()
     rerender()
     rerender()
+    expect(createOrderSpy).toHaveBeenCalledTimes(1)
 
     const [secondOrder, secondReplace, secondAppend, secondSettle] = result.current
     // Same holder: no fresh createNativeChatTranscriptOrder (order+Map) on re-render.

--- a/src/renderer/src/components/native-chat/use-native-chat-transcript-order.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-transcript-order.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useNativeChatTranscriptOrder } from './use-native-chat-transcript-order'
+
+describe('useNativeChatTranscriptOrder', () => {
+  it('keeps order and updater identity stable across parent re-renders', () => {
+    const { result, rerender } = renderHook(() => useNativeChatTranscriptOrder())
+    const [firstOrder, firstReplace, firstAppend, firstSettle] = result.current
+    const firstMap = firstOrder.messageSequenceById
+
+    rerender()
+    rerender()
+    rerender()
+
+    const [secondOrder, secondReplace, secondAppend, secondSettle] = result.current
+    // Same holder: no fresh createNativeChatTranscriptOrder (order+Map) on re-render.
+    expect(secondOrder).toBe(firstOrder)
+    expect(secondOrder.messageSequenceById).toBe(firstMap)
+    expect(secondReplace).toBe(firstReplace)
+    expect(secondAppend).toBe(firstAppend)
+    expect(secondSettle).toBe(firstSettle)
+
+    act(() => {
+      firstReplace()
+    })
+    expect(result.current[0]).not.toBe(firstOrder)
+    expect(result.current[0].generation).toBe(firstOrder.generation + 1)
+    expect(result.current[1]).toBe(firstReplace)
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-transcript-order.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-transcript-order.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState, type MutableRefObject } from 'react'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import {
   appendNativeChatTranscriptOrder,
@@ -8,21 +8,38 @@ import {
   type NativeChatTranscriptOrder
 } from './native-chat-transcript-order'
 
+/** Narrow the lazy-seeded ref; create only if somehow still empty. */
+function readSeededTranscriptOrder(
+  ref: MutableRefObject<NativeChatTranscriptOrder | null>
+): NativeChatTranscriptOrder {
+  const existing = ref.current
+  if (existing !== null) {
+    return existing
+  }
+  const created = createNativeChatTranscriptOrder()
+  ref.current = created
+  return created
+}
+
 export function useNativeChatTranscriptOrder(): readonly [
   NativeChatTranscriptOrder,
   () => void,
   (messages: readonly NativeChatMessage[], retainedCount: number) => void,
   (messages: readonly NativeChatMessage[], retainedCount: number) => void
 ] {
-  const currentRef = useRef(createNativeChatTranscriptOrder())
-  const [current, setCurrent] = useState(currentRef.current)
+  // Lazy-init once: useRef(create...) allocates a discarded order+Map every render.
+  const currentRef = useRef<NativeChatTranscriptOrder | null>(null)
+  if (currentRef.current === null) {
+    currentRef.current = createNativeChatTranscriptOrder()
+  }
+  const [current, setCurrent] = useState(() => readSeededTranscriptOrder(currentRef))
   const replace = useCallback(() => {
-    currentRef.current = replaceNativeChatTranscriptOrder(currentRef.current)
+    currentRef.current = replaceNativeChatTranscriptOrder(readSeededTranscriptOrder(currentRef))
     setCurrent(currentRef.current)
   }, [])
   const append = useCallback((messages: readonly NativeChatMessage[], retainedCount: number) => {
     currentRef.current = appendNativeChatTranscriptOrder(
-      currentRef.current,
+      readSeededTranscriptOrder(currentRef),
       messages,
       retainedCount
     )
@@ -30,7 +47,7 @@ export function useNativeChatTranscriptOrder(): readonly [
   }, [])
   const settle = useCallback((messages: readonly NativeChatMessage[], retainedCount: number) => {
     currentRef.current = settleNativeChatTranscriptOrder(
-      currentRef.current,
+      readSeededTranscriptOrder(currentRef),
       messages,
       retainedCount
     )

--- a/src/renderer/src/components/native-chat/use-native-chat-transcript-order.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-transcript-order.ts
@@ -4,12 +4,14 @@ import {
   appendNativeChatTranscriptOrder,
   createNativeChatTranscriptOrder,
   replaceNativeChatTranscriptOrder,
+  settleNativeChatTranscriptOrder,
   type NativeChatTranscriptOrder
 } from './native-chat-transcript-order'
 
 export function useNativeChatTranscriptOrder(): readonly [
   NativeChatTranscriptOrder,
   () => void,
+  (messages: readonly NativeChatMessage[], retainedCount: number) => void,
   (messages: readonly NativeChatMessage[], retainedCount: number) => void
 ] {
   const currentRef = useRef(createNativeChatTranscriptOrder())
@@ -26,5 +28,13 @@ export function useNativeChatTranscriptOrder(): readonly [
     )
     setCurrent(currentRef.current)
   }, [])
-  return [current, replace, append]
+  const settle = useCallback((messages: readonly NativeChatMessage[], retainedCount: number) => {
+    currentRef.current = settleNativeChatTranscriptOrder(
+      currentRef.current,
+      messages,
+      retainedCount
+    )
+    setCurrent(currentRef.current)
+  }, [])
+  return [current, replace, append, settle]
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-transcript-order.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-transcript-order.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef, useState } from 'react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import {
+  appendNativeChatTranscriptOrder,
+  createNativeChatTranscriptOrder,
+  replaceNativeChatTranscriptOrder,
+  type NativeChatTranscriptOrder
+} from './native-chat-transcript-order'
+
+export function useNativeChatTranscriptOrder(): readonly [
+  NativeChatTranscriptOrder,
+  () => void,
+  (messages: readonly NativeChatMessage[], retainedCount: number) => void
+] {
+  const currentRef = useRef(createNativeChatTranscriptOrder())
+  const [current, setCurrent] = useState(currentRef.current)
+  const replace = useCallback(() => {
+    currentRef.current = replaceNativeChatTranscriptOrder(currentRef.current)
+    setCurrent(currentRef.current)
+  }, [])
+  const append = useCallback((messages: readonly NativeChatMessage[], retainedCount: number) => {
+    currentRef.current = appendNativeChatTranscriptOrder(
+      currentRef.current,
+      messages,
+      retainedCount
+    )
+    setCurrent(currentRef.current)
+  }, [])
+  return [current, replace, append]
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​917 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​144 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​773 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1275 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​432 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​843 |

<!-- /orca-pr-loc -->

## Summary

Fixes #11519 / STA-2989: Chat UI pending-echo matching and `/clear` filtering compared renderer-clock `sentAt` to host/provider transcript `message.timestamp`. On remote runtimes those are different machines, so host-behind stranded optimistic bubbles forever and blanked post-clear transcripts, while host-ahead retired echoes against older identical prompts and let pre-clear rows survive `/clear`.

### Change

1. **Echo retirement** — `nativeChatPendingMatchingAfter` / `messageIsAfterPendingTimestamp` only use host-domain bounds (`matchingAfterTimestamp` / `afterMessageTimestamp`). Never fall back to renderer `sentAt`. Without a host bound, identity + occurrence matching sees the full list.
2. **`/clear`** — record the message ids visible at clear time and hide those ids. No wall-clock comparison across domains.
3. **Extract** command-marker cache/boundary helpers into `native-chat-command-markers.ts` (+ thin hook) so files stay under max-lines.

Does **not** duplicate #11509 (conversation retain on session replace) or #13513 (cancelled-send occurrence release). Those PRs document this clock-domain mix as a known unfixed limit (#11519).

## Screenshots

No visual change in the correct state — this removes permanent stale bubbles / blank post-clear lists that should not appear. Behavior is pinned by unit tests (host-behind and host-ahead at both echo retirement and `/clear`).

## Testing

- [x] `pnpm lint` (via pre-commit oxlint on changed files; max-lines clean, no new bypasses)
- [x] `pnpm typecheck:web`
- [ ] `pnpm typecheck` (full three-project; web-only change path exercised)
- [x] Focused tests: `native-chat-pending.test.ts`, `native-chat-pending-occurrence.test.ts`, `NativeChatInteractiveCard.test.tsx` (68 passed)
- [x] Broader: `src/renderer/src/components/native-chat/` (69 files / 719 tests passed)
- [ ] `pnpm build` — not run; renderer-only pure TS with no main/preload/packaging surface
- [x] Added host-behind / host-ahead regressions for echo retirement and `/clear`

**SHA:** `5bc65d45e8b838bc7edec9735ab78c8defb9c549`

## AI Review Report

Self-reviewed for pure logic, React effects, tests, and repo fit:

- **Pure logic:** removed the only cross-domain comparisons; `/clear` is id-set membership (O(n) over page-sized lists). Occurrence inheritance no longer copies renderer `sentAt` into a field labeled host-domain.
- **React:** slash markers live in a small hook; deps are `commandMarkerScope` + `messages`. No new subscription or render loop.
- **Cross-platform:** renderer-only TypeScript — no paths, shell, shortcuts, or Electron main/IPC changes. Same on macOS/Linux/Windows; remote SSH/runtime is the motivating case.
- **Wire compatibility:** no RPC/stream frame changes (optional in-memory marker field only).
- **Residual:** send-into-empty while history is still loading with an identical completed prompt can still claim an unbound echo via occurrence matching — the old `sentAt` filter already failed the same way when the host clock was ahead.

## Security Audit

No new attack surface.

- **Input:** message ids and slash command strings already on the path; id hide-set is equality over internal transcript ids.
- **Command execution / paths / auth / secrets / IPC:** none added.
- **Dependencies:** none added.
- **Memory:** command-marker cache still LRU-bounded; id arrays capped with the existing 8-marker limit.

## Notes

- Merge-independent of #11509 / #13513 (those leave this as known limit 4 / known limits note).
- Folder workspaces and local panes keep host-domain bounds when a boundary message exists; empty-at-send no longer pretends renderer time is host time.