### PR TITLE
fix(orchestration): refuse a self-addressed ask instead of blocking

### DIFF
--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -94,6 +94,7 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'orchestration_migration_required',
   'operation_unknown',
   'question_not_found',
+  'ask_self_addressed',
   'answer_conflict',
   'stale_delivery',
   'waiter_exists',

--- a/src/main/runtime/rpc/methods/orchestration-ask-request.ts
+++ b/src/main/runtime/rpc/methods/orchestration-ask-request.ts
@@ -6,6 +6,29 @@ export type AskRequestTarget =
   | { kind: 'resume'; question: QuestionRow }
   | { kind: 'create'; run: RunRow }
 
+// Why: an explicit --run or --to that disagrees with the Dispatch's own Run must fail rather than
+// be ignored, or the caller waits on a Question filed under a Run it did not name.
+function assertExplicitTargetMatchesRun(args: {
+  dispatchId: string
+  runId: string
+  coordinatorHandle?: string | null
+  declaredRun?: string
+  to?: string
+}): void {
+  if (args.declaredRun && args.declaredRun !== args.runId) {
+    throw new OrchestrationError(
+      'dispatch_run_mismatch',
+      `Dispatch ${args.dispatchId} belongs to Run ${args.runId}, not ${args.declaredRun}.`
+    )
+  }
+  if (args.to && args.to !== `run:${args.runId}` && args.to !== args.coordinatorHandle) {
+    throw new OrchestrationError(
+      'dispatch_run_mismatch',
+      `ask from Dispatch ${args.dispatchId} must target its owning Run ${args.runId}.`
+    )
+  }
+}
+
 /**
  * Resolves what an ask refers to, reading only. Kept separate from the answerability guard so
  * the caller can validate the request first: a bad resume id or a mismatched Run has its own
@@ -27,6 +50,16 @@ export function resolveAskRequestTarget(args: {
         `Question ${args.resume} does not belong to this active Dispatch.`
       )
     }
+    // Why: resume recovers an already-committed Question, including one filed under a legacy Run,
+    // so the Run is read for its coordinator handle only — an unresolvable Run must not turn
+    // resume itself into an error the way it does for a fresh ask.
+    assertExplicitTargetMatchesRun({
+      dispatchId: dispatch.id,
+      runId: dispatch.run_id,
+      coordinatorHandle: db.getRun(dispatch.run_id)?.coordinator_handle,
+      declaredRun: args.run,
+      to: args.to
+    })
     return { kind: 'resume', question }
   }
 
@@ -34,17 +67,12 @@ export function resolveAskRequestTarget(args: {
   if (!run || run.legacy === 1) {
     throw new OrchestrationError('run_not_found', `Run ${dispatch.run_id} was not found.`)
   }
-  if (args.run && args.run !== run.id) {
-    throw new OrchestrationError(
-      'dispatch_run_mismatch',
-      `Dispatch ${dispatch.id} belongs to Run ${run.id}, not ${args.run}.`
-    )
-  }
-  if (args.to && args.to !== `run:${run.id}` && args.to !== run.coordinator_handle) {
-    throw new OrchestrationError(
-      'dispatch_run_mismatch',
-      `ask from Dispatch ${dispatch.id} must target its owning Run ${run.id}.`
-    )
-  }
+  assertExplicitTargetMatchesRun({
+    dispatchId: dispatch.id,
+    runId: run.id,
+    coordinatorHandle: run.coordinator_handle,
+    declaredRun: args.run,
+    to: args.to
+  })
   return { kind: 'create', run }
 }

--- a/src/main/runtime/rpc/methods/orchestration-ask-request.ts
+++ b/src/main/runtime/rpc/methods/orchestration-ask-request.ts
@@ -1,0 +1,50 @@
+import type { OrchestrationDb } from '../../orchestration/db'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+import type { QuestionRow, RunRow } from '../../orchestration/types'
+
+export type AskRequestTarget =
+  | { kind: 'resume'; question: QuestionRow }
+  | { kind: 'create'; run: RunRow }
+
+/**
+ * Resolves what an ask refers to, reading only. Kept separate from the answerability guard so
+ * the caller can validate the request first: a bad resume id or a mismatched Run has its own
+ * error code, and a guard that ran earlier would shadow it.
+ */
+export function resolveAskRequestTarget(args: {
+  db: OrchestrationDb
+  dispatch: { id: string; run_id: string }
+  resume?: string
+  run?: string
+  to?: string
+}): AskRequestTarget {
+  const { db, dispatch } = args
+  if (args.resume) {
+    const question = db.getQuestion(args.resume)
+    if (!question || question.dispatch_id !== dispatch.id) {
+      throw new OrchestrationError(
+        'question_not_found',
+        `Question ${args.resume} does not belong to this active Dispatch.`
+      )
+    }
+    return { kind: 'resume', question }
+  }
+
+  const run = db.getRun(dispatch.run_id)
+  if (!run || run.legacy === 1) {
+    throw new OrchestrationError('run_not_found', `Run ${dispatch.run_id} was not found.`)
+  }
+  if (args.run && args.run !== run.id) {
+    throw new OrchestrationError(
+      'dispatch_run_mismatch',
+      `Dispatch ${dispatch.id} belongs to Run ${run.id}, not ${args.run}.`
+    )
+  }
+  if (args.to && args.to !== `run:${run.id}` && args.to !== run.coordinator_handle) {
+    throw new OrchestrationError(
+      'dispatch_run_mismatch',
+      `ask from Dispatch ${dispatch.id} must target its owning Run ${run.id}.`
+    )
+  }
+  return { kind: 'create', run }
+}

--- a/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts
@@ -180,6 +180,55 @@ describe('orchestration.ask self-addressed refusal', () => {
     expect(questionMessages(runId)).toHaveLength(0)
   })
 
+  // Why: resume takes the same explicit targets as a fresh ask, so ignoring them would let a
+  // caller wait on a Question filed under a Run it did not name.
+  it('reports a mismatched explicit target on a resumed Question as dispatch_run_mismatch', async () => {
+    setup()
+    const runId = createRun('term_general')
+    const dispatchId = dispatchTo(runId, 'term_worker')
+    const owned = db.createQuestion({
+      runId,
+      dispatchId,
+      askerHandle: 'term_worker',
+      question: 'proceed?'
+    })
+    const foreignRunId = createRun('term_captain')
+
+    await expect(
+      ask({ from: 'term_worker', resume: owned.question.message_id, run: foreignRunId })
+    ).rejects.toMatchObject({ code: 'dispatch_run_mismatch' })
+    await expect(
+      ask({ from: 'term_worker', resume: owned.question.message_id, to: `run:${foreignRunId}` })
+    ).rejects.toMatchObject({ code: 'dispatch_run_mismatch' })
+    await expect(
+      ask({ from: 'term_worker', resume: owned.question.message_id, to: 'term_captain' })
+    ).rejects.toMatchObject({ code: 'dispatch_run_mismatch' })
+  })
+
+  it('accepts an explicit target that agrees with the resumed Question owning Run', async () => {
+    setup()
+    const runId = createRun('term_general')
+    const dispatchId = dispatchTo(runId, 'term_worker')
+    const owned = db.createQuestion({
+      runId,
+      dispatchId,
+      askerHandle: 'term_worker',
+      question: 'proceed?'
+    })
+
+    await expect(
+      ask({ from: 'term_worker', resume: owned.question.message_id, run: runId })
+    ).resolves.toMatchObject({ timedOut: true })
+    await expect(
+      ask({ from: 'term_worker', resume: owned.question.message_id, to: `run:${runId}` })
+    ).resolves.toMatchObject({ timedOut: true })
+    await expect(
+      ask({ from: 'term_worker', resume: owned.question.message_id, to: 'term_general' })
+    ).resolves.toMatchObject({ timedOut: true })
+    // Resume must not create a second Question for the same thread.
+    expect(questionMessages(runId)).toHaveLength(1)
+  })
+
   it('leaves the undispatched coordinator error unchanged', async () => {
     setup()
     createRun('term_captain')

--- a/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts
@@ -145,6 +145,41 @@ describe('orchestration.ask self-addressed refusal', () => {
     expect(questionMessages(runId)).toMatchObject([{ to_handle: `run:${runId}` }])
   })
 
+  // Why: the guard must not shadow a more specific error — an invalid request has to report
+  // what is wrong with the request, not that the caller happens to coordinate its own Run.
+  it('reports a resume id from another Dispatch as question_not_found', async () => {
+    setup()
+    const runId = createRun('term_captain')
+    dispatchTo(runId, 'term_captain')
+    const otherRunId = createRun('term_general')
+    const otherDispatchId = dispatchTo(otherRunId, 'term_worker')
+    const foreign = db.createQuestion({
+      runId: otherRunId,
+      dispatchId: otherDispatchId,
+      askerHandle: 'term_worker',
+      question: 'not yours'
+    })
+
+    await expect(
+      ask({ from: 'term_captain', resume: foreign.question.message_id })
+    ).rejects.toMatchObject({ code: 'question_not_found' })
+  })
+
+  it('reports an explicit Run target that is not the caller Dispatch Run as dispatch_run_mismatch', async () => {
+    setup()
+    const runId = createRun('term_captain')
+    dispatchTo(runId, 'term_captain')
+    const otherRunId = createRun('term_general')
+
+    await expect(
+      ask({ from: 'term_captain', question: 'proceed?', run: otherRunId })
+    ).rejects.toMatchObject({ code: 'dispatch_run_mismatch' })
+    await expect(
+      ask({ from: 'term_captain', question: 'proceed?', to: `run:${otherRunId}` })
+    ).rejects.toMatchObject({ code: 'dispatch_run_mismatch' })
+    expect(questionMessages(runId)).toHaveLength(0)
+  })
+
   it('leaves the undispatched coordinator error unchanged', async () => {
     setup()
     createRun('term_captain')

--- a/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_METHODS } from './orchestration'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcContext } from '../core'
+import { OrchestrationDb } from '../../orchestration/db'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
+
+const CAPTAIN_PANE = 'tab_captain:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const GENERAL_PANE = 'tab_general:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const WORKER_PANE = 'tab_worker:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+describe('orchestration.ask self-addressed refusal', () => {
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let ctx: RpcContext
+
+  const paneByHandle: Record<string, string> = {
+    term_captain: CAPTAIN_PANE,
+    term_general: GENERAL_PANE,
+    term_worker: WORKER_PANE
+  }
+
+  function setup(): void {
+    db = new OrchestrationDb(':memory:')
+    runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation(
+      (handle) => paneByHandle[handle] ?? null
+    )
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation(
+      (handle) => `runtime_test:${handle}:1`
+    )
+    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    ctx = { runtime }
+  }
+
+  afterEach(() => {
+    db.close()
+    vi.restoreAllMocks()
+  })
+
+  function createRun(coordinatorHandle: string): string {
+    return db.createRun({
+      objective: `Run for ${coordinatorHandle}`,
+      coordinatorHandle,
+      coordinatorPaneKey: paneByHandle[coordinatorHandle] as string
+    }).id
+  }
+
+  function dispatchTo(runId: string, assigneeHandle: string): string {
+    const task = db.createTask({ spec: 'question work', runId })
+    return db.createDispatchContext(task.id, assigneeHandle, paneByHandle[assigneeHandle]).id
+  }
+
+  async function ask(params: Record<string, unknown>) {
+    const method = ORCHESTRATION_METHODS.find((m) => m.name === 'orchestration.ask')
+    if (!method) {
+      throw new Error('orchestration.ask is not registered')
+    }
+    // Why: timeoutMs 0 makes the wait loop return immediately, so a legitimate ask
+    // resolves without a message-arrival fixture.
+    return method.handler(method.params?.parse({ timeoutMs: 0, ...params }), ctx)
+  }
+
+  function questionMessages(runId: string) {
+    return db
+      .getInbox(100)
+      .filter((message) => message.type === 'question' && message.run_id === runId)
+  }
+
+  it('refuses when the asker coordinates the Run its Dispatch belongs to', async () => {
+    setup()
+    const runId = createRun('term_captain')
+    const dispatchId = dispatchTo(runId, 'term_captain')
+
+    await expect(ask({ from: 'term_captain', question: 'proceed?' })).rejects.toMatchObject({
+      code: 'ask_self_addressed',
+      message: expect.stringContaining(`orchestration send --to run:${runId}`),
+      data: { effectsApplied: false }
+    })
+    expect(questionMessages(runId)).toHaveLength(0)
+    expect(db.getDispatchContextById(dispatchId)?.status).toBe('dispatched')
+  })
+
+  it('refuses to resume a Question whose Run the asker has since taken over', async () => {
+    setup()
+    const runId = createRun('term_general')
+    const dispatchId = dispatchTo(runId, 'term_captain')
+    const created = db.createQuestion({
+      runId,
+      dispatchId,
+      askerHandle: 'term_captain',
+      question: 'proceed?'
+    })
+    db.bindRun({
+      runId,
+      coordinatorHandle: 'term_captain',
+      coordinatorPaneKey: CAPTAIN_PANE
+    })
+
+    await expect(
+      ask({ from: 'term_captain', resume: created.question.message_id })
+    ).rejects.toMatchObject({ code: 'ask_self_addressed' })
+  })
+
+  it('reports the refusal as a typed RPC error code', async () => {
+    setup()
+    const runId = createRun('term_captain')
+    dispatchTo(runId, 'term_captain')
+
+    const response = await new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS }).dispatch({
+      id: 'req_1',
+      authToken: 'token',
+      method: 'orchestration.ask',
+      params: { from: 'term_captain', question: 'proceed?', timeoutMs: 0 },
+      orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION
+    })
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'ask_self_addressed' } })
+  })
+
+  it('allows a nested coordinator to ask the Run that dispatched it', async () => {
+    setup()
+    const parentRunId = createRun('term_general')
+    dispatchTo(parentRunId, 'term_captain')
+    // The nested coordinator owns its own Run; only the parent Run's inbox is asked.
+    const childRunId = createRun('term_captain')
+
+    await expect(ask({ from: 'term_captain', question: 'proceed?' })).resolves.toMatchObject({
+      timedOut: true
+    })
+    expect(questionMessages(parentRunId)).toMatchObject([{ to_handle: `run:${parentRunId}` }])
+    expect(questionMessages(childRunId)).toHaveLength(0)
+  })
+
+  it('allows a dispatched worker that coordinates no Run', async () => {
+    setup()
+    const runId = createRun('term_general')
+    dispatchTo(runId, 'term_worker')
+
+    await expect(ask({ from: 'term_worker', question: 'proceed?' })).resolves.toMatchObject({
+      timedOut: true
+    })
+    expect(questionMessages(runId)).toMatchObject([{ to_handle: `run:${runId}` }])
+  })
+
+  it('leaves the undispatched coordinator error unchanged', async () => {
+    setup()
+    createRun('term_captain')
+
+    await expect(ask({ from: 'term_captain', question: 'proceed?' })).rejects.toMatchObject({
+      code: 'dispatch_inactive'
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.ts
+++ b/src/main/runtime/rpc/methods/orchestration-ask-self-addressed.ts
@@ -1,0 +1,25 @@
+import type { OrchestrationDb } from '../../orchestration/db'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+
+// Why: a Question sits in its Run's home inbox, and orchestration.reply only accepts an answer
+// from the pane currently bound as that Run's coordinator. When the asker is that pane, the only
+// process allowed to answer is the one blocked on the answer, so the wait can never end.
+export function assertAskIsAnswerable(args: {
+  db: OrchestrationDb
+  runId: string
+  dispatchId: string
+  callerPaneKey?: string
+}): void {
+  if (!args.callerPaneKey) {
+    return
+  }
+  const boundRun = args.db.getCurrentRunForPane(args.callerPaneKey)
+  if (boundRun?.id !== args.runId) {
+    return
+  }
+  throw new OrchestrationError(
+    'ask_self_addressed',
+    `ask from Dispatch ${args.dispatchId} would deliver the Question to the home inbox of Run ${args.runId}, and this terminal is that Run's bound coordinator, so no other reader could answer it. Use "orchestration send --to run:${args.runId}" for a non-blocking message, or ask again once another terminal holds the Run.`,
+    { effectsApplied: false }
+  )
+}

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../shared/orchestration-rpc-contract'
 import { clampOrchestrationAskTimeoutMs } from '../../../../shared/orchestration-ask-timeout'
 import { assertAskIsAnswerable } from './orchestration-ask-self-addressed'
+import { resolveAskRequestTarget } from './orchestration-ask-request'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 import { resolveRunScope } from './orchestration-run-scope'
 import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
@@ -1413,6 +1414,20 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           throw new OrchestrationError('dispatch_capability_invalid', authority.reason)
         }
       }
+      const options =
+        params.options
+          ?.split(',')
+          .map((s) => s.trim())
+          .filter(Boolean) ?? []
+      // Why: resolve the request first — a bad resume id or a foreign Run target has its own
+      // error code, and the answerability guard below would otherwise shadow it.
+      const target = resolveAskRequestTarget({
+        db,
+        dispatch: activeDispatch,
+        resume: params.resume,
+        run: params.run,
+        to: params.to
+      })
       // Why: refuse before the Question exists, so a self-addressed ask applies no effects.
       assertAskIsAnswerable({
         db,
@@ -1420,39 +1435,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         dispatchId: activeDispatch.id,
         callerPaneKey: paneKey
       })
-      const options =
-        params.options
-          ?.split(',')
-          .map((s) => s.trim())
-          .filter(Boolean) ?? []
-      let question = params.resume ? db.getQuestion(params.resume) : undefined
-      if (params.resume) {
-        if (!question || question.dispatch_id !== activeDispatch.id) {
-          throw new OrchestrationError(
-            'question_not_found',
-            `Question ${params.resume} does not belong to this active Dispatch.`
-          )
-        }
-      } else {
-        const run = db.getRun(activeDispatch.run_id)
-        if (!run || run.legacy === 1) {
-          throw new OrchestrationError(
-            'run_not_found',
-            `Run ${activeDispatch.run_id} was not found.`
-          )
-        }
-        if (params.run && params.run !== run.id) {
-          throw new OrchestrationError(
-            'dispatch_run_mismatch',
-            `Dispatch ${activeDispatch.id} belongs to Run ${run.id}, not ${params.run}.`
-          )
-        }
-        if (params.to && params.to !== `run:${run.id}` && params.to !== run.coordinator_handle) {
-          throw new OrchestrationError(
-            'dispatch_run_mismatch',
-            `ask from Dispatch ${activeDispatch.id} must target its owning Run ${run.id}.`
-          )
-        }
+      const openQuestion = (run: RunRow) => {
         const created = db.createQuestion({
           runId: run.id,
           dispatchId: activeDispatch.id,
@@ -1460,9 +1443,10 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           question: params.question as string,
           options
         })
-        question = created.question
         runtime.notifyMessageArrived(`run:${run.id}`, created.message.type)
+        return created.question
       }
+      const question = target.kind === 'resume' ? target.question : openQuestion(target.run)
 
       const questionId = question.message_id
       recordMutationReceipt?.({

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -19,6 +19,7 @@ import {
   orchestrationSkillRecoveryData
 } from '../../../../shared/orchestration-rpc-contract'
 import { clampOrchestrationAskTimeoutMs } from '../../../../shared/orchestration-ask-timeout'
+import { assertAskIsAnswerable } from './orchestration-ask-self-addressed'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 import { resolveRunScope } from './orchestration-run-scope'
 import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
@@ -1412,6 +1413,13 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           throw new OrchestrationError('dispatch_capability_invalid', authority.reason)
         }
       }
+      // Why: refuse before the Question exists, so a self-addressed ask applies no effects.
+      assertAskIsAnswerable({
+        db,
+        runId: activeDispatch.run_id,
+        dispatchId: activeDispatch.id,
+        callerPaneKey: paneKey
+      })
       const options =
         params.options
           ?.split(',')


### PR DESCRIPTION
`orca orchestration ask` now refuses, with a typed error, when the question it would post could only be answered by the terminal that is about to block on it.

## What we saw

A dispatched terminal that had taken over the Run its Dispatch belongs to ran `orchestration ask` and never came back. It sat for more than twenty minutes on 2026-08-09; the only way out was `orca terminal send --interrupt` from a second terminal, which is not a protocol a worker can rely on.

The mechanism is in the code, not in the agent. `orchestration.ask` writes the Question to `run:<id>`, the home inbox of the Run its active Dispatch belongs to (`createQuestion` in `src/main/runtime/orchestration/db.ts`). The only way to answer is `orchestration.reply`, which resolves the Run with `requireCurrentConsumer: true` — so the answer must come from the pane currently bound as that Run's coordinator. When the asker holds that binding, the one process allowed to answer is the one waiting for the answer. The wait cannot end. A worker that is dispatched inside a Run and later runs `run-use` on that same Run lands in exactly this state.

Every other `ask` has a reader on the far side and is untouched: a dispatched worker that coordinates no Run, and a nested coordinator that owns its own Run while asking the parent Run that dispatched it, both still post their question and wait for it. The check compares the caller's Run binding against the Dispatch's Run, so owning a different Run changes nothing.

## The change

`orchestration.ask` calls `assertAskIsAnswerable` before it creates the Question, so a refusal applies no effects. The error is `ask_self_addressed`, added to the structured passthrough allowlist next to `run_not_found`, `dispatch_run_mismatch` and `consumer_fenced`, and its message names the Run and the way forward: `orchestration send --to run:<id>` for a non-blocking message, or ask again once another terminal holds the Run.

## Why a refusal and not the feature

Issue #13362 asks for parent Runs, which would give an unaddressed `ask` from a Run's own coordinator somewhere to climb to. That is a Run-model change. This PR does not implement it, does not change routing, and does not touch the mailbox model. It only removes the hang, which is the part that costs an agent its whole session. #13362 stays open for the larger ask.

## Test plan

New suite `src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts` (6 tests): the refusal with no Question written and the Dispatch left alone; a `--resume` after the asker took the Run over; the code surviving the RPC error envelope; the nested coordinator asking its parent Run; a plain dispatched worker; and the unchanged `dispatch_inactive` for an undispatched coordinator.

- `npx vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-ask-self-addressed.test.ts` — 6 passed
- `npx vitest run --config config/vitest.config.ts src/main/runtime/orchestration src/main/runtime/rpc` — 164 files, 1594 passed, 3 skipped
- `pnpm lint` — passed
- `pnpm typecheck` — passed

A full `pnpm test` run on a heavily loaded machine had 5 unrelated failures (a native-chat timer assertion and a fuzz test that hit the 30s limit); the orchestration and RPC suites above are green.
