### PR TITLE
fix(daemon): stop losing a startup command when the shell-ready marker is late

### DIFF
--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -624,6 +624,23 @@ describe('Session', () => {
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('never delivered'))
       })
 
+      it('names the deadline this session waited, not the default one', () => {
+        createSession({
+          shellReadySupported: true,
+          shellReadyTimeoutMs: 2_000,
+          shellReadyLateMarkerGraceMs: 5_000
+        })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(2_000 + 5_000)
+
+        expect(subprocess.written).toEqual(['claude\n'])
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('after 7000ms'))
+        expect(warn).not.toHaveBeenCalledWith(
+          expect.stringContaining(`after ${SHELL_READY_TIMEOUT_MS + 5_000}ms`)
+        )
+      })
+
       // Why: shortening the barrier is how Codex opts out of marker-gated delivery.
       it('gives no grace window to a session that shortened the barrier', () => {
         createSession({ shellReadySupported: true, shellReadyTimeoutMs: 300 })

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { SESSION_FORCE_KILL_RETRY_MS, Session } from './session'
+import {
+  SESSION_FORCE_KILL_RETRY_MS,
+  SHELL_READY_LATE_MARKER_GRACE_MS,
+  SHELL_READY_TIMEOUT_MS,
+  Session
+} from './session'
 import type { SessionState, ShellReadyState } from './types'
 import type { TuiAgent } from '../../shared/types'
 
@@ -103,6 +108,7 @@ describe('Session', () => {
   function createSession(opts?: {
     shellReadySupported?: boolean
     shellReadyTimeoutMs?: number
+    shellReadyLateMarkerGraceMs?: number
     cols?: number
     rows?: number
     launchAgent?: TuiAgent
@@ -125,6 +131,9 @@ describe('Session', () => {
       ...(opts?.startupIngress ? { startupIngress: opts.startupIngress } : {}),
       ...(opts?.shellReadyTimeoutMs !== undefined
         ? { shellReadyTimeoutMs: opts.shellReadyTimeoutMs }
+        : {}),
+      ...(opts?.shellReadyLateMarkerGraceMs !== undefined
+        ? { shellReadyLateMarkerGraceMs: opts.shellReadyLateMarkerGraceMs }
         : {})
     })
     return session
@@ -535,6 +544,96 @@ describe('Session', () => {
       vi.advanceTimersByTime(1)
       expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
       expect(subprocess.written).toEqual(['codex\n'])
+    })
+
+    // A startup command has no one to notice it was dropped, so it is not released by the ready
+    // deadline the way keystrokes are — it waits for the marker, and every path that ends without
+    // one says so. See SHELL_READY_LATE_MARKER_GRACE_MS.
+    describe('startup command delivery', () => {
+      let warn: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      })
+
+      afterEach(() => {
+        warn.mockRestore()
+      })
+
+      it('delivers the startup command once the marker arrives', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+
+        subprocess.simulateData('\x1b]777;orca-shell-ready\x07\r\nuser@host $ ')
+        vi.advanceTimersByTime(30)
+
+        expect(session.shellState).toBe('ready' satisfies ShellReadyState)
+        expect(subprocess.written).toEqual(['claude\n'])
+        expect(warn).not.toHaveBeenCalled()
+      })
+
+      it('keeps holding the startup command past the deadline while keystrokes go through', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+        session.write('typed')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS)
+
+        expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
+        expect(subprocess.written).toEqual(['typed'])
+      })
+
+      it('delivers the startup command on a marker that arrives after the deadline', () => {
+        createSession({ shellReadySupported: true })
+        const received: string[] = []
+        session.attachClient({ onData: (data) => received.push(data), onExit: () => {} })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS + SHELL_READY_LATE_MARKER_GRACE_MS - 1)
+        expect(subprocess.written).toEqual([])
+
+        subprocess.simulateData('\x1b]777;orca-shell-ready\x07\r\nuser@host $ ')
+        vi.advanceTimersByTime(30)
+
+        expect(session.shellState).toBe('ready' satisfies ShellReadyState)
+        expect(subprocess.written).toEqual(['claude\n'])
+        // The late marker is still stripped, so it never reaches the pane.
+        expect(received.join('')).toBe('\r\nuser@host $ ')
+        expect(warn).not.toHaveBeenCalled()
+      })
+
+      it('writes the startup command without proof once the grace deadline passes, and says so', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS + SHELL_READY_LATE_MARKER_GRACE_MS)
+
+        expect(subprocess.written).toEqual(['claude\n'])
+        expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('without proof'))
+      })
+
+      it('reports a startup command the shell exited before ever reading', () => {
+        createSession({ shellReadySupported: true })
+        session.writeStartupCommand('claude\n')
+
+        vi.advanceTimersByTime(SHELL_READY_TIMEOUT_MS)
+        subprocess.simulateExit(1)
+
+        expect(subprocess.written).toEqual([])
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('never delivered'))
+      })
+
+      // Why: shortening the barrier is how Codex opts out of marker-gated delivery.
+      it('gives no grace window to a session that shortened the barrier', () => {
+        createSession({ shellReadySupported: true, shellReadyTimeoutMs: 300 })
+        session.writeStartupCommand('codex\n')
+
+        vi.advanceTimersByTime(300)
+
+        expect(subprocess.written).toEqual(['codex\n'])
+        expect(warn).not.toHaveBeenCalled()
+      })
     })
 
     it('detects marker split across data chunks', () => {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -132,6 +132,7 @@ export class Session {
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
   private heldStartupCommand: string | null = null
+  private readonly shellReadyTimeoutMs: number
   private readonly shellReadyLateMarkerGraceMs: number
   private shellReadyLateMarkerTimer: ReturnType<typeof setTimeout> | null = null
   private releaseStartupDeviceAttributesResponder: (() => void) | null = null
@@ -179,6 +180,9 @@ export class Session {
         ? undefined
         : opts.historySeedChunks.every((chunk) => this.emulator.writeSync(chunk))
 
+    // Why: the late-marker warning has to name the deadline this session actually waited, so the
+    // effective timeout is resolved once here instead of re-derived from the default at print time.
+    this.shellReadyTimeoutMs = opts.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS
     this.shellReadyLateMarkerGraceMs =
       opts.shellReadyLateMarkerGraceMs ??
       (opts.shellReadyTimeoutMs === undefined ? SHELL_READY_LATE_MARKER_GRACE_MS : 0)
@@ -197,7 +201,7 @@ export class Session {
       this.startupDeviceAttributesQueryFilter = new StartupDeviceAttributesQueryFilter()
       this.shellReadyTimer = setTimeout(() => {
         this.onShellReadyTimeout()
-      }, opts.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS)
+      }, this.shellReadyTimeoutMs)
     } else {
       this._shellState = 'unsupported'
     }
@@ -826,7 +830,7 @@ export class Session {
     }
     console.warn(
       `[daemon/session] ${this.sessionId}: no shell-ready marker after ${
-        SHELL_READY_TIMEOUT_MS + this.shellReadyLateMarkerGraceMs
+        this.shellReadyTimeoutMs + this.shellReadyLateMarkerGraceMs
       }ms; writing the startup command without proof the shell is reading it`
     )
     this.releaseHeldShellReadyBytes()

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -34,7 +34,12 @@ import type {
 import type { PtyOwnerBackend } from '../../shared/pty-owner-backend'
 import { createPtySlaveEchoProbe } from '../../shared/pty-slave-line-discipline-echo'
 
-const SHELL_READY_TIMEOUT_MS = 15_000
+export const SHELL_READY_TIMEOUT_MS = 15_000
+// Why: a cold worktree under load has been measured taking ~30s to reach its first prompt,
+// twice SHELL_READY_TIMEOUT_MS. Past that deadline queued keystrokes are released so the pane
+// stays typeable, but the startup command keeps waiting for the marker for this much longer —
+// written into a shell that is not reading yet it is swallowed and the launch is lost silently.
+export const SHELL_READY_LATE_MARKER_GRACE_MS = 30_000
 // Why: Codex skips marker-gated command delivery; this only bounds older daemon/local paths that still report shell-ready for Codex.
 export const CODEX_SHELL_READY_TIMEOUT_MS = 300
 const KILL_TIMEOUT_MS = 5_000
@@ -90,6 +95,10 @@ export type SessionOptions = {
   subprocess: SubprocessHandle
   shellReadySupported: boolean
   shellReadyTimeoutMs?: number
+  /** Extra wait for a late ready marker before the startup command is written without proof.
+   *  Defaults to 0 whenever shellReadyTimeoutMs is set: shortening the barrier is how a caller
+   *  (Codex) opts out of marker-gated delivery, and it must not inherit the longer wait. */
+  shellReadyLateMarkerGraceMs?: number
   historySeedChunks?: readonly string[]
   scrollback?: number
   wslDistro?: string
@@ -122,6 +131,9 @@ export class Session {
   private readonly onSessionExit?: (code: number) => void
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
+  private heldStartupCommand: string | null = null
+  private readonly shellReadyLateMarkerGraceMs: number
+  private shellReadyLateMarkerTimer: ReturnType<typeof setTimeout> | null = null
   private releaseStartupDeviceAttributesResponder: (() => void) | null = null
   private startupDeviceAttributesQueryFilter: StartupDeviceAttributesQueryFilter | null = null
   private shellReadyScanState: ShellReadyScanState | null = null
@@ -167,6 +179,10 @@ export class Session {
         ? undefined
         : opts.historySeedChunks.every((chunk) => this.emulator.writeSync(chunk))
 
+    this.shellReadyLateMarkerGraceMs =
+      opts.shellReadyLateMarkerGraceMs ??
+      (opts.shellReadyTimeoutMs === undefined ? SHELL_READY_LATE_MARKER_GRACE_MS : 0)
+
     if (opts.shellReadySupported) {
       this._shellState = 'pending'
       this.shellReadyScanState = createShellReadyScanState()
@@ -186,7 +202,9 @@ export class Session {
       this._shellState = 'unsupported'
     }
 
-    this.postReadyFlushGate = new PostReadyFlushGate(() => this.flushPreReadyQueue())
+    this.postReadyFlushGate = new PostReadyFlushGate(() =>
+      this.flushPreReadyQueue({ includeStartupCommand: true })
+    )
     const echoProbe = createPtySlaveEchoProbe(this.subprocess.slavePath)
     this.startupIngress = new PtyStartupIngress({
       ...(opts.startupIngress ? { intent: opts.startupIngress } : {}),
@@ -260,6 +278,22 @@ export class Session {
     }
 
     this.subprocess.write(data)
+  }
+
+  /** Delivery path for the command a session is launched with. Unlike `write`, it is not released
+   *  by the shell-ready deadline: a startup command written before the shell reads its PTY is
+   *  swallowed, and the caller is left with a healthy-looking session that never ran anything. It
+   *  waits for the ready marker instead, and the daemon logs the two outcomes that are not proof
+   *  of delivery — the grace deadline expiring, and the shell exiting while it is still held. */
+  writeStartupCommand(data: string): void {
+    if (this._state === 'exited' || this._disposed) {
+      return
+    }
+    if (this._shellState === 'pending' && this.heldStartupCommand === null) {
+      this.heldStartupCommand = data
+      return
+    }
+    this.write(data)
   }
 
   resize(cols: number, rows: number): void {
@@ -599,10 +633,8 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
-    if (this.shellReadyTimer) {
-      clearTimeout(this.shellReadyTimer)
-      this.shellReadyTimer = null
-    }
+    this.clearShellReadyTimers()
+    this.reportUndeliveredStartupCommand()
     this.shellReadyScanState = null
     this.preReadyStdinQueue = []
     this.postReadyFlushGate.clear()
@@ -649,7 +681,9 @@ export class Session {
     }
 
     let releaseStartupDeviceAttributes = false
-    if (this._shellState === 'pending' && this.shellReadyScanState) {
+    // Why the scan state, not the 'pending' state: it outlives the deadline while a held startup
+    // command waits on a late marker, and the marker bytes must be stripped whenever it does.
+    if (this.shellReadyScanState) {
       const scanned = scanForShellReady(this.shellReadyScanState, data)
       data = scanned.output
       if (scanned.matched) {
@@ -708,10 +742,8 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
-    if (this.shellReadyTimer) {
-      clearTimeout(this.shellReadyTimer)
-      this.shellReadyTimer = null
-    }
+    this.clearShellReadyTimers()
+    this.reportUndeliveredStartupCommand()
     this.postReadyFlushGate.clear()
 
     // Why: release the ptmx fd here or node-pty's _socket leaks the master fd until GC (docs/fix-pty-fd-leak.md).
@@ -759,11 +791,8 @@ export class Session {
   private transitionToReady(postMarkerBytesObserved = false): void {
     this._shellState = 'ready'
     this.shellReadyScanState = null
-    if (this.shellReadyTimer) {
-      clearTimeout(this.shellReadyTimer)
-      this.shellReadyTimer = null
-    }
-    if (this.preReadyStdinQueue.length === 0) {
+    this.clearShellReadyTimers()
+    if (this.preReadyStdinQueue.length === 0 && this.heldStartupCommand === null) {
       return
     }
     this.postReadyFlushGate.arm(postMarkerBytesObserved)
@@ -776,15 +805,71 @@ export class Session {
     }
     this._shellState = 'timed_out'
     this.releaseStartupDeviceAttributes()
-    this.releaseHeldShellReadyBytes()
-    this.flushPreReadyQueue()
+    if (this.heldStartupCommand === null || this.shellReadyLateMarkerGraceMs <= 0) {
+      this.releaseHeldShellReadyBytes()
+      this.flushPreReadyQueue({ includeStartupCommand: true })
+      return
+    }
+    // Why the queue splits here: keystrokes must go through or the pane is unusable, but the
+    // startup command has no one to notice it was dropped, so it keeps waiting. The marker scanner
+    // stays armed — a late marker is still proof the shell reads, and still has to be stripped.
+    this.flushPreReadyQueue({ includeStartupCommand: false })
+    this.shellReadyLateMarkerTimer = setTimeout(() => {
+      this.onShellReadyLateMarkerGraceExpired()
+    }, this.shellReadyLateMarkerGraceMs)
   }
 
-  private flushPreReadyQueue(): void {
+  private onShellReadyLateMarkerGraceExpired(): void {
+    this.shellReadyLateMarkerTimer = null
+    if (this._shellState !== 'timed_out' || this.heldStartupCommand === null) {
+      return
+    }
+    console.warn(
+      `[daemon/session] ${this.sessionId}: no shell-ready marker after ${
+        SHELL_READY_TIMEOUT_MS + this.shellReadyLateMarkerGraceMs
+      }ms; writing the startup command without proof the shell is reading it`
+    )
+    this.releaseHeldShellReadyBytes()
+    this.flushPreReadyQueue({ includeStartupCommand: true })
+  }
+
+  private flushPreReadyQueue(opts: { includeStartupCommand: boolean }): void {
+    const startupCommand = opts.includeStartupCommand ? this.heldStartupCommand : null
+    if (startupCommand !== null) {
+      this.heldStartupCommand = null
+    }
     const queued = this.preReadyStdinQueue
     this.preReadyStdinQueue = []
+    // Why first: the host writes it before any client input can arrive, so releasing it ahead of
+    // the queue is what preserves the order the caller asked for.
+    if (startupCommand !== null) {
+      this.subprocess.write(startupCommand)
+    }
     for (const data of queued) {
       this.subprocess.write(data)
+    }
+  }
+
+  /** The other non-delivery outcome: the session ended before the shell ever proved it was reading,
+   *  so the launch never happened. Silence here is what makes a lost session look like a healthy one. */
+  private reportUndeliveredStartupCommand(): void {
+    if (this.heldStartupCommand === null) {
+      return
+    }
+    this.heldStartupCommand = null
+    console.warn(
+      `[daemon/session] ${this.sessionId}: session ended before the shell-ready marker; its startup command was never delivered`
+    )
+  }
+
+  private clearShellReadyTimers(): void {
+    if (this.shellReadyTimer) {
+      clearTimeout(this.shellReadyTimer)
+      this.shellReadyTimer = null
+    }
+    if (this.shellReadyLateMarkerTimer) {
+      clearTimeout(this.shellReadyLateMarkerTimer)
+      this.shellReadyLateMarkerTimer = null
     }
   }
 

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -123,7 +123,7 @@ export async function createOrAttachTerminalSession(
   if (opts.command && !subprocess.startupCommandDeliveredInShellArgs) {
     const submit = process.platform === 'win32' ? '\r' : '\n'
     // Why: only Orca-wrapped shells advertise the paste-safe startup barrier.
-    session.write(
+    session.writeStartupCommand(
       buildStartupCommandSubmission(opts.command, {
         submit,
         bracketedPasteSafe: shellReadySupported

--- a/src/renderer/src/components/settings/manage-sessions-format.ts
+++ b/src/renderer/src/components/settings/manage-sessions-format.ts
@@ -32,5 +32,10 @@ export function formatState(session: PtyManagementSession): string {
   if (session.shellState === 'pending') {
     return 'starting'
   }
+  // Why surfaced: the shell never proved it was reading, so any startup command this session was
+  // launched with may have gone nowhere. Reporting it beats a session that reads as healthy.
+  if (session.shellState === 'timed_out') {
+    return 'starting (unconfirmed)'
+  }
   return session.state
 }


### PR DESCRIPTION
A startup command is now either delivered to a shell that is reading, or the daemon says it was not — instead of being written blind fifteen seconds in and lost without a word.

## What #12840 left

#12840 (STA-3417) put a marker-gated barrier in front of the startup command, so it is no longer written into a shell that has not started reading its PTY. It fixed the common case, and this PR is not a correction of it — it is the tail it left.

The barrier gives up after `SHELL_READY_TIMEOUT_MS` (15s) and then flushes the queue into the PTY anyway:

```ts
private onShellReadyTimeout(): void {
  this._shellState = 'timed_out'
  this.releaseStartupDeviceAttributes()
  this.releaseHeldShellReadyBytes()
  this.flushPreReadyQueue()      // writes everything into the PTY regardless
}
```

That is the same blind write #12840 removed, fifteen seconds later. When it is swallowed, the caller gets a session that looks healthy and never ran anything. `_shellState` does become `timed_out`, but nothing reads it: `createOrAttach` returns it at t=0 when it is still `pending`, and the only renderer that formats it (`manage-sessions-format.ts`) had no branch for it and fell through to "running".

## What this changes

The startup command gets its own path, separate from keystrokes.

- `Session.writeStartupCommand` holds it out of `preReadyStdinQueue`. The 15s deadline still releases queued keystrokes — a pane that will not take input is unusable — but the command keeps waiting for the marker for `SHELL_READY_LATE_MARKER_GRACE_MS` (30s) longer.
- A marker that arrives late is still proof the shell is reading, so the command is delivered then, exactly once, through the existing `PostReadyFlushGate`. `shellState` goes to `ready`. This turns the measured failure into a correct delivery rather than a loss.
- The marker scanner stays armed past the deadline for the same reason. That also fixes a smaller existing bug: today a marker arriving after the deadline reaches the pane as raw OSC 777 bytes, because the scanner that strips it has already been torn down.
- Two outcomes are not proof of delivery, and both now say so in the daemon log: the grace deadline expiring, which still writes the command but without evidence, and the session ending while it is still held, which never writes it at all.
- `shellState` stays `timed_out` in the first case, and Manage Sessions reports `starting (unconfirmed)` instead of showing the session as running.

Delivery is still exactly one write on every path. The command is never written twice — worth stating explicitly, because a doubled send is its own bug and it is visible in live panes today (scrollback showing `caffeinate … claude … "$(caffeinate … claude …`).

Shortening the barrier is how a caller opts out of marker-gated delivery, so a session that passes an explicit `shellReadyTimeoutMs` — Codex, at 300ms — gets no grace window and behaves exactly as before.

## On the constant

I did not raise `SHELL_READY_TIMEOUT_MS`. A bigger number is an arms race with an unbounded prompt and it hides the tail instead of reporting it. 15s still governs when keystrokes are released, which is the part a user feels. The new 30s is a second, reported window that only the startup command waits in, and it ends in a log line rather than in silence.

## Measurement

**Reported (Mac, Orca 1.4.176, 2026-08-10).** In a freshly created Orca-managed worktree of a large repo, a new pane did not execute typed input for roughly **30s** — twice the 15s timeout. Method: create the worktree, create a pane, send `echo MARK` every three or four seconds, read the pane back with `orca terminal read --limit 200`. The first five or six markers never ran; the later ones did. In the same session a pane in the repo's warm main checkout executed a startup `--command` immediately, three times out of three. Roughly ten seconds of the thirty was fish waiting for a Primary Device Attribute answer that Orca's workspace panes do not send; disabling fish's `query-term` feature narrowed the window to about eight seconds but did not close it.

**My own attempt (Mac, macOS 25.4, fish 4.7.1, same repo, 2026-08-10) did not reproduce a stall past 15s**, and I would rather say so than quote a number I did not take. Method: one pane in a warm checkout, then a fresh `orca worktree create --setup run` of this repo and six panes in it — one immediately after creation and five in a burst — each launched with `--command 'echo ORCA_MARK_$(date +%s)'` while four `pnpm install` processes and five recursive `find` passes ran. Every pane executed its startup command within **1–2s** of creation; the slowest observation across eight panes was 2s.

What I could confirm on this machine, and what it says about the window:

- `fish -c 'status features'` reports `query-term off` and `mark-prompt on`. `query-term` being off by default in fish 4.7 removes the ~10s DA1 component of the reported 30s, which is the most likely reason the stall did not reproduce here.
- Several unrelated live Orca panes carry fish's banner: *"no response to Primary Device Attribute query … This fish process will no longer wait for outstanding queries"* — the stall path itself, observed in the wild.

So the reported 30s stands as the case this is written against, on a fish build where `query-term` was still in play, and the fix is written to report rather than to assume: if the tail is shorter than 30s on a given machine, nothing waits longer than it has to; if it is longer, the outcome is logged instead of lost.

## Test plan

Ran on this branch:

- `pnpm test` on the touched areas — `src/main/daemon` and `src/renderer/src/components/settings`: **248 files / 2425 tests passed**, 2 skipped.
- `pnpm typecheck` (node, cli, web): **green**.
- `pnpm lint` (oxlint, switch exhaustiveness, styled scrollbars, localization catalog + coverage): **green**.
- Full `pnpm test` run: 4591 files passed. Four failures, all reproduced or explained off this branch — `wsl-hook-relay-manager.test.ts` and `wsl-hook-relay-live.integration.test.ts` fail identically on a clean `upstream/main` checkout on this machine (WSL paths on macOS), and `ssh-pty-provider-agent-session-create-operation.test.ts` passed on both a clean tree and a re-run, so it is flaky here rather than a regression.

New tests in `src/main/daemon/session.test.ts` cover every branch of the new behaviour:

| case | expectation |
| --- | --- |
| marker arrives normally | delivered once through the flush gate, `ready`, no warning |
| marker never arrives, deadline passes | keystrokes go through, command still held, `timed_out` |
| marker arrives after the deadline | delivered once, `ready`, marker bytes stripped from fan-out, no warning |
| grace deadline expires | written without proof, `timed_out`, warning logged |
| session exits while the command is held | never written, warning logged |
| shortened barrier (Codex) | no grace window, written at the short deadline |

Manual: created and read back eight panes through `orca terminal create` / `orca terminal read` as described above, then removed the probe worktree.

## Scope

Deliberately not in this PR:

- **The non-daemon path.** `local-pty-provider.ts` has the same shape at `STARTUP_COMMAND_READY_MAX_WAIT_MS = 1500`, but it is the fallback the daemon adapter replaces via `setLocalPtyProvider()`, and mirroring it would double the diff. Worth a follow-up.
- **Carrying the outcome out to `orchestration worker-start` / `terminal create`.** Those return before the barrier resolves, so a caller-facing signal needs a new stream event, and per `docs/reference/remote-wire-compatibility.md` a new stream opcode has to be capability-negotiated because decoders drop unknown opcodes silently. That is a wire change, not a tail fix. This PR makes the existing `shellState` field honest — it already reaches clients through `listSessions` — and logs the rest.
- **Readiness by capability instead of by shell name.** `shellPathSupportsPtyStartupBarrier` is an allowlist, so nushell, xonsh and every future shell keep the blind write. fish 4.x emits OSC 133 prompt markers by default (`mark-prompt`, confirmed on 4.7.1 above), zsh and bash do under the usual integrations, and Orca already handles prompt marks for zsh. Keying the barrier on an OSC 133 prompt-start with the per-shell wrapper as fallback would cover every shell and shrink the per-shell maintenance. It does not fit cleanly into this diff — it changes what readiness *means*, not what happens when readiness is late — so I have left it out and it should be filed as its own issue.

Refs #12840, STA-3417.
