### PR TITLE
perf(runtime): hydrate lineage snapshot once

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -40886,6 +40886,57 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
+  it('hydrates inferred lineage once for the combined lineage snapshot', async () => {
+    const lineage = {
+      worktreeId: 'repo-1::/tmp/child',
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: 'repo-1::/tmp/parent',
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    } satisfies WorktreeLineage
+    const workspaceLineage = {
+      childWorkspaceKey: 'worktree:repo-1::/tmp/child',
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: 'folder:folder-1',
+      parentInstanceId: null,
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    } satisfies WorkspaceLineage
+    const getAllWorktreeLineage = vi.fn(() => ({ [lineage.worktreeId]: lineage }))
+    const getAllWorkspaceLineage = vi.fn(() => ({
+      [workspaceLineage.childWorkspaceKey]: workspaceLineage
+    }))
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeLineage,
+      getAllWorkspaceLineage
+    } as never)
+    const hydrateInferredWorktreeLineage = vi
+      .spyOn(runtime, 'hydrateInferredWorktreeLineage')
+      .mockResolvedValue(undefined)
+
+    await expect(runtime.listWorktreeLineageSnapshot()).resolves.toEqual({
+      lineage: { [lineage.worktreeId]: lineage },
+      workspaceLineage: { [workspaceLineage.childWorkspaceKey]: workspaceLineage }
+    })
+
+    expect(hydrateInferredWorktreeLineage).toHaveBeenCalledOnce()
+    expect(getAllWorktreeLineage).toHaveBeenCalledOnce()
+    expect(getAllWorkspaceLineage).toHaveBeenCalledOnce()
+
+    const hydrationError = new Error('lineage hydration failed')
+    hydrateInferredWorktreeLineage.mockRejectedValueOnce(hydrationError)
+    getAllWorktreeLineage.mockClear()
+    getAllWorkspaceLineage.mockClear()
+
+    await expect(runtime.listWorktreeLineageSnapshot()).rejects.toBe(hydrationError)
+    expect(getAllWorktreeLineage).not.toHaveBeenCalled()
+    expect(getAllWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
   it('infers orchestration lineage from task-id comments when dispatch is completed', async () => {
     const workerPath = '/tmp/worktree-worker'
     const childPath = '/tmp/workspaces/worker-child'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -28559,6 +28559,17 @@ export class OrcaRuntimeService {
     return this.store?.getAllWorktreeLineage?.() ?? {}
   }
 
+  async listWorktreeLineageSnapshot(): Promise<{
+    lineage: Record<string, WorktreeLineage>
+    workspaceLineage: Record<WorkspaceKey, WorkspaceLineage>
+  }> {
+    await this.hydrateInferredWorktreeLineage()
+    return {
+      lineage: this.store?.getAllWorktreeLineage?.() ?? {},
+      workspaceLineage: this.store?.getAllWorkspaceLineage?.() ?? {}
+    }
+  }
+
   async listWorkspaceLineage(): Promise<Record<WorkspaceKey, WorkspaceLineage>> {
     await this.hydrateInferredWorktreeLineage()
     return this.store?.getAllWorkspaceLineage?.() ?? {}

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -831,15 +831,16 @@ describe('worktree RPC methods', () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       dedupeWorktreeCreate: passthroughDedupe,
-      listWorktreeLineage: vi.fn().mockResolvedValue(lineage),
-      listWorkspaceLineage: vi.fn().mockResolvedValue({})
+      listWorktreeLineageSnapshot: vi.fn().mockResolvedValue({
+        lineage,
+        workspaceLineage: {}
+      })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
 
     const response = await dispatcher.dispatch(makeRequest('worktree.lineageList'))
 
-    expect(runtime.listWorktreeLineage).toHaveBeenCalled()
-    expect(runtime.listWorkspaceLineage).toHaveBeenCalled()
+    expect(runtime.listWorktreeLineageSnapshot).toHaveBeenCalledOnce()
     expect(response).toMatchObject({ ok: true, result: { lineage, workspaceLineage: {} } })
   })
 

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -60,10 +60,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.lineageList',
     params: null,
-    handler: async (_params, { runtime }) => ({
-      lineage: await runtime.listWorktreeLineage(),
-      workspaceLineage: await runtime.listWorkspaceLineage()
-    })
+    handler: async (_params, { runtime }) => runtime.listWorktreeLineageSnapshot()
   }),
   defineMethod({
     name: 'worktree.show',


### PR DESCRIPTION
## Summary

- hydrate inferred worktree lineage once when serving `worktree.lineageList`
- read both lineage maps from the same hydrated snapshot
- preserve the standalone lineage methods and the existing RPC contract

## ELI5

The remote Orca server keeps two views of the same workspace family tree. Previously, one request effectively said: update the family tree, return view one, update it again, then return view two.

Now it updates the family tree once and returns both views from that snapshot. Callers receive the same answer, but the server avoids a redundant lineage pass on every request. The old second pass usually reused the short-lived worktree cache, so this PR does not claim that it removes a second Git scan.

## Screenshots

No visual change.

## Compatibility

- no RPC names, parameters, response shapes, or stream content changed
- mixed client and remote-server versions remain supported
- standalone lineage callers keep their existing behavior
- SSH hosts and folder workspaces use the same hydration path as before

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.177 pnpm test`
- [x] Electron build
- [x] Added tests for one hydration, both maps, and hydration failure ordering

Focused validation: 2 files passed; 1,099 tests passed and 1 skipped. Full compatibility suite: 4,595 files and 49,278 tests passed; 16 files and 99 tests skipped. `git diff --check` passed.

## AI Review Report

Two independent adversarial reviews reported READY with no P0-P2 findings. They checked the RPC response shape, error propagation, standalone-method behavior, runtime pinning assumptions, SSH and folder-workspace behavior, mixed-version compatibility, and macOS/Linux/Windows concerns. The tests explicitly verify that map reads occur only after the single hydration succeeds.

## Security Audit

The change adds no input, command execution, path handling, authentication, secret, dependency, or new IPC surface. The existing RPC method and validation boundary are unchanged; hydration failures still propagate without returning a partial snapshot.

## Notes

This is an isolated server-side work reduction. It does not change renderer behavior or require a coordinated client/server rollout.