### PR TITLE
feat(native-chat): add Droid agent support and composer-on-top layout

### DIFF
--- a/src/main/ai-vault/session-scanner-agent-sources.ts
+++ b/src/main/ai-vault/session-scanner-agent-sources.ts
@@ -38,8 +38,9 @@ const DEVIN_TRANSCRIPTS_DIR = join(
   process.env.DEVIN_HOME?.trim() || join(homedir(), '.local', 'share', 'devin', 'cli'),
   'transcripts'
 )
-const DROID_SESSIONS_DIR = join(homedir(), '.factory', 'sessions')
-const DROID_PROJECTS_DIR = join(homedir(), '.factory', 'projects')
+const FACTORY_HOME_DIR = process.env.FACTORY_HOME?.trim() || join(homedir(), '.factory')
+const DROID_SESSIONS_DIR = join(FACTORY_HOME_DIR, 'sessions')
+const DROID_PROJECTS_DIR = join(FACTORY_HOME_DIR, 'projects')
 
 /**
  * Where one agent's session files live and which of them count as sessions.

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -53,9 +53,17 @@ function ompSessionsDir(): string {
   )
 }
 
+/** Mirrors the AI Vault scanner's Droid root (`~/.factory/sessions`, honoring
+ *  FACTORY_HOME) so both resolve the same transcript for one session. */
+function droidSessionsDir(): string {
+  return join(process.env.FACTORY_HOME?.trim() || join(homedir(), '.factory'), 'sessions')
+}
+
 export type ResolveSessionFileOptions = {
   /** Override the Claude projects root (used by tests / isolated scans). */
   claudeProjectsDir?: string
+  /** Override the Droid sessions root (`~/.factory/sessions`). */
+  droidSessionsDir?: string
   /** Override the Codex sessions roots, searched in order (tests / isolated
    *  scans). Defaults to the orca-managed home then CODEX_HOME/~/.codex. */
   codexSessionsDirs?: string[]
@@ -123,6 +131,13 @@ export async function resolveSessionFilePath(
       // Why: enumerating WSL homes spawns wsl.exe per distro, which boots ones the
       // user left stopped. Only pay that after this host's own Codex roots miss.
       overrideDirs ? undefined : wslCodexSessionsDirs,
+      signal
+    )
+  }
+  if (transcriptAgent === 'droid') {
+    return resolveDroidSessionFile(
+      trimmedId,
+      options.droidSessionsDir ?? droidSessionsDir(),
       signal
     )
   }
@@ -203,6 +218,24 @@ async function findCodexRolloutInDirs(
     }
   }
   return null
+}
+
+// Droid keeps one directory per working directory (`-Users-ran-Projects-orca`)
+// holding `<session id>.jsonl` plus a `<session id>.settings.json` sidecar, and
+// the hook's session_id is that exact base name — so match it the way Claude is
+// matched rather than as a suffix, which would let the sidecar or a longer id win.
+async function resolveDroidSessionFile(
+  sessionId: string,
+  sessionsDir: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const targetName = `${sessionId}.jsonl`
+  const files = await walkSessionFiles(sessionsDir, 'droid', [], {
+    extensions: new Set(['.jsonl']),
+    filePredicate: (path) => basename(path) === targetName,
+    signal
+  })
+  return files[0] ?? null
 }
 
 async function resolveGrokSessionFile(

--- a/src/main/native-chat/transcript-line-decoders-droid.ts
+++ b/src/main/native-chat/transcript-line-decoders-droid.ts
@@ -1,0 +1,133 @@
+// Droid (Factory CLI) JSONL line → NativeChatMessage decoder.
+//
+// Droid writes Claude's content-block vocabulary (text / thinking / tool_use /
+// tool_result) but wraps every turn as `{type: 'message', message: {...}}` and
+// declares who each row was written for via `message.visibility`, so the shared
+// `claudeContentBlocks` mapper is reused and only the envelope differs.
+
+import { isKnownHarnessInjectedUserTurnText } from '../../shared/harness-injected-user-turns'
+import {
+  isTextBlock,
+  NATIVE_CHAT_INTERRUPTED_STATUS_TEXT,
+  type NativeChatBlock,
+  type NativeChatMessage
+} from '../../shared/native-chat-types'
+import {
+  asRecord,
+  extractString,
+  parseJsonObject,
+  timestampMs
+} from '../ai-vault/session-scanner-values'
+import { claudeContentBlocks } from './transcript-record-blocks'
+
+/** Rows the conversation never shows:
+ *  - `llm_only`: context Droid injects for the model only (external file-change
+ *    notices); Droid's own transcript hides these too.
+ *  - hook rows: `user_only` bookkeeping for a fired hook whose text is the event
+ *    name ("Hook execution: PreToolUse"), usually with no content at all. */
+function isDroidHiddenRow(message: Record<string, unknown>): boolean {
+  return message.visibility === 'llm_only' || message.hookEventName !== undefined
+}
+
+/** Droid records an aborted turn as a `both`-visibility row carrying only its
+ *  abort notice — the same conversation status Claude and Codex surface as an
+ *  interrupted marker rather than as a prompt. */
+const DROID_ABORT_NOTICES = new Set(['error: request was aborted.', 'request cancelled by user'])
+
+function isDroidAbortNotice(message: Record<string, unknown>): boolean {
+  if (message.visibility !== 'both' || !Array.isArray(message.content)) {
+    return false
+  }
+  return (
+    message.content.length > 0 &&
+    message.content.every((item) => {
+      const block = asRecord(item)
+      const text = block?.type === 'text' ? extractString(block.text) : null
+      return text !== null && DROID_ABORT_NOTICES.has(text.trim().toLowerCase())
+    })
+  )
+}
+
+/**
+ * Decode one Droid session row. Conversation turns are `type: 'message'` with a
+ * user or assistant role; session bookkeeping (`session_start`, `session_end`,
+ * `todo_state`, `compaction_state`, `agent_turn_outcome`) and unknown record
+ * types are skipped so one novel line can never fail a read.
+ */
+export function decodeDroidTranscriptLine(
+  line: string,
+  fallbackId: string
+): NativeChatMessage | null {
+  const record = parseJsonObject(line)
+  if (!record || record.type !== 'message') {
+    return null
+  }
+  const message = asRecord(record.message)
+  if (!message) {
+    return null
+  }
+  const id = extractString(record.id) ?? fallbackId
+  const timestamp = lineTimestamp(record.timestamp)
+  if (isDroidAbortNotice(message)) {
+    return {
+      id,
+      role: 'system',
+      blocks: [{ type: 'text', text: NATIVE_CHAT_INTERRUPTED_STATUS_TEXT }],
+      timestamp,
+      source: 'transcript'
+    }
+  }
+  if (isDroidHiddenRow(message)) {
+    return null
+  }
+  const role = extractString(message.role)
+  if (role !== 'user' && role !== 'assistant') {
+    return null
+  }
+  const blocks = droidBlocks(message, role)
+  if (blocks.length === 0) {
+    return null
+  }
+  return { id, role: droidRole(role, blocks), blocks, timestamp, source: 'transcript' }
+}
+
+function droidBlocks(
+  message: Record<string, unknown>,
+  role: 'user' | 'assistant'
+): NativeChatBlock[] {
+  const blocks = claudeContentBlocks(message.content)
+  if (role === 'assistant') {
+    return blocks
+  }
+  // Why: a `user_only` row that is not hook bookkeeping is Droid narrating to
+  // the user — a cancelled tool call's synthetic result. Its tool output is real
+  // conversation, but the prose beside it is chrome that must not be attributed
+  // to the user as a prompt.
+  if (message.visibility === 'user_only') {
+    return blocks.filter((block) => block.type === 'tool-result')
+  }
+  // Why: unlike Claude, Droid appends injected context (system-reminders, tagged
+  // file contents) as extra text blocks *inside* the user's own turn, so the
+  // downstream whole-message noise filter cannot reach it. Drop per block.
+  return blocks.filter(
+    (block) => !isTextBlock(block) || !isKnownHarnessInjectedUserTurnText(block.text)
+  )
+}
+
+/** Droid returns every tool's output as a user turn of `tool_result` blocks, so
+ *  a row made up solely of them is the tool speaking, not the user. */
+function droidRole(
+  role: 'user' | 'assistant',
+  blocks: readonly NativeChatBlock[]
+): NativeChatMessage['role'] {
+  if (role === 'assistant') {
+    return 'assistant'
+  }
+  return blocks.every((block) => block.type === 'tool-result') ? 'tool' : 'user'
+}
+
+/** `timestampMs` yields NaN for an unparsable value; the chat model wants null. */
+function lineTimestamp(value: unknown): number | null {
+  const parsed = timestampMs(value)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/main/native-chat/transcript-line-decoders.droid.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.droid.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_INTERRUPTED_STATUS_TEXT } from '../../shared/native-chat-types'
+import { decodeDroidTranscriptLine } from './transcript-line-decoders'
+
+const line = (record: unknown): string => JSON.stringify(record)
+
+const message = (role: string, content: unknown, extra: Record<string, unknown> = {}): string =>
+  line({
+    type: 'message',
+    id: 'rec-1',
+    parentId: 'rec-0',
+    timestamp: '2026-07-16T00:27:02.222Z',
+    message: { role, content, ...extra }
+  })
+
+describe('decodeDroidTranscriptLine', () => {
+  it('skips malformed lines, bookkeeping records, and unknown types', () => {
+    expect(decodeDroidTranscriptLine('not json', 'f')).toBeNull()
+    expect(decodeDroidTranscriptLine(line({ type: 'session_start', id: 'a' }), 'f')).toBeNull()
+    expect(decodeDroidTranscriptLine(line({ type: 'session_end', id: 'a' }), 'f')).toBeNull()
+    expect(decodeDroidTranscriptLine(line({ type: 'todo_state', todos: [] }), 'f')).toBeNull()
+    expect(decodeDroidTranscriptLine(line({ type: 'compaction_state' }), 'f')).toBeNull()
+    expect(
+      decodeDroidTranscriptLine(line({ type: 'agent_turn_outcome', turnId: 't' }), 'f')
+    ).toBeNull()
+    expect(decodeDroidTranscriptLine(line({ type: 'a-type-from-the-future' }), 'f')).toBeNull()
+    expect(decodeDroidTranscriptLine(line({ type: 'message' }), 'f')).toBeNull()
+  })
+
+  it('decodes a user turn', () => {
+    expect(
+      decodeDroidTranscriptLine(message('user', [{ type: 'text', text: 'ship it' }]), 'f')
+    ).toEqual({
+      id: 'rec-1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'ship it' }],
+      timestamp: Date.parse('2026-07-16T00:27:02.222Z'),
+      source: 'transcript'
+    })
+  })
+
+  it('falls back to the offset id and a null timestamp when the record omits them', () => {
+    const decoded = decodeDroidTranscriptLine(
+      line({ type: 'message', message: { role: 'user', content: 'hi' } }),
+      'fallback-id'
+    )
+    expect(decoded).toEqual({
+      id: 'fallback-id',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'hi' }],
+      timestamp: null,
+      source: 'transcript'
+    })
+  })
+
+  it('keeps thinking, prose, and tool calls together on a mixed assistant turn', () => {
+    const decoded = decodeDroidTranscriptLine(
+      message('assistant', [
+        { type: 'thinking', thinking: 'Weighing two options', signature: 'sig' },
+        { type: 'text', text: 'Reading it now.' },
+        { type: 'tool_use', id: 'toolu_1', name: 'Read', input: { file_path: '/a' } }
+      ]),
+      'f'
+    )
+    expect(decoded?.role).toBe('assistant')
+    expect(decoded?.blocks).toEqual([
+      { type: 'text', text: 'Weighing two options' },
+      { type: 'text', text: 'Reading it now.' },
+      { type: 'tool-call', name: 'Read', input: { file_path: '/a' } }
+    ])
+  })
+
+  it('attributes a tool-result-only user row to the tool, not the user', () => {
+    const decoded = decodeDroidTranscriptLine(
+      message('user', [
+        { type: 'tool_result', tool_use_id: 'toolu_1', content: 'File created successfully' }
+      ]),
+      'f'
+    )
+    expect(decoded?.role).toBe('tool')
+    expect(decoded?.blocks).toEqual([{ type: 'tool-result', output: 'File created successfully' }])
+  })
+
+  it('marks a failed tool result as an error', () => {
+    const decoded = decodeDroidTranscriptLine(
+      message('user', [{ type: 'tool_result', content: 'boom', is_error: true }]),
+      'f'
+    )
+    expect(decoded?.blocks).toEqual([{ type: 'tool-result', output: 'boom', isError: true }])
+  })
+
+  // Droid appends injected context as extra text blocks inside the user's own
+  // turn, unlike Claude which writes them as separate rows the noise filter drops.
+  it('strips injected context blocks but keeps the prompt the user typed', () => {
+    const decoded = decodeDroidTranscriptLine(
+      message('user', [
+        { type: 'text', text: '<system-reminder>\n\nUser system info…\n</system-reminder>' },
+        { type: 'text', text: 'please read the skill' },
+        { type: 'text', text: '<system-reminder>\nUser tagged file: /a\n</system-reminder>' }
+      ]),
+      'f'
+    )
+    expect(decoded?.role).toBe('user')
+    expect(decoded?.blocks).toEqual([{ type: 'text', text: 'please read the skill' }])
+  })
+
+  it('drops a user row that is only injected context', () => {
+    expect(
+      decodeDroidTranscriptLine(
+        message('user', [
+          { type: 'text', text: '<system-reminder>only context</system-reminder>' }
+        ]),
+        'f'
+      )
+    ).toBeNull()
+  })
+
+  it('drops llm_only rows and hook bookkeeping rows', () => {
+    expect(
+      decodeDroidTranscriptLine(
+        message('user', [{ type: 'text', text: 'file changed on disk' }], {
+          visibility: 'llm_only'
+        }),
+        'f'
+      )
+    ).toBeNull()
+    expect(
+      decodeDroidTranscriptLine(
+        message('user', [{ type: 'text', text: 'Hook execution: PreToolUse' }], {
+          visibility: 'user_only',
+          hookEventName: 'PreToolUse'
+        }),
+        'f'
+      )
+    ).toBeNull()
+  })
+
+  it('keeps a cancelled tool result from a user_only row but drops its prose', () => {
+    const decoded = decodeDroidTranscriptLine(
+      message(
+        'user',
+        [
+          { type: 'text', text: 'Tool call cancelled by user' },
+          { type: 'tool_result', tool_use_id: 'toolu_1', content: 'cancelled' }
+        ],
+        { visibility: 'user_only' }
+      ),
+      'f'
+    )
+    expect(decoded?.role).toBe('tool')
+    expect(decoded?.blocks).toEqual([{ type: 'tool-result', output: 'cancelled' }])
+  })
+
+  it('renders an abort notice as the interrupted conversation marker', () => {
+    for (const text of ['Error: Request was aborted.', 'Request cancelled by user']) {
+      const decoded = decodeDroidTranscriptLine(
+        message('user', [{ type: 'text', text }], { visibility: 'both' }),
+        'f'
+      )
+      expect(decoded).toEqual({
+        id: 'rec-1',
+        role: 'system',
+        blocks: [{ type: 'text', text: NATIVE_CHAT_INTERRUPTED_STATUS_TEXT }],
+        timestamp: Date.parse('2026-07-16T00:27:02.222Z'),
+        source: 'transcript'
+      })
+    }
+  })
+
+  it('keeps a `both` row that is not an abort notice as conversation', () => {
+    const decoded = decodeDroidTranscriptLine(
+      message('user', [{ type: 'text', text: 'Switched model to claude-opus-5' }], {
+        visibility: 'both'
+      }),
+      'f'
+    )
+    expect(decoded?.role).toBe('user')
+    expect(decoded?.blocks).toEqual([{ type: 'text', text: 'Switched model to claude-opus-5' }])
+  })
+
+  // Droid inlines images as base64 with no path or URL, so there is nothing the
+  // renderer can point at — the row must not become an empty bubble.
+  it('drops an inline base64 image with no other content', () => {
+    expect(
+      decodeDroidTranscriptLine(
+        message('user', [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }
+        ]),
+        'f'
+      )
+    ).toBeNull()
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders.ts
+++ b/src/main/native-chat/transcript-line-decoders.ts
@@ -11,5 +11,6 @@
 
 export { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
 export { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
+export { decodeDroidTranscriptLine } from './transcript-line-decoders-droid'
 export { decodeGrokTranscriptLine } from './transcript-line-decoders-grok'
 export { decodeOmpTranscriptLine } from './transcript-line-decoders-omp'

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -10,6 +10,7 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from './sessio
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
+  decodeDroidTranscriptLine,
   decodeGrokTranscriptLine,
   decodeOmpTranscriptLine
 } from './transcript-line-decoders'
@@ -52,6 +53,9 @@ export async function readNativeChatTranscript(
     }
     if (transcriptAgent === 'codex') {
       return { messages: await readTranscript(filePath, decodeCodexTranscriptLine) }
+    }
+    if (transcriptAgent === 'droid') {
+      return { messages: await readTranscript(filePath, decodeDroidTranscriptLine) }
     }
     if (transcriptAgent === 'grok') {
       return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -9,6 +9,7 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from './sessio
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
+  decodeDroidTranscriptLine,
   decodeGrokTranscriptLine,
   decodeOmpTranscriptLine
 } from './transcript-line-decoders'
@@ -30,6 +31,9 @@ export function nativeChatLineDecoderForAgent(agent: AgentType): NativeChatLineD
   }
   if (transcriptAgent === 'codex') {
     return decodeCodexTranscriptLine
+  }
+  if (transcriptAgent === 'droid') {
+    return decodeDroidTranscriptLine
   }
   if (transcriptAgent === 'grok') {
     return decodeGrokTranscriptLine

--- a/src/main/native-chat/transcript-turn-lifecycle-droid.test.ts
+++ b/src/main/native-chat/transcript-turn-lifecycle-droid.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { nativeChatTurnLifecycleDecoderForAgent } from './transcript-turn-lifecycle'
+import { decodeDroidTurnLifecycle } from './transcript-turn-lifecycle-droid'
+
+const line = (record: unknown): string => JSON.stringify(record)
+
+const userTurn = (text: string, extra: Record<string, unknown> = {}): string =>
+  line({
+    type: 'message',
+    id: 'rec-9',
+    timestamp: '2026-07-16T00:27:02.222Z',
+    message: { role: 'user', content: [{ type: 'text', text }], ...extra }
+  })
+
+describe('decodeDroidTurnLifecycle', () => {
+  it('is the registered decoder for droid', () => {
+    expect(nativeChatTurnLifecycleDecoderForAgent('droid')).toBe(decodeDroidTurnLifecycle)
+  })
+
+  it('decodes turn outcomes', () => {
+    expect(
+      decodeDroidTurnLifecycle(
+        line({ type: 'agent_turn_outcome', turnId: 'turn-1', reason: 'completed' }),
+        'fallback'
+      )
+    ).toEqual({ state: 'completed', turnId: 'turn-1', timestamp: null })
+
+    expect(
+      decodeDroidTurnLifecycle(
+        line({ type: 'agent_turn_outcome', turnId: 'turn-2', reason: 'cancelled' }),
+        'fallback'
+      )
+    ).toEqual({ state: 'interrupted', turnId: 'turn-2', timestamp: null })
+  })
+
+  it('falls back to the offset id when an outcome omits its turn id', () => {
+    expect(
+      decodeDroidTurnLifecycle(
+        line({ type: 'agent_turn_outcome', reason: 'completed' }),
+        'fallback'
+      )
+    ).toEqual({ state: 'completed', turnId: 'fallback', timestamp: null })
+  })
+
+  it('ignores an unrecognized outcome reason rather than guessing a state', () => {
+    expect(
+      decodeDroidTurnLifecycle(
+        line({ type: 'agent_turn_outcome', turnId: 't', reason: 'a-reason-from-the-future' }),
+        'fallback'
+      )
+    ).toBeNull()
+  })
+
+  it('opens a generation on a user prompt, timestamped from the row', () => {
+    expect(decodeDroidTurnLifecycle(userTurn('ship it'), 'fallback')).toEqual({
+      state: 'working',
+      turnId: 'rec-9',
+      timestamp: Date.parse('2026-07-16T00:27:02.222Z')
+    })
+  })
+
+  it('does not open a generation for tool results, injected context, or hook rows', () => {
+    expect(
+      decodeDroidTurnLifecycle(
+        line({
+          type: 'message',
+          id: 'rec-1',
+          message: { role: 'user', content: [{ type: 'tool_result', content: 'ok' }] }
+        }),
+        'fallback'
+      )
+    ).toBeNull()
+    expect(
+      decodeDroidTurnLifecycle(userTurn('<system-reminder>context</system-reminder>'), 'f')
+    ).toBeNull()
+    expect(
+      decodeDroidTurnLifecycle(
+        userTurn('Hook execution: PreToolUse', {
+          visibility: 'user_only',
+          hookEventName: 'PreToolUse'
+        }),
+        'f'
+      )
+    ).toBeNull()
+  })
+
+  it('ignores assistant rows and unrelated records', () => {
+    expect(decodeDroidTurnLifecycle('not json', 'f')).toBeNull()
+    expect(decodeDroidTurnLifecycle(line({ type: 'todo_state' }), 'f')).toBeNull()
+    expect(
+      decodeDroidTurnLifecycle(
+        line({
+          type: 'message',
+          id: 'rec-2',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] }
+        }),
+        'f'
+      )
+    ).toBeNull()
+  })
+})

--- a/src/main/native-chat/transcript-turn-lifecycle-droid.ts
+++ b/src/main/native-chat/transcript-turn-lifecycle-droid.ts
@@ -1,0 +1,58 @@
+import type { NativeChatTurnLifecycle } from '../../shared/native-chat-types'
+import { isNoiseMessage } from '../../shared/native-chat-noise'
+import {
+  asRecord,
+  extractString,
+  parseJsonObject,
+  timestampMs
+} from '../ai-vault/session-scanner-values'
+import { decodeDroidTranscriptLine } from './transcript-line-decoders-droid'
+
+/**
+ * Droid turn boundaries. Unlike Grok and omp, Droid publishes an explicit
+ * per-turn verdict (`agent_turn_outcome`), so the chat spinner can settle on
+ * provider evidence instead of trailing assistant prose.
+ *
+ * Known gap: that record carries no timestamp, so a terminal marker is trusted
+ * unconditionally (see `lifecycleTerminatesCurrentTurn`). The next prompt's own
+ * `working` marker — which does carry the row's timestamp — restores the
+ * spinner, so the exposure is the sub-second window between a prompt's hook and
+ * its transcript flush.
+ */
+export function decodeDroidTurnLifecycle(
+  line: string,
+  fallbackId: string
+): NativeChatTurnLifecycle | null {
+  const record = parseJsonObject(line)
+  if (!record) {
+    return null
+  }
+  if (record.type === 'agent_turn_outcome') {
+    const reason = extractString(record.reason)
+    if (reason !== 'completed' && reason !== 'cancelled') {
+      return null
+    }
+    return {
+      state: reason === 'cancelled' ? 'interrupted' : 'completed',
+      turnId: extractString(record.turnId) ?? fallbackId,
+      timestamp: lifecycleTimestamp(record.timestamp)
+    }
+  }
+  if (record.type !== 'message' || asRecord(record.message)?.role !== 'user') {
+    return null
+  }
+  const decoded = decodeDroidTranscriptLine(line, fallbackId)
+  // Why: only a user-authored prompt opens a generation. Tool results arrive as
+  // user rows too (decoded to role `tool`), and harness-injected turns fire the
+  // same hooks without being prompts — treating either as working would overwrite
+  // a real terminal marker and re-stick the spinner after done/interrupt.
+  if (decoded?.role !== 'user' || isNoiseMessage(decoded)) {
+    return null
+  }
+  return { state: 'working', turnId: decoded.id, timestamp: decoded.timestamp ?? null }
+}
+
+function lifecycleTimestamp(value: unknown): number | null {
+  const parsed = timestampMs(value)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/main/native-chat/transcript-turn-lifecycle.ts
+++ b/src/main/native-chat/transcript-turn-lifecycle.ts
@@ -8,6 +8,7 @@ import {
   timestampMs
 } from '../ai-vault/session-scanner-values'
 import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+import { decodeDroidTurnLifecycle } from './transcript-turn-lifecycle-droid'
 import {
   claudeInterruptedMessageId,
   CODEX_EVENT_TURN_ABORTED,
@@ -29,6 +30,9 @@ export function nativeChatTurnLifecycleDecoderForAgent(
   }
   if (transcriptAgent === 'claude') {
     return decodeClaudeTurnLifecycle
+  }
+  if (transcriptAgent === 'droid') {
+    return decodeDroidTurnLifecycle
   }
   return null
 }

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -170,6 +170,14 @@ export function buildSkillDiscoverySources(
       'home',
       ['agent-skills'],
       'cursor'
+    ),
+    source(
+      'home-droid',
+      'Droid home',
+      pathApi.join(home, '.factory', 'skills'),
+      'home',
+      ['agent-skills'],
+      'droid'
     )
   ]
 
@@ -204,6 +212,14 @@ export function buildSkillDiscoverySources(
         'repo',
         ['claude'],
         'claude'
+      ),
+      source(
+        `repo-droid-${stablePathId(repoPath)}`,
+        `${label} .factory`,
+        pathApi.join(repoPath, '.factory', 'skills'),
+        'repo',
+        ['agent-skills'],
+        'droid'
       )
     )
   }

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -7,6 +7,7 @@ import type {
 import { Image as ImageIcon, ImageOff, X } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
+import { useAppStore } from '../../store'
 import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
 import { basename } from '@/lib/path'
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
@@ -97,10 +98,12 @@ export function NativeChatComposerField({
   sessionOptionsSurface,
   sessionOptionsSnapshot
 }: NativeChatComposerFieldProps): React.JSX.Element {
+  const composerOnTop = useAppStore((store) => store.settings?.nativeChatComposerOnTop === true)
   return (
     <div className="shrink-0 bg-background">
-      {/* Extra bottom padding keeps the input box off the window rim. */}
-      <div className="px-3 pt-2 pb-4 sm:px-4">
+      {/* Extra padding on the rim side keeps the input box off the window edge —
+          which is the top edge in the composer-on-top layout. */}
+      <div className={cn('px-3 sm:px-4', composerOnTop ? 'pt-4 pb-2' : 'pt-2 pb-4')}>
         <div className="relative mx-auto w-full max-w-4xl">
           {autocomplete.mode === 'slash' || autocomplete.mode === 'skill' ? (
             <NativeChatPickerMenu

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.orientation.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.orientation.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { NativeChatMessageList } from './NativeChatMessageList'
+
+function message(id: string, text: string, timestamp: number): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+function session(overrides: Partial<NativeChatLiveSession> = {}): NativeChatLiveSession {
+  return {
+    messages: [
+      message('m1', 'oldest turn', 1),
+      message('m2', 'middle turn', 2),
+      message('m3', 'newest turn', 3)
+    ],
+    status: 'ready',
+    sessionId: 'session-1',
+    agent: 'droid',
+    hasMore: false,
+    loadingEarlier: false,
+    loadEarlier: vi.fn(),
+    readPhase: 'ready',
+    ...overrides
+  }
+}
+
+function renderedTurnOrder(): string[] {
+  return screen
+    .getAllByText(/turn$/)
+    .map((node) => node.textContent ?? '')
+    .filter((text) => text.endsWith('turn'))
+}
+
+describe('NativeChatMessageList orientation', () => {
+  afterEach(cleanup)
+
+  it('reads oldest to newest by default', () => {
+    render(
+      <NativeChatMessageList
+        session={session()}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    expect(renderedTurnOrder()).toEqual(['oldest turn', 'middle turn', 'newest turn'])
+  })
+
+  // The whole point of the composer-on-top layout: the newest turn renders
+  // adjacent to the input instead of a scroll-height away from it.
+  it('puts the newest turn first when the composer is on top', () => {
+    render(
+      <NativeChatMessageList
+        session={session()}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+        orientation="newest-first"
+      />
+    )
+
+    expect(renderedTurnOrder()).toEqual(['newest turn', 'middle turn', 'oldest turn'])
+  })
+
+  it('keeps the paging control on the oldest edge in both orientations', () => {
+    const withHistory = session({ hasMore: true })
+    const { rerender } = render(
+      <NativeChatMessageList
+        session={withHistory}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+    const loadEarlier = screen.getByRole('button', { name: 'Load earlier messages' })
+    const oldest = screen.getByText('oldest turn')
+    // DOM order mirrors paint order in both layouts, so comparing positions is
+    // enough: the control precedes the oldest turn when reading downward…
+    expect(loadEarlier.compareDocumentPosition(oldest) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+
+    rerender(
+      <NativeChatMessageList
+        session={withHistory}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+        orientation="newest-first"
+      />
+    )
+    // …and follows it when the newest turn is rendered first.
+    const reversedControl = screen.getByRole('button', { name: 'Load earlier messages' })
+    const reversedOldest = screen.getByText('oldest turn')
+    expect(
+      reversedControl.compareDocumentPosition(reversedOldest) & Node.DOCUMENT_POSITION_PRECEDING
+    ).toBe(Node.DOCUMENT_POSITION_PRECEDING)
+  })
+
+  it('points the jump affordance at whichever edge holds the newest turn', () => {
+    const { container, rerender } = render(
+      <NativeChatMessageList
+        session={session()}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+        orientation="newest-first"
+      />
+    )
+    const scroller = container.querySelector('.overflow-y-auto')
+    expect(scroller).not.toBeNull()
+    // Padding belongs to the oldest edge; the newest edge abuts the composer.
+    expect(scroller).toHaveClass('pb-10')
+    expect(scroller).not.toHaveClass('pt-10')
+
+    rerender(
+      <NativeChatMessageList
+        session={session()}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+    expect(container.querySelector('.overflow-y-auto')).toHaveClass('pt-10')
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -15,7 +15,16 @@ import type { NativeChatLiveSession } from './use-native-chat-live-session'
 import { orderNativeChatMessages } from './native-chat-message-grouping'
 import { stripNoiseMessages } from './native-chat-noise'
 import { foldToolMessages, splitNativeChatBlocks } from './native-chat-tool-fold'
-import { isNearBottom, shouldShowJumpToLatest, type ScrollGeometry } from './native-chat-autoscroll'
+import type { ScrollGeometry } from './native-chat-autoscroll'
+import {
+  isAtOldestEdge,
+  isPinnedToLatest,
+  latestScrollTop,
+  orientNativeChatMessages,
+  shouldShowJumpAffordance,
+  tracksPrependAnchor,
+  type NativeChatListOrientation
+} from './native-chat-list-orientation'
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
@@ -95,6 +104,57 @@ function AgentControls({
         <ArrowUp className="size-3.5" />
       </button>
     </div>
+  )
+}
+
+/** Paging control at the transcript's oldest edge (top by default, bottom when
+ *  the newest turn is rendered first). */
+function LoadEarlierRow({
+  loadingEarlier,
+  onLoadEarlier
+}: {
+  loadingEarlier: boolean
+  onLoadEarlier: () => void
+}): React.JSX.Element {
+  return (
+    <div className="flex justify-center py-1">
+      <button
+        type="button"
+        onClick={onLoadEarlier}
+        disabled={loadingEarlier}
+        className="rounded-md px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+      >
+        {loadingEarlier
+          ? translate('components.native-chat.loadingEarlier', 'Loading…')
+          : translate('components.native-chat.loadEarlier', 'Load earlier messages')}
+      </button>
+    </div>
+  )
+}
+
+/** Re-pins the viewport to the newest turn; sits on whichever edge holds it. */
+function JumpToLatestButton({
+  newestFirst,
+  onClick
+}: {
+  newestFirst: boolean
+  onClick: () => void
+}): React.JSX.Element {
+  const label = translate('components.native-chat.jumpToLatest', 'Jump to latest')
+  const Icon = newestFirst ? ArrowUp : ArrowDown
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className={cn(
+        'absolute left-1/2 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        newestFirst ? 'top-3' : 'bottom-3'
+      )}
+    >
+      <Icon className="size-3.5" />
+      <span>{label}</span>
+    </button>
   )
 }
 
@@ -240,7 +300,8 @@ export function NativeChatMessageList({
   fontScale,
   onLinkClick,
   allowFileUriLinks = false,
-  failedDeliveryMessageIds
+  failedDeliveryMessageIds,
+  orientation = 'newest-last'
 }: {
   session: NativeChatLiveSession
   isWorking: boolean
@@ -251,17 +312,20 @@ export function NativeChatMessageList({
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
   failedDeliveryMessageIds?: ReadonlySet<string>
+  /** Which end holds the newest turn; 'newest-first' pairs with a top composer. */
+  orientation?: NativeChatListOrientation
 }): React.JSX.Element {
+  const newestFirst = orientation === 'newest-first'
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
-  const [stuckToBottom, setStuckToBottom] = useState(true)
+  const [pinnedToLatest, setPinnedToLatest] = useState(true)
   const [showJump, setShowJump] = useState(false)
 
-  // Why: mirror stuck state into a ref so the auto-scroll layout effect can read
-  // it without depending on it — depending on stuckToBottom (which scrollToBottom
+  // Why: mirror pinned state into a ref so the auto-scroll layout effect can read
+  // it without depending on it — depending on pinnedToLatest (which scrollToLatest
   // sets) would re-fire the effect in a self-loop.
-  const stuckToBottomRef = useRef(stuckToBottom)
-  stuckToBottomRef.current = stuckToBottom
+  const pinnedToLatestRef = useRef(pinnedToLatest)
+  pinnedToLatestRef.current = pinnedToLatest
 
   const { hasMore, loadingEarlier, loadEarlier } = session
 
@@ -273,6 +337,10 @@ export function NativeChatMessageList({
   const messages = useMemo(
     () => foldToolMessages(orderNativeChatMessages(stripNoiseMessages(session.messages))),
     [session.messages]
+  )
+  const orderedMessages = useMemo(
+    () => orientNativeChatMessages(orientation, messages),
+    [orientation, messages]
   )
   const showTypingIndicator =
     isWorking && !messages.some((message) => message.id === NATIVE_CHAT_STREAMING_ID)
@@ -288,26 +356,28 @@ export function NativeChatMessageList({
       return
     }
     const geometry = geometryOf(el)
-    const stick = isNearBottom(geometry)
-    setStuckToBottom(stick)
-    setShowJump(shouldShowJumpToLatest(stick, geometry))
-    // Near the top — page in older history, anchoring the current position so the
-    // prepend doesn't yank the view.
-    if (geometry.scrollTop < 80 && hasMore && !loadingEarlier) {
-      prependAnchorRef.current = { scrollHeight: el.scrollHeight, scrollTop: el.scrollTop }
+    const pinned = isPinnedToLatest(orientation, geometry)
+    setPinnedToLatest(pinned)
+    setShowJump(shouldShowJumpAffordance(orientation, pinned, geometry))
+    // At the oldest edge — page in older history, anchoring the current position
+    // so the prepend doesn't yank the view.
+    if (isAtOldestEdge(orientation, geometry) && hasMore && !loadingEarlier) {
+      prependAnchorRef.current = tracksPrependAnchor(orientation)
+        ? { scrollHeight: el.scrollHeight, scrollTop: el.scrollTop }
+        : null
       loadEarlier()
     }
-  }, [hasMore, loadingEarlier, loadEarlier])
+  }, [orientation, hasMore, loadingEarlier, loadEarlier])
 
-  const scrollToBottom = useCallback(() => {
+  const scrollToLatest = useCallback(() => {
     const el = scrollRef.current
     if (!el) {
       return
     }
-    el.scrollTop = el.scrollHeight
-    setStuckToBottom(true)
+    el.scrollTop = latestScrollTop(orientation, geometryOf(el))
+    setPinnedToLatest(true)
     setShowJump(false)
-  }, [])
+  }, [orientation])
 
   // Align a single message's top to the top of the scroll viewport.
   const scrollMessageToTop = useCallback((el: HTMLElement) => {
@@ -316,16 +386,16 @@ export function NativeChatMessageList({
       return
     }
     // Detach synchronously (not just via the pending onScroll) so an in-place
-    // streaming growth can't re-pin to the bottom mid-flight and fight this
+    // streaming growth can't re-pin to the newest turn mid-flight and fight this
     // deliberate scroll. The ref is what the resize observer reads.
-    stuckToBottomRef.current = false
-    setStuckToBottom(false)
+    pinnedToLatestRef.current = false
+    setPinnedToLatest(false)
     const delta = el.getBoundingClientRect().top - container.getBoundingClientRect().top
     container.scrollTo({ top: container.scrollTop + delta, behavior: 'smooth' })
   }, [])
 
-  // Re-pin to the bottom when new content arrives, but only if the user hasn't
-  // scrolled up. Layout effect so the jump happens before paint (no flicker).
+  // Re-pin to the newest turn when content arrives, but only if the user hasn't
+  // scrolled away. Layout effect so the jump happens before paint (no flicker).
   // When an older page just prepended, restore the prior position instead.
   useLayoutEffect(() => {
     const el = scrollRef.current
@@ -337,24 +407,24 @@ export function NativeChatMessageList({
       prependAnchorRef.current = null
       return
     }
-    if (stuckToBottomRef.current) {
-      scrollToBottom()
+    if (pinnedToLatestRef.current) {
+      scrollToLatest()
     }
-  }, [messages.length, isWorking, showTypingIndicator, scrollToBottom])
+  }, [messages.length, isWorking, showTypingIndicator, scrollToLatest])
 
   // Content growing without a message-count change (a streaming assistant turn
   // extends its own message in place) never re-fires the layout effect above.
   // Observe the container so those in-place growths still re-pin: stay glued to
-  // the bottom while stuck, otherwise just refresh the jump affordance. This is
-  // what removes most "Jump to latest" clicks during a live response.
+  // the newest turn while pinned, otherwise just refresh the jump affordance.
+  // This is what removes most "Jump to latest" clicks during a live response.
   useEffect(() => {
     const el = scrollRef.current
     if (!el || typeof ResizeObserver === 'undefined') {
       return
     }
     const observer = new ResizeObserver(() => {
-      if (stuckToBottomRef.current) {
-        scrollToBottom()
+      if (pinnedToLatestRef.current) {
+        scrollToLatest()
       } else {
         handleScroll()
       }
@@ -366,14 +436,24 @@ export function NativeChatMessageList({
       observer.observe(contentRef.current)
     }
     return () => observer.disconnect()
-  }, [handleScroll, scrollToBottom])
+  }, [handleScroll, scrollToLatest])
+
+  const loadEarlierRow = hasMore ? (
+    <LoadEarlierRow loadingEarlier={loadingEarlier} onLoadEarlier={loadEarlier} />
+  ) : null
+  const typingRow = showTypingIndicator ? <TypingIndicatorRow /> : null
 
   return (
     <div className="relative min-h-0 flex-1">
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="scrollbar-sleek h-full overflow-y-auto px-3 pt-10 pb-4 sm:px-4"
+        className={cn(
+          'scrollbar-sleek h-full overflow-y-auto px-3 sm:px-4',
+          // The breathing room belongs on the oldest edge; the newest edge sits
+          // against the composer.
+          newestFirst ? 'pt-4 pb-10' : 'pt-10 pb-4'
+        )}
       >
         <div
           ref={contentRef}
@@ -385,21 +465,8 @@ export function NativeChatMessageList({
           // the desktop analog of the mobile pinch-zoom (Chromium/Electron only).
           style={{ zoom: fontScale }}
         >
-          {hasMore ? (
-            <div className="flex justify-center py-1">
-              <button
-                type="button"
-                onClick={loadEarlier}
-                disabled={loadingEarlier}
-                className="rounded-md px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-              >
-                {loadingEarlier
-                  ? translate('components.native-chat.loadingEarlier', 'Loading…')
-                  : translate('components.native-chat.loadEarlier', 'Load earlier messages')}
-              </button>
-            </div>
-          ) : null}
-          {messages.map((message) => (
+          {newestFirst ? typingRow : loadEarlierRow}
+          {orderedMessages.map((message) => (
             <MessageRow
               key={message.id}
               message={message}
@@ -410,20 +477,10 @@ export function NativeChatMessageList({
               deliveryFailed={failedDeliveryMessageIds?.has(message.id) === true}
             />
           ))}
-          {showTypingIndicator ? <TypingIndicatorRow /> : null}
+          {newestFirst ? loadEarlierRow : typingRow}
         </div>
       </div>
-      {showJump ? (
-        <button
-          type="button"
-          onClick={scrollToBottom}
-          aria-label={translate('components.native-chat.jumpToLatest', 'Jump to latest')}
-          className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <ArrowDown className="size-3.5" />
-          <span>{translate('components.native-chat.jumpToLatest', 'Jump to latest')}</span>
-        </button>
-      ) : null}
+      {showJump ? <JumpToLatestButton newestFirst={newestFirst} onClick={scrollToLatest} /> : null}
     </div>
   )
 }

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
+import { cn } from '@/lib/utils'
 import { useAppStore } from '../../store'
+import { nativeChatListOrientation } from './native-chat-list-orientation'
 import { useNativeChatLaunchDraftSignal } from './use-native-chat-launch-draft-adoption'
 import type { NativeChatSession } from '../../../../shared/native-chat-types'
 import { useNativeChatRetainedSession } from './use-native-chat-retained-session'
@@ -38,11 +40,7 @@ import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage
 } from '../../../../shared/native-chat-streaming'
-import {
-  shouldFocusNativeChatComposerFromEditingKey,
-  shouldFocusNativeChatPaneFromPointerTarget,
-  shouldRedirectNativeChatTyping
-} from './native-chat-typing-redirect'
+import { useNativeChatPaneCapture } from './use-native-chat-pane-capture'
 import {
   emptyNativeChatContextMenuActions,
   useNativeChatContextMenu
@@ -366,42 +364,29 @@ function NativeChatResolvedView({
   // the chord is inert on the loading/empty/error states and elsewhere.
   const fontScale = useNativeChatFontScale(isConversation)
 
+  // Opt-in top-down reading order: composer pinned above the transcript with the
+  // newest turn directly beneath it.
+  const composerOnTop = useAppStore((s) => s.settings?.nativeChatComposerOnTop === true)
+  const paneCapture = useNativeChatPaneCapture({
+    rootRef,
+    composerRef,
+    onSelectionCapture: contextMenu.onSelectionCapture,
+    onContextMenuCapture: contextMenu.onContextMenuCapture
+  })
+
   return (
     <div
       ref={rootRef}
       data-native-chat-root="true"
       tabIndex={-1}
-      onPointerDownCapture={(event) => {
-        if (event.button === 2) {
-          contextMenu.onSelectionCapture()
-          event.preventDefault()
-          event.stopPropagation()
-          return
-        }
-        if (event.button === 0 && shouldFocusNativeChatPaneFromPointerTarget(event.target)) {
-          rootRef.current?.focus({ preventScroll: true })
-        }
-      }}
-      onKeyDownCapture={(event) => {
-        // Backspace/Delete outside an input focuses the composer (like typing)
-        // but inserts nothing — let the now-focused field handle the keystroke.
-        if (shouldFocusNativeChatComposerFromEditingKey(event)) {
-          composerRef.current?.focus()
-          return
-        }
-        if (!shouldRedirectNativeChatTyping(event)) {
-          return
-        }
-        if (!composerRef.current?.insertTypedText(event.key)) {
-          return
-        }
-        event.preventDefault()
-        event.stopPropagation()
-      }}
-      onMouseUpCapture={contextMenu.onSelectionCapture}
-      onKeyUpCapture={contextMenu.onSelectionCapture}
-      onContextMenuCapture={contextMenu.onContextMenuCapture}
-      className="flex h-full min-h-0 w-full flex-col bg-background focus:outline-none"
+      {...paneCapture}
+      // Why column-reverse rather than reordering the JSX: it flips only the
+      // painted order of the three regions (transcript, interactive card,
+      // composer) while the transcript keeps its own scroll container intact.
+      className={cn(
+        'flex h-full min-h-0 w-full bg-background focus:outline-none',
+        composerOnTop ? 'flex-col-reverse' : 'flex-col'
+      )}
     >
       <div className="flex min-h-0 flex-1 flex-col">
         {viewState.kind === 'loading' ? (
@@ -419,6 +404,7 @@ function NativeChatResolvedView({
             onLinkClick={nativeChatFileLinkClick}
             allowFileUriLinks={fileLinkContext !== null}
             failedDeliveryMessageIds={failedLaunchPromptMessageIds}
+            orientation={nativeChatListOrientation(composerOnTop)}
           />
         )}
       </div>

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.ts
@@ -2,6 +2,7 @@ import { translate } from '@/i18n/i18n'
 import {
   buildAskAnswerKeys,
   buildCodexAskAnswerKeys,
+  buildDroidAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
   parseAskFromStatus,
@@ -17,6 +18,7 @@ import {
 export {
   buildAskAnswerKeys,
   buildCodexAskAnswerKeys,
+  buildDroidAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
   parseAskFromStatus,

--- a/src/renderer/src/components/native-chat/native-chat-list-orientation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-list-orientation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_BOTTOM_THRESHOLD_PX } from './native-chat-autoscroll'
+import {
+  distanceFromLatest,
+  isAtOldestEdge,
+  isPinnedToLatest,
+  latestScrollTop,
+  nativeChatListOrientation,
+  orientNativeChatMessages,
+  shouldShowJumpAffordance,
+  tracksPrependAnchor
+} from './native-chat-list-orientation'
+
+// A 500px-tall transcript in a 100px viewport: scrollTop 0 = top, 400 = bottom.
+const at = (scrollTop: number) => ({ scrollTop, scrollHeight: 500, clientHeight: 100 })
+const shorterThanViewport = { scrollTop: 0, scrollHeight: 80, clientHeight: 100 }
+
+describe('nativeChatListOrientation', () => {
+  it('maps the composer-on-top setting onto the newest end', () => {
+    expect(nativeChatListOrientation(true)).toBe('newest-first')
+    expect(nativeChatListOrientation(false)).toBe('newest-last')
+  })
+})
+
+describe('distanceFromLatest', () => {
+  it('measures from the bottom when the newest turn is last', () => {
+    expect(distanceFromLatest('newest-last', at(400))).toBe(0)
+    expect(distanceFromLatest('newest-last', at(0))).toBe(400)
+  })
+
+  it('measures from the top when the newest turn is first', () => {
+    expect(distanceFromLatest('newest-first', at(0))).toBe(0)
+    expect(distanceFromLatest('newest-first', at(400))).toBe(400)
+  })
+
+  it('treats an unscrollable transcript as pinned in both orientations', () => {
+    expect(distanceFromLatest('newest-first', shorterThanViewport)).toBe(0)
+    expect(distanceFromLatest('newest-last', shorterThanViewport)).toBe(0)
+  })
+})
+
+describe('isPinnedToLatest', () => {
+  it('stays pinned within the slack that absorbs streaming jitter', () => {
+    expect(isPinnedToLatest('newest-first', at(NATIVE_CHAT_BOTTOM_THRESHOLD_PX))).toBe(true)
+    expect(isPinnedToLatest('newest-first', at(NATIVE_CHAT_BOTTOM_THRESHOLD_PX + 1))).toBe(false)
+    expect(isPinnedToLatest('newest-last', at(400 - NATIVE_CHAT_BOTTOM_THRESHOLD_PX))).toBe(true)
+    expect(isPinnedToLatest('newest-last', at(400 - NATIVE_CHAT_BOTTOM_THRESHOLD_PX - 1))).toBe(
+      false
+    )
+  })
+})
+
+describe('shouldShowJumpAffordance', () => {
+  it('stays hidden while pinned', () => {
+    expect(shouldShowJumpAffordance('newest-first', true, at(400))).toBe(false)
+    expect(shouldShowJumpAffordance('newest-last', true, at(0))).toBe(false)
+  })
+
+  it('shows once the newest turn is off-screen', () => {
+    expect(shouldShowJumpAffordance('newest-first', false, at(400))).toBe(true)
+    expect(shouldShowJumpAffordance('newest-last', false, at(0))).toBe(true)
+  })
+
+  it('never shows when there is nothing to scroll', () => {
+    expect(shouldShowJumpAffordance('newest-first', false, shorterThanViewport)).toBe(false)
+    expect(shouldShowJumpAffordance('newest-last', false, shorterThanViewport)).toBe(false)
+  })
+})
+
+describe('latestScrollTop', () => {
+  it('pins to the top for newest-first and the bottom for newest-last', () => {
+    expect(latestScrollTop('newest-first', at(400))).toBe(0)
+    expect(latestScrollTop('newest-last', at(0))).toBe(500)
+  })
+})
+
+describe('isAtOldestEdge', () => {
+  it('pages from the top when the oldest turn is first', () => {
+    expect(isAtOldestEdge('newest-last', at(10))).toBe(true)
+    expect(isAtOldestEdge('newest-last', at(200))).toBe(false)
+  })
+
+  it('pages from the bottom when the oldest turn is last', () => {
+    expect(isAtOldestEdge('newest-first', at(390))).toBe(true)
+    expect(isAtOldestEdge('newest-first', at(200))).toBe(false)
+  })
+})
+
+describe('tracksPrependAnchor', () => {
+  it('anchors only where older turns land above the viewport', () => {
+    expect(tracksPrependAnchor('newest-last')).toBe(true)
+    expect(tracksPrependAnchor('newest-first')).toBe(false)
+  })
+})
+
+describe('orientNativeChatMessages', () => {
+  it('reverses without mutating the memoized source array', () => {
+    const messages = ['first', 'second', 'third']
+    expect(orientNativeChatMessages('newest-first', messages)).toEqual(['third', 'second', 'first'])
+    expect(messages).toEqual(['first', 'second', 'third'])
+  })
+
+  it('returns the same array reference when the order is unchanged', () => {
+    const messages = ['first', 'second']
+    expect(orientNativeChatMessages('newest-last', messages)).toBe(messages)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-list-orientation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-list-orientation.ts
@@ -1,0 +1,91 @@
+// Which end of the message list holds the newest turn. The default chat reads
+// downward (newest last, composer underneath); the composer-on-top layout reads
+// the transcript newest-first so the live turn stays next to the input.
+//
+// Why reverse the rendered order instead of `flex-col-reverse`: a reversed flex
+// container overflows toward its block-start, which breaks scroll anchoring and
+// the paging edge. Rendering newest-first in a normal column keeps the newest
+// turn at scrollTop 0, so "pinned to latest" is just "pinned to the top".
+
+import {
+  distanceFromBottom,
+  NATIVE_CHAT_BOTTOM_THRESHOLD_PX,
+  type ScrollGeometry
+} from './native-chat-autoscroll'
+
+export type NativeChatListOrientation = 'newest-last' | 'newest-first'
+
+/** Distance from the oldest end within which the next page is requested. */
+export const NATIVE_CHAT_LOAD_EARLIER_THRESHOLD_PX = 80
+
+export function nativeChatListOrientation(composerOnTop: boolean): NativeChatListOrientation {
+  return composerOnTop ? 'newest-first' : 'newest-last'
+}
+
+/** Px between the viewport and the edge that holds the newest turn. */
+export function distanceFromLatest(
+  orientation: NativeChatListOrientation,
+  geometry: ScrollGeometry
+): number {
+  return orientation === 'newest-first'
+    ? Math.max(0, geometry.scrollTop)
+    : distanceFromBottom(geometry)
+}
+
+/** True when new content should keep the viewport pinned to the newest turn. */
+export function isPinnedToLatest(
+  orientation: NativeChatListOrientation,
+  geometry: ScrollGeometry,
+  threshold: number = NATIVE_CHAT_BOTTOM_THRESHOLD_PX
+): boolean {
+  return distanceFromLatest(orientation, geometry) <= threshold
+}
+
+/** Show "jump to latest" only once the user has detached far enough that the
+ *  newest turn is actually off-screen. */
+export function shouldShowJumpAffordance(
+  orientation: NativeChatListOrientation,
+  pinnedToLatest: boolean,
+  geometry: ScrollGeometry,
+  threshold: number = NATIVE_CHAT_BOTTOM_THRESHOLD_PX
+): boolean {
+  if (pinnedToLatest) {
+    return false
+  }
+  return distanceFromLatest(orientation, geometry) > threshold
+}
+
+/** scrollTop that puts the newest turn in view. */
+export function latestScrollTop(
+  orientation: NativeChatListOrientation,
+  geometry: ScrollGeometry
+): number {
+  return orientation === 'newest-first' ? 0 : geometry.scrollHeight
+}
+
+/** True when the viewport has reached the oldest end and history should page in. */
+export function isAtOldestEdge(
+  orientation: NativeChatListOrientation,
+  geometry: ScrollGeometry,
+  threshold: number = NATIVE_CHAT_LOAD_EARLIER_THRESHOLD_PX
+): boolean {
+  return orientation === 'newest-first'
+    ? distanceFromBottom(geometry) < threshold
+    : geometry.scrollTop < threshold
+}
+
+/** Only the newest-last layout needs a prepend anchor: there older turns land
+ *  above the viewport and push it down. Newest-first appends them below the
+ *  viewport, so scrollTop already points at the same content. */
+export function tracksPrependAnchor(orientation: NativeChatListOrientation): boolean {
+  return orientation === 'newest-last'
+}
+
+/** The list in render order for this orientation (newest-first reverses a copy;
+ *  the caller's array is memoized and must not be mutated). */
+export function orientNativeChatMessages<T>(
+  orientation: NativeChatListOrientation,
+  messages: readonly T[]
+): readonly T[] {
+  return orientation === 'newest-first' ? messages.toReversed() : messages
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -10,8 +10,10 @@ import {
 import {
   buildAskAnswerKeys,
   buildCodexAskAnswerKeys,
+  buildDroidAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
+  type AskAnswerKeyGroup,
   type AskAnswerSelection,
   type AskPrompt
 } from './native-chat-interactive-prompt'
@@ -25,6 +27,22 @@ import { inferQuestionAnsweredFromCurrentStatus } from '../terminal-pane/agent-q
 // ESC is the agent-TUI interrupt/cancel key over the PTY (matches how the
 // composer forwards Escape). Used to cancel a question or deny an approval.
 const ESC = '\x1b'
+
+/** Each stepped selector has its own state machine; only the transcript agent
+ *  identifies which. Claude's builder is the default for its own format. */
+function buildSteppedAskAnswerKeys(
+  transcriptAgent: ReturnType<typeof resolveNativeChatTranscriptAgent>,
+  prompt: AskPrompt,
+  selections: AskAnswerSelection[]
+): AskAnswerKeyGroup[] {
+  if (transcriptAgent === 'codex') {
+    return buildCodexAskAnswerKeys(prompt, selections)
+  }
+  if (transcriptAgent === 'droid') {
+    return buildDroidAskAnswerKeys(prompt, selections)
+  }
+  return buildAskAnswerKeys(prompt, selections)
+}
 
 export type NativeChatInteractiveSend = {
   /** Deliver the answer to an AskUserQuestion prompt. Claude-format selectors
@@ -93,10 +111,11 @@ export function useNativeChatInteractiveSend(
       // Cancel any prior in-flight answer before starting a new one.
       cancelInFlight()
       const settings = getSettingsForAgentTabRuntimeOwner(terminalTabId)
-      // Claude and Codex ignore pasted labels but have different selector state
-      // machines; Grok commits pasted text. OpenClaude follows Claude's path.
+      // Claude, Codex, and Droid all ignore pasted labels but have different
+      // selector state machines; Grok commits pasted text. OpenClaude follows
+      // Claude's path.
       const stepsAnswer = shouldStepNativeChatAskAnswer(agent)
-      const buildsCodexAnswer = resolveNativeChatTranscriptAgent(agent) === 'codex'
+      const steppedAnswerAgent = resolveNativeChatTranscriptAgent(agent)
       // Why: pin the answered question's baseline BEFORE delivery. A late settle
       // callback (paced writes + remote acceptance can span seconds on SSH) must
       // not read the live status and mint a fresh baseline for a replacement
@@ -132,9 +151,7 @@ export function useNativeChatInteractiveSend(
         ? sendNativeChatAskAnswer(
             settings,
             targetPtyId,
-            buildsCodexAnswer
-              ? buildCodexAskAnswerKeys(prompt, selections)
-              : buildAskAnswerKeys(prompt, selections),
+            buildSteppedAskAnswerKeys(steppedAnswerAgent, prompt, selections),
             onSettled
           )
         : sendNativeChatMessage(settings, targetPtyId, formatAskAnswer(prompt, selections))

--- a/src/renderer/src/components/native-chat/use-native-chat-pane-capture.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pane-capture.ts
@@ -1,0 +1,69 @@
+import { useMemo, type DOMAttributes, type RefObject } from 'react'
+import {
+  shouldFocusNativeChatComposerFromEditingKey,
+  shouldFocusNativeChatPaneFromPointerTarget,
+  shouldRedirectNativeChatTyping
+} from './native-chat-typing-redirect'
+import type { NativeChatComposerHandle } from './NativeChatComposer'
+
+type NativeChatPaneCaptureProps = Pick<
+  DOMAttributes<HTMLDivElement>,
+  | 'onPointerDownCapture'
+  | 'onKeyDownCapture'
+  | 'onMouseUpCapture'
+  | 'onKeyUpCapture'
+  | 'onContextMenuCapture'
+>
+
+/**
+ * Pane-level capture handlers for the chat root: right-click opens the chat's own
+ * menu (never the pane's), a plain click focuses the pane so the typing redirect
+ * works, and typing anywhere outside an input lands in the composer.
+ */
+export function useNativeChatPaneCapture({
+  rootRef,
+  composerRef,
+  onSelectionCapture,
+  onContextMenuCapture
+}: {
+  rootRef: RefObject<HTMLDivElement | null>
+  composerRef: RefObject<NativeChatComposerHandle | null>
+  onSelectionCapture: () => void
+  onContextMenuCapture: DOMAttributes<HTMLDivElement>['onContextMenuCapture']
+}): NativeChatPaneCaptureProps {
+  return useMemo(
+    () => ({
+      onPointerDownCapture: (event) => {
+        if (event.button === 2) {
+          onSelectionCapture()
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+        if (event.button === 0 && shouldFocusNativeChatPaneFromPointerTarget(event.target)) {
+          rootRef.current?.focus({ preventScroll: true })
+        }
+      },
+      onKeyDownCapture: (event) => {
+        // Backspace/Delete outside an input focuses the composer (like typing)
+        // but inserts nothing — let the now-focused field handle the keystroke.
+        if (shouldFocusNativeChatComposerFromEditingKey(event)) {
+          composerRef.current?.focus()
+          return
+        }
+        if (!shouldRedirectNativeChatTyping(event)) {
+          return
+        }
+        if (!composerRef.current?.insertTypedText(event.key)) {
+          return
+        }
+        event.preventDefault()
+        event.stopPropagation()
+      },
+      onMouseUpCapture: onSelectionCapture,
+      onKeyUpCapture: onSelectionCapture,
+      onContextMenuCapture
+    }),
+    [rootRef, composerRef, onSelectionCapture, onContextMenuCapture]
+  )
+}

--- a/src/renderer/src/components/settings/NativeChatExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/NativeChatExperimentalSetting.tsx
@@ -20,6 +20,7 @@ export function NativeChatExperimentalSetting({
   const nativeChatEnabled = settings.experimentalNativeChat === true
   const openByDefault = settings.openAgentTabsInChatByDefault === true
   const defaultView: NativeChatDefaultView = openByDefault ? 'native-chat' : 'terminal-chat'
+  const composerOnTop = settings.nativeChatComposerOnTop === true
 
   return (
     <SearchableSetting
@@ -58,7 +59,31 @@ export function NativeChatExperimentalSetting({
         />
       </div>
       {nativeChatEnabled ? (
-        <div className="ml-4 border-l border-border pl-4">
+        <div className="ml-4 space-y-3 border-l border-border pl-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>
+                {translate(
+                  'auto.components.settings.ExperimentalPane.nativeChat.composerOnTopTitle',
+                  'Composer on top'
+                )}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.ExperimentalPane.nativeChat.composerOnTopCopy',
+                  'Put the input above the transcript and read newest-first, so replies appear at eye level instead of the bottom of the pane.'
+                )}
+              </p>
+            </div>
+            <SettingsSwitch
+              checked={composerOnTop}
+              ariaLabel={translate(
+                'auto.components.settings.ExperimentalPane.nativeChat.composerOnTopToggleLabel',
+                'Toggle composer on top'
+              )}
+              onChange={() => updateSettings({ nativeChatComposerOnTop: !composerOnTop })}
+            />
+          </div>
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 shrink space-y-0.5">
               <Label>

--- a/src/renderer/src/components/settings/native-chat-experimental-search-entry.ts
+++ b/src/renderer/src/components/settings/native-chat-experimental-search-entry.ts
@@ -35,6 +35,14 @@ export function getNativeChatExperimentalSearchEntry(): SettingsSearchEntry {
         'grok'
       ),
       ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.nativeChat.droid',
+        'droid'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.nativeChat.layout',
+        'layout'
+      ),
+      ...translateSearchKeyword(
         'auto.components.settings.experimental.search.nativeChat.terminal',
         'terminal'
       ),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6059,7 +6059,10 @@
             "defaultCopy": "Choose how new supported agent terminal tabs open.",
             "defaultViewLabel": "Default Chat UI view",
             "defaultViewTerminal": "Terminal chat",
-            "defaultViewNative": "Chat UI"
+            "defaultViewNative": "Chat UI",
+            "composerOnTopTitle": "Composer on top",
+            "composerOnTopCopy": "Put the input above the transcript and read newest-first, so replies appear at eye level instead of the bottom of the pane.",
+            "composerOnTopToggleLabel": "Toggle composer on top"
           },
           "agentDashboard": {
             "title": "Agent Dashboard",

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -847,6 +847,17 @@ function hasAnyOwnField(record: Record<string, unknown>, keys: readonly string[]
   return keys.some((key) => hasOwnField(record, key))
 }
 
+/** The first present, non-null tool-input payload among alternative hook keys. */
+function firstDefinedToolInput(record: Record<string, unknown>, keys: readonly string[]): unknown {
+  for (const key of keys) {
+    const value = record[key]
+    if (value !== undefined && value !== null) {
+      return value
+    }
+  }
+  return undefined
+}
+
 function toolUpdate(
   fields: Pick<ToolSnapshot, 'toolName' | 'toolInput' | 'interactivePrompt'>,
   options?: { hasToolInputField?: boolean }
@@ -2134,8 +2145,17 @@ function extractDroidToolFields(
       deriveToolInputPreview(toolName, hookPayload.tool_input) ??
       deriveToolInputPreview(toolName, hookPayload.input) ??
       deriveToolInputPreview(toolName, hookPayload.arguments)
+    // Why: Droid reports AskUser's questionnaire under whichever of these keys the
+    // hook carries; without the envelope the question card has nothing to render
+    // and the pane can only show a bare "waiting" state.
+    const rawToolInput =
+      firstDefinedToolInput(hookPayload, ['tool_input', 'input', 'arguments']) ?? undefined
     const update: ToolSnapshot = toolUpdate(
-      { toolName, toolInput },
+      {
+        toolName,
+        toolInput,
+        interactivePrompt: deriveInteractivePrompt(toolName, rawToolInput, eventName)
+      },
       { hasToolInputField: hasAnyOwnField(hookPayload, ['tool_input', 'input', 'arguments']) }
     )
     if (eventName === 'PostToolUse') {

--- a/src/shared/agent-model-probe-spec.ts
+++ b/src/shared/agent-model-probe-spec.ts
@@ -1,4 +1,5 @@
 import { getCommitMessageAgentSpec, type CommitMessageAgentSpec } from './commit-message-agent-spec'
+import { DROID_MODEL_LIST_ARGS, parseDroidModelList } from './droid-model-list-probe'
 import { GROK_MODEL_LIST_ARGS, parseGrokModelList } from './grok-model-list-probe'
 import type { TuiAgent } from './types'
 
@@ -22,6 +23,21 @@ const MODEL_DISCOVERY_ONLY_SPECS: Partial<Record<TuiAgent, AgentModelProbeSpec>>
     // second model list here that can drift from it.
     models: [],
     defaultModelId: 'grok-4.5'
+  },
+  droid: {
+    id: 'droid',
+    label: 'Droid',
+    binary: 'droid',
+    modelSource: 'dynamic',
+    modelDiscovery: {
+      binary: 'droid',
+      args: DROID_MODEL_LIST_ARGS,
+      parse: parseDroidModelList
+    },
+    models: [],
+    // Why: the interactive CLI's model comes from account/session settings, not a
+    // flag, so no id here can be stated as the one it runs with.
+    defaultModelId: ''
   }
 }
 

--- a/src/shared/agent-question-answered-intent.ts
+++ b/src/shared/agent-question-answered-intent.ts
@@ -12,13 +12,19 @@ export type AgentQuestionAnsweredInferenceRequest = {
 }
 
 /** True for the ask-the-user-a-question tool across agents: Claude's
- *  `AskUserQuestion`, grok/Pi's `ask_user_question`, and Codex ≥0.145's
- *  `request_user_input` (same questions/options input shape).
+ *  `AskUserQuestion`, grok/Pi's `ask_user_question`, Codex ≥0.145's
+ *  `request_user_input` (same questions/options input shape), and Droid's
+ *  `AskUser` (a plain-text questionnaire — see
+ *  `native-chat-ask-droid-questionnaire.ts`).
  *  Why: this is the structured "pick an option" prompt whose full input the
  *  clients render as a live card. */
 export function isAskUserQuestionTool(toolName: string | undefined): boolean {
   const normalized = toolName?.replaceAll(/[^a-z0-9]/gi, '').toLowerCase()
-  return normalized === 'askuserquestion' || normalized === 'requestuserinput'
+  return (
+    normalized === 'askuserquestion' ||
+    normalized === 'requestuserinput' ||
+    normalized === 'askuser'
+  )
 }
 
 const QUESTION_ANSWER_ENTER_INPUTS: ReadonlySet<string> = new Set([

--- a/src/shared/agent-session-option-catalog-droid.test.ts
+++ b/src/shared/agent-session-option-catalog-droid.test.ts
@@ -54,12 +54,12 @@ describe('droid session option catalog', () => {
     expect(draftModel?.kind.type === 'select' ? draftModel.kind.currentValue : null).toBeUndefined()
   })
 
-  it('routes a live change into droid\u2019s own /model selector', () => {
+  it('does not auto-switch to terminal for /model — the chat UI sends it as plain text', () => {
     const liveModel = snapshot('live', [{ id: 'Opus 5', label: 'Opus 5', options: [] }])[0]
-    expect(liveModel).toMatchObject({ settable: true, action: { type: 'agent-picker' } })
+    expect(liveModel).toMatchObject({ settable: false, disabledReason: 'set-when-session-starts' })
+    expect(liveModel?.action).toBeUndefined()
     expect(DROID_SESSION_OPTION_CATALOG.modelApply.midSession).toEqual({
-      kind: 'agent-picker',
-      command: '/model'
+      kind: 'unsupported'
     })
   })
 

--- a/src/shared/agent-session-option-catalog-droid.test.ts
+++ b/src/shared/agent-session-option-catalog-droid.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentModelProbeSpec } from './agent-model-probe-spec'
+import { getAgentSessionOptionCatalog } from './agent-session-option-catalog'
+import { DROID_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-droid'
+import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
+import { buildNativeChatSessionOptionSnapshot } from './native-chat-session-option-snapshot'
+import { createNativeChatSessionOptionRecord } from './native-chat-session-option-state'
+
+const HELP = `Model details:
+  - Auto Model: supports reasoning: No; supported: [none]; default: none
+  - Opus 5: supports reasoning: Yes; supported: [off, low, medium, high]; default: high
+`
+
+function snapshot(mode: 'draft' | 'live', models = DROID_SESSION_OPTION_CATALOG.models) {
+  return buildNativeChatSessionOptionSnapshot({
+    catalog: DROID_SESSION_OPTION_CATALOG,
+    models,
+    record: createNativeChatSessionOptionRecord('droid'),
+    mode,
+    modelLabel: 'Model'
+  })
+}
+
+describe('droid session option catalog', () => {
+  it('is registered for the droid agent', () => {
+    expect(getAgentSessionOptionCatalog('droid')).toBe(DROID_SESSION_OPTION_CATALOG)
+  })
+
+  // Interactive droid ignores unknown flags silently (verified against v0.191.1),
+  // so a seeded model would present a choice the launch drops without erroring.
+  it('seeds no models and shows no pill until the host probe lands', () => {
+    expect(DROID_SESSION_OPTION_CATALOG.models).toEqual([])
+    expect(snapshot('draft')).toEqual([])
+    expect(snapshot('live')).toEqual([])
+  })
+
+  it('emits no launch flags, since only `droid exec` accepts a model', () => {
+    expect(DROID_SESSION_OPTION_CATALOG.modelApply.launchArgs).toBeUndefined()
+    expect(resolveAgentSessionOptionLaunch('droid', { model: 'Opus 5' })).toEqual({
+      args: [],
+      appliedValues: {}
+    })
+  })
+
+  it('reports the model as settable only after the session starts', () => {
+    const models = [{ id: 'Opus 5', label: 'Opus 5', options: [] }]
+    const draftModel = snapshot('draft', models)[0]
+    expect(draftModel).toMatchObject({
+      id: 'model',
+      settable: false,
+      disabledReason: 'available-after-session-start'
+    })
+    // No fabricated current value: droid's model comes from account settings.
+    expect(draftModel?.kind.type === 'select' ? draftModel.kind.currentValue : null).toBeUndefined()
+  })
+
+  it('routes a live change into droid\u2019s own /model selector', () => {
+    const liveModel = snapshot('live', [{ id: 'Opus 5', label: 'Opus 5', options: [] }])[0]
+    expect(liveModel).toMatchObject({ settable: true, action: { type: 'agent-picker' } })
+    expect(DROID_SESSION_OPTION_CATALOG.modelApply.midSession).toEqual({
+      kind: 'agent-picker',
+      command: '/model'
+    })
+  })
+
+  it('offers no reasoning-effort rows the interactive CLI could not apply', () => {
+    const models = [{ id: 'Opus 5', label: 'Opus 5', options: [] }]
+    expect(snapshot('live', models).map(({ id }) => id)).toEqual(['model'])
+  })
+
+  it('discovers models through the same probe the catalog documents', () => {
+    const spec = getAgentModelProbeSpec('droid')
+    expect(spec?.modelSource).toBe('dynamic')
+    expect(spec?.modelDiscovery?.binary).toBe('droid')
+    expect(DROID_SESSION_OPTION_CATALOG.listModels?.command).toBe(
+      `droid ${spec?.modelDiscovery?.args.join(' ')}`
+    )
+    expect(DROID_SESSION_OPTION_CATALOG.listModels?.parse(HELP)).toEqual([
+      { id: 'Auto Model', label: 'Auto Model', options: [] },
+      { id: 'Opus 5', label: 'Opus 5', options: [] }
+    ])
+  })
+
+  it('keeps droid out of the commit-message agent registry', () => {
+    expect(getAgentModelProbeSpec('droid')?.models).toEqual([])
+    expect('buildArgs' in (getAgentModelProbeSpec('droid') ?? {})).toBe(false)
+  })
+})

--- a/src/shared/agent-session-option-catalog-droid.ts
+++ b/src/shared/agent-session-option-catalog-droid.ts
@@ -1,0 +1,28 @@
+import type { AgentSessionOptionCatalog, CatalogModel } from './agent-session-option-catalog-types'
+import { parseDroidModelList } from './droid-model-list-probe'
+
+function parseDroidCatalogModels(stdout: string): CatalogModel[] {
+  return parseDroidModelList(stdout).map((model) => ({ ...model, options: [] }))
+}
+
+export const DROID_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
+  // Why empty: interactive `droid` publishes no model list of its own and — verified
+  // against v0.191.1 — silently ignores unknown flags, so a seeded row would claim a
+  // choice the launch cannot make and never error. The once-per-host probe supplies
+  // the account's real list, and until it lands there is no model pill at all.
+  models: [],
+  modelApply: {
+    // Why no launchArgs: `-m/--model` exists only on `droid exec`. Passing it to the
+    // interactive CLI is dropped without warning, so the draft honestly reports the
+    // model as available only after the session starts.
+    //
+    // Why agent-picker: `/model` opens Droid's own selector pane and takes no
+    // argument, and the selection is never echoed back, so no command can carry a
+    // model id and no dispatch result could be trusted as the new value.
+    midSession: { kind: 'agent-picker', command: '/model' }
+  },
+  // Reasoning effort is deliberately absent: `droid exec` takes `-r`, but the
+  // interactive CLI has neither the flag nor a slash command for it, so every
+  // surface would render a control that can never apply.
+  listModels: { command: 'droid exec --help', parse: parseDroidCatalogModels }
+}

--- a/src/shared/agent-session-option-catalog-droid.ts
+++ b/src/shared/agent-session-option-catalog-droid.ts
@@ -16,10 +16,11 @@ export const DROID_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // interactive CLI is dropped without warning, so the draft honestly reports the
     // model as available only after the session starts.
     //
-    // Why agent-picker: `/model` opens Droid's own selector pane and takes no
-    // argument, and the selection is never echoed back, so no command can carry a
-    // model id and no dispatch result could be trusted as the new value.
-    midSession: { kind: 'agent-picker', command: '/model' }
+    // Why unsupported: `/model` opens Droid's own interactive selector pane that
+    // takes no argument and never echoes the selection back, so the chat UI cannot
+    // track or verify the result. Marking it unsupported sends the command as plain
+    // text when the user types it, without auto-switching to the terminal view.
+    midSession: { kind: 'unsupported' }
   },
   // Reasoning effort is deliberately absent: `droid exec` takes `-r`, but the
   // interactive CLI has neither the flag nor a slash command for it, so every

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -4,6 +4,7 @@ import {
   CODEX_SESSION_OPTION_CATALOG,
   createClaudeCatalogOptions
 } from './agent-session-option-catalog-claude-codex'
+import { DROID_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-droid'
 import {
   CURSOR_SESSION_OPTION_CATALOG,
   GEMINI_SESSION_OPTION_CATALOG
@@ -32,7 +33,8 @@ const CATALOGS: AgentSessionOptionCatalogMap = {
   codex: CODEX_SESSION_OPTION_CATALOG,
   gemini: GEMINI_SESSION_OPTION_CATALOG,
   cursor: CURSOR_SESSION_OPTION_CATALOG,
-  grok: GROK_SESSION_OPTION_CATALOG
+  grok: GROK_SESSION_OPTION_CATALOG,
+  droid: DROID_SESSION_OPTION_CATALOG
 }
 
 export function getAgentSessionOptionCatalog(agent: AgentType): AgentSessionOptionCatalog | null {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -268,6 +268,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalLinkActionPopoverEnabled: true,
     openAgentTabsInChatByDefault: false,
     experimentalNativeChat: false,
+    nativeChatComposerOnTop: false,
     nativeChatSessionOptions: {},
     openInApplications: [...DEFAULT_OPEN_IN_APPLICATIONS],
     rightSidebarOpenByDefault: true,

--- a/src/shared/droid-model-list-probe.test.ts
+++ b/src/shared/droid-model-list-probe.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { DROID_MODEL_LIST_ARGS, parseDroidModelList } from './droid-model-list-probe'
+
+// Verbatim excerpt of `droid exec --help` (v0.191.1), including the surrounding
+// prose the parser must ignore.
+const HELP = `Autonomy Levels:
+  --auto low                 Low-risk operations - Basic file operations
+                             • File creation/modification in non-system directories
+
+Examples:
+  droid exec --model gpt-5 --list-tools --output-format json
+  droid exec --model custom:deepseek-v3 "analyze this code"
+
+Model details:
+  - Auto Model: supports reasoning: No; supported: [none]; default: none
+  - Fable 5: supports reasoning: Yes; supported: [off, low, medium, high, xhigh, max]; default: high
+  - Opus 5 Fast Mode: supports reasoning: Yes; supported: [off, low, medium, high, xhigh, max]; default: high
+  - GPT-5.6 Sol: supports reasoning: Yes; supported: [none, low, medium, high, xhigh, max]; default: medium
+  - Gemini 3.6 Flash: supports reasoning: Yes; supported: [minimal, low, medium, high]; default: high
+  - GLM-5.2 (Droid Core): supports reasoning: Yes; supported: [off, high, max]; default: high
+`
+
+describe('parseDroidModelList', () => {
+  it('probes through the one machine-readable surface droid exposes', () => {
+    expect(DROID_MODEL_LIST_ARGS).toEqual(['exec', '--help'])
+  })
+
+  it('reads the account model list in the CLI\u2019s own order', () => {
+    expect(parseDroidModelList(HELP).map(({ label }) => label)).toEqual([
+      'Auto Model',
+      'Fable 5',
+      'Opus 5 Fast Mode',
+      'GPT-5.6 Sol',
+      'Gemini 3.6 Flash',
+      'GLM-5.2 (Droid Core)'
+    ])
+  })
+
+  // The interactive CLI takes no model id, so the label is the identity — see the
+  // module comment. A slugged id would be one the CLI never publishes.
+  it('identifies models by their printed label', () => {
+    expect(parseDroidModelList(HELP)[3]).toEqual({ id: 'GPT-5.6 Sol', label: 'GPT-5.6 Sol' })
+  })
+
+  it('ignores everything outside the model-details section', () => {
+    const models = parseDroidModelList(HELP)
+    expect(models.some(({ label }) => label.includes('droid exec'))).toBe(false)
+    expect(models.some(({ label }) => label.includes('auto low'))).toBe(false)
+  })
+
+  it('claims no models when the section is absent or the format moved', () => {
+    expect(parseDroidModelList('')).toEqual([])
+    expect(parseDroidModelList('Options:\n  -m, --model <id>  Model ID to use')).toEqual([])
+    expect(parseDroidModelList('Model details:\n  - Opus 5\n  - Sonnet 5\n')).toEqual([])
+  })
+
+  it('names no default: droid picks one from account settings, not a flag', () => {
+    expect(parseDroidModelList(HELP).some((model) => model.isDefault)).toBe(false)
+  })
+
+  it('keeps the first row when a label repeats', () => {
+    const duplicated = `Model details:
+  - Opus 5: supports reasoning: Yes; supported: [off, high]; default: high
+  - Opus 5: supports reasoning: Yes; supported: [off, high]; default: high
+`
+    expect(parseDroidModelList(duplicated)).toEqual([{ id: 'Opus 5', label: 'Opus 5' }])
+  })
+})

--- a/src/shared/droid-model-list-probe.ts
+++ b/src/shared/droid-model-list-probe.ts
@@ -1,0 +1,38 @@
+import type { CommitMessageModel } from './commit-message-agent-spec'
+
+// Why: `droid` has no `models` subcommand and no JSON listing. `droid exec --help`
+// ends with a "Model details:" section enumerating exactly the models the signed-in
+// account may use on this host, which is the only machine-readable surface there is.
+export const DROID_MODEL_LIST_ARGS = ['exec', '--help']
+
+const MODEL_DETAILS_HEADER = 'Model details:'
+
+// Why anchor on the full row shape: the help text is prose, so a looser pattern
+// would turn example lines and autonomy bullets into selectable models.
+const MODEL_DETAIL_LINE =
+  /^-\s+(?<label>.+?):\s+supports reasoning:\s+(?:yes|no);\s+supported:\s+\[[^\]]*\];\s+default:\s+\S+.*$/i
+
+/**
+ * Models Droid lists for this account, in the CLI's own order.
+ *
+ * The ids are the human labels: Droid's help prints labels only, and the
+ * interactive CLI (which native chat drives) has no `--model` flag to send an id
+ * to — the model is chosen inside Droid's own `/model` selector. Deriving slugs
+ * would invent ids the CLI never publishes, so the label stays the identity.
+ */
+export function parseDroidModelList(stdout: string): CommitMessageModel[] {
+  const lines = stdout.split(/\r?\n/)
+  const headerIndex = lines.findIndex((line) => line.trim() === MODEL_DETAILS_HEADER)
+  if (headerIndex === -1) {
+    return []
+  }
+  const byLabel = new Map<string, CommitMessageModel>()
+  for (const line of lines.slice(headerIndex + 1)) {
+    const label = MODEL_DETAIL_LINE.exec(line.trim())?.groups?.label?.trim()
+    if (!label || byLabel.has(label)) {
+      continue
+    }
+    byLabel.set(label, { id: label, label })
+  }
+  return [...byLabel.values()]
+}

--- a/src/shared/native-chat-agent-profiles.ts
+++ b/src/shared/native-chat-agent-profiles.ts
@@ -28,6 +28,14 @@ const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfi
     skillPrefix: '/',
     groupedSlash: true,
     skillSourceOwner: 'grok'
+  },
+  // Droid registers every user-invocable skill as a slash command of its own
+  // name (skipping ones that collide with a built-in), so skills and commands
+  // share the `/` namespace exactly as they do in Claude.
+  droid: {
+    skillPrefix: '/',
+    groupedSlash: true,
+    skillSourceOwner: 'droid'
   }
 }
 

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,10 +1,11 @@
-export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'omp'
+export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'droid' | 'grok' | 'omp'
 
 /** Agents whose transcripts the native chat view can parse and render. */
 export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
   'claude',
   'openclaude',
   'codex',
+  'droid',
   'grok',
   'omp'
 ])
@@ -19,17 +20,17 @@ export function isNativeChatSupportedAgent(agent: string | null | undefined): bo
  *  so the chat view must stay closed instead of loading forever. */
 export function nativeChatRequiresLocalTranscript(agent: string | null | undefined): boolean {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'grok' || transcriptAgent === 'omp'
+  return transcriptAgent === 'grok' || transcriptAgent === 'omp' || transcriptAgent === 'droid'
 }
 
-/** True when the agent renders a digit-commit question selector that ignores
- *  typed label text (pasting "Blue" + Enter commits the highlighted FIRST
- *  option — STA-1860): Claude's AskUserQuestion and Codex 0.145's
- *  request_user_input card both behave this way, so answers must be delivered
- *  as per-option keystrokes. Other agents commit a pasted answer. */
+/** True when the agent renders a selector that ignores typed label text (pasting
+ *  "Blue" + Enter commits the highlighted FIRST option — STA-1860), so answers
+ *  must be delivered as navigation keystrokes: Claude's AskUserQuestion, Codex
+ *  0.145's request_user_input, and Droid's AskUser (arrow-navigated, with no
+ *  option digits at all). Other agents commit a pasted answer. */
 export function shouldStepNativeChatAskAnswer(agent: string | null | undefined): boolean {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'claude' || transcriptAgent === 'codex'
+  return transcriptAgent === 'claude' || transcriptAgent === 'codex' || transcriptAgent === 'droid'
 }
 
 export function resolveNativeChatTranscriptAgent(
@@ -40,7 +41,7 @@ export function resolveNativeChatTranscriptAgent(
   if (agent === 'claude' || agent === 'openclaude') {
     return 'claude'
   }
-  if (agent === 'codex' || agent === 'grok' || agent === 'omp') {
+  if (agent === 'codex' || agent === 'droid' || agent === 'grok' || agent === 'omp') {
     return agent
   }
   return null

--- a/src/shared/native-chat-ask-droid-keys.ts
+++ b/src/shared/native-chat-ask-droid-keys.ts
@@ -1,0 +1,118 @@
+// Keystrokes that answer Droid's AskUser selector.
+//
+// Droid's selector has NO option-number shortcuts: any printable character
+// switches the row into "own answer" text entry, so a digit would type "1" as
+// free text instead of picking option 1 (the STA-1860 failure mode, one agent
+// over). Its verified state machine, read off the shipped binary:
+//
+//   - each question starts highlighted on option 0; up/down move the highlight,
+//     and down past the last option enters own-answer text entry
+//   - single-select: Enter commits the highlighted option
+//   - multi-select: Enter TOGGLES the highlighted checkbox; right-arrow submits
+//     the checked set
+//   - own answer: the first printable input becomes the text, Enter commits it
+//     (multi-select instead moves focus to Continue, which Enter then submits)
+//   - committing an answer jumps to the next question with no answer yet, and
+//     the whole questionnaire is submitted once every question has one
+//
+// That last rule is why this walks Droid's cursor rather than assuming one
+// question per pass: a skipped question stays selected, and every later
+// keystroke would otherwise land on the wrong question.
+
+import type {
+  AskAnswerKeyGroup,
+  AskAnswerSelection,
+  AskPrompt,
+  AskQuestion
+} from './native-chat-ask-types'
+
+const ENTER = '\r'
+const DOWN = '\x1b[B'
+const RIGHT = '\x1b[C'
+const TAB = '\t'
+
+/** Droid reads a paste as one printable input, so the text must stay single-line:
+ *  a multi-line body would be bracketed-paste framed, and the selector drops any
+ *  input containing an escape while it is showing options. */
+function singleLine(value: string): string {
+  return value.replaceAll(/\s+/g, ' ').trim()
+}
+
+function pickedLabels(question: AskQuestion, selection: AskAnswerSelection | undefined): string[] {
+  return (selection?.indices ?? [])
+    .map((index) => question.options[index]?.label ?? '')
+    .filter((label) => label.length > 0)
+}
+
+function isAnswered(selection: AskAnswerSelection | undefined): boolean {
+  return (selection?.indices.length ?? 0) > 0 || singleLine(selection?.other ?? '').length > 0
+}
+
+/** Droid's own advance: the next question (cyclic) that still has no answer. */
+function nextUnanswered(current: number, total: number, answered: ReadonlySet<number>): number {
+  for (let step = 1; step <= total; step += 1) {
+    const candidate = (current + step) % total
+    if (!answered.has(candidate)) {
+      return candidate
+    }
+  }
+  return current
+}
+
+export function buildDroidAskAnswerKeys(
+  prompt: AskPrompt,
+  selections: AskAnswerSelection[]
+): AskAnswerKeyGroup[] {
+  const questions = prompt.questions
+  const total = questions.length
+  const groups: AskAnswerKeyGroup[] = []
+  const answered = new Set<number>()
+  let cursor = 0
+
+  questions.forEach((question, questionIndex) => {
+    const selection = selections[questionIndex]
+    if (!isAnswered(selection)) {
+      return
+    }
+    // Tab walks questions without committing anything. Only a multi-select with
+    // a pending answer submits on Tab, and this never leaves one in that state.
+    for (let step = 0; step < (questionIndex - cursor + total) % total; step += 1) {
+      groups.push({ raw: TAB })
+    }
+    cursor = questionIndex
+    const other = singleLine(selection?.other ?? '')
+
+    if (question.multiSelect) {
+      let row = 0
+      for (const index of [...(selection?.indices ?? [])].sort((left, right) => left - right)) {
+        for (let step = row; step < index; step += 1) {
+          groups.push({ raw: DOWN })
+        }
+        row = index
+        groups.push({ raw: ENTER })
+      }
+      if (other) {
+        // A printable input opens text entry from wherever the highlight sits;
+        // Enter then parks on Continue, which the second Enter submits.
+        groups.push({ text: other }, { raw: ENTER }, { raw: ENTER })
+      } else {
+        groups.push({ raw: RIGHT })
+      }
+    } else if (other) {
+      // Single-select carries one value, so a free-text answer absorbs any
+      // picked labels rather than being dropped.
+      groups.push({ text: [...pickedLabels(question, selection), other].join(', ') })
+      groups.push({ raw: ENTER })
+    } else {
+      for (let step = 0; step < selection!.indices[0]!; step += 1) {
+        groups.push({ raw: DOWN })
+      }
+      groups.push({ raw: ENTER })
+    }
+
+    answered.add(questionIndex)
+    cursor = nextUnanswered(questionIndex, total, answered)
+  })
+
+  return groups
+}

--- a/src/shared/native-chat-ask-droid-questionnaire.ts
+++ b/src/shared/native-chat-ask-droid-questionnaire.ts
@@ -1,0 +1,192 @@
+// Droid's AskUser tool takes a plain-text `questionnaire` string, not the
+// `{questions: [...]}` object every other agent's ask tool uses. This is a
+// faithful transcription of the grammar the shipped `droid` binary parses
+// (markers, line-splitting, caps, and validation), so Orca's card renders
+// exactly the questionnaire Droid's own selector is showing — and refuses the
+// ones Droid itself rejects, where a rendered card could only mis-deliver.
+
+import type { AskPrompt, AskQuestion } from './native-chat-ask-types'
+
+const FENCED_BLOCK = /```(?:\w+)?\s*([\s\S]*?)```/m
+const QUESTION_LINE = /^(?:(?:\d+[.)]|[-*•])\s*)?\[question\]\s*(.+?)\s*(\(multi\))?\s*$/i
+const TOPIC_LINE = /^(?:(?:\d+[.)]|[-*•])\s*)?\[topic\]\s*(.+?)\s*$/i
+const OPTION_LINE = /^(?:(?:\d+[.)]|[-*•])\s*)?\[option\]\s*(.+?)\s*$/i
+const NUMBERED_LINE = /^(\d+)[.)]\s+(.+?)\s*(\(multi\))?\s*$/i
+const MULTI_SUFFIX = /^(.*?)\s*\(multi\)\s*$/i
+const MARKDOWN_HEADER = /^#+\s/
+const FENCE_MARKER = /^```/
+const CRAMMED_QUESTION_START = /^(?:\d+[.)]|[-*•])?\s*\[question\]/i
+const CRAMMED_TRAILING_MARKER = /\[question\].*\[(topic|option)\]/i
+
+const MAX_QUESTIONS = 10
+const MIN_OPTIONS = 1
+const MAX_OPTIONS = 10
+/** Droid's fallback when a question declares no options at all. */
+const IMPLIED_OPTIONS = ['Yes', 'No']
+
+type Draft = {
+  kind: 'explicit' | 'implicit'
+  question: string
+  topic?: string
+  options: string[]
+  multiSelect: boolean
+}
+
+/** Droid emits the topic as a single token, so its own tabs read `Model-choice`. */
+function normalizeTopic(value: string): string {
+  return value.trim().replaceAll(/\s+/g, '-')
+}
+
+/** A model can put `[question] … [topic] … [option] …` on one line; Droid breaks
+ *  those apart before parsing, so the same line must split here too. */
+function splitCrammedMarkers(line: string): string {
+  if (!CRAMMED_QUESTION_START.test(line) || !CRAMMED_TRAILING_MARKER.test(line)) {
+    return line
+  }
+  return line
+    .replaceAll(/([.?!)])\s+\[(topic)\]/gi, '$1\n[$2]')
+    .replaceAll(/([\w)])\s+\[(option)\]/g, '$1\n[$2]')
+}
+
+function questionnaireLines(raw: string): string[] {
+  // A fenced block wins over the surrounding prose: models often wrap the
+  // questionnaire in ``` and Droid parses only the fence's contents.
+  const body = FENCED_BLOCK.exec(raw)?.[1] ?? raw
+  const lines = body
+    .split('\n')
+    .map((line) => splitCrammedMarkers(line))
+    .join('\n')
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+    .filter((line) => {
+      const trimmed = line.trim()
+      return !MARKDOWN_HEADER.test(trimmed) && !FENCE_MARKER.test(trimmed)
+    })
+  const firstQuestion = lines.findIndex((line) => QUESTION_LINE.test(line.trim()))
+  return firstQuestion > 0 ? lines.slice(firstQuestion) : lines
+}
+
+/** Close the open draft into a question, or reject the questionnaire the way
+ *  Droid does (option count out of range, duplicate option labels). */
+function closeDraft(draft: Draft, questions: AskQuestion[]): boolean {
+  const options = draft.options.length === 0 ? [...IMPLIED_OPTIONS] : draft.options
+  if (options.length < MIN_OPTIONS || options.length > MAX_OPTIONS) {
+    return false
+  }
+  const seen = new Set<string>()
+  for (const option of options) {
+    const key = option.trim().toLowerCase()
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+  }
+  questions.push({
+    question: draft.question,
+    ...(draft.topic ? { header: draft.topic } : {}),
+    multiSelect: draft.multiSelect,
+    options: options.map((label) => ({ label }))
+  })
+  return true
+}
+
+function nextNonEmptyLine(lines: readonly string[], from: number): string {
+  for (let index = from; index < lines.length; index += 1) {
+    const trimmed = lines[index]?.trim()
+    if (trimmed) {
+      return trimmed
+    }
+  }
+  return ''
+}
+
+/** Parse Droid's `{ questionnaire: string }` AskUser input. Returns null for any
+ *  input Droid's own parser would reject, so no card is offered for a
+ *  questionnaire whose selector is showing a format error instead of options. */
+export function parseDroidQuestionnaire(input: unknown): AskPrompt | null {
+  const raw = (input as { questionnaire?: unknown } | null)?.questionnaire
+  if (typeof raw !== 'string') {
+    return null
+  }
+  const lines = questionnaireLines(raw)
+  const questions: AskQuestion[] = []
+  let draft: Draft | null = null
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = lines[index]!.trim()
+    if (!trimmed) {
+      continue
+    }
+    const question = QUESTION_LINE.exec(trimmed)
+    if (question) {
+      if (draft && !closeDraft(draft, questions)) {
+        return null
+      }
+      draft = null
+      const text = (question[1] ?? '').trim()
+      if (!text || questions.length >= MAX_QUESTIONS) {
+        return null
+      }
+      draft = { kind: 'explicit', question: text, options: [], multiSelect: !!question[2] }
+      continue
+    }
+    const topic = TOPIC_LINE.exec(trimmed)
+    if (topic) {
+      const text = (topic[1] ?? '').trim()
+      if (!draft || !text) {
+        return null
+      }
+      draft.topic = normalizeTopic(text)
+      continue
+    }
+    const option = OPTION_LINE.exec(trimmed)
+    if (option) {
+      const text = (option[1] ?? '').trim()
+      if (!draft || !text || draft.options.length >= MAX_OPTIONS) {
+        return null
+      }
+      draft.options.push(text)
+      continue
+    }
+    // A wrapped question keeps accumulating until its first topic/option line.
+    if (draft?.kind === 'explicit' && !draft.topic && draft.options.length === 0) {
+      const multi = MULTI_SUFFIX.exec(trimmed)
+      if (multi) {
+        draft.multiSelect = true
+        if (multi[1]) {
+          draft.question += `\n${multi[1]}`
+        }
+      } else {
+        draft.question += `\n${trimmed}`
+      }
+      continue
+    }
+    // `1. Which one?` opens a question only when its own topic/option lines follow.
+    const numbered = NUMBERED_LINE.exec(trimmed)
+    if (!numbered) {
+      continue
+    }
+    const following = nextNonEmptyLine(lines, index + 1)
+    if (!TOPIC_LINE.test(following) && !OPTION_LINE.test(following)) {
+      continue
+    }
+    if (draft && !closeDraft(draft, questions)) {
+      return null
+    }
+    draft = null
+    if (questions.length >= MAX_QUESTIONS) {
+      return null
+    }
+    draft = {
+      kind: 'implicit',
+      question: (numbered[2] ?? '').trim(),
+      options: [],
+      multiSelect: !!numbered[3]
+    }
+  }
+
+  if (draft && !closeDraft(draft, questions)) {
+    return null
+  }
+  return questions.length > 0 ? { questions } : null
+}

--- a/src/shared/native-chat-ask-droid.test.ts
+++ b/src/shared/native-chat-ask-droid.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest'
+import { buildDroidAskAnswerKeys } from './native-chat-ask-droid-keys'
+import { parseDroidQuestionnaire } from './native-chat-ask-droid-questionnaire'
+import { parseAskFromStatus, type AskAnswerSelection, type AskPrompt } from './native-chat-ask'
+
+const ENTER = '\r'
+const DOWN = '\x1b[B'
+const RIGHT = '\x1b[C'
+const TAB = '\t'
+
+const questionnaire = (text: string): { questionnaire: string } => ({ questionnaire: text })
+
+describe('parseDroidQuestionnaire', () => {
+  it('rejects anything that is not a questionnaire string', () => {
+    expect(parseDroidQuestionnaire(null)).toBeNull()
+    expect(parseDroidQuestionnaire({})).toBeNull()
+    expect(parseDroidQuestionnaire({ questionnaire: 42 })).toBeNull()
+    expect(parseDroidQuestionnaire(questionnaire('just prose, no markers'))).toBeNull()
+  })
+
+  it('parses the numbered marker form Droid documents', () => {
+    expect(
+      parseDroidQuestionnaire(
+        questionnaire(
+          [
+            '1. [question] Which remote should origin point at?',
+            '[topic] Remote',
+            '[option] ranaroussi/orca',
+            '[option] stablyai/orca',
+            '',
+            '2. [question] Which surfaces get the flag? (multi)',
+            '[topic] Reversed layout',
+            '[option] Desktop',
+            '[option] Mobile'
+          ].join('\n')
+        )
+      )
+    ).toEqual({
+      questions: [
+        {
+          question: 'Which remote should origin point at?',
+          header: 'Remote',
+          multiSelect: false,
+          options: [{ label: 'ranaroussi/orca' }, { label: 'stablyai/orca' }]
+        },
+        {
+          question: 'Which surfaces get the flag?',
+          header: 'Reversed-layout',
+          multiSelect: true,
+          options: [{ label: 'Desktop' }, { label: 'Mobile' }]
+        }
+      ]
+    })
+  })
+
+  it('accepts bare markers with no numbering and no topic', () => {
+    expect(
+      parseDroidQuestionnaire(
+        questionnaire(['[question] Ship it?', '[option] Yes', '[option] Later'].join('\n'))
+      )
+    ).toEqual({
+      questions: [
+        {
+          question: 'Ship it?',
+          multiSelect: false,
+          options: [{ label: 'Yes' }, { label: 'Later' }]
+        }
+      ]
+    })
+  })
+
+  it('defaults an option-less question to Yes/No', () => {
+    expect(parseDroidQuestionnaire(questionnaire('[question] Proceed?'))?.questions[0]).toEqual({
+      question: 'Proceed?',
+      multiSelect: false,
+      options: [{ label: 'Yes' }, { label: 'No' }]
+    })
+  })
+
+  it('splits markers crammed onto one line', () => {
+    expect(
+      parseDroidQuestionnaire(
+        questionnaire('1. [question] Pick one? [topic] Pick [option] A [option] B')
+      )
+    ).toEqual({
+      questions: [
+        {
+          question: 'Pick one?',
+          header: 'Pick',
+          multiSelect: false,
+          options: [{ label: 'A' }, { label: 'B' }]
+        }
+      ]
+    })
+  })
+
+  it('reads the fenced block and drops headers, fences, and preamble', () => {
+    const parsed = parseDroidQuestionnaire(
+      questionnaire(
+        [
+          'Some preamble the model added.',
+          '```markdown',
+          '## Heading',
+          '[question] Which one?',
+          '[option] A',
+          '[option] B',
+          '```'
+        ].join('\n')
+      )
+    )
+    expect(parsed?.questions).toEqual([
+      {
+        question: 'Which one?',
+        multiSelect: false,
+        options: [{ label: 'A' }, { label: 'B' }]
+      }
+    ])
+  })
+
+  it('folds a wrapped question body into the question text', () => {
+    expect(
+      parseDroidQuestionnaire(
+        questionnaire(
+          [
+            '[question] Which approach?',
+            'It changes how launch args are emitted.',
+            '[option] Flag',
+            '[option] Settings file'
+          ].join('\n')
+        )
+      )?.questions[0]?.question
+    ).toBe('Which approach?\nIt changes how launch args are emitted.')
+  })
+
+  it('opens an implicit numbered question only when its options follow', () => {
+    expect(
+      parseDroidQuestionnaire(
+        questionnaire(['1. Which one?', '[option] A', '[option] B'].join('\n'))
+      )?.questions
+    ).toEqual([
+      { question: 'Which one?', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] }
+    ])
+    expect(parseDroidQuestionnaire(questionnaire('1. Just a numbered sentence.'))).toBeNull()
+  })
+
+  // A card must never appear for a questionnaire whose selector is showing a
+  // format error: its options do not exist, so every keystroke would misfire.
+  it('rejects what Droid itself rejects', () => {
+    expect(parseDroidQuestionnaire(questionnaire('[question]'))).toBeNull()
+    expect(parseDroidQuestionnaire(questionnaire('[option] orphan'))).toBeNull()
+    expect(parseDroidQuestionnaire(questionnaire('[topic] orphan'))).toBeNull()
+    expect(
+      parseDroidQuestionnaire(
+        questionnaire(['[question] Pick?', '[option] A', '[option] a'].join('\n'))
+      )
+    ).toBeNull()
+    const elevenOptions = ['[question] Pick?'].concat(
+      Array.from({ length: 11 }, (_, index) => `[option] ${index}`)
+    )
+    expect(parseDroidQuestionnaire(questionnaire(elevenOptions.join('\n')))).toBeNull()
+    const elevenQuestions = Array.from(
+      { length: 11 },
+      (_, index) => `[question] Q${index}\n[option] A\n[option] B`
+    )
+    expect(parseDroidQuestionnaire(questionnaire(elevenQuestions.join('\n')))).toBeNull()
+  })
+
+  it('is the registered parser for the AskUser tool', () => {
+    const prompt = parseAskFromStatus(
+      JSON.stringify(questionnaire('[question] Ship?\n[option] Yes\n[option] No')),
+      'AskUser'
+    )
+    expect(prompt?.questions[0]?.options).toEqual([{ label: 'Yes' }, { label: 'No' }])
+  })
+})
+
+const prompt = (...questions: AskPrompt['questions']): AskPrompt => ({ questions })
+const single = (...labels: string[]): AskPrompt['questions'][number] => ({
+  question: 'q',
+  multiSelect: false,
+  options: labels.map((label) => ({ label }))
+})
+const multi = (...labels: string[]): AskPrompt['questions'][number] => ({
+  ...single(...labels),
+  multiSelect: true
+})
+const pick = (...indices: number[]): AskAnswerSelection => ({ indices })
+
+describe('buildDroidAskAnswerKeys', () => {
+  it('walks down to the picked option and commits it', () => {
+    expect(buildDroidAskAnswerKeys(prompt(single('A', 'B', 'C')), [pick(2)])).toEqual([
+      { raw: DOWN },
+      { raw: DOWN },
+      { raw: ENTER }
+    ])
+  })
+
+  it('commits the first option with no navigation', () => {
+    expect(buildDroidAskAnswerKeys(prompt(single('A', 'B')), [pick(0)])).toEqual([{ raw: ENTER }])
+  })
+
+  it('sends free text as one printable input, then commits', () => {
+    expect(
+      buildDroidAskAnswerKeys(prompt(single('A', 'B')), [{ indices: [], other: 'something  else' }])
+    ).toEqual([{ text: 'something else' }, { raw: ENTER }])
+  })
+
+  it('folds a picked label into the free-text answer a single-select can carry', () => {
+    expect(
+      buildDroidAskAnswerKeys(prompt(single('A', 'B')), [{ indices: [1], other: 'and more' }])
+    ).toEqual([{ text: 'B, and more' }, { raw: ENTER }])
+  })
+
+  it('toggles each checkbox in row order, then submits with right-arrow', () => {
+    expect(buildDroidAskAnswerKeys(prompt(multi('A', 'B', 'C')), [pick(2, 0)])).toEqual([
+      { raw: ENTER },
+      { raw: DOWN },
+      { raw: DOWN },
+      { raw: ENTER },
+      { raw: RIGHT }
+    ])
+  })
+
+  it('submits a multi-select free-text answer through the Continue row', () => {
+    expect(
+      buildDroidAskAnswerKeys(prompt(multi('A', 'B')), [{ indices: [0], other: 'plus this' }])
+    ).toEqual([{ raw: ENTER }, { text: 'plus this' }, { raw: ENTER }, { raw: ENTER }])
+  })
+
+  it('relies on the selector auto-advancing between answered questions', () => {
+    expect(
+      buildDroidAskAnswerKeys(prompt(single('A', 'B'), single('C', 'D')), [pick(1), pick(0)])
+    ).toEqual([{ raw: DOWN }, { raw: ENTER }, { raw: ENTER }])
+  })
+
+  // The selector jumps to the next question with no answer yet, so a skipped
+  // question leaves the cursor there and later keystrokes must account for it.
+  it('tabs across a skipped question instead of assuming the cursor advanced', () => {
+    expect(
+      buildDroidAskAnswerKeys(prompt(single('A', 'B'), single('C', 'D'), single('E', 'F')), [
+        pick(0),
+        { indices: [] },
+        pick(1)
+      ])
+    ).toEqual([{ raw: ENTER }, { raw: TAB }, { raw: DOWN }, { raw: ENTER }])
+  })
+
+  it('sends nothing when no question carries an answer', () => {
+    expect(buildDroidAskAnswerKeys(prompt(single('A', 'B')), [{ indices: [] }])).toEqual([])
+  })
+})

--- a/src/shared/native-chat-ask-types.ts
+++ b/src/shared/native-chat-ask-types.ts
@@ -13,3 +13,13 @@ export type AskPrompt = { questions: AskQuestion[] }
 /** A parser turns one agent's interactive-question tool input into the normalized
  *  AskPrompt the card renders. */
 export type InteractiveQuestionParser = (input: unknown) => AskPrompt | null
+
+/** One question's chosen answer, normalized for delivery: the selected option
+ *  indices (in option order) plus any free-text "other" answer. Index-based (not
+ *  label text) because every stepped selector commits a row, not typed text. */
+export type AskAnswerSelection = { indices: number[]; other?: string }
+
+/** A single keystroke group to write to the agent PTY. `raw` bytes (option
+ *  numbers, Enter, arrows) are written verbatim as keystrokes; `text` is a
+ *  free-text answer the caller runs through its paste sanitizer before writing. */
+export type AskAnswerKeyGroup = { raw: string } | { text: string }

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -1,4 +1,7 @@
+import { parseDroidQuestionnaire } from './native-chat-ask-droid-questionnaire'
 import type {
+  AskAnswerKeyGroup,
+  AskAnswerSelection,
   AskOption,
   AskPrompt,
   AskQuestion,
@@ -6,7 +9,15 @@ import type {
 } from './native-chat-ask-types'
 import { isInterruptedStatusMessage, type NativeChatMessage } from './native-chat-types'
 
-export type { AskOption, AskPrompt, AskQuestion, InteractiveQuestionParser }
+export type {
+  AskAnswerKeyGroup,
+  AskAnswerSelection,
+  AskOption,
+  AskPrompt,
+  AskQuestion,
+  InteractiveQuestionParser
+}
+export { buildDroidAskAnswerKeys } from './native-chat-ask-droid-keys'
 
 const QUESTION_TOOL_PARSERS = new Map<string, InteractiveQuestionParser>()
 
@@ -75,6 +86,10 @@ function parseOptions(raw: unknown): AskOption[] {
 for (const name of ['AskUserQuestion', 'ask_user_question', 'askUserQuestion']) {
   QUESTION_TOOL_PARSERS.set(name, parseQuestionsShape)
 }
+// Droid's AskUser ships a plain-text questionnaire instead of a questions array.
+for (const name of ['AskUser', 'ask-user', 'ask_user']) {
+  QUESTION_TOOL_PARSERS.set(name, parseDroidQuestionnaire)
+}
 
 function parseToolInput(toolName: string | undefined, input: unknown): AskPrompt | null {
   const parser = toolName ? QUESTION_TOOL_PARSERS.get(toolName) : undefined
@@ -139,17 +154,6 @@ export function resolveNativeChatAsk(args: {
 }): AskPrompt | null {
   return args.liveAsk ?? (args.transcriptSettled ? extractPendingAsk(args.messages) : null)
 }
-
-/** One question's chosen answer, normalized for delivery: the selected option
- *  indices (in option order) plus any free-text "other" answer. Index-based (not
- *  label text) so the answer can be delivered by the selector's stable option
- *  number — see `buildAskAnswerKeys`. */
-export type AskAnswerSelection = { indices: number[]; other?: string }
-
-/** A single keystroke group to write to the agent PTY. `raw` bytes (option
- *  numbers, Enter, arrows) are written verbatim as keystrokes; `text` is a
- *  free-text answer the caller runs through its paste sanitizer before writing. */
-export type AskAnswerKeyGroup = { raw: string } | { text: string }
 
 /** True when this question is answered (a picked option or typed free text). */
 function isAnswered(sel: AskAnswerSelection | undefined): boolean {

--- a/src/shared/native-chat-slash-commands.ts
+++ b/src/shared/native-chat-slash-commands.ts
@@ -78,10 +78,55 @@ const CODEX_COMMANDS: readonly SlashCommandSuggestion[] = [
   { name: 'subagents', description: 'Switch the active agent thread' }
 ]
 
+// Read off the command registry the shipped `droid` binary itself builds, so a
+// name here is one the TUI really dispatches. Aliases Droid registers (`/cd`,
+// `/clear`, `/favorite`) are omitted in favor of their primary name.
+const DROID_COMMANDS: readonly SlashCommandSuggestion[] = [
+  { name: 'model', description: 'Open the model selector' },
+  { name: 'new', description: 'Start a fresh session, resetting model and autonomy' },
+  { name: 'compress', description: 'Compress the current session' },
+  { name: 'context', description: 'Show context window usage' },
+  { name: 'cost', description: 'Show token usage and cost' },
+  { name: 'copy', description: 'Copy the last response to the clipboard' },
+  { name: 'btw', description: 'Ask a side question without polluting the transcript' },
+  { name: 'review', description: 'Review the current changes' },
+  { name: 'missions', description: 'Enter, manage, and resume missions' },
+  { name: 'droids', description: 'Manage custom droids (subagents)' },
+  { name: 'skills', description: 'Manage prompt-based skills' },
+  { name: 'commands', description: 'Manage custom slash commands' },
+  { name: 'create-skill', description: 'Create a skill from this conversation' },
+  { name: 'loop', description: 'Configure or run the agent loop' },
+  { name: 'automations', description: 'Manage local scheduled automations' },
+  { name: 'sessions', description: 'List and resume previous sessions' },
+  { name: 'fork', description: 'Fork this session into a new one' },
+  { name: 'tree', description: 'Navigate the session fork tree' },
+  { name: 'rewind-conversation', description: 'Rewind to an earlier message' },
+  { name: 'rename', description: 'Rename the current session' },
+  { name: 'pin', description: 'Pin the current session' },
+  { name: 'share', description: 'Share this session with your organization' },
+  { name: 'cwd', description: 'Change the working directory' },
+  { name: 'status', description: 'Show CLI status and configuration' },
+  { name: 'stats', description: 'Show usage statistics' },
+  { name: 'limits', description: 'Show credit rate limits and usage' },
+  { name: 'settings', description: 'Configure application settings' },
+  { name: 'statusline', description: 'Configure the status line' },
+  { name: 'themes', description: 'Choose a color theme' },
+  { name: 'language', description: 'Switch the display language' },
+  { name: 'hooks', description: 'Manage tool execution hooks' },
+  { name: 'mcp', description: 'Manage MCP servers' },
+  { name: 'plugins', description: 'Manage plugins and marketplaces' },
+  { name: 'ide', description: 'Connect to an IDE extension' },
+  { name: 'diagnostics', description: 'Show settings configuration errors' },
+  { name: 'bug', description: 'Report a bug to Factory' },
+  { name: 'help', description: 'Show available slash commands' },
+  { name: 'quit', description: 'Exit the Droid CLI' }
+]
+
 const COMMANDS_BY_AGENT: Partial<Record<AgentType, readonly SlashCommandSuggestion[]>> = {
   claude: CLAUDE_COMMANDS,
   openclaude: CLAUDE_COMMANDS,
-  codex: CODEX_COMMANDS
+  codex: CODEX_COMMANDS,
+  droid: DROID_COMMANDS
 }
 
 /** Known slash commands for an agent, falling back to a small common set so the

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -256,7 +256,8 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalAgentHibernation',
   'experimentalEphemeralVms',
   'geminiCliOAuthEnabled',
-  'openAgentTabsInChatByDefault'
+  'openAgentTabsInChatByDefault',
+  'nativeChatComposerOnTop'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]
 export const settingsChangedKeySchema = z.enum(SETTINGS_CHANGED_WHITELIST)
 export type SettingsChangedKey = z.infer<typeof settingsChangedKeySchema>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2889,6 +2889,8 @@ export type GlobalSettings = {
   openAgentTabsInChatByDefault?: boolean
   /** Experimental native chat surface for Claude/Codex sessions; off by default. */
   experimentalNativeChat?: boolean
+  /** Desktop Chat UI reads top-down from the composer: input pinned above the transcript, newest turn directly beneath it. */
+  nativeChatComposerOnTop?: boolean
   /** Last explicit native-chat model + option selections; live panes need an applied/dispatched record before showing a value. */
   nativeChatSessionOptions?: PersistedNativeChatSessionOptions
   /** Extra launcher rows for the worktree "Open in" submenu. VS Code is always shown first. */


### PR DESCRIPTION
## Summary

Adds full Droid (Factory's CLI agent) support to the experimental Chat UI, plus an opt-in setting that reverses the chat layout so the composer sits above the transcript.

### Droid support

- **Transcript decoder** for `~/.factory/sessions/<cwd-slug>/<id>.jsonl` (honors `FACTORY_HOME`), with `visibility` filtering (`llm_only`/`user_only`/`both`) and per-block injected-context removal (Droid appends `<system-reminder>` and tagged-file dumps as extra text blocks inside the user's own turn)
- **Turn lifecycle decoder** for `agent_turn_outcome` records (completed/cancelled)
- **Session file resolver** via exact-basename walk (hook `session_id` = file basename, like Claude)
- **AskUser question card**: questionnaire parser transcribed verbatim from the shipped `droid` binary's grammar (numbered markers, fenced blocks, implicit numbering, caps at 10 questions / 1-10 options, Yes/No default). Arrow-navigation answer keys match the selector's state machine -- Droid's selector has **no option digits** (any printable char switches to free-text entry), and committing jumps to the next *unanswered* question. This directly avoids the STA-1860 class of bug where guessed keystrokes silently commit the wrong option
- **38 verified slash commands** + `~/.factory/skills` and `<repo>/.factory/skills` discovery roots
- **Model picker**: `droid exec --help` "Model details:" section is a real per-account model probe, fed through Orca's existing discovery machinery (works on local, WSL, and SSH hosts). `/model` routes to Droid's own TUI selector (`agent-picker`), since interactive `droid` has no `-m` flag and silently ignores unknown flags (verified against v0.191.1)
- **Hook listener**: extracts `interactivePrompt` from `tool_input`/`input`/`arguments`; `isAskUserQuestionTool` matches `askuser`

### Composer on top

- `nativeChatComposerOnTop` setting under Settings > Experimental > Chat UI
- Reversed layout renders newest-first in a normal column (not `flex-col-reverse` on the scroller, which breaks scroll anchoring and the paging edge)
- Root pane uses `flex-col-reverse` to flip the three regions (transcript, interactive card, composer)
- Padding, load-earlier control, typing indicator, and jump affordance all follow the newest edge
- Pure orientation helpers extracted to `native-chat-list-orientation.ts` to keep `NativeChatView.tsx` and `NativeChatMessageList.tsx` under their `max-lines` budgets

<img width="1200" height="816" alt="image" src="https://github.com/user-attachments/assets/74f59259-9235-419c-91c6-80d55b4aabaa" />

## Design decisions

- **No `--auto` / `--use-spec` pills**: Orca's launch resolver emits option flags only when a model is selected, and interactive Droid can't select one at launch (no `-m` flag). These would let users pick a value that silently never reaches the command line.
- **No reasoning-effort row**: `droid exec` takes `-r`, but the interactive CLI has neither the flag nor a slash command for it.
- **Model identities are labels, not slugs**: `droid exec --help` prints human-readable labels only ("Opus 5", "GPT-5.6 Sol"), and the interactive CLI takes no model id at all. Deriving slugs would invent ids the CLI never publishes.

## Tests

73 new tests across:
- Droid transcript decoder (13) and turn lifecycle (7)
- AskUser questionnaire parser (10) and answer key builder (9)
- List orientation geometry helpers (14)
- Message list DOM orientation (4)
- Droid model list probe (7)
- Droid session option catalog (8)

Full suite: 6917 passed, 1 pre-existing environment failure (`posix-command-path-lookup.test.ts`, ServBay node symlink -- untouched by this PR). `pnpm typecheck`, `oxlint`, max-lines ratchet, reliability gates, and all three localization verifications pass.

## Follow-up (not in this PR)

Reading Droid's `<session>.settings.json` sidecar to display the real current model/reasoning effort in the pill. Needs a main-process read + IPC, which per `docs/reference/remote-wire-compatibility.md` wants capability negotiation for remote hosts.
