### PR TITLE
fix(browser): keep one identity across hosts during Google sign-in (STA-3811)

### DIFF
--- a/src/main/browser/browser-google-auth-ua.ts
+++ b/src/main/browser/browser-google-auth-ua.ts
@@ -49,3 +49,11 @@ export function setUserAgentHeader(headers: Record<string, string>, value: strin
   const existing = Object.keys(headers).find((key) => key.toLowerCase() === 'user-agent')
   headers[existing ?? 'User-Agent'] = value
 }
+
+// Why: the outgoing header carries the WebContents UA override, so reading it
+// (case-insensitively) tells us whether a request originated from the Firefox
+// auth document even when its destination host isn't an auth host.
+export function currentUserAgent(headers: Record<string, string>): string | undefined {
+  const existing = Object.keys(headers).find((key) => key.toLowerCase() === 'user-agent')
+  return existing ? headers[existing] : undefined
+}

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -28,6 +28,7 @@ vi.mock('./browser-manager', () => ({
 }))
 
 import { browserSessionRegistry } from './browser-session-registry'
+import { googleAuthUserAgent } from './browser-google-auth-ua'
 import { setupClientHintsOverride } from './browser-session-ua'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import {
@@ -438,6 +439,81 @@ describe('BrowserSessionRegistry', () => {
       expect(modified['sec-ch-ua']).toBeUndefined()
       expect(modified['sec-ch-ua-full-version-list']).toBeUndefined()
       expect(modified['sec-ch-ua-platform']).toBeUndefined()
+    })
+
+    it('strips client hints on a cross-host request that carries the Firefox auth UA', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      setupClientHintsOverride(
+        mockSess,
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      )
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      // Subresource/XHR to a non-auth Google host while the auth document is on
+      // screen: the WebContents Firefox UA leaks onto the request header.
+      listener(
+        {
+          url: 'https://play.google.com/log',
+          requestHeaders: {
+            'User-Agent': googleAuthUserAgent(),
+            'sec-ch-ua': 'old',
+            'sec-ch-ua-full-version-list': 'old',
+            'sec-ch-ua-platform': '"macOS"',
+            'sec-ch-ua-mobile': '?0'
+          }
+        },
+        callback
+      )
+      const modified = callback.mock.calls[0][0].requestHeaders
+      // UA stays Firefox and every client hint is dropped — one consistent identity.
+      expect(modified['User-Agent']).toBe(googleAuthUserAgent())
+      expect(modified['sec-ch-ua']).toBeUndefined()
+      expect(modified['sec-ch-ua-full-version-list']).toBeUndefined()
+      expect(modified['sec-ch-ua-platform']).toBeUndefined()
+      expect(modified['sec-ch-ua-mobile']).toBeUndefined()
+    })
+
+    it('keeps the clean Chrome identity on cross-host requests that carry the Chrome UA', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const chromeUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      setupClientHintsOverride(mockSess, chromeUa)
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      // Regression guard: non-Google sites (Cloudflare) must keep Chrome hints.
+      listener(
+        {
+          url: 'https://example.com/api',
+          requestHeaders: { 'User-Agent': chromeUa, 'sec-ch-ua': 'old' }
+        },
+        callback
+      )
+      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
+    })
+
+    it('does not strip hints for the Firefox UA when googleAuthOverride is disabled', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const chromeUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      setupClientHintsOverride(mockSess, chromeUa, { googleAuthOverride: false })
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener(
+        {
+          url: 'https://play.google.com/log',
+          requestHeaders: { 'User-Agent': googleAuthUserAgent(), 'sec-ch-ua': 'old' }
+        },
+        callback
+      )
+      // Imported-native profiles never install the Firefox switch, so the strip
+      // branch stays inert and hints are aligned to Chrome instead.
+      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
     })
 
     it('keeps Chrome client hints on Google app subdomains (not auth hosts)', () => {

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -1,6 +1,7 @@
 import type { Session } from 'electron'
 
 import {
+  currentUserAgent,
   googleAuthUserAgent,
   isGoogleAuthUrl,
   setUserAgentHeader,
@@ -44,6 +45,18 @@ export function setupClientHintsOverride(
       // in inside the app and Google issues self-refreshing bound cookies. Strip
       // sec-ch-ua* because real Firefox sends none.
       setUserAgentHeader(headers, firefoxUa)
+      stripClientHints(headers)
+      callback({ requestHeaders: headers })
+      return
+    }
+    if (options.googleAuthOverride !== false && currentUserAgent(headers) === firefoxUa) {
+      // Why: while the auth document is on screen the WebContents UA is Firefox,
+      // so its cross-host subresource/XHR requests (gstatic, play.google.com, the
+      // sign-in challenge endpoints) reach here carrying the Firefox UA yet still
+      // bearing Chromium client hints. Rewriting those to Chrome pairs a Firefox
+      // UA with Chrome hints — a sharper cross-host identity tell than either
+      // alone, which can stall Google's password-submit challenge. Real Firefox
+      // sends no client hints, so strip them to keep one identity for the flow.
       stripClientHints(headers)
       callback({ requestHeaders: headers })
       return

--- a/tests/tools/google-signin-ua-probe.cjs
+++ b/tests/tools/google-signin-ua-probe.cjs
@@ -9,12 +9,26 @@ const MODES = new Set([
   'electron-auth',
   'electron-fixed',
   'firefox-auth',
-  'firefox-fixed'
+  'firefox-fixed',
+  // Replicates the SHIPPED app exactly (setupClientHintsOverride +
+  // applyGoogleAuthUserAgent): Firefox UA is written to the WebContents on auth
+  // navs and to the request header only for auth-host URLs; every other request
+  // keeps whatever UA the WebContents carries. Logs incoming vs outgoing
+  // identity for ALL requests to expose cross-host mismatches during the flow.
+  'app-current',
+  // Same, but with the STA-3811 fix: the header layer strips client hints on any
+  // request already carrying the Firefox auth UA, regardless of destination host.
+  'app-fixed'
 ])
 const mode = process.argv.find((arg) => arg.startsWith('--mode='))?.slice('--mode='.length)
 if (!mode || !MODES.has(mode)) {
   throw new Error(`Expected --mode=${[...MODES].join('|')}`)
 }
+
+const headless = process.argv.includes('--headless')
+const exitAfterMs = Number(
+  process.argv.find((arg) => arg.startsWith('--exit-after-ms='))?.slice('--exit-after-ms='.length)
+)
 
 const profileRoot = mkdtempSync(join(tmpdir(), `orca-google-signin-${mode}-`))
 const partition = `persist:google-signin-${mode}`
@@ -56,6 +70,30 @@ function safeUrl(rawUrl) {
   } catch {
     return '<invalid>'
   }
+}
+
+function hostOf(rawUrl) {
+  try {
+    return new URL(rawUrl).hostname.toLowerCase()
+  } catch {
+    return '<invalid>'
+  }
+}
+
+// A Firefox UA paired with any sec-ch-ua header is the cross-host tell we hunt:
+// real Firefox emits no client hints, so the two surfaces contradict each other.
+function detectUaHintMismatch(headers) {
+  const ua = headers['user-agent'] || ''
+  const isFirefox = /Firefox\/\d/.test(ua) && !/Chrome\//.test(ua)
+  const hasHints = Object.keys(headers).some((key) => key.startsWith('sec-ch-ua'))
+  if (isFirefox && hasHints) {
+    return 'firefox-ua-with-chrome-hints'
+  }
+  const isChrome = /Chrome\/\d/.test(ua)
+  if (isChrome && !hasHints) {
+    return 'chrome-ua-without-hints'
+  }
+  return null
 }
 
 function setHeader(headers, name, value) {
@@ -126,8 +164,47 @@ app.whenReady().then(async () => {
   identities.cleaned = cleanElectronUserAgent(identities.native)
   browserSession.setUserAgent(identityForUrl('about:blank', identities))
 
+  const isAppMode = mode === 'app-current' || mode === 'app-fixed'
+
   browserSession.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
     const headers = details.requestHeaders
+    const incoming = relevantHeaders(headers)
+
+    if (isAppMode) {
+      // Mirror setupClientHintsOverride: only auth-host URLs get the Firefox UA
+      // header + hint strip; every other request keeps its incoming UA (which is
+      // the WebContents UA — Firefox while the auth document is on screen).
+      if (isGoogleAuthUrl(details.url)) {
+        setHeader(headers, 'user-agent', identities.firefox)
+        removeClientHints(headers)
+      } else {
+        const currentUa = incoming['user-agent']
+        // STA-3811 fix: a request already carrying the Firefox auth UA came from
+        // the auth document; real Firefox sends no client hints, so strip them
+        // instead of rewriting to Chrome — keeping UA and hints one story.
+        if (mode === 'app-fixed' && currentUa === identities.firefox) {
+          removeClientHints(headers)
+        } else {
+          // Real setupClientHintsOverride builds Chrome hints once from the
+          // session's cleaned UA (a closure), never from the per-request UA.
+          applyChromeClientHints(headers, identities.cleaned)
+        }
+      }
+      const outgoing = relevantHeaders(headers)
+      const uaMismatch = detectUaHintMismatch(outgoing)
+      log('request', {
+        url: safeUrl(details.url),
+        host: hostOf(details.url),
+        resourceType: details.resourceType,
+        isAuthHost: isGoogleAuthUrl(details.url),
+        incoming,
+        outgoing,
+        uaHintMismatch: uaMismatch
+      })
+      callback({ requestHeaders: headers })
+      return
+    }
+
     const identity = identityForUrl(details.url, identities)
     setHeader(headers, 'user-agent', identity)
     if (identity === identities.firefox) {
@@ -144,8 +221,15 @@ app.whenReady().then(async () => {
     callback({ requestHeaders: headers })
   })
 
+  if (Number.isFinite(exitAfterMs) && exitAfterMs > 0) {
+    setTimeout(() => {
+      log('exit', { reason: 'timeout', exitAfterMs })
+      app.quit()
+    }, exitAfterMs)
+  }
+
   const window = new BrowserWindow({
-    show: true,
+    show: !headless,
     title: `Google sign-in UA probe: ${mode}`,
     width: 980,
     height: 840,
@@ -159,6 +243,24 @@ app.whenReady().then(async () => {
 
   window.webContents.on('did-start-navigation', (_event, url, _inPlace, isMainFrame) => {
     if (!isMainFrame) {
+      return
+    }
+    if (isAppMode) {
+      // Mirror applyGoogleAuthUserAgent: Firefox UA on auth navs, restore the
+      // cleaned session UA otherwise. This WebContents UA is what leaks onto
+      // cross-host subresource requests while the auth document is on screen.
+      const current = window.webContents.getUserAgent()
+      if (isGoogleAuthUrl(url)) {
+        if (current !== identities.firefox) {
+          window.webContents.setUserAgent(identities.firefox)
+        }
+      } else if (current === identities.firefox) {
+        window.webContents.setUserAgent(identities.cleaned)
+      }
+      log('main-frame-navigation', {
+        url: safeUrl(url),
+        appliedUserAgent: window.webContents.getUserAgent()
+      })
       return
     }
     const identity = identityForUrl(url, identities)


### PR DESCRIPTION
## Summary

Direct in-app Google sign-in (the #12884 Firefox-UA-on-auth-hosts fix) reaches the genuine password page but, for some accounts, greys out with a frozen progress bar after clicking **Next** and never advances (STA-3811). Root cause: a **cross-host identity inconsistency**. While the auth document is on screen, `applyGoogleAuthUserAgent` sets the WebContents UA to Firefox — so `navigator.userAgent` **and the default request `User-Agent` header for every subresource/XHR** become Firefox, including requests to non-auth Google hosts (`www.gstatic.com`, `play.google.com`, the sign-in challenge endpoints). The header layer (`setupClientHintsOverride`) only Firefox-izes requests whose **URL** is an auth host; for every other request it rewrote `sec-ch-ua` to Chrome brands. The result on the wire: **Firefox UA paired with Chrome client hints** on each cross-host request — a sharper bot tell than either signal alone, and a plausible cause of Google's anti-abuse flow stalling the challenge (a hang) rather than issuing a clean rejection.

This is fix **1/4** for STA-3811 (the correctness prerequisite). It does **not** touch cookie-import code (owned by other workers).

### Fix
In `setupClientHintsOverride`, when a request already carries the Firefox auth UA (regardless of destination host), **strip all client hints** (real Firefox sends none) instead of rewriting them to Chrome. The UA and hint surfaces then tell one consistent Firefox story for the whole sign-in flow. Gated on the same `googleAuthOverride` flag as the auth-host switch, so:
- **Imported-native profiles** never install the Firefox switch → branch stays inert.
- **Non-Google sites** carry the cleaned-Chrome UA, not Firefox → they still get Chrome hints, so the Cloudflare/Turnstile default is untouched.

### Evidence
Extended `tests/tools/google-signin-ua-probe.cjs` with `app-current` / `app-fixed` modes that mirror the shipped code exactly and log per-request identity (incoming vs outgoing UA + hints) for **all** requests. On the real `accounts.google.com` load:

| mode | cross-host `firefox-ua-with-chrome-hints` mismatches |
| --- | --- |
| `app-current` (shipped) | **18** (www.gstatic.com, fonts.gstatic.com, play.google.com) |
| `app-fixed` (this PR) | **0** — cross-host requests present a clean Firefox identity, no client hints |

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` (tsconfig.node) — clean
- [x] `pnpm oxlint` (changed files) — clean
- [x] Changed-file vitest: `src/main/browser/` — 33 files / 591 tests pass, incl. 3 new cases (strip-on-Firefox-cross-host, keep-Chrome-on-non-Google, inert-when-googleAuthOverride-false)
- [x] `oxfmt --check` — clean
- [ ] `pnpm build` (not run in this worker)

## AI Review Report

Reviewed the request-header override path for scope creep and layer disagreement. Confirmed the new branch keys off the outgoing `User-Agent` header value (case-insensitive), which faithfully reflects the WebContents UA override for subresources — verified empirically via the probe (incoming UA = Firefox on gstatic/play.google.com requests). Cross-platform: the Firefox UA's platform token is chosen by `process.platform` (unchanged); the fix itself is a platform-agnostic string comparison, so macOS/Linux/Windows behave identically. No shortcuts, paths, or shell behavior touched.

## Security Audit

No command execution, path handling, secrets, or IPC changes. Input handling is limited to reading one request header and comparing it to a fixed UA constant, then conditionally deleting `sec-ch-ua*` headers. The change only ever **removes** headers on the Firefox-auth path — it cannot widen what a non-Google site sees. No follow-up needed.

## Notes

Fix 1/4 for STA-3811. Remaining follow-ups (separate tickets/PRs, not this change): in-app sign-in ordering vs cookie imports, and the import-preserves-in-app-Google-session product change. A residual JS-layer inconsistency (`navigator.userAgentData` still reports Chromium brands under the Firefox UA) is out of scope here; Google's initial checks tolerate it (the QA reaches the real password page), and the header-layer wire identity is the surface implicated in the submit hang.
