### PR TITLE
perf(orchestration): remove mutation receipt capacity scans

### DIFF
--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -57,6 +57,10 @@ import {
   releaseContextOnlyDispatch,
   type ContextOnlyDispatchReleaseResult
 } from './context-only-dispatch-release'
+import {
+  ensureMutationReceiptCapacity,
+  migrateMutationReceiptCapacity
+} from './mutation-receipt-capacity'
 
 // Why: leaf UUID is the remint-stable pane identity (tab half changes on break-out); exact match covers legacy/unparseable keys.
 function isEquivalentPaneKey(a: string, b: string): boolean {
@@ -261,9 +265,6 @@ export const LEGACY_RUN_ID = ORCHESTRATION_LEGACY_RUN_ID
 export const LEGACY_CONTRACT_VERSION = 0
 export const CURRENT_CONTRACT_VERSION = ORCHESTRATION_CONTRACT_VERSION
 
-const MUTATION_RECEIPT_MAX_ROWS = 10_000
-const MUTATION_RECEIPT_MAX_AGE_DAYS = 30
-
 export type RunListPage = {
   runs: RunRow[]
   nextCursor: string | null
@@ -281,8 +282,8 @@ type RunListCursor = {
   id: string
 }
 
-// Schema versions: v2 'heartbeat'+last_heartbeat_at, v3 delivered_at, v4 task-creator terminal, v5 task_title/display_name, v6 pane identity, v7 lightweight Runs, v8 crash-safe Run deliveries, v9 durable question threads, v10 Dispatch capabilities, v11 durable mutation receipts, v12 composed worker state, v18 post-v6 version-skew repair, v19 adopted legacy Runs and compatibility receipts, v20 legacy question backfill, v21 legacy scheduler-loss provenance, v22 dispatch assignee lookup, v23 worker terminal resource ownership, v24 creator-incarnation authority, v25 active Dispatch handle lookup.
-const SCHEMA_VERSION = 25
+// Schema versions: v2 'heartbeat'+last_heartbeat_at, v3 delivered_at, v4 task-creator terminal, v5 task_title/display_name, v6 pane identity, v7 lightweight Runs, v8 crash-safe Run deliveries, v9 durable question threads, v10 Dispatch capabilities, v11 durable mutation receipts, v12 composed worker state, v18 post-v6 version-skew repair, v19 adopted legacy Runs and compatibility receipts, v20 legacy question backfill, v21 legacy scheduler-loss provenance, v22 dispatch assignee lookup, v23 worker terminal resource ownership, v24 creator-incarnation authority, v25 active Dispatch handle lookup, v26 indexed mutation receipt capacity.
+const SCHEMA_VERSION = 26
 
 function hardenOrchestrationDatabaseFiles(dbPath: string | ':memory:'): void {
   if (dbPath === ':memory:' || process.platform === 'win32') {
@@ -983,6 +984,9 @@ export class OrchestrationDb {
             WHERE assignee_handle IS NOT NULL AND status IN ('pending', 'dispatched');
         `)
       }
+      if (current < 26) {
+        migrateMutationReceiptCapacity(this.db)
+      }
       this.db.exec(`
         CREATE INDEX IF NOT EXISTS idx_dispatch_assignee_pane_leaf
           ON dispatch_contexts(${DISPATCH_PANE_KEY_MATCH_SUFFIX_SQL})
@@ -1398,44 +1402,6 @@ export class OrchestrationDb {
 
   // ── Durable mutation receipts ──
 
-  private ensureMutationReceiptCapacity(): void {
-    this.db
-      .prepare(
-        `DELETE FROM mutation_receipts
-         WHERE state = 'completed'
-           AND updated_at < datetime('now', ?)`
-      )
-      .run(`-${MUTATION_RECEIPT_MAX_AGE_DAYS} days`)
-
-    const row = this.db.prepare('SELECT COUNT(*) AS count FROM mutation_receipts').get() as {
-      count: number
-    }
-    const completedToRemove = row.count - MUTATION_RECEIPT_MAX_ROWS + 1
-    if (completedToRemove > 0) {
-      this.db
-        .prepare(
-          `DELETE FROM mutation_receipts
-           WHERE rowid IN (
-             SELECT rowid FROM mutation_receipts
-             WHERE state = 'completed'
-             ORDER BY updated_at ASC, rowid ASC
-             LIMIT ?
-           )`
-        )
-        .run(completedToRemove)
-    }
-
-    const retained = this.db.prepare('SELECT COUNT(*) AS count FROM mutation_receipts').get() as {
-      count: number
-    }
-    if (retained.count >= MUTATION_RECEIPT_MAX_ROWS) {
-      throw new OrchestrationError(
-        'mutation_ledger_full',
-        'The durable mutation ledger is full of unresolved operations. Resolve or inspect them before starting another mutation.'
-      )
-    }
-  }
-
   beginMutationReceipt(params: {
     callerFingerprint: string
     requestId: string
@@ -1458,7 +1424,7 @@ export class OrchestrationDb {
         this.db.exec('COMMIT')
         return { disposition: existing.state, row: existing }
       }
-      this.ensureMutationReceiptCapacity()
+      ensureMutationReceiptCapacity(this.db)
       this.db
         .prepare(
           `INSERT INTO mutation_receipts (
@@ -4009,7 +3975,7 @@ export class OrchestrationDb {
             `Mutation ${receipt.requestId} already has a durable acceptance record.`
           )
         }
-        this.ensureMutationReceiptCapacity()
+        ensureMutationReceiptCapacity(this.db)
         this.db
           .prepare(
             `INSERT INTO mutation_receipts (
@@ -4642,7 +4608,7 @@ export class OrchestrationDb {
           `Remote attachment request ${params.mutationReceipt.requestId} already exists.`
         )
       }
-      this.ensureMutationReceiptCapacity()
+      ensureMutationReceiptCapacity(this.db)
       this.db
         .prepare(
           `INSERT INTO mutation_receipts (

--- a/src/main/runtime/orchestration/mutation-receipt-capacity.test.ts
+++ b/src/main/runtime/orchestration/mutation-receipt-capacity.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+import { MUTATION_RECEIPT_MAX_ROWS } from './mutation-receipt-capacity'
+
+function sqliteFor(db: OrchestrationDb): Database.Database {
+  return (db as unknown as { db: Database.Database }).db
+}
+
+function insertReceipts(
+  sqlite: Database.Database,
+  count: number,
+  state: 'pending' | 'completed'
+): void {
+  sqlite
+    .prepare(
+      `WITH RECURSIVE receipt_numbers(value) AS (
+         VALUES (1)
+         UNION ALL
+         SELECT value + 1 FROM receipt_numbers WHERE value < ?
+       )
+       INSERT INTO mutation_receipts (
+         caller_fingerprint, request_id, method, payload_hash, state
+       )
+       SELECT 'caller', printf('request_%05d', value), 'orchestration.send',
+              printf('hash_%05d', value), ?
+       FROM receipt_numbers`
+    )
+    .run(count, state)
+}
+
+function beginReceipt(db: OrchestrationDb, requestId: string): void {
+  db.beginMutationReceipt({
+    callerFingerprint: 'new-caller',
+    requestId,
+    method: 'orchestration.send',
+    payloadHash: `hash-${requestId}`
+  })
+}
+
+describe('mutation receipt capacity schema', () => {
+  let db: OrchestrationDb | undefined
+  let secondDb: OrchestrationDb | undefined
+  let tempDir: string | undefined
+
+  afterEach(() => {
+    secondDb?.close()
+    db?.close()
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the completed receipt index for age and capacity pruning', () => {
+    db = new OrchestrationDb(':memory:')
+    const sqlite = sqliteFor(db)
+    insertReceipts(sqlite, 10, 'completed')
+
+    const agePlan = sqlite
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         DELETE FROM mutation_receipts
+         WHERE state = 'completed'
+           AND updated_at < datetime('now', ?)`
+      )
+      .all('-30 days') as { detail: string }[]
+    const capacityPlan = sqlite
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT rowid FROM mutation_receipts
+         WHERE state = 'completed'
+         ORDER BY updated_at ASC, rowid ASC
+         LIMIT ?`
+      )
+      .all(64) as { detail: string }[]
+    const details = [...agePlan, ...capacityPlan].map((row) => row.detail).join('\n')
+
+    expect(details).toContain('idx_mutation_receipts_completed_updated')
+    expect(details).not.toContain('USE TEMP B-TREE')
+    expect(details).not.toMatch(/SCAN mutation_receipts(?:\n|$)/)
+  })
+
+  it('migrates a populated v25 database and tracks writes from older connections', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-mutation-receipt-migration-'))
+    const dbPath = join(tempDir, 'orchestration.db')
+    db = new OrchestrationDb(dbPath)
+    insertReceipts(sqliteFor(db), 20, 'completed')
+    db.close()
+    db = undefined
+
+    const oldDb = new Database(dbPath)
+    oldDb.exec(`
+      DROP TRIGGER mutation_receipts_count_insert;
+      DROP TRIGGER mutation_receipts_count_delete;
+      DROP TABLE mutation_receipt_ledger;
+      DROP INDEX idx_mutation_receipts_completed_updated;
+    `)
+    oldDb.pragma('user_version = 25')
+    oldDb.close()
+
+    db = new OrchestrationDb(dbPath)
+    const sqlite = sqliteFor(db)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(26)
+    expect(sqlite.prepare('SELECT receipt_count FROM mutation_receipt_ledger').get()).toEqual({
+      receipt_count: 20
+    })
+
+    const olderConnection = new Database(dbPath)
+    olderConnection.exec(`
+      INSERT INTO mutation_receipts (
+        caller_fingerprint, request_id, method, payload_hash, state
+      ) VALUES ('old-client', 'inserted', 'orchestration.send', 'hash', 'pending');
+      DELETE FROM mutation_receipts
+      WHERE caller_fingerprint = 'old-client' AND request_id = 'inserted';
+    `)
+    olderConnection.close()
+
+    expect(sqlite.prepare('SELECT receipt_count FROM mutation_receipt_ledger').get()).toEqual({
+      receipt_count: 20
+    })
+  })
+
+  it('amortizes capacity pruning while retaining the newest replay records', () => {
+    db = new OrchestrationDb(':memory:')
+    const sqlite = sqliteFor(db)
+    insertReceipts(sqlite, MUTATION_RECEIPT_MAX_ROWS, 'completed')
+
+    beginReceipt(db, 'first')
+    const afterFirst = sqlite
+      .prepare('SELECT receipt_count FROM mutation_receipt_ledger')
+      .get() as { receipt_count: number }
+    beginReceipt(db, 'second')
+    const afterSecond = sqlite
+      .prepare('SELECT receipt_count FROM mutation_receipt_ledger')
+      .get() as { receipt_count: number }
+
+    expect(afterFirst.receipt_count).toBe(MUTATION_RECEIPT_MAX_ROWS - 63)
+    expect(afterSecond.receipt_count).toBe(afterFirst.receipt_count + 1)
+    expect(db.getMutationReceipt('caller', 'request_00064')).toBeUndefined()
+    expect(db.getMutationReceipt('caller', 'request_00065')).toMatchObject({ state: 'completed' })
+    expect(db.getMutationReceipt('caller', 'request_10000')).toMatchObject({ state: 'completed' })
+  })
+
+  it('keeps the row limit exact across independent database connections', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-mutation-receipt-concurrency-'))
+    const dbPath = join(tempDir, 'orchestration.db')
+    db = new OrchestrationDb(dbPath)
+    secondDb = new OrchestrationDb(dbPath)
+    const sqlite = sqliteFor(db)
+    insertReceipts(sqlite, MUTATION_RECEIPT_MAX_ROWS - 1, 'pending')
+    sqlite.exec(`
+      INSERT INTO mutation_receipts (
+        caller_fingerprint, request_id, method, payload_hash, state
+      ) VALUES ('caller', 'completed-slot', 'orchestration.send', 'hash', 'completed')
+    `)
+
+    beginReceipt(db, 'first-connection')
+    expect(() => beginReceipt(secondDb!, 'second-connection')).toThrowError(
+      expect.objectContaining({ code: 'mutation_ledger_full' })
+    )
+    db.discardPendingMutationReceipt('new-caller', 'first-connection')
+    beginReceipt(secondDb, 'second-connection')
+
+    expect(sqlite.prepare('SELECT receipt_count FROM mutation_receipt_ledger').get()).toEqual({
+      receipt_count: MUTATION_RECEIPT_MAX_ROWS
+    })
+  })
+})

--- a/src/main/runtime/orchestration/mutation-receipt-capacity.ts
+++ b/src/main/runtime/orchestration/mutation-receipt-capacity.ts
@@ -1,0 +1,79 @@
+import type Database from '../../sqlite/sync-database'
+import { OrchestrationError } from './orchestration-error'
+
+export const MUTATION_RECEIPT_MAX_ROWS = 10_000
+const MUTATION_RECEIPT_MAX_AGE_DAYS = 30
+const MUTATION_RECEIPT_PRUNE_BATCH_SIZE = 64
+
+export function migrateMutationReceiptCapacity(db: Database.Database): void {
+  // Why: database triggers keep the count exact for concurrent connections and older binaries.
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_mutation_receipts_completed_updated
+      ON mutation_receipts(updated_at) WHERE state = 'completed';
+
+    CREATE TABLE IF NOT EXISTS mutation_receipt_ledger (
+      singleton     INTEGER PRIMARY KEY CHECK(singleton = 1),
+      receipt_count INTEGER NOT NULL CHECK(receipt_count >= 0)
+    );
+
+    INSERT INTO mutation_receipt_ledger (singleton, receipt_count)
+    SELECT 1, COUNT(*) FROM mutation_receipts
+    -- SQLite needs a WHERE to disambiguate SELECT UPSERT syntax.
+    WHERE true
+    ON CONFLICT(singleton) DO UPDATE SET receipt_count = excluded.receipt_count;
+
+    CREATE TRIGGER IF NOT EXISTS mutation_receipts_count_insert
+    AFTER INSERT ON mutation_receipts
+    BEGIN
+      UPDATE mutation_receipt_ledger
+      SET receipt_count = receipt_count + 1
+      WHERE singleton = 1;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS mutation_receipts_count_delete
+    AFTER DELETE ON mutation_receipts
+    BEGIN
+      UPDATE mutation_receipt_ledger
+      SET receipt_count = receipt_count - 1
+      WHERE singleton = 1;
+    END;
+  `)
+}
+
+function receiptCount(db: Database.Database): number {
+  const row = db
+    .prepare('SELECT receipt_count FROM mutation_receipt_ledger WHERE singleton = 1')
+    .get() as { receipt_count: number } | undefined
+  if (!row) {
+    throw new Error('Mutation receipt ledger metadata is missing.')
+  }
+  return row.receipt_count
+}
+
+export function ensureMutationReceiptCapacity(db: Database.Database): void {
+  db.prepare(
+    `DELETE FROM mutation_receipts
+     WHERE state = 'completed'
+       AND updated_at < datetime('now', ?)`
+  ).run(`-${MUTATION_RECEIPT_MAX_AGE_DAYS} days`)
+
+  const count = receiptCount(db)
+  if (count >= MUTATION_RECEIPT_MAX_ROWS) {
+    db.prepare(
+      `DELETE FROM mutation_receipts
+       WHERE rowid IN (
+         SELECT rowid FROM mutation_receipts
+         WHERE state = 'completed'
+         ORDER BY updated_at ASC, rowid ASC
+         LIMIT ?
+       )`
+    ).run(count - MUTATION_RECEIPT_MAX_ROWS + MUTATION_RECEIPT_PRUNE_BATCH_SIZE)
+  }
+
+  if (receiptCount(db) >= MUTATION_RECEIPT_MAX_ROWS) {
+    throw new OrchestrationError(
+      'mutation_ledger_full',
+      'The durable mutation ledger is full of unresolved operations. Resolve or inspect them before starting another mutation.'
+    )
+  }
+}

--- a/src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts
+++ b/src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts
@@ -74,7 +74,7 @@ describe('OrchestrationDb bounded mutation receipts', () => {
     const count = sqliteFor(db)
       .prepare('SELECT COUNT(*) AS count FROM mutation_receipts')
       .get() as { count: number }
-    expect(count.count).toBe(MUTATION_RECEIPT_MAX_ROWS)
+    expect(count.count).toBeLessThanOrEqual(MUTATION_RECEIPT_MAX_ROWS)
     expect(db.getMutationReceipt('caller', 'request_00001')).toBeUndefined()
     expect(db.getMutationReceipt('caller', 'request_10000')).toMatchObject({ state: 'completed' })
     expect(db.getMutationReceipt('caller', 'new')).toMatchObject({ state: 'pending' })
@@ -117,7 +117,7 @@ describe('OrchestrationDb bounded mutation receipts', () => {
     const count = sqliteFor(db)
       .prepare('SELECT COUNT(*) AS count FROM mutation_receipts')
       .get() as { count: number }
-    expect(count.count).toBe(MUTATION_RECEIPT_MAX_ROWS)
+    expect(count.count).toBeLessThanOrEqual(MUTATION_RECEIPT_MAX_ROWS)
     expect(db.getMutationReceipt('caller', 'request_00001')).toBeUndefined()
     expect(db.getMutationReceipt('caller', 'remote_pruned')).toMatchObject({ state: 'pending' })
     expect(db.getRemoteDispatchAttachment('ctx_remote_pruned')).toBeDefined()
@@ -240,7 +240,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(25)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(26)
     expect(db.getDispatchContextById(dispatch.id)).toMatchObject({ assignee_handle: 'term_worker' })
     expect(db.getTask(task.id)).toMatchObject({
       created_by_pane_key: null,
@@ -277,7 +277,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db.close()
     db = new OrchestrationDb(dbPath)
-    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(25)
+    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(26)
     expect(db.getDispatchContextById(dispatch.id)).toBeDefined()
   })
 
@@ -309,7 +309,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(25)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(26)
     expect(db.getTask(task.id)).toMatchObject({
       created_by_pane_key: 'tab_creator:leaf_creator',
       created_by_process_incarnation: 'pty_creator:incarnation-a',
@@ -328,7 +328,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db.close()
     db = new OrchestrationDb(dbPath)
-    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(25)
+    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(26)
     expect(db.getTask(task.id)?.created_by_process_incarnation).toBe('pty_creator:incarnation-a')
   })
 })

--- a/tests/tools/benchmarks/mutation-receipt-capacity-bench.mjs
+++ b/tests/tools/benchmarks/mutation-receipt-capacity-bench.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import { DatabaseSync } from 'node:sqlite'
+import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+
+const ROW_LIMIT = 10_000
+const PRUNE_BATCH_SIZE = 64
+
+function parseArgs(argv) {
+  const options = { iterations: 32, payloadBytes: 9_500 }
+  for (let index = 2; index < argv.length; index += 1) {
+    const value = argv[index + 1]
+    if (argv[index] === '--iterations') {
+      options.iterations = Number(value)
+    } else if (argv[index] === '--payload-bytes') {
+      options.payloadBytes = Number(value)
+    } else {
+      throw new Error(`Unknown argument: ${argv[index]}`)
+    }
+    index += 1
+  }
+  if (!Number.isSafeInteger(options.iterations) || options.iterations < 1) {
+    throw new Error('--iterations must be a positive integer')
+  }
+  if (!Number.isSafeInteger(options.payloadBytes) || options.payloadBytes < 0) {
+    throw new Error('--payload-bytes must be a non-negative integer')
+  }
+  return options
+}
+
+function createFixture(path, payloadBytes, optimized) {
+  const db = new DatabaseSync(path)
+  db.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = NORMAL;
+    CREATE TABLE mutation_receipts (
+      caller_fingerprint TEXT NOT NULL,
+      request_id TEXT NOT NULL,
+      method TEXT NOT NULL,
+      payload_hash TEXT NOT NULL,
+      state TEXT NOT NULL,
+      receipt BLOB,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (caller_fingerprint, request_id)
+    );
+    WITH RECURSIVE receipt_numbers(value) AS (
+      VALUES (1)
+      UNION ALL
+      SELECT value + 1 FROM receipt_numbers WHERE value < ${ROW_LIMIT}
+    )
+    INSERT INTO mutation_receipts (
+      caller_fingerprint, request_id, method, payload_hash, state, receipt
+    )
+    SELECT 'caller', printf('request_%05d', value), 'orchestration.send',
+           printf('hash_%05d', value), 'completed', zeroblob(${payloadBytes})
+    FROM receipt_numbers;
+  `)
+  if (optimized) {
+    db.exec(`
+      CREATE INDEX idx_mutation_receipts_completed_updated
+        ON mutation_receipts(updated_at) WHERE state = 'completed';
+      CREATE TABLE mutation_receipt_ledger (
+        singleton INTEGER PRIMARY KEY,
+        receipt_count INTEGER NOT NULL
+      );
+      INSERT INTO mutation_receipt_ledger VALUES (1, ${ROW_LIMIT});
+      CREATE TRIGGER mutation_receipts_count_insert AFTER INSERT ON mutation_receipts
+      BEGIN
+        UPDATE mutation_receipt_ledger SET receipt_count = receipt_count + 1;
+      END;
+      CREATE TRIGGER mutation_receipts_count_delete AFTER DELETE ON mutation_receipts
+      BEGIN
+        UPDATE mutation_receipt_ledger SET receipt_count = receipt_count - 1;
+      END;
+    `)
+  }
+  db.exec('PRAGMA wal_checkpoint(TRUNCATE)')
+  return db
+}
+
+function runLegacyMutation(db, iteration) {
+  db.exec('BEGIN IMMEDIATE')
+  db.prepare(
+    `DELETE FROM mutation_receipts
+     WHERE state = 'completed' AND updated_at < datetime('now', '-30 days')`
+  ).run()
+  const { count } = db.prepare('SELECT COUNT(*) AS count FROM mutation_receipts').get()
+  const completedToRemove = count - ROW_LIMIT + 1
+  if (completedToRemove > 0) {
+    db.prepare(
+      `DELETE FROM mutation_receipts WHERE rowid IN (
+         SELECT rowid FROM mutation_receipts WHERE state = 'completed'
+         ORDER BY updated_at, rowid LIMIT ?
+       )`
+    ).run(completedToRemove)
+  }
+  db.prepare('SELECT COUNT(*) AS count FROM mutation_receipts').get()
+  insertReceipt(db, iteration)
+  db.exec('COMMIT')
+}
+
+function runOptimizedMutation(db, iteration) {
+  db.exec('BEGIN IMMEDIATE')
+  db.prepare(
+    `DELETE FROM mutation_receipts
+     WHERE state = 'completed' AND updated_at < datetime('now', '-30 days')`
+  ).run()
+  const { receipt_count: count } = db
+    .prepare('SELECT receipt_count FROM mutation_receipt_ledger WHERE singleton = 1')
+    .get()
+  if (count >= ROW_LIMIT) {
+    db.prepare(
+      `DELETE FROM mutation_receipts WHERE rowid IN (
+         SELECT rowid FROM mutation_receipts WHERE state = 'completed'
+         ORDER BY updated_at, rowid LIMIT ?
+       )`
+    ).run(count - ROW_LIMIT + PRUNE_BATCH_SIZE)
+  }
+  db.prepare('SELECT receipt_count FROM mutation_receipt_ledger WHERE singleton = 1').get()
+  insertReceipt(db, iteration)
+  db.exec('COMMIT')
+}
+
+function insertReceipt(db, iteration) {
+  db.prepare(
+    `INSERT INTO mutation_receipts (
+       caller_fingerprint, request_id, method, payload_hash, state
+     ) VALUES ('benchmark', ?, 'orchestration.send', ?, 'pending')`
+  ).run(`new_${iteration}`, `new_hash_${iteration}`)
+}
+
+function percentile(sorted, fraction) {
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)]
+}
+
+function measure(db, iterations, mutation) {
+  const samplesMs = []
+  for (let index = 0; index < iterations; index += 1) {
+    const startedAt = performance.now()
+    mutation(db, index)
+    samplesMs.push(performance.now() - startedAt)
+  }
+  const sorted = samplesMs.toSorted((left, right) => left - right)
+  return {
+    firstMs: samplesMs[0],
+    medianMs: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+    maxMs: sorted.at(-1),
+    totalMs: samplesMs.reduce((sum, value) => sum + value, 0)
+  }
+}
+
+const options = parseArgs(process.argv)
+const fixtureDir = mkdtempSync(join(tmpdir(), 'orca-mutation-receipt-bench-'))
+try {
+  const legacyPath = join(fixtureDir, 'legacy.db')
+  const optimizedPath = join(fixtureDir, 'optimized.db')
+  const legacyDb = createFixture(legacyPath, options.payloadBytes, false)
+  const optimizedDb = createFixture(optimizedPath, options.payloadBytes, true)
+  const databaseBytes = statSync(legacyPath).size
+  const legacy = measure(legacyDb, options.iterations, runLegacyMutation)
+  const optimized = measure(optimizedDb, options.iterations, runOptimizedMutation)
+  legacyDb.close()
+  optimizedDb.close()
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        rows: ROW_LIMIT,
+        payloadBytes: options.payloadBytes,
+        databaseBytes,
+        iterations: options.iterations,
+        legacy,
+        optimized,
+        medianSpeedup: legacy.medianMs / optimized.medianMs,
+        totalSpeedup: legacy.totalMs / optimized.totalMs
+      },
+      null,
+      2
+    )}\n`
+  )
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- add a schema-v26 partial covering index for completed-receipt retention and oldest-first pruning
- replace per-mutation table counts with an exact trigger-maintained ledger count that remains correct for concurrent connections and writes from older binaries
- prune 64 completed receipts at the high-water mark to amortize cleanup while preserving the 10,000-row hard cap, 30-day retention, pending-receipt fail-closed behavior, and replay ordering

## Performance

Reproduction:

```text
node tests/tools/benchmarks/mutation-receipt-capacity-bench.mjs --iterations 64 --payload-bytes 9500
```

On a 102,776,832-byte (98.02 MiB), 10,000-row WAL fixture:

| Capacity path | Median | p95 | Max | 64 mutations |
| --- | ---: | ---: | ---: | ---: |
| Previous full scans/sort | 32.620 ms | 41.840 ms | 51.255 ms | 2,174.174 ms |
| Indexed/count-ledger path | 0.031 ms | 0.045 ms | 0.606 ms | 2.657 ms |

That is a 1,055x median speedup and 818x total reduction in this run. `EXPLAIN QUERY PLAN` regression coverage verifies the retention seek and oldest-completed walk use `idx_mutation_receipts_completed_updated` without a temporary B-tree.

## Validation

- orchestration database suite: 320 passed, 2 skipped
- focused migration/capacity suite: 13 passed
- `pnpm run typecheck:node`
- `pnpm lint`
- max-lines ratchet: no new bypasses
- full unit run: 49,267 passed, 99 skipped; 14 unrelated inherited-agent-environment failures remained in three PTY/relay test files

## Electron evidence

Launched this checkout through `REMOTE_DEBUGGING_PORT=9336 node config/scripts/run-electron-vite-dev.mjs`, attached only through CDP, and verified the visible app was rendered with zero console errors. The automation identity reported `devRepoRoot` as `/Users/brennanbenson/orca/workspaces/orca/perf-mutation-ledger-capacity`; the live database reported schema v26, both count triggers, the ledger row, and the covering-index query plan.

![Visible Orca dev instance](https://github.com/user-attachments/assets/333f50fc-559f-42f2-807a-3505f8ff2ada)

## Residual risk

The additive migration performs one index-build scan on an existing receipt table. Older binaries can continue operating against the additive schema and keep the counter exact through database triggers, but they retain the slower capacity query until updated.