### PR TITLE
perf(orchestration): skip redundant federation acknowledgments

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -147,6 +147,7 @@ import type {
   OrchestrationEnvironmentTransport,
   OrchestrationWorkerServer
 } from './orchestration/environment-transport'
+import { clearFederationAckCheckpoints } from './orchestration/federation-ack-checkpoints'
 import { syncFederatedDispatch } from './orchestration/federation-sync'
 import { formatMessagePointer } from './orchestration/formatter'
 import { selectExactWorkerProviderSession } from './orchestration/worker-provider-session'
@@ -2661,7 +2662,10 @@ export class OrcaRuntimeService {
   private managedHookReconciliationTail: Promise<void> = Promise.resolve()
   private readonly orchestrationEnvironmentTransport: OrchestrationEnvironmentTransport | null
   private readonly orchestrationFederationTimers = new Map<string, ReturnType<typeof setInterval>>()
-  private readonly orchestrationFederationSyncs = new Map<string, Promise<void>>()
+  private readonly orchestrationFederationSyncs = new Map<
+    string,
+    { db: OrchestrationDb; promise: Promise<void> }
+  >()
   private readonly orchestrationFederationWarnings = new Set<string>()
   private rendererGraphEpoch = 0
   private graphStatus: RuntimeGraphStatus = 'unavailable'
@@ -3794,6 +3798,9 @@ export class OrcaRuntimeService {
   }
 
   setOrchestrationDb(db: OrchestrationDb): void {
+    clearFederationAckCheckpoints(this)
+    this.orchestrationFederationSyncs.clear()
+    this.orchestrationFederationWarnings.clear()
     this._orchestrationDb = db
   }
 
@@ -4624,27 +4631,44 @@ export class OrcaRuntimeService {
     )
   }
 
-  private syncOrchestrationFederatedDispatch(dispatchId: string): Promise<void> {
+  syncOrchestrationFederatedDispatch(dispatchId: string): Promise<void> {
+    const db = this.getOrchestrationDb()
     const current = this.orchestrationFederationSyncs.get(dispatchId)
-    if (current) {
-      return current
+    if (current?.db === db) {
+      return current.promise
     }
     const sync = syncFederatedDispatch(this, dispatchId)
       .then(() => {
-        this.orchestrationFederationWarnings.delete(dispatchId)
+        if (this.orchestrationFederationSyncs.get(dispatchId)?.promise === sync) {
+          this.orchestrationFederationWarnings.delete(dispatchId)
+        }
       })
       .catch((error: unknown) => {
-        if (!this.orchestrationFederationWarnings.has(dispatchId)) {
+        if (
+          this.orchestrationFederationSyncs.get(dispatchId)?.promise === sync &&
+          !this.orchestrationFederationWarnings.has(dispatchId)
+        ) {
           console.warn(`[orchestration] Federation sync failed for ${dispatchId}:`, error)
           this.orchestrationFederationWarnings.add(dispatchId)
         }
         throw error
       })
       .finally(() => {
-        this.orchestrationFederationSyncs.delete(dispatchId)
+        if (this.orchestrationFederationSyncs.get(dispatchId)?.promise === sync) {
+          this.orchestrationFederationSyncs.delete(dispatchId)
+        }
       })
-    this.orchestrationFederationSyncs.set(dispatchId, sync)
+    this.orchestrationFederationSyncs.set(dispatchId, { db, promise: sync })
     return sync
+  }
+
+  async syncOrchestrationFederatedDispatchAfterCurrent(dispatchId: string): Promise<void> {
+    const db = this.getOrchestrationDb()
+    const current = this.orchestrationFederationSyncs.get(dispatchId)
+    if (current?.db === db) {
+      await current.promise.catch(() => undefined)
+    }
+    await this.syncOrchestrationFederatedDispatch(dispatchId)
   }
 
   ensureOrchestrationFederationRelay(runId?: string): void {
@@ -4681,6 +4705,8 @@ export class OrcaRuntimeService {
     }
     this.orchestrationFederationTimers.clear()
     this.orchestrationFederationWarnings.clear()
+    this.orchestrationFederationSyncs.clear()
+    clearFederationAckCheckpoints(this)
   }
 
   getStartedAt(): number {

--- a/src/main/runtime/orchestration/federation-ack-checkpoints.ts
+++ b/src/main/runtime/orchestration/federation-ack-checkpoints.ts
@@ -1,0 +1,71 @@
+import type { OrcaRuntimeService } from '../orca-runtime'
+
+export type FederationAckIdentity = {
+  environmentId: string
+  peerFingerprint: string
+  remoteRuntimeEpoch: string
+}
+
+type FederationAckCheckpoint = FederationAckIdentity & { throughSequence: number }
+type FederationAckDispatchState = { checkpoint: FederationAckCheckpoint | null }
+type FederationAckRuntimeState = { byDispatch: Map<string, FederationAckDispatchState> }
+
+export type FederationAckLease = {
+  runtimeState: FederationAckRuntimeState
+  dispatchState: FederationAckDispatchState
+}
+
+const federationAckStates = new WeakMap<OrcaRuntimeService, FederationAckRuntimeState>()
+
+export function clearFederationAckCheckpoints(runtime: OrcaRuntimeService): void {
+  federationAckStates.delete(runtime)
+}
+
+export function acquireFederationAckLease(
+  runtime: OrcaRuntimeService,
+  dispatchId: string
+): FederationAckLease {
+  let runtimeState = federationAckStates.get(runtime)
+  if (!runtimeState) {
+    runtimeState = { byDispatch: new Map() }
+    federationAckStates.set(runtime, runtimeState)
+  }
+  let dispatchState = runtimeState.byDispatch.get(dispatchId)
+  if (!dispatchState) {
+    dispatchState = { checkpoint: null }
+    runtimeState.byDispatch.set(dispatchId, dispatchState)
+  }
+  return { runtimeState, dispatchState }
+}
+
+export function getFederationAckedThrough(
+  lease: FederationAckLease,
+  identity: FederationAckIdentity
+): number {
+  const checkpoint = lease.dispatchState.checkpoint
+  return checkpoint?.environmentId === identity.environmentId &&
+    checkpoint.peerFingerprint === identity.peerFingerprint &&
+    checkpoint.remoteRuntimeEpoch === identity.remoteRuntimeEpoch
+    ? checkpoint.throughSequence
+    : 0
+}
+
+export function recordFederationAckCheckpoint(
+  runtime: OrcaRuntimeService,
+  lease: FederationAckLease,
+  checkpoint: FederationAckCheckpoint
+): void {
+  if (federationAckStates.get(runtime) !== lease.runtimeState) {
+    return
+  }
+  const current = lease.dispatchState.checkpoint
+  if (
+    current?.environmentId === checkpoint.environmentId &&
+    current.peerFingerprint === checkpoint.peerFingerprint &&
+    current.remoteRuntimeEpoch === checkpoint.remoteRuntimeEpoch &&
+    current.throughSequence >= checkpoint.throughSequence
+  ) {
+    return
+  }
+  lease.dispatchState.checkpoint = checkpoint
+}

--- a/src/main/runtime/orchestration/federation-sync.test.ts
+++ b/src/main/runtime/orchestration/federation-sync.test.ts
@@ -1,5 +1,91 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../orca-runtime'
+import {
+  acquireFederationAckLease,
+  clearFederationAckCheckpoints,
+  getFederationAckedThrough,
+  recordFederationAckCheckpoint,
+  type FederationAckIdentity
+} from './federation-ack-checkpoints'
 import { parseRelayedMessage } from './federation-sync'
+
+function createIdleSyncHarness() {
+  let remoteRuntimeEpoch = 'remote_epoch_1'
+  let blockedAck: { reached: () => void; released: Promise<void> } | null = null
+  let blockedPull: { reached: () => void; released: Promise<void> } | null = null
+  const federated = {
+    environment_id: 'environment_windows',
+    environment_name: 'windows',
+    peer_fingerprint: 'windows_peer_fingerprint',
+    to_home_imported_sequence: 2
+  }
+  const createDb = () =>
+    ({
+      getFederatedDispatch: () => federated,
+      getDispatchContextById: () => ({ run_id: 'run_home', task_id: 'task_home' }),
+      getWorkerDispatch: () => ({ state: 'ready' }),
+      listPendingFederationRelay: () => []
+    }) as never
+  const runtime = new OrcaRuntimeService()
+  runtime.setOrchestrationDb(createDb())
+  vi.spyOn(runtime, 'resolveOrchestrationWorkerServer').mockReturnValue({
+    peerFingerprint: federated.peer_fingerprint
+  } as never)
+  const remoteCall = vi
+    .spyOn(runtime, 'callOrchestrationWorkerServer')
+    .mockImplementation(async (_environmentId, method) => {
+      if (method === 'orchestration.federationPull') {
+        const gate = blockedPull
+        if (gate) {
+          gate.reached()
+          await gate.released
+          if (blockedPull === gate) {
+            blockedPull = null
+          }
+        }
+        return { runtimeEpoch: remoteRuntimeEpoch, items: [] }
+      }
+      if (method === 'orchestration.federationAck') {
+        const gate = blockedAck
+        if (gate) {
+          gate.reached()
+          await gate.released
+          if (blockedAck === gate) {
+            blockedAck = null
+          }
+        }
+        return { acknowledgedThrough: federated.to_home_imported_sequence }
+      }
+      throw new Error(`Unexpected method ${method}`)
+    })
+  return {
+    runtime,
+    remoteCall,
+    advanceCursor: () => {
+      federated.to_home_imported_sequence += 1
+    },
+    restartRemote: () => {
+      remoteRuntimeEpoch = 'remote_epoch_2'
+    },
+    replaceDb: () => runtime.setOrchestrationDb(createDb()),
+    blockAck: () => {
+      let noteReached!: () => void
+      let release!: () => void
+      const reached = new Promise<void>((resolve) => (noteReached = resolve))
+      const released = new Promise<void>((resolve) => (release = resolve))
+      blockedAck = { reached: noteReached, released }
+      return { reached, release }
+    },
+    blockPull: () => {
+      let noteReached!: () => void
+      let release!: () => void
+      const reached = new Promise<void>((resolve) => (noteReached = resolve))
+      const released = new Promise<void>((resolve) => (release = resolve))
+      blockedPull = { reached: noteReached, released }
+      return { reached, release }
+    }
+  }
+}
 
 describe('federation relay parsing', () => {
   it('accepts a supported message type', () => {
@@ -14,5 +100,162 @@ describe('federation relay parsing', () => {
     expect(() =>
       parseRelayedMessage(JSON.stringify({ subject: 'bad', body: 'Blocked', type: 'invented' }))
     ).toThrowError('Federated relay message type invented is not supported.')
+  })
+})
+
+describe('federation relay acknowledgments', () => {
+  it('acknowledges only new progress until remote runtime identity changes', async () => {
+    const { runtime, remoteCall, advanceCursor, restartRemote } = createIdleSyncHarness()
+    const ackCalls = () =>
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(ackCalls()).toHaveLength(1)
+
+    advanceCursor()
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(ackCalls()).toHaveLength(2)
+
+    restartRemote()
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(ackCalls().map(([, , params]) => params)).toEqual([
+      { dispatchId: 'dispatch_remote', throughSequence: 2 },
+      { dispatchId: 'dispatch_remote', throughSequence: 3 },
+      { dispatchId: 'dispatch_remote', throughSequence: 3 }
+    ])
+  })
+
+  it('coalesces overlapping syncs while an acknowledgment is in flight', async () => {
+    const { runtime, remoteCall, blockAck } = createIdleSyncHarness()
+    const gate = blockAck()
+
+    const first = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    await gate.reached
+    const second = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(second).toBe(first)
+    gate.release()
+    await Promise.all([first, second])
+
+    expect(
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+    ).toHaveLength(1)
+  })
+
+  it('pulls again after a sync that predates a terminal observation', async () => {
+    const { runtime, remoteCall, blockPull } = createIdleSyncHarness()
+    const gate = blockPull()
+
+    const oldSync = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    await gate.reached
+    const freshSync = runtime.syncOrchestrationFederatedDispatchAfterCurrent('dispatch_remote')
+    expect(
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationPull')
+    ).toHaveLength(1)
+    gate.release()
+    await Promise.all([oldSync, freshSync])
+
+    expect(
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationPull')
+    ).toHaveLength(2)
+    expect(
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+    ).toHaveLength(1)
+  })
+
+  it('starts a new sync when the orchestration database changes in flight', async () => {
+    const { runtime, remoteCall, blockAck, replaceDb } = createIdleSyncHarness()
+    const gate = blockAck()
+
+    const oldSync = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    await gate.reached
+    replaceDb()
+    const newSync = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(newSync).not.toBe(oldSync)
+    await vi.waitFor(() =>
+      expect(
+        remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+      ).toHaveLength(2)
+    )
+    gate.release()
+    await Promise.all([oldSync, newSync])
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+
+    expect(
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+    ).toHaveLength(2)
+  })
+
+  it('starts a new sync when relay state resets in flight', async () => {
+    const { runtime, remoteCall, blockAck } = createIdleSyncHarness()
+    const gate = blockAck()
+
+    const oldSync = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    await gate.reached
+    runtime.stopOrchestrationFederationRelay()
+    const newSync = runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(newSync).not.toBe(oldSync)
+    await vi.waitFor(() =>
+      expect(
+        remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+      ).toHaveLength(2)
+    )
+    gate.release()
+    await Promise.all([oldSync, newSync])
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+
+    expect(
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+    ).toHaveLength(2)
+  })
+
+  it('matches checkpoints only to their exact remote identity and never moves backward', () => {
+    const runtime = {} as OrcaRuntimeService
+    const identity: FederationAckIdentity = {
+      environmentId: 'environment_windows',
+      peerFingerprint: 'windows_peer_fingerprint',
+      remoteRuntimeEpoch: 'remote_epoch_1'
+    }
+    const lease = acquireFederationAckLease(runtime, 'dispatch_remote')
+    recordFederationAckCheckpoint(runtime, lease, {
+      ...identity,
+      throughSequence: 2
+    })
+
+    recordFederationAckCheckpoint(runtime, lease, {
+      ...identity,
+      throughSequence: 3
+    })
+    recordFederationAckCheckpoint(runtime, lease, {
+      ...identity,
+      throughSequence: 2
+    })
+
+    expect(getFederationAckedThrough(lease, identity)).toBe(3)
+    expect(
+      getFederationAckedThrough(lease, { ...identity, remoteRuntimeEpoch: 'remote_epoch_2' })
+    ).toBe(0)
+    expect(
+      getFederationAckedThrough(lease, { ...identity, peerFingerprint: 'replacement_peer' })
+    ).toBe(0)
+    expect(getFederationAckedThrough(lease, { ...identity, environmentId: 'replacement' })).toBe(0)
+  })
+
+  it('fences delayed writes after runtime reset', () => {
+    const runtime = {} as OrcaRuntimeService
+    const identity: FederationAckIdentity = {
+      environmentId: 'environment_windows',
+      peerFingerprint: 'windows_peer_fingerprint',
+      remoteRuntimeEpoch: 'remote_epoch_1'
+    }
+    const staleRuntimeLease = acquireFederationAckLease(runtime, 'dispatch_remote')
+    clearFederationAckCheckpoints(runtime)
+    recordFederationAckCheckpoint(runtime, staleRuntimeLease, {
+      ...identity,
+      throughSequence: 2
+    })
+    expect(
+      getFederationAckedThrough(acquireFederationAckLease(runtime, 'dispatch_remote'), identity)
+    ).toBe(0)
   })
 })

--- a/src/main/runtime/orchestration/federation-sync.ts
+++ b/src/main/runtime/orchestration/federation-sync.ts
@@ -6,6 +6,11 @@ import {
 } from './types'
 import type { OrcaRuntimeService } from '../orca-runtime'
 import { OrchestrationError } from './orchestration-error'
+import {
+  acquireFederationAckLease,
+  getFederationAckedThrough,
+  recordFederationAckCheckpoint
+} from './federation-ack-checkpoints'
 
 const MESSAGE_TYPE_SET = new Set<MessageType>(MESSAGE_TYPES)
 
@@ -52,6 +57,7 @@ export async function syncFederatedDispatch(
       `Saved environment ${federated.environment_name} now identifies a different Orca server.`
     )
   }
+  const ackLease = acquireFederationAckLease(runtime, dispatchId)
 
   const pulled = (await runtime.callOrchestrationWorkerServer(
     federated.environment_id,
@@ -95,7 +101,12 @@ export async function syncFederatedDispatch(
     imported += stored.duplicate ? 0 : 1
   }
 
-  if (cursor > 0) {
+  const ackIdentity = {
+    environmentId: federated.environment_id,
+    peerFingerprint: federated.peer_fingerprint,
+    remoteRuntimeEpoch: pulled.runtimeEpoch
+  }
+  if (cursor > getFederationAckedThrough(ackLease, ackIdentity)) {
     await runtime.callOrchestrationWorkerServer(
       federated.environment_id,
       'orchestration.federationAck',
@@ -103,6 +114,10 @@ export async function syncFederatedDispatch(
       15_000,
       { orchestrationRequestId: `relay_ack_${dispatchId}_${cursor}` }
     )
+    recordFederationAckCheckpoint(runtime, ackLease, {
+      ...ackIdentity,
+      throughSequence: cursor
+    })
   }
   const toWorker =
     db.getWorkerDispatch(dispatchId)?.state === 'ready'

--- a/src/main/runtime/rpc/methods/orchestration-federation.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.test.ts
@@ -508,7 +508,7 @@ describe('orchestration federation', () => {
   it('retries a lost relay acknowledgment without duplicating the home message', async () => {
     const task = createHomeTask()
     await homeDispatcher.dispatch(startRequest(task.id))
-    const dispatch = homeDb.getDispatchContext(task.id)!
+    homeRuntime.stopOrchestrationFederationRelay()
     const prompt = vi.mocked(workerRuntime.sendTerminalAgentPrompt).mock.calls[0]?.[1] ?? ''
     const capability = prompt.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1]
     await workerDispatcher.dispatch({
@@ -526,6 +526,7 @@ describe('orchestration federation', () => {
       }
     })
     loseNextAckResponse = true
+    const remoteCall = vi.spyOn(homeRuntime, 'callOrchestrationWorkerServer')
 
     await expect(homeRuntime.syncOrchestrationFederation()).resolves.toBeUndefined()
     await homeRuntime.syncOrchestrationFederation()
@@ -535,7 +536,10 @@ describe('orchestration federation', () => {
         .getRunMailboxHistory(task.run_id, 10)
         .filter((message) => message.subject === 'Checkpoint')
     ).toHaveLength(1)
-    expect(homeDb.getFederatedDispatch(dispatch.id)?.to_home_imported_sequence).toBe(1)
+    const acknowledgments = remoteCall.mock.calls.filter(
+      ([, method]) => method === 'orchestration.federationAck'
+    )
+    expect(acknowledgments).toHaveLength(2)
   })
 
   it('rejects a reordered relay gap, then converges without loss or duplication', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-worker-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-control.ts
@@ -4,7 +4,6 @@ import {
   type OrchestrationWorkerReadResult
 } from '../../../../shared/orchestration-worker-output'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
-import { syncFederatedDispatch } from '../../orchestration/federation-sync'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, requiredString } from '../schemas'
 import {
@@ -54,7 +53,9 @@ export const ORCHESTRATION_WORKER_CONTROL_METHODS: RpcMethod[] = [
           attachment.state === 'succeeded' ||
           (attachment.state === 'failed' && attachment.stage === 'worker_report_queued')
         ) {
-          await syncFederatedDispatch(runtime, params.dispatch).catch(() => undefined)
+          await runtime
+            .syncOrchestrationFederatedDispatchAfterCurrent(params.dispatch)
+            .catch(() => undefined)
         } else if (
           attachment.state === 'stopped' &&
           ['stopping', 'stop_unknown'].includes(worker.state)

--- a/src/main/runtime/rpc/methods/orchestration-worker-stop.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-stop.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
-import { syncFederatedDispatch } from '../../orchestration/federation-sync'
 import { defineMethod, type RpcMethod } from '../core'
 import { requiredString } from '../schemas'
 import {
@@ -49,7 +48,9 @@ export const ORCHESTRATION_WORKER_STOP_METHODS: RpcMethod[] = [
           }
           if (remote.state === 'succeeded' || remote.state === 'failed') {
             db.resumeFederatedWorkerForTerminalRelay(params.dispatch)
-            await syncFederatedDispatch(runtime, params.dispatch).catch(() => undefined)
+            await runtime
+              .syncOrchestrationFederatedDispatchAfterCurrent(params.dispatch)
+              .catch(() => undefined)
             return {
               dispatchId: params.dispatch,
               state: db.getWorkerDispatch(params.dispatch)?.state ?? remote.state,

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -3075,9 +3075,11 @@ describe('orchestration RPC methods', () => {
     it('resets all state', async () => {
       setup()
       seedResetState()
+      const stopRelay = vi.spyOn(runtime, 'stopOrchestrationFederationRelay')
 
       const result = (await call('orchestration.reset', { all: true })) as { reset: string }
       expect(result.reset).toBe('all')
+      expect(stopRelay).toHaveBeenCalledOnce()
       expect(db.getInbox()).toHaveLength(0)
       expect(db.listTasks()).toHaveLength(0)
     })
@@ -3085,8 +3087,10 @@ describe('orchestration RPC methods', () => {
     it('resets tasks only', async () => {
       setup()
       seedResetState()
+      const stopRelay = vi.spyOn(runtime, 'stopOrchestrationFederationRelay')
 
       await call('orchestration.reset', { tasks: true })
+      expect(stopRelay).toHaveBeenCalledOnce()
       expect(db.getInbox()).toHaveLength(1)
       expect(db.listTasks()).toHaveLength(0)
     })
@@ -3094,8 +3098,10 @@ describe('orchestration RPC methods', () => {
     it('resets messages only', async () => {
       setup()
       seedResetState()
+      const stopRelay = vi.spyOn(runtime, 'stopOrchestrationFederationRelay')
 
       await call('orchestration.reset', { messages: true })
+      expect(stopRelay).not.toHaveBeenCalled()
       expect(db.getInbox()).toHaveLength(0)
       expect(db.listTasks()).toHaveLength(1)
     })

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1527,10 +1527,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
       if (params.all) {
+        runtime.stopOrchestrationFederationRelay()
         db.resetAll()
         return { reset: 'all' }
       }
       if (params.tasks) {
+        runtime.stopOrchestrationFederationRelay()
         db.resetTasks()
         return { reset: 'tasks' }
       }


### PR DESCRIPTION
## Summary

- Remember the last successfully acknowledged federation checkpoint per dispatch.
- Keep polling for new remote work, but skip the unchanged `federationAck` call on idle one-second ticks.
- Fence checkpoint state across database, runtime epoch, peer, reset, and overlapping-sync boundaries.

## ELI5

After Orca tells a remote worker, “I received everything through message 12,” it no longer repeats that same confirmation every second. It still checks for new work, and it confirms again after new progress or a restart.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.177 pnpm test` — 4,596 files passed, 15 skipped; 49,286 tests passed, 97 skipped
- [x] `pnpm build`
- [x] Added regression coverage for ACK loss, identity changes, monotonic checkpoints, reset/database fencing, overlapping syncs, and terminal trailing pulls

The baseline ref is pinned because an unrelated repository tag named `v799` currently outranks the intended release tag during automatic baseline selection.

## AI Review Report

Adversarial review checked lost ACK responses, same-ID database replacement, reset-generation races, overlapping callers, backward checkpoint writes, terminal-state freshness, and warning-cache leakage. The implementation was tightened for each flagged race and the focused federation/runtime suites were rerun after the fixes.

Cross-platform review found no OS-specific shortcut, label, path, shell, or Electron behavior in this change. The optimization is transport-neutral and preserves native, SSH, relay, folder-workspace, and git-worktree behavior. It makes no remote wire-format or capability changes.

## Security Audit

No new inputs, command execution, filesystem paths, authentication flows, secrets, dependencies, or IPC surfaces are introduced. Checkpoint state is process-local and keyed by existing trusted runtime identity fields. Failures remain retryable and are only checkpointed after a successful acknowledgement.

## Notes

This reduces idle federation traffic by one remote round trip per second per dispatch while preserving the pull that discovers new work. It is intentionally separate from the renderer/remote-host optimization PRs.
