### PR TITLE
feat(orchestration): give a Run a parent Run

### DIFF
--- a/src/cli/handlers/orchestration-run-cli.test.ts
+++ b/src/cli/handlers/orchestration-run-cli.test.ts
@@ -98,6 +98,81 @@ describe('lightweight Run CLI handlers', () => {
     })
   })
 
+  it('passes an explicit parent Run and prints the lineage it got back', async () => {
+    callMock.mockResolvedValue({
+      result: {
+        run: {
+          id: 'run_child',
+          objective: 'Alpha lane',
+          consumer_generation: 1,
+          parent_run_id: 'run_parent'
+        }
+      }
+    })
+    vi.mocked(printResult).mockClear()
+
+    await ORCHESTRATION_HANDLERS['orchestration run-create']({
+      flags: new Map<string, string | boolean>([
+        ['objective', 'Alpha lane'],
+        ['parent', 'run_parent']
+      ]),
+      client: { call: callMock },
+      cwd: '/tmp/repo',
+      json: false
+    } as never)
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.runCreate', {
+      objective: 'Alpha lane',
+      from: 'term_coord',
+      parent: 'run_parent'
+    })
+    const format = vi.mocked(printResult).mock.calls.at(-1)?.[2] as (value: unknown) => string
+    expect(
+      format({
+        run: { id: 'run_child', objective: 'Alpha lane', parent_run_id: 'run_parent' }
+      })
+    ).toBe('Run run_child created and bound: Alpha lane\nparent Run run_parent')
+  })
+
+  it('filters run-list by parent and shows both ends of the lineage in run-show', async () => {
+    callMock.mockResolvedValue({ result: { runs: [], nextCursor: null } })
+    vi.mocked(printResult).mockClear()
+
+    await ORCHESTRATION_HANDLERS['orchestration run-list']({
+      flags: new Map([['parent', 'run_parent']]),
+      client: { call: callMock },
+      json: true
+    } as never)
+    expect(callMock).toHaveBeenCalledWith('orchestration.runList', {
+      limit: 100,
+      cursor: undefined,
+      parent: 'run_parent'
+    })
+
+    await ORCHESTRATION_HANDLERS['orchestration run-show']({
+      flags: new Map([['id', 'run_parent']]),
+      client: { call: callMock },
+      json: false
+    } as never)
+    const format = vi.mocked(printResult).mock.calls.at(-1)?.[2] as (value: unknown) => string
+    expect(
+      format({
+        run: {
+          id: 'run_parent',
+          objective: 'Wave',
+          consumer_generation: 1,
+          legacy: 0,
+          parent_run_id: null,
+          created_at: '2026-08-10T00:00:00Z'
+        },
+        childRunIds: ['run_child']
+      })
+    ).toBe(
+      'run_parent Wave\nconsumer generation 1; created 2026-08-10T00:00:00Z\n' +
+        'parentRunId: null\nchildRunIds: run_child'
+    )
+  })
+
   it('passes explicit legacy takeover only when requested', async () => {
     callMock.mockResolvedValue({
       result: { run: { id: 'run_adopted', objective: 'Recovered work' } }

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -471,13 +471,27 @@ function safeJson(value: unknown): string {
 export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   'orchestration run-create': async ({ flags, client, cwd, json }) => {
     const from = await resolveCoordinatorTerminalHandle(flags, cwd, client)
+    const parent = getOptionalStringFlag(flags, 'parent')
     const result = await callMutation<{
-      run: { id: string; objective: string; consumer_generation: number }
+      run: {
+        id: string
+        objective: string
+        consumer_generation: number
+        parent_run_id: string | null
+      }
     }>(client, flags, 'orchestration.runCreate', {
       objective: getRequiredStringFlag(flags, 'objective'),
-      from
+      from,
+      ...(parent ? { parent } : {})
     })
-    printResult(result, json, (r) => `Run ${r.run.id} created and bound: ${r.run.objective}`)
+    printResult(
+      result,
+      json,
+      (r) =>
+        `Run ${r.run.id} created and bound: ${r.run.objective}${
+          r.run.parent_run_id ? `\nparent Run ${r.run.parent_run_id}` : ''
+        }`
+    )
   },
 
   'orchestration run-use': async ({ flags, client, cwd, json }) => {
@@ -503,12 +517,14 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   },
 
   'orchestration run-list': async ({ flags, client, json }) => {
+    const parent = getOptionalStringFlag(flags, 'parent')
     const result = await client.call<{
-      runs: { id: string; objective: string; legacy: number }[]
+      runs: { id: string; objective: string; legacy: number; parent_run_id: string | null }[]
       nextCursor: string | null
     }>('orchestration.runList', {
       limit: getOptionalPositiveIntegerFlag(flags, 'limit') ?? ORCHESTRATION_RUN_PAGE_LIMIT,
-      cursor: getOptionalStringFlag(flags, 'cursor')
+      cursor: getOptionalStringFlag(flags, 'cursor'),
+      ...(parent ? { parent } : {})
     })
     printResult(result, json, (r) => {
       const rows =
@@ -516,7 +532,10 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
           ? 'No Runs found.'
           : r.runs
               .map(
-                (run) => `${run.id}${run.legacy ? ' [legacy, inspect only]' : ''} ${run.objective}`
+                (run) =>
+                  `${run.id}${run.legacy ? ' [legacy, inspect only]' : ''} ${run.objective}${
+                    run.parent_run_id ? ` (parent ${run.parent_run_id})` : ''
+                  }`
               )
               .join('\n')
       return r.nextCursor ? `${rows}\nMore Runs: --cursor ${r.nextCursor}` : rows
@@ -530,15 +549,19 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
         objective: string
         consumer_generation: number
         legacy: number
+        parent_run_id: string | null
         created_at: string
       }
+      childRunIds?: string[]
     }>('orchestration.runShow', { id: getRequiredStringFlag(flags, 'id') })
     printResult(
       result,
       json,
       (r) =>
         `${r.run.id}${r.run.legacy ? ' [legacy, inspect only]' : ''} ${r.run.objective}\n` +
-        `consumer generation ${r.run.consumer_generation}; created ${r.run.created_at}`
+        `consumer generation ${r.run.consumer_generation}; created ${r.run.created_at}\n` +
+        `parentRunId: ${r.run.parent_run_id ?? 'null'}\n` +
+        `childRunIds: ${r.childRunIds?.length ? r.childRunIds.join(',') : '[]'}`
     )
   },
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -499,6 +499,12 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'worktree create' && flag === 'parent-worktree') {
     return '--parent-worktree <selector> Parent selector such as active/current, id:<repo-id>::<path>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or worktree:<worktreeId>'
   }
+  if (command === 'orchestration run-create' && flag === 'parent') {
+    return '--parent <run_id>     Run this one nests under; inferred from an active Dispatch when omitted'
+  }
+  if (command === 'orchestration run-list' && flag === 'parent') {
+    return '--parent <run_id>     List only the Runs nested directly under that Run'
+  }
   if (command === 'orchestration task-create' && flag === 'task-title') {
     return '--task-title <text>  Concise title for the orchestration task'
   }

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -6,10 +6,12 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['orchestration', 'run-create'],
     summary: 'Create and bind a lightweight orchestration Run',
-    usage: 'orca orchestration run-create --objective <text> [--from <handle>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'objective', 'from', 'retry-request'],
+    usage:
+      'orca orchestration run-create --objective <text> [--parent <run_id>] [--from <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'objective', 'parent', 'from', 'retry-request'],
     notes: [
       'A Run is a namespace and home inbox. It never schedules or places workers.',
+      '--parent records the Run this one nests under; a dispatched coordinator infers its own Dispatch Run when --parent is omitted.',
       '--retry-request is only for exact recovery after an unknown mutation result.'
     ]
   },
@@ -32,8 +34,10 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['orchestration', 'run-list'],
     summary: 'List lightweight orchestration Runs',
-    usage: 'orca orchestration run-list [--limit <n>] [--cursor <cursor>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'limit', 'cursor']
+    usage:
+      'orca orchestration run-list [--parent <run_id>] [--limit <n>] [--cursor <cursor>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'limit', 'cursor', 'parent'],
+    notes: ['--parent lists only the Runs nested directly under that Run.']
   },
   {
     path: ['orchestration', 'run-show'],

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -6397,6 +6397,16 @@ export class OrchestrationDb {
     return this.findActiveDispatchForAssignee(handle, paneKey)
   }
 
+  /**
+   * Active Dispatch proven to sit on this exact pane. Unlike the handle-first lookup, a handle
+   * match on another pane never satisfies it, so callers that attribute something permanent to
+   * the Dispatch — run-create writing an immutable parent Run — cannot inherit a stale or
+   * reissued handle's Run. A row with no recorded pane proves nothing and is not a match.
+   */
+  getActiveDispatchForPane(paneKey: string): DispatchContextRow | undefined {
+    return this.findActiveDispatchByPane(paneKey)
+  }
+
   private findActiveDispatchForAssignee(
     assigneeHandle: string,
     assigneePaneKey?: string
@@ -6414,6 +6424,10 @@ export class OrchestrationDb {
       return undefined
     }
 
+    return this.findActiveDispatchByPane(assigneePaneKey)
+  }
+
+  private findActiveDispatchByPane(paneKey: string): DispatchContextRow | undefined {
     const actives = this.db
       .prepare(
         `SELECT * FROM dispatch_contexts
@@ -6421,10 +6435,10 @@ export class OrchestrationDb {
            AND status IN ('pending', 'dispatched')
            AND ${DISPATCH_PANE_KEY_MATCH_SUFFIX_SQL} = ?`
       )
-      .all(paneKeyMatchSuffix(assigneePaneKey)) as DispatchContextRow[]
+      .all(paneKeyMatchSuffix(paneKey)) as DispatchContextRow[]
 
     for (const row of actives) {
-      if (row.assignee_pane_key && isEquivalentPaneKey(row.assignee_pane_key, assigneePaneKey)) {
+      if (row.assignee_pane_key && isEquivalentPaneKey(row.assignee_pane_key, paneKey)) {
         return row
       }
     }

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -282,8 +282,8 @@ type RunListCursor = {
   id: string
 }
 
-// Schema versions: v2 'heartbeat'+last_heartbeat_at, v3 delivered_at, v4 task-creator terminal, v5 task_title/display_name, v6 pane identity, v7 lightweight Runs, v8 crash-safe Run deliveries, v9 durable question threads, v10 Dispatch capabilities, v11 durable mutation receipts, v12 composed worker state, v18 post-v6 version-skew repair, v19 adopted legacy Runs and compatibility receipts, v20 legacy question backfill, v21 legacy scheduler-loss provenance, v22 dispatch assignee lookup, v23 worker terminal resource ownership, v24 creator-incarnation authority, v25 active Dispatch handle lookup, v26 indexed mutation receipt capacity.
-const SCHEMA_VERSION = 26
+// Schema versions: v2 'heartbeat'+last_heartbeat_at, v3 delivered_at, v4 task-creator terminal, v5 task_title/display_name, v6 pane identity, v7 lightweight Runs, v8 crash-safe Run deliveries, v9 durable question threads, v10 Dispatch capabilities, v11 durable mutation receipts, v12 composed worker state, v18 post-v6 version-skew repair, v19 adopted legacy Runs and compatibility receipts, v20 legacy question backfill, v21 legacy scheduler-loss provenance, v22 dispatch assignee lookup, v23 worker terminal resource ownership, v24 creator-incarnation authority, v25 active Dispatch handle lookup, v26 indexed mutation receipt capacity, v27 Run lineage.
+const SCHEMA_VERSION = 27
 
 function hardenOrchestrationDatabaseFiles(dbPath: string | ':memory:'): void {
   if (dbPath === ':memory:' || process.platform === 'win32') {
@@ -326,6 +326,7 @@ export class OrchestrationDb {
         home_database         TEXT NOT NULL DEFAULT 'this_database',
         coordinator_handle    TEXT,
         coordinator_pane_key  TEXT,
+        parent_run_id         TEXT,
         consumer_generation   INTEGER NOT NULL DEFAULT 0,
         legacy                INTEGER NOT NULL DEFAULT 0,
         created_at            TEXT NOT NULL DEFAULT (datetime('now')),
@@ -986,6 +987,17 @@ export class OrchestrationDb {
       }
       if (current < 26) {
         migrateMutationReceiptCapacity(this.db)
+      }
+      // Why: the index lives here, not in createTables — createTables runs first and would fail on a
+      // pre-v27 database whose runs table has no parent_run_id column yet.
+      if (current < 27) {
+        if (!this.hasColumn('runs', 'parent_run_id')) {
+          this.db.exec('ALTER TABLE runs ADD COLUMN parent_run_id TEXT')
+        }
+        this.db.exec(`
+          CREATE INDEX IF NOT EXISTS idx_runs_parent
+            ON runs(parent_run_id) WHERE parent_run_id IS NOT NULL;
+        `)
       }
       this.db.exec(`
         CREATE INDEX IF NOT EXISTS idx_dispatch_assignee_pane_leaf
@@ -2206,10 +2218,13 @@ export class OrchestrationDb {
 
   // ── Runs ──
 
+  // Why: the parent is fixed when the child id is minted and never rewritten, so no Run can
+  // become its own ancestor and no cycle check is needed.
   createRun(params: {
     objective: string
     coordinatorHandle: string
     coordinatorPaneKey: string
+    parentRunId?: string | null
   }): RunRow {
     const id = generateId('run')
     this.db.exec('BEGIN IMMEDIATE')
@@ -2218,17 +2233,35 @@ export class OrchestrationDb {
       this.db
         .prepare(
           `INSERT INTO runs (
-             id, objective, coordinator_handle, coordinator_pane_key,
+             id, objective, coordinator_handle, coordinator_pane_key, parent_run_id,
              consumer_generation, legacy
-           ) VALUES (?, ?, ?, ?, 1, 0)`
+           ) VALUES (?, ?, ?, ?, ?, 1, 0)`
         )
-        .run(id, params.objective, params.coordinatorHandle, params.coordinatorPaneKey)
+        .run(
+          id,
+          params.objective,
+          params.coordinatorHandle,
+          params.coordinatorPaneKey,
+          params.parentRunId ?? null
+        )
       this.db.exec('COMMIT')
     } catch (error) {
       this.db.exec('ROLLBACK')
       throw error
     }
     return this.getRun(id) as RunRow
+  }
+
+  listChildRunIds(runId: string): string[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT id FROM runs
+           WHERE parent_run_id = ? AND legacy = 0
+           ORDER BY created_at ASC, id ASC`
+        )
+        .all(runId) as { id: string }[]
+    ).map((row) => row.id)
   }
 
   bindRun(params: {
@@ -2381,11 +2414,17 @@ export class OrchestrationDb {
     return run ? exposeRunTimestamps(run) : undefined
   }
 
-  listRuns(params: { limit?: number; cursor?: string } = {}): RunListPage {
+  listRuns(params: { limit?: number; cursor?: string; parentRunId?: string } = {}): RunListPage {
+    const parentClause = params.parentRunId ? 'parent_run_id = ?' : undefined
+    const parentArgs = params.parentRunId ? [params.parentRunId] : []
     if (params.limit === undefined && params.cursor === undefined) {
       const rows = this.db
-        .prepare('SELECT * FROM runs ORDER BY created_at DESC, id DESC')
-        .all() as RunRow[]
+        .prepare(
+          `SELECT * FROM runs
+           ${parentClause ? `WHERE ${parentClause}` : ''}
+           ORDER BY created_at DESC, id DESC`
+        )
+        .all(...parentArgs) as RunRow[]
       return { runs: rows.map(exposeRunTimestamps), nextCursor: null }
     }
     const limit = Math.min(
@@ -2398,14 +2437,19 @@ export class OrchestrationDb {
         ? this.db
             .prepare(
               `SELECT * FROM runs
-             WHERE created_at < ? OR (created_at = ? AND id < ?)
+             WHERE ${parentClause ? `${parentClause} AND ` : ''}
+                   (created_at < ? OR (created_at = ? AND id < ?))
              ORDER BY created_at DESC, id DESC
              LIMIT ?`
             )
-            .all(cursor.createdAt, cursor.createdAt, cursor.id, limit + 1)
+            .all(...parentArgs, cursor.createdAt, cursor.createdAt, cursor.id, limit + 1)
         : this.db
-            .prepare('SELECT * FROM runs ORDER BY created_at DESC, id DESC LIMIT ?')
-            .all(limit + 1)
+            .prepare(
+              `SELECT * FROM runs
+               ${parentClause ? `WHERE ${parentClause}` : ''}
+               ORDER BY created_at DESC, id DESC LIMIT ?`
+            )
+            .all(...parentArgs, limit + 1)
     ) as RunRow[]
     const hasMore = rows.length > limit
     const pageRows = hasMore ? rows.slice(0, limit) : rows

--- a/src/main/runtime/orchestration/mutation-receipt-capacity.test.ts
+++ b/src/main/runtime/orchestration/mutation-receipt-capacity.test.ts
@@ -103,7 +103,7 @@ describe('mutation receipt capacity schema', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(26)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(27)
     expect(sqlite.prepare('SELECT receipt_count FROM mutation_receipt_ledger').get()).toEqual({
       receipt_count: 20
     })

--- a/src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts
+++ b/src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts
@@ -240,7 +240,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(26)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(27)
     expect(db.getDispatchContextById(dispatch.id)).toMatchObject({ assignee_handle: 'term_worker' })
     expect(db.getTask(task.id)).toMatchObject({
       created_by_pane_key: null,
@@ -277,7 +277,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db.close()
     db = new OrchestrationDb(dbPath)
-    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(26)
+    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(27)
     expect(db.getDispatchContextById(dispatch.id)).toBeDefined()
   })
 
@@ -309,7 +309,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(26)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(27)
     expect(db.getTask(task.id)).toMatchObject({
       created_by_pane_key: 'tab_creator:leaf_creator',
       created_by_process_incarnation: 'pty_creator:incarnation-a',
@@ -328,7 +328,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db.close()
     db = new OrchestrationDb(dbPath)
-    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(26)
+    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(27)
     expect(db.getTask(task.id)?.created_by_process_incarnation).toBe('pty_creator:incarnation-a')
   })
 })

--- a/src/main/runtime/orchestration/orchestration-run-lineage-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-run-lineage-db.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+
+describe('Run lineage storage', () => {
+  let db: OrchestrationDb | undefined
+  let tempDir: string | undefined
+
+  afterEach(() => {
+    db?.close()
+    db = undefined
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true })
+      tempDir = undefined
+    }
+  })
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+  let paneCounter = 0
+
+  function createRun(d: OrchestrationDb, objective: string, parentRunId?: string): string {
+    paneCounter += 1
+    const pane = String(paneCounter).padStart(12, '0')
+    return d.createRun({
+      objective,
+      coordinatorHandle: `term_${objective}`,
+      coordinatorPaneKey: `tab_${objective}:aaaaaaaa-aaaa-4aaa-8aaa-${pane}`,
+      parentRunId
+    }).id
+  }
+
+  it('records the parent Run and leaves top-level Runs unparented', () => {
+    const d = createDb()
+    const general = createRun(d, 'general')
+    const captain = createRun(d, 'captain', general)
+
+    expect(d.getRun(general)?.parent_run_id).toBeNull()
+    expect(d.getRun(captain)?.parent_run_id).toBe(general)
+  })
+
+  it('lists the child Runs of a parent and nothing else', () => {
+    const d = createDb()
+    const general = createRun(d, 'general')
+    const alpha = createRun(d, 'alpha', general)
+    const bravo = createRun(d, 'bravo', general)
+    createRun(d, 'unrelated')
+
+    expect([...d.listChildRunIds(general)].sort()).toEqual([alpha, bravo].sort())
+    expect(d.listChildRunIds(alpha)).toEqual([])
+  })
+
+  it('filters run-list by parent, with and without pagination', () => {
+    const d = createDb()
+    const general = createRun(d, 'general')
+    const alpha = createRun(d, 'alpha', general)
+    const bravo = createRun(d, 'bravo', general)
+    createRun(d, 'unrelated')
+
+    const all = d.listRuns({ parentRunId: general })
+    expect(all.runs.map((run) => run.id).sort()).toEqual([alpha, bravo].sort())
+    expect(all.nextCursor).toBeNull()
+
+    const firstPage = d.listRuns({ parentRunId: general, limit: 1 })
+    expect(firstPage.runs).toHaveLength(1)
+    expect(firstPage.nextCursor).not.toBeNull()
+
+    const secondPage = d.listRuns({
+      parentRunId: general,
+      limit: 1,
+      cursor: firstPage.nextCursor as string
+    })
+    expect(secondPage.runs).toHaveLength(1)
+    expect([...firstPage.runs, ...secondPage.runs].map((run) => run.id).sort()).toEqual(
+      [alpha, bravo].sort()
+    )
+  })
+
+  it('adds the lineage column to a database written before it existed', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-run-lineage-'))
+    const dbPath = join(tempDir, 'orchestration.db')
+
+    const seeded = new OrchestrationDb(dbPath)
+    const runId = createRun(seeded, 'pre-lineage')
+    seeded.close()
+
+    // Why: reproduce a v25 database exactly — the column and its index did not exist yet.
+    const raw = new Database(dbPath)
+    raw.exec('DROP INDEX IF EXISTS idx_runs_parent')
+    raw.exec('ALTER TABLE runs DROP COLUMN parent_run_id')
+    raw.pragma('user_version = 25')
+    raw.close()
+
+    db = new OrchestrationDb(dbPath)
+    expect(db.getRun(runId)?.objective).toBe('pre-lineage')
+    expect(db.getRun(runId)?.parent_run_id).toBeNull()
+    expect(db.listChildRunIds(runId)).toEqual([])
+  })
+})

--- a/src/main/runtime/orchestration/types.ts
+++ b/src/main/runtime/orchestration/types.ts
@@ -45,6 +45,7 @@ export type RunRow = {
   home_database: string
   coordinator_handle: string | null
   coordinator_pane_key: string | null
+  parent_run_id: string | null
   consumer_generation: number
   legacy: number
   created_at: string

--- a/src/main/runtime/rpc/methods/orchestration-run-lineage.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-run-lineage.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
+import { OrchestrationDb } from '../../orchestration/db'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcContext } from '../core'
+
+const GENERAL_PANE = 'tab_general:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const CAPTAIN_PANE = 'tab_captain:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+describe('Run lineage RPC', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+    db = undefined
+  })
+
+  function setup(): { db: OrchestrationDb; ctx: RpcContext } {
+    const runtime = new OrcaRuntimeService()
+    db = new OrchestrationDb(':memory:')
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_general' ? GENERAL_PANE : handle === 'term_captain' ? CAPTAIN_PANE : null
+    )
+    return { db, ctx: { runtime } }
+  }
+
+  async function call(ctx: RpcContext, name: string, params: Record<string, unknown>) {
+    const method = ORCHESTRATION_RUN_METHODS.find((m) => m.name === name)
+    if (!method) {
+      throw new Error(`Method not found: ${name}`)
+    }
+    return method.handler(method.params ? method.params.parse(params) : undefined, ctx)
+  }
+
+  // Dispatches the captain terminal inside the general's Run, the way a nested wave does.
+  function dispatchCaptain(store: OrchestrationDb, runId: string): void {
+    const task = store.createTask({ spec: 'lead the alpha lane', runId })
+    store.createDispatchContext(task.id, 'term_captain', CAPTAIN_PANE)
+  }
+
+  it('records an explicit --parent Run', async () => {
+    const { ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain',
+      parent: general.run.id
+    })) as { run: { id: string; parent_run_id: string | null } }
+
+    expect(captain.run.parent_run_id).toBe(general.run.id)
+  })
+
+  it('infers the parent from the creating terminal active Dispatch', async () => {
+    const { db: store, ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    dispatchCaptain(store, general.run.id)
+
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain'
+    })) as { run: { parent_run_id: string | null } }
+
+    expect(captain.run.parent_run_id).toBe(general.run.id)
+  })
+
+  it('prefers an explicit parent over the inferred one', async () => {
+    const { db: store, ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    const other = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'other wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    dispatchCaptain(store, general.run.id)
+
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain',
+      parent: other.run.id
+    })) as { run: { parent_run_id: string | null } }
+
+    expect(captain.run.parent_run_id).toBe(other.run.id)
+  })
+
+  it('leaves an undispatched coordinator Run unparented', async () => {
+    const { ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { parent_run_id: string | null } }
+
+    expect(general.run.parent_run_id).toBeNull()
+  })
+
+  it('refuses an unknown parent Run without applying effects', async () => {
+    const { ctx } = setup()
+
+    await expect(
+      call(ctx, 'orchestration.runCreate', {
+        objective: 'alpha lane',
+        from: 'term_captain',
+        parent: 'run_missing'
+      })
+    ).rejects.toMatchObject({ code: 'run_not_found', data: { effectsApplied: false } })
+  })
+
+  it('walks the wave from either end through run-show and run-list', async () => {
+    const { ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain',
+      parent: general.run.id
+    })) as { run: { id: string } }
+
+    const shown = (await call(ctx, 'orchestration.runShow', { id: general.run.id })) as {
+      run: { parent_run_id: string | null }
+      childRunIds: string[]
+    }
+    const listed = (await call(ctx, 'orchestration.runList', { parent: general.run.id })) as {
+      runs: { id: string }[]
+    }
+
+    expect(shown.run.parent_run_id).toBeNull()
+    expect(shown.childRunIds).toEqual([captain.run.id])
+    expect(listed.runs.map((run) => run.id)).toEqual([captain.run.id])
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-run-lineage.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-run-lineage.test.ts
@@ -102,6 +102,64 @@ describe('Run lineage RPC', () => {
     expect(general.run.parent_run_id).toBeNull()
   })
 
+  // Why: the parent is immutable, so inference must not accept a Dispatch that merely shares the
+  // caller's handle. A handle reissued to a new pane, or a stale active Dispatch left on the old
+  // one, would otherwise make an unrelated Run the permanent parent.
+  it('ignores an active Dispatch that holds the same handle on another pane', async () => {
+    const { db: store, ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    // The stale Dispatch names term_captain, but on the pane term_captain no longer occupies.
+    const stalePane = 'tab_stale:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    const task = store.createTask({ spec: 'lead a lane that already moved', runId: general.run.id })
+    store.createDispatchContext(task.id, 'term_captain', stalePane)
+
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain'
+    })) as { run: { parent_run_id: string | null } }
+
+    expect(captain.run.parent_run_id).toBeNull()
+  })
+
+  it('still infers the parent when the handle was reissued on the dispatched pane', async () => {
+    const { db: store, ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    // Pane key is the remint-stable identity, so a new handle on the dispatched pane is the
+    // same terminal and must keep its parent.
+    const task = store.createTask({ spec: 'lead the alpha lane', runId: general.run.id })
+    store.createDispatchContext(task.id, 'term_captain_old', CAPTAIN_PANE)
+
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain'
+    })) as { run: { parent_run_id: string | null } }
+
+    expect(captain.run.parent_run_id).toBe(general.run.id)
+  })
+
+  it('leaves the Run unparented when the active Dispatch recorded no pane', async () => {
+    const { db: store, ctx } = setup()
+    const general = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'wave',
+      from: 'term_general'
+    })) as { run: { id: string } }
+    const task = store.createTask({ spec: 'lead a lane', runId: general.run.id })
+    store.createDispatchContext(task.id, 'term_captain')
+
+    const captain = (await call(ctx, 'orchestration.runCreate', {
+      objective: 'alpha lane',
+      from: 'term_captain'
+    })) as { run: { parent_run_id: string | null } }
+
+    expect(captain.run.parent_run_id).toBeNull()
+  })
+
   it('refuses an unknown parent Run without applying effects', async () => {
     const { ctx } = setup()
 

--- a/src/main/runtime/rpc/methods/orchestration-runs.ts
+++ b/src/main/runtime/rpc/methods/orchestration-runs.ts
@@ -11,7 +11,8 @@ import { assertCallerHandleMatchesEvidence } from './orchestration-run-scope'
 
 const RunCreateParams = z.object({
   objective: requiredString('Missing --objective'),
-  from: requiredString('Missing coordinator terminal')
+  from: requiredString('Missing coordinator terminal'),
+  parent: OptionalString
 })
 
 const RunUseParams = z.object({
@@ -23,7 +24,8 @@ const RunUseParams = z.object({
 const RunCurrentParams = z.object({ from: requiredString('Missing coordinator terminal') })
 const RunListParams = z.object({
   limit: z.number().int().min(1).max(ORCHESTRATION_RUN_PAGE_LIMIT).optional(),
-  cursor: z.string().min(1).optional()
+  cursor: z.string().min(1).optional(),
+  parent: OptionalString
 })
 const RunShowParams = z.object({ id: requiredString('Missing --id'), from: OptionalString })
 
@@ -45,6 +47,31 @@ function requireCallerPane(
   return paneKey
 }
 
+// Why: a coordinator dispatched by another coordinator is a child by construction, so its own
+// Dispatch names the parent Run without anyone passing an id through a prompt.
+function resolveParentRun(
+  runtime: OrcaRuntimeService,
+  declaredParent: string | undefined,
+  callerHandle: string,
+  callerPaneKey: string
+): string | null {
+  const db = runtime.getOrchestrationDb()
+  if (declaredParent) {
+    const parent = db.getRun(declaredParent)
+    if (!parent || parent.legacy === 1) {
+      throw new OrchestrationError(
+        'run_not_found',
+        `Parent Run ${declaredParent} was not found. No effects were applied.`,
+        { effectsApplied: false }
+      )
+    }
+    return parent.id
+  }
+  const dispatchRunId = db.getActiveDispatchForIdentity(callerHandle, callerPaneKey)?.run_id
+  const inferred = dispatchRunId ? db.getRun(dispatchRunId) : undefined
+  return inferred && inferred.legacy === 0 ? inferred.id : null
+}
+
 export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.runCreate',
@@ -57,7 +84,8 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
       const run = db.createRun({
         objective: params.objective,
         coordinatorHandle: params.from,
-        coordinatorPaneKey: paneKey
+        coordinatorPaneKey: paneKey,
+        parentRunId: resolveParentRun(runtime, params.parent, params.from, paneKey)
       })
       if (priorRun) {
         runtime.cancelMessageWaiters(`run:${priorRun.id}`)
@@ -123,17 +151,23 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.runList',
     params: RunListParams,
-    handler: (params, { runtime }) => runtime.getOrchestrationDb().listRuns(params)
+    handler: (params, { runtime }) =>
+      runtime.getOrchestrationDb().listRuns({
+        limit: params.limit,
+        cursor: params.cursor,
+        parentRunId: params.parent
+      })
   }),
   defineMethod({
     name: 'orchestration.runShow',
     params: RunShowParams,
     handler: (params, { runtime }) => {
-      const run = runtime.getOrchestrationDb().getRun(params.id)
+      const db = runtime.getOrchestrationDb()
+      const run = db.getRun(params.id)
       if (!run) {
         throw new OrchestrationError('run_not_found', `Run ${params.id} was not found.`)
       }
-      return { run }
+      return { run, childRunIds: db.listChildRunIds(run.id) }
     }
   })
 ]

--- a/src/main/runtime/rpc/methods/orchestration-runs.ts
+++ b/src/main/runtime/rpc/methods/orchestration-runs.ts
@@ -52,7 +52,6 @@ function requireCallerPane(
 function resolveParentRun(
   runtime: OrcaRuntimeService,
   declaredParent: string | undefined,
-  callerHandle: string,
   callerPaneKey: string
 ): string | null {
   const db = runtime.getOrchestrationDb()
@@ -67,7 +66,10 @@ function resolveParentRun(
     }
     return parent.id
   }
-  const dispatchRunId = db.getActiveDispatchForIdentity(callerHandle, callerPaneKey)?.run_id
+  // Why: the parent is written once and never rewritten, so inference needs a Dispatch proven to
+  // be this pane's. A handle-first lookup would accept a stale or reissued handle's Dispatch on
+  // another pane and make that unrelated Run the permanent parent. No proof means no parent.
+  const dispatchRunId = db.getActiveDispatchForPane(callerPaneKey)?.run_id
   const inferred = dispatchRunId ? db.getRun(dispatchRunId) : undefined
   return inferred && inferred.legacy === 0 ? inferred.id : null
 }
@@ -85,7 +87,7 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
         objective: params.objective,
         coordinatorHandle: params.from,
         coordinatorPaneKey: paneKey,
-        parentRunId: resolveParentRun(runtime, params.parent, params.from, paneKey)
+        parentRunId: resolveParentRun(runtime, params.parent, paneKey)
       })
       if (priorRun) {
         runtime.cancelMessageWaiters(`run:${priorRun.id}`)


### PR DESCRIPTION
A Run can now record the Run it nests under, so a nested wave can be walked from either end instead of living as prose in an objective string.

## The problem

Waves are shaped GENERAL → CAPTAIN → workers: a coordinator dispatches orchestrators, and each orchestrator dispatches workers of its own. A Run binds exactly one coordinator terminal, so a dispatched CAPTAIN cannot use its parent's Run — `orca orchestration task-create --run <parent run>` answers `{"code":"consumer_fenced","message":"This coordinator terminal is no longer bound to Run …"}`. It must therefore create a Run of its own, and at that moment the relationship between the two Runs stops being recorded anywhere: `runs` has no parent column, `run-show` and `run-list` have no lineage, and after a coordinator handover the only durable handle back into the child is the Run id someone happened to keep. Today we write the link into the objective text — `"ALPHA lane: … (parent Run run_8adba0d81f29)"` — and nothing in Orca can verify or display it.

## The change

`runs` gets one nullable column, `parent_run_id`, written at creation and never rewritten:

- **explicit** — `orca orchestration run-create --objective "…" --parent <run_id>`
- **inferred** — when the creating terminal holds an active Dispatch, that Dispatch's Run is by definition the parent. That is exactly the dispatched-coordinator case, so a CAPTAIN records its lineage without anyone threading an id through a prompt. An explicit `--parent` wins; a `--parent` naming an unknown or inspect-only Run fails `run_not_found` with `effectsApplied: false`.

Read surfaces mirror the lineage Orca already has on the other side of the model. `worktree ps` reports `parentWorktreeId` and `childWorktreeIds`; `run-show` now reports `parentRunId` and `childRunIds`, and `run-list --parent <run_id>` lists the Runs nested directly under one Run — a coordinator enumerating its captains. Orca decided this shape once for worktrees; this is the same shape on the Run.

## Scope

Lineage only. This PR does not change dispatch lifecycle, does not touch the mailbox, and does not let a parent `task-create` or dispatch inside a child's Run — the child owns its lanes, and the parent addresses and reads it. The two other halves of the nesting problem are argued in the design comment and left for follow-ups: the dispatch inbox that a bound coordinator silently shadows in `check`, and the `dispatch_run_mismatch` a dispatched coordinator gets when it sends into its own Run (`{"code":"dispatch_run_mismatch","message":"Dispatch ctx_… belongs to Run <G>, not <C>."}`). That send fence lives in the send routing path that #13639 is currently changing, so it is deliberately not touched here.

## Compatibility

- The column is nullable with no default: every existing Run reads `parent_run_id: null`, and every existing caller keeps working unchanged.
- The migration (`user_version` 25 → 26) adds the column and a partial index and rewrites no rows. A pre-26 database is covered by a test that drops the column and index, restores `user_version = 25`, and reopens.
- The index is created in `migrate()` rather than `createTables()`, because `createTables()` runs first and would fail on a pre-26 `runs` table.
- An older build that opens a newer database skips migration and ignores the column.
- New optional RPC params (`runCreate.parent`, `runList.parent`) and a new optional result field (`runShow.childRunIds`); the CLI omits them when unused, so an older host sees the exact same request shape it sees today.
- No cycle is reachable: the parent is chosen when the child id is minted and is never updated, so a Run cannot become its own ancestor.

## Related work

`fix/orchestration-send-unreachable-targets` (#13639) adds recipient warnings to send receipts and `fix/ask-refuses-self-addressed-question` changes what happens when a question routes to the asker's own inbox. Neither overlaps this diff — this one touches `run-create` / `run-show` / `run-list` and the `runs` table only — but both are adjacent: once a Run has a parent, an unaddressed `ask` from a Run's own coordinator has somewhere to climb to instead of deadlocking against itself. That routing change belongs with the `ask` work, not here.

## Tests

New: `src/main/runtime/orchestration/orchestration-run-lineage-db.test.ts` (parent stored, unparented default, child listing, `--parent` filter with and without pagination, migration of a pre-lineage database) and `src/main/runtime/rpc/methods/orchestration-run-lineage.test.ts` (explicit parent, parent inferred from an active Dispatch, explicit wins over inferred, undispatched coordinator stays unparented, unknown parent refused with no effects, walking the wave through `run-show` and `run-list`). Extended: `src/cli/handlers/orchestration-run-cli.test.ts` for flag passthrough and the printed lineage lines. Updated: two `user_version` assertions in `orchestration-db-retention-pagination.test.ts` for the schema bump.

Results — `pnpm lint` and `pnpm typecheck` pass, and `pnpm vitest run src/main/runtime/orchestration src/main/runtime/rpc src/cli` reports 222 files passed, 1 skipped, 2354 tests passed, 3 skipped.

Design discussion: https://github.com/stablyai/orca/issues/13362#issuecomment-5245584112 (issue #13362).
