### PR TITLE
feat(workspaces): review preserved branches after bulk delete

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -141,6 +141,7 @@ import {
   registerSshProviderRequestAbort
 } from '../ssh/ssh-provider-authority'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
+import { preservedBranchCleanupScopeKey } from '../../shared/preserved-branch-cleanup'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -521,15 +522,18 @@ type WorktreeRemovalInFlight = {
 }
 
 type PreservedBranchCleanupTarget = {
+  worktreeId: string
+  hostId: ExecutionHostId
   branchName: string
   head: string
   pushTarget?: GitPushTarget
 }
 
-const preservedBranchCleanupByWorktreeId = new Map<string, PreservedBranchCleanupTarget>()
+const preservedBranchCleanupByScope = new Map<string, PreservedBranchCleanupTarget>()
 
 function rememberPreservedBranchCleanupTarget(
   worktreeId: string,
+  hostId: ExecutionHostId,
   result: RemoveWorktreeResult | undefined,
   fallbackHead: string | undefined,
   pushTarget: GitPushTarget | undefined
@@ -541,14 +545,16 @@ function rememberPreservedBranchCleanupTarget(
         `Cannot safely offer force-delete for preserved branch "${result.preservedBranch.branchName}" without its saved commit.`
       )
     }
-    preservedBranchCleanupByWorktreeId.set(worktreeId, {
+    preservedBranchCleanupByScope.set(preservedBranchCleanupScopeKey({ worktreeId, hostId }), {
+      worktreeId,
+      hostId,
       branchName: result.preservedBranch.branchName,
       head,
       ...(pushTarget ? { pushTarget } : {})
     })
     return
   }
-  preservedBranchCleanupByWorktreeId.delete(worktreeId)
+  preservedBranchCleanupByScope.delete(preservedBranchCleanupScopeKey({ worktreeId, hostId }))
 }
 
 function preserveBranchHeadFallback(
@@ -570,9 +576,21 @@ function preserveBranchHeadFallback(
 function getPreservedBranchCleanupTarget(
   worktreeId: string,
   branchName: string,
-  expectedHead: string
+  expectedHead: string,
+  hostId?: ExecutionHostId
 ): PreservedBranchCleanupTarget {
-  const target = preservedBranchCleanupByWorktreeId.get(worktreeId)
+  const exactTarget = hostId
+    ? preservedBranchCleanupByScope.get(preservedBranchCleanupScopeKey({ worktreeId, hostId }))
+    : undefined
+  const legacyMatches = hostId
+    ? []
+    : [...preservedBranchCleanupByScope.values()].filter(
+        (target) =>
+          target.worktreeId === worktreeId &&
+          target.branchName === branchName &&
+          target.head === expectedHead
+      )
+  const target = exactTarget ?? (legacyMatches.length === 1 ? legacyMatches[0] : undefined)
   if (!target || target.branchName !== branchName || target.head !== expectedHead) {
     throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
   }
@@ -2399,7 +2417,9 @@ export function registerWorktreeHandlers(
             await withWorktreeRemoveStageSpan('metadata_purge', 'folder', async () => {
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
             })
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+            preservedBranchCleanupByScope.delete(
+              preservedBranchCleanupScopeKey({ worktreeId: args.worktreeId, hostId: removalHostId })
+            )
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
           }
@@ -2508,7 +2528,12 @@ export function registerWorktreeHandlers(
               }
               runtime.clearOptimisticReconcileToken(args.worktreeId)
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+              preservedBranchCleanupByScope.delete(
+                preservedBranchCleanupScopeKey({
+                  worktreeId: args.worktreeId,
+                  hostId: removalHostId
+                })
+              )
               notifyWorktreesChanged(mainWindow, repoId)
               return {}
             }
@@ -2553,7 +2578,12 @@ export function registerWorktreeHandlers(
                 )
                 runtime.clearOptimisticReconcileToken(args.worktreeId)
                 removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-                preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+                preservedBranchCleanupByScope.delete(
+                  preservedBranchCleanupScopeKey({
+                    worktreeId: args.worktreeId,
+                    hostId: removalHostId
+                  })
+                )
                 invalidateAuthorizedRootsCache()
                 notifyWorktreesChanged(mainWindow, repoId)
                 return {}
@@ -2585,7 +2615,12 @@ export function registerWorktreeHandlers(
               }
               runtime.clearOptimisticReconcileToken(args.worktreeId)
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+              preservedBranchCleanupByScope.delete(
+                preservedBranchCleanupScopeKey({
+                  worktreeId: args.worktreeId,
+                  hostId: removalHostId
+                })
+              )
               notifyWorktreesChanged(mainWindow, repoId)
               return {}
             }
@@ -2633,6 +2668,7 @@ export function registerWorktreeHandlers(
             )
             rememberPreservedBranchCleanupTarget(
               args.worktreeId,
+              removalHostId,
               removalResult,
               registeredWorktree.head,
               removedPushTarget
@@ -2730,6 +2766,7 @@ export function registerWorktreeHandlers(
             )
             rememberPreservedBranchCleanupTarget(
               args.worktreeId,
+              removalHostId,
               removalResult,
               registeredWorktree.head,
               removedPushTarget
@@ -2883,7 +2920,12 @@ export function registerWorktreeHandlers(
                 )
                 runtime.clearOptimisticReconcileToken(args.worktreeId)
                 removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-                preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+                preservedBranchCleanupByScope.delete(
+                  preservedBranchCleanupScopeKey({
+                    worktreeId: args.worktreeId,
+                    hostId: removalHostId
+                  })
+                )
                 invalidateAuthorizedRootsCache()
                 notifyWorktreesChanged(mainWindow, repoId)
                 removalCompleted = true
@@ -2907,6 +2949,7 @@ export function registerWorktreeHandlers(
           )
           rememberPreservedBranchCleanupTarget(
             args.worktreeId,
+            removalHostId,
             removalResult,
             refreshedRegisteredWorktree.head,
             removedPushTarget
@@ -3010,7 +3053,17 @@ export function registerWorktreeHandlers(
         removeWorktreeMetadataAndTransientState(store, args.worktreeId, ownerHost?.id)
         // Why: cached roots outlive the forgotten workspace, so an ownerless path stays filesystem-authorized until a rebuild.
         invalidateAuthorizedRootsCache()
-        preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+        if (ownerHost?.id) {
+          preservedBranchCleanupByScope.delete(
+            preservedBranchCleanupScopeKey({ worktreeId: args.worktreeId, hostId: ownerHost.id })
+          )
+        } else {
+          for (const [key, target] of preservedBranchCleanupByScope) {
+            if (target.worktreeId === args.worktreeId) {
+              preservedBranchCleanupByScope.delete(key)
+            }
+          }
+        }
         notifyWorktreesChanged(mainWindow, repoId)
         return {}
       })()
@@ -3029,15 +3082,21 @@ export function registerWorktreeHandlers(
     'worktrees:forceDeletePreservedBranch',
     async (
       _event,
-      args: { worktreeId: string; branchName: string; expectedHead: string }
+      args: {
+        worktreeId: string
+        branchName: string
+        expectedHead: string
+        hostId?: ExecutionHostId
+      }
     ): Promise<ForceDeleteWorktreeBranchResult> => {
       const { repoId } = parseWorktreeId(args.worktreeId)
       const cleanupTarget = getPreservedBranchCleanupTarget(
         args.worktreeId,
         args.branchName,
-        args.expectedHead
+        args.expectedHead,
+        args.hostId
       )
-      const repo = store.getRepo(repoId)
+      const repo = getRepoForWorktreeRemoval(store, repoId, cleanupTarget.hostId)
       if (!repo) {
         throw new Error(`Repo not found: ${repoId}`)
       }
@@ -3080,7 +3139,12 @@ export function registerWorktreeHandlers(
         )
       }
 
-      preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+      preservedBranchCleanupByScope.delete(
+        preservedBranchCleanupScopeKey({
+          worktreeId: args.worktreeId,
+          hostId: cleanupTarget.hostId
+        })
+      )
       return { deleted: true }
     }
   )

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -248,6 +248,7 @@ import {
   toSshExecutionHostId,
   type ExecutionHostId
 } from '../../shared/execution-host'
+import { preservedBranchCleanupScopeKey } from '../../shared/preserved-branch-cleanup'
 import { getRegisteredSshState } from '../ipc/ssh'
 import type {
   AgentProviderSessionMetadata,
@@ -2111,6 +2112,8 @@ type RuntimeWorktreeRemovalInFlight = {
 }
 
 type PreservedBranchCleanupTarget = {
+  worktreeId: string
+  hostId?: ExecutionHostId
   branchName: string
   head: string
   pushTarget?: GitPushTarget
@@ -3174,7 +3177,7 @@ export class OrcaRuntimeService {
   private canonicalFetchKeyCache = new Map<string, string>()
   private optimisticReconcileTokens = new Map<string, string>()
   private removeManagedWorktreeInFlight = new Map<string, RuntimeWorktreeRemovalInFlight>()
-  private preservedBranchCleanupByWorktreeId = new Map<string, PreservedBranchCleanupTarget>()
+  private preservedBranchCleanupByScope = new Map<string, PreservedBranchCleanupTarget>()
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private readonly getSshProviderFn: ((connectionId: string) => IPtyProvider | undefined) | null
   private readonly onPtyStopped: ((ptyId: string) => void) | null
@@ -24051,6 +24054,7 @@ export class OrcaRuntimeService {
 
   private rememberPreservedBranchCleanupTarget(
     worktreeId: string,
+    hostId: ExecutionHostId | undefined,
     result: RemoveWorktreeResult | undefined,
     fallbackHead: string | undefined,
     pushTarget: GitPushTarget | undefined
@@ -24062,14 +24066,21 @@ export class OrcaRuntimeService {
           `Cannot safely offer force-delete for preserved branch "${result.preservedBranch.branchName}" without its saved commit.`
         )
       }
-      this.preservedBranchCleanupByWorktreeId.set(worktreeId, {
-        branchName: result.preservedBranch.branchName,
-        head,
-        ...(pushTarget ? { pushTarget } : {})
-      })
+      this.preservedBranchCleanupByScope.set(
+        preservedBranchCleanupScopeKey({ worktreeId, hostId }),
+        {
+          worktreeId,
+          ...(hostId ? { hostId } : {}),
+          branchName: result.preservedBranch.branchName,
+          head,
+          ...(pushTarget ? { pushTarget } : {})
+        }
+      )
       return
     }
-    this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+    this.preservedBranchCleanupByScope.delete(
+      preservedBranchCleanupScopeKey({ worktreeId, hostId })
+    )
   }
 
   private preserveBranchHeadFallback(
@@ -24091,15 +24102,29 @@ export class OrcaRuntimeService {
   async forceDeletePreservedBranch(
     worktreeSelector: string,
     branchName: string,
-    expectedHead: string
+    expectedHead: string,
+    hostId?: string
   ): Promise<ForceDeleteWorktreeBranchResult> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
     const removalTarget = parseExactWorktreeIdSelector(worktreeSelector)
-    const cleanupTarget = removalTarget
-      ? this.preservedBranchCleanupByWorktreeId.get(removalTarget.id)
+    const normalizedHostId = parseExecutionHostId(hostId)?.id
+    const exactTarget = removalTarget
+      ? this.preservedBranchCleanupByScope.get(
+          preservedBranchCleanupScopeKey({ worktreeId: removalTarget.id, hostId: normalizedHostId })
+        )
       : undefined
+    const legacyMatches =
+      removalTarget && !hostId
+        ? [...this.preservedBranchCleanupByScope.values()].filter(
+            (target) =>
+              target.worktreeId === removalTarget.id &&
+              target.branchName === branchName &&
+              target.head === expectedHead
+          )
+        : []
+    const cleanupTarget = exactTarget ?? (legacyMatches.length === 1 ? legacyMatches[0] : undefined)
     if (
       !removalTarget ||
       !cleanupTarget ||
@@ -24153,7 +24178,12 @@ export class OrcaRuntimeService {
       )
     }
 
-    this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+    this.preservedBranchCleanupByScope.delete(
+      preservedBranchCleanupScopeKey({
+        worktreeId: removalTarget.id,
+        hostId: cleanupTarget.hostId
+      })
+    )
     return { deleted: true }
   }
 
@@ -24163,13 +24193,19 @@ export class OrcaRuntimeService {
     runHooks = false,
     // Why (#11960): only an explicit Force Delete waives PTY-stop proof; `force`
     // alone is already set by the ordinary delete confirmation.
-    allowUnverifiedPtyStop = false
+    allowUnverifiedPtyStop = false,
+    hostId?: string
   ): Promise<RemoveWorktreeResult & { warning?: string }> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
     const store = this.store
+    const cleanupHostId = parseExecutionHostId(hostId)?.id
     const removalTarget = await this.resolveWorktreeRemovalTarget(worktreeSelector)
+    const cleanupScopeKey = preservedBranchCleanupScopeKey({
+      worktreeId: removalTarget.id,
+      hostId: cleanupHostId
+    })
     const optionsKey = getRuntimeWorktreeRemovalOptionsKey(force, runHooks, allowUnverifiedPtyStop)
     const inFlightRemoval = this.removeManagedWorktreeInFlight.get(removalTarget.id)
     if (inFlightRemoval) {
@@ -24233,7 +24269,7 @@ export class OrcaRuntimeService {
           }
           this.clearOptimisticReconcileToken(removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-          this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+          this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
           this.invalidateResolvedWorktreeCache()
           this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
           invalidateAuthorizedRootsCache()
@@ -24276,7 +24312,7 @@ export class OrcaRuntimeService {
             })
           }
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-          this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+          this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
           this.invalidateResolvedWorktreeCache()
           this.notifyWorktreesChanged(repo.id)
           return {}
@@ -24381,7 +24417,7 @@ export class OrcaRuntimeService {
             }
             this.clearOptimisticReconcileToken(removalTarget.id)
             this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-            this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+            this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
             this.invalidateResolvedWorktreeCache()
             this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
             invalidateAuthorizedRootsCache()
@@ -24430,7 +24466,7 @@ export class OrcaRuntimeService {
               )
               this.clearOptimisticReconcileToken(removalTarget.id)
               this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-              this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+              this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
               this.invalidateResolvedWorktreeCache()
               this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
               invalidateAuthorizedRootsCache()
@@ -24466,7 +24502,7 @@ export class OrcaRuntimeService {
                 ))
             this.clearOptimisticReconcileToken(removalTarget.id)
             this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-            this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+            this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
             this.invalidateResolvedWorktreeCache()
             this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
             invalidateAuthorizedRootsCache()
@@ -24513,6 +24549,7 @@ export class OrcaRuntimeService {
           )
           this.rememberPreservedBranchCleanupTarget(
             removalTarget.id,
+            cleanupHostId,
             removalResult,
             registeredWorktree.head,
             removedPushTarget
@@ -24558,6 +24595,7 @@ export class OrcaRuntimeService {
           )
           this.rememberPreservedBranchCleanupTarget(
             removalTarget.id,
+            cleanupHostId,
             removalResult,
             registeredWorktree.head,
             removedPushTarget
@@ -24720,7 +24758,7 @@ export class OrcaRuntimeService {
               )
               this.clearOptimisticReconcileToken(removalTarget.id)
               this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-              this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+              this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
               this.invalidateResolvedWorktreeCache()
               this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
               invalidateAuthorizedRootsCache()
@@ -24747,6 +24785,7 @@ export class OrcaRuntimeService {
         )
         this.rememberPreservedBranchCleanupTarget(
           removalTarget.id,
+          cleanupHostId,
           removalResult,
           refreshedRegisteredWorktree.head,
           removedPushTarget

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -275,6 +275,7 @@ export const WorktreeSet = WorktreeSelector.extend({
 })
 
 export const WorktreeRemove = WorktreeSelector.extend({
+  hostId: OptionalString,
   force: OptionalBoolean,
   // Why (#11960): the CLI's --force is an unambiguous force affordance, but the
   // desktop sets `force` for an ordinary confirmed delete too, so the PTY-stop
@@ -284,6 +285,7 @@ export const WorktreeRemove = WorktreeSelector.extend({
 })
 
 export const WorktreeForceDeleteBranch = WorktreeSelector.extend({
+  hostId: OptionalString,
   branchName: z
     .unknown()
     .transform((v) => (typeof v === 'string' ? v : ''))

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -275,7 +275,8 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         params.worktree,
         params.force === true,
         params.runHooks === true,
-        params.allowUnverifiedPtyStop === true
+        params.allowUnverifiedPtyStop === true,
+        params.hostId
       )
       return { removed: true, ...result }
     }
@@ -284,6 +285,11 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.forceDeleteBranch',
     params: WorktreeForceDeleteBranch,
     handler: async (params, { runtime }) =>
-      runtime.forceDeletePreservedBranch(params.worktree, params.branchName, params.expectedHead)
+      runtime.forceDeletePreservedBranch(
+        params.worktree,
+        params.branchName,
+        params.expectedHead,
+        params.hostId
+      )
   })
 ]

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -271,13 +271,15 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.rm',
     params: WorktreeRemove,
     handler: async (params, { runtime }) => {
-      const result = await runtime.removeManagedWorktree(
+      const removalArgs = [
         params.worktree,
         params.force === true,
         params.runHooks === true,
-        params.allowUnverifiedPtyStop === true,
-        params.hostId
-      )
+        params.allowUnverifiedPtyStop === true
+      ] as const
+      const result = params.hostId
+        ? await runtime.removeManagedWorktree(...removalArgs, params.hostId)
+        : await runtime.removeManagedWorktree(...removalArgs)
       return { removed: true, ...result }
     }
   }),
@@ -285,11 +287,17 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.forceDeleteBranch',
     params: WorktreeForceDeleteBranch,
     handler: async (params, { runtime }) =>
-      runtime.forceDeletePreservedBranch(
-        params.worktree,
-        params.branchName,
-        params.expectedHead,
-        params.hostId
-      )
+      params.hostId
+        ? runtime.forceDeletePreservedBranch(
+            params.worktree,
+            params.branchName,
+            params.expectedHead,
+            params.hostId
+          )
+        : runtime.forceDeletePreservedBranch(
+            params.worktree,
+            params.branchName,
+            params.expectedHead
+          )
   })
 ]

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1482,6 +1482,7 @@ export type PreloadApi = {
       worktreeId: string
       branchName: string
       expectedHead: string
+      hostId?: ExecutionHostId
     }) => Promise<ForceDeleteWorktreeBranchResult>
     updateMeta: (args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => Promise<Worktree>
     listLineage: () => Promise<{

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -361,6 +361,9 @@ const AddProjectFromFolderDialog = lazy(
 )
 const ProjectAddedDialog = lazy(() => import('./components/sidebar/ProjectAddedDialog'))
 const DeleteWorktreeDialog = lazy(() => import('./components/sidebar/DeleteWorktreeDialog'))
+const PreservedBranchBatchReviewModal = lazy(
+  () => import('./components/sidebar/PreservedBranchBatchReviewModal')
+)
 const DictationController = lazy(() =>
   import('./components/dictation/DictationController').then((module) => ({
     default: module.DictationController
@@ -2701,6 +2704,16 @@ function App(): React.JSX.Element {
                   compact
                 >
                   <DeleteWorktreeDialog />
+                </RecoverableRenderErrorBoundary>
+              ) : null}
+              {activeModal === 'preserved-branch-review' ? (
+                <RecoverableRenderErrorBoundary
+                  boundaryId="modal.preserved-branch-review"
+                  surface="modal"
+                  resetKey
+                  compact
+                >
+                  <PreservedBranchBatchReviewModal />
                 </RecoverableRenderErrorBoundary>
               ) : null}
             </Suspense>

--- a/src/renderer/src/components/sidebar/PreservedBranchBatchReviewDialog.tsx
+++ b/src/renderer/src/components/sidebar/PreservedBranchBatchReviewDialog.tsx
@@ -15,15 +15,12 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { Label } from '../ui/label'
+import { preservedBranchCleanupKey } from '@/lib/preserved-branch-cleanup'
 
 type ActionablePreservedBranch = PreservedBranchCleanup & { expectedHead: string }
 
-function pluralize(count: number, singular: string, plural: string): string {
-  return count === 1 ? singular : plural
-}
-
 function selectionKey(branch: PreservedBranchCleanup): string {
-  return `${branch.worktreeId}\0${branch.branchName}\0${branch.expectedHead ?? ''}`
+  return preservedBranchCleanupKey(branch)
 }
 
 function getRepositoryLabel(branch: PreservedBranchCleanup): string {
@@ -80,13 +77,13 @@ export function PreservedBranchBatchReviewDialog({
         <DialogHeader>
           <DialogTitle className="text-sm">
             {translate(
-              'auto.components.sidebar.preservedBranchBatchReview.title',
+              'auto.components.sidebar.PreservedBranchBatchReviewDialog.c4bf8e7eaf',
               'Review kept branches'
             )}
           </DialogTitle>
           <DialogDescription>
             {translate(
-              'auto.components.sidebar.preservedBranchBatchReview.description',
+              'auto.components.sidebar.PreservedBranchBatchReviewDialog.f21976c9a8',
               'Select the local branches you want to force delete. Unselected branches stay in their repositories.'
             )}
           </DialogDescription>
@@ -103,13 +100,13 @@ export function PreservedBranchBatchReviewDialog({
                 }
               />
               {translate(
-                'auto.components.sidebar.preservedBranchBatchReview.selectAll',
+                'auto.components.sidebar.PreservedBranchBatchReviewDialog.38c947f7c5',
                 'Select all'
               )}
             </Label>
             <span className="text-[11px] tabular-nums text-muted-foreground">
               {translate(
-                'auto.components.sidebar.preservedBranchBatchReview.selectedCount',
+                'auto.components.sidebar.PreservedBranchBatchReviewDialog.9602129d38',
                 '{{value0}} of {{value1}} selected',
                 { value0: selectedBranches.length, value1: actionableBranches.length }
               )}
@@ -150,11 +147,11 @@ export function PreservedBranchBatchReviewDialog({
                   <span className="text-[11px] whitespace-nowrap text-muted-foreground">
                     {actionableBranch
                       ? translate(
-                          'auto.components.sidebar.preservedBranchBatchReview.mayBeUnmerged',
+                          'auto.components.sidebar.PreservedBranchBatchReviewDialog.ee39e872d5',
                           'May be unmerged'
                         )
                       : translate(
-                          'auto.components.sidebar.preservedBranchBatchReview.headUnavailable',
+                          'auto.components.sidebar.PreservedBranchBatchReviewDialog.676db406fd',
                           'Head unavailable'
                         )}
                   </span>
@@ -166,7 +163,10 @@ export function PreservedBranchBatchReviewDialog({
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            {translate('auto.components.sidebar.preservedBranchBatchReview.cancel', 'Cancel')}
+            {translate(
+              'auto.components.sidebar.PreservedBranchBatchReviewDialog.285e1e4882',
+              'Cancel'
+            )}
           </Button>
           <Button
             type="button"
@@ -176,12 +176,9 @@ export function PreservedBranchBatchReviewDialog({
           >
             <Trash2 />
             {translate(
-              'auto.components.sidebar.preservedBranchBatchReview.forceDeleteSelected',
-              'Force Delete {{value0}} {{value1}}',
-              {
-                value0: selectedBranches.length,
-                value1: pluralize(selectedBranches.length, 'Branch', 'Branches')
-              }
+              'auto.components.sidebar.PreservedBranchBatchReviewDialog.a0f9863597',
+              'Force Delete {{count}} Branches',
+              { count: selectedBranches.length }
             )}
           </Button>
         </DialogFooter>

--- a/src/renderer/src/components/sidebar/PreservedBranchBatchReviewDialog.tsx
+++ b/src/renderer/src/components/sidebar/PreservedBranchBatchReviewDialog.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import { translate } from '@/i18n/i18n'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+import { useAppStore } from '@/store'
+import { Button } from '../ui/button'
+import { Checkbox } from '../ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { Label } from '../ui/label'
+
+type ActionablePreservedBranch = PreservedBranchCleanup & { expectedHead: string }
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return count === 1 ? singular : plural
+}
+
+function selectionKey(branch: PreservedBranchCleanup): string {
+  return `${branch.worktreeId}\0${branch.branchName}\0${branch.expectedHead ?? ''}`
+}
+
+function getRepositoryLabel(branch: PreservedBranchCleanup): string {
+  const repoId = getRepoIdFromWorktreeId(branch.worktreeId)
+  return useAppStore.getState().repos?.find((repo) => repo.id === repoId)?.displayName || repoId
+}
+
+export function PreservedBranchBatchReviewDialog({
+  branches,
+  open,
+  onOpenChange,
+  onForceDelete
+}: {
+  branches: readonly PreservedBranchCleanup[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onForceDelete: (branches: readonly ActionablePreservedBranch[]) => void
+}): React.JSX.Element {
+  const actionableBranches = useMemo(
+    () =>
+      branches.filter((branch): branch is ActionablePreservedBranch =>
+        Boolean(branch.expectedHead)
+      ),
+    [branches]
+  )
+  const actionableKeys = useMemo(
+    () => actionableBranches.map((branch) => selectionKey(branch)),
+    [actionableBranches]
+  )
+  const [selectedKeys, setSelectedKeys] = useState<ReadonlySet<string>>(
+    () => new Set(actionableKeys)
+  )
+  const selectedBranches = actionableBranches.filter((branch) =>
+    selectedKeys.has(selectionKey(branch))
+  )
+  const allSelected = selectedBranches.length === actionableBranches.length
+  const someSelected = selectedBranches.length > 0 && !allSelected
+
+  const setBranchSelected = (branch: ActionablePreservedBranch, selected: boolean): void => {
+    setSelectedKeys((current) => {
+      const next = new Set(current)
+      if (selected) {
+        next.add(selectionKey(branch))
+      } else {
+        next.delete(selectionKey(branch))
+      }
+      return next
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-sm">
+            {translate(
+              'auto.components.sidebar.preservedBranchBatchReview.title',
+              'Review kept branches'
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {translate(
+              'auto.components.sidebar.preservedBranchBatchReview.description',
+              'Select the local branches you want to force delete. Unselected branches stay in their repositories.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-72 overflow-y-auto scrollbar-sleek rounded-md border border-border/70 bg-muted/35 text-xs">
+          <div className="sticky top-0 z-10 flex min-h-9 items-center justify-between gap-3 border-b border-border/70 bg-background/95 px-3 backdrop-blur-sm">
+            <Label htmlFor="preserved-branch-select-all" className="gap-2 text-xs">
+              <Checkbox
+                id="preserved-branch-select-all"
+                checked={someSelected ? 'indeterminate' : allSelected}
+                onCheckedChange={(checked) =>
+                  setSelectedKeys(checked === true ? new Set(actionableKeys) : new Set())
+                }
+              />
+              {translate(
+                'auto.components.sidebar.preservedBranchBatchReview.selectAll',
+                'Select all'
+              )}
+            </Label>
+            <span className="text-[11px] tabular-nums text-muted-foreground">
+              {translate(
+                'auto.components.sidebar.preservedBranchBatchReview.selectedCount',
+                '{{value0}} of {{value1}} selected',
+                { value0: selectedBranches.length, value1: actionableBranches.length }
+              )}
+            </span>
+          </div>
+
+          <ul className="px-3">
+            {branches.map((branch, index) => {
+              const actionableBranch = branch.expectedHead
+                ? (branch as ActionablePreservedBranch)
+                : null
+              const branchKey = selectionKey(branch)
+              const checkboxId = `preserved-branch-${index}`
+              return (
+                <li
+                  key={branchKey}
+                  className="grid min-h-11 grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 border-b border-border/50 py-1.5 last:border-0"
+                >
+                  <Checkbox
+                    id={checkboxId}
+                    checked={actionableBranch ? selectedKeys.has(branchKey) : false}
+                    disabled={!actionableBranch}
+                    onCheckedChange={(checked) => {
+                      if (actionableBranch) {
+                        setBranchSelected(actionableBranch, checked === true)
+                      }
+                    }}
+                  />
+                  <Label htmlFor={checkboxId} className="block min-w-0 cursor-pointer leading-snug">
+                    <span className="block break-all font-mono font-medium text-foreground">
+                      {branch.branchName}
+                    </span>
+                    <span className="mt-0.5 block break-all text-[11px] text-muted-foreground">
+                      {getRepositoryLabel(branch)}
+                      {branch.expectedHead ? ` · ${branch.expectedHead.slice(0, 7)}` : ''}
+                    </span>
+                  </Label>
+                  <span className="text-[11px] whitespace-nowrap text-muted-foreground">
+                    {actionableBranch
+                      ? translate(
+                          'auto.components.sidebar.preservedBranchBatchReview.mayBeUnmerged',
+                          'May be unmerged'
+                        )
+                      : translate(
+                          'auto.components.sidebar.preservedBranchBatchReview.headUnavailable',
+                          'Head unavailable'
+                        )}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {translate('auto.components.sidebar.preservedBranchBatchReview.cancel', 'Cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={selectedBranches.length === 0}
+            onClick={() => onForceDelete(selectedBranches)}
+          >
+            <Trash2 />
+            {translate(
+              'auto.components.sidebar.preservedBranchBatchReview.forceDeleteSelected',
+              'Force Delete {{value0}} {{value1}}',
+              {
+                value0: selectedBranches.length,
+                value1: pluralize(selectedBranches.length, 'Branch', 'Branches')
+              }
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/sidebar/PreservedBranchBatchReviewModal.tsx
+++ b/src/renderer/src/components/sidebar/PreservedBranchBatchReviewModal.tsx
@@ -15,7 +15,9 @@ function isPreservedBranchCleanup(value: unknown): value is PreservedBranchClean
   return (
     typeof branch.worktreeId === 'string' &&
     typeof branch.branchName === 'string' &&
-    (branch.expectedHead === undefined || typeof branch.expectedHead === 'string')
+    (branch.expectedHead === undefined || typeof branch.expectedHead === 'string') &&
+    (branch.hostId === undefined || typeof branch.hostId === 'string') &&
+    (branch.runtimeEnvironmentId === undefined || typeof branch.runtimeEnvironmentId === 'string')
   )
 }
 

--- a/src/renderer/src/components/sidebar/PreservedBranchBatchReviewModal.tsx
+++ b/src/renderer/src/components/sidebar/PreservedBranchBatchReviewModal.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+import { useAppStore } from '@/store'
+import { PreservedBranchBatchReviewDialog } from './PreservedBranchBatchReviewDialog'
+import {
+  forceDeletePreservedBranchBatch,
+  type ActionablePreservedBranch
+} from './preserved-branch-batch-toast'
+
+function isPreservedBranchCleanup(value: unknown): value is PreservedBranchCleanup {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const branch = value as Partial<PreservedBranchCleanup>
+  return (
+    typeof branch.worktreeId === 'string' &&
+    typeof branch.branchName === 'string' &&
+    (branch.expectedHead === undefined || typeof branch.expectedHead === 'string')
+  )
+}
+
+function getModalBranches(value: unknown): PreservedBranchCleanup[] {
+  return Array.isArray(value) ? value.filter(isPreservedBranchCleanup) : []
+}
+
+export default function PreservedBranchBatchReviewModal(): React.JSX.Element {
+  const activeModal = useAppStore((state) => state.activeModal)
+  const modalData = useAppStore((state) => state.modalData)
+  const closeModal = useAppStore((state) => state.closeModal)
+  const branches = useMemo(() => getModalBranches(modalData.branches), [modalData.branches])
+  const open = activeModal === 'preserved-branch-review' && branches.length > 0
+
+  const handleForceDelete = (selectedBranches: readonly ActionablePreservedBranch[]): void => {
+    closeModal()
+    void forceDeletePreservedBranchBatch(selectedBranches)
+  }
+
+  return (
+    <PreservedBranchBatchReviewDialog
+      branches={branches}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          closeModal()
+        }
+      }}
+      onForceDelete={handleForceDelete}
+    />
+  )
+}

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -224,7 +224,11 @@ describe('delete worktree flow', () => {
     )
 
     const deletion = runWorktreeDeletesInParallel(targets)
-    await vi.waitFor(() => expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false))
+    await vi.waitFor(() =>
+      expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false, {
+        suppressPreservedBranchToast: true
+      })
+    )
     setWorktrees([
       { id: 'wt-1', instanceId: 'instance-1', path: '/workspaces/first-longer' },
       { id: 'wt-2', instanceId: 'replacement-instance', path: '/workspaces/second' }
@@ -232,7 +236,9 @@ describe('delete worktree flow', () => {
     finishFirst({ ok: true })
 
     await expect(deletion).resolves.toEqual(['wt-1'])
-    expect(mocks.state.removeWorktree).not.toHaveBeenCalledWith('wt-2', false)
+    expect(mocks.state.removeWorktree).not.toHaveBeenCalledWith('wt-2', false, {
+      suppressPreservedBranchToast: true
+    })
     expect(toast.info).toHaveBeenCalledWith(
       'Workspace list changed',
       expect.objectContaining({

--- a/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
@@ -46,8 +46,13 @@ vi.mock('sonner', () => ({
   }
 }))
 
+vi.mock('./preserved-branch-batch-toast', () => ({
+  showPreservedBranchBatchToast: vi.fn()
+}))
+
 import { toast } from 'sonner'
 import { runWorktreeDeletesInParallel } from './delete-worktree-flow'
+import { showPreservedBranchBatchToast } from './preserved-branch-batch-toast'
 
 function runDeletesForCurrentWorktrees(
   targets: Parameters<typeof runWorktreeDeletesInParallel>[0],
@@ -70,13 +75,14 @@ function deferredDeleteResult(): {
 
 describe('runWorktreeDeletesInParallel', () => {
   beforeEach(() => {
-    mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
+    mocks.state.removeWorktree.mockReset().mockResolvedValue({ ok: true })
     mocks.state.clearWorktreeDeleteState.mockClear()
     mocks.state.markWorktreesDeleting.mockClear()
     mocks.state.worktreeMap = new Map()
     mocks.state.deleteStateByWorktreeId = {}
     vi.mocked(toast.error).mockClear()
     vi.mocked(toast.info).mockClear()
+    vi.mocked(showPreservedBranchBatchToast).mockClear()
   })
 
   it('starts every selected delete before waiting for earlier deletes to finish', async () => {
@@ -92,8 +98,12 @@ describe('runWorktreeDeletesInParallel', () => {
     ])
 
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(2)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', false)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', false, {
+      suppressPreservedBranchToast: true
+    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', false, {
+      suppressPreservedBranchToast: true
+    })
     expect(mocks.state.markWorktreesDeleting).toHaveBeenCalledWith(['wt-1', 'wt-2'])
 
     second.resolve({ ok: true })
@@ -124,12 +134,16 @@ describe('runWorktreeDeletesInParallel', () => {
       canForceDelete: false
     })
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false, {
+      suppressPreservedBranchToast: true
+    })
 
     childDelete.resolve({ ok: true })
 
     await expect(deleted).resolves.toEqual(['parent', 'child'])
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false, {
+      suppressPreservedBranchToast: true
+    })
   })
 
   it('deletes nested workspaces before their parent within the same repo', async () => {
@@ -138,8 +152,12 @@ describe('runWorktreeDeletesInParallel', () => {
       { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
     ])
 
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false, {
+      suppressPreservedBranchToast: true
+    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false, {
+      suppressPreservedBranchToast: true
+    })
   })
 
   it('passes confirmed force to each delete', async () => {
@@ -151,8 +169,12 @@ describe('runWorktreeDeletesInParallel', () => {
       { force: true }
     )
 
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', true)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', true)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', true, {
+      suppressPreservedBranchToast: true
+    })
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', true, {
+      suppressPreservedBranchToast: true
+    })
   })
 
   it('deletes a duplicated target identity only once', async () => {
@@ -192,8 +214,35 @@ describe('runWorktreeDeletesInParallel', () => {
     ).resolves.toEqual([])
 
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false, {
+      suppressPreservedBranchToast: true
+    })
     expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('parent')
     expect(mocks.state.deleteStateByWorktreeId['parent']).toBeUndefined()
+  })
+
+  it('replaces per-workspace branch warnings with one batch result', async () => {
+    mocks.state.removeWorktree
+      .mockResolvedValueOnce({
+        ok: true,
+        preservedBranch: { branchName: 'feature/one', head: 'head-one' }
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        preservedBranch: { branchName: 'feature/two', head: 'head-two' }
+      })
+
+    await expect(
+      runDeletesForCurrentWorktrees([
+        { id: 'wt-1', displayName: 'one', repoId: 'repo-a', path: '/workspaces/one' },
+        { id: 'wt-2', displayName: 'two', repoId: 'repo-b', path: '/workspaces/two' }
+      ])
+    ).resolves.toEqual(['wt-1', 'wt-2'])
+
+    expect(showPreservedBranchBatchToast).toHaveBeenCalledOnce()
+    expect(showPreservedBranchBatchToast).toHaveBeenCalledWith(2, [
+      { worktreeId: 'wt-1', branchName: 'feature/one', expectedHead: 'head-one' },
+      { worktreeId: 'wt-2', branchName: 'feature/two', expectedHead: 'head-two' }
+    ])
   })
 })

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+import PreservedBranchBatchReviewModal from './PreservedBranchBatchReviewModal'
+import {
+  forceDeletePreservedBranchBatch,
+  showPreservedBranchBatchToast
+} from './preserved-branch-batch-toast'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    activeModal: 'none',
+    modalData: {} as Record<string, unknown>,
+    repos: [],
+    closeModal: vi.fn(),
+    openModal: vi.fn(),
+    forceDeletePreservedBranch: vi.fn()
+  }
+  return { state }
+})
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+    { getState: () => mocks.state }
+  )
+  return { useAppStore }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+const mountedRoots: Root[] = []
+
+function renderToastBody(): HTMLElement {
+  const description = vi.mocked(toast.warning).mock.calls.at(-1)?.[1]
+    ?.description as React.ReactElement
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  act(() => root.render(description))
+  return container
+}
+
+function renderReviewModal(branches: readonly PreservedBranchCleanup[]): void {
+  mocks.state.activeModal = 'preserved-branch-review'
+  mocks.state.modalData = { branches }
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  act(() => root.render(<PreservedBranchBatchReviewModal />))
+}
+
+async function clickButton(container: HTMLElement, label: string): Promise<void> {
+  const button = [...container.querySelectorAll('button')].find(
+    (element) => element.textContent?.trim() === label
+  )
+  if (!button) {
+    throw new Error(`button "${label}" not found`)
+  }
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await Promise.resolve()
+  })
+}
+
+async function clickCheckbox(id: string): Promise<void> {
+  const checkbox = document.getElementById(id)
+  if (!checkbox) {
+    throw new Error(`checkbox "${id}" not found`)
+  }
+  await act(async () => {
+    checkbox.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  mocks.state.activeModal = 'none'
+  mocks.state.modalData = {}
+  mocks.state.closeModal.mockReset()
+  mocks.state.openModal.mockReset()
+  mocks.state.forceDeletePreservedBranch.mockReset().mockResolvedValue({ ok: true, deleted: true })
+})
+
+afterEach(() => {
+  mountedRoots.splice(0).forEach((root) => act(() => root.unmount()))
+  document.body.innerHTML = ''
+  vi.clearAllMocks()
+})
+
+describe('showPreservedBranchBatchToast', () => {
+  it('explains disk cleanup and opens one review dialog for the batch', async () => {
+    const branches = [
+      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' },
+      { worktreeId: 'repo-b::two', branchName: 'feature/two', expectedHead: 'head-two' }
+    ]
+    showPreservedBranchBatchToast(12, branches)
+    const body = renderToastBody()
+
+    expect(toast.warning).toHaveBeenCalledWith(
+      '12 workspaces removed, 2 branches kept',
+      expect.objectContaining({ dismissible: true, duration: Infinity })
+    )
+    expect(body.textContent).toContain('Kept branches do not retain workspace folders')
+    expect(body.textContent).toContain('Orca may continue freeing workspace disk space')
+
+    await clickButton(body, 'Review 2 Branches')
+
+    expect(mocks.state.openModal).toHaveBeenCalledWith('preserved-branch-review', { branches })
+    expect(toast.dismiss).toHaveBeenCalledWith('preserved-branch-batch:repo-a::one:2')
+    expect(mocks.state.forceDeletePreservedBranch).not.toHaveBeenCalled()
+  })
+
+  it('force-deletes only the branches selected in review', async () => {
+    renderReviewModal([
+      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' },
+      { worktreeId: 'repo-b::two', branchName: 'feature/two', expectedHead: 'head-two' }
+    ])
+
+    expect(document.body.textContent).toContain('Review kept branches')
+    expect(document.body.textContent).toContain('2 of 2 selected')
+    await clickCheckbox('preserved-branch-1')
+    expect(document.body.textContent).toContain('1 of 2 selected')
+    expect(
+      document.getElementById('preserved-branch-select-all')?.querySelector('.lucide-minus')
+    ).not.toBeNull()
+    await clickButton(document.body, 'Force Delete 1 Branch')
+
+    expect(mocks.state.closeModal).toHaveBeenCalledOnce()
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledOnce()
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledWith(
+      'repo-a::one',
+      'feature/one',
+      'head-one',
+      { suppressToast: true }
+    )
+    expect(toast.success).toHaveBeenCalledWith('Local branches deleted: 1', {
+      id: 'force-delete-branch-batch:repo-a::one:1'
+    })
+  })
+
+  it('keeps older-server branches visible without offering an unsafe delete', () => {
+    showPreservedBranchBatchToast(3, [{ worktreeId: 'repo-a::one', branchName: 'feature/one' }])
+    const body = renderToastBody()
+
+    expect(body.querySelector('button')).toBeNull()
+    expect(toast.warning).toHaveBeenCalledWith(
+      '3 workspaces removed, 1 branch kept',
+      expect.not.objectContaining({ duration: Infinity })
+    )
+  })
+
+  it('serializes branch deletion within one repository', async () => {
+    let resolveFirst: (result: { ok: true; deleted: true }) => void = () => {}
+    mocks.state.forceDeletePreservedBranch
+      .mockReset()
+      .mockReturnValueOnce(
+        new Promise<{ ok: true; deleted: true }>((resolve) => {
+          resolveFirst = resolve
+        })
+      )
+      .mockResolvedValueOnce({ ok: true, deleted: true })
+    const deletion = forceDeletePreservedBranchBatch([
+      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' },
+      { worktreeId: 'repo-a::two', branchName: 'feature/two', expectedHead: 'head-two' }
+    ])
+
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledTimes(1)
+    resolveFirst({ ok: true, deleted: true })
+    await deletion
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows an unavailable branch without blocking review of actionable branches', async () => {
+    renderReviewModal([
+      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' },
+      { worktreeId: 'repo-b::two', branchName: 'feature/two' }
+    ])
+
+    expect(document.body.textContent).toContain('Head unavailable')
+    expect((document.getElementById('preserved-branch-1') as HTMLButtonElement).disabled).toBe(true)
+    await clickButton(document.body, 'Force Delete 1 Branch')
+
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledOnce()
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledWith(
+      'repo-a::one',
+      'feature/one',
+      'head-one',
+      { suppressToast: true }
+    )
+  })
+})

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
@@ -16,10 +16,6 @@ type PreservedBranchDeleteResult = {
   result: { ok: true; deleted: true } | { ok: false; error: string }
 }
 
-function pluralize(count: number, singular: string, plural: string): string {
-  return count === 1 ? singular : plural
-}
-
 function PreservedBranchBatchToastBody({
   branches,
   onReview
@@ -32,24 +28,18 @@ function PreservedBranchBatchToastBody({
     <div className="flex w-[300px] max-w-[calc(100vw-96px)] flex-col gap-3">
       <p className="min-w-0 break-words text-sm leading-5 text-popover-foreground/80">
         {translate(
-          'auto.components.sidebar.preservedBranchBatch.diskCopy',
-          'Git kept {{value0}} local {{value1}} because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.',
-          {
-            value0: branches.length,
-            value1: pluralize(branches.length, 'branch', 'branches')
-          }
+          'auto.components.sidebar.preserved.branch.batch.toast.a3cdd9d9e6',
+          'Git kept {{count}} local branches because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.',
+          { count: branches.length }
         )}
       </p>
       {actionableCount > 0 ? (
         <Button type="button" variant="destructive" size="sm" className="w-full" onClick={onReview}>
           <Trash2 className="size-3.5" />
           {translate(
-            'auto.components.sidebar.preservedBranchBatch.review',
-            'Review {{value0}} {{value1}}',
-            {
-              value0: actionableCount,
-              value1: pluralize(actionableCount, 'Branch', 'Branches')
-            }
+            'auto.components.sidebar.preserved.branch.batch.toast.6310412304',
+            'Review {{count}} Branches',
+            { count: actionableCount }
           )}
         </Button>
       ) : null}
@@ -66,6 +56,16 @@ export function showPreservedBranchBatchToast(
   }
   const actionableCount = branches.filter((branch) => branch.expectedHead).length
   const toastId = `preserved-branch-batch:${branches[0].worktreeId}:${branches.length}`
+  const removedWorkspaces = translate(
+    'auto.components.sidebar.preserved.branch.batch.toast.cea24c2b7d',
+    '{{count}} workspaces removed',
+    { count: workspaceCount }
+  )
+  const keptBranches = translate(
+    'auto.components.sidebar.preserved.branch.batch.toast.0e0379f24a',
+    '{{count}} branches kept',
+    { count: branches.length }
+  )
   const onReview = (): void => {
     useAppStore.getState().openModal('preserved-branch-review', { branches })
     toast.dismiss(toastId)
@@ -73,14 +73,9 @@ export function showPreservedBranchBatchToast(
 
   toast.warning(
     translate(
-      'auto.components.sidebar.preservedBranchBatch.title',
-      '{{value0}} {{value1}} removed, {{value2}} {{value3}} kept',
-      {
-        value0: workspaceCount,
-        value1: pluralize(workspaceCount, 'workspace', 'workspaces'),
-        value2: branches.length,
-        value3: pluralize(branches.length, 'branch', 'branches')
-      }
+      'auto.components.sidebar.preserved.branch.batch.toast.4cf75caab7',
+      '{{value0}}, {{value1}}',
+      { value0: removedWorkspaces, value1: keptBranches }
     ),
     {
       id: toastId,
@@ -100,7 +95,7 @@ export async function forceDeletePreservedBranchBatch(
   const progressToastId = `force-delete-branch-batch:${branches[0].worktreeId}:${branches.length}`
   toast.loading(
     translate(
-      'auto.components.sidebar.preservedBranchBatch.deleting',
+      'auto.components.sidebar.preserved.branch.batch.toast.e61d78054f',
       'Deleting local branches: {{value0}}',
       { value0: branches.length }
     ),
@@ -127,7 +122,11 @@ export async function forceDeletePreservedBranchBatch(
           result: await useAppStore
             .getState()
             .forceDeletePreservedBranch(branch.worktreeId, branch.branchName, branch.expectedHead, {
-              suppressToast: true
+              suppressToast: true,
+              ...(branch.hostId ? { hostId: branch.hostId } : {}),
+              ...(branch.runtimeEnvironmentId
+                ? { runtimeEnvironmentId: branch.runtimeEnvironmentId }
+                : {})
             })
         })
       }
@@ -139,7 +138,7 @@ export async function forceDeletePreservedBranchBatch(
   if (failures.length === 0) {
     toast.success(
       translate(
-        'auto.components.sidebar.preservedBranchBatch.deleted',
+        'auto.components.sidebar.preserved.branch.batch.toast.1e1a5f6763',
         'Local branches deleted: {{value0}}',
         { value0: branches.length }
       ),
@@ -155,7 +154,7 @@ export async function forceDeletePreservedBranchBatch(
   const failedBranches = failures.map(({ branch }) => branch)
   toast.error(
     translate(
-      'auto.components.sidebar.preservedBranchBatch.failed',
+      'auto.components.sidebar.preserved.branch.batch.toast.43d9395605',
       '{{value0}} deleted, {{value1}} not deleted',
       { value0: deletedCount, value1: failures.length }
     ),
@@ -177,12 +176,9 @@ export async function forceDeletePreservedBranchBatch(
           >
             <Trash2 className="size-3.5" />
             {translate(
-              'auto.components.sidebar.preservedBranchBatch.retry',
-              'Retry {{value0}} {{value1}}',
-              {
-                value0: failedBranches.length,
-                value1: pluralize(failedBranches.length, 'Branch', 'Branches')
-              }
+              'auto.components.sidebar.preserved.branch.batch.toast.d42f1f14e0',
+              'Retry {{count}} Branches',
+              { count: failedBranches.length }
             )}
           </Button>
         </div>

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
@@ -1,0 +1,194 @@
+import { Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import { Button } from '../ui/button'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+
+const BRANCH_REPO_DELETE_CONCURRENCY = 4
+
+export type ActionablePreservedBranch = PreservedBranchCleanup & { expectedHead: string }
+
+type PreservedBranchDeleteResult = {
+  branch: ActionablePreservedBranch
+  result: { ok: true; deleted: true } | { ok: false; error: string }
+}
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return count === 1 ? singular : plural
+}
+
+function PreservedBranchBatchToastBody({
+  branches,
+  onReview
+}: {
+  branches: readonly PreservedBranchCleanup[]
+  onReview: () => void
+}): React.JSX.Element {
+  const actionableCount = branches.filter((branch) => branch.expectedHead).length
+  return (
+    <div className="flex w-[300px] max-w-[calc(100vw-96px)] flex-col gap-3">
+      <p className="min-w-0 break-words text-sm leading-5 text-popover-foreground/80">
+        {translate(
+          'auto.components.sidebar.preservedBranchBatch.diskCopy',
+          'Git kept {{value0}} local {{value1}} because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.',
+          {
+            value0: branches.length,
+            value1: pluralize(branches.length, 'branch', 'branches')
+          }
+        )}
+      </p>
+      {actionableCount > 0 ? (
+        <Button type="button" variant="destructive" size="sm" className="w-full" onClick={onReview}>
+          <Trash2 className="size-3.5" />
+          {translate(
+            'auto.components.sidebar.preservedBranchBatch.review',
+            'Review {{value0}} {{value1}}',
+            {
+              value0: actionableCount,
+              value1: pluralize(actionableCount, 'Branch', 'Branches')
+            }
+          )}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+export function showPreservedBranchBatchToast(
+  workspaceCount: number,
+  branches: readonly PreservedBranchCleanup[]
+): void {
+  if (branches.length === 0) {
+    return
+  }
+  const actionableCount = branches.filter((branch) => branch.expectedHead).length
+  const toastId = `preserved-branch-batch:${branches[0].worktreeId}:${branches.length}`
+  const onReview = (): void => {
+    useAppStore.getState().openModal('preserved-branch-review', { branches })
+    toast.dismiss(toastId)
+  }
+
+  toast.warning(
+    translate(
+      'auto.components.sidebar.preservedBranchBatch.title',
+      '{{value0}} {{value1}} removed, {{value2}} {{value3}} kept',
+      {
+        value0: workspaceCount,
+        value1: pluralize(workspaceCount, 'workspace', 'workspaces'),
+        value2: branches.length,
+        value3: pluralize(branches.length, 'branch', 'branches')
+      }
+    ),
+    {
+      id: toastId,
+      description: <PreservedBranchBatchToastBody branches={branches} onReview={onReview} />,
+      dismissible: true,
+      ...(actionableCount > 0 ? { duration: Infinity } : {})
+    }
+  )
+}
+
+export async function forceDeletePreservedBranchBatch(
+  branches: readonly ActionablePreservedBranch[]
+): Promise<void> {
+  if (branches.length === 0) {
+    return
+  }
+  const progressToastId = `force-delete-branch-batch:${branches[0].worktreeId}:${branches.length}`
+  toast.loading(
+    translate(
+      'auto.components.sidebar.preservedBranchBatch.deleting',
+      'Deleting local branches: {{value0}}',
+      { value0: branches.length }
+    ),
+    { id: progressToastId }
+  )
+  const branchesByRepo = new Map<string, ActionablePreservedBranch[]>()
+  for (const branch of branches) {
+    const repoId = getRepoIdFromWorktreeId(branch.worktreeId)
+    const repoBranches = branchesByRepo.get(repoId)
+    if (repoBranches) {
+      repoBranches.push(branch)
+    } else {
+      branchesByRepo.set(repoId, [branch])
+    }
+  }
+  const groupResults = await mapWithConcurrency(
+    [...branchesByRepo.values()],
+    BRANCH_REPO_DELETE_CONCURRENCY,
+    async (repoBranches) => {
+      const results: PreservedBranchDeleteResult[] = []
+      for (const branch of repoBranches) {
+        results.push({
+          branch,
+          result: await useAppStore
+            .getState()
+            .forceDeletePreservedBranch(branch.worktreeId, branch.branchName, branch.expectedHead, {
+              suppressToast: true
+            })
+        })
+      }
+      return results
+    }
+  )
+  const results = groupResults.flat()
+  const failures = results.filter((result) => !result.result.ok)
+  if (failures.length === 0) {
+    toast.success(
+      translate(
+        'auto.components.sidebar.preservedBranchBatch.deleted',
+        'Local branches deleted: {{value0}}',
+        { value0: branches.length }
+      ),
+      { id: progressToastId }
+    )
+    return
+  }
+  const deletedCount = branches.length - failures.length
+  const description = failures
+    .map(({ branch, result }) => (result.ok ? '' : `${branch.branchName}: ${result.error}`))
+    .filter(Boolean)
+    .join('; ')
+  const failedBranches = failures.map(({ branch }) => branch)
+  toast.error(
+    translate(
+      'auto.components.sidebar.preservedBranchBatch.failed',
+      '{{value0}} deleted, {{value1}} not deleted',
+      { value0: deletedCount, value1: failures.length }
+    ),
+    {
+      id: progressToastId,
+      description: (
+        <div className="flex w-[300px] max-w-[calc(100vw-96px)] flex-col gap-3">
+          <p className="min-w-0 break-words text-sm leading-5 text-popover-foreground/80">
+            {description}
+          </p>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            className="w-full"
+            onClick={() => {
+              void forceDeletePreservedBranchBatch(failedBranches)
+            }}
+          >
+            <Trash2 className="size-3.5" />
+            {translate(
+              'auto.components.sidebar.preservedBranchBatch.retry',
+              'Retry {{value0}} {{value1}}',
+              {
+                value0: failedBranches.length,
+                value1: pluralize(failedBranches.length, 'Branch', 'Branches')
+              }
+            )}
+          </Button>
+        </div>
+      ),
+      duration: Infinity,
+      dismissible: true
+    }
+  )
+}

--- a/src/renderer/src/components/sidebar/preserved-branch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-toast.tsx
@@ -63,7 +63,7 @@ function PreservedBranchToastBody({
         <div className="flex min-w-0 overflow-hidden">
           <Button
             type="button"
-            variant="default"
+            variant="destructive"
             size="sm"
             className="w-full min-w-0"
             onClick={onForceDelete}

--- a/src/renderer/src/components/sidebar/worktree-delete-execution.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-execution.ts
@@ -135,7 +135,11 @@ export function runWorktreeDeleteWithToast(
           options.onPreservedBranch?.({
             worktreeId,
             branchName: result.preservedBranch.branchName,
-            expectedHead: result.preservedBranch.head
+            expectedHead: result.preservedBranch.head,
+            ...(result.preservedBranch.hostId ? { hostId: result.preservedBranch.hostId } : {}),
+            ...(result.preservedBranch.runtimeEnvironmentId
+              ? { runtimeEnvironmentId: result.preservedBranch.runtimeEnvironmentId }
+              : {})
           })
         }
         if (focusSuccessor) {

--- a/src/renderer/src/components/sidebar/worktree-delete-execution.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-execution.ts
@@ -11,6 +11,8 @@ import type { Worktree } from '../../../../shared/types'
 import { prepareActiveWorktreeFocusAfterDelete } from './active-worktree-focus-after-delete'
 import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
 import { showWorkspaceListChangedToast } from './stale-workspace-list-toast'
+import { showPreservedBranchBatchToast } from './preserved-branch-batch-toast'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
 import type { WorktreeDeleteWithToastOptions } from './worktree-delete-request'
 
 // A failed delete usually means unresolved changes, so land on the diff panel.
@@ -55,6 +57,8 @@ export async function runWorktreeDeletesInParallel(
     // Children must leave first or Git rejects their registered ancestor.
     group.sort((a, b) => b.path.length - a.path.length)
   }
+  const preservedBranches: PreservedBranchCleanup[] = []
+  const aggregatePreservedBranches = uniqueTargets.length > 1
   let listChanged = false
   const groupResults = await Promise.all(
     Array.from(groups.values()).map(async (group) => {
@@ -74,7 +78,12 @@ export async function runWorktreeDeletesInParallel(
         }
         const deleted = await runWorktreeDeleteWithToast(target.id, target.displayName, {
           ...options,
-          focusSuccessorOnDelete: false
+          focusSuccessorOnDelete: false,
+          suppressPreservedBranchToast: aggregatePreservedBranches,
+          onPreservedBranch: (branch) => {
+            preservedBranches.push(branch)
+            options.onPreservedBranch?.(branch)
+          }
         })
         if (deleted) {
           deletedInGroup.push(target.id)
@@ -94,6 +103,15 @@ export async function runWorktreeDeletesInParallel(
   if (activeWorktreeIdBefore && deletedSet.has(activeWorktreeIdBefore)) {
     commitBatchFocus?.()
   }
+  if (aggregatePreservedBranches && preservedBranches.length > 0) {
+    const targetOrder = new Map(uniqueTargets.map((target, index) => [target.id, index]))
+    preservedBranches.sort(
+      (left, right) =>
+        (targetOrder.get(left.worktreeId) ?? Number.MAX_SAFE_INTEGER) -
+        (targetOrder.get(right.worktreeId) ?? Number.MAX_SAFE_INTEGER)
+    )
+    showPreservedBranchBatchToast(deletedSet.size, preservedBranches)
+  }
   return uniqueTargets.filter((target) => deletedSet.has(target.id)).map((target) => target.id)
 }
 
@@ -107,9 +125,19 @@ export function runWorktreeDeleteWithToast(
   const commitFocus = prepareActiveWorktreeFocusAfterDelete(worktreeId)
   const focusSuccessor = options.focusSuccessorOnDelete !== false
 
-  return removeWorktree(worktreeId, options.force === true)
+  const removal = options.suppressPreservedBranchToast
+    ? removeWorktree(worktreeId, options.force === true, { suppressPreservedBranchToast: true })
+    : removeWorktree(worktreeId, options.force === true)
+  return removal
     .then((result) => {
       if (result.ok) {
+        if (result.preservedBranch) {
+          options.onPreservedBranch?.({
+            worktreeId,
+            branchName: result.preservedBranch.branchName,
+            expectedHead: result.preservedBranch.head
+          })
+        }
         if (focusSuccessor) {
           commitFocus()
         }

--- a/src/renderer/src/components/sidebar/worktree-delete-request.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-request.ts
@@ -1,4 +1,5 @@
 import type { Worktree } from '../../../../shared/types'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
 
 export type WorktreeBatchDeleteOptions = {
   forceConfirm?: boolean
@@ -14,6 +15,8 @@ export type WorktreeDeleteOptions = {
 export type WorktreeDeleteWithToastOptions = {
   force?: boolean
   onForceDeleted?: (worktreeId: string) => void
+  onPreservedBranch?: (branch: PreservedBranchCleanup) => void
+  suppressPreservedBranchToast?: boolean
   // Batch deletion commits one focus handoff after all targets settle.
   focusSuccessorOnDelete?: boolean
 }

--- a/src/renderer/src/components/ui/checkbox.tsx
+++ b/src/renderer/src/components/ui/checkbox.tsx
@@ -1,15 +1,20 @@
 'use client'
 
 import * as React from 'react'
-import { CheckIcon } from 'lucide-react'
+import { CheckIcon, MinusIcon } from 'lucide-react'
 import { Checkbox as CheckboxPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 
-function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+function Checkbox({
+  className,
+  checked,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
+      checked={checked}
       className={cn(
         'peer size-4 shrink-0 rounded-[4px] border border-border bg-background shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
         className
@@ -20,7 +25,11 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current"
       >
-        <CheckIcon className="size-3.5" />
+        {checked === 'indeterminate' ? (
+          <MinusIcon className="size-3.5" />
+        ) : (
+          <CheckIcon className="size-3.5" />
+        )}
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
@@ -14,6 +14,12 @@ vi.mock('sonner', () => ({
   }
 }))
 
+vi.mock('../sidebar/preserved-branch-batch-toast', () => ({
+  showPreservedBranchBatchToast: vi.fn()
+}))
+
+import { showPreservedBranchBatchToast } from '../sidebar/preserved-branch-batch-toast'
+
 async function settleBackgroundRemoval(): Promise<void> {
   for (let index = 0; index < 10; index += 1) {
     await Promise.resolve()
@@ -129,6 +135,54 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
       removedCount: 2,
       failedCount: 0
     })
+  })
+
+  it('reports all preserved branches in one cleanup result', async () => {
+    const first = makeCandidate()
+    const second = makeCandidate({
+      worktreeId: 'repo-1::/repo/beta',
+      displayName: 'beta',
+      branch: 'beta',
+      path: '/repo/beta'
+    })
+    const firstBranch = {
+      worktreeId: first.worktreeId,
+      branchName: 'feature/alpha',
+      expectedHead: 'alpha-head'
+    }
+    const secondBranch = {
+      worktreeId: second.worktreeId,
+      branchName: 'feature/beta',
+      expectedHead: 'beta-head'
+    }
+    const onResult = vi.fn()
+
+    startWorkspaceCleanupBackgroundRemoval({
+      candidates: [first, second],
+      removeCandidates: vi
+        .fn()
+        .mockResolvedValueOnce({
+          removedIds: [first.worktreeId],
+          failures: [],
+          preservedBranches: [firstBranch]
+        })
+        .mockResolvedValueOnce({
+          removedIds: [second.worktreeId],
+          failures: [],
+          preservedBranches: [secondBranch]
+        }),
+      onProgress: vi.fn(),
+      onResult
+    })
+    await settleBackgroundRemoval()
+
+    expect(onResult).toHaveBeenCalledWith({
+      removedIds: [first.worktreeId, second.worktreeId],
+      failures: [],
+      preservedBranches: [firstBranch, secondBranch]
+    })
+    expect(showPreservedBranchBatchToast).toHaveBeenCalledWith(2, [firstBranch, secondBranch])
+    expect(toast.success).not.toHaveBeenCalledWith('Removed workspaces: 2')
   })
 
   it('removes nested candidates before their parent workspace', async () => {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.ts
@@ -75,6 +75,7 @@ export function startWorkspaceCleanupBackgroundRemoval({
   const count = candidates.length
   const removedIds: string[] = []
   const failures: WorkspaceCleanupFailure[] = []
+  const preservedBranches: NonNullable<WorkspaceCleanupRemoveResult['preservedBranches']> = []
   const failedCandidates: WorkspaceCleanupCandidate[] = []
   const lateSettlementTrackers: WorkspaceCleanupLateSettlementTracker[] = []
   // Why: rows past the removal deadline are still removing; their skip fallout
@@ -200,6 +201,7 @@ export function startWorkspaceCleanupBackgroundRemoval({
               pendingSettlementFailures.delete(timeoutFailure)
               provisionallyBlocked.delete(candidate)
               removedIds.push(...lateResult.removedIds)
+              preservedBranches.push(...(lateResult.preservedBranches ?? []))
               reportFailures(lateResult.failures)
               if (lateResult.failures.length === 0) {
                 removeArrayEntry(failedCandidates, candidate)
@@ -212,6 +214,7 @@ export function startWorkspaceCleanupBackgroundRemoval({
         }
         const result = outcome.result
         removedIds.push(...result.removedIds)
+        preservedBranches.push(...(result.preservedBranches ?? []))
         reportFailures(result.failures)
         if (result.failures.length > 0) {
           failedCandidates.push(candidate)
@@ -244,7 +247,11 @@ export function startWorkspaceCleanupBackgroundRemoval({
         }
       })
     )
-    const result = { removedIds, failures }
+    const result: WorkspaceCleanupRemoveResult = {
+      removedIds,
+      failures,
+      ...(preservedBranches.length > 0 ? { preservedBranches } : {})
+    }
     try {
       onResult?.(result)
     } catch (callbackError) {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-toasts.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-toasts.ts
@@ -4,12 +4,15 @@ import type {
   WorkspaceCleanupRemoveResult
 } from '@/store/slices/workspace-cleanup'
 import { translate } from '@/i18n/i18n'
+import { showPreservedBranchBatchToast } from '../sidebar/preserved-branch-batch-toast'
 
 export function showWorkspaceCleanupRemovalResultToasts(
   result: WorkspaceCleanupRemoveResult,
   pendingSettlementFailures?: ReadonlySet<WorkspaceCleanupFailure>
 ): void {
-  if (result.removedIds.length > 0) {
+  if (result.preservedBranches && result.preservedBranches.length > 0) {
+    showPreservedBranchBatchToast(result.removedIds.length, result.preservedBranches)
+  } else if (result.removedIds.length > 0) {
     toast.success(
       translate(
         'auto.components.workspace.cleanup.backgroundRemoval.removed',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5335,24 +5335,44 @@
           "authFailedTooltip": "{{value0}} · authentication failed",
           "failedTooltip": "{{value0}} · connection failed"
         },
-        "preservedBranchBatch": {
-          "diskCopy": "Git kept {{value0}} local {{value1}} because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.",
-          "title": "{{value0}} {{value1}} removed, {{value2}} {{value3}} kept",
-          "deleting": "Deleting local branches: {{value0}}",
-          "deleted": "Local branches deleted: {{value0}}",
-          "failed": "{{value0}} deleted, {{value1}} not deleted",
-          "retry": "Retry {{value0}} {{value1}}",
-          "review": "Review {{value0}} {{value1}}"
+        "preserved": {
+          "branch": {
+            "batch": {
+              "toast": {
+                "a3cdd9d9e6": "Git kept {{count}} local branches because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.",
+                "a3cdd9d9e6_one": "Git kept {{count}} local branch because it may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.",
+                "a3cdd9d9e6_other": "Git kept {{count}} local branches because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.",
+                "6310412304": "Review {{count}} Branches",
+                "6310412304_one": "Review {{count}} Branch",
+                "6310412304_other": "Review {{count}} Branches",
+                "cea24c2b7d": "{{count}} workspaces removed",
+                "cea24c2b7d_one": "{{count}} workspace removed",
+                "cea24c2b7d_other": "{{count}} workspaces removed",
+                "0e0379f24a": "{{count}} branches kept",
+                "0e0379f24a_one": "{{count}} branch kept",
+                "0e0379f24a_other": "{{count}} branches kept",
+                "4cf75caab7": "{{value0}}, {{value1}}",
+                "e61d78054f": "Deleting local branches: {{value0}}",
+                "1e1a5f6763": "Local branches deleted: {{value0}}",
+                "43d9395605": "{{value0}} deleted, {{value1}} not deleted",
+                "d42f1f14e0": "Retry {{count}} Branches",
+                "d42f1f14e0_one": "Retry {{count}} Branch",
+                "d42f1f14e0_other": "Retry {{count}} Branches"
+              }
+            }
+          }
         },
-        "preservedBranchBatchReview": {
-          "title": "Review kept branches",
-          "description": "Select the local branches you want to force delete. Unselected branches stay in their repositories.",
-          "selectAll": "Select all",
-          "selectedCount": "{{value0}} of {{value1}} selected",
-          "mayBeUnmerged": "May be unmerged",
-          "headUnavailable": "Head unavailable",
-          "cancel": "Cancel",
-          "forceDeleteSelected": "Force Delete {{value0}} {{value1}}"
+        "PreservedBranchBatchReviewDialog": {
+          "c4bf8e7eaf": "Review kept branches",
+          "f21976c9a8": "Select the local branches you want to force delete. Unselected branches stay in their repositories.",
+          "38c947f7c5": "Select all",
+          "9602129d38": "{{value0}} of {{value1}} selected",
+          "ee39e872d5": "May be unmerged",
+          "676db406fd": "Head unavailable",
+          "285e1e4882": "Cancel",
+          "a0f9863597": "Force Delete {{count}} Branches",
+          "a0f9863597_one": "Force Delete {{count}} Branch",
+          "a0f9863597_other": "Force Delete {{count}} Branches"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5334,6 +5334,25 @@
           "connectName": "Connect to SSH host {{value0}}",
           "authFailedTooltip": "{{value0}} · authentication failed",
           "failedTooltip": "{{value0}} · connection failed"
+        },
+        "preservedBranchBatch": {
+          "diskCopy": "Git kept {{value0}} local {{value1}} because they may contain unmerged commits. Kept branches do not retain workspace folders; their commits remain in the repository. Orca may continue freeing workspace disk space in the background.",
+          "title": "{{value0}} {{value1}} removed, {{value2}} {{value3}} kept",
+          "deleting": "Deleting local branches: {{value0}}",
+          "deleted": "Local branches deleted: {{value0}}",
+          "failed": "{{value0}} deleted, {{value1}} not deleted",
+          "retry": "Retry {{value0}} {{value1}}",
+          "review": "Review {{value0}} {{value1}}"
+        },
+        "preservedBranchBatchReview": {
+          "title": "Review kept branches",
+          "description": "Select the local branches you want to force delete. Unselected branches stay in their repositories.",
+          "selectAll": "Select all",
+          "selectedCount": "{{value0}} of {{value1}} selected",
+          "mayBeUnmerged": "May be unmerged",
+          "headUnavailable": "Head unavailable",
+          "cancel": "Cancel",
+          "forceDeleteSelected": "Force Delete {{value0}} {{value1}}"
         }
       },
       "shared": {

--- a/src/renderer/src/lib/preserved-branch-cleanup.ts
+++ b/src/renderer/src/lib/preserved-branch-cleanup.ts
@@ -1,5 +1,5 @@
-export type PreservedBranchCleanup = {
-  worktreeId: string
-  branchName: string
-  expectedHead?: string
-}
+export {
+  preservedBranchCleanupKey,
+  preservedBranchCleanupScopeKey,
+  type PreservedBranchCleanup
+} from '../../../shared/preserved-branch-cleanup'

--- a/src/renderer/src/lib/preserved-branch-cleanup.ts
+++ b/src/renderer/src/lib/preserved-branch-cleanup.ts
@@ -1,0 +1,5 @@
+export type PreservedBranchCleanup = {
+  worktreeId: string
+  branchName: string
+  expectedHead?: string
+}

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -218,7 +218,7 @@ describe('removeWorktree cascade', () => {
 
     expect(result).toEqual({
       ok: true,
-      preservedBranch: { branchName: 'feature/test', head: 'def456' }
+      preservedBranch: { branchName: 'feature/test', head: 'def456', hostId: 'local' }
     })
     expect(toast.warning).toHaveBeenCalledWith('Worktree deleted, branch kept', {
       id: 'preserved-branch:feature/test:def456',
@@ -254,7 +254,7 @@ describe('removeWorktree cascade', () => {
 
     expect(result).toEqual({
       ok: true,
-      preservedBranch: { branchName: 'feature/test', head: 'def456' }
+      preservedBranch: { branchName: 'feature/test', head: 'def456', hostId: 'local' }
     })
     expect(toast.warning).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -792,6 +792,7 @@ export type UISlice = {
     | 'create-worktree'
     | 'edit-meta'
     | 'delete-worktree'
+    | 'preserved-branch-review'
     | 'forget-ssh-workspace'
     | 'confirm-add-project-from-folder'
     | 'confirm-non-git-folder'

--- a/src/renderer/src/store/slices/workspace-cleanup-removal-preflight.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-removal-preflight.test.ts
@@ -89,6 +89,38 @@ describe('workspace cleanup removal and protection', () => {
     expect(store.getState().workspaceCleanupScan?.candidates).toEqual([])
   })
 
+  it('returns preserved branches for the cleanup batch summary', async () => {
+    const candidate = makeCandidate()
+    installWorkspaceCleanupApi(
+      vi.fn(async () => ({ scannedAt: NOW, candidates: [candidate], errors: [] }))
+    )
+    const removeWorktree = vi.fn().mockResolvedValue({
+      ok: true,
+      preservedBranch: { branchName: 'feature/cleanup', head: 'saved-head' }
+    })
+    const store = createCleanupTestStore(removeWorktree)
+    store.setState({
+      workspaceCleanupScan: { scannedAt: NOW, candidates: [candidate], errors: [] }
+    } as Partial<AppState>)
+
+    await expect(
+      store.getState().removeWorkspaceCleanupCandidates([candidate.worktreeId])
+    ).resolves.toEqual({
+      removedIds: [candidate.worktreeId],
+      failures: [],
+      preservedBranches: [
+        {
+          worktreeId: candidate.worktreeId,
+          branchName: 'feature/cleanup',
+          expectedHead: 'saved-head'
+        }
+      ]
+    })
+    expect(removeWorktree).toHaveBeenCalledWith(candidate.worktreeId, false, {
+      suppressPreservedBranchToast: true
+    })
+  })
+
   it('demotes an active suggested workspace when it was not viewed from cleanup', async () => {
     const [candidate] = await enrichWorkspaceCleanupCandidates(
       [makeCandidate()],

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -24,6 +24,7 @@ import {
 import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { classifyTitleActivity, isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
 import { translate } from '@/i18n/i18n'
+import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
 
 export type WorkspaceCleanupFailure = {
   worktreeId: string
@@ -34,6 +35,7 @@ export type WorkspaceCleanupFailure = {
 export type WorkspaceCleanupRemoveResult = {
   removedIds: string[]
   failures: WorkspaceCleanupFailure[]
+  preservedBranches?: PreservedBranchCleanup[]
 }
 
 export type WorkspaceCleanupRemoveOptions = {
@@ -300,6 +302,7 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
   removeWorkspaceCleanupCandidates: async (worktreeIds, options) => {
     const removedIds: string[] = []
     const failures: WorkspaceCleanupFailure[] = []
+    const preservedBranches: PreservedBranchCleanup[] = []
     const approvedCandidatesByWorktreeId = new Map(
       (options?.approvedCandidates ?? []).map((candidate) => [candidate.worktreeId, candidate])
     )
@@ -336,6 +339,13 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
       )
       if (result.ok) {
         removedIds.push(candidate.worktreeId)
+        if (result.preservedBranch) {
+          preservedBranches.push({
+            worktreeId: candidate.worktreeId,
+            branchName: result.preservedBranch.branchName,
+            expectedHead: result.preservedBranch.head
+          })
+        }
       } else {
         failures.push({
           worktreeId: candidate.worktreeId,
@@ -361,7 +371,11 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
       }))
     }
 
-    return { removedIds, failures }
+    return {
+      removedIds,
+      failures,
+      ...(preservedBranches.length > 0 ? { preservedBranches } : {})
+    }
   }
 })
 

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -47,6 +47,13 @@ export type WorktreeDeleteState = {
   lockReason?: string | null
 }
 
+type RendererRemoveWorktreeResult = Omit<RemoveWorktreeResult, 'preservedBranch'> & {
+  preservedBranch?: NonNullable<RemoveWorktreeResult['preservedBranch']> & {
+    hostId?: ExecutionHostId
+    runtimeEnvironmentId?: string
+  }
+}
+
 export type WorktreeFetchOptions = {
   requireAuthoritative?: boolean
   executionHostId?: ExecutionHostId
@@ -236,14 +243,18 @@ export type WorktreeSlice = {
       // PTY stopped; `force` alone is set by the ordinary delete confirmation.
       allowUnverifiedPtyStop?: boolean
     }
-  ) => Promise<({ ok: true } & RemoveWorktreeResult) | { ok: false; error: string }>
+  ) => Promise<({ ok: true } & RendererRemoveWorktreeResult) | { ok: false; error: string }>
   markWorktreesDeleting: (worktreeIds: readonly string[]) => void
   markWorktreesQueuedForDeletion: (worktreeIds: readonly string[]) => void
   forceDeletePreservedBranch: (
     worktreeId: string,
     branchName: string,
     expectedHead: string,
-    options?: { suppressToast?: boolean }
+    options?: {
+      suppressToast?: boolean
+      hostId?: ExecutionHostId
+      runtimeEnvironmentId?: string
+    }
   ) => Promise<({ ok: true } & ForceDeleteWorktreeBranchResult) | { ok: false; error: string }>
   clearWorktreeDeleteState: (worktreeId: string) => void
   /** Never rejects — most callers fire-and-forget. Callers that own a surface

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -242,7 +242,8 @@ export type WorktreeSlice = {
   forceDeletePreservedBranch: (
     worktreeId: string,
     branchName: string,
-    expectedHead: string
+    expectedHead: string,
+    options?: { suppressToast?: boolean }
   ) => Promise<({ ok: true } & ForceDeleteWorktreeBranchResult) | { ok: false; error: string }>
   clearWorktreeDeleteState: (worktreeId: string) => void
   /** Never rejects — most callers fire-and-forget. Callers that own a surface

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6097,11 +6097,13 @@ describe('worktree remote runtime mutations', () => {
       method: 'worktree.rm',
       params: {
         worktree: `id:${wt.id}`,
+        hostId: 'runtime:env-1',
         force: undefined,
         allowUnverifiedPtyStop: false,
         runHooks: true
       },
-      timeoutMs: 60_000
+      timeoutMs: 60_000,
+      expectedEnvironmentPairingRevision: undefined
     })
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
     expect(store.getState().shutdownWorktreeTerminals).toHaveBeenCalledWith(wt.id, {
@@ -6144,13 +6146,19 @@ describe('worktree remote runtime mutations', () => {
 
     expect(result).toEqual({
       ok: true,
-      preservedBranch: { branchName: 'feature/nested', head: 'saved-head' }
+      preservedBranch: {
+        branchName: 'feature/nested',
+        head: 'saved-head',
+        hostId: 'ssh:hub-private-target',
+        runtimeEnvironmentId: 'owner-hub'
+      }
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'owner-hub',
       method: 'worktree.rm',
       params: {
         worktree: `id:${wt.id}`,
+        hostId: 'ssh:hub-private-target',
         force: undefined,
         allowUnverifiedPtyStop: false,
         runHooks: true
@@ -6171,10 +6179,83 @@ describe('worktree remote runtime mutations', () => {
       params: {
         worktree: `id:${wt.id}`,
         branchName: 'feature/nested',
-        expectedHead: 'saved-head'
+        expectedHead: 'saved-head',
+        hostId: 'ssh:hub-private-target'
       },
       timeoutMs: 15_000
     })
+  })
+
+  it('retains separate preserved-branch cleanup routes for sequential same-id hosts', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-shared::/same/path'
+    const localWorktree = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo-shared',
+      path: '/same/path',
+      hostId: 'local'
+    })
+    const remoteWorktree = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo-shared',
+      path: '/same/path',
+      hostId: 'ssh:shared-target',
+      runtimeOwnerEnvironmentId: 'shared-hub'
+    })
+    mockApi.worktrees.remove.mockResolvedValueOnce({
+      preservedBranch: { branchName: 'feature/local', head: 'local-head' }
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) =>
+      Promise.resolve({
+        id: `rpc-${method}`,
+        ok: true,
+        result:
+          method === 'repo.hooksCheck'
+            ? { hasHooks: false, hooks: null, mayNeedUpdate: false }
+            : method === 'worktree.rm'
+              ? {
+                  preservedBranch: { branchName: 'feature/remote', head: 'remote-head' }
+                }
+              : { deleted: true },
+        _meta: { runtimeId: 'runtime-shared-hub' }
+      })
+    )
+    store.setState({
+      worktreesByRepo: { 'repo-shared': [localWorktree] }
+    } as Partial<AppState>)
+
+    await store.getState().removeWorktree(worktreeId)
+    store.setState({
+      worktreesByRepo: { 'repo-shared': [remoteWorktree] }
+    } as Partial<AppState>)
+    await store.getState().removeWorktree(worktreeId)
+
+    await store
+      .getState()
+      .forceDeletePreservedBranch(worktreeId, 'feature/local', 'local-head', { hostId: 'local' })
+    await store.getState().forceDeletePreservedBranch(worktreeId, 'feature/remote', 'remote-head', {
+      hostId: 'ssh:shared-target',
+      runtimeEnvironmentId: 'shared-hub'
+    })
+
+    expect(mockApi.worktrees.forceDeletePreservedBranch).toHaveBeenCalledWith({
+      worktreeId,
+      branchName: 'feature/local',
+      expectedHead: 'local-head',
+      hostId: 'local'
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'shared-hub',
+        method: 'worktree.forceDeleteBranch',
+        params: {
+          worktree: `id:${worktreeId}`,
+          branchName: 'feature/remote',
+          expectedHead: 'remote-head',
+          hostId: 'ssh:shared-target'
+        }
+      })
+    )
   })
 
   it('fails HUB-owned SSH removal closed when the exact id has two HUB owners', async () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6120,12 +6120,21 @@ describe('worktree remote runtime mutations', () => {
       hostId: 'ssh:hub-private-target',
       runtimeOwnerEnvironmentId: 'owner-hub'
     })
-    runtimeEnvironmentCall.mockResolvedValue({
-      id: 'rpc-rm-nested',
-      ok: true,
-      result: { removed: true },
-      _meta: { runtimeId: 'runtime-owner-hub' }
-    })
+    runtimeEnvironmentCall
+      .mockResolvedValueOnce({
+        id: 'rpc-rm-nested',
+        ok: true,
+        result: {
+          preservedBranch: { branchName: 'feature/nested', head: 'saved-head' }
+        },
+        _meta: { runtimeId: 'runtime-owner-hub' }
+      })
+      .mockResolvedValueOnce({
+        id: 'rpc-force-delete-branch',
+        ok: true,
+        result: { deleted: true },
+        _meta: { runtimeId: 'runtime-owner-hub' }
+      })
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'different-hub' } as never,
       worktreesByRepo: { 'repo-ssh': [wt] }
@@ -6133,8 +6142,11 @@ describe('worktree remote runtime mutations', () => {
 
     const result = await store.getState().removeWorktree(wt.id)
 
-    expect(result).toEqual({ ok: true })
-    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+    expect(result).toEqual({
+      ok: true,
+      preservedBranch: { branchName: 'feature/nested', head: 'saved-head' }
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'owner-hub',
       method: 'worktree.rm',
       params: {
@@ -6146,6 +6158,23 @@ describe('worktree remote runtime mutations', () => {
       timeoutMs: 60_000
     })
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([])
+
+    const forceResult = await store
+      .getState()
+      .forceDeletePreservedBranch(wt.id, 'feature/nested', 'saved-head')
+
+    expect(forceResult).toEqual({ ok: true, deleted: true })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
+      selector: 'owner-hub',
+      method: 'worktree.forceDeleteBranch',
+      params: {
+        worktree: `id:${wt.id}`,
+        branchName: 'feature/nested',
+        expectedHead: 'saved-head'
+      },
+      timeoutMs: 15_000
+    })
   })
 
   it('fails HUB-owned SSH removal closed when the exact id has two HUB owners', async () => {
@@ -6437,6 +6466,22 @@ describe('worktree remote runtime mutations', () => {
       timeoutMs: 15_000
     })
     expect(mockApi.worktrees.forceDeletePreservedBranch).not.toHaveBeenCalled()
+  })
+
+  it('suppresses per-branch feedback for an aggregate delete', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    store.setState({ worktreesByRepo: { repo1: [wt] } } as Partial<AppState>)
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
+
+    const result = await store
+      .getState()
+      .forceDeletePreservedBranch(wt.id, 'feature/test', 'abc123', { suppressToast: true })
+
+    expect(result).toEqual({ ok: true, deleted: true })
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('fails preserved branch deletion closed for two HUB owners', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -120,6 +120,10 @@ import {
   type DetectedWorktreeRefreshLease
 } from './detected-worktree-refresh-leases'
 import { getTerminalActivationSpawnSuppression } from './terminal-activation-spawn-suppression'
+import {
+  preservedBranchCleanupKey,
+  type PreservedBranchCleanup
+} from '../../../../shared/preserved-branch-cleanup'
 import type {
   HostQualifiedDetectedWorktreeResult,
   HostQualifiedKnownWorktreeResult,
@@ -143,9 +147,9 @@ const FOLDER_WORKSPACE_ACTIVITY_PERSIST_INTERVAL_MS = 1_000
 export const WORKTREE_REFRESH_CONCURRENCY = 8
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
-const preservedBranchRuntimeTargetByWorktreeId = new Map<
+const preservedBranchRuntimeTargetByCleanupKey = new Map<
   string,
-  ReturnType<typeof getActiveRuntimeTarget>
+  { cleanup: PreservedBranchCleanup; target: ReturnType<typeof getActiveRuntimeTarget> }
 >()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 const hostedReviewPushTargetLookupsInFlight = new Set<string>()
@@ -4339,6 +4343,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 'worktree.rm',
                 {
                   worktree: toRuntimeWorktreeSelector(worktreeId),
+                  ...(hostId ? { hostId } : {}),
                   force,
                   allowUnverifiedPtyStop: options?.allowUnverifiedPtyStop === true,
                   runHooks: !skipArchive
@@ -4686,18 +4691,46 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // Why: Source Control may be unmounted during deletion, so it can't be the only stale-draft cleanup path.
       clearSessionCommitDraftForWorktree(worktreeId)
       const preservedBranch = removalResult?.preservedBranch
+      const cleanup = preservedBranch
+        ? {
+            worktreeId,
+            branchName: preservedBranch.branchName,
+            expectedHead: preservedBranch.head,
+            ...(hostId ? { hostId } : {}),
+            ...(removalRoute?.runtimeEnvironmentId
+              ? { runtimeEnvironmentId: removalRoute.runtimeEnvironmentId }
+              : {})
+          }
+        : null
       if (preservedBranch) {
-        preservedBranchRuntimeTargetByWorktreeId.set(worktreeId, target)
-      } else {
-        preservedBranchRuntimeTargetByWorktreeId.delete(worktreeId)
+        preservedBranchRuntimeTargetByCleanupKey.set(preservedBranchCleanupKey(cleanup!), {
+          cleanup: cleanup!,
+          target
+        })
       }
       if (preservedBranch && options?.suppressPreservedBranchToast !== true) {
         showPreservedBranchToast(removalResult, worktreeBeforeRemoval, (branch, expectedHead) => {
-          void get().forceDeletePreservedBranch(worktreeId, branch, expectedHead)
+          void get().forceDeletePreservedBranch(worktreeId, branch, expectedHead, {
+            ...(hostId ? { hostId } : {}),
+            ...(removalRoute?.runtimeEnvironmentId
+              ? { runtimeEnvironmentId: removalRoute.runtimeEnvironmentId }
+              : {})
+          })
         })
       }
       pruneHostedReviewLinkMutationGenerations([worktreeId])
-      return preservedBranch ? { ok: true as const, preservedBranch } : { ok: true as const }
+      return preservedBranch && cleanup
+        ? {
+            ok: true as const,
+            preservedBranch: {
+              ...preservedBranch,
+              ...(cleanup.hostId ? { hostId: cleanup.hostId } : {}),
+              ...(cleanup.runtimeEnvironmentId
+                ? { runtimeEnvironmentId: cleanup.runtimeEnvironmentId }
+                : {})
+            }
+          }
+        : { ok: true as const }
     } catch (err) {
       // Why: git refusing a non-force delete for dirty/untracked files is a handled user decision, not an app error.
       console.warn('Failed to remove worktree:', err)
@@ -4776,20 +4809,54 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   forceDeletePreservedBranch: async (worktreeId, branchName, expectedHead, options) => {
     try {
+      const requestedCleanup: PreservedBranchCleanup = {
+        worktreeId,
+        branchName,
+        expectedHead,
+        ...(options?.hostId ? { hostId: options.hostId } : {}),
+        ...(options?.runtimeEnvironmentId
+          ? { runtimeEnvironmentId: options.runtimeEnvironmentId }
+          : {})
+      }
+      const requestedCleanupKey = preservedBranchCleanupKey(requestedCleanup)
+      const exactRetainedTarget = preservedBranchRuntimeTargetByCleanupKey.get(requestedCleanupKey)
+      const matchingRetainedTargets = exactRetainedTarget
+        ? [exactRetainedTarget]
+        : [...preservedBranchRuntimeTargetByCleanupKey.values()].filter(
+            ({ cleanup }) =>
+              cleanup.worktreeId === worktreeId &&
+              cleanup.branchName === branchName &&
+              cleanup.expectedHead === expectedHead
+          )
+      const retainedTarget =
+        exactRetainedTarget ??
+        (options?.hostId || options?.runtimeEnvironmentId || matchingRetainedTargets.length !== 1
+          ? undefined
+          : matchingRetainedTargets[0])
+      if ((options?.hostId || options?.runtimeEnvironmentId) && !retainedTarget) {
+        throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
+      }
+      const cleanupHostId = options?.hostId ?? retainedTarget?.cleanup.hostId
       // Why: the removed row no longer records its nested HUB owner, so retain the deletion-time route.
       const target =
-        preservedBranchRuntimeTargetByWorktreeId.get(worktreeId) ??
+        retainedTarget?.target ??
         getActiveRuntimeTarget(settingsForWorktreeOwner(get(), worktreeId))
       const result = await (target.kind === 'local'
         ? window.api.worktrees.forceDeletePreservedBranch({
             worktreeId,
             branchName,
-            expectedHead
+            expectedHead,
+            ...(cleanupHostId ? { hostId: cleanupHostId } : {})
           })
         : callRuntimeRpc<ForceDeleteWorktreeBranchResult>(
             target,
             'worktree.forceDeleteBranch',
-            { worktree: toRuntimeWorktreeSelector(worktreeId), branchName, expectedHead },
+            {
+              worktree: toRuntimeWorktreeSelector(worktreeId),
+              branchName,
+              expectedHead,
+              ...(cleanupHostId ? { hostId: cleanupHostId } : {})
+            },
             { timeoutMs: 15_000 }
           ))
       if (options?.suppressToast !== true) {
@@ -4801,7 +4868,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           )
         })
       }
-      preservedBranchRuntimeTargetByWorktreeId.delete(worktreeId)
+      preservedBranchRuntimeTargetByCleanupKey.delete(
+        retainedTarget ? preservedBranchCleanupKey(retainedTarget.cleanup) : requestedCleanupKey
+      )
       return { ok: true as const, ...result }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err)

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -143,6 +143,10 @@ const FOLDER_WORKSPACE_ACTIVITY_PERSIST_INTERVAL_MS = 1_000
 export const WORKTREE_REFRESH_CONCURRENCY = 8
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
+const preservedBranchRuntimeTargetByWorktreeId = new Map<
+  string,
+  ReturnType<typeof getActiveRuntimeTarget>
+>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 const hostedReviewPushTargetLookupsInFlight = new Set<string>()
 const runtimeDetectedWorktreeRefreshesInFlight = new Map<
@@ -4682,6 +4686,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // Why: Source Control may be unmounted during deletion, so it can't be the only stale-draft cleanup path.
       clearSessionCommitDraftForWorktree(worktreeId)
       const preservedBranch = removalResult?.preservedBranch
+      if (preservedBranch) {
+        preservedBranchRuntimeTargetByWorktreeId.set(worktreeId, target)
+      } else {
+        preservedBranchRuntimeTargetByWorktreeId.delete(worktreeId)
+      }
       if (preservedBranch && options?.suppressPreservedBranchToast !== true) {
         showPreservedBranchToast(removalResult, worktreeBeforeRemoval, (branch, expectedHead) => {
           void get().forceDeletePreservedBranch(worktreeId, branch, expectedHead)
@@ -4765,9 +4774,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     })
   },
 
-  forceDeletePreservedBranch: async (worktreeId, branchName, expectedHead) => {
+  forceDeletePreservedBranch: async (worktreeId, branchName, expectedHead, options) => {
     try {
-      const target = getActiveRuntimeTarget(settingsForWorktreeOwner(get(), worktreeId))
+      // Why: the removed row no longer records its nested HUB owner, so retain the deletion-time route.
+      const target =
+        preservedBranchRuntimeTargetByWorktreeId.get(worktreeId) ??
+        getActiveRuntimeTarget(settingsForWorktreeOwner(get(), worktreeId))
       const result = await (target.kind === 'local'
         ? window.api.worktrees.forceDeletePreservedBranch({
             worktreeId,
@@ -4780,17 +4792,27 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             { worktree: toRuntimeWorktreeSelector(worktreeId), branchName, expectedHead },
             { timeoutMs: 15_000 }
           ))
-      toast.success(translate('auto.store.slices.worktrees.19db0085fb', 'Local branch deleted'), {
-        description: translate('auto.store.slices.worktrees.5a58e03a26', 'Deleted "{{value0}}".', {
-          value0: branchName
+      if (options?.suppressToast !== true) {
+        toast.success(translate('auto.store.slices.worktrees.19db0085fb', 'Local branch deleted'), {
+          description: translate(
+            'auto.store.slices.worktrees.5a58e03a26',
+            'Deleted "{{value0}}".',
+            { value0: branchName }
+          )
         })
-      })
+      }
+      preservedBranchRuntimeTargetByWorktreeId.delete(worktreeId)
       return { ok: true as const, ...result }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err)
-      toast.error(translate('auto.store.slices.worktrees.0216895fb5', 'Failed to delete branch'), {
-        description: error
-      })
+      if (options?.suppressToast !== true) {
+        toast.error(
+          translate('auto.store.slices.worktrees.0216895fb5', 'Failed to delete branch'),
+          {
+            description: error
+          }
+        )
+      }
       return { ok: false as const, error }
     }
   },

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1831,10 +1831,11 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         targetBranch,
         isCrossRepository
       }),
-    remove: async ({ worktreeId, force, allowUnverifiedPtyStop, skipArchive }) => {
+    remove: async ({ worktreeId, hostId, force, allowUnverifiedPtyStop, skipArchive }) => {
       invalidateRuntimeWorktreeCaches()
       return callRuntimeResult<RemoveWorktreeResult>('worktree.rm', {
         worktree: toRuntimeWorktreeSelector(worktreeId),
+        ...(hostId ? { hostId } : {}),
         force,
         // Why (#11960): the web client renders the same Force Delete affordances, so
         // dropping this field here would leave paired clients permanently wedged.
@@ -1846,11 +1847,12 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
     forgetLocal: () => {
       throw new Error('Forgetting a workspace is unavailable in paired web clients.')
     },
-    forceDeletePreservedBranch: ({ worktreeId, branchName, expectedHead }) =>
+    forceDeletePreservedBranch: ({ worktreeId, branchName, expectedHead, hostId }) =>
       callRuntimeResult<ForceDeleteWorktreeBranchResult>('worktree.forceDeleteBranch', {
         worktree: toRuntimeWorktreeSelector(worktreeId),
         branchName,
-        expectedHead
+        expectedHead,
+        ...(hostId ? { hostId } : {})
       }),
     updateMeta: async ({ worktreeId, updates }) => {
       const rpcUpdates =

--- a/src/shared/preserved-branch-cleanup.ts
+++ b/src/shared/preserved-branch-cleanup.ts
@@ -1,0 +1,23 @@
+import type { ExecutionHostId } from './execution-host'
+
+export type PreservedBranchCleanup = {
+  worktreeId: string
+  branchName: string
+  expectedHead?: string
+  hostId?: ExecutionHostId
+  runtimeEnvironmentId?: string
+}
+
+export function preservedBranchCleanupScopeKey(
+  cleanup: Pick<PreservedBranchCleanup, 'worktreeId' | 'hostId' | 'runtimeEnvironmentId'>
+): string {
+  return [cleanup.hostId ?? '', cleanup.runtimeEnvironmentId ?? '', cleanup.worktreeId].join('\0')
+}
+
+export function preservedBranchCleanupKey(cleanup: PreservedBranchCleanup): string {
+  return [
+    preservedBranchCleanupScopeKey(cleanup),
+    cleanup.branchName,
+    cleanup.expectedHead ?? ''
+  ].join('\0')
+}


### PR DESCRIPTION
## Summary

- Replace per-workspace retained-branch warnings with one aggregate cleanup result.
- Add a selectable review dialog so users can force-delete some preserved branches and keep others.
- Preserve execution-host routing after workspace rows are removed and serialize branch deletion per repository.
- Support sidebar batch deletion and Resource Manager cleanup, including mixed-version hosts.

## Screenshots

![Preserved branch review dialog with 6 of 7 branches selected](https://github.com/user-attachments/assets/1399adc3-4d85-4c39-a0ba-1c02a775242a)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:

- `pnpm run typecheck:web`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- Localization catalog, extraction, and coverage checks
- 458 focused tests across workspace deletion, cleanup, routing, and retained-branch behavior

## AI Review Report

Reviewed the aggregate deletion flow for per-repository serialization, stable expected-head guards, partial failures and retries, selection granularity, and preservation of local, SSH, and HUB execution routes after workspace rows are removed. Verified that folder workspaces remain unchanged and mixed-version hosts show unverifiable branches as disabled.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. No shortcuts, shell commands, or platform-specific paths were added; the UI uses shared Orca primitives and host-neutral store and IPC calls.

## Security Audit

No new dependencies or wire/IPC shapes were introduced. Modal payloads are validated before use. Destructive branch deletion retains the expected-head compare-and-delete guard, and invalid or unverifiable branches cannot be selected. No authentication, secret handling, command interpolation, or new filesystem path handling was added.

## Notes

The full repository lint, test, and build commands were not run. The focused regression suite, web typecheck, changed-code quality gate, localization checks, and max-lines gate passed.