### PR TITLE
perf(renderer): keep the repos array identity across no-op refetches

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -149,7 +149,7 @@ function PreflightBanner({
   repos
 }: {
   issues: PreflightIssue[]
-  repos: Repo[]
+  repos: readonly Repo[]
 }): React.JSX.Element | null {
   // Why: keying the seed on the current GitHub project set means adding a new
   // GitHub project (which changes the key) re-evaluates dismissals, so a lapsed

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -84,7 +84,7 @@ type NewWorkspaceComposerCardProps = {
   nameInputRef?: React.RefObject<HTMLInputElement | null>
   quickAgent: TuiAgent | null
   onQuickAgentChange: (agent: TuiAgent | null) => void
-  eligibleRepos: RepoOption[]
+  eligibleRepos: readonly RepoOption[]
   repoId: string
   projectOptions?: NewWorkspaceProjectOption[]
   selectedProjectId?: string | null
@@ -98,7 +98,7 @@ type NewWorkspaceComposerCardProps = {
   selectedEphemeralVmRecipeId?: string | null
   onEphemeralVmRecipeChange?: (recipeId: string | null) => void
   ephemeralVmRecipeError?: string | null
-  repoBackedSearchRepos?: RepoOption[]
+  repoBackedSearchRepos?: readonly RepoOption[]
   repoBackedSourcesDisabled?: boolean
   allowSmartNameAddProject?: boolean
   smartNameRepoSwitchTarget?: 'project' | 'task-source'

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -61,7 +61,7 @@ type AutomationEditorDialogProps = {
   isSaving: boolean
   canSave: boolean
   createTarget: AutomationCreateTarget
-  repos: Repo[]
+  repos: readonly Repo[]
   projectHostSetups: ProjectHostSetup[]
   automationYamlHooksByRepoKey: Record<string, OrcaHooks | null>
   getAutomationHooksCacheKey: (repoId: string) => string

--- a/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
@@ -31,7 +31,7 @@ type AutomationEditorDialogFooterProps = {
   isHermesCreate: boolean
   isSaving: boolean
   canSave: boolean
-  repos: Repo[]
+  repos: readonly Repo[]
   projectHostSetups: ProjectHostSetup[]
   automationYamlHooksByRepoKey: Record<string, OrcaHooks | null>
   getAutomationHooksCacheKey: (repoId: string) => string

--- a/src/renderer/src/components/automations/AutomationProjectCombobox.tsx
+++ b/src/renderer/src/components/automations/AutomationProjectCombobox.tsx
@@ -19,7 +19,7 @@ import {
 } from './automation-project-groups'
 
 type AutomationProjectComboboxProps = {
-  repos: Repo[]
+  repos: readonly Repo[]
   value: string
   onValueChange: (repoId: string) => void
   placeholder?: string

--- a/src/renderer/src/components/dashboard/dashboard-worktree-launch-options.test.ts
+++ b/src/renderer/src/components/dashboard/dashboard-worktree-launch-options.test.ts
@@ -94,8 +94,22 @@ describe('buildDashboardWorktreeLaunchOptions', () => {
     const options = buildDashboardWorktreeLaunchOptions(
       state({
         repos: [
-          { id: 'repo-ssh', connectionId: 'ssh-1' },
-          { id: 'repo-runtime', executionHostId: 'runtime:hub-1' }
+          {
+            id: 'repo-ssh',
+            path: '/repo-ssh',
+            displayName: 'repo-ssh',
+            badgeColor: 'blue',
+            addedAt: 1,
+            connectionId: 'ssh-1'
+          },
+          {
+            id: 'repo-runtime',
+            path: '/repo-runtime',
+            displayName: 'repo-runtime',
+            badgeColor: 'blue',
+            addedAt: 1,
+            executionHostId: 'runtime:hub-1'
+          }
         ] as LaunchState['repos'],
         worktreesByRepo: {
           'repo-ssh': [{ id: 'ssh-worktree', repoId: 'repo-ssh' }],

--- a/src/renderer/src/components/dashboard/useRetainedAgents.ts
+++ b/src/renderer/src/components/dashboard/useRetainedAgents.ts
@@ -22,7 +22,7 @@ import { parsePaneKey } from '../../../../shared/stable-pane-id'
 type RetainedAgentSnapshot = Map<string, { row: DashboardAgentRow; worktreeId: string }>
 
 type RetainedAgentsSyncInputs = {
-  repos: Repo[]
+  repos: readonly Repo[]
   worktreesByRepo: Record<string, Worktree[]>
   folderWorkspaces: FolderWorkspace[]
   tabsByWorktree: Record<string, TerminalTab[]>
@@ -38,7 +38,7 @@ function paneKeyTabId(paneKey: string): string | null {
 }
 
 function buildLiveTabIndex(args: {
-  repos: Repo[]
+  repos: readonly Repo[]
   worktreesByRepo: Record<string, Worktree[]>
   folderWorkspaces: FolderWorkspace[]
   tabsByWorktree: Record<string, TerminalTab[]>

--- a/src/renderer/src/components/landing-preflight-dismissal.ts
+++ b/src/renderer/src/components/landing-preflight-dismissal.ts
@@ -23,7 +23,7 @@ function storageKey(issueId: string): string {
 
 /** GitHub-backed project identity keys for the current repo set, de-duped so
  *  the same GitHub project added twice doesn't read as two distinct projects. */
-export function githubProjectKeys(repos: Repo[]): string[] {
+export function githubProjectKeys(repos: readonly Repo[]): string[] {
   const keys = repos
     .filter((repo) => isGitHubBackedRepo(repo))
     .map((repo) => getProjectIdentityKey(repo))
@@ -45,7 +45,7 @@ function readRecord(issueId: string): DismissalRecord | null {
 
 /** True when the issue was dismissed and no new GitHub project has appeared
  *  since. A GitHub key present now but absent from the snapshot re-surfaces it. */
-export function isPreflightIssueDismissed(issueId: string, repos: Repo[]): boolean {
+export function isPreflightIssueDismissed(issueId: string, repos: readonly Repo[]): boolean {
   const record = readRecord(issueId)
   if (!record) {
     return false
@@ -55,7 +55,7 @@ export function isPreflightIssueDismissed(issueId: string, repos: Repo[]): boole
   return !hasNewGithubProject
 }
 
-export function dismissPreflightIssue(issueId: string, repos: Repo[]): void {
+export function dismissPreflightIssue(issueId: string, repos: readonly Repo[]): void {
   try {
     const record: DismissalRecord = { githubKeys: githubProjectKeys(repos) }
     localStorage.setItem(storageKey(issueId), JSON.stringify(record))

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -114,7 +114,7 @@ type RepoOption = ReturnType<typeof useAppStore.getState>['repos'][number]
 const EMPTY_REPO_SEARCH_REPOS: readonly RepoOption[] = []
 
 type SmartWorkspaceNameFieldProps = {
-  repos: RepoOption[]
+  repos: readonly RepoOption[]
   repoId: string
   onRepoChange: (repoId: string) => void
   value: string

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -19,7 +19,7 @@ import RepoBadgeLabel from './RepoBadgeLabel'
 import { translate } from '@/i18n/i18n'
 
 type RepoComboboxProps = {
-  repos: Repo[]
+  repos: readonly Repo[]
   value: string
   onValueChange: (repoId: string) => void
   onValueSelected?: (repoId: string) => void

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
@@ -217,7 +217,7 @@ describe('useGitStatusPolling rerender stability', () => {
     useAppStore.setState({
       repos: [{ ...repo, connectionId: 'ssh-1' }],
       sshConnectionStates: new Map([
-        ['ssh-1', { status: 'disconnected', error: null, reconnectAttempt: 0 }]
+        ['ssh-1', { targetId: 'ssh-1', status: 'disconnected', error: null, reconnectAttempt: 0 }]
       ])
     } as Partial<AppState>)
     await renderHook()

--- a/src/renderer/src/components/settings/QuickCommandsScopeFilter.tsx
+++ b/src/renderer/src/components/settings/QuickCommandsScopeFilter.tsx
@@ -21,7 +21,7 @@ function ScopeTriggerLabel({
 }: {
   showAll: boolean
   effectiveSelection: ReadonlySet<string>
-  repos: Repo[]
+  repos: readonly Repo[]
 }): React.JSX.Element {
   if (showAll) {
     return (
@@ -57,7 +57,7 @@ export function QuickCommandsScopeFilter({
   handleSelectAll,
   toggleScope
 }: {
-  repos: Repo[]
+  repos: readonly Repo[]
   effectiveSelection: ReadonlySet<string>
   showAll: boolean
   scopePopoverOpen: boolean

--- a/src/renderer/src/components/status-bar/resource-usage-open-slices.test.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-open-slices.test.ts
@@ -117,7 +117,16 @@ describe('resource usage open slices', () => {
   })
 
   it('gates repo and worktree slices only while closed', () => {
-    const repos = [{ id: 'repo-1', path: '/repo', kind: 'git' }] as AppState['repos']
+    const repos = [
+      {
+        id: 'repo-1',
+        path: '/repo',
+        displayName: 'repo',
+        badgeColor: 'blue',
+        addedAt: 1,
+        kind: 'git'
+      }
+    ] as AppState['repos']
     const row = worktree()
     const worktreesByRepo = {
       'repo-1': [row]

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAdvancedSection.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAdvancedSection.tsx
@@ -11,7 +11,7 @@ import { TerminalQuickCommandScopeField } from './TerminalQuickCommandScopeField
 
 type TerminalQuickCommandAdvancedSectionProps = {
   draft: TerminalQuickCommand
-  repos: Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
+  repos: readonly Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
   advancedOpen: boolean
   selectedScope: ReturnType<typeof getTerminalQuickCommandScope>
   selectedRepoId: string

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -39,7 +39,7 @@ type TerminalQuickCommandDialogProps = {
   open: boolean
   mode: TerminalQuickCommandDialogMode
   command: TerminalQuickCommand
-  repos?: Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
+  repos?: readonly Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
   onOpenChange: (open: boolean) => void
   onSave: (command: TerminalQuickCommand) => void
 }

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandScopeField.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandScopeField.tsx
@@ -18,7 +18,7 @@ import { QUICK_COMMAND_TOGGLE_ITEM_CLASS } from './terminal-quick-command-toggle
 import { translate } from '@/i18n/i18n'
 
 type TerminalQuickCommandScopeFieldProps = {
-  repos: Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
+  repos: readonly Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
   selectedScope: TerminalQuickCommandScope
   selectedRepoId: string
   selectedRepoMissing: boolean
@@ -32,7 +32,7 @@ function getRepoLabel(repo: Pick<Repo, 'displayName' | 'path'>): string {
 }
 
 export function getQuickCommandProjectScopeRepoId(
-  repos: Pick<Repo, 'id'>[],
+  repos: readonly Pick<Repo, 'id'>[],
   lastRepoScopeId: string | null
 ): string | null {
   return lastRepoScopeId ?? repos[0]?.id ?? null

--- a/src/renderer/src/components/ui/repo-multi-combobox.tsx
+++ b/src/renderer/src/components/ui/repo-multi-combobox.tsx
@@ -16,7 +16,7 @@ import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
 import { translate } from '@/i18n/i18n'
 
 type RepoMultiComboboxProps = {
-  repos: Repo[]
+  repos: readonly Repo[]
   /** Currently selected repo ids. The component enforces `selected.size >= 1`
    *  by disabling the last-selected checkbox. */
   selected: ReadonlySet<string>
@@ -32,7 +32,10 @@ type RepoMultiComboboxProps = {
   triggerClassName?: string
 }
 
-function renderTriggerLabel(repos: Repo[], selected: ReadonlySet<string>): React.JSX.Element {
+function renderTriggerLabel(
+  repos: readonly Repo[],
+  selected: ReadonlySet<string>
+): React.JSX.Element {
   if (repos.length === 0) {
     return (
       <span className="text-muted-foreground">

--- a/src/renderer/src/hooks/useAgentDetectionTarget.test.ts
+++ b/src/renderer/src/hooks/useAgentDetectionTarget.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../shared/types'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { getAgentDetectionTargetKeyForWorktree } from './useAgentDetectionTarget'
 
 describe('getAgentDetectionTargetKeyForWorktree', () => {
   it('uses an explicit runtime owner without scanning ambiguous child SSH repos', () => {
     let projectGroupReads = 0
-    const repos = Array.from({ length: 100 }, (_, index) => {
-      const repo = {
+    const repos: readonly Repo[] = Array.from({ length: 100 }, (_, index) => {
+      const repo: Repo = {
         id: `repo-${index}`,
         connectionId: `ssh-${index}`,
         executionHostId: `ssh:ssh-${index}`,
-        path: `/workspace/repo-${index}`
+        path: `/workspace/repo-${index}`,
+        displayName: `repo-${index}`,
+        badgeColor: 'blue',
+        addedAt: 1
       }
       Object.defineProperty(repo, 'projectGroupId', {
         enumerable: true,

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -291,7 +291,10 @@ describe('ensureHooksConfirmed', () => {
       repos: [
         {
           id: 'repo-1',
+          path: '/repo-1',
           displayName: 'Repo One',
+          badgeColor: 'blue',
+          addedAt: 1,
           hookSettings: {
             mode: 'auto',
             commandSourcePolicy: 'local-only',
@@ -318,7 +321,10 @@ describe('ensureHooksConfirmed', () => {
       repos: [
         {
           id: 'repo-1',
+          path: '/repo-1',
           displayName: 'Repo One',
+          badgeColor: 'blue',
+          addedAt: 1,
           hookSettings: {
             mode: 'auto',
             scripts: { setup: 'echo local', archive: '' }

--- a/src/renderer/src/lib/folder-workspace-connection.ts
+++ b/src/renderer/src/lib/folder-workspace-connection.ts
@@ -6,7 +6,7 @@ import { parseExecutionHostId } from '../../../shared/execution-host'
 export type FolderWorkspaceConnectionState = {
   folderWorkspaces: FolderWorkspace[]
   projectGroups: ProjectGroup[]
-  repos: Repo[]
+  repos: readonly Repo[]
 }
 
 function getFolderScopeCandidateRepos(args: {

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -35,7 +35,7 @@ type StoreAccessor = () => {
   > | null
   setActiveWorktree: (worktreeId: string) => void
   createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
-  repos?: LocalhostLinkRepo[]
+  repos?: readonly LocalhostLinkRepo[]
   projects?: LocalhostLinkProject[]
   worktreesByRepo?: Record<string, LocalhostLinkWorktree[]>
   allWorktrees?: () => LocalhostLinkWorktree[]

--- a/src/renderer/src/lib/local-preflight-context-cache.test.ts
+++ b/src/renderer/src/lib/local-preflight-context-cache.test.ts
@@ -16,11 +16,15 @@ afterEach(() => {
   resetLocalPreflightContextCachesForTests()
 })
 
+function makeRepos(id: string, path: string): AppState['repos'] {
+  return [{ id, path, displayName: id, badgeColor: 'blue', addedAt: 1 }]
+}
+
 function makeWslState(distro: string): AppState {
   return {
     activeRepoId: 'repo-1',
     activeWorktreeId: null,
-    repos: [{ id: 'repo-1', path: `\\\\wsl.localhost\\${distro}\\home\\alice\\repo` }],
+    repos: makeRepos('repo-1', `\\\\wsl.localhost\\${distro}\\home\\alice\\repo`),
     worktreesByRepo: {}
   } as AppState
 }
@@ -29,7 +33,7 @@ function makeWindowsProjectState(projectId: string): AppState {
   return {
     activeRepoId: projectId,
     activeWorktreeId: null,
-    repos: [{ id: projectId, path: `C:\\Users\\alice\\${projectId}` }],
+    repos: makeRepos(projectId, `C:\\Users\\alice\\${projectId}`),
     settings: {},
     worktreesByRepo: {}
   } as AppState

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -11,26 +11,30 @@ import {
 } from './local-preflight-context'
 
 function makeState(args: {
-  repoPath?: string | null
+  repoPath?: string
   worktreePath?: string | null
   repo?: Partial<Repo>
   worktree?: Partial<Worktree>
 }): AppState {
   const repoId = 'repo-1'
   const worktreeId = `${repoId}::worktree-1`
+  const repos: AppState['repos'] =
+    args.repoPath === undefined
+      ? []
+      : [
+          {
+            id: repoId,
+            path: args.repoPath,
+            displayName: repoId,
+            badgeColor: 'blue',
+            addedAt: 1,
+            ...args.repo
+          }
+        ]
   return {
     activeRepoId: repoId,
     activeWorktreeId: args.worktreePath === undefined ? null : worktreeId,
-    repos:
-      args.repoPath === undefined
-        ? []
-        : [
-            {
-              id: repoId,
-              path: args.repoPath,
-              ...args.repo
-            }
-          ],
+    repos,
     worktreesByRepo:
       args.worktreePath === undefined
         ? {}

--- a/src/renderer/src/lib/repo-search.ts
+++ b/src/renderer/src/lib/repo-search.ts
@@ -38,7 +38,7 @@ function matchScore(repo: Repo, query: string): number | null {
   return null
 }
 
-export function searchRepos(repos: Repo[], rawQuery: string): Repo[] {
+export function searchRepos(repos: readonly Repo[], rawQuery: string): readonly Repo[] {
   if (isRepoSearchQueryTooLarge(rawQuery)) {
     return []
   }

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -126,7 +126,7 @@ async function resolveRepoSlug(
 }
 
 async function buildIndex(
-  repos: Repo[],
+  repos: readonly Repo[],
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
 ): Promise<{ index: SlugIndex; upstreamIndex: SlugIndex; retryDelayMs: number | null }> {
   // Why: evict cached entries for repos that no longer exist in state so

--- a/src/renderer/src/lib/workspace-port-localhost-label-selector.ts
+++ b/src/renderer/src/lib/workspace-port-localhost-label-selector.ts
@@ -9,8 +9,8 @@ import { localhostWorktreeLabelRouteForPort } from './workspace-port-localhost-l
 // this is the single source for both reactive and imperative call sites.
 type LocalhostLabelLookupState = {
   settings?: Pick<GlobalSettings, 'localhostWorktreeLabelsEnabled'> | null
-  repos?: Repo[]
-  projects?: Project[]
+  repos?: readonly Repo[]
+  projects?: readonly Project[]
   getKnownWorktreeById?: (worktreeId: string) => { projectId?: string | null } | null | undefined
 }
 

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -327,6 +327,10 @@ describe('createDetectedAgentsSlice WSL context', () => {
       projects: [
         {
           id: 'repo-1',
+          displayName: 'repo-1',
+          badgeColor: 'blue',
+          createdAt: 1,
+          updatedAt: 1,
           sourceRepoIds: ['repo-1'],
           localWindowsRuntimePreference: { kind: 'windows-host' }
         }

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6408,17 +6408,18 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       _meta: { runtimeId: 'remote-runtime' }
     })
     const store = createTestStore()
+    const repos: AppState['repos'] = [
+      {
+        id: 'runtime-repo-id',
+        path: '/server/repo',
+        displayName: 'repo',
+        badgeColor: 'blue',
+        addedAt: 1
+      }
+    ]
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'env-1' },
-      repos: [
-        {
-          id: 'runtime-repo-id',
-          path: '/server/repo',
-          displayName: 'repo',
-          badgeColor: 'blue',
-          addedAt: 1
-        }
-      ]
+      repos
     } as Partial<AppState>)
 
     await store.getState().fetchWorkItems('caller-repo-id', '/server/repo', 24, 'is:open', {
@@ -6508,17 +6509,18 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       _meta: { runtimeId: 'source-runtime' }
     })
     const store = createTestStore()
+    const repos: AppState['repos'] = [
+      {
+        id: 'local-repo-id',
+        path: '/server/repo',
+        displayName: 'repo',
+        badgeColor: 'blue',
+        addedAt: 1
+      }
+    ]
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
-      repos: [
-        {
-          id: 'local-repo-id',
-          path: '/server/repo',
-          displayName: 'repo',
-          badgeColor: 'blue',
-          addedAt: 1
-        }
-      ]
+      repos
     } as Partial<AppState>)
 
     const sourceContext = {

--- a/src/renderer/src/store/slices/preflight.test.ts
+++ b/src/renderer/src/store/slices/preflight.test.ts
@@ -265,11 +265,12 @@ describe('createPreflightSlice', () => {
       new Error('Project runtime requires repair before preflight: wsl-distro-required')
     )
     const store = createTestStore()
+    const repos: AppState['repos'] = [makeRepo({ id: 'repo-1', path: 'C:\\repo' })]
     store.setState({
       settings: {
         localWindowsRuntimeDefault: { kind: 'wsl', distro: null }
       },
-      repos: [makeRepo({ id: 'repo-1', path: 'C:\\repo' })],
+      repos,
       worktreesByRepo: {},
       activeRepoId: 'repo-1',
       activeWorktreeId: null

--- a/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
@@ -14,6 +14,50 @@ describe('reconcileFetchedRepos', () => {
     expect(reconcileFetchedRepos(previous, next)).toBe(previous)
   })
 
+  it('reconciles repos whose nested records were rebuilt by hydration and IPC', () => {
+    // Why: main's hydrateRepo reconstructs hookSettings on every list and structured-clone
+    // rebuilds the rest, so a reference compare would report every real repo as changed.
+    const nested = (): Partial<Repo> => ({
+      hookSettings: { mode: 'auto', scripts: { setup: 'echo hi', archive: '' } },
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/o/n',
+        remoteName: 'origin',
+        remoteUrl: 'git@github.com:o/n.git'
+      },
+      importedExternalWorktreePaths: ['/a', '/b']
+    })
+    const previous = [makeRepo('a', nested())]
+    const next = structuredClone([makeRepo('a', nested())]) as Repo[]
+
+    expect(reconcileFetchedRepos(previous, next)).toBe(previous)
+  })
+
+  it('treats a changed nested field as a real change', () => {
+    const previous = [makeRepo('a', { importedExternalWorktreePaths: ['/a'] })]
+    const next = [makeRepo('a', { importedExternalWorktreePaths: ['/b'] })]
+    const result = reconcileFetchedRepos(previous, next)
+
+    expect(result).not.toBe(previous)
+    expect(result[0].importedExternalWorktreePaths).toEqual(['/b'])
+  })
+
+  it('treats a nested field gaining a key as a real change', () => {
+    const previous = [
+      makeRepo('a', { hookSettings: { mode: 'auto', scripts: { setup: '', archive: '' } } })
+    ]
+    const next = [
+      makeRepo('a', {
+        hookSettings: {
+          mode: 'auto',
+          setupRunPolicy: 'run-by-default',
+          scripts: { setup: '', archive: '' }
+        }
+      })
+    ]
+
+    expect(reconcileFetchedRepos(previous, next)).not.toBe(previous)
+  })
+
   it('reuses unchanged repo objects while reflecting a reorder', () => {
     const previous = [makeRepo('a'), makeRepo('b')]
     const next = [makeRepo('b'), makeRepo('a')]

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -27,7 +27,10 @@ function areReposEqual(a: Repo, b: Repo): boolean {
   return true
 }
 
-export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): Repo[] {
+export function reconcileFetchedRepos(
+  previous: readonly Repo[],
+  next: readonly Repo[]
+): readonly Repo[] {
   const previousById = new Map(previous.map((repo) => [getRepoHostIdentity(repo), repo]))
   let identical = next.length === previous.length
   const reconciled = next.map((repo, index) => {
@@ -41,5 +44,5 @@ export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): 
     identical = false
     return repo
   })
-  return identical ? (previous as Repo[]) : reconciled
+  return identical ? previous : reconciled
 }

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -8,6 +8,45 @@ import { getRepoHostIdentity } from './repo-host-identity'
 // virtualizer to rebuild + re-measure a tick after the drop — the visible jump.
 // Reusing equal objects (and the whole array when nothing moved) makes the echo
 // a no-op render.
+// Why: `Repo` carries nested records (hookSettings, upstream, gitRemoteIdentity, repoIcon, path
+// arrays). IPC structured-clone rebuilds those every fetch, and main's hydrateRepo always
+// reconstructs hookSettings — so a reference compare reports every repo as changed and no repo
+// ever reconciles. Compare nested plain values structurally; they are small sanitized records.
+function areValuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true
+  }
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+    return false
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((item, index) => areValuesEqual(item, b[index]))
+    )
+  }
+  // Why: only plain records are safe to walk — anything exotic falls back to reference equality.
+  if (
+    Object.getPrototypeOf(a) !== Object.prototype ||
+    Object.getPrototypeOf(b) !== Object.prototype
+  ) {
+    return false
+  }
+  const aRecord = a as Record<string, unknown>
+  const bRecord = b as Record<string, unknown>
+  const keys = Object.keys(aRecord)
+  if (keys.length !== Object.keys(bRecord).length) {
+    return false
+  }
+  return keys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(bRecord, key) &&
+      areValuesEqual(aRecord[key], bRecord[key])
+  )
+}
+
 function areReposEqual(a: Repo, b: Repo): boolean {
   if (a === b) {
     return true
@@ -20,7 +59,7 @@ function areReposEqual(a: Repo, b: Repo): boolean {
     if (!Object.prototype.hasOwnProperty.call(b, key)) {
       return false
     }
-    if (a[key] !== b[key]) {
+    if (!areValuesEqual(a[key], b[key])) {
       return false
     }
   }

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createTestStore, makeWorktree } from './store-test-helpers'
 import { workItemsCacheKey } from './github'
-import type { Project, ProjectHostSetup } from '../../../../shared/types'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
 import { toast } from 'sonner'
 import {
   installReposRuntimeRoutingHarness,
@@ -53,7 +53,21 @@ describe('repo slice runtime routing', () => {
   })
 
   it('keeps the repos array identity across a refetch that changes nothing', async () => {
-    reposList.mockResolvedValue([localRepo])
+    // Why: main rebuilds nested records (hookSettings et al) per list and IPC clones them, so a
+    // production-shaped repo — not a scalar-only fixture — is what proves reconciliation works.
+    const hydrated = (): Repo => ({
+      ...localRepo,
+      kind: 'git',
+      gitUsername: 'octocat',
+      hookSettings: { mode: 'auto', scripts: { setup: 'echo hi', archive: '' } },
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/octocat/local',
+        remoteName: 'origin',
+        remoteUrl: 'git@github.com:octocat/local.git'
+      },
+      importedExternalWorktreePaths: ['/local/wt']
+    })
+    reposList.mockImplementation(async () => [hydrated()])
     const store = createTestStore()
     await store.getState().fetchRepos()
     const reposRef = store.getState().repos
@@ -62,6 +76,7 @@ describe('repo slice runtime routing', () => {
 
     // Why: identity-keyed renderer memos (repo lookup index, selectors) rebuild on a new array.
     expect(store.getState().repos).toBe(reposRef)
+    expect(store.getState().repos[0]).toBe(reposRef[0])
   })
 
   it('replaces the repos array identity when a refetch adds a repo', async () => {

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -52,6 +52,31 @@ describe('repo slice runtime routing', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
+  it('keeps the repos array identity across a refetch that changes nothing', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const reposRef = store.getState().repos
+
+    await store.getState().fetchRepos()
+
+    // Why: identity-keyed renderer memos (repo lookup index, selectors) rebuild on a new array.
+    expect(store.getState().repos).toBe(reposRef)
+  })
+
+  it('replaces the repos array identity when a refetch adds a repo', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const reposRef = store.getState().repos
+    reposList.mockResolvedValue([localRepo, { ...localRepo, id: 'second', path: '/second' }])
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).not.toBe(reposRef)
+    expect(store.getState().repos).toHaveLength(2)
+  })
+
   it('fetches repos from the active remote runtime environment', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-1',

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -880,9 +880,9 @@ function mergeByIdentity<T>(
 
 function mergeFetchedReposForHost(
   previous: readonly Repo[],
-  fetched: Repo[],
+  fetched: readonly Repo[],
   hostId: string
-): Repo[] {
+): readonly Repo[] {
   const fetchedWithProjectGroups = applyInheritedProjectGroups(previous, fetched)
   const fetchedIdentities = new Set(fetchedWithProjectGroups.map(getRepoHostIdentity))
   const preserved = previous.filter((repo) => {
@@ -1049,7 +1049,7 @@ function mergeFetchedFolderWorkspacesForHost({
 }
 
 type FetchedRepoCatalog = {
-  repos: Repo[]
+  repos: readonly Repo[]
   projectHostSetupCompatibility: ProjectHostSetupProjection
   hostId: ReturnType<typeof getRuntimeTargetHostId>
 }
@@ -1110,7 +1110,7 @@ function mergeFetchedRepoCatalog(
   catalog: FetchedRepoCatalog,
   currentRepos: readonly Repo[]
 ): {
-  repos: Repo[]
+  repos: readonly Repo[]
   projectHostSetupCompatibility: ProjectHostSetupProjection
   hostId: ReturnType<typeof getRuntimeTargetHostId>
 } {
@@ -1619,7 +1619,7 @@ function getFolderWorkspacePathStatusRequestSnapshotForRead(
 }
 
 export type RepoSlice = {
-  repos: Repo[]
+  repos: readonly Repo[]
   projects: Project[]
   projectHostSetups: ProjectHostSetup[]
   projectGroups: ProjectGroup[]

--- a/src/renderer/src/store/slices/superseded-ssh-repo-rows.test.ts
+++ b/src/renderer/src/store/slices/superseded-ssh-repo-rows.test.ts
@@ -31,6 +31,12 @@ describe('reconcileReadoptedSshRepoRows', () => {
     expect(result.pendingReadoptions).toEqual([])
   })
 
+  it('returns the input array when nothing is pruned', () => {
+    const repos = [repo({ id: 'shared', path: '/local' })]
+
+    expect(reconcileReadoptedSshRepoRows(repos, []).repos).toBe(repos)
+  })
+
   it('keeps evidence pending when repos:changed has not delivered the new row yet', () => {
     const oldSsh = repo({ id: 'shared', connectionId: 'ssh-old' })
 

--- a/src/renderer/src/store/slices/superseded-ssh-repo-rows.ts
+++ b/src/renderer/src/store/slices/superseded-ssh-repo-rows.ts
@@ -3,7 +3,7 @@ import type { Repo } from '../../../../shared/types'
 import { getRepoExecutionHostId, toSshExecutionHostId } from '../../../../shared/execution-host'
 
 export type SshRepoReconciliation = {
-  repos: Repo[]
+  repos: readonly Repo[]
   pendingReadoptions: SshRepoReadoption[]
 }
 
@@ -56,7 +56,7 @@ export function reconcileReadoptedSshRepoRows(
   // Why: pruning nothing must hand back the input array, or the copy alone would defeat the
   // referential stability reconcileFetchedRepos just established upstream.
   if (prunedOwners.size === 0) {
-    return { repos: repos as Repo[], pendingReadoptions }
+    return { repos, pendingReadoptions }
   }
   return {
     repos: repos.filter(

--- a/src/renderer/src/store/slices/superseded-ssh-repo-rows.ts
+++ b/src/renderer/src/store/slices/superseded-ssh-repo-rows.ts
@@ -53,8 +53,10 @@ export function reconcileReadoptedSshRepoRows(
     }
   }
 
+  // Why: pruning nothing must hand back the input array, or the copy alone would defeat the
+  // referential stability reconcileFetchedRepos just established upstream.
   if (prunedOwners.size === 0) {
-    return { repos: [...repos], pendingReadoptions }
+    return { repos: repos as Repo[], pendingReadoptions }
   }
   return {
     repos: repos.filter(

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -14,6 +14,7 @@ import type {
   WorktreeLineage,
   WorkspaceLineage,
   ProjectHostSetup,
+  Repo,
   WorktreeMeta
 } from '../../../../shared/types'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
@@ -6065,7 +6066,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const repoIdsWithRemovedOwners = new Set<string>()
       const survivingRepoIds = new Set<string>()
       const repoIdsWithSurvivingOwners = new Set<string>()
-      const survivingRepos: AppState['repos'] = []
+      const survivingRepos: Repo[] = []
       for (const repo of s.repos) {
         if (isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)) {
           repoIdsWithRemovedOwners.add(repo.id)

--- a/src/shared/manual-repo-order.test.ts
+++ b/src/shared/manual-repo-order.test.ts
@@ -27,6 +27,26 @@ describe('manual repo order', () => {
     expect(applyManualRepoOrder([localBravo, localAlpha], [])).toEqual([localBravo, localAlpha])
   })
 
+  it('returns the input array when no overlay exists', () => {
+    const repos = [localBravo, localAlpha]
+
+    expect(applyManualRepoOrder(repos, [])).toBe(repos)
+  })
+
+  it('returns the input array when the saved order moves nothing', () => {
+    const repos = [localAlpha, remoteCharlie, localBravo, remoteDelta]
+
+    expect(applyManualRepoOrder(repos, getManualRepoOrder(repos))).toBe(repos)
+  })
+
+  it('returns a new array when the saved order actually reorders', () => {
+    const repos = [localBravo, localAlpha]
+    const reordered = applyManualRepoOrder(repos, getManualRepoOrder([localAlpha, localBravo]))
+
+    expect(reordered).not.toBe(repos)
+    expect(reordered).toEqual([localAlpha, localBravo])
+  })
+
   it('restores a host-qualified cross-host interleaving', () => {
     const order = getManualRepoOrder([localAlpha, remoteCharlie, localBravo, remoteDelta])
 

--- a/src/shared/manual-repo-order.ts
+++ b/src/shared/manual-repo-order.ts
@@ -43,11 +43,13 @@ export function applyManualRepoOrder(
   order: readonly ManualRepoOrderEntry[] | null | undefined
 ): Repo[] {
   const normalized = normalizeManualRepoOrder(order)
+  // Why: results flow straight back into `repos`, so a reorder that moves nothing must return
+  // the input — a fresh array would invalidate every identity-keyed repo memo downstream.
   if (normalized.length === 0) {
-    return [...repos]
+    return repos as Repo[]
   }
   const rankByKey = new Map(normalized.map((entry, index) => [getEntryKey(entry), index]))
-  return repos
+  const ordered = repos
     .map((repo, index) => ({
       repo,
       index,
@@ -66,4 +68,5 @@ export function applyManualRepoOrder(
       return a.rank - b.rank || a.index - b.index
     })
     .map(({ repo }) => repo)
+  return ordered.every((repo, index) => repo === repos[index]) ? (repos as Repo[]) : ordered
 }

--- a/src/shared/manual-repo-order.ts
+++ b/src/shared/manual-repo-order.ts
@@ -41,12 +41,12 @@ export function getManualRepoOrder(repos: readonly Repo[]): ManualRepoOrderEntry
 export function applyManualRepoOrder(
   repos: readonly Repo[],
   order: readonly ManualRepoOrderEntry[] | null | undefined
-): Repo[] {
+): readonly Repo[] {
   const normalized = normalizeManualRepoOrder(order)
   // Why: results flow straight back into `repos`, so a reorder that moves nothing must return
   // the input — a fresh array would invalidate every identity-keyed repo memo downstream.
   if (normalized.length === 0) {
-    return repos as Repo[]
+    return repos
   }
   const rankByKey = new Map(normalized.map((entry, index) => [getEntryKey(entry), index]))
   const ordered = repos
@@ -68,5 +68,5 @@ export function applyManualRepoOrder(
       return a.rank - b.rank || a.index - b.index
     })
     .map(({ repo }) => repo)
-  return ordered.every((repo, index) => repo === repos[index]) ? (repos as Repo[]) : ordered
+  return ordered.every((repo, index) => repo === repos[index]) ? repos : ordered
 }


### PR DESCRIPTION
## Summary

Follow-up to #13698, which added a repo lookup index keyed on the **identity** of the `repos` array. That identity was being destroyed on every repo refresh in three separate places. This PR fixes all three, then makes the array `readonly` so the guarantee can't be broken later.

| Commit | What |
|---|---|
| `eb703b8` | Stop two functions copying the array when they change nothing (+6 tests) |
| `3f86147` | Widen `RepoSlice['repos']` to `readonly Repo[]`; type-only |
| `417cad2` | Compare nested repo fields structurally, so reconciliation actually fires |

> **Note for reviewers:** an adversarial review of the first two commits found they were a **no-op in production** — the chain broke at a step upstream of both. `417cad2` is that fix, and the end-to-end test was rewritten because it had been passing for a fixture-only reason. Details below.

## The plain-English version

Orca keeps a list of your projects in memory: `state.repos`.

Several caches decide "did anything change?" with a shortcut. Rather than compare every project one by one, they ask **"is this the exact same array object as last time?"** Same object → reuse the cached answer. Different object → rebuild.

That only works if code hands back *the same array* when nothing changed. A copy is a different object even when the contents are identical, so a pointless copy is indistinguishable from a real change.

The codebase already knew this — `reconcileFetchedRepos` exists specifically to return the original array when a refresh brings back identical data. But three separate things were defeating it.

## Where the chain broke — all three links

Every repo refresh runs these in order:

| # | Step | Problem |
|---|---|---|
| 1 | `reconcileFetchedRepos` | Compared nested fields by **reference**, so no repo ever matched |
| 2 | `reconcileReadoptedSshRepoRows:57` | `return { repos: [...repos] }` on its no-prune path |
| 3 | `applyManualRepoOrder` | Always allocated, even when the order moved nothing |

**Step 1 is the one that mattered most, and I initially missed it.** `areReposEqual` compares fields with `!==`. Every repo the renderer receives carries nested records that are brand-new objects every fetch, for two independent reasons:

- `hydrateRepo` (`persistence.ts:5109`) **unconditionally** rebuilds `hookSettings` for every repo — even a pristine one with no user config — on every `repos:list`.
- IPC structured-clone (and the JSON hop for SSH/runtime hosts) reclones `gitRemoteIdentity`, `upstream`, `repoIcon`, and the path arrays.

So every repo compared unequal, `identical` went false, and the array was rebuilt — **regardless of steps 2 and 3.** Fixing any subset of the three achieves nothing.

## The fix

- **Step 1** — compare nested plain records structurally. They're small sanitized values; anything non-plain falls back to reference equality. A genuinely changed nested value still correctly busts identity (covered by tests).
- **Step 2** — no-prune path returns `repos` instead of `[...repos]`.
- **Step 3** — returns `repos` when there's no saved order, and after sorting when the result is element-wise identical. That `.every` costs 1.1 µs at 200 repos vs. the 71 µs sort it follows.

## What this actually buys — measured, and less than I first claimed

Reconciliation now succeeds where it previously always failed:

| | 200 repos | 1200 repos |
|---|---|---|
| Shallow compare (main today) | 86 µs, **0/200 preserved** | 440 µs, **0/200 preserved** |
| Structural compare (this PR) | 161 µs, **200/200 preserved** | 779 µs, **200/200 preserved** |

Main already pays the full field scan and *always* fails — the extra ~75 µs converts guaranteed waste into a guaranteed hit.

Downstream cache rebuilds avoided are roughly **100 µs at 200 repos, ~0.5 ms at 1200** — real but not perceptible on its own. **The substantive win is that `state.repos` keeping identity means zustand subscribers selecting `repos` stop re-rendering on every refresh**, which is React work, not microseconds.

### Corrections to my earlier claims

An adversarial audit caught these; I'd rather cut a claim than ship an inaccurate one.

- ~~"seven identity-keyed caches"~~ → **four** genuinely benefit: `repoMapCache` (`worktree-repo-index.ts:12`), `project-host-setup-selector.ts:9`, `worktrees.ts:482`, `getGitHubRepoLookupIndex`. I'd wrongly listed `worktree-repo-index.ts:11` and `selectors.ts:37`, which are keyed on **`worktreesByRepo`**, not `repos`.
- `project-host-setup-selector.ts:15`/`:19` are multi-level caches also keyed on `projects` and `projectHostSetups`, which are rebuilt every refresh anyway — so they still miss.
- `getGitHubRepoLookupIndex` construction is 0.2 µs; its value is amortized lookups, not rebuild cost.

## Safety: `readonly` at the type level

Preserving identity means handing callers **the array that is live store state**. Rather than rely on an audit staying true forever, this makes mutation inexpressible:

```ts
export type RepoSlice = {
  repos: readonly Repo[]   // was: Repo[]
```

Propagated honestly across 34 files — **no `as Repo[]`, `as unknown as`, or `@ts-expect-error` added.** Read-only consumers take `readonly Repo[]`; genuine local accumulators are annotated `Repo[]` and built from copies.

**It removes more footguns than it adds.** All four pre-existing `as Repo[]` casts in this chain are gone (`repo-identity-reconcile.ts:44`, `superseded-ssh-repo-rows.ts`, `manual-repo-order.ts` ×2). `grep -rn "as Repo\[\]" src/` returns **zero non-test hits** — fewer than `main` today.

The compiler earned its keep immediately: it flagged `worktrees.ts:6073` doing `survivingRepos.push(...)` on a value typed `AppState['repos']` (safe — a local accumulator — but exactly the hazard). It also surfaced three unrelated pre-existing fixture lies that `Array<T>` bivariance had masked; two are fixed, and `useAgentDetectionTarget.test.ts`'s `projectGroups` remains structurally incomplete — pre-existing, flagged rather than papered over.

## Testing

**The end-to-end test previously passed for a fixture-only reason.** Its repo had five scalar fields and the mock returned the same object on both calls — the one shape production never produces. It now builds a production-shaped repo (`hookSettings`, `gitRemoteIdentity`, path arrays) fresh per call, and **fails without `417cad2`**.

Every identity test was verified to fail against a reverted source, so none are vacuous:

- `repo-identity-reconcile.test.ts` — reconciles repos whose nested records were rebuilt by hydration + `structuredClone`; a changed nested value and a nested key gaining a field both still count as real changes.
- `manual-repo-order.test.ts` — returns the input with no overlay and when the order moves nothing; returns a **new** array when it genuinely reorders.
- `superseded-ssh-repo-rows.test.ts` — returns the input when nothing is pruned.
- `repos.test.ts` — end-to-end identity preserved on a no-op refetch; correctly replaced when a repo is added.

- [x] 13,819 component tests
- [x] 11,244 store / shared / lib / hooks tests
- [x] 20,486 main-process tests
- [x] `tsc` web + node + cli — zero errors
- [x] oxlint, oxfmt, max-lines ratchet

## Adversarial review

Two independent reviewers attacked this. Both found the P1 above. Beyond it, the following were attacked and came back clean: **aliasing** (no caller mutates a returned repos array; enforced by the compiler now), **over-aggressive preservation** (`ordered` is a permutation so lengths always match; contents cannot change while identity is preserved), **staleness** (no consumer relied on identity churning), **the readonly widening** (all non-test hunks are pure type changes; no assertion weakened), and **cross-platform / SSH / folder-workspace** (`getRepoExecutionHostId` normalizes identically for local, `ssh:*`, `runtime:*`).

## Residual risk

- Sibling slices still churn every refresh: `projects`, `projectHostSetups` (`filterSetupsForPrunedRepoRows` returns `[...setups]` unconditionally) and `folderWorkspacePathStatuses` (reset to `{}`). Components selecting those still re-render, so the render-churn reduction is partial. Pre-existing; a natural follow-up.
- `applyManualRepoOrder` still runs the full sort before discovering the order was unchanged — identity is preserved, but the work isn't skipped.
