### PR TITLE
fix(mobile): stop showing accepted messages as queued

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -276,7 +276,6 @@ function AgentControls({
 
 function MobileNativeChatMessageImpl({
   message,
-  queued,
   toolsExpanded = false,
   fontScale = 1,
   messageIndex,
@@ -284,7 +283,6 @@ function MobileNativeChatMessageImpl({
   onOpenFile
 }: {
   message: NativeChatMessage
-  queued?: boolean
   toolsExpanded?: boolean
   /** Multiplies all chat text sizes for pinch-to-zoom (1 = no change). */
   fontScale?: number
@@ -328,27 +326,24 @@ function MobileNativeChatMessageImpl({
 
   // Copy + scroll-to-top, shown inline with the first tool call (or after the
   // prose when there are no tools).
-  const controls =
-    isAgent && !queued ? (
-      <AgentControls
-        onCopy={handleCopy}
-        onScrollToTop={
-          onScrollToMessage && messageIndex !== undefined
-            ? () => onScrollToMessage(messageIndex)
-            : undefined
-        }
-      />
-    ) : null
+  const controls = isAgent ? (
+    <AgentControls
+      onCopy={handleCopy}
+      onScrollToTop={
+        onScrollToMessage && messageIndex !== undefined
+          ? () => onScrollToMessage(messageIndex)
+          : undefined
+      }
+    />
+  ) : null
 
   return (
     <View style={[styles.row, isUser && styles.rowUser]}>
-      {isUser && queued ? <Text style={styles.queuedTag}>Queued</Text> : null}
       <View
         style={[
           styles.content,
           isUser && styles.userBubble,
           isReasoning && styles.reasoning,
-          queued && styles.queued,
           copied && styles.copied
         ]}
       >

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -71,6 +71,7 @@ type Overrides = {
   onClearSendError?: () => void
   inputLockReason?: 'disconnected' | 'waiting' | null
   onSend?: (text: string) => Promise<boolean>
+  pending?: Parameters<typeof MobileNativeChatView>[0]['pending']
 }
 
 function assistantTurn(id: string, text: string): NativeChatMessage {
@@ -115,6 +116,13 @@ describe('MobileNativeChatView', () => {
   function listIds(): string[] {
     const list = renderer!.root.find((node) => node.type === 'FlatList')
     return (list.props.data as { id: string }[]).map((row) => row.id)
+  }
+
+  function renderedRow(id: string): ReturnType<typeof createElement> {
+    const list = renderer!.root.find((node) => node.type === 'FlatList')
+    const data = list.props.data as NativeChatMessage[]
+    const index = data.findIndex((row) => row.id === id)
+    return list.props.renderItem({ item: data[index], index })
   }
 
   function banners(): ReactTestInstance[] {
@@ -185,6 +193,15 @@ describe('MobileNativeChatView', () => {
     await update({ folded, streaming: 'The tests' })
 
     expect(listIds()).toEqual(['a1', 'streaming'])
+  })
+
+  it('renders an accepted optimistic image send without a queued state', async () => {
+    await render({
+      pending: [{ id: 'pending-1', text: 'look', images: ['file:///phone-photo.jpg'] }]
+    })
+
+    expect(listIds()).toEqual(['pending-1'])
+    expect(renderedRow('pending-1').props).not.toHaveProperty('queued')
   })
 
   it('keeps a visible lock through a subscribed-end lease blip', async () => {

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -58,8 +58,7 @@ type Props = {
   loadingEarlier?: boolean
   onLoadEarlier?: () => void
   onSend: (text: string) => Promise<boolean>
-  /** Optimistic queued sends (owned by the route so they survive view switches). */
-  /** Optimistic user echoes, including any ridden-along image preview URIs. */
+  /** Accepted user echoes awaiting transcript replacement, including image previews. */
   pending: MobileNativeChatPendingItem[]
   /** Local photo URIs retained when the authoritative transcript replaces an
    *  optimistic image bubble. */
@@ -176,9 +175,8 @@ export function MobileNativeChatView({
     []
   )
 
-  const pendingIds = useMemo(() => new Set(pending.map((p) => p.id)), [pending])
   // `data` is the list source: folded transcript + synthetic streaming bubble +
-  // route-owned optimistic queued messages. Memoize on the same deps so the
+  // route-owned accepted echoes. Memoize on the same deps so the
   // downstream autoscroll effects/`renderItem` keep referential stability.
   const { data } = useMemo(
     () =>
@@ -248,7 +246,6 @@ export function MobileNativeChatView({
     ({ item, index }: { item: NativeChatMessage; index: number }) => (
       <MobileNativeChatMessage
         message={item}
-        queued={pendingIds.has(item.id)}
         toolsExpanded={toolsExpanded}
         fontScale={fontScale}
         messageIndex={index}
@@ -256,7 +253,7 @@ export function MobileNativeChatView({
         onOpenFile={onOpenFile}
       />
     ),
-    [pendingIds, toolsExpanded, fontScale, onScrollToMessage, onOpenFile]
+    [toolsExpanded, fontScale, onScrollToMessage, onOpenFile]
   )
 
   const emptyState = mobileNativeChatEmptyState(status, agent ?? null, error)

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -49,15 +49,6 @@ export const styles = StyleSheet.create({
   reasoning: {
     opacity: 0.7
   },
-  queued: {
-    opacity: 0.55
-  },
-  queuedTag: {
-    color: colors.textMuted,
-    fontSize: 11,
-    fontWeight: '600',
-    marginBottom: 2
-  },
   toolRun: {
     marginTop: spacing.xs
   },

--- a/mobile/src/session/mobile-native-chat-render-data.ts
+++ b/mobile/src/session/mobile-native-chat-render-data.ts
@@ -51,7 +51,7 @@ export function foldMobileNativeChatMessages(messages: NativeChatMessage[]): Nat
 
 /** Assemble the list data the chat renders: the folded transcript, then a
  *  synthetic bubble for the streaming text the gate let through, then the
- *  route-owned optimistic "queued" messages at the tail. */
+ *  route-owned accepted optimistic messages at the tail. */
 export function buildMobileNativeChatTransientData({
   folded,
   streaming,

--- a/mobile/src/session/mobile-native-chat-send-classification.ts
+++ b/mobile/src/session/mobile-native-chat-send-classification.ts
@@ -2,7 +2,7 @@
 // (src/renderer/src/components/native-chat/NativeChatComposer.tsx): slash/skill
 // sends are TUI control actions, not chat turns — they never echo as a user
 // bubble, because the transcript will never contain a matching user turn and
-// the optimistic echo would sit at "Queued" forever.
+// the optimistic echo would never reconcile.
 
 import {
   getNativeChatAgentProfile,

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -181,7 +181,7 @@ export function useMobileNativeChatMessageSend(args: {
       })
       // Why (desktop parity): a slash/skill send dispatches into the agent's own
       // TUI, not the conversation — the transcript never echoes it as a user
-      // turn, so an optimistic bubble would sit at "Queued" forever and the
+      // turn, so an optimistic bubble would never reconcile and the
       // unconfirmed hold could never observe a landing.
       const classification = classifyMobileNativeChatSend(agent, text)
       if (outcome === 'unknown') {


### PR DESCRIPTION
## Summary

Mobile no longer labels an accepted optimistic chat message as `Queued` while waiting for the authoritative transcript to replace it. The accepted bubble remains visible, including local image previews, without implying that delivery is still pending.

Adds regression coverage for an accepted image-and-text message awaiting transcript reconciliation.

## Screenshots

Not included. The visual change removes the stale `Queued` label and dimming; it was validated live in the iPhone 17 Pro emulator by sending a message, confirming the terminal received it, and confirming the mobile accessibility tree rendered the accepted user bubble without a queued state.

## Testing

- [x] `pnpm --dir mobile lint`
- [x] `pnpm --dir mobile typecheck`
- [x] `pnpm --dir mobile test` — 438 files passed, 3,428 tests passed, 3 skipped
- [ ] `pnpm build` — not run; this is a React Native presentation-state change covered by typecheck, lint, tests, and emulator QA
- [x] Added a regression test for an accepted optimistic image-and-text message

## AI Review Report

Reviewed the send lifecycle from RPC settlement through optimistic echo creation and transcript reconciliation. Confirmed that optimistic entries are created only after an accepted transport result, remain scoped to their originating session, retain image previews, and are eventually replaced by authoritative transcript entries. The main issue found was presentation code treating transcript reconciliation as delivery state; the fix removes that false queued state without changing send, retry, deduplication, or wire behavior.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change is confined to shared React Native rendering state and introduces no shortcuts, labels with platform-specific modifiers, filesystem paths, shell behavior, native modules, or Electron-specific behavior.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, IPC, RPC fields, or remote wire behavior are introduced. The change only removes a local presentation flag after the existing accepted-send acknowledgment and adds test coverage. No security follow-up is needed.

## Notes

The exact app version installed on a physical phone is not exposed in the mobile-host handshake. The issue was present in current mobile source version 0.0.43 before this fix.
