### PR TITLE
perf: Stop orchestration interaction UI broadcast storms

### DIFF
--- a/src/main/persistence-feature-interaction-broadcast.benchmark.test.ts
+++ b/src/main/persistence-feature-interaction-broadcast.benchmark.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { normalizeFeatureInteractions } from '../shared/feature-interactions'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => tmpdir() },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf8')
+  }
+}))
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: () => ({}) }))
+
+import { Store } from './persistence'
+
+const INTERACTIONS = 200
+const tempDirs: string[] = []
+
+function createStore(name: string): { dataFile: string; store: Store } {
+  const dir = mkdtempSync(join(tmpdir(), `orca-ui-broadcast-${name}-`))
+  tempDirs.push(dir)
+  const dataFile = join(dir, 'orca-data.json')
+  return { dataFile, store: new Store({ dataFile }) }
+}
+
+describe('feature interaction UI broadcast benchmark', () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reduces repeated interaction recording to one material UI broadcast', () => {
+    const { store: legacyStore } = createStore('legacy')
+    const { dataFile, store: optimizedStore } = createStore('optimized')
+    let legacyBroadcasts = 0
+    let optimizedBroadcasts = 0
+    legacyStore.onUIChanged(() => legacyBroadcasts++)
+    optimizedStore.onUIChanged(() => optimizedBroadcasts++)
+
+    const legacyStart = performance.now()
+    for (let index = 0; index < INTERACTIONS; index++) {
+      const featureInteractions = normalizeFeatureInteractions(
+        legacyStore.getUI().featureInteractions
+      )
+      const existing = featureInteractions['agent-orchestration']
+      legacyStore.updateUI({
+        featureInteractions: {
+          ...featureInteractions,
+          'agent-orchestration': {
+            firstInteractedAt: existing?.firstInteractedAt ?? 1,
+            interactionCount: (existing?.interactionCount ?? 0) + 1
+          }
+        }
+      })
+    }
+    const legacyMs = performance.now() - legacyStart
+
+    const optimizedStart = performance.now()
+    for (let index = 0; index < INTERACTIONS; index++) {
+      optimizedStore.recordFeatureInteraction('agent-orchestration')
+    }
+    const optimizedMs = performance.now() - optimizedStart
+
+    expect(legacyBroadcasts).toBe(INTERACTIONS)
+    expect(optimizedBroadcasts).toBe(1)
+    expect(
+      optimizedStore.getUI().featureInteractions?.['agent-orchestration']?.interactionCount
+    ).toBe(INTERACTIONS)
+    optimizedStore.flush()
+    expect(
+      new Store({ dataFile }).getUI().featureInteractions?.['agent-orchestration']?.interactionCount
+    ).toBe(INTERACTIONS)
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[bench] ${INTERACTIONS} orchestration interactions: ` +
+        `full-state broadcasts ${legacyBroadcasts} -> ${optimizedBroadcasts}; ` +
+        `main-thread mutation ${legacyMs.toFixed(2)}ms -> ${optimizedMs.toFixed(2)}ms`
+    )
+  })
+})

--- a/src/main/persistence-feature-interaction-broadcast.benchmark.test.ts
+++ b/src/main/persistence-feature-interaction-broadcast.benchmark.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { normalizeFeatureInteractions } from '../shared/feature-interactions'
+import type { PersistedState } from '../shared/types'
 
 vi.mock('electron', () => ({
   app: { getPath: () => tmpdir() },
@@ -77,8 +78,11 @@ describe('feature interaction UI broadcast benchmark', () => {
     expect(
       new Store({ dataFile }).getUI().featureInteractions?.['agent-orchestration']?.interactionCount
     ).toBe(INTERACTIONS)
+    const persisted = JSON.parse(readFileSync(dataFile, 'utf8')) as PersistedState
+    expect(persisted.featureInteractionTelemetryBuckets?.['agent-orchestration']).toBe(
+      'count_200_499'
+    )
 
-    // eslint-disable-next-line no-console
     console.log(
       `[bench] ${INTERACTIONS} orchestration interactions: ` +
         `full-state broadcasts ${legacyBroadcasts} -> ${optimizedBroadcasts}; ` +

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -5778,7 +5778,7 @@ export class Store {
     }
   }
 
-  // Why: UI view-state is written from both desktop and mobile (ui.set RPC), so notify to keep bi-directional sync (desktop hydrates UI only once).
+  // Why: renderer-visible UI state is written from desktop and mobile, so notify to keep bi-directional sync.
   onUIChanged(listener: (ui: PersistedState['ui']) => void): () => void {
     this.uiChangeListeners.add(listener)
     return () => {
@@ -6189,7 +6189,8 @@ export class Store {
       (lastEmittedBucket === null ||
         compareFeatureInteractionUsageBuckets(nextBucket, lastEmittedBucket) > 0)
 
-    this.updateUI({
+    this.state.ui = {
+      ...this.state.ui,
       featureInteractions: {
         ...featureInteractions,
         [id]: {
@@ -6197,11 +6198,15 @@ export class Store {
           interactionCount: nextCount
         }
       }
-    })
+    }
     this.state.featureInteractionTelemetryBuckets = shouldEmit
       ? { ...telemetryBuckets, [id]: nextBucket }
       : telemetryBuckets
     this.scheduleSave()
+    // Why: live UI only consumes the seen transition; count-only telemetry must not re-hydrate the renderer.
+    if (!existing) {
+      this.notifyUIChanged()
+    }
 
     if (shouldEmit) {
       track('feature_interaction_usage_bucket_reached', {


### PR DESCRIPTION
## Summary

- Persist every feature-interaction count and telemetry bucket without routing count-only changes through the full UI normalization path.
- Main process sends the persisted UI snapshot over Electron IPC to every open local Orca window only when a feature first transitions from unseen to seen, which is the only live renderer projection that changes.
- Add a real-store benchmark regression that compares the previous full-state mutation path with the optimized path and verifies counts and telemetry buckets survive disk reload.

## What happens before and after

This path runs whenever Orca records a feature interaction through `Store.recordFeatureInteraction`—for this incident, repeated `agent-orchestration` activity from orchestration runtime use.

| Call | Before this PR | After this PR |
|---|---|---|
| First interaction (`0 → 1`) | Increment count, persist count/bucket, return updated UI, and main process sends the full UI snapshot over Electron IPC to every open local Orca window. | Exactly the same. The main-to-renderer IPC event is required because renderer-visible state changes from unseen to seen. |
| Later interactions (`1 → 2`, `2 → 3`, …) | Increment count, persist count/bucket, return updated UI, and main process sends the full UI snapshot over Electron IPC to every open local Orca window every time. Each IPC event caused every renderer to run UI hydration even though no visible value changed. | Increment count, persist count/bucket, and return updated UI exactly as before, but do not send that IPC event. Only the internal usage count changed. |
| Older client using `ui.set` | Normalize, merge, persist, and broadcast through the existing general UI path. | Unchanged. |

The deliberate behavior change is limited to one internal event: repeated interactions after the feature is already seen no longer send redundant `ui:stateChanged` IPC events from the main process to every local Electron renderer. No live renderer reads these counts to render UI; renderer behavior depends on whether the interaction exists, and that first unseen-to-seen transition still sends that IPC event immediately.

Everything else remains the same: orchestration commands, task and dispatch lifecycle, UI flows, RPC shapes and responses, persisted counts, telemetry buckets and events, mobile/remote behavior, and mixed-version compatibility. There is no wire-format or capability change.

## Performance

- Captured baseline: 199 of 200 UI events were orchestration increments over 30.675s (6.49/s). In a 42.803s window, 168 hydration-attributed long tasks blocked 10,809ms (25.3% wall time), with a 1,921ms maximum.
- Deterministic 200-interaction benchmark: full-state broadcasts fell from 200 to 1 (99.5% reduction); main-thread mutation time fell from 11.02ms to 3.51ms in the recorded run.
- Electron steady-state burst at reviewed HEAD: all 200 counts persisted, with 0 `ui:stateChanged` IPC events, 0 renderer hydrations, 0 long tasks, and 29.6ms total IPC-loop time.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence-feature-interaction-broadcast.benchmark.test.ts src/main/persistence.test.ts src/main/runtime/rpc/dispatcher-feature-interactions.test.ts src/main/runtime/rpc/methods/client-ui.test.ts src/main/ipc/ui.test.ts` — 515 passed.
- `pnpm run typecheck` — passed.
- Changed-code quality and focused oxlint — passed with 0 findings.
- Refreshed PR CI — all required checks passed, including Node 24/26 test shards, cross-version wire compatibility, package, and Windows package.
- Same-model post-fix review — clean.

## Electron evidence

The reviewed Electron run verified exact worktree identity, persisted count `1 → 201`, telemetry bucket `count_200_499`, 0 redundant main-to-renderer IPC events, 0 renderer hydrations, 0 long tasks, and 0 console errors.

[Electron QA measurements and before/after screenshots](https://github.com/stablyai/orca/pull/13651#issuecomment-5246608068)

![Orchestration settings after the measured burst](https://github.com/user-attachments/assets/fbdba652-8b10-4cbc-9a2d-6daaebbf3338)