### PR TITLE
fix(ssh): release the relay-loss watcher before teardown mux writes

### DIFF
--- a/src/main/ssh/ssh-relay-session-relay-loss.test.ts
+++ b/src/main/ssh/ssh-relay-session-relay-loss.test.ts
@@ -232,6 +232,53 @@ describe('SshRelaySession relay loss during setup', () => {
     expect(unregisterSshFilesystemProvider).toHaveBeenCalledWith('target-1')
   })
 
+  // #13548 follow-up: cancelling the in-flight port scan emits rpc.cancel on the control
+  // lane, which a saturated writer turns into mux.dispose('connection_lost'). That fires
+  // during our own teardown, so it must not be reported as a lost relay.
+  it.each([
+    ['detach', (session: SshRelaySession) => session.beginShutdownDetach()],
+    ['dispose', (session: SshRelaySession) => session.dispose()]
+  ])(
+    'does not report relay loss when the port-scan cancel kills the mux on %s',
+    async (_path, teardown) => {
+      const { session, onRelayLost } = createSession()
+      // Mirrors SshChannelMultiplexer.request: an in-flight request whose signal aborts
+      // emits rpc.cancel, and the mock mux dies on that notify like a saturated writer.
+      muxRequestMock.mockImplementation(
+        async (method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
+          if (method !== 'ports.detect') {
+            return []
+          }
+          const mux = session.getMux() as unknown as {
+            failNotifyMethod: string | null
+            notify: (method: string, params?: unknown) => void
+          }
+          mux.failNotifyMethod = 'rpc.cancel'
+          return new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => {
+                mux.notify('rpc.cancel', { id: 1 })
+                reject(new Error('cancelled'))
+              },
+              { once: true }
+            )
+          })
+        }
+      )
+
+      await session.establish({} as SshConnection)
+      expect(session.getState()).toBe('ready')
+      expect(muxRequestMock).toHaveBeenCalledWith('ports.detect', undefined, expect.anything())
+      const mux = session.getMux() as unknown as { notify: ReturnType<typeof vi.fn> }
+
+      teardown(session)
+
+      expect(mux.notify).toHaveBeenCalledWith('rpc.cancel', { id: 1 })
+      expect(onRelayLost).not.toHaveBeenCalled()
+    }
+  )
+
   // #11953: reattachKnownPtys swallows every per-PTY failure, so a mux killed by the
   // reattach burst itself never reaches the catch — the post-reattach gate has to notice.
   it('routes a mux that dies during PTY reattach into relay-loss recovery', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -651,6 +651,7 @@ export class SshRelaySession {
     this.currentConnection = conn
 
     // Why: stop scanning before teardownProviders so the poll timer can't fire against a disposed multiplexer.
+    this.releaseRelayLossWatcher()
     this.stopPortScanning()
     await this.portForwardManager.removeAllForwards(this.targetId)
     this.broadcastEmptyLists()
@@ -836,6 +837,7 @@ export class SshRelaySession {
     // Why: the whole in-memory half runs before any await so a concurrent connect can never observe
     // a half-torn session; only the durability barriers below are deferred onto the returned promise.
     this.abortController?.abort()
+    this.releaseRelayLossWatcher()
     this.stopPortScanning()
     this.broadcastEmptyLists()
     this.teardownProviders('shutdown')
@@ -909,6 +911,7 @@ export class SshRelaySession {
     }
     detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
     this.abortController?.abort()
+    this.releaseRelayLossWatcher()
     this.stopPortScanning()
     this.broadcastEmptyLists()
     this.teardownProviders('connection_lost')
@@ -928,6 +931,7 @@ export class SshRelaySession {
       // teardown call below throws unexpectedly.
       detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
       this.abortController?.abort()
+      this.releaseRelayLossWatcher()
       this.stopPortScanning()
       this.broadcastEmptyLists()
       // Why: disconnect keeps PTY ownership so a later manual connect can reattach.
@@ -947,9 +951,19 @@ export class SshRelaySession {
 
   // ── Private ───────────────────────────────────────────────────────
 
+  // Why: teardown itself can kill the mux — an aborted request emits rpc.cancel, and a saturated
+  // control lane turns that admission failure into mux.dispose('connection_lost'). Every teardown
+  // path must release the watcher before its first mux write, or our own shutdown re-enters
+  // recovery as a spurious relay loss. teardownProviders is not early enough: stopPortScanning
+  // runs ahead of it and is what emits that frame.
+  private releaseRelayLossWatcher(): void {
+    this.muxDisposeCleanup?.()
+    this.muxDisposeCleanup = null
+  }
+
   // Why: onStateChange only fires on SSH-level reconnects, so watch for relay-channel loss while SSH stays up and fire onRelayLost.
   private watchMuxForRelayLoss(mux: SshChannelMultiplexer): void {
-    this.muxDisposeCleanup?.()
+    this.releaseRelayLossWatcher()
     this.muxDisposeCleanup = mux.onDispose((reason) => {
       if (reason === 'connection_lost' && this.mux === mux && !this.isDisposed()) {
         console.warn(
@@ -1560,8 +1574,7 @@ export class SshRelaySession {
     reason: 'shutdown' | 'connection_lost',
     outputGenerationReason: string = reason
   ): void {
-    this.muxDisposeCleanup?.()
-    this.muxDisposeCleanup = null
+    this.releaseRelayLossWatcher()
     this.muxNotificationCleanup?.()
     this.muxNotificationCleanup = null
     for (const cleanup of this.ptyRecoveryNotificationCleanups) {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -640,6 +640,7 @@ export class SshRelaySession {
       return
     }
 
+    this.releaseRelayLossWatcher()
     // Cancel any in-flight reconnect
     this.abortController?.abort()
     const abortController = new AbortController()
@@ -651,7 +652,6 @@ export class SshRelaySession {
     this.currentConnection = conn
 
     // Why: stop scanning before teardownProviders so the poll timer can't fire against a disposed multiplexer.
-    this.releaseRelayLossWatcher()
     this.stopPortScanning()
     await this.portForwardManager.removeAllForwards(this.targetId)
     this.broadcastEmptyLists()
@@ -836,8 +836,8 @@ export class SshRelaySession {
   private runDisposal(pendingDetach: Promise<void> | null): Promise<void> {
     // Why: the whole in-memory half runs before any await so a concurrent connect can never observe
     // a half-torn session; only the durability barriers below are deferred onto the returned promise.
-    this.abortController?.abort()
     this.releaseRelayLossWatcher()
+    this.abortController?.abort()
     this.stopPortScanning()
     this.broadcastEmptyLists()
     this.teardownProviders('shutdown')
@@ -910,8 +910,8 @@ export class SshRelaySession {
       return
     }
     detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
-    this.abortController?.abort()
     this.releaseRelayLossWatcher()
+    this.abortController?.abort()
     this.stopPortScanning()
     this.broadcastEmptyLists()
     this.teardownProviders('connection_lost')
@@ -930,8 +930,8 @@ export class SshRelaySession {
       // step — a fast reconnect must reclaim this identity instead of minting one, even if a
       // teardown call below throws unexpectedly.
       detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
-      this.abortController?.abort()
       this.releaseRelayLossWatcher()
+      this.abortController?.abort()
       this.stopPortScanning()
       this.broadcastEmptyLists()
       // Why: disconnect keeps PTY ownership so a later manual connect can reattach.
@@ -955,7 +955,9 @@ export class SshRelaySession {
   // control lane turns that admission failure into mux.dispose('connection_lost'). Every teardown
   // path must release the watcher before its first mux write, or our own shutdown re-enters
   // recovery as a spurious relay loss. teardownProviders is not early enough: stopPortScanning
-  // runs ahead of it and is what emits that frame.
+  // runs ahead of it and is what emits that frame. Call this ahead of abortController.abort()
+  // too — that signal reaches no mux request today, but plumbing it into one would otherwise
+  // reopen the same hole silently.
   private releaseRelayLossWatcher(): void {
     this.muxDisposeCleanup?.()
     this.muxDisposeCleanup = null


### PR DESCRIPTION
## The one-sentence version

Our own teardown could look like a lost relay, because #13548 gave port-scan cancellation a frame to send and the relay-loss watcher was still armed when it went out.

## The bug

#13548 made `stopPortScanning()` abort the in-flight `ports.detect` request. Aborting emits `rpc.cancel` on the control lane (`ssh-channel-multiplexer.ts:260`) — a frame port scans never sent before.

If the control lane is saturated at that instant, `enqueue` does not drop the frame. It calls `fail()`:

```ts
// ssh-multiplexer-transport-writer.ts:84
const admissionError = this.admissionError(data.length, lane)
if (admissionError) {
  settle({ ok: false, error: admissionError })
  this.fail(admissionError)   // -> handleProtocolError -> mux.dispose('connection_lost')
  return false
}
```

That reaches the relay-loss watcher (`ssh-relay-session.ts:965`), whose guard passes: reason is `'connection_lost'`, `this.mux === mux`, and `_state` is not yet `'disposed'`. So `_onRelayLost` fires from inside our own shutdown.

`teardownProviders` was already written to prevent exactly this — it releases the watcher at its very top, *before* disposing the mux. But `stopPortScanning()` runs ahead of `teardownProviders` on all four paths, and it is what emits the frame. The release was one step too late.

```mermaid
flowchart TB
    A["reconnect / dispose / detach"] --> B["stopPortScanning()"]
    B --> C["abort in-flight ports.detect"]
    C --> D["notify('rpc.cancel')"]
    D --> E{"control lane saturated?"}
    E -->|no| F["frame sent, normal teardown"]
    E -->|yes| G["enqueue -> fail() -> mux.dispose('connection_lost')"]
    G --> H["watcher still armed -> _onRelayLost"]
    H --> I["redundant relay redeploy scheduled"]
```

## The fix

Hoist the release into `releaseRelayLossWatcher()` and call it before `stopPortScanning()` on all four teardown paths (`:654` reconnect, `:840` runDisposal, `:914` beginShutdownDetach, `:934` runDetach). `teardownProviders` and `watchMuxForRelayLoss` now delegate to the same method, so there is one definition of "stop listening for relay loss".

The method carries a comment pinning the ordering invariant, which was previously load-bearing but undocumented — reordering those two lines in `teardownProviders` would have silently reintroduced this.

## Impact, stated honestly

Low. It needs the control lane already at `CONTROL_QUEUE_MAX_FRAMES = 512` or over its byte reserve at the exact moment of teardown — a state where the transport is already stalled and the mux is doomed regardless.

And the consumer absorbs most of it: `ssh.ts:798` never reconnects synchronously, debounces via `if (state.reconnectTimer) return`, bounds retries at `RELAY_LOST_MAX_ATTEMPTS`, and re-validates the session at fire time. The realistic worst case was a redundant relay redeploy that supersedes an in-flight reconnect attempt and burns one of six attempts toward the "Click Reconnect manually" terminal error. Nothing was corrupted.

Worth fixing because it is three lines and removes a class of self-inflicted reconnect churn, not because it was breaking users.

## What does NOT change

No behavior on any healthy path. The watcher is released a few statements earlier on paths that were about to release it anyway; between those statements the mux is torn down and replaced regardless. Reconnect failures still reach `_onRelayLost` through the existing catch at `:795`, so no relay-loss coverage is lost.

## Testing

The new cases fail without the fix and pass with it — verified by stashing the source change:

```
FAIL  does not report relay loss when the port-scan cancel kills the mux on detach
FAIL  does not report relay loss when the port-scan cancel kills the mux on dispose
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

The test mirrors the real contract on both sides: the mock `request` emits `rpc.cancel` when its signal aborts, and the mock mux dies on that notify the way a saturated writer does.

Note this confirms the `runDisposal` path was affected too. It is not exempt on the grounds that it passes `'shutdown'` to `teardownProviders` — the writer's failure path hardcodes `dispose('connection_lost')`, and it fires before `teardownProviders` is reached.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `src/main/ssh` + `src/relay` — 2641 passed

Pre-existing and unrelated: 3 failures in `ssh-connection-sftp-namespace.test.ts` (SFTP realpath-abort) reproduce on clean `main`. They pass in CI but fail locally, which suggests a timing sensitivity worth a separate look.

Follow-up to #13548.

Made with [Orca](https://github.com/stablyai/orca) 🐋
