### PR TITLE
[perf-remote] perf(renderer): collapse terminal host selectors

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -32,16 +32,8 @@ import TerminalSearch from '@/components/TerminalSearch'
 import type { PtyTransport } from './pty-transport'
 import type { PtyTransportRecoveryState } from './pty-transport-types'
 import { fitPanes, isWindowsUserAgent } from './pane-helpers'
-import { getConnectionId, getConnectionIdFromState } from '@/lib/connection-context'
-import {
-  getExplicitRuntimeEnvironmentIdForWorktree,
-  getRuntimeEnvironmentIdForWorktree
-} from '@/lib/worktree-runtime-owner'
-import {
-  selectRuntimeAwareSshStatus,
-  selectRuntimeAwareSshTargetLabel,
-  selectRuntimeAwareSshTargetRemoved
-} from '@/store/slices/runtime-environment-ssh'
+import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { hydrateRuntimeEnvironmentSshState } from '@/runtime/runtime-environment-ssh-state'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
@@ -123,7 +115,6 @@ import {
   resolveNativeChatLeafRoute,
   type NativeChatLeafRoute
 } from '../native-chat/native-chat-leaf-routing'
-import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit, safeFitAndThen } from '@/lib/pane-manager/pane-tree-ops'
 import { clearTerminalScrollbackAndFollowOutput } from '@/lib/pane-manager/terminal-scrollback-clear'
@@ -169,7 +160,6 @@ import {
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
   getRepoExecutionHostId,
-  isRuntimeOwnedSshTargetId,
   LOCAL_EXECUTION_HOST_ID,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
@@ -243,6 +233,7 @@ import {
   getCachedUnifiedTerminalTabForWorktree
 } from './terminal-unified-tab-lookup'
 import { resolveNativeChatLeafTitleAgent } from './native-chat-leaf-title-agent'
+import { selectTerminalPaneHostState } from './terminal-pane-host-state'
 import {
   isXtermHelperTextarea,
   releaseTerminalFocusForOutsidePointerDown,
@@ -349,37 +340,14 @@ function TerminalPane(
   const isRendererVisible = isVisible && isWorktreeActive
   const isVisibleRef = useRef(isRendererVisible)
   isVisibleRef.current = isRendererVisible
-  const sshReconnectTargetId = useAppStore((store) => {
-    const connectionId = getConnectionIdFromState(store, worktreeId)
-    // Why: runtime-owned SSH targets are internal plumbing users can't connect to, so a reconnect prompt would mislead.
-    if (!connectionId || isRuntimeOwnedSshTargetId(connectionId)) {
-      return null
-    }
-    return connectionId
-  })
-  const nativeChatTranscriptIsLocalReadable = useAppStore((store) =>
-    isNativeChatTranscriptLocalReadable(getConnectionIdFromState(store, worktreeId))
-  )
-  // Which machine's SSH store this target belongs to: a remote server's per-environment bucket, or null for this machine's local SSH maps.
-  const sshReconnectEnvironmentId = useAppStore((store) =>
-    sshReconnectTargetId ? getExplicitRuntimeEnvironmentIdForWorktree(store, worktreeId) : null
-  )
-  const sshReconnectStatus = useAppStore((store) =>
-    sshReconnectTargetId
-      ? selectRuntimeAwareSshStatus(store, sshReconnectEnvironmentId, sshReconnectTargetId)
-      : null
-  )
-  const sshReconnectTargetLabel = useAppStore((store) =>
-    sshReconnectTargetId
-      ? selectRuntimeAwareSshTargetLabel(store, sshReconnectEnvironmentId, sshReconnectTargetId)
-      : ''
-  )
-  // Why: a ghost target (removed from its host) can only fail reconnect, so the overlay offers Remove instead of Connect.
-  const sshReconnectTargetRemoved = useAppStore((store) =>
-    sshReconnectTargetId
-      ? selectRuntimeAwareSshTargetRemoved(store, sshReconnectEnvironmentId, sshReconnectTargetId)
-      : false
-  )
+  const {
+    nativeChatTranscriptIsLocalReadable,
+    sshReconnectEnvironmentId,
+    sshReconnectStatus,
+    sshReconnectTargetId,
+    sshReconnectTargetLabel,
+    sshReconnectTargetRemoved
+  } = useAppStore(useShallow((store) => selectTerminalPaneHostState(store, worktreeId)))
   useEffect(() => {
     if (!sshReconnectEnvironmentId) {
       return

--- a/src/renderer/src/components/terminal-pane/terminal-pane-host-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-host-state.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import { selectTerminalPaneHostState } from './terminal-pane-host-state'
+
+function makeState(overrides: Record<string, unknown>): AppState {
+  return {
+    activeWorktreeId: null,
+    detectedWorktreesByRepo: {},
+    folderWorkspaces: [],
+    projectGroups: [],
+    removedSshTargetLabels: new Map(),
+    repos: [],
+    runtimeStatusByEnvironmentId: new Map(),
+    sshConnectionStates: new Map(),
+    sshStateByEnvironment: new Map(),
+    sshTargetLabels: new Map(),
+    sshTargetsHydrated: true,
+    worktreesByRepo: {},
+    ...overrides
+  } as unknown as AppState
+}
+
+describe('selectTerminalPaneHostState', () => {
+  it('resolves local and direct SSH workspaces without changing reconnect semantics', () => {
+    const localState = makeState({
+      repos: [{ id: 'repo-local' }],
+      worktreesByRepo: {
+        'repo-local': [{ id: 'wt-local', repoId: 'repo-local' }]
+      }
+    })
+
+    expect(selectTerminalPaneHostState(localState, 'wt-local')).toEqual({
+      nativeChatTranscriptIsLocalReadable: true,
+      sshReconnectEnvironmentId: null,
+      sshReconnectStatus: null,
+      sshReconnectTargetId: null,
+      sshReconnectTargetLabel: '',
+      sshReconnectTargetRemoved: false
+    })
+
+    const sshState = makeState({
+      repos: [{ id: 'repo-ssh', connectionId: 'ssh-a' }],
+      sshConnectionStates: new Map([
+        ['ssh-a', { targetId: 'ssh-a', status: 'connected', error: null, reconnectAttempt: 0 }]
+      ]),
+      sshTargetLabels: new Map([['ssh-a', 'devbox']]),
+      worktreesByRepo: {
+        'repo-ssh': [{ id: 'wt-ssh', repoId: 'repo-ssh' }]
+      }
+    })
+
+    expect(selectTerminalPaneHostState(sshState, 'wt-ssh')).toEqual({
+      nativeChatTranscriptIsLocalReadable: false,
+      sshReconnectEnvironmentId: null,
+      sshReconnectStatus: 'connected',
+      sshReconnectTargetId: 'ssh-a',
+      sshReconnectTargetLabel: 'devbox',
+      sshReconnectTargetRemoved: false
+    })
+  })
+
+  it('reads nested SSH state from the worktree owner runtime', () => {
+    const state = makeState({
+      repos: [
+        {
+          id: 'repo-runtime',
+          connectionId: 'ssh-nested',
+          executionHostId: 'runtime:env-a'
+        }
+      ],
+      runtimeStatusByEnvironmentId: new Map([
+        ['env-a', { status: { runtimeId: 'runtime-a' }, checkedAt: 1 }]
+      ]),
+      sshStateByEnvironment: new Map([
+        [
+          'env-a',
+          {
+            connectionStates: new Map([
+              [
+                'ssh-nested',
+                {
+                  targetId: 'ssh-nested',
+                  status: 'disconnected',
+                  error: null,
+                  reconnectAttempt: 0
+                }
+              ]
+            ]),
+            targetLabels: new Map([['ssh-nested', 'build box']]),
+            removedTargetLabels: new Map(),
+            targetsHydrated: true
+          }
+        ]
+      ]),
+      worktreesByRepo: {
+        'repo-runtime': [
+          {
+            id: 'wt-runtime',
+            repoId: 'repo-runtime',
+            hostId: 'runtime:env-a',
+            runtimeOwnerEnvironmentId: 'env-a'
+          }
+        ]
+      }
+    })
+
+    expect(selectTerminalPaneHostState(state, 'wt-runtime')).toEqual({
+      nativeChatTranscriptIsLocalReadable: false,
+      sshReconnectEnvironmentId: 'env-a',
+      sshReconnectStatus: 'disconnected',
+      sshReconnectTargetId: 'ssh-nested',
+      sshReconnectTargetLabel: 'build box',
+      sshReconnectTargetRemoved: false
+    })
+  })
+
+  it('keeps runtime-owned SSH plumbing out of reconnect UI', () => {
+    const state = makeState({
+      repos: [{ id: 'repo-ephemeral', connectionId: 'runtime-ssh-vm-a' }],
+      worktreesByRepo: {
+        'repo-ephemeral': [{ id: 'wt-ephemeral', repoId: 'repo-ephemeral' }]
+      }
+    })
+
+    expect(selectTerminalPaneHostState(state, 'wt-ephemeral')).toEqual({
+      nativeChatTranscriptIsLocalReadable: true,
+      sshReconnectEnvironmentId: null,
+      sshReconnectStatus: null,
+      sshReconnectTargetId: null,
+      sshReconnectTargetLabel: '',
+      sshReconnectTargetRemoved: false
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-host-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-host-state.ts
@@ -1,0 +1,61 @@
+import type { AppState } from '@/store/types'
+import { getConnectionIdFromState } from '@/lib/connection-context'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+import {
+  selectRuntimeAwareSshStatus,
+  selectRuntimeAwareSshTargetLabel,
+  selectRuntimeAwareSshTargetRemoved
+} from '@/store/slices/runtime-environment-ssh'
+import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+
+export type TerminalPaneHostState = {
+  nativeChatTranscriptIsLocalReadable: boolean
+  sshReconnectEnvironmentId: string | null
+  sshReconnectStatus: ReturnType<typeof selectRuntimeAwareSshStatus>
+  sshReconnectTargetId: string | null
+  sshReconnectTargetLabel: string
+  sshReconnectTargetRemoved: boolean
+}
+
+export function selectTerminalPaneHostState(
+  state: AppState,
+  worktreeId: string
+): TerminalPaneHostState {
+  const connectionId = getConnectionIdFromState(state, worktreeId)
+  const nativeChatTranscriptIsLocalReadableResult =
+    isNativeChatTranscriptLocalReadable(connectionId)
+  const sshReconnectTargetId =
+    connectionId && !isRuntimeOwnedSshTargetId(connectionId) ? connectionId : null
+  if (!sshReconnectTargetId) {
+    return {
+      nativeChatTranscriptIsLocalReadable: nativeChatTranscriptIsLocalReadableResult,
+      sshReconnectEnvironmentId: null,
+      sshReconnectStatus: null,
+      sshReconnectTargetId: null,
+      sshReconnectTargetLabel: '',
+      sshReconnectTargetRemoved: false
+    }
+  }
+  const sshReconnectEnvironmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  return {
+    nativeChatTranscriptIsLocalReadable: nativeChatTranscriptIsLocalReadableResult,
+    sshReconnectEnvironmentId,
+    sshReconnectStatus: selectRuntimeAwareSshStatus(
+      state,
+      sshReconnectEnvironmentId,
+      sshReconnectTargetId
+    ),
+    sshReconnectTargetId,
+    sshReconnectTargetLabel: selectRuntimeAwareSshTargetLabel(
+      state,
+      sshReconnectEnvironmentId,
+      sshReconnectTargetId
+    ),
+    sshReconnectTargetRemoved: selectRuntimeAwareSshTargetRemoved(
+      state,
+      sshReconnectEnvironmentId,
+      sshReconnectTargetId
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- replace six per-`TerminalPane` host/SSH Zustand subscriptions with one shallow selector
- resolve each pane's workspace connection ownership once per store publication instead of twice
- preserve local, direct SSH, nested-runtime SSH, reconnect, removal, and native-chat readability behavior

## ELI5

Every open terminal pane had six little watchers asking Orca where that terminal lives and whether its SSH host is healthy. Any renderer state update woke all six watchers, even when the update had nothing to do with terminals or remote hosts.

This gives each terminal pane one watcher that answers all six questions in one pass. With many workspaces spread across remote Orca servers, that means much less repeated bookkeeping while agents and orchestrator work are producing lots of state updates.

## Performance

- Zustand subscriptions per mounted terminal pane: 6 → 1
- repeated workspace connection lookups in this group: 2 → 1 per store publication
- unrelated publications still execute the single selector, but `useShallow` suppresses renders when its six observable values are unchanged

## Correctness and compatibility

- renderer-only selector composition; no RPC, stream, persistence, schema, or wire changes
- mixed-version clients and remote Orca servers are unaffected
- runtime-owned SSH plumbing remains excluded from reconnect UI
- nested SSH state remains scoped to the owning runtime environment, including same-ID isolation
- folder-workspace and ambiguous-owner behavior continues through the existing ownership resolvers

## Validation

- adversarial review: READY, no P0–P2 findings
- focused selector/ownership/SSH suites: 42 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:electron-vite`
- changed-file lint and formatting
- `git diff --check`

## Residual risk

No live many-host packaged profile was run; the improvement is structural and scales with mounted terminal pane count and renderer store publication rate.
