### PR TITLE
Fix repo-scoped Quick Commands across remote hosts

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -23,6 +23,8 @@ import {
   useTerminalQuickCommandHosts
 } from '@/hooks/use-terminal-quick-command-hosts'
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import { useProjectHostSetupProjection } from '@/store/selectors'
+import { terminalQuickCommandMatchesWorkspaceProject } from '@/lib/terminal-quick-command-project-scope'
 
 type TabBarQuickCommandsButtonProps = {
   worktreeId: string
@@ -35,6 +37,7 @@ export function TabBarQuickCommandsButton({
 }: TabBarQuickCommandsButtonProps): React.JSX.Element | null {
   const recentByGroup = useAppStore((s) => s.recentQuickCommandIdByGroup)
   const repos = useAppStore((s) => s.repos)
+  const projectHostSetupProjection = useProjectHostSetupProjection()
   const { executionHostId, hosts, refreshRemoteHost, remoteHostLoadFailed, remoteHostPending } =
     useTerminalQuickCommandHosts(worktreeId)
   const confirm = useConfirmationDialog()
@@ -61,12 +64,20 @@ export function TabBarQuickCommandsButton({
       const scope = getTerminalQuickCommandScope(command)
       if (scope.type === 'global') {
         globalList.push(entry)
-      } else if (scope.type === 'repo' && repoId !== null && scope.repoId === repoId) {
+      } else if (
+        scope.type === 'repo' &&
+        terminalQuickCommandMatchesWorkspaceProject(command, {
+          commandHostId: entry.hostId,
+          projectHostSetups: projectHostSetupProjection.setups,
+          targetHostId: executionHostId,
+          targetRepoId: repoId
+        })
+      ) {
         repoList.push(entry)
       }
     }
     return { repoCommands: repoList, globalCommands: globalList }
-  }, [hosts, repoId])
+  }, [executionHostId, hosts, projectHostSetupProjection.setups, repoId])
 
   const recentId = recentByGroup[groupId] ?? null
   // Why: split-button label prefers the most recently used command for this

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -164,13 +164,13 @@ import {
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
-import { useRepoById } from '@/store/selectors'
+import { useProjectHostSetupProjection, useRepoById } from '@/store/selectors'
 import { refitAndRefreshAllTerminalPanes } from '@/lib/pane-manager/pane-manager-registry'
 import {
   getTerminalQuickCommandScope,
-  isTerminalQuickCommandComplete,
-  terminalQuickCommandMatchesRepo
+  isTerminalQuickCommandComplete
 } from '../../../../shared/terminal-quick-commands'
+import { terminalQuickCommandMatchesWorkspaceProject } from '@/lib/terminal-quick-command-project-scope'
 import {
   createTerminalQuickCommandDraft,
   TerminalQuickCommandDialog
@@ -787,6 +787,7 @@ function TerminalPane(
   const quickCommandRepoId =
     worktreeId === FLOATING_TERMINAL_WORKTREE_ID ? null : getRepoIdFromWorktreeId(worktreeId)
   const quickCommandRepo = useRepoById(quickCommandRepoId)
+  const projectHostSetupProjection = useProjectHostSetupProjection()
   const quickCommandRepoLabel = quickCommandRepo
     ? quickCommandRepo.displayName || quickCommandRepo.path
     : quickCommandRepoId
@@ -2518,6 +2519,7 @@ function TerminalPane(
     rightClickToPaste
   })
   const {
+    executionHostId: quickCommandExecutionHostId,
     hosts: quickCommandHosts,
     refreshRemoteHost: refreshQuickCommandRemoteHost,
     remoteHostLoadFailed: quickCommandHostLoadFailed,
@@ -2536,12 +2538,23 @@ function TerminalPane(
           repoCommands: commands.filter((command) => {
             const scope = getTerminalQuickCommandScope(command)
             return (
-              scope.type === 'repo' && terminalQuickCommandMatchesRepo(command, quickCommandRepoId)
+              scope.type === 'repo' &&
+              terminalQuickCommandMatchesWorkspaceProject(command, {
+                commandHostId: host.hostId,
+                projectHostSetups: projectHostSetupProjection.setups,
+                targetHostId: quickCommandExecutionHostId,
+                targetRepoId: quickCommandRepoId
+              })
             )
           })
         }
       }),
-    [quickCommandHosts, quickCommandRepoId]
+    [
+      projectHostSetupProjection.setups,
+      quickCommandExecutionHostId,
+      quickCommandHosts,
+      quickCommandRepoId
+    ]
   )
   useEffect(() => {
     if (contextMenu.open) {

--- a/src/renderer/src/lib/terminal-quick-command-project-scope.test.ts
+++ b/src/renderer/src/lib/terminal-quick-command-project-scope.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
+import type { ProjectHostSetup, Repo, TerminalQuickCommand } from '../../../shared/types'
+import { terminalQuickCommandMatchesWorkspaceProject } from './terminal-quick-command-project-scope'
+
+type ScopeSetup = Pick<ProjectHostSetup, 'hostId' | 'projectId' | 'repoId'>
+
+const LOCAL_REPO_ID = '32a0226d-9f33-42e8-8b7b-24867dea06d4'
+const WINDOWS_REPO_ID = 'a0a2b4a4-1bff-494c-b005-d77918abc6a7'
+
+function command(repoId: string): TerminalQuickCommand {
+  return {
+    id: 'test-orca',
+    label: 'Test Orca',
+    action: 'terminal-command',
+    command: 'pnpm test',
+    appendEnter: true,
+    scope: { type: 'repo', repoId }
+  }
+}
+
+function setup(
+  hostId: ExecutionHostId,
+  repoId: string,
+  projectId = 'github:stablyai/orca'
+): ScopeSetup {
+  return { hostId, projectId, repoId }
+}
+
+describe('terminalQuickCommandMatchesWorkspaceProject', () => {
+  it.each<ExecutionHostId>(['runtime:windows-2', 'ssh:windows-2'])(
+    'shows a local repo command in the same project on %s',
+    (targetHostId) => {
+      const projectHostSetups = [
+        setup('local', LOCAL_REPO_ID),
+        setup(targetHostId, WINDOWS_REPO_ID)
+      ]
+
+      expect(
+        terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+          commandHostId: 'local',
+          projectHostSetups,
+          targetHostId,
+          targetRepoId: WINDOWS_REPO_ID
+        })
+      ).toBe(true)
+    }
+  )
+
+  it('matches the user topology from host-fetched repo catalogs', () => {
+    const repo = (id: string, path: string, executionHostId?: ExecutionHostId): Repo => ({
+      id,
+      path,
+      displayName: 'orca',
+      badgeColor: '#737373',
+      addedAt: 100,
+      kind: 'git',
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/stablyai/orca',
+        remoteName: 'origin',
+        remoteUrl: 'git@github.com:stablyai/orca.git'
+      },
+      ...(executionHostId ? { executionHostId } : {})
+    })
+    const projectHostSetups = projectHostSetupProjectionFromRepos([
+      repo(LOCAL_REPO_ID, '/Users/alice/orca'),
+      repo(WINDOWS_REPO_ID, 'C:\\Users\\alice\\orca', 'runtime:windows-2')
+    ]).setups
+
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+        commandHostId: 'local',
+        projectHostSetups,
+        targetHostId: 'runtime:windows-2',
+        targetRepoId: WINDOWS_REPO_ID
+      })
+    ).toBe(true)
+  })
+
+  it('does not show a repo command for a different known project', () => {
+    const projectHostSetups = [
+      setup('local', LOCAL_REPO_ID),
+      setup('runtime:windows-2', WINDOWS_REPO_ID, 'github:stablyai/other')
+    ]
+
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+        commandHostId: 'local',
+        projectHostSetups,
+        targetHostId: 'runtime:windows-2',
+        targetRepoId: WINDOWS_REPO_ID
+      })
+    ).toBe(false)
+  })
+
+  it('does not trust colliding cross-host repo ids when both projects are known', () => {
+    const projectHostSetups = [
+      setup('local', LOCAL_REPO_ID),
+      setup('runtime:windows-2', LOCAL_REPO_ID, 'github:stablyai/other')
+    ]
+
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+        commandHostId: 'local',
+        projectHostSetups,
+        targetHostId: 'runtime:windows-2',
+        targetRepoId: LOCAL_REPO_ID
+      })
+    ).toBe(false)
+  })
+
+  it('preserves exact repo-id matching when legacy project metadata is unavailable', () => {
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+        commandHostId: 'local',
+        projectHostSetups: [],
+        targetHostId: 'runtime:legacy',
+        targetRepoId: LOCAL_REPO_ID
+      })
+    ).toBe(true)
+  })
+
+  it('resolves a settings-owned command whose repo executes through SSH', () => {
+    const projectHostSetups = [
+      setup('ssh:builder', LOCAL_REPO_ID),
+      setup('runtime:windows-2', WINDOWS_REPO_ID)
+    ]
+
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+        commandHostId: 'local',
+        projectHostSetups,
+        targetHostId: 'runtime:windows-2',
+        targetRepoId: WINDOWS_REPO_ID
+      })
+    ).toBe(true)
+  })
+
+  it('keeps a remote-host repo command visible on its own repo', () => {
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(WINDOWS_REPO_ID), {
+        commandHostId: 'runtime:windows-2',
+        projectHostSetups: [],
+        targetHostId: 'runtime:windows-2',
+        targetRepoId: WINDOWS_REPO_ID
+      })
+    ).toBe(true)
+  })
+
+  it('keeps global commands visible without a repo and repo commands hidden', () => {
+    const globalCommand: TerminalQuickCommand = {
+      ...command(LOCAL_REPO_ID),
+      scope: { type: 'global' }
+    }
+    const context = {
+      commandHostId: 'local' as const,
+      projectHostSetups: [],
+      targetHostId: 'runtime:folder' as const,
+      targetRepoId: null
+    }
+
+    expect(terminalQuickCommandMatchesWorkspaceProject(globalCommand, context)).toBe(true)
+    expect(terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), context)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/terminal-quick-command-project-scope.test.ts
+++ b/src/renderer/src/lib/terminal-quick-command-project-scope.test.ts
@@ -110,6 +110,19 @@ describe('terminalQuickCommandMatchesWorkspaceProject', () => {
     ).toBe(false)
   })
 
+  it('does not infer a missing target setup from another host repo id', () => {
+    const projectHostSetups = [setup('local', LOCAL_REPO_ID), setup('ssh:builder', WINDOWS_REPO_ID)]
+
+    expect(
+      terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {
+        commandHostId: 'local',
+        projectHostSetups,
+        targetHostId: 'runtime:windows-2',
+        targetRepoId: WINDOWS_REPO_ID
+      })
+    ).toBe(false)
+  })
+
   it('preserves exact repo-id matching when legacy project metadata is unavailable', () => {
     expect(
       terminalQuickCommandMatchesWorkspaceProject(command(LOCAL_REPO_ID), {

--- a/src/renderer/src/lib/terminal-quick-command-project-scope.ts
+++ b/src/renderer/src/lib/terminal-quick-command-project-scope.ts
@@ -1,0 +1,68 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import { getTerminalQuickCommandScope } from '../../../shared/terminal-quick-commands'
+import type { ProjectHostSetup, TerminalQuickCommand } from '../../../shared/types'
+
+type TerminalQuickCommandProjectContext = {
+  commandHostId: ExecutionHostId
+  projectHostSetups: readonly Pick<ProjectHostSetup, 'hostId' | 'projectId' | 'repoId'>[]
+  targetHostId: ExecutionHostId
+  targetRepoId: string | null
+}
+
+type ProjectResolution =
+  | { kind: 'resolved'; projectId: string }
+  | { kind: 'ambiguous' }
+  | { kind: 'unknown' }
+
+function resolveProject(
+  setups: TerminalQuickCommandProjectContext['projectHostSetups'],
+  hostId: ExecutionHostId,
+  repoId: string
+): ProjectResolution {
+  const hostMatches = setups.filter((setup) => setup.hostId === hostId && setup.repoId === repoId)
+  // Why: commands belong to a settings host, while its repo can execute through that host's SSH.
+  const candidates =
+    hostMatches.length > 0 ? hostMatches : setups.filter((s) => s.repoId === repoId)
+  const projectIds = new Set(candidates.map((setup) => setup.projectId))
+  if (projectIds.size === 0) {
+    return { kind: 'unknown' }
+  }
+  if (projectIds.size > 1) {
+    return { kind: 'ambiguous' }
+  }
+  return { kind: 'resolved', projectId: [...projectIds][0] }
+}
+
+export function terminalQuickCommandMatchesWorkspaceProject(
+  command: TerminalQuickCommand,
+  context: TerminalQuickCommandProjectContext
+): boolean {
+  const scope = getTerminalQuickCommandScope(command)
+  if (scope.type === 'global') {
+    return true
+  }
+  if (context.targetRepoId === null) {
+    return false
+  }
+  if (context.commandHostId === context.targetHostId && scope.repoId === context.targetRepoId) {
+    return true
+  }
+
+  const commandProject = resolveProject(
+    context.projectHostSetups,
+    context.commandHostId,
+    scope.repoId
+  )
+  const targetProject = resolveProject(
+    context.projectHostSetups,
+    context.targetHostId,
+    context.targetRepoId
+  )
+  if (commandProject.kind === 'ambiguous' || targetProject.kind === 'ambiguous') {
+    return false
+  }
+  if (commandProject.kind === 'resolved' && targetProject.kind === 'resolved') {
+    return commandProject.projectId === targetProject.projectId
+  }
+  return scope.repoId === context.targetRepoId
+}

--- a/src/renderer/src/lib/terminal-quick-command-project-scope.ts
+++ b/src/renderer/src/lib/terminal-quick-command-project-scope.ts
@@ -17,12 +17,15 @@ type ProjectResolution =
 function resolveProject(
   setups: TerminalQuickCommandProjectContext['projectHostSetups'],
   hostId: ExecutionHostId,
-  repoId: string
+  repoId: string,
+  allowAnyHostFallback: boolean
 ): ProjectResolution {
   const hostMatches = setups.filter((setup) => setup.hostId === hostId && setup.repoId === repoId)
   // Why: commands belong to a settings host, while its repo can execute through that host's SSH.
   const candidates =
-    hostMatches.length > 0 ? hostMatches : setups.filter((s) => s.repoId === repoId)
+    hostMatches.length > 0 || !allowAnyHostFallback
+      ? hostMatches
+      : setups.filter((s) => s.repoId === repoId)
   const projectIds = new Set(candidates.map((setup) => setup.projectId))
   if (projectIds.size === 0) {
     return { kind: 'unknown' }
@@ -51,12 +54,14 @@ export function terminalQuickCommandMatchesWorkspaceProject(
   const commandProject = resolveProject(
     context.projectHostSetups,
     context.commandHostId,
-    scope.repoId
+    scope.repoId,
+    true
   )
   const targetProject = resolveProject(
     context.projectHostSetups,
     context.targetHostId,
-    context.targetRepoId
+    context.targetRepoId,
+    false
   )
   if (commandProject.kind === 'ambiguous' || targetProject.kind === 'ambiguous') {
     return false


### PR DESCRIPTION
## What changed

Repo-scoped Quick Commands now match the active workspace by logical project identity across hosts, instead of requiring the host-local repo UUID to be identical.

This fixes the reported topology where all five Local Mac commands target repo `32a0…`, while the same Orca project on windows 2 is repo `a0a2…`. Exact repo-ID matching remains the compatibility fallback when project metadata is unavailable. Known unrelated projects stay isolated.

Both invocation surfaces use the same matcher:

- tab-bar Quick Commands menu
- terminal right-click Quick Commands submenu

No RPC or remote wire format changes.

## Regression coverage

The deterministic test models the reported Local Mac + windows 2 UUIDs and proves:

- same logical project with different host-local repo IDs is visible
- paired-runtime and SSH targets behave consistently
- unrelated known projects remain hidden
- colliding cross-host IDs do not leak across known projects
- legacy exact-ID fallback, globals, folder workspaces, and remote-owned commands are preserved
- disabling the project-equivalence branch makes the positive regression cases fail

## Validation

- 60 focused tests across matcher, host discovery, project projection, tab menu, and context menu
- `pnpm typecheck`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run verify:localization-extraction`
- `git diff --check origin/main...HEAD`
- CI: 44 passed, 1 skipped, 0 failed

## AI Review Report

Reviewed project identity resolution, ambiguous and colliding repo IDs, legacy metadata fallback, host ownership, remote-owned commands, folder workspaces, SSH execution, and both Quick Command invocation surfaces. The original ID-only implementation was rejected after reproducing the user's repo-scoped failure; the replacement uses known setup project IDs and keeps exact-ID matching only as the compatibility fallback. CodeRabbit's latest review produced no actionable code findings.

Cross-platform review covered macOS, Linux, and Windows. The change introduces no shortcuts, labels, paths, shell commands, native modules, or Electron platform branches. Windows repo paths and paired-runtime host IDs are covered in the regression test and the Windows package CI job passes.

## Security Audit

The matcher is renderer-only and performs read-only comparisons of existing host, project, and repo identifiers. It adds no command interpolation or execution path, filesystem/path handling, authentication, secrets, dependency, IPC, RPC, or wire-format changes. Ambiguous project mappings fail closed, and known unrelated projects remain isolated to prevent command disclosure across project scopes.

## Notes

The UI changes only in remote/multi-host cases where equivalent project setups have different host-local repo IDs; ordinary local behavior and global commands remain unchanged. Commands remain grouped and labeled by their owning host, preserving remote-host-specific commands. Mixed-version remote compatibility is unaffected because no exchanged payload changed.
