### PR TITLE
perf: Stop unchanged worktree refresh churn

### DIFF
--- a/config/scripts/worktree-refresh-churn-benchmark.mjs
+++ b/config/scripts/worktree-refresh-churn-benchmark.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks'
+import { planWorktreeSortOrderUpdates } from '../../src/shared/worktree-sort-order-update.ts'
+
+const WORKTREE_COUNT = 655
+const TAB_COUNT = 1_895
+const REFRESH_COUNT = 10
+const ROUNDS = 15
+const BATCHES_PER_ROUND = 100
+
+function makeFixture() {
+  const worktrees = Array.from({ length: WORKTREE_COUNT }, (_, index) => ({
+    id: `repo-${index % 15}::/workspace/${index}`,
+    sortOrder: WORKTREE_COUNT - index,
+    lastActivityAt: index % 19,
+    isArchived: false
+  }))
+  const tabs = Array.from({ length: TAB_COUNT }, (_, index) => ({
+    worktreeId: worktrees[index % worktrees.length].id,
+    live: index % 3 === 0
+  }))
+  return { worktrees, tabs }
+}
+
+function runSidebarProjection(worktrees, tabs) {
+  const liveTabsByWorktree = new Map()
+  for (const tab of tabs) {
+    if (tab.live) {
+      liveTabsByWorktree.set(tab.worktreeId, (liveTabsByWorktree.get(tab.worktreeId) ?? 0) + 1)
+    }
+  }
+  const sorted = [...worktrees].sort(
+    (left, right) =>
+      (liveTabsByWorktree.get(right.id) ?? 0) - (liveTabsByWorktree.get(left.id) ?? 0) ||
+      right.lastActivityAt - left.lastActivityAt ||
+      right.sortOrder - left.sortOrder
+  )
+  return sorted.map((worktree) => worktree.id)
+}
+
+function runBaseline() {
+  const fixture = makeFixture()
+  let worktrees = fixture.worktrees
+  let publications = 0
+  let persistenceWrites = 0
+  for (let refresh = 0; refresh < REFRESH_COUNT; refresh += 1) {
+    const now = 1_000_000 + refresh
+    worktrees = worktrees.map((worktree, index) => ({
+      ...worktree,
+      sortOrder: now - index * 1000
+    }))
+    publications += 1
+    runSidebarProjection(worktrees, fixture.tabs)
+    persistenceWrites += worktrees.length
+  }
+  return { publications, persistenceWrites }
+}
+
+function runCandidate() {
+  const fixture = makeFixture()
+  const metaById = new Map(fixture.worktrees.map((worktree) => [worktree.id, worktree]))
+  const requestedIds = fixture.worktrees.map((worktree) => worktree.id)
+  let publications = 0
+  let persistenceWrites = 0
+  for (let refresh = 0; refresh < REFRESH_COUNT; refresh += 1) {
+    const updates = planWorktreeSortOrderUpdates(
+      requestedIds,
+      (worktreeId) => metaById.get(worktreeId),
+      1_000_000 + refresh
+    )
+    if (updates.length === 0) {
+      continue
+    }
+    for (const update of updates) {
+      metaById.set(update.worktreeId, {
+        ...metaById.get(update.worktreeId),
+        sortOrder: update.sortOrder
+      })
+    }
+    publications += 1
+    persistenceWrites += updates.length
+    runSidebarProjection([...metaById.values()], fixture.tabs)
+  }
+  return { publications, persistenceWrites }
+}
+
+function measureBatch(run) {
+  let counters
+  const startedAt = performance.now()
+  for (let batch = 0; batch < BATCHES_PER_ROUND; batch += 1) {
+    counters = run()
+  }
+  return { elapsedMs: (performance.now() - startedAt) / BATCHES_PER_ROUND, counters }
+}
+
+function measureComparison() {
+  runBaseline()
+  runCandidate()
+  const samples = Array.from({ length: ROUNDS }, (_, round) => {
+    let baseline
+    let candidate
+    if (round % 2 === 0) {
+      baseline = measureBatch(runBaseline)
+      candidate = measureBatch(runCandidate)
+    } else {
+      candidate = measureBatch(runCandidate)
+      baseline = measureBatch(runBaseline)
+    }
+    return { baseline, candidate, ratio: candidate.elapsedMs / baseline.elapsedMs }
+  }).sort((left, right) => left.ratio - right.ratio)
+  return samples[Math.floor(samples.length / 2)]
+}
+
+const { baseline, candidate } = measureComparison()
+if (baseline.counters.publications !== REFRESH_COUNT || candidate.counters.publications !== 0) {
+  throw new Error('Benchmark fixture no longer reproduces the refresh feedback loop')
+}
+
+console.log(
+  `Worktree refresh churn: ${WORKTREE_COUNT} worktrees, ${TAB_COUNT} tabs, ${REFRESH_COUNT} refreshes`
+)
+console.log(
+  `Before: ${baseline.elapsedMs.toFixed(3)} ms, ${baseline.counters.publications} catalog publications, ${baseline.counters.persistenceWrites} rank writes`
+)
+console.log(
+  `After:  ${candidate.elapsedMs.toFixed(3)} ms, ${candidate.counters.publications} catalog publications, ${candidate.counters.persistenceWrites} rank writes`
+)
+console.log(
+  `Reduction: ${((1 - candidate.elapsedMs / baseline.elapsedMs) * 100).toFixed(1)}% CPU, 100% feedback publications`
+)

--- a/config/scripts/worktree-refresh-churn-benchmark.mjs
+++ b/config/scripts/worktree-refresh-churn-benchmark.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import { performance } from 'node:perf_hooks'
 import { planWorktreeSortOrderUpdates } from '../../src/shared/worktree-sort-order-update.ts'
+import { reuseEqualCatalogRows } from '../../src/renderer/src/store/slices/worktree-catalog-reconciliation.ts'
 
 const WORKTREE_COUNT = 655
 const TAB_COUNT = 1_895
 const REFRESH_COUNT = 10
 const ROUNDS = 15
-const BATCHES_PER_ROUND = 100
+const BATCHES_PER_ROUND = 25
 
 function makeFixture() {
   const worktrees = Array.from({ length: WORKTREE_COUNT }, (_, index) => ({
@@ -40,18 +41,27 @@ function runSidebarProjection(worktrees, tabs) {
 
 function runBaseline() {
   const fixture = makeFixture()
-  let worktrees = fixture.worktrees
+  const metaById = new Map(fixture.worktrees.map((worktree) => [worktree.id, worktree]))
+  const requestedIds = fixture.worktrees.map((worktree) => worktree.id)
+  let catalog = fixture.worktrees
   let publications = 0
   let persistenceWrites = 0
   for (let refresh = 0; refresh < REFRESH_COUNT; refresh += 1) {
     const now = 1_000_000 + refresh
-    worktrees = worktrees.map((worktree, index) => ({
-      ...worktree,
-      sortOrder: now - index * 1000
-    }))
-    publications += 1
-    runSidebarProjection(worktrees, fixture.tabs)
-    persistenceWrites += worktrees.length
+    requestedIds.forEach((worktreeId, index) => {
+      metaById.set(worktreeId, {
+        ...metaById.get(worktreeId),
+        sortOrder: now - index * 1000
+      })
+      persistenceWrites += 1
+    })
+    const incoming = structuredClone(requestedIds.map((worktreeId) => metaById.get(worktreeId)))
+    const reconciled = reuseEqualCatalogRows(catalog, incoming)
+    if (reconciled !== catalog) {
+      catalog = reconciled
+      publications += 1
+      runSidebarProjection(catalog, fixture.tabs)
+    }
   }
   return { publications, persistenceWrites }
 }
@@ -60,6 +70,7 @@ function runCandidate() {
   const fixture = makeFixture()
   const metaById = new Map(fixture.worktrees.map((worktree) => [worktree.id, worktree]))
   const requestedIds = fixture.worktrees.map((worktree) => worktree.id)
+  let catalog = fixture.worktrees
   let publications = 0
   let persistenceWrites = 0
   for (let refresh = 0; refresh < REFRESH_COUNT; refresh += 1) {
@@ -68,18 +79,20 @@ function runCandidate() {
       (worktreeId) => metaById.get(worktreeId),
       1_000_000 + refresh
     )
-    if (updates.length === 0) {
-      continue
-    }
     for (const update of updates) {
       metaById.set(update.worktreeId, {
         ...metaById.get(update.worktreeId),
         sortOrder: update.sortOrder
       })
     }
-    publications += 1
     persistenceWrites += updates.length
-    runSidebarProjection([...metaById.values()], fixture.tabs)
+    const incoming = structuredClone(requestedIds.map((worktreeId) => metaById.get(worktreeId)))
+    const reconciled = reuseEqualCatalogRows(catalog, incoming)
+    if (reconciled !== catalog) {
+      catalog = reconciled
+      publications += 1
+      runSidebarProjection(catalog, fixture.tabs)
+    }
   }
   return { publications, persistenceWrites }
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "bench:main-thread-jank": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/main-thread-jank-bench.mjs",
     "bench:worktree-deletion": "node tests/tools/benchmarks/worktree-deletion-dev-bench.mjs",
     "bench:zustand-selector-fanout": "node config/scripts/zustand-selector-fanout-benchmark.mjs",
+    "bench:worktree-refresh-churn": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/worktree-refresh-churn-benchmark.mjs",
     "bench:multi-workspace-typing": "pnpm run ensure:electron-runtime && node config/scripts/run-multi-workspace-typing-bench.mjs",
     "bench:cold-park-reveal": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/terminal-cold-park-reveal-bench.mjs",
     "bench:cold-park-resource": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/terminal-cold-park-resource-bench.mjs",

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -603,6 +603,18 @@ describe('registerWorktreeHandlers', () => {
     expect(orderedTargets).not.toContain(staleId)
   })
 
+  it('persistSortOrder skips ranks that already represent the requested order', () => {
+    const firstId = 'repo-1::/workspace/first'
+    const secondId = 'repo-1::/workspace/second'
+    store.getWorktreeMeta.mockImplementation((id: string) => ({
+      sortOrder: id === firstId ? 200 : 100
+    }))
+
+    handlers['worktrees:persistSortOrder'](null, { orderedIds: [firstId, secondId] })
+
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
   it('prefetches the local default create base through the runtime refresh cache', async () => {
     const repo = {
       id: 'repo-1',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -8,6 +8,7 @@ import { isFolderRepo } from '../../shared/repo-kind'
 import { readBranchRenameFailureOutputForDisplay } from '../agent-hooks/branch-rename-failure-output'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
+import { planWorktreeSortOrderUpdates } from '../../shared/worktree-sort-order-update'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
 import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
 import { WorkspaceLinkedItemSchema } from '../../shared/workspace-linked-item-schema'
@@ -3142,18 +3143,13 @@ export function registerWorktreeHandlers(
     if (!Array.isArray(args?.orderedIds) || args.orderedIds.length === 0) {
       return
     }
-    const now = Date.now()
-    for (let i = 0; i < args.orderedIds.length; i++) {
-      // Why: a sidebar-order snapshot must only reorder worktrees that already
-      // exist — it must never create one. Without this guard a stale id the
-      // renderer still lists (e.g. a removed repo's `${repoId}::${path}`) gets a
-      // fresh worktreeMeta entry minted here, resurrecting an orphan/duplicate
-      // workspace on the next launch. setWorktreeMeta has no repo-existence check.
-      if (!store.getWorktreeMeta(args.orderedIds[i])) {
-        continue
-      }
-      // Descending timestamps: first item gets highest sortOrder so b - a sorts first-wins on cold start.
-      store.setWorktreeMeta(args.orderedIds[i], { sortOrder: now - i * 1000 })
+    const updates = planWorktreeSortOrderUpdates(
+      args.orderedIds,
+      (worktreeId) => store.getWorktreeMeta(worktreeId),
+      Date.now()
+    )
+    for (const update of updates) {
+      store.setWorktreeMeta(update.worktreeId, { sortOrder: update.sortOrder })
     }
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -39320,6 +39320,35 @@ describe('OrcaRuntimeService', () => {
     expect(reposChanged).not.toHaveBeenCalled()
   })
 
+  it('persists changed worktree order once and emits targeted invalidations', () => {
+    const firstId = `${TEST_REPO_ID}::/tmp/first`
+    const secondId = `${TEST_REPO_ID}::/tmp/second`
+    const metaById: Record<string, Partial<WorktreeMeta>> = {
+      [firstId]: { sortOrder: 200 },
+      [secondId]: { sortOrder: 100 }
+    }
+    const setWorktreeMeta = vi.fn((id: string, updates: Partial<WorktreeMeta>) => {
+      metaById[id] = { ...metaById[id], ...updates }
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorktreeMeta: (id: string) => metaById[id],
+      setWorktreeMeta
+    } as never)
+    const events: { type: string; repoId?: string }[] = []
+    const unsubscribe = runtime.onClientEvent((event) => events.push(event))
+
+    expect(runtime.persistManagedWorktreeSortOrder([firstId, secondId])).toEqual({ updated: 0 })
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+    expect(events).toEqual([])
+
+    expect(runtime.persistManagedWorktreeSortOrder([secondId, firstId])).toEqual({ updated: 2 })
+    unsubscribe()
+
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(events).toEqual([{ type: 'worktreesChanged', repoId: TEST_REPO_ID }])
+  })
+
   it('worktree scan cache: folder metadata invalidation preserves raw scans', async () => {
     vi.mocked(listWorktrees).mockClear()
     const runtime = createRuntime()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10,6 +10,7 @@ import {
   normalizeTerminalTitle
 } from '../../shared/agent-detection'
 import { extractOscTitleScanTail } from '../../shared/osc-title-scan-tail'
+import { planWorktreeSortOrderUpdates } from '../../shared/worktree-sort-order-update'
 import { isArtifactSharingEnabled } from '../../shared/artifact-sharing-gate'
 import { sortDirEntries } from '../../shared/file-name-sort'
 import { isServerDriveListRequest, listWindowsDrives } from './windows-drive-listing'
@@ -23566,21 +23567,29 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
-    const now = Date.now()
-    let updated = 0
-    for (let i = 0; i < orderedIds.length; i++) {
-      // Why: a sort-order snapshot must only reorder existing worktrees, never
-      // mint new meta — a stale id would otherwise resurrect an orphan workspace
-      // (setWorktreeMeta has no repo-existence check).
-      if (!this.store.getWorktreeMeta(orderedIds[i])) {
-        continue
-      }
-      this.store.setWorktreeMeta(orderedIds[i], { sortOrder: now - i * 1000 })
-      updated++
+    const store = this.store
+    const updates = planWorktreeSortOrderUpdates(
+      orderedIds,
+      (worktreeId) => store.getWorktreeMeta(worktreeId),
+      Date.now()
+    )
+    for (const update of updates) {
+      store.setWorktreeMeta(update.worktreeId, { sortOrder: update.sortOrder })
+    }
+    if (updates.length === 0) {
+      return { updated: 0 }
     }
     this.invalidateResolvedWorktreeCache()
-    this.notifyReposChanged()
-    return { updated }
+    const changedRepoIds = new Set(
+      updates.flatMap((update) => {
+        const parsed = splitWorktreeId(update.worktreeId)
+        return parsed ? [parsed.repoId] : []
+      })
+    )
+    for (const repoId of changedRepoIds) {
+      this.notifyWorktreesChanged(repoId)
+    }
+    return { updated: updates.length }
   }
 
   async resolveManagedPrBase(args: {

--- a/src/renderer/src/components/sidebar/WorktreeList.card-memo-stability.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.card-memo-stability.test.tsx
@@ -333,6 +333,11 @@ describe('WorktreeCard memo bail-out across epoch bumps', () => {
     mountedRoots.push(root)
 
     await renderList(root)
+    const renderedOrder = (): (string | null)[] =>
+      [...container.querySelectorAll('[data-mock-worktree-card]')].map((card) =>
+        card.getAttribute('data-mock-worktree-card')
+      )
+    expect(renderedOrder()).toEqual(['wt-a', 'wt-b'])
     expect(trackSpy).not.toHaveBeenCalledWith('smart_sort_class_distribution', expect.anything())
 
     const now = Date.now()
@@ -354,6 +359,7 @@ describe('WorktreeCard memo bail-out across epoch bumps', () => {
     }
     await renderList(root)
 
+    expect(renderedOrder()).toEqual(['wt-a', 'wt-b'])
     expect(trackSpy).toHaveBeenCalledWith(
       'smart_sort_class_distribution',
       expect.objectContaining({ class_3: 1, total_worktrees: 2 })
@@ -368,6 +374,7 @@ describe('WorktreeCard memo bail-out across epoch bumps', () => {
     }
     await renderList(root)
 
+    expect(renderedOrder()).toEqual(['wt-a', 'wt-b'])
     expect(trackSpy).toHaveBeenCalledWith('smart_sort_class_1_promotion', { cause: 'blocked' })
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeList.card-memo-stability.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.card-memo-stability.test.tsx
@@ -3,6 +3,7 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -17,6 +18,7 @@ const mockStore = vi.hoisted(() => ({
 // (React.memo shallow-equal props) does NOT invoke it — which is the claim
 // under test: order-preserving epoch bumps must not re-render cards.
 const cardRenderSpy = vi.hoisted(() => vi.fn())
+const trackSpy = vi.hoisted(() => vi.fn())
 
 type WorktreeListComponent = React.ComponentType<{
   scrollOffsetRef: React.RefObject<number>
@@ -95,6 +97,8 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/lib/sidebar-worktree-activation', () => ({
   activateWorktreeFromSidebar: mockStore.activateWorktreeFromSidebar
 }))
+
+vi.mock('@/lib/telemetry', () => ({ track: trackSpy }))
 
 vi.mock('@/lib/worktree-activation', () => ({
   activateAndRevealWorktree: vi.fn()
@@ -319,5 +323,51 @@ describe('WorktreeCard memo bail-out across epoch bumps', () => {
     // The changed card re-renders; identity reuse must not freeze real updates.
     expect(cardRenderSpy.mock.calls.length).toBeGreaterThan(countAfterMount)
     expect(cardRenderSpy).toHaveBeenCalledWith('wt-a')
+  })
+
+  it('tracks Smart attention changes that preserve the displayed order', async () => {
+    mockStore.state = { ...mockStore.state, sortBy: 'smart' }
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    mountedRoots.push(root)
+
+    await renderList(root)
+    expect(trackSpy).not.toHaveBeenCalledWith('smart_sort_class_distribution', expect.anything())
+
+    const now = Date.now()
+    const paneKey = 'tab-a:11111111-1111-4111-8111-111111111111'
+    const working: AgentStatusEntry = {
+      state: 'working',
+      prompt: '',
+      updatedAt: now,
+      stateStartedAt: now,
+      agentType: 'codex',
+      paneKey,
+      worktreeId: 'wt-a',
+      stateHistory: []
+    }
+    mockStore.state = {
+      ...mockStore.state,
+      agentStatusByPaneKey: { [paneKey]: working },
+      repos: [...(mockStore.state.repos as Repo[])]
+    }
+    await renderList(root)
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'smart_sort_class_distribution',
+      expect.objectContaining({ class_3: 1, total_worktrees: 2 })
+    )
+
+    mockStore.state = {
+      ...mockStore.state,
+      agentStatusByPaneKey: {
+        [paneKey]: { ...working, state: 'blocked', stateStartedAt: now + 1, updatedAt: now + 1 }
+      },
+      repos: [...(mockStore.state.repos as Repo[])]
+    }
+    await renderList(root)
+
+    expect(trackSpy).toHaveBeenCalledWith('smart_sort_class_1_promotion', { cause: 'blocked' })
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5430,9 +5430,9 @@ const WorktreeList = React.memo(function WorktreeList({
     }
     prevClassByWorktreeIdRef.current = next
     hasObservedSmartOnceRef.current = true
-  }, [sortBy, sortedIds])
+  }, [sortBy, recomputedSortedIds])
 
-  // Why retry on sortedIds: Smart may activate before attention hydrates; fire once, then stay quiet until the user leaves Smart.
+  // Why retry on recomputation: Smart may activate before attention hydrates; fire once, then stay quiet until the user leaves Smart.
   const hasTrackedSmartDistributionRef = useRef(false)
   useEffect(() => {
     if (sortBy !== 'smart') {
@@ -5469,7 +5469,7 @@ const WorktreeList = React.memo(function WorktreeList({
       total_worktrees: attention.size
     })
     hasTrackedSmartDistributionRef.current = true
-  }, [sortBy, sortedIds])
+  }, [sortBy, recomputedSortedIds])
 
   // Why fire on the transition: switching away from Smart is the signal; compare via ref so a round-trip doesn't double-fire.
   const prevSortByRef = useRef(sortBy)

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5355,7 +5355,7 @@ const WorktreeList = React.memo(function WorktreeList({
   // Why a ref alongside the memo: telemetry effects need the last attention map without re-reading store state.
   const lastAttentionByWorktreeRef = useRef<Map<string, WorktreeAttention> | null>(null)
 
-  const sortedIds = useMemo(() => {
+  const recomputedSortedIds = useMemo(() => {
     const state = useAppStore.getState()
     const nonArchivedWorktrees = getAllWorktreesFromState(state).filter(
       (worktree) => !worktree.isArchived
@@ -5403,6 +5403,8 @@ const WorktreeList = React.memo(function WorktreeList({
     // debouncedSortEpoch is an intentional trigger not read in the memo; its change (debounced) signals a recompute.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSortEpoch, repoMap, sortBy])
+  // Why: stable ID order prevents rank-only refreshes from echoing an unchanged snapshot.
+  const sortedIds = useReusedArrayIdentity(recomputedSortedIds)
 
   // Why a ref of prior class: fire class_1_promotion only on transitions into Class 1, not every recompute that stays there.
   const prevClassByWorktreeIdRef = useRef<Map<string, SmartClass>>(new Map())

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -5,7 +5,7 @@ import {
 } from './runtime-project-refresh-scheduler'
 
 describe('refreshRuntimeProjectWorktrees', () => {
-  it('pins same-ID repo refreshes to the event runtime', async () => {
+  it('deduplicates same-host repo IDs and pins the refresh to the event runtime', async () => {
     const fetchWorktrees = vi.fn().mockResolvedValue(true)
 
     await refreshRuntimeProjectWorktrees(
@@ -14,11 +14,8 @@ describe('refreshRuntimeProjectWorktrees', () => {
       fetchWorktrees
     )
 
-    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
-    expect(fetchWorktrees).toHaveBeenNthCalledWith(1, 'same-repo', {
-      executionHostId: 'runtime:env-1'
-    })
-    expect(fetchWorktrees).toHaveBeenNthCalledWith(2, 'same-repo', {
+    expect(fetchWorktrees).toHaveBeenCalledTimes(1)
+    expect(fetchWorktrees).toHaveBeenCalledWith('same-repo', {
       executionHostId: 'runtime:env-1'
     })
   })

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -35,16 +35,17 @@ export async function refreshRuntimeProjectWorktrees(
 ): Promise<void> {
   let nextIndex = 0
   const failures: { repoId: string; error: unknown }[] = []
-  const workerCount = Math.min(concurrency, repos.length)
+  const repoIds = [...new Set(repos.map((repo) => repo.id))]
+  const workerCount = Math.min(concurrency, repoIds.length)
   const executionHostId = toRuntimeExecutionHostId(environmentId)
 
   // Why: one coalesced event can represent many repos; bound probes without dropping host identity.
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
-      while (nextIndex < repos.length) {
+      while (nextIndex < repoIds.length) {
         const index = nextIndex
         nextIndex += 1
-        const repoId = repos[index].id
+        const repoId = repoIds[index]
         try {
           await fetchWorktrees(repoId, { executionHostId })
         } catch (error) {

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -41,4 +41,14 @@ describe('reuseEqualCatalogRows', () => {
 
     expect(reuseEqualCatalogRows(current, incoming)[0]).toBe(incoming[0])
   })
+
+  it('reuses same-ID rows from different hosts independently', () => {
+    const current = [
+      { id: 'repo::/same/path', hostId: 'ssh:a' },
+      { id: 'repo::/same/path', hostId: 'ssh:b' }
+    ]
+    const incoming = structuredClone(current)
+
+    expect(reuseEqualCatalogRows(current, incoming)).toBe(current)
+  })
 })

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -59,8 +59,16 @@ describe('reuseEqualCatalogRows', () => {
       { id: 'repo::/same/path', hostId: 'ssh:a' },
       { id: 'repo::/same/path', hostId: 'ssh:b' }
     ]
-    const incoming = structuredClone(current)
+    const equivalent = structuredClone(current)
 
-    expect(reuseEqualCatalogRows(current, incoming)).toBe(current)
+    expect(reuseEqualCatalogRows(current, equivalent)).toBe(current)
+
+    const incoming = structuredClone(current.toReversed())
+    const reconciled = reuseEqualCatalogRows(current, incoming)
+
+    expect(reconciled).not.toBe(current)
+    expect(reconciled.map((row) => row.hostId)).toEqual(['ssh:b', 'ssh:a'])
+    expect(reconciled[0]).toBe(current[1])
+    expect(reconciled[1]).toBe(current[0])
   })
 })

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { catalogRowsEqual, reuseEqualCatalogRows } from './worktree-catalog-reconciliation'
+
+describe('reuseEqualCatalogRows', () => {
+  it('reuses rows with equivalent nested catalog data', () => {
+    const current = [
+      { id: 'a', nested: { labels: ['one', 'two'] }, optional: undefined },
+      { id: 'b', nested: { labels: ['three'] } }
+    ]
+    const incoming = [
+      { id: 'a', nested: { labels: ['one', 'two'] } },
+      { id: 'b', nested: { labels: ['three'] } }
+    ]
+
+    const reconciled = reuseEqualCatalogRows(current, incoming)
+
+    expect(reconciled).toBe(current)
+    expect(catalogRowsEqual(current, incoming)).toBe(true)
+  })
+
+  it('reuses unaffected rows while publishing nested changes', () => {
+    const current = [
+      { id: 'a', nested: { value: 1 } },
+      { id: 'b', nested: { value: 2 } }
+    ]
+    const incoming = [
+      { id: 'a', nested: { value: 3 } },
+      { id: 'b', nested: { value: 2 } }
+    ]
+
+    const reconciled = reuseEqualCatalogRows(current, incoming)
+
+    expect(reconciled).not.toBe(current)
+    expect(reconciled[0]).toBe(incoming[0])
+    expect(reconciled[1]).toBe(current[1])
+  })
+
+  it('does not hide host ownership changes', () => {
+    const current = [{ id: 'a', runtimeOwnerEnvironmentId: 'env-a' }]
+    const incoming = [{ id: 'a', runtimeOwnerEnvironmentId: 'env-b' }]
+
+    expect(reuseEqualCatalogRows(current, incoming)[0]).toBe(incoming[0])
+  })
+})

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { catalogRowsEqual, reuseEqualCatalogRows } from './worktree-catalog-reconciliation'
 
 describe('reuseEqualCatalogRows', () => {
+  it('does not traverse a catalog already reconciled by identity', () => {
+    const current = [
+      {
+        get id(): string {
+          throw new Error('catalog row was traversed')
+        }
+      }
+    ]
+
+    expect(catalogRowsEqual(current, current)).toBe(true)
+  })
+
   it('reuses rows with equivalent nested catalog data', () => {
     const current = [
       { id: 'a', nested: { labels: ['one', 'two'] }, optional: undefined },

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -1,0 +1,56 @@
+type CatalogRow = { id: string }
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function catalogValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false
+    }
+    return left.every((value, index) => catalogValuesEqual(value, right[index]))
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) {
+    return false
+  }
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)])
+  for (const key of keys) {
+    if (!catalogValuesEqual(left[key], right[key])) {
+      return false
+    }
+  }
+  return true
+}
+
+export function reuseEqualCatalogRows<T extends CatalogRow>(
+  current: readonly T[] | undefined,
+  incoming: readonly T[]
+): T[] {
+  if (!current) {
+    return [...incoming]
+  }
+  const currentById = new Map(current.map((row) => [row.id, row]))
+  const reconciled = incoming.map((row) => {
+    const previous = currentById.get(row.id)
+    return previous && catalogValuesEqual(previous, row) ? previous : row
+  })
+  return current.length === reconciled.length &&
+    current.every((row, index) => row === reconciled[index])
+    ? (current as T[])
+    : reconciled
+}
+
+export function catalogRowsEqual<T extends CatalogRow>(
+  current: readonly T[] | undefined,
+  incoming: readonly T[]
+): boolean {
+  return reuseEqualCatalogRows(current, incoming) === current
+}

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -63,5 +63,8 @@ export function catalogRowsEqual<T extends CatalogRow>(
   current: readonly T[] | undefined,
   incoming: readonly T[]
 ): boolean {
+  if (current === incoming) {
+    return true
+  }
   return reuseEqualCatalogRows(current, incoming) === current
 }

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -37,10 +37,21 @@ export function reuseEqualCatalogRows<T extends CatalogRow>(
   if (!current) {
     return [...incoming]
   }
-  const currentById = new Map(current.map((row) => [row.id, row]))
+  const currentById = new Map<string, T[]>()
+  for (const row of current) {
+    const candidates = currentById.get(row.id)
+    if (candidates) {
+      candidates.push(row)
+    } else {
+      currentById.set(row.id, [row])
+    }
+  }
   const reconciled = incoming.map((row) => {
-    const previous = currentById.get(row.id)
-    return previous && catalogValuesEqual(previous, row) ? previous : row
+    const candidates = currentById.get(row.id)
+    const previousIndex = candidates?.findIndex((candidate) => catalogValuesEqual(candidate, row))
+    return previousIndex !== undefined && previousIndex >= 0
+      ? candidates!.splice(previousIndex, 1)[0]
+      : row
   })
   return current.length === reconciled.length &&
     current.every((row, index) => row === reconciled[index])

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -487,6 +487,92 @@ describe('fetchWorktrees', () => {
     expect(result).toBe(true)
   })
 
+  it('retains catalog and row references for a cloned unchanged runtime payload', async () => {
+    const store = createTestStore()
+    const first = makeWorktree({
+      id: 'repo1::/path/first',
+      repoId: 'repo1',
+      path: '/path/first',
+      createdAt: 123,
+      sparsePresetId: 'preset-1',
+      pushTarget: {
+        remoteName: 'origin',
+        branchName: 'feature',
+        remoteCreated: true
+      },
+      cliProvenance: {
+        kind: 'created-by-cli',
+        createdAt: 123,
+        callerTerminalHandle: 'term-1',
+        startupAgent: 'codex'
+      }
+    })
+    const second = makeWorktree({
+      id: 'repo1::/path/second',
+      repoId: 'repo1',
+      path: '/path/second'
+    })
+    const detected = makeDetectedResult('repo1', [first, second])
+    store.setState({
+      worktreesByRepo: { repo1: [first, second] },
+      detectedWorktreesByRepo: { repo1: detected },
+      sortEpoch: 7
+    } as Partial<AppState>)
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      structuredClone(makeDetectedResult('repo1', [first, second]))
+    )
+    const before = store.getState()
+    const subscriber = vi.fn()
+    const unsubscribe = store.subscribe(subscriber)
+
+    await store.getState().fetchWorktrees('repo1')
+    unsubscribe()
+
+    const after = store.getState()
+    expect(after.worktreesByRepo).toBe(before.worktreesByRepo)
+    expect(after.worktreesByRepo.repo1).toBe(before.worktreesByRepo.repo1)
+    expect(after.detectedWorktreesByRepo).toBe(before.detectedWorktreesByRepo)
+    expect(after.detectedWorktreesByRepo.repo1).toBe(before.detectedWorktreesByRepo.repo1)
+    expect(after.sortEpoch).toBe(7)
+    expect(subscriber).not.toHaveBeenCalled()
+  })
+
+  it('reuses unaffected catalog rows while publishing a previously untracked field change', async () => {
+    const store = createTestStore()
+    const changed = makeWorktree({
+      id: 'repo1::/path/changed',
+      repoId: 'repo1',
+      path: '/path/changed',
+      pushTarget: { remoteName: 'origin', branchName: 'feature', remoteCreated: false }
+    })
+    const stable = makeWorktree({
+      id: 'repo1::/path/stable',
+      repoId: 'repo1',
+      path: '/path/stable'
+    })
+    const detected = makeDetectedResult('repo1', [changed, stable])
+    store.setState({
+      worktreesByRepo: { repo1: [changed, stable] },
+      detectedWorktreesByRepo: { repo1: detected },
+      sortEpoch: 7
+    } as Partial<AppState>)
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [
+        { ...changed, pushTarget: { ...changed.pushTarget!, remoteCreated: true } },
+        { ...stable }
+      ])
+    )
+
+    await store.getState().fetchWorktrees('repo1')
+
+    const after = store.getState()
+    expect(after.worktreesByRepo.repo1[0]).not.toBe(changed)
+    expect(after.worktreesByRepo.repo1[0].pushTarget?.remoteCreated).toBe(true)
+    expect(after.worktreesByRepo.repo1[1]).toBe(stable)
+    expect(after.detectedWorktreesByRepo.repo1.worktrees[1]).toBe(detected.worktrees[1])
+    expect(after.sortEpoch).toBe(8)
+  })
+
   it('updates the repo entry and bumps sortEpoch when git reports a branch change', async () => {
     const store = createTestStore()
     const existing = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -28,8 +28,6 @@ import {
 } from './worktree-helpers'
 import { projectWorktreeTabModelReconciliation } from './tabs'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree-id'
-import { areWorkspaceLinkedItemsEqual } from '../../../../shared/workspace-linked-item'
-import { areTaskSourceContextsEqual } from '../../../../shared/task-source-context'
 import {
   remapClosedTerminalTabSnapshotCwds,
   type ClosedTerminalTabSnapshot
@@ -129,6 +127,7 @@ import type {
 } from '../../../../shared/detected-worktree-provider-contract'
 import type { DirectSshAuthority } from '../../../../shared/ssh-types'
 import { findIndexedWorktreeOwnerForHost } from '@/lib/worktree-runtime-owner-index'
+import { catalogRowsEqual, reuseEqualCatalogRows } from './worktree-catalog-reconciliation'
 export type { WorktreeSlice, WorktreeDeleteState } from './worktree-helpers'
 
 // Why: old runtime servers only have `worktree.list`; preserve the large-list UI hydration parity used before `worktree.detectedList` existed.
@@ -312,107 +311,8 @@ function showLocalBaseRefRefreshToast(
   )
 }
 
-function arraysShallowEqual(a: string[] | undefined, b: string[] | undefined): boolean {
-  if (a === b) {
-    return true
-  }
-  if (!a || !b || a.length !== b.length) {
-    return !a?.length && !b?.length
-  }
-  return a.every((v, i) => v === b[i])
-}
-
-function areLineageRecordsEqual(
-  a: WorktreeLineage | null | undefined,
-  b: WorktreeLineage | null | undefined
-): boolean {
-  if (!a || !b) {
-    return !a && !b
-  }
-  return (
-    a.worktreeId === b.worktreeId &&
-    a.worktreeInstanceId === b.worktreeInstanceId &&
-    a.parentWorktreeId === b.parentWorktreeId &&
-    a.parentWorktreeInstanceId === b.parentWorktreeInstanceId &&
-    a.origin === b.origin &&
-    a.capture.source === b.capture.source &&
-    a.capture.confidence === b.capture.confidence &&
-    a.orchestrationRunId === b.orchestrationRunId &&
-    a.taskId === b.taskId &&
-    a.coordinatorHandle === b.coordinatorHandle &&
-    a.createdByTerminalHandle === b.createdByTerminalHandle &&
-    a.createdAt === b.createdAt
-  )
-}
-
 function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): boolean {
-  if (!current || current.length !== next.length) {
-    return false
-  }
-
-  return current.every((worktree, index) => {
-    const candidate = next[index]
-    return (
-      worktree.id === candidate.id &&
-      worktree.instanceId === candidate.instanceId &&
-      worktree.repoId === candidate.repoId &&
-      worktree.projectId === candidate.projectId &&
-      worktree.hostId === candidate.hostId &&
-      worktree.projectHostSetupId === candidate.projectHostSetupId &&
-      worktree.path === candidate.path &&
-      worktree.head === candidate.head &&
-      worktree.branch === candidate.branch &&
-      worktree.isBare === candidate.isBare &&
-      worktree.isMainWorktree === candidate.isMainWorktree &&
-      worktree.isSparse === candidate.isSparse &&
-      worktree.displayName === candidate.displayName &&
-      worktree.comment === candidate.comment &&
-      worktree.linkedIssue === candidate.linkedIssue &&
-      worktree.linkedPR === candidate.linkedPR &&
-      worktree.linkedLinearIssue === candidate.linkedLinearIssue &&
-      (worktree.linkedLinearIssueWorkspaceId ?? null) ===
-        (candidate.linkedLinearIssueWorkspaceId ?? null) &&
-      (worktree.linkedLinearIssueOrganizationUrlKey ?? null) ===
-        (candidate.linkedLinearIssueOrganizationUrlKey ?? null) &&
-      worktree.linkedGitLabMR === candidate.linkedGitLabMR &&
-      worktree.linkedGitLabIssue === candidate.linkedGitLabIssue &&
-      worktree.linkedBitbucketPR === candidate.linkedBitbucketPR &&
-      worktree.linkedAzureDevOpsPR === candidate.linkedAzureDevOpsPR &&
-      worktree.linkedGiteaPR === candidate.linkedGiteaPR &&
-      areWorkspaceLinkedItemsEqual(worktree.linkedWorkItem, candidate.linkedWorkItem) &&
-      areTaskSourceContextsEqual(
-        worktree.linkedTaskSourceContext,
-        candidate.linkedTaskSourceContext
-      ) &&
-      worktree.isArchived === candidate.isArchived &&
-      worktree.isUnread === candidate.isUnread &&
-      worktree.isPinned === candidate.isPinned &&
-      worktree.sortOrder === candidate.sortOrder &&
-      worktree.manualOrder === candidate.manualOrder &&
-      worktree.lastActivityAt === candidate.lastActivityAt &&
-      worktree.workspaceStatus === candidate.workspaceStatus &&
-      worktree.createdWithAgent === candidate.createdWithAgent &&
-      worktree.pendingFirstAgentMessageRename === candidate.pendingFirstAgentMessageRename &&
-      worktree.firstAgentMessageRenameError === candidate.firstAgentMessageRenameError &&
-      worktree.baseRef === candidate.baseRef &&
-      worktree.pushTarget?.remoteName === candidate.pushTarget?.remoteName &&
-      worktree.pushTarget?.branchName === candidate.pushTarget?.branchName &&
-      worktree.pushTarget?.remoteUrl === candidate.pushTarget?.remoteUrl &&
-      worktree.sparseBaseRef === candidate.sparseBaseRef &&
-      arraysShallowEqual(worktree.sparseDirectories, candidate.sparseDirectories) &&
-      arraysShallowEqual(worktree.priorWorktreeIds, candidate.priorWorktreeIds) &&
-      (worktree as WorktreeWithLineage).parentWorktreeId ===
-        (candidate as WorktreeWithLineage).parentWorktreeId &&
-      arraysShallowEqual(
-        (worktree as WorktreeWithLineage).childWorktreeIds,
-        (candidate as WorktreeWithLineage).childWorktreeIds
-      ) &&
-      areLineageRecordsEqual(
-        (worktree as WorktreeWithLineage).lineage,
-        (candidate as WorktreeWithLineage).lineage
-      )
-    )
-  })
+  return catalogRowsEqual(current, next)
 }
 
 function areDetectedWorktreeResultsEqual(
@@ -424,15 +324,7 @@ function areDetectedWorktreeResultsEqual(
     current.repoId === next.repoId &&
     current.authoritative === next.authoritative &&
     current.source === next.source &&
-    areWorktreesEqual(current.worktrees, next.worktrees) &&
-    current.worktrees.every((worktree, index) => {
-      const candidate = next.worktrees[index]
-      return (
-        worktree.ownership === candidate.ownership &&
-        worktree.selectedCheckout === candidate.selectedCheckout &&
-        worktree.visible === candidate.visible
-      )
-    })
+    catalogRowsEqual(current.worktrees, next.worktrees)
   )
 }
 
@@ -649,7 +541,7 @@ function worktreeMatchesHost(
 }
 
 function mergeWorktreesForHost<
-  T extends { hostId?: ExecutionHostId; runtimeOwnerEnvironmentId?: string }
+  T extends { id: string; hostId?: ExecutionHostId; runtimeOwnerEnvironmentId?: string }
 >(
   current: readonly T[] | undefined,
   refreshed: readonly T[],
@@ -658,13 +550,17 @@ function mergeWorktreesForHost<
 ): T[] {
   // Why: host-scoped refreshes replace that host in place so alternating local/runtime refreshes don't churn sibling row order or sortEpoch.
   const existing = current ?? []
+  const reconciled = reuseEqualCatalogRows(
+    existing.filter((worktree) => worktreeMatchesHost(worktree, hostId, options)),
+    refreshed
+  )
   const next: T[] = []
   let inserted = false
 
   for (const worktree of existing) {
     if (worktreeMatchesHost(worktree, hostId, options)) {
       if (!inserted) {
-        next.push(...refreshed)
+        next.push(...reconciled)
         inserted = true
       }
       continue
@@ -672,7 +568,12 @@ function mergeWorktreesForHost<
     next.push(worktree)
   }
 
-  return inserted ? next : [...next, ...refreshed]
+  if (!inserted) {
+    next.push(...reconciled)
+  }
+  return existing.length === next.length && existing.every((row, index) => row === next[index])
+    ? (existing as T[])
+    : next
 }
 
 function mergeDetectedWorktreesForHost(
@@ -686,9 +587,19 @@ function mergeDetectedWorktreesForHost(
     refreshed.worktrees,
     current?.worktrees
   ).map((worktree) => withRepoHostOwnership(worktree, hostId, setup))
+  const worktrees = mergeWorktreesForHost(current?.worktrees, refreshedForHost, hostId, options)
+  if (
+    current &&
+    current.repoId === refreshed.repoId &&
+    current.authoritative === refreshed.authoritative &&
+    current.source === refreshed.source &&
+    current.worktrees === worktrees
+  ) {
+    return current
+  }
   return {
     ...refreshed,
-    worktrees: mergeWorktreesForHost(current?.worktrees, refreshedForHost, hostId, options)
+    worktrees
   }
 }
 

--- a/src/shared/worktree-sort-order-update.test.ts
+++ b/src/shared/worktree-sort-order-update.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { planWorktreeSortOrderUpdates } from './worktree-sort-order-update'
+
+describe('planWorktreeSortOrderUpdates', () => {
+  it('skips an order that is already represented by descending ranks', () => {
+    const getMeta = vi.fn((id: string) => ({
+      sortOrder: id === 'a' ? 300 : id === 'b' ? 200 : 100
+    }))
+
+    expect(planWorktreeSortOrderUpdates(['a', 'b', 'c'], getMeta, 1_000)).toEqual([])
+  })
+
+  it('re-ranks changed order and ignores stale worktree IDs', () => {
+    const getMeta = vi.fn((id: string) => {
+      if (id === 'stale') {
+        return undefined
+      }
+      return { sortOrder: id === 'a' ? 100 : 200 }
+    })
+
+    expect(planWorktreeSortOrderUpdates(['a', 'stale', 'b'], getMeta, 5_000)).toEqual([
+      { worktreeId: 'a', sortOrder: 5_000 },
+      { worktreeId: 'b', sortOrder: 4_000 }
+    ])
+  })
+
+  it('ranks a duplicate worktree ID only once', () => {
+    const getMeta = vi.fn((id: string) => ({ sortOrder: id === 'a' ? 100 : 200 }))
+
+    expect(planWorktreeSortOrderUpdates(['a', 'a', 'b'], getMeta, 5_000)).toEqual([
+      { worktreeId: 'a', sortOrder: 5_000 },
+      { worktreeId: 'b', sortOrder: 4_000 }
+    ])
+    expect(getMeta).toHaveBeenCalledTimes(2)
+  })
+
+  it('initializes missing ranks without manufacturing metadata', () => {
+    const getMeta = vi.fn((id: string) => (id === 'known' ? {} : undefined))
+
+    expect(planWorktreeSortOrderUpdates(['known', 'missing'], getMeta, 9_000)).toEqual([
+      { worktreeId: 'known', sortOrder: 9_000 }
+    ])
+  })
+})

--- a/src/shared/worktree-sort-order-update.ts
+++ b/src/shared/worktree-sort-order-update.ts
@@ -1,0 +1,32 @@
+export type WorktreeSortOrderUpdate = {
+  worktreeId: string
+  sortOrder: number
+}
+
+type WorktreeSortOrderMeta = {
+  sortOrder?: number
+}
+
+export function planWorktreeSortOrderUpdates(
+  orderedIds: readonly string[],
+  getMeta: (worktreeId: string) => WorktreeSortOrderMeta | undefined,
+  now: number
+): WorktreeSortOrderUpdate[] {
+  const uniqueIds = [...new Set(orderedIds)]
+  const existing = uniqueIds.flatMap((worktreeId) => {
+    const meta = getMeta(worktreeId)
+    return meta ? [{ worktreeId, sortOrder: meta.sortOrder }] : []
+  })
+  const alreadyOrdered = existing.every(
+    (entry, index) =>
+      Number.isFinite(entry.sortOrder) &&
+      (index === 0 || existing[index - 1].sortOrder! > entry.sortOrder!)
+  )
+  if (alreadyOrdered) {
+    return []
+  }
+  return existing.map((entry, index) => ({
+    worktreeId: entry.worktreeId,
+    sortOrder: now - index * 1000
+  }))
+}


### PR DESCRIPTION
## What users experienced

There is intentionally no visual change to the sidebar. The problem was invisible background work: with Smart sort active, an unchanged worktree refresh could make Orca save the same sidebar order again, publish a new worktree catalog, and recompute the sidebar even though no row moved and no worktree data changed.

This was most costly in large or remote workspaces, where the redundant cycle also meant extra metadata writes, IPC/RPC traffic, store updates, and React work. Users could experience higher CPU use, reduced responsiveness, fan/battery impact, or avoidable remote traffic while the sidebar looked exactly the same.

## Before and after

For one unchanged refresh:

**Before**
1. The sidebar recomputed the same ordered list but produced a new array.
2. Smart-sort persistence rewrote every worktree's rank using new timestamps.
3. Those writes emitted a broad change notification.
4. Orca fetched and published a newly cloned catalog.
5. The sidebar recomputed again, despite rendering the same order.

**After**
1. An unchanged ordered list reuses its previous array identity.
2. Sort persistence verifies that ranks already represent that order and writes nothing.
3. Structurally unchanged catalog rows and host-scoped arrays reuse their previous identities.
4. No notification or store publication is emitted for an unchanged refresh.
5. A real order or worktree change still writes, publishes, and invalidates only the affected repository.

## Performance

At the traced scale of 655 worktrees, 1,895 tabs, and 10 unchanged refreshes:

| Work performed | Before | After |
|---|---:|---:|
| Sort-rank metadata writes | 6,550 | 0 |
| Worktree catalog publications | 10 | 0 |
| Modeled hot-path CPU | baseline | 16.4%–18.9% lower |
| Visible sidebar result | unchanged | unchanged |

The CPU percentage is for the benchmarked refresh path, not a claim that the entire application is 16%–19% faster. The larger win is eliminating the feedback work completely: no redundant writes, publications, sidebar recomputations, or remote refresh fanout.

## Implementation summary

- Make local and runtime worktree sort-order persistence idempotent.
- Reuse structurally unchanged catalog rows, results, and host-scoped arrays.
- Keep unchanged sidebar ID order referentially stable while preserving Smart-sort telemetry recomputation.
- Deduplicate same-host runtime refreshes and target invalidation to repositories that actually changed.

## Verification

- Focused Vitest: 1,622 passed, 1 skipped
- TypeScript node, CLI, and web projects: passed
- Changed-code native, type-aware, and React quality gates: zero new findings
- Max-lines ratchet and diff checks: passed
- Electron QA on a 587-row detected catalog: 10 unchanged refreshes produced 0 store publications, stable catalog/row references, and 0 `persistSortOrder` calls
- Final same-model review verdict: CLEAN with no edits
- CI: green across both Node test matrices, packaging, Windows packaging, wire compatibility, static analysis, and typechecking
