### PR TITLE
fix(browser): offer one-click recovery from Google CookieMismatch (STA-3811)

### DIFF
--- a/src/main/browser/browser-google-cookie-mismatch-recovery.test.ts
+++ b/src/main/browser/browser-google-cookie-mismatch-recovery.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Cookie } from 'electron'
+import {
+  GoogleCookieMismatchPromptThrottle,
+  clearGoogleCookies,
+  googleCookieMismatchRecoveryUrl,
+  isGoogleCookieMismatchUrl
+} from './browser-google-cookie-mismatch-recovery'
+
+function cookie(domain: string, name: string, path = '/', secure = true): Cookie {
+  return {
+    domain,
+    name,
+    path,
+    secure,
+    sameSite: 'unspecified',
+    value: 'secret'
+  }
+}
+
+describe('isGoogleCookieMismatchUrl', () => {
+  it('matches the CookieMismatch page on accounts.google.com only', () => {
+    expect(isGoogleCookieMismatchUrl('https://accounts.google.com/CookieMismatch')).toBe(true)
+    expect(
+      isGoogleCookieMismatchUrl(
+        'https://accounts.google.com/CookieMismatch?continue=https%3A%2F%2Fmail.google.com%2F'
+      )
+    ).toBe(true)
+    expect(isGoogleCookieMismatchUrl('https://accounts.google.com/CookieMismatch/')).toBe(true)
+    expect(isGoogleCookieMismatchUrl('https://Accounts.Google.Com/cookiemismatch')).toBe(true)
+  })
+
+  it('rejects other paths, hosts, and schemes', () => {
+    expect(isGoogleCookieMismatchUrl('https://accounts.google.com/signin')).toBe(false)
+    expect(isGoogleCookieMismatchUrl('https://accounts.google.com/CookieMismatchFoo')).toBe(false)
+    expect(
+      isGoogleCookieMismatchUrl('https://accounts.google.com.evil.example/CookieMismatch')
+    ).toBe(false)
+    expect(isGoogleCookieMismatchUrl('https://google.com/CookieMismatch')).toBe(false)
+    expect(isGoogleCookieMismatchUrl('file:///CookieMismatch')).toBe(false)
+    expect(isGoogleCookieMismatchUrl('not a url')).toBe(false)
+  })
+})
+
+describe('googleCookieMismatchRecoveryUrl', () => {
+  it('recovers the continue target when it is a Google https URL', () => {
+    expect(
+      googleCookieMismatchRecoveryUrl(
+        'https://accounts.google.com/CookieMismatch?continue=https%3A%2F%2Fmail.google.com%2Fmail%2F'
+      )
+    ).toBe('https://mail.google.com/mail/')
+  })
+
+  it('falls back to the sign-in page for missing, non-Google, or insecure continue targets', () => {
+    expect(googleCookieMismatchRecoveryUrl('https://accounts.google.com/CookieMismatch')).toBe(
+      'https://accounts.google.com/'
+    )
+    expect(
+      googleCookieMismatchRecoveryUrl(
+        'https://accounts.google.com/CookieMismatch?continue=https%3A%2F%2Fevil.example%2F'
+      )
+    ).toBe('https://accounts.google.com/')
+    expect(
+      googleCookieMismatchRecoveryUrl(
+        'https://accounts.google.com/CookieMismatch?continue=http%3A%2F%2Fmail.google.com%2F'
+      )
+    ).toBe('https://accounts.google.com/')
+    expect(
+      googleCookieMismatchRecoveryUrl('https://accounts.google.com/CookieMismatch?continue=%25')
+    ).toBe('https://accounts.google.com/')
+  })
+})
+
+describe('clearGoogleCookies', () => {
+  it('removes google.com-family cookies and retains every other domain', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValue([
+        cookie('.google.com', 'SID'),
+        cookie('accounts.google.com', 'ACCOUNT_CHOOSER', '/signin'),
+        cookie('.accounts.google.com', 'LSID', '/', false),
+        cookie('.google.com.evil.example', 'suffix-confusion'),
+        cookie('.github.com', 'user_session'),
+        cookie('.example.com', 'unrelated')
+      ])
+    const remove = vi.fn().mockResolvedValue(undefined)
+
+    const result = await clearGoogleCookies({ get, remove })
+
+    expect(result).toEqual({ removed: 3, failed: 0 })
+    expect(remove.mock.calls).toEqual([
+      ['https://google.com/', 'SID'],
+      ['https://accounts.google.com/signin', 'ACCOUNT_CHOOSER'],
+      ['http://accounts.google.com/', 'LSID']
+    ])
+  })
+
+  it('keeps clearing after a single cookie fails to remove', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValue([cookie('.google.com', 'SID'), cookie('.google.com', 'HSID')])
+    const remove = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('locked'))
+      .mockResolvedValueOnce(undefined)
+
+    const result = await clearGoogleCookies({ get, remove })
+
+    expect(result).toEqual({ removed: 1, failed: 1 })
+    expect(remove).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('GoogleCookieMismatchPromptThrottle', () => {
+  it('prompts once per partition per cooldown window', () => {
+    let clock = 0
+    const throttle = new GoogleCookieMismatchPromptThrottle(() => clock)
+    const session = {}
+
+    expect(throttle.shouldPrompt(session)).toBe(true)
+    expect(throttle.shouldPrompt(session)).toBe(false)
+    clock += 30_000
+    expect(throttle.shouldPrompt(session)).toBe(false)
+    clock += 2 * 60_000
+    expect(throttle.shouldPrompt(session)).toBe(true)
+  })
+
+  it('tracks partitions independently', () => {
+    const throttle = new GoogleCookieMismatchPromptThrottle(() => 0)
+    const sessionA = {}
+    const sessionB = {}
+
+    expect(throttle.shouldPrompt(sessionA)).toBe(true)
+    expect(throttle.shouldPrompt(sessionB)).toBe(true)
+    expect(throttle.shouldPrompt(sessionA)).toBe(false)
+  })
+})

--- a/src/main/browser/browser-google-cookie-mismatch-recovery.test.ts
+++ b/src/main/browser/browser-google-cookie-mismatch-recovery.test.ts
@@ -125,6 +125,15 @@ describe('GoogleCookieMismatchPromptThrottle', () => {
     expect(throttle.shouldPrompt(session)).toBe(true)
   })
 
+  it('allows a new prompt after the prior recovery is no longer actionable', () => {
+    const throttle = new GoogleCookieMismatchPromptThrottle(() => 0)
+    const session = {}
+
+    expect(throttle.shouldPrompt(session)).toBe(true)
+    throttle.reset(session)
+    expect(throttle.shouldPrompt(session)).toBe(true)
+  })
+
   it('tracks partitions independently', () => {
     const throttle = new GoogleCookieMismatchPromptThrottle(() => 0)
     const sessionA = {}

--- a/src/main/browser/browser-google-cookie-mismatch-recovery.ts
+++ b/src/main/browser/browser-google-cookie-mismatch-recovery.ts
@@ -1,0 +1,95 @@
+// Why: accounts.google.com/CookieMismatch is a dead end that tells the user to clear
+// cookies by hand — unreachable advice inside an embedded browser. Orca offers the fix
+// instead: on the user's click it clears the partition's google.com-family cookies (the
+// only ones Google's mismatch check reads) and reloads sign-in, so every other site's
+// session survives. Nothing is ever cleared without that click.
+
+import type { Cookie, Cookies } from 'electron'
+import { normalizeCookieDomain } from './browser-cookie-import-policy'
+
+const COOKIE_MISMATCH_HOST = 'accounts.google.com'
+const RECOVERY_FALLBACK_URL = 'https://accounts.google.com/'
+
+export function isGoogleCookieMismatchUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl)
+    return (
+      (url.protocol === 'https:' || url.protocol === 'http:') &&
+      url.hostname.toLowerCase() === COOKIE_MISMATCH_HOST &&
+      /^\/cookiemismatch(?:\/|$)/i.test(url.pathname)
+    )
+  } catch {
+    return false
+  }
+}
+
+function isGoogleCookieDomain(normalizedDomain: string): boolean {
+  return normalizedDomain === 'google.com' || normalizedDomain.endsWith('.google.com')
+}
+
+// Why: honor the flow's own continue target only when it stays on Google over https —
+// auto-navigating wherever a query param points would hand redirect control to the page.
+export function googleCookieMismatchRecoveryUrl(mismatchUrl: string): string {
+  try {
+    const continueParam = new URL(mismatchUrl).searchParams.get('continue')
+    if (continueParam) {
+      const target = new URL(continueParam)
+      if (target.protocol === 'https:' && isGoogleCookieDomain(target.hostname.toLowerCase())) {
+        return target.toString()
+      }
+    }
+  } catch {
+    // fall through to the plain sign-in page
+  }
+  return RECOVERY_FALLBACK_URL
+}
+
+function cookieRemovalUrl(cookie: Cookie, normalizedDomain: string): string {
+  const url = new URL(`${cookie.secure ? 'https' : 'http'}://${normalizedDomain}/`)
+  url.pathname = cookie.path?.startsWith('/') ? cookie.path : '/'
+  return url.toString()
+}
+
+// Why: per-cookie best effort — one undeletable cookie must not strand the rest, and a
+// partial clear still usually resolves the mismatch.
+export async function clearGoogleCookies(
+  store: Pick<Cookies, 'get' | 'remove'>
+): Promise<{ removed: number; failed: number }> {
+  const cookies = await store.get({})
+  let removed = 0
+  let failed = 0
+  for (const cookie of cookies) {
+    const domain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null
+    if (!domain || !isGoogleCookieDomain(domain)) {
+      continue
+    }
+    try {
+      await store.remove(cookieRemovalUrl(cookie, domain), cookie.name)
+      removed++
+    } catch {
+      failed++
+    }
+  }
+  return { removed, failed }
+}
+
+const PROMPT_COOLDOWN_MS = 2 * 60_000
+
+// Why: a mismatch that recurs (or lands in several tabs at once) must not stack toasts.
+// Keyed by session so one prompt covers the whole partition; WeakMap lets dead sessions GC.
+export class GoogleCookieMismatchPromptThrottle {
+  private readonly lastPromptBySession = new WeakMap<object, number>()
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  // Why: check-and-mark in one step so two mismatch navs racing in the same partition
+  // cannot both prompt.
+  shouldPrompt(session: object): boolean {
+    const last = this.lastPromptBySession.get(session)
+    if (last !== undefined && this.now() - last < PROMPT_COOLDOWN_MS) {
+      return false
+    }
+    this.lastPromptBySession.set(session, this.now())
+    return true
+  }
+}

--- a/src/main/browser/browser-google-cookie-mismatch-recovery.ts
+++ b/src/main/browser/browser-google-cookie-mismatch-recovery.ts
@@ -92,4 +92,8 @@ export class GoogleCookieMismatchPromptThrottle {
     this.lastPromptBySession.set(session, this.now())
     return true
   }
+
+  reset(session: object): void {
+    this.lastPromptBySession.delete(session)
+  }
 }

--- a/src/main/browser/browser-manager-google-cookie-mismatch.test.ts
+++ b/src/main/browser/browser-manager-google-cookie-mismatch.test.ts
@@ -325,4 +325,23 @@ describe('browserManager Google CookieMismatch prompt', () => {
     await expect(recovery).resolves.toBe(false)
     expect(guest.loadURL).not.toHaveBeenCalled()
   })
+
+  it('does not overwrite a newer navigation after an in-flight cookie clear', async () => {
+    let resolveCookies: ((cookies: Cookie[]) => void) | undefined
+    const partition = createPartition()
+    partition.cookies.get.mockImplementation(
+      () => new Promise<Cookie[]>((resolve) => (resolveCookies = resolve))
+    )
+    const guest = createGuest(719, partition)
+    mount([guest])
+    register(guest, 'browser-1')
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+
+    const recovery = browserManager.recoverFromGoogleCookieMismatch('browser-1')
+    guest.emit('did-navigate', {}, 'https://example.com/')
+    resolveCookies?.([])
+
+    await expect(recovery).resolves.toBe(false)
+    expect(guest.loadURL).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/browser/browser-manager-google-cookie-mismatch.test.ts
+++ b/src/main/browser/browser-manager-google-cookie-mismatch.test.ts
@@ -55,6 +55,7 @@ function createPartition(): Partition {
 function createGuest(id: number, session: Partition = createPartition()): Guest {
   const handlers = new Map<string, ((...args: unknown[]) => void)[]>()
   const loadURL = vi.fn().mockResolvedValue(undefined)
+  let currentUrl = 'about:blank'
   const webContents = {
     id,
     isDestroyed: vi.fn(() => false),
@@ -62,7 +63,7 @@ function createGuest(id: number, session: Partition = createPartition()): Guest 
     setBackgroundThrottling: vi.fn(),
     setWindowOpenHandler: vi.fn(),
     openDevTools: vi.fn(),
-    getURL: vi.fn(() => MISMATCH_URL),
+    getURL: vi.fn(() => currentUrl),
     loadURL,
     on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       handlers.set(event, [...(handlers.get(event) ?? []), handler])
@@ -73,6 +74,9 @@ function createGuest(id: number, session: Partition = createPartition()): Guest 
   return {
     webContents,
     emit: (event, ...args) => {
+      if (event === 'did-navigate' && typeof args[1] === 'string') {
+        currentUrl = args[1]
+      }
       for (const handler of handlers.get(event) ?? []) {
         handler(...args)
       }
@@ -116,7 +120,8 @@ describe('browserManager Google CookieMismatch prompt', () => {
     guest.emit('did-navigate', {}, MISMATCH_URL)
 
     expect(rendererSendMock).toHaveBeenCalledWith('browser:google-cookie-mismatch-detected', {
-      browserPageId: 'browser-1'
+      browserPageId: 'browser-1',
+      active: true
     })
     // The destructive half waits for the user's click.
     expect(guest.cookieRemove).not.toHaveBeenCalled()
@@ -169,6 +174,97 @@ describe('browserManager Google CookieMismatch prompt', () => {
     ).toHaveLength(2)
   })
 
+  it('does not consume the partition prompt throttle before a renderer is eligible', () => {
+    const partition = createPartition()
+    const unregistered = createGuest(710, partition)
+    const registered = createGuest(711, partition)
+    mount([unregistered, registered])
+    browserManager.attachGuestPolicies(unregistered.webContents)
+    register(registered, 'browser-2')
+
+    unregistered.emit('did-navigate', {}, MISMATCH_URL)
+    registered.emit('did-navigate', {}, MISMATCH_URL)
+
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:google-cookie-mismatch-detected', {
+      browserPageId: 'browser-2',
+      active: true
+    })
+  })
+
+  it('prompts when a guest registers after committing the mismatch page', () => {
+    const guest = createGuest(712)
+    mount([guest])
+    browserManager.attachGuestPolicies(guest.webContents)
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.webContents.id,
+      rendererWebContentsId: RENDERER_WEB_CONTENTS_ID
+    })
+
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:google-cookie-mismatch-detected', {
+      browserPageId: 'browser-1',
+      active: true
+    })
+  })
+
+  it('invalidates the reset and dismisses its prompt after navigating away', async () => {
+    const guest = createGuest(713)
+    mount([guest])
+    register(guest, 'browser-1')
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+    rendererSendMock.mockClear()
+
+    guest.emit('did-navigate', {}, 'https://example.com/')
+
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:google-cookie-mismatch-detected', {
+      browserPageId: 'browser-1',
+      active: false
+    })
+    await expect(browserManager.recoverFromGoogleCookieMismatch('browser-1')).resolves.toBe(false)
+    expect(guest.cookieRemove).not.toHaveBeenCalled()
+    expect(guest.loadURL).not.toHaveBeenCalled()
+  })
+
+  it('moves the partition prompt to another mismatched tab when its owner leaves', () => {
+    const partition = createPartition()
+    const first = createGuest(715, partition)
+    const second = createGuest(716, partition)
+    mount([first, second])
+    register(first, 'browser-1')
+    register(second, 'browser-2')
+    first.emit('did-navigate', {}, MISMATCH_URL)
+    second.emit('did-navigate', {}, MISMATCH_URL)
+    rendererSendMock.mockClear()
+
+    first.emit('did-navigate', {}, 'https://example.com/')
+
+    expect(rendererSendMock.mock.calls).toEqual([
+      ['browser:google-cookie-mismatch-detected', { browserPageId: 'browser-1', active: false }],
+      ['browser:google-cookie-mismatch-detected', { browserPageId: 'browser-2', active: true }]
+    ])
+  })
+
+  it('moves the partition prompt when its owning guest is torn down', () => {
+    const partition = createPartition()
+    const first = createGuest(717, partition)
+    const second = createGuest(718, partition)
+    mount([first, second])
+    register(first, 'browser-1')
+    register(second, 'browser-2')
+    first.emit('did-navigate', {}, MISMATCH_URL)
+    second.emit('did-navigate', {}, MISMATCH_URL)
+    rendererSendMock.mockClear()
+
+    browserManager.unregisterGuest('browser-1')
+
+    expect(rendererSendMock.mock.calls).toEqual([
+      ['browser:google-cookie-mismatch-detected', { browserPageId: 'browser-1', active: false }],
+      ['browser:google-cookie-mismatch-detected', { browserPageId: 'browser-2', active: true }]
+    ])
+  })
+
   it('clears only Google cookies and reloads the flow when the user accepts', async () => {
     const guest = createGuest(707)
     mount([guest])
@@ -209,5 +305,24 @@ describe('browserManager Google CookieMismatch prompt', () => {
 
     await expect(browserManager.recoverFromGoogleCookieMismatch('browser-1')).resolves.toBe(false)
     expect(guest.cookieRemove).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate a retired guest after an in-flight cookie clear', async () => {
+    let resolveCookies: ((cookies: Cookie[]) => void) | undefined
+    const partition = createPartition()
+    partition.cookies.get.mockImplementation(
+      () => new Promise<Cookie[]>((resolve) => (resolveCookies = resolve))
+    )
+    const guest = createGuest(714, partition)
+    mount([guest])
+    register(guest, 'browser-1')
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+
+    const recovery = browserManager.recoverFromGoogleCookieMismatch('browser-1')
+    browserManager.unregisterGuest('browser-1')
+    resolveCookies?.([])
+
+    await expect(recovery).resolves.toBe(false)
+    expect(guest.loadURL).not.toHaveBeenCalled()
   })
 })

--- a/src/main/browser/browser-manager-google-cookie-mismatch.test.ts
+++ b/src/main/browser/browser-manager-google-cookie-mismatch.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Cookie } from 'electron'
+
+const { webContentsFromIdMock, rendererSendMock } = vi.hoisted(() => ({
+  webContentsFromIdMock: vi.fn(),
+  rendererSendMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/downloads') },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  clipboard: { writeText: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn() },
+  screen: { getCursorScreenPoint: vi.fn(() => ({ x: 0, y: 0 })) },
+  webContents: { fromId: webContentsFromIdMock }
+}))
+
+import { browserManager } from './browser-manager'
+
+const MISMATCH_URL =
+  'https://accounts.google.com/CookieMismatch?continue=https%3A%2F%2Fmail.google.com%2Fmail%2F'
+const RENDERER_WEB_CONTENTS_ID = 6001
+
+function cookie(domain: string, name: string): Cookie {
+  return { domain, name, path: '/', secure: true, sameSite: 'unspecified', value: 'secret' }
+}
+
+type Guest = {
+  webContents: Electron.WebContents
+  emit: (event: string, ...args: unknown[]) => void
+  cookieRemove: ReturnType<typeof vi.fn>
+  loadURL: ReturnType<typeof vi.fn>
+}
+
+type Partition = { cookies: { get: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> } }
+
+// Why: one session object shared by every tab in the partition — its identity is what the
+// prompt throttle keys on.
+function createPartition(): Partition {
+  return {
+    cookies: {
+      get: vi
+        .fn()
+        .mockResolvedValue([
+          cookie('.google.com', 'SID'),
+          cookie('accounts.google.com', 'LSID'),
+          cookie('.github.com', 'user_session')
+        ]),
+      remove: vi.fn().mockResolvedValue(undefined)
+    }
+  }
+}
+
+function createGuest(id: number, session: Partition = createPartition()): Guest {
+  const handlers = new Map<string, ((...args: unknown[]) => void)[]>()
+  const loadURL = vi.fn().mockResolvedValue(undefined)
+  const webContents = {
+    id,
+    isDestroyed: vi.fn(() => false),
+    getType: vi.fn(() => 'webview'),
+    setBackgroundThrottling: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    openDevTools: vi.fn(),
+    getURL: vi.fn(() => MISMATCH_URL),
+    loadURL,
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler])
+    }),
+    off: vi.fn(),
+    session
+  } as unknown as Electron.WebContents
+  return {
+    webContents,
+    emit: (event, ...args) => {
+      for (const handler of handlers.get(event) ?? []) {
+        handler(...args)
+      }
+    },
+    cookieRemove: session.cookies.remove,
+    loadURL
+  }
+}
+
+function register(guest: Guest, browserPageId: string): void {
+  browserManager.attachGuestPolicies(guest.webContents)
+  browserManager.registerGuest({
+    browserPageId,
+    webContentsId: guest.webContents.id,
+    rendererWebContentsId: RENDERER_WEB_CONTENTS_ID
+  })
+}
+
+describe('browserManager Google CookieMismatch prompt', () => {
+  beforeEach(() => {
+    webContentsFromIdMock.mockReset()
+    rendererSendMock.mockReset()
+    browserManager.unregisterAll()
+    browserManager.setSettingsResolver(() => ({}))
+  })
+
+  function mount(guests: Guest[]): void {
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === RENDERER_WEB_CONTENTS_ID) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return guests.find((guest) => guest.webContents.id === id)?.webContents ?? null
+    })
+  }
+
+  it('prompts the renderer on a committed mismatch navigation without clearing anything', () => {
+    const guest = createGuest(701)
+    mount([guest])
+    register(guest, 'browser-1')
+
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:google-cookie-mismatch-detected', {
+      browserPageId: 'browser-1'
+    })
+    // The destructive half waits for the user's click.
+    expect(guest.cookieRemove).not.toHaveBeenCalled()
+    expect(guest.loadURL).not.toHaveBeenCalled()
+  })
+
+  it('ignores navigations that are not the CookieMismatch page', () => {
+    const guest = createGuest(702)
+    mount([guest])
+    register(guest, 'browser-1')
+
+    guest.emit('did-navigate', {}, 'https://accounts.google.com/signin')
+
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
+  it('prompts once per partition even when the mismatch recurs across tabs', () => {
+    const partition = createPartition()
+    const first = createGuest(703, partition)
+    const second = createGuest(704, partition)
+    mount([first, second])
+    register(first, 'browser-1')
+    register(second, 'browser-2')
+
+    first.emit('did-navigate', {}, MISMATCH_URL)
+    first.emit('did-navigate', {}, MISMATCH_URL)
+    second.emit('did-navigate', {}, MISMATCH_URL)
+
+    expect(
+      rendererSendMock.mock.calls.filter(
+        ([channel]) => channel === 'browser:google-cookie-mismatch-detected'
+      )
+    ).toHaveLength(1)
+  })
+
+  it('prompts separately for a different partition', () => {
+    const first = createGuest(705)
+    const second = createGuest(706)
+    mount([first, second])
+    register(first, 'browser-1')
+    register(second, 'browser-2')
+
+    first.emit('did-navigate', {}, MISMATCH_URL)
+    second.emit('did-navigate', {}, MISMATCH_URL)
+
+    expect(
+      rendererSendMock.mock.calls.filter(
+        ([channel]) => channel === 'browser:google-cookie-mismatch-detected'
+      )
+    ).toHaveLength(2)
+  })
+
+  it('clears only Google cookies and reloads the flow when the user accepts', async () => {
+    const guest = createGuest(707)
+    mount([guest])
+    register(guest, 'browser-1')
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+
+    await expect(browserManager.recoverFromGoogleCookieMismatch('browser-1')).resolves.toBe(true)
+
+    expect(guest.cookieRemove.mock.calls).toEqual([
+      ['https://google.com/', 'SID'],
+      ['https://accounts.google.com/', 'LSID']
+    ])
+    expect(guest.loadURL).toHaveBeenCalledWith('https://mail.google.com/mail/')
+  })
+
+  it('refuses to clear when no mismatch was detected for the tab', async () => {
+    const guest = createGuest(708)
+    mount([guest])
+    register(guest, 'browser-1')
+
+    await expect(browserManager.recoverFromGoogleCookieMismatch('browser-1')).resolves.toBe(false)
+    await expect(browserManager.recoverFromGoogleCookieMismatch('browser-unknown')).resolves.toBe(
+      false
+    )
+
+    expect(guest.cookieRemove).not.toHaveBeenCalled()
+    expect(guest.loadURL).not.toHaveBeenCalled()
+  })
+
+  it('does not re-clear on a repeated accept for the same detection', async () => {
+    const guest = createGuest(709)
+    mount([guest])
+    register(guest, 'browser-1')
+    guest.emit('did-navigate', {}, MISMATCH_URL)
+
+    await browserManager.recoverFromGoogleCookieMismatch('browser-1')
+    guest.cookieRemove.mockClear()
+
+    await expect(browserManager.recoverFromGoogleCookieMismatch('browser-1')).resolves.toBe(false)
+    expect(guest.cookieRemove).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -45,6 +45,12 @@ import {
 import { cleanElectronUserAgent } from './browser-session-ua'
 import { getBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
+import {
+  GoogleCookieMismatchPromptThrottle,
+  clearGoogleCookies,
+  googleCookieMismatchRecoveryUrl,
+  isGoogleCookieMismatchUrl
+} from './browser-google-cookie-mismatch-recovery'
 import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
 import type {
   BrowserViewportOverride,
@@ -259,6 +265,8 @@ export class BrowserManager {
   private readonly pendingDownloadIdsByGuestId = new Map<number, string[]>()
   private readonly downloadsById = new Map<string, ActiveDownload>()
   private readonly grabSessionController = new BrowserGrabSessionController()
+  private readonly googleCookieMismatchPromptThrottle = new GoogleCookieMismatchPromptThrottle()
+  private readonly googleCookieMismatchUrlByGuestId = new Map<number, string>()
 
   setDictationShortcutForwardingPredicate(predicate: (() => boolean) | null): void {
     this.shouldForwardDictationShortcut = predicate
@@ -898,6 +906,9 @@ export class BrowserManager {
       // Why: a committed nav makes the did-start-navigation stash obsolete; drop it so a later ERR_ABORTED can't restore an error over it.
       this.clearedLoadErrorsByGuestId.delete(guest.id)
       this.certificateTrustController?.onMainFrameNavigationCommitted(guest.id, url)
+      // Why: detect at commit, not did-start-navigation — a sign-in nav that 302s into
+      // CookieMismatch never re-fires did-start-navigation with the mismatch URL.
+      this.maybePromptGoogleCookieMismatchRecovery(guest, url)
     }
 
     guest.on('will-navigate', navigationGuard)
@@ -941,6 +952,57 @@ export class BrowserManager {
         guest.off('did-fail-load', didFailLoadHandler)
       }
     })
+  }
+
+  // Why: applies in every UA mode — CookieMismatch is about the cookie jar, not the
+  // identity a profile presents, so native-UA profiles hit it the same way. Detection only
+  // offers the fix; cookies are cleared in recoverFromGoogleCookieMismatch, on the user's click.
+  private maybePromptGoogleCookieMismatchRecovery(guest: Electron.WebContents, url: string): void {
+    if (!isGoogleCookieMismatchUrl(url)) {
+      return
+    }
+    // Why: stash the mismatch URL so the click recovers to the flow's own continue target —
+    // the renderer never gets to name a navigation target.
+    this.googleCookieMismatchUrlByGuestId.set(guest.id, url)
+    if (!this.googleCookieMismatchPromptThrottle.shouldPrompt(guest.session)) {
+      return
+    }
+    const browserPageId = this.tabIdByWebContentsId.get(guest.id)
+    if (!browserPageId) {
+      return
+    }
+    const renderer = this.resolveRendererForBrowserTab(browserPageId)
+    renderer?.send('browser:google-cookie-mismatch-detected', { browserPageId })
+  }
+
+  // Why: user-initiated only — this is the destructive half, reached from the toast action.
+  async recoverFromGoogleCookieMismatch(browserPageId: string): Promise<boolean> {
+    const webContentsId = this.webContentsIdByTabId.get(browserPageId)
+    if (webContentsId === undefined) {
+      return false
+    }
+    const mismatchUrl = this.googleCookieMismatchUrlByGuestId.get(webContentsId)
+    if (!mismatchUrl) {
+      return false
+    }
+    const guest = webContents.fromId(webContentsId)
+    if (!guest || guest.isDestroyed()) {
+      return false
+    }
+    this.googleCookieMismatchUrlByGuestId.delete(webContentsId)
+    try {
+      await clearGoogleCookies(guest.session.cookies)
+    } catch (error) {
+      // Why: navigate anyway — a persisting mismatch just shows Google's page again.
+      console.error('[browser-manager] Google CookieMismatch cookie clear failed', error)
+    }
+    if (guest.isDestroyed()) {
+      return false
+    }
+    await guest.loadURL(googleCookieMismatchRecoveryUrl(mismatchUrl)).catch(() => {
+      // a failed load surfaces through the tab's normal load-error overlay
+    })
+    return true
   }
 
   // Why: navigator.userAgent (read by Google's auth JS) reflects the WebContents UA,
@@ -1123,6 +1185,7 @@ export class BrowserManager {
     this.clearedLoadErrorsByGuestId.delete(guestWebContentsId)
     this.pendingPermissionEventsByGuestId.delete(guestWebContentsId)
     this.pendingPopupEventsByGuestId.delete(guestWebContentsId)
+    this.googleCookieMismatchUrlByGuestId.delete(guestWebContentsId)
     this.cancelPendingDownloadsForGuest(guestWebContentsId)
   }
 
@@ -1319,6 +1382,7 @@ export class BrowserManager {
     this.clearedLoadErrorsByGuestId.clear()
     this.pendingPermissionEventsByGuestId.clear()
     this.pendingPopupEventsByGuestId.clear()
+    this.googleCookieMismatchUrlByGuestId.clear()
     this.pendingDownloadIdsByGuestId.clear()
     this.mouseWheelZoomCleanupByTabId.clear()
     this.annotationViewportBridgeOpsByTabId.clear()

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -1042,7 +1042,12 @@ export class BrowserManager {
       // Why: navigate anyway — a persisting mismatch just shows Google's page again.
       console.error('[browser-manager] Google CookieMismatch cookie clear failed', error)
     }
-    if (guest.isDestroyed() || this.webContentsIdByTabId.get(browserPageId) !== webContentsId) {
+    if (
+      guest.isDestroyed() ||
+      this.webContentsIdByTabId.get(browserPageId) !== webContentsId ||
+      this.pendingNavigationByGuestId.has(webContentsId) ||
+      !isGoogleCookieMismatchUrl(guest.getURL())
+    ) {
       return false
     }
     await guest.loadURL(googleCookieMismatchRecoveryUrl(mismatchUrl)).catch(() => {

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -267,6 +267,8 @@ export class BrowserManager {
   private readonly grabSessionController = new BrowserGrabSessionController()
   private readonly googleCookieMismatchPromptThrottle = new GoogleCookieMismatchPromptThrottle()
   private readonly googleCookieMismatchUrlByGuestId = new Map<number, string>()
+  private readonly googleCookieMismatchPromptSessionByGuestId = new Map<number, object>()
+  private suppressGoogleCookieMismatchPromptPromotion = false
 
   setDictationShortcutForwardingPredicate(predicate: (() => boolean) | null): void {
     this.shouldForwardDictationShortcut = predicate
@@ -959,20 +961,64 @@ export class BrowserManager {
   // offers the fix; cookies are cleared in recoverFromGoogleCookieMismatch, on the user's click.
   private maybePromptGoogleCookieMismatchRecovery(guest: Electron.WebContents, url: string): void {
     if (!isGoogleCookieMismatchUrl(url)) {
+      this.clearGoogleCookieMismatchRecovery(guest)
       return
     }
     // Why: stash the mismatch URL so the click recovers to the flow's own continue target —
     // the renderer never gets to name a navigation target.
     this.googleCookieMismatchUrlByGuestId.set(guest.id, url)
-    if (!this.googleCookieMismatchPromptThrottle.shouldPrompt(guest.session)) {
-      return
-    }
     const browserPageId = this.tabIdByWebContentsId.get(guest.id)
     if (!browserPageId) {
       return
     }
     const renderer = this.resolveRendererForBrowserTab(browserPageId)
-    renderer?.send('browser:google-cookie-mismatch-detected', { browserPageId })
+    if (!renderer || !this.googleCookieMismatchPromptThrottle.shouldPrompt(guest.session)) {
+      return
+    }
+    this.googleCookieMismatchPromptSessionByGuestId.set(guest.id, guest.session)
+    renderer.send('browser:google-cookie-mismatch-detected', { browserPageId, active: true })
+  }
+
+  private clearGoogleCookieMismatchRecovery(
+    guest: Electron.WebContents,
+    promotePendingPrompt = true
+  ): void {
+    if (!this.googleCookieMismatchUrlByGuestId.delete(guest.id)) {
+      return
+    }
+    const promptSession = this.googleCookieMismatchPromptSessionByGuestId.get(guest.id)
+    if (!promptSession) {
+      return
+    }
+    this.googleCookieMismatchPromptSessionByGuestId.delete(guest.id)
+    this.googleCookieMismatchPromptThrottle.reset(promptSession)
+    const browserPageId = this.tabIdByWebContentsId.get(guest.id)
+    if (!browserPageId) {
+      return
+    }
+    this.resolveRendererForBrowserTab(browserPageId)?.send(
+      'browser:google-cookie-mismatch-detected',
+      { browserPageId, active: false }
+    )
+    if (promotePendingPrompt) {
+      this.promptPendingGoogleCookieMismatchRecovery(promptSession)
+    }
+  }
+
+  private promptPendingGoogleCookieMismatchRecovery(session: object): void {
+    for (const [guestId, mismatchUrl] of this.googleCookieMismatchUrlByGuestId) {
+      const guest = webContents.fromId(guestId)
+      if (!guest || guest.isDestroyed()) {
+        this.googleCookieMismatchUrlByGuestId.delete(guestId)
+        continue
+      }
+      if (guest.session === session) {
+        this.maybePromptGoogleCookieMismatchRecovery(guest, mismatchUrl)
+        if (this.googleCookieMismatchPromptSessionByGuestId.has(guestId)) {
+          return
+        }
+      }
+    }
   }
 
   // Why: user-initiated only — this is the destructive half, reached from the toast action.
@@ -989,14 +1035,14 @@ export class BrowserManager {
     if (!guest || guest.isDestroyed()) {
       return false
     }
-    this.googleCookieMismatchUrlByGuestId.delete(webContentsId)
+    this.clearGoogleCookieMismatchRecovery(guest, false)
     try {
       await clearGoogleCookies(guest.session.cookies)
     } catch (error) {
       // Why: navigate anyway — a persisting mismatch just shows Google's page again.
       console.error('[browser-manager] Google CookieMismatch cookie clear failed', error)
     }
-    if (guest.isDestroyed()) {
+    if (guest.isDestroyed() || this.webContentsIdByTabId.get(browserPageId) !== webContentsId) {
       return false
     }
     await guest.loadURL(googleCookieMismatchRecoveryUrl(mismatchUrl)).catch(() => {
@@ -1186,6 +1232,20 @@ export class BrowserManager {
     this.pendingPermissionEventsByGuestId.delete(guestWebContentsId)
     this.pendingPopupEventsByGuestId.delete(guestWebContentsId)
     this.googleCookieMismatchUrlByGuestId.delete(guestWebContentsId)
+    const promptSession = this.googleCookieMismatchPromptSessionByGuestId.get(guestWebContentsId)
+    if (promptSession) {
+      if (browserTabId) {
+        this.resolveRendererForBrowserTab(browserTabId)?.send(
+          'browser:google-cookie-mismatch-detected',
+          { browserPageId: browserTabId, active: false }
+        )
+      }
+      this.googleCookieMismatchPromptThrottle.reset(promptSession)
+      this.googleCookieMismatchPromptSessionByGuestId.delete(guestWebContentsId)
+      if (!this.suppressGoogleCookieMismatchPromptPromotion) {
+        this.promptPendingGoogleCookieMismatchRecovery(promptSession)
+      }
+    }
     this.cancelPendingDownloadsForGuest(guestWebContentsId)
   }
 
@@ -1255,6 +1315,10 @@ export class BrowserManager {
     this.flushPendingPermissionEvents(browserTabId, webContentsId)
     this.flushPendingPopupEvents(browserTabId, webContentsId)
     this.flushPendingDownloadRequests(browserTabId, webContentsId)
+    const pendingMismatchUrl = this.googleCookieMismatchUrlByGuestId.get(webContentsId)
+    if (pendingMismatchUrl) {
+      this.maybePromptGoogleCookieMismatchRecovery(guest, pendingMismatchUrl)
+    }
     return true
   }
 
@@ -1359,9 +1423,11 @@ export class BrowserManager {
       this.cancelDownloadInternal(downloadId, 'Orca is shutting down.')
     }
     browserDownloadDestinationReservations.clear()
+    this.suppressGoogleCookieMismatchPromptPromotion = true
     for (const browserTabId of this.webContentsIdByTabId.keys()) {
       this.unregisterGuest(browserTabId)
     }
+    this.suppressGoogleCookieMismatchPromptPromotion = false
     this.policyAttachedGuestIds.clear()
     this.offscreenGuestIds.clear()
     // Why: unregisterGuest skips guests that were policy-attached but never registered; invoke their cleanup closures here.
@@ -1383,6 +1449,7 @@ export class BrowserManager {
     this.pendingPermissionEventsByGuestId.clear()
     this.pendingPopupEventsByGuestId.clear()
     this.googleCookieMismatchUrlByGuestId.clear()
+    this.googleCookieMismatchPromptSessionByGuestId.clear()
     this.pendingDownloadIdsByGuestId.clear()
     this.mouseWheelZoomCleanupByTabId.clear()
     this.annotationViewportBridgeOpsByTabId.clear()

--- a/src/main/ipc/browser-google-cookie-mismatch-handler.test.ts
+++ b/src/main/ipc/browser-google-cookie-mismatch-handler.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, recoverFromGoogleCookieMismatchMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  recoverFromGoogleCookieMismatchMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  ipcMain: { removeHandler: vi.fn(), handle: handleMock },
+  webContents: { fromId: vi.fn(() => ({ isDestroyed: () => false })) }
+}))
+
+vi.mock('../browser/browser-manager', () => ({
+  browserCertificateTrustController: { proceed: vi.fn() },
+  browserManager: {
+    registerGuest: vi.fn(() => true),
+    attachGuestPolicies: vi.fn(),
+    unregisterGuest: vi.fn(),
+    getGuestWebContentsId: vi.fn(),
+    getWebContentsIdByTabId: vi.fn(() => new Map()),
+    getWorktreeIdForTab: vi.fn(),
+    getAuthorizedGuest: vi.fn(),
+    setGrabMode: vi.fn(),
+    openDevTools: vi.fn(),
+    setAnnotationViewportBridge: vi.fn(),
+    cancelDownload: vi.fn(),
+    recoverFromGoogleCookieMismatch: recoverFromGoogleCookieMismatchMock
+  }
+}))
+
+import { registerBrowserHandlers } from './browser'
+
+type RecoverHandler = (
+  event: { sender: Electron.WebContents },
+  args: unknown
+) => Promise<boolean> | boolean
+
+const trustedSender = {
+  id: 91,
+  isDestroyed: () => false,
+  getType: () => 'window',
+  getURL: () => 'file:///renderer/index.html'
+} as Electron.WebContents
+
+describe('browser:recoverGoogleCookieMismatch', () => {
+  let recover: RecoverHandler
+
+  beforeEach(() => {
+    vi.stubEnv('ELECTRON_RENDERER_URL', '')
+    handleMock.mockReset()
+    recoverFromGoogleCookieMismatchMock.mockReset()
+    recoverFromGoogleCookieMismatchMock.mockResolvedValue(true)
+    registerBrowserHandlers()
+    recover = handleMock.mock.calls.find(
+      ([channel]) => channel === 'browser:recoverGoogleCookieMismatch'
+    )?.[1] as RecoverHandler
+  })
+
+  it('runs the reset for the trusted renderer', async () => {
+    await expect(recover({ sender: trustedSender }, { browserPageId: 'page-1' })).resolves.toBe(
+      true
+    )
+    expect(recoverFromGoogleCookieMismatchMock).toHaveBeenCalledWith('page-1')
+  })
+
+  it('rejects untrusted senders and malformed arguments', async () => {
+    const guestSender = {
+      id: 92,
+      isDestroyed: () => false,
+      getType: () => 'webview',
+      getURL: () => 'https://accounts.google.com/CookieMismatch'
+    } as Electron.WebContents
+
+    await expect(recover({ sender: guestSender }, { browserPageId: 'page-1' })).resolves.toBe(false)
+    for (const args of [null, {}, { browserPageId: 7 }]) {
+      await expect(recover({ sender: trustedSender }, args)).resolves.toBe(false)
+    }
+    expect(recoverFromGoogleCookieMismatchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/browser-google-cookie-mismatch-handler.test.ts
+++ b/src/main/ipc/browser-google-cookie-mismatch-handler.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { handleMock, recoverFromGoogleCookieMismatchMock } = vi.hoisted(() => ({
-  handleMock: vi.fn(),
-  recoverFromGoogleCookieMismatchMock: vi.fn()
-}))
+const { getAuthorizedGuestMock, handleMock, recoverFromGoogleCookieMismatchMock } = vi.hoisted(
+  () => ({
+    getAuthorizedGuestMock: vi.fn(),
+    handleMock: vi.fn(),
+    recoverFromGoogleCookieMismatchMock: vi.fn()
+  })
+)
 
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: vi.fn() },
@@ -20,7 +23,7 @@ vi.mock('../browser/browser-manager', () => ({
     getGuestWebContentsId: vi.fn(),
     getWebContentsIdByTabId: vi.fn(() => new Map()),
     getWorktreeIdForTab: vi.fn(),
-    getAuthorizedGuest: vi.fn(),
+    getAuthorizedGuest: getAuthorizedGuestMock,
     setGrabMode: vi.fn(),
     openDevTools: vi.fn(),
     setAnnotationViewportBridge: vi.fn(),
@@ -49,6 +52,8 @@ describe('browser:recoverGoogleCookieMismatch', () => {
   beforeEach(() => {
     vi.stubEnv('ELECTRON_RENDERER_URL', '')
     handleMock.mockReset()
+    getAuthorizedGuestMock.mockReset()
+    getAuthorizedGuestMock.mockReturnValue({})
     recoverFromGoogleCookieMismatchMock.mockReset()
     recoverFromGoogleCookieMismatchMock.mockResolvedValue(true)
     registerBrowserHandlers()
@@ -62,6 +67,17 @@ describe('browser:recoverGoogleCookieMismatch', () => {
       true
     )
     expect(recoverFromGoogleCookieMismatchMock).toHaveBeenCalledWith('page-1')
+    expect(getAuthorizedGuestMock).toHaveBeenCalledWith('page-1', trustedSender.id)
+  })
+
+  it('rejects a trusted renderer that does not own the requested page', async () => {
+    getAuthorizedGuestMock.mockReturnValue(null)
+
+    await expect(recover({ sender: trustedSender }, { browserPageId: 'page-1' })).resolves.toBe(
+      false
+    )
+
+    expect(recoverFromGoogleCookieMismatchMock).not.toHaveBeenCalled()
   })
 
   it('rejects untrusted senders and malformed arguments', async () => {

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -348,6 +348,9 @@ export function registerBrowserHandlers(): void {
       if (!isTrustedBrowserRenderer(event.sender) || typeof args?.browserPageId !== 'string') {
         return false
       }
+      if (!browserManager.getAuthorizedGuest(args.browserPageId, event.sender.id)) {
+        return false
+      }
       return browserManager.recoverFromGoogleCookieMismatch(args.browserPageId)
     }
   )

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -221,6 +221,7 @@ export function registerBrowserHandlers(): void {
   ipcMain.removeHandler('browser:extractHoverPayload')
   ipcMain.removeHandler('browser:activeTabChanged')
   ipcMain.removeHandler('browser:proceedCertificate')
+  ipcMain.removeHandler('browser:recoverGoogleCookieMismatch')
 
   const registerGuest = (
     event: Electron.IpcMainInvokeEvent,
@@ -336,6 +337,18 @@ export function registerBrowserHandlers(): void {
         return { ok: false, reason: 'missing' }
       }
       return browserCertificateTrustController.proceed(args.browserPageId, args.challengeId)
+    }
+  )
+
+  // Why: the toast action is the only path that clears cookies; the tab's stashed mismatch
+  // URL (not renderer input) decides where it navigates.
+  ipcMain.handle(
+    'browser:recoverGoogleCookieMismatch',
+    async (event, args: { browserPageId?: unknown }): Promise<boolean> => {
+      if (!isTrustedBrowserRenderer(event.sender) || typeof args?.browserPageId !== 'string') {
+        return false
+      }
+      return browserManager.recoverFromGoogleCookieMismatch(args.browserPageId)
     }
   )
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -607,7 +607,7 @@ export type BrowserApi = {
   }) => Promise<BrowserCertificateProceedResult>
   onPermissionDenied: (callback: (event: BrowserPermissionDeniedEvent) => void) => () => void
   onGoogleCookieMismatchDetected: (
-    callback: (event: { browserPageId: string }) => void
+    callback: (event: { browserPageId: string; active: boolean }) => void
   ) => () => void
   recoverGoogleCookieMismatch: (args: { browserPageId: string }) => Promise<boolean>
   onPopup: (callback: (event: BrowserPopupEvent) => void) => () => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -606,6 +606,10 @@ export type BrowserApi = {
     challengeId: string
   }) => Promise<BrowserCertificateProceedResult>
   onPermissionDenied: (callback: (event: BrowserPermissionDeniedEvent) => void) => () => void
+  onGoogleCookieMismatchDetected: (
+    callback: (event: { browserPageId: string }) => void
+  ) => () => void
+  recoverGoogleCookieMismatch: (args: { browserPageId: string }) => Promise<boolean>
   onPopup: (callback: (event: BrowserPopupEvent) => void) => () => void
   onDownloadRequested: (callback: (event: BrowserDownloadRequestedEvent) => void) => () => void
   onDownloadProgress: (callback: (event: BrowserDownloadProgressEvent) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2582,10 +2582,12 @@ const api = {
     },
 
     onGoogleCookieMismatchDetected: (
-      callback: (event: { browserPageId: string }) => void
+      callback: (event: { browserPageId: string; active: boolean }) => void
     ): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: { browserPageId: string }) =>
-        callback(data)
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { browserPageId: string; active: boolean }
+      ) => callback(data)
       ipcRenderer.on('browser:google-cookie-mismatch-detected', listener)
       return () => ipcRenderer.removeListener('browser:google-cookie-mismatch-detected', listener)
     },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2581,6 +2581,18 @@ const api = {
       return () => ipcRenderer.removeListener('browser:permission-denied', listener)
     },
 
+    onGoogleCookieMismatchDetected: (
+      callback: (event: { browserPageId: string }) => void
+    ): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: { browserPageId: string }) =>
+        callback(data)
+      ipcRenderer.on('browser:google-cookie-mismatch-detected', listener)
+      return () => ipcRenderer.removeListener('browser:google-cookie-mismatch-detected', listener)
+    },
+
+    recoverGoogleCookieMismatch: (args: { browserPageId: string }): Promise<boolean> =>
+      ipcRenderer.invoke('browser:recoverGoogleCookieMismatch', args),
+
     onPopup: (
       callback: (event: {
         browserPageId: string

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -187,6 +187,7 @@ import {
 import { shouldPollChromiumErrorPage } from './chromium-error-page-polling'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
 import { translate } from '@/i18n/i18n'
+import { toast } from 'sonner'
 import { isBrowserPagePanePaintable } from './browser-page-paintability'
 import { useMarkupMode, type MarkupCaptureContext } from './markup/useMarkupMode'
 import { MarkupOverlay } from './markup/MarkupOverlay'
@@ -2903,6 +2904,50 @@ function BrowserPagePane({
         return
       }
       setResourceNotice(formatPermissionNotice(event))
+    })
+  }, [browserTab.id])
+
+  // Why: the reset is destructive, so it stays the user's call — the toast offers it and
+  // waits (main clears nothing on its own). Fixed id keeps a recurring mismatch to one toast.
+  useEffect(() => {
+    return window.api.browser.onGoogleCookieMismatchDetected((event) => {
+      if (event.browserPageId !== browserTab.id) {
+        return
+      }
+      toast.warning(
+        translate(
+          'auto.components.browser.pane.BrowserPane.googleCookieMismatchTitle',
+          'Google sign-in hit a stale-cookie error'
+        ),
+        {
+          id: `google-cookie-mismatch-${browserTab.id}`,
+          duration: Infinity,
+          description: translate(
+            'auto.components.browser.pane.BrowserPane.googleCookieMismatchDescription',
+            "Reset Orca's Google cookies to sign in again — other sites are unaffected."
+          ),
+          action: {
+            label: translate(
+              'auto.components.browser.pane.BrowserPane.googleCookieMismatchAction',
+              'Reset Google cookies'
+            ),
+            onClick: () => {
+              void window.api.browser
+                .recoverGoogleCookieMismatch({ browserPageId: browserTab.id })
+                .then((ok) => {
+                  if (!ok) {
+                    toast.error(
+                      translate(
+                        'auto.components.browser.pane.BrowserPane.googleCookieMismatchFailed',
+                        "Couldn't reset Google cookies"
+                      )
+                    )
+                  }
+                })
+            }
+          }
+        }
+      )
     })
   }, [browserTab.id])
 

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2910,35 +2910,41 @@ function BrowserPagePane({
   // Why: the reset is destructive, so it stays the user's call — the toast offers it and
   // waits (main clears nothing on its own). Fixed id keeps a recurring mismatch to one toast.
   useEffect(() => {
-    return window.api.browser.onGoogleCookieMismatchDetected((event) => {
+    const toastId = `google-cookie-mismatch-${browserTab.id}`
+    const unsubscribe = window.api.browser.onGoogleCookieMismatchDetected((event) => {
       if (event.browserPageId !== browserTab.id) {
+        return
+      }
+      if (!event.active) {
+        toast.dismiss(toastId)
         return
       }
       toast.warning(
         translate(
-          'auto.components.browser.pane.BrowserPane.googleCookieMismatchTitle',
+          'auto.components.browser.pane.BrowserPane.381861c274',
           'Google sign-in hit a stale-cookie error'
         ),
         {
-          id: `google-cookie-mismatch-${browserTab.id}`,
+          id: toastId,
           duration: Infinity,
           description: translate(
-            'auto.components.browser.pane.BrowserPane.googleCookieMismatchDescription',
+            'auto.components.browser.pane.BrowserPane.41da63c3f5',
             "Reset Orca's Google cookies to sign in again — other sites are unaffected."
           ),
           action: {
             label: translate(
-              'auto.components.browser.pane.BrowserPane.googleCookieMismatchAction',
+              'auto.components.browser.pane.BrowserPane.4efe542903',
               'Reset Google cookies'
             ),
             onClick: () => {
+              toast.dismiss(toastId)
               void window.api.browser
                 .recoverGoogleCookieMismatch({ browserPageId: browserTab.id })
                 .then((ok) => {
                   if (!ok) {
                     toast.error(
                       translate(
-                        'auto.components.browser.pane.BrowserPane.googleCookieMismatchFailed',
+                        'auto.components.browser.pane.BrowserPane.76fe482422',
                         "Couldn't reset Google cookies"
                       )
                     )
@@ -2949,6 +2955,10 @@ function BrowserPagePane({
         }
       )
     })
+    return () => {
+      unsubscribe()
+      toast.dismiss(toastId)
+    }
   }, [browserTab.id])
 
   useEffect(() => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14081,7 +14081,11 @@
             "6e776f9ef9": "Download failed",
             "756bfc25c9": "Open",
             "09a9489aa5": "Show",
-            "2a4c4b8e1f": "Copy"
+            "2a4c4b8e1f": "Copy",
+            "googleCookieMismatchTitle": "Google sign-in hit a stale-cookie error",
+            "googleCookieMismatchDescription": "Reset Orca's Google cookies to sign in again — other sites are unaffected.",
+            "googleCookieMismatchAction": "Reset Google cookies",
+            "googleCookieMismatchFailed": "Couldn't reset Google cookies"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Cancel",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14082,10 +14082,10 @@
             "756bfc25c9": "Open",
             "09a9489aa5": "Show",
             "2a4c4b8e1f": "Copy",
-            "googleCookieMismatchTitle": "Google sign-in hit a stale-cookie error",
-            "googleCookieMismatchDescription": "Reset Orca's Google cookies to sign in again — other sites are unaffected.",
-            "googleCookieMismatchAction": "Reset Google cookies",
-            "googleCookieMismatchFailed": "Couldn't reset Google cookies"
+            "381861c274": "Google sign-in hit a stale-cookie error",
+            "41da63c3f5": "Reset Orca's Google cookies to sign in again — other sites are unaffected.",
+            "4efe542903": "Reset Google cookies",
+            "76fe482422": "Couldn't reset Google cookies"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Cancel",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2280,6 +2280,8 @@ function createBrowserApi(): NonNullable<Partial<PreloadApi>['browser']> {
     onCertificateFailureChanged: () => noopUnsubscribe,
     proceedCertificate: () => Promise.resolve({ ok: false, reason: 'missing' }),
     onPermissionDenied: () => noopUnsubscribe,
+    onGoogleCookieMismatchDetected: () => noopUnsubscribe,
+    recoverGoogleCookieMismatch: () => Promise.resolve(false),
     onPopup: () => noopUnsubscribe,
     onDownloadRequested: () => noopUnsubscribe,
     onDownloadProgress: () => noopUnsubscribe,


### PR DESCRIPTION
## Summary

STA-3811 fix 3/4: after a cookie import, navigating Google sign-in can land on `accounts.google.com/CookieMismatch` — Google's dead-end page telling the user to clear cookies manually, which they can't easily do from inside the embedded browser. Orca now detects a committed main-frame navigation onto that page and **offers** the fix instead of performing it: a toast says sign-in hit a stale-cookie error and carries a **Reset Google cookies** action. Nothing is cleared until the user clicks it.

- On the click (and only then): clear the partition's **google.com-family cookies only** (every other site's session survives), then navigate the tab back into the flow — the flow's `continue` URL when it stays on Google over https, else `https://accounts.google.com/`.
- Detection at `did-navigate` (commit), not `did-start-navigation` — a sign-in nav that 302s into CookieMismatch never re-fires `did-start-navigation` with the mismatch URL.
- Prompt throttle: at most one toast per partition per 2-minute window (session-keyed WeakMap), plus a per-tab toast id, so a recurring mismatch or several tabs in one partition can't stack toasts. The destructive step needs no loop guard now that it is user-initiated.
- The navigation target comes from the mismatch URL stashed in main, never from renderer input; the IPC handler only accepts a `browserPageId` string from the trusted renderer.
- Applies in every UA mode (clean-Firefox and native alike) — the mismatch is about the cookie jar, not the presented identity.
- Cookie import code untouched.

## Screenshots

No new surface: a standard sonner warning toast using the existing action-toast idiom ("Google sign-in hit a stale-cookie error" / "Reset Orca's Google cookies to sign in again — other sites are unaffected." / action **Reset Google cookies**), single-line description (sonner collapses newlines), `duration: Infinity` like Orca's other actionable toasts so the offer waits for the user.

## Testing

- [x] `pnpm lint` (oxlint clean; `audit:code-quality:native`, `audit:code-quality:type-aware`, and all three localization verifies pass) plus `check:code-quality:changed` — 0 new native / type-aware / React Doctor findings across the 10 changed files
- [x] `pnpm typecheck` (non-incremental `typecheck:tsc` — node, cli, and web projects clean)
- [x] `pnpm test` — targeted with explicit `--config config/vitest.config.ts`: `browser-google-cookie-mismatch-recovery.test.ts`, the new `browser-manager-google-cookie-mismatch.test.ts` and `browser-google-cookie-mismatch-handler.test.ts`, `browser-manager.test.ts`, `browser-manager-grab.test.ts`, `ipc/browser.test.ts` (151 tests), and all 42 browser-pane renderer suites (332 tests)
- [ ] `pnpm build` — left to CI; change is plain TS modules with no packaging impact
- [x] Tests cover: the detection predicate (host/path/scheme edges incl. `accounts.google.com.evil.example`), the recovery-target rules, the scoped clear (Google cookies removed with correct removal URLs, github/example cookies retained, per-cookie failure tolerated), detection prompting the renderer **without** clearing or navigating, one prompt per partition across repeats and tabs, independent partitions prompting separately, the user-action path clearing only Google cookies and navigating to the continue target, and refusal to clear for a tab with no pending detection (incl. a repeated accept)

## AI Review Report

Self-reviewed the diff for: silent destructive behavior (removed — clearing is now reachable only through `recoverFromGoogleCookieMismatch`, called by one IPC handler behind `isTrustedBrowserRenderer`), redirect-vs-start-navigation detection gap (detection stays at commit), open-redirect via the `continue` param (only https Google-family targets honored, and the URL comes from main's own stash), suffix-confusion domains (`normalizeCookieDomain` + exact/`.google.com`-suffix match, covered by tests), replayed accepts (the stash is consumed, so a second click is a no-op), and destroyed-guest races (checked before and after the clear). Per-guest state is dropped in `cleanupGuestPolicyAttachment` and `unregisterAll`, so nothing leaks past a process swap or teardown. Cross-platform: no platform-dependent code — URL parsing, Electron cookies API, and IPC behave identically on macOS/Linux/Windows; no shortcuts, labels, paths, or shell usage touched.

## Security Audit

The renderer can now ask main to clear cookies, so the handler validates the sender (`isTrustedBrowserRenderer`) and the argument shape, and takes only a `browserPageId` — no URL, domain, or cookie name crosses the boundary. Main refuses unless that tab has a mismatch it detected itself, and derives the navigation target from the stashed mismatch URL restricted to https Google-family hosts. Cookie deletion is scoped by normalized domain (rejects `user@google.com`, `google.com.evil.example`, etc. via the existing hardened `normalizeCookieDomain`) and only ever *removes* cookies in the guest's own partition — no values are read out or transmitted. The main→renderer notification is a `browserPageId` payload only.

## Notes

Offscreen/remote-driven guests with no attached renderer simply get no prompt (and no clear) — the page behaves exactly as it does today. If the clear partially fails, the navigation still runs; a persisting mismatch then shows Google's page again with the offer available after the throttle window, so behavior degrades to the status quo, never worse.
