### PR TITLE
fix(terminal): report limited when an un-cursored read withholds transcript lines

### DIFF
--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -200,6 +200,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'cursor', 'limit'],
     notes: [
       'Omit --terminal to target the active terminal in the current worktree.',
+      'A read returns a bounded window, not the whole buffer: without --limit it returns at most the last 120 rows, and a full-screen TUI returns only the visible screen. Check limited in the output.',
       'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
       'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',
       'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17949,6 +17949,41 @@ describe('OrcaRuntimeService', () => {
     liveScreen.dispose()
   })
 
+  it('reports limited on an un-cursored read that withholds redrawn transcript lines', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'A\r\nB\r\nC\r\n\x1b[2A\x1b[2K\x1b[1GB2\r\n', 100)
+
+    const preview = await runtime.readTerminal(terminal.handle)
+
+    // The redraw collapses the preview to 2 rows while 4 completed lines stay pageable.
+    expect(preview).toMatchObject({
+      tail: ['A', 'B2'],
+      returnedLineCount: 2,
+      oldestCursor: '0',
+      latestCursor: '4',
+      limited: true
+    })
+  })
+
+  it('keeps an un-cursored read unlimited when its preview covers every retained line', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'A\r\nB\r\nC\r\n', 100)
+
+    await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({
+      tail: ['A', 'B', 'C'],
+      returnedLineCount: 3,
+      oldestCursor: '0',
+      latestCursor: '3',
+      limited: false
+    })
+  })
+
   it('records completed transcript lines before later CUU redraws in the same PTY chunk', async () => {
     const runtime = new OrcaRuntimeService(store)
     syncSinglePty(runtime)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -36409,12 +36409,18 @@ function readTerminalTail(args: {
     (charBoundedTail.slicedFirstLine && charBoundedStartIndex < args.completedLineCount)
   // Why: a long partial line trimmed by the char budget can't be recovered via nextCursor, since cursor reads only page completed lines.
   const truncatedByNonPageablePartial = charBoundedTail.limited && !hasPageableOmittedCompletedLines
+  // Why: the preview buffer is a live-screen model that redraws collapse, so it can hold far fewer
+  // rows than the retained transcript. Without this the response says "caught up" and callers stop.
+  const withholdsRetainedTranscriptLines = latestCursor - oldestCursor > charBoundedTail.tail.length
   return {
     handle: args.handle,
     status: args.status,
     tail: charBoundedTail.tail,
     truncated: args.bufferTruncated || truncatedByNonPageablePartial,
-    limited: lineBoundedTail.length < allLines.length || charBoundedTail.limited,
+    limited:
+      lineBoundedTail.length < allLines.length ||
+      charBoundedTail.limited ||
+      withholdsRetainedTranscriptLines,
     oldestCursor: String(oldestCursor),
     nextCursor: String(latestCursor),
     latestCursor: String(latestCursor),


### PR DESCRIPTION
## Behaviour change

An un-cursored `orca terminal read` now sets `limited: true` when the retained transcript holds more completed lines than the response returned. Cursor semantics, the default limit, and which buffer the read draws from are all unchanged.

Fixes #12333.

## Evidence

Reproduced on `upstream/main` against a live pane, using the released CLI:

```
$ orca terminal send --terminal $H --text "seq 1 20" --enter
$ orca terminal read --terminal $H --json
returned 21  limited False  truncated False  oldest 0  latest 21     # honest

$ orca terminal send --terminal $H --text "seq 1 40 | less" --enter
$ orca terminal read --terminal $H --json
returned 24  limited False  truncated False  oldest 0  latest 61     # withholds 37 lines
tail begins: ['17', '18', '19', '20']

$ orca terminal read --terminal $H --cursor 0 --limit 200 --json
returned 61  limited False  oldest 0  latest 61
tail begins: ['', '1', '2', '3', '4', '5']
```

The bare read returned 24 of 61 retained lines and reported `limited: false` with `nextCursor === latestCursor`. Both of those mean "you are caught up".

The repo's own CUU fixture reproduces the same thing without a live pane. After `A\r\nB\r\nC\r\n\x1b[2A\x1b[2K\x1b[1GB2\r\n`, an un-cursored read returns 2 rows while `latestCursor` is `4`, and before this change reported `limited: false`.

## Why it matters

This is not a cosmetic flag. `skill-guides/orca-cli.md` tells callers to keep paging "while `limited` is true and `nextCursor !== latestCursor`". On this path both stop conditions are satisfied at once, so a caller following the shipped rule exactly stops reading and concludes the pane produced nothing.

We watched that happen. An agent-driven probe sent `echo RDY5` into a pane every four seconds and read the pane back with a bare `terminal read --terminal <h> --json`. Eighteen probes in a row appeared to execute nothing and the operator concluded the pane was dead for ninety seconds. The pane was fine — a cursor read showed 28 retained lines, 12 of them the `RDY5` output the earlier reads had not returned. Two independent agents reached the same wrong diagnosis within an hour, and in both cases the wrong diagnosis came from the tool's response, not from the system under test. #12333 reports the same inversion from a different pair of sessions, where a healthy worker was stopped on the strength of it.

## The change

`readTerminalTail` computes its content and its `limited` flag against the preview buffer, but derives `oldestCursor` / `nextCursor` / `latestCursor` from the transcript. Those are two different buffers: the preview is a live-screen model that in-place redraws rewrite and delete rows from, while the transcript is monotonic. Nothing was dropped relative to the preview, so `limited` stayed `false` while the transcript kept growing.

One added condition in the un-cursored branch of `readTerminalTail`, plus the `--help` line that says a bare read is a bounded window.

Per #12333's analysis, this sits in `readTerminalTail` rather than in `withVisibleSnapshotFallback`, so the leaf path, the live-PTY path, SSH/remote hosts and headless hosts get the same contract — the fallback behaves differently per host and a fix leaning on it would not hold on headless or remote. It is deliberately the signalling fix only: #12333 also proposes that `nextCursor` should stop equalling `latestCursor` while unread lines exist, which changes cursor semantics and belongs in its own PR.

## Compatibility

`limited` is an existing optional boolean on `RuntimeTerminalRead`; no wire shape changes, so no capability negotiation is needed and mixed client/host versions stay fine. The change is host-independent and platform-independent — no path handling, no provider-specific branches.

The direction of the change is conservative: a caller that ignores `limited` sees identical output, and a caller that honours it now pages where it previously stopped. The human formatter already renders this as `warning: output limited; page retained output with --cursor <n> --limit <count>`, so no formatter change was needed.

Adjacent work: #10231 touches alt-screen scrollback restore near `withVisibleSnapshotFallback`; this PR does not modify that function, so they should not conflict. #7433 asks for the `--json` result schema in `--help` — the one help line here names the window and points at `limited`, but does not document the full schema, so #7433 stays open.

## Test plan

Two tests added next to the existing CUU redraw tests in `src/main/runtime/orca-runtime.test.ts`:

- an un-cursored read after a CUU redraw returns 2 rows with `latestCursor: '4'` and now reports `limited: true`
- an un-cursored read whose preview covers every retained line still reports `limited: false`, so the flag does not become noise

Run on this branch:

```
pnpm vitest run src/main/runtime      258 files passed, 3860 passed | 6 skipped
pnpm vitest run src/cli                58 files passed,  754 passed
pnpm typecheck                         clean
pnpm lint                              clean
```

The second test fails without the production change; the first fails without it too.