### PR TITLE
feat(orchestration): let a dual-role terminal read its Dispatch mailbox

### DIFF
--- a/src/cli/handlers/orchestration-check-mailbox-selector.test.ts
+++ b/src/cli/handlers/orchestration-check-mailbox-selector.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.hoisted(() => vi.fn())
 const getTerminalHandleMock = vi.hoisted(() => vi.fn())
+const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
 
 vi.mock('../format', () => ({ printResult: vi.fn() }))
 vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
@@ -15,6 +16,16 @@ describe('orchestration check mailbox selector', () => {
     getTerminalHandleMock.mockReset()
     vi.mocked(printResult).mockClear()
     process.env.ORCA_TERMINAL_HANDLE = 'term_captain'
+  })
+
+  // Why: ORCA_TERMINAL_HANDLE is process-global and vitest reuses a worker across files, so
+  // leaving term_captain behind would make an unrelated file's result depend on run order.
+  afterEach(() => {
+    if (originalTerminalHandle === undefined) {
+      delete process.env.ORCA_TERMINAL_HANDLE
+    } else {
+      process.env.ORCA_TERMINAL_HANDLE = originalTerminalHandle
+    }
   })
 
   const invokeCheck = (flags: Map<string, string | boolean>) =>

--- a/src/cli/handlers/orchestration-check-mailbox-selector.test.ts
+++ b/src/cli/handlers/orchestration-check-mailbox-selector.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.hoisted(() => vi.fn())
+const getTerminalHandleMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
+
+import { printResult } from '../format'
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+
+describe('orchestration check mailbox selector', () => {
+  beforeEach(() => {
+    callMock.mockReset().mockResolvedValue({ result: { messages: [], count: 0 } })
+    getTerminalHandleMock.mockReset()
+    vi.mocked(printResult).mockClear()
+    process.env.ORCA_TERMINAL_HANDLE = 'term_captain'
+  })
+
+  const invokeCheck = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration check']({
+      flags,
+      client: { call: callMock },
+      cwd: '/tmp/repo',
+      json: true
+    } as never)
+
+  it('passes the requested mailbox to the runtime', async () => {
+    await invokeCheck(new Map([['as', 'dispatch']]))
+
+    expect(callMock).toHaveBeenCalledWith(
+      'orchestration.check',
+      expect.objectContaining({ terminal: 'term_captain', as: 'dispatch' })
+    )
+  })
+
+  it('leaves the request unchanged when no mailbox is named', async () => {
+    await invokeCheck(new Map())
+
+    expect(callMock).toHaveBeenCalledWith(
+      'orchestration.check',
+      expect.objectContaining({ as: undefined })
+    )
+  })
+
+  it('rejects an unknown mailbox before calling the runtime', async () => {
+    await expect(invokeCheck(new Map([['as', 'worker']]))).rejects.toMatchObject({
+      code: 'invalid_argument',
+      message: 'Invalid --as. Expected dispatch or coordinator.'
+    })
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('tells the reader which Dispatch the Run mailbox shadowed', async () => {
+    callMock.mockResolvedValue({
+      result: { messages: [], count: 0, shadowedDispatchId: 'ctx_cd4015c1ea15' }
+    })
+
+    await invokeCheck(new Map())
+
+    const format = vi.mocked(printResult).mock.calls.at(-1)?.[2] as (value: unknown) => string
+    expect(format({ messages: [], count: 0, shadowedDispatchId: 'ctx_cd4015c1ea15' })).toBe(
+      'No messages.\nDispatch ctx_cd4015c1ea15 also holds mail for this terminal; read it with --as dispatch.'
+    )
+  })
+})

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -623,6 +623,13 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     const timeoutMs = getOptionalPositiveIntegerValueFlag(flags, 'timeout-ms')
     const explicitTerminal = getOptionalStringFlag(flags, 'terminal')
     const terminal = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'terminal')
+    const mailbox = getOptionalStringFlag(flags, 'as')
+    if (mailbox !== undefined && mailbox !== 'dispatch' && mailbox !== 'coordinator') {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'Invalid --as. Expected dispatch or coordinator.'
+      )
+    }
 
     // Why: Claude Code auto-backgrounds subprocesses silent ~2 min; emit JSON keepalives to stderr (stdout stays one payload). See §3.4.
     const stopKeepalive = wait ? startCheckKeepalive(timeoutMs) : null
@@ -630,6 +637,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       messages: MessageSummary[]
       count: number
       formatted?: string
+      shadowedDispatchId?: string
       deliveryId?: string | null
       runId?: string
       timedOut?: boolean
@@ -651,6 +659,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
         inject: flags.has('inject') ? true : undefined,
         compatibilityCliCommand: resolveCompatibilityCliCommand(),
         run: getOptionalStringFlag(flags, 'run'),
+        as: mailbox,
         ack: getOptionalStringFlag(flags, 'ack'),
         wait: wait ? true : undefined,
         timeoutMs

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -499,6 +499,9 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'worktree create' && flag === 'parent-worktree') {
     return '--parent-worktree <selector> Parent selector such as active/current, id:<repo-id>::<path>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or worktree:<worktreeId>'
   }
+  if (command === 'orchestration check' && flag === 'as') {
+    return '--as <mailbox>        Mailbox to read: dispatch or coordinator (default: coordinator when a Run is bound)'
+  }
   if (command === 'orchestration task-create' && flag === 'task-title') {
     return '--task-title <text>  Concise title for the orchestration task'
   }

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -80,8 +80,9 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     path: ['orchestration', 'check'],
     summary: 'Check messages for a terminal',
     usage:
-      'orca orchestration check [--terminal <handle>] [--run <run_id>] [--ack <delivery_id>] [--unread | --peek | --all] [--types <type,...>] [--format] [--wait] [--timeout-ms <n>] [--json]\n' +
+      'orca orchestration check [--terminal <handle>] [--run <run_id>] [--as <dispatch|coordinator>] [--ack <delivery_id>] [--unread | --peek | --all] [--types <type,...>] [--format] [--wait] [--timeout-ms <n>] [--json]\n' +
       "  default: return the bound Run's oldest unacknowledged FIFO batch.\n" +
+      "  --as dispatch: read this terminal's Dispatch mailbox even while it is bound as a coordinator.\n" +
       '  --ack: acknowledge the prior whole batch before checking/waiting.\n' +
       '  --peek: return only unread messages without marking them read.\n' +
       '  --all: return every message for the handle; does not mark read.\n' +
@@ -94,6 +95,7 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
       ...GLOBAL_FLAGS,
       'terminal',
       'run',
+      'as',
       'ack',
       'unread',
       'peek',
@@ -107,7 +109,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     notes: [
       'On Windows PowerShell, quote comma-separated type filters, e.g. --types "worker_done,escalation".',
       '--format renders the returned rows as local text only; it never writes to another terminal.',
-      'A bound Run replays the same Delivery until --ack; process every message before acknowledging.'
+      'A bound Run replays the same Delivery until --ack; process every message before acknowledging.',
+      'A terminal that is both dispatched and bound as a coordinator reads the Run mailbox by default; the response reports the Dispatch it shadowed, and --as dispatch reads that shelf instead.'
     ]
   },
   {

--- a/src/main/runtime/rpc/methods/orchestration-check-dual-role.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-check-dual-role.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_METHODS } from './orchestration'
+import { OrchestrationDb } from '../../orchestration/db'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcContext } from '../core'
+
+const GENERAL_PANE = 'tab_general:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const CAPTAIN_PANE = 'tab_captain:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+describe('check on a terminal that is both dispatched and coordinator-bound', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+    db = undefined
+  })
+
+  function setup(): { db: OrchestrationDb; ctx: RpcContext } {
+    const runtime = new OrcaRuntimeService()
+    db = new OrchestrationDb(':memory:')
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_general' ? GENERAL_PANE : handle === 'term_captain' ? CAPTAIN_PANE : null
+    )
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation(
+      (handle) => `runtime_test:${handle}:1`
+    )
+    return { db, ctx: { runtime } }
+  }
+
+  async function call(ctx: RpcContext, params: Record<string, unknown>) {
+    const method = ORCHESTRATION_METHODS.find((m) => m.name === 'orchestration.check')
+    if (!method) {
+      throw new Error('orchestration.check is not registered')
+    }
+    return method.handler(method.params ? method.params.parse(params) : undefined, ctx)
+  }
+
+  // A captain dispatched inside the general's Run, then bound as coordinator of its own Run.
+  function buildDualRoleCaptain(store: OrchestrationDb): {
+    dispatchId: string
+    captainRun: string
+  } {
+    const generalRun = store.createRun({
+      objective: 'wave',
+      coordinatorHandle: 'term_general',
+      coordinatorPaneKey: GENERAL_PANE
+    })
+    const task = store.createTask({ spec: 'lead the alpha lane', runId: generalRun.id })
+    const dispatch = store.createDispatchContext(task.id, 'term_captain', CAPTAIN_PANE)
+    const captainRun = store.createRun({
+      objective: 'alpha lane',
+      coordinatorHandle: 'term_captain',
+      coordinatorPaneKey: CAPTAIN_PANE
+    })
+    return { dispatchId: dispatch.id, captainRun: captainRun.id }
+  }
+
+  it('reports the Dispatch its Run binding shadowed', async () => {
+    const { db: store, ctx } = setup()
+    const { dispatchId } = buildDualRoleCaptain(store)
+
+    const checked = (await call(ctx, { terminal: 'term_captain' })) as {
+      runId: string
+      dispatchId?: string
+      shadowedDispatchId?: string
+    }
+
+    expect(checked.shadowedDispatchId).toBe(dispatchId)
+    expect(checked.dispatchId).toBeUndefined()
+  })
+
+  it('reads the Dispatch shelf with --as dispatch while the Run stays bound', async () => {
+    const { db: store, ctx } = setup()
+    const { dispatchId, captainRun } = buildDualRoleCaptain(store)
+    store.insertMessage({
+      from: 'term_general',
+      to: `dispatch:${dispatchId}`,
+      subject: 'lane guidance',
+      runId: captainRun
+    })
+
+    const checked = (await call(ctx, { terminal: 'term_captain', as: 'dispatch' })) as {
+      dispatchId: string
+      messages: { subject: string }[]
+      shadowedDispatchId?: string
+    }
+
+    expect(checked.dispatchId).toBe(dispatchId)
+    expect(checked.messages.map((message) => message.subject)).toEqual(['lane guidance'])
+    expect(checked.shadowedDispatchId).toBeUndefined()
+    // The coordinator binding is untouched by reading the other mailbox.
+    expect(store.getCurrentRunForPane(CAPTAIN_PANE)?.id).toBe(captainRun)
+  })
+
+  it('keeps the Run mailbox as the default for a dual-role terminal', async () => {
+    const { db: store, ctx } = setup()
+    const { captainRun } = buildDualRoleCaptain(store)
+    store.insertMessage({
+      from: 'term_worker',
+      to: `run:${captainRun}`,
+      subject: 'lane status',
+      runId: captainRun
+    })
+
+    const checked = (await call(ctx, { terminal: 'term_captain' })) as {
+      runId: string
+      messages: { subject: string }[]
+    }
+
+    expect(checked.runId).toBe(captainRun)
+    expect(checked.messages.map((message) => message.subject)).toEqual(['lane status'])
+  })
+
+  it('leaves a coordinator that holds no Dispatch unchanged', async () => {
+    const { db: store, ctx } = setup()
+    store.createRun({
+      objective: 'wave',
+      coordinatorHandle: 'term_general',
+      coordinatorPaneKey: GENERAL_PANE
+    })
+
+    const checked = (await call(ctx, { terminal: 'term_general' })) as {
+      shadowedDispatchId?: string
+    }
+
+    expect(checked.shadowedDispatchId).toBeUndefined()
+  })
+
+  it('refuses --as dispatch when the terminal holds no active Dispatch', async () => {
+    const { db: store, ctx } = setup()
+    store.createRun({
+      objective: 'wave',
+      coordinatorHandle: 'term_general',
+      coordinatorPaneKey: GENERAL_PANE
+    })
+
+    await expect(call(ctx, { terminal: 'term_general', as: 'dispatch' })).rejects.toMatchObject({
+      code: 'dispatch_not_found'
+    })
+  })
+
+  it('refuses --as dispatch combined with an explicit --run', async () => {
+    const { db: store, ctx } = setup()
+    const { captainRun } = buildDualRoleCaptain(store)
+
+    await expect(
+      call(ctx, { terminal: 'term_captain', as: 'dispatch', run: captainRun })
+    ).rejects.toThrow(/--run selects a Run mailbox/)
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -121,6 +121,8 @@ const CheckParams = z
     compatibilityQuestionAck: OptionalString,
     compatibilityCliCommand: z.enum(['orca', 'orca-ide', 'orca-dev']).optional(),
     run: OptionalString,
+    // Why: a terminal can be both a dispatched worker and a bound coordinator; this picks which mailbox to read.
+    as: z.enum(['dispatch', 'coordinator']).optional(),
     wait: OptionalBoolean,
     timeoutMs: OptionalFiniteNumber
   })
@@ -135,6 +137,12 @@ const CheckParams = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Choose at most one message read mode: --unread, --peek, or --all.'
+      })
+    }
+    if (params.as === 'dispatch' && params.run) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '--run selects a Run mailbox and cannot be combined with --as dispatch.'
       })
     }
   })
@@ -695,7 +703,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       // Why: a live runtime handle is authoritative; pane metadata is only the restart fallback.
       const paneKey = runtime.getTerminalPaneKey(handle) ?? params.terminalPaneKey
       const boundRun = paneKey ? db.getCurrentRunForPane(paneKey) : undefined
-      if (params.run || boundRun) {
+      // Why: a dispatched sub-coordinator holds both roles; its Dispatch shelf used to be unreachable
+      // because the Run binding always won. Report it, and let --as pick the other mailbox.
+      const shadowedDispatch =
+        boundRun && params.as !== 'dispatch'
+          ? db.getActiveDispatchForIdentity(handle, paneKey ?? undefined)
+          : undefined
+      const shadowed = shadowedDispatch ? { shadowedDispatchId: shadowedDispatch.id } : {}
+      if (params.as !== 'dispatch' && (params.run || boundRun)) {
         const run = resolveRunScope(runtime, {
           runId: params.run,
           callerTerminalHandle: handle,
@@ -734,11 +749,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           if (params.format || params.inject) {
             return {
               ...result,
+              ...shadowed,
               formatted: messages.map(formatMessageBanner).join('\n\n'),
               runId: run.id
             }
           }
-          return { ...result, runId: run.id }
+          return { ...result, ...shadowed, runId: run.id }
         }
 
         const readDelivery = (wakeTypes?: MessageType[]) =>
@@ -750,6 +766,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         let current = readDelivery(params.wait ? typeFilter : undefined)
         if (current) {
           return {
+            ...shadowed,
             runId: run.id,
             deliveryId: current.delivery.id,
             messages: current.messages,
@@ -766,6 +783,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         }
         if (!params.wait) {
           return {
+            ...shadowed,
             runId: run.id,
             deliveryId: null,
             messages: [],
@@ -812,6 +830,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         }
         if (waitResult === 'timed_out') {
           return {
+            ...shadowed,
             runId: run.id,
             deliveryId: null,
             messages: [],
@@ -824,6 +843,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         }
         if (waitResult === 'cancelled') {
           return {
+            ...shadowed,
             runId: run.id,
             deliveryId: null,
             messages: [],
@@ -837,6 +857,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
 
         current = readDelivery(typeFilter)
         return {
+          ...shadowed,
           runId: run.id,
           deliveryId: current?.delivery.id ?? null,
           messages: current?.messages ?? [],
@@ -873,6 +894,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         : remoteAttachment
           ? { dispatchId: remoteAttachment.dispatch_id, runId: undefined }
           : undefined
+      // Why: --as dispatch names one mailbox, so falling back to the handle inbox would repeat the
+      // silent substitution this selector exists to end.
+      if (params.as === 'dispatch' && !workerMailbox) {
+        throw new OrchestrationError(
+          'dispatch_not_found',
+          `Terminal ${handle} holds no active Dispatch to read.`
+        )
+      }
       if (workerMailbox) {
         const address = `dispatch:${workerMailbox.dispatchId}`
         const showAll = params.all === true || (params.unread === false && params.peek !== true)

--- a/src/shared/orchestration-check-output.ts
+++ b/src/shared/orchestration-check-output.ts
@@ -35,6 +35,9 @@ export type OrchestrationCheckOutput = {
   messages: OrchestrationMessageSummary[]
   count: number
   formatted?: string
+  // Why: set when this terminal is a dispatched worker as well as a bound coordinator, so the
+  // Dispatch shelf it did not read stays visible instead of silently shadowed.
+  shadowedDispatchId?: string
   deliveryId?: string | null
   timedOut?: boolean
   cancelled?: boolean
@@ -80,20 +83,23 @@ export function formatOrchestrationCheckText(
         : '[LEGACY COMPATIBILITY]\n'
     : ''
   const deliveryNotice = formatCurrentDeliveryNotice(prepared.legacyCompatibility?.currentDelivery)
+  const shadowNotice = prepared.shadowedDispatchId
+    ? `\nDispatch ${prepared.shadowedDispatchId} also holds mail for this terminal; read it with --as dispatch.`
+    : ''
   if (prepared.formatted) {
-    return `${legacyHeader}${prepared.formatted}${deliveryNotice}`
+    return `${legacyHeader}${prepared.formatted}${deliveryNotice}${shadowNotice}`
   }
   if (prepared.count === 0) {
     if (prepared.timedOut) {
-      return `${legacyHeader}Wait timed out; no messages were consumed.${deliveryNotice}`
+      return `${legacyHeader}Wait timed out; no messages were consumed.${deliveryNotice}${shadowNotice}`
     }
     if (prepared.cancelled) {
       const cancelled = prepared.connectionLost
         ? 'Wait cancelled because the connection closed; no messages were consumed.'
         : 'Wait cancelled; no messages were consumed.'
-      return `${legacyHeader}${cancelled}${deliveryNotice}`
+      return `${legacyHeader}${cancelled}${deliveryNotice}${shadowNotice}`
     }
-    return `${legacyHeader}No messages.${deliveryNotice}`
+    return `${legacyHeader}No messages.${deliveryNotice}${shadowNotice}`
   }
   const rendered = prepared.messages
     .map(
@@ -105,7 +111,7 @@ export function formatOrchestrationCheckText(
     )
     .join('\n')
   const output = prepared.deliveryId ? `Delivery ${prepared.deliveryId}\n${rendered}` : rendered
-  return `${legacyHeader}${output}${deliveryNotice}`
+  return `${legacyHeader}${output}${deliveryNotice}${shadowNotice}`
 }
 
 export function prepareOrchestrationCheckOutput<T extends OrchestrationCheckOutput>(


### PR DESCRIPTION
A terminal that is both a dispatched worker and a bound coordinator can now read either of its two mailboxes, and is told when one of them was shadowed.

## The problem

In a nested wave, the middle layer holds two roles: it is a worker its parent dispatched, and the coordinator of its own Run. `orchestration.check` resolves the Run binding first — `const boundRun = paneKey ? db.getCurrentRunForPane(paneKey) : undefined`, then `if (params.run || boundRun)` — so the Dispatch branch below is unreachable once such a terminal binds a Run. A message addressed to its Dispatch stops being returned, with no error, no warning, and no flag to read the shelf. The mail is not lost — it reappears if a successor takes the Run — but nothing tells the terminal it exists. That silent substitution is what this PR ends.

## The change

- `check --as dispatch` reads the terminal's Dispatch mailbox even while a Run is bound. If the terminal holds no active Dispatch it fails `dispatch_not_found` instead of quietly reading some other mailbox, and it cannot be combined with `--run`, which names the opposite mailbox.
- `check --as coordinator` names today's default explicitly.
- When a bound coordinator also holds an active Dispatch, the Run-mailbox response now carries `shadowedDispatchId`, and the text output adds a line — `Dispatch ctx_… also holds mail for this terminal; read it with --as dispatch.` — so the shadowing is visible even to a caller that never learns the new flag.

## Why a selector rather than a union

The two mailboxes have different consumption protocols. The Run mailbox is a single delivery cursor with `--ack` and one exclusive waiter; the Dispatch mailbox is unread plus `markAsRead`. Returning both from one call would make `--ack` and `--wait` mean two things at once and need two acknowledgement channels in one result — a mailbox redesign, not a fix. The other candidate, refusing the double role at `run-create`, is honest but closes the nesting shape entirely: a dispatched coordinator would have to choose between staying reachable by its parent and having a Run of its own. Argued in full in the design comment linked below.

## Compatibility

- The default path is unchanged for every terminal that holds only one role: `--as` is optional, and when it is absent the branch condition is exactly the one that shipped.
- `shadowedDispatchId` is an additive optional field on an existing result, set only for a terminal that genuinely holds both roles. Older clients ignore it.
- The CLI sends `as` only when the flag is given, so an older host sees the same request shape it sees today, and it validates the value before the call so a typo fails locally.
- No dispatch lifecycle, no mailbox storage, and no existing concept is renamed.

## Related work

This is the second half of the nesting problem reported in #13362. The first half — lineage on the Run — is #13648, and the two are independent: that one touches `run-create` / `run-show` / `run-list` and the `runs` table, this one touches `orchestration.check` and the check output. The remaining piece, the `dispatch_run_mismatch` a dispatched coordinator gets when it sends into its own Run, lives in the send routing path that #13639 is currently changing and is deliberately left alone here.

## Tests

New: `src/main/runtime/rpc/methods/orchestration-check-dual-role.test.ts` — a captain dispatched inside a parent Run and then bound to its own Run reports `shadowedDispatchId`; `--as dispatch` returns the Dispatch mail and leaves the Run binding intact; the Run mailbox stays the default; a coordinator with no Dispatch is unaffected; `--as dispatch` without a Dispatch is refused; `--as dispatch` with `--run` is refused. Also `src/cli/handlers/orchestration-check-mailbox-selector.test.ts` — flag passthrough, an unknown `--as` refused before the call, and the shadow notice in text output.

Results — `pnpm lint` and `pnpm typecheck` pass; `pnpm vitest run src/main/runtime/orchestration src/main/runtime/rpc src/cli src/shared` reports 656 files passed, 4 skipped, 6647 tests passed, 19 skipped.

Design discussion: https://github.com/stablyai/orca/issues/13362#issuecomment-5245584112 (issue #13362).
