### PR TITLE
fix(orchestration): refuse and report unreachable send targets

### DIFF
--- a/src/cli/handlers/orchestration-send-receipt-warnings.test.ts
+++ b/src/cli/handlers/orchestration-send-receipt-warnings.test.ts
@@ -56,6 +56,24 @@ it('prints one warning line per unreachable fan-out recipient', async () => {
   )
 })
 
+it('shows a partial fan-out as a smaller recipient count plus the skipped recipient', async () => {
+  const line = await send({
+    messages: [{ id: 'msg_1' }],
+    recipients: 1,
+    warnings: [
+      {
+        code: 'recipient_unreachable',
+        recipient: 'term_orphan',
+        message: 'No live terminal holds term_orphan, so no message was created for it.'
+      }
+    ]
+  })
+
+  expect(line).toBe(
+    'Sent 1 messages to 1 recipients\nWarning: No live terminal holds term_orphan, so no message was created for it.'
+  )
+})
+
 it('leaves a clean receipt unchanged', async () => {
   expect(await send({ message: { id: 'msg_1' } })).toBe('Sent msg_1')
 })

--- a/src/cli/handlers/orchestration-send-receipt-warnings.test.ts
+++ b/src/cli/handlers/orchestration-send-receipt-warnings.test.ts
@@ -1,0 +1,61 @@
+import { expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: vi.fn() }))
+
+import { printResult } from '../format'
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+
+async function send(result: unknown): Promise<string> {
+  callMock.mockReset().mockResolvedValueOnce({ result })
+  await ORCHESTRATION_HANDLERS['orchestration send']({
+    flags: new Map([
+      ['from', 'term_worker'],
+      ['to', 'term_coord'],
+      ['subject', 'ping']
+    ]),
+    client: { call: callMock },
+    cwd: '/tmp/repo',
+    json: false
+  } as never)
+  const call = vi.mocked(printResult).mock.calls.at(-1)
+  const format = call?.[2] as (value: unknown) => string
+  return format(result)
+}
+
+it('prints the recipients a send could not reach', async () => {
+  const line = await send({
+    message: { id: 'msg_1' },
+    warnings: [
+      {
+        code: 'recipient_reads_other_mailbox',
+        recipient: 'term_coord',
+        message: 'term_coord reads run:run_1, and that mailbox never returns handle mail.'
+      }
+    ]
+  })
+
+  expect(line).toBe(
+    'Sent msg_1\nWarning: term_coord reads run:run_1, and that mailbox never returns handle mail.'
+  )
+})
+
+it('prints one warning line per unreachable fan-out recipient', async () => {
+  const line = await send({
+    messages: [{ id: 'msg_1' }, { id: 'msg_2' }],
+    recipients: 2,
+    warnings: [
+      { code: 'recipient_reads_other_mailbox', recipient: 'term_coord', message: 'coord warning' },
+      { code: 'no_live_terminal', recipient: 'term_worker', message: 'worker warning' }
+    ]
+  })
+
+  expect(line).toBe(
+    'Sent 2 messages to 2 recipients\nWarning: coord warning\nWarning: worker warning'
+  )
+})
+
+it('leaves a clean receipt unchanged', async () => {
+  expect(await send({ message: { id: 'msg_1' } })).toBe('Sent msg_1')
+})

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -96,9 +96,19 @@ type LifecycleSendRejection = {
   reason: string
 }
 
+type SendRecipientWarning = {
+  code: string
+  recipient: string
+  message: string
+}
+
 type OrchestrationSendResult =
-  | { message: { id: string }; lifecycle?: LifecycleSendRejection }
-  | { messages: { id: string }[]; recipients: number }
+  | {
+      message: { id: string }
+      lifecycle?: LifecycleSendRejection
+      warnings?: SendRecipientWarning[]
+    }
+  | { messages: { id: string }[]; recipients: number; warnings?: SendRecipientWarning[] }
   | {
       relay: {
         messageId: string
@@ -594,11 +604,18 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       process.exitCode = 1
     }
     printResult(result, json, (r) => {
+      // Why: an accepted address is not a read address, so the receipt has to say which
+      // recipients resolved to a mailbox nobody polls (#13363).
+      const warnings = 'warnings' in r && r.warnings ? r.warnings : []
+      const withWarnings = (line: string): string =>
+        warnings.length > 0
+          ? [line, ...warnings.map((warning) => `Warning: ${warning.message}`)].join('\n')
+          : line
       if ('message' in r) {
         if (r.lifecycle?.action === 'rejected') {
           return `Rejected ${r.message.id}: ${r.lifecycle.reason}`
         }
-        return `Sent ${r.message.id}`
+        return withWarnings(`Sent ${r.message.id}`)
       }
       if ('relay' in r) {
         if (r.relay.destination === 'worker') {
@@ -606,7 +623,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
         }
         return `Queued ${r.relay.messageId} for Run home (Dispatch ${r.relay.dispatchId})`
       }
-      return `Sent ${r.messages.length} messages to ${r.recipients} recipients`
+      return withWarnings(`Sent ${r.messages.length} messages to ${r.recipients} recipients`)
     })
   },
 

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -69,6 +69,7 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'task_not_found',
   'task_not_startable',
   'dispatch_not_found',
+  'terminal_not_found',
   'dispatch_run_mismatch',
   'dispatch_inactive',
   'worker_identity_changed',

--- a/src/main/runtime/rpc/methods/orchestration-recipient-reachability.ts
+++ b/src/main/runtime/rpc/methods/orchestration-recipient-reachability.ts
@@ -6,6 +6,7 @@ export type SendRecipientWarningCode =
   | 'no_live_terminal'
   | 'recipient_reads_other_mailbox'
   | 'recipient_outside_run'
+  | 'recipient_unreachable'
 
 export type SendRecipientWarning = {
   code: SendRecipientWarningCode
@@ -95,4 +96,17 @@ export function resolveTerminalRecipientReach(params: {
   }
 
   return { deliverable: true }
+}
+
+/**
+ * Group membership is discovered, not chosen, so one unreachable member must not fail a
+ * broadcast to the live ones. The recipient is dropped before insertion and named here
+ * instead, which is what distinguishes it from `no_live_terminal` on a row that was stored.
+ */
+export function unreachableRecipientWarning(handle: string): SendRecipientWarning {
+  return {
+    code: 'recipient_unreachable',
+    recipient: handle,
+    message: `No live terminal holds ${handle} and no active Dispatch names it, so no message was created for that recipient.`
+  }
 }

--- a/src/main/runtime/rpc/methods/orchestration-recipient-reachability.ts
+++ b/src/main/runtime/rpc/methods/orchestration-recipient-reachability.ts
@@ -1,0 +1,98 @@
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RunRow } from '../../orchestration/types'
+
+export type SendRecipientWarningCode =
+  | 'no_live_terminal'
+  | 'recipient_reads_other_mailbox'
+  | 'recipient_outside_run'
+
+export type SendRecipientWarning = {
+  code: SendRecipientWarningCode
+  recipient: string
+  message: string
+}
+
+export type TerminalRecipientReach = {
+  /** False only when nothing — no live pane, no active Dispatch — can ever surface the row. */
+  deliverable: boolean
+  warning?: SendRecipientWarning
+}
+
+/**
+ * A legacy `to_handle` row is readable through `orchestration check` only when the recipient
+ * still reads the per-handle mailbox. A coordinator reads `run:<id>` and a worker reads
+ * `dispatch:<id>`, and neither query returns bare-handle rows, so an accepted address is not
+ * the same thing as a delivered message (#13363).
+ */
+export function resolveTerminalRecipientReach(params: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  handle: string
+  run: RunRow | undefined
+}): TerminalRecipientReach {
+  const { runtime, db, handle, run } = params
+  const paneKey = runtime.getTerminalPaneKey(handle)
+  const activeDispatch = db.getActiveDispatchForTerminal(handle)
+  if (!paneKey) {
+    // Why: the adopted Run retains pre-update work for inspection and its handles are expected
+    // to be dead, so refusing there would drop a retained worker's report instead of keeping it.
+    const retainedLegacyRun = run !== undefined && run.id === db.getLegacyAdoption()?.adopted_run_id
+    if (!activeDispatch && !retainedLegacyRun) {
+      return {
+        deliverable: false,
+        warning: {
+          code: 'no_live_terminal',
+          recipient: handle,
+          message: `No live terminal holds ${handle} and no active Dispatch names it, so nothing will read this message.`
+        }
+      }
+    }
+    // Why: an in-flight worker whose pane key is momentarily unresolvable must still receive
+    // status mail (#13458); it just cannot be pushed until that pane comes back.
+    return {
+      deliverable: true,
+      warning: {
+        code: 'no_live_terminal',
+        recipient: handle,
+        message: activeDispatch
+          ? `No live terminal holds ${handle}. The message waits for the pane of Dispatch ${activeDispatch.id} to reattach.`
+          : `No live terminal holds ${handle}. Run ${run?.id} is retained pre-update state, so the message is stored for inspection only.`
+      }
+    }
+  }
+
+  const boundRun = db.getCurrentRunForPane(paneKey)
+  const identityDispatch = db.getActiveDispatchForIdentity(handle, paneKey)
+  const polledMailbox = boundRun
+    ? `run:${boundRun.id}`
+    : identityDispatch
+      ? `dispatch:${identityDispatch.id}`
+      : undefined
+  if (polledMailbox) {
+    return {
+      deliverable: true,
+      warning: {
+        code: 'recipient_reads_other_mailbox',
+        recipient: handle,
+        message: `${handle} reads ${polledMailbox}, and that mailbox never returns messages addressed to a bare terminal handle. Address ${polledMailbox} instead.`
+      }
+    }
+  }
+
+  // Why: a Run participant already returned above through its own mailbox, so anything left is
+  // outside the Run this row is filed under — including a coordinator handle that run-use
+  // replaced, which stays a live terminal and hides the takeover from the sender.
+  if (run && run.coordinator_handle !== handle) {
+    return {
+      deliverable: true,
+      warning: {
+        code: 'recipient_outside_run',
+        recipient: handle,
+        message: `${handle} is neither the coordinator nor an active worker of Run ${run.id}. The message is filed under that Run but only ${handle} can read it, so the Run's coordinator never sees it.`
+      }
+    }
+  }
+
+  return { deliverable: true }
+}

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -480,6 +480,57 @@ describe('orchestration RPC methods', () => {
       expect(fencedTerminal.count).toBe(1)
     })
 
+    // Why these two: the reachability warning describes the address, not the outcome, so a
+    // lifecycle receipt that returns early owes the sender the same warning the ordinary
+    // receipt carries. Both of these returned a bare receipt and swallowed it.
+    it('keeps the reachability warning on a suppressed lifecycle receipt', async () => {
+      // Why no bound Run: a heartbeat naming a dispatchId is readdressed to the sender's Run
+      // when it has one, and a `run:` address carries no bare-handle warning to lose.
+      setup(false)
+      const task = db.createTask({ spec: 'work with no resolvable pane' })
+      db.createDispatchContext(task.id, 'term_worker')
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_sender',
+        to: 'term_worker',
+        subject: 'still alive',
+        type: 'heartbeat',
+        // Why an unknown dispatch: reconcile suppresses a heartbeat for one that is not
+        // dispatched, which is the early return under test.
+        payload: JSON.stringify({ dispatchId: 'dispatch_gone' })
+      })) as { warnings?: { code: string; recipient: string }[] }
+
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: 'no_live_terminal', recipient: 'term_worker' })
+      ])
+    })
+
+    it('keeps the reachability warning on a rejected lifecycle receipt', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work with no resolvable pane' })
+      db.createDispatchContext(task.id, 'term_worker')
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_coord',
+        to: 'term_worker',
+        subject: 'done',
+        type: 'worker_done',
+        // Why no dispatchId: reconcile rejects the report, which is the early return under
+        // test. The outcome is required earlier, by the send-path guard.
+        payload: JSON.stringify({ taskId: task.id, outcome: 'succeeded' })
+      })) as {
+        lifecycle: { action: string; code: string }
+        warnings?: { code: string; recipient: string }[]
+      }
+
+      expect(result.lifecycle).toMatchObject({ action: 'rejected', code: 'missing_dispatch_id' })
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: 'no_live_terminal', recipient: 'term_worker' })
+      ])
+    })
+
     it('reports no warnings for a live terminal outside any Run', async () => {
       setup(false)
       vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -845,6 +845,14 @@ describe('orchestration RPC methods', () => {
         totalCount: terminals.length,
         truncated: false
       })
+      // Why: a listed terminal normally holds a pane, so default every group member to one;
+      // tests that need an unreachable member override this mock.
+      const panesByHandle = new Map(
+        terminals.map((terminal) => [terminal.handle, `${terminal.tabId}:${terminal.leafId}`])
+      )
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle: string) =>
+        handle === 'term_coord' ? coordinatorPaneKey : (panesByHandle.get(handle) ?? null)
+      )
       vi.spyOn(runtime, 'getAgentStatusForHandle').mockImplementation(
         (handle: string) => agentStatuses?.[handle] ?? null
       )
@@ -908,6 +916,79 @@ describe('orchestration RPC methods', () => {
       })) as { count: number; dispatchId: string }
       expect(coordCheck.count).toBe(0)
       expect(workerCheck).toMatchObject({ count: 0, dispatchId: dispatch.id })
+    })
+
+    it('skips a fan-out member nothing can reach and names it on the receipt', async () => {
+      setupWithTerminals([
+        makeSummary('term_sender', { tabId: 'tab_sender', leafId: 'leaf_sender' }),
+        makeSummary('term_live', { tabId: 'tab_live', leafId: 'leaf_live' }),
+        // An orphaned PTY is listed as a terminal but owns no pane, so nothing reads its mail.
+        makeSummary('term_orphan', { tabId: 'pty:orphan', leafId: 'pty:orphan' })
+      ])
+      const panes: Record<string, string> = {
+        term_sender: 'tab_sender:leaf_sender',
+        term_live: 'tab_live:leaf_live'
+      }
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) => panes[handle] ?? null)
+
+      const result = (await call('orchestration.send', {
+        from: 'term_sender',
+        to: '@all',
+        subject: 'broadcast'
+      })) as {
+        messages: { to_handle: string }[]
+        recipients: number
+        warnings: { code: string; recipient: string }[]
+      }
+
+      expect(result.messages.map((message) => message.to_handle)).toEqual(['term_live'])
+      expect(result.recipients).toBe(1)
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: 'recipient_unreachable', recipient: 'term_orphan' })
+      ])
+      // The skipped recipient must own no row at all, not an unread one.
+      expect(db.getUnreadMessages('term_orphan')).toHaveLength(0)
+      expect(db.getUnreadMessages('term_live')).toHaveLength(1)
+    })
+
+    it('refuses a fan-out when no resolved recipient can be reached', async () => {
+      setupWithTerminals([
+        makeSummary('term_sender', { tabId: 'tab_sender', leafId: 'leaf_sender' }),
+        makeSummary('term_orphan_a', { tabId: 'pty:a', leafId: 'pty:a' }),
+        makeSummary('term_orphan_b', { tabId: 'pty:b', leafId: 'pty:b' })
+      ])
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+        handle === 'term_sender' ? 'tab_sender:leaf_sender' : null
+      )
+
+      await expect(
+        call('orchestration.send', { from: 'term_sender', to: '@all', subject: 'broadcast' })
+      ).rejects.toMatchObject({ code: 'terminal_not_found' })
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('keeps delivering to a worktree group when one member has no pane', async () => {
+      setupWithTerminals([
+        makeSummary('term_sender', { worktreeId: 'wt_x', tabId: 'tab_s', leafId: 'leaf_s' }),
+        makeSummary('term_live', { worktreeId: 'wt_x', tabId: 'tab_l', leafId: 'leaf_l' }),
+        makeSummary('term_orphan', { worktreeId: 'wt_x', tabId: 'pty:o', leafId: 'pty:o' })
+      ])
+      const panes: Record<string, string> = {
+        term_sender: 'tab_s:leaf_s',
+        term_live: 'tab_l:leaf_l'
+      }
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) => panes[handle] ?? null)
+
+      const result = (await call('orchestration.send', {
+        from: 'term_sender',
+        to: '@worktree:wt_x',
+        subject: 'worktree broadcast'
+      })) as { recipients: number; warnings: { code: string; recipient: string }[] }
+
+      expect(result.recipients).toBe(1)
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: 'recipient_unreachable', recipient: 'term_orphan' })
+      ])
     })
 
     it('continues to fan out status messages to groups', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -375,6 +375,128 @@ describe('orchestration RPC methods', () => {
       ).rejects.toMatchObject({ code: 'invalid_argument' })
     })
 
+    it('refuses a bare terminal handle no reader holds', async () => {
+      setup()
+      await expect(
+        call('orchestration.send', {
+          from: 'term_coord',
+          to: 'term_00000000-0000-0000-0000-000000000000',
+          subject: 'gone'
+        })
+      ).rejects.toMatchObject({ code: 'terminal_not_found' })
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('accepts an active Dispatch assignee without a pane and warns that nothing is live', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work with no resolvable pane' })
+      db.createDispatchContext(task.id, 'term_worker')
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_coord',
+        to: 'term_worker',
+        subject: 'how is it going?',
+        type: 'status'
+      })) as { message: { to_handle: string }; warnings: { code: string; recipient: string }[] }
+
+      expect(result.message.to_handle).toBe('term_worker')
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: 'no_live_terminal', recipient: 'term_worker' })
+      ])
+      expect(db.getUnreadMessages('term_worker')).toHaveLength(1)
+    })
+
+    it('warns that a live worker reads its Dispatch mailbox, not its handle', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work' })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker', 'tab_worker:leaf_worker')
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+        handle === 'term_coord' ? coordinatorPaneKey : 'tab_worker:leaf_worker'
+      )
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_coord',
+        to: 'term_worker',
+        subject: 'status ping'
+      })) as { warnings: { code: string; message: string }[] }
+
+      expect(result.warnings[0].code).toBe('recipient_reads_other_mailbox')
+      expect(result.warnings[0].message).toContain(`dispatch:${dispatch.id}`)
+
+      const workerCheck = (await call('orchestration.check', {
+        terminal: 'term_worker'
+      })) as { count: number }
+      expect(workerCheck.count).toBe(0)
+    })
+
+    it('warns that a coordinator reads its Run mailbox, not its handle', async () => {
+      setup()
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'status ping'
+      })) as { warnings: { code: string; message: string }[] }
+
+      expect(result.warnings[0].code).toBe('recipient_reads_other_mailbox')
+      expect(result.warnings[0].message).toContain(`run:${activeRunId}`)
+    })
+
+    it('warns when a coordinator handle that run-use replaced is addressed', async () => {
+      setup()
+      const newPane = 'tab_new:22222222-2222-4222-9222-222222222222'
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+        handle === 'term_coord' ? coordinatorPaneKey : newPane
+      )
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+      db.bindRun({
+        runId: activeRunId as string,
+        coordinatorHandle: 'term_new',
+        coordinatorPaneKey: newPane
+      })
+
+      const result = (await call('orchestration.send', {
+        from: 'term_new',
+        to: 'term_coord',
+        subject: 'handover mail'
+      })) as { warnings: { code: string; recipient: string }[] }
+
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: 'recipient_outside_run', recipient: 'term_coord' })
+      ])
+      // The fenced terminal still reads its own mailbox; the Run mailbox never sees the row.
+      const runMailbox = (await call('orchestration.check', {
+        terminal: 'term_new',
+        all: true
+      })) as { count: number }
+      expect(runMailbox.count).toBe(0)
+      const fencedTerminal = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        all: true
+      })) as { count: number }
+      expect(fencedTerminal.count).toBe(1)
+    })
+
+    it('reports no warnings for a live terminal outside any Run', async () => {
+      setup(false)
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+        handle === 'term_plain' ? 'tab_plain:33333333-3333-4333-8333-333333333333' : null
+      )
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_sender',
+        to: 'term_plain',
+        subject: 'plain mail'
+      })) as Record<string, unknown>
+
+      expect(result.warnings).toBeUndefined()
+      expect(db.getUnreadMessages('term_plain')).toHaveLength(1)
+    })
+
     it('stores the runtime-observed sender pane key on the message row', async () => {
       setup()
       vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_runtime:leaf_runtime')
@@ -741,6 +863,51 @@ describe('orchestration RPC methods', () => {
       expect(result.messages).toHaveLength(2)
       const recipients = result.messages.map((m) => m.to_handle).sort()
       expect(recipients).toEqual(['term_b', 'term_c'])
+    })
+
+    it('names the fan-out recipients whose check will not return the row', async () => {
+      setupWithTerminals([
+        makeSummary('term_sender', { tabId: 'tab_sender', leafId: 'leaf_sender' }),
+        makeSummary('term_coord', { tabId: 'tab_coord', leafId: 'leaf_coord' }),
+        makeSummary('term_worker', { tabId: 'tab_worker', leafId: 'leaf_worker' })
+      ])
+      const task = db.createTask({ spec: 'work' })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker', 'tab_worker:leaf_worker')
+      const panes: Record<string, string> = {
+        term_coord: coordinatorPaneKey,
+        term_worker: 'tab_worker:leaf_worker',
+        term_sender: 'tab_sender:leaf_sender'
+      }
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) => panes[handle] ?? null)
+
+      const result = (await call('orchestration.send', {
+        from: 'term_sender',
+        to: '@all',
+        subject: 'broadcast'
+      })) as {
+        recipients: number
+        warnings: { code: string; recipient: string; message: string }[]
+      }
+
+      expect(result.recipients).toBe(2)
+      expect(result.warnings.map((warning) => warning.recipient).sort()).toEqual([
+        'term_coord',
+        'term_worker'
+      ])
+      expect(
+        result.warnings.every((warning) => warning.code === 'recipient_reads_other_mailbox')
+      ).toBe(true)
+
+      const coordCheck = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        all: true
+      })) as { count: number }
+      const workerCheck = (await call('orchestration.check', {
+        terminal: 'term_worker',
+        all: true
+      })) as { count: number; dispatchId: string }
+      expect(coordCheck.count).toBe(0)
+      expect(workerCheck).toMatchObject({ count: 0, dispatchId: dispatch.id })
     })
 
     it('continues to fan out status messages to groups', async () => {
@@ -1566,6 +1733,10 @@ describe('orchestration RPC methods', () => {
 
     it('keeps waiting for requested types when an unrelated status arrives', async () => {
       setup()
+      // Why: send now refuses handles with no live terminal, so give the recipient a pane.
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+        handle === 'coord' ? 'tab_coord:99999999-9999-4999-8999-999999999999' : null
+      )
 
       const waitPromise = call('orchestration.check', {
         terminal: 'coord',

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -525,6 +525,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         throw new OrchestrationError('terminal_not_found', `Terminal ${to} was not found.`)
       }
       const sendWarnings = bareHandleReach?.warning ? [bareHandleReach.warning] : []
+      // Why a helper and not a spread at each return: the warning describes the address, so
+      // every direct receipt owes it to the sender, including the lifecycle ones that return
+      // early. Three of them used to drop it, and a bare `no_live_terminal` is exactly the
+      // case a sender cannot see any other way.
+      const withSendWarnings = <T extends object>(receipt: T): T =>
+        sendWarnings.length > 0 ? { ...receipt, warnings: sendWarnings } : receipt
 
       if (!isGroupAddress(to)) {
         const federatedDispatchId = routing.dispatchId
@@ -621,14 +627,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
                 authority.reason
               ) ?? msg
             runtime.notifyMessageArrived(to, rejection.type)
-            return {
+            return withSendWarnings({
               message: rejection,
               lifecycle: {
                 action: 'rejected',
                 code: 'dispatch_capability_invalid',
                 reason: authority.reason
               }
-            }
+            })
           }
         }
         // Why: reconcile releases the dispatch lock before waking recipients, else a woken coordinator re-dispatches while the lock is still held.
@@ -636,16 +642,16 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           const reconciled = reconcileLifecycleMessage(db, msg)
           // Why: a suppressed message is already read, so skip the notify that would wake a check --wait waiter to an empty result.
           if (reconciled.action === 'suppressed') {
-            return { message: msg }
+            return withSendWarnings({ message: msg })
           }
           if (reconciled.action === 'rejected') {
             const rejection = db.getMessageById(msg.id) ?? msg
             runtime.notifyMessageArrived(to, rejection.type)
-            return { message: rejection, lifecycle: reconciled }
+            return withSendWarnings({ message: rejection, lifecycle: reconciled })
           }
         }
         runtime.notifyMessageArrived(to, msg.type)
-        return { message: msg, ...(sendWarnings.length > 0 ? { warnings: sendWarnings } : {}) }
+        return withSendWarnings({ message: msg })
       }
 
       // Why: fan out one message per recipient (independent read-tracking) but share a thread_id for correlation (Section 4.5).

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -21,7 +21,10 @@ import {
 import { clampOrchestrationAskTimeoutMs } from '../../../../shared/orchestration-ask-timeout'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 import { resolveRunScope } from './orchestration-run-scope'
-import { resolveTerminalRecipientReach } from './orchestration-recipient-reachability'
+import {
+  resolveTerminalRecipientReach,
+  unreachableRecipientWarning
+} from './orchestration-recipient-reachability'
 import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
 import { ORCHESTRATION_WORKER_METHODS } from './orchestration-worker-methods'
 import { ORCHESTRATION_FEDERATION_METHODS } from './orchestration-federation-methods'
@@ -657,9 +660,26 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         throw new Error(`No recipients resolved for group address: ${to}`)
       }
 
+      // Why: resolve reach before any row exists — a fan-out member with no live pane and no
+      // active Dispatch would otherwise be stored and notified before anyone noticed nothing
+      // could read it (#13363).
+      const recipientReach = handles.map((handle) => ({
+        handle,
+        reach: resolveTerminalRecipientReach({ runtime, db, handle, run: routing.run })
+      }))
+      const deliverable = recipientReach.filter(({ reach }) => reach.deliverable)
+      if (deliverable.length === 0) {
+        // Why: refusing the whole group for one dead member would let a single orphaned pane
+        // block a broadcast, so only a fan-out that would store nothing readable at all fails.
+        throw new OrchestrationError(
+          'terminal_not_found',
+          `No recipient of ${to} has a live terminal or an active Dispatch.`
+        )
+      }
+
       revalidateLegacyCoordinator?.()
       const threadId = params.threadId ?? `thread_${Date.now()}`
-      const messages = handles.map((handle) =>
+      const messages = deliverable.map(({ handle }) =>
         db.insertMessage({
           from,
           to: handle,
@@ -683,16 +703,18 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       }
 
       // Why: fan-out rows are legacy-handle rows too, so every recipient already reading a Run
-      // or Dispatch mailbox gets a message its check will never return (#13363). The group form
-      // stays accepted — its members are live terminals — so the receipt names them instead.
-      const groupWarnings = handles.flatMap((handle) => {
-        const reach = resolveTerminalRecipientReach({ runtime, db, handle, run: routing.run })
+      // or Dispatch mailbox gets a message its check will never return (#13363). Those are
+      // stored and warned about; a recipient nothing can reach is dropped and named instead.
+      const groupWarnings = recipientReach.flatMap(({ handle, reach }) => {
+        if (!reach.deliverable) {
+          return [unreachableRecipientWarning(handle)]
+        }
         return reach.warning ? [reach.warning] : []
       })
 
       return {
         messages,
-        recipients: handles.length,
+        recipients: messages.length,
         ...(groupWarnings.length > 0 ? { warnings: groupWarnings } : {})
       }
     }

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -21,6 +21,7 @@ import {
 import { clampOrchestrationAskTimeoutMs } from '../../../../shared/orchestration-ask-timeout'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 import { resolveRunScope } from './orchestration-run-scope'
+import { resolveTerminalRecipientReach } from './orchestration-recipient-reachability'
 import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
 import { ORCHESTRATION_WORKER_METHODS } from './orchestration-worker-methods'
 import { ORCHESTRATION_FEDERATION_METHODS } from './orchestration-federation-methods'
@@ -511,6 +512,17 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         )
       }
 
+      const bareHandleReach =
+        isGroupAddress(to) || to.startsWith('run:') || to.startsWith('dispatch:')
+          ? undefined
+          : resolveTerminalRecipientReach({ runtime, db, handle: to, run: routing.run })
+      if (bareHandleReach && !bareHandleReach.deliverable) {
+        // Why: a handle with no live pane and no active Dispatch stores mail no reader can
+        // ever surface, so refuse it the way run:/dispatch: are refused (#13363).
+        throw new OrchestrationError('terminal_not_found', `Terminal ${to} was not found.`)
+      }
+      const sendWarnings = bareHandleReach?.warning ? [bareHandleReach.warning] : []
+
       if (!isGroupAddress(to)) {
         const federatedDispatchId = routing.dispatchId
         const federatedTarget =
@@ -630,7 +642,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           }
         }
         runtime.notifyMessageArrived(to, msg.type)
-        return { message: msg }
+        return { message: msg, ...(sendWarnings.length > 0 ? { warnings: sendWarnings } : {}) }
       }
 
       // Why: fan out one message per recipient (independent read-tracking) but share a thread_id for correlation (Section 4.5).
@@ -670,7 +682,19 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         runtime.notifyMessageArrived(message.to_handle, message.type)
       }
 
-      return { messages, recipients: handles.length }
+      // Why: fan-out rows are legacy-handle rows too, so every recipient already reading a Run
+      // or Dispatch mailbox gets a message its check will never return (#13363). The group form
+      // stays accepted — its members are live terminals — so the receipt names them instead.
+      const groupWarnings = handles.flatMap((handle) => {
+        const reach = resolveTerminalRecipientReach({ runtime, db, handle, run: routing.run })
+        return reach.warning ? [reach.warning] : []
+      })
+
+      return {
+        messages,
+        recipients: handles.length,
+        ...(groupWarnings.length > 0 ? { warnings: groupWarnings } : {})
+      }
     }
   }),
 

--- a/src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts
+++ b/src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts
@@ -368,7 +368,10 @@ describe('orchestration runtime update settlement', () => {
     )
 
     expect(resultOf(response)).toMatchObject({
-      message: { type: 'status', body: WORK_BYTES.toString('utf8') }
+      message: { type: 'status', body: WORK_BYTES.toString('utf8') },
+      // Why: the pre-update coordinator handle has no live reader, so the receipt says so
+      // rather than refusing mail the adopted Run is meant to retain (#13363).
+      warnings: [expect.objectContaining({ code: 'no_live_terminal' })]
     })
     expect(harness.db.getTask(harness.taskId)).toMatchObject({ status: 'dispatched' })
     expect(harness.db.getDispatchContextById(harness.dispatchId)).toMatchObject({

--- a/src/main/ssh/ssh-remote-orca-cli.test.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.test.ts
@@ -81,6 +81,7 @@ describe('runRemoteOrcaCli', () => {
       }),
       getLegacyAdoption: vi.fn(() => undefined),
       getActiveDispatchForIdentity: vi.fn(() => undefined),
+      getActiveDispatchForTerminal: vi.fn(() => undefined),
       getCurrentRunForPane: vi.fn(() => undefined),
       findActiveRemoteAttachmentForPane: vi.fn(() => undefined)
     }
@@ -95,7 +96,9 @@ describe('runRemoteOrcaCli', () => {
         liveLeafCount: 1
       }),
       getOrchestrationDb: () => db,
-      getTerminalPaneKey: () => null,
+      // Why: the recipient is a live terminal on the host; send refuses handles nothing holds.
+      getTerminalPaneKey: (handle: string) =>
+        handle === 'term_windows' ? 'tab_windows:leaf_windows' : null,
       deliverPendingMessagesForHandle: vi.fn(),
       notifyMessageArrived: vi.fn(),
       linearIssueContext: vi.fn(async (request: unknown) => ({


### PR DESCRIPTION
## Summary

`orchestration send` now refuses a terminal handle that no reader holds, and when it accepts an address that nothing polls it says so on the receipt instead of answering a bare `ok: true`.

This builds on **#13458** by @bbingz, which found the same hole and fixed the clearest part of it. That PR is right about the shape of the check and right about the exception: an active Dispatch assignee whose pane key is not momentarily resolvable must still receive status mail, so `getTerminalPaneKey` alone cannot be the test. That carve-out is kept here, with its reasoning, and this PR is meant to land instead of #13458 rather than beside it — if #13458 goes in first I will rebase and cut this down to the remainder.

The delta is three things.

### 1. A live handle is not the same as a reachable handle

I checked the coordinator-handover case from the issue before building on it, and the code does not say what the issue says. `run-use` rebinds `runs.coordinator_handle` and `runs.coordinator_pane_key` and bumps `consumer_generation`; the previous coordinator's terminal keeps running, and because the pane-to-Run binding lives on `runs.coordinator_pane_key`, that pane ends up bound to nothing. So mail addressed to the pre-handover handle **is** readable — the fenced terminal's own `orchestration check` returns it through the per-handle branch. What breaks is different, and worse to debug: the row is filed under the Run, the Run's mailbox only selects `to_handle = 'run:<id>'`, and the current coordinator never sees it. The sender gets `ok: true` for a message the coordinator it meant to reach will never read.

That is the general rule, not a handover quirk. A legacy `to_handle` row is only returned by the per-handle branch of `orchestration check`. A coordinator reads `run:<id>`; a worker with an active Dispatch reads `dispatch:<id>`; neither query returns bare-handle rows. So the useful question is the one the issue asks — is this handle still an addressee anyone reads — and it is answerable from the code. Refusing here would be wrong: those terminals are live and do receive the row, both by push-on-idle and by their own `check`. The receipt says it instead.

### 2. Group forms

`@all` and `@worktree:<id>` write one legacy-handle row per live terminal, so every recipient that is a coordinator or an active worker gets a row its `check` will never return — the ~23 invisible rows in the issue. Both options in the issue were open. I chose reporting over rerouting: fan-out exists to give each recipient independent read tracking (§4.5), and folding those rows into the Run mailbox would collapse that and drop group chatter into the fenced-delivery/ack protocol that lifecycle mail depends on, where a new coordinator generation would replay it. The group form also stays accepted — its members come from `listTerminals`, so they are live by construction. The receipt now names the recipients whose `check` will not surface the message.

### 3. Warnings on the receipt

`orchestration.send` gains an optional `warnings` array (`{ code, recipient, message }`), and the CLI prints one `Warning:` line per entry. Three codes:

- `no_live_terminal` — accepted through a carve-out, but nothing holds the handle right now.
- `recipient_reads_other_mailbox` — the recipient polls `run:<id>` or `dispatch:<id>`, so this row will not appear in its `check`; the message names the address to use instead.
- `recipient_outside_run` — the row is filed under a Run the recipient does not belong to, which is what a stale coordinator handle looks like after a handover.

A new optional result field is wire-safe for older clients per `docs/reference/remote-wire-compatibility.md`.

### One more thing #13458 will hit

The bare refusal on its own breaks `orchestration-runtime-update-settlement.test.ts` on current `main`: after a contract update the adopted Run keeps pre-update work for inspection, its `coordinator_handle` is `NULL`, and a retained worker's only address is a handle the runtime can no longer resolve. Refusing there drops the report the adopted Run exists to keep. So sends filed under the adopted Run are accepted with a `no_live_terminal` warning rather than refused. Worth knowing for #13458 as it stands.

## Reproduction

Before (from the issue):

```
$ orca orchestration send --to run:run_deadbeef0000 --subject x --body y --json
{"ok":false,"error":{"code":"run_not_found", …}}

$ orca orchestration send --to dispatch:ctx_deadbeef0000 --subject x --body y --json
{"ok":false,"error":{"code":"dispatch_not_found", …}}

$ orca orchestration send --to term_00000000-0000-0000-0000-000000000000 --subject x --body y --json
{"ok":true,"result":{"message":{"id":"msg_8a5597b2290c", …}}}
```

After, as asserted by the tests in this PR:

```
$ orca orchestration send --to term_00000000-0000-0000-0000-000000000000 --subject x --body y --json
{"ok":false,"error":{"code":"terminal_not_found", …}}

# handle of a coordinator that run-use replaced
$ orca orchestration send --to term_<pre-handover> --subject x --body y --json
{"ok":true,"result":{"message":{…},"warnings":[{"code":"recipient_outside_run","recipient":"term_<pre-handover>", …}]}}

$ orca orchestration send --to @all --subject x --body y
Sent 2 messages to 2 recipients
Warning: term_coord reads run:run_…, and that mailbox never returns messages addressed to a bare terminal handle. Address run:run_… instead.
Warning: term_worker reads dispatch:ctx_…, and that mailbox never returns messages addressed to a bare terminal handle. Address dispatch:ctx_… instead.
```

I could not exercise the packaged CLI against a live runtime from this environment, so the `after` block is the RPC behaviour the tests assert, not a transcript. The invisibility claims behind it were verified against the real `OrchestrationDb` and `OrcaRuntimeService`, not mocks of them: the tests send through the RPC handler and then read back through `orchestration.check`.

## Test plan

- `vitest run src/main/runtime/rpc/methods/orchestration.test.ts` — 160 passed. New cases: unknown handle refused with `terminal_not_found` and no row stored; active Dispatch assignee without a pane accepted with `no_live_terminal`; live worker warned with `recipient_reads_other_mailbox` and its `check` proven empty; coordinator warned with the `run:` mailbox named; handle replaced by `run-use` warned with `recipient_outside_run`, with the Run mailbox proven empty and the fenced terminal proven still able to read; plain live terminal outside any Run gets no warnings; `@all` names both unreachable recipients and both checks proven empty.
- `vitest run src/cli/handlers/orchestration-send-receipt-warnings.test.ts` — 3 passed (single receipt, fan-out receipt, clean receipt unchanged).
- `vitest run src/main/runtime/rpc src/cli/handlers` — 157 files, 1552 passed, 1 skipped.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- `pnpm test` (full suite) — 4594 files passed, 49271 passed, 99 skipped. Two failures remain, both in `src/main/agent-hooks/` WSL relay tests; they fail identically on unmodified `upstream/main` in this environment (no WSL host).
- `src/main/ssh/ssh-remote-orca-cli.test.ts` — its fixture resolved every handle to a null pane, so the new validation refused its recipient. The fixture now resolves the recipient the way a host runtime does; second commit.
- Not run: manual CLI verification against a live runtime.

Fixes #13363


## Follow-up: unreachable fan-out recipients (review round 2)

CodeRabbit found a hole this PR had left open: group fan-out resolved recipient reach only
*after* every row was inserted and notified, so an unreachable member still got a row nobody
can read. It is reachable in practice — `terminal.list` reports a connected PTY that owns no
pane (`buildPtyTerminalSummary`, leaf id `pty:<ptyId>`), and `getTerminalPaneKey` returns null
for it because the id is not a pane UUID. Reach now resolves before `db.insertMessage`.

**The judgement call, stated on purpose.** The bot asked for all-or-nothing: refuse the whole
fan-out if any member is unreachable. I chose per-recipient reporting instead. Group membership
is discovered rather than chosen — the sender picks `@all`, not who is in it — so one orphaned
pane would block a broadcast to every live agent, with no way for the sender to exclude the
offender. That trades a storage bug for an availability bug.

Unreachable recipients are therefore dropped before insertion and named on the receipt under a
new warning code `recipient_unreachable`, distinct from `no_live_terminal`, which reports a row
that *was* stored (an in-flight Dispatch assignee whose pane is momentarily unresolvable).
`recipients` counts delivered rows rather than resolved handles. The strict rule survives where
it still earns its keep: a fan-out in which no recipient is reachable stores nothing readable at
all, so it throws `terminal_not_found` and writes no rows.

```
$ orca orchestration send --to @all --subject x --body y
Sent 1 messages to 1 recipients
Warning: No live terminal holds term_<orphan> and no active Dispatch names it, so no message was created for that recipient.
```

Added tests: `skips a fan-out member nothing can reach and names it on the receipt`,
`refuses a fan-out when no resolved recipient can be reached`, and
`keeps delivering to a worktree group when one member has no pane` (the `@worktree:<id>` form),
plus a CLI receipt case for the partial-delivery line. `vitest run` over the four touched
suites: 194 passed. `pnpm lint` and `pnpm typecheck` clean.
