### PR TITLE
perf(automations): release completed run observers

### DIFF
--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -11,6 +11,7 @@ const mockOnDispatchRequested = vi.fn()
 const mockRendererReady = vi.fn()
 const mockFinalizeTerminalOwnership = vi.fn()
 const mockReleaseTerminalOwnership = vi.fn()
+const mockDisposeRunObservation = vi.fn()
 const mockSshNeedsPassphrasePrompt = vi.fn()
 const mockSshGetState = vi.fn()
 const mockSshConnect = vi.fn()
@@ -180,6 +181,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
       paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
       ptyId: 'agent-pty',
       startupPlan: {},
+      disposeRunObservation: mockDisposeRunObservation,
       terminalOwnership: {
         finalize: mockFinalizeTerminalOwnership,
         release: mockReleaseTerminalOwnership
@@ -222,7 +224,12 @@ describe('useAutomationDispatchEvents setup launch', () => {
     )
     mockLaunchAgentBackgroundSession.mockImplementation(async () => {
       order.push('agent')
-      return { tabId: 'agent-tab', ptyId: 'agent-pty', startupPlan: {} }
+      return {
+        tabId: 'agent-tab',
+        ptyId: 'agent-pty',
+        startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation
+      }
     })
 
     await registerAndDispatch()
@@ -523,6 +530,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
         ptyId: 'agent-pty',
         startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation,
         terminalOwnership: {
           finalize: mockFinalizeTerminalOwnership,
           release: mockReleaseTerminalOwnership
@@ -541,6 +549,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
       'clear-terminal-identity'
     ])
     expect(mockReleaseTerminalOwnership).not.toHaveBeenCalled()
+    expect(mockDisposeRunObservation).toHaveBeenCalledOnce()
     // Why: the retired terminal is gone; the run must drop its pane/pty pointers
     // so "View run" resolves to the workspace/snapshot, not an unavailable terminal.
     expect(mockMarkDispatchResult).toHaveBeenLastCalledWith({
@@ -563,6 +572,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
         ptyId: 'agent-pty',
         startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation,
         terminalOwnership: {
           finalize: mockFinalizeTerminalOwnership,
           release: mockReleaseTerminalOwnership
@@ -593,6 +603,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
         ptyId: 'agent-pty',
         startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation,
         terminalOwnership: {
           finalize: mockFinalizeTerminalOwnership,
           release: mockReleaseTerminalOwnership
@@ -623,6 +634,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
         ptyId: 'agent-pty',
         startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation,
         terminalOwnership: {
           finalize: mockFinalizeTerminalOwnership,
           release: mockReleaseTerminalOwnership
@@ -664,6 +676,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
         ptyId: 'agent-pty',
         startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation,
         terminalOwnership: {
           finalize: mockFinalizeTerminalOwnership,
           release: mockReleaseTerminalOwnership
@@ -692,6 +705,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
         ptyId: 'agent-pty',
         startupPlan: {},
+        disposeRunObservation: mockDisposeRunObservation,
         terminalOwnership: {
           finalize: mockFinalizeTerminalOwnership,
           release: mockReleaseTerminalOwnership

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -300,8 +300,8 @@ export function useAutomationDispatchEvents(): void {
             )
           let dispatchMarked = false
           let pendingExitCode: number | null = null
-          let pendingDone = false
-          let completionMarked = false
+          let pendingDone = false,
+            completionMarked = false
           let unsubscribeAgentStatus = (): void => {}
           let unsubscribeSessionObserver = (): void => {}
           let releaseReuseDispatchTab = (): void => {}
@@ -553,9 +553,9 @@ export function useAutomationDispatchEvents(): void {
             throw new Error('Unable to build an agent launch plan.')
           }
           terminalOwnership = result.terminalOwnership
+          unsubscribeSessionObserver = result.disposeRunObservation
           if (automation.reuseSession) {
-            // Why: the first fresh launch is the seed for later reuse and must
-            // survive completion under the same policy as an already-reused tab.
+            // Why: a fresh launch seeds reuse and must survive completion like an already-reused tab.
             releaseTerminalOwnership()
           }
           const launchedTabId = result.tabId

--- a/src/renderer/src/lib/agent-background-run-observation.ts
+++ b/src/renderer/src/lib/agent-background-run-observation.ts
@@ -1,0 +1,67 @@
+import { runBestEffortAgentBackgroundCleanups } from '@/lib/agent-background-session-cleanup'
+import { callRuntimeRpc, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import { subscribeToRuntimeTerminalData } from '@/runtime/runtime-terminal-stream'
+
+type RemoteRunObservationArgs = {
+  settings: Parameters<typeof subscribeToRuntimeTerminalData>[0]
+  ptyId: string
+  clientId: string
+  runtimeTarget: Extract<RuntimeClientTarget, { kind: 'environment' }>
+  terminal: string
+  onData: (data: string) => void
+  onExit: (code: number) => void
+}
+
+export type AgentBackgroundRunObservation = {
+  dispose: () => void
+  startRemote: (args: RemoteRunObservationArgs) => Promise<void>
+  setDataUnsubscribe: (unsubscribe: () => void) => void
+  setExitUnsubscribe: (unsubscribe: () => void) => void
+}
+
+export function createAgentBackgroundRunObservation(): AgentBackgroundRunObservation {
+  const exitWaitController = new AbortController()
+  let disposed = false
+  let unsubscribeData = (): void => {}
+  let unsubscribeExit = (): void => {}
+  // An awaited remote subscription can resolve after disposal; close its late handle immediately.
+  const retainUnlessDisposed = (unsubscribe: () => void): (() => void) => {
+    if (!disposed) {
+      return unsubscribe
+    }
+    runBestEffortAgentBackgroundCleanups(unsubscribe)
+    return () => {}
+  }
+
+  return {
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      exitWaitController.abort()
+      runBestEffortAgentBackgroundCleanups(unsubscribeExit, unsubscribeData)
+      unsubscribeData = (): void => {}
+      unsubscribeExit = (): void => {}
+    },
+    startRemote: async (args) => {
+      unsubscribeData = retainUnlessDisposed(
+        await subscribeToRuntimeTerminalData(args.settings, args.ptyId, args.clientId, args.onData)
+      )
+      void callRuntimeRpc<{ wait: { exitCode?: number | null } }>(
+        args.runtimeTarget,
+        'terminal.wait',
+        { terminal: args.terminal, for: 'exit' },
+        { timeoutMs: 24 * 60 * 60 * 1000, signal: exitWaitController.signal }
+      )
+        .then((result) => args.onExit(result.wait.exitCode ?? 0))
+        .catch(() => {})
+    },
+    setDataUnsubscribe: (unsubscribe) => {
+      unsubscribeData = retainUnlessDisposed(unsubscribe)
+    },
+    setExitUnsubscribe: (unsubscribe) => {
+      unsubscribeExit = retainUnlessDisposed(unsubscribe)
+    }
+  }
+}

--- a/src/renderer/src/lib/agent-background-session-contract.ts
+++ b/src/renderer/src/lib/agent-background-session-contract.ts
@@ -21,4 +21,5 @@ export type LaunchAgentBackgroundSessionResult = {
   ptyId: string
   startupPlan: AgentStartupPlan
   terminalOwnership: AutomationTerminalOwnership | null
+  disposeRunObservation: () => void
 }

--- a/src/renderer/src/lib/automation-session-observer.test.ts
+++ b/src/renderer/src/lib/automation-session-observer.test.ts
@@ -153,6 +153,39 @@ describe('observeExistingAutomationSession', () => {
     expect(onAgentStatus).toHaveBeenCalledTimes(1)
   })
 
+  it('releases all 16 remote long-poll slots when completed run observers dispose', async () => {
+    const closeStreams = Array.from({ length: 16 }, () => vi.fn())
+    mockSubscribeTerminal.mockImplementation(async () => ({
+      close: closeStreams[mockSubscribeTerminal.mock.calls.length - 1]
+    }))
+    const { observeExistingAutomationSession } = await import('./automation-session-observer')
+
+    const disposers = await Promise.all(
+      Array.from({ length: 16 }, (_, index) =>
+        observeExistingAutomationSession({
+          ptyId: `remote:env-1@@terminal-${index}`,
+          paneKey: PANE_KEY,
+          runId: `run-${index}`,
+          onData: vi.fn(),
+          onAgentStatus: vi.fn(),
+          onExit: vi.fn()
+        })
+      )
+    )
+    const waitSignals = mockCallRuntimeRpc.mock.calls.map(
+      (call) => (call[3] as { signal: AbortSignal }).signal
+    )
+    expect(waitSignals).toHaveLength(16)
+    expect(waitSignals.every((signal) => !signal.aborted)).toBe(true)
+
+    for (const dispose of disposers) {
+      dispose()
+    }
+
+    expect(waitSignals.every((signal) => signal.aborted)).toBe(true)
+    expect(closeStreams.every((close) => close.mock.calls.length === 1)).toBe(true)
+  })
+
   it('stamps the exact SSH PTY in the legacy renderer fallback', async () => {
     state.settings.terminalMainSideEffectAuthority = false
     const ptyId = toAppSshPtyId('ssh-a', 'pty-1')

--- a/src/renderer/src/lib/automation-session-observer.ts
+++ b/src/renderer/src/lib/automation-session-observer.ts
@@ -53,6 +53,7 @@ export async function observeExistingAutomationSession(args: {
 
   if (isRemoteRuntimePtyId(ptyId)) {
     let disposed = false
+    const waitController = new AbortController()
     const ownerEnvironmentId = getRemoteRuntimePtyEnvironmentId(ptyId)
     const runtimeTarget = ownerEnvironmentId
       ? ({ kind: 'environment', environmentId: ownerEnvironmentId } as const)
@@ -75,7 +76,7 @@ export async function observeExistingAutomationSession(args: {
       runtimeTarget,
       'terminal.wait',
       { terminal, for: 'exit' },
-      { timeoutMs: 24 * 60 * 60 * 1000 }
+      { timeoutMs: 24 * 60 * 60 * 1000, signal: waitController.signal }
     )
       .then((result) => {
         if (!disposed) {
@@ -85,6 +86,7 @@ export async function observeExistingAutomationSession(args: {
       .catch(() => {})
     return () => {
       disposed = true
+      waitController.abort()
       stream.close()
     }
   }

--- a/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
@@ -408,6 +408,42 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
     })
   })
 
+  it('closes the remote stream and exit wait when run observation ends', async () => {
+    useRemoteAgentBackgroundRuntime(state)
+    const streamSend = vi.fn()
+    const waitUnsubscribe = vi.fn()
+    mockRuntimeEnvironmentSubscribe.mockImplementation(async (request, callbacks) => {
+      if (request.method === 'terminal.multiplex') {
+        queueMicrotask(() => callbacks.onResponse({ ok: true, result: { type: 'ready' } }))
+        return { unsubscribe: vi.fn(), sendBinary: streamSend }
+      }
+      if (request.method === 'terminal.wait') {
+        return { unsubscribe: waitUnsubscribe, sendBinary: vi.fn() }
+      }
+      throw new Error(`Unexpected runtime subscription: ${request.method}`)
+    })
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+    const result = await launchAgentBackgroundSession({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'run the automation'
+    })
+    await vi.waitFor(() =>
+      expect(mockRuntimeEnvironmentSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'terminal.wait' }),
+        expect.any(Object)
+      )
+    )
+    const sendsBeforeDispose = streamSend.mock.calls.length
+
+    result?.disposeRunObservation()
+    result?.disposeRunObservation()
+
+    await vi.waitFor(() => expect(waitUnsubscribe).toHaveBeenCalledOnce())
+    expect(streamSend.mock.calls.length).toBe(sendsBeforeDispose + 1)
+  })
+
   it('preserves the legacy background spawn on an old remote host', async () => {
     useRemoteAgentBackgroundRuntime(state)
     mockRuntimeEnvironmentTransportCall.mockImplementation((request: { method: string }) => {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -20,19 +20,17 @@ import {
   type EagerPtyHandle
 } from '@/components/terminal-pane/pty-dispatcher'
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import { retireProvider } from '@/lib/retire-unowned-background-terminal'
 import { createRuntimeAgentBackgroundTerminal } from '@/lib/runtime-agent-background-create'
-import {
-  subscribeToRuntimeTerminalData,
-  toRemoteRuntimePtyId
-} from '@/runtime/runtime-terminal-stream'
+import { toRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import { createSshBackgroundStartupDelivery } from '@/lib/ssh-background-startup-delivery'
 import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { runBestEffortAgentBackgroundCleanups } from '@/lib/agent-background-session-cleanup'
+import { createAgentBackgroundRunObservation } from '@/lib/agent-background-run-observation'
 import type { bindAutomationTerminal } from '@/lib/automation-terminal-ownership'
 import {
   adoptAgentBackgroundSessionTab,
@@ -132,15 +130,13 @@ export async function launchAgentBackgroundSession(
   let exitHandled = false,
     eagerPtyBuffer: EagerPtyHandle | null = null
   let terminalOwnership: ReturnType<typeof bindAutomationTerminal> = null
-  let unsubscribeExit = (): void => {},
-    unsubscribeData = (): void => {}
+  const runObservation = createAgentBackgroundRunObservation()
   const handleExit = (exitPtyId: string, code: number): void => {
     if (exitHandled) {
       return
     }
     exitHandled = true
-    unsubscribeExit()
-    unsubscribeData()
+    runObservation.dispose()
     sshStartupDelivery.clear()
     if (tab) {
       useAppStore.getState().clearTabPtyId(tab.id, exitPtyId)
@@ -264,27 +260,24 @@ export async function launchAgentBackgroundSession(
       if (!runtimeTerminalHandle) {
         throw new Error('Runtime terminal id is invalid.')
       }
-      unsubscribeData = await subscribeToRuntimeTerminalData(
-        store.settings,
+      await runObservation.startRemote({
+        settings: store.settings,
         ptyId,
-        `desktop:background:${tab.id}`,
-        handleData
-      )
-      void callRuntimeRpc<{ wait: { exitCode?: number | null } }>(
+        clientId: `desktop:background:${tab.id}`,
         runtimeTarget,
-        'terminal.wait',
-        { terminal: runtimeTerminalHandle, for: 'exit' },
-        { timeoutMs: 24 * 60 * 60 * 1000 }
-      )
-        .then((result) => handleExit(ptyId, result.wait.exitCode ?? 0))
-        .catch(() => {})
+        terminal: runtimeTerminalHandle,
+        onData: handleData,
+        onExit: (code) => handleExit(ptyId, code)
+      })
     } else {
       eagerPtyBuffer = registerEagerPtyBuffer(ptyId, handleExit)
-      unsubscribeData = subscribeToPtyData(ptyId, handleData)
+      runObservation.setDataUnsubscribe(subscribeToPtyData(ptyId, handleData))
       // Why: opening the workspace attaches a real terminal transport and disposes
       // the eager exit handler. This sidecar keeps automation completion tracking
       // alive regardless of whether the tab is hidden or mounted.
-      unsubscribeExit = subscribeToPtyExit(ptyId, (code) => handleExit(ptyId, code))
+      runObservation.setExitUnsubscribe(
+        subscribeToPtyExit(ptyId, (code) => handleExit(ptyId, code))
+      )
     }
     sshStartupDelivery.armFallback(ptyId)
 
@@ -296,14 +289,21 @@ export async function launchAgentBackgroundSession(
       scheduleAgentBackgroundDraft(tab.id, pasteDraftAfterLaunch, agent)
     }
 
-    return { tabId: tab.id, paneKey, ptyId, startupPlan, terminalOwnership }
+    return {
+      tabId: tab.id,
+      paneKey,
+      ptyId,
+      startupPlan,
+      terminalOwnership,
+      disposeRunObservation: runObservation.dispose
+    }
   } catch (error) {
     // Why: terminal creation and stream subscription are separate remote calls.
     // A failure between them must not strand an invisible runtime terminal.
     exitHandled = true
     terminalOwnership?.release()
     const createdTab = tab
-    runBestEffortAgentBackgroundCleanups(unsubscribeExit, unsubscribeData)
+    runObservation.dispose()
     runBestEffortAgentBackgroundCleanups(() => eagerPtyBuffer?.dispose())
     runBestEffortAgentBackgroundCleanups(() => sshStartupDelivery.clear())
     if (createdTab) {


### PR DESCRIPTION
## Summary

- Abort remote `terminal.wait` calls and close terminal-data streams as soon as an automation run stops being observed.
- Register the fresh-launch observer with the same completion cleanup already used for reused sessions.
- Make cleanup idempotent and close subscription handles that arrive after teardown.

### ELI5

The remote runtime has 16 parking spaces for long-running watchers. Finished automations kept their spaces for up to 24 hours, so after 16 runs a new watcher could be turned away as `runtime_busy`. Completion now returns both the parking space and the stream handle immediately.

```mermaid
flowchart LR
  A[Automation completes or is disposed] --> B[Run observer cleanup]
  B --> C[Abort terminal.wait]
  B --> D[Close terminal data stream]
  C --> E[Remote server releases long-poll slot]
  D --> F[Renderer releases stream observer]
  E --> G[Next wait is admitted]
```

## Quantified proof

| | Before | After |
| --- | ---: | ---: |
| Completed observers retained after cleanup | 16 waits + 16 streams | 0 waits + 0 streams |
| Long-poll signals aborted | 0 / 16 | 16 / 16 |
| Terminal streams closed | 0 / 16 | 16 / 16 |
| Next wait at saturation | `runtime_busy` | admitted |

The renderer regression deliberately fills all 16 remote long-poll slots, disposes every completed observer, and requires every signal to abort and every stream to close. The server transport regression independently proves that closing a waiting client changes `activeLongPolls` from 1 to 0 and immediately admits another request.

## Reliability contract

- **Invariant — `automation.run-observer-cleanup`:** once a run no longer needs completion observation, every data and exit observer is released exactly once, including observers whose async subscription resolves after cleanup.
- **Failure source:** completed fresh and reused remote automations left 24-hour `terminal.wait` calls and stream observers alive.
- **Oracle:** 16 completed observers produce 16 aborted wait signals, 16 closed streams, and no admission failure for the next wait.
- **Gate:** deterministic renderer lifecycle tests plus the runtime long-poll release regression. A dedicated manifest entry does not exist yet; that registration and soak history remain an explicit accepted gap.
- **Performance budget:** cleanup removes one long-poll and one stream per completed remote run; it adds no polling, retry, scan, timer, subprocess, or provider fanout.
- **Diagnostics:** retained-resource behavior is observable through aborted request signals, stream close counts, `activeLongPolls`, and `runtime_busy` admission.

## Provider / platform matrix

| Surface | Status | Evidence / boundary |
| --- | --- | --- |
| Remote runtime | Covered | Fresh and reused session tests cover wait abort, stream close, idempotence, and late subscription disposal. |
| Local / direct SSH | Covered | Focused launch and observer suites preserve local/SSH data and exit subscription cleanup. |
| Daemon / WSL | Unaffected | No daemon protocol, PTY identity, shell, or path behavior changed. |
| Mobile / relay | Unaffected | No mobile-facing RPC schema, stream opcode, persisted mobile state, or relay contract changed. |
| macOS / Linux / Windows | Static parity | The change uses platform-neutral `AbortController` and existing cleanup APIs; no new platform branch, path, shell, or native module was added. |
| Mixed client / host versions | Compatible | No RPC parameter, response, capability, or opcode changed; cancellation closes the existing client request. |

## Testing

- Focused local validation: 6 files / 96 tests passed.
- Independent focused validation: 6 files / 174 tests passed.
- Full typecheck passed.
- Full lint and audit passed; nine existing `WorktreeJumpPalette` warnings reproduce on the base branch, while changed-code findings are zero.
- Full suite: 4,593 files / 49,274 tests passed.
  - One updater timer test failed only under full parallel load and passed alone.
  - The cross-version harness auto-selected unrelated local tag `v799`; with `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.178`, all 4 wire tests passed.
- `git diff --check` passed.

## Security / compatibility

- No dependency, lockfile, persistence, authentication, or filesystem changes.
- No new RPC shape or stream opcode.
- Cleanup is best-effort and idempotent, and late async handles are fenced and closed immediately.

## Screenshots

No visual change.

---

## Triage review (2026-08-15)

**Status:** MERGEABLE / clean, all checks green. Held pending owner decision.

| | |
|---|---|
| **Perf impact if merged** | Narrow but real, and it is a correctness-perf fix rather than a micro-optimization. The remote runtime has 16 long-poll slots; finished automations held theirs for up to 24 hours, so after 16 runs a new watcher could be turned away as `runtime_busy`. Completion now returns both the slot and the stream handle immediately. |
| **User-facing trade-off** | One caveat, on the remote wire. Slot release depends on the host honouring the abort. Against an **older Orca host** that does not act on `rpc.cancel`, the client frees its local handle but the host may hold the wait until its own timeout, so the fix is partial on mixed client/host versions. This is less benefit, not a regression — behaviour degrades to exactly what ships today. |
| **Resolvable?** | The mixed-version behaviour is a coverage gap rather than a defect. What is missing is a remote-host test asserting the degraded path, roughly 30 lines. |

### Verified during review

- A fresh `SshGitProvider` is constructed per connection establishment, so a reconnect cannot inherit an observer from a previous generation.
- `runObservation.dispose()` is called from `handleExit`, which already closed the data stream on exit before this change — no new window for dropped trailing output.
- `retainUnlessDisposed` correctly closes subscription handles that resolve after teardown.

### Nits (non-blocking)

- `useAutomationDispatchEvents.ts` collapses two `let` declarations into one comma-joined statement, and rewrites an adjacent comment. Both are unrelated to the fix and add diff noise.

### Residual risk

Users on older remote hosts keep today's behaviour. Users on current hosts stop hitting `runtime_busy` after 16 completed automation runs.
