### PR TITLE
fix(dashboard): keep agent map rings open while the pointer works inside them

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentMap.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMap.test.tsx
@@ -1,137 +1,16 @@
 // @vitest-environment happy-dom
 
 import '@testing-library/jest-dom/vitest'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type {
-  DashboardCard,
-  DashboardSleepWorkspaceArgs,
-  DashboardSpawnAgentArgs
-} from '../../../../shared/dashboard-snapshot'
-import type { TuiAgent } from '../../../../shared/types'
+import { act, cleanup, fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import { AgentMap } from './AgentMap'
 import { agentMapAttentionMarkerScale } from './AgentMapWorktreeRingNode'
 import type { AgentMapState } from './agent-map-filter'
 import { AGENT_MAP_AGENT_RADIUS } from './agent-map-layout'
-
-const NOW = 2_000_000_000
-
-function card(overrides: Partial<DashboardCard> = {}): DashboardCard {
-  return {
-    paneKey: 'pane-1',
-    ptyId: 'pty-1',
-    agentType: 'codex',
-    bucket: 'working',
-    dotState: 'working',
-    task: 'Build map',
-    repoId: 'repo-1',
-    worktreeId: 'worktree-1',
-    tabId: 'tab-1',
-    leafId: 'leaf-1',
-    repoName: 'Orca',
-    worktreeName: 'Agent map',
-    conversationName: 'Agent alpha',
-    startedAt: NOW - 10 * 60_000,
-    finishedAt: null,
-    stateChangedAt: NOW - 1_000,
-    unseen: false,
-    hostKind: 'local',
-    workspaceKind: 'worktree',
-    ...overrides
-  }
-}
-
-function renderMap(
-  cards: DashboardCard[],
-  {
-    onOpenTerminal = vi.fn(),
-    selectedPaneKey = null,
-    compact = false,
-    workspaceContextMenusEnabled = false,
-    enabledStates,
-    showOrchestrationLinks,
-    launchableAgentsByWorktreeId,
-    onSpawnAgent,
-    onSleepWorkspace
-  }: {
-    onOpenTerminal?: (card: DashboardCard) => void
-    selectedPaneKey?: string | null
-    compact?: boolean
-    workspaceContextMenusEnabled?: boolean
-    enabledStates?: ReadonlySet<AgentMapState>
-    showOrchestrationLinks?: boolean
-    launchableAgentsByWorktreeId?: Record<string, TuiAgent[]>
-    onSpawnAgent?: (args: DashboardSpawnAgentArgs) => void
-    onSleepWorkspace?: (args: DashboardSleepWorkspaceArgs) => void
-  } = {}
-): ReturnType<typeof render> {
-  return render(
-    <AgentMap
-      cards={cards}
-      now={NOW}
-      onOpenTerminal={onOpenTerminal}
-      selectedPaneKey={selectedPaneKey}
-      compact={compact}
-      workspaceContextMenusEnabled={workspaceContextMenusEnabled}
-      enabledStates={enabledStates}
-      showOrchestrationLinks={showOrchestrationLinks}
-      launchableAgentsByWorktreeId={launchableAgentsByWorktreeId}
-      onSpawnAgent={onSpawnAgent}
-      onSleepWorkspace={onSleepWorkspace}
-    />
-  )
-}
+import { card, installAgentMapEnvironment, NOW, renderMap } from './agent-map-render-test-harness'
 
 describe('AgentMap', () => {
-  const originalUserAgent = navigator.userAgent
-  let boundsSpy: ReturnType<typeof vi.spyOn>
-
-  beforeEach(() => {
-    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: 'Linux' })
-    vi.stubGlobal(
-      'matchMedia',
-      vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
-    )
-    boundsSpy = vi
-      .spyOn(Element.prototype, 'getBoundingClientRect')
-      .mockImplementation(function getBounds(this: Element) {
-        if (this.classList.contains('agent-map-canvas') || this instanceof SVGSVGElement) {
-          return {
-            x: 0,
-            y: 0,
-            left: 0,
-            top: 0,
-            right: 400,
-            bottom: 300,
-            width: 400,
-            height: 300,
-            toJSON: () => ({})
-          }
-        }
-        return {
-          x: 0,
-          y: 0,
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-          width: 0,
-          height: 0,
-          toJSON: () => ({})
-        }
-      })
-  })
-
-  afterEach(() => {
-    cleanup()
-    vi.clearAllMocks()
-    vi.unstubAllGlobals()
-    boundsSpy.mockRestore()
-    Object.defineProperty(navigator, 'userAgent', {
-      configurable: true,
-      value: originalUserAgent
-    })
-  })
+  const environment = installAgentMapEnvironment()
 
   it('renders the amber marker only for unread agents', () => {
     const finished = card({
@@ -162,23 +41,6 @@ describe('AgentMap', () => {
     )
     expect(unreadMarker).toHaveAttribute('vector-effect', 'none')
     expect(doneNode).toHaveAccessibleName(/unread/)
-  })
-
-  it.each([
-    { bucket: 'working', dotState: 'working', unseen: false, glows: true },
-    { bucket: 'attention', dotState: 'waiting', unseen: false, glows: true },
-    { bucket: 'attention', dotState: 'blocked', unseen: false, glows: true },
-    { bucket: 'done', dotState: 'done', unseen: true, glows: false },
-    { bucket: 'idle', dotState: 'idle', unseen: false, glows: false }
-  ] as const)('applies the expected halo for $dotState agents', (state) => {
-    const { container } = renderMap([card(state)])
-    const glow = container.querySelector('[data-agent-map-agent-status-glow]')
-
-    if (state.glows) {
-      expect(glow).toHaveAttribute('data-agent-active-status', state.dotState)
-      return
-    }
-    expect(glow).not.toBeInTheDocument()
   })
 
   it('lets attention override working on the worktree glow', () => {
@@ -631,13 +493,13 @@ describe('AgentMap', () => {
       labelGroup?.getAttribute('transform')?.match(/scale\(([^)]+)\)/)?.[1]
     )
 
-    const readsBeforeZoom = boundsSpy.mock.calls.length
+    const readsBeforeZoom = environment.boundsSpy.mock.calls.length
     fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }))
 
     const zoomedScale = Number(
       labelGroup?.getAttribute('transform')?.match(/scale\(([^)]+)\)/)?.[1]
     )
-    expect(boundsSpy).toHaveBeenCalledTimes(readsBeforeZoom)
+    expect(environment.boundsSpy).toHaveBeenCalledTimes(readsBeforeZoom)
     expect(zoomedScale).toBeGreaterThan(initialScale)
   })
 
@@ -656,18 +518,18 @@ describe('AgentMap', () => {
       releasePointerCapture: vi.fn()
     })
 
-    const readsBeforeHover = boundsSpy.mock.calls.length
+    const readsBeforeHover = environment.boundsSpy.mock.calls.length
     fireEvent.pointerMove(svg, { pointerId: 1, clientX: 20, clientY: 20 })
-    expect(boundsSpy).toHaveBeenCalledTimes(readsBeforeHover)
+    expect(environment.boundsSpy).toHaveBeenCalledTimes(readsBeforeHover)
 
     fireEvent.pointerDown(svg, { pointerId: 1, clientX: 20, clientY: 20 })
     expect(svg.setPointerCapture).toHaveBeenCalledWith(1)
-    const readsAfterPointerDown = boundsSpy.mock.calls.length
+    const readsAfterPointerDown = environment.boundsSpy.mock.calls.length
     const initialViewBox = svg.getAttribute('viewBox')
     fireEvent.pointerMove(svg, { pointerId: 1, clientX: 30, clientY: 20 })
     fireEvent.pointerMove(svg, { pointerId: 1, clientX: 40, clientY: 20 })
 
-    expect(boundsSpy).toHaveBeenCalledTimes(readsAfterPointerDown)
+    expect(environment.boundsSpy).toHaveBeenCalledTimes(readsAfterPointerDown)
     expect(requestFrame).toHaveBeenCalledOnce()
     expect(svg).toHaveAttribute('viewBox', initialViewBox)
 
@@ -675,7 +537,7 @@ describe('AgentMap', () => {
     expect(svg.getAttribute('viewBox')).not.toBe(initialViewBox)
 
     requestFrame.mockClear()
-    const readsBeforeWheel = boundsSpy.mock.calls.length
+    const readsBeforeWheel = environment.boundsSpy.mock.calls.length
     const wheel = (): void => {
       const event = new Event('wheel', { bubbles: true, cancelable: true })
       Object.defineProperties(event, {
@@ -688,7 +550,7 @@ describe('AgentMap', () => {
     }
     wheel()
     wheel()
-    expect(boundsSpy).toHaveBeenCalledTimes(readsBeforeWheel + 1)
+    expect(environment.boundsSpy).toHaveBeenCalledTimes(readsBeforeWheel + 1)
     expect(requestFrame).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/components/dashboard-popout/AgentMapCanvas.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapCanvas.tsx
@@ -87,7 +87,7 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
     const pendingViewportRef = useRef<AgentMapViewport | null>(null)
     const interactionBoundsRef = useRef<DOMRect | null>(null)
     const hasShownProjectsRef = useRef(layout.projects.length > 0)
-    const { held, hold, release: releaseHold } = useAgentMapPointerHold()
+    const { held, hold, release: releaseHold, clearDrag } = useAgentMapPointerHold(dragRef)
     const clearInteractionBounds = useCallback(() => {
       interactionBoundsRef.current = null
     }, [])
@@ -317,7 +317,7 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
               'Nested project, workspace, and agent map'
             )}
             onPointerDown={(event) => {
-              if (event.button !== 0) {
+              if (event.button !== 0 || dragRef.current) {
                 return
               }
               if (
@@ -360,16 +360,15 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
               })
             }}
             onPointerUp={(event) => {
-              if (dragRef.current?.pointerId === event.pointerId) {
-                dragRef.current = null
+              if (clearDrag(event.pointerId)) {
                 event.currentTarget.releasePointerCapture(event.pointerId)
               }
             }}
             onPointerCancel={(event) => {
-              if (dragRef.current?.pointerId === event.pointerId) {
-                dragRef.current = null
-                releaseHold()
-              }
+              clearDrag(event.pointerId)
+            }}
+            onLostPointerCapture={(event) => {
+              clearDrag(event.pointerId)
             }}
             onPointerLeave={() => {
               if (!dragRef.current) {

--- a/src/renderer/src/components/dashboard-popout/AgentMapCanvas.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapCanvas.tsx
@@ -28,6 +28,7 @@ import {
 import type { AgentMapViewport } from './agent-map-viewport-transition'
 import { useAgentMapContextMenus } from './useAgentMapContextMenus'
 import { useAgentMapCanvasSize } from './useAgentMapCanvasSize'
+import { useAgentMapPointerHold } from './useAgentMapPointerHold'
 import { useAgentMapMotionLayout } from './useAgentMapMotionLayout'
 import { useAgentMapSelectedFocus } from './useAgentMapSelectedFocus'
 import { useAgentMapViewportTransition } from './useAgentMapViewportTransition'
@@ -86,6 +87,7 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
     const pendingViewportRef = useRef<AgentMapViewport | null>(null)
     const interactionBoundsRef = useRef<DOMRect | null>(null)
     const hasShownProjectsRef = useRef(layout.projects.length > 0)
+    const { held, hold, release: releaseHold } = useAgentMapPointerHold()
     const clearInteractionBounds = useCallback(() => {
       interactionBoundsRef.current = null
     }, [])
@@ -337,11 +339,16 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
                 worldPerPixelX: baseWidth / current.zoom / bounds.width,
                 worldPerPixelY: baseHeight / current.zoom / bounds.height
               }
+              hold(event.target as Element)
               event.currentTarget.setPointerCapture(event.pointerId)
             }}
             onPointerMove={(event) => {
               const drag = dragRef.current
-              if (!drag || drag.pointerId !== event.pointerId) {
+              if (!drag) {
+                releaseHold()
+                return
+              }
+              if (drag.pointerId !== event.pointerId) {
                 return
               }
               scheduleViewport({
@@ -361,6 +368,12 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
             onPointerCancel={(event) => {
               if (dragRef.current?.pointerId === event.pointerId) {
                 dragRef.current = null
+                releaseHold()
+              }
+            }}
+            onPointerLeave={() => {
+              if (!dragRef.current) {
+                releaseHold()
               }
             }}
           >
@@ -370,6 +383,8 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
               zoom={zoom}
               labelScale={labelScale}
               mapScale={mapScale}
+              heldProjectId={held?.projectId ?? null}
+              heldWorktreeId={held?.worktreeId ?? null}
               selectedPaneKey={selectedPaneKey}
               allowAggregation={allowAggregation}
               showOrchestrationLinks={showOrchestrationLinks}

--- a/src/renderer/src/components/dashboard-popout/AgentMapProjectLabel.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapProjectLabel.test.tsx
@@ -39,6 +39,8 @@ describe('AgentMapScene project labels', () => {
           zoom={1}
           labelScale={1}
           mapScale={0.5}
+          heldProjectId={null}
+          heldWorktreeId={null}
           selectedPaneKey={null}
           allowAggregation
           showOrchestrationLinks

--- a/src/renderer/src/components/dashboard-popout/AgentMapRingHover.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapRingHover.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { fireEvent } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { card, installAgentMapEnvironment, renderMap } from './agent-map-render-test-harness'
+
+/** A ring has to stay open for as long as the pointer is working inside it —
+ *  across its own contents, and across a pan drag that takes pointer capture. */
+describe('AgentMap ring hover', () => {
+  installAgentMapEnvironment()
+
+  it('reveals the hovered workspace name and agent count above every other label', () => {
+    const { container } = renderMap([
+      card(),
+      card({ paneKey: 'pane-2', conversationName: 'Agent beta' })
+    ])
+    expect(container.querySelector('[data-agent-map-hover-label]')).not.toBeInTheDocument()
+
+    fireEvent.pointerOver(container.querySelector('.agent-map-worktree-group')!)
+
+    const hovered = container.querySelector('[data-agent-map-hover-label]')!
+    expect(hovered.querySelector('.agent-map-worktree-label')).toHaveTextContent('Agent map')
+    expect(hovered.querySelector('.agent-map-worktree-count')).toHaveTextContent('2 agents')
+    expect(hovered.querySelector('.agent-map-worktree-label-group')).toHaveClass(
+      'is-active',
+      'is-count-visible'
+    )
+    // The hovered name is hoisted, not duplicated, and draws after every ring.
+    const labels = container.querySelectorAll('.agent-map-worktree-label-group')
+    expect(labels).toHaveLength(1)
+    const lastRing = [...container.querySelectorAll('[data-agent-map-worktree]')].at(-1)!
+    expect(lastRing.compareDocumentPosition(labels[0]) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(4)
+  })
+
+  it('hides the hovered workspace label again when the pointer leaves', () => {
+    const { container } = renderMap([card()])
+    const group = container.querySelector('.agent-map-worktree-group')!
+
+    fireEvent.pointerOver(group)
+    expect(container.querySelector('[data-agent-map-hover-label]')).toBeInTheDocument()
+
+    fireEvent.pointerOut(group)
+    expect(container.querySelector('[data-agent-map-hover-label]')).not.toBeInTheDocument()
+  })
+
+  it('keeps the pressed rings lit for the whole pan drag', () => {
+    const { container } = renderMap([card()])
+    const svg = container.querySelector('svg')!
+    const projectRing = container.querySelector('[data-agent-map-project-id]')!
+    const worktreeGroup = container.querySelector('.agent-map-worktree-group')!
+    // Pointer capture retargets :hover to the <svg> mid-gesture, so CSS alone
+    // cannot hold the ring open — the class has to survive the drag.
+    fireEvent.pointerDown(projectRing, { button: 0, pointerId: 1 })
+
+    expect(projectRing).toHaveClass('is-held')
+
+    fireEvent.pointerMove(svg, { pointerId: 1, clientX: 40, clientY: 24 })
+    expect(projectRing).toHaveClass('is-held')
+
+    // Hover only resumes on the first move after release, when the browser
+    // recomputes :hover in that same event — so neither reads off in between.
+    fireEvent.pointerUp(svg, { pointerId: 1 })
+    expect(projectRing).toHaveClass('is-held')
+
+    fireEvent.pointerMove(svg, { pointerId: 1, clientX: 41, clientY: 25 })
+    expect(projectRing).not.toHaveClass('is-held')
+    expect(worktreeGroup).not.toHaveClass('is-held')
+  })
+
+  it('holds the workspace name up while panning from inside that workspace', () => {
+    const { container } = renderMap([card()])
+    const svg = container.querySelector('svg')!
+    const worktreeGroup = container.querySelector('[data-agent-map-worktree-id]')!
+    // The aggregate bubble sits inside the group but is not the ring, so a press
+    // there pans rather than opening the workspace popover.
+    fireEvent.pointerDown(worktreeGroup, { button: 0, pointerId: 1 })
+    fireEvent.pointerMove(svg, { pointerId: 1, clientX: 40, clientY: 24 })
+
+    expect(worktreeGroup).toHaveClass('is-held')
+    expect(container.querySelector('[data-agent-map-hover-label]')).toBeInTheDocument()
+  })
+
+  it('drops the held rings when the pan is cancelled', () => {
+    const { container } = renderMap([card()])
+    const svg = container.querySelector('svg')!
+    const projectRing = container.querySelector('[data-agent-map-project-id]')!
+
+    fireEvent.pointerDown(projectRing, { button: 0, pointerId: 1 })
+    fireEvent.pointerCancel(svg, { pointerId: 1 })
+
+    expect(projectRing).not.toHaveClass('is-held')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/AgentMapRingHover.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapRingHover.test.tsx
@@ -58,12 +58,7 @@ describe('AgentMap ring hover', () => {
     fireEvent.pointerMove(svg, { pointerId: 1, clientX: 40, clientY: 24 })
     expect(projectRing).toHaveClass('is-held')
 
-    // Hover only resumes on the first move after release, when the browser
-    // recomputes :hover in that same event — so neither reads off in between.
     fireEvent.pointerUp(svg, { pointerId: 1 })
-    expect(projectRing).toHaveClass('is-held')
-
-    fireEvent.pointerMove(svg, { pointerId: 1, clientX: 41, clientY: 25 })
     expect(projectRing).not.toHaveClass('is-held')
     expect(worktreeGroup).not.toHaveClass('is-held')
   })
@@ -90,5 +85,40 @@ describe('AgentMap ring hover', () => {
     fireEvent.pointerCancel(svg, { pointerId: 1 })
 
     expect(projectRing).not.toHaveClass('is-held')
+  })
+
+  it('drops the held rings and drag when pointer capture is lost', () => {
+    const { container } = renderMap([card()])
+    const svg = container.querySelector('svg')!
+    const projectRing = container.querySelector('[data-agent-map-project-id]')!
+
+    fireEvent.pointerDown(projectRing, { button: 0, pointerId: 1 })
+    fireEvent.lostPointerCapture(svg, { pointerId: 1 })
+
+    expect(projectRing).not.toHaveClass('is-held')
+  })
+
+  it('keeps a focused workspace label visible after its pointer leaves', () => {
+    const { container } = renderMap([card()])
+    const group = container.querySelector('.agent-map-worktree-group')!
+    const ring = container.querySelector<SVGCircleElement>('.agent-map-worktree-ring')!
+
+    ring.focus()
+    fireEvent.pointerOver(group)
+    fireEvent.pointerOut(group)
+
+    expect(container.querySelector('[data-agent-map-hover-label]')).toBeInTheDocument()
+  })
+
+  it('keeps a hovered workspace label visible after its focus leaves', () => {
+    const { container } = renderMap([card()])
+    const group = container.querySelector('.agent-map-worktree-group')!
+    const ring = container.querySelector<SVGCircleElement>('.agent-map-worktree-ring')!
+
+    fireEvent.pointerOver(group)
+    ring.focus()
+    ring.blur()
+
+    expect(container.querySelector('[data-agent-map-hover-label]')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/dashboard-popout/AgentMapScene.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapScene.tsx
@@ -80,11 +80,15 @@ export const AgentMapScene = memo(function AgentMapScene({
   onAgentKeyDown
 }: AgentMapSceneProps): React.JSX.Element {
   const [hoveredWorktreeId, setHoveredWorktreeId] = useState<string | null>(null)
-  // A pan that starts inside a workspace keeps that workspace's name up: pointer
-  // capture fires a spurious leave the moment the drag begins.
-  const activeWorktreeId = heldWorktreeId ?? hoveredWorktreeId
-  const handleLabelActiveChange = useCallback((worktreeId: string, active: boolean): void => {
+  const [focusedWorktreeId, setFocusedWorktreeId] = useState<string | null>(null)
+  const activeWorktreeId = heldWorktreeId ?? hoveredWorktreeId ?? focusedWorktreeId
+  const handleLabelHoverChange = useCallback((worktreeId: string, active: boolean): void => {
     setHoveredWorktreeId((current) =>
+      active ? worktreeId : current === worktreeId ? null : current
+    )
+  }, [])
+  const handleLabelFocusChange = useCallback((worktreeId: string, active: boolean): void => {
+    setFocusedWorktreeId((current) =>
       active ? worktreeId : current === worktreeId ? null : current
     )
   }, [])
@@ -211,7 +215,8 @@ export const AgentMapScene = memo(function AgentMapScene({
                 onSelectAgent={onSelectAgent}
                 onSpawnAgent={onSpawnAgent}
                 onOpenWorkspaceContextMenu={onOpenWorkspaceContextMenu}
-                onLabelActiveChange={handleLabelActiveChange}
+                onLabelHoverChange={handleLabelHoverChange}
+                onLabelFocusChange={handleLabelFocusChange}
                 onAgentKeyDown={onAgentKeyDown}
               />
             ))}

--- a/src/renderer/src/components/dashboard-popout/AgentMapScene.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapScene.tsx
@@ -22,6 +22,9 @@ type AgentMapSceneProps = {
   zoom: number
   labelScale: number
   mapScale: number
+  /** Rings the pointer was pressed in; they stay lit for the whole pan drag. */
+  heldProjectId: string | null
+  heldWorktreeId: string | null
   selectedPaneKey: string | null
   allowAggregation: boolean
   showOrchestrationLinks: boolean
@@ -63,6 +66,8 @@ export const AgentMapScene = memo(function AgentMapScene({
   zoom,
   labelScale,
   mapScale,
+  heldProjectId,
+  heldWorktreeId,
   selectedPaneKey,
   allowAggregation,
   showOrchestrationLinks,
@@ -74,9 +79,12 @@ export const AgentMapScene = memo(function AgentMapScene({
   onOpenWorkspaceContextMenu,
   onAgentKeyDown
 }: AgentMapSceneProps): React.JSX.Element {
-  const [activeWorktreeId, setActiveWorktreeId] = useState<string | null>(null)
+  const [hoveredWorktreeId, setHoveredWorktreeId] = useState<string | null>(null)
+  // A pan that starts inside a workspace keeps that workspace's name up: pointer
+  // capture fires a spurious leave the moment the drag begins.
+  const activeWorktreeId = heldWorktreeId ?? hoveredWorktreeId
   const handleLabelActiveChange = useCallback((worktreeId: string, active: boolean): void => {
-    setActiveWorktreeId((current) =>
+    setHoveredWorktreeId((current) =>
       active ? worktreeId : current === worktreeId ? null : current
     )
   }, [])
@@ -84,6 +92,19 @@ export const AgentMapScene = memo(function AgentMapScene({
     () => selectVisibleAgentMapLabels(layout, labelScale, mapScale),
     [labelScale, layout, mapScale]
   )
+  const activeWorktree = useMemo(() => {
+    if (!activeWorktreeId) {
+      return null
+    }
+    for (const project of layout.projects) {
+      for (const worktree of project.worktrees) {
+        if (worktree.id === activeWorktreeId) {
+          return worktree
+        }
+      }
+    }
+    return null
+  }, [activeWorktreeId, layout])
   const visibleAgentsByPaneKey = useMemo(() => {
     const agents = new Map<string, VisibleAgentLocation>()
     for (const project of layout.projects) {
@@ -125,7 +146,8 @@ export const AgentMapScene = memo(function AgentMapScene({
         return (
           <g
             key={project.id}
-            className={`agent-map-project-node${project.motionState ? ` is-${project.motionState}` : ''}`}
+            className={`agent-map-project-node${project.motionState ? ` is-${project.motionState}` : ''}${heldProjectId === project.id ? ' is-held' : ''}`}
+            data-agent-map-project-id={project.id}
             aria-hidden={project.motionState === 'exiting' || undefined}
           >
             <circle
@@ -180,6 +202,7 @@ export const AgentMapScene = memo(function AgentMapScene({
                 worktree={worktree}
                 zoom={zoom}
                 mapScale={mapScale}
+                held={heldWorktreeId === worktree.id}
                 selectedPaneKey={selectedPaneKey}
                 allowAggregation={allowAggregation}
                 showOrchestrationLinks={showOrchestrationLinks}
@@ -193,19 +216,18 @@ export const AgentMapScene = memo(function AgentMapScene({
               />
             ))}
             <g className="agent-map-worktree-label-layer">
-              {project.worktrees.map((worktree) => (
-                <AgentMapWorktreeLabel
-                  key={worktree.id}
-                  worktree={worktree}
-                  visible={visibleLabels.worktreeIds.has(worktree.id)}
-                  active={
-                    activeWorktreeId === worktree.id &&
-                    visibleLabels.worktreeAgentSafeIds.has(worktree.id)
-                  }
-                  labelScale={labelScale}
-                  mapScale={mapScale}
-                />
-              ))}
+              {project.worktrees.map((worktree) =>
+                worktree.id === activeWorktreeId ? null : (
+                  <AgentMapWorktreeLabel
+                    key={worktree.id}
+                    worktree={worktree}
+                    visible={visibleLabels.worktreeIds.has(worktree.id)}
+                    active={false}
+                    labelScale={labelScale}
+                    mapScale={mapScale}
+                  />
+                )
+              )}
             </g>
             <g
               transform={`translate(${project.x} ${project.y - project.radius}) scale(${labelScale})`}
@@ -237,6 +259,19 @@ export const AgentMapScene = memo(function AgentMapScene({
           </g>
         )
       })}
+      {/* Drawn last so a hovered name clears every other project's rings, and
+       *  outside the declutter pass so it reads at any zoom. */}
+      {activeWorktree ? (
+        <g className="agent-map-worktree-hover-label-layer" data-agent-map-hover-label="">
+          <AgentMapWorktreeLabel
+            worktree={activeWorktree}
+            visible={visibleLabels.worktreeIds.has(activeWorktree.id)}
+            active
+            labelScale={labelScale}
+            mapScale={mapScale}
+          />
+        </g>
+      ) : null}
     </>
   )
 })

--- a/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it } from 'vitest'
+import { card, installAgentMapEnvironment, renderMap } from './agent-map-render-test-harness'
+
+describe('AgentMap status glow', () => {
+  installAgentMapEnvironment()
+
+  it.each([
+    { bucket: 'working', dotState: 'working', unseen: false, glows: true },
+    { bucket: 'attention', dotState: 'waiting', unseen: false, glows: true },
+    { bucket: 'attention', dotState: 'blocked', unseen: false, glows: true },
+    { bucket: 'done', dotState: 'done', unseen: true, glows: false },
+    { bucket: 'idle', dotState: 'idle', unseen: false, glows: false }
+  ] as const)('applies the expected halo for $dotState agents', (state) => {
+    const { container } = renderMap([card(state)])
+    const glow = container.querySelector('[data-agent-map-agent-status-glow]')
+
+    if (state.glows) {
+      expect(glow).toHaveAttribute('data-agent-active-status', state.dotState)
+      return
+    }
+    expect(glow).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeLabel.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeLabel.tsx
@@ -17,7 +17,8 @@ export const AgentMapWorktreeLabel = memo(function AgentMapWorktreeLabel({
   labelScale,
   mapScale
 }: AgentMapWorktreeLabelProps): React.JSX.Element {
-  const showCount = visible && (active || worktree.radius * mapScale >= 80)
+  // Hover is an explicit ask for this workspace's detail, so it outranks declutter.
+  const showCount = active || (visible && worktree.radius * mapScale >= 80)
   const agentCountText = translate(
     'dashboardPopout.map.agentCount',
     worktree.agents.length === 1 ? '{{count}} agent' : '{{count}} agents',

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
@@ -22,6 +22,8 @@ type AgentMapWorktreeRingNodeProps = {
   worktree: AgentMapWorktreeRing
   zoom: number
   mapScale: number
+  /** Pressed at the start of a pan drag; keeps the ring lit through the gesture. */
+  held: boolean
   selectedPaneKey: string | null
   allowAggregation: boolean
   showOrchestrationLinks: boolean
@@ -175,6 +177,7 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
   worktree,
   zoom,
   mapScale,
+  held,
   selectedPaneKey,
   allowAggregation,
   showOrchestrationLinks,
@@ -196,7 +199,8 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
   return (
     <Popover open={detailsOpen && !exiting} onOpenChange={setDetailsOpen}>
       <g
-        className={`agent-map-worktree-group${worktree.motionState ? ` is-${worktree.motionState}` : ''}`}
+        className={`agent-map-worktree-group${worktree.motionState ? ` is-${worktree.motionState}` : ''}${held ? ' is-held' : ''}`}
+        data-agent-map-worktree-id={worktree.id}
         aria-hidden={exiting || undefined}
         onPointerEnter={() => onLabelActiveChange(worktree.id, true)}
         onPointerLeave={() => onLabelActiveChange(worktree.id, false)}

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
@@ -35,7 +35,8 @@ type AgentMapWorktreeRingNodeProps = {
     event: React.MouseEvent<SVGCircleElement>,
     worktree: AgentMapWorktreeRing
   ) => void
-  onLabelActiveChange: (worktreeId: string, active: boolean) => void
+  onLabelHoverChange: (worktreeId: string, active: boolean) => void
+  onLabelFocusChange: (worktreeId: string, active: boolean) => void
   onAgentKeyDown: (event: React.KeyboardEvent<SVGGElement>, agent: AgentMapAgentNode) => void
 }
 
@@ -186,7 +187,8 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
   onSelectAgent,
   onSpawnAgent,
   onOpenWorkspaceContextMenu,
-  onLabelActiveChange,
+  onLabelHoverChange,
+  onLabelFocusChange,
   onAgentKeyDown
 }: AgentMapWorktreeRingNodeProps): React.JSX.Element {
   const [detailsOpen, setDetailsOpen] = useState(false)
@@ -202,12 +204,12 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
         className={`agent-map-worktree-group${worktree.motionState ? ` is-${worktree.motionState}` : ''}${held ? ' is-held' : ''}`}
         data-agent-map-worktree-id={worktree.id}
         aria-hidden={exiting || undefined}
-        onPointerEnter={() => onLabelActiveChange(worktree.id, true)}
-        onPointerLeave={() => onLabelActiveChange(worktree.id, false)}
-        onFocus={() => onLabelActiveChange(worktree.id, true)}
+        onPointerEnter={() => onLabelHoverChange(worktree.id, true)}
+        onPointerLeave={() => onLabelHoverChange(worktree.id, false)}
+        onFocus={() => onLabelFocusChange(worktree.id, true)}
         onBlur={(event) => {
           if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-            onLabelActiveChange(worktree.id, false)
+            onLabelFocusChange(worktree.id, false)
           }
         }}
       >

--- a/src/renderer/src/components/dashboard-popout/agent-map-hover-containment.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-hover-containment.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(
+  resolve(process.cwd(), 'src/renderer/src/components/dashboard-popout/agent-map.css'),
+  'utf8'
+)
+
+const PROJECT_SCALE =
+  /:where\(\.agent-map-project-node:hover,\s*\.agent-map-project-node\.is-held\)\s*\.agent-map-project-ring\s*\{([^}]*)\}/
+const WORKTREE_SCALE =
+  /:where\(\.agent-map-worktree-group:hover,\s*\.agent-map-worktree-group\.is-held\)\s*\.agent-map-worktree-ring\s*\{([^}]*)\}/
+
+/** A ring that only reacts to :hover on itself pulses shut whenever the pointer
+ *  crosses onto something drawn inside it, and again when a pan drag takes
+ *  pointer capture. Both triggers have to live on the containing group. */
+describe('Agent Map hover containment', () => {
+  it('scales each ring from its containing group, never from the ring element', () => {
+    expect(css).not.toMatch(/\.agent-map-(?:project|worktree)-ring:hover/)
+    expect(css.match(PROJECT_SCALE)?.[1]).toContain('transform: scale')
+    expect(css.match(WORKTREE_SCALE)?.[1]).toContain('transform: scale')
+  })
+
+  it('keeps the group-scoped hover at ring specificity so state rules still win', () => {
+    // `:where()` contributes no specificity, so the workspace state rules keep
+    // overriding hover fill and stroke — but only while they stay below it.
+    const hoverAt = css.search(WORKTREE_SCALE)
+
+    expect(hoverAt).toBeGreaterThan(css.indexOf('.agent-map-worktree-ring {'))
+    for (const state of ['.is-open', '.is-selected', '.is-working', '.is-blocked']) {
+      expect(css.indexOf(`.agent-map-worktree-ring${state}`)).toBeGreaterThan(hoverAt)
+    }
+  })
+
+  it('drops both hover triggers under reduced motion', () => {
+    const reducedMotion = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'))
+
+    expect(reducedMotion).toContain('.agent-map-project-node.is-held')
+    expect(reducedMotion).toContain('.agent-map-worktree-group.is-held')
+    expect(reducedMotion).toMatch(/\.agent-map-project-node:hover/)
+    expect(reducedMotion).toMatch(/\.agent-map-worktree-group:hover/)
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/agent-map-hover-containment.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-hover-containment.test.ts
@@ -8,9 +8,9 @@ const css = readFileSync(
 )
 
 const PROJECT_SCALE =
-  /:where\(\.agent-map-project-node:hover,\s*\.agent-map-project-node\.is-held\)\s*\.agent-map-project-ring\s*\{([^}]*)\}/
+  /:where\(\s*\.agent-map-project-node:hover,\s*\.agent-map-project-node:focus-within,\s*\.agent-map-project-node\.is-held\s*\)\s*\.agent-map-project-ring\s*\{([^}]*)\}/
 const WORKTREE_SCALE =
-  /:where\(\.agent-map-worktree-group:hover,\s*\.agent-map-worktree-group\.is-held\)\s*\.agent-map-worktree-ring\s*\{([^}]*)\}/
+  /:where\(\s*\.agent-map-worktree-group:hover,\s*\.agent-map-worktree-group:focus-within,\s*\.agent-map-worktree-group\.is-held\s*\)\s*\.agent-map-worktree-ring\s*\{([^}]*)\}/
 
 /** A ring that only reacts to :hover on itself pulses shut whenever the pointer
  *  crosses onto something drawn inside it, and again when a pan drag takes
@@ -31,6 +31,11 @@ describe('Agent Map hover containment', () => {
     for (const state of ['.is-open', '.is-selected', '.is-working', '.is-blocked']) {
       expect(css.indexOf(`.agent-map-worktree-ring${state}`)).toBeGreaterThan(hoverAt)
     }
+  })
+
+  it('expands containing rings for keyboard focus as well as pointer hover', () => {
+    expect(css.match(PROJECT_SCALE)?.[0]).toContain('.agent-map-project-node:focus-within')
+    expect(css.match(WORKTREE_SCALE)?.[0]).toContain('.agent-map-worktree-group:focus-within')
   })
 
   it('drops both hover triggers under reduced motion', () => {

--- a/src/renderer/src/components/dashboard-popout/agent-map-label-declutter.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-label-declutter.test.ts
@@ -90,19 +90,6 @@ describe('selectVisibleAgentMapLabels', () => {
     const labels = selectVisibleAgentMapLabels(layoutOf([covered]), 1, 1)
 
     expect(labels.worktreeIds.size).toBe(0)
-    expect(labels.worktreeAgentSafeIds.size).toBe(0)
-  })
-
-  it('keeps a collision-suppressed workspace title safe to reveal away from agents', () => {
-    const layout = layoutOf([
-      worktree({ id: 'busy', x: 0, y: 0, statusCounts: statusCounts({ working: 3 }) }),
-      worktree({ id: 'calm', name: 'beta', x: 0, y: 0, statusCounts: statusCounts({ done: 1 }) })
-    ])
-
-    const labels = selectVisibleAgentMapLabels(layout, 1, 1)
-
-    expect([...labels.worktreeIds]).toEqual(['busy'])
-    expect([...labels.worktreeAgentSafeIds].sort()).toEqual(['busy', 'calm'])
   })
 
   it('lets a blocked workspace outrank a busier neighbour for the surviving label', () => {

--- a/src/renderer/src/components/dashboard-popout/agent-map-label-declutter.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-label-declutter.ts
@@ -38,8 +38,6 @@ type LabelGrid = Map<number, Map<number, LabelBox[]>>
 export type AgentMapVisibleLabels = {
   /** Worktree ring ids whose name can render without colliding. */
   worktreeIds: Set<string>
-  /** Worktree names that hover/focus may reveal without covering an agent. */
-  worktreeAgentSafeIds: Set<string>
   /** Project ids whose agent/workspace count line still has room. The count is
    *  the first thing dropped: it repeats what the filter rail already says. */
   projectCountIds: Set<string>
@@ -221,7 +219,6 @@ export function selectVisibleAgentMapLabels(
   })
 
   const worktreeIds = new Set<string>()
-  const worktreeAgentSafeIds = new Set<string>()
   for (const worktree of candidates.slice(0, MAX_LABEL_CANDIDATES)) {
     const box = baselineBox(
       worktree.x,
@@ -234,7 +231,6 @@ export function selectVisibleAgentMapLabels(
     if (collides(agentGrid, box)) {
       continue
     }
-    worktreeAgentSafeIds.add(worktree.id)
     if (collides(grid, box)) {
       continue
     }
@@ -261,5 +257,5 @@ export function selectVisibleAgentMapLabels(
     projectCountIds.add(project.id)
   }
 
-  return { worktreeIds, worktreeAgentSafeIds, projectCountIds }
+  return { worktreeIds, projectCountIds }
 }

--- a/src/renderer/src/components/dashboard-popout/agent-map-render-test-harness.tsx
+++ b/src/renderer/src/components/dashboard-popout/agent-map-render-test-harness.tsx
@@ -1,0 +1,133 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, vi } from 'vitest'
+import type {
+  DashboardCard,
+  DashboardSleepWorkspaceArgs,
+  DashboardSpawnAgentArgs
+} from '../../../../shared/dashboard-snapshot'
+import type { TuiAgent } from '../../../../shared/types'
+import { AgentMap } from './AgentMap'
+import type { AgentMapState } from './agent-map-filter'
+
+export const NOW = 2_000_000_000
+
+export function card(overrides: Partial<DashboardCard> = {}): DashboardCard {
+  return {
+    paneKey: 'pane-1',
+    ptyId: 'pty-1',
+    agentType: 'codex',
+    bucket: 'working',
+    dotState: 'working',
+    task: 'Build map',
+    repoId: 'repo-1',
+    worktreeId: 'worktree-1',
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    repoName: 'Orca',
+    worktreeName: 'Agent map',
+    conversationName: 'Agent alpha',
+    startedAt: NOW - 10 * 60_000,
+    finishedAt: null,
+    stateChangedAt: NOW - 1_000,
+    unseen: false,
+    hostKind: 'local',
+    workspaceKind: 'worktree',
+    ...overrides
+  }
+}
+
+export type RenderMapOptions = {
+  onOpenTerminal?: (card: DashboardCard) => void
+  selectedPaneKey?: string | null
+  compact?: boolean
+  workspaceContextMenusEnabled?: boolean
+  enabledStates?: ReadonlySet<AgentMapState>
+  showOrchestrationLinks?: boolean
+  launchableAgentsByWorktreeId?: Record<string, TuiAgent[]>
+  onSpawnAgent?: (args: DashboardSpawnAgentArgs) => void
+  onSleepWorkspace?: (args: DashboardSleepWorkspaceArgs) => void
+}
+
+export function renderMap(
+  cards: DashboardCard[],
+  {
+    onOpenTerminal = vi.fn(),
+    selectedPaneKey = null,
+    compact = false,
+    workspaceContextMenusEnabled = false,
+    enabledStates,
+    showOrchestrationLinks,
+    launchableAgentsByWorktreeId,
+    onSpawnAgent,
+    onSleepWorkspace
+  }: RenderMapOptions = {}
+): ReturnType<typeof render> {
+  return render(
+    <AgentMap
+      cards={cards}
+      now={NOW}
+      onOpenTerminal={onOpenTerminal}
+      selectedPaneKey={selectedPaneKey}
+      compact={compact}
+      workspaceContextMenusEnabled={workspaceContextMenusEnabled}
+      enabledStates={enabledStates}
+      showOrchestrationLinks={showOrchestrationLinks}
+      launchableAgentsByWorktreeId={launchableAgentsByWorktreeId}
+      onSpawnAgent={onSpawnAgent}
+      onSleepWorkspace={onSleepWorkspace}
+    />
+  )
+}
+
+export type AgentMapTestEnvironment = {
+  /** Exposed so tests can assert the canvas does not re-read layout when idle. */
+  boundsSpy: ReturnType<typeof vi.spyOn>
+}
+
+const CANVAS_BOUNDS = {
+  x: 0,
+  y: 0,
+  left: 0,
+  top: 0,
+  right: 400,
+  bottom: 300,
+  width: 400,
+  height: 300,
+  toJSON: () => ({})
+}
+const ZERO_BOUNDS = { ...CANVAS_BOUNDS, right: 0, bottom: 0, width: 0, height: 0 }
+
+/** Gives the map a measurable canvas and a non-Mac platform, the way every map
+ *  suite needs it. Call once per describe block. */
+export function installAgentMapEnvironment(): AgentMapTestEnvironment {
+  const environment = {} as AgentMapTestEnvironment
+  const originalUserAgent = navigator.userAgent
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'userAgent', { configurable: true, value: 'Linux' })
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+    )
+    environment.boundsSpy = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBounds(this: Element) {
+        return this.classList.contains('agent-map-canvas') || this instanceof SVGSVGElement
+          ? CANVAS_BOUNDS
+          : ZERO_BOUNDS
+      })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    environment.boundsSpy.mockRestore()
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: originalUserAgent
+    })
+  })
+
+  return environment
+}

--- a/src/renderer/src/components/dashboard-popout/agent-map.css
+++ b/src/renderer/src/components/dashboard-popout/agent-map.css
@@ -31,12 +31,13 @@
   vector-effect: non-scaling-stroke;
 }
 
-/* Hover the containing group, not the ring itself: the ring is a sibling of the
- * contents drawn inside it, so element-level :hover drops the moment the pointer
- * crosses onto a child and the ring pulses open/closed. `.is-held` covers the pan
- * drag, where pointer capture retargets :hover to the <svg>. `:where()` keeps the
- * original specificity so the state rules below still win the same properties. */
-:where(.agent-map-project-node:hover, .agent-map-project-node.is-held) .agent-map-project-ring {
+/* Group hover includes nested contents; held state bridges pointer capture. */
+:where(
+    .agent-map-project-node:hover,
+    .agent-map-project-node:focus-within,
+    .agent-map-project-node.is-held
+  )
+  .agent-map-project-ring {
   fill: color-mix(in srgb, var(--card) 42%, transparent);
   stroke: var(--ring);
   transform: scale(1.018);
@@ -159,7 +160,11 @@
   stroke: color-mix(in srgb, var(--color-yellow-500) 28%, transparent);
 }
 
-:where(.agent-map-worktree-group:hover, .agent-map-worktree-group.is-held)
+:where(
+    .agent-map-worktree-group:hover,
+    .agent-map-worktree-group:focus-within,
+    .agent-map-worktree-group.is-held
+  )
   .agent-map-worktree-ring {
   fill: color-mix(in srgb, var(--card) 72%, transparent);
   stroke: var(--ring);
@@ -491,8 +496,17 @@
     transition: none;
   }
 
-  :where(.agent-map-project-node:hover, .agent-map-project-node.is-held) .agent-map-project-ring,
-  :where(.agent-map-worktree-group:hover, .agent-map-worktree-group.is-held)
+  :where(
+      .agent-map-project-node:hover,
+      .agent-map-project-node:focus-within,
+      .agent-map-project-node.is-held
+    )
+    .agent-map-project-ring,
+  :where(
+      .agent-map-worktree-group:hover,
+      .agent-map-worktree-group:focus-within,
+      .agent-map-worktree-group.is-held
+    )
     .agent-map-worktree-ring,
   .agent-map-agent-node:hover .agent-map-agent-visual,
   .agent-map-agent-node:focus-visible .agent-map-agent-visual {

--- a/src/renderer/src/components/dashboard-popout/agent-map.css
+++ b/src/renderer/src/components/dashboard-popout/agent-map.css
@@ -31,7 +31,12 @@
   vector-effect: non-scaling-stroke;
 }
 
-.agent-map-project-ring:hover {
+/* Hover the containing group, not the ring itself: the ring is a sibling of the
+ * contents drawn inside it, so element-level :hover drops the moment the pointer
+ * crosses onto a child and the ring pulses open/closed. `.is-held` covers the pan
+ * drag, where pointer capture retargets :hover to the <svg>. `:where()` keeps the
+ * original specificity so the state rules below still win the same properties. */
+:where(.agent-map-project-node:hover, .agent-map-project-node.is-held) .agent-map-project-ring {
   fill: color-mix(in srgb, var(--card) 42%, transparent);
   stroke: var(--ring);
   transform: scale(1.018);
@@ -154,7 +159,8 @@
   stroke: color-mix(in srgb, var(--color-yellow-500) 28%, transparent);
 }
 
-.agent-map-worktree-ring:hover {
+:where(.agent-map-worktree-group:hover, .agent-map-worktree-group.is-held)
+  .agent-map-worktree-ring {
   fill: color-mix(in srgb, var(--card) 72%, transparent);
   stroke: var(--ring);
   transform: scale(1.035);
@@ -201,6 +207,11 @@
 .agent-map-worktree-count {
   font-size: 11px;
   text-anchor: middle;
+}
+
+.agent-map-worktree-label-layer,
+.agent-map-worktree-hover-label-layer {
+  pointer-events: none;
 }
 
 .agent-map-worktree-label-group {
@@ -480,8 +491,9 @@
     transition: none;
   }
 
-  .agent-map-project-ring:hover,
-  .agent-map-worktree-ring:hover,
+  :where(.agent-map-project-node:hover, .agent-map-project-node.is-held) .agent-map-project-ring,
+  :where(.agent-map-worktree-group:hover, .agent-map-worktree-group.is-held)
+    .agent-map-worktree-ring,
   .agent-map-agent-node:hover .agent-map-agent-visual,
   .agent-map-agent-node:focus-visible .agent-map-agent-visual {
     transform: none;

--- a/src/renderer/src/components/dashboard-popout/useAgentMapPointerHold.ts
+++ b/src/renderer/src/components/dashboard-popout/useAgentMapPointerHold.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react'
+
+export type AgentMapPointerHold = {
+  projectId: string | null
+  worktreeId: string | null
+}
+
+function closestId(target: Element, attribute: string): string | null {
+  return target.closest(`[${attribute}]`)?.getAttribute(attribute) ?? null
+}
+
+/**
+ * Remembers which rings a pan drag started in. Pointer capture retargets
+ * `:hover` to the `<svg>` for the whole gesture, so the ring under the pointer
+ * would otherwise collapse the moment the drag begins. The hold is released on
+ * the first move after the button comes up — the browser recomputes `:hover` in
+ * that same event, so the two never both read "not hovered".
+ */
+export function useAgentMapPointerHold(): {
+  held: AgentMapPointerHold | null
+  hold: (target: Element) => void
+  release: () => void
+} {
+  const [held, setHeld] = useState<AgentMapPointerHold | null>(null)
+  const hold = useCallback((target: Element): void => {
+    const projectId = closestId(target, 'data-agent-map-project-id')
+    const worktreeId = closestId(target, 'data-agent-map-worktree-id')
+    // A pan off empty canvas holds nothing, so leave the memoized scene alone.
+    setHeld(projectId === null && worktreeId === null ? null : { projectId, worktreeId })
+  }, [])
+  const release = useCallback((): void => {
+    setHeld((current) => (current === null ? current : null))
+  }, [])
+  return { held, hold, release }
+}

--- a/src/renderer/src/components/dashboard-popout/useAgentMapPointerHold.ts
+++ b/src/renderer/src/components/dashboard-popout/useAgentMapPointerHold.ts
@@ -1,9 +1,11 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, type RefObject } from 'react'
 
 export type AgentMapPointerHold = {
   projectId: string | null
   worktreeId: string | null
 }
+
+type AgentMapPointerDragRef = RefObject<{ pointerId: number } | null>
 
 function closestId(target: Element, attribute: string): string | null {
   return target.closest(`[${attribute}]`)?.getAttribute(attribute) ?? null
@@ -12,14 +14,13 @@ function closestId(target: Element, attribute: string): string | null {
 /**
  * Remembers which rings a pan drag started in. Pointer capture retargets
  * `:hover` to the `<svg>` for the whole gesture, so the ring under the pointer
- * would otherwise collapse the moment the drag begins. The hold is released on
- * the first move after the button comes up — the browser recomputes `:hover` in
- * that same event, so the two never both read "not hovered".
+ * would otherwise collapse until the gesture ends.
  */
-export function useAgentMapPointerHold(): {
+export function useAgentMapPointerHold(dragRef: AgentMapPointerDragRef): {
   held: AgentMapPointerHold | null
   hold: (target: Element) => void
   release: () => void
+  clearDrag: (pointerId: number) => boolean
 } {
   const [held, setHeld] = useState<AgentMapPointerHold | null>(null)
   const hold = useCallback((target: Element): void => {
@@ -31,5 +32,16 @@ export function useAgentMapPointerHold(): {
   const release = useCallback((): void => {
     setHeld((current) => (current === null ? current : null))
   }, [])
-  return { held, hold, release }
+  const clearDrag = useCallback(
+    (pointerId: number): boolean => {
+      if (dragRef.current?.pointerId !== pointerId) {
+        return false
+      }
+      dragRef.current = null
+      release()
+      return true
+    },
+    [dragRef, release]
+  )
+  return { held, hold, release, clearDrag }
 }


### PR DESCRIPTION
## Summary

Hovering the agent map made the rings pulse open and shut. Two separate causes, both fixed here.

**Rings collapsed when the pointer moved inside them.** The project and workspace rings drove their hover styling from `:hover` on the ring element itself. A ring is a sibling of everything drawn inside it, so the style dropped the instant the pointer crossed onto a workspace or an agent — the ring you were working inside kept shrinking. The trigger now lives on the containing group.

**A pan drag killed it outright.** `setPointerCapture` retargets `:hover` to the `<svg>` for the whole gesture, so the ring the drag started in collapsed on the first move and stayed collapsed through release. Measured before the fix: `1.018 → 1.0` on the first `pointermove` after `pointerdown`. A new `.is-held` class, driven by which rings the press landed in, covers the gesture. It releases immediately on pointer-up or lost pointer capture. If the pointer is still inside the ring, group hover remains active for a seamless handoff; otherwise the ring closes immediately without stale held state.

Both hover rules are wrapped in `:where()`, which contributes no specificity, so the existing `.is-open` / `.is-selected` / `.is-working|waiting|blocked` rules keep winning exactly the properties they won before.

**Hovering a workspace now always shows its name and agent count.** That label was gated behind the declutter pass, which suppresses any label whose box overlaps an agent — at fleet zoom that is nearly every one, so hovering revealed nothing at all. Hover is an explicit request for that workspace, so it now bypasses declutter and draws in a layer above every project rather than being washed out by a neighbouring project's ring fill. The label is hoisted, not duplicated. `worktreeAgentSafeIds` was the only consumer of the old gate and is removed with it.

## Screenshots

Hovering an agent *inside* a workspace, at default fleet zoom — left is `main`, right is this branch. The workspace name and count only appear on the right; on the left the map says nothing about what you are pointing at.

![compare-onagent.png](https://github.com/user-attachments/assets/da271249-cd12-4bf0-8d1b-d71a4618ae71)

Full interaction — settle on a workspace ring, move onto an agent inside it, then press and pan.

**Before** — rings flicker as the pointer crosses into them, no label, and the ring collapses the moment the drag starts:

![agent-map-before.gif](https://github.com/user-attachments/assets/864e4bcf-2bf5-4eaf-9c2c-361bf4b12057)

**After** — the ring stays open across its own contents and through the whole drag, and the workspace names itself:

![agent-map-after.gif](https://github.com/user-attachments/assets/b93dc505-9394-4d4f-9548-0566b23b47d9)

Ring scale traced in Chrome across a full press-drag-release gesture, sampling `getComputedStyle().transform` on the project ring:

| | hover | press | drag ×6 | release | next move | away |
|---|---|---|---|---|---|---|
| before | 1.018 | 1.018 | **1.0** | 1.0 | 1.0 | 1.0 |
| after | 1.018 | 1.018 | **1.018** | 1.018 | 1.018 | 1.0 |

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm test` is left unchecked deliberately. Two local full-suite runs each came back with a handful of red, and every one was a timeout under load rather than a real failure — the machine was running 100+ vitest workers, and the failures landed in SSH/WSL terminals, Codex prefill, MiMo/Pi/OMP overlay env, the updater, payload fuzzing, and a macOS helper script, none of which this change can reach. One did land in `dashboard-popout`: `AgentMapWorkspaceContextMenu.test.tsx` took 14s and failed one case. Since this change does touch that component, I re-ran it in isolation three times — 10/10 each time — and the whole `dashboard-popout` folder passes 231/231 on an idle machine. CI is the authoritative run here.

What did pass, repeatedly and on an idle machine: all 28 `dashboard-popout` test files, 231 tests.

New `AgentMapRingHover.test.tsx` covers the five behaviours that regress silently: the hover label reveals name + count and is hoisted above every ring rather than duplicated; it clears on pointer-out; the pressed rings stay `.is-held` across the drag and release immediately on pointer-up or lost pointer capture; a pan started inside a workspace keeps that workspace's name up; and a cancelled pan drops the hold. `agent-map-hover-containment.test.ts` pins the CSS itself — that neither ring is ever styled from `-ring:hover` again, that the group-scoped rules stay above the state rules in source order so specificity still resolves the same way, and that reduced motion drops both triggers.

Verification was done against a generated fleet (14 projects / 60 workspaces / ~300 agents) driven through real Chrome, not just jsdom, because the defect is in pointer capture and hover recomputation — neither of which jsdom models. The harness was scratch and is not part of this PR.

Two files crossed the `max-lines` cap while adding the tests. Rather than bump or disable the rule, `AgentMap.test.tsx` gave up its shared `card()` / `renderMap()` / env stubs to `agent-map-render-test-harness.tsx`, and the pointer-hold state moved out of `AgentMapCanvas.tsx` into `useAgentMapPointerHold.ts`.

## AI Review Report

Reviewed the full diff for correctness, regression risk, performance, and cross-platform behaviour.

**Specificity regression.** The main risk in moving a `:hover` rule to an ancestor is that the descendant selector gains specificity and starts overriding state rules it used to lose to. `.agent-map-worktree-ring.is-working` (0,2,0) currently beats `:hover` on `stroke` purely by source order, and `.is-open` beats it on `fill`. `:where()` keeps the new rules at (0,1,0), preserving both outcomes; a test now asserts the state rules stay below the hover rule in the file, since that ordering is what carries the result.

**Render cost during pan.** `AgentMapScene` is memoized specifically so a drag costs one `viewBox` write instead of a full scene re-render. The held ids change only at drag start and release, never on `pointermove`, so that invariant holds. Reviewing this surfaced one real waste: a pan starting on empty canvas held nothing but still re-rendered the scene. The hook now stores `null` when neither id resolves, and React bails out — background pans are back to zero re-renders. `releaseHold()` fires on every non-dragging `pointermove`, but the functional updater returns the identical `null` so React skips the render; the existing "avoids idle pointer layout reads" test still passes.

**Label layer.** Hoisting the hovered label out of its project group and suppressing the in-project copy happens in one commit, so there is no frame with two copies or none. Exiting worktrees resolve to `null` and drop the label. Both label layers are `pointer-events: none`, so the hoisted layer cannot intercept and cause the flicker it exists to fix.

**Cross-platform (macOS / Linux / Windows) — explicitly checked.** No keyboard shortcuts, accelerators, or modifier keys touched, so no `metaKey`/`ctrlKey` or `⌘`/`Ctrl` label concerns. No file paths, shell invocation, or Electron main-process code. No IPC, RPC, stream frames, or published content, so the remote wire contract is unchanged and mixed client/host versions are unaffected. No Git commands. The change is renderer CSS plus React state: `:where()` is Chromium 88+ and pointer capture's hover retargeting is specified behaviour implemented identically across Chromium platforms, so all three desktop targets get the same result from the same code with no platform branches. Works the same for git worktrees and folder workspaces (the ring is keyed on the map's workspace identity either way), and for local, SSH, WSL, and remote hosts, since nothing here reads host kind.

**Accessibility.** The hovered label moves in the DOM but is the same `<text>` content that was already rendered; the ring's `aria-label` already names the workspace, so nothing new is announced and nothing is lost. Keyboard focus still drives the label through the same `onFocus`/`onBlur` path.

## Security Audit

No new attack surface. This is renderer-only presentation code: CSS selectors, two `data-*` attributes carrying ids that were already in the React tree, and local component state. No input parsing, no command execution, no path handling, no auth or secrets, no IPC or preload surface, no network calls, no new dependencies. The one DOM read is `event.target.closest('[data-agent-map-project-id]')` on a pointer event inside the app's own SVG; the value is compared against ids the same component rendered and is never interpolated into a selector, URL, or command. Removing `worktreeAgentSafeIds` narrows a public type rather than widening one. No follow-up needed.

## Notes

- The merge gate is complete: same-model high-reasoning review returned clean after fixes, and final Electron QA evidence is attached in [this PR comment](https://github.com/stablyai/orca/pull/13682#issuecomment-5247398221).
- Behaviour change worth a second opinion: a hovered workspace label now draws over agents inside its own ring at fleet zoom, because it deliberately bypasses the declutter pass. That is the point of the change, but it is a trade of momentary occlusion for always being able to identify what you are pointing at.
- The project ring does not stay expanded while a workspace popover is open and the pointer has moved away. Left alone as out of scope; easy follow-up if it reads as the same annoyance.

