### PR TITLE
fix(native-chat): open composer pickers upward

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -40,7 +40,23 @@ vi.mock('@/components/ui/dropdown-menu', () => {
       children: React.ReactNode
       disabled?: boolean
     }) => <div data-disabled={disabled || undefined}>{children}</div>,
-    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuContent: ({
+      children,
+      side,
+      collisionPadding
+    }: {
+      children: React.ReactNode
+      side?: string
+      collisionPadding?: number
+    }) => (
+      <div
+        data-testid="session-option-menu"
+        data-side={side}
+        data-collision-padding={collisionPadding}
+      >
+        {children}
+      </div>
+    ),
     DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     DropdownMenuSeparator: () => <hr />,
     DropdownMenuItem: ({
@@ -172,6 +188,23 @@ const fast: SessionOptionDescriptor = {
 afterEach(() => cleanup())
 
 describe('NativeChatSessionOptionPickers', () => {
+  it('prefers collision-aware upward placement for model and option menus', () => {
+    render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[model(), effort]}
+        isWorking={false}
+      />
+    )
+
+    const menus = screen.getAllByTestId('session-option-menu')
+    expect(menus).toHaveLength(2)
+    for (const menu of menus) {
+      expect(menu.getAttribute('data-side')).toBe('top')
+      expect(menu.getAttribute('data-collision-padding')).toBe('8')
+    }
+  })
+
   it('renders model and joined option labels, and hides an empty options pill', () => {
     const { rerender } = render(
       <NativeChatSessionOptionPickers

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -242,7 +242,7 @@ function NativeChatSessionOptionPickersInner({
             disabledReason={optionsReason}
             dispatched={options.some((descriptor) => descriptor.valueSource === 'dispatched')}
           />
-          <DropdownMenuContent align="start" className="w-60">
+          <DropdownMenuContent align="start" side="top" collisionPadding={8} className="w-60">
             {options.map((descriptor, index) => {
               const reason = nativeChatSessionOptionDisabledReason(descriptor.disabledReason)
               return (
@@ -272,7 +272,7 @@ function NativeChatSessionOptionPickersInner({
           disabledReason={modelReason}
           dispatched={model.valueSource === 'dispatched'}
         />
-        <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuContent align="start" side="top" collisionPadding={8} className="w-64">
           {modelReason && !model.settable ? (
             <DropdownMenuLabel className="font-normal">{modelReason}</DropdownMenuLabel>
           ) : null}


### PR DESCRIPTION
## Summary

Native-chat composer session-option menus now prefer the top side of their existing Radix dropdown primitive and keep an 8px collision buffer. Before, the model pill's “Choose in agent picker…” action could render below the bottom-docked composer and clip at the viewport edge; after, the model menu and the combined options menu (effort, fast mode, and other session options) open upward, while Radix can still flip them on collision.

The sibling slash/skill autocomplete already renders above the composer, and the native-chat context menu already uses the collision-aware dropdown primitive, so neither needed a change.

## Screenshots

Before (menu opens downward and clips at the window edge):

![Before](https://github.com/user-attachments/assets/31f280e4-c6ea-42b5-8e13-13bfffab34eb)

After (Electron validation; menu is fully visible above the composer):

![After](https://github.com/user-attachments/assets/36f43e25-0e45-441b-99f4-ff45acb9a4fe)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 49,532 passed and 102 skipped; 3 unrelated environment-sensitive failures occurred in `agent-exec-handler` (inherited `GIT_CONFIG_*` injection) and `macos-computer-helper-owner-loss-processes` (timing). Both failing files passed on a clean targeted rerun: 31/31.
- [x] `pnpm build`
- [x] Added regression coverage that verifies both the model and combined options dropdowns prefer `side="top"` with collision padding.
- [x] Targeted picker test: 11/11 passed.
- [x] Electron QA through CDP: the live model menu reported `data-side="top"`, opened above its trigger, and remained fully inside the 1728×960 viewport.

## AI Review Report

Reviewed the placement primitive, both session-option menus, and sibling native-chat composer menus. The review verified that the change preserves Radix focus handling and collision flipping, keeps model/effort behavior unchanged, and introduces no custom positioning; it also checked macOS, Linux, and Windows for shortcuts, labels, paths, shell behavior, and Electron differences, none of which are changed by these renderer-only placement props.

The mobile structured picker was checked separately. It uses the shared full-screen `BottomDrawer`, whose native modal, safe-area maximum height, scrolling, and keyboard inset handling keep it inside the mobile viewport, so there is no equivalent clipping defect and no mobile change was needed.

## Security Audit

This change only configures dropdown placement and test mocks. It adds no input handling, command execution, path access, auth, secrets, dependency, IPC, remote-wire, or host behavior, so no security follow-up is needed.

## Notes

Affected desktop menus: the model pill and the combined options pill that contains effort, fast mode, and any other surfaced session options. SSH and folder workspaces use the same renderer component and require no special handling; no wire or provider-specific behavior changed.
