### PR TITLE
fix(repo): promote folders re-added as git

### DIFF
--- a/src/main/ipc/repos-add-linked-worktree.test.ts
+++ b/src/main/ipc/repos-add-linked-worktree.test.ts
@@ -155,6 +155,33 @@ describe('repos:add with git worktrees', () => {
     expect(mockStore.addRepo).toHaveBeenCalledTimes(1)
   })
 
+  it('promotes a tracked folder when the same path is re-added as git', async () => {
+    const folderRepo = {
+      ...trackedMainRepo(),
+      id: 'folder-repo-id',
+      path: '/Users/dev/projects/promoted',
+      kind: 'folder'
+    } as Repo
+    mockStore.getRepos.mockReturnValue([folderRepo])
+    mockStore.updateRepo.mockReturnValue({
+      ...folderRepo,
+      kind: 'git',
+      projectHostSetupMethod: 'imported-existing-folder'
+    })
+
+    const result = await callAdd({ path: folderRepo.path, kind: 'git' })
+
+    expect(isGitRepoMock).toHaveBeenCalledWith(folderRepo.path)
+    expect(result).toEqual({
+      repo: expect.objectContaining({ id: folderRepo.id, kind: 'git' })
+    })
+    expect(mockStore.updateRepo).toHaveBeenCalledWith(folderRepo.id, {
+      kind: 'git',
+      projectHostSetupMethod: 'imported-existing-folder'
+    })
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
   it('matches the tracked main checkout across path separator differences', async () => {
     mockStore.getRepos.mockReturnValue([
       { ...trackedMainRepo(), path: 'C:\\Users\\dev\\projects\\orca' } as Repo

--- a/src/main/ipc/repos-add-linked-worktree.test.ts
+++ b/src/main/ipc/repos-add-linked-worktree.test.ts
@@ -160,13 +160,14 @@ describe('repos:add with git worktrees', () => {
       ...trackedMainRepo(),
       id: 'folder-repo-id',
       path: '/Users/dev/projects/promoted',
-      kind: 'folder'
+      kind: 'folder',
+      projectHostSetupMethod: 'cloned'
     } as Repo
     mockStore.getRepos.mockReturnValue([folderRepo])
     mockStore.updateRepo.mockReturnValue({
       ...folderRepo,
       kind: 'git',
-      projectHostSetupMethod: 'imported-existing-folder'
+      externalWorktreeVisibility: 'hide'
     })
 
     const result = await callAdd({ path: folderRepo.path, kind: 'git' })
@@ -177,7 +178,8 @@ describe('repos:add with git worktrees', () => {
     })
     expect(mockStore.updateRepo).toHaveBeenCalledWith(folderRepo.id, {
       kind: 'git',
-      projectHostSetupMethod: 'imported-existing-folder'
+      externalWorktreeVisibility: 'hide',
+      projectHostSetupMethod: 'cloned'
     })
     expect(mockStore.addRepo).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -296,6 +296,7 @@ async function addLocalRepoFromPath(
     if (repoKind === 'git' && isFolderRepo(existing)) {
       const updated = store.updateRepo(existing.id, {
         kind: 'git',
+        externalWorktreeVisibility: existing.externalWorktreeVisibility ?? 'hide',
         projectHostSetupMethod: existing.projectHostSetupMethod ?? 'imported-existing-folder'
       })
       if (updated) {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -293,6 +293,15 @@ async function addLocalRepoFromPath(
     .getRepos()
     .find((repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === pathKey)
   if (existing) {
+    if (repoKind === 'git' && isFolderRepo(existing)) {
+      const updated = store.updateRepo(existing.id, {
+        kind: 'git',
+        projectHostSetupMethod: existing.projectHostSetupMethod ?? 'imported-existing-folder'
+      })
+      if (updated) {
+        return { repo: updated, alreadyExisted: true }
+      }
+    }
     return { repo: existing, alreadyExisted: true }
   }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7310,6 +7310,45 @@ describe('OrcaRuntimeService', () => {
     expect(added).toEqual([expect.objectContaining({ badgeColor: DEFAULT_REPO_BADGE_COLOR })])
   })
 
+  it('promotes an existing folder after git init and explicit git re-add', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-promotion-'))
+    const repos: Record<string, unknown>[] = []
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [...repos] as never,
+      addRepo: (repo: Record<string, unknown>) => {
+        repos.push(repo)
+      },
+      getRepo: (id: string) => repos.find((repo) => repo.id === id) as never,
+      updateRepo: vi.fn((id: string, updates: Record<string, unknown>) => {
+        const index = repos.findIndex((repo) => repo.id === id)
+        if (index === -1) {
+          return null
+        }
+        repos[index] = { ...repos[index], ...updates }
+        return repos[index] as never
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    try {
+      const folder = await runtime.addRepo(tempRoot, 'folder')
+      execFileSync('git', ['init', '-q'], { cwd: tempRoot })
+      const readded = await runtime.addRepo(tempRoot, 'git')
+
+      expect(folder.kind).toBe('folder')
+      expect(readded).toMatchObject({ id: folder.id, kind: 'git' })
+      expect(repos).toHaveLength(1)
+      expect(runtimeStore.updateRepo).toHaveBeenCalledWith(folder.id, { kind: 'git' })
+      expect(prepareLocalWorktreeRootForRepoMock).toHaveBeenLastCalledWith(
+        runtimeStore,
+        expect.objectContaining({ id: folder.id, kind: 'git' })
+      )
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
   it('prepares the runtime worktree root when adding a repo', async () => {
     const added: Record<string, unknown>[] = []
     const runtimeStore = {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7333,13 +7333,27 @@ describe('OrcaRuntimeService', () => {
 
     try {
       const folder = await runtime.addRepo(tempRoot, 'folder')
+      runtimeStore.updateRepo(folder.id, {
+        badgeColor: '#123456',
+        projectHostSetupMethod: 'cloned'
+      })
+      runtimeStore.updateRepo.mockClear()
       execFileSync('git', ['init', '-q'], { cwd: tempRoot })
       const readded = await runtime.addRepo(tempRoot, 'git')
 
       expect(folder.kind).toBe('folder')
-      expect(readded).toMatchObject({ id: folder.id, kind: 'git' })
+      expect(readded).toMatchObject({
+        id: folder.id,
+        kind: 'git',
+        badgeColor: '#123456',
+        projectHostSetupMethod: 'cloned',
+        externalWorktreeVisibility: 'hide'
+      })
       expect(repos).toHaveLength(1)
-      expect(runtimeStore.updateRepo).toHaveBeenCalledWith(folder.id, { kind: 'git' })
+      expect(runtimeStore.updateRepo).toHaveBeenCalledWith(
+        folder.id,
+        expect.objectContaining({ kind: 'git' })
+      )
       expect(prepareLocalWorktreeRootForRepoMock).toHaveBeenLastCalledWith(
         runtimeStore,
         expect.objectContaining({ id: folder.id, kind: 'git' })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18655,13 +18655,23 @@ export class OrcaRuntimeService {
       // connectionId), so we never stamp local/ssh onto it — that would re-attribute a
       // real local project to the wrong host. Runtime is the only host that lost its
       // identity to the pre-#7018 path-only import and needs the backfill.
-      if (
+      const shouldAdoptRuntimeHost =
         existing.executionHostId == null &&
         parseExecutionHostId(executionHostId)?.kind === 'runtime'
-      ) {
+      const shouldPromoteToGit = kind === 'git' && isFolderRepo(existing)
+      if (shouldAdoptRuntimeHost || shouldPromoteToGit) {
+        const updates: Parameters<Store['updateRepo']>[1] = {}
+        if (shouldAdoptRuntimeHost) {
+          updates.executionHostId = executionHostId
+        }
+        if (shouldPromoteToGit) {
+          updates.kind = 'git'
+        }
         const adopted =
-          this.store.updateRepo(existing.id, { executionHostId }) ??
-          ({ ...existing, executionHostId } as Repo)
+          this.store.updateRepo(existing.id, updates) ?? ({ ...existing, ...updates } as Repo)
+        if (shouldPromoteToGit) {
+          await prepareLocalWorktreeRootForRepo(this.store, adopted)
+        }
         this.invalidateResolvedWorktreeCache()
         this.invalidateWorktreeScanCacheForRepo(existing.id)
         this.notifyReposChanged()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18666,6 +18666,7 @@ export class OrcaRuntimeService {
         }
         if (shouldPromoteToGit) {
           updates.kind = 'git'
+          updates.externalWorktreeVisibility = existing.externalWorktreeVisibility ?? 'hide'
         }
         const adopted =
           this.store.updateRepo(existing.id, updates) ?? ({ ...existing, ...updates } as Repo)


### PR DESCRIPTION
## Summary

When a folder already tracked by Orca becomes a Git repository, explicitly re-adding the same path as Git now promotes the existing project instead of returning the stale folder record. The promotion preserves the project ID and metadata, initializes missing Git worktree visibility, prepares the local worktree root, and refreshes runtime caches.

Fixes #13630

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (passes with pre-existing warnings)
- [x] `pnpm typecheck`
- [x] `pnpm test` (49,421 passed, 99 skipped; run with OpenClaw-specific Codex environment variables unset, a neutral temp directory/umask, and an explicit cross-version release baseline)
- [x] `pnpm build`
- [x] Added high-quality regression tests for desktop IPC and runtime API promotion, including same-ID behavior, metadata preservation, visibility defaults, and worktree-root preparation (1,087 focused tests passed, 1 skipped)

## AI Review Report

The AI review traced both add paths, compared promotion behavior with fresh Git project creation and existing clone promotion, and checked data-integrity, cache-invalidation, notification, and metadata-preservation risks. Review feedback identified a missing external-worktree visibility default; the implementation was updated to initialize `hide` only when no explicit user value exists, and tests were strengthened to preserve setup metadata.

Compatibility review:

- macOS, Linux, and Windows: path matching continues to use the existing cross-platform normalization; no shortcuts, labels, shell commands, or Electron UI behavior changed.
- Local: desktop IPC and runtime API paths are covered.
- SSH/remote: remote promotion is intentionally excluded because it requires asynchronous remote probing and mixed-version handling; existing SSH behavior is unchanged.
- Folder workspaces: promotion is one-way and only occurs after the requested path passes the existing Git repository validation.
- Agents and integrations: no agent protocol, provider, source-control integration, or Git-provider behavior changed.
- Performance: no watcher or periodic scan was added; work occurs only during explicit add/re-add.
- UI quality: no visual or layout change.

## Security Audit

- Input and path handling reuse the existing absolute/path-normalization and `isGitRepo` validation paths.
- No new command construction, shell execution, IPC surface, authentication flow, secret handling, dependency, or network request was added.
- The update is limited to the already-authorized project record at the normalized matching path and preserves its ID and unrelated metadata.
- No additional security follow-up is required for this scoped explicit-re-add fix.

## Notes

- Automatic promotion after `git init` without an explicit re-add is out of scope and can be handled separately through a refresh/discovery design.
- SSH/remote folder-to-Git promotion is also out of scope for this PR.
- No schema, dependency, or release-version changes.
- X (Twitter) handle: not listed on the contributor's GitHub profile; happy to add one if needed.
