### PR TITLE
perf(renderer): unmount closed Quick Open content

### DIFF
--- a/src/renderer/src/components/QuickOpen.mount-gating.test.tsx
+++ b/src/renderer/src/components/QuickOpen.mount-gating.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import QuickOpen from './QuickOpen'
+
+const contentProbe = vi.hoisted(() => ({
+  enabled: vi.fn(),
+  renders: vi.fn(),
+  storeNotifications: vi.fn(),
+  subscriptions: vi.fn(),
+  unsubscriptions: vi.fn()
+}))
+
+vi.mock('@/components/quick-open-file-list', async () => {
+  const React = await import('react')
+  return {
+    useRuntimeFileListForWorktree: ({ enabled }: { enabled: boolean }) => {
+      contentProbe.enabled(enabled)
+      contentProbe.renders()
+      React.useEffect(() => {
+        contentProbe.subscriptions()
+        const unsubscribe = useAppStore.subscribe(() => contentProbe.storeNotifications())
+        return () => {
+          contentProbe.unsubscriptions()
+          unsubscribe()
+        }
+      }, [])
+      return { files: [], loading: false, loadError: null }
+    }
+  }
+})
+
+vi.mock('@/hooks/useModalReturnFocus', () => ({
+  useModalReturnFocus: () => ({ captureReturnFocus: vi.fn(), skipReturnFocus: vi.fn() })
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/ui/command', () => {
+  return {
+    CommandDialog: ({ children, open }: { children: ReactNode; open?: boolean }) =>
+      open ? <div data-command-dialog="true">{children}</div> : null,
+    CommandInput: () => <input data-command-input="true" />,
+    CommandList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    CommandEmpty: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    CommandItem: ({ children }: { children: ReactNode }) => <div>{children}</div>
+  }
+})
+
+const initialAppState = useAppStore.getInitialState()
+let testContainer: HTMLDivElement
+let testRoot: Root
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function activeContentSubscriptions(): number {
+  return (
+    contentProbe.subscriptions.mock.calls.length - contentProbe.unsubscriptions.mock.calls.length
+  )
+}
+
+async function churnClosedStore(count: number): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < count; index += 1) {
+      useAppStore.setState({ activeWorktreeId: `remote-background-${index}` })
+    }
+  })
+}
+
+describe('QuickOpen mount gating', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    contentProbe.enabled.mockClear()
+    contentProbe.renders.mockClear()
+    contentProbe.storeNotifications.mockClear()
+    contentProbe.subscriptions.mockClear()
+    contentProbe.unsubscriptions.mockClear()
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({ activeModal: 'quick-open', activeWorktreeId: null })
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => testRoot.unmount())
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('unmounts subscribed content after the close linger', async () => {
+    await act(async () => testRoot.render(<QuickOpen />))
+    await flushEffects()
+
+    expect(testContainer.querySelector('[data-command-dialog="true"]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+
+    await act(async () => useAppStore.setState({ activeModal: 'none' }))
+
+    expect(testContainer.querySelector('[data-command-dialog="true"]')).toBeNull()
+    expect(contentProbe.enabled).toHaveBeenLastCalledWith(false)
+    expect(activeContentSubscriptions()).toBe(1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    expect(activeContentSubscriptions()).toBe(1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(activeContentSubscriptions()).toBe(0)
+
+    const rendersAfterUnmount = contentProbe.renders.mock.calls.length
+    const notificationsAfterUnmount = contentProbe.storeNotifications.mock.calls.length
+    await churnClosedStore(1_000)
+
+    expect(contentProbe.renders).toHaveBeenCalledTimes(rendersAfterUnmount)
+    expect(contentProbe.storeNotifications).toHaveBeenCalledTimes(notificationsAfterUnmount)
+  })
+
+  it('cancels the pending unmount when reopened during the linger', async () => {
+    await act(async () => testRoot.render(<QuickOpen />))
+    await flushEffects()
+
+    await act(async () => useAppStore.setState({ activeModal: 'none' }))
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    await act(async () => useAppStore.setState({ activeModal: 'quick-open' }))
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+    expect(testContainer.querySelector('[data-command-dialog="true"]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+  })
+})

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useDeferredValue, useMemo, useState } from 'react'
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
 import { detectLanguage } from '@/lib/language-detect'
@@ -21,6 +21,8 @@ import {
   QuickOpenInstallRgGuidance
 } from '@/components/quick-open-install-rg-guidance'
 
+const QUICK_OPEN_CLOSE_LINGER_MS = 300
+
 function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <span className="rounded-full border border-border/60 bg-muted/35 px-2 py-0.5 text-[10px] font-medium text-foreground/85">
@@ -31,6 +33,24 @@ function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Eleme
 
 export default function QuickOpen(): React.JSX.Element | null {
   const visible = useAppStore((s) => s.activeModal === 'quick-open')
+  const [lingering, setLingering] = useState(visible)
+  useEffect(() => {
+    if (visible) {
+      setLingering(true)
+      return
+    }
+    // Why: keep scan cancellation and the dialog exit animation mounted before releasing remote file state.
+    const timer = window.setTimeout(() => setLingering(false), QUICK_OPEN_CLOSE_LINGER_MS)
+    return () => window.clearTimeout(timer)
+  }, [visible])
+
+  if (!visible && !lingering) {
+    return null
+  }
+  return <QuickOpenContent visible={visible} />
+}
+
+function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element {
   const closeModal = useAppStore((s) => s.closeModal)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const openFile = useAppStore((s) => s.openFile)

--- a/src/renderer/src/components/quick-open-file-list.react.test.tsx
+++ b/src/renderer/src/components/quick-open-file-list.react.test.tsx
@@ -192,6 +192,43 @@ describe('useRuntimeFileListForWorktree', () => {
     expect(cancelRuntimeFileListMock).toHaveBeenCalledWith(listContext, listRequest.requestToken)
   })
 
+  it('cancels the in-flight scan as soon as listing is disabled', async () => {
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+    listRuntimeFilesMock.mockReturnValue(new Promise<string[]>(() => {}))
+
+    useAppStore.setState({
+      folderWorkspaces: [makeFolderWorkspace({ connectionId: 'ssh-1' })],
+      projectGroups: [makeProjectGroup({ connectionId: 'ssh-1' })],
+      repos: [],
+      worktreesByRepo: {}
+    } as Partial<AppState>)
+
+    const root = await renderProbe({
+      enabled: true,
+      onState: () => {},
+      worktreeId: workspaceKey
+    })
+    await waitForListRuntimeFilesCall()
+
+    const [listContext, listRequest] = listRuntimeFilesMock.mock.calls[0]
+    expect(listContext.connectionId).toBe('ssh-1')
+    expect(cancelRuntimeFileListMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      root.render(
+        createElement(HookProbe, {
+          enabled: false,
+          onState: () => {},
+          worktreeId: workspaceKey
+        })
+      )
+    })
+    await flushEffects()
+
+    expect(cancelRuntimeFileListMock).toHaveBeenCalledTimes(1)
+    expect(cancelRuntimeFileListMock).toHaveBeenCalledWith(listContext, listRequest.requestToken)
+  })
+
   it('does not restart the scan when unrelated ownership metadata changes', async () => {
     const workspaceKey = folderWorkspaceKey('folder-workspace-1')
     useAppStore.setState({


### PR DESCRIPTION
## Summary

- Keep only a one-selector visibility shell mounted after Quick Open has been used.
- Keep the full palette content alive for its 300 ms close animation, then unmount it and release its remote file state and subscriptions.
- Disable file listing immediately on close so an in-flight local or direct-SSH scan is canceled before the linger ends.

This is a focused follow-up to #13525 for the Quick Open surface.

## ELI5

Quick Open is like a big filing cabinet that Orca builds when you press the shortcut. Previously, closing the cabinet hid it but left all of its drawers and index cards spread out behind the wall. Remote-host updates could still ring all of its listeners.

Now closing it immediately stops supported local/direct-SSH scans, leaves the cabinet around just long enough for the closing animation, and then packs everything away. One tiny doorbell remains so Orca knows when to open it again.

```mermaid
sequenceDiagram
  actor User
  participant Shell as Quick Open shell (1 selector)
  participant Content as Search content (9 selectors)
  participant Scan as Local / direct-SSH scan

  User->>Shell: Close Quick Open
  Shell->>Content: visible = false
  Content->>Scan: Cancel exact request token immediately
  Note over Shell,Content: Keep mounted through 300 ms exit animation
  Shell-xContent: Unmount and release file/index state
  Note over Shell: Closed store updates reach only the visibility selector

  User->>Shell: Reopen before 300 ms
  Shell->>Shell: Cancel pending unmount
  Shell->>Content: Reuse the mounted content
```

## Improvement proof

- **Closed Zustand subscriptions: 10 → 1.** Before this change, the hidden component retained one visibility selector plus nine content selectors: three direct Quick Open selectors, two from `useActiveWorktree`, and four from the runtime file-list hook. After the linger, only the visibility shell remains.
- **Closed store churn:** the regression test publishes 1,000 representative store writes after unmount and observes zero additional content renders or content notifications.
- **Memory release:** Quick Open can retain the full `QUICK_OPEN_LISTING_MAX_RESULTS` response (20,001 paths) plus a 20,001-record normalized search index. Both become collectible when the content unmounts.
- **Bounded claim:** visible result rendering was already capped at 50 rows and ranking was already memoized. The measured win here is closed-state memory/subscription cleanup, not a claimed ranking-speed improvement.

## Behavior and regression checks

- Closing hides the dialog immediately and keeps content mounted through 299 ms; content unmounts at 300 ms.
- Reopening during the linger cancels the pending unmount and keeps exactly one content subscription.
- The close render supplies `enabled=false` before unmount.
- A genuinely pending SSH file-list request is canceled exactly once with its original context and request token when `enabled` changes from true to false.
- Query reset, focus restoration, and the existing exit animation remain on the mounted close path.
- No visual change.

## Testing

- [x] Focused Quick Open suite: 6 files / 28 tests passed.
- [x] Immediate-cancellation and mount-gating tests: 2 files / 6 tests passed.
- [x] Full `pnpm typecheck` passed.
- [x] Full `pnpm lint` passed; only nine pre-existing `WorktreeJumpPalette.tsx` exhaustive-deps warnings were reported.
- [x] Changed-code quality: 0 findings across 3 files.
- [x] Max-lines ratchet and 73-gate reliability manifest checks passed.
- [x] Full desktop build passed, including relay outputs for Linux x64/arm64, Windows x64/arm64, macOS x64/arm64, WSL, CLI, Electron renderer, and projected web client.
- [x] `git diff --check` passed.

## Compatibility and residual risk

- Renderer-only lifecycle change: no RPC/IPC shape, stream opcode, persistence schema, dependency, or mobile-facing surface changed.
- Local, folder-workspace, SSH, and paired-runtime routing remains in the existing file-list hook; the new test specifically pins immediate direct-SSH cancellation.
- Paired-runtime `files.listAll` has no cancellation token today, so a scan already in flight can continue until its existing 15-second RPC timeout. The content still unmounts and ignores the result. This gap predates this PR.
- The lightweight shell stays mounted, so opening remains responsive and does not depend on local-only worktree behavior.

No user-facing regressions are known.

## AI review report

An independent exact-tip review found no code P0/P1/P2 issues. It traced the 300 ms close/reopen race, immediate SSH cancellation, query/focus behavior, subscription and memory claims, platform/remoting assumptions, and wire compatibility. The review identified the paired-runtime documentation overclaim above; this description now records that residual gap precisely.
