### PR TITLE
fix(terminal): open WSL UNC links with Windows path form

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -58,16 +58,19 @@ export function mapTerminalFilePath(
   worktreePath: string,
   wslDistro?: string | null
 ): string {
+  // Why: //wsl.localhost/... and \\wsl.localhost\... are the same file. Keep the
+  // backslash form so open tabs and file watchers match the Files sidebar (#13349).
+  const alreadyUnc = parseWslUncPath(filePath)
+  if (alreadyUnc) {
+    return toWindowsWslPath(alreadyUnc.linuxPath, alreadyUnc.distro)
+  }
   const distro = wslDistro?.trim() || parseWslUncPath(worktreePath)?.distro
-  if (!distro || !filePath.startsWith('/') || filePath.startsWith('//')) {
+  if (!distro || !filePath.startsWith('/')) {
     return filePath
   }
   // Why: /mnt/<drive> is a Windows drive mounted into WSL — reach it directly
   // instead of routing a native file back through the 9P share.
-  if (/^\/mnt\/[a-z](\/|$)/.test(filePath)) {
-    return toWindowsWslPath(filePath, distro)
-  }
-  return `//wsl.localhost/${distro}${filePath}`
+  return toWindowsWslPath(filePath, distro)
 }
 
 // Why: remote-runtime panes print the remote host's POSIX paths; the local WSL

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -785,17 +785,17 @@ describe('handleOscLink', () => {
     await flushDoubleRaf()
 
     expect(authorizeExternalPathMock).toHaveBeenCalledWith({
-      targetPath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      targetPath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     })
     expect(openFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+        filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
       }),
       { forceContentReload: true }
     )
     expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
-      fileId: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
+      fileId: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
       line: 5,
       column: 3,
       matchLength: 0
@@ -817,17 +817,17 @@ describe('handleOscLink', () => {
     await flushDoubleRaf()
 
     expect(authorizeExternalPathMock).toHaveBeenCalledWith({
-      targetPath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      targetPath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     })
     expect(openFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+        filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
       }),
       { forceContentReload: true }
     )
     expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
-      fileId: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
+      fileId: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
       line: 5,
       column: 3,
       matchLength: 0
@@ -1666,7 +1666,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
         runtimeEnvironmentId: null,
         pathExistsCache: new Map([
-          ['active\0//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md', true]
+          ['active\0\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md', true]
         ])
       }
     )
@@ -1675,17 +1675,17 @@ describe('createFilePathLinkProvider range bounds', () => {
 
     expect(opened).toBe(true)
     expect(statMock).toHaveBeenCalledWith({
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     })
     expect(openFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+        filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
       }),
       { forceContentReload: true }
     )
     expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
-      fileId: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
+      fileId: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
       line: 5,
       column: 3,
       matchLength: 0
@@ -1873,7 +1873,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     ['modern', '\\\\wsl.localhost\\Ubuntu\\home\\repo'],
     ['legacy', '\\\\wsl$\\Ubuntu\\home\\repo']
   ])('maps POSIX terminal links for a %s WSL worktree', async (_label, worktreePath) => {
-    const mappedPath = '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    const mappedPath = '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     vi.mocked(window.api.shell.pathExists).mockImplementation(
       async (pathValue) => pathValue === mappedPath
     )
@@ -1912,7 +1912,7 @@ describe('createFilePathLinkProvider range bounds', () => {
   })
 
   it('resolves relative POSIX terminal links against the pane cwd before mapping', async () => {
-    const mappedPath = '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    const mappedPath = '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     vi.mocked(window.api.shell.pathExists).mockImplementation(
       async (pathValue) => pathValue === mappedPath
     )
@@ -1930,10 +1930,16 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(window.api.shell.pathExists).toHaveBeenCalledWith(mappedPath)
   })
 
-  it('preserves existing UNC and native paths', () => {
+  it('canonicalizes WSL UNC to the Windows backslash form', () => {
     expect(
       mapTerminalFilePath('//wsl.localhost/Ubuntu/root/file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
-    ).toBe('//wsl.localhost/Ubuntu/root/file.md')
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\root\\file.md')
+    expect(
+      mapTerminalFilePath(
+        '\\\\wsl.localhost\\Ubuntu\\root\\file.md',
+        '\\\\wsl.localhost\\Ubuntu\\repo'
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\root\\file.md')
     expect(
       mapTerminalFilePath('\\\\server\\share\\file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
     ).toBe('\\\\server\\share\\file.md')
@@ -1949,7 +1955,7 @@ describe('createFilePathLinkProvider range bounds', () => {
 
   it('maps POSIX paths with the pane WSL distro when the worktree is on a Windows drive', () => {
     expect(mapTerminalFilePath('/home/alice/notes.md', 'C:\\repo', 'Ubuntu')).toBe(
-      '//wsl.localhost/Ubuntu/home/alice/notes.md'
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\notes.md'
     )
     expect(mapTerminalFilePath('/mnt/c/repo/README.md', 'C:\\repo', 'Ubuntu')).toBe(
       'C:\\repo\\README.md'


### PR DESCRIPTION
## Summary
- Terminal links like `//wsl.localhost/Ubuntu/...` opened files under a different path string than the Files sidebar (`\\wsl.localhost\Ubuntu\...`).
- File-change watchers and open-tab identity use the stored path, so the forward-slash form stayed stale after edits.
- Canonicalize WSL UNC (both `//` and `\\` inputs) to the Windows backslash form when mapping terminal paths so open + watch match the sidebar.

## Test plan
- [x] `terminal-link-handlers` tests (98)
- [ ] Manual on Windows: click `//wsl.localhost/...` terminal link, edit file in WSL, editor should refresh

Fixes #13349