### PR TITLE
fix(native-chat): type Codex slash commands

### DIFF
--- a/mobile/src/session/MobileNativeChatComposer.test.ts
+++ b/mobile/src/session/MobileNativeChatComposer.test.ts
@@ -298,11 +298,12 @@ describe('MobileNativeChatComposer', () => {
   })
 
   it('moves the caret to the insert point after an autocomplete pick, then releases control', async () => {
+    const onChangeText = vi.fn()
     await act(async () => {
       renderer = create(
         createElement(MobileNativeChatComposer, {
           value: '/c',
-          onChangeText: vi.fn(),
+          onChangeText,
           onSend: vi.fn().mockResolvedValue(true),
           agent: 'claude'
         })
@@ -325,6 +326,7 @@ describe('MobileNativeChatComposer', () => {
       (node) => node.type === 'Pressable' && !node.props.accessibilityLabel
     )[0] as { props: { onPress: () => void } }
     await act(async () => firstSuggestion.props.onPress())
+    expect(onChangeText).toHaveBeenCalledWith('/clear ')
     // `/clear ` is 7 chars — the caret jumps just past the inserted command + space.
     expect(input().props.selection).toEqual({ start: 7, end: 7 })
     // The next native selection event releases control so manual placement still works.

--- a/mobile/src/session/mobile-native-chat-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-send.test.ts
@@ -322,6 +322,34 @@ describe('typeMobileNativeChatCommandWithOutcome', () => {
       }))
     )
   })
+
+  it('retires a parked launch draft only with the final typed Enter', async () => {
+    vi.useFakeTimers()
+    const client = clientWithResponse({
+      id: 'request',
+      ok: true,
+      result: { send: { accepted: true } },
+      _meta: { runtimeId: 'runtime' }
+    })
+    const result = typeMobileNativeChatCommandWithOutcome({
+      client,
+      terminal: 'term',
+      command: '/model',
+      resolvedLaunchDraft: { text: 'seed', createdAt: 7 }
+    })
+    await vi.runAllTimersAsync()
+    await result
+
+    const params = vi.mocked(client.sendRequest).mock.calls.map((call) => call[1]) as Array<{
+      text: string
+      resolvedLaunchDraft?: { text: string; createdAt: number }
+    }>
+    expect(params.slice(0, -1).every((entry) => entry.resolvedLaunchDraft === undefined)).toBe(true)
+    expect(params.at(-1)).toMatchObject({
+      text: '\r',
+      resolvedLaunchDraft: { text: 'seed', createdAt: 7 }
+    })
+  })
 })
 
 describe('clearMobileNativeChatInput', () => {

--- a/mobile/src/session/mobile-native-chat-send.ts
+++ b/mobile/src/session/mobile-native-chat-send.ts
@@ -98,20 +98,28 @@ export async function typeMobileNativeChatCommandWithOutcome(args: {
   client: RpcClient
   terminal: string
   command: string
+  resolvedLaunchDraft?: { text: string; createdAt: number }
   mobileClient?: MobileTerminalClient
   deadline?: number
 }): Promise<MobileNativeChatSendOutcome> {
+  let writeIndex = 0
   return typeAgentTuiCommand({
     command: args.command,
-    write: (key) =>
-      sendMobileNativeChatMessageWithOutcome({
+    write: (key) => {
+      const isSubmit = writeIndex === args.command.length + 1
+      writeIndex += 1
+      return sendMobileNativeChatMessageWithOutcome({
         client: args.client,
         terminal: args.terminal,
         text: key,
         enter: false,
+        ...(isSubmit && args.resolvedLaunchDraft
+          ? { resolvedLaunchDraft: args.resolvedLaunchDraft }
+          : {}),
         ...(args.mobileClient ? { mobileClient: args.mobileClient } : {}),
         ...(args.deadline === undefined ? {} : { deadline: args.deadline })
       })
+    }
   })
 }
 

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -219,24 +219,33 @@ describe('useMobileNativeChatMessageSend', () => {
     expect(onCommandSend).toHaveBeenCalledWith('/clear')
   })
 
-  it('never creates an optimistic echo for an unknown slash token', async () => {
-    // `/model` is not in Claude's autocomplete catalog, but the session-option
-    // recorder still recognizes it without claiming a generic command ran.
-    mount(() => null)
-    await act(async () => {
-      await api!.send('/model sonnet')
-    })
-    expect(acceptSend).not.toHaveBeenCalled()
-    expect(onCommandSend).toHaveBeenCalledWith('/model sonnet')
-  })
+  it.each(['claude', 'openclaude'] as const)(
+    'keeps %s composer slash sends pasted',
+    async (agent) => {
+      // `/model` is not in Claude's autocomplete catalog, but the session-option
+      // recorder still recognizes it without claiming a generic command ran.
+      mount(() => null, agent)
+      await act(async () => {
+        await api!.send('/model sonnet')
+      })
+      expect(acceptSend).not.toHaveBeenCalled()
+      expect(onCommandSend).toHaveBeenCalledWith('/model sonnet')
+      expect(sendWithOutcome).toHaveBeenCalledOnce()
+      expect(typeCommandWithOutcome).not.toHaveBeenCalled()
+    }
+  )
 
-  it('classifies per agent: /model is a catalog command for Codex', async () => {
+  it('types Codex composer slash sends instead of pasting them', async () => {
     mount(() => null, 'codex')
     await act(async () => {
       await api!.send('/model')
     })
     expect(acceptSend).not.toHaveBeenCalled()
     expect(onCommandSend).toHaveBeenCalledWith('/model')
+    expect(typeCommandWithOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ command: '/model', terminal: 'term' })
+    )
+    expect(sendWithOutcome).not.toHaveBeenCalled()
   })
 
   it('holds only chat sends for transcript confirmation on a lost ack', async () => {
@@ -252,17 +261,20 @@ describe('useMobileNativeChatMessageSend', () => {
     expect(holdUnconfirmedSend).toHaveBeenCalledTimes(1)
   })
 
-  it('dispatchCommand surfaces the outcome without echo or composer sync', async () => {
-    mount(() => ({ text: DRAFT, createdAt: 1 }))
-    let outcome: string | undefined
-    await act(async () => {
-      outcome = await api!.dispatchCommand('/model sonnet')
-    })
-    expect(outcome).toBe('accepted')
-    expect(acceptSend).not.toHaveBeenCalled()
-    expect(onCommandSend).not.toHaveBeenCalled()
-    expect(sentArgs().resolvedLaunchDraft).toBeUndefined()
-  })
+  it.each(['claude', 'openclaude'] as const)(
+    'keeps %s session-option commands pasted',
+    async (agent) => {
+      mount(() => ({ text: DRAFT, createdAt: 1 }), agent)
+      let outcome: string | undefined
+      await act(async () => {
+        outcome = await api!.dispatchCommand('/model sonnet', { delivery: 'type' })
+      })
+      expect(outcome).toBe('accepted')
+      expect(acceptSend).not.toHaveBeenCalled()
+      expect(onCommandSend).not.toHaveBeenCalled()
+      expect(sentArgs().resolvedLaunchDraft).toBeUndefined()
+    }
+  )
 
   it('routes typed picker commands around the pasted composer-text send', async () => {
     mount(() => null, 'codex')
@@ -271,6 +283,18 @@ describe('useMobileNativeChatMessageSend', () => {
       outcome = await api!.dispatchCommand('/model', { delivery: 'type' })
     })
     expect(outcome).toBe('accepted')
+    expect(typeCommandWithOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ command: '/model', terminal: 'term' })
+    )
+    expect(sendWithOutcome).not.toHaveBeenCalled()
+  })
+
+  it('types Codex session-option commands without caller delivery metadata', async () => {
+    mount(() => null, 'codex')
+    await act(async () => {
+      await api!.dispatchCommand('/model')
+    })
+
     expect(typeCommandWithOutcome).toHaveBeenCalledWith(
       expect.objectContaining({ command: '/model', terminal: 'term' })
     )

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -248,6 +248,19 @@ describe('useMobileNativeChatMessageSend', () => {
     expect(sendWithOutcome).not.toHaveBeenCalled()
   })
 
+  it('keeps Codex skill sends pasted', async () => {
+    mount(() => null, 'codex')
+    await act(async () => {
+      await api!.send('$ref-oss')
+    })
+    expect(acceptSend).not.toHaveBeenCalled()
+    expect(onCommandSend).toHaveBeenCalledWith('$ref-oss')
+    expect(sendWithOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ text: '$ref-oss', terminal: 'term' })
+    )
+    expect(typeCommandWithOutcome).not.toHaveBeenCalled()
+  })
+
   it('holds only chat sends for transcript confirmation on a lost ack', async () => {
     sendWithOutcome.mockResolvedValue('unknown')
     mount(() => null)

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -155,40 +155,39 @@ export function useMobileNativeChatMessageSend(args: {
           return 'rejected'
         }
       }
-      const outcome = await sendMobileNativeChatMessageWithOutcome({
-        client,
-        terminal: handle,
-        text,
-        // Why: pre-clear only when nothing was deliberately pasted first. The heal
-        // above fires only for terminals a mobile image paste marked, so a desktop
-        // launch-draft prefill parked on the input line would otherwise glue onto
-        // this message. An image send already led its own paste with Ctrl+U, and a
-        // second one here would wipe the image it just pasted (desktop's image path
-        // likewise clears once, before the paste, and never again).
-        //
-        // Also skipped once the dedicated clear above ran: the line is already
-        // empty, and a Ctrl+U written immediately before body text in the SAME
-        // write reaches the agent as a literal control character rather than a
-        // keypress (observed live as a stray \x15 heading the received message).
-        clearInputFirst: !images?.length && !seededLaunchDraft,
-        ...(syncComposer && typeof seededLaunchDraft?.createdAt === 'number'
-          ? {
-              resolvedLaunchDraft: {
-                text: seededLaunchDraft.text,
-                createdAt: seededLaunchDraft.createdAt
-              }
-            }
-          : {}),
-        deadline,
-        ...(deviceTokenRef.current
-          ? { mobileClient: { id: deviceTokenRef.current, type: 'mobile' } }
-          : {})
-      })
+      const classification = classifyMobileNativeChatSend(agent, text)
+      const mobileClient = deviceTokenRef.current
+        ? { id: deviceTokenRef.current, type: 'mobile' as const }
+        : undefined
+      const resolvedLaunchDraft =
+        syncComposer && typeof seededLaunchDraft?.createdAt === 'number'
+          ? { text: seededLaunchDraft.text, createdAt: seededLaunchDraft.createdAt }
+          : undefined
+      const outcome =
+        agent === 'codex' && classification !== 'chat' && !images?.length
+          ? await typeMobileNativeChatCommandWithOutcome({
+              client,
+              terminal: handle,
+              command: text,
+              ...(resolvedLaunchDraft ? { resolvedLaunchDraft } : {}),
+              ...(mobileClient ? { mobileClient } : {}),
+              deadline
+            })
+          : await sendMobileNativeChatMessageWithOutcome({
+              client,
+              terminal: handle,
+              text,
+              // Why: an image send already cleared before its paste; a second
+              // clear here would wipe the image before submission.
+              clearInputFirst: !images?.length && !seededLaunchDraft,
+              ...(resolvedLaunchDraft ? { resolvedLaunchDraft } : {}),
+              deadline,
+              ...(mobileClient ? { mobileClient } : {})
+            })
       // Why (desktop parity): a slash/skill send dispatches into the agent's own
       // TUI, not the conversation — the transcript never echoes it as a user
       // turn, so an optimistic bubble would never reconcile and the
       // unconfirmed hold could never observe a landing.
-      const classification = classifyMobileNativeChatSend(agent, text)
       if (outcome === 'unknown') {
         if (classification === 'chat') {
           // Why: an ack-lost send usually WAS delivered (issue seen on cellular
@@ -276,14 +275,14 @@ export function useMobileNativeChatMessageSend(args: {
   const dispatchCommand = useCallback(
     async (
       text: string,
-      options?: { delivery?: CatalogCommandDelivery }
+      _options?: { delivery?: CatalogCommandDelivery }
     ): Promise<MobileNativeChatSendOutcome> => {
       const terminal = handleRef.current
       if (terminal && !acquireMobileNativeChatTerminalWrite(terminal)) {
         return 'rejected'
       }
       try {
-        if (options?.delivery === 'type') {
+        if (agentRef.current === 'codex') {
           if (!client || !terminal || !enabled) {
             return 'rejected'
           }

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -8,6 +8,7 @@ import {
   type MobileNativeChatSendOutcome
 } from './mobile-native-chat-send'
 import type { CatalogCommandDelivery } from '../../../src/shared/agent-session-option-catalog'
+import { isSlashCommandDraft } from '../../../src/shared/native-chat-slash-commands'
 import { healMobileNativeChatStaleInput } from './mobile-native-chat-stale-input'
 import { classifyMobileNativeChatSend } from './mobile-native-chat-send-classification'
 import {
@@ -164,7 +165,10 @@ export function useMobileNativeChatMessageSend(args: {
           ? { text: seededLaunchDraft.text, createdAt: seededLaunchDraft.createdAt }
           : undefined
       const outcome =
-        agent === 'codex' && classification !== 'chat' && !images?.length
+        agent === 'codex' &&
+        classification !== 'chat' &&
+        isSlashCommandDraft(text) &&
+        !images?.length
           ? await typeMobileNativeChatCommandWithOutcome({
               client,
               terminal: handle,

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -259,6 +259,23 @@ describe('NativeChatComposer', () => {
     expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
   })
 
+  it('keeps Codex skill sends pasted', () => {
+    mocks.draft = '$ref-oss'
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatMessage).toHaveBeenCalledWith({}, 'pty-1', '$ref-oss', undefined)
+    expect(mocks.sendNativeChatTypedCommand).not.toHaveBeenCalled()
+  })
+
   it.each(['claude', 'openclaude'] as const)('keeps %s slash composer sends pasted', (agent) => {
     mocks.draft = '/clear'
     render(

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -30,9 +30,11 @@ const mocks = vi.hoisted(() => ({
   } | null,
   createClaudeModelSwitchConfirmationObserver: vi.fn(),
   discoverCommitMessageModels: vi.fn(),
+  draft: 'hello',
   getMainBufferSnapshot: vi.fn(),
   sendHandle: { cancel: vi.fn(), settleAfterMs: 500 },
   sendNativeChatMessage: vi.fn(),
+  sendNativeChatTypedCommand: vi.fn(),
   sendNativeChatMessageVerified: vi.fn(),
   typeNativeChatCommand: vi.fn(),
   trackPendingSend: vi.fn(),
@@ -64,6 +66,7 @@ vi.mock('@/lib/agent-paste-draft', () => ({
 }))
 vi.mock('./native-chat-runtime-send', () => ({
   sendNativeChatMessage: (...args: unknown[]) => mocks.sendNativeChatMessage(...args),
+  sendNativeChatTypedCommand: (...args: unknown[]) => mocks.sendNativeChatTypedCommand(...args),
   sendNativeChatMessageVerified: (...args: unknown[]) =>
     mocks.sendNativeChatMessageVerified(...args),
   typeNativeChatCommand: (...args: unknown[]) => mocks.typeNativeChatCommand(...args),
@@ -87,7 +90,7 @@ vi.mock('@/lib/native-chat-telemetry', () => ({
 vi.mock('./use-native-chat-draft', () => ({
   useNativeChatDraft: (scopeKey: string) => {
     mocks.draftScopeKeys.push(scopeKey)
-    return { draft: 'hello', setDraft: mocks.setDraft }
+    return { draft: mocks.draft, setDraft: mocks.setDraft }
   }
 }))
 vi.mock('./native-chat-draft-cache', () => ({
@@ -144,6 +147,7 @@ describe('NativeChatComposer', () => {
     clearNativeChatModelEnrichmentForTests()
     mocks.fieldProps = null
     mocks.modelSwitchOutcome = 'applied'
+    mocks.draft = 'hello'
     mocks.draftScopeKeys.length = 0
     mocks.confirmationObserver = null
     mocks.createClaudeModelSwitchConfirmationObserver.mockImplementation(() => {
@@ -182,6 +186,7 @@ describe('NativeChatComposer', () => {
       ]
     })
     mocks.sendNativeChatMessage.mockReturnValue(mocks.sendHandle)
+    mocks.sendNativeChatTypedCommand.mockReturnValue(mocks.sendHandle)
     mocks.sendNativeChatMessageVerified.mockResolvedValue(true)
     mocks.typeNativeChatCommand.mockResolvedValue(true)
     mocks.sendHandle.settleAfterMs = 500
@@ -235,6 +240,40 @@ describe('NativeChatComposer', () => {
 
     expect(onOptimisticSend).toHaveBeenCalledWith('hello', [])
     expect(mocks.trackPendingSend).toHaveBeenCalledWith(mocks.sendHandle, 'pending-1')
+  })
+
+  it('types Codex slash composer sends instead of pasting them', () => {
+    mocks.draft = '/status'
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatTypedCommand).toHaveBeenCalledWith({}, 'pty-1', '/status')
+    expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
+  })
+
+  it.each(['claude', 'openclaude'] as const)('keeps %s slash composer sends pasted', (agent) => {
+    mocks.draft = '/clear'
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent={agent}
+      />
+    )
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatMessage).toHaveBeenCalledWith({}, 'pty-1', '/clear', undefined)
+    expect(mocks.sendNativeChatTypedCommand).not.toHaveBeenCalled()
   })
 
   it('retires the launch-draft seed once a send clears the TUI input line', () => {

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -11,6 +11,7 @@ import {
 import type { NativeChatSendHandle } from './native-chat-runtime-send'
 import { resolveNativeChatLaunchDraftSend } from './native-chat-launch-draft-send'
 import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
+import { isSlashCommandDraft } from '../../../../shared/native-chat-slash-commands'
 import { emitNativeChatMessageSent } from '@/lib/native-chat-telemetry'
 import {
   applyMentionSuggestion,
@@ -265,7 +266,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       // them silently when the text starts with the agent's slash/skill prefix.
       if (classification !== 'chat' && imagePaths.length === 0) {
         pendingHandle =
-          agent === 'codex'
+          agent === 'codex' && isSlashCommandDraft(text)
             ? sendNativeChatTypedCommand(target.settings, target.ptyId, text)
             : sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
       } else if (imagePaths.length > 0) {

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -4,6 +4,7 @@ import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 import {
   sendNativeChatMessage,
+  sendNativeChatTypedCommand,
   sendNativeChatMessageWithImageAttachments,
   submitNativeChatPrompt
 } from './native-chat-runtime-send'
@@ -263,7 +264,10 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       // command/unknown send, otherwise `clearImageAttachments()` below drops
       // them silently when the text starts with the agent's slash/skill prefix.
       if (classification !== 'chat' && imagePaths.length === 0) {
-        pendingHandle = sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
+        pendingHandle =
+          agent === 'codex'
+            ? sendNativeChatTypedCommand(target.settings, target.ptyId, text)
+            : sendNativeChatMessage(target.settings, target.ptyId, text, sendOptions)
       } else if (imagePaths.length > 0) {
         pendingHandle = sendNativeChatMessageWithImageAttachments(
           target.settings,

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/runtime/runtime-terminal-inspection', () => ({
 
 import {
   sendNativeChatMessage,
+  sendNativeChatTypedCommand,
   sendNativeChatMessageVerified,
   typeNativeChatCommand,
   sendNativeChatMessageWithImageAttachments,
@@ -256,6 +257,7 @@ describe('sendNativeChatMessageVerified', () => {
 describe('typeNativeChatCommand', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    sendRuntimePtyInput.mockReset().mockReturnValue(true)
     sendRuntimePtyInputVerified.mockReset().mockResolvedValue(true)
     resetNativeChatPtySendQueuesForTests()
   })
@@ -277,6 +279,39 @@ describe('typeNativeChatCommand', () => {
       'd',
       'e',
       'l',
+      NATIVE_CHAT_SUBMIT
+    ])
+  })
+
+  it('queues composer commands as the same paced key sequence', async () => {
+    const handle = sendNativeChatTypedCommand(SETTINGS, PTY, '/status')
+    await vi.runAllTimersAsync()
+    await handle.settled
+
+    expectWriteOrder(sendRuntimePtyInputVerified.mock.calls, [
+      NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
+      '/',
+      's',
+      't',
+      'a',
+      't',
+      'u',
+      's',
+      NATIVE_CHAT_SUBMIT
+    ])
+  })
+
+  it('does not clear into the next queued send after cancellation', async () => {
+    const command = sendNativeChatTypedCommand(SETTINGS, PTY, '/status')
+    command.cancel()
+    const next = sendNativeChatMessage(SETTINGS, PTY, 'next')
+    await vi.runAllTimersAsync()
+    await Promise.all([command.settled, next.settled])
+
+    expectWriteOrder(sendRuntimePtyInput.mock.calls, [
+      NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
+      NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
+      buildNativeChatPasteBytes('next'),
       NATIVE_CHAT_SUBMIT
     ])
   })

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send.ts
@@ -19,7 +19,10 @@ import {
   buildNativeChatPasteBytes,
   NATIVE_CHAT_SUBMIT
 } from './native-chat-send'
-import { typeAgentTuiCommand } from '../../../../shared/agent-tui-command-typing'
+import {
+  AGENT_TUI_COMMAND_KEY_INTERVAL_MS,
+  typeAgentTuiCommand
+} from '../../../../shared/agent-tui-command-typing'
 import {
   cancelNativeChatPtySends,
   enqueueNativeChatPtySend,
@@ -230,6 +233,43 @@ export async function typeNativeChatCommand(
       (await sendRuntimePtyInputVerified(settings, ptyId, key)) ? 'accepted' : 'rejected'
   })
   return outcome === 'accepted'
+}
+
+/** Queues a typed slash command with composer sends on the same PTY. */
+export function sendNativeChatTypedCommand(
+  settings: RuntimeSettings,
+  ptyId: string,
+  command: string
+): NativeChatSendHandle {
+  const controller = new AbortController()
+  return enqueueNativeChatPtySend(
+    ptyId,
+    (command.length + 1) * AGENT_TUI_COMMAND_KEY_INTERVAL_MS,
+    ({ isCancelled, markSubmitted }) => {
+      const finish = (outcome: 'accepted' | 'rejected' | 'unknown'): void => {
+        if (!isCancelled() && outcome !== 'accepted') {
+          clearUnsubmittedAgentInput(settings, ptyId)
+        }
+        markSubmitted()
+      }
+      void typeAgentTuiCommand({
+        command,
+        signal: controller.signal,
+        write: async (key) => {
+          if (isCancelled()) {
+            return 'rejected'
+          }
+          return (await sendRuntimePtyInputVerified(settings, ptyId, key)) ? 'accepted' : 'rejected'
+        }
+      }).then(finish, () => finish('rejected'))
+    },
+    {
+      onCancelUnsubmitted: () => {
+        controller.abort()
+        clearUnsubmittedAgentInput(settings, ptyId)
+      }
+    }
+  )
 }
 
 export function sendNativeChatMessageWithImageAttachments(

--- a/src/renderer/src/components/native-chat/use-native-chat-picker-command-dispatch.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-picker-command-dispatch.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EMPTY_HISTORY } from './native-chat-composer-state'
+
+const sendNativeChatMessage = vi.fn()
+const sendNativeChatTypedCommand = vi.fn()
+
+vi.mock('./native-chat-runtime-send', () => ({
+  sendNativeChatMessage: (...args: unknown[]) => sendNativeChatMessage(...args),
+  sendNativeChatTypedCommand: (...args: unknown[]) => sendNativeChatTypedCommand(...args)
+}))
+vi.mock('@/lib/native-chat-telemetry', () => ({
+  emitNativeChatMessageSent: vi.fn(),
+  emitNativeChatPickerItemAccepted: vi.fn(),
+  emitNativeChatSendClassified: vi.fn()
+}))
+
+import { useNativeChatPickerCommandDispatch } from './use-native-chat-picker-command-dispatch'
+
+const COMMAND = {
+  kind: 'command' as const,
+  id: 'command:status',
+  name: 'status',
+  description: 'Show status',
+  skillCollision: false
+}
+
+function renderDispatch(agent: 'codex' | 'claude' | 'openclaude') {
+  return renderHook(() =>
+    useNativeChatPickerCommandDispatch({
+      agent,
+      disabled: false,
+      isDispatchingSessionOption: false,
+      resolveTarget: () => ({ settings: {}, ptyId: 'pty-1' }),
+      sessionOptionsSurface: null,
+      trackPendingSend: vi.fn(),
+      setHistory: vi.fn((update) => update(EMPTY_HISTORY)),
+      setDraft: vi.fn(),
+      setCaret: vi.fn(),
+      setActiveSuggestion: vi.fn(),
+      clearSkillOrigin: vi.fn(),
+      clearImageAttachments: vi.fn(),
+      setNotice: vi.fn()
+    })
+  )
+}
+
+describe('useNativeChatPickerCommandDispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const handle = { cancel: vi.fn(), settleAfterMs: 0 }
+    sendNativeChatMessage.mockReturnValue(handle)
+    sendNativeChatTypedCommand.mockReturnValue(handle)
+  })
+
+  it('types Codex autocomplete commands', () => {
+    const hook = renderDispatch('codex')
+    act(() => hook.result.current(COMMAND))
+
+    expect(sendNativeChatTypedCommand).toHaveBeenCalledWith({}, 'pty-1', '/status')
+    expect(sendNativeChatMessage).not.toHaveBeenCalled()
+  })
+
+  it.each(['claude', 'openclaude'] as const)('keeps %s autocomplete commands pasted', (agent) => {
+    const hook = renderDispatch(agent)
+    act(() => hook.result.current(COMMAND))
+
+    expect(sendNativeChatMessage).toHaveBeenCalledWith({}, 'pty-1', '/status')
+    expect(sendNativeChatTypedCommand).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-picker-command-dispatch.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-picker-command-dispatch.ts
@@ -5,7 +5,7 @@ import {
   emitNativeChatPickerItemAccepted,
   emitNativeChatSendClassified
 } from '@/lib/native-chat-telemetry'
-import { sendNativeChatMessage } from './native-chat-runtime-send'
+import { sendNativeChatMessage, sendNativeChatTypedCommand } from './native-chat-runtime-send'
 import {
   nativeChatComposerTargetIsRemote,
   type NativeChatResolvedTarget
@@ -57,7 +57,11 @@ export function useNativeChatPickerCommandDispatch(args: {
       if (!target || disabled || isDispatchingSessionOption) {
         return
       }
-      trackPendingSend(sendNativeChatMessage(target.settings, target.ptyId, text))
+      trackPendingSend(
+        agent === 'codex'
+          ? sendNativeChatTypedCommand(target.settings, target.ptyId, text)
+          : sendNativeChatMessage(target.settings, target.ptyId, text)
+      )
       emitNativeChatPickerItemAccepted({ agent, itemKind: 'command' })
       // Why: picker dispatch is a catalog-verified command send; it must leave
       // the same telemetry and composer state as the typed path — including

--- a/src/renderer/src/components/native-chat/use-native-chat-session-option-command.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-option-command.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sendNativeChatMessageVerified = vi.fn()
+const typeNativeChatCommand = vi.fn()
+
+vi.mock('./native-chat-runtime-send', () => ({
+  sendNativeChatMessageVerified: (...args: unknown[]) => sendNativeChatMessageVerified(...args),
+  typeNativeChatCommand: (...args: unknown[]) => typeNativeChatCommand(...args)
+}))
+vi.mock('./native-chat-pty-send-queue', () => ({
+  cancelNativeChatPtySends: vi.fn(),
+  waitForNativeChatPtyIdle: vi.fn()
+}))
+vi.mock('@/lib/native-chat-telemetry', () => ({ emitNativeChatMessageSent: vi.fn() }))
+
+import { useNativeChatSessionOptionCommand } from './use-native-chat-session-option-command'
+
+function renderDispatch(agent: 'codex' | 'claude' | 'openclaude') {
+  return renderHook(() =>
+    useNativeChatSessionOptionCommand({
+      agent,
+      disabled: false,
+      resolveTarget: () => ({ settings: {}, ptyId: 'pty-1' }),
+      setHistory: vi.fn()
+    })
+  )
+}
+
+describe('useNativeChatSessionOptionCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sendNativeChatMessageVerified.mockResolvedValue(true)
+    typeNativeChatCommand.mockResolvedValue(true)
+  })
+
+  it('types Codex option commands even without caller delivery metadata', async () => {
+    const hook = renderDispatch('codex')
+    await act(() => hook.result.current.dispatch('/model'))
+
+    expect(typeNativeChatCommand).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      '/model',
+      expect.any(AbortSignal)
+    )
+    expect(sendNativeChatMessageVerified).not.toHaveBeenCalled()
+  })
+
+  it.each(['claude', 'openclaude'] as const)('keeps %s option commands pasted', async (agent) => {
+    const hook = renderDispatch(agent)
+    await act(() => hook.result.current.dispatch('/model sonnet', { delivery: 'type' }))
+
+    expect(sendNativeChatMessageVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      '/model sonnet',
+      expect.any(AbortSignal)
+    )
+    expect(typeNativeChatCommand).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-session-option-command.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-option-command.ts
@@ -87,7 +87,7 @@ export function useNativeChatSessionOptionCommand(args: {
           observer.arm()
         }
         const accepted =
-          options?.delivery === 'type'
+          agent === 'codex'
             ? await typeNativeChatCommand(
                 target.settings,
                 target.ptyId,


### PR DESCRIPTION
## Summary

This PR is stacked on #13669 at `a9f7a49254` and targets `main`; until #13669 merges, its two dependency commits appear in this PR's commit list.

- Route every remaining Codex native-chat slash-command sender through #13669's shared paced key writer (`Ctrl+U`, one PTY write per character, Enter).
- Keep Claude and OpenClaude on their existing bracketed-paste path, with explicit parity assertions even when legacy delivery metadata requests typing.
- Serialize desktop typed composer/autocomplete commands with ordinary native-chat sends, and preserve mobile launch-draft retirement on the final accepted Enter.

### Per-site fix and regression coverage

| Site | Fix | Regression coverage |
| --- | --- | --- |
| `NativeChatComposer.tsx` | Codex composer slash/unknown-token sends use the queued typed-command handle; image sends retain their attachment path | `NativeChatComposer.test.tsx` covers Codex typed dispatch and Claude/OpenClaude paste parity |
| `use-native-chat-picker-command-dispatch.ts` | Codex autocomplete acceptance uses the typed handle | New hook test covers Codex plus Claude/OpenClaude parity |
| `use-native-chat-session-option-command.ts` → `native-chat-runtime-send.ts` | Agent-gated Codex option commands use the shared writer; typed commands share the PTY send queue and cancellation cannot clear a following send | New hook test, runtime key-order test, and cancellation serialization test |
| `use-mobile-native-chat-message-send.ts` + `use-mobile-native-chat-session-options.ts` | Codex composer and option commands use the shared mobile typed writer; Claude/OpenClaude remain pasted | Mobile message-send and existing session-option suites cover composer, model/effort picker, no-metadata dispatch, and parity |
| `MobileNativeChatComposerSuggestions.tsx` | No production change: suggestions insert slash text into the fixed composer send path | Composer test explicitly verifies `/clear ` insertion; mobile message-send test verifies that resulting Codex slash text is typed |

## Screenshots

No visual change.

Electron validation on the dev build accepted `/status` from Codex native-chat autocomplete and rendered Codex's status panel in the terminal, confirming the command reached the TUI instead of the model as prose.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full root run was terminated with exit 143 after unrelated environment-sensitive/time-out failures; the focused root suite passed 81 tests across 5 files
- [ ] `pnpm build` — full packaging was not run; the Electron dev build completed successfully for UI validation
- [x] Added or updated high-quality tests that would catch regressions
- [x] Mobile full suite: 3,432 passed and 3 skipped across 438 files
- [x] Mobile typecheck, lint, and format check
- [x] Node 24 changed-code quality gate: zero findings
- [x] Electron dev-build validation through CDP

## AI Review Report

Reviewed agent gating, PTY byte shape, composer/autocomplete/option coverage, cancellation and per-PTY serialization, launch-draft retirement, mixed local/SSH routing, mobile RPC ambiguity, and the two generic senders from the audit. The review caught a cancellation race where a late cleanup could clear the next queued message; the implementation now suppresses cleanup after cancellation, with a focused regression test. Cross-platform review covered macOS, Linux, and Windows: the change uses portable PTY control bytes and existing runtime/RPC routing, adds no shortcut or label differences, makes no path or shell assumptions, and introduces no Electron-specific platform branch.

## Security Audit

Slash text is delivered only to an already-running Codex TUI through the existing terminal input APIs; it is never evaluated by a shell. The change adds no dependency, auth, secret, filesystem, executable, permission, or new IPC/wire surface, and mobile continues using the existing `terminal.send` request shape. No follow-up security work is needed.

## Notes

- Dependency: #13669 must merge first, or this PR can be rebased onto `main` afterward.
- `agent-followup-delivery.ts` remains unchanged: its sole production caller delivers generated workspace launch prompts, not agent-TUI slash controls.
- Plugin `terminal.sendText` remains unchanged: it is an intentionally agent-agnostic raw terminal API, and no real plugin caller narrows it to slash commands for an agent TUI.
- Folder workspaces, git worktrees, SSH hosts, and mixed-version remotes retain the existing terminal routing; no wire change is required.
