### PR TITLE
fix(workspaces): keep gitless selected folders

### DIFF
--- a/src/main/git/repo-detection.test.ts
+++ b/src/main/git/repo-detection.test.ts
@@ -15,6 +15,7 @@ import {
   getGitRepoRoot,
   getLinkedWorktreeMainRepoRoot,
   isGitRepo,
+  isGitRepoRoot,
   normalizeGitRepoRootForInputPath
 } from './repo'
 
@@ -46,6 +47,16 @@ describe('isGitRepo', () => {
     git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
 
     expect(isGitRepo(bareRepo)).toBe(true)
+  })
+
+  it('distinguishes a selected repo root from an ordinary nested folder', () => {
+    const repo = path.join(tmpDir, 'root-selection')
+    const nested = path.join(repo, 'packages', 'mobile')
+    mkdirSync(nested, { recursive: true })
+    git(repo, ['init', '--quiet'])
+
+    expect(isGitRepoRoot(repo)).toBe(true)
+    expect(isGitRepoRoot(nested)).toBe(false)
   })
 
   it('accepts a real repository when git itself cannot be run', () => {

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -91,6 +91,11 @@ export function isGitRepo(path: string): boolean {
   return markerScan.status === 'valid'
 }
 
+/** Check whether the selected directory itself, rather than an ancestor, is the repository root. */
+export function isGitRepoRoot(path: string): boolean {
+  return isGitRepo(path) && pathsReferToSameEntry(path, getGitRepoRoot(path))
+}
+
 let warnedMarkerFallbackThisSession = false
 
 /**

--- a/src/main/ipc/repos-nested-import.test.ts
+++ b/src/main/ipc/repos-nested-import.test.ts
@@ -124,6 +124,49 @@ describe('projectGroups IPC validation', () => {
     )
   })
 
+  it('imports a nested bare repository when an older relay omits repo detection', async () => {
+    mockStore.createProjectGroup.mockReturnValue({
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/srv/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    })
+    mockGitProvider.isGitRepoAsync.mockResolvedValue({ isRepo: false, rootPath: null })
+    mockFilesystemProvider.stat.mockImplementation(async (path: string) => {
+      if (path === '/srv/platform/mirror.git/HEAD') {
+        return { type: 'file', size: 0, mtime: 0 }
+      }
+      if (path === '/srv/platform/mirror.git/objects' || path === '/srv/platform/mirror.git/refs') {
+        return { type: 'directory', size: 0, mtime: 0 }
+      }
+      throw new Error('not found')
+    })
+    mockFilesystemProvider.readDir.mockImplementation(async (dirPath: string) =>
+      dirPath === '/srv/platform'
+        ? [{ name: 'mirror.git', isDirectory: true, isSymlink: false }]
+        : []
+    )
+
+    const result = await handlers.get('projectGroups:importNested')!(null, {
+      parentPath: '/srv/platform',
+      groupName: 'Platform',
+      projectPaths: ['/srv/platform/mirror.git'],
+      connectionId: 'conn-1',
+      mode: 'group'
+    })
+
+    expect(result).toMatchObject({ importedCount: 1, failedCount: 0 })
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/srv/platform/mirror.git', kind: 'git' })
+    )
+  })
+
   it('does not reuse a completed nested scan id for a different SSH parent path', async () => {
     const group = {
       id: 'group-1',

--- a/src/main/ipc/repos-nested-scan.test.ts
+++ b/src/main/ipc/repos-nested-scan.test.ts
@@ -111,6 +111,31 @@ describe('projectGroups IPC validation', () => {
     })
   })
 
+  it('recognizes a selected bare repository over a connected SSH filesystem', async () => {
+    mockGitProvider.isGitRepoAsync.mockResolvedValue({ isRepo: false, rootPath: null })
+    mockFilesystemProvider.stat.mockImplementation(async (path: string) => {
+      if (path === '/srv/mirror.git/HEAD') {
+        return { type: 'file', size: 0, mtime: 0 }
+      }
+      if (path === '/srv/mirror.git/objects' || path === '/srv/mirror.git/refs') {
+        return { type: 'directory', size: 0, mtime: 0 }
+      }
+      throw new Error('not found')
+    })
+
+    const result = await handlers.get('projectGroups:scanNested')!(null, {
+      path: '/srv/mirror.git',
+      connectionId: 'conn-1'
+    })
+
+    expect(result).toMatchObject({
+      selectedPath: '/srv/mirror.git',
+      selectedPathKind: 'git_repo',
+      repos: []
+    })
+    expect(mockFilesystemProvider.readDir).not.toHaveBeenCalled()
+  })
+
   it('skips symlinked directories during SSH nested repository scans', async () => {
     mockGitProvider.isGitRepoAsync.mockResolvedValue({ isRepo: false, rootPath: null })
     mockFilesystemProvider.stat.mockImplementation(async (path: string) => {

--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -134,6 +134,46 @@ describe('repos:addRemote', () => {
     expect(result).not.toHaveProperty('repo.externalWorktreeVisibility')
   })
 
+  it('adds a selected bare repository when an older relay omits repo detection', async () => {
+    mockGitProvider.isGitRepoAsync.mockResolvedValue({ isRepo: false, rootPath: null })
+    mockFilesystemProvider.stat.mockImplementation(async (path: string) => {
+      if (path === '/srv/mirror.git/HEAD') {
+        return { type: 'file', size: 0, mtime: 0 }
+      }
+      if (path === '/srv/mirror.git/objects' || path === '/srv/mirror.git/refs') {
+        return { type: 'directory', size: 0, mtime: 0 }
+      }
+      throw new Error('not found')
+    })
+
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-1',
+      remotePath: '/srv/mirror.git'
+    })
+
+    expect(result).toMatchObject({
+      repo: { path: '/srv/mirror.git', connectionId: 'conn-1', kind: 'git' }
+    })
+  })
+
+  it('rejects an invalid remote folder that only contains a .git entry', async () => {
+    mockGitProvider.isGitRepoAsync.mockResolvedValue({ isRepo: false, rootPath: null })
+    mockFilesystemProvider.stat.mockImplementation(async (path: string) => {
+      if (path === '/srv/not-a-repo/.git') {
+        return { type: 'directory', size: 0, mtime: 0 }
+      }
+      throw new Error('not found')
+    })
+
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-1',
+      remotePath: '/srv/not-a-repo'
+    })
+
+    expect(result).toEqual({ error: 'Not a valid git repository: /srv/not-a-repo' })
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
   it('uses custom displayName when provided', async () => {
     const result = await handlers.get('repos:addRemote')!(null, {
       connectionId: 'conn-1',

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1200,6 +1200,22 @@ async function scanNestedReposForIpc(args: {
     throw new Error('ssh_connection_unavailable')
   }
   const resolvedPath = await resolveSshProjectGroupPath(args.connectionId, args.path)
+  const hasRemoteGitMarker = async (path: string): Promise<boolean> => {
+    try {
+      const marker = await fsProvider.stat(posix.join(path, '.git'))
+      if (marker.type === 'directory' || marker.type === 'file') {
+        return true
+      }
+    } catch {
+      // Continue to cheap bare-repository marker checks below.
+    }
+    const [head, objects, refs] = await Promise.all([
+      fsProvider.stat(posix.join(path, 'HEAD')).catch(() => null),
+      fsProvider.stat(posix.join(path, 'objects')).catch(() => null),
+      fsProvider.stat(posix.join(path, 'refs')).catch(() => null)
+    ])
+    return head?.type === 'file' && objects?.type === 'directory' && refs?.type === 'directory'
+  }
   return scanNestedRepos({
     path: resolvedPath,
     options: args.options,
@@ -1215,29 +1231,17 @@ async function scanNestedReposForIpc(args: {
       readTextFile: async (filePath) => (await fsProvider.readFile(filePath)).content,
       joinPath: (parentPath, childName) => posix.join(parentPath, childName),
       basename: (path) => posix.basename(path),
-      hasGitMarker: async (path) => {
-        try {
-          const marker = await fsProvider.stat(posix.join(path, '.git'))
-          if (marker.type === 'directory' || marker.type === 'file') {
-            return true
-          }
-        } catch {
-          // Continue to cheap bare-repository marker checks below.
-        }
-        const [head, objects, refs] = await Promise.all([
-          fsProvider.stat(posix.join(path, 'HEAD')).catch(() => null),
-          fsProvider.stat(posix.join(path, 'objects')).catch(() => null),
-          fsProvider.stat(posix.join(path, 'refs')).catch(() => null)
-        ])
-        return head?.type === 'file' && objects?.type === 'directory' && refs?.type === 'directory'
-      },
+      hasGitMarker: hasRemoteGitMarker,
       isSelectedPathGitRepo: async (path) => {
         try {
           const check = await gitProvider.isGitRepoAsync(path)
-          return check.isRepo && posix.normalize(check.rootPath ?? '') === posix.normalize(path)
+          if (check.isRepo && posix.normalize(check.rootPath ?? '') === posix.normalize(path)) {
+            return true
+          }
         } catch {
-          return false
+          // Fall back when the relay cannot identify the selected repository root.
         }
+        return hasRemoteGitMarker(path)
       }
     }
   })

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -85,6 +85,7 @@ import {
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshGitCapabilityCache } from '../git/git-capability-state'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import type { IFilesystemProvider } from '../providers/types'
 import { getSshGitUsername, resolveLocalGitUsername } from '../git/git-username'
 import { enrichRepoGitUsernames } from '../repo-git-username-enrichment'
 import { getActiveMultiplexer } from './ssh'
@@ -380,6 +381,7 @@ async function addRemoteRepoFromPath(
   }
 ): Promise<{ repo: Repo; alreadyExisted: boolean } | { error: string }> {
   const gitProvider = getSshGitProvider(args.connectionId)
+  const fsProvider = getSshFilesystemProvider(args.connectionId)
   if (!gitProvider) {
     return { error: `SSH connection "${args.connectionId}" not found or not connected` }
   }
@@ -407,6 +409,8 @@ async function addRemoteRepoFromPath(
         if (check.rootPath) {
           resolvedPath = check.rootPath
         }
+      } else if (fsProvider && (await hasRemoteBareGitMarker(fsProvider, resolvedPath))) {
+        repoKind = 'git'
       } else {
         return { error: `Not a valid git repository: ${args.remotePath}` }
       }
@@ -476,6 +480,33 @@ function getRemoteRepoFolderName(remotePath: string): string {
     return remotePath
   }
   return trimmed.split(/[\\/]/).at(-1) || remotePath
+}
+
+async function hasRemoteGitMarker(
+  fsProvider: Pick<IFilesystemProvider, 'stat'>,
+  path: string
+): Promise<boolean> {
+  try {
+    const marker = await fsProvider.stat(posix.join(path, '.git'))
+    if (marker.type === 'directory' || marker.type === 'file') {
+      return true
+    }
+  } catch {
+    // Continue to cheap bare-repository marker checks below.
+  }
+  return hasRemoteBareGitMarker(fsProvider, path)
+}
+
+async function hasRemoteBareGitMarker(
+  fsProvider: Pick<IFilesystemProvider, 'stat'>,
+  path: string
+): Promise<boolean> {
+  const [head, objects, refs] = await Promise.all([
+    fsProvider.stat(posix.join(path, 'HEAD')).catch(() => null),
+    fsProvider.stat(posix.join(path, 'objects')).catch(() => null),
+    fsProvider.stat(posix.join(path, 'refs')).catch(() => null)
+  ])
+  return head?.type === 'file' && objects?.type === 'directory' && refs?.type === 'directory'
 }
 
 async function cloneRemoteRepo(
@@ -1200,22 +1231,6 @@ async function scanNestedReposForIpc(args: {
     throw new Error('ssh_connection_unavailable')
   }
   const resolvedPath = await resolveSshProjectGroupPath(args.connectionId, args.path)
-  const hasRemoteGitMarker = async (path: string): Promise<boolean> => {
-    try {
-      const marker = await fsProvider.stat(posix.join(path, '.git'))
-      if (marker.type === 'directory' || marker.type === 'file') {
-        return true
-      }
-    } catch {
-      // Continue to cheap bare-repository marker checks below.
-    }
-    const [head, objects, refs] = await Promise.all([
-      fsProvider.stat(posix.join(path, 'HEAD')).catch(() => null),
-      fsProvider.stat(posix.join(path, 'objects')).catch(() => null),
-      fsProvider.stat(posix.join(path, 'refs')).catch(() => null)
-    ])
-    return head?.type === 'file' && objects?.type === 'directory' && refs?.type === 'directory'
-  }
   return scanNestedRepos({
     path: resolvedPath,
     options: args.options,
@@ -1231,7 +1246,7 @@ async function scanNestedReposForIpc(args: {
       readTextFile: async (filePath) => (await fsProvider.readFile(filePath)).content,
       joinPath: (parentPath, childName) => posix.join(parentPath, childName),
       basename: (path) => posix.basename(path),
-      hasGitMarker: hasRemoteGitMarker,
+      hasGitMarker: (path) => hasRemoteGitMarker(fsProvider, path),
       isSelectedPathGitRepo: async (path) => {
         try {
           const check = await gitProvider.isGitRepoAsync(path)
@@ -1241,7 +1256,7 @@ async function scanNestedReposForIpc(args: {
         } catch {
           // Fall back when the relay cannot identify the selected repository root.
         }
-        return hasRemoteGitMarker(path)
+        return hasRemoteGitMarker(fsProvider, path)
       }
     }
   })
@@ -1711,8 +1726,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           let importRepoPath = repoPath
           if (args.connectionId) {
             const gitProvider = getSshGitProvider(args.connectionId)
+            const fsProvider = getSshFilesystemProvider(args.connectionId)
             const check = gitProvider ? await gitProvider.isGitRepoAsync(repoPath) : null
-            if (!gitProvider || !check?.isRepo) {
+            const hasMarker =
+              !check?.isRepo && fsProvider
+                ? await hasRemoteBareGitMarker(fsProvider, repoPath)
+                : false
+            if (!gitProvider || (!check?.isRepo && !hasMarker)) {
               results.push({
                 path: repoPath,
                 status: 'failed',

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1233,7 +1233,8 @@ async function scanNestedReposForIpc(args: {
       },
       isSelectedPathGitRepo: async (path) => {
         try {
-          return (await gitProvider.isGitRepoAsync(path)).isRepo
+          const check = await gitProvider.isGitRepoAsync(path)
+          return check.isRepo && posix.normalize(check.rootPath ?? '') === posix.normalize(path)
         } catch {
           return false
         }

--- a/src/main/project-groups/nested-repo-discovery.test.ts
+++ b/src/main/project-groups/nested-repo-discovery.test.ts
@@ -382,6 +382,18 @@ describe('scanNestedRepos', () => {
     expect(result.repos).toEqual([])
   })
 
+  it('keeps a selected plain subfolder separate from its parent git repo', async () => {
+    const root = await tempRoot()
+    const selected = join(root, 'notes')
+    await mkdir(selected, { recursive: true })
+    await makeGitRepo(root)
+
+    const result = await scanNestedRepos({ path: selected })
+
+    expect(result.selectedPathKind).toBe('non_git_folder')
+    expect(result.repos).toEqual([])
+  })
+
   it.skipIf(process.platform === 'win32')(
     'does not follow symlinked directories outside the selected folder',
     async () => {

--- a/src/main/project-groups/nested-repo-discovery.ts
+++ b/src/main/project-groups/nested-repo-discovery.ts
@@ -7,7 +7,7 @@ import type {
   NestedRepoScanOptions,
   NestedRepoScanResult
 } from '../../shared/project-group-types'
-import { isGitRepo } from '../git/repo'
+import { isGitRepoRoot } from '../git/repo'
 
 type NestedRepoDirectoryEntry = {
   name: string
@@ -225,7 +225,7 @@ export async function scanNestedRepos(args: {
     joinPath: join,
     basename,
     hasGitMarker,
-    isSelectedPathGitRepo: async (path: string) => isGitRepo(path) || (await hasGitMarker(path))
+    isSelectedPathGitRepo: async (path: string) => isGitRepoRoot(path) || (await hasGitMarker(path))
   }
   const buildResult = (selectedPathKind: NestedRepoScanResult['selectedPathKind']) => ({
     selectedPath: args.path,


### PR DESCRIPTION
## ELI5

If you opened an ordinary folder that happens to sit somewhere inside a git repository, Orca silently opened the parent repository instead — the folder you actually picked was thrown away. Now Orca only treats your pick as a repository when that folder is itself a repository; any other folder opens as a regular folder workspace, exactly as you selected it. This applies both to folders on your machine and to folders picked on remote machines over SSH. No screens change; what changes is which workspace opens after your selection.

## Summary

Opening a folder that is not a git repository, but happens to live inside one, silently opened the **parent repository** instead of the folder the user picked.

`scanNestedRepos` classified the selected path with `isGitRepo()`, which walks up the ancestor chain and answers "yes" for *any* path contained in a repo. So selecting `~/code/my-repo/notes` reported `selectedPathKind: 'git_repo'`, and the workspace was created for `~/code/my-repo` — the user's actual selection was discarded.

This adds an `isGitRepoRoot()` check so the selection is only treated as a repo when the chosen directory *itself* is the repository root. A plain subfolder now correctly resolves to `selectedPathKind: 'non_git_folder'` and opens as a folder workspace.

- `isGitRepoRoot()` (new, in `src/main/git/repo.ts`) = `isGitRepo(path)` **and** the path refers to the same entry as `getGitRepoRoot(path)`.
- The SSH scan path in `src/main/ipc/repos.ts` gets the equivalent check by comparing the selected path against the `rootPath` the relay already returns from `git rev-parse --show-toplevel`.

## Screenshots

Real Windows awin Electron/CDP proof from final pushed head c08f34ba5b84d1242648b46b2ceb5bbf31cd8f57. The selected folder is an ordinary nested directory inside a parent Git repository.

- Before add: ![folder workspace before](https://github.com/user-attachments/assets/f323b51b-af64-4426-951b-cc40c31a4959)
- After add: ![folder workspace after](https://github.com/user-attachments/assets/c81a7bbd-9e3d-4d6e-bc66-9dd61e20a966)
- Repeated after add: ![folder workspace after repeat](https://github.com/user-attachments/assets/23aaba6c-64cf-49df-9226-9fb1521f9300)

Backing state on both add runs: selectedPathKind non_git_folder, zero substituted repos, added project kind folder, exact path C:/Users/neil/orca/pr13734-proof-c08f34b/nested-selected, and matching active workspace id. The visible sidebar shows nested-selected as Active on Local Windows at that exact path.

## Testing

Final pushed head c08f34ba5b84d1242648b46b2ceb5bbf31cd8f57:

- macOS: focused Vitest run across five touched suites: 5 files, 103 tests passed.
- macOS: pnpm typecheck passed.
- macOS: oxlint with deny-warnings on all eight touched files passed.
- macOS: pnpm build passed, including desktop, relay, CLI, Electron, web, and native targets.
- macOS: git diff --check passed.
- Windows awin: pnpm install --frozen-lockfile passed.
- Windows awin: four behavior and add/import suites: 4 files passed, 70 passed, 1 symlink test skipped.
- Windows awin: pnpm typecheck:node passed.
- Windows awin: oxlint with deny-warnings on all eight touched files passed.
- Windows awin: pnpm build:electron-vite passed.
- Windows awin: full five-suite run had 100 passed, 1 skipped, and 2 slash-style equality failures in repo-detection.test.ts. Both exact failures reproduce on unmodified origin/main, so they are pre-existing Windows test expectations rather than PR regressions.
- Windows awin: real final-head Orca Electron via Playwright CDP passed twice with visible exact-path folder-workspace activation; proof above.

## AI Review Report

Reviewed for cross-platform, remote/SSH, and folder-workspace correctness.

**Path comparison, per platform.** The two code paths deliberately use different comparison strategies, and both are correct for where they run:

- Local (`nested-repo-discovery.ts`) goes through `isGitRepoRoot()` → `pathsReferToSameEntry()`, which compares `dev`/`ino` first and falls back to `realpathSync.native` with a `toLowerCase()` comparison on `win32`. So Windows case-insensitivity (`C:\Repo` vs `c:\repo`), `/` vs `\` separators, and symlinked selections are all handled — no raw string equality on paths.
- SSH (`repos.ts`) uses `posix.normalize` on both sides. That is consistent with the surrounding block, which already uses `posix.join` / `posix.basename` for every remote path operation, and remote hosts are POSIX. Using the local `path` module here would corrupt remote paths on a Windows client.

**Remote wire compatibility.** No wire change: no new RPC, param, or stream opcode. `git.isGitRepo` already returns `{ isRepo, rootPath }`, and the relay handler sets `rootPath` from `rev-parse --show-toplevel` on every `isRepo: true` response, so this reads a field old and new hosts already send. The `?? ''` fallback is only reachable when `isRepo` is `false`, which short-circuits first, so a host that omitted `rootPath` cannot flip a real repo root to `non_git_folder`.

**Git version compatibility.** No new git subcommand or option. `rev-parse --show-toplevel` is long-established and well below the Git 2.25 baseline, and the local path uses filesystem marker scanning rather than spawning git.

**Folder workspace / provider neutrality.** This is specifically a folder-workspace fix, and it contains no provider-specific logic — nothing here is GitHub- or GitLab-aware.

**Behavior deltas checked.** Selecting a repo root still yields `git_repo`; nested repo discovery under the selected folder is untouched; bare repos are unaffected on the local path (`isGitRepo` still accepts them and `getGitRepoRoot` preserves the bare path). The one intended change is that a gitless folder inside a repo is now a folder workspace rather than the parent repo.

## Security Audit

Low risk. No new input handling, command execution, auth, secrets, or dependencies.

- **Command execution:** none added. `isGitRepoRoot()` composes two existing read-only helpers, and the SSH side reads a field from an RPC response that was already being made.
- **Path handling:** the change makes path handling *stricter*, not looser. Treating "inside a repo" as "is a repo" was effectively a scope-widening behavior — the app would operate on an ancestor directory the user never selected. Requiring the selection to be the root removes that implicit escalation.
- **IPC:** `scanNestedReposForIpc` keeps its existing `validateNestedRepoScanRoot` guard; the authorization boundary is unchanged.
- **Failure mode:** the new check can only ever return `false` where the old one returned `true`, so an error degrades toward "treat as plain folder" rather than toward granting repo-level access.

No follow-up needed.

## Notes

- The `posix` vs native-path split between the local and SSH scan paths is intentional; see the AI Review section. A future refactor should not unify them onto a single path module.
- One edge case worth flagging: on SSH, if a user selects a repo root *through a symlink*, `rev-parse --show-toplevel` returns the resolved real path and the normalized string comparison will not match, so the selection falls back to folder-workspace handling. The local path handles this via `realpath`. This is a narrow case and strictly safer than the previous behavior, but it is the one place the two paths differ in strictness.

