### PR TITLE
fix(cloud): name the transport failure sign-in and Relay swallow

### DIFF
--- a/src/main/orca-profiles/profile-cloud-service.test.ts
+++ b/src/main/orca-profiles/profile-cloud-service.test.ts
@@ -178,6 +178,29 @@ describe('Orca cloud profile service', () => {
     })
   })
 
+  it('names the transport reason behind a token exchange that reports only "fetch failed"', async () => {
+    configureCloudEnv()
+    beginOrcaCloudPkceFlowMock.mockResolvedValue({
+      code: 'auth-code',
+      codeVerifier: 'verifier',
+      nonce: 'nonce',
+      redirectUri: 'http://127.0.0.1:1/auth/callback',
+      state: 'state'
+    })
+    exchangeOrcaCloudAuthCodeMock.mockRejectedValue(
+      new TypeError('fetch failed', {
+        cause: Object.assign(new Error('...'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' })
+      })
+    )
+
+    const result = await connectCurrentOrcaProfile(userDataPath)
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: 'fetch failed (SELF_SIGNED_CERT_IN_CHAIN)'
+    })
+  })
+
   it('does not report a saved cloud session as connected when cloud config is unavailable', async () => {
     configureCloudEnv()
     mockSuccessfulConnect()

--- a/src/main/orca-profiles/profile-cloud-service.ts
+++ b/src/main/orca-profiles/profile-cloud-service.ts
@@ -6,6 +6,7 @@ import type {
   SelectOrcaProfileOrgResult,
   SignOutCurrentOrcaProfileResult
 } from '../../shared/orca-profiles'
+import { networkTransportErrorCode } from '../../shared/network-transport-error-code'
 import { ensureActiveOrcaProfile } from './profile-index-store'
 import { getOrcaCloudAuthConfig, isOrcaCloudDevAuthEnabled } from './profile-cloud-auth-config'
 import {
@@ -95,10 +96,13 @@ export async function connectCurrentOrcaProfile(
         auth: getCurrentOrcaProfileAuthStatus(userDataPath)
       }
     }
+    // Why: the token exchange rejects with the bare message "fetch failed"; without the
+    // transport code the sign-in toast cannot distinguish an untrusted TLS chain from DNS.
+    const networkCode = networkTransportErrorCode(error)
     return {
       status: 'failed',
       auth: getCurrentOrcaProfileAuthStatus(userDataPath),
-      error: message
+      error: networkCode ? `${message} (${networkCode})` : message
     }
   }
 }

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -878,14 +878,16 @@ export class OrcaRuntimeRpcServer {
     try {
       relayPairing = await relayProvider.createPairingRelay(device.deviceId)
     } catch (error) {
-      // Why: the raw provider error can carry request metadata or credentials — log only the validated code.
+      // Why: the raw provider error can carry request metadata or credentials — log only the validated codes.
       const relayFailure = mobileRelayMintFailureFromUnknown({
         stage: 'create_pairing_relay',
         error,
         fallbackCode: 'relay_mint_failed',
         fallbackMessage: 'Relay pairing invite request failed'
       })
-      console.warn(`[runtime] Failed to create Relay pairing invite: ${relayFailure.code}`)
+      console.warn(
+        `[runtime] Failed to create Relay pairing invite: ${relayFailure.code}${relayFailure.networkCode ? ` (${relayFailure.networkCode})` : ''}`
+      )
       return refuseAutomaticWithoutRelay(relayFailure)
     }
     const currentDevice = this.deviceRegistry?.getDevice(device.deviceId)

--- a/src/shared/error-own-data-property.ts
+++ b/src/shared/error-own-data-property.ts
@@ -1,0 +1,22 @@
+/**
+ * Reads one own data property off a caught value.
+ *
+ * Why: failure reporting runs inside catch blocks, where throwing again replaces the failure
+ * being reported with a second one. `in`, plain property access, and `instanceof` all run
+ * accessors or Proxy traps that can throw, so this reads a descriptor instead and accepts only
+ * a data property. Inherited values are ignored too, so a polluted prototype cannot supply one.
+ *
+ * A Proxy still observes the descriptor lookup — no standard inspection avoids that — but the
+ * result is contained: this returns undefined instead of propagating a throw.
+ */
+export function errorOwnDataProperty(value: unknown, key: string): unknown {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/shared/mobile-relay-mint-failure.test.ts
+++ b/src/shared/mobile-relay-mint-failure.test.ts
@@ -32,6 +32,21 @@ describe('mobileRelayMintFailureFromUnknown', () => {
     })
   })
 
+  it('reads a Relay code off a message that is not carried by an Error', () => {
+    expect(
+      mobileRelayMintFailureFromUnknown({
+        stage: 'create_pairing_relay',
+        error: { message: 'relay_control_not_active' },
+        fallbackCode: 'relay_mint_failed',
+        fallbackMessage: 'Relay pairing invite request failed'
+      })
+    ).toEqual({
+      code: 'relay_control_not_active',
+      stage: 'create_pairing_relay',
+      message: 'Relay pairing invite request failed'
+    })
+  })
+
   it('falls back for error values that are neither objects nor Errors', () => {
     expect(
       mobileRelayMintFailureFromUnknown({
@@ -47,11 +62,75 @@ describe('mobileRelayMintFailureFromUnknown', () => {
     })
   })
 
+  it('carries the transport reason a relay_* code cannot express', () => {
+    expect(
+      mobileRelayMintFailureFromUnknown({
+        stage: 'create_pairing_relay',
+        error: new TypeError('fetch failed', {
+          cause: Object.assign(new Error('...'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' })
+        }),
+        fallbackCode: 'relay_mint_failed',
+        fallbackMessage: 'Relay pairing invite request failed'
+      })
+    ).toEqual({
+      code: 'relay_mint_failed',
+      stage: 'create_pairing_relay',
+      message: 'Relay pairing invite request failed',
+      networkCode: 'SELF_SIGNED_CERT_IN_CHAIN'
+    })
+  })
+
   it('redacts free-form error messages', () => {
     expect(
       mobileRelayMintFailureFromUnknown({
         stage: 'create_pairing_relay',
         error: new Error('request failed for https://relay.example/token/secret'),
+        fallbackCode: 'relay_mint_failed',
+        fallbackMessage: 'Relay pairing invite request failed'
+      })
+    ).toEqual({
+      code: 'relay_mint_failed',
+      stage: 'create_pairing_relay',
+      message: 'Relay pairing invite request failed'
+    })
+  })
+
+  it('still returns a structured failure when the error resists inspection', () => {
+    const hostile = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor: () => {
+          throw new Error('boom')
+        },
+        get: () => {
+          throw new Error('boom')
+        },
+        has: () => {
+          throw new Error('boom')
+        }
+      }
+    )
+    expect(
+      mobileRelayMintFailureFromUnknown({
+        stage: 'create_pairing_relay',
+        error: hostile,
+        fallbackCode: 'relay_mint_failed',
+        fallbackMessage: 'Relay pairing invite request failed'
+      })
+    ).toEqual({
+      code: 'relay_mint_failed',
+      stage: 'create_pairing_relay',
+      message: 'Relay pairing invite request failed'
+    })
+  })
+
+  it('does not admit a request URL through the transport code', () => {
+    expect(
+      mobileRelayMintFailureFromUnknown({
+        stage: 'create_pairing_relay',
+        error: new TypeError('fetch failed', {
+          cause: { code: 'https://relay.example/v1/assign?token=secret' }
+        }),
         fallbackCode: 'relay_mint_failed',
         fallbackMessage: 'Relay pairing invite request failed'
       })

--- a/src/shared/mobile-relay-mint-failure.ts
+++ b/src/shared/mobile-relay-mint-failure.ts
@@ -1,3 +1,6 @@
+import { errorOwnDataProperty } from './error-own-data-property'
+import { networkTransportErrorCode } from './network-transport-error-code'
+
 /**
  * Structured failure when an Anywhere (Orca Relay) pairing mint cannot attach Relay.
  * Returned instead of silently degrading to a LAN-only QR under the Relay label.
@@ -12,6 +15,8 @@ export type MobileRelayMintFailure = {
   code: string
   stage: MobileRelayMintFailureStage
   message: string
+  // Why: a relay_* code names the mint step that failed, not the transport reason underneath it.
+  networkCode?: string
 }
 
 export function mobileRelayMintFailureFromUnknown(args: {
@@ -20,22 +25,26 @@ export function mobileRelayMintFailureFromUnknown(args: {
   fallbackCode: string
   fallbackMessage: string
 }): MobileRelayMintFailure {
+  // Why descriptor reads: this runs inside a catch block, so a malformed error must not throw
+  // again here. `message` stands in for the old `instanceof Error` branch — the pattern below
+  // is what actually decides whether a value is admitted.
+  const errorCode = errorOwnDataProperty(args.error, 'code')
+  const errorMessage = errorOwnDataProperty(args.error, 'message')
   const candidateCode =
-    typeof args.error === 'object' &&
-    args.error !== null &&
-    'code' in args.error &&
-    typeof args.error.code === 'string'
-      ? args.error.code
-      : args.error instanceof Error
-        ? args.error.message
+    typeof errorCode === 'string'
+      ? errorCode
+      : typeof errorMessage === 'string'
+        ? errorMessage
         : null
   const code =
     candidateCode != null && /^relay_[a-z0-9_]{1,74}$/.test(candidateCode)
       ? candidateCode
       : args.fallbackCode
+  const networkCode = networkTransportErrorCode(args.error)
   return {
     code,
     stage: args.stage,
-    message: args.fallbackMessage
+    message: args.fallbackMessage,
+    ...(networkCode ? { networkCode } : {})
   }
 }

--- a/src/shared/network-transport-error-code.test.ts
+++ b/src/shared/network-transport-error-code.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { networkTransportErrorCode } from './network-transport-error-code'
+
+function fetchRejection(code: string): Error {
+  // Shape of a real global fetch rejection: a bare message with the reason on the cause.
+  return new TypeError('fetch failed', { cause: Object.assign(new Error('...'), { code }) })
+}
+
+describe('networkTransportErrorCode', () => {
+  it('reads the reason a fetch rejection hides behind its cause', () => {
+    expect(networkTransportErrorCode(fetchRejection('SELF_SIGNED_CERT_IN_CHAIN'))).toBe(
+      'SELF_SIGNED_CERT_IN_CHAIN'
+    )
+    expect(networkTransportErrorCode(fetchRejection('ENOTFOUND'))).toBe('ENOTFOUND')
+  })
+
+  it('reads a code carried directly on the error', () => {
+    expect(networkTransportErrorCode(Object.assign(new Error('x'), { code: 'ETIMEDOUT' }))).toBe(
+      'ETIMEDOUT'
+    )
+  })
+
+  it('walks nested causes up to the bound', () => {
+    const nested = new TypeError('fetch failed', {
+      cause: new Error('socket', {
+        cause: Object.assign(new Error('tls'), { code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' })
+      })
+    })
+    expect(networkTransportErrorCode(nested)).toBe('UNABLE_TO_VERIFY_LEAF_SIGNATURE')
+  })
+
+  it('returns null past the depth bound so a cause chain cannot loop', () => {
+    const deep = { cause: { cause: { cause: { cause: { code: 'ETIMEDOUT' } } } } }
+    expect(networkTransportErrorCode(deep)).toBeNull()
+    const cyclic: { code?: string; cause?: unknown } = {}
+    cyclic.cause = cyclic
+    expect(networkTransportErrorCode(cyclic)).toBeNull()
+  })
+
+  it('never throws or invokes accessors while inspecting a hostile error', () => {
+    const throwingGetter = {}
+    Object.defineProperty(throwingGetter, 'code', {
+      get() {
+        throw new Error('boom')
+      }
+    })
+    expect(networkTransportErrorCode(throwingGetter)).toBeNull()
+
+    let getterCalls = 0
+    const sideEffectGetter = {}
+    Object.defineProperty(sideEffectGetter, 'code', {
+      get() {
+        getterCalls += 1
+        return 'ETIMEDOUT'
+      }
+    })
+    expect(networkTransportErrorCode(sideEffectGetter)).toBeNull()
+    expect(getterCalls).toBe(0)
+
+    let trapCalls = 0
+    const trapped = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor: () => {
+          trapCalls += 1
+          throw new Error('boom')
+        },
+        get: () => {
+          trapCalls += 1
+          throw new Error('boom')
+        },
+        has: () => {
+          trapCalls += 1
+          throw new Error('boom')
+        }
+      }
+    )
+    expect(networkTransportErrorCode(trapped)).toBeNull()
+    expect(trapCalls).toBeGreaterThan(0)
+  })
+
+  it('ignores an inherited code so a polluted prototype cannot invent a reason', () => {
+    class PollutedError extends Error {}
+    Object.defineProperty(PollutedError.prototype, 'code', {
+      value: 'ETIMEDOUT',
+      configurable: true
+    })
+    expect(networkTransportErrorCode(new PollutedError('x'))).toBeNull()
+    expect(networkTransportErrorCode(Object.create({ code: 'ETIMEDOUT' }))).toBeNull()
+  })
+
+  it('refuses anything outside the vocabulary so raw error text cannot escape', () => {
+    expect(networkTransportErrorCode(fetchRejection('https://relay.example/v1/assign'))).toBeNull()
+    expect(networkTransportErrorCode(fetchRejection('self_signed_cert_in_chain'))).toBeNull()
+    expect(networkTransportErrorCode(new Error('SELF_SIGNED_CERT_IN_CHAIN'))).toBeNull()
+    expect(networkTransportErrorCode({ code: 42 })).toBeNull()
+    expect(networkTransportErrorCode(null)).toBeNull()
+    expect(networkTransportErrorCode('ETIMEDOUT')).toBeNull()
+  })
+})

--- a/src/shared/network-transport-error-code.ts
+++ b/src/shared/network-transport-error-code.ts
@@ -1,0 +1,55 @@
+import { errorOwnDataProperty } from './error-own-data-property'
+
+/**
+ * Extracts the transport reason behind a failed request as an allow-listed code.
+ *
+ * Why: when a request fails in transport — an untrusted TLS chain, DNS, a refused connection —
+ * `fetch` rejects with the same message "fetch failed" for every one of them, and the reason
+ * that tells them apart lives only on the nested `cause`. Callers cannot forward the raw error
+ * because it can carry request URLs or credentials, so this returns nothing but an exact match
+ * from the fixed vocabulary below.
+ */
+
+const TRANSPORT_ERROR_CODES: ReadonlySet<string> = new Set([
+  // Certificate validation — untrusted, expired, or mismatched. A network that terminates TLS
+  // with a root the OS trusts but Node does not shows up as the untrusted-chain codes.
+  'CERT_HAS_EXPIRED',
+  'CERT_NOT_YET_VALID',
+  'CERT_UNTRUSTED',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  // Reachability and name resolution.
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'EPROTO',
+  'ETIMEDOUT',
+  // Undici surfaces its own timeouts rather than an errno.
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET'
+])
+
+// Why: undici nests cause chains, and a bound stops a self-referential chain from looping.
+const MAX_CAUSE_DEPTH = 4
+
+export function networkTransportErrorCode(error: unknown): string | null {
+  let current: unknown = error
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current != null; depth += 1) {
+    const code = errorOwnDataProperty(current, 'code')
+    if (typeof code === 'string' && TRANSPORT_ERROR_CODES.has(code)) {
+      return code
+    }
+    current = errorOwnDataProperty(current, 'cause')
+  }
+  return null
+}


### PR DESCRIPTION
Related to #13735

## Scope

Diagnostics only. No transport, TLS policy, or trust store changes here, and nothing that fails today starts succeeding. #13735 describes the underlying trust-store split and asks which direction you want for the transport half; this PR only stops the reason from being thrown away, so triage does not require reading the source.

## Problem

A request that fails in transport rejects with the message `fetch failed` for every cause — an untrusted TLS chain, DNS, a refused connection — and the reason that tells them apart is only on the nested `cause`.

- `profile-cloud-service.ts` returned that bare message as its failure string, and the renderer already shows it as a toast description, so a user behind a TLS-inspecting network saw `Failed to connect profile / fetch failed`.
- `mobileRelayMintFailureFromUnknown` keeps a code only when it matches `/^relay_[a-z0-9_]{1,74}$/`, so an uppercase transport code like `SELF_SIGNED_CERT_IN_CHAIN` was replaced by the `relay_mint_failed` fallback and did not reach the `Copy diagnostics` payload or the warn line.

## Change

`networkTransportErrorCode(error)` walks up to four `cause` levels and returns a code only on exact match against a fixed uppercase vocabulary of certificate-validation, reachability, and undici timeout codes. Anything else yields `null`. That code is appended to the sign-in failure string and carried on `MobileRelayMintFailure` as an optional `networkCode`, which reaches the existing diagnostics payload and log line with no UI change.

The sign-in toast now reads `fetch failed (SELF_SIGNED_CERT_IN_CHAIN)`.

## Why the vocabulary is an exact-match set

`runtime-rpc.ts:881` deliberately refuses to log raw provider errors because they can carry request metadata or credentials. That constraint is preserved by construction: only a member of the fixed set is ever returned, so a URL, token, or free-form message cannot travel through the new field. A test asserts a `cause.code` of `https://relay.example/v1/assign?token=secret` produces no `networkCode`.

## Why the property reads look paranoid

`errorOwnDataProperty` reads an own data descriptor rather than using `in`, indexed access, or `instanceof`. All of this runs inside `catch` blocks, where an accessor or Proxy trap that throws would replace the failure being reported with a second one — sign-in would throw out of its own handler, and Relay pairing would skip its structured failure response. Reading a data descriptor also ignores inherited properties, so a polluted prototype cannot invent a code. A Proxy still observes the descriptor lookup; no standard reflective inspection avoids that, and the doc comment says so rather than claiming otherwise.

This also covers the pre-existing unguarded reads in `mobileRelayMintFailureFromUnknown`. Its `instanceof Error` plus `.message` branch became a `message` descriptor read, which widens provenance from `Error` instances to any own string `message` — the unchanged `relay_*` pattern is still what decides admission, and there is a test for the widened case.

## Compatibility

`networkCode` is optional and crosses only local Electron IPC as part of the pairing-offer result; it does not cross the remote runtime wire. Older preload/renderer code ignores it. No RPC method, required parameter, stream opcode, payload shape, Git command, dependency, or persisted state changes.

## Evidence

- New `network-transport-error-code.test.ts`: extraction from a nested `cause`, a code carried directly, cause-depth bounding, cyclic causes, a throwing getter, a getter asserted never to run, a Proxy whose traps all throw, prototype-supplied codes, and rejection of lowercase, URL-shaped, non-string, and message-only values.
- Extended `mobile-relay-mint-failure.test.ts`: the transport code is attached, a URL cannot become one, a hostile Proxy still yields the structured fallback, and a non-`Error` own `message` is admitted under the existing pattern.
- Extended `profile-cloud-service.test.ts`: a token exchange rejecting with `TypeError: fetch failed` and `cause.code = SELF_SIGNED_CERT_IN_CHAIN` produces `fetch failed (SELF_SIGNED_CERT_IN_CHAIN)`.
- Full suite: 4489 passed, 16 skipped, across 458 files. Typecheck, oxlint (plain and type-aware), oxfmt, and the max-lines ratchet all pass.

## Unproved gaps

Behaviour on Windows and Linux under TLS interception was reasoned about but not run; the vocabulary is platform-independent Node/undici/OpenSSL codes, so I expect no difference, but I have not observed it. The reproduction itself was done on macOS against one inline-inspection vendor.
