### PR TITLE
fix(orchestration): stop calling a readiness timeout a failed launch

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-agent-readiness-wait.ts
+++ b/src/main/runtime/rpc/methods/orchestration-agent-readiness-wait.ts
@@ -1,0 +1,78 @@
+import type { RuntimeTerminalState, RuntimeTerminalWait } from '../../../../shared/runtime-types'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+
+/** Marks a readiness failure whose launched agent is still running, so the
+ *  start receipt reports an unknown outcome instead of a failed launch. */
+export const AGENT_READINESS_OUTCOME_UNKNOWN_CODE = 'agent_readiness_outcome_unknown'
+
+type ReadinessRuntime = Pick<OrcaRuntimeService, 'waitForTerminal' | 'showTerminal'>
+
+export type AgentReadinessObservation = {
+  wait: RuntimeTerminalWait
+  /** The wait ran out of time instead of observing the pane settle, so it holds no verdict. */
+  timedOut: boolean
+  timeoutMs: number
+}
+
+export async function observeAgentReadiness(args: {
+  runtime: ReadinessRuntime
+  terminalHandle: string
+  timeoutMs: number
+}): Promise<AgentReadinessObservation> {
+  try {
+    const wait = await args.runtime.waitForTerminal(args.terminalHandle, {
+      condition: 'tui-idle',
+      timeoutMs: args.timeoutMs
+    })
+    return { wait, timedOut: false, timeoutMs: args.timeoutMs }
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== 'timeout') {
+      throw error
+    }
+    // Why: a readiness timeout is the absence of a verdict; probe the pane so a
+    // still-running agent is not reported as a launch that never happened.
+    return {
+      wait: {
+        handle: args.terminalHandle,
+        condition: 'tui-idle',
+        satisfied: false,
+        status: await readAgentTerminalState(args.runtime, args.terminalHandle),
+        exitCode: null
+      },
+      timedOut: true,
+      timeoutMs: args.timeoutMs
+    }
+  }
+}
+
+export function agentReadinessFailure(observation: AgentReadinessObservation): Error {
+  const { wait } = observation
+  if (wait.blockedReason) {
+    return new Error(`Agent startup blocked: ${wait.blockedReason}`)
+  }
+  if (!observation.timedOut) {
+    return new Error(`Agent did not become ready (${wait.status}).`)
+  }
+  const error = new Error(
+    `Agent readiness timed out after ${observation.timeoutMs}ms (terminal ${wait.status}).`
+  )
+  return wait.status === 'running'
+    ? Object.assign(error, { code: AGENT_READINESS_OUTCOME_UNKNOWN_CODE })
+    : error
+}
+
+async function readAgentTerminalState(
+  runtime: ReadinessRuntime,
+  handle: string
+): Promise<RuntimeTerminalState> {
+  try {
+    const terminal = await runtime.showTerminal(handle)
+    if (terminal.connected === true) {
+      return 'running'
+    }
+    return terminal.connected === false ? 'exited' : 'unknown'
+  } catch {
+    // Why: a handle that can no longer be shown is not evidence of a live agent.
+    return 'unknown'
+  }
+}

--- a/src/main/runtime/rpc/methods/orchestration-federation-effects.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-effects.ts
@@ -1,3 +1,5 @@
+import { AGENT_READINESS_OUTCOME_UNKNOWN_CODE } from './orchestration-agent-readiness-wait'
+
 export type FederationEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
   action?: string
@@ -69,6 +71,9 @@ export function isFederationEffectUnknown(error: unknown, stage: string): boolea
       ? (error as { code: string }).code
       : ''
   if (code === 'operation_unknown') {
+    return true
+  }
+  if (code === AGENT_READINESS_OUTCOME_UNKNOWN_CODE && stage === 'agent_readiness') {
     return true
   }
   if (!['worktree_create', 'terminal_create', 'dispatch_input'].includes(stage)) {

--- a/src/main/runtime/rpc/methods/orchestration-federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.ts
@@ -2,6 +2,7 @@ import type { TuiAgent } from '../../../../shared/types'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
+import { agentReadinessFailure, observeAgentReadiness } from './orchestration-agent-readiness-wait'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
 import {
   appendFederationSetupEffect,
@@ -195,20 +196,17 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
         }
         persistFederatedReadinessStage(setupStage)
         failedStage = 'agent_readiness'
-        const wait = await runtime.waitForTerminal(terminalHandle, {
-          condition: 'tui-idle',
+        const readiness = await observeAgentReadiness({
+          runtime,
+          terminalHandle,
           timeoutMs: params.timeoutMs ?? 60_000
         })
-        persistFederatedSetupWaitOutcome({ ...setupStage, wait })
-        if (!wait.satisfied) {
+        persistFederatedSetupWaitOutcome({ ...setupStage, wait: readiness.wait })
+        if (!readiness.wait.satisfied) {
           if (setup.state === 'failed') {
             failedStage = 'setup_wait'
           }
-          throw new Error(
-            wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
-              : `Agent did not become ready (${wait.status}).`
-          )
+          throw agentReadinessFailure(readiness)
         }
         const paneKey = runtime.getTerminalPaneKey(terminalHandle)
         const processIncarnation = runtime.getTerminalProcessIncarnation(terminalHandle)

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -2,6 +2,7 @@ import type { AgentLaunchPreferences } from '../../../../shared/agent-session-ho
 import type { TuiAgent } from '../../../../shared/types'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
+import { AGENT_READINESS_OUTCOME_UNKNOWN_CODE } from './orchestration-agent-readiness-wait'
 
 export type WorkerEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
@@ -272,6 +273,9 @@ export function isUnknownWorkerStartOutcome(error: unknown, stage: string): bool
       ? (error as { code: string }).code
       : ''
   if (code === 'operation_unknown') {
+    return true
+  }
+  if (code === AGENT_READINESS_OUTCOME_UNKNOWN_CODE && stage === 'agent_readiness') {
     return true
   }
   if (stage !== 'worktree_create') {

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -124,6 +124,65 @@ describe('orchestration new-worktree workers', () => {
     }
   }
 
+  function mockAgentTerminal(connected: boolean) {
+    vi.mocked(runtime.showTerminal).mockImplementation(((handle: string) =>
+      Promise.resolve(
+        handle === 'term_worker'
+          ? { handle, worktreeId: 'repo::created', connected }
+          : { handle: 'term_coord', worktreeId: 'repo::parent', status: 'running' }
+      )) as never)
+  }
+
+  it('reports an unknown outcome when readiness times out on a still-running agent', async () => {
+    mockCreatedWorktree()
+    mockAgentTerminal(true)
+    vi.mocked(runtime.waitForTerminal).mockRejectedValue(new Error('timeout'))
+
+    const { result, task } = await startWorker({ name: 'late-agent' })
+
+    expect(result).toMatchObject({
+      state: 'outcome_unknown',
+      failedStage: 'agent_readiness',
+      lastError: 'Agent readiness timed out after 60000ms (terminal running).',
+      residualResources: expect.arrayContaining([
+        expect.objectContaining({ kind: 'worktree', id: 'repo::created' }),
+        expect.objectContaining({ kind: 'terminal', id: 'term_worker' })
+      ]),
+      nextCommands: expect.arrayContaining([expect.stringContaining('worker-abandon')])
+    })
+    expect(db.getTask(task.id)?.status).toBe('blocked')
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+  })
+
+  it('still fails a readiness timeout when the agent terminal is gone', async () => {
+    mockCreatedWorktree()
+    mockAgentTerminal(false)
+    vi.mocked(runtime.waitForTerminal).mockRejectedValue(new Error('timeout'))
+
+    const { result, task } = await startWorker({ name: 'dead-agent' })
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      failedStage: 'agent_readiness',
+      lastError: 'Agent readiness timed out after 60000ms (terminal exited).'
+    })
+    expect(db.getTask(task.id)?.status).toBe('failed')
+  })
+
+  it('still fails when the agent terminal exits during readiness', async () => {
+    mockCreatedWorktree()
+    mockAgentTerminal(true)
+    vi.mocked(runtime.waitForTerminal).mockRejectedValue(new Error('terminal_exited'))
+
+    const { result } = await startWorker({ name: 'exited-agent' })
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      failedStage: 'agent_readiness',
+      lastError: 'terminal_exited'
+    })
+  })
+
   it('creates an independent top-level worktree and reuses its agent terminal', async () => {
     mockCreatedWorktree()
 

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -2,6 +2,7 @@ import type { TuiAgent } from '../../../../shared/types'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
+import { agentReadinessFailure, observeAgentReadiness } from './orchestration-agent-readiness-wait'
 import { startFederatedWorker } from './orchestration-federated-worker-start'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
 import { WorkerStartParams } from './orchestration-worker-start-schema'
@@ -194,20 +195,17 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         persistWorkerReadinessStage(setupStage)
 
         failedStage = 'agent_readiness'
-        const wait = await runtime.waitForTerminal(terminalHandle, {
-          condition: 'tui-idle',
+        const readiness = await observeAgentReadiness({
+          runtime,
+          terminalHandle,
           timeoutMs: params.timeoutMs ?? 60_000
         })
-        persistWorkerSetupWaitOutcome({ ...setupStage, wait })
-        if (!wait.satisfied) {
+        persistWorkerSetupWaitOutcome({ ...setupStage, wait: readiness.wait })
+        if (!readiness.wait.satisfied) {
           if (setupReceipt.state === 'failed') {
             failedStage = 'setup_wait'
           }
-          throw new Error(
-            wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
-              : `Agent did not become ready (${wait.status}).`
-          )
+          throw agentReadinessFailure(readiness)
         }
         const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
         const capability = db.prepareStartingWorkerAuthority({


### PR DESCRIPTION
A `worker-start` that times out at `agent_readiness` now reports `outcome_unknown` when the launched agent terminal is still running, instead of reporting `failed` for a lane whose agent is alive.

Fixes the first half of #13653.

## Evidence

Orca v1.4.176, 2026-08-10, macOS, one host with a 1-minute load average above 200. Seven lanes were dispatched with `worker-start --worktree new-child --agent claude --model claude-opus-5 --effort high`. Every one returned `state: failed`, `failedStage: agent_readiness`, `lastError: "timeout"`, `timeoutMs: 60000`, with effects showing the child worktree created and an agent terminal attached. `worker-show` reported `capability_revoked_at` set and both resources under `residual_resources`.

The agents were alive the whole time. Their transcripts kept growing minutes later and six of the seven wrote their deliverables. Every later `worker_done` was rejected, because `settleWorkerReportInTransaction` requires a `dispatched` dispatch and task (`src/main/runtime/orchestration/db.ts:6499`). A retry into the same worktree added a second agent terminal.

Traced in the source on `upstream/main`:

- a `tui-idle` wait rejects with `new Error('timeout')` (`src/main/runtime/orca-runtime.ts:17236` and `:17334`) — that is the literal `lastError` above;
- the rejection lands in the `workerStart` catch with `failedStage = 'agent_readiness'`;
- `isUnknownWorkerStartOutcome` returns `true` only for `code: 'operation_unknown'` or stage `worktree_create`, so the timeout took the `failed` path;
- `db.failWorkerStart` then set the dispatch and the task to `failed` and revoked the capability, and nothing anywhere stopped the process.

A timeout is the absence of a verdict. The daemon holds evidence the caller does not — whether the pane is still connected — and did not consult it.

## The change

`observeAgentReadiness` wraps the readiness wait. On a `timeout` rejection it probes the agent terminal with `showTerminal`; a still-connected terminal yields an unsatisfied wait with status `running` and an error tagged `agent_readiness_outcome_unknown`, which the two start-receipt classifiers map to the existing `outcome_unknown` path.

Behaviour by outcome, after this change:

| readiness outcome | before | after |
| --- | --- | --- |
| idle observed | `ready` | `ready` |
| timeout, terminal still connected | `failed` | `outcome_unknown` |
| timeout, terminal gone or exited | `failed` | `failed` |
| `terminal_exited` rejection | `failed` | `failed` |
| startup blocked (trust prompt, permission) | `failed` | `failed` |

Only the no-verdict case moves. Blocked and exited are real verdicts and stay `failed`.

`outcome_unknown` is not a new state: it already exists for a worktree create whose outcome could not be confirmed, it leaves the task `blocked` rather than `failed`, and the orchestration skill already documents its recovery — "either `worker-stop --dispatch <id>` and inspect again, or explicitly `worker-abandon --dispatch <id>` while accepting that resources may still be live." That is the correct advice for this lane, and it is better than a coordinator that reads `failed` and blind-retries into a worktree that already has an agent on it.

The same edit is applied to the federated attach path, which had the identical ordering and the identical fault on the worker server.

## Compatibility

- **CLI contract is unchanged.** `orchestration worker-start` already sets exit code 1 for any state other than `ready`, so a scripted caller sees no change in success or failure.
- **No wire or schema change.** `outcome_unknown` is already produced by this method, already carried by `orchestration.federationAttachStart`, and already handled on the home side of a federated start (`orchestration-federated-worker-start.ts:197`). An older client reading a newer host sees a state it already knows.
- **`lastError` text changes for this case only**, from the bare `timeout` to `Agent readiness timed out after 60000ms (terminal running).` The word "timeout" is kept in the string.
- **One new intermediate write.** The timeout path now reaches `persistWorkerSetupWaitOutcome`, which it previously skipped because the wait rejected. The final stage is unchanged, since the failure receipt overwrites it.
- **Windows, Linux, macOS, SSH.** The probe is `showTerminal`, which is already the liveness source used by `inspectWorkerTerminal` for `worker-show` and `worker-read`. No path, shell, or platform assumption is added.
- **Not fixed here:** a late worker still cannot report. The capability is minted after readiness, so a lane that dies at `agent_readiness` never received a preamble or a dispatch identity. That is the second fault in #13653 and it is a design decision, not a patch.

## Relationship to #13642

Related but distinct. #13642 fixes a launch that never starts because a startup command is lost, which under fish produced the same 60-second `agent_readiness` timeout for a different reason. That is a launch bug; this is a verdict bug. With a perfect launch, a slow agent start on a loaded machine still times out, and before this change still reported `failed` for a running agent. The two changes touch different files and do not conflict.

## Test plan

Three cases added to `src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts`:

1. readiness timeout with the agent terminal still connected — expects `outcome_unknown`, task `blocked`, the worktree and terminal in `residualResources`, `nextCommands` offering `worker-abandon`, and no prompt sent;
2. readiness timeout with the terminal gone — expects `failed` and task `failed`;
3. `terminal_exited` during readiness — expects `failed` with `lastError: terminal_exited`.

Ran on this branch:

```
npx vitest run --config config/vitest.config.ts \
  src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts \
  src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
  -> 2 files, 23 tests passed

npx vitest run --config config/vitest.config.ts \
  orchestration.test.ts orchestration-federation-setup.test.ts \
  orchestration-workers-recovery.test.ts orchestration-worker-dispatch-db.test.ts \
  orchestration-worker-cli.test.ts orchestration-worker-release-recovery.test.ts \
  orchestration-manual-dispatch-release.test.ts
  -> 7 files, 192 tests passed

pnpm typecheck  -> passed
pnpm lint       -> passed
```

The full `pnpm test` run finished with 49275 passed and 5 failures, all in unrelated timing-sensitive files (a renderer usage-snapshot benchmark asserting a render under 10 ms measured 13.9 ms, and a near-cap payload fuzz test hitting its timeout). The host was running several other agent workloads at the time; no orchestration test failed.
