### PR TITLE
Report the failing command and PATH when a POSIX setup runner fails

### DIFF
--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -246,69 +246,88 @@ describe('createSetupRunnerScript', () => {
     }
   )
 
+  /** Write the generated runner for `script` and run it under a minimal PATH. */
+  async function runPosixRunner(
+    script: string
+  ): Promise<{ status: number | null; stdout: string; stderr: string }> {
+    const { buildPosixRunnerScript } = await import('./hooks')
+    const { mkdtempSync, rmSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+    const { spawnSync } = await vi.importActual<typeof NodeChildProcess>('node:child_process')
+
+    const dir = mkdtempSync(join(tmpdir(), 'orca-posix-runner-'))
+    try {
+      const runnerPath = join(dir, 'setup-runner.sh')
+      writeFileSync(runnerPath, buildPosixRunnerScript(script), 'utf-8')
+      const result = spawnSync('bash', [runnerPath], {
+        encoding: 'utf-8',
+        env: { PATH: '/usr/bin:/bin' },
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+      return { status: result.status, stdout: result.stdout, stderr: result.stderr }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  const countReports = (stderr: string): number =>
+    stderr.split('\n').filter((line) => line.startsWith('Orca setup: command failed')).length
+
   it.skipIf(process.platform === 'win32')(
     'reports the failing command and the PATH it ran with when a command is missing',
     async () => {
       // Regression: a version-manager tool that resolves in the user's terminal is absent in the
       // runner, and the bare `command not found` says nothing about the PATH the runner had.
-      const { buildPosixRunnerScript } = await import('./hooks')
-      const { mkdtempSync, rmSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
-      const { execFileSync } = await vi.importActual<typeof NodeChildProcess>('node:child_process')
+      const result = await runPosixRunner('orca-missing-tool install\necho NEVER\n')
 
-      const dir = mkdtempSync(join(tmpdir(), 'orca-posix-runner-'))
-      try {
-        const runnerPath = join(dir, 'setup-runner.sh')
-        writeFileSync(
-          runnerPath,
-          buildPosixRunnerScript('orca-missing-tool install\necho NEVER\n'),
-          'utf-8'
-        )
+      expect(result.status).toBe(127)
+      expect(result.stderr).toContain('Orca setup: command failed with status 127')
+      expect(result.stderr).toContain('orca-missing-tool install')
+      expect(result.stderr).toContain('/usr/bin:/bin')
+      expect(result.stdout).not.toContain('NEVER')
+      expect(countReports(result.stderr)).toBe(1)
+    }
+  )
 
-        const failure = (() => {
-          try {
-            execFileSync('bash', [runnerPath], {
-              encoding: 'utf-8',
-              env: { PATH: '/usr/bin:/bin' }
-            })
-            return null
-          } catch (error) {
-            return error as { status?: number; stdout?: string; stderr?: string }
-          }
-        })()
+  it.skipIf(process.platform === 'win32')(
+    'reports a failure raised inside a script function exactly once',
+    async () => {
+      // Regression: bash does not inherit an ERR trap into a function, so a script that wraps its
+      // work in one used to fail with no report at all.
+      const result = await runPosixRunner(
+        'install_tools() { orca-missing-tool install; }\ninstall_tools\necho NEVER\n'
+      )
 
-        expect(failure?.status).toBe(127)
-        expect(failure?.stderr).toContain('Orca setup: command failed with status 127')
-        expect(failure?.stderr).toContain('orca-missing-tool install')
-        expect(failure?.stderr).toContain('/usr/bin:/bin')
-        expect(failure?.stdout).not.toContain('NEVER')
-      } finally {
-        rmSync(dir, { recursive: true, force: true })
-      }
+      expect(result.status).toBe(127)
+      expect(result.stderr).toContain('Orca setup: command failed with status 127')
+      expect(result.stderr).toContain('orca-missing-tool install')
+      expect(result.stdout).not.toContain('NEVER')
+      expect(countReports(result.stderr)).toBe(1)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'reports a failing command substitution once, not once per shell',
+    async () => {
+      // Regression: `set -E` would report this twice, once in the substitution subshell and once
+      // in the parent.
+      const result = await runPosixRunner('value=$(orca-missing-tool print)\necho NEVER\n')
+
+      expect(result.status).toBe(127)
+      expect(result.stderr).toContain('orca-missing-tool print')
+      expect(result.stdout).not.toContain('NEVER')
+      expect(countReports(result.stderr)).toBe(1)
     }
   )
 
   it.skipIf(process.platform === 'win32')(
     'stays silent while a runner script succeeds',
     async () => {
-      const { buildPosixRunnerScript } = await import('./hooks')
-      const { mkdtempSync, rmSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
-      const { execFileSync } = await vi.importActual<typeof NodeChildProcess>('node:child_process')
+      const result = await runPosixRunner('echo SETUP_RAN\n')
 
-      const dir = mkdtempSync(join(tmpdir(), 'orca-posix-runner-'))
-      try {
-        const runnerPath = join(dir, 'setup-runner.sh')
-        writeFileSync(runnerPath, buildPosixRunnerScript('echo SETUP_RAN\n'), 'utf-8')
-
-        const output = execFileSync('bash', [runnerPath], {
-          encoding: 'utf-8',
-          stdio: ['ignore', 'pipe', 'pipe']
-        })
-
-        expect(output).toContain('SETUP_RAN')
-        expect(output).not.toContain('Orca setup:')
-      } finally {
-        rmSync(dir, { recursive: true, force: true })
-      }
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('SETUP_RAN')
+      expect(result.stdout).not.toContain('Orca setup:')
+      expect(result.stderr).not.toContain('Orca setup:')
     }
   )
 

--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -6,6 +6,12 @@ import { join } from 'node:path'
 import type { Repo } from '../shared/types'
 
 import { describe, expect, it, vi } from 'vitest'
+import { getPosixRunnerFailureReportPrelude } from './setup-runner-failure-report'
+
+/** Expected POSIX runner content: Orca's header, then the script. */
+function posixRunnerContent(body: string): string {
+  return `#!/usr/bin/env bash\nset -e\n${getPosixRunnerFailureReportPrelude()}${body}`
+}
 
 const { execFileSyncMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn()
@@ -118,7 +124,7 @@ describe('createSetupRunnerScript', () => {
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
         'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\n',
+        posixRunnerContent('pnpm install\n'),
         'utf-8'
       )
       // Why: chmod over a native Windows path is meaningless; only the WSL branch sets the bit.
@@ -240,6 +246,72 @@ describe('createSetupRunnerScript', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'reports the failing command and the PATH it ran with when a command is missing',
+    async () => {
+      // Regression: a version-manager tool that resolves in the user's terminal is absent in the
+      // runner, and the bare `command not found` says nothing about the PATH the runner had.
+      const { buildPosixRunnerScript } = await import('./hooks')
+      const { mkdtempSync, rmSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+      const { execFileSync } = await vi.importActual<typeof NodeChildProcess>('node:child_process')
+
+      const dir = mkdtempSync(join(tmpdir(), 'orca-posix-runner-'))
+      try {
+        const runnerPath = join(dir, 'setup-runner.sh')
+        writeFileSync(
+          runnerPath,
+          buildPosixRunnerScript('orca-missing-tool install\necho NEVER\n'),
+          'utf-8'
+        )
+
+        const failure = (() => {
+          try {
+            execFileSync('bash', [runnerPath], {
+              encoding: 'utf-8',
+              env: { PATH: '/usr/bin:/bin' }
+            })
+            return null
+          } catch (error) {
+            return error as { status?: number; stdout?: string; stderr?: string }
+          }
+        })()
+
+        expect(failure?.status).toBe(127)
+        expect(failure?.stderr).toContain('Orca setup: command failed with status 127')
+        expect(failure?.stderr).toContain('orca-missing-tool install')
+        expect(failure?.stderr).toContain('/usr/bin:/bin')
+        expect(failure?.stdout).not.toContain('NEVER')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'stays silent while a runner script succeeds',
+    async () => {
+      const { buildPosixRunnerScript } = await import('./hooks')
+      const { mkdtempSync, rmSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+      const { execFileSync } = await vi.importActual<typeof NodeChildProcess>('node:child_process')
+
+      const dir = mkdtempSync(join(tmpdir(), 'orca-posix-runner-'))
+      try {
+        const runnerPath = join(dir, 'setup-runner.sh')
+        writeFileSync(runnerPath, buildPosixRunnerScript('echo SETUP_RAN\n'), 'utf-8')
+
+        const output = execFileSync('bash', [runnerPath], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+
+        expect(output).toContain('SETUP_RAN')
+        expect(output).not.toContain('Orca setup:')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('derives ORCA_WORKSPACE_NAME from a POSIX worktree path', async () => {
     const originalPlatform = process.platform
 
@@ -301,7 +373,7 @@ describe('createSetupRunnerScript', () => {
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
         '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\n',
+        posixRunnerContent('pnpm install\n'),
         'utf-8'
       )
       expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(
@@ -347,7 +419,7 @@ describe('createSetupRunnerScript', () => {
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
         '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\n',
+        posixRunnerContent('pnpm install\n'),
         'utf-8'
       )
       expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(
@@ -402,7 +474,7 @@ describe('createIssueCommandRunnerScript', () => {
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
         '/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh',
-        '#!/usr/bin/env bash\nset -e\ncodex exec "long command"\nclaude -p "review it"\n',
+        posixRunnerContent('codex exec "long command"\nclaude -p "review it"\n'),
         'utf-8'
       )
       expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -5,6 +5,12 @@ import type * as GitRunner from './git/runner'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { getDefaultTabsLaunch, parseOrcaYaml } from './hooks'
+import { getPosixRunnerFailureReportPrelude } from './setup-runner-failure-report'
+
+/** Expected POSIX runner content: Orca's header, any replayed shebang options, then the script. */
+function posixRunnerContent(body: string, declaredOptions = ''): string {
+  return `#!/usr/bin/env bash\nset -e\n${declaredOptions}${getPosixRunnerFailureReportPrelude()}${body}`
+}
 
 // Mock fs and path used by loadHooks
 vi.mock('fs', () => ({
@@ -567,7 +573,7 @@ describe('runner script builders', () => {
     try {
       const result = buildPosixRunnerScript(script)
 
-      expect(result.startsWith('#!/usr/bin/env bash\nset -e\necho setup\n')).toBe(true)
+      expect(result.startsWith(posixRunnerContent('echo setup\n'))).toBe(true)
       expect(result.endsWith('echo done\n')).toBe(true)
       const usedCrlfReplace = replaceSpy.mock.calls.some(
         ([pattern]) => pattern instanceof RegExp && pattern.source === '\\r\\n'
@@ -1181,7 +1187,7 @@ describe('runHook', () => {
       expect(mkdirSyncMock).toHaveBeenCalled()
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         expect.stringContaining('setup-runner.sh'),
-        '#!/usr/bin/env bash\nset -e\necho hello\n',
+        posixRunnerContent('echo hello\n'),
         'utf-8'
       )
       expect(chmodSyncMock).toHaveBeenCalledWith(expect.stringContaining('setup-runner.sh'), 0o755)
@@ -1282,7 +1288,7 @@ describe('createSetupRunnerScript', () => {
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         'C:\\repo\\.git\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\nnpm run build\n',
+        posixRunnerContent('pnpm install\nnpm run build\n'),
         'utf-8'
       )
       expect(chmodSyncMock).not.toHaveBeenCalled()
@@ -1389,7 +1395,7 @@ describe('createSetupRunnerScript', () => {
 
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         'C:\\repo\\.git\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\nset -euo pipefail\nmake build | tee build.log\n',
+        posixRunnerContent('make build | tee build.log\n', 'set -euo pipefail\n'),
         'utf-8'
       )
     } finally {
@@ -1457,7 +1463,7 @@ describe('createSetupRunnerScript', () => {
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         '/test/repo/.git/orca/setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\n',
+        posixRunnerContent('pnpm install\n'),
         'utf-8'
       )
       expect(chmodSyncMock).toHaveBeenCalledWith('/test/repo/.git/orca/setup-runner.sh', 0o755)
@@ -1536,7 +1542,7 @@ describe('createIssueCommandRunnerScript', () => {
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         'C:\\repo\\.git\\orca\\issue-command-runner.sh',
-        '#!/usr/bin/env bash\nset -e\ngh issue view 42\n',
+        posixRunnerContent('gh issue view 42\n'),
         'utf-8'
       )
       expect(result.shell).toEqual({ family: 'posix' })

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -20,6 +20,7 @@ import { resolveWindowsGitBashShellPath } from './git-bash'
 import { gitExecFileSync, promptGuardShellEnv } from './git/runner'
 import { isWslPath, parseWslPath, toWindowsWslPath, toLinuxPath } from './wsl'
 import { addWorktreeSetupWslInteropEnv } from './pty/wsl-orca-env'
+import { getPosixRunnerFailureReportPrelude } from './setup-runner-failure-report'
 import type {
   HookCommandSourcePolicy,
   OrcaHooks,
@@ -495,7 +496,7 @@ export function buildPosixRunnerScript(script: string): string {
     ? `set ${shebang.shellOptions.join(' ')}\n`
     : ''
   const body = shebang ? stripLeadingShebangLine(script) : script
-  return `#!/usr/bin/env bash\nset -e\n${declaredOptions}${normalizeCrlfScriptLineEndings(body)}\n`
+  return `#!/usr/bin/env bash\nset -e\n${declaredOptions}${getPosixRunnerFailureReportPrelude()}${normalizeCrlfScriptLineEndings(body)}\n`
 }
 
 function normalizeCrlfScriptLineEndings(script: string): string {

--- a/src/main/setup-runner-failure-report.ts
+++ b/src/main/setup-runner-failure-report.ts
@@ -1,0 +1,31 @@
+/**
+ * Failure diagnostics injected into the POSIX setup/issue-command runner.
+ *
+ * Why: the runner is unattended automation that reads no shell startup file, so a tool installed by
+ * a version manager (mise, asdf, nvm, volta) can be absent here while it resolves in the user's own
+ * terminal. The shell then reports only `command not found`, which names neither the PATH the hook
+ * had nor the reason it differed. Print both on failure so the operator can act on the first run.
+ */
+
+const REPORT_FUNCTION_NAME = '__orca_report_runner_failure'
+
+const REPORT_MISSING_COMMAND = [
+  `printf 'Orca setup: that command is not on the PATH this script ran with:\\n%s\\n' "$PATH" >&2`,
+  `printf 'Orca setup: this script runs without your interactive shell startup files, so a tool installed by a version manager (mise, asdf, nvm, volta) is found here only when its shim directory is on PATH.\\n' >&2`
+].join('; ')
+
+const REPORT_FUNCTION_BODY = [
+  'local status=$1',
+  'local failed_command=$2',
+  `printf 'Orca setup: command failed with status %s: %s\\n' "$status" "$failed_command" >&2`,
+  `if [ "$status" = 127 ]; then ${REPORT_MISSING_COMMAND}; fi`
+].join('; ')
+
+/**
+ * Bash prelude that reports the failing command, its status, and — for status 127 — the PATH the
+ * runner ran with. Kept to a single line so the shell's own `line N` errors still point at the
+ * user's script line, and emitted before the script so its `ERR` trap covers every line of it.
+ */
+export function getPosixRunnerFailureReportPrelude(): string {
+  return `${REPORT_FUNCTION_NAME}() { ${REPORT_FUNCTION_BODY}; }; trap '${REPORT_FUNCTION_NAME} "$?" "$BASH_COMMAND"' ERR\n`
+}

--- a/src/main/setup-runner-failure-report.ts
+++ b/src/main/setup-runner-failure-report.ts
@@ -8,6 +8,8 @@
  */
 
 const REPORT_FUNCTION_NAME = '__orca_report_runner_failure'
+const EXIT_FUNCTION_NAME = '__orca_report_runner_exit'
+const REPORTED_FLAG_NAME = '__orca_runner_failure_reported'
 
 const REPORT_MISSING_COMMAND = [
   `printf 'Orca setup: that command is not on the PATH this script ran with:\\n%s\\n' "$PATH" >&2`,
@@ -17,15 +19,35 @@ const REPORT_MISSING_COMMAND = [
 const REPORT_FUNCTION_BODY = [
   'local status=$1',
   'local failed_command=$2',
+  `${REPORTED_FLAG_NAME}=1`,
   `printf 'Orca setup: command failed with status %s: %s\\n' "$status" "$failed_command" >&2`,
   `if [ "$status" = 127 ]; then ${REPORT_MISSING_COMMAND}; fi`
+].join('; ')
+
+// Why: the ERR trap is not inherited by functions, so a script that wraps its work in one would
+// fail silently. `set -E` would inherit it but then reports a command substitution twice, once in
+// the subshell and once in the parent. The EXIT fallback instead reports whatever the ERR trap
+// missed, and the flag keeps every failure to a single report without errtrace.
+const EXIT_FUNCTION_BODY = [
+  'local status=$?',
+  `if [ "$status" != 0 ] && [ -z "\${${REPORTED_FLAG_NAME}:-}" ]; then ${REPORT_FUNCTION_NAME} "$status" "$BASH_COMMAND"; fi`
 ].join('; ')
 
 /**
  * Bash prelude that reports the failing command, its status, and — for status 127 — the PATH the
  * runner ran with. Kept to a single line so the shell's own `line N` errors still point at the
- * user's script line, and emitted before the script so its `ERR` trap covers every line of it.
+ * user's script line, and emitted before the script so its traps cover every line of it.
+ *
+ * Reports once per run and leaves the exit status untouched. Known limits: a script that installs
+ * its own `EXIT` trap replaces the fallback (top-level failures still report through `ERR`), and
+ * bash 3.2 names the trap rather than the command when a bare subshell is the only thing that
+ * fails.
  */
 export function getPosixRunnerFailureReportPrelude(): string {
-  return `${REPORT_FUNCTION_NAME}() { ${REPORT_FUNCTION_BODY}; }; trap '${REPORT_FUNCTION_NAME} "$?" "$BASH_COMMAND"' ERR\n`
+  return [
+    `${REPORT_FUNCTION_NAME}() { ${REPORT_FUNCTION_BODY}; }`,
+    `trap '${REPORT_FUNCTION_NAME} "$?" "$BASH_COMMAND"' ERR`,
+    `${EXIT_FUNCTION_NAME}() { ${EXIT_FUNCTION_BODY}; }`,
+    `trap ${EXIT_FUNCTION_NAME} EXIT\n`
+  ].join('; ')
 }


### PR DESCRIPTION
## What changes

A POSIX setup (or issue-command) runner that fails now says which command failed and, when the
command was not found, which `PATH` it ran with.

## Why

A setup hook is unattended automation: the runner is launched as `bash <runner>` and reads no shell
startup file. A tool installed by a version manager therefore can be missing inside the hook while
it resolves without trouble in the user's own terminal, and today the only output is the shell's own
`command not found`. That message names neither the `PATH` the hook had nor the reason it differed
from the terminal, so the operator cannot act on it.

Reported in #13688, which also maps every environment a setup hook can run in and lists the wider
discovery gaps. This PR takes only the smallest part: making the failure legible. It changes no
`PATH` and no exit status.

## Evidence

Before, on a machine whose toolchain is pinned with mise (`eval "$(mise activate zsh)"` in
`~/.zshrc`, `bun` at `~/.local/share/mise/shims/bun`), a hook of `bun install` in an environment
without the interactive startup files:

```text
zsh:3: command not found: bun
zsh:4: command not found: bun
```

After, the same failure through the generated runner:

```console
$ env -i HOME=$HOME PATH=/usr/bin:/bin:/usr/sbin:/sbin bash setup-runner.sh
setup-runner.sh: line 6: bun: command not found
Orca setup: command failed with status 127: bun install
Orca setup: that command is not on the PATH this script ran with:
/usr/bin:/bin:/usr/sbin:/sbin
Orca setup: this script runs without your interactive shell startup files, so a tool installed by a version manager (mise, asdf, nvm, volta) is found here only when its shim directory is on PATH.
$ echo $?
127
```

## Compatibility

- **POSIX only.** The Windows `.cmd` runner (`buildWindowsRunnerScript`) is untouched, as is the
  WSL branch, which runs the same POSIX runner and so gets the same report.
- **Exit status is preserved.** An `ERR` trap does not change the status, and `set -e` still aborts
  at the failing line; the runner exits 127 exactly as before.
- **Shebang options still replay.** The trap is installed after any `set -euo pipefail` the script's
  own `#!` line declared, so it runs under the options the author asked for.
- **The prelude is a single line**, so the line numbers bash prints for the user's script move by
  one, not by the height of the prelude.
- Output appears only on failure; a successful runner prints nothing extra (covered by a test).
- The same runner builder serves issue commands, which get the identical report.

## Test plan

- `pnpm vitest run src/main/hooks-runner.test.ts src/main/hooks.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts` — 1423 passed, 1 skipped.
  Two new real-`bash` cases in `hooks-runner.test.ts`: a missing command reports status 127, the
  command text, and the `PATH`, and stops before the next line; a succeeding script prints no
  `Orca setup:` line.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- Manual: generated the runner for a mise-pinned `bun install` script and ran it under
  `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin`, output above.
