### PR TITLE
Fix notification clicks with Agent Dashboard pop-out

### DIFF
--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -15,6 +15,7 @@ const {
   notificationCtorMock,
   notificationIsSupportedMock,
   getAllWindowsMock,
+  getTrustedUIRendererWindowMock,
   shellOpenExternalMock
 } = vi.hoisted(() => {
   const removeHandlerMock = vi.fn()
@@ -35,6 +36,7 @@ const {
   })
   const notificationIsSupportedMock = vi.fn(() => true)
   const getAllWindowsMock = vi.fn(() => [])
+  const getTrustedUIRendererWindowMock = vi.fn()
   const shellOpenExternalMock = vi.fn()
   return {
     removeHandlerMock,
@@ -47,6 +49,7 @@ const {
     notificationCtorMock,
     notificationIsSupportedMock,
     getAllWindowsMock,
+    getTrustedUIRendererWindowMock,
     shellOpenExternalMock
   }
 })
@@ -79,6 +82,10 @@ const { readAuthorizationStatusMock } = vi.hoisted(() => ({
 
 vi.mock('./notification-authorization-status', () => ({
   readNotificationAuthorizationStatus: readAuthorizationStatusMock
+}))
+
+vi.mock('./ui', () => ({
+  getTrustedUIRendererWindow: getTrustedUIRendererWindowMock
 }))
 
 // Why: notifications.ts pulls in the tray module (for the minimized attention
@@ -121,6 +128,8 @@ describe('registerNotificationHandlers', () => {
     readAuthorizationStatusMock.mockResolvedValue(null)
     getAllWindowsMock.mockReset()
     getAllWindowsMock.mockReturnValue([])
+    getTrustedUIRendererWindowMock.mockReset()
+    getTrustedUIRendererWindowMock.mockReturnValue(null)
     shellOpenExternalMock.mockClear()
     setTrayAttentionMock.mockClear()
   })
@@ -452,20 +461,30 @@ describe('registerNotificationHandlers', () => {
     }
   })
 
-  it('focuses the originating terminal pane when a notification with paneKey is clicked', async () => {
+  it('focuses the originating terminal pane in the main window when a dashboard popout is open', async () => {
+    const popoutSend = vi.fn()
+    const popoutFocus = vi.fn()
     const webContentsSend = vi.fn()
     const restore = vi.fn()
     const focus = vi.fn()
-    getAllWindowsMock.mockReturnValue([
-      {
-        isDestroyed: () => false,
-        isFocused: () => false,
-        isMinimized: () => true,
-        restore,
-        focus,
-        webContents: { send: webContentsSend }
-      } as never
-    ])
+    const popoutWindow = {
+      isDestroyed: () => false,
+      isFocused: () => true,
+      isMinimized: () => false,
+      restore: vi.fn(),
+      focus: popoutFocus,
+      webContents: { send: popoutSend }
+    }
+    const mainWindow = {
+      isDestroyed: () => false,
+      isFocused: () => false,
+      isMinimized: () => true,
+      restore,
+      focus,
+      webContents: { send: webContentsSend }
+    }
+    getAllWindowsMock.mockReturnValue([popoutWindow, mainWindow] as never)
+    getTrustedUIRendererWindowMock.mockReturnValue(mainWindow)
     registerNotificationHandlers({
       getSettings: () => ({
         notifications: {
@@ -486,8 +505,11 @@ describe('registerNotificationHandlers', () => {
 
     getNotificationEventHandler('click')()
 
+    expect(getTrustedUIRendererWindowMock).toHaveBeenCalledTimes(1)
     expect(restore).toHaveBeenCalledTimes(1)
     expect(focus).toHaveBeenCalledTimes(1)
+    expect(popoutFocus).not.toHaveBeenCalled()
+    expect(popoutSend).not.toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
     expect(notificationRemoveListenerMock).toHaveBeenCalledWith('click', expect.any(Function))
     expect(webContentsSend).toHaveBeenCalledWith('ui:activateWorktree', {

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -466,6 +466,7 @@ describe('registerNotificationHandlers', () => {
     const popoutFocus = vi.fn()
     const webContentsSend = vi.fn()
     const restore = vi.fn()
+    const show = vi.fn()
     const focus = vi.fn()
     const popoutWindow = {
       isDestroyed: () => false,
@@ -480,6 +481,7 @@ describe('registerNotificationHandlers', () => {
       isFocused: () => false,
       isMinimized: () => true,
       restore,
+      show,
       focus,
       webContents: { send: webContentsSend }
     }
@@ -507,6 +509,7 @@ describe('registerNotificationHandlers', () => {
 
     expect(getTrustedUIRendererWindowMock).toHaveBeenCalledTimes(1)
     expect(restore).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledTimes(1)
     expect(focus).toHaveBeenCalledTimes(1)
     expect(popoutFocus).not.toHaveBeenCalled()
     expect(popoutSend).not.toHaveBeenCalled()

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -523,6 +523,7 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
             if (win.isMinimized()) {
               win.restore()
             }
+            win.show()
             win.focus()
             win.webContents.send('ui:activateWorktree', {
               repoId,

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -28,6 +28,7 @@ import { readNotificationAuthorizationStatus } from './notification-authorizatio
 import { parsePaneKey } from '../../shared/stable-pane-id'
 import { setTrayAttention } from '../tray/system-tray'
 import { isMainWindowVisible } from '../window/main-window-visibility'
+import { getTrustedUIRendererWindow } from './ui'
 
 const NOTIFICATION_COOLDOWN_MS = 5000
 const MAX_RECENT_NOTIFICATION_KEYS = 50
@@ -512,8 +513,8 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
           const repoId = getRepoIdFromWorktreeId(args.worktreeId)
           clickHandler = () => {
             release()
-            const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
-            if (!win) {
+            const win = getTrustedUIRendererWindow()
+            if (!win || win.isDestroyed()) {
               return
             }
             if (process.platform === 'darwin') {


### PR DESCRIPTION
## Summary

- Route desktop notification clicks to Orca’s registered main renderer window instead of the first live `BrowserWindow`.
- Reveal, restore, and focus the registered main window before activating the originating worktree and terminal pane.
- Add regression coverage where the focused Agent Dashboard pop-out appears first in Electron window order.

## Screenshots

No visual change. [Electron multi-window QA screenshots](https://github.com/stablyai/orca/pull/13680#issuecomment-5246969175) show the exact validated HEAD with the main workspace and Agent Dashboard/Agent Map pop-outs.

## Testing

- [x] PR CI static analysis, typecheck, Git compatibility, shell contracts, and verification passed.
- [x] PR CI passed all Node 24 and Node 26 test shards.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/notifications.test.ts src/main/ipc/ui.test.ts src/main/ipc/dashboard-popout.test.ts` — 80 passed.
- [x] PR CI package checks passed on macOS/Linux and Windows.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Electron validation attached to the intended worktree build and opened the real Agent Map pop-out beside the originating main workspace and terminal. The isolated development bundle was blocked by macOS notification permissions, so the native banner click itself was exercised through the main-process regression test rather than OS input automation.

## AI Review Report

Reviewed the notification lifecycle, Electron window selection, trusted renderer registration, minimized-window restoration, worktree activation, stable pane targeting, and notification cleanup. The key risk was sending navigation IPC to a companion pop-out or another retained window; the fix uses the existing exact trusted-main-window registry and safely no-ops when that window is unavailable or destroyed.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. The window targeting is platform-neutral; the existing macOS-only `app.focus({ steal: true })` behavior remains runtime-gated. This PR changes no shortcuts, labels, filesystem paths, shell commands, Git behavior, SSH behavior, or remote wire contracts.

## Security Audit

The change narrows privileged navigation IPC delivery from an arbitrary live Electron window to the registered trusted UI renderer. No new input parsing, command execution, path handling, authentication, secrets, dependencies, or wire surface is introduced. Notification-provided worktree and pane identifiers continue through the existing validation/parsing path.

## Notes

The bug reproduced in the regression before the fix: with the dashboard pop-out first, the main window was not restored or focused and received no navigation events.
