### PR TITLE
perf(renderer): scope batched open-file reconciliation by worktree

### DIFF
--- a/src/renderer/src/runtime/web-session-open-files-batch-equivalence.test.ts
+++ b/src/renderer/src/runtime/web-session-open-files-batch-equivalence.test.ts
@@ -1,0 +1,214 @@
+/* Why: the batched open-file path reconciles against a slot-keyed draft instead of
+ * rebuilding the global array per snapshot. These seeded cases assert it stays
+ * indistinguishable from repeated single-snapshot reconciliation. */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import type { OpenFile } from '../store/slices/editor'
+import { resetWebSessionFocusIntentForTests } from './web-session-focus-intent'
+import { resetWebSessionCloseIntentForTests } from './web-session-close-intent'
+import { resetWebSessionReorderIntentForTests } from './web-session-reorder-intent'
+import { resetWebAgentSessionHandoffsForTests } from './web-agent-session-handoff'
+import {
+  applyWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshots,
+  resetWebSessionTabsSnapshotFreshnessForTests,
+  type WebSessionTabsSyncState
+} from './web-session-tabs-sync'
+
+vi.mock('../store', () => ({ useAppStore: { setState: vi.fn() } }))
+
+const ENV = 'web-env-1'
+const NOW = 1_700_000_000_000
+const WORKTREES = ['repo::/w0', 'repo::/w1', 'repo::/w2', 'repo::/bystander']
+const PATHS = ['/repo/a.ts', '/repo/b.ts', '/repo/c.ts', '/repo/d.ts']
+const ENVS: (string | null | undefined)[] = [ENV, 'other-env', null, undefined]
+
+/** Deterministic LCG so a failing case is reproducible from its seed. */
+function makeRandom(seed: number): () => number {
+  let value = seed >>> 0
+  return () => {
+    value = (value * 1664525 + 1013904223) >>> 0
+    return value / 0x100000000
+  }
+}
+
+function resetModuleState(): void {
+  resetWebSessionTabsSnapshotFreshnessForTests()
+  resetWebSessionFocusIntentForTests()
+  resetWebSessionCloseIntentForTests()
+  resetWebSessionReorderIntentForTests()
+  resetWebAgentSessionHandoffsForTests()
+}
+
+function baseState(overrides: Partial<WebSessionTabsSyncState>): WebSessionTabsSyncState {
+  return {
+    activeBrowserTabId: null,
+    activeBrowserTabIdByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    activeGroupIdByWorktree: {},
+    activeTabId: null,
+    activeTabIdByWorktree: {},
+    activeTabType: 'terminal',
+    activeTabTypeByWorktree: {},
+    activeWorktreeId: WORKTREES[0]!,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    browserCertificateFailuresByPageId: {},
+    browserPagesByWorkspace: {},
+    browserTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    openFiles: [],
+    ptyIdsByTabId: {},
+    remoteBrowserPageHandlesByPageId: {},
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    unifiedTabsByWorktree: {},
+    unreadTerminalTabs: {},
+    sortEpoch: 0,
+    ...overrides
+  }
+}
+
+function pick<T>(random: () => number, items: readonly T[]): T {
+  return items[Math.floor(random() * items.length)]!
+}
+
+function makeCase(seed: number): {
+  state: WebSessionTabsSyncState
+  snapshots: RuntimeMobileSessionTabsResult[]
+} {
+  const random = makeRandom(seed)
+  const openFiles: OpenFile[] = []
+  const fileCount = Math.floor(random() * 9)
+  for (let i = 0; i < fileCount; i += 1) {
+    const path = pick(random, PATHS)
+    const isPreview = random() < 0.2
+    openFiles.push({
+      id: isPreview ? `markdown-preview::${path}` : path,
+      filePath: path,
+      relativePath: path.slice('/repo/'.length),
+      worktreeId: pick(random, WORKTREES),
+      language: 'typescript',
+      isDirty: random() < 0.5,
+      runtimeEnvironmentId: pick(random, ENVS),
+      mode: isPreview ? 'markdown-preview' : 'edit',
+      mirroredFromRuntimeSession: random() < 0.7,
+      // Why: the mirrored file overwrites every compared field, so only a preserved
+      // field like this can reveal which duplicate seeded it.
+      lastKnownDiskSignature: `sig-${seed}-${i}`
+    } as OpenFile)
+  }
+
+  const snapshots: RuntimeMobileSessionTabsResult[] = []
+  const snapshotCount = 1 + Math.floor(random() * 7)
+  for (let s = 0; s < snapshotCount; s += 1) {
+    const worktree = pick(random, WORKTREES)
+    const tabs: RuntimeMobileSessionTabsResult['tabs'] = []
+    const editorCount = Math.floor(random() * 4)
+    const usedPaths = new Set<string>()
+    for (let e = 0; e < editorCount; e += 1) {
+      const path = pick(random, PATHS)
+      if (usedPaths.has(path)) {
+        continue
+      }
+      usedPaths.add(path)
+      const relativePath = path.slice('/repo/'.length)
+      tabs.push(
+        random() < 0.25
+          ? ({
+              type: 'markdown',
+              id: `host-md-${s}-${e}`,
+              title: relativePath,
+              filePath: path,
+              relativePath,
+              language: 'markdown',
+              mode: 'markdown-preview',
+              isDirty: false,
+              isActive: e === 0,
+              sourceFileId: path,
+              sourceFilePath: path,
+              sourceRelativePath: relativePath,
+              documentVersion: `file:${path}`
+            } as RuntimeMobileSessionTabsResult['tabs'][number])
+          : ({
+              type: 'file',
+              id: `host-file-${s}-${e}`,
+              title: relativePath,
+              filePath: path,
+              relativePath,
+              language: 'typescript',
+              isDirty: random() < 0.5,
+              isActive: e === 0
+            } as RuntimeMobileSessionTabsResult['tabs'][number])
+      )
+    }
+    const activeTab = tabs[0]
+    snapshots.push({
+      worktree,
+      publicationEpoch: 'epoch-1',
+      snapshotVersion: s + 1,
+      activeGroupId: `host-group-${worktree}`,
+      activeTabId: activeTab?.id ?? null,
+      activeTabType: activeTab ? (activeTab.type === 'markdown' ? 'markdown' : 'file') : null,
+      tabs
+    })
+  }
+
+  const activeFile = openFiles[Math.floor(random() * Math.max(openFiles.length, 1))]
+  return {
+    state: baseState({
+      openFiles,
+      activeFileId: activeFile?.id ?? null,
+      activeFileIdByWorktree: activeFile ? { [activeFile.worktreeId]: activeFile.id } : {},
+      activeTabTypeByWorktree: activeFile ? { [activeFile.worktreeId]: 'editor' } : {},
+      activeWorktreeId: pick(random, WORKTREES)
+    }),
+    snapshots
+  }
+}
+
+describe('batched open-file reconciliation', () => {
+  beforeEach(() => {
+    resetModuleState()
+  })
+
+  it('matches repeated single-snapshot reconciliation for every seeded case', () => {
+    const divergences: string[] = []
+    for (let seed = 1; seed <= 400; seed += 1) {
+      const { state, snapshots } = makeCase(seed)
+      const stateCopy = structuredClone(state)
+
+      resetModuleState()
+      let sequential = state
+      for (const snapshot of snapshots) {
+        const patch = applyWebSessionTabsSnapshot(sequential, snapshot, ENV, NOW)
+        if (patch !== sequential) {
+          sequential = { ...sequential, ...patch }
+        }
+      }
+
+      resetModuleState()
+      const batched = {
+        ...state,
+        ...applyWebSessionTabsSnapshots(state, snapshots, ENV, NOW)
+      }
+
+      try {
+        expect(batched.openFiles).toEqual(sequential.openFiles)
+        expect(batched.activeFileId).toEqual(sequential.activeFileId)
+        expect(batched.activeFileIdByWorktree).toEqual(sequential.activeFileIdByWorktree)
+        expect(batched.activeTabTypeByWorktree).toEqual(sequential.activeTabTypeByWorktree)
+        expect(batched.unifiedTabsByWorktree).toEqual(sequential.unifiedTabsByWorktree)
+        expect(state).toEqual(stateCopy)
+      } catch (error) {
+        divergences.push(
+          `seed ${seed}: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`
+        )
+      }
+    }
+    expect(divergences).toEqual([])
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2498,6 +2498,466 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(initial).toEqual(initialCopy)
   })
 
+  it('matches sequential open-file reconciliation across an editor-heavy batch', () => {
+    const secondWorktree = 'repo::/other-worktree'
+    const editorSurface = (
+      id: string,
+      path: string,
+      overrides: { isDirty?: boolean } = {}
+    ): RuntimeMobileSessionTabsResult['tabs'][number] =>
+      ({
+        type: 'file',
+        id,
+        title: pathPosix.basename(path),
+        filePath: path,
+        relativePath: path.replace(/^\/repo\//, ''),
+        language: 'typescript',
+        isDirty: overrides.isDirty ?? false,
+        isActive: true
+      }) as RuntimeMobileSessionTabsResult['tabs'][number]
+    const mirroredFile = (path: string, worktree: string): OpenFile =>
+      ({
+        id: path,
+        filePath: path,
+        relativePath: path.replace(/^\/repo\//, ''),
+        worktreeId: worktree,
+        language: 'typescript',
+        isDirty: false,
+        runtimeEnvironmentId: ENV,
+        mode: 'edit',
+        mirroredFromRuntimeSession: true
+      }) as OpenFile
+    const initial = makeState({
+      activeWorktreeId: WT,
+      activeFileId: '/repo/a.ts',
+      activeFileIdByWorktree: { [WT]: '/repo/a.ts' },
+      openFiles: [
+        // Why: a bystander worktree's files must keep their positions through the batch.
+        mirroredFile('/repo/bystander-1.ts', 'repo::/bystander'),
+        mirroredFile('/repo/a.ts', WT),
+        // Why: locally opened (not host-mirrored) files must survive a host omission.
+        {
+          ...mirroredFile('/repo/local-only.ts', WT),
+          mirroredFromRuntimeSession: false
+        } as OpenFile,
+        // Why: same (worktree, id) as a mirrored file but a different environment —
+        // the duplicate case that makes the first-wins lookup observable.
+        {
+          ...mirroredFile('/repo/a.ts', WT),
+          runtimeEnvironmentId: 'other-env'
+        } as OpenFile,
+        mirroredFile('/repo/dropped.ts', WT),
+        mirroredFile('/repo/bystander-2.ts', 'repo::/bystander'),
+        mirroredFile('/repo/second.ts', secondWorktree)
+      ]
+    })
+    const snapshots: RuntimeMobileSessionTabsResult[] = [
+      // Drops /repo/dropped.ts and flips a.ts dirty.
+      makeSnapshot([editorSurface('host-a', '/repo/a.ts', { isDirty: true })], {
+        activeTabId: 'host-a',
+        activeTabType: 'file'
+      }),
+      makeSnapshot([editorSurface('host-second', '/repo/second.ts')], {
+        worktree: secondWorktree,
+        activeGroupId: 'host-group-2',
+        activeTabId: 'host-second',
+        activeTabType: 'file'
+      }),
+      // Same worktree again: adds a file, so the batch must see snapshot 1's result.
+      makeSnapshot(
+        [
+          editorSurface('host-a', '/repo/a.ts', { isDirty: true }),
+          editorSurface('host-b', '/repo/b.ts')
+        ],
+        { snapshotVersion: 2, activeTabId: 'host-b', activeTabType: 'file' }
+      ),
+      // Host drops every editor for the second worktree.
+      makeSnapshot([], {
+        worktree: secondWorktree,
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null
+      })
+    ]
+    const initialCopy = structuredClone(initial)
+
+    let sequential = initial
+    for (const snapshot of snapshots) {
+      const patch = applyWebSessionTabsSnapshot(sequential, snapshot, ENV, NOW)
+      if (patch !== sequential) {
+        sequential = { ...sequential, ...patch }
+      }
+    }
+
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    const batched = {
+      ...initial,
+      ...applyWebSessionTabsSnapshots(initial, snapshots, ENV, NOW)
+    }
+
+    expect(batched.openFiles).toEqual(sequential.openFiles)
+    expect(batched).toEqual(sequential)
+    expect(initial).toEqual(initialCopy)
+    // Pin the observable outcomes rather than only cross-checking the two paths.
+    expect(batched.openFiles.map((file) => file.id)).toEqual([
+      '/repo/bystander-1.ts',
+      '/repo/local-only.ts',
+      '/repo/a.ts',
+      '/repo/bystander-2.ts',
+      '/repo/a.ts',
+      '/repo/b.ts'
+    ])
+    expect(
+      batched.openFiles.find(
+        (file) => file.id === '/repo/a.ts' && file.runtimeEnvironmentId === 'other-env'
+      )
+    ).toBeDefined()
+    expect(batched.openFiles.some((file) => file.id === '/repo/dropped.ts')).toBe(false)
+    expect(batched.openFiles.some((file) => file.id === '/repo/second.ts')).toBe(false)
+  })
+
+  it('seeds a mirrored editor file from the first duplicate open file, as find() did', () => {
+    // Why: two entries share (worktree, id) and differ only in a field the mirrored
+    // file inherits, so which duplicate seeds the spread is observable.
+    const duplicate = (signature: string, environmentId: string | null): OpenFile =>
+      ({
+        id: '/repo/dup.ts',
+        filePath: '/repo/dup.ts',
+        relativePath: 'dup.ts',
+        worktreeId: WT,
+        language: 'typescript',
+        isDirty: false,
+        runtimeEnvironmentId: environmentId,
+        mode: 'edit',
+        mirroredFromRuntimeSession: true,
+        lastKnownDiskSignature: signature
+      }) as OpenFile
+    const snapshot = makeSnapshot(
+      [
+        {
+          type: 'file',
+          id: 'host-dup',
+          title: 'dup.ts',
+          filePath: '/repo/dup.ts',
+          relativePath: 'dup.ts',
+          language: 'typescript',
+          // Why: a compared field must differ, or the reconciled array is equal and
+          // the patch is suppressed before the inherited signature is observable.
+          isDirty: true,
+          isActive: true
+        } as RuntimeMobileSessionTabsResult['tabs'][number]
+      ],
+      { activeTabId: 'host-dup', activeTabType: 'file' }
+    )
+
+    for (const label of ['single', 'batch'] as const) {
+      resetWebSessionTabsSnapshotFreshnessForTests()
+      const state = makeState({
+        openFiles: [duplicate('winner', 'other-env'), duplicate('loser', ENV)]
+      })
+      const patch = (
+        label === 'single'
+          ? applyWebSessionTabsSnapshot(state, snapshot, ENV, NOW)
+          : applyWebSessionTabsSnapshots(state, [snapshot], ENV, NOW)
+      ) as Partial<WebSessionTabsSyncState>
+      const mirrored = patch.openFiles?.find(
+        (file) => file.id === '/repo/dup.ts' && file.runtimeEnvironmentId === ENV
+      )
+      expect(mirrored?.lastKnownDiskSignature, label).toBe('winner')
+    }
+  })
+
+  it('keeps the editor pane visible when the host republishes the active editor file', () => {
+    // Why: the active file is re-mirrored, so it leaves the surviving set as a
+    // replaced id and must come back as a mirrored id — otherwise focus falls
+    // through to the terminal on every reconnect.
+    const activeFile = {
+      id: '/repo/focused.ts',
+      filePath: '/repo/focused.ts',
+      relativePath: 'focused.ts',
+      worktreeId: WT,
+      language: 'typescript',
+      isDirty: false,
+      runtimeEnvironmentId: ENV,
+      mode: 'edit',
+      mirroredFromRuntimeSession: true
+    } as OpenFile
+    const snapshot = makeSnapshot(
+      [
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'host shell',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        },
+        {
+          type: 'file',
+          id: 'host-focused',
+          title: 'focused.ts',
+          filePath: '/repo/focused.ts',
+          relativePath: 'focused.ts',
+          language: 'typescript',
+          isDirty: false,
+          isActive: false
+        } as RuntimeMobileSessionTabsResult['tabs'][number]
+      ],
+      { activeTabId: HOST_SURFACE_ID, activeTabType: 'terminal' }
+    )
+
+    for (const label of ['single', 'batch'] as const) {
+      resetWebSessionTabsSnapshotFreshnessForTests()
+      const state = makeState({
+        activeWorktreeId: WT,
+        activeFileId: activeFile.id,
+        activeFileIdByWorktree: { [WT]: activeFile.id },
+        activeTabTypeByWorktree: { [WT]: 'editor' },
+        activeTabType: 'editor',
+        openFiles: [activeFile]
+      })
+      const patch = (
+        label === 'single'
+          ? applyWebSessionTabsSnapshot(state, snapshot, ENV, NOW)
+          : applyWebSessionTabsSnapshots(state, [snapshot], ENV, NOW)
+      ) as Partial<WebSessionTabsSyncState>
+      const nextTabType = patch.activeTabTypeByWorktree?.[WT] ?? state.activeTabTypeByWorktree[WT]
+      expect(nextTabType, label).toBe('editor')
+      expect(patch.activeFileIdByWorktree?.[WT] ?? state.activeFileIdByWorktree[WT], label).toBe(
+        activeFile.id
+      )
+    }
+  })
+
+  it('rebuilds an open file the batch closed and reopened, as sequential does', () => {
+    // Why: a batch whose net effect is openFileEqual to its input must still adopt the
+    // rebuilt file. Deferring the equality check to the end of the batch would keep the
+    // pre-batch object and its per-file state (autosave gates, disk signature).
+    const beforeBatch = {
+      id: '/repo/a.ts',
+      filePath: '/repo/a.ts',
+      relativePath: 'a.ts',
+      worktreeId: WT,
+      language: 'typescript',
+      isDirty: false,
+      runtimeEnvironmentId: ENV,
+      mode: 'edit',
+      mirroredFromRuntimeSession: true,
+      lastKnownDiskSignature: 'stale-signature'
+    } as OpenFile
+    const editorSnapshot = (path: string, version: number): RuntimeMobileSessionTabsResult =>
+      makeSnapshot(
+        [
+          {
+            type: 'file',
+            id: `host-${path}`,
+            title: path,
+            filePath: path,
+            relativePath: path.slice('/repo/'.length),
+            language: 'typescript',
+            isDirty: false,
+            isActive: true
+          } as RuntimeMobileSessionTabsResult['tabs'][number]
+        ],
+        { snapshotVersion: version, activeTabId: `host-${path}`, activeTabType: 'file' }
+      )
+    // Closes a.ts, then reopens it — net content is equal, but the object is new.
+    const snapshots = [editorSnapshot('/repo/b.ts', 1), editorSnapshot('/repo/a.ts', 2)]
+    const state = makeState({ openFiles: [beforeBatch] })
+
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    let sequential = state
+    for (const snapshot of snapshots) {
+      const patch = applyWebSessionTabsSnapshot(sequential, snapshot, ENV, NOW)
+      if (patch !== sequential) {
+        sequential = { ...sequential, ...patch }
+      }
+    }
+
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    const batched = { ...state, ...applyWebSessionTabsSnapshots(state, snapshots, ENV, NOW) }
+
+    expect(batched.openFiles).toEqual(sequential.openFiles)
+    expect(batched.openFiles.map((file) => file.id)).toEqual(['/repo/a.ts'])
+    expect(batched.openFiles[0]?.lastKnownDiskSignature).toBeUndefined()
+  })
+
+  it('keeps the matching-environment duplicate when a batch rebuild is a no-op', () => {
+    // Why: the rebuilt file is seeded from the first (worktree, id) match, which here
+    // belongs to another environment. When the rebuild changes nothing, the original
+    // must survive rather than be swapped for a clone of the other environment's entry.
+    const duplicate = (environmentId: string, signature: string): OpenFile =>
+      ({
+        id: '/repo/b.ts',
+        filePath: '/repo/b.ts',
+        relativePath: 'b.ts',
+        worktreeId: WT,
+        language: 'typescript',
+        isDirty: false,
+        runtimeEnvironmentId: environmentId,
+        mode: 'edit',
+        mirroredFromRuntimeSession: true,
+        lastKnownDiskSignature: signature
+      }) as OpenFile
+    const state = makeState({
+      openFiles: [duplicate('other-env', 'sig-other-env'), duplicate(ENV, 'sig-this-env')]
+    })
+    const republish = makeSnapshot(
+      [
+        {
+          type: 'file',
+          id: 'host-b',
+          title: 'b.ts',
+          filePath: '/repo/b.ts',
+          relativePath: 'b.ts',
+          language: 'typescript',
+          isDirty: false,
+          isActive: true
+        } as RuntimeMobileSessionTabsResult['tabs'][number]
+      ],
+      { activeTabId: 'host-b', activeTabType: 'file' }
+    )
+    // A second worktree changes, so the batch cannot stay a whole-array no-op.
+    const otherWorktree = makeSnapshot(
+      [
+        {
+          type: 'file',
+          id: 'host-x',
+          title: 'x.ts',
+          filePath: '/other/x.ts',
+          relativePath: 'x.ts',
+          language: 'typescript',
+          isDirty: false,
+          isActive: true
+        } as RuntimeMobileSessionTabsResult['tabs'][number]
+      ],
+      {
+        worktree: 'repo::/other',
+        activeGroupId: 'host-group-other',
+        activeTabId: 'host-x',
+        activeTabType: 'file'
+      }
+    )
+    const snapshots = [republish, otherWorktree]
+
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    let sequential = state
+    for (const snapshot of snapshots) {
+      const patch = applyWebSessionTabsSnapshot(sequential, snapshot, ENV, NOW)
+      if (patch !== sequential) {
+        sequential = { ...sequential, ...patch }
+      }
+    }
+
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    const batched = { ...state, ...applyWebSessionTabsSnapshots(state, snapshots, ENV, NOW) }
+
+    expect(batched.openFiles).toEqual(sequential.openFiles)
+    expect(
+      batched.openFiles
+        .filter((file) => file.id === '/repo/b.ts')
+        .map((file) => file.lastKnownDiskSignature)
+    ).toEqual(['sig-other-env', 'sig-this-env'])
+  })
+
+  it('keeps another environment’s duplicate active when this environment culls the id', () => {
+    // Why: culling is scoped to the publishing environment. A same-id file owned by a
+    // different environment survives, so it must still count as the active editor.
+    const duplicate = (environmentId: string): OpenFile =>
+      ({
+        id: '/repo/shared.ts',
+        filePath: '/repo/shared.ts',
+        relativePath: 'shared.ts',
+        worktreeId: WT,
+        language: 'typescript',
+        isDirty: false,
+        runtimeEnvironmentId: environmentId,
+        mode: 'edit',
+        mirroredFromRuntimeSession: true
+      }) as OpenFile
+    // Publishes a terminal and no editors, so this environment culls /repo/shared.ts.
+    const snapshot = makeSnapshot([
+      {
+        type: 'terminal',
+        id: HOST_SURFACE_ID,
+        title: 'host shell',
+        parentTabId: 'host-tab-1',
+        leafId: LEAF_ID,
+        isActive: true,
+        status: 'ready',
+        terminal: 'terminal-1'
+      }
+    ])
+
+    for (const label of ['single', 'batch'] as const) {
+      resetWebSessionTabsSnapshotFreshnessForTests()
+      const state = makeState({
+        activeWorktreeId: WT,
+        activeFileId: '/repo/shared.ts',
+        activeFileIdByWorktree: { [WT]: '/repo/shared.ts' },
+        activeTabTypeByWorktree: { [WT]: 'editor' },
+        activeTabType: 'editor',
+        openFiles: [duplicate('other-env'), duplicate(ENV)]
+      })
+      const patch = (
+        label === 'single'
+          ? applyWebSessionTabsSnapshot(state, snapshot, ENV, NOW)
+          : applyWebSessionTabsSnapshots(state, [snapshot], ENV, NOW)
+      ) as Partial<WebSessionTabsSyncState>
+      const nextOpenFiles = patch.openFiles ?? state.openFiles
+      expect(
+        nextOpenFiles.map((file) => file.runtimeEnvironmentId),
+        label
+      ).toEqual(['other-env'])
+      expect(patch.activeTabTypeByWorktree?.[WT] ?? state.activeTabTypeByWorktree[WT], label).toBe(
+        'editor'
+      )
+    }
+  })
+
+  it('keeps a batch that only revisits unchanged open files off the patch', () => {
+    const unchanged: OpenFile = {
+      id: '/repo/steady.ts',
+      filePath: '/repo/steady.ts',
+      relativePath: 'steady.ts',
+      worktreeId: WT,
+      language: 'typescript',
+      isDirty: false,
+      runtimeEnvironmentId: ENV,
+      mode: 'edit',
+      mirroredFromRuntimeSession: true
+    } as OpenFile
+    const state = makeState({ openFiles: [unchanged] })
+    const snapshot = makeSnapshot(
+      [
+        {
+          type: 'file',
+          id: 'host-steady',
+          title: 'steady.ts',
+          filePath: '/repo/steady.ts',
+          relativePath: 'steady.ts',
+          language: 'typescript',
+          isDirty: false,
+          isActive: true
+        } as RuntimeMobileSessionTabsResult['tabs'][number]
+      ],
+      { activeTabId: 'host-steady', activeTabType: 'file' }
+    )
+
+    const patch = applyWebSessionTabsSnapshots(
+      state,
+      [snapshot],
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(Object.prototype.hasOwnProperty.call(patch, 'openFiles')).toBe(false)
+    expect(state.openFiles).toEqual([unchanged])
+  })
+
   it('replaces temporary web-created tabs once the host publishes the same PTY', () => {
     const localTab: TerminalTab = {
       id: 'local-web-tab',

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -191,9 +191,19 @@ type WebSessionTabsBatchRecordKey =
   | 'unifiedTabsByWorktree'
   | 'unreadTerminalTabs'
 
+/** Open files bucketed by worktree. A snapshot only reconciles its own worktree, so a
+ *  batch can decide there is nothing to do without walking every open file in the app.
+ *  `source` pins the array it describes; each rebuild updates it in place instead of
+ *  re-bucketing, so a batch never pays for the whole array twice. */
+type WebSessionOpenFilesIndex = {
+  source: readonly OpenFile[]
+  byWorktree: Map<string, OpenFile[]>
+}
+
 type WebSessionTabsBatchContext = {
   agentPaneKeysByTabId: Map<string, Set<string>> | null
   changedRecords: Set<WebSessionTabsBatchRecordKey>
+  openFilesIndex: WebSessionOpenFilesIndex | null
 }
 
 function isSessionTabsListAllResult(value: unknown): value is SessionTabsListAllResult {
@@ -1094,6 +1104,7 @@ function buildMirroredEditorTabs(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
   state: WebSessionTabsSyncState,
+  worktreeOpenFileById: ReadonlyMap<string, OpenFile>,
   hostGroupIdByTabId: ReadonlyMap<string, string>,
   fallbackGroupId: string,
   sortOffset: number,
@@ -1101,9 +1112,7 @@ function buildMirroredEditorTabs(
 ): MirroredEditorTab[] {
   return snapshot.tabs.filter(isReadyEditorTab).map((tab, index) => {
     const fileId = localEditorFileId(tab)
-    const existingFile = state.openFiles.find(
-      (file) => file.worktreeId === snapshot.worktree && file.id === fileId
-    )
+    const existingFile = worktreeOpenFileById.get(fileId)
     const existingUnifiedTab = findExistingEditorUnifiedTab(
       state,
       snapshot.worktree,
@@ -1810,6 +1819,63 @@ function sameOpenFiles(a: readonly OpenFile[], b: readonly OpenFile[]): boolean 
   return a.every((file, index) => openFileEqual(file, b[index]!))
 }
 
+/** This worktree's open files — the only scope a snapshot reconciles, so a batch can
+ *  answer from here instead of walking every open file in the app. */
+function webSessionOpenFilesForWorktree(
+  state: WebSessionTabsSyncState,
+  worktreeId: string,
+  batchContext?: WebSessionTabsBatchContext
+): readonly OpenFile[] {
+  if (!batchContext) {
+    return state.openFiles.filter((file) => file.worktreeId === worktreeId)
+  }
+  let index = batchContext.openFilesIndex
+  if (!index || index.source !== state.openFiles) {
+    const byWorktree = new Map<string, OpenFile[]>()
+    for (const file of state.openFiles) {
+      const bucket = byWorktree.get(file.worktreeId) ?? []
+      bucket.push(file)
+      byWorktree.set(file.worktreeId, bucket)
+    }
+    index = { source: state.openFiles, byWorktree }
+    batchContext.openFilesIndex = index
+  }
+  return index.byWorktree.get(worktreeId) ?? []
+}
+
+/** Retargets the index at the array a snapshot just produced, re-bucketing only the
+ *  worktree that changed. Rebuilding it wholesale would cost the entire array again on
+ *  every snapshot, which is the cost this index exists to avoid. */
+function advanceWebSessionOpenFilesIndex(
+  batchContext: WebSessionTabsBatchContext | undefined,
+  nextOpenFiles: readonly OpenFile[],
+  worktreeId: string
+): void {
+  const index = batchContext?.openFilesIndex
+  if (!index || index.source === nextOpenFiles) {
+    return
+  }
+  const bucket: OpenFile[] = []
+  for (const file of nextOpenFiles) {
+    if (file.worktreeId === worktreeId) {
+      bucket.push(file)
+    }
+  }
+  index.byWorktree.set(worktreeId, bucket)
+  index.source = nextOpenFiles
+}
+
+/** Mirrors `openFiles.find()` first-wins lookup, which duplicate ids make observable. */
+function firstOpenFileByIdForWorktree(files: readonly OpenFile[]): Map<string, OpenFile> {
+  const byId = new Map<string, OpenFile>()
+  for (const file of files) {
+    if (!byId.has(file.id)) {
+      byId.set(file.id, file)
+    }
+  }
+  return byId
+}
+
 function tabEqual(a: Tab, b: Tab): boolean {
   return (
     a.id === b.id &&
@@ -2085,10 +2151,12 @@ function applyWebSessionTabsSnapshotWithContext(
       ? [...retainedBrowserTabs, ...mirroredBrowserTabs.map((entry) => entry.workspace)]
       : null
   const readyEditorTabs = snapshot.tabs.filter(isReadyEditorTab)
+  const worktreeOpenFiles = webSessionOpenFilesForWorktree(state, worktreeId, batchContext)
   const mirroredEditorTabs = buildMirroredEditorTabs(
     snapshot,
     environmentId,
     state,
+    firstOpenFileByIdForWorktree(worktreeOpenFiles),
     hostGroupIdByTabId,
     targetGroupId,
     mirroredTerminalTabEntries.length + mirroredBrowserTabs.length,
@@ -2097,10 +2165,9 @@ function applyWebSessionTabsSnapshotWithContext(
   const mirroredEditorFileIds = new Set(mirroredEditorTabs.map((entry) => entry.file.id))
   const mirroredEditorHostTabIds = new Set(mirroredEditorTabs.map((entry) => entry.hostTabId))
   const removedEditorFileIds = new Set(
-    state.openFiles
+    worktreeOpenFiles
       .filter(
         (file) =>
-          file.worktreeId === worktreeId &&
           file.runtimeEnvironmentId === environmentId &&
           (file.mode === 'edit' || file.mode === 'markdown-preview') &&
           // Why: only cull host-mirrored tabs; locally opened files have no host counterpart, so their omission isn't a close signal.
@@ -2109,7 +2176,25 @@ function applyWebSessionTabsSnapshotWithContext(
       )
       .map((file) => file.id)
   )
+  const isReplacedOpenFile = (file: OpenFile): boolean =>
+    file.runtimeEnvironmentId === environmentId &&
+    (removedEditorFileIds.has(file.id) || mirroredEditorFileIds.has(file.id))
+  const replacedOpenFileCount = worktreeOpenFiles.filter(isReplacedOpenFile).length
+  // Why: both consumers below ask only about this worktree, so the surviving ids answer
+  // them in worktree scope instead of walking every open file in the app.
+  const nextWorktreeOpenFileIds = new Set<string>(
+    worktreeOpenFiles.filter((file) => !isReplacedOpenFile(file)).map((file) => file.id)
+  )
+  for (const fileId of mirroredEditorFileIds) {
+    nextWorktreeOpenFileIds.add(fileId)
+  }
+  const mirroredOpenFiles = mirroredEditorTabs.map((entry) => entry.file)
   const nextOpenFiles = (() => {
+    // Why: with nothing to drop or mirror, rebuilding reproduces the array exactly, so
+    // skip the global rebuild the equality check below would have thrown away anyway.
+    if (replacedOpenFileCount === 0 && mirroredOpenFiles.length === 0) {
+      return state.openFiles
+    }
     const retained = state.openFiles.filter(
       (file) =>
         !(
@@ -2118,9 +2203,10 @@ function applyWebSessionTabsSnapshotWithContext(
           (removedEditorFileIds.has(file.id) || mirroredEditorFileIds.has(file.id))
         )
     )
-    const next = [...retained, ...mirroredEditorTabs.map((entry) => entry.file)]
+    const next = [...retained, ...mirroredOpenFiles]
     return sameOpenFiles(state.openFiles, next) ? state.openFiles : next
   })()
+  advanceWebSessionOpenFilesIndex(batchContext, nextOpenFiles, worktreeId)
   const currentUnifiedTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
   const retainedUnifiedTabs = currentUnifiedTabs.filter((tab) => {
     if (tab.contentType === 'browser') {
@@ -2248,13 +2334,10 @@ function applyWebSessionTabsSnapshotWithContext(
       ? (activeMirroredBrowserWorkspaceId ?? mirroredBrowserTabs[0]?.workspace.id)
       : mirroredBrowserTabs[0]?.workspace.id) ??
     null
+  const activeEditorFileIdForWorktree = state.activeFileIdByWorktree[worktreeId]
   const currentActiveEditorStillExists =
-    state.activeFileIdByWorktree[worktreeId] &&
-    nextOpenFiles.some(
-      (file) =>
-        file.worktreeId === worktreeId && file.id === state.activeFileIdByWorktree[worktreeId]
-    )
-      ? state.activeFileIdByWorktree[worktreeId]
+    activeEditorFileIdForWorktree && nextWorktreeOpenFileIds.has(activeEditorFileIdForWorktree)
+      ? activeEditorFileIdForWorktree
       : null
   const intentEditorFileId = honorSnapshotActiveFocus
     ? (intentMirroredEditor?.file.id ?? null)
@@ -2771,8 +2854,7 @@ function applyWebSessionTabsSnapshotWithContext(
       ? state.activeTabId
       : null
   const currentActiveEditorStillValid =
-    state.activeFileId &&
-    nextOpenFiles.some((file) => file.worktreeId === worktreeId && file.id === state.activeFileId)
+    state.activeFileId && nextWorktreeOpenFileIds.has(state.activeFileId)
       ? state.activeFileId
       : null
   const nextActiveTabId = isActiveWorktree
@@ -2894,7 +2976,8 @@ export function applyWebSessionTabsSnapshots(
   const nextState = { ...state }
   const batchContext: WebSessionTabsBatchContext = {
     agentPaneKeysByTabId: null,
-    changedRecords: new Set()
+    changedRecords: new Set(),
+    openFilesIndex: null
   }
   let mergedPatch: Partial<WebSessionTabsSyncState> = {}
   for (const snapshot of snapshots) {


### PR DESCRIPTION
## What this is

The follow-up flagged while reviewing #13676. That PR made batched snapshot reconciliation linear for terminals and agents, but left `openFiles` rebuilt per snapshot.

## The cost

Every snapshot in a batch scanned the whole `openFiles` array three times (cull set, retained filter, equality check) and did a linear `find` per editor tab. `openFiles` is global, so a snapshot for workspace 900 paid for files belonging to workspaces it never touches — including files whose worktree isn't in the batch at all.

Measured on a synthetic reconnect, 1,200 workspaces, same fixture before and after:

| Fixture | Before | After | |
| --- | ---: | ---: | ---: |
| no workspace has editors, 3,000 open files | 99.7 ms | 3.1 ms | **32×** |
| 5% of workspaces have editors, 3,000 open files | 105.3 ms | 7.7 ms | **13.7×** |
| every workspace has editors, 3,000 open files | 113.9 ms | 84.2 ms | 1.35× |
| every workspace has editors, no bystanders | 69.9 ms | 53.1 ms | 1.3× |

The first row is the point: 99.7 ms spent entirely on files no snapshot in the batch touches.

The last two rows are honest about the limit. When every workspace owns editors, each snapshot legitimately produces a *different* array — the mirrored files move to the end — so sequential reconciliation genuinely emits N distinct arrays. That rebuild is the specified behavior, not an implementation artifact, and it stays.

## How

- Bucket open files by worktree for the life of a batch. A snapshot only reconciles its own worktree, so the cull set, the surviving-id set, and the `existingFile` lookup all answer from that bucket.
- Skip the global rebuild when a snapshot has nothing to drop and nothing to mirror — the rebuild would reproduce the array exactly and the existing equality check would discard it.
- Retarget the index at the array each snapshot produced, re-bucketing only the worktree that changed.
- The per-editor-tab `openFiles.find()` becomes a map lookup, so the O(editors x files) term is gone everywhere, batch or not.

## Semantics are unchanged, deliberately

`openFiles` still flows through each snapshot's patch, so the `sameOpenFiles` bail is still evaluated per snapshot against the current array.

An earlier draft of this change deferred that bail to the end of the batch and kept a slot-keyed draft. That was fully linear in every fixture — but it diverged from sequential reconciliation, because `openFileEqual` compares 15 of `OpenFile`'s ~35 fields, so "equal" does not mean "same object". Two cases fell out:

1. A batch that closes and reopens a file has a net effect that is `openFileEqual` to its input, so the end-of-batch check suppressed the patch and kept the **pre-batch** object — retaining per-file state (`lastKnownDiskSignature`, autosave gates) that sequential rebuilds away.
2. With two entries sharing `(worktreeId, id)` and differing in `runtimeEnvironmentId`, the rebuilt file is seeded from the *first* match but replaces the *environment-matching* one. When sequential bails, the original survives; the deferred draft had already swapped it for a clone of the other environment's entry.

Both are pinned as regression tests here, and both fail against that draft.

## Testing

- `pnpm vitest src/renderer/src/runtime/ src/renderer/src/store/` — 227 files, 3,078 tests passed
- Typecheck, oxlint, oxfmt, and the max-lines ratchet all clean. No `max-lines` suppression added.
- New: a 400-case seeded differential suite asserting the batch path matches repeated single-snapshot reconciliation, over duplicate ids, mixed `runtimeEnvironmentId` (`string` / `null` / `undefined`), markdown-preview and edit modes, repeated worktrees, and bystander worktrees.
- New unit tests for both divergences above, the duplicate first-wins lookup, cross-environment culling, and active-editor focus survival.

The tests were validated by mutation testing rather than assumed: 6 deliberate faults injected into the implementation (last-wins lookup, dropped environment scoping, unconditional early-out, dropped mirrored/removed id handling, wrong-worktree re-bucketing, ignored mirror flag) — **all 6 caught**. Two earlier gaps that mutation testing exposed are now covered; one surviving mutant (never advancing the index) is perf-only by construction, since the `source !== state.openFiles` identity check turns a stale index into a rebuild.

Made with [Orca](https://github.com/stablyai/orca) 🐋
