### PR TITLE
fix(ipc): scope request cancellation to the sender object

### DIFF
--- a/src/main/ipc/sender-scoped-request-cancellation.test.ts
+++ b/src/main/ipc/sender-scoped-request-cancellation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { IpcMainInvokeEvent } from 'electron'
+import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
+
+// Why: only `sender` identity matters here; the rest of the invoke event is unused.
+const eventFor = (sender: object): IpcMainInvokeEvent => ({ sender }) as IpcMainInvokeEvent
+
+describe('createSenderScopedRequestCancellations', () => {
+  it('aborts the previous request when one sender reuses a token', () => {
+    const registry = createSenderScopedRequestCancellations()
+    const event = eventFor({ id: 1 })
+
+    const first = registry.begin(event, 'token')
+    const second = registry.begin(event, 'token')
+
+    expect(first?.signal.aborted).toBe(true)
+    expect(second?.signal.aborted).toBe(false)
+  })
+
+  it('keeps two senders that share a token isolated', () => {
+    const registry = createSenderScopedRequestCancellations()
+    const senderA = { id: 1 }
+    const senderB = { id: 2 }
+    const first = registry.begin(eventFor(senderA), 'token')
+    const second = registry.begin(eventFor(senderB), 'token')
+
+    registry.cancel(eventFor(senderB), 'token')
+
+    expect(first?.signal.aborted).toBe(false)
+    expect(second?.signal.aborted).toBe(true)
+  })
+
+  it('does not let a recycled webContents id reach the previous renderer request', () => {
+    const registry = createSenderScopedRequestCancellations()
+    const closed = { id: 7 }
+    const pending = registry.begin(eventFor(closed), 'token')
+
+    // Electron recycles webContents ids, so a later renderer can present id 7 again.
+    const recycled = { id: 7 }
+    registry.cancel(eventFor(recycled), 'token')
+
+    expect(pending?.signal.aborted).toBe(false)
+  })
+
+  it('does not let a recycled id replace the previous renderer registration', () => {
+    const registry = createSenderScopedRequestCancellations()
+    const pending = registry.begin(eventFor({ id: 7 }), 'token')
+
+    const replacement = registry.begin(eventFor({ id: 7 }), 'token')
+
+    expect(pending?.signal.aborted).toBe(false)
+    expect(replacement?.signal.aborted).toBe(false)
+  })
+
+  it('ignores a finish from a recycled id holding a different controller', () => {
+    const registry = createSenderScopedRequestCancellations()
+    const sender = { id: 7 }
+    const controller = registry.begin(eventFor(sender), 'token')
+
+    registry.finish(eventFor({ id: 7 }), 'token', controller)
+    registry.cancel(eventFor(sender), 'token')
+
+    expect(controller?.signal.aborted).toBe(true)
+  })
+
+  it('drops the registration once its request settles', () => {
+    const registry = createSenderScopedRequestCancellations()
+    const sender = { id: 1 }
+    const controller = registry.begin(eventFor(sender), 'token')
+
+    registry.finish(eventFor(sender), 'token', controller)
+    registry.cancel(eventFor(sender), 'token')
+
+    expect(controller?.signal.aborted).toBe(false)
+  })
+
+  it('returns null without registering when the token is empty', () => {
+    const registry = createSenderScopedRequestCancellations()
+    expect(registry.begin(eventFor({ id: 1 }), undefined)).toBeNull()
+    expect(registry.begin(eventFor({ id: 1 }), '')).toBeNull()
+  })
+})

--- a/src/main/ipc/sender-scoped-request-cancellation.ts
+++ b/src/main/ipc/sender-scoped-request-cancellation.ts
@@ -20,31 +20,41 @@ export type SenderScopedRequestCancellations = {
  * registers.
  */
 export function createSenderScopedRequestCancellations(): SenderScopedRequestCancellations {
-  const controllers = new Map<string, AbortController>()
-  const keyFor = (event: IpcMainInvokeEvent, requestToken: string): string =>
-    `${event.sender.id}\0${requestToken}`
+  type Sender = IpcMainInvokeEvent['sender']
+  // Why: webContents ids are recycled once a window closes, so an id-derived key
+  // can hand a new renderer the registration slot of a previous one.
+  const controllersBySender = new WeakMap<Sender, Map<string, AbortController>>()
+  const controllersFor = (sender: Sender): Map<string, AbortController> => {
+    const existing = controllersBySender.get(sender)
+    if (existing) {
+      return existing
+    }
+    const created = new Map<string, AbortController>()
+    controllersBySender.set(sender, created)
+    return created
+  }
   return {
     begin: (event, requestToken) => {
       if (!requestToken) {
         return null
       }
-      const key = keyFor(event, requestToken)
-      controllers.get(key)?.abort()
+      const controllers = controllersFor(event.sender)
+      controllers.get(requestToken)?.abort()
       const controller = new AbortController()
-      controllers.set(key, controller)
+      controllers.set(requestToken, controller)
       return controller
     },
     finish: (event, requestToken, controller) => {
       if (!requestToken || !controller) {
         return
       }
-      const key = keyFor(event, requestToken)
-      if (controllers.get(key) === controller) {
-        controllers.delete(key)
+      const controllers = controllersBySender.get(event.sender)
+      if (controllers?.get(requestToken) === controller) {
+        controllers.delete(requestToken)
       }
     },
     cancel: (event, requestToken) => {
-      controllers.get(keyFor(event, requestToken))?.abort()
+      controllersBySender.get(event.sender)?.get(requestToken)?.abort()
     }
   }
 }


### PR DESCRIPTION
## Summary

`webContents` ids are recycled by Electron after a window closes. The IPC cancellation registry keyed its map on a string built from that id (`` `${event.sender.id}\0${requestToken}` ``), so a **new** renderer that happened to receive a **retired** renderer's numeric id inherited its registration slot.

This re-keys the registry on the `webContents` object itself via a `WeakMap`. Identity becomes exact, and entries for collected senders drop out on their own instead of accumulating in a process-lifetime `Map`.

## The bug in one picture

```mermaid
flowchart TB
    subgraph BEFORE["Before — key is `${sender.id}\0${token}`"]
        direction TB
        A1["Window A (id 7)<br/>begin('list')"] --> K1["key: 7\0list"]
        A2["Window A closes<br/>request still in flight"] -.-> K1
        B1["Window B opens<br/>Electron reissues id 7"] --> K2["key: 7\0list"]
        K2 -->|"same key"| X["Window B's cancel/begin/finish<br/>hits Window A's controller"]
    end

    subgraph AFTER["After — key is the webContents object"]
        direction TB
        C1["Window A (id 7)"] --> W1["WeakMap entry: objectA"]
        C2["Window B (id 7, new object)"] --> W2["WeakMap entry: objectB"]
        W1 --- N["distinct entries<br/>no crosstalk"]
        W2 --- N
    end
```

## What could actually go wrong

Three reachable misroutes, all requiring only that Electron reuse a numeric id — which it does routinely, and which on macOS happens without an app restart because closing a window does not quit the app:

| Path | Symptom before |
|---|---|
| `cancel()` | Window B cancelling its own request aborts Window A's unrelated in-flight request |
| `begin()` | Window B registering the same token aborts Window A's live request as if it were a token reuse |
| `finish()` | Window B settling evicts Window A's still-live registration, so A's later `cancel()` silently does nothing |

The four consumers are `fs:listFiles`, `git:status`, `aiVault:listSessions`, and `worktrees:listDetected`.

## Scope

This is the **correctness half** of #13593, split out and landed on its own. That PR bundled this re-keying together with a new "abort every in-flight request when the sender is destroyed" behavior. The destroy-abort turned out to have real user-facing consequences (a skipped persistent `pruneLineageForMissingRepoWorktrees`, rejected IPC handlers on the two handlers lacking a cancellation-to-result guard, and new `rpc.cancel` frames to remote relays on window close), so it is not included here.

Nothing in this PR changes when a request is aborted. It only changes **which** requests a given renderer can reach.

## Behavior and compatibility

- No new abort triggers. `begin`/`finish`/`cancel` abort under exactly the conditions they did before.
- No RPC, stream, wire, protocol, schema, or persisted-state surface touched. Main-process only.
- No platform-specific behavior; no SSH/relay/folder-workspace/WSL divergence.
- `WeakMap` replaces a `Map` that was never pruned for destroyed senders, so this also removes a small process-lifetime retention.

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Focused suite: 7/7 pass

Each guard was verified to actually fail against the previous implementation rather than merely pass against the new one. Reverting `sender-scoped-request-cancellation.ts` to `origin/main` and rerunning gives **3 failures**, one per misroute above:

```
× does not let a recycled webContents id reach the previous renderer request
× does not let a recycled id replace the previous renderer registration
× ignores a finish from a recycled id holding a different controller
```

The remaining four tests (token-reuse abort, cross-sender isolation, settle-then-cancel, empty token) pass on both implementations and pin the behavior that must **not** change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
