### PR TITLE
feat(serve): add --no-rotate-pairing flag for a static pairing URL

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -37,6 +37,7 @@ export const BOOLEAN_FLAGS = new Set([
   'mobile',
   'mobile-pairing',
   'no-pairing',
+  'no-rotate-pairing',
   'parent-current',
   'provision',
   'ready',

--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -127,6 +127,7 @@ export const CORE_HANDLERS: Record<string, CommandHandler> = {
           ? (flags.get('pairing-address') as string)
           : null,
       noPairing: flags.get('no-pairing') === true,
+      noRotatePairing: flags.get('no-rotate-pairing') === true,
       mobilePairing: flags.get('mobile-pairing') === true,
       recipeJson: flags.get('recipe-json') === true,
       projectRoot

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2154,6 +2154,7 @@ describe('orca cli worktree awareness', () => {
       port: '6768',
       pairingAddress: '100.64.1.20',
       noPairing: true,
+      noRotatePairing: false,
       mobilePairing: false,
       recipeJson: false,
       projectRoot: null
@@ -2173,6 +2174,7 @@ describe('orca cli worktree awareness', () => {
       port: null,
       pairingAddress: '100.64.1.20',
       noPairing: false,
+      noRotatePairing: false,
       mobilePairing: true,
       recipeJson: false,
       projectRoot: null
@@ -2199,6 +2201,7 @@ describe('orca cli worktree awareness', () => {
       port: null,
       pairingAddress: 'wss://sandbox.example.com',
       noPairing: false,
+      noRotatePairing: false,
       mobilePairing: false,
       recipeJson: true,
       projectRoot: '/workspace/repo'

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -80,6 +80,7 @@ export function serveOrcaApp(
     port?: string | null
     pairingAddress?: string | null
     noPairing?: boolean
+    noRotatePairing?: boolean
     mobilePairing?: boolean
     recipeJson?: boolean
     projectRoot?: string | null
@@ -102,6 +103,9 @@ export function serveOrcaApp(
   }
   if (args.noPairing) {
     childArgs.push('--serve-no-pairing')
+  }
+  if (args.noRotatePairing) {
+    childArgs.push('--serve-no-rotate-pairing')
   }
   if (args.mobilePairing) {
     childArgs.push('--serve-mobile-pairing')

--- a/src/cli/specs/serve.ts
+++ b/src/cli/specs/serve.ts
@@ -6,13 +6,14 @@ export const SERVE_COMMAND_SPECS: CommandSpec[] = [
     path: ['serve'],
     summary: 'Start an Orca runtime server without opening a desktop window',
     usage:
-      'orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--project-root <path>] [--recipe-json] [--json]',
+      'orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--no-rotate-pairing] [--project-root <path>] [--recipe-json] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'port',
       'pairing-address',
       'mobile-pairing',
       'no-pairing',
+      'no-rotate-pairing',
       'project-root',
       'recipe-json'
     ],
@@ -21,11 +22,13 @@ export const SERVE_COMMAND_SPECS: CommandSpec[] = [
       '--pairing-address changes only the client-advertised address; use a reachable LAN, Tailscale, SSH-forward, or reverse-proxy endpoint.',
       'Use --recipe-json with --project-root from VM recipes to print the recipe result JSON and leave the server running.',
       'Use --mobile-pairing to print a mobile-scoped pairing QR/link instead of the default runtime-environment pairing link.',
+      'Use --no-rotate-pairing to keep the same pairing URL across restarts (and across pairs). Default behavior is to rotate the pending device on each restart once any device has paired, so previously-printed URLs stop working. The flag opts in to a static URL suitable for bookmarking; treat the URL as a long-lived credential and rotate it explicitly via `orca device revoke` if it leaks.',
       'When the web client bundle is available, the server also prints a browser URL with the pairing data embedded.'
     ],
     examples: [
       'orca serve',
       'orca serve --json',
+      'orca serve --no-rotate-pairing',
       'orca serve --project-root /workspace/repo --pairing-address wss://sandbox.example.com --recipe-json',
       'orca serve --port 6768 --pairing-address 100.64.1.20',
       'orca serve --pairing-address 100.64.1.20 --mobile-pairing'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1771,6 +1771,7 @@ type ServeOptions = {
   wsPort?: number
   pairingAddress: string | null
   noPairing: boolean
+  noRotatePairing: boolean
   mobilePairing: boolean
   recipeJson: boolean
   projectRoot: string | null
@@ -1799,6 +1800,7 @@ function getServeOptions(argv = process.argv): ServeOptions {
     ...(wsPort !== undefined ? { wsPort } : {}),
     pairingAddress: valueAfter('--serve-pairing-address'),
     noPairing: argv.includes('--serve-no-pairing'),
+    noRotatePairing: argv.includes('--serve-no-rotate-pairing'),
     mobilePairing: argv.includes('--serve-mobile-pairing'),
     recipeJson: argv.includes('--serve-recipe-json'),
     projectRoot: valueAfter('--serve-project-root')
@@ -1859,7 +1861,8 @@ async function printServeReady(options: ServeOptions): Promise<void> {
     : runtimeRpc.createPairingOffer({
         address: options.pairingAddress,
         name: `${options.mobilePairing ? 'Mobile' : 'CLI'} ${new Date().toLocaleDateString()}`,
-        scope: options.mobilePairing ? 'mobile' : 'runtime'
+        scope: options.mobilePairing ? 'mobile' : 'runtime',
+        noRotate: options.noRotatePairing
       })
   const pairingQr =
     pairing.available && options.mobilePairing

--- a/src/main/runtime/device-registry.ts
+++ b/src/main/runtime/device-registry.ts
@@ -103,15 +103,19 @@ export class DeviceRegistry {
   // a stable pairing URL suitable for bookmarking. The caller (cli/runtime-rpc)
   // is responsible for gating this on a user-facing flag; do not invoke from
   // places that depend on the implicit rotation-after-pair.
+  //
+  // Why reverse: addDevice appends to `this.devices`, so the most-recent same-scope
+  // entry sits at the end. A forward find() would return the oldest surviving
+  // device of that scope and the pairing URL would point at a stale token.
   getOrCreatePendingDevice(
     name: string,
     scope: DeviceScope = 'mobile',
     pairingReach: RuntimePairingReach = 'network',
     options?: { noRotate?: boolean }
   ): DeviceEntry {
-    const existing = this.devices.find((d) =>
-      options?.noRotate ? d.scope === scope : d.lastSeenAt === 0 && d.scope === scope
-    )
+    const existing = options?.noRotate
+      ? this.devices.toReversed().find((d) => d.scope === scope)
+      : this.devices.find((d) => d.lastSeenAt === 0 && d.scope === scope)
     if (existing) {
       // Why: the same pending token can be re-advertised at a broader reach; widen it but never narrow it,
       // or a link already handed out for off-host use would stop being served after the next launch.

--- a/src/main/runtime/device-registry.ts
+++ b/src/main/runtime/device-registry.ts
@@ -97,12 +97,21 @@ export class DeviceRegistry {
   // copy-button flow that encourages regeneration) leaves an orphaned token
   // forever. Returns an existing never-scanned entry if present; otherwise
   // mints a new one and drops any stale pending entries.
+  //
+  // When `noRotate` is true, the lookup ignores `lastSeenAt` so the most-recent
+  // device of this scope is reused across restarts and across pairs. This produces
+  // a stable pairing URL suitable for bookmarking. The caller (cli/runtime-rpc)
+  // is responsible for gating this on a user-facing flag; do not invoke from
+  // places that depend on the implicit rotation-after-pair.
   getOrCreatePendingDevice(
     name: string,
     scope: DeviceScope = 'mobile',
-    pairingReach: RuntimePairingReach = 'network'
+    pairingReach: RuntimePairingReach = 'network',
+    options?: { noRotate?: boolean }
   ): DeviceEntry {
-    const existing = this.devices.find((d) => d.lastSeenAt === 0 && d.scope === scope)
+    const existing = this.devices.find((d) =>
+      options?.noRotate ? d.scope === scope : d.lastSeenAt === 0 && d.scope === scope
+    )
     if (existing) {
       // Why: the same pending token can be re-advertised at a broader reach; widen it but never narrow it,
       // or a link already handed out for off-host use would stop being served after the next launch.

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -5763,6 +5763,24 @@ describe('OrcaRuntimeRpcServer WebSocket bind host (STA-2370)', () => {
     expect(second.pairingReach).toBe('network')
   })
 
+  it('noRotate selects the most-recent same-scope device, not the oldest surviving one', () => {
+    // Why: addDevice appends to the registry, so the most-recent same-scope entry sits at the end.
+    // A forward find() would return the oldest device and the URL would point at a stale token.
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const registry = new DeviceRegistry(userDataPath)
+    const older = registry.addDevice('Old server', 'runtime', 'network')
+    const newer = registry.addDevice('New server', 'runtime', 'network')
+    // Mark older as paired so the default-rotation lookup would skip it; noRotate ignores that.
+    registry.updateLastSeen(older.deviceId)
+    // With noRotate, the lookup must return the newer entry (last in the array).
+    const resolved = registry.getOrCreatePendingDevice('Server', 'runtime', 'network', {
+      noRotate: true
+    })
+    expect(resolved.deviceId).toBe(newer.deviceId)
+    expect(resolved.token).toBe(newer.token)
+    expect(resolved.deviceId).not.toBe(older.deviceId)
+  })
+
   it('binds all interfaces at startup for a connected device paired before pairingReach existed', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
     // Why: registries written by older desktops only ever held network-reach grants; a missing field must

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -5770,8 +5770,10 @@ describe('OrcaRuntimeRpcServer WebSocket bind host (STA-2370)', () => {
     const registry = new DeviceRegistry(userDataPath)
     const older = registry.addDevice('Old server', 'runtime', 'network')
     const newer = registry.addDevice('New server', 'runtime', 'network')
-    // Mark older as paired so the default-rotation lookup would skip it; noRotate ignores that.
+    // Mark both devices as paired so default rotation cannot reuse either existing entry —
+    // without noRotate, getOrCreatePendingDevice would mint a third device here.
     registry.updateLastSeen(older.deviceId)
+    registry.updateLastSeen(newer.deviceId)
     // With noRotate, the lookup must return the newer entry (last in the array).
     const resolved = registry.getOrCreatePendingDevice('Server', 'runtime', 'network', {
       noRotate: true
@@ -5779,6 +5781,8 @@ describe('OrcaRuntimeRpcServer WebSocket bind host (STA-2370)', () => {
     expect(resolved.deviceId).toBe(newer.deviceId)
     expect(resolved.token).toBe(newer.token)
     expect(resolved.deviceId).not.toBe(older.deviceId)
+    // Confirm no third device was minted.
+    expect(registry.listDevices()).toHaveLength(2)
   })
 
   it('binds all interfaces at startup for a connected device paired before pairingReach existed', async () => {

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -5721,6 +5721,48 @@ describe('OrcaRuntimeRpcServer WebSocket bind host (STA-2370)', () => {
     }
   })
 
+  it('rotates the pending device after a pair by default, so the URL changes on next launch', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const registry = new DeviceRegistry(userDataPath)
+    const first = registry.getOrCreatePendingDevice('Server', 'runtime')
+    registry.updateLastSeen(first.deviceId)
+    // Default: a previously-paired device is no longer pending, so a fresh pending device is minted.
+    const second = registry.getOrCreatePendingDevice('Server', 'runtime')
+    expect(second.deviceId).not.toBe(first.deviceId)
+    expect(second.token).not.toBe(first.token)
+  })
+
+  it('keeps the same pending device across pairs when noRotate is set, so the URL stays stable', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const registry = new DeviceRegistry(userDataPath)
+    const first = registry.getOrCreatePendingDevice('Server', 'runtime', 'network', {
+      noRotate: true
+    })
+    registry.updateLastSeen(first.deviceId)
+    // With noRotate: the same device entry is returned even after a pair — token is stable.
+    const second = registry.getOrCreatePendingDevice('Server', 'runtime', 'network', {
+      noRotate: true
+    })
+    expect(second.deviceId).toBe(first.deviceId)
+    expect(second.token).toBe(first.token)
+  })
+
+  it('noRotate preserves the pairingReach widening rule so a long-lived URL still reaches off-host', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const registry = new DeviceRegistry(userDataPath)
+    const first = registry.getOrCreatePendingDevice('Server', 'runtime', 'this-computer', {
+      noRotate: true
+    })
+    // A long-lived URL must remain reachable once the operator widens reach to 'network'.
+    // The widening rule applies regardless of noRotate — without it, a previously local URL
+    // would stop working off-host on the next launch.
+    const second = registry.getOrCreatePendingDevice('Server', 'runtime', 'network', {
+      noRotate: true
+    })
+    expect(second.deviceId).toBe(first.deviceId)
+    expect(second.pairingReach).toBe('network')
+  })
+
   it('binds all interfaces at startup for a connected device paired before pairingReach existed', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
     // Why: registries written by older desktops only ever held network-reach grants; a missing field must

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -666,6 +666,9 @@ export class OrcaRuntimeRpcServer {
     // Why: STA-2370 — recorded on the grant so a "This computer only" client reconnecting cannot make the
     // next launch bind every interface. Defaults to network reach, which is what every other caller means.
     reach?: RuntimePairingReach
+    // Why: --no-rotate-pairing lets the operator pin a static pairing URL across restarts and pairs.
+    // Default false preserves the implicit rotation-after-pair semantics that revoke a leaked URL on next launch.
+    noRotate?: boolean
   }):
     | PairingOfferUnavailable
     | {
@@ -705,7 +708,9 @@ export class OrcaRuntimeRpcServer {
       const reach = args.reach ?? 'network'
       device = args.rotate
         ? this.deviceRegistry.rotatePendingDevice(deviceName, scope, reach)
-        : this.deviceRegistry.getOrCreatePendingDevice(deviceName, scope, reach)
+        : this.deviceRegistry.getOrCreatePendingDevice(deviceName, scope, reach, {
+            noRotate: args.noRotate
+          })
     } catch (error) {
       console.error('[runtime] Failed to persist pairing credential:', error)
       return pairingUnavailable('device_registry_unavailable', DEVICE_REGISTRY_UNAVAILABLE_GUIDANCE)

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -11,6 +11,7 @@ const SERVE_FLAG = '--serve'
 const CLI_TO_SERVE_FLAG = new Map([
   ['--json', '--serve-json'],
   ['--no-pairing', '--serve-no-pairing'],
+  ['--no-rotate-pairing', '--serve-no-rotate-pairing'],
   ['--mobile-pairing', '--serve-mobile-pairing'],
   ['--recipe-json', '--serve-recipe-json']
 ])


### PR DESCRIPTION
## Summary

Adds `--no-rotate-pairing` to `orca serve`. When set, the headless runtime keeps the same pending device across restarts and across pairs, so the printed pairing URL is byte-for-byte stable until the operator explicitly rotates (via `orca device revoke` or by deleting the registry entry).

Default behavior is unchanged: after a device pairs, the next launch mints a fresh pending device with a new token, which rotates the URL. The static-URL behavior is only safe when the operator controls URL distribution (bookmark, password manager, internal wiki). Anyone with the URL can pair, so treat it as a long-lived credential.

Wire-through is end-to-end:

- CLI: flag added to `BOOLEAN_FLAGS`, the `serve` spec (`usage`, `notes`, `allowedFlags`, `examples`), and the argv rewrite from CLI-form to `--serve-no-rotate-pairing`.
- CLI shim: `serveOrcaApp` accepts `noRotatePairing` and forwards `--serve-no-rotate-pairing` to the spawned Electron child.
- Main process: `ServeOptions` carries the flag, parsed in `getServeOptions`. `printServeReady` passes it to `runtimeRpc.createPairingOffer`.
- Runtime: `createPairingOffer` accepts `noRotate?: boolean` and threads it through to `DeviceRegistry.getOrCreatePendingDevice`.
- Registry: `getOrCreatePendingDevice` skips the `lastSeenAt === 0` filter when `noRotate: true`. The existing `pairingReach` widening rule still applies so a long-lived URL remains reachable once the operator widens reach to `'network'`.

## Screenshots

No visual change. This is a CLI flag affecting server-only behavior.

## Testing

- [x] `pnpm lint` — clean (lint-staged ran on commit)
- [x] `pnpm typecheck` — clean on rebased tree
- [x] `pnpm test` — `src/cli/serve-electron-flag-parity.test.ts` is 11/11 pass; the parity test enumerates the spec's `allowedFlags` and verifies the CLI-to-`--serve-*` argv rewrite, that `serveOrcaApp` spawns with the matching `--serve-<flag>`, and that `getServeOptions` reads the same name. Adding `no-rotate-pairing` to the spec means this test now covers the new flag end-to-end automatically. `src/cli/index.test.ts` updated for the new `noRotatePairing` field on `serveOrcaApp` calls (3 tests). `src/main/runtime/runtime-rpc.test.ts` added 3 new tests:
  - default rotation: after a pair, the next call mints a new device (regression guard against the rotating behavior being lost)
  - noRotate: after a pair, the next call returns the same device and token
  - noRotate + pairingReach widening: a long-lived URL still widens to `'network'` when the operator asks for it
- [x] `pnpm build` — `pnpm run build:cli` and `pnpm run build:electron-vite` both rebuilt cleanly on the rebased branch; ready for the full pipeline.
- [x] Added or updated high-quality tests: yes, the three new tests in `runtime-rpc.test.ts` cover the new behavior end-to-end at the device-registry layer. The CLI-side wiring is automatically covered by the existing parity test.

## AI Review Report

Reviewed the change with the assistant. Main risks checked:

- **Cross-platform compatibility**: macOS and Windows are unaffected. `device-registry.ts` and `runtime-rpc.ts` are platform-agnostic. The flag short-circuits at the device-registry lookup; no platform-specific code paths.
- **SSH/remote/local compatibility**: The flag is host-side only. It does not change anything a paired client exchanges with the host. Existing clients paired to a serve that started with `--no-rotate-pairing` see the same wire shape they would for any serve; only the URL printed at startup is stable.
- **Agent/integration compatibility**: The agent hooks server and the PTY runtime are independent of the device registry. No provider-specific code is touched.
- **Performance risk**: Negligible. The lookup is a single `find` over an array typically containing 1–10 device entries. The `noRotate: true` path is one fewer comparison than the default path.
- **UI quality**: No UI change. No new shadcn primitives, no tokens, no styling.
- **Security risk**: The pairing URL is now long-lived when this flag is set. The runtime-rpc comment, the spec note, and the CLI help text all explicitly call out that this treats the URL as a long-lived credential. The default behavior (rotation) is unchanged. Operators who don't set the flag are unaffected.
- **Backward compatibility**: Strictly additive. The `options` parameter on `getOrCreatePendingDevice` is optional; existing callers (in `runtime-rpc.ts` and elsewhere) continue to work without changes. The CLI flag is opt-in.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependencies, and IPC.

- **Input handling**: The flag is a boolean. It goes through the standard CLI boolean-flag pipeline (`BOOLEAN_FLAGS` set, argv rewrite, `process.argv.includes` check, JSON-RPC method dispatch). No string parsing, no path interpolation, no shell expansion.
- **Command execution**: The flag is appended to the Electron child argv in `serveOrcaApp`. No new shell invocation. The CLI shim's `childArgs.push('--serve-no-rotate-pairing')` is a static string.
- **Path handling**: None added.
- **Auth/secrets**: The flag changes the lifetime of a pairing token (the device entry's `token` field). With `--no-rotate-pairing`, the token is stable across restarts and across pairs. With default behavior, the token rotates on each new pending device after a pair. The token is opaque random bytes (existing comment at `device-registry.ts:95-99`); no change to its unpredictability.
- **Dependencies**: None added.
- **IPC**: No new IPC channels. The flag flows through the same ServeOptions path the operator-facing flags already use.
- **Remote wire compatibility**: The new flag is host-side only and does not change anything a paired client exchanges with the host. The pairing URL contains the same `{v, endpoint, deviceToken, publicKeyB64, scope}` payload as before; `deviceToken` is just no longer rotating.

No follow-up needed.

## Notes

- **Platform-specific behavior**: None. The flag is host-side and platform-agnostic.
- **Trade-off**: Useful for operators who want a bookmarkable URL or a QR code on a sticker; risky for any deployment where the URL is shared beyond the operator's control. The default (rotation) is the safer choice for most deployments.
- **Rotation path**: To rotate the URL on a serve running with `--no-rotate-pairing`, the operator can use `orca device revoke <deviceId>` (the static device's id, available via `orca device list`) or delete the device entry from `orca-devices.json`. The next launch will mint a new pending device and the URL will change.
- **Pre-pairing stability**: Even without this flag, the URL is stable across restarts until the first pair (the existing pending device is reused). The flag is what extends that stability to *post-pair* — across any number of pairs, until the operator explicitly rotates.
- **Pairing reach**: The existing widening rule (`this-computer` → `network`) still applies when `noRotate: true`. Without this, a previously-local URL would stop working off-host on the next launch. The test `noRotate preserves the pairingReach widening rule so a long-lived URL still reaches off-host` documents this.
- **Not in this PR**: A CLI flag to rotate from the command line (e.g., `orca serve --rotate-pairing` to delete-then-recreate). Today's workaround is `orca device revoke` or editing the registry. A future PR could add a one-shot rotation flag if needed.
