### PR TITLE
perf(runtime): coalesce project lineage refreshes

### DIFF
--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createRuntimeProjectRefreshScheduler,
-  refreshRuntimeProjectWorktrees
+  refreshRuntimeProjectWorktrees,
+  refreshRuntimeProjectWorktreesAndLineage
 } from './runtime-project-refresh-scheduler'
 
 describe('refreshRuntimeProjectWorktrees', () => {
@@ -16,8 +17,53 @@ describe('refreshRuntimeProjectWorktrees', () => {
 
     expect(fetchWorktrees).toHaveBeenCalledTimes(1)
     expect(fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      executionHostId: 'runtime:env-1',
+      suppressRemoteLineageRefresh: true
+    })
+  })
+
+  it('runs one final host lineage refresh after a repo failure', async () => {
+    const error = new Error('repo refresh failed')
+    const fetchWorktrees = vi.fn().mockResolvedValueOnce(true).mockRejectedValueOnce(error)
+    const fetchWorktreeLineage = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      refreshRuntimeProjectWorktreesAndLineage(
+        'env-1',
+        [{ id: 'repo-1' }, { id: 'repo-2' }],
+        fetchWorktrees,
+        fetchWorktreeLineage
+      )
+    ).rejects.toThrow('Failed to refresh 1 runtime project worktree(s): repo-2')
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
+    expect(fetchWorktreeLineage).toHaveBeenCalledWith({
       executionHostId: 'runtime:env-1'
     })
+  })
+
+  it('retains both repo and final lineage failures', async () => {
+    const repoError = new Error('repo refresh failed')
+    const lineageError = new Error('lineage refresh failed')
+    const fetchWorktrees = vi.fn().mockRejectedValue(repoError)
+    const fetchWorktreeLineage = vi.fn().mockRejectedValue(lineageError)
+
+    const rejection = await refreshRuntimeProjectWorktreesAndLineage(
+      'env-1',
+      [{ id: 'repo-1' }],
+      fetchWorktrees,
+      fetchWorktreeLineage
+    ).catch((error: unknown) => error)
+
+    expect(rejection).toBeInstanceOf(AggregateError)
+    expect((rejection as AggregateError).errors).toEqual([
+      expect.objectContaining({
+        message: 'Failed to refresh 1 runtime project worktree(s): repo-1',
+        errors: [repoError]
+      }),
+      lineageError
+    ])
   })
 })
 

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -29,7 +29,10 @@ export async function refreshRuntimeProjectWorktrees(
   repos: readonly { id: string }[],
   fetchWorktrees: (
     repoId: string,
-    options: { executionHostId: ExecutionHostId }
+    options: {
+      executionHostId: ExecutionHostId
+      suppressRemoteLineageRefresh: true
+    }
   ) => Promise<unknown>,
   concurrency = DEFAULT_REFRESH_CONCURRENCY
 ): Promise<void> {
@@ -47,7 +50,10 @@ export async function refreshRuntimeProjectWorktrees(
         nextIndex += 1
         const repoId = repoIds[index]
         try {
-          await fetchWorktrees(repoId, { executionHostId })
+          await fetchWorktrees(repoId, {
+            executionHostId,
+            suppressRemoteLineageRefresh: true
+          })
         } catch (error) {
           failures.push({ repoId, error })
         }
@@ -61,6 +67,36 @@ export async function refreshRuntimeProjectWorktrees(
         .map((failure) => failure.repoId)
         .join(', ')}`
     )
+  }
+}
+
+export async function refreshRuntimeProjectWorktreesAndLineage(
+  environmentId: string,
+  repos: readonly { id: string }[],
+  fetchWorktrees: Parameters<typeof refreshRuntimeProjectWorktrees>[2],
+  fetchWorktreeLineage: (options: { executionHostId: ExecutionHostId }) => Promise<unknown>
+): Promise<void> {
+  const executionHostId = toRuntimeExecutionHostId(environmentId)
+  let worktreeFailure: { error: unknown } | null = null
+  try {
+    await refreshRuntimeProjectWorktrees(environmentId, repos, fetchWorktrees)
+  } catch (error) {
+    worktreeFailure = { error }
+  }
+  // Why: a failed repo refresh must not strand the host-wide lineage snapshot.
+  try {
+    await fetchWorktreeLineage({ executionHostId })
+  } catch (lineageError) {
+    if (!worktreeFailure) {
+      throw lineageError
+    }
+    throw new AggregateError(
+      [worktreeFailure.error, lineageError],
+      'Failed to refresh runtime project worktrees and lineage'
+    )
+  }
+  if (worktreeFailure) {
+    throw worktreeFailure.error
   }
 }
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4971,7 +4971,8 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', {
-      executionHostId: 'runtime:env-1'
+      executionHostId: 'runtime:env-1',
+      suppressRemoteLineageRefresh: true
     })
     expect(fetchWorktreeLineage).toHaveBeenCalledWith({
       executionHostId: 'runtime:env-1'

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -105,7 +105,7 @@ import {
 } from '@/runtime/runtime-environment-ssh-state'
 import {
   createRuntimeProjectRefreshScheduler,
-  refreshRuntimeProjectWorktrees
+  refreshRuntimeProjectWorktreesAndLineage
 } from './runtime-project-refresh-scheduler'
 import { createRuntimeClientEventsSync } from './runtime-client-events-sync'
 import { detectLanguage } from '@/lib/language-detect'
@@ -800,7 +800,10 @@ export function useIpcEvents(): void {
         options?.forceLocalOwner
           ? { forceLocalOwner: true }
           : options?.executionHostId
-            ? { executionHostId: options.executionHostId }
+            ? {
+                executionHostId: options.executionHostId,
+                suppressRemoteLineageRefresh: true
+              }
             : undefined
       )
       await useAppStore
@@ -907,12 +910,12 @@ export function useIpcEvents(): void {
         // Why: refresh the env's SSH bucket on (re)connect so a pre-drop snapshot can't keep a reconnect overlay stale.
         void hydrateRuntimeEnvironmentSshState(environmentId, { force: true }).catch(() => {})
         const repos = await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
-        await refreshRuntimeProjectWorktrees(environmentId, repos, (repoId, options) =>
-          useAppStore.getState().fetchWorktrees(repoId, options)
+        await refreshRuntimeProjectWorktreesAndLineage(
+          environmentId,
+          repos,
+          (repoId, options) => useAppStore.getState().fetchWorktrees(repoId, options),
+          (options) => useAppStore.getState().fetchWorktreeLineage(options)
         )
-        await useAppStore.getState().fetchWorktreeLineage({
-          executionHostId: toRuntimeExecutionHostId(environmentId)
-        })
       },
       onError: (error) => {
         console.error('Failed to refresh runtime projects:', error)

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -58,6 +58,8 @@ export type WorktreeFetchOptions = {
   requireAuthoritative?: boolean
   executionHostId?: ExecutionHostId
   forceLocalOwner?: boolean
+  /** Skip automatic remote lineage when the caller owns a final host-wide refresh. */
+  suppressRemoteLineageRefresh?: boolean
 }
 
 export type DirectSshWorktreeFetchOptions = WorktreeFetchOptions & {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3187,6 +3187,65 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(7)
   })
 
+  it('defers remote lineage when a caller owns the final host refresh', async () => {
+    const store = createTestStore()
+    const worktree = makeWorktree({
+      id: 'repo1::/remote/wt1',
+      repoId: 'repo1',
+      path: '/remote/wt1',
+      branch: 'refs/heads/remote'
+    })
+    const lineage = makeLineage({ worktreeId: worktree.id })
+    const workspaceLineage = makeWorkspaceLineage({
+      childWorkspaceKey: worktreeWorkspaceKey(worktree.id)
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: {}
+    } as Partial<AppState>)
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      const result =
+        method === 'worktree.lineageList'
+          ? {
+              lineage: { [lineage.worktreeId]: lineage },
+              workspaceLineage: { [workspaceLineage.childWorkspaceKey]: workspaceLineage }
+            }
+          : makeDetectedResult('repo1', [worktree])
+      return Promise.resolve({
+        id: 'rpc-1',
+        ok: true,
+        result,
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+    })
+
+    await store.getState().fetchWorktrees('repo1', {
+      executionHostId: 'runtime:env-1',
+      suppressRemoteLineageRefresh: true
+    })
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([
+      expect.objectContaining({ id: worktree.id, hostId: 'runtime:env-1' })
+    ])
+    expect(
+      runtimeEnvironmentCall.mock.calls.filter(
+        ([request]) => request.method === 'worktree.lineageList'
+      )
+    ).toHaveLength(0)
+
+    await store.getState().fetchWorktreeLineage({ executionHostId: 'runtime:env-1' })
+
+    expect(
+      runtimeEnvironmentCall.mock.calls.filter(
+        ([request]) => request.method === 'worktree.lineageList'
+      )
+    ).toHaveLength(1)
+    expect(store.getState().worktreeLineageById).toEqual({ [lineage.worktreeId]: lineage })
+    expect(store.getState().workspaceLineageByChildKey).toEqual({
+      [workspaceLineage.childWorkspaceKey]: workspaceLineage
+    })
+  })
+
   it('keeps a successful remote worktree refresh when lineage refresh fails', async () => {
     const store = createTestStore()
     const refreshed = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -3447,7 +3447,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           : false
       }
       // Direct SSH lineage requires its own qualified authority result.
-      if (!directSshAuthority) {
+      // Bulk runtime callers apply one final host-wide snapshot after all repo merges.
+      if (!directSshAuthority && !options?.suppressRemoteLineageRefresh) {
         await refreshRemoteWorktreeLineageBestEffort(settings, set)
       }
       return directCallerAuthority ? refresh.providerResult! : refresh.result.authoritative


### PR DESCRIPTION
## Summary

- suppress each per-repo automatic lineage snapshot only when a runtime project event owns a final host-wide refresh
- reduce runtime worktreesChanged handling from 2 lineage RPCs to 1
- reduce runtime reposChanged handling from R + 1 lineage RPCs to 1 for R repos
- run the final host-pinned snapshot after every repo worker settles, including repo failure paths
- preserve both repo and lineage errors if both stages fail
- leave standalone, local, and direct-SSH worktree refresh behavior unchanged

## ELI5

Lineage is the remote Orca server family tree for all workspaces on that server. Previously, when a server reported project changes, the client asked for the entire family tree once after refreshing every individual project, then asked for it one more time at the end. A server with 20 projects could therefore receive 21 copies of the same full-server request.

Now the client refreshes the project lists first and asks for the full family tree once at the end. A single worktree-change event also drops from two family-tree requests to one.

## Compatibility

- no RPC names, parameters, response shapes, or stream content changed
- mixed client and remote-server versions remain supported
- the final request stays pinned to the runtime that emitted the event
- folder-workspace lineage remains included in the final host-wide snapshot
- direct SSH and local callers keep their existing paths

## Validation

- two independent adversarial reviews: READY, no P0-P2 findings
- focused scheduler, IPC-event, and worktree tests: 386 passed
- typecheck passed
- Electron build passed
- lint passed
- ORCA_CROSS_VERSION_BASELINE_REF=v1.4.177 pnpm test: 4,595 files passed; 49,280 tests passed; 16 files and 99 tests skipped
- git diff --check passed