### PR TITLE
Open right sidebar by default for new web profiles

### DIFF
--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -2140,8 +2140,18 @@ describe('web UI preload API', () => {
     expect(runtimeCalls).toEqual([])
   })
 
-  it('migrates missing right sidebar visibility from the effective web legacy default', async () => {
+  it('defaults missing right sidebar visibility to open for new web profiles', async () => {
     const { api } = await installApi('Linux')
+
+    const ui = await api.ui.get()
+
+    // Why: match getDefaultUIState / desktop so new users discover the explorer panel.
+    expect(ui.rightSidebarOpen).toBe(true)
+  })
+
+  it('migrates missing right sidebar visibility from an explicit legacy settings default', async () => {
+    const { api, storage } = await installApi('Linux')
+    storage.setItem('orca.web.settings.v1', JSON.stringify({ rightSidebarOpenByDefault: false }))
 
     const ui = await api.ui.get()
 
@@ -2150,11 +2160,11 @@ describe('web UI preload API', () => {
 
   it('keeps explicit local right sidebar visibility over the legacy default', async () => {
     const { api, storage } = await installApi('Linux')
-    storage.setItem('orca.web.ui.v1', JSON.stringify({ rightSidebarOpen: true }))
+    storage.setItem('orca.web.ui.v1', JSON.stringify({ rightSidebarOpen: false }))
 
     const ui = await api.ui.get()
 
-    expect(ui.rightSidebarOpen).toBe(true)
+    expect(ui.rightSidebarOpen).toBe(false)
   })
 
   it('seeds missing local card display properties from runtime-backed compact settings when ui.get is unavailable', async () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3698,11 +3698,13 @@ function getStoredSettings(): GlobalSettings {
       // Keep readJson's invalid-JSON fallback non-destructive.
     }
   }
+  // Why only floatingTerminal: desktop-only chrome. Do not override
+  // rightSidebarOpenByDefault — shared defaults keep it open so new web profiles
+  // match desktop and discover the explorer panel.
   return mergeSettings(
     {
       ...defaults,
       floatingTerminalEnabled: false,
-      rightSidebarOpenByDefault: false,
       activeRuntimeEnvironmentId: null
     },
     migratedStored


### PR DESCRIPTION
## Problem

New web profiles had the right sidebar closed by default, while desktop opened it by default. This inconsistency meant new users on web didn't discover the explorer panel.

## Solution

Remove the explicit `rightSidebarOpenByDefault: false` override from web preload settings. New web profiles now inherit the system default of `true`, matching desktop behavior and helping users discover the feature.

The change respects explicit user preferences: if a user or legacy settings explicitly set the sidebar closed, that choice is preserved; only new profiles get the open default.

## Testing

Updated tests to verify:
- New web profiles default to right sidebar open
- Explicit legacy settings `rightSidebarOpenByDefault: false` are respected
- Explicit local UI state always overrides defaults

All test scenarios pass with the new behavior.