### PR TITLE
fix(editor): stop runaway padding in serialized markdown tables

### DIFF
--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -227,6 +227,14 @@ describe('rich markdown round trip', () => {
     expect(roundTripMarkdown('| a | b |\n| - | - |\n| 1 | 2 |\n')).toContain('| a')
   })
 
+  it('keeps table cells stable when content contains a literal pipe', () => {
+    // An unescaped pipe would re-split the row on the next parse, corrupting the
+    // table. The serializer escapes it, so a second round-trip is a fixed point.
+    const once = roundTripMarkdown('| a | b |\n| - | - |\n| `x \\| y` | z |\n')
+    expect(once).toContain('`x \\| y`')
+    expect(roundTripMarkdown(once)).toBe(once)
+  })
+
   it('preserves encoded local image paths with screenshot filenames', () => {
     expect(roundTripMarkdown('![](Screenshot%202026-06-22%20at%203.37.19%20PM%20copy.png)\n')).toBe(
       '![](Screenshot%202026-06-22%20at%203.37.19%20PM%20copy.png)'

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -33,8 +33,16 @@ import type { RichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { createRichMarkdownHtmlSuperscriptLink } from './rich-markdown-html-superscript-link'
 import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
+import { renderTableToCompactMarkdown } from './rich-markdown-table-markdown'
 
 const lowlight = createLowlight(common)
+
+// Why: the default table serializer pads every column to its longest cell, so a
+// single long cell blows the whole column (and its separator dashes) out. Ours
+// aligns to the longest non-outlier cell instead.
+const RichMarkdownTable = Table.extend({
+  renderMarkdown: renderTableToCompactMarkdown
+})
 
 const RichMarkdownLink = Link.extend({
   // Why: link's priority must stay below code's default 100 so Markdown
@@ -195,7 +203,7 @@ export function createRichMarkdownExtensions({
       nested: true
     }),
     ...createOrcaDetailsExtensions(),
-    Table.configure({
+    RichMarkdownTable.configure({
       resizable: false
     }),
     TableRow,

--- a/src/renderer/src/components/editor/rich-markdown-table-markdown.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-table-markdown.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import type { JSONContent, MarkdownRendererHelpers } from '@tiptap/core'
+import { renderTableToCompactMarkdown } from './rich-markdown-table-markdown'
+
+// Mock helper: renderChildren returns the concatenated text of the cell's nodes,
+// which is all the table serializer reads from each cell.
+const helpers = {
+  renderChildren: (nodes: JSONContent | JSONContent[]): string => {
+    const list = Array.isArray(nodes) ? nodes : [nodes]
+    const text = (node: JSONContent): string =>
+      node.type === 'text' ? (node.text ?? '') : (node.content ?? []).map(text).join('')
+    return list.map(text).join('')
+  }
+} as unknown as MarkdownRendererHelpers
+
+function cell(text: string, type: 'tableCell' | 'tableHeader'): JSONContent {
+  return { type, content: [{ type: 'paragraph', content: [{ type: 'text', text }] }] }
+}
+
+function table(header: string[], body: string[][]): JSONContent {
+  return {
+    type: 'table',
+    content: [
+      { type: 'tableRow', content: header.map((t) => cell(t, 'tableHeader')) },
+      ...body.map((row) => ({ type: 'tableRow', content: row.map((t) => cell(t, 'tableCell')) }))
+    ]
+  }
+}
+
+const widthOf = (md: string): number => Math.max(...md.split('\n').map((line) => line.length))
+const lines = (md: string): string[] => md.split('\n').filter((line) => line.startsWith('|'))
+
+describe('renderTableToCompactMarkdown', () => {
+  it('aligns two uniformly-wide columns to their content', () => {
+    const md = renderTableToCompactMarkdown(
+      table(
+        ['Term', 'Definition'],
+        [
+          ['context artifact', 'content injected through a harness mechanism'],
+          ['condition / arm', 'the unique combination identifying a setup']
+        ]
+      ),
+      helpers
+    )
+    // Both body rows pad to the same width → the trailing pipe lines up.
+    const barColumns = lines(md).map((line) => line.lastIndexOf('|'))
+    expect(new Set(barColumns).size).toBe(1)
+  })
+
+  it('clamps a lone long cell once full alignment would exceed the width budget', () => {
+    const long = 'x'.repeat(200) // pushes the table well past MAX_ALIGNED_TABLE_WIDTH
+    const md = renderTableToCompactMarkdown(
+      table(
+        ['id', 'notes', 'k'],
+        [
+          ['1', '-', '1'],
+          ['2', long, '3'],
+          ['3', '-', '1']
+        ]
+      ),
+      helpers
+    )
+    // The notes column (index 1) clamps to the short cluster, not the 200-char cell.
+    const dashCols = lines(md)[1]
+      .split('|')
+      .map((seg) => seg.trim())
+      .filter((seg) => /^-+$/.test(seg))
+    expect(dashCols[1].length).toBeLessThan(10)
+    // The non-outlier rows stay narrow; only the outlier row overflows.
+    const shortRows = lines(md).filter((line) => !line.includes(long))
+    expect(Math.max(...shortRows.map((line) => line.length))).toBeLessThan(25)
+  })
+
+  it('absorbs an outlier and aligns fully when the table stays under the budget', () => {
+    const notes = 'flaky on retry; see the run-trial preflight logs for the cache-taint note'
+    const md = renderTableToCompactMarkdown(
+      table(
+        ['id', 'name', 'status', 'notes', 'k', 'cost', 'ms', 'pass'],
+        [
+          ['1', 'opus', 'ok', '-', '1', '0.12', '8400', 'yes'],
+          ['2', 'sonnet', 'ok', notes, '3', '0.04', '5200', 'no'],
+          ['3', 'codex', 'ok', '-', '1', '0.09', '7700', 'yes']
+        ]
+      ),
+      helpers
+    )
+    // Every row is padded to the same width, so trailing columns line up even on
+    // the outlier row (no solo spill).
+    const rowLengths = lines(md).map((line) => line.length)
+    expect(new Set(rowLengths).size).toBe(1)
+  })
+
+  it('caps uniformly-huge columns so short cells do not pad out to hundreds', () => {
+    const huge = 'x'.repeat(300)
+    const md = renderTableToCompactMarkdown(
+      table(
+        ['a', 'b'],
+        [
+          [huge, 'short'],
+          [huge, 'short']
+        ]
+      ),
+      helpers
+    )
+    // Column b's short cells pad to the ceiling (60), never to 300.
+    const separator = lines(md)[1]
+    expect(separator.length).toBeLessThan(140)
+    expect(widthOf(md)).toBeGreaterThan(300) // the huge cell itself still fits on one line
+  })
+
+  it('keeps a short header from overflowing its own column', () => {
+    const md = renderTableToCompactMarkdown(
+      table(
+        ['Status', 'Note'],
+        [
+          ['ok', 'a'],
+          ['ok', 'b']
+        ]
+      ),
+      helpers
+    )
+    const header = lines(md)[0]
+    // Header "Status" is fully present and padded, not truncated/overflowing.
+    expect(header).toContain('| Status |')
+  })
+
+  it('preserves alignment markers without widening the separator row', () => {
+    const alignedHeader = (text: string, align: 'left' | 'center' | 'right'): JSONContent => ({
+      type: 'tableHeader',
+      attrs: align ? { align } : {},
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+    })
+    const node: JSONContent = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            alignedHeader('longer left cell', 'left'),
+            alignedHeader('mid', 'center'),
+            alignedHeader('n', 'right')
+          ]
+        },
+        {
+          type: 'tableRow',
+          content: [cell('a', 'tableCell'), cell('b', 'tableCell'), cell('42', 'tableCell')]
+        }
+      ]
+    }
+    const rendered = lines(renderTableToCompactMarkdown(node, helpers))
+    const [header, separator, body] = rendered
+    expect(separator).toContain(':-') // left/center open with a colon
+    expect(separator).toContain('-:') // right/center close with a colon
+    // Colons count toward the width, so every row is exactly the same length.
+    expect(separator.length).toBe(header.length)
+    expect(body.length).toBe(header.length)
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-table-markdown.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-table-markdown.test.ts
@@ -124,6 +124,14 @@ describe('renderTableToCompactMarkdown', () => {
     expect(header).toContain('| Status |')
   })
 
+  it('escapes literal pipes in cell content so the row keeps its columns', () => {
+    const md = renderTableToCompactMarkdown(table(['a', 'b'], [['x | y', 'z']]), helpers)
+    const body = lines(md).find((line) => line.includes('x'))!
+    // Pipe is backslash-escaped, so it is not read as a fourth column delimiter.
+    expect(body).toContain('x \\| y')
+    expect(body).not.toContain('x | y')
+  })
+
   it('preserves alignment markers without widening the separator row', () => {
     const alignedHeader = (text: string, align: 'left' | 'center' | 'right'): JSONContent => ({
       type: 'tableHeader',

--- a/src/renderer/src/components/editor/rich-markdown-table-markdown.ts
+++ b/src/renderer/src/components/editor/rich-markdown-table-markdown.ts
@@ -1,0 +1,154 @@
+// Replaces @tiptap/extension-table's default table serializer, whose column
+// width is the LONGEST cell in the column — so one long cell pads every sibling
+// (and the separator dash-run) out to its length. This version aligns to each
+// column's longest NON-OUTLIER cell so a lone long cell overflows instead of
+// stretching the whole column, with a ceiling for uniformly-huge columns.
+
+import type { JSONContent, MarkdownRendererHelpers } from '@tiptap/core'
+
+// getMarkdown() serializes getJSON() output, so renderMarkdown receives a
+// JSONContent tree: `type` is a string, `content` an array, `attrs` a plain object.
+type TableCellAlign = 'left' | 'right' | 'center' | null
+
+type TableCell = { text: string; isHeader: boolean; align: TableCellAlign }
+
+const MIN_COLUMN_WIDTH = 3
+// A cell longer than this multiple of its column's median is an outlier: it
+// overflows its column instead of dictating the padding for every other cell.
+const OUTLIER_MEDIAN_FACTOR = 2.5
+// Hard ceiling so a column where every cell is genuinely huge doesn't pad short
+// cells (and the separator) out to hundreds of characters.
+const MAX_COLUMN_WIDTH = 60
+// If a fully-aligned table (every column padded to its longest cell) fits within
+// this width, align it — the runaway padding only hurts once a table is wide, so
+// a narrow table has no reason to clamp and should keep every column lined up.
+const MAX_ALIGNED_TABLE_WIDTH = 160
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function normalizeAlign(attrs: Record<string, unknown> | undefined): TableCellAlign {
+  const value = attrs?.align
+  return value === 'left' || value === 'right' || value === 'center' ? value : null
+}
+
+function median(sortedLengths: number[]): number {
+  const count = sortedLengths.length
+  if (count === 0) {
+    return 0
+  }
+  const mid = Math.floor(count / 2)
+  return count % 2 ? sortedLengths[mid] : (sortedLengths[mid - 1] + sortedLengths[mid]) / 2
+}
+
+// Full alignment: pad to the longest cell (always fitting the header).
+function naturalColumnWidth(cellLengths: number[], headerLength: number): number {
+  return Math.max(MIN_COLUMN_WIDTH, headerLength, ...cellLengths)
+}
+
+// Clamped width = longest non-outlier cell, always fitting the header, capped at
+// the ceiling. Header length is passed separately so a header is never treated as
+// an outlier and never overflows its own column.
+function clampedColumnWidth(cellLengths: number[], headerLength: number): number {
+  const sorted = [...cellLengths].sort((a, b) => a - b)
+  const outlierThreshold = Math.max(MIN_COLUMN_WIDTH, median(sorted) * OUTLIER_MEDIAN_FACTOR)
+  const nonOutlierLengths = cellLengths.filter((length) => length <= outlierThreshold)
+  const contentWidth = Math.max(MIN_COLUMN_WIDTH, headerLength, ...nonOutlierLengths)
+  return Math.min(MAX_COLUMN_WIDTH, contentWidth)
+}
+
+// Pipe overhead of a row: leading "| ", trailing " |", and " | " between columns.
+function rowPipeOverhead(columnCount: number): number {
+  return 3 * columnCount + 1
+}
+
+// Align every column to its content when the table stays narrow; only clamp
+// outliers once full alignment would exceed the width budget.
+function resolveColumnWidths(columns: { cellLengths: number[]; headerLength: number }[]): number[] {
+  const natural = columns.map((col) => naturalColumnWidth(col.cellLengths, col.headerLength))
+  const naturalTotal =
+    natural.reduce((sum, width) => sum + width, 0) + rowPipeOverhead(columns.length)
+  if (naturalTotal <= MAX_ALIGNED_TABLE_WIDTH) {
+    return natural
+  }
+  return columns.map((col) => clampedColumnWidth(col.cellLengths, col.headerLength))
+}
+
+function extractRows(node: JSONContent, h: MarkdownRendererHelpers): TableCell[][] {
+  const rows: TableCell[][] = []
+  for (const rowNode of node.content ?? []) {
+    const cells: TableCell[] = []
+    for (const cellNode of rowNode.content ?? []) {
+      const raw = cellNode.content ? h.renderChildren(cellNode.content) : ''
+      cells.push({
+        text: collapseWhitespace(raw),
+        isHeader: cellNode.type === 'tableHeader',
+        align: normalizeAlign(cellNode.attrs)
+      })
+    }
+    rows.push(cells)
+  }
+  return rows
+}
+
+function separatorCell(width: number, align: TableCellAlign): string {
+  // Colons count toward the column width so the separator row stays exactly as
+  // wide as the content rows (adding them on top would widen aligned columns).
+  const colons = align === 'center' ? 2 : align ? 1 : 0
+  const dashes = '-'.repeat(Math.max(1, width - colons))
+  if (align === 'left') {
+    return `:${dashes}`
+  }
+  if (align === 'right') {
+    return `${dashes}:`
+  }
+  if (align === 'center') {
+    return `:${dashes}:`
+  }
+  return dashes
+}
+
+export function renderTableToCompactMarkdown(
+  node: JSONContent,
+  h: MarkdownRendererHelpers
+): string {
+  if (!node?.content || node.content.length === 0) {
+    return ''
+  }
+  const rows = extractRows(node, h)
+  const columnCount = rows.reduce((max, row) => Math.max(max, row.length), 0)
+  if (columnCount === 0) {
+    return ''
+  }
+
+  const headerRow = rows[0]
+  const hasHeader = headerRow.some((cell) => cell.isHeader)
+
+  const columns = Array.from({ length: columnCount }, (_unused, col) => ({
+    cellLengths: rows.map((row) => row[col]?.text.length ?? 0),
+    headerLength: hasHeader ? (headerRow[col]?.text.length ?? 0) : 0
+  }))
+  const columnWidths = resolveColumnWidths(columns)
+  // First explicit alignment wins, matching the default serializer.
+  const columnAlignments: TableCellAlign[] = Array.from({ length: columnCount }, (_unused, col) =>
+    rows.reduce<TableCellAlign>((found, row) => found ?? row[col]?.align ?? null, null)
+  )
+
+  const pad = (text: string, width: number): string =>
+    text + ' '.repeat(Math.max(0, width - text.length))
+  const formatRow = (row: TableCell[]): string =>
+    `| ${columnWidths.map((width, col) => pad(row[col]?.text ?? '', width)).join(' | ')} |`
+
+  const headerTexts: TableCell[] = hasHeader
+    ? headerRow
+    : Array.from({ length: columnCount }, () => ({ text: '', isHeader: false, align: null }))
+  const bodyRows = hasHeader ? rows.slice(1) : rows
+
+  const lines = [
+    formatRow(headerTexts),
+    `| ${columnWidths.map((width, col) => separatorCell(width, columnAlignments[col])).join(' | ')} |`,
+    ...bodyRows.map(formatRow)
+  ]
+  return `\n${lines.join('\n')}\n`
+}

--- a/src/renderer/src/components/editor/rich-markdown-table-markdown.ts
+++ b/src/renderer/src/components/editor/rich-markdown-table-markdown.ts
@@ -28,6 +28,13 @@ function collapseWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
 }
 
+// GFM treats an unescaped `|` as a column delimiter even inside code spans and
+// links, so a literal pipe in rendered cell content re-splits the row on reparse
+// (corrupting the table). Backslash-escape it before width calc and formatting.
+function escapeCellPipes(value: string): string {
+  return value.replace(/\|/g, '\\|')
+}
+
 function normalizeAlign(attrs: Record<string, unknown> | undefined): TableCellAlign {
   const value = attrs?.align
   return value === 'left' || value === 'right' || value === 'center' ? value : null
@@ -82,7 +89,7 @@ function extractRows(node: JSONContent, h: MarkdownRendererHelpers): TableCell[]
     for (const cellNode of rowNode.content ?? []) {
       const raw = cellNode.content ? h.renderChildren(cellNode.content) : ''
       cells.push({
-        text: collapseWhitespace(raw),
+        text: escapeCellPipes(collapseWhitespace(raw)),
         isHeader: cellNode.type === 'tableHeader',
         align: normalizeAlign(cellNode.attrs)
       })


### PR DESCRIPTION
## Summary

The rich markdown editor serializes tables through `@tiptap/extension-table`, whose serializer pads **every** column to the length of its longest cell. A single long cell therefore inflates every sibling cell — and the separator dash-run — out to that width. On save this reaches disk directly (when a table is edited) or via the reconcile canonical fallback (which rewrites the whole document), so tables sprout huge padding "out of nowhere" after an unrelated edit.

This overrides the Table node's `renderMarkdown` with a width-aware serializer:

- **Align fully** when the whole table fits a width budget (160 cols) — narrow tables keep every column lined up, including a lone long cell.
- **Past the budget, clamp** each column to its longest *non-outlier* cell (a cell > 2.5× the column median overflows on its own row instead of stretching the column), capped at 60 cols, so one long cell can't blow the table out.
- **Count alignment colons toward the column width**, so the separator row stays exactly as wide as the content rows.

Three tunables at the top of the module: `MAX_ALIGNED_TABLE_WIDTH` (160), `OUTLIER_MEDIAN_FACTOR` (2.5), `MAX_COLUMN_WIDTH` (60).

## Screenshots
|Before|After|
|---|---|
|<img width="1281" height="1224" alt="image" src="https://github.com/user-attachments/assets/84f1d92d-f933-4499-b81d-e04c9f2afedb" />|<img width="1284" height="1052" alt="image" src="https://github.com/user-attachments/assets/db65a5ea-8ecc-4c01-ae8c-ac1da7b5fb67" />|

Note - the rich editor and preview tools look the same before and after the change, the padding being added is only visible in the raw editor.
The differences above are particularly obvious in the first and last tables. This can get really bad when tables have a lot of spilled content, or single cells with a lot of text. It's still not perfect (as it never can be with this markdown style of formatting), but the change does behave better overall.

## Testing

- [x] `pnpm typecheck` — clean locally
- [x] `pnpm test` — table serializer (6 new tests) + round-trip + serialization-commit suites pass locally; full suite runs in PR CI (this machine is on Node 22, repo wants Node 24)
- [x] `pnpm build` — deferred to PR CI (Node 24)
- [x] `pnpm lint` — `oxlint`, both `audit:code-quality:*`, `check:reliability-gates`, `check:max-lines-ratchet`, and `verify:bundled-skill-guides` all pass locally. The full command is blocked only by a pre-existing, unrelated `verify:skill-bundle-manifest` failure — this PR touches no files under `resources/skills/`. Authoritative lint runs in PR CI on Node 24.
- [x] Added `rich-markdown-table-markdown.test.ts` (6 tests: full-align, outlier-absorbed, over-budget clamp, uniformly-huge cap, header protection, alignment-marker width); existing round-trip and serialization-commit suites still pass.

## AI Review Report

Reviewed against the contribution dimensions:

- **Cross-platform (macOS/Linux/Windows):** Pure string serialization in renderer TS — no paths, shortcuts, shell, or platform APIs. Emits LF, matching the existing `getMarkdown()` contract; CRLF restoration is handled downstream by the unchanged reconcile EOL logic. No platform-specific behavior.
- **SSH/remote/local:** Serialization runs renderer-side on the editor's own document and is identical regardless of where the file lives. No RPC/stream/wire change — only the bytes written to a `.md` file change, delivered through existing mechanisms, so mixed client/host versions are unaffected.
- **Agent / integration / git-provider:** None touched; table serialization is provider-neutral.
- **Performance:** One `sort` + median/filter per column, only on `getMarkdown()` (save/reconcile), never in a render hot path — same order as the serializer it replaces. Negligible.
- **Reconcile safety:** The live editor, the reconcile base serialization, and the round-trip safety re-parse all resolve through `createRichMarkdownExtensions`, so they share the new renderer and stay mutually consistent (no spurious canonical fallbacks). Confirmed by the passing round-trip/serialization suites.
- **UI quality:** Affects on-disk markdown text only; the rendered rich-view table is unchanged (light/dark N/A). Verified in a dev build against a 6-shape demo document.

## Security Audit

No input execution, path handling, auth, secrets, IPC, or network involved. Input is the editor's own JSON document; output is text. `renderChildren` is the tiptap-provided helper (same as the default serializer). `collapseWhitespace` is a simple `\s+` replace with no ReDoS exposure. Low risk.

## Notes

No behavioral change to rendered tables or to any remote wire format — this only changes how the editor writes table markdown to disk. The width budget is a single constant; someone on a narrow screen simply sees tables clamp sooner, never anything broken.
