### PR TITLE
fix(sidebar): close the workspace rename editor opened by the shortcut

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.editor-lifecycle.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.editor-lifecycle.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/workspace-emoji/WorkspaceEmojiSuggestionPopover', () => ({
+  WorkspaceEmojiSuggestionPopover: () => null
+}))
+
+vi.mock('@/components/workspace-emoji/useWorkspaceEmojiShortcodeInput', () => ({
+  useWorkspaceEmojiShortcodeInput: ({
+    onValueChange
+  }: {
+    onValueChange: (value: string) => void
+  }) => ({
+    close: vi.fn(),
+    commandValue: '',
+    handleKeyDown: () => false,
+    handleValueChange: (value: string) => onValueChange(value),
+    onCommandValueChange: vi.fn(),
+    open: false,
+    selectSuggestion: vi.fn(),
+    suggestions: [],
+    syncCursor: vi.fn()
+  })
+}))
+
+afterEach(() => {
+  cleanup()
+  // cleanup only unmounts, so a prototype spy would outlive its test
+  vi.restoreAllMocks()
+})
+
+const DISPLAY_NAME = 'Feature workspace'
+
+function renameEditor(): HTMLInputElement | null {
+  return screen.queryByRole<HTMLInputElement>('textbox', { name: 'Rename workspace' })
+}
+
+type HarnessProps = {
+  displayName?: string
+  onRename?: (displayName: string) => Promise<void> | void
+  onEditingChange?: (editing: boolean) => void
+  showUnreadEmphasis?: boolean
+}
+
+// Mirrors WorktreeCard: the card clears the trigger as soon as the title consumes it,
+// so from then on the editor stays open on its own state.
+function ShortcutRenameHarness({
+  displayName = DISPLAY_NAME,
+  onRename = vi.fn(),
+  onEditingChange,
+  showUnreadEmphasis = false
+}: HarnessProps): React.JSX.Element {
+  const [renameRequested, setRenameRequested] = useState(true)
+  return (
+    <WorktreeTitleInlineRename
+      displayName={displayName}
+      showUnreadEmphasis={showUnreadEmphasis}
+      onRename={onRename}
+      onEditingChange={onEditingChange}
+      beginEditing={renameRequested}
+      onBeginEditingConsumed={() => setRenameRequested(false)}
+    />
+  )
+}
+
+function openEditorByShortcut(props: HarnessProps = {}): {
+  input: HTMLInputElement
+  markUnread: () => void
+  renameElsewhere: (displayName: string) => void
+} {
+  const { rerender } = render(<ShortcutRenameHarness {...props} />)
+  const input = renameEditor()
+  if (!input) {
+    throw new Error('the rename shortcut did not open an editor')
+  }
+  return {
+    input,
+    markUnread: () => rerender(<ShortcutRenameHarness {...props} showUnreadEmphasis={true} />),
+    renameElsewhere: (displayName) =>
+      rerender(<ShortcutRenameHarness {...props} displayName={displayName} />)
+  }
+}
+
+describe('WorktreeTitleInlineRename editor lifecycle', () => {
+  it('closes the shortcut-opened editor on Escape', () => {
+    const { input } = openEditorByShortcut()
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(renameEditor()).toBeNull()
+  })
+
+  it('closes the shortcut-opened editor once the rename commits', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined)
+    const { input } = openEditorByShortcut({ onRename })
+
+    fireEvent.change(input, { target: { value: 'Renamed workspace' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(renameEditor()).toBeNull())
+    expect(onRename).toHaveBeenCalledWith('Renamed workspace')
+  })
+
+  it('closes the shortcut-opened editor when it loses focus', async () => {
+    const { input } = openEditorByShortcut()
+
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(renameEditor()).toBeNull())
+  })
+
+  // The parent re-enables drag off this callback, so a close that skips it leaves the
+  // card wedged even though the editor disappeared.
+  it('reports both edit-mode transitions to the parent exactly once', () => {
+    const onEditingChange = vi.fn()
+    const { input } = openEditorByShortcut({ onEditingChange })
+
+    expect(onEditingChange.mock.calls).toEqual([[true]])
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onEditingChange.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('opens the editor on double-click and reports it the same way', () => {
+    const onEditingChange = vi.fn()
+    render(
+      <WorktreeTitleInlineRename
+        displayName={DISPLAY_NAME}
+        onRename={vi.fn()}
+        onEditingChange={onEditingChange}
+      />
+    )
+    expect(renameEditor()).toBeNull()
+
+    fireEvent.doubleClick(screen.getByText(DISPLAY_NAME))
+
+    expect(renameEditor()).not.toBeNull()
+    expect(onEditingChange.mock.calls).toEqual([[true]])
+  })
+
+  it('focuses and selects the current name when the editor opens', () => {
+    const select = vi.spyOn(HTMLInputElement.prototype, 'select')
+
+    const { input } = openEditorByShortcut()
+
+    expect(document.activeElement).toBe(input)
+    expect(select).toHaveBeenCalledTimes(1)
+  })
+
+  // The hovercard editor never sets the unread flag, so a title change is the only
+  // way its key used to move.
+  it('leaves an open editor untouched when the workspace is renamed elsewhere', () => {
+    const { input, renameElsewhere } = openEditorByShortcut()
+    fireEvent.change(input, { target: { value: 'Half typed name' } })
+    const selectAfterOpen = vi.spyOn(HTMLInputElement.prototype, 'select')
+
+    renameElsewhere('Renamed by an agent')
+
+    expect(renameEditor()).toBe(input)
+    expect(input.value).toBe('Half typed name')
+    expect(document.activeElement).toBe(input)
+    expect(selectAfterOpen).not.toHaveBeenCalled()
+  })
+
+  it('leaves an open editor untouched when an unread notification arrives', () => {
+    const { input, markUnread } = openEditorByShortcut()
+    fireEvent.change(input, { target: { value: 'Half typed name' } })
+    const selectAfterOpen = vi.spyOn(HTMLInputElement.prototype, 'select')
+
+    markUnread()
+
+    // A remount re-runs focus + select and the next keystroke replaces the name; the
+    // value and focus assertions catch the same loss arriving without one.
+    expect(renameEditor()).toBe(input)
+    expect(input.value).toBe('Half typed name')
+    expect(document.activeElement).toBe(input)
+    expect(selectAfterOpen).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.editor-lifecycle.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.editor-lifecycle.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { useState } from 'react'
+import { StrictMode, useState } from 'react'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
@@ -128,6 +128,18 @@ describe('WorktreeTitleInlineRename editor lifecycle', () => {
     fireEvent.keyDown(input, { key: 'Escape' })
 
     expect(onEditingChange.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('reports the shortcut-open transition once in Strict Mode', () => {
+    const onEditingChange = vi.fn()
+
+    render(
+      <StrictMode>
+        <ShortcutRenameHarness onEditingChange={onEditingChange} />
+      </StrictMode>
+    )
+
+    expect(onEditingChange.mock.calls).toEqual([[true]])
   })
 
   it('opens the editor on double-click and reports it the same way', () => {

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -64,7 +64,6 @@ export function WorktreeTitleInlineRename({
   beginEditing = false,
   onBeginEditingConsumed
 }: WorktreeTitleInlineRenameProps): React.JSX.Element {
-  const editingRef = useRef(false)
   const savingRef = useRef(false)
   const mountedRef = useRef(true)
   const titleElementRef = useRef<HTMLSpanElement | null>(null)
@@ -100,7 +99,7 @@ export function WorktreeTitleInlineRename({
       titleElementRef.current = node
       // Why: wrapped titles render in full and never truncate, so skip the measure +
       // ResizeObserver entirely — for that mode it could only churn unused state.
-      if (!node || editingRef.current || wrapTitle) {
+      if (!node || editing || wrapTitle) {
         measureTitleTruncated(null)
         return
       }
@@ -120,9 +119,11 @@ export function WorktreeTitleInlineRename({
       observer.observe(node)
       titleResizeObserverRef.current = observer
     },
-    [measureTitleTruncated, wrapTitle]
+    [editing, measureTitleTruncated, wrapTitle]
   )
 
+  // Why: remounts the rendered title so truncation is measured again. The editor must
+  // not share it — an unread flip would remount the input and reselect what was typed.
   const titleElementKey = `${displayName}:${showUnreadEmphasis ? 'unread' : 'read'}`
   // Why: the sidebar row needs a text-only editor to avoid layout jumps; the
   // hovercard can use a compact field that reads more like native rename UI.
@@ -133,12 +134,13 @@ export function WorktreeTitleInlineRename({
   const savingInputClassName = editingPresentation === 'field' ? 'pr-6' : 'pr-4'
   const savingSpinnerClassName = editingPresentation === 'field' ? 'right-1.5' : 'right-0'
 
+  // Why: the guard reads the rendered `editing`, so callers must be reachable only from
+  // the branch they belong to; a timer or subscription would capture a stale value.
   const setEditingMode = useCallback(
     (nextEditing: boolean) => {
-      if (editingRef.current === nextEditing) {
+      if (editing === nextEditing) {
         return
       }
-      editingRef.current = nextEditing
       if (nextEditing) {
         measureTitleTruncated(null)
       }
@@ -146,8 +148,14 @@ export function WorktreeTitleInlineRename({
       // Why: the parent card disables drag while renaming; an Effect leaves one draggable commit.
       onEditingChange?.(nextEditing)
     },
-    [measureTitleTruncated, onEditingChange]
+    [editing, measureTitleTruncated, onEditingChange]
   )
+
+  // Why: double-click and the shortcut both open here, so neither can skip a step.
+  const openRenameEditor = useCallback(() => {
+    setValue(displayName)
+    setEditingMode(true)
+  }, [displayName, setEditingMode])
 
   const handleInputRef = useCallback((input: HTMLInputElement | null) => {
     inputElementRef.current = input
@@ -170,9 +178,8 @@ export function WorktreeTitleInlineRename({
     if (disabled || editing) {
       return
     }
-    setValue(displayName)
-    setEditing(true)
-  }, [beginEditing, disabled, editing, displayName, onBeginEditingConsumed])
+    openRenameEditor()
+  }, [beginEditing, disabled, editing, onBeginEditingConsumed, openRenameEditor])
 
   const stopCardEvent = useCallback((event: React.SyntheticEvent) => {
     event.stopPropagation()
@@ -185,10 +192,9 @@ export function WorktreeTitleInlineRename({
       }
       event.preventDefault()
       event.stopPropagation()
-      setValue(displayName)
-      setEditingMode(true)
+      openRenameEditor()
     },
-    [disabled, displayName, setEditingMode]
+    [disabled, openRenameEditor]
   )
 
   const cancelRename = useCallback(() => {
@@ -260,7 +266,6 @@ export function WorktreeTitleInlineRename({
     return (
       <>
         <span
-          key={`editing:${titleElementKey}`}
           ref={handleRootRef}
           className={cn(
             'relative grid min-w-0 truncate leading-tight text-foreground',

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -64,6 +64,7 @@ export function WorktreeTitleInlineRename({
   beginEditing = false,
   onBeginEditingConsumed
 }: WorktreeTitleInlineRenameProps): React.JSX.Element {
+  const editingRef = useRef(false)
   const savingRef = useRef(false)
   const mountedRef = useRef(true)
   const titleElementRef = useRef<HTMLSpanElement | null>(null)
@@ -99,7 +100,7 @@ export function WorktreeTitleInlineRename({
       titleElementRef.current = node
       // Why: wrapped titles render in full and never truncate, so skip the measure +
       // ResizeObserver entirely — for that mode it could only churn unused state.
-      if (!node || editing || wrapTitle) {
+      if (!node || editingRef.current || wrapTitle) {
         measureTitleTruncated(null)
         return
       }
@@ -119,7 +120,7 @@ export function WorktreeTitleInlineRename({
       observer.observe(node)
       titleResizeObserverRef.current = observer
     },
-    [editing, measureTitleTruncated, wrapTitle]
+    [measureTitleTruncated, wrapTitle]
   )
 
   // Why: remounts the rendered title so truncation is measured again. The editor must
@@ -134,13 +135,12 @@ export function WorktreeTitleInlineRename({
   const savingInputClassName = editingPresentation === 'field' ? 'pr-6' : 'pr-4'
   const savingSpinnerClassName = editingPresentation === 'field' ? 'right-1.5' : 'right-0'
 
-  // Why: the guard reads the rendered `editing`, so callers must be reachable only from
-  // the branch they belong to; a timer or subscription would capture a stale value.
   const setEditingMode = useCallback(
     (nextEditing: boolean) => {
-      if (editing === nextEditing) {
+      if (editingRef.current === nextEditing) {
         return
       }
+      editingRef.current = nextEditing
       if (nextEditing) {
         measureTitleTruncated(null)
       }
@@ -148,7 +148,7 @@ export function WorktreeTitleInlineRename({
       // Why: the parent card disables drag while renaming; an Effect leaves one draggable commit.
       onEditingChange?.(nextEditing)
     },
-    [editing, measureTitleTruncated, onEditingChange]
+    [measureTitleTruncated, onEditingChange]
   )
 
   // Why: double-click and the shortcut both open here, so neither can skip a step.


### PR DESCRIPTION
## Summary

The `workspace.rename` shortcut (`⌘⌥R`) opened a rename editor that could not be closed by Enter, Escape, or clicking away. Because the sidebar editor is borderless, the row looked exactly like a committed rename while it was still live — there was no visual tell at all. When an agent notification then marked the row unread, the input remounted, refocused, and selected the whole name, so the next keystroke replaced it.

- Route both ways into the editor — double-click and the shortcut — through a single `openRenameEditor`.
- Drop `editingRef` so `editing` state is the only source of truth for edit mode.
- Keep the display-name/unread React key on the rendered title, and off the editor.

### What went wrong

1. The `beginEditing` effect opened the editor with `setEditing(true)` while every other transition went through `setEditingMode`. That setter mirrors the flag into `editingRef` and guards on it, so after a shortcut-opened edit the ref still said `false`. Escape, commit, and blur all run through the setter, so all three returned early — a shortcut-opened editor stayed on screen until the card itself unmounted.
2. The editing element's React key was derived from the display name and the unread flag. Neither is an edit, but both changed the key, so React remounted the input and the ref callback re-ran `focus()` and `select()`.

### Why it is shaped this way

Adding the missing `setEditingMode` call would have fixed the symptom and left the split that produced it. Instead the two states become one and the two entry points become one, so a caller cannot put the editor on screen while skipping part of the transition. The key stays where remounting does real work — re-measuring truncation on the rendered title — and leaves the editor, where it could only destroy work in progress.

Two intended consequences: the shortcut path now reports edit mode through `onEditingChange`, which it never did, so `WorktreeCard` disables drag and hides the hover-details surface for it exactly as it already did for double-click. And defect 2 was never shortcut-specific — the double-click and hovercard editors were remounted the same way, the hovercard by a title change alone since it never sets the unread flag — so both inherit the fix.

## Screenshots

Both recordings run the same steps against the same workspace: the `workspace.rename` shortcut opens the editor, `renamed-workspace` is typed, Enter commits, and an agent notification then marks the row unread. Each step is captioned.

**Before.** Enter saves the name and leaves the editor open with nothing on screen to say so. The notification then re-selects the whole title, and one keystroke after that the workspace is called `x`.

![Workspace rename editor before the fix: Enter leaves the editor open, a notification selects the whole name, and the next keystroke replaces it](https://raw.githubusercontent.com/socar-jian/orca/assets/rename-editor/rename-editor-before.gif)

**After.** Enter commits and closes the editor, and the row shows the new name above its unchanged branch. The notification only marks the row unread.

![Workspace rename editor after the fix: Enter commits and closes the editor, and the notification only marks the row unread](https://raw.githubusercontent.com/socar-jian/orca/assets/rename-editor/rename-editor-after.gif)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`WorktreeTitleInlineRename.editor-lifecycle.test.tsx` renders the component through a harness that mirrors how `WorktreeCard` raises and clears the rename trigger, then drives its real keyboard and blur handlers. Six of the eight cases fail on `main`:

| case | on `main` |
| --- | --- |
| Escape closes the shortcut-opened editor | input still mounted |
| commit closes the shortcut-opened editor | input still mounted |
| blur closes the shortcut-opened editor | input still mounted |
| both edit-mode transitions reach the parent exactly once | parent never hears the shortcut-opened edit |
| a rename landing elsewhere leaves the open editor alone | input replaced by a new node |
| an unread notification leaves the open editor alone | input replaced by a new node |
| double-click opens the editor and reports it the same way | passes — guards the entry point this change rewired |
| the editor focuses and selects the name when it opens | passes — guards behavior the key removal could have dropped |

The two remount cases cover both halves of the old key, and each asserts node identity, the typed value, and focus, so the same loss arriving without a remount is caught too.

That the suite pins the mechanism and not just the disappearance was checked by mutation: bypassing `setEditingMode` on close, making `startRename` a no-op, deleting the `onEditingChange` call, and deleting `focus()`/`select()` each fail at least one case now, and each passed the suite before these cases existed.

The sibling `WorktreeTitleInlineRename.begin-editing.test.tsx` stays entirely green under the pre-fix component: its fake hook runtime returns a new `useRef` object per render, so ref state cannot be modelled there at all.

`pnpm test` fails in two unrelated places — two fork-upstream cases in `src/main/repo-icon-autodetect.test.ts`, and the `tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` suite, which fails to load. Both reproduce identically with every change in this PR stashed on a clean checkout of the same `main` commit; the repo-icon ones look environmental, since the checkout under test is itself a fork.

## AI Review Report

Reviewed with Claude Code (Claude Opus 5), including a side-by-side harness that renders `main`'s component and this branch's through identical scripted sequences.

- **Cross-platform (macOS, Linux, Windows).** No platform branches added or touched; the component only receives a `beginEditing` boolean, so it behaves identically on all three. See Notes for the one platform-specific fact about the shortcut itself.
- **SSH / remote / local and folder workspaces.** The component takes `displayName` and an `onRename` callback and assumes nothing about where the workspace lives. The rename round-trip is the parent's `handleRenameTitle`, untouched, which reaches local and remote targets exactly as before.
- **Agents, integrations, git providers.** Nothing provider-specific. The unread flag behind defect 2 is raised by any agent's notification path; the fix is agnostic to which one raised it.
- **Performance.** `handleRootRef` and `setEditingMode` gain `editing` in their dependency arrays, which cascades to `openRenameEditor` and `startRename`. That recreates four callbacks twice per rename, on a component already re-rendering for the flip, and its siblings were already recreated every render by the emoji hook's fresh return object. Removing the editor key is a net win: unread flips no longer rebuild an input. Observer accounting across mount, open, close, unread flip, and unmount leaves no ResizeObserver connected.
- **UI quality.** No token, class, or layout change. The editor keeps its borderless presentation in the sidebar and its field presentation in the hovercard.
- **Security.** See below.

Also verified: React 19 StrictMode (the branch opens and closes cleanly and consumes the request once; `main` cannot close at all), ref detach/attach ordering when `editing` flips (`mountedRef` ends correct in every transition), and a rename landing mid-edit (the typed value survives and still commits).

One alternative considered and rejected: making the `beginEditing` effect fire on the rising edge, so a request a parent leaves raised could not reopen a closed editor. I built it and measured it against `main`, and it loses more than it gains — the guard drops the *consume* along with the open, and `renamingWorktreeId` has exactly one writer of `null` in the renderer, so a dropped consume leaves the request raised in the store and the next card mount for that worktree pops the editor open unprompted. A request raised while `disabled` and enabled later also stopped opening. Today's only caller gates the raised flag and the clearing callback on the same condition, so the effect-plus-consume shape already holds. If this contract should stop trusting parents, the repo's idiom for that is a monotonic nonce compared against a consumed ref (`use-ssh-add-target-intent.ts`), which means changing the prop type — its own change, not this one.

## Security Audit

The diff adds no input parsing, command execution, path handling, IPC, auth, secrets, or dependencies; it changes React state ownership and a render key inside one presentational component. The pre-existing paths around it are unchanged: the committed name still travels `onRename` → `updateWorktreeMeta` → `window.api.worktrees.updateMeta` over IPC (or `callRuntimeRpc` for remote targets), still trimmed by `getWorktreeTitleRenameCommit`, and the only logging on that path is the store's existing failure `console.error`. The component's own input handling — the emoji shortcode scanner — is untouched. No follow-up needed.

## Notes

The component change is platform-neutral, but `workspace.rename` ships a default binding on macOS only: `src/shared/keybindings.ts` defines it as `darwin: ['Mod+Alt+R']` with empty Linux and Windows lists, because `Ctrl+R` and `Ctrl+Shift+R` are already taken there. On those platforms this path is reachable only through a user-assigned binding. Verified on macOS; the regression tests run under happy-dom like the other renderer component tests.

**X handle.** [@hgijeon](https://x.com/hgijeon)
