### PR TITLE
perf(renderer): preserve unchanged remote mirror resources

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync-mirror-identity.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-mirror-identity.test.ts
@@ -1,0 +1,389 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import type { BrowserCertificateFailure } from '../../../shared/types'
+import {
+  applyWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshots,
+  applyFreshWebSessionTabsSnapshot,
+  resetWebSessionTabsSnapshotFreshnessForTests,
+  type WebSessionTabsSyncState
+} from './web-session-tabs-sync'
+
+const ENVIRONMENT_ID = 'web-env-1'
+const NOW = 1_700_000_000_000
+const WORKTREE_A = 'repo::/worktree-a'
+const WORKTREE_B = 'repo::/worktree-b'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const HOST_TAB_ID = 'host-tab-1'
+const MIRRORED_TAB_ID = toWebTerminalSurfaceTabId(HOST_TAB_ID)
+
+const CERTIFICATE_FAILURE: BrowserCertificateFailure = {
+  challengeId: 'challenge-1',
+  browserPageId: 'host-browser-page-1',
+  errorCode: -202,
+  error: 'ERR_CERT_AUTHORITY_INVALID',
+  origin: 'https://localhost:3443',
+  displayHost: 'localhost:3443',
+  canProceed: true,
+  observedAt: 123
+}
+
+function makeState(overrides: Partial<WebSessionTabsSyncState> = {}): WebSessionTabsSyncState {
+  return {
+    activeBrowserTabId: null,
+    activeBrowserTabIdByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    activeGroupIdByWorktree: {},
+    activeTabId: null,
+    activeTabIdByWorktree: {},
+    activeTabType: 'terminal',
+    activeTabTypeByWorktree: {},
+    activeWorktreeId: null,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    browserCertificateFailuresByPageId: {},
+    browserPagesByWorkspace: {},
+    browserTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    openFiles: [],
+    ptyIdsByTabId: {},
+    remoteBrowserPageHandlesByPageId: {},
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    unifiedTabsByWorktree: {},
+    unreadTerminalTabs: {},
+    sortEpoch: 0,
+    ...overrides
+  }
+}
+
+function makeSnapshot(
+  worktree: string,
+  tabs: RuntimeMobileSessionTabsResult['tabs'],
+  activeTabType: RuntimeMobileSessionTabsResult['activeTabType'] = 'terminal'
+): RuntimeMobileSessionTabsResult {
+  return {
+    worktree,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: `group:${worktree}`,
+    activeTabId: tabs.find((tab) => tab.isActive)?.id ?? null,
+    activeTabType,
+    tabs
+  }
+}
+
+function makeTerminalSnapshot(
+  options: {
+    worktree?: string
+    title?: string
+    terminal?: string | null
+  } = {}
+): RuntimeMobileSessionTabsResult {
+  const worktree = options.worktree ?? WORKTREE_A
+  const terminal = options.terminal === undefined ? 'terminal-1' : options.terminal
+  return makeSnapshot(worktree, [
+    {
+      type: 'terminal',
+      id: `${HOST_TAB_ID}::${LEAF_ID}`,
+      parentTabId: HOST_TAB_ID,
+      leafId: LEAF_ID,
+      title: options.title ?? 'host shell',
+      isActive: true,
+      ...(terminal === null
+        ? { status: 'pending-handle' as const, terminal: null }
+        : { status: 'ready' as const, terminal })
+    }
+  ])
+}
+
+function makeBrowserSnapshot(
+  options: {
+    worktree?: string
+    pageId?: string
+    tabId?: string
+    workspaceId?: string
+    title?: string
+    url?: string
+    loading?: boolean
+    certificateFailure?: BrowserCertificateFailure | null
+  } = {}
+): RuntimeMobileSessionTabsResult {
+  const worktree = options.worktree ?? WORKTREE_A
+  const pageId = options.pageId ?? 'host-browser-page-1'
+  const certificateFailure =
+    options.certificateFailure === undefined
+      ? { ...CERTIFICATE_FAILURE, browserPageId: pageId }
+      : options.certificateFailure
+        ? { ...options.certificateFailure }
+        : null
+  return makeSnapshot(
+    worktree,
+    [
+      {
+        type: 'browser',
+        id: options.tabId ?? 'host-browser-tab',
+        browserWorkspaceId: options.workspaceId ?? 'host-browser-workspace',
+        browserPageId: pageId,
+        title: options.title ?? 'Example Domain',
+        url: options.url ?? 'https://example.com/',
+        loading: options.loading ?? false,
+        canGoBack: false,
+        canGoForward: false,
+        certificateFailure,
+        isActive: true
+      }
+    ],
+    'browser'
+  )
+}
+
+function applySnapshot(
+  state: WebSessionTabsSyncState,
+  snapshot: RuntimeMobileSessionTabsResult,
+  now = NOW
+): WebSessionTabsSyncState {
+  const patch = applyWebSessionTabsSnapshot(state, snapshot, ENVIRONMENT_ID, now)
+  return patch === state ? state : { ...state, ...patch }
+}
+
+describe('remote mirror resource identity', () => {
+  beforeEach(() => {
+    resetWebSessionTabsSnapshotFreshnessForTests()
+  })
+
+  it('keeps PTY arrays and layouts stable on an exact terminal replay', () => {
+    const state = applySnapshot(makeState(), makeTerminalSnapshot())
+    const ptyIds = state.ptyIdsByTabId
+    const layouts = state.terminalLayoutsByTabId
+
+    const replayed = applyWebSessionTabsSnapshot(
+      state,
+      makeTerminalSnapshot(),
+      ENVIRONMENT_ID,
+      NOW + 1
+    )
+
+    expect(replayed).toBe(state)
+    expect(state.ptyIdsByTabId).toBe(ptyIds)
+    expect(state.terminalLayoutsByTabId).toBe(layouts)
+  })
+
+  it('updates terminal metadata without replacing PTY arrays or layouts', () => {
+    const state = applySnapshot(makeState(), makeTerminalSnapshot())
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeTerminalSnapshot({ title: 'renamed shell' }),
+      ENVIRONMENT_ID,
+      NOW + 1
+    )
+    const next = { ...state, ...patch }
+
+    expect(next.tabsByWorktree[WORKTREE_A]?.[0]?.title).toBe('renamed shell')
+    expect(next.ptyIdsByTabId).toBe(state.ptyIdsByTabId)
+    expect(next.terminalLayoutsByTabId).toBe(state.terminalLayoutsByTabId)
+  })
+
+  it('clears unread state on replay without replacing PTY arrays or layouts', () => {
+    const hydrated = applySnapshot(makeState(), makeTerminalSnapshot())
+    const state = {
+      ...hydrated,
+      unreadTerminalTabs: { [MIRRORED_TAB_ID]: true as const }
+    }
+    const next = applySnapshot(state, makeTerminalSnapshot(), NOW + 1)
+
+    expect(next.unreadTerminalTabs).not.toHaveProperty(MIRRORED_TAB_ID)
+    expect(next.ptyIdsByTabId).toBe(state.ptyIdsByTabId)
+    expect(next.terminalLayoutsByTabId).toBe(state.terminalLayoutsByTabId)
+  })
+
+  it('replaces PTY arrays and layouts when the host rotates the handle', () => {
+    const state = applySnapshot(makeState(), makeTerminalSnapshot())
+    const next = applySnapshot(state, makeTerminalSnapshot({ terminal: 'terminal-2' }), NOW + 1)
+
+    expect(next.ptyIdsByTabId).not.toBe(state.ptyIdsByTabId)
+    expect(next.terminalLayoutsByTabId).not.toBe(state.terminalLayoutsByTabId)
+    expect(next.ptyIdsByTabId[MIRRORED_TAB_ID]).toEqual(['remote:web-env-1@@terminal-2'])
+    expect(next.terminalLayoutsByTabId[MIRRORED_TAB_ID]?.ptyIdsByLeafId).toEqual({
+      [LEAF_ID]: 'remote:web-env-1@@terminal-2'
+    })
+  })
+
+  it('removes the PTY key when a ready terminal becomes pending', () => {
+    const state = applySnapshot(makeState(), makeTerminalSnapshot())
+    const next = applySnapshot(state, makeTerminalSnapshot({ terminal: null }), NOW + 1)
+
+    expect(next.ptyIdsByTabId).not.toBe(state.ptyIdsByTabId)
+    expect(next.ptyIdsByTabId).not.toHaveProperty(MIRRORED_TAB_ID)
+    expect(next.terminalLayoutsByTabId[MIRRORED_TAB_ID]?.ptyIdsByLeafId).toEqual({})
+  })
+
+  it('cleans up terminal resources and unread state when the host omits the tab', () => {
+    const hydrated = applySnapshot(makeState(), makeTerminalSnapshot())
+    const state = {
+      ...hydrated,
+      unreadTerminalTabs: { [MIRRORED_TAB_ID]: true as const }
+    }
+    const next = applySnapshot(state, makeSnapshot(WORKTREE_A, [], null), NOW + 1)
+
+    expect(next.ptyIdsByTabId).not.toHaveProperty(MIRRORED_TAB_ID)
+    expect(next.terminalLayoutsByTabId).not.toHaveProperty(MIRRORED_TAB_ID)
+    expect(next.unreadTerminalTabs).not.toHaveProperty(MIRRORED_TAB_ID)
+  })
+
+  it('keeps browser pages, handles, and certificate failures stable on exact replay', () => {
+    const state = applySnapshot(makeState(), makeBrowserSnapshot())
+
+    const replayed = applyWebSessionTabsSnapshot(
+      state,
+      makeBrowserSnapshot(),
+      ENVIRONMENT_ID,
+      NOW + 1
+    )
+
+    expect(replayed).toBe(state)
+  })
+
+  it('updates browser metadata without replacing handles or certificate failures', () => {
+    const state = applySnapshot(makeState(), makeBrowserSnapshot())
+    const next = applySnapshot(
+      state,
+      makeBrowserSnapshot({
+        title: 'Changed title',
+        url: 'https://example.com/changed',
+        loading: true
+      }),
+      NOW + 1
+    )
+
+    expect(next.browserPagesByWorkspace).not.toBe(state.browserPagesByWorkspace)
+    expect(next.remoteBrowserPageHandlesByPageId).toBe(state.remoteBrowserPageHandlesByPageId)
+    expect(next.browserCertificateFailuresByPageId).toBe(state.browserCertificateFailuresByPageId)
+  })
+
+  it('clears a same-page certificate failure without replacing its page or handle', () => {
+    const state = applySnapshot(makeState(), makeBrowserSnapshot())
+    const next = applySnapshot(state, makeBrowserSnapshot({ certificateFailure: null }), NOW + 1)
+
+    expect(next.browserPagesByWorkspace).toBe(state.browserPagesByWorkspace)
+    expect(next.remoteBrowserPageHandlesByPageId).toBe(state.remoteBrowserPageHandlesByPageId)
+    expect(next.browserCertificateFailuresByPageId).not.toBe(
+      state.browserCertificateFailuresByPageId
+    )
+    expect(next.browserCertificateFailuresByPageId).not.toHaveProperty('host-browser-page-1')
+  })
+
+  it('cleans up replaced browser page handles and certificate failures', () => {
+    const state = applySnapshot(makeState(), makeBrowserSnapshot())
+    const next = applySnapshot(
+      state,
+      makeBrowserSnapshot({
+        pageId: 'host-browser-page-2',
+        certificateFailure: null
+      }),
+      NOW + 1
+    )
+
+    expect(next.browserPagesByWorkspace['host-browser-workspace']?.map((page) => page.id)).toEqual([
+      'host-browser-page-2'
+    ])
+    expect(next.remoteBrowserPageHandlesByPageId).not.toHaveProperty('host-browser-page-1')
+    expect(next.remoteBrowserPageHandlesByPageId['host-browser-page-2']).toEqual({
+      environmentId: ENVIRONMENT_ID,
+      remotePageId: 'host-browser-page-2'
+    })
+    expect(next.browserCertificateFailuresByPageId).not.toHaveProperty('host-browser-page-1')
+  })
+
+  it('keeps resource maps stable across an unchanged multi-worktree browser batch', () => {
+    const snapshots = [
+      makeBrowserSnapshot({ worktree: WORKTREE_A }),
+      makeBrowserSnapshot({
+        worktree: WORKTREE_B,
+        tabId: 'host-browser-tab-2',
+        workspaceId: 'host-browser-workspace-2',
+        pageId: 'host-browser-page-2'
+      })
+    ]
+    const initial = applyWebSessionTabsSnapshots(makeState(), snapshots, ENVIRONMENT_ID, NOW)
+    const state = { ...makeState(), ...initial }
+
+    const replayed = applyWebSessionTabsSnapshots(state, snapshots, ENVIRONMENT_ID, NOW + 1)
+
+    expect(replayed).toBe(state)
+  })
+
+  it('preserves unchanged browser resources when a sibling worktree replaces its page', () => {
+    const worktreeBSnapshot = makeBrowserSnapshot({
+      worktree: WORKTREE_B,
+      tabId: 'host-browser-tab-2',
+      workspaceId: 'host-browser-workspace-2',
+      pageId: 'host-browser-page-2'
+    })
+    const initial = applyWebSessionTabsSnapshots(
+      makeState(),
+      [makeBrowserSnapshot(), worktreeBSnapshot],
+      ENVIRONMENT_ID,
+      NOW
+    )
+    const state = { ...makeState(), ...initial }
+    const pages = state.browserPagesByWorkspace['host-browser-workspace-2']
+    const page = pages?.[0]
+    const handle = state.remoteBrowserPageHandlesByPageId['host-browser-page-2']
+    const certificate = state.browserCertificateFailuresByPageId['host-browser-page-2']
+
+    const patch = applyWebSessionTabsSnapshots(
+      state,
+      [
+        makeBrowserSnapshot({ pageId: 'host-browser-page-3', certificateFailure: null }),
+        worktreeBSnapshot
+      ],
+      ENVIRONMENT_ID,
+      NOW + 1
+    )
+    const next = { ...state, ...patch }
+
+    expect(next.browserPagesByWorkspace['host-browser-workspace-2']).toBe(pages)
+    expect(next.browserPagesByWorkspace['host-browser-workspace-2']?.[0]).toBe(page)
+    expect(next.remoteBrowserPageHandlesByPageId['host-browser-page-2']).toBe(handle)
+    expect(next.browserCertificateFailuresByPageId['host-browser-page-2']).toBe(certificate)
+  })
+
+  it('emits no store updates for 128 accepted identical resource frames', () => {
+    const terminal = makeTerminalSnapshot()
+    const browser = makeBrowserSnapshot()
+    const snapshot = {
+      ...browser,
+      tabs: [...terminal.tabs.map((tab) => ({ ...tab, isActive: false })), ...browser.tabs]
+    }
+    const store = createStore<WebSessionTabsSyncState>(() => makeState())
+    let notifications = 0
+    store.subscribe(() => {
+      notifications += 1
+    })
+    store.setState((state) =>
+      applyFreshWebSessionTabsSnapshot(state, snapshot, ENVIRONMENT_ID, NOW)
+    )
+    notifications = 0
+    const initial = store.getState()
+
+    for (let snapshotVersion = 2; snapshotVersion <= 129; snapshotVersion += 1) {
+      store.setState((state) =>
+        applyFreshWebSessionTabsSnapshot(
+          state,
+          { ...snapshot, snapshotVersion },
+          ENVIRONMENT_ID,
+          NOW + snapshotVersion
+        )
+      )
+    }
+
+    expect(notifications).toBe(0)
+    expect(store.getState()).toBe(initial)
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync-remote-status-title-flap.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-remote-status-title-flap.test.ts
@@ -59,8 +59,9 @@ import {
   resetRendererOwnedAgentStatusPanesForTests
 } from '../components/terminal-pane/renderer-owned-agent-status-registry'
 import {
-  applyFreshWebSessionTabsSnapshot,
-  resetWebSessionTabsSnapshotFreshnessForTests
+  applyWebSessionTabsSnapshot,
+  resetWebSessionTabsSnapshotFreshnessForTests,
+  shouldApplyWebSessionTabsSnapshot
 } from './web-session-tabs-sync'
 
 // Why: web-session-tabs-sync imports the app-level store singleton; this
@@ -148,9 +149,9 @@ function applyHostSnapshot(
   now: number
 ): void {
   const state = store.getState()
-  const patch = applyFreshWebSessionTabsSnapshot(state, snapshot, ENV, now)
   // The freshness gate must accept every republished frame (monotonic version).
-  expect(patch).not.toBe(state)
+  expect(shouldApplyWebSessionTabsSnapshot(snapshot, ENV)).toBe(true)
+  const patch = applyWebSessionTabsSnapshot(state, snapshot, ENV, now)
   store.setState(patch as Partial<AppState>)
 }
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -3102,28 +3102,30 @@ describe('applyWebSessionTabsSnapshot', () => {
       }
     }
 
+    const state = makeState({
+      activeTabId: mirroredTabId,
+      activeTabIdByWorktree: { [WT]: mirroredTabId },
+      activeTabType: 'terminal',
+      activeTabTypeByWorktree: { [WT]: 'terminal' },
+      tabsByWorktree: {
+        [WT]: [
+          {
+            id: mirroredTabId,
+            ptyId: 'remote:web-env-1@@terminal-2',
+            worktreeId: WT,
+            title: 'right pane',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: NOW
+          }
+        ]
+      },
+      terminalLayoutsByTabId: { [mirroredTabId]: currentLayout }
+    })
+
     const patch = applyWebSessionTabsSnapshot(
-      makeState({
-        activeTabId: mirroredTabId,
-        activeTabIdByWorktree: { [WT]: mirroredTabId },
-        activeTabType: 'terminal',
-        activeTabTypeByWorktree: { [WT]: 'terminal' },
-        tabsByWorktree: {
-          [WT]: [
-            {
-              id: mirroredTabId,
-              ptyId: 'remote:web-env-1@@terminal-2',
-              worktreeId: WT,
-              title: 'right pane',
-              customTitle: null,
-              color: null,
-              sortOrder: 0,
-              createdAt: NOW
-            }
-          ]
-        },
-        terminalLayoutsByTabId: { [mirroredTabId]: currentLayout }
-      }),
+      state,
       makeSnapshot([
         {
           type: 'terminal',
@@ -3163,7 +3165,11 @@ describe('applyWebSessionTabsSnapshot', () => {
       ptyId: 'remote:web-env-1@@terminal-2',
       title: 'right pane'
     })
+    // No layout patch at all, and the effective layout keeps the local active leaf.
     expect(patch.terminalLayoutsByTabId).toBeUndefined()
+    expect({ ...state, ...patch }.terminalLayoutsByTabId[mirroredTabId]?.activeLeafId).toBe(
+      SECOND_LEAF_ID
+    )
   })
 
   it('removes a null-pty pending activation tab when the host publishes the initial terminal', () => {
@@ -3540,6 +3546,7 @@ describe('applyWebSessionTabsSnapshot', () => {
         title: 'Example Domain'
       }
     ])
+    // Absent key, not a missing handle: the seeded { ENV, 'host-browser-page' } handle matched.
     expect(patch.remoteBrowserPageHandlesByPageId).toBeUndefined()
     expect(patch.unifiedTabsByWorktree?.[WT]?.map((tab) => tab.id)).toEqual([
       'local-browser-unified'

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -3163,7 +3163,7 @@ describe('applyWebSessionTabsSnapshot', () => {
       ptyId: 'remote:web-env-1@@terminal-2',
       title: 'right pane'
     })
-    expect(patch.terminalLayoutsByTabId?.[mirroredTabId]?.activeLeafId).toBe(SECOND_LEAF_ID)
+    expect(patch.terminalLayoutsByTabId).toBeUndefined()
   })
 
   it('removes a null-pty pending activation tab when the host publishes the initial terminal', () => {
@@ -3540,10 +3540,7 @@ describe('applyWebSessionTabsSnapshot', () => {
         title: 'Example Domain'
       }
     ])
-    expect(patch.remoteBrowserPageHandlesByPageId?.[page.id]).toEqual({
-      environmentId: ENV,
-      remotePageId: 'host-browser-page'
-    })
+    expect(patch.remoteBrowserPageHandlesByPageId).toBeUndefined()
     expect(patch.unifiedTabsByWorktree?.[WT]?.map((tab) => tab.id)).toEqual([
       'local-browser-unified'
     ])

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1215,6 +1215,8 @@ function buildMirroredBrowserTabs(
       browserRuntimeEnvironmentId: environmentId,
       viewportPresetId: existing?.page.viewportPresetId ?? null
     }
+    // Why: reuse hinges on browserPageEqual comparing workspaceId — the removed-workspace
+    // page-list cleanup gates on page.workspaceId matching this entry's workspace.id.
     const page = existing && browserPageEqual(existing.page, nextPage) ? existing.page : nextPage
     const workspace: BrowserWorkspace = {
       id: workspaceId,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1200,7 +1200,7 @@ function buildMirroredBrowserTabs(
     const createdAt = existing?.page.createdAt ?? now + sortOffset + index
     const groupId = hostGroupIdByTabId.get(tab.id) ?? fallbackGroupId
     const title = tab.title.trim() || 'Browser'
-    const page: BrowserPage = {
+    const nextPage: BrowserPage = {
       id: pageId,
       workspaceId,
       worktreeId: snapshot.worktree,
@@ -1215,6 +1215,7 @@ function buildMirroredBrowserTabs(
       browserRuntimeEnvironmentId: environmentId,
       viewportPresetId: existing?.page.viewportPresetId ?? null
     }
+    const page = existing && browserPageEqual(existing.page, nextPage) ? existing.page : nextPage
     const workspace: BrowserWorkspace = {
       id: workspaceId,
       worktreeId: snapshot.worktree,
@@ -2031,6 +2032,9 @@ function applyWebSessionTabsSnapshotWithContext(
   const removedTerminalIds = new Set(
     currentTerminalTabs.filter((tab) => !retainedTerminalIds.has(tab.id)).map((tab) => tab.id)
   )
+  const removedTerminalResourceIds = [...removedTerminalIds].filter(
+    (tabId) => !mirroredTerminalIds.has(tabId)
+  )
   for (const provisionalTabId of exactProvisionalHandoffs) {
     clearWebAgentSessionHandoff({ environmentId, worktreeId, provisionalTabId })
   }
@@ -2398,7 +2402,7 @@ function applyWebSessionTabsSnapshotWithContext(
   })()
 
   let nextPtyIdsByTabId = state.ptyIdsByTabId
-  for (const removedId of removedTerminalIds) {
+  for (const removedId of removedTerminalResourceIds) {
     if (nextPtyIdsByTabId[removedId]) {
       nextPtyIdsByTabId =
         nextPtyIdsByTabId === state.ptyIdsByTabId
@@ -2408,6 +2412,16 @@ function applyWebSessionTabsSnapshotWithContext(
     }
   }
   for (const { tab, ptyIds } of mirroredTerminalTabs) {
+    if (ptyIds.length === 0) {
+      if (nextPtyIdsByTabId[tab.id]) {
+        nextPtyIdsByTabId =
+          nextPtyIdsByTabId === state.ptyIdsByTabId
+            ? writableWebSessionTabsRecord(state, 'ptyIdsByTabId', batchContext)
+            : nextPtyIdsByTabId
+        delete nextPtyIdsByTabId[tab.id]
+      }
+      continue
+    }
     const current = nextPtyIdsByTabId[tab.id] ?? []
     if (!sameStringArray(current, ptyIds)) {
       nextPtyIdsByTabId =
@@ -2419,7 +2433,7 @@ function applyWebSessionTabsSnapshotWithContext(
   }
 
   let nextTerminalLayoutsByTabId = state.terminalLayoutsByTabId
-  for (const removedId of removedTerminalIds) {
+  for (const removedId of removedTerminalResourceIds) {
     if (nextTerminalLayoutsByTabId[removedId]) {
       nextTerminalLayoutsByTabId =
         nextTerminalLayoutsByTabId === state.terminalLayoutsByTabId
@@ -2473,33 +2487,52 @@ function applyWebSessionTabsSnapshotWithContext(
   let nextBrowserPagesByWorkspace = state.browserPagesByWorkspace
   let nextRemoteBrowserPageHandlesByPageId = state.remoteBrowserPageHandlesByPageId
   let nextBrowserCertificateFailuresByPageId = state.browserCertificateFailuresByPageId
-  for (const removedWorkspaceId of removedBrowserWorkspaceIds) {
-    const pages = nextBrowserPagesByWorkspace[removedWorkspaceId] ?? []
-    if (nextBrowserPagesByWorkspace[removedWorkspaceId]) {
-      nextBrowserPagesByWorkspace =
-        nextBrowserPagesByWorkspace === state.browserPagesByWorkspace
-          ? writableWebSessionTabsRecord(state, 'browserPagesByWorkspace', batchContext)
-          : nextBrowserPagesByWorkspace
-      delete nextBrowserPagesByWorkspace[removedWorkspaceId]
-    }
-    for (const page of pages) {
-      if (nextBrowserCertificateFailuresByPageId[page.id]) {
-        nextBrowserCertificateFailuresByPageId =
-          nextBrowserCertificateFailuresByPageId === state.browserCertificateFailuresByPageId
-            ? writableWebSessionTabsRecord(
-                state,
-                'browserCertificateFailuresByPageId',
-                batchContext
-              )
-            : nextBrowserCertificateFailuresByPageId
-        delete nextBrowserCertificateFailuresByPageId[page.id]
+  if (removedBrowserWorkspaceIds.size > 0) {
+    const nextBrowserWorkspaceIds = new Set(nextBrowserTabs?.map((tab) => tab.id) ?? [])
+    const nextBrowserPageIds = new Set(mirroredBrowserTabs.map((entry) => entry.page.id))
+    for (const workspace of retainedBrowserTabs) {
+      for (const page of state.browserPagesByWorkspace[workspace.id] ?? []) {
+        nextBrowserPageIds.add(page.id)
       }
-      if (nextRemoteBrowserPageHandlesByPageId[page.id]) {
-        nextRemoteBrowserPageHandlesByPageId =
-          nextRemoteBrowserPageHandlesByPageId === state.remoteBrowserPageHandlesByPageId
-            ? writableWebSessionTabsRecord(state, 'remoteBrowserPageHandlesByPageId', batchContext)
-            : nextRemoteBrowserPageHandlesByPageId
-        delete nextRemoteBrowserPageHandlesByPageId[page.id]
+    }
+    for (const removedWorkspaceId of removedBrowserWorkspaceIds) {
+      const pages = nextBrowserPagesByWorkspace[removedWorkspaceId] ?? []
+      if (
+        !nextBrowserWorkspaceIds.has(removedWorkspaceId) &&
+        nextBrowserPagesByWorkspace[removedWorkspaceId]
+      ) {
+        nextBrowserPagesByWorkspace =
+          nextBrowserPagesByWorkspace === state.browserPagesByWorkspace
+            ? writableWebSessionTabsRecord(state, 'browserPagesByWorkspace', batchContext)
+            : nextBrowserPagesByWorkspace
+        delete nextBrowserPagesByWorkspace[removedWorkspaceId]
+      }
+      for (const page of pages) {
+        if (nextBrowserPageIds.has(page.id)) {
+          continue
+        }
+        if (nextBrowserCertificateFailuresByPageId[page.id]) {
+          nextBrowserCertificateFailuresByPageId =
+            nextBrowserCertificateFailuresByPageId === state.browserCertificateFailuresByPageId
+              ? writableWebSessionTabsRecord(
+                  state,
+                  'browserCertificateFailuresByPageId',
+                  batchContext
+                )
+              : nextBrowserCertificateFailuresByPageId
+          delete nextBrowserCertificateFailuresByPageId[page.id]
+        }
+        if (nextRemoteBrowserPageHandlesByPageId[page.id]) {
+          nextRemoteBrowserPageHandlesByPageId =
+            nextRemoteBrowserPageHandlesByPageId === state.remoteBrowserPageHandlesByPageId
+              ? writableWebSessionTabsRecord(
+                  state,
+                  'remoteBrowserPageHandlesByPageId',
+                  batchContext
+                )
+              : nextRemoteBrowserPageHandlesByPageId
+          delete nextRemoteBrowserPageHandlesByPageId[page.id]
+        }
       }
     }
   }


### PR DESCRIPTION
## The one-sentence version

Remote hosts send the same workspace state over and over. Orca used to throw away its copy and rebuild an identical one every single time, waking every component watching it. Now it keeps what did not change.

---

## The problem

Every accepted host snapshot ran cleanup like this: delete the terminal PTY arrays, delete the layouts, delete the browser pages, delete the remote page handles, delete the certificate records — then immediately re-add all of them from the incoming snapshot.

When the snapshot is identical to what is already there (which, on a busy host, is most of them), the **data** ends up the same but every object is brand new. In an identity-based store like Zustand, a new object means "this changed" — so every subscriber wakes up and re-checks its work.

```mermaid
flowchart TB
    subgraph BEFORE["Before — rebuild everything, every frame"]
        B1["Host frame arrives<br/>(identical content)"] --> B2["Delete PTY arrays, layouts,<br/>pages, handles, certs"]
        B2 --> B3["Re-add all of them<br/>as NEW objects"]
        B3 --> B4["Store: 'everything changed'"]
        B4 --> B5["Every subscriber re-runs"]
    end

    subgraph AFTER["After — keep what is unchanged"]
        A1["Host frame arrives<br/>(identical content)"] --> A2["Compare field by field"]
        A2 --> A3{"Actually different?"}
        A3 -->|No| A4["Keep the existing object"]
        A3 -->|Yes| A5["Replace it"]
        A4 --> A6["Store: 'nothing changed'<br/>zero notifications"]
    end
```

Busy hosts send several of these per second, and this is especially visible right after you switch back to Orca.

## Measured

Deterministic Zustand oracle, 128 monotonically newer but otherwise identical terminal + browser frames:

| Metric | Before | After |
| --- | ---: | ---: |
| Store notifications | 128 | **0** |
| Resource-map identity changes | 640 | **0** |

Local synthetic reconciliation microbenchmark:

| Scenario | Before | After |
| --- | ---: | ---: |
| Terminal replay, 10,000 unrelated resources | 4.35 ms | **10.7 µs** |
| Browser replay, 10,000 unrelated resources | 9.29 ms | **6.3 µs** |
| Empty frame, 1,000 retained local pages | 65.9 µs | 63.4 µs |

That last row is the guard against cheating: it confirms the new comparison work does not shift cost onto snapshots that have nothing to clean up.

## Why content is provably identical

The three cleanup rewrites are each net-equivalent because the mirrored re-add loops authoritatively rewrite every id the new gates skip deleting:

- **Terminal PTY ids / layouts** — the new `ptyIds.length === 0` branch replicates the old delete, and the layout loop's `!terminalLayoutEqual(existing, layout)` check covers all seven `TerminalLayoutSnapshot` fields.
- **Browser pages** — `browserPageEqual` compares all 13 fields declared on `BrowserPage` (`src/shared/types.ts:981-998`), so a preserved page is field-for-field identical.
- **Workspace / certificate / handle cleanup** — walked case by case: exact replay, page replacement, workspace omission, multi-page workspace, cross-worktree page move, duplicate host workspace ids. Net state is the same in each; the mirrored loop rewrites pages, handles and certs for every surviving page id.

Lifecycle behavior is preserved for PTY rotation, ready-to-pending transitions, provisional handoffs, omitted tabs, and unread clearing.

---

## What reviewers should actually look at

Content does not change. **How often the store announces a change** does — and two things in the app listen for the announcement rather than for the content.

### 1. Mobile/runtime-graph publishes get less frequent

`App.tsx:1253-1279` subscribes to the store and gates on `canSkipRuntimeMobileSessionSyncKeyBuild` / `runtimeMobileSessionSyncKeysEqual`, both of which compare `terminalLayoutsByTabId` and `browserPagesByWorkspace` **by reference** (`sync-runtime-graph.ts:390-401, 683-690`).

Before, constant remote snapshot churn kept scheduling a graph sync. Now it does not.

That matters because `syncRuntimeGraph()` is the **only** path that re-reads DOM-derived state — `serializePaneTree` of the live pane tree, `manager.getActivePane()`, `mountedSurfaceCaptureByTabId` — and ships it to main via `window.api.runtime.syncWindowGraph`. So any DOM or pane-manager change that does **not** call `scheduleRuntimeGraphSync()` itself would now reach main and paired **mobile** clients later than before.

I could not construct such a gap — register/unregister and `focusRuntimeTerminalSurface` do schedule explicitly, and pane splits go through the store — but I also could not prove one does not exist. **This is the item worth a second opinion, ideally with a paired mobile client attached to a busy host.**

### 2. Session writes and remote-workspace uploads get less frequent

`session-write-subscriber.ts`'s `sessionRelevantFieldChanged` returns true for **any** reference change on session-relevant fields other than `tabsByWorktree`/`unifiedTabsByWorktree`. So churn on these maps previously triggered a session write plus `window.api.remoteWorkspace.setForConnectedTargets(...)` on every accepted frame.

Persisted content is byte-identical, so this looks purely beneficial — but it does reduce how often the local session file and connected remote targets are refreshed.

### 3. Two small state-shape divergences (believed inert)

- **Empty PTY case.** The new `ptyIds.length === 0` branch **deletes** the key where the old code would have written an empty array `[]`. Reachable only when a mirrored tab id is not in `removedTerminalIds` but has a stale non-empty entry. Every consumer checked — `tab-has-live-pty.ts:12`, `worktree-card-status-inputs.ts:35-38`, and all `Object.entries(ptyIdsByTabId)` iterations in status-bar, orca-profiles, and codex-stale-pane-sweep — treats `[]` and absent identically.
- **Retained layout quirks.** Because `terminalLayoutEqual` normalizes optional fields (`?? null`, `?? {}`), a preserved layout may keep e.g. `titlesByLeafId: {}` where the old unconditional overwrite would have omitted the key. All consumers use `?? {}` or optional chaining, and `sync-runtime-graph.ts:791-795` reaches the same outcome for `{}` vs `undefined` — but this does change what gets JSON-serialized into the persisted session.

**Honest limitation:** these maps have roughly 100 consumers and not all were traced. The ones above are the ones checked.

## Reliability contract

- **Invariant:** `terminal-session.layout-pty-ownership` and `terminal-performance.store-and-git-hot-paths` — unchanged same-id remote resources retain identity; real lifecycle changes still reconcile and clean up.
- **Failure source:** renderer CPU spikes with busy remote hosts, especially after switching back to Orca.
- **Oracle:** exact replay, title-only update, unread clearing, PTY rotation, ready-to-pending, omission, page replacement, and cross-worktree page move.

## Status

All CI green on a rebase onto current `main`.

The earlier `package` / `verify` failures were **not** caused by this change — the branch was 64 commits behind and its base predated a fix for `config/electron-vite-target.config.ts` ("config must export or return an object"). Rebasing resolved them; `build:electron-vite:parallel` now passes locally and in CI.

## Review notes (post-rebase)

Rebasing onto current `main` conflicted with #13676, which replaced `{ ...state.X }` with the batch-aware `writableWebSessionTabsRecord(state, key, batchContext)`. Resolved by keeping this PR's structure with the helper substituted throughout. **One defect was caught in the process:** git auto-merged the new `ptyIds.length === 0` branch as purely additive, leaving it on the old `{ ...state.ptyIdsByTabId }` idiom, which would have bypassed the batch's copy-on-write bookkeeping. Now fixed.

Resolution of the three items flagged above:

1. **Runtime-graph / mobile publish frequency — not a regression.** The incidental trigger being removed only ever existed for worktrees with a remote host publishing snapshots; purely local workspaces never had it. So any DOM/pane mutation lacking its own `scheduleRuntimeGraphSync()` would already be stale today for local workspaces — this change makes remote behave like local rather than creating a new failure class. The codebase already treats explicit scheduling as the contract for non-store mutations (`App.tsx:1482`: "System theme changes don't mutate the store, so mobile terminal colors need an explicit graph republish"), and register/unregister and `focusRuntimeTerminalSurface` each schedule (`sync-runtime-graph.ts:252,260,279`).

2. **Session writes / remote-workspace uploads — a benefit, not a risk.** `session-write-subscriber.ts:190` exists precisely to skip the timer reset and payload rebuild when nothing changed. Previously remote churn defeated that gate on every accepted frame; now it works as designed. Persisted content is unchanged, so no write is lost.

3. **State-shape divergences — bounded and inert.**
   - The `ptyIds.length === 0` delete matches the old net result on every reachable input: `shouldReplaceTerminalTab` returns `true` for *every* mirrored surface id, so a mirrored id present in `currentTerminalTabs` is always in `removedTerminalIds`, where old and new both land on absent. The `[]`-vs-absent divergence needs an orphaned `ptyIdsByTabId` entry with no matching tab; every path that drops a tab keeps the two maps in sync. (Note: switching the guard to `?.length` would *introduce* a divergence on the reachable path, so the truthiness check is correct as written.) `ptyIdsByTabId` is not in `WorkspaceSessionState` — never persisted, never sent over the wire — and no reader distinguishes `[]` from absent.
   - Retained-layout `{}` vs omitted: every `titlesByLeafId` consumer reads via `?.[leafId]`, `?? {}`, or a spread, so `{}` and absent are indistinguishable. Key *presence* in `terminalLayoutsByTabId` is identical old-vs-new, which matters for the two presence-sensitive consumers (`terminals.ts:916,3700`). A non-empty record still forces an overwrite, so no title or scrollback can be resurrected.

Equality functions were checked for completeness: `terminalLayoutEqual` covers all 7 fields of `TerminalLayoutSnapshot`, and `browserPageEqual` covers all 13 fields of `BrowserPage` (`BrowserLoadError`'s 3 subfields are all required, so `null`-vs-object cannot alias). `MirroredTerminalTab.layout` is non-nullable and `layout.root` is provably non-null, so every id whose delete is now skipped is guaranteed to be rewritten.

Added a comment at the page-reuse site recording that the removed-workspace cleanup gate depends on `browserPageEqual` continuing to compare `workspaceId`, and restored the layout-value assertion that the patch-only rewrite had dropped.

Verified locally: typecheck, lint (incl. reliability gates), `build:electron-vite:parallel`, and the full suite — **49,423 passing, 0 regressions**. The only failing spec, `cross-version-terminal-wire.unit.test.ts`, fails identically on clean `origin/main` in the same worktree (it needs a materialized release checkout) and passes in CI.
