### PR TITLE
perf(renderer): skip remote event key rebuilds on unrelated state

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -58,6 +58,45 @@ describe('buildRuntimeClientEventEnvironmentKey', () => {
   })
 })
 
+describe('runtime client-event subscription gate', () => {
+  it('re-arms after a failed reconcile so the next publication retries', async () => {
+    let failNextStatusRead = false
+    const statusReads: string[] = []
+    const runtimeStatusByEnvironmentId = new Map<string, { status: string } | null>()
+    runtimeStatusByEnvironmentId.get = (environmentId: string) => {
+      statusReads.push(environmentId)
+      if (failNextStatusRead) {
+        failNextStatusRead = false
+        throw new Error('reconcile failed')
+      }
+      return undefined
+    }
+    const storeState = createHarnessStoreState({
+      tabsByWorktree: {},
+      runtimeEnvironments: [{ id: 'env-1' }],
+      runtimeStatusByEnvironmentId
+    })
+    const harness = await loadIpcEventsHarness(storeState)
+    const { useAppStore } = await import('../store')
+    const { bumpRuntimeClientEventSubscriptionGeneration } =
+      await import('@/runtime/runtime-client-event-subscription-invalidation')
+    harness.useIpcEvents()
+    const reconcile = vi.mocked(useAppStore.subscribe).mock.calls[0]?.[0] as (
+      state: unknown
+    ) => void
+
+    bumpRuntimeClientEventSubscriptionGeneration()
+    failNextStatusRead = true
+    expect(() => reconcile(storeState)).toThrow('reconcile failed')
+    const readsAfterFailure = statusReads.length
+
+    // Same store references as the failed publication: only the failure re-arm can drive this.
+    reconcile(storeState)
+
+    expect(statusReads.length).toBeGreaterThan(readsAfterFailure)
+  })
+})
+
 describe('getNewlyConnectedRuntimeEnvironmentIds', () => {
   it('returns only environments that became connected', () => {
     expect(getNewlyConnectedRuntimeEnvironmentIds(['env-a'], ['env-a', 'env-b'])).toEqual(['env-b'])

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -183,7 +183,10 @@ import {
   type DirectSshConnectedStateOrigin
 } from './direct-ssh-state-routing'
 import { isDirectSshReconnectCoordinatorRoutingEnabled } from './direct-ssh-reconnect-rollout'
-import { createRuntimeClientEventSubscriptionInvalidationGate } from '@/runtime/runtime-client-event-subscription-invalidation'
+import {
+  bumpRuntimeClientEventSubscriptionGeneration,
+  createRuntimeClientEventSubscriptionInvalidationGate
+} from '@/runtime/runtime-client-event-subscription-invalidation'
 
 function getShortcutPlatform(): NodeJS.Platform {
   if (navigator.userAgent.includes('Mac')) {
@@ -1037,41 +1040,47 @@ export function useIpcEvents(): void {
       if (!runtimeClientEventSubscriptionInvalidation.changed(state)) {
         return
       }
-      const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
-      const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
-      const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()
-      const nextReachableKey = buildRuntimeClientEventEnvironmentKey(nextReachableEnvironmentIds)
-      if (
-        nextKey === runtimeClientEventEnvironmentKey &&
-        nextReachableKey === reachableRuntimeEnvironmentKey
-      ) {
-        return
+      try {
+        const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
+        const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
+        const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()
+        const nextReachableKey = buildRuntimeClientEventEnvironmentKey(nextReachableEnvironmentIds)
+        if (
+          nextKey === runtimeClientEventEnvironmentKey &&
+          nextReachableKey === reachableRuntimeEnvironmentKey
+        ) {
+          return
+        }
+        for (const environmentId of getRuntimeProjectRefreshEnvironmentIds({
+          previousDesired: runtimeClientEventEnvironmentIds,
+          nextDesired: nextEnvironmentIds,
+          previousReachable: reachableRuntimeEnvironmentIds,
+          nextReachable: nextReachableEnvironmentIds
+        })) {
+          runtimeProjectRefreshScheduler.request(environmentId)
+        }
+        for (const environmentId of getNewlyDisconnectedRuntimeEnvironmentIds(
+          reachableRuntimeEnvironmentIds,
+          nextReachableEnvironmentIds
+        )) {
+          // No-op when the environment has no SSH bucket (e.g. web client).
+          useAppStore.getState().markEnvironmentSshStateStale(environmentId)
+        }
+        runtimeClientEventEnvironmentIds = nextEnvironmentIds
+        reachableRuntimeEnvironmentIds = nextReachableEnvironmentIds
+        // Nested stale-state writes can advance the out-of-store SSH generation.
+        runtimeClientEventEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
+          runtimeClientEventEnvironmentIds
+        )
+        reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
+          reachableRuntimeEnvironmentIds
+        )
+        runtimeClientEventsSync.sync()
+      } catch (error) {
+        // Why: the gate already consumed this publication, so re-arm it or the subscription stays stale forever.
+        bumpRuntimeClientEventSubscriptionGeneration()
+        throw error
       }
-      for (const environmentId of getRuntimeProjectRefreshEnvironmentIds({
-        previousDesired: runtimeClientEventEnvironmentIds,
-        nextDesired: nextEnvironmentIds,
-        previousReachable: reachableRuntimeEnvironmentIds,
-        nextReachable: nextReachableEnvironmentIds
-      })) {
-        runtimeProjectRefreshScheduler.request(environmentId)
-      }
-      for (const environmentId of getNewlyDisconnectedRuntimeEnvironmentIds(
-        reachableRuntimeEnvironmentIds,
-        nextReachableEnvironmentIds
-      )) {
-        // No-op when the environment has no SSH bucket (e.g. web client).
-        useAppStore.getState().markEnvironmentSshStateStale(environmentId)
-      }
-      runtimeClientEventEnvironmentIds = nextEnvironmentIds
-      reachableRuntimeEnvironmentIds = nextReachableEnvironmentIds
-      // Nested stale-state writes can advance the out-of-store SSH generation.
-      runtimeClientEventEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
-        runtimeClientEventEnvironmentIds
-      )
-      reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
-        reachableRuntimeEnvironmentIds
-      )
-      runtimeClientEventsSync.sync()
     })
     unsubs.push(runtimeClientEventsSync.stop)
     unsubs.push(runtimeProjectRefreshScheduler.stop)

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -183,6 +183,7 @@ import {
   type DirectSshConnectedStateOrigin
 } from './direct-ssh-state-routing'
 import { isDirectSshReconnectCoordinatorRoutingEnabled } from './direct-ssh-reconnect-rollout'
+import { createRuntimeClientEventSubscriptionInvalidationGate } from '@/runtime/runtime-client-event-subscription-invalidation'
 
 function getShortcutPlatform(): NodeJS.Platform {
   if (navigator.userAgent.includes('Mac')) {
@@ -563,6 +564,7 @@ function getReachableRuntimeEnvironmentIds(): string[] {
 }
 
 export function buildRuntimeClientEventEnvironmentKey(environmentIds: string[]): string {
+  // Why: out-of-Zustand generations require matching store-gate invalidation producers.
   return [...new Set(environmentIds)]
     .sort()
     .map(
@@ -1028,7 +1030,13 @@ export function useIpcEvents(): void {
     let reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
       reachableRuntimeEnvironmentIds
     )
-    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe(() => {
+    const runtimeClientEventSubscriptionInvalidation =
+      createRuntimeClientEventSubscriptionInvalidationGate(useAppStore.getState())
+    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe((state) => {
+      // Why: agent and terminal ticks otherwise rebuild and sort every remote-host key.
+      if (!runtimeClientEventSubscriptionInvalidation.changed(state)) {
+        return
+      }
       const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
       const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
       const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()
@@ -1055,9 +1063,14 @@ export function useIpcEvents(): void {
         useAppStore.getState().markEnvironmentSshStateStale(environmentId)
       }
       runtimeClientEventEnvironmentIds = nextEnvironmentIds
-      runtimeClientEventEnvironmentKey = nextKey
       reachableRuntimeEnvironmentIds = nextReachableEnvironmentIds
-      reachableRuntimeEnvironmentKey = nextReachableKey
+      // Nested stale-state writes can advance the out-of-store SSH generation.
+      runtimeClientEventEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
+        runtimeClientEventEnvironmentIds
+      )
+      reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
+        reachableRuntimeEnvironmentIds
+      )
       runtimeClientEventsSync.sync()
     })
     unsubs.push(runtimeClientEventsSync.stop)

--- a/src/renderer/src/runtime/runtime-client-event-subscription-invalidation.test.ts
+++ b/src/renderer/src/runtime/runtime-client-event-subscription-invalidation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  bumpRuntimeClientEventSubscriptionGeneration,
+  createRuntimeClientEventSubscriptionInvalidationGate
+} from './runtime-client-event-subscription-invalidation'
+import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
+import { createTestStore } from '@/store/slices/store-test-helpers'
+
+type InputState = Pick<
+  AppState,
+  'runtimeEnvironments' | 'runtimeStatusByEnvironmentId' | 'settings'
+>
+
+function createState(): InputState {
+  return {
+    runtimeEnvironments: [],
+    runtimeStatusByEnvironmentId: new Map(),
+    settings: null
+  }
+}
+
+describe('runtime client-event subscription invalidation', () => {
+  it('ignores publications that preserve every subscription input', () => {
+    const state = createState()
+    const gate = createRuntimeClientEventSubscriptionInvalidationGate(state)
+
+    expect(gate.changed(state)).toBe(false)
+    expect(gate.changed({ ...state })).toBe(false)
+  })
+
+  it('detects catalog, status, and normalized active-environment changes', () => {
+    const initial = createState()
+    const gate = createRuntimeClientEventSubscriptionInvalidationGate(initial)
+    const catalogChanged = { ...initial, runtimeEnvironments: [...initial.runtimeEnvironments] }
+    expect(gate.changed(catalogChanged)).toBe(true)
+
+    const statusChanged = {
+      ...catalogChanged,
+      runtimeStatusByEnvironmentId: new Map(catalogChanged.runtimeStatusByEnvironmentId)
+    }
+    expect(gate.changed(statusChanged)).toBe(true)
+
+    const activeChanged = {
+      ...statusChanged,
+      settings: { activeRuntimeEnvironmentId: ' env-1 ' } as AppState['settings']
+    }
+    expect(gate.changed(activeChanged)).toBe(true)
+    expect(
+      gate.changed({
+        ...activeChanged,
+        settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings']
+      })
+    ).toBe(false)
+  })
+
+  it('detects out-of-store generation changes with identical Zustand references', () => {
+    const state = createState()
+    const gate = createRuntimeClientEventSubscriptionInvalidationGate(state)
+
+    bumpRuntimeClientEventSubscriptionGeneration()
+
+    expect(gate.changed(state)).toBe(true)
+    expect(gate.changed(state)).toBe(false)
+  })
+
+  it('tracks silent runtime and nested SSH generation advances', () => {
+    const store = createTestStore()
+    const initial = store.getState()
+    const gate = createRuntimeClientEventSubscriptionInvalidationGate(initial)
+
+    initial.clearRuntimeEnvironmentStatus('missing')
+    expect(store.getState()).toBe(initial)
+    expect(gate.changed(store.getState())).toBe(true)
+
+    initial.markEnvironmentSshStateStale('missing')
+    expect(store.getState()).toBe(initial)
+    expect(gate.changed(store.getState())).toBe(true)
+  })
+
+  it('tracks pairing revision replacement without relying on Zustand identity', () => {
+    const state = createState()
+    const gate = createRuntimeClientEventSubscriptionInvalidationGate(state)
+
+    replaceRuntimeEnvironmentRevisions([])
+
+    expect(gate.changed(state)).toBe(true)
+  })
+})

--- a/src/renderer/src/runtime/runtime-client-event-subscription-invalidation.ts
+++ b/src/renderer/src/runtime/runtime-client-event-subscription-invalidation.ts
@@ -1,0 +1,40 @@
+import type { AppState } from '@/store/types'
+
+type RuntimeClientEventSubscriptionState = Pick<
+  AppState,
+  'runtimeEnvironments' | 'runtimeStatusByEnvironmentId' | 'settings'
+>
+
+let subscriptionGeneration = 0
+
+/** Invalidates the store gate when an out-of-Zustand key component changes. */
+export function bumpRuntimeClientEventSubscriptionGeneration(): void {
+  subscriptionGeneration += 1
+}
+
+export function createRuntimeClientEventSubscriptionInvalidationGate(
+  initialState: RuntimeClientEventSubscriptionState
+): { changed: (state: RuntimeClientEventSubscriptionState) => boolean } {
+  let activeEnvironmentId = initialState.settings?.activeRuntimeEnvironmentId?.trim() || null
+  let environments = initialState.runtimeEnvironments
+  let generation = subscriptionGeneration
+  let statuses = initialState.runtimeStatusByEnvironmentId
+  return {
+    changed: (state) => {
+      const nextActiveEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim() || null
+      if (
+        activeEnvironmentId === nextActiveEnvironmentId &&
+        environments === state.runtimeEnvironments &&
+        generation === subscriptionGeneration &&
+        statuses === state.runtimeStatusByEnvironmentId
+      ) {
+        return false
+      }
+      activeEnvironmentId = nextActiveEnvironmentId
+      environments = state.runtimeEnvironments
+      generation = subscriptionGeneration
+      statuses = state.runtimeStatusByEnvironmentId
+      return true
+    }
+  }
+}

--- a/src/renderer/src/runtime/runtime-environment-revision.ts
+++ b/src/renderer/src/runtime/runtime-environment-revision.ts
@@ -1,8 +1,11 @@
+import { bumpRuntimeClientEventSubscriptionGeneration } from './runtime-client-event-subscription-invalidation'
+
 const revisionByEnvironmentId = new Map<string, number>()
 
 export function replaceRuntimeEnvironmentRevisions(
   environments: readonly { id: string; createdAt: number; pairingRevision?: number }[]
 ): void {
+  bumpRuntimeClientEventSubscriptionGeneration()
   revisionByEnvironmentId.clear()
   for (const environment of environments) {
     revisionByEnvironmentId.set(

--- a/src/renderer/src/store/slices/runtime-environment-ssh.ts
+++ b/src/renderer/src/store/slices/runtime-environment-ssh.ts
@@ -6,6 +6,7 @@ import type {
   SshTargetSummary
 } from '../../../../shared/ssh-types'
 import { sshConnectionStatesEqual, sshTargetLabelsEqual } from './ssh-target-cleanup'
+import { bumpRuntimeClientEventSubscriptionGeneration } from '@/runtime/runtime-client-event-subscription-invalidation'
 
 /**
  * SSH state of one remote Orca server's own SSH targets, mirrored on this
@@ -100,6 +101,7 @@ function advanceEnvironmentSshStateGeneration(environmentId: string): void {
     environmentId,
     getEnvironmentSshStateGeneration(environmentId) + 1
   )
+  bumpRuntimeClientEventSubscriptionGeneration()
 }
 
 function generationIsCurrent(environmentId: string, generation: number | undefined): boolean {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -11,6 +11,7 @@ import {
 import { replaceRuntimeEnvironmentRevisions } from '@/runtime/runtime-environment-revision'
 import { translate } from '@/i18n/i18n'
 import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-context'
+import { bumpRuntimeClientEventSubscriptionGeneration } from '@/runtime/runtime-client-event-subscription-invalidation'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -67,9 +68,8 @@ const connectionGenerationByEnvironment = new Map<string, number>()
 const activeRuntimeDisconnectedToasts = new Map<string, symbol>()
 const RUNTIME_DISCONNECTED_TOAST_DURATION_MS = 4_000
 
-function getRuntimeDisconnectedToastId(environmentId: string): string {
-  return `runtime-environment-disconnected:${environmentId}`
-}
+const getRuntimeDisconnectedToastId = (environmentId: string): string =>
+  `runtime-environment-disconnected:${environmentId}`
 
 function showRuntimeDisconnectedToast(environmentId: string, getState: () => AppState): void {
   const environment = getState().runtimeEnvironments.find((entry) => entry.id === environmentId)
@@ -138,10 +138,9 @@ function showRuntimeDisconnectedToast(environmentId: string, getState: () => App
 
 function dismissRuntimeDisconnectedToast(environmentId: string): void {
   const toastId = getRuntimeDisconnectedToastId(environmentId)
-  if (!activeRuntimeDisconnectedToasts.delete(toastId)) {
-    return
+  if (activeRuntimeDisconnectedToasts.delete(toastId)) {
+    toast.dismiss?.(toastId)
   }
-  toast.dismiss?.(toastId)
 }
 
 export function getRuntimeEnvironmentConnectionGeneration(environmentId: string): number {
@@ -154,6 +153,7 @@ export const clearRuntimeEnvironmentConnectionGenerationsForTests = (): void =>
 function advanceRuntimeEnvironmentConnectionGeneration(environmentId: string): number {
   const next = getRuntimeEnvironmentConnectionGeneration(environmentId) + 1
   connectionGenerationByEnvironment.set(environmentId, next)
+  bumpRuntimeClientEventSubscriptionGeneration()
   return next
 }
 


### PR DESCRIPTION
## Summary

- gate runtime client-event subscription reconciliation on the state that can actually change host membership or subscription generations
- aggregate out-of-Zustand connection, nested-SSH, and pairing generations so silent generation advances still invalidate safely
- preserve fresh keys across nested SSH stale-state publications

## ELI5

Before this change, every little renderer state update walked and sorted the full list of remote Orca servers just to confirm that event subscriptions had not changed. Busy agents and orchestrator work generate lots of those updates, so the bookkeeping multiplied with the number of configured servers.

Now Orca first checks four cheap signals. If none changed, it stops immediately. Real connects, disconnects, re-pairs, active-host changes, and nested SSH generation changes still rebuild and reconcile the subscriptions.

## Performance

The unchanged path goes from `O(hosts × log(hosts))` work plus arrays, sets, strings, and sorts to allocation-free `O(1)` reference/scalar checks.

An illustrative synthetic run over 200,000 unrelated publications with 25 hosts measured about 1,160 ms for the old key rebuilding versus 1.9 ms for the gate. This is directional microbenchmark evidence, not an end-to-end app claim; absolute impact depends on renderer store-write rate.

## Correctness and compatibility

- renderer-only scheduling change; no RPC, stream, schema, persistence, or wire changes
- remote Orca servers and clients can remain on mixed versions
- SSH and folder-workspace routing behavior is unchanged
- out-of-store generation writers explicitly bump the aggregate invalidation signal, including paths that return the identical Zustand state
- nested stale-state writes re-read final generation keys before synchronization

## Validation

- adversarial review: READY, no proven P0-P2 findings
- focused runtime event/status/SSH suites: 160 tests passed locally; reviewer independently passed 175 focused tests
- full suite: 49,268 passed, 99 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:electron-vite`
- `git diff --check`

## Residual risks

- A replay against an absent/already-stale nested SSH bucket can still wait for the next Zustand publication before rekeying. This is pre-existing behavior and the new aggregate generation preserves that next-publication recovery.
- A future out-of-Zustand field added to the subscription key must also bump the invalidation generation; the coupling is documented next to the key builder.
- No live many-host packaged profile was run.
