### PR TITLE
perf(renderer): unmount closed Workspace Board content

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.mount-gating.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.mount-gating.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { readStoreListenerCount } from '@/store/store-listener-census'
+import type * as ContextualTour from '@/components/contextual-tours/use-contextual-tour'
+import type * as VisibleWorkspaceKanban from './use-visible-workspace-kanban-worktree-ids'
+import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
+
+const { contentProbe, contextualTourMock } = vi.hoisted(() => ({
+  contentProbe: {
+    mounts: vi.fn(),
+    projections: vi.fn(),
+    renders: vi.fn(),
+    storeNotifications: vi.fn(),
+    unmounts: vi.fn()
+  },
+  contextualTourMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), warning: vi.fn() } }))
+
+vi.mock('@/components/ui/sheet', () => ({
+  // Why: keep children mounted while closed so this measures Orca's gate, not Radix's portal.
+  Sheet: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-sheet-open={open ? 'true' : 'false'}>{children}</div>
+  ),
+  SheetContent: ({
+    children,
+    'data-workspace-board-drag-preview': dragPreview
+  }: {
+    children: React.ReactNode
+    'data-workspace-board-drag-preview'?: string
+  }) => (
+    <div data-workspace-board-drag-preview={dragPreview} data-slot="sheet-content">
+      {children}
+    </div>
+  )
+}))
+
+vi.mock('./WorkspaceKanbanDrawerHeader', () => ({
+  default: () => <div data-workspace-board-heavy-content="true" />
+}))
+vi.mock('./WorkspaceKanbanLaneGrid', () => ({ default: () => <div /> }))
+vi.mock('./WorkspaceKanbanPinDropTarget', () => ({ default: () => <div /> }))
+vi.mock('./WorkspaceKanbanAreaSelectionOverlay', () => ({
+  default: React.forwardRef<HTMLDivElement>((_, ref) => <div ref={ref} />)
+}))
+
+vi.mock('./use-visible-workspace-kanban-worktree-ids', async (importOriginal) => {
+  const actual = await importOriginal<typeof VisibleWorkspaceKanban>()
+  return {
+    ...actual,
+    useVisibleWorkspaceKanbanWorktreeIds: (
+      params: Parameters<typeof actual.useVisibleWorkspaceKanbanWorktreeIds>[0]
+    ) => {
+      const visibleIds = actual.useVisibleWorkspaceKanbanWorktreeIds(params)
+      contentProbe.renders()
+      contentProbe.projections()
+      React.useEffect(() => {
+        contentProbe.mounts()
+        const unsubscribe = useAppStore.subscribe(() => contentProbe.storeNotifications())
+        return () => {
+          contentProbe.unmounts()
+          unsubscribe()
+        }
+      }, [])
+      return visibleIds
+    }
+  }
+})
+
+vi.mock('./use-workspace-kanban-selection', () => ({
+  useWorkspaceKanbanSelection: () => ({
+    selectedWorktreeIds: new Set<string>(),
+    selectedWorktrees: [],
+    selectionAnchorId: null,
+    updateSelectionForGesture: vi.fn(),
+    updateSelectionForArea: vi.fn(),
+    clearSelection: vi.fn(),
+    selectForContextMenu: vi.fn(() => [])
+  })
+}))
+vi.mock('./use-workspace-kanban-area-selection', () => ({
+  useWorkspaceKanbanAreaSelection: () => ({ handleAreaSelectionPointerDown: vi.fn() })
+}))
+vi.mock('./use-workspace-kanban-column-resize', () => ({
+  useWorkspaceKanbanColumnResize: () => ({
+    columnWidth: 308,
+    isResizingColumn: false,
+    onColumnResizeStart: vi.fn(),
+    onColumnResizeKeyDown: vi.fn()
+  })
+}))
+vi.mock('./use-workspace-kanban-card-pointer-drag', () => ({
+  useWorkspaceKanbanCardPointerDrag: () => ({
+    isPointerDragActiveRef: { current: false },
+    onCardPointerDownCapture: vi.fn()
+  })
+}))
+vi.mock('./use-workspace-kanban-shift-wheel-scroll', () => ({
+  useWorkspaceKanbanShiftWheelScroll: vi.fn()
+}))
+vi.mock('./use-workspace-kanban-outside-dismiss', () => ({
+  isWorkspaceBoardKeepOpenTarget: () => false,
+  useWorkspaceKanbanOutsideDismiss: vi.fn()
+}))
+vi.mock('./use-workspace-status-drop', () => ({ useWorkspaceStatusDocumentDrop: vi.fn() }))
+vi.mock('@/components/contextual-tours/use-contextual-tour', async (importOriginal) => {
+  const actual = await importOriginal<typeof ContextualTour>()
+  return {
+    ...actual,
+    useContextualTour: (...args: Parameters<typeof actual.useContextualTour>) => {
+      contextualTourMock(...args)
+      actual.useContextualTour(...args)
+    }
+  }
+})
+
+const initialAppState = useAppStore.getInitialState()
+const onOpenChange = vi.fn()
+const onMenuOpenChange = vi.fn()
+let testContainer: HTMLDivElement
+let testRoot: Root
+
+function activeContentSubscriptions(): number {
+  return contentProbe.mounts.mock.calls.length - contentProbe.unmounts.mock.calls.length
+}
+
+function requireStoreListenerCount(): number {
+  const count = readStoreListenerCount()
+  expect(count).not.toBeNull()
+  return count ?? 0
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderDrawer(open: boolean, dragPreview = false): Promise<void> {
+  await act(async () => {
+    testRoot.render(
+      <WorkspaceKanbanDrawer
+        open={open}
+        statusBarVisible={true}
+        dragPreview={dragPreview}
+        preserveOpenForMenu={false}
+        onOpenChange={onOpenChange}
+        onMenuOpenChange={onMenuOpenChange}
+      />
+    )
+  })
+  await flushEffects()
+}
+
+async function churnRemoteWorkspaceState(count: number): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < count; index += 1) {
+      useAppStore.setState({
+        worktreesByRepo: {},
+        tabsByWorktree: {},
+        ptyIdsByTabId: {},
+        browserTabsByWorktree: {},
+        agentStatusEpoch: index
+      })
+    }
+  })
+}
+
+describe('WorkspaceKanbanDrawer mount gating', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    Object.values(contentProbe).forEach((probe) => probe.mockClear())
+    contextualTourMock.mockClear()
+    onOpenChange.mockClear()
+    onMenuOpenChange.mockClear()
+    useAppStore.setState(initialAppState, true)
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => testRoot.unmount())
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('unmounts heavy content after the close animation and isolates closed churn', async () => {
+    const listenerBaseline = requireStoreListenerCount()
+    await renderDrawer(false)
+    const closedListenerCount = requireStoreListenerCount()
+
+    expect(closedListenerCount).toBe(listenerBaseline)
+    expect(testContainer.querySelector('[data-workspace-board-heavy-content]')).toBeNull()
+    expect(activeContentSubscriptions()).toBe(0)
+
+    await renderDrawer(true)
+    const openListenerCount = requireStoreListenerCount()
+    expect(openListenerCount).toBeGreaterThan(closedListenerCount + 15)
+    expect(activeContentSubscriptions()).toBe(1)
+
+    await renderDrawer(false)
+    expect(testContainer.querySelector('[data-sheet-open="false"]')).not.toBeNull()
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    expect(testContainer.querySelector('[data-workspace-board-heavy-content]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+
+    const lingeringNotifications = contentProbe.storeNotifications.mock.calls.length
+    await churnRemoteWorkspaceState(1)
+    expect(contentProbe.storeNotifications).toHaveBeenCalledTimes(lingeringNotifications + 1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(testContainer.querySelector('[data-workspace-board-heavy-content]')).toBeNull()
+    expect(activeContentSubscriptions()).toBe(0)
+    expect(requireStoreListenerCount()).toBe(closedListenerCount)
+
+    const hiddenProjectionCount = contentProbe.projections.mock.calls.length
+    const hiddenRenderCount = contentProbe.renders.mock.calls.length
+    const hiddenNotificationCount = contentProbe.storeNotifications.mock.calls.length
+    await churnRemoteWorkspaceState(1_000)
+
+    expect(contentProbe.projections).toHaveBeenCalledTimes(hiddenProjectionCount)
+    expect(contentProbe.renders).toHaveBeenCalledTimes(hiddenRenderCount)
+    expect(contentProbe.storeNotifications).toHaveBeenCalledTimes(hiddenNotificationCount)
+  })
+
+  it('cancels the pending unmount when reopened at 299 ms', async () => {
+    await renderDrawer(true)
+    await renderDrawer(false)
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    await renderDrawer(true)
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+    expect(testContainer.querySelector('[data-sheet-open="true"]')).not.toBeNull()
+    expect(testContainer.querySelector('[data-workspace-board-heavy-content]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+  })
+
+  it('preserves drag preview presentation when the preview becomes a full board', async () => {
+    await renderDrawer(true, true)
+
+    expect(testContainer.querySelector('[data-workspace-board-drag-preview="true"]')).not.toBeNull()
+    expect(contextualTourMock).toHaveBeenLastCalledWith(
+      'workspace-board',
+      false,
+      'workspace_board_visible'
+    )
+
+    await renderDrawer(true, false)
+
+    expect(testContainer.querySelector('[data-workspace-board-drag-preview]')).toBeNull()
+    expect(contextualTourMock).toHaveBeenLastCalledWith(
+      'workspace-board',
+      true,
+      'workspace_board_visible'
+    )
+    expect(contentProbe.mounts).toHaveBeenCalledTimes(1)
+    expect(activeContentSubscriptions()).toBe(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -66,6 +66,9 @@ type WorkspaceKanbanDrawerProps = {
   onMenuOpenChange: (open: boolean) => void
 }
 
+// Why: outlast the Sheet close animation so the board does not disappear mid-slide.
+const WORKSPACE_BOARD_CLOSE_LINGER_MS = 300
+
 function formatTaskStatusSyncMessage(message: WorkspaceBoardTaskStatusSyncMessage): string {
   switch (message.kind) {
     case 'issue-read-failed':
@@ -140,7 +143,26 @@ function formatTaskStatusSyncDescription(result: WorkspaceBoardTaskStatusSyncRes
     .join('. ')
 }
 
-export default function WorkspaceKanbanDrawer({
+export default function WorkspaceKanbanDrawer(
+  props: WorkspaceKanbanDrawerProps
+): React.JSX.Element | null {
+  const [lingering, setLingering] = useState(props.open)
+  useEffect(() => {
+    if (props.open) {
+      setLingering(true)
+      return
+    }
+    const timer = window.setTimeout(() => setLingering(false), WORKSPACE_BOARD_CLOSE_LINGER_MS)
+    return () => window.clearTimeout(timer)
+  }, [props.open])
+
+  if (!props.open && !lingering) {
+    return null
+  }
+  return <WorkspaceKanbanDrawerContent {...props} />
+}
+
+function WorkspaceKanbanDrawerContent({
   leftSidebarStyle,
   open,
   statusBarVisible,


### PR DESCRIPTION
## Summary

- Keep the heavyweight Workspace Board mounted only while it is open or completing its close animation.
- Retain the board for 300 ms after close so Radix's 200 ms Sheet exit remains intact, then release its subscriptions and derived workspace state.
- Cancel the pending unmount when the board reopens, including the drag-preview-to-full-board transition.

This is a focused follow-up to #13525 for another hidden renderer surface that stays active under remote-host churn.

## ELI5

The Workspace Board is like a wall covered with cards. Orca used to pull a curtain over that wall when you closed it, but 45 listeners behind the curtain kept sorting and regrouping the hidden cards whenever work changed on a remote machine.

Now Orca lets the curtain finish sliding for a fraction of a second, then takes the hidden wall down. When you reopen it, the board is rebuilt from current store state.

```mermaid
flowchart LR
  U[Remote worktree, tab, PTY, browser, or agent update] --> S{Board state}
  S -->|Open| B[Board content mounted<br/>45 production listeners]
  S -->|Closing, first 300 ms| A[Exit animation<br/>hooks receive open = false]
  S -->|Closed after 300 ms| N[Content unmounted<br/>0 board listeners]
  B --> P[Rebuild visible IDs, groups, lanes, search, and drag projections]
  A --> X[Finish Sheet slide-out]
  N --> Z[No board render or projection work]
```

## Improvement proof

- **Closed board listeners: 45 → 0.** The real Zustand listener census rises by 46 while the test board is mounted: 45 production subscriptions plus one explicit test probe. At the 300 ms boundary it returns exactly to the pre-mount baseline.
- **Closed store churn:** after unmount, the regression publishes 1,000 representative worktree, terminal, browser, and agent updates. It observes zero additional heavy-content renders, visibility projections, or content notifications.
- **Derived-state release:** closing now releases the all-worktree visibility set, status grouping, worktree map, board/lane arrays, search projection, selection state, and drag projections instead of retaining them for every sidebar-open session.
- **No hidden DOM-listener work:** the lingering content receives `open=false` immediately, disabling open-only drag/drop, selection, outside-dismiss, wheel, and tour behavior before unmount.

## Behavior and regression checks

- Heavy content remains present through 299 ms and unmounts at 300 ms, safely beyond the Sheet's 200 ms close animation.
- Reopening at 299 ms cancels the pending unmount and retains one content instance with no duplicate subscriptions.
- Drag preview can become the full board without remounting or enabling the contextual tour prematurely.
- The initially closed board does not mount heavyweight content.
- No visual change.

## Testing

- [x] Broader Workspace Board matrix: 14 files / 113 tests passed.
- [x] Focused drawer matrix: 6 files / 48 tests passed.
- [x] Full `pnpm typecheck` passed.
- [x] Full `pnpm lint` passed; only pre-existing `WorktreeJumpPalette.tsx` exhaustive-deps warnings were reported.
- [x] Changed-code quality: 0 findings across 2 files.
- [x] Max-lines ratchet and 73-gate reliability manifest checks passed.
- [x] Electron/Vite production build passed.
- [x] Formatting and `git diff --check` passed.

## Compatibility and residual risk

- Renderer-only lifecycle change: no RPC/IPC payload, stream opcode, persistence schema, dependency, or mobile-facing surface changed.
- Remote, SSH, local, folder-workspace, and git-worktree data still enters through the same store selectors; only the closed consumer lifetime changes.
- Board-local query and selection state now resets once the close animation completes. Those states were already cleared/disabled by the closed-board hooks and are not persisted user data.

No user-facing regressions are known.

## AI review report

An independent review found no P0/P1/P2 issues. It traced the Sheet animation boundary, close/reopen races, drag preview, contextual-tour cleanup, open-only DOM listeners, listener/projection claims, and macOS/Linux/Windows/SSH/folder-workspace assumptions.
