### PR TITLE
perf(runtime): batch legacy worker recovery persistence

### DIFF
--- a/config/scripts/legacy-worker-recovery-persistence-benchmark.mjs
+++ b/config/scripts/legacy-worker-recovery-persistence-benchmark.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Run: node config/scripts/legacy-worker-recovery-persistence-benchmark.mjs
 import { closeSync, fsyncSync, openSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { mkdir, open, readFile, rename } from 'node:fs/promises'
+import { mkdtemp, open, readFile, rename } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
@@ -38,8 +38,7 @@ if (
   throw new Error('recovery persistence implementation changed; update this benchmark')
 }
 
-const root = join(tmpdir(), `orca-legacy-recovery-benchmark-${process.pid}`)
-await mkdir(root, { recursive: true })
+const root = await mkdtemp(join(tmpdir(), 'orca-legacy-recovery-benchmark-'))
 const filler = 'x'.repeat(fixtureMiB * 1024 * 1024)
 
 function payload(state) {

--- a/config/scripts/legacy-worker-recovery-persistence-benchmark.mjs
+++ b/config/scripts/legacy-worker-recovery-persistence-benchmark.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// Run: node config/scripts/legacy-worker-recovery-persistence-benchmark.mjs
+import { closeSync, fsyncSync, openSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdir, open, readFile, rename } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const runtimePath = join(repoRoot, 'src/main/runtime/orca-runtime.ts')
+const args = new Map(
+  process.argv.slice(2).map((value, index, values) => [value, values[index + 1]])
+)
+const fixtureMiB = Number(args.get('--fixture-mib') ?? 24)
+const trials = Number(args.get('--trials') ?? 3)
+const jsonOutput = process.argv.includes('--json')
+
+if (!Number.isInteger(fixtureMiB) || fixtureMiB < 1 || !Number.isInteger(trials) || trials < 1) {
+  throw new Error('fixture-mib and trials must be positive integers')
+}
+
+const runtimeSource = await readFile(runtimePath, 'utf8')
+const recoveryStart = runtimeSource.indexOf(
+  'private async persistLegacyWorkerTerminalRecoveryBatch'
+)
+const recoveryEnd = runtimeSource.indexOf(
+  'private reconcileMissingLegacyWorkerTerminal',
+  recoveryStart
+)
+const recoverySource = runtimeSource.slice(recoveryStart, recoveryEnd)
+if (
+  recoveryStart < 0 ||
+  recoveryEnd < 0 ||
+  !recoverySource.includes('await this.flushWorkspaceSessionOrThrowAsync()') ||
+  recoverySource.includes('flushOrThrow()')
+) {
+  throw new Error('recovery persistence implementation changed; update this benchmark')
+}
+
+const root = join(tmpdir(), `orca-legacy-recovery-benchmark-${process.pid}`)
+await mkdir(root, { recursive: true })
+const filler = 'x'.repeat(fixtureMiB * 1024 * 1024)
+
+function payload(state) {
+  return JSON.stringify({ state, filler })
+}
+
+function writeDurableSync(path, body) {
+  const tempPath = `${path}.sync.tmp`
+  writeFileSync(tempPath, body)
+  const fd = openSync(tempPath, 'r')
+  try {
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+  renameSync(tempPath, path)
+}
+
+async function writeDurableAsync(path, body) {
+  const tempPath = `${path}.async.tmp`
+  const handle = await open(tempPath, 'w')
+  try {
+    await handle.writeFile(body)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  await rename(tempPath, path)
+}
+
+async function measure(run) {
+  let maxEventLoopDelayMs = 0
+  let expected = performance.now() + 1
+  const timer = setInterval(() => {
+    const now = performance.now()
+    maxEventLoopDelayMs = Math.max(maxEventLoopDelayMs, now - expected)
+    expected = now + 1
+  }, 1)
+  await new Promise((resolve) => setTimeout(resolve, 5))
+  const startedAt = performance.now()
+  await run()
+  const durationMs = performance.now() - startedAt
+  await new Promise((resolve) => setTimeout(resolve, 5))
+  clearInterval(timer)
+  return { durationMs, maxEventLoopDelayMs }
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+async function runLegacy(path) {
+  const state = { fenced: false, surfacePresent: true, recoveryRecordPresent: true }
+  state.fenced = true
+  writeDurableSync(path, payload(state))
+  state.surfacePresent = false
+  writeDurableSync(path, payload(state))
+  state.recoveryRecordPresent = false
+  writeDurableSync(path, payload(state))
+}
+
+async function runBatched(path) {
+  const state = { fenced: false, surfacePresent: true, recoveryRecordPresent: true }
+  state.fenced = true
+  state.surfacePresent = false
+  state.recoveryRecordPresent = false
+  await writeDurableAsync(path, payload(state))
+}
+
+try {
+  const legacy = []
+  const batched = []
+  for (let index = 0; index < trials; index += 1) {
+    legacy.push(await measure(() => runLegacy(join(root, `legacy-${index}.json`))))
+    batched.push(await measure(() => runBatched(join(root, `batched-${index}.json`))))
+  }
+  const result = {
+    benchmark: 'legacy-worker-recovery-persistence',
+    fixtureMiB,
+    trials,
+    legacy: {
+      durableWrites: 3,
+      medianDurationMs: median(legacy.map((sample) => sample.durationMs)),
+      medianMaxEventLoopDelayMs: median(legacy.map((sample) => sample.maxEventLoopDelayMs))
+    },
+    batchedAsync: {
+      durableWrites: 1,
+      medianDurationMs: median(batched.map((sample) => sample.durationMs)),
+      medianMaxEventLoopDelayMs: median(batched.map((sample) => sample.maxEventLoopDelayMs))
+    }
+  }
+  if (jsonOutput) {
+    console.log(JSON.stringify(result))
+  } else {
+    console.log(JSON.stringify(result, null, 2))
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19079,6 +19079,71 @@ describe('OrcaRuntimeService', () => {
     ).rejects.toThrow('terminal_orphan_competing_owner')
   })
 
+  it('preserves concurrent workspace-session changes when async orphan persistence fails', async () => {
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: TEST_REPO_ID,
+      activeWorktreeId: TEST_WORKTREE_ID,
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] }
+    }
+    const { runtimeStore, getSession, setSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const durableWrite = deferred<void>()
+    const durableWriteStarted = deferred<void>()
+    const runtime = new OrcaRuntimeService({
+      ...runtimeStore,
+      flushPendingOrThrowAsync: vi.fn(() => {
+        durableWriteStarted.resolve()
+        return durableWrite.promise
+      })
+    } as never)
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: 'pty-async-rollback',
+          incarnationId: 'inc-async-rollback',
+          terminalHandle: 'term_async_rollback',
+          title: 'Async rollback',
+          cwd: TEST_WORKTREE_PATH,
+          worktreeId: TEST_WORKTREE_ID,
+          wslDistro: null
+        }
+      ]
+    })
+    const before = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+
+    const adoption = runtime.adoptTerminalOrphans({
+      worktree: `id:${TEST_WORKTREE_ID}`,
+      expectedTopologyRevision: before.topologyRevisions?.[TEST_WORKTREE_ID] ?? 0,
+      claims: [
+        {
+          terminal: 'term_async_rollback',
+          ptyId: 'pty-async-rollback',
+          incarnationId: 'inc-async-rollback',
+          tabId: 'tab-async-rollback',
+          leafId: HEADLESS_LEAF_ID
+        }
+      ]
+    })
+    await durableWriteStarted.promise
+    setSession({
+      ...getSession(),
+      activeTabIdByWorktree: {
+        ...getSession().activeTabIdByWorktree,
+        'concurrent-worktree': 'concurrent-tab'
+      }
+    })
+    durableWrite.reject(new Error('disk unavailable'))
+
+    await expect(adoption).rejects.toThrow('disk unavailable')
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
+    expect(getSession().terminalLayoutsByTabId['tab-async-rollback']).toBeUndefined()
+    expect(getSession().activeTabIdByWorktree?.['concurrent-worktree']).toBe('concurrent-tab')
+    expect(getSession().terminalTopologyRevisionByRepoId?.[TEST_REPO_ID] ?? 0).toBe(0)
+  })
+
   function publishLegacyWorkerReveal(
     runtime: OrcaRuntimeService,
     identity: { worktreeId: string; tabId: string; leafId: string; ptyId: string },
@@ -19845,17 +19910,23 @@ describe('OrcaRuntimeService', () => {
         }
       }
     }
-    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const { runtimeStore, getSession, setSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const durableWrite = deferred<void>()
+    const durableWriteStarted = deferred<void>()
     let flushCount = 0
-    const flushOrThrow = vi.fn(() => {
+    const flushPendingOrThrowAsync = vi.fn(() => {
       flushCount += 1
-      if (flushCount === 2) {
-        throw new Error('disk unavailable')
+      if (flushCount === 1) {
+        return Promise.resolve()
       }
+      durableWriteStarted.resolve()
+      return durableWrite.promise
     })
-    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow } as never, undefined, {
-      canRecoverPersistentLocalPtys: () => true
-    })
+    const runtime = new OrcaRuntimeService(
+      { ...runtimeStore, flushPendingOrThrowAsync } as never,
+      undefined,
+      { canRecoverPersistentLocalPtys: () => true }
+    )
     runtime.setOrchestrationDb({
       listLegacyWorkerTerminalRecoveryRows: () => [
         {
@@ -19904,18 +19975,35 @@ describe('OrcaRuntimeService', () => {
     } as never)
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    await expect(
-      runtime.reconcileLegacyWorkerTerminals({ materializeRenderer: true })
-    ).resolves.toMatchObject({
+    const recovery = runtime.reconcileLegacyWorkerTerminals({ materializeRenderer: true })
+    await durableWriteStarted.promise
+    const concurrentPaneKey = `concurrent:${HEADLESS_SECOND_LEAF_ID}`
+    setSession({
+      ...getSession(),
+      sleepingAgentSessionsByPaneKey: {
+        ...getSession().sleepingAgentSessionsByPaneKey,
+        [concurrentPaneKey]: {
+          ...session.sleepingAgentSessionsByPaneKey![workerPaneKey]!,
+          paneKey: concurrentPaneKey,
+          tabId: 'concurrent-tab'
+        }
+      }
+    })
+    durableWrite.reject(new Error('disk unavailable'))
+
+    await expect(recovery).resolves.toMatchObject({
       adoptedDispatchIds: [],
       exitedDispatchIds: [],
       deferredDispatchIds: ['dispatch-persistence-failure']
     })
-    expect(flushOrThrow).toHaveBeenCalledTimes(2)
+    expect(flushPendingOrThrowAsync).toHaveBeenCalledTimes(2)
     expect(revealTerminalSession).toHaveBeenCalledOnce()
     expect(
       getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]?.automaticResumeBlockedBy
     ).toBe('legacy-orchestration-worker')
+    expect(getSession().sleepingAgentSessionsByPaneKey?.[concurrentPaneKey]?.tabId).toBe(
+      'concurrent-tab'
+    )
     expect(resolveLegacyWorkerTerminalRecovery).not.toHaveBeenCalled()
     warn.mockRestore()
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -20108,7 +20108,7 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('retries missing-worker recovery when clearing its persisted resume fence fails', async () => {
+  it('waits for durability before retry settles a resolution already present in memory', async () => {
     const workerPaneKey = `legacy-missing-retry:${HEADLESS_LEAF_ID}`
     const incarnationId = '34343434-3434-4434-8434-343434343434'
     const session: WorkspaceSessionState = {
@@ -20129,16 +20129,26 @@ describe('OrcaRuntimeService', () => {
         }
       }
     }
-    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
-    const flushOrThrow = vi
-      .fn()
-      .mockImplementationOnce(() => {
-        throw new Error('disk unavailable')
-      })
-      .mockImplementation(() => undefined)
-    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow } as never, undefined, {
-      canRecoverPersistentLocalPtys: () => true
+    const { runtimeStore, getSession, setSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const firstDurableWrite = deferred<void>()
+    const firstDurableWriteStarted = deferred<void>()
+    const retryDurableWrite = deferred<void>()
+    const retryDurableWriteStarted = deferred<void>()
+    let flushCount = 0
+    const flushPendingOrThrowAsync = vi.fn(() => {
+      flushCount += 1
+      if (flushCount === 1) {
+        firstDurableWriteStarted.resolve()
+        return firstDurableWrite.promise
+      }
+      retryDurableWriteStarted.resolve()
+      return retryDurableWrite.promise
     })
+    const runtime = new OrcaRuntimeService(
+      { ...runtimeStore, flushPendingOrThrowAsync } as never,
+      undefined,
+      { canRecoverPersistentLocalPtys: () => true }
+    )
     const db = new OrchestrationDb(':memory:')
     try {
       const task = db.createTask({ spec: 'retry missing worker recovery' })
@@ -20168,20 +20178,30 @@ describe('OrcaRuntimeService', () => {
       runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-      await expect(runtime.reconcileLegacyWorkerTerminals()).resolves.toMatchObject({
+      const firstRecovery = runtime.reconcileLegacyWorkerTerminals()
+      await firstDurableWriteStarted.promise
+      setSession({ ...getSession(), sleepingAgentSessionsByPaneKey: undefined })
+      firstDurableWrite.reject(new Error('disk unavailable'))
+
+      await expect(firstRecovery).resolves.toMatchObject({
         exitedDispatchIds: [],
         deferredDispatchIds: [started.dispatch.id]
       })
       expect(db.getDispatchContextById(started.dispatch.id)?.status).toBe('dispatched')
       expect(db.getWorkerDispatch(started.dispatch.id)?.state).toBe('ready')
-      expect(
-        getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]?.automaticResumeBlockedBy
-      ).toBe('legacy-orchestration-worker')
+      expect(getSession().sleepingAgentSessionsByPaneKey).toBeUndefined()
 
-      await expect(runtime.reconcileLegacyWorkerTerminals()).resolves.toMatchObject({
+      const retry = runtime.reconcileLegacyWorkerTerminals()
+      await retryDurableWriteStarted.promise
+      expect(db.getDispatchContextById(started.dispatch.id)?.status).toBe('dispatched')
+      expect(db.getWorkerDispatch(started.dispatch.id)?.state).toBe('ready')
+      retryDurableWrite.resolve()
+
+      await expect(retry).resolves.toMatchObject({
         exitedDispatchIds: [started.dispatch.id],
         deferredDispatchIds: []
       })
+      expect(flushPendingOrThrowAsync).toHaveBeenCalledTimes(2)
       expect(db.getWorkerDispatch(started.dispatch.id)?.state).toBe('abandoned')
       expect(getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]).toBeUndefined()
       expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19849,7 +19849,7 @@ describe('OrcaRuntimeService', () => {
     let flushCount = 0
     const flushOrThrow = vi.fn(() => {
       flushCount += 1
-      if (flushCount === 1 || flushCount === 3) {
+      if (flushCount === 2) {
         throw new Error('disk unavailable')
       }
     })
@@ -19911,7 +19911,7 @@ describe('OrcaRuntimeService', () => {
       exitedDispatchIds: [],
       deferredDispatchIds: ['dispatch-persistence-failure']
     })
-    expect(flushOrThrow).toHaveBeenCalledTimes(3)
+    expect(flushOrThrow).toHaveBeenCalledTimes(2)
     expect(revealTerminalSession).toHaveBeenCalledOnce()
     expect(
       getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]?.automaticResumeBlockedBy
@@ -19942,8 +19942,17 @@ describe('OrcaRuntimeService', () => {
       }
     }
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const durableWrite = deferred<void>()
+    const durableWriteStarted = deferred<void>()
+    const flushPendingOrThrowAsync = vi.fn(() => {
+      durableWriteStarted.resolve()
+      return durableWrite.promise
+    })
+    const flushOrThrow = vi.fn(() => {
+      throw new Error('synchronous persistence must not run')
+    })
     const runtime = new OrcaRuntimeService(
-      { ...runtimeStore, flushOrThrow: vi.fn() } as never,
+      { ...runtimeStore, flushOrThrow, flushPendingOrThrowAsync } as never,
       undefined,
       { canRecoverPersistentLocalPtys: () => true }
     )
@@ -19975,12 +19984,24 @@ describe('OrcaRuntimeService', () => {
       const resolveLegacyWorkerTerminalRecovery = vi.fn()
       runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
 
-      await expect(runtime.reconcileLegacyWorkerTerminals()).resolves.toMatchObject({
+      const recovery = runtime.reconcileLegacyWorkerTerminals()
+      await durableWriteStarted.promise
+
+      expect(resolveLegacyWorkerTerminalRecovery).not.toHaveBeenCalled()
+      expect(db.getDispatchContextById(started.dispatch.id)?.status).toBe('dispatched')
+      durableWrite.resolve()
+
+      await expect(recovery).resolves.toMatchObject({
         adoptedDispatchIds: [],
         exitedDispatchIds: [started.dispatch.id],
         deferredDispatchIds: []
       })
 
+      expect(flushPendingOrThrowAsync).toHaveBeenCalledOnce()
+      expect(flushPendingOrThrowAsync).toHaveBeenCalledWith({
+        drainToStableGeneration: false
+      })
+      expect(flushOrThrow).not.toHaveBeenCalled()
       expect(db.getDispatchContextById(started.dispatch.id)).toMatchObject({
         status: 'failed',
         failure_count: 1
@@ -20023,7 +20044,6 @@ describe('OrcaRuntimeService', () => {
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
     const flushOrThrow = vi
       .fn()
-      .mockImplementationOnce(() => undefined)
       .mockImplementationOnce(() => {
         throw new Error('disk unavailable')
       })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4001,7 +4001,6 @@ export class OrcaRuntimeService {
     const originalSessions = new Map<ExecutionHostId, WorkspaceSessionState>()
     const stagedSessions = new Map<ExecutionHostId, WorkspaceSessionState>()
     const stagedDispatchIds = new Set<string>()
-    let changed = false
     try {
       for (const { candidate, resolution } of resolutions) {
         const hostId = this.tryGetWorkspaceSessionHostIdForWorktree(candidate.worktreeId)
@@ -4028,12 +4027,11 @@ export class OrcaRuntimeService {
         }
         if (next !== session) {
           store.setWorkspaceSession(next, hostId)
-          changed = true
         }
         stagedSessions.set(hostId, store.getWorkspaceSession(hostId))
         stagedDispatchIds.add(candidate.dispatchId)
       }
-      if (changed) {
+      if (stagedDispatchIds.size > 0) {
         await this.flushWorkspaceSessionOrThrowAsync()
       }
       return stagedDispatchIds

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1116,6 +1116,7 @@ type RuntimeStore = {
   getWorkspaceSessionHostIds?: Store['getWorkspaceSessionHostIds']
   setWorkspaceSession?: Store['setWorkspaceSession']
   flushOrThrow?: Store['flushOrThrow']
+  flushPendingOrThrowAsync?: Store['flushPendingOrThrowAsync']
   persistPtyBinding?: Store['persistPtyBinding']
   getSshRemotePtyLeases?: Store['getSshRemotePtyLeases']
   getUI?: Store['getUI']
@@ -1976,6 +1977,11 @@ export type LegacyWorkerTerminalRecoveryResult = {
   adoptedDispatchIds: string[]
   exitedDispatchIds: string[]
   deferredDispatchIds: string[]
+}
+
+type LegacyWorkerTerminalRecoveryResolution = {
+  candidate: LegacyWorkerTerminalRecoveryPlan['candidates'][number]
+  resolution: 'adopted' | 'exited'
 }
 
 export type OrchestrationCompatibilityCallerAuthority = Readonly<{
@@ -3803,7 +3809,11 @@ export class OrcaRuntimeService {
   prepareLegacyWorkerTerminalRecovery(): LegacyWorkerTerminalRecoveryPlan {
     const plan = this.getLegacyWorkerTerminalRecoveryPlan()
     const store = this.store
-    if (!store?.getWorkspaceSession || !store.setWorkspaceSession || !store.flushOrThrow) {
+    if (
+      !store?.getWorkspaceSession ||
+      !store.setWorkspaceSession ||
+      (!store.flushPendingOrThrowAsync && !store.flushOrThrow)
+    ) {
       return plan
     }
     const sessions = new Map<
@@ -3858,11 +3868,23 @@ export class OrcaRuntimeService {
       for (const [hostId, state] of changed) {
         store.setWorkspaceSession(state.next, hostId)
       }
-      store.flushOrThrow()
     } catch (error) {
-      console.warn('[orchestration] failed to persist legacy worker resume fence', error)
+      console.warn('[orchestration] failed to stage legacy worker resume fence', error)
     }
     return plan
+  }
+
+  private async flushWorkspaceSessionOrThrowAsync(): Promise<void> {
+    const store = this.store
+    if (store?.flushPendingOrThrowAsync) {
+      await store.flushPendingOrThrowAsync({ drainToStableGeneration: false })
+      return
+    }
+    if (store?.flushOrThrow) {
+      store.flushOrThrow()
+      return
+    }
+    throw new Error('workspace_session_persistence_unavailable')
   }
 
   async reconcileLegacyWorkerTerminals(
@@ -3964,33 +3986,63 @@ export class OrcaRuntimeService {
     )
   }
 
-  private persistLegacyWorkerTerminalRecoveryResolution(
-    candidate: LegacyWorkerTerminalRecoveryPlan['candidates'][number],
-    resolution: 'adopted' | 'exited'
-  ): boolean {
+  private async persistLegacyWorkerTerminalRecoveryBatch(
+    resolutions: readonly LegacyWorkerTerminalRecoveryResolution[]
+  ): Promise<ReadonlySet<string>> {
     const store = this.store
-    const session = this.getWorkspaceSessionForWorktree(candidate.worktreeId)
-    if (!store?.setWorkspaceSession || !store.flushOrThrow || !session) {
-      return false
+    if (
+      !store?.getWorkspaceSession ||
+      !store.setWorkspaceSession ||
+      (!store.flushPendingOrThrowAsync && !store.flushOrThrow)
+    ) {
+      return new Set()
     }
-    const record = session.sleepingAgentSessionsByPaneKey?.[candidate.paneKey]
-    if (!record || !runtimeWorktreeIdsEqual(record.worktreeId, candidate.worktreeId)) {
-      return true
-    }
-    const next = structuredClone(session)
-    delete next.sleepingAgentSessionsByPaneKey?.[candidate.paneKey]
+    const originalSessions = new Map<ExecutionHostId, WorkspaceSessionState>()
+    const stagedDispatchIds = new Set<string>()
+    let changed = false
     try {
-      this.setWorkspaceSessionForWorktree(candidate.worktreeId, next)
-      store.flushOrThrow()
-      return true
+      for (const { candidate, resolution } of resolutions) {
+        const hostId = this.tryGetWorkspaceSessionHostIdForWorktree(candidate.worktreeId)
+        const session = hostId ? store.getWorkspaceSession(hostId) : null
+        if (!hostId || !session) {
+          continue
+        }
+        originalSessions.set(hostId, originalSessions.get(hostId) ?? session)
+        let next =
+          resolution === 'exited'
+            ? retireTerminalSurfaceFromPersistence(session, {
+                worktreeId: candidate.worktreeId,
+                parentTabId: candidate.tabId,
+                leafId: candidate.leafId,
+                ptyId: candidate.ptyId,
+                incarnationId: candidate.incarnationId
+              })
+            : session
+        const record = next.sleepingAgentSessionsByPaneKey?.[candidate.paneKey]
+        if (record && runtimeWorktreeIdsEqual(record.worktreeId, candidate.worktreeId)) {
+          const sleepingAgentSessionsByPaneKey = { ...next.sleepingAgentSessionsByPaneKey }
+          delete sleepingAgentSessionsByPaneKey[candidate.paneKey]
+          next = { ...next, sleepingAgentSessionsByPaneKey }
+        }
+        if (next !== session) {
+          store.setWorkspaceSession(next, hostId)
+          changed = true
+        }
+        stagedDispatchIds.add(candidate.dispatchId)
+      }
+      if (changed) {
+        await this.flushWorkspaceSessionOrThrowAsync()
+      }
+      return stagedDispatchIds
     } catch (error) {
-      this.setWorkspaceSessionForWorktree(candidate.worktreeId, session)
-      console.warn('[orchestration] failed to persist legacy worker recovery resolution', {
-        dispatchId: candidate.dispatchId,
-        resolution,
+      for (const [hostId, session] of originalSessions) {
+        store.setWorkspaceSession(session, hostId)
+      }
+      console.warn('[orchestration] failed to persist legacy worker recovery batch', {
+        dispatchIds: [...stagedDispatchIds],
         error
       })
-      return false
+      return new Set()
     }
   }
 
@@ -4015,48 +4067,9 @@ export class OrcaRuntimeService {
     }
   }
 
-  private resolveExitedLegacyWorkerTerminal(
-    candidate: LegacyWorkerTerminalRecoveryPlan['candidates'][number]
-  ): boolean {
-    if (
-      !this.rollbackLegacyWorkerTerminalSurface(candidate) ||
-      !this.persistLegacyWorkerTerminalRecoveryResolution(candidate, 'exited') ||
-      !this.reconcileMissingLegacyWorkerTerminal(candidate)
-    ) {
-      return false
-    }
-    this.notifier?.resolveLegacyWorkerTerminalRecovery?.(candidate.paneKey, 'exited')
-    return true
-  }
-
   private rollbackLegacyWorkerTerminalSurface(
     candidate: LegacyWorkerTerminalRecoveryPlan['candidates'][number]
-  ): boolean {
-    const store = this.store
-    const session = this.getWorkspaceSessionForWorktree(candidate.worktreeId)
-    if (store?.setWorkspaceSession && store.flushOrThrow && session) {
-      const retired = retireTerminalSurfaceFromPersistence(session, {
-        worktreeId: candidate.worktreeId,
-        parentTabId: candidate.tabId,
-        leafId: candidate.leafId,
-        ptyId: candidate.ptyId,
-        incarnationId: candidate.incarnationId
-      })
-      if (retired !== session) {
-        try {
-          this.setWorkspaceSessionForWorktree(candidate.worktreeId, retired)
-          store.flushOrThrow()
-        } catch (error) {
-          this.setWorkspaceSessionForWorktree(candidate.worktreeId, session)
-          console.warn('[orchestration] failed to persist legacy worker surface rollback', {
-            dispatchId: candidate.dispatchId,
-            error
-          })
-          return false
-        }
-      }
-    }
-
+  ): void {
     const snapshot = this.mobileSessionTabsByWorktree.get(candidate.worktreeId)
     if (snapshot) {
       const retired = retireTerminalSurfacesFromSnapshot({
@@ -4104,13 +4117,6 @@ export class OrcaRuntimeService {
       'rolled_back',
       candidate.ptyId
     )
-    return true
-  }
-
-  private resolveReplacedLegacyWorkerTerminal(
-    candidate: LegacyWorkerTerminalRecoveryPlan['candidates'][number]
-  ): boolean {
-    return this.resolveExitedLegacyWorkerTerminal(candidate)
   }
 
   private updateLegacyWorkerTerminalRecoveryRetry(
@@ -4190,6 +4196,7 @@ export class OrcaRuntimeService {
     const adoptedDispatchIds: string[] = []
     const exitedDispatchIds: string[] = []
     const deferredDispatchIds = new Set(plan.ambiguousDispatchIds)
+    const pendingResolutions: LegacyWorkerTerminalRecoveryResolution[] = []
     const recoveryCandidatesByProvider = new Map<
       string,
       {
@@ -4256,11 +4263,7 @@ export class OrcaRuntimeService {
       }
       for (const { candidate, workspace } of provider.entries) {
         if (!inventory.livePtyIds.has(candidate.ptyId)) {
-          if (this.resolveExitedLegacyWorkerTerminal(candidate)) {
-            exitedDispatchIds.push(candidate.dispatchId)
-          } else {
-            deferredDispatchIds.add(candidate.dispatchId)
-          }
+          pendingResolutions.push({ candidate, resolution: 'exited' })
           continue
         }
         const controllerIdentity = inventory.terminalIdentityByPtyId.get(candidate.ptyId)
@@ -4272,11 +4275,7 @@ export class OrcaRuntimeService {
           controllerIdentity.handle !== candidate.terminalHandle ||
           controllerIdentity.incarnationId !== candidate.incarnationId
         ) {
-          if (this.resolveReplacedLegacyWorkerTerminal(candidate)) {
-            exitedDispatchIds.push(candidate.dispatchId)
-          } else {
-            deferredDispatchIds.add(candidate.dispatchId)
-          }
+          pendingResolutions.push({ candidate, resolution: 'exited' })
           continue
         }
         const preAdoptionInventory = await this.refreshPtyWorktreeRecordsWithControllerInventory(
@@ -4290,11 +4289,7 @@ export class OrcaRuntimeService {
           continue
         }
         if (!preAdoptionInventory.livePtyIds.has(candidate.ptyId)) {
-          if (this.resolveExitedLegacyWorkerTerminal(candidate)) {
-            exitedDispatchIds.push(candidate.dispatchId)
-          } else {
-            deferredDispatchIds.add(candidate.dispatchId)
-          }
+          pendingResolutions.push({ candidate, resolution: 'exited' })
           continue
         }
         const preAdoptionIdentity = preAdoptionInventory.terminalIdentityByPtyId.get(
@@ -4308,11 +4303,7 @@ export class OrcaRuntimeService {
           preAdoptionIdentity.handle !== candidate.terminalHandle ||
           preAdoptionIdentity.incarnationId !== candidate.incarnationId
         ) {
-          if (this.resolveReplacedLegacyWorkerTerminal(candidate)) {
-            exitedDispatchIds.push(candidate.dispatchId)
-          } else {
-            deferredDispatchIds.add(candidate.dispatchId)
-          }
+          pendingResolutions.push({ candidate, resolution: 'exited' })
           continue
         }
         const session = this.getWorkspaceSessionForWorktree(candidate.worktreeId)
@@ -4443,11 +4434,7 @@ export class OrcaRuntimeService {
         if (!finalInventory.livePtyIds.has(candidate.ptyId)) {
           this.legacyWorkerTerminalReceiptEpochByPane.delete(candidate.paneKey)
           this.onPtyExit(candidate.ptyId, 0, candidate.incarnationId)
-          if (this.resolveExitedLegacyWorkerTerminal(candidate)) {
-            exitedDispatchIds.push(candidate.dispatchId)
-          } else {
-            deferredDispatchIds.add(candidate.dispatchId)
-          }
+          pendingResolutions.push({ candidate, resolution: 'exited' })
           continue
         }
         const finalIdentity = finalInventory.terminalIdentityByPtyId.get(candidate.ptyId)
@@ -4461,21 +4448,32 @@ export class OrcaRuntimeService {
           finalIdentity.incarnationId !== candidate.incarnationId
         ) {
           this.legacyWorkerTerminalReceiptEpochByPane.delete(candidate.paneKey)
-          if (this.resolveReplacedLegacyWorkerTerminal(candidate)) {
-            exitedDispatchIds.push(candidate.dispatchId)
-          } else {
-            deferredDispatchIds.add(candidate.dispatchId)
-          }
+          pendingResolutions.push({ candidate, resolution: 'exited' })
           continue
         }
-        if (!this.persistLegacyWorkerTerminalRecoveryResolution(candidate, 'adopted')) {
-          deferredDispatchIds.add(candidate.dispatchId)
-          continue
-        }
+        pendingResolutions.push({ candidate, resolution: 'adopted' })
+      }
+    }
+    const persistedDispatchIds =
+      await this.persistLegacyWorkerTerminalRecoveryBatch(pendingResolutions)
+    for (const { candidate, resolution } of pendingResolutions) {
+      if (!persistedDispatchIds.has(candidate.dispatchId)) {
+        deferredDispatchIds.add(candidate.dispatchId)
+        continue
+      }
+      if (resolution === 'adopted') {
         this.legacyWorkerRecoveredPtys.add(candidate.ptyId)
         this.notifier?.resolveLegacyWorkerTerminalRecovery?.(candidate.paneKey, 'adopted')
         adoptedDispatchIds.push(candidate.dispatchId)
+        continue
       }
+      this.rollbackLegacyWorkerTerminalSurface(candidate)
+      if (!this.reconcileMissingLegacyWorkerTerminal(candidate)) {
+        deferredDispatchIds.add(candidate.dispatchId)
+        continue
+      }
+      this.notifier?.resolveLegacyWorkerTerminalRecovery?.(candidate.paneKey, 'exited')
+      exitedDispatchIds.push(candidate.dispatchId)
     }
     const result = {
       blockedPaneCount: plan.blockedPanes.length,
@@ -15447,7 +15445,11 @@ export class OrcaRuntimeService {
     const { livePtyIds, terminalIdentityByPtyId } = inventory
     const store = this.store
     const session = this.getWorkspaceSessionForWorktree(workspace.id)
-    if (!store?.setWorkspaceSession || !store.flushOrThrow || !session) {
+    if (
+      !store?.setWorkspaceSession ||
+      (!store.flushPendingOrThrowAsync && !store.flushOrThrow) ||
+      !session
+    ) {
       throw new Error('workspace_session_unavailable')
     }
     const sessionWorktreeId = resolveTerminalSessionWorktreeId(session, workspace.id)
@@ -15869,7 +15871,7 @@ export class OrcaRuntimeService {
     const persisted = advanceTerminalTopologyRevision(next, workspace.id)
     try {
       this.setWorkspaceSessionForWorktree(workspace.id, persisted)
-      store.flushOrThrow()
+      await this.flushWorkspaceSessionOrThrowAsync()
     } catch (error) {
       this.setWorkspaceSessionForWorktree(workspace.id, session)
       throw error

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -111,6 +111,7 @@ import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { OrchestrationDb } from './orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
+import { rollbackWorkspaceSessionAfterFailedAsyncWrite } from './workspace-session-failed-write-rollback'
 import { OrchestrationError } from './orchestration/orchestration-error'
 import {
   planLegacyWorkerTerminalRecovery,
@@ -3998,6 +3999,7 @@ export class OrcaRuntimeService {
       return new Set()
     }
     const originalSessions = new Map<ExecutionHostId, WorkspaceSessionState>()
+    const stagedSessions = new Map<ExecutionHostId, WorkspaceSessionState>()
     const stagedDispatchIds = new Set<string>()
     let changed = false
     try {
@@ -4028,6 +4030,7 @@ export class OrcaRuntimeService {
           store.setWorkspaceSession(next, hostId)
           changed = true
         }
+        stagedSessions.set(hostId, store.getWorkspaceSession(hostId))
         stagedDispatchIds.add(candidate.dispatchId)
       }
       if (changed) {
@@ -4035,8 +4038,16 @@ export class OrcaRuntimeService {
       }
       return stagedDispatchIds
     } catch (error) {
-      for (const [hostId, session] of originalSessions) {
-        store.setWorkspaceSession(session, hostId)
+      for (const [hostId, original] of originalSessions) {
+        const staged = stagedSessions.get(hostId)
+        const current = store.getWorkspaceSession(hostId)
+        if (!staged || !current) {
+          continue
+        }
+        const rolledBack = rollbackWorkspaceSessionAfterFailedAsyncWrite(original, staged, current)
+        if (rolledBack !== current) {
+          store.setWorkspaceSession(rolledBack, hostId)
+        }
       }
       console.warn('[orchestration] failed to persist legacy worker recovery batch', {
         dispatchIds: [...stagedDispatchIds],
@@ -15869,11 +15880,19 @@ export class OrcaRuntimeService {
       [workspace.id]: activeGroup.id
     }
     const persisted = advanceTerminalTopologyRevision(next, workspace.id)
+    let staged: WorkspaceSessionState | null = null
     try {
       this.setWorkspaceSessionForWorktree(workspace.id, persisted)
+      staged = this.getWorkspaceSessionForWorktree(workspace.id)
       await this.flushWorkspaceSessionOrThrowAsync()
     } catch (error) {
-      this.setWorkspaceSessionForWorktree(workspace.id, session)
+      const current = this.getWorkspaceSessionForWorktree(workspace.id)
+      if (staged && current) {
+        const rolledBack = rollbackWorkspaceSessionAfterFailedAsyncWrite(session, staged, current)
+        if (rolledBack !== current) {
+          this.setWorkspaceSessionForWorktree(workspace.id, rolledBack)
+        }
+      }
       throw error
     }
     for (const { claim, pty, paneKey } of validated) {

--- a/src/main/runtime/workspace-session-failed-write-rollback.ts
+++ b/src/main/runtime/workspace-session-failed-write-rollback.ts
@@ -1,0 +1,62 @@
+import { isDeepStrictEqual } from 'node:util'
+import type { WorkspaceSessionState } from '../../shared/types'
+
+const MISSING = Symbol('missing')
+type RollbackValue = unknown | typeof MISSING
+
+function isRecord(value: RollbackValue): value is Record<string, unknown> {
+  return (
+    value !== MISSING &&
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+function rollbackValue(
+  original: RollbackValue,
+  staged: RollbackValue,
+  current: RollbackValue
+): RollbackValue {
+  if (isDeepStrictEqual(original, staged)) {
+    return current
+  }
+  if (isDeepStrictEqual(current, staged)) {
+    return original
+  }
+  if (!isRecord(original) || !isRecord(staged) || !isRecord(current)) {
+    return current
+  }
+  let changed = false
+  const next: Record<string, unknown> = { ...current }
+  for (const key of new Set([
+    ...Object.keys(original),
+    ...Object.keys(staged),
+    ...Object.keys(current)
+  ])) {
+    const value = rollbackValue(
+      Object.hasOwn(original, key) ? original[key] : MISSING,
+      Object.hasOwn(staged, key) ? staged[key] : MISSING,
+      Object.hasOwn(current, key) ? current[key] : MISSING
+    )
+    if (value === MISSING) {
+      if (Object.hasOwn(next, key)) {
+        delete next[key]
+        changed = true
+      }
+    } else if (!Object.hasOwn(current, key) || !isDeepStrictEqual(current[key], value)) {
+      next[key] = value
+      changed = true
+    }
+  }
+  return changed ? next : current
+}
+
+export function rollbackWorkspaceSessionAfterFailedAsyncWrite(
+  original: WorkspaceSessionState,
+  staged: WorkspaceSessionState,
+  current: WorkspaceSessionState
+): WorkspaceSessionState {
+  return rollbackValue(original, staged, current) as WorkspaceSessionState
+}


### PR DESCRIPTION
## Summary

- stage startup recovery fences without synchronously fsyncing the main thread
- batch adopted/exited recovery resolutions across host-scoped workspace sessions
- await the existing asynchronous durability barrier before DB settlement or renderer notification, with full in-memory rollback on write failure
- move terminal-orphan adoption to the same async durability barrier

## User impact: before and after

**Before:** During startup recovery, Orca could serialize, synchronously write, and `fsync` the full workspace session once for each legacy worker it recovered. Because this ran on Electron's main event loop, users could see a frozen or slow-to-respond window—especially with large workspace state, slower disks, or several terminals to recover.

**After:** Orca stages all recovery changes in memory and persists them with one asynchronous durable write. The UI remains responsive during the disk work, and recovery is not marked complete until that write is safely persisted. If persistence fails, unrelated concurrent workspace changes are preserved and a retry cannot settle recovery before the state is actually durable.

On a synthetic 24 MiB workspace-session fixture over three trials:

| User-facing cost | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Durable disk writes | 3 | 1 | 67% fewer |
| Median total time | 92.5 ms | 58.2 ms | 37% faster |
| Main event-loop stall | 93.0 ms | 2.2 ms | 97.6% lower (~42× smaller) |

The event-loop result is the key user-visible improvement: instead of Orca freezing for roughly the duration of persistence, the UI stays responsive while the write runs. The production profile that motivated this work found 3.852 seconds of synchronous persistence inside a 4.479-second recovery operation. Actual savings vary with workspace size, disk speed, and the number of terminals needing recovery; ordinary startups without recovery work are less affected.

## Profile and benchmark

The 56.623 s evidence profile attributed 4,479 ms to legacy worker reconciliation, including 3,852 ms in synchronous persistence, 2,114 ms building state, 962 ms in synchronous file writes, and 861 ms in fsync.

Reproduction:

    node config/scripts/legacy-worker-recovery-persistence-benchmark.mjs --json

On a 24 MiB fixture over three trials:

| Metric | Legacy | Batched async |
| --- | ---: | ---: |
| Durable writes | 3 | 1 |
| Median wall time | 92.5 ms | 58.2 ms |
| Median maximum event-loop delay | 93.0 ms | 2.2 ms |

## Validation

- pnpm run typecheck:node
- pnpm exec vitest run src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime-terminal-retirement.test.ts src/main/runtime/mobile-session-terminal-persistence-retirement.test.ts src/main/persistence-async-write-syscalls.test.ts — 1,126 passed, 1 skipped
- direct oxlint with warnings denied, oxfmt check, and max-lines ratchet
- Electron CDP validation on this exact checkout: identity matched the branch/worktree, the visible General settings surface rendered with zero console errors, and three back/settings cycles completed in 78–141 ms / 192–231 ms

## Residual risk

The synthetic benchmark isolates the proven persistence mechanism rather than reconstructing a pre-update legacy worker database inside the dev profile. Recovery durability, failure rollback, host partitioning, and notification ordering are covered by the runtime regression suite.

## Electron evidence

![Validated General settings surface](https://github.com/user-attachments/assets/972e5265-ac97-4b14-aeea-6c27b27e9fd5)


