### PR TITLE
fix(codex): keep system-default auth native when hooks are unavailable

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1078,9 +1078,6 @@ describe('CodexRuntimeHomeService', () => {
       getRuntimeCodexHomePath(),
       getSystemCodexHomePath()
     ])
-    service.setRealHomeLaneGate(() => false)
-    expect(service.getSelectedHostCodexHomeRoute()).toBe('shared-home')
-    expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([getRuntimeCodexHomePath()])
     const markerPath = join(
       testState.userDataDir,
       'codex-session-backfill',
@@ -1088,13 +1085,10 @@ describe('CodexRuntimeHomeService', () => {
     )
     mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
     writeFileSync(markerPath, '{}\n', 'utf-8')
-    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(existsSync(markerPath)).toBe(false)
-    expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
-      true
-    )
+    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(existsSync(markerPath)).toBe(true)
+    expect(service.beginHostSystemDefaultSessionMigrationLaunch(null)).toBeNull()
     service.finishHostSystemDefaultSessionMigrationPass()
-    service.setRealHomeLaneGate(() => true)
     const perSpawnCustomHome = join(testState.fakeHomeDir, 'per-spawn-custom-codex-home')
     writeFileSync(markerPath, '{}\n', 'utf-8')
     expect(service.isHostSystemDefaultRealHome({ CODEX_HOME: perSpawnCustomHome })).toBe(false)
@@ -1147,6 +1141,81 @@ describe('CodexRuntimeHomeService', () => {
         process.env.ORCA_CODEX_HOME = previousOrcaCodexHome
       }
     }
+  })
+
+  it.each(['file', 'keyring', 'auto'] as const)(
+    'keeps %s credential storage on the native system-default home',
+    async (credentialStore) => {
+      writePaneRegistry({
+        'native-home-pane': {
+          selectionKey: 'host',
+          accountId: null,
+          homeRoute: 'real-home'
+        }
+      })
+      const staleRuntimeAuth = createCodexAuthJson(
+        'account-b@example.test',
+        'account-b',
+        'runtime-b'
+      )
+      const systemConfig = `cli_auth_credentials_store = "${credentialStore}"\nmodel = "gpt-test"\n`
+      const runtimeConfig = 'model = "runtime-sentinel"\n'
+      writeFileSync(getRuntimeCodexAuthPath(), staleRuntimeAuth, 'utf-8')
+      writeFileSync(join(getSystemCodexHomePath(), 'config.toml'), systemConfig, 'utf-8')
+      writeFileSync(join(getRuntimeCodexHomePath(), 'config.toml'), runtimeConfig, 'utf-8')
+      if (credentialStore === 'file') {
+        writeFileSync(
+          getSystemCodexAuthPath(),
+          createCodexAuthJson('account-a@example.test', 'account-a', 'host-a'),
+          'utf-8'
+        )
+      }
+      const store = createStore(createSettings({ shellStartupEnvProbeSupported: true }))
+
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+
+      expect(service.prepareForCodexLaunch()).toBeNull()
+      expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
+      expect(readFileSync(getRuntimeCodexAuthPath(), 'utf-8')).toBe(staleRuntimeAuth)
+      expect(readFileSync(join(getSystemCodexHomePath(), 'config.toml'), 'utf-8')).toBe(
+        systemConfig
+      )
+      expect(readFileSync(join(getRuntimeCodexHomePath(), 'config.toml'), 'utf-8')).toBe(
+        runtimeConfig
+      )
+    }
+  )
+
+  it('uses the current native file credential after host account changes and logout', async () => {
+    writePaneRegistry({
+      'native-home-pane': {
+        selectionKey: 'host',
+        accountId: null,
+        homeRoute: 'real-home'
+      }
+    })
+    const hostAuthA = createCodexAuthJson('account-a@example.test', 'account-a', 'host-a')
+    const hostAuthB = createCodexAuthJson('account-b@example.test', 'account-b', 'host-b')
+    const staleRuntimeAuth = createCodexAuthJson(
+      'account-b@example.test',
+      'account-b',
+      'runtime-old-b'
+    )
+    writeFileSync(getSystemCodexAuthPath(), hostAuthA, 'utf-8')
+    writeFileSync(getRuntimeCodexAuthPath(), staleRuntimeAuth, 'utf-8')
+    const store = createStore(createSettings({ shellStartupEnvProbeSupported: true }))
+
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.prepareForCodexLaunch()).toBeNull()
+    writeFileSync(getSystemCodexAuthPath(), hostAuthB, 'utf-8')
+    expect(service.prepareForCodexLaunch()).toBeNull()
+    rmSync(getSystemCodexAuthPath())
+    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.getSelectedHostCodexHomeRoute()).toBe('real-home')
+    expect(readFileSync(getRuntimeCodexAuthPath(), 'utf-8')).toBe(staleRuntimeAuth)
   })
 
   it('seeds shared auth for a pane-local custom home on the real-home lane', async () => {
@@ -1272,7 +1341,6 @@ describe('CodexRuntimeHomeService', () => {
 
     const service = new CodexRuntimeHomeService(store as never)
 
-    service.setRealHomeLaneGate(() => true)
     expect(readFileSync(getRuntimeCodexAuthPath(), 'utf-8')).toBe(oldSystemAuth)
     expect(readFileSync(join(getRuntimeCodexHomePath(), 'config.toml'), 'utf-8')).toContain(
       'stale-provider'
@@ -1294,8 +1362,6 @@ describe('CodexRuntimeHomeService', () => {
 
     setShellStartupEnvProbeSupportedForTest(true)
     const restartedService = new CodexRuntimeHomeService(store as never)
-    restartedService.setRealHomeLaneGate(() => true)
-
     expect(restartedService.prepareForCodexLaunch()).toBeNull()
     expect(readFileSync(getRuntimeCodexAuthPath(), 'utf-8')).toBe(managedAuth)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
@@ -1700,8 +1766,6 @@ describe('CodexRuntimeHomeService', () => {
         }
       )
       const restartedService = new CodexRuntimeHomeService(store as never)
-      restartedService.setRealHomeLaneGate(() => true)
-
       expect(existsSync(getRuntimeCodexAuthPath())).toBe(false)
       writeFileSync(getSystemCodexAuthPath(), reloginAuth, 'utf-8')
       expect(restartedService.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
@@ -1748,7 +1812,6 @@ describe('CodexRuntimeHomeService', () => {
       }
     )
     const restartedService = new CodexRuntimeHomeService(store as never)
-    restartedService.setRealHomeLaneGate(() => true)
     restartedService.reconcileLegacySharedHomeForRetainedPanes()
 
     settings.activeCodexManagedAccountId = 'account-1'
@@ -1764,7 +1827,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(readFileSync(getRuntimeCodexAuthPath(), 'utf-8')).toBe(reloginAuth)
   })
 
-  it('preserves shared config changes when a pending real-home lane falls back', async () => {
+  it('preserves shared config changes while shell probing remains unavailable', async () => {
     const systemConfigPath = join(getSystemCodexHomePath(), 'config.toml')
     const runtimeConfigPath = join(getRuntimeCodexHomePath(), 'config.toml')
     writeFileSync(systemConfigPath, 'model = "baseline"\n', 'utf-8')
@@ -1775,8 +1838,6 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
     writeFileSync(runtimeConfigPath, 'model = "runtime-change"\n', 'utf-8')
 
-    setShellStartupEnvProbeSupportedForTest(true)
-    service.setRealHomeLaneGate(() => false)
     service.reconcileLegacySharedHomeForRetainedPanes()
     expect(readFileSync(systemConfigPath, 'utf-8')).toBe('model = "baseline"\n')
     expect(readFileSync(runtimeConfigPath, 'utf-8')).toBe('model = "runtime-change"\n')
@@ -4084,7 +4145,6 @@ describe('CodexRuntimeHomeService', () => {
     expect(existsSync(getRuntimeCodexAuthPath())).toBe(false)
 
     setShellStartupEnvProbeSupportedForTest(true)
-    service.setRealHomeLaneGate(() => true)
     writeFileSync(getSystemCodexAuthPath(), reloginAuth, 'utf-8')
     service.reconcileLegacySharedHomeForRetainedPanes()
 

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -580,15 +580,6 @@ export class CodexRuntimeHomeService {
     return [...homes.values()]
   }
 
-  // Why: the real-home hook installer flips this gate off when the trust-grant
-  // client reports the host incapable, keeping that host byte-identical to the
-  // managed lane instead of shipping status-blind panes.
-  private realHomeLaneGate: () => boolean = () => true
-
-  setRealHomeLaneGate(gate: () => boolean): void {
-    this.realHomeLaneGate = gate
-  }
-
   // Why: real-home routing applies only to the host system-default selection.
   // Managed accounts run in their own homes; Windows (no shell-startup probe)
   // and custom CODEX_HOMEs stay on the mirror until cleanup can be tracked
@@ -605,7 +596,7 @@ export class CodexRuntimeHomeService {
   }
 
   isHostSystemDefaultRealHome(launchEnv?: NodeJS.ProcessEnv): boolean {
-    return this.isHostSystemDefaultRealHomeSelected(launchEnv) && this.realHomeLaneGate()
+    return this.isHostSystemDefaultRealHomeSelected(launchEnv)
   }
 
   reconcileLegacySharedHomeForRetainedPanes(): void {

--- a/src/main/codex/codex-real-home-hook-install.test.ts
+++ b/src/main/codex/codex-real-home-hook-install.test.ts
@@ -40,6 +40,7 @@ vi.mock('./codex-hook-trust-grant', () => ({
 import {
   ensureRealHomeCodexHookState,
   getRealHomeCodexHookLane,
+  isRealHomeCodexHookLaneUsable,
   _internals
 } from './codex-real-home-hook-install'
 import { getCodexManagedHookInstallMaterial } from './hook-service'
@@ -139,7 +140,7 @@ describe('ensureRealHomeCodexHookState (install)', () => {
     ).toBe(true)
   })
 
-  it('keeps the managed lane for unknown top-level fields Codex cannot load', () => {
+  it('skips the status hook for unknown top-level fields Codex cannot load', () => {
     grantSucceeds()
     const userConfig = {
       hooks: {
@@ -211,7 +212,7 @@ describe('ensureRealHomeCodexHookState (install)', () => {
     }
   )
 
-  it('keeps the managed lane and original bytes when the pristine backup cannot be created', () => {
+  it('skips the status hook and preserves bytes when the pristine backup cannot be created', () => {
     grantSucceeds()
     const original = `${JSON.stringify({ hooks: { Stop: [] } }, null, 2)}\n`
     writeFileSync(getRealHooksJsonPath(), original, 'utf-8')
@@ -261,6 +262,7 @@ describe('ensureRealHomeCodexHookState (install)', () => {
 
     expect(lane).toBe('unavailable')
     expect(getRealHomeCodexHookLane()).toBe('unavailable')
+    expect(isRealHomeCodexHookLaneUsable()).toBe(false)
     expect(readFileSync(getRealHooksJsonPath(), 'utf-8')).toBe(userRaw)
   })
 
@@ -286,7 +288,7 @@ describe('ensureRealHomeCodexHookState (install)', () => {
     )
 
     expect(warning).toHaveBeenCalledWith(
-      '[codex-real-home-hooks] ensure failed; staying on managed lane:',
+      '[codex-real-home-hooks] ensure failed; status hook unavailable:',
       expect.any(Error)
     )
   })
@@ -306,7 +308,7 @@ describe('ensureRealHomeCodexHookState (install)', () => {
     expect(existsSync(getRealHooksJsonPath())).toBe(false)
   })
 
-  it('leaves an unparseable hooks.json untouched and keeps the managed lane', () => {
+  it('leaves an unparseable hooks.json untouched and skips the status hook', () => {
     writeFileSync(getRealHooksJsonPath(), '{not json', 'utf-8')
 
     const lane = ensureRealHomeCodexHookState({ hooksEnabled: true, userDataPath: userDataDir })

--- a/src/main/codex/codex-real-home-hook-install.ts
+++ b/src/main/codex/codex-real-home-hook-install.ts
@@ -34,8 +34,8 @@ import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-
  * - 'installed': entry appended LAST in ~/.codex/hooks.json and trusted by
  *   codex itself through the app-server grant client.
  * - 'unavailable': the grant lane could not trust the entry (old binary,
- *   unsupported RPC, verify failure). The entry is rolled back and the host
- *   stays on the managed-home lane.
+ *   unsupported RPC, verify failure). The entry is rolled back and native-home
+ *   launches continue without the optional Orca status hook.
  * - 'removed': hooks are opted out; Orca entries are swept from the real home.
  */
 export type RealHomeCodexHookLane = 'pending' | 'installed' | 'unavailable' | 'removed'
@@ -48,9 +48,9 @@ export function getRealHomeCodexHookLane(): RealHomeCodexHookLane {
 }
 
 /**
- * Routing gate consumed by CodexRuntimeHomeService. Both a failed install and
- * a failed opt-out cleanup use the managed lane so no half-mutated hook state
- * can diverge from PTY, rate-limit, or commit-message routing.
+ * Whether the real-home installer currently owns Orca's system-home hook
+ * entry. This controls hook cleanup only; authentication always stays on the
+ * native home for the host system-default account.
  */
 export function isRealHomeCodexHookLaneUsable(): boolean {
   return currentLane !== 'unavailable'
@@ -87,7 +87,7 @@ function assertHooksJsonGeneration(
  * the Orca status hook when enabled, sweeps it when opted out. Idempotent and
  * synchronous (launch prep); repeat calls are cheap — an unchanged hooks.json
  * write no-ops and a valid grant ledger skips the RPC session entirely.
- * Never throws: any failure logs and leaves the host on the managed lane.
+ * Never throws: any failure logs and leaves native-home authentication intact.
  */
 export function ensureRealHomeCodexHookState(args: {
   hooksEnabled: boolean
@@ -106,7 +106,7 @@ export function ensureRealHomeCodexHookState(args: {
       installRetryAfterMs = 0
     }
   } catch (error) {
-    console.warn('[codex-real-home-hooks] ensure failed; staying on managed lane:', error)
+    console.warn('[codex-real-home-hooks] ensure failed; status hook unavailable:', error)
     currentLane = 'unavailable'
     if (args.hooksEnabled) {
       installRetryAfterMs = Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
@@ -124,9 +124,9 @@ function installRealHomeCodexHook(userDataPath: string): RealHomeCodexHookLane {
   // snapshot and be silently overwritten by the stale parse.
   const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
   if (!config) {
-    // Why: an unparseable user file must never be clobbered; without a hook
-    // entry the managed lane keeps status working for this host.
-    console.warn('[codex-real-home-hooks] could not parse', hooksJsonPath, '- managed lane kept')
+    // Why: an unparseable user file must never be clobbered. Authentication
+    // remains on the native home without Orca status.
+    console.warn('[codex-real-home-hooks] could not parse', hooksJsonPath, '- status hook skipped')
     installRetryAfterMs = Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
     return 'unavailable'
   }
@@ -205,8 +205,8 @@ function installRealHomeCodexHook(userDataPath: string): RealHomeCodexHookLane {
 
   // Why: never leave an untrusted Orca entry in the user's real home — it
   // would surface as "Hooks need review". Roll the file back to its prior
-  // bytes and keep this host on the managed-home lane; the grant client
-  // already logged the fallback reason.
+  // bytes. Native-home authentication remains authoritative; the grant client
+  // already logged why the optional status hook is unavailable.
   try {
     restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
   } finally {
@@ -218,7 +218,7 @@ function installRealHomeCodexHook(userDataPath: string): RealHomeCodexHookLane {
   }
   installRetryAfterMs = getInstallRetryAfterMs(grant.reason)
   console.warn(
-    `[codex-real-home-hooks] trust grant unavailable (${grant.reason}); entry rolled back, managed lane kept`
+    `[codex-real-home-hooks] trust grant unavailable (${grant.reason}); entry rolled back, status hook skipped`
   )
   return 'unavailable'
 }
@@ -351,7 +351,7 @@ function backupRealHomeHooksJsonOnce(userDataPath: string, previousRaw: string |
     return
   }
   // Why: this lane mutates the user's real Codex home. If the required
-  // pristine recovery copy cannot be created, keep the managed lane intact.
+  // pristine recovery copy cannot be created, leave the native home untouched.
   mkdirSync(backupDir, { recursive: true })
   writeFileAtomically(backupPath, previousRaw, { mode: 0o600 })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1033,8 +1033,8 @@ function prepareCodexRuntimeHomeForLaunch(
     }
     // Why (flag ON, system default): the hook entry must exist — appended last
     // and trusted by codex's own app-server grant — in the real ~/.codex before
-    // the pane spawns. An incapable grant flips the lane gate so the launch
-    // below falls back to the managed home instead of a status-blind pane.
+    // the pane spawns. A failed grant removes only Orca's optional status hook;
+    // authentication still comes from the user's native Codex home.
     ensureRealHomeCodexHookState({
       hooksEnabled: isAgentStatusHooksEnabled(store?.getSettings()),
       userDataPath: app.getPath('userData')
@@ -1047,8 +1047,8 @@ function prepareCodexRuntimeHomeForLaunch(
   })
   if (runtimeHomePath === null && !realHomeHooksPrepared) {
     // Why: launch prep can reject an untrusted managed home and clear its
-    // selection. Establish hook capability for that newly selected lane, then
-    // re-resolve if the capability gate rejects it.
+    // selection. Establish hook state for that newly selected lane, then
+    // re-resolve after the selection change.
     realHomeHooksPrepared = ensureRealHomeHooksIfSelected()
     if (realHomeHooksPrepared) {
       runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv, {
@@ -2367,17 +2367,14 @@ void app.whenReady().then(async () => {
   rateLimits = new RateLimitService()
   codexRuntimeHome = new CodexRuntimeHomeService(store)
   void startCodexStateDbBackfillRecoveryInBackground(getOrcaManagedCodexHomePath())
-  // Why: an incapable trust-grant host must fall back to the managed home for
-  // every consumer (PTY env, rate limits, commit messages) in one place.
-  codexRuntimeHome.setRealHomeLaneGate(() => isRealHomeCodexHookLaneUsable())
-  // Why: while the real-home lane owns ~/.codex/hooks.json, the legacy
-  // system-home sweep inside managed installs would delete the entry the
-  // real-home installer just appended. Flag OFF, hooks off, or an incapable
-  // trust lane re-arms the sweep so downgrade, opt-out, and rollback converge.
+  // Why: the real-home installer owns system-home hooks only while its trust
+  // lane is usable. If trust is unavailable, legacy cleanup may remove an old
+  // Orca entry, but authentication still stays on the native Codex home.
   setSystemCodexHomeHookSweepSuppressed(
     () =>
       codexRuntimeHome !== null &&
       codexRuntimeHome.isHostSystemDefaultRealHome() &&
+      isRealHomeCodexHookLaneUsable() &&
       isAgentStatusHooksEnabled(store?.getSettings())
   )
   codexSessionMigration = createCodexSessionMigrationScheduler({
@@ -2813,8 +2810,8 @@ void app.whenReady().then(async () => {
   })
   nativeTheme.themeSource = store.getSettings().theme ?? 'system'
   if (codexRuntimeHome.isHostSystemDefaultRealHomeSelected()) {
-    // Why: establish capability before managed-hook reconciliation so an
-    // incapable host re-arms and completes the legacy real-home sweep now.
+    // Why: settle installation or rollback before managed-hook reconciliation;
+    // credential routing does not depend on this optional status capability.
     ensureRealHomeCodexHookState({
       hooksEnabled: isAgentStatusHooksEnabled(store.getSettings()),
       userDataPath: app.getPath('userData')

--- a/src/main/startup/serve-desktop-activation-wiring.test.ts
+++ b/src/main/startup/serve-desktop-activation-wiring.test.ts
@@ -32,6 +32,18 @@ describe('serve desktop activation wiring', () => {
     )
   })
 
+  it('keeps headless system-default Codex auth independent from optional status-hook trust', () => {
+    const serveIndex = source.indexOf('if (serveOptions) {')
+    const headlessRegistrationIndex = source.indexOf('registerHeadlessPtyRuntime(', serveIndex)
+    const headlessRegistration = source.slice(
+      headlessRegistrationIndex,
+      source.indexOf(')', headlessRegistrationIndex) + 1
+    )
+
+    expect(headlessRegistration).toContain('prepareCodexRuntimeHomeForLaunch')
+    expect(source).not.toContain('codexRuntimeHome.setRealHomeLaneGate(')
+  })
+
   it('publishes the named headless sentinel and only enables promotion after RPC is ready', () => {
     const serveIndex = source.indexOf('if (serveOptions) {')
     const sentinelIndex = source.indexOf(


### PR DESCRIPTION
## Summary

Fixes #13746.

When Codex uses Orca's system-default account, keep it on the host's native `CODEX_HOME` even if the optional status-hook trust grant is unavailable. Previously, hook capability gated `isHostSystemDefaultRealHome()`, so a failed grant redirected new terminals to Orca's shared managed home, where an older login could remain.

The primary reported `unsupported` case does not self-heal within the process: `unsupported`, `unsupported-cached`, and `disabled` set the retry deadline to `POSITIVE_INFINITY`. Only transient failures retry after five minutes. The old behavior could therefore pin authentication to a mirrored credential for the rest of the process. This change removes that coupling: the hook entry is still rolled back when trust is unavailable, but authentication remains native.

With this change:

- a new Orca Codex terminal sees the same account as host Codex;
- switching from account A to account B, or logging out, is visible without copying credentials;
- explicit Orca-managed accounts remain isolated;
- Codex continues to own `file`, `keyring`, and `auto` credential storage;
- optional hook cleanup remains gated by the trust lane.

`isHostSystemDefaultRealHome()` also controls session discovery, legacy session resume, and retained shared-home auth/config reconciliation. Those compatibility paths now follow native system-default routing even when the optional hook is unavailable. Existing retained panes keep their launch-time home and continue the existing compatibility reconciliation; new panes use the native home.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full suite was not rerun on the rebased head
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Current rebased-head validation:

- focused Vitest run: 3 files, 130 tests passed;
- `pnpm typecheck` passed;
- `pnpm lint` passed (the base branch still reports its existing `WorktreeJumpPalette.tsx` dependency warnings);
- `pnpm build` passed on Linux; the optional `/usr/local/bin/orca-dev` symlink reported the expected permission warning and did not fail the build.

Earlier pre-rebase full-suite attempts passed 49,408 and 49,425 tests respectively but ended nonzero because unrelated renderer/cross-version files timed out under concurrency; those timed-out files passed in isolation. These are not reported as successful full-suite runs.

## AI Review Report

The review followed native-home selection, hook installation and rollback, account refresh/logout, rate-limit reads, session discovery, legacy session resume, retained-pane reconciliation, PTY environment construction, and headless registration. Rebasing required one conflict resolution: the latest `main` retained-hook-home resolver was preserved while the obsolete routing gate was removed.

Cross-platform and integration review found the behavior change is limited to the POSIX native system-default route used by Linux desktop/headless and macOS. Windows, WSL, custom `CODEX_HOME`, explicit managed accounts, other agents, and renderer behavior are unchanged. SSH/headless uses the same launch-preparation callback. No new work was added to a hot loop or IPC path.

## Security Audit

This change does not read, copy, serialize, hash, log, or emit credential contents. It relies on Codex's native storage behavior, including keyring and auto modes. Existing generation-guarded atomic hook rollback remains in place, and hook trust failure no longer changes the authentication home.

The unrelated `.gitignore` changes were removed from this PR, including the broad exceptions flagged by review. No dependency, IPC schema, command execution, or telemetry payload was added. Tests use synthetic credentials only.

## Notes

Live credential validation was not performed. Before release, please verify account A, switch to account B, logout, and explicit managed-account selection on a Linux headless host. Recreate an existing pane after upgrade to use the native route.

Fork CI still requires maintainer approval; no remote CI success is claimed here.

X handle: not provided.
