### PR TITLE
perf(renderer): cap remote project refresh concurrency

### DIFF
--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -5,6 +5,17 @@ import {
   refreshRuntimeProjectWorktreesAndLineage
 } from './runtime-project-refresh-scheduler'
 
+function createPendingRefresh(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve = (): void => {}
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
 describe('refreshRuntimeProjectWorktrees', () => {
   it('deduplicates same-host repo IDs and pins the refresh to the event runtime', async () => {
     const fetchWorktrees = vi.fn().mockResolvedValue(true)
@@ -64,6 +75,25 @@ describe('refreshRuntimeProjectWorktrees', () => {
       }),
       lineageError
     ])
+  })
+
+  it('keeps same-ID repo refreshes isolated across environments', async () => {
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+
+    await Promise.all([
+      refreshRuntimeProjectWorktrees('env-1', [{ id: 'same-repo' }], fetchWorktrees),
+      refreshRuntimeProjectWorktrees('env-2', [{ id: 'same-repo' }], fetchWorktrees)
+    ])
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      executionHostId: 'runtime:env-1',
+      suppressRemoteLineageRefresh: true
+    })
+    expect(fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      executionHostId: 'runtime:env-2',
+      suppressRemoteLineageRefresh: true
+    })
   })
 })
 
@@ -167,5 +197,401 @@ describe('createRuntimeProjectRefreshScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
 
     expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('caps cross-host refreshes and admits waiting hosts in FIFO order', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    let activeRefreshes = 0
+    let peakActiveRefreshes = 0
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      activeRefreshes += 1
+      peakActiveRefreshes = Math.max(peakActiveRefreshes, activeRefreshes)
+      return next.promise.finally(() => {
+        activeRefreshes -= 1
+      })
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 2
+    })
+
+    for (const environmentId of ['env-1', 'env-2', 'env-3', 'env-4', 'env-5']) {
+      scheduler.request(environmentId)
+    }
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['env-1', 'env-2'])
+
+    pending.get('env-1')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3'
+    ])
+
+    pending.get('env-2')?.resolve()
+    pending.get('env-3')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3',
+      'env-4',
+      'env-5'
+    ])
+    expect(peakActiveRefreshes).toBe(2)
+
+    scheduler.stop()
+    for (const entry of pending.values()) {
+      entry.resolve()
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    expect(activeRefreshes).toBe(0)
+  })
+
+  it('reserves capacity for the prioritized host', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 2,
+      getPrioritizedEnvironmentId: () => 'active'
+    })
+
+    scheduler.request('background-1')
+    scheduler.request('background-2')
+    scheduler.request('active')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background-1',
+      'active'
+    ])
+
+    pending.get('active')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh).toHaveBeenCalledTimes(2)
+
+    pending.get('background-1')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background-1',
+      'active',
+      'background-2'
+    ])
+
+    scheduler.stop()
+    pending.get('background-2')?.resolve()
+  })
+
+  it('runs two background hosts concurrently beside the reserved foreground lane', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const entry = createPendingRefresh()
+      pending.set(environmentId, entry)
+      return entry.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      getPrioritizedEnvironmentId: () => 'active'
+    })
+
+    // Why: the reserved slot is never lent out, so the default cap must leave two
+    // background lanes; at a cap of 2 this serialized discovery to one host at a time.
+    scheduler.request('background-1')
+    scheduler.request('background-2')
+    scheduler.request('background-3')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background-1',
+      'background-2'
+    ])
+
+    scheduler.stop()
+    pending.get('background-1')?.resolve()
+    pending.get('background-2')?.resolve()
+  })
+
+  it('still admits the foreground host while both background lanes are busy', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const entry = createPendingRefresh()
+      pending.set(environmentId, entry)
+      return entry.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      getPrioritizedEnvironmentId: () => 'active'
+    })
+
+    scheduler.request('background-1')
+    scheduler.request('background-2')
+    scheduler.request('background-3')
+    scheduler.request('active')
+    await vi.advanceTimersByTimeAsync(100)
+
+    // Why: the foreground must never queue behind background work, even when every
+    // background lane is occupied and more hosts are still waiting.
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background-1',
+      'background-2',
+      'active'
+    ])
+
+    scheduler.stop()
+    pending.forEach((entry) => entry.resolve())
+  })
+
+  it('admits a queued host when it becomes prioritized', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    let activeEnvironmentId = 'none'
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 2,
+      getPrioritizedEnvironmentId: () => activeEnvironmentId
+    })
+
+    scheduler.request('background')
+    scheduler.request('next-active')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['background'])
+
+    activeEnvironmentId = 'next-active'
+    scheduler.reprioritize()
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background',
+      'next-active'
+    ])
+
+    scheduler.stop()
+    pending.get('background')?.resolve()
+    pending.get('next-active')?.resolve()
+  })
+
+  it('admits newly prioritized work before an earlier background waiter', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    let activeEnvironmentId = 'active-1'
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 2,
+      getPrioritizedEnvironmentId: () => activeEnvironmentId
+    })
+
+    for (const environmentId of [
+      'active-1',
+      'background-running',
+      'background-waiting',
+      'active-2'
+    ]) {
+      scheduler.request(environmentId)
+    }
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running'
+    ])
+
+    activeEnvironmentId = 'active-2'
+    scheduler.reprioritize()
+    pending.get('background-running')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running',
+      'active-2'
+    ])
+
+    scheduler.stop()
+    pending.get('active-1')?.resolve()
+    pending.get('active-2')?.resolve()
+  })
+
+  it('reclassifies the old foreground before admitting more background work', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    let activeEnvironmentId = 'active-1'
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 2,
+      getPrioritizedEnvironmentId: () => activeEnvironmentId
+    })
+
+    scheduler.request('active-1')
+    scheduler.request('background-running')
+    scheduler.request('background-waiting')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running'
+    ])
+
+    activeEnvironmentId = 'active-2'
+    scheduler.reprioritize()
+    pending.get('background-running')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh).toHaveBeenCalledTimes(2)
+
+    scheduler.request('active-2')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running',
+      'active-2'
+    ])
+
+    scheduler.stop()
+    pending.get('active-1')?.resolve()
+    pending.get('active-2')?.resolve()
+  })
+
+  it('coalesces queued requests and puts an in-flight follow-up behind waiting hosts', async () => {
+    const calls: { environmentId: string; pending: ReturnType<typeof createPendingRefresh> }[] = []
+    const isEnvironmentDesired = vi.fn(() => true)
+    const getPrioritizedEnvironmentId = vi.fn(() => null)
+    const refresh = vi.fn((environmentId: string) => {
+      const pending = createPendingRefresh()
+      calls.push({ environmentId, pending })
+      return pending.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 1,
+      isEnvironmentDesired,
+      getPrioritizedEnvironmentId
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-2')
+    scheduler.request('env-2')
+    await vi.advanceTimersByTimeAsync(100)
+    const desiredChecks = isEnvironmentDesired.mock.calls.length
+    const priorityChecks = getPrioritizedEnvironmentId.mock.calls.length
+    scheduler.request('env-2')
+    scheduler.request('env-2')
+    scheduler.request('env-1')
+    scheduler.request('env-1')
+    expect(isEnvironmentDesired).toHaveBeenCalledTimes(desiredChecks)
+    expect(getPrioritizedEnvironmentId).toHaveBeenCalledTimes(priorityChecks)
+
+    calls[0].pending.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['env-1', 'env-2'])
+
+    scheduler.request('env-3')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    calls[1].pending.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3'
+    ])
+
+    calls[2].pending.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3',
+      'env-1'
+    ])
+
+    scheduler.stop()
+    calls[3].pending.resolve()
+  })
+
+  it('releases capacity after failure and skips hosts removed before admission', async () => {
+    const first = createPendingRefresh()
+    const third = createPendingRefresh()
+    const desired = new Set(['env-1', 'env-2', 'env-3'])
+    const onError = vi.fn()
+    const refresh = vi.fn(async (environmentId: string) => {
+      if (environmentId === 'env-1') {
+        await first.promise
+        throw new Error('offline')
+      }
+      await third.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 1,
+      isEnvironmentDesired: (environmentId) => desired.has(environmentId),
+      onError
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-2')
+    scheduler.request('env-3')
+    await vi.advanceTimersByTimeAsync(100)
+    desired.delete('env-2')
+    first.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['env-1', 'env-3'])
+
+    scheduler.stop()
+    third.resolve()
+  })
+
+  it('does not admit queued or follow-up work after stop', async () => {
+    const first = createPendingRefresh()
+    const refresh = vi.fn(() => first.promise)
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 1
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-2')
+    await vi.advanceTimersByTimeAsync(100)
+    scheduler.request('env-1')
+    scheduler.stop()
+    first.resolve()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(refresh).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -4,6 +4,17 @@ import {
   refreshRuntimeProjectWorktrees
 } from './runtime-project-refresh-scheduler'
 
+function createPendingRefresh(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve = (): void => {}
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
 describe('refreshRuntimeProjectWorktrees', () => {
   it('pins same-ID repo refreshes to the event runtime', async () => {
     const fetchWorktrees = vi.fn().mockResolvedValue(true)
@@ -20,6 +31,23 @@ describe('refreshRuntimeProjectWorktrees', () => {
     })
     expect(fetchWorktrees).toHaveBeenNthCalledWith(2, 'same-repo', {
       executionHostId: 'runtime:env-1'
+    })
+  })
+
+  it('keeps same-ID repo refreshes isolated across environments', async () => {
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+
+    await Promise.all([
+      refreshRuntimeProjectWorktrees('env-1', [{ id: 'same-repo' }], fetchWorktrees),
+      refreshRuntimeProjectWorktrees('env-2', [{ id: 'same-repo' }], fetchWorktrees)
+    ])
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      executionHostId: 'runtime:env-1'
+    })
+    expect(fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      executionHostId: 'runtime:env-2'
     })
   })
 })
@@ -124,5 +152,333 @@ describe('createRuntimeProjectRefreshScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
 
     expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('caps cross-host refreshes and admits waiting hosts in FIFO order', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    let activeRefreshes = 0
+    let peakActiveRefreshes = 0
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      activeRefreshes += 1
+      peakActiveRefreshes = Math.max(peakActiveRefreshes, activeRefreshes)
+      return next.promise.finally(() => {
+        activeRefreshes -= 1
+      })
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000
+    })
+
+    for (const environmentId of ['env-1', 'env-2', 'env-3', 'env-4', 'env-5']) {
+      scheduler.request(environmentId)
+    }
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['env-1', 'env-2'])
+
+    pending.get('env-1')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3'
+    ])
+
+    pending.get('env-2')?.resolve()
+    pending.get('env-3')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3',
+      'env-4',
+      'env-5'
+    ])
+    expect(peakActiveRefreshes).toBe(2)
+
+    scheduler.stop()
+    for (const entry of pending.values()) {
+      entry.resolve()
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    expect(activeRefreshes).toBe(0)
+  })
+
+  it('reserves capacity for the prioritized host', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      getPrioritizedEnvironmentId: () => 'active'
+    })
+
+    scheduler.request('background-1')
+    scheduler.request('background-2')
+    scheduler.request('active')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background-1',
+      'active'
+    ])
+
+    pending.get('active')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh).toHaveBeenCalledTimes(2)
+
+    pending.get('background-1')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background-1',
+      'active',
+      'background-2'
+    ])
+
+    scheduler.stop()
+    pending.get('background-2')?.resolve()
+  })
+
+  it('admits a queued host when it becomes prioritized', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    let activeEnvironmentId = 'none'
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      getPrioritizedEnvironmentId: () => activeEnvironmentId
+    })
+
+    scheduler.request('background')
+    scheduler.request('next-active')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['background'])
+
+    activeEnvironmentId = 'next-active'
+    scheduler.reprioritize()
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'background',
+      'next-active'
+    ])
+
+    scheduler.stop()
+    pending.get('background')?.resolve()
+    pending.get('next-active')?.resolve()
+  })
+
+  it('admits newly prioritized work before an earlier background waiter', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    let activeEnvironmentId = 'active-1'
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      getPrioritizedEnvironmentId: () => activeEnvironmentId
+    })
+
+    for (const environmentId of [
+      'active-1',
+      'background-running',
+      'background-waiting',
+      'active-2'
+    ]) {
+      scheduler.request(environmentId)
+    }
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running'
+    ])
+
+    activeEnvironmentId = 'active-2'
+    scheduler.reprioritize()
+    pending.get('background-running')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running',
+      'active-2'
+    ])
+
+    scheduler.stop()
+    pending.get('active-1')?.resolve()
+    pending.get('active-2')?.resolve()
+  })
+
+  it('reclassifies the old foreground before admitting more background work', async () => {
+    const pending = new Map<string, ReturnType<typeof createPendingRefresh>>()
+    const refresh = vi.fn((environmentId: string) => {
+      const next = createPendingRefresh()
+      pending.set(environmentId, next)
+      return next.promise
+    })
+    let activeEnvironmentId = 'active-1'
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      getPrioritizedEnvironmentId: () => activeEnvironmentId
+    })
+
+    scheduler.request('active-1')
+    scheduler.request('background-running')
+    scheduler.request('background-waiting')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running'
+    ])
+
+    activeEnvironmentId = 'active-2'
+    scheduler.reprioritize()
+    pending.get('background-running')?.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh).toHaveBeenCalledTimes(2)
+
+    scheduler.request('active-2')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'active-1',
+      'background-running',
+      'active-2'
+    ])
+
+    scheduler.stop()
+    pending.get('active-1')?.resolve()
+    pending.get('active-2')?.resolve()
+  })
+
+  it('coalesces queued requests and puts an in-flight follow-up behind waiting hosts', async () => {
+    const calls: { environmentId: string; pending: ReturnType<typeof createPendingRefresh> }[] = []
+    const isEnvironmentDesired = vi.fn(() => true)
+    const getPrioritizedEnvironmentId = vi.fn(() => null)
+    const refresh = vi.fn((environmentId: string) => {
+      const pending = createPendingRefresh()
+      calls.push({ environmentId, pending })
+      return pending.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 1,
+      isEnvironmentDesired,
+      getPrioritizedEnvironmentId
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-2')
+    scheduler.request('env-2')
+    await vi.advanceTimersByTimeAsync(100)
+    const desiredChecks = isEnvironmentDesired.mock.calls.length
+    const priorityChecks = getPrioritizedEnvironmentId.mock.calls.length
+    scheduler.request('env-2')
+    scheduler.request('env-2')
+    scheduler.request('env-1')
+    scheduler.request('env-1')
+    expect(isEnvironmentDesired).toHaveBeenCalledTimes(desiredChecks)
+    expect(getPrioritizedEnvironmentId).toHaveBeenCalledTimes(priorityChecks)
+
+    calls[0].pending.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['env-1', 'env-2'])
+
+    scheduler.request('env-3')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    calls[1].pending.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3'
+    ])
+
+    calls[2].pending.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual([
+      'env-1',
+      'env-2',
+      'env-3',
+      'env-1'
+    ])
+
+    scheduler.stop()
+    calls[3].pending.resolve()
+  })
+
+  it('releases capacity after failure and skips hosts removed before admission', async () => {
+    const first = createPendingRefresh()
+    const third = createPendingRefresh()
+    const desired = new Set(['env-1', 'env-2', 'env-3'])
+    const onError = vi.fn()
+    const refresh = vi.fn(async (environmentId: string) => {
+      if (environmentId === 'env-1') {
+        await first.promise
+        throw new Error('offline')
+      }
+      await third.promise
+    })
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 1,
+      isEnvironmentDesired: (environmentId) => desired.has(environmentId),
+      onError
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-2')
+    scheduler.request('env-3')
+    await vi.advanceTimersByTimeAsync(100)
+    desired.delete('env-2')
+    first.resolve()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(refresh.mock.calls.map(([environmentId]) => environmentId)).toEqual(['env-1', 'env-3'])
+
+    scheduler.stop()
+    third.resolve()
+  })
+
+  it('does not admit queued or follow-up work after stop', async () => {
+    const first = createPendingRefresh()
+    const refresh = vi.fn(() => first.promise)
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000,
+      maxConcurrentRefreshes: 1
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-2')
+    await vi.advanceTimersByTimeAsync(100)
+    scheduler.request('env-1')
+    scheduler.stop()
+    first.resolve()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(refresh).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -4,12 +4,16 @@ export type RuntimeProjectRefreshSchedulerDeps = {
   refresh: (environmentId: string) => Promise<void>
   debounceMs?: number
   minIntervalMs?: number
+  maxConcurrentRefreshes?: number
+  isEnvironmentDesired?: (environmentId: string) => boolean
+  getPrioritizedEnvironmentId?: () => string | null
   now?: () => number
   onError?: (error: unknown) => void
 }
 
 export type RuntimeProjectRefreshScheduler = {
   request: (environmentId: string) => void
+  reprioritize: () => void
   stop: () => void
 }
 
@@ -17,12 +21,22 @@ type RefreshEntry = {
   inFlight: boolean
   lastStartedAt: number
   pending: boolean
+  queued: boolean
   timer: ReturnType<typeof setTimeout> | null
+}
+
+type ReadyRefresh = {
+  environmentId: string
+  entry: RefreshEntry
 }
 
 const DEFAULT_DEBOUNCE_MS = 250
 const DEFAULT_MIN_INTERVAL_MS = 5_000
-const DEFAULT_REFRESH_CONCURRENCY = 5
+// Why 3, not 2: one slot is reserved for the foreground workspace and is not lent out,
+// so a cap of 2 left exactly one background lane and serialized host discovery. Three
+// keeps the reservation intact while giving background hosts the two lanes we intend.
+const DEFAULT_ENVIRONMENT_REFRESH_CONCURRENCY = 3
+const DEFAULT_WORKTREE_REFRESH_CONCURRENCY = 5
 
 export async function refreshRuntimeProjectWorktrees(
   environmentId: string,
@@ -34,7 +48,7 @@ export async function refreshRuntimeProjectWorktrees(
       suppressRemoteLineageRefresh: true
     }
   ) => Promise<unknown>,
-  concurrency = DEFAULT_REFRESH_CONCURRENCY
+  concurrency = DEFAULT_WORKTREE_REFRESH_CONCURRENCY
 ): Promise<void> {
   let nextIndex = 0
   const failures: { repoId: string; error: unknown }[] = []
@@ -105,8 +119,19 @@ export function createRuntimeProjectRefreshScheduler(
 ): RuntimeProjectRefreshScheduler {
   const debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS
   const minIntervalMs = deps.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS
+  const maxConcurrentRefreshes = Math.max(
+    1,
+    Math.floor(deps.maxConcurrentRefreshes ?? DEFAULT_ENVIRONMENT_REFRESH_CONCURRENCY)
+  )
+  const isEnvironmentDesired = deps.isEnvironmentDesired ?? (() => true)
+  const maxConcurrentNonPriorityRefreshes =
+    deps.getPrioritizedEnvironmentId && maxConcurrentRefreshes > 1
+      ? maxConcurrentRefreshes - 1
+      : maxConcurrentRefreshes
   const now = deps.now ?? Date.now
   const entries = new Map<string, RefreshEntry>()
+  const readyQueue: ReadyRefresh[] = []
+  const activeEnvironmentIds = new Set<string>()
   let stopped = false
 
   const getEntry = (environmentId: string): RefreshEntry => {
@@ -116,6 +141,7 @@ export function createRuntimeProjectRefreshScheduler(
         inFlight: false,
         lastStartedAt: 0,
         pending: false,
+        queued: false,
         timer: null
       }
       entries.set(environmentId, entry)
@@ -123,8 +149,80 @@ export function createRuntimeProjectRefreshScheduler(
     return entry
   }
 
-  const schedule = (environmentId: string, entry: RefreshEntry): void => {
-    if (stopped || entry.inFlight || entry.timer) {
+  function takeNextReadyRefresh(prioritizedEnvironmentId: string | null): ReadyRefresh | null {
+    if (prioritizedEnvironmentId) {
+      const prioritizedEntry = entries.get(prioritizedEnvironmentId)
+      if (prioritizedEntry?.queued) {
+        const prioritizedIndex = readyQueue.findIndex(
+          (next) => next.environmentId === prioritizedEnvironmentId
+        )
+        if (prioritizedIndex !== -1) {
+          const [next] = readyQueue.splice(prioritizedIndex, 1)
+          next.entry.queued = false
+          if (next.entry.pending && !next.entry.inFlight) {
+            if (isEnvironmentDesired(next.environmentId)) {
+              return next
+            }
+            next.entry.pending = false
+            entries.delete(next.environmentId)
+          }
+        }
+      }
+    }
+    let activeNonPriorityRefreshes = 0
+    for (const environmentId of activeEnvironmentIds) {
+      if (environmentId !== prioritizedEnvironmentId) {
+        activeNonPriorityRefreshes += 1
+      }
+    }
+    if (
+      readyQueue.length === 0 ||
+      activeNonPriorityRefreshes >= maxConcurrentNonPriorityRefreshes
+    ) {
+      return null
+    }
+    while (readyQueue.length > 0) {
+      const next = readyQueue.shift()!
+      next.entry.queued = false
+      if (!next.entry.pending || next.entry.inFlight) {
+        continue
+      }
+      if (!isEnvironmentDesired(next.environmentId)) {
+        next.entry.pending = false
+        entries.delete(next.environmentId)
+        continue
+      }
+      return next
+    }
+    return null
+  }
+
+  function drainQueue(): void {
+    if (stopped) {
+      return
+    }
+    const prioritizedEnvironmentId = deps.getPrioritizedEnvironmentId?.() ?? null
+    while (activeEnvironmentIds.size < maxConcurrentRefreshes && readyQueue.length > 0) {
+      const next = takeNextReadyRefresh(prioritizedEnvironmentId)
+      if (!next) {
+        return
+      }
+      activeEnvironmentIds.add(next.environmentId)
+      void run(next.environmentId, next.entry)
+    }
+  }
+
+  function enqueue(environmentId: string, entry: RefreshEntry): void {
+    if (stopped || entry.inFlight || entry.queued || !entry.pending) {
+      return
+    }
+    entry.queued = true
+    readyQueue.push({ environmentId, entry })
+    drainQueue()
+  }
+
+  function schedule(environmentId: string, entry: RefreshEntry): void {
+    if (stopped || entry.inFlight || entry.queued || entry.timer) {
       return
     }
     const elapsed = entry.lastStartedAt > 0 ? now() - entry.lastStartedAt : minIntervalMs
@@ -132,14 +230,11 @@ export function createRuntimeProjectRefreshScheduler(
     const delay = Math.max(debounceMs, throttleDelay)
     entry.timer = setTimeout(() => {
       entry.timer = null
-      void run(environmentId, entry)
+      enqueue(environmentId, entry)
     }, delay)
   }
 
-  const run = async (environmentId: string, entry: RefreshEntry): Promise<void> => {
-    if (stopped || !entry.pending) {
-      return
-    }
+  async function run(environmentId: string, entry: RefreshEntry): Promise<void> {
     entry.pending = false
     entry.inFlight = true
     entry.lastStartedAt = now()
@@ -149,11 +244,13 @@ export function createRuntimeProjectRefreshScheduler(
       deps.onError?.(error)
     } finally {
       entry.inFlight = false
-      if (entry.pending) {
+      activeEnvironmentIds.delete(environmentId)
+      if (!stopped && entry.pending) {
         // Why: runtime repo events can be noisy while a remote server is merely
         // connected; keep discovery live without letting it drive the renderer.
         schedule(environmentId, entry)
       }
+      drainQueue()
     }
   }
 
@@ -174,8 +271,9 @@ export function createRuntimeProjectRefreshScheduler(
         clearTimeout(entry.timer)
       }
     }
+    readyQueue.length = 0
     entries.clear()
   }
 
-  return { request, stop }
+  return { request, reprioritize: drainQueue, stop }
 }

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -4,12 +4,16 @@ export type RuntimeProjectRefreshSchedulerDeps = {
   refresh: (environmentId: string) => Promise<void>
   debounceMs?: number
   minIntervalMs?: number
+  maxConcurrentRefreshes?: number
+  isEnvironmentDesired?: (environmentId: string) => boolean
+  getPrioritizedEnvironmentId?: () => string | null
   now?: () => number
   onError?: (error: unknown) => void
 }
 
 export type RuntimeProjectRefreshScheduler = {
   request: (environmentId: string) => void
+  reprioritize: () => void
   stop: () => void
 }
 
@@ -17,12 +21,20 @@ type RefreshEntry = {
   inFlight: boolean
   lastStartedAt: number
   pending: boolean
+  queued: boolean
   timer: ReturnType<typeof setTimeout> | null
+}
+
+type ReadyRefresh = {
+  environmentId: string
+  entry: RefreshEntry
 }
 
 const DEFAULT_DEBOUNCE_MS = 250
 const DEFAULT_MIN_INTERVAL_MS = 5_000
-const DEFAULT_REFRESH_CONCURRENCY = 5
+// Why: cap scans at ten while reserving one host slot for the foreground workspace.
+const DEFAULT_ENVIRONMENT_REFRESH_CONCURRENCY = 2
+const DEFAULT_WORKTREE_REFRESH_CONCURRENCY = 5
 
 export async function refreshRuntimeProjectWorktrees(
   environmentId: string,
@@ -31,7 +43,7 @@ export async function refreshRuntimeProjectWorktrees(
     repoId: string,
     options: { executionHostId: ExecutionHostId }
   ) => Promise<unknown>,
-  concurrency = DEFAULT_REFRESH_CONCURRENCY
+  concurrency = DEFAULT_WORKTREE_REFRESH_CONCURRENCY
 ): Promise<void> {
   let nextIndex = 0
   const failures: { repoId: string; error: unknown }[] = []
@@ -68,8 +80,19 @@ export function createRuntimeProjectRefreshScheduler(
 ): RuntimeProjectRefreshScheduler {
   const debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS
   const minIntervalMs = deps.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS
+  const maxConcurrentRefreshes = Math.max(
+    1,
+    Math.floor(deps.maxConcurrentRefreshes ?? DEFAULT_ENVIRONMENT_REFRESH_CONCURRENCY)
+  )
+  const isEnvironmentDesired = deps.isEnvironmentDesired ?? (() => true)
+  const maxConcurrentNonPriorityRefreshes =
+    deps.getPrioritizedEnvironmentId && maxConcurrentRefreshes > 1
+      ? maxConcurrentRefreshes - 1
+      : maxConcurrentRefreshes
   const now = deps.now ?? Date.now
   const entries = new Map<string, RefreshEntry>()
+  const readyQueue: ReadyRefresh[] = []
+  const activeEnvironmentIds = new Set<string>()
   let stopped = false
 
   const getEntry = (environmentId: string): RefreshEntry => {
@@ -79,6 +102,7 @@ export function createRuntimeProjectRefreshScheduler(
         inFlight: false,
         lastStartedAt: 0,
         pending: false,
+        queued: false,
         timer: null
       }
       entries.set(environmentId, entry)
@@ -86,8 +110,80 @@ export function createRuntimeProjectRefreshScheduler(
     return entry
   }
 
-  const schedule = (environmentId: string, entry: RefreshEntry): void => {
-    if (stopped || entry.inFlight || entry.timer) {
+  function takeNextReadyRefresh(prioritizedEnvironmentId: string | null): ReadyRefresh | null {
+    if (prioritizedEnvironmentId) {
+      const prioritizedEntry = entries.get(prioritizedEnvironmentId)
+      if (prioritizedEntry?.queued) {
+        const prioritizedIndex = readyQueue.findIndex(
+          (next) => next.environmentId === prioritizedEnvironmentId
+        )
+        if (prioritizedIndex >= 0) {
+          const [next] = readyQueue.splice(prioritizedIndex, 1)
+          next.entry.queued = false
+          if (next.entry.pending && !next.entry.inFlight) {
+            if (isEnvironmentDesired(next.environmentId)) {
+              return next
+            }
+            next.entry.pending = false
+            entries.delete(next.environmentId)
+          }
+        }
+      }
+    }
+    let activeNonPriorityRefreshes = 0
+    for (const environmentId of activeEnvironmentIds) {
+      if (environmentId !== prioritizedEnvironmentId) {
+        activeNonPriorityRefreshes += 1
+      }
+    }
+    if (
+      readyQueue.length === 0 ||
+      activeNonPriorityRefreshes >= maxConcurrentNonPriorityRefreshes
+    ) {
+      return null
+    }
+    while (readyQueue.length > 0) {
+      const next = readyQueue.shift()!
+      next.entry.queued = false
+      if (!next.entry.pending || next.entry.inFlight) {
+        continue
+      }
+      if (!isEnvironmentDesired(next.environmentId)) {
+        next.entry.pending = false
+        entries.delete(next.environmentId)
+        continue
+      }
+      return next
+    }
+    return null
+  }
+
+  function drainQueue(): void {
+    if (stopped) {
+      return
+    }
+    const prioritizedEnvironmentId = deps.getPrioritizedEnvironmentId?.() ?? null
+    while (activeEnvironmentIds.size < maxConcurrentRefreshes && readyQueue.length > 0) {
+      const next = takeNextReadyRefresh(prioritizedEnvironmentId)
+      if (!next) {
+        return
+      }
+      activeEnvironmentIds.add(next.environmentId)
+      void run(next.environmentId, next.entry)
+    }
+  }
+
+  function enqueue(environmentId: string, entry: RefreshEntry): void {
+    if (stopped || entry.inFlight || entry.queued || !entry.pending) {
+      return
+    }
+    entry.queued = true
+    readyQueue.push({ environmentId, entry })
+    drainQueue()
+  }
+
+  function schedule(environmentId: string, entry: RefreshEntry): void {
+    if (stopped || entry.inFlight || entry.queued || entry.timer) {
       return
     }
     const elapsed = entry.lastStartedAt > 0 ? now() - entry.lastStartedAt : minIntervalMs
@@ -95,14 +191,11 @@ export function createRuntimeProjectRefreshScheduler(
     const delay = Math.max(debounceMs, throttleDelay)
     entry.timer = setTimeout(() => {
       entry.timer = null
-      void run(environmentId, entry)
+      enqueue(environmentId, entry)
     }, delay)
   }
 
-  const run = async (environmentId: string, entry: RefreshEntry): Promise<void> => {
-    if (stopped || !entry.pending) {
-      return
-    }
+  async function run(environmentId: string, entry: RefreshEntry): Promise<void> {
     entry.pending = false
     entry.inFlight = true
     entry.lastStartedAt = now()
@@ -112,11 +205,13 @@ export function createRuntimeProjectRefreshScheduler(
       deps.onError?.(error)
     } finally {
       entry.inFlight = false
-      if (entry.pending) {
+      activeEnvironmentIds.delete(environmentId)
+      if (!stopped && entry.pending) {
         // Why: runtime repo events can be noisy while a remote server is merely
         // connected; keep discovery live without letting it drive the renderer.
         schedule(environmentId, entry)
       }
+      drainQueue()
     }
   }
 
@@ -137,8 +232,9 @@ export function createRuntimeProjectRefreshScheduler(
         clearTimeout(entry.timer)
       }
     }
+    readyQueue.length = 0
     entries.clear()
   }
 
-  return { request, stop }
+  return { request, reprioritize: drainQueue, stop }
 }

--- a/src/renderer/src/hooks/useIpcEvents-runtime-project-refresh-priority.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-runtime-project-refresh-priority.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildStoreState,
+  type StoreSubscribeListener
+} from './ipc-events-agent-status-store-test-fixtures'
+import {
+  buildWindowApi,
+  stubAuxiliaryModules,
+  stubReactSyncEffect
+} from './ipc-events-agent-status-window-test-fixtures'
+import type * as RuntimeProjectRefreshSchedulerModule from './runtime-project-refresh-scheduler'
+
+describe('useIpcEvents runtime project refresh prioritization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('reprioritizes queued runtime refreshes when the active workspace owner changes', async () => {
+    const request = vi.fn()
+    const reprioritize = vi.fn()
+    const stop = vi.fn()
+    const storeListeners: StoreSubscribeListener[] = []
+    let storeState = buildStoreState({
+      activeWorktreeId: 'local-worktree',
+      activeWorkspaceExecutionHostId: 'local'
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          storeListeners.push(listener)
+          return () => {}
+        }),
+        getState: () => storeState
+      }
+    }))
+    vi.doMock('./runtime-project-refresh-scheduler', async () => {
+      const actual = await vi.importActual<typeof RuntimeProjectRefreshSchedulerModule>(
+        './runtime-project-refresh-scheduler'
+      )
+      return {
+        ...actual,
+        createRuntimeProjectRefreshScheduler: () => ({ request, reprioritize, stop })
+      }
+    })
+    stubAuxiliaryModules()
+    vi.stubGlobal('window', buildWindowApi({ onSet: () => () => {} }))
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    const previousState = storeState
+    storeState = {
+      ...storeState,
+      activeWorktreeId: 'remote-worktree',
+      activeWorkspaceExecutionHostId: 'runtime:env-2'
+    }
+    for (const listener of storeListeners) {
+      listener(storeState, previousState)
+    }
+
+    expect(reprioritize).toHaveBeenCalledOnce()
+    expect(request).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this test file keeps the hook wiring mocks close to the assertions so IPC event behavior stays understandable and maintainable. */
 import type * as ReactModule from 'react'
+import type * as RuntimeProjectRefreshSchedulerModule from './runtime-project-refresh-scheduler'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildRuntimeClientEventEnvironmentKey,
@@ -5311,6 +5312,54 @@ describe('useIpcEvents agent status snapshot integration', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllGlobals()
+  })
+
+  it('reprioritizes queued runtime refreshes when the active workspace owner changes', async () => {
+    const request = vi.fn()
+    const reprioritize = vi.fn()
+    const stop = vi.fn()
+    const storeListeners: StoreSubscribeListener[] = []
+    let storeState = buildStoreState({
+      activeWorktreeId: 'local-worktree',
+      activeWorkspaceExecutionHostId: 'local'
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          storeListeners.push(listener)
+          return () => {}
+        }),
+        getState: () => storeState
+      }
+    }))
+    vi.doMock('./runtime-project-refresh-scheduler', async () => {
+      const actual = await vi.importActual<typeof RuntimeProjectRefreshSchedulerModule>(
+        './runtime-project-refresh-scheduler'
+      )
+      return {
+        ...actual,
+        createRuntimeProjectRefreshScheduler: () => ({ request, reprioritize, stop })
+      }
+    })
+    stubAuxiliaryModules()
+    vi.stubGlobal('window', buildWindowApi({ onSet: () => () => {} }))
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    const previousState = storeState
+    storeState = {
+      ...storeState,
+      activeWorktreeId: 'remote-worktree',
+      activeWorkspaceExecutionHostId: 'runtime:env-2'
+    }
+    for (const listener of storeListeners) {
+      listener(storeState, previousState)
+    }
+
+    expect(reprioritize).toHaveBeenCalledOnce()
+    expect(request).not.toHaveBeenCalled()
   })
 
   it('retires the exact sleeping record after adopted or exited legacy worker recovery', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -541,6 +541,15 @@ function getActiveRuntimeEnvironmentId(): string | null {
   return useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
 }
 
+function getPrioritizedRuntimeProjectRefreshEnvironmentId(): string | null {
+  const state = useAppStore.getState()
+  return (
+    getRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId) ??
+    state.settings?.activeRuntimeEnvironmentId?.trim() ??
+    null
+  )
+}
+
 function getRuntimeClientEventEnvironmentIds(): string[] {
   const state = useAppStore.getState()
   const ids = new Set<string>()
@@ -933,6 +942,9 @@ export function useIpcEvents(): void {
     }
 
     const runtimeProjectRefreshScheduler = createRuntimeProjectRefreshScheduler({
+      isEnvironmentDesired: (environmentId) =>
+        getRuntimeClientEventEnvironmentIds().includes(environmentId),
+      getPrioritizedEnvironmentId: getPrioritizedRuntimeProjectRefreshEnvironmentId,
       refresh: async (environmentId) => {
         // Why: project events can reveal target CRUD, but known target states already arrive by push.
         void refreshRuntimeEnvironmentSshTargetMetadata(environmentId).catch(() => {})
@@ -1066,7 +1078,15 @@ export function useIpcEvents(): void {
     let reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
       reachableRuntimeEnvironmentIds
     )
-    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe(() => {
+    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe((state, previousState) => {
+      if (
+        state.activeWorktreeId !== previousState.activeWorktreeId ||
+        state.activeWorkspaceExecutionHostId !== previousState.activeWorkspaceExecutionHostId ||
+        state.settings?.activeRuntimeEnvironmentId !==
+          previousState.settings?.activeRuntimeEnvironmentId
+      ) {
+        runtimeProjectRefreshScheduler.reprioritize()
+      }
       const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
       const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
       const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -533,6 +533,15 @@ function getActiveRuntimeEnvironmentId(): string | null {
   return useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
 }
 
+function getPrioritizedRuntimeProjectRefreshEnvironmentId(): string | null {
+  const state = useAppStore.getState()
+  return (
+    getRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId) ??
+    state.settings?.activeRuntimeEnvironmentId?.trim() ??
+    null
+  )
+}
+
 function getRuntimeClientEventEnvironmentIds(): string[] {
   const state = useAppStore.getState()
   const ids = new Set<string>()
@@ -901,6 +910,9 @@ export function useIpcEvents(): void {
     }
 
     const runtimeProjectRefreshScheduler = createRuntimeProjectRefreshScheduler({
+      isEnvironmentDesired: (environmentId) =>
+        getRuntimeClientEventEnvironmentIds().includes(environmentId),
+      getPrioritizedEnvironmentId: getPrioritizedRuntimeProjectRefreshEnvironmentId,
       refresh: async (environmentId) => {
         // Why: refresh the env's SSH bucket on (re)connect so a pre-drop snapshot can't keep a reconnect overlay stale.
         void hydrateRuntimeEnvironmentSshState(environmentId, { force: true }).catch(() => {})
@@ -1023,7 +1035,15 @@ export function useIpcEvents(): void {
     let reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
       reachableRuntimeEnvironmentIds
     )
-    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe(() => {
+    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe((state, previousState) => {
+      if (
+        state.activeWorktreeId !== previousState.activeWorktreeId ||
+        state.activeWorkspaceExecutionHostId !== previousState.activeWorkspaceExecutionHostId ||
+        state.settings?.activeRuntimeEnvironmentId !==
+          previousState.settings?.activeRuntimeEnvironmentId
+      ) {
+        runtimeProjectRefreshScheduler.reprioritize()
+      }
       const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
       const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
       const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | +492 | 0 | +492 |
| Prod | 2 | +130 | −12 | +118 |

<!-- /orca-pr-loc -->

## Summary

- cap event-driven runtime project refreshes at two environments globally
- reserve one slot for the currently viewed workspace host, with the configured active server as fallback
- keep background hosts FIFO, coalesce duplicate events, and drop removed hosts before admission
- wake priority changes without starting extra refreshes or changing debounce/throttle behavior

## ELI5

Before, every remote Orca server could open five project-scanning lanes at the same time. Adding more saved hosts added more lanes, so ten hosts could produce up to fifty concurrent worktree scans from this path. That matches the observation that deleting remote hosts made the slowdown disappear.

Now all remote servers share one traffic controller. At most two hosts refresh at once, so this path tops out at ten worktree scans, and one host slot stays available for the workspace currently on screen. Repeated notifications from the same host collapse into one refresh instead of cutting the line repeatedly.

## Scope

This caps the runtime client event, reconnect, and reachability project-refresh path. It does not claim to cap every all-host loader in the app. There are no RPC or remote wire changes.

## Correctness notes

- foreground priority follows explicit workspace ownership, including folder workspaces and nested SSH, then falls back to the configured active runtime
- focus changes reclassify in-flight hosts dynamically so an old foreground host cannot consume the reserved lane as hidden background work
- a newly focused host runs next when a real in-flight promise settles; permits are not released early because the underlying RPC work is not cancellable
- per-environment debounce, minimum interval, and five-worktree worker cap remain intact

## Validation

- 118 focused scheduler and useIpcEvents tests passed
- full suite: 49,273 passed, 99 skipped
- pnpm typecheck
- pnpm lint, including code-quality and max-lines gates
- pnpm build:electron-vite
- adversarial concurrency, integration, liveness, and test-gap reviews: no P0-P2 findings

---

## Triage review (2026-08-15)

**Status:** MERGEABLE / clean, all checks green. Held pending owner decision.

| | |
|---|---|
| **Perf impact if merged** | Real, and likely the largest win in this batch. Before: every remote Orca server could open 5 project-scanning lanes at once, so 10 saved hosts could produce up to 50 concurrent worktree scans from this path. This matches the reported observation that deleting remote hosts made the slowdown disappear. After: 3 total lanes (1 reserved foreground + 2 background). |
| **User-facing trade-off** | Yes, mild. Background host discovery is now serialized 2-at-a-time, so with many saved hosts a background host's worktree list refreshes later than it does today. The foreground workspace is protected by the reserved lane and never queues behind background work. |
| **Resolvable?** | No — the serialization *is* the fix. The tunable part is the lane math, which has been corrected (see below). |

### Lane math correction

An earlier revision made the foreground reservation dynamic (hold a lane only while the prioritized host has pending work). The existing `reclassifies the old foreground before admitting more background work` test correctly rejected it: if the foreground switches before the new host requests, background fills both lanes and the foreground then queues behind an un-preemptable refresh — exactly what the reservation exists to prevent.

The shipped fix instead raises the cap from 2 to 3. A cap of 2 left exactly one background lane once the reserved slot was subtracted, which serialized host discovery entirely.

### Residual risk

Workspaces with a large number of saved remote hosts will see background worktree lists settle more slowly than today. No correctness impact; foreground latency improves.
