### PR TITLE
feat(editor): run the project's formatter after a save

### DIFF
--- a/src/main/format-on-save-process.ts
+++ b/src/main/format-on-save-process.ts
@@ -1,0 +1,236 @@
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
+import {
+  expandFormatOnSaveCommand,
+  type FormatOnSaveResult
+} from '../shared/format-on-save-command'
+import { getCmdExePath } from '../shared/windows-batch-spawn'
+import { parseWslPath, toLinuxPath } from './wsl'
+import { FORMAT_ON_SAVE_TIMEOUT_MS } from './format-on-save-timeout'
+
+// Why: a chatty-but-successful formatter (`black --verbose`, `prettier
+// --loglevel debug`) must not be reported as a failure just for talking. Output
+// is only read to explain a non-zero exit, so past this cap it is truncated
+// rather than turned into an error.
+const FORMAT_ON_SAVE_OUTPUT_CAP_BYTES = 1024 * 1024
+
+export type FormatCommandExecution = {
+  command: string
+  worktreePath: string
+  absoluteFilePath: string
+  relativePath: string
+}
+
+export async function executeFormatCommand({
+  command,
+  worktreePath,
+  absoluteFilePath,
+  relativePath
+}: FormatCommandExecution): Promise<FormatOnSaveResult> {
+  const wslInfo = parseWslPath(worktreePath)
+
+  if (wslInfo) {
+    // Why: the worktree lives on the WSL filesystem, so the formatter and the
+    // paths it receives must both be Linux-side; a Windows-native run would
+    // either miss the toolchain or crawl over the 9P bridge.
+    const wslCommand = expandFormatOnSaveCommand({
+      command,
+      absolutePath: toLinuxPath(absoluteFilePath),
+      relativePath,
+      platform: 'linux'
+    })
+    return runWslFormatCommand(wslInfo.distro, wslInfo.linuxPath, wslCommand)
+  }
+
+  const expanded = expandFormatOnSaveCommand({
+    command,
+    absolutePath: absoluteFilePath,
+    relativePath,
+    platform: process.platform
+  })
+
+  const isWindows = process.platform === 'win32'
+  const shell = getFormatShell()
+  const shellArgs = isWindows ? ['/d', '/s', '/c', expanded] : ['-c', expanded]
+
+  return new Promise<FormatOnSaveResult>((resolve) => {
+    let settled = false
+    let timedOut = false
+    let stdout = ''
+    let stderr = ''
+
+    // Why: `exec`'s timeout signals the shell only. A formatter it started
+    // (`npx prettier` and friends) survives, and since the in-flight slot is
+    // released when the callback fires, that orphan can rewrite the file on top
+    // of a later save — a lost edit rather than a reported failure. Run the
+    // shell in its own process group so the whole group can be killed.
+    let child: ChildProcess
+    try {
+      child = spawn(shell, shellArgs, {
+        cwd: worktreePath,
+        detached: !isWindows,
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    } catch (error) {
+      resolve({
+        status: 'failed',
+        message: error instanceof Error ? error.message : String(error)
+      })
+      return
+    }
+
+    const finish = (result: FormatOnSaveResult): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      killFormatterProcessTree(child)
+    }, FORMAT_ON_SAVE_TIMEOUT_MS)
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      if (stdout.length < FORMAT_ON_SAVE_OUTPUT_CAP_BYTES) {
+        stdout += String(chunk)
+      }
+    })
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      if (stderr.length < FORMAT_ON_SAVE_OUTPUT_CAP_BYTES) {
+        stderr += String(chunk)
+      }
+    })
+
+    child.on('error', (error) => {
+      finish({ status: 'failed', message: error.message })
+    })
+
+    child.on('close', (code) => {
+      if (timedOut) {
+        finish({
+          status: 'failed',
+          message: `Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`
+        })
+        return
+      }
+      if (code === 0) {
+        finish({ status: 'completed' })
+        return
+      }
+      const message = [stderr.trim(), stdout.trim()].find((candidate) => candidate.length > 0)
+      finish({ status: 'failed', message: message ?? `Formatter exited with code ${code}.` })
+    })
+  })
+}
+
+function killFormatterProcessTree(child: ChildProcess): void {
+  const pid = child.pid
+  if (pid === undefined) {
+    return
+  }
+
+  if (process.platform === 'win32') {
+    // Why: Windows has no process groups to signal; taskkill /T walks the tree.
+    try {
+      execFile('taskkill', ['/pid', String(pid), '/t', '/f'], () => undefined)
+    } catch {
+      child.kill()
+    }
+    return
+  }
+
+  try {
+    // Why: `detached` above made the shell a group leader, so the negative pid
+    // reaches the formatter it spawned as well.
+    process.kill(-pid, 'SIGKILL')
+  } catch {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+function runWslFormatCommand(
+  distro: string | null,
+  linuxCwd: string,
+  expandedCommand: string
+): Promise<FormatOnSaveResult> {
+  // Why: execFile avoids cmd.exe, which mangles the quoting the expansion just applied.
+  const escapedCwd = linuxCwd.split("'").join(`'\\''`)
+  const bashCommand = `cd '${escapedCwd}' && ${expandedCommand}`
+  const distroArgs = distro ? ['-d', distro] : []
+
+  return new Promise<FormatOnSaveResult>((resolve) => {
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null, stdout = '', stderr = ''): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      resolve(toFormatResult(error, stdout, stderr))
+    }
+
+    // Why: execFile's own timeout only signals wsl.exe, which can outlive the guest command.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(new Error(`Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`))
+    }, FORMAT_ON_SAVE_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        'wsl.exe',
+        [...distroArgs, '--', 'bash', '-c', bashCommand],
+        {
+          timeout: FORMAT_ON_SAVE_TIMEOUT_MS,
+          maxBuffer: FORMAT_ON_SAVE_OUTPUT_CAP_BYTES,
+          encoding: 'utf-8'
+        },
+        (error, stdout, stderr) => {
+          finish(error ?? null, stdout, stderr)
+        }
+      )
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+}
+
+function toFormatResult(
+  error: Error | null,
+  stdout: string | Buffer,
+  stderr: string | Buffer
+): FormatOnSaveResult {
+  if (!error) {
+    return { status: 'completed' }
+  }
+
+  // Why: a killed process reports the same "Command failed" as a parse error,
+  // and its stderr is usually empty — name the timeout so the user knows to look
+  // at the command rather than at their file.
+  if ((error as { killed?: boolean }).killed) {
+    return {
+      status: 'failed',
+      message: `Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`
+    }
+  }
+
+  // Why: formatters put the actionable parse error on stderr and exit non-zero;
+  // the Node error message alone ("Command failed") tells the user nothing.
+  const message = [String(stderr).trim(), String(stdout).trim(), error.message.trim()].find(
+    (candidate) => candidate.length > 0
+  )
+
+  return { status: 'failed', message: message ?? 'Formatter failed.' }
+}
+
+function getFormatShell(): string {
+  return process.platform === 'win32' ? getCmdExePath() : '/bin/bash'
+}

--- a/src/main/format-on-save-runner.test.ts
+++ b/src/main/format-on-save-runner.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execMock = vi.fn()
+const execFileMock = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  exec: (...args: unknown[]) => execMock(...args),
+  execFile: (...args: unknown[]) => execFileMock(...args)
+}))
+
+vi.mock('./wsl', () => ({
+  parseWslPath: vi.fn(() => null),
+  toLinuxPath: vi.fn((value: string) => value)
+}))
+
+import { _resetFormatOnSaveInFlightForTests, runFormatOnSave } from './format-on-save-runner'
+import { parseWslPath } from './wsl'
+import type { RepoFormatOnSaveSettings } from '../shared/types'
+
+const enabledSettings: RepoFormatOnSaveSettings = {
+  enabled: true,
+  command: 'prettier --write ${file}',
+  include: ['**/*.ts']
+}
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+
+function resolveExecWith(error: Error | null, stdout = '', stderr = ''): void {
+  execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
+    callback(error, stdout, stderr)
+    return {}
+  })
+}
+
+beforeEach(() => {
+  execMock.mockReset()
+  execFileMock.mockReset()
+  _resetFormatOnSaveInFlightForTests()
+  vi.mocked(parseWslPath).mockReturnValue(null)
+  resolveExecWith(null)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('runFormatOnSave', () => {
+  it('skips when the repo has no formatter configured', async () => {
+    await expect(
+      runFormatOnSave({
+        settings: { enabled: false, command: '', include: [] },
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'not-configured' })
+    expect(execMock).not.toHaveBeenCalled()
+  })
+
+  it('skips files the include globs do not cover', async () => {
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.css'
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'not-included' })
+    expect(execMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to format a file outside the worktree', async () => {
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/elsewhere/src/a.ts'
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'outside-worktree' })
+    expect(execMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the command in the worktree root with the saved path substituted', async () => {
+    await runFormatOnSave({
+      settings: enabledSettings,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/a.ts'
+    })
+
+    const [command, options] = execMock.mock.calls[0]
+    expect(command).toBe("prettier --write '/repo/src/a.ts'")
+    expect((options as { cwd: string }).cwd).toBe('/repo')
+  })
+
+  it('reports the formatter stderr when the command exits non-zero', async () => {
+    resolveExecWith(new Error('Command failed'), '', 'SyntaxError: Unexpected token (3:1)')
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+    ).resolves.toEqual({
+      status: 'failed',
+      message: 'SyntaxError: Unexpected token (3:1)'
+    })
+  })
+
+  it('falls back to the process error when the formatter prints nothing', async () => {
+    resolveExecWith(new Error('spawn prettier ENOENT'))
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+    ).resolves.toEqual({ status: 'failed', message: 'spawn prettier ENOENT' })
+  })
+
+  it('skips a second run while the same file is still being formatted', async () => {
+    let release: (() => void) | undefined
+    execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
+      release = () => callback(null, '', '')
+      return {}
+    })
+
+    const first = runFormatOnSave({
+      settings: enabledSettings,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/a.ts'
+    })
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'already-running' })
+
+    release?.()
+    await expect(first).resolves.toEqual({ status: 'completed' })
+    expect(execMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('frees the in-flight slot after a failed run so the next save can format', async () => {
+    resolveExecWith(new Error('Command failed'), '', 'boom')
+    await runFormatOnSave({
+      settings: enabledSettings,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/a.ts'
+    })
+
+    resolveExecWith(null)
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+    ).resolves.toEqual({ status: 'completed' })
+  })
+
+  it('routes a WSL worktree through wsl.exe with linux paths', async () => {
+    vi.mocked(parseWslPath).mockReturnValue({ distro: 'Ubuntu', linuxPath: '/home/dev/repo' })
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+        callback(null, '', '')
+        return { kill: vi.fn() }
+      }
+    )
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo',
+        absoluteFilePath: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo\\src\\a.ts'
+      })
+    ).resolves.toEqual({ status: 'completed' })
+
+    const [file, args] = execFileMock.mock.calls[0]
+    expect(file).toBe('wsl.exe')
+    expect(args).toEqual([
+      '-d',
+      'Ubuntu',
+      '--',
+      'bash',
+      '-c',
+      expect.stringContaining("cd '/home/dev/repo' && prettier --write")
+    ])
+    expect(execMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/format-on-save-runner.test.ts
+++ b/src/main/format-on-save-runner.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const execMock = vi.fn()
+import { EventEmitter } from 'node:events'
+
+const spawnMock = vi.fn()
 const execFileMock = vi.fn()
 
 vi.mock('node:child_process', () => ({
-  exec: (...args: unknown[]) => execMock(...args),
+  spawn: (...args: unknown[]) => spawnMock(...args),
   execFile: (...args: unknown[]) => execFileMock(...args)
 }))
 
@@ -13,7 +15,11 @@ vi.mock('./wsl', () => ({
   toLinuxPath: vi.fn((value: string) => value)
 }))
 
-import { _resetFormatOnSaveInFlightForTests, runFormatOnSave } from './format-on-save-runner'
+import {
+  _resetFormatOnSaveInFlightForTests,
+  FORMAT_ON_SAVE_TIMEOUT_MS,
+  runFormatOnSave
+} from './format-on-save-runner'
 import { parseWslPath } from './wsl'
 import type { RepoFormatOnSaveSettings } from '../shared/types'
 
@@ -25,19 +31,68 @@ const enabledSettings: RepoFormatOnSaveSettings = {
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
 
-function resolveExecWith(error: Error | null, stdout = '', stderr = ''): void {
-  execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
-    callback(error, stdout, stderr)
-    return {}
+const IS_WINDOWS_HOST = process.platform === 'win32'
+
+/** Quotes a path the way the runner does on whichever host the suite runs on. */
+function hostQuoted(value: string): string {
+  return IS_WINDOWS_HOST ? `"${value}"` : `'${value}'`
+}
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  pid: number | undefined = 4242
+  kill = vi.fn()
+}
+
+let lastChild: FakeChildProcess | null = null
+
+/** Drives the spawned child to a close, mirroring the real event order. */
+function spawnResolvesWith(code: number | null, stdout = '', stderr = ''): void {
+  spawnMock.mockImplementation(() => {
+    const child = new FakeChildProcess()
+    lastChild = child
+    queueMicrotask(() => {
+      if (stdout) {
+        child.stdout.emit('data', stdout)
+      }
+      if (stderr) {
+        child.stderr.emit('data', stderr)
+      }
+      child.emit('close', code)
+    })
+    return child
   })
 }
 
+/** Spawns a child that never closes until the returned callback runs. */
+function spawnPending(): () => void {
+  let release: (() => void) | undefined
+  spawnMock.mockImplementation(() => {
+    const child = new FakeChildProcess()
+    lastChild = child
+    release = () => child.emit('close', 0)
+    return child
+  })
+  return () => release?.()
+}
+
+function spawnedCommand(callIndex = 0): string {
+  const args = spawnMock.mock.calls[callIndex][1] as string[]
+  return args.at(-1) ?? ''
+}
+
+function resolveExecWith(error: Error | null, stdout = '', stderr = ''): void {
+  spawnResolvesWith(error ? 1 : 0, stdout, error && !stderr && !stdout ? error.message : stderr)
+}
+
 beforeEach(() => {
-  execMock.mockReset()
+  spawnMock.mockReset()
   execFileMock.mockReset()
+  lastChild = null
   _resetFormatOnSaveInFlightForTests()
   vi.mocked(parseWslPath).mockReturnValue(null)
-  resolveExecWith(null)
+  spawnResolvesWith(0)
 })
 
 afterEach(() => {
@@ -53,7 +108,7 @@ describe('runFormatOnSave', () => {
         absoluteFilePath: '/repo/src/a.ts'
       })
     ).resolves.toEqual({ status: 'skipped', reason: 'not-configured' })
-    expect(execMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('skips files the include globs do not cover', async () => {
@@ -64,7 +119,7 @@ describe('runFormatOnSave', () => {
         absoluteFilePath: '/repo/src/a.css'
       })
     ).resolves.toEqual({ status: 'skipped', reason: 'not-included' })
-    expect(execMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('refuses to format a file outside the worktree', async () => {
@@ -75,7 +130,7 @@ describe('runFormatOnSave', () => {
         absoluteFilePath: '/elsewhere/src/a.ts'
       })
     ).resolves.toEqual({ status: 'skipped', reason: 'outside-worktree' })
-    expect(execMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('runs the command in the worktree root with the saved path substituted', async () => {
@@ -85,9 +140,10 @@ describe('runFormatOnSave', () => {
       absoluteFilePath: '/repo/src/a.ts'
     })
 
-    const [command, options] = execMock.mock.calls[0]
-    expect(command).toBe("prettier --write '/repo/src/a.ts'")
-    expect((options as { cwd: string }).cwd).toBe('/repo')
+    // Why: quoting follows the host shell, so derive the expectation instead of
+    // hardcoding POSIX quotes — this suite also runs on Windows CI.
+    expect(spawnedCommand()).toBe(`prettier --write ${hostQuoted('/repo/src/a.ts')}`)
+    expect((spawnMock.mock.calls[0][2] as { cwd: string }).cwd).toBe('/repo')
   })
 
   it('reports the formatter stderr when the command exits non-zero', async () => {
@@ -118,11 +174,7 @@ describe('runFormatOnSave', () => {
   })
 
   it('skips a second run while the same file is still being formatted', async () => {
-    let release: (() => void) | undefined
-    execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
-      release = () => callback(null, '', '')
-      return {}
-    })
+    const release = spawnPending()
 
     const first = runFormatOnSave({
       settings: enabledSettings,
@@ -138,9 +190,9 @@ describe('runFormatOnSave', () => {
       })
     ).resolves.toEqual({ status: 'skipped', reason: 'already-running' })
 
-    release?.()
+    release()
     await expect(first).resolves.toEqual({ status: 'completed' })
-    expect(execMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
   it('frees the in-flight slot after a failed run so the next save can format', async () => {
@@ -162,10 +214,7 @@ describe('runFormatOnSave', () => {
   })
 
   it('keeps posix paths case-sensitive so two real files never share a slot', async () => {
-    execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
-      callback(null, '', '')
-      return {}
-    })
+    spawnResolvesWith(0)
     const anyFile = { ...enabledSettings, include: [] }
 
     await runFormatOnSave({
@@ -179,44 +228,63 @@ describe('runFormatOnSave', () => {
       absoluteFilePath: '/repo/src/A.TS'
     })
 
-    expect(execMock).toHaveBeenCalledTimes(2)
+    expect(spawnMock).toHaveBeenCalledTimes(2)
   })
 
   it('does not report a chatty but successful formatter as failed', async () => {
-    // Why: node's 1 MB default maxBuffer would kill `black --verbose` mid-run and
-    // surface it as a failure even though the file was rewritten.
-    await runFormatOnSave({
-      settings: enabledSettings,
-      worktreePath: '/repo',
-      absoluteFilePath: '/repo/src/a.ts'
-    })
+    // Why: `black --verbose` and `prettier --loglevel debug` succeed while
+    // printing megabytes; output volume must not turn into an error.
+    spawnResolvesWith(0, 'x'.repeat(4 * 1024 * 1024), 'y'.repeat(4 * 1024 * 1024))
 
-    const options = execMock.mock.calls[0][1] as { maxBuffer?: number }
-    expect(options.maxBuffer).toBeGreaterThanOrEqual(8 * 1024 * 1024)
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+    ).resolves.toEqual({ status: 'completed' })
   })
 
-  it('names the timeout instead of surfacing a bare "Command failed"', async () => {
-    const timedOut = Object.assign(new Error('Command failed'), { killed: true })
-    resolveExecWith(timedOut, '', '')
+  it('kills the whole process group when the formatter times out', async () => {
+    vi.useFakeTimers()
+    try {
+      spawnPending()
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
-    const result = await runFormatOnSave({
-      settings: enabledSettings,
-      worktreePath: '/repo',
-      absoluteFilePath: '/repo/src/a.ts'
-    })
+      const pending = runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/repo',
+        absoluteFilePath: '/repo/src/a.ts'
+      })
+      await vi.advanceTimersByTimeAsync(FORMAT_ON_SAVE_TIMEOUT_MS + 10)
 
-    expect(result.status).toBe('failed')
-    expect(result).toMatchObject({ message: expect.stringContaining('timed out') })
+      if (process.platform === 'win32') {
+        expect(execFileMock).toHaveBeenCalledWith(
+          'taskkill',
+          expect.arrayContaining(['/t', '/f']),
+          expect.any(Function)
+        )
+      } else {
+        // Why: the negative pid reaches the formatter the shell spawned, which a
+        // plain child.kill() would leave running to overwrite a later save.
+        expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGKILL')
+      }
+
+      lastChild?.emit('close', null)
+      await expect(pending).resolves.toMatchObject({
+        status: 'failed',
+        message: expect.stringContaining('timed out')
+      })
+      killSpy.mockRestore()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('shares one in-flight slot across differently-cased windows paths', async () => {
     // Why: Windows resolves paths case-insensitively, so two tabs on the same
     // file would otherwise run the formatter over each other's output.
-    let release: (() => void) | undefined
-    execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
-      release = () => callback(null, '', '')
-      return {}
-    })
+    const release = spawnPending()
 
     // Why: include globs stay case-sensitive like every other glob matcher, so
     // this case tests the in-flight key alone.
@@ -237,7 +305,7 @@ describe('runFormatOnSave', () => {
 
     release?.()
     await expect(first).resolves.toEqual({ status: 'completed' })
-    expect(execMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
   it('runs the formatter on the remote host for an SSH worktree', async () => {
@@ -265,7 +333,7 @@ describe('runFormatOnSave', () => {
       timeoutMs: expect.any(Number)
     })
     // Why: the local shell must not be touched for a file that lives elsewhere.
-    expect(execMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('uses cmd.exe when the SSH host is Windows', async () => {
@@ -421,6 +489,6 @@ describe('runFormatOnSave', () => {
       '-c',
       expect.stringContaining("cd '/home/dev/repo' && prettier --write")
     ])
-    expect(execMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/format-on-save-runner.test.ts
+++ b/src/main/format-on-save-runner.test.ts
@@ -161,6 +161,85 @@ describe('runFormatOnSave', () => {
     ).resolves.toEqual({ status: 'completed' })
   })
 
+  it('keeps posix paths case-sensitive so two real files never share a slot', async () => {
+    execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
+      callback(null, '', '')
+      return {}
+    })
+    const anyFile = { ...enabledSettings, include: [] }
+
+    await runFormatOnSave({
+      settings: anyFile,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/a.ts'
+    })
+    await runFormatOnSave({
+      settings: anyFile,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/A.TS'
+    })
+
+    expect(execMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not report a chatty but successful formatter as failed', async () => {
+    // Why: node's 1 MB default maxBuffer would kill `black --verbose` mid-run and
+    // surface it as a failure even though the file was rewritten.
+    await runFormatOnSave({
+      settings: enabledSettings,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/a.ts'
+    })
+
+    const options = execMock.mock.calls[0][1] as { maxBuffer?: number }
+    expect(options.maxBuffer).toBeGreaterThanOrEqual(8 * 1024 * 1024)
+  })
+
+  it('names the timeout instead of surfacing a bare "Command failed"', async () => {
+    const timedOut = Object.assign(new Error('Command failed'), { killed: true })
+    resolveExecWith(timedOut, '', '')
+
+    const result = await runFormatOnSave({
+      settings: enabledSettings,
+      worktreePath: '/repo',
+      absoluteFilePath: '/repo/src/a.ts'
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result).toMatchObject({ message: expect.stringContaining('timed out') })
+  })
+
+  it('shares one in-flight slot across differently-cased windows paths', async () => {
+    // Why: Windows resolves paths case-insensitively, so two tabs on the same
+    // file would otherwise run the formatter over each other's output.
+    let release: (() => void) | undefined
+    execMock.mockImplementation((_command: string, _options: unknown, callback: ExecCallback) => {
+      release = () => callback(null, '', '')
+      return {}
+    })
+
+    // Why: include globs stay case-sensitive like every other glob matcher, so
+    // this case tests the in-flight key alone.
+    const anyFile = { ...enabledSettings, include: [] }
+    const first = runFormatOnSave({
+      settings: anyFile,
+      worktreePath: 'C:\\repo',
+      absoluteFilePath: 'C:\\repo\\src\\a.ts'
+    })
+
+    await expect(
+      runFormatOnSave({
+        settings: anyFile,
+        worktreePath: 'C:\\repo',
+        absoluteFilePath: 'C:\\repo\\src\\A.TS'
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'already-running' })
+
+    release?.()
+    await expect(first).resolves.toEqual({ status: 'completed' })
+    expect(execMock).toHaveBeenCalledTimes(1)
+  })
+
   it('routes a WSL worktree through wsl.exe with linux paths', async () => {
     vi.mocked(parseWslPath).mockReturnValue({ distro: 'Ubuntu', linuxPath: '/home/dev/repo' })
     execFileMock.mockImplementation(

--- a/src/main/format-on-save-runner.test.ts
+++ b/src/main/format-on-save-runner.test.ts
@@ -240,6 +240,160 @@ describe('runFormatOnSave', () => {
     expect(execMock).toHaveBeenCalledTimes(1)
   })
 
+  it('runs the formatter on the remote host for an SSH worktree', async () => {
+    const remoteExec = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    })
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/srv/repo',
+        absoluteFilePath: '/srv/repo/src/a.ts',
+        remoteExec,
+        hostScope: 'ssh-1'
+      })
+    ).resolves.toEqual({ status: 'completed' })
+
+    expect(remoteExec).toHaveBeenCalledWith({
+      binary: '/bin/bash',
+      args: ['-lc', "prettier --write '/srv/repo/src/a.ts'"],
+      cwd: '/srv/repo',
+      timeoutMs: expect.any(Number)
+    })
+    // Why: the local shell must not be touched for a file that lives elsewhere.
+    expect(execMock).not.toHaveBeenCalled()
+  })
+
+  it('uses cmd.exe when the SSH host is Windows', async () => {
+    const remoteExec = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    })
+
+    await runFormatOnSave({
+      settings: { ...enabledSettings, include: [] },
+      worktreePath: 'C:\\srv\\repo',
+      absoluteFilePath: 'C:\\srv\\repo\\src\\a.ts',
+      remoteExec,
+      hostScope: 'ssh-win'
+    })
+
+    const call = remoteExec.mock.calls[0][0]
+    expect(call.binary).toBe('cmd.exe')
+    expect(call.args.slice(0, 3)).toEqual(['/d', '/s', '/c'])
+    expect(call.args[3]).toContain('"C:\\srv\\repo\\src\\a.ts"')
+  })
+
+  it('reports a remote formatter failure with its stderr', async () => {
+    const remoteExec = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: 'SyntaxError: line 3',
+      exitCode: 2,
+      timedOut: false
+    })
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/srv/repo',
+        absoluteFilePath: '/srv/repo/src/a.ts',
+        remoteExec,
+        hostScope: 'ssh-1'
+      })
+    ).resolves.toEqual({ status: 'failed', message: 'SyntaxError: line 3' })
+  })
+
+  it('names a remote timeout and a remote spawn failure distinctly', async () => {
+    const timedOut = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exitCode: null,
+      timedOut: true
+    })
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/srv/repo',
+        absoluteFilePath: '/srv/repo/src/a.ts',
+        remoteExec: timedOut,
+        hostScope: 'ssh-1'
+      })
+    ).resolves.toMatchObject({ status: 'failed', message: expect.stringContaining('timed out') })
+
+    const spawnFailed = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exitCode: null,
+      timedOut: false,
+      spawnError: 'bash: not found'
+    })
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/srv/repo',
+        absoluteFilePath: '/srv/repo/src/a.ts',
+        remoteExec: spawnFailed,
+        hostScope: 'ssh-1'
+      })
+    ).resolves.toEqual({ status: 'failed', message: 'bash: not found' })
+  })
+
+  it('treats a dropped relay as a skip, not a formatter failure', async () => {
+    // Why: the save already landed; a transport error must not read as the
+    // formatter rejecting the user's file.
+    const remoteExec = vi.fn().mockRejectedValue(new Error('relay disconnected'))
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/srv/repo',
+        absoluteFilePath: '/srv/repo/src/a.ts',
+        remoteExec,
+        hostScope: 'ssh-1'
+      })
+    ).resolves.toEqual({ status: 'skipped', reason: 'unsupported-host' })
+  })
+
+  it('keeps in-flight slots separate per host for an identical path', async () => {
+    let releaseFirst: (() => void) | undefined
+    const slowRemote = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseFirst = () => resolve({ stdout: '', stderr: '', exitCode: 0, timedOut: false })
+        })
+    )
+    const fastRemote = vi
+      .fn()
+      .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0, timedOut: false })
+
+    const first = runFormatOnSave({
+      settings: enabledSettings,
+      worktreePath: '/srv/repo',
+      absoluteFilePath: '/srv/repo/src/a.ts',
+      remoteExec: slowRemote,
+      hostScope: 'ssh-1'
+    })
+
+    await expect(
+      runFormatOnSave({
+        settings: enabledSettings,
+        worktreePath: '/srv/repo',
+        absoluteFilePath: '/srv/repo/src/a.ts',
+        remoteExec: fastRemote,
+        hostScope: 'ssh-2'
+      })
+    ).resolves.toEqual({ status: 'completed' })
+
+    releaseFirst?.()
+    await expect(first).resolves.toEqual({ status: 'completed' })
+  })
+
   it('routes a WSL worktree through wsl.exe with linux paths', async () => {
     vi.mocked(parseWslPath).mockReturnValue({ distro: 'Ubuntu', linuxPath: '/home/dev/repo' })
     execFileMock.mockImplementation(

--- a/src/main/format-on-save-runner.ts
+++ b/src/main/format-on-save-runner.ts
@@ -6,6 +6,7 @@ import {
   type FormatOnSaveResult
 } from '../shared/format-on-save-command'
 import {
+  normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators,
   relativePathInsideRoot
 } from '../shared/cross-platform-path'
@@ -14,6 +15,12 @@ import type { RepoFormatOnSaveSettings } from '../shared/types'
 
 /** Long enough for a cold `npx prettier`, short enough that a hung formatter frees the file quickly. */
 export const FORMAT_ON_SAVE_TIMEOUT_MS = 20_000
+
+// Why: node's 1 MB default turns a chatty-but-successful formatter (`black
+// --verbose`, `prettier --loglevel debug`) into a reported failure even though
+// the file was rewritten correctly. The output is discarded on success, so the
+// only thing a larger cap costs is a transient buffer.
+const FORMAT_ON_SAVE_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
 export type FormatOnSaveRequest = {
   settings: RepoFormatOnSaveSettings | undefined | null
@@ -44,7 +51,10 @@ export async function runFormatOnSave({
     return { status: 'skipped', reason: 'not-included' }
   }
 
-  const inFlightKey = normalizeRuntimePathSeparators(absoluteFilePath)
+  // Why: use the comparison form so Windows' case-insensitive paths share one
+  // in-flight slot. POSIX paths are left case-sensitive on purpose — folding them
+  // would treat two genuinely different files as one.
+  const inFlightKey = normalizeRuntimePathForComparison(absoluteFilePath)
   if (inFlightPaths.has(inFlightKey)) {
     return { status: 'skipped', reason: 'already-running' }
   }
@@ -118,6 +128,7 @@ async function executeFormatCommand({
       {
         cwd: worktreePath,
         timeout: FORMAT_ON_SAVE_TIMEOUT_MS,
+        maxBuffer: FORMAT_ON_SAVE_MAX_BUFFER_BYTES,
         shell: getFormatShell(),
         encoding: 'utf-8'
       },
@@ -161,7 +172,11 @@ function runWslFormatCommand(
       child = execFile(
         'wsl.exe',
         [...distroArgs, '--', 'bash', '-c', bashCommand],
-        { timeout: FORMAT_ON_SAVE_TIMEOUT_MS, encoding: 'utf-8' },
+        {
+          timeout: FORMAT_ON_SAVE_TIMEOUT_MS,
+          maxBuffer: FORMAT_ON_SAVE_MAX_BUFFER_BYTES,
+          encoding: 'utf-8'
+        },
         (error, stdout, stderr) => {
           finish(error ?? null, stdout, stderr)
         }
@@ -179,6 +194,16 @@ function toFormatResult(
 ): FormatOnSaveResult {
   if (!error) {
     return { status: 'completed' }
+  }
+
+  // Why: a killed process reports the same "Command failed" as a parse error,
+  // and its stderr is usually empty — name the timeout so the user knows to look
+  // at the command rather than at their file.
+  if ((error as { killed?: boolean }).killed) {
+    return {
+      status: 'failed',
+      message: `Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`
+    }
   }
 
   // Why: formatters put the actionable parse error on stderr and exit non-zero;

--- a/src/main/format-on-save-runner.ts
+++ b/src/main/format-on-save-runner.ts
@@ -6,10 +6,13 @@ import {
   type FormatOnSaveResult
 } from '../shared/format-on-save-command'
 import {
+  isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators,
   relativePathInsideRoot
 } from '../shared/cross-platform-path'
+import { stableInFlightKey } from '../shared/in-flight-promise-dedupe'
+import { getCmdExePath } from '../shared/windows-batch-spawn'
 import { parseWslPath, toLinuxPath } from './wsl'
 import type { RepoFormatOnSaveSettings } from '../shared/types'
 
@@ -22,10 +25,33 @@ export const FORMAT_ON_SAVE_TIMEOUT_MS = 20_000
 // only thing a larger cap costs is a transient buffer.
 const FORMAT_ON_SAVE_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
+export type RemoteFormatExecResult = {
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  timedOut: boolean
+  spawnError?: string
+}
+
+/**
+ * Runs the formatter on the host that owns the file. Injected rather than
+ * imported so the runner keeps no SSH provider dependency.
+ */
+export type RemoteFormatExecutor = (request: {
+  binary: string
+  args: string[]
+  cwd: string
+  timeoutMs: number
+}) => Promise<RemoteFormatExecResult>
+
 export type FormatOnSaveRequest = {
   settings: RepoFormatOnSaveSettings | undefined | null
   worktreePath: string
   absoluteFilePath: string
+  /** Present for SSH-backed repos; absent means the file lives on this machine. */
+  remoteExec?: RemoteFormatExecutor
+  /** Scopes the in-flight slot so an identical path on two hosts doesn't collide. */
+  hostScope?: string
 }
 
 // Why: autosave fires on a short debounce and a formatter rewrites the file it
@@ -35,7 +61,9 @@ const inFlightPaths = new Set<string>()
 export async function runFormatOnSave({
   settings,
   worktreePath,
-  absoluteFilePath
+  absoluteFilePath,
+  remoteExec,
+  hostScope
 }: FormatOnSaveRequest): Promise<FormatOnSaveResult> {
   if (!isFormatOnSaveConfigured(settings) || !settings) {
     return { status: 'skipped', reason: 'not-configured' }
@@ -54,13 +82,25 @@ export async function runFormatOnSave({
   // Why: use the comparison form so Windows' case-insensitive paths share one
   // in-flight slot. POSIX paths are left case-sensitive on purpose — folding them
   // would treat two genuinely different files as one.
-  const inFlightKey = normalizeRuntimePathForComparison(absoluteFilePath)
+  const inFlightKey = stableInFlightKey([
+    hostScope ?? 'local',
+    normalizeRuntimePathForComparison(absoluteFilePath)
+  ])
   if (inFlightPaths.has(inFlightKey)) {
     return { status: 'skipped', reason: 'already-running' }
   }
 
   inFlightPaths.add(inFlightKey)
   try {
+    if (remoteExec) {
+      return await executeRemoteFormatCommand({
+        command: settings.command,
+        worktreePath,
+        absoluteFilePath,
+        relativePath,
+        remoteExec
+      })
+    }
     return await executeFormatCommand({
       command: settings.command,
       worktreePath,
@@ -70,6 +110,62 @@ export async function runFormatOnSave({
   } finally {
     inFlightPaths.delete(inFlightKey)
   }
+}
+
+type RemoteFormatCommandExecution = FormatCommandExecution & {
+  remoteExec: RemoteFormatExecutor
+}
+
+async function executeRemoteFormatCommand({
+  command,
+  worktreePath,
+  absoluteFilePath,
+  relativePath,
+  remoteExec
+}: RemoteFormatCommandExecution): Promise<FormatOnSaveResult> {
+  // Why: the remote host's shell decides the quoting, not this machine's. A
+  // Windows SSH host is detected the same way the worktree hooks detect it —
+  // from the shape of the remote path.
+  const isWindowsRemote = isWindowsAbsolutePathLike(worktreePath)
+  const expanded = expandFormatOnSaveCommand({
+    command,
+    absolutePath: absoluteFilePath,
+    relativePath,
+    platform: isWindowsRemote ? 'win32' : 'linux'
+  })
+
+  let result: RemoteFormatExecResult
+  try {
+    result = await remoteExec({
+      binary: isWindowsRemote ? 'cmd.exe' : '/bin/bash',
+      args: isWindowsRemote ? ['/d', '/s', '/c', expanded] : ['-lc', expanded],
+      cwd: worktreePath,
+      timeoutMs: FORMAT_ON_SAVE_TIMEOUT_MS
+    })
+  } catch (error) {
+    // Why: a dropped relay must not be reported as the formatter rejecting the
+    // file — the save already succeeded, so this is a skip, not a failure.
+    console.warn('[format-on-save] remote exec unavailable', error)
+    return { status: 'skipped', reason: 'unsupported-host' }
+  }
+
+  if (result.spawnError) {
+    return { status: 'failed', message: result.spawnError }
+  }
+  if (result.timedOut) {
+    return {
+      status: 'failed',
+      message: `Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`
+    }
+  }
+  if (result.exitCode === 0) {
+    return { status: 'completed' }
+  }
+
+  const message = [result.stderr?.trim(), result.stdout?.trim()].find(
+    (candidate) => candidate && candidate.length > 0
+  )
+  return { status: 'failed', message: message ?? 'Formatter failed.' }
 }
 
 export function getWorktreeRelativePath(
@@ -216,11 +312,7 @@ function toFormatResult(
 }
 
 function getFormatShell(): string | undefined {
-  if (process.platform === 'win32') {
-    return process.env.ComSpec || 'cmd.exe'
-  }
-
-  return '/bin/bash'
+  return process.platform === 'win32' ? getCmdExePath() : '/bin/bash'
 }
 
 export function _resetFormatOnSaveInFlightForTests(): void {

--- a/src/main/format-on-save-runner.ts
+++ b/src/main/format-on-save-runner.ts
@@ -1,0 +1,203 @@
+import { exec, execFile } from 'node:child_process'
+import {
+  expandFormatOnSaveCommand,
+  isFormatOnSaveConfigured,
+  matchesFormatOnSaveInclude,
+  type FormatOnSaveResult
+} from '../shared/format-on-save-command'
+import {
+  normalizeRuntimePathSeparators,
+  relativePathInsideRoot
+} from '../shared/cross-platform-path'
+import { parseWslPath, toLinuxPath } from './wsl'
+import type { RepoFormatOnSaveSettings } from '../shared/types'
+
+/** Long enough for a cold `npx prettier`, short enough that a hung formatter frees the file quickly. */
+export const FORMAT_ON_SAVE_TIMEOUT_MS = 20_000
+
+export type FormatOnSaveRequest = {
+  settings: RepoFormatOnSaveSettings | undefined | null
+  worktreePath: string
+  absoluteFilePath: string
+}
+
+// Why: autosave fires on a short debounce and a formatter rewrites the file it
+// is reading; overlapping runs on one path race each other's output.
+const inFlightPaths = new Set<string>()
+
+export async function runFormatOnSave({
+  settings,
+  worktreePath,
+  absoluteFilePath
+}: FormatOnSaveRequest): Promise<FormatOnSaveResult> {
+  if (!isFormatOnSaveConfigured(settings) || !settings) {
+    return { status: 'skipped', reason: 'not-configured' }
+  }
+
+  const relativePath = getWorktreeRelativePath(worktreePath, absoluteFilePath)
+  if (relativePath === null) {
+    // Why: the command runs with the worktree as cwd, so a file outside it has no meaningful ${relativeFile}.
+    return { status: 'skipped', reason: 'outside-worktree' }
+  }
+
+  if (!matchesFormatOnSaveInclude(relativePath, settings.include)) {
+    return { status: 'skipped', reason: 'not-included' }
+  }
+
+  const inFlightKey = normalizeRuntimePathSeparators(absoluteFilePath)
+  if (inFlightPaths.has(inFlightKey)) {
+    return { status: 'skipped', reason: 'already-running' }
+  }
+
+  inFlightPaths.add(inFlightKey)
+  try {
+    return await executeFormatCommand({
+      command: settings.command,
+      worktreePath,
+      absoluteFilePath,
+      relativePath
+    })
+  } finally {
+    inFlightPaths.delete(inFlightKey)
+  }
+}
+
+export function getWorktreeRelativePath(
+  worktreePath: string,
+  absoluteFilePath: string
+): string | null {
+  // Why: node's `path.relative` resolves against the host platform, so a WSL UNC
+  // worktree only parses correctly on Windows. This comparison is platform-free,
+  // which also lets CI cover the WSL branch.
+  const relativePath = relativePathInsideRoot(worktreePath, absoluteFilePath)
+  if (!relativePath) {
+    return null
+  }
+
+  return normalizeRuntimePathSeparators(relativePath)
+}
+
+type FormatCommandExecution = {
+  command: string
+  worktreePath: string
+  absoluteFilePath: string
+  relativePath: string
+}
+
+async function executeFormatCommand({
+  command,
+  worktreePath,
+  absoluteFilePath,
+  relativePath
+}: FormatCommandExecution): Promise<FormatOnSaveResult> {
+  const wslInfo = parseWslPath(worktreePath)
+
+  if (wslInfo) {
+    // Why: the worktree lives on the WSL filesystem, so the formatter and the
+    // paths it receives must both be Linux-side; a Windows-native run would
+    // either miss the toolchain or crawl over the 9P bridge.
+    const wslCommand = expandFormatOnSaveCommand({
+      command,
+      absolutePath: toLinuxPath(absoluteFilePath),
+      relativePath,
+      platform: 'linux'
+    })
+    return runWslFormatCommand(wslInfo.distro, wslInfo.linuxPath, wslCommand)
+  }
+
+  const expanded = expandFormatOnSaveCommand({
+    command,
+    absolutePath: absoluteFilePath,
+    relativePath,
+    platform: process.platform
+  })
+
+  return new Promise<FormatOnSaveResult>((resolve) => {
+    exec(
+      expanded,
+      {
+        cwd: worktreePath,
+        timeout: FORMAT_ON_SAVE_TIMEOUT_MS,
+        shell: getFormatShell(),
+        encoding: 'utf-8'
+      },
+      (error, stdout, stderr) => {
+        resolve(toFormatResult(error, stdout, stderr))
+      }
+    )
+  })
+}
+
+function runWslFormatCommand(
+  distro: string | null,
+  linuxCwd: string,
+  expandedCommand: string
+): Promise<FormatOnSaveResult> {
+  // Why: execFile avoids cmd.exe, which mangles the quoting the expansion just applied.
+  const escapedCwd = linuxCwd.split("'").join(`'\\''`)
+  const bashCommand = `cd '${escapedCwd}' && ${expandedCommand}`
+  const distroArgs = distro ? ['-d', distro] : []
+
+  return new Promise<FormatOnSaveResult>((resolve) => {
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null, stdout = '', stderr = ''): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      resolve(toFormatResult(error, stdout, stderr))
+    }
+
+    // Why: execFile's own timeout only signals wsl.exe, which can outlive the guest command.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(new Error(`Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`))
+    }, FORMAT_ON_SAVE_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        'wsl.exe',
+        [...distroArgs, '--', 'bash', '-c', bashCommand],
+        { timeout: FORMAT_ON_SAVE_TIMEOUT_MS, encoding: 'utf-8' },
+        (error, stdout, stderr) => {
+          finish(error ?? null, stdout, stderr)
+        }
+      )
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+}
+
+function toFormatResult(
+  error: Error | null,
+  stdout: string | Buffer,
+  stderr: string | Buffer
+): FormatOnSaveResult {
+  if (!error) {
+    return { status: 'completed' }
+  }
+
+  // Why: formatters put the actionable parse error on stderr and exit non-zero;
+  // the Node error message alone ("Command failed") tells the user nothing.
+  const message = [String(stderr).trim(), String(stdout).trim(), error.message.trim()].find(
+    (candidate) => candidate.length > 0
+  )
+
+  return { status: 'failed', message: message ?? 'Formatter failed.' }
+}
+
+function getFormatShell(): string | undefined {
+  if (process.platform === 'win32') {
+    return process.env.ComSpec || 'cmd.exe'
+  }
+
+  return '/bin/bash'
+}
+
+export function _resetFormatOnSaveInFlightForTests(): void {
+  inFlightPaths.clear()
+}

--- a/src/main/format-on-save-runner.ts
+++ b/src/main/format-on-save-runner.ts
@@ -1,10 +1,13 @@
-import { exec, execFile } from 'node:child_process'
 import {
   expandFormatOnSaveCommand,
   isFormatOnSaveConfigured,
   matchesFormatOnSaveInclude,
   type FormatOnSaveResult
 } from '../shared/format-on-save-command'
+import { executeFormatCommand, type FormatCommandExecution } from './format-on-save-process'
+import { FORMAT_ON_SAVE_TIMEOUT_MS } from './format-on-save-timeout'
+
+export { FORMAT_ON_SAVE_TIMEOUT_MS }
 import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison,
@@ -12,18 +15,7 @@ import {
   relativePathInsideRoot
 } from '../shared/cross-platform-path'
 import { stableInFlightKey } from '../shared/in-flight-promise-dedupe'
-import { getCmdExePath } from '../shared/windows-batch-spawn'
-import { parseWslPath, toLinuxPath } from './wsl'
 import type { RepoFormatOnSaveSettings } from '../shared/types'
-
-/** Long enough for a cold `npx prettier`, short enough that a hung formatter frees the file quickly. */
-export const FORMAT_ON_SAVE_TIMEOUT_MS = 20_000
-
-// Why: node's 1 MB default turns a chatty-but-successful formatter (`black
-// --verbose`, `prettier --loglevel debug`) into a reported failure even though
-// the file was rewritten correctly. The output is discarded on success, so the
-// only thing a larger cap costs is a transient buffer.
-const FORMAT_ON_SAVE_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
 export type RemoteFormatExecResult = {
   stdout: string
@@ -181,138 +173,6 @@ export function getWorktreeRelativePath(
   }
 
   return normalizeRuntimePathSeparators(relativePath)
-}
-
-type FormatCommandExecution = {
-  command: string
-  worktreePath: string
-  absoluteFilePath: string
-  relativePath: string
-}
-
-async function executeFormatCommand({
-  command,
-  worktreePath,
-  absoluteFilePath,
-  relativePath
-}: FormatCommandExecution): Promise<FormatOnSaveResult> {
-  const wslInfo = parseWslPath(worktreePath)
-
-  if (wslInfo) {
-    // Why: the worktree lives on the WSL filesystem, so the formatter and the
-    // paths it receives must both be Linux-side; a Windows-native run would
-    // either miss the toolchain or crawl over the 9P bridge.
-    const wslCommand = expandFormatOnSaveCommand({
-      command,
-      absolutePath: toLinuxPath(absoluteFilePath),
-      relativePath,
-      platform: 'linux'
-    })
-    return runWslFormatCommand(wslInfo.distro, wslInfo.linuxPath, wslCommand)
-  }
-
-  const expanded = expandFormatOnSaveCommand({
-    command,
-    absolutePath: absoluteFilePath,
-    relativePath,
-    platform: process.platform
-  })
-
-  return new Promise<FormatOnSaveResult>((resolve) => {
-    exec(
-      expanded,
-      {
-        cwd: worktreePath,
-        timeout: FORMAT_ON_SAVE_TIMEOUT_MS,
-        maxBuffer: FORMAT_ON_SAVE_MAX_BUFFER_BYTES,
-        shell: getFormatShell(),
-        encoding: 'utf-8'
-      },
-      (error, stdout, stderr) => {
-        resolve(toFormatResult(error, stdout, stderr))
-      }
-    )
-  })
-}
-
-function runWslFormatCommand(
-  distro: string | null,
-  linuxCwd: string,
-  expandedCommand: string
-): Promise<FormatOnSaveResult> {
-  // Why: execFile avoids cmd.exe, which mangles the quoting the expansion just applied.
-  const escapedCwd = linuxCwd.split("'").join(`'\\''`)
-  const bashCommand = `cd '${escapedCwd}' && ${expandedCommand}`
-  const distroArgs = distro ? ['-d', distro] : []
-
-  return new Promise<FormatOnSaveResult>((resolve) => {
-    let child: ReturnType<typeof execFile> | null = null
-    let settled = false
-
-    const finish = (error: Error | null, stdout = '', stderr = ''): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      clearTimeout(timeout)
-      resolve(toFormatResult(error, stdout, stderr))
-    }
-
-    // Why: execFile's own timeout only signals wsl.exe, which can outlive the guest command.
-    const timeout = setTimeout(() => {
-      child?.kill()
-      finish(new Error(`Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`))
-    }, FORMAT_ON_SAVE_TIMEOUT_MS)
-
-    try {
-      child = execFile(
-        'wsl.exe',
-        [...distroArgs, '--', 'bash', '-c', bashCommand],
-        {
-          timeout: FORMAT_ON_SAVE_TIMEOUT_MS,
-          maxBuffer: FORMAT_ON_SAVE_MAX_BUFFER_BYTES,
-          encoding: 'utf-8'
-        },
-        (error, stdout, stderr) => {
-          finish(error ?? null, stdout, stderr)
-        }
-      )
-    } catch (error) {
-      finish(error instanceof Error ? error : new Error(String(error)))
-    }
-  })
-}
-
-function toFormatResult(
-  error: Error | null,
-  stdout: string | Buffer,
-  stderr: string | Buffer
-): FormatOnSaveResult {
-  if (!error) {
-    return { status: 'completed' }
-  }
-
-  // Why: a killed process reports the same "Command failed" as a parse error,
-  // and its stderr is usually empty — name the timeout so the user knows to look
-  // at the command rather than at their file.
-  if ((error as { killed?: boolean }).killed) {
-    return {
-      status: 'failed',
-      message: `Formatter timed out after ${FORMAT_ON_SAVE_TIMEOUT_MS}ms.`
-    }
-  }
-
-  // Why: formatters put the actionable parse error on stderr and exit non-zero;
-  // the Node error message alone ("Command failed") tells the user nothing.
-  const message = [String(stderr).trim(), String(stdout).trim(), error.message.trim()].find(
-    (candidate) => candidate.length > 0
-  )
-
-  return { status: 'failed', message: message ?? 'Formatter failed.' }
-}
-
-function getFormatShell(): string | undefined {
-  return process.platform === 'win32' ? getCmdExePath() : '/bin/bash'
 }
 
 export function _resetFormatOnSaveInFlightForTests(): void {

--- a/src/main/format-on-save-timeout.ts
+++ b/src/main/format-on-save-timeout.ts
@@ -1,0 +1,2 @@
+/** Long enough for a cold `npx prettier`, short enough that a hung formatter frees the file quickly. */
+export const FORMAT_ON_SAVE_TIMEOUT_MS = 20_000

--- a/src/main/ipc/editor-format-on-save.test.ts
+++ b/src/main/ipc/editor-format-on-save.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../shared/types'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  runFormatOnSave: vi.fn(),
+  resolveRegisteredWorktreePath: vi.fn()
+}))
+
+const handleMock = mocks.handle
+const removeHandlerMock = mocks.removeHandler
+const runFormatOnSaveMock = mocks.runFormatOnSave
+const resolveRegisteredWorktreePathMock = mocks.resolveRegisteredWorktreePath
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mocks.handle,
+    removeHandler: mocks.removeHandler
+  }
+}))
+
+vi.mock('../format-on-save-runner', () => ({
+  runFormatOnSave: mocks.runFormatOnSave
+}))
+
+vi.mock('./filesystem-auth', () => ({
+  resolveRegisteredWorktreePath: mocks.resolveRegisteredWorktreePath
+}))
+
+import { registerEditorFormatOnSaveHandlers } from './editor-format-on-save'
+
+const CONFIGURED = {
+  enabled: true,
+  command: 'prettier --write ${file}',
+  include: ['**/*.ts']
+}
+
+function localRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#000000',
+    addedAt: 1,
+    kind: 'git',
+    formatOnSave: CONFIGURED,
+    ...overrides
+  } as Repo
+}
+
+function registerWith(repo: Repo | undefined): (args: unknown) => Promise<unknown> {
+  const store = { getRepo: vi.fn(() => repo) }
+  registerEditorFormatOnSaveHandlers(store as never)
+  const entry = handleMock.mock.calls.find((call) => call[0] === 'editor:formatOnSave')
+  if (!entry) {
+    throw new Error('handler was not registered')
+  }
+  return (args: unknown) => entry[1](null, args)
+}
+
+const VALID_ARGS = {
+  repoId: 'repo-1',
+  worktreePath: '/repo',
+  filePath: '/repo/src/a.ts'
+}
+
+beforeEach(() => {
+  handleMock.mockReset()
+  removeHandlerMock.mockReset()
+  runFormatOnSaveMock.mockReset()
+  runFormatOnSaveMock.mockResolvedValue({ status: 'completed' })
+  resolveRegisteredWorktreePathMock.mockReset()
+  resolveRegisteredWorktreePathMock.mockImplementation(async (value: string) => value)
+})
+
+describe('editor:formatOnSave handler', () => {
+  it('runs the command stored on the repo, never one supplied by the caller', async () => {
+    const invoke = registerWith(localRepo())
+
+    await invoke({ ...VALID_ARGS, command: 'rm -rf ~', settings: { command: 'rm -rf ~' } })
+
+    expect(runFormatOnSaveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({ command: CONFIGURED.command })
+      })
+    )
+    const passed = runFormatOnSaveMock.mock.calls[0][0]
+    expect(JSON.stringify(passed)).not.toContain('rm -rf')
+  })
+
+  it('authorizes the worktree path before running anything', async () => {
+    resolveRegisteredWorktreePathMock.mockRejectedValue(
+      new Error('Access denied: unknown repository or worktree path')
+    )
+    const invoke = registerWith(localRepo())
+
+    await expect(invoke({ ...VALID_ARGS, worktreePath: '/etc' })).rejects.toThrow('Access denied')
+    expect(runFormatOnSaveMock).not.toHaveBeenCalled()
+  })
+
+  it('skips SSH-backed repos instead of running a local command for a remote file', async () => {
+    const invoke = registerWith(localRepo({ connectionId: 'ssh-target-1' }))
+
+    await expect(invoke(VALID_ARGS)).resolves.toEqual({
+      status: 'skipped',
+      reason: 'unsupported-host'
+    })
+    expect(runFormatOnSaveMock).not.toHaveBeenCalled()
+  })
+
+  it('skips repos owned by a runtime host', async () => {
+    const invoke = registerWith(localRepo({ executionHostId: 'runtime:env-1' }))
+
+    await expect(invoke(VALID_ARGS)).resolves.toEqual({
+      status: 'skipped',
+      reason: 'unsupported-host'
+    })
+    expect(runFormatOnSaveMock).not.toHaveBeenCalled()
+  })
+
+  it('skips an unknown repo id without touching the authorizer', async () => {
+    const invoke = registerWith(undefined)
+
+    await expect(invoke(VALID_ARGS)).resolves.toEqual({
+      status: 'skipped',
+      reason: 'not-configured'
+    })
+    expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
+    expect(runFormatOnSaveMock).not.toHaveBeenCalled()
+  })
+
+  it('skips a repo that has not configured a formatter', async () => {
+    const invoke = registerWith(localRepo({ formatOnSave: undefined }))
+
+    await expect(invoke(VALID_ARGS)).resolves.toEqual({
+      status: 'skipped',
+      reason: 'not-configured'
+    })
+    expect(runFormatOnSaveMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed payloads before resolving any path', async () => {
+    const invoke = registerWith(localRepo())
+
+    await expect(invoke({ repoId: 'repo-1', worktreePath: '/repo' })).rejects.toThrow(
+      'requires a repo, worktree, and file path'
+    )
+    await expect(invoke({ ...VALID_ARGS, filePath: '/repo/a\0.ts' })).rejects.toThrow(
+      'Access denied'
+    )
+    expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
+    expect(runFormatOnSaveMock).not.toHaveBeenCalled()
+  })
+
+  it('passes the authorized path to the runner, not the caller-supplied one', async () => {
+    resolveRegisteredWorktreePathMock.mockResolvedValue('/resolved/repo')
+    const invoke = registerWith(localRepo())
+
+    await invoke({ ...VALID_ARGS, worktreePath: '/repo/../repo' })
+
+    expect(runFormatOnSaveMock).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreePath: '/resolved/repo' })
+    )
+  })
+
+  it('replaces a stale handler when handlers are re-registered', () => {
+    registerWith(localRepo())
+    expect(removeHandlerMock).toHaveBeenCalledWith('editor:formatOnSave')
+  })
+})

--- a/src/main/ipc/editor-format-on-save.test.ts
+++ b/src/main/ipc/editor-format-on-save.test.ts
@@ -5,13 +5,15 @@ const mocks = vi.hoisted(() => ({
   handle: vi.fn(),
   removeHandler: vi.fn(),
   runFormatOnSave: vi.fn(),
-  resolveRegisteredWorktreePath: vi.fn()
+  resolveRegisteredWorktreePath: vi.fn(),
+  getSshGitProvider: vi.fn()
 }))
 
 const handleMock = mocks.handle
 const removeHandlerMock = mocks.removeHandler
 const runFormatOnSaveMock = mocks.runFormatOnSave
 const resolveRegisteredWorktreePathMock = mocks.resolveRegisteredWorktreePath
+const getSshGitProviderMock = mocks.getSshGitProvider
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -26,6 +28,10 @@ vi.mock('../format-on-save-runner', () => ({
 
 vi.mock('./filesystem-auth', () => ({
   resolveRegisteredWorktreePath: mocks.resolveRegisteredWorktreePath
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: mocks.getSshGitProvider
 }))
 
 import { registerEditorFormatOnSaveHandlers } from './editor-format-on-save'
@@ -72,6 +78,8 @@ beforeEach(() => {
   runFormatOnSaveMock.mockResolvedValue({ status: 'completed' })
   resolveRegisteredWorktreePathMock.mockReset()
   resolveRegisteredWorktreePathMock.mockImplementation(async (value: string) => value)
+  getSshGitProviderMock.mockReset()
+  getSshGitProviderMock.mockReturnValue(undefined)
 })
 
 describe('editor:formatOnSave handler', () => {
@@ -99,7 +107,36 @@ describe('editor:formatOnSave handler', () => {
     expect(runFormatOnSaveMock).not.toHaveBeenCalled()
   })
 
-  it('skips SSH-backed repos instead of running a local command for a remote file', async () => {
+  it('formats an SSH repo through its relay rather than running the command locally', async () => {
+    const execNonInteractive = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    })
+    getSshGitProviderMock.mockReturnValue({ execNonInteractive })
+    const invoke = registerWith(localRepo({ connectionId: 'ssh-target-1' }))
+
+    await invoke(VALID_ARGS)
+
+    const passed = runFormatOnSaveMock.mock.calls[0][0]
+    expect(passed.remoteExec).toBeTypeOf('function')
+    expect(passed.hostScope).toBe('ssh-target-1')
+    // Why: remote paths belong to the remote host; the local registered-root
+    // check would reject or rewrite them.
+    expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
+
+    await passed.remoteExec({
+      binary: '/bin/bash',
+      args: ['-lc', 'fmt'],
+      cwd: '/srv',
+      timeoutMs: 1
+    })
+    expect(execNonInteractive).toHaveBeenCalledWith('/bin/bash', ['-lc', 'fmt'], '/srv', 1)
+  })
+
+  it('skips an SSH repo whose relay is not connected', async () => {
+    getSshGitProviderMock.mockReturnValue(undefined)
     const invoke = registerWith(localRepo({ connectionId: 'ssh-target-1' }))
 
     await expect(invoke(VALID_ARGS)).resolves.toEqual({

--- a/src/main/ipc/editor-format-on-save.test.ts
+++ b/src/main/ipc/editor-format-on-save.test.ts
@@ -5,14 +5,14 @@ const mocks = vi.hoisted(() => ({
   handle: vi.fn(),
   removeHandler: vi.fn(),
   runFormatOnSave: vi.fn(),
-  resolveRegisteredWorktreePath: vi.fn(),
+  resolveRepoOwnedWorktreePath: vi.fn(),
   getSshGitProvider: vi.fn()
 }))
 
 const handleMock = mocks.handle
 const removeHandlerMock = mocks.removeHandler
 const runFormatOnSaveMock = mocks.runFormatOnSave
-const resolveRegisteredWorktreePathMock = mocks.resolveRegisteredWorktreePath
+const resolveRepoOwnedWorktreePathMock = mocks.resolveRepoOwnedWorktreePath
 const getSshGitProviderMock = mocks.getSshGitProvider
 
 vi.mock('electron', () => ({
@@ -26,8 +26,8 @@ vi.mock('../format-on-save-runner', () => ({
   runFormatOnSave: mocks.runFormatOnSave
 }))
 
-vi.mock('./filesystem-auth', () => ({
-  resolveRegisteredWorktreePath: mocks.resolveRegisteredWorktreePath
+vi.mock('./repo-owned-worktree-path', () => ({
+  resolveRepoOwnedWorktreePath: mocks.resolveRepoOwnedWorktreePath
 }))
 
 vi.mock('../providers/ssh-git-dispatch', () => ({
@@ -76,8 +76,10 @@ beforeEach(() => {
   removeHandlerMock.mockReset()
   runFormatOnSaveMock.mockReset()
   runFormatOnSaveMock.mockResolvedValue({ status: 'completed' })
-  resolveRegisteredWorktreePathMock.mockReset()
-  resolveRegisteredWorktreePathMock.mockImplementation(async (value: string) => value)
+  resolveRepoOwnedWorktreePathMock.mockReset()
+  resolveRepoOwnedWorktreePathMock.mockImplementation(
+    async (_repo: unknown, _store: unknown, value: string) => value
+  )
   getSshGitProviderMock.mockReset()
   getSshGitProviderMock.mockReturnValue(undefined)
 })
@@ -97,9 +99,9 @@ describe('editor:formatOnSave handler', () => {
     expect(JSON.stringify(passed)).not.toContain('rm -rf')
   })
 
-  it('authorizes the worktree path before running anything', async () => {
-    resolveRegisteredWorktreePathMock.mockRejectedValue(
-      new Error('Access denied: unknown repository or worktree path')
+  it('refuses a worktree that belongs to a different repo', async () => {
+    resolveRepoOwnedWorktreePathMock.mockRejectedValue(
+      new Error('Access denied: worktree does not belong to repository')
     )
     const invoke = registerWith(localRepo())
 
@@ -122,9 +124,13 @@ describe('editor:formatOnSave handler', () => {
     const passed = runFormatOnSaveMock.mock.calls[0][0]
     expect(passed.remoteExec).toBeTypeOf('function')
     expect(passed.hostScope).toBe('ssh-target-1')
-    // Why: remote paths belong to the remote host; the local registered-root
-    // check would reject or rewrite them.
-    expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
+    // Why: the remote path is authorized against the repo too — the helper
+    // handles the remote path shape rather than resolving it locally.
+    expect(resolveRepoOwnedWorktreePathMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'repo-1' }),
+      expect.anything(),
+      VALID_ARGS.worktreePath
+    )
 
     await passed.remoteExec({
       binary: '/bin/bash',
@@ -163,7 +169,7 @@ describe('editor:formatOnSave handler', () => {
       status: 'skipped',
       reason: 'not-configured'
     })
-    expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
+    expect(resolveRepoOwnedWorktreePathMock).not.toHaveBeenCalled()
     expect(runFormatOnSaveMock).not.toHaveBeenCalled()
   })
 
@@ -186,12 +192,12 @@ describe('editor:formatOnSave handler', () => {
     await expect(invoke({ ...VALID_ARGS, filePath: '/repo/a\0.ts' })).rejects.toThrow(
       'Access denied'
     )
-    expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
+    expect(resolveRepoOwnedWorktreePathMock).not.toHaveBeenCalled()
     expect(runFormatOnSaveMock).not.toHaveBeenCalled()
   })
 
   it('passes the authorized path to the runner, not the caller-supplied one', async () => {
-    resolveRegisteredWorktreePathMock.mockResolvedValue('/resolved/repo')
+    resolveRepoOwnedWorktreePathMock.mockResolvedValue('/resolved/repo')
     const invoke = registerWith(localRepo())
 
     await invoke({ ...VALID_ARGS, worktreePath: '/repo/../repo' })

--- a/src/main/ipc/editor-format-on-save.ts
+++ b/src/main/ipc/editor-format-on-save.ts
@@ -8,7 +8,7 @@ import {
 } from '../../shared/format-on-save-command'
 import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
-import { resolveRegisteredWorktreePath } from './filesystem-auth'
+import { resolveRepoOwnedWorktreePath } from './repo-owned-worktree-path'
 import type { RemoteFormatExecutor } from '../format-on-save-runner'
 
 type FormatOnSaveArgs = {
@@ -43,6 +43,11 @@ export function registerEditorFormatOnSaveHandlers(store: Store): void {
         return { status: 'skipped', reason: 'unsupported-host' }
       }
 
+      // Why: proves the worktree is registered AND owned by this repo, so a
+      // caller cannot pair one repo's configured command with another repo's
+      // worktree. Handles the remote path shape for SSH repos too.
+      const worktreePath = await resolveRepoOwnedWorktreePath(repo, store, args.worktreePath)
+
       if (repo.connectionId) {
         const remoteExec = createRemoteFormatExecutor(repo.connectionId)
         if (!remoteExec) {
@@ -52,16 +57,13 @@ export function registerEditorFormatOnSaveHandlers(store: Store): void {
         }
         return runFormatOnSave({
           settings,
-          // Why: remote paths are the remote host's to validate; the local
-          // registered-root check would reject or rewrite them.
-          worktreePath: args.worktreePath,
+          worktreePath,
           absoluteFilePath: args.filePath,
           remoteExec,
           hostScope: repo.connectionId
         })
       }
 
-      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       return runFormatOnSave({
         settings,
         worktreePath,

--- a/src/main/ipc/editor-format-on-save.ts
+++ b/src/main/ipc/editor-format-on-save.ts
@@ -1,0 +1,66 @@
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import { runFormatOnSave } from '../format-on-save-runner'
+import {
+  isFormatOnSaveConfigured,
+  normalizeRepoFormatOnSaveSettings,
+  type FormatOnSaveResult
+} from '../../shared/format-on-save-command'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
+import { resolveRegisteredWorktreePath } from './filesystem-auth'
+
+type FormatOnSaveArgs = {
+  repoId: string
+  worktreePath: string
+  filePath: string
+}
+
+export function registerEditorFormatOnSaveHandlers(store: Store): void {
+  ipcMain.removeHandler('editor:formatOnSave')
+
+  ipcMain.handle(
+    'editor:formatOnSave',
+    async (_event, rawArgs: unknown): Promise<FormatOnSaveResult> => {
+      const args = parseFormatOnSaveArgs(rawArgs)
+      const repo = store.getRepo(args.repoId)
+      if (!repo) {
+        return { status: 'skipped', reason: 'not-configured' }
+      }
+
+      // Why: the command is read from the repo record, never from the renderer —
+      // otherwise this handler would be an arbitrary-command-execution channel.
+      const settings = normalizeRepoFormatOnSaveSettings(repo.formatOnSave)
+      if (!isFormatOnSaveConfigured(settings)) {
+        return { status: 'skipped', reason: 'not-configured' }
+      }
+
+      const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+      if (repo.connectionId || (host && host.kind !== 'local')) {
+        return { status: 'skipped', reason: 'unsupported-host' }
+      }
+
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      return runFormatOnSave({
+        settings,
+        worktreePath,
+        absoluteFilePath: args.filePath
+      })
+    }
+  )
+}
+
+function parseFormatOnSaveArgs(rawArgs: unknown): FormatOnSaveArgs {
+  const args = (rawArgs ?? {}) as Partial<FormatOnSaveArgs>
+  const repoId = typeof args.repoId === 'string' ? args.repoId : ''
+  const worktreePath = typeof args.worktreePath === 'string' ? args.worktreePath : ''
+  const filePath = typeof args.filePath === 'string' ? args.filePath : ''
+
+  if (!repoId || !worktreePath || !filePath) {
+    throw new Error('Format on save requires a repo, worktree, and file path.')
+  }
+  if (filePath.includes('\0')) {
+    throw new Error('Access denied: invalid file path')
+  }
+
+  return { repoId, worktreePath, filePath }
+}

--- a/src/main/ipc/editor-format-on-save.ts
+++ b/src/main/ipc/editor-format-on-save.ts
@@ -7,7 +7,9 @@ import {
   type FormatOnSaveResult
 } from '../../shared/format-on-save-command'
 import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import { resolveRegisteredWorktreePath } from './filesystem-auth'
+import type { RemoteFormatExecutor } from '../format-on-save-runner'
 
 type FormatOnSaveArgs = {
   repoId: string
@@ -35,8 +37,28 @@ export function registerEditorFormatOnSaveHandlers(store: Store): void {
       }
 
       const host = parseExecutionHostId(getRepoExecutionHostId(repo))
-      if (repo.connectionId || (host && host.kind !== 'local')) {
+      // Why: runtime hosts have no non-interactive exec channel of their own, so
+      // the formatter can't reach the file. SSH does, via agent.execNonInteractive.
+      if (!repo.connectionId && host && host.kind !== 'local') {
         return { status: 'skipped', reason: 'unsupported-host' }
+      }
+
+      if (repo.connectionId) {
+        const remoteExec = createRemoteFormatExecutor(repo.connectionId)
+        if (!remoteExec) {
+          // Why: a disconnected SSH host isn't a formatter failure — the save
+          // already landed, so stay quiet and let the next save format.
+          return { status: 'skipped', reason: 'unsupported-host' }
+        }
+        return runFormatOnSave({
+          settings,
+          // Why: remote paths are the remote host's to validate; the local
+          // registered-root check would reject or rewrite them.
+          worktreePath: args.worktreePath,
+          absoluteFilePath: args.filePath,
+          remoteExec,
+          hostScope: repo.connectionId
+        })
       }
 
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
@@ -47,6 +69,16 @@ export function registerEditorFormatOnSaveHandlers(store: Store): void {
       })
     }
   )
+}
+
+function createRemoteFormatExecutor(connectionId: string): RemoteFormatExecutor | null {
+  const provider = getSshGitProvider(connectionId)
+  if (!provider) {
+    return null
+  }
+
+  return ({ binary, args, cwd, timeoutMs }) =>
+    provider.execNonInteractive(binary, args, cwd, timeoutMs)
 }
 
 function parseFormatOnSaveArgs(rawArgs: unknown): FormatOnSaveArgs {

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -1,5 +1,5 @@
+import { resolve } from 'node:path'
 import { ipcMain } from 'electron'
-import { posix, resolve } from 'node:path'
 import type {
   CreateHostedReviewArgs,
   HostedReviewCreationEligibilityArgs,
@@ -13,8 +13,7 @@ import {
   getHostedReviewCreationEligibility
 } from '../source-control/hosted-review-creation'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
-import { resolveRegisteredWorktreePath } from './filesystem-auth'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { resolveRepoOwnedWorktreePath } from './repo-owned-worktree-path'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 
@@ -32,48 +31,6 @@ function assertRegisteredRepo(repoPath: string, store: Store, repoId?: string): 
     throw new Error('Access denied: unknown repository path')
   }
   return repo
-}
-
-async function resolveHostedReviewWorktreePath(
-  repo: Repo,
-  store: Store,
-  worktreePath?: string
-): Promise<string> {
-  if (!worktreePath) {
-    return repo.path
-  }
-  if (repo.connectionId) {
-    const remoteWorktreePath = normalizeRemoteHostedReviewPath(worktreePath)
-    const repoWorktrees = await listRepoWorktrees(repo)
-    if (
-      !repoWorktrees.some(
-        (worktree) => normalizeRemoteHostedReviewPath(worktree.path) === remoteWorktreePath
-      )
-    ) {
-      throw new Error('Access denied: worktree does not belong to repository')
-    }
-    return remoteWorktreePath
-  }
-  const resolvedWorktreePath = await resolveRegisteredWorktreePath(worktreePath, store)
-  const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
-  const repoWorktrees =
-    Object.keys(localGitOptions).length > 0
-      ? await listRepoWorktrees(repo, localGitOptions)
-      : await listRepoWorktrees(repo)
-  if (!repoWorktrees.some((worktree) => resolve(worktree.path) === resolvedWorktreePath)) {
-    throw new Error('Access denied: worktree does not belong to repository')
-  }
-  return resolvedWorktreePath
-}
-
-function normalizeRemoteHostedReviewPath(remotePath: string): string {
-  if (!remotePath || remotePath.includes('\0')) {
-    throw new Error('Access denied: invalid worktree path')
-  }
-  // Why: SSH worktree paths belong to the remote POSIX host. Local path.resolve
-  // rewrites them on Windows and cannot authorize remote-only paths.
-  const normalized = posix.normalize(remotePath)
-  return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized
 }
 
 export function registerHostedReviewHandlers(store: Store, stats: StatsCollector): void {
@@ -108,7 +65,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
     'hostedReview:getCreationEligibility',
     async (_event, args: HostedReviewCreationEligibilityArgs) => {
       const repo = assertRegisteredRepo(args.repoPath, store, args.repoId)
-      const worktreePath = await resolveHostedReviewWorktreePath(repo, store, args.worktreePath)
+      const worktreePath = await resolveRepoOwnedWorktreePath(repo, store, args.worktreePath)
       const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
       return getHostedReviewCreationEligibility({
         ...args,
@@ -121,7 +78,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
 
   ipcMain.handle('hostedReview:create', async (_event, args: CreateHostedReviewArgs) => {
     const repo = assertRegisteredRepo(args.repoPath, store, args.repoId)
-    const worktreePath = await resolveHostedReviewWorktreePath(repo, store, args.worktreePath)
+    const worktreePath = await resolveRepoOwnedWorktreePath(repo, store, args.worktreePath)
     const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
     // Why: the dirty preflight must not count Orca's own shared symlinks as user work (issue #10451).
     // Remote creation never materializes them, and `repo.path` is a path on the

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -62,6 +62,7 @@ const {
   registerWorkspaceSpaceHandlersMock,
   registerWorkspacePortHandlersMock,
   registerLocalhostWorktreeLabelHandlersMock,
+  registerEditorFormatOnSaveHandlersMock,
   registerNativeChatHandlersMock,
   registerEmulatorFrameStreamHandlersMock,
   registerEmulatorVideoStreamHandlersMock
@@ -127,6 +128,7 @@ const {
   registerWorkspaceSpaceHandlersMock: vi.fn(),
   registerWorkspacePortHandlersMock: vi.fn(),
   registerLocalhostWorktreeLabelHandlersMock: vi.fn(),
+  registerEditorFormatOnSaveHandlersMock: vi.fn(),
   registerNativeChatHandlersMock: vi.fn(),
   registerEmulatorFrameStreamHandlersMock: vi.fn(),
   registerEmulatorVideoStreamHandlersMock: vi.fn()
@@ -240,6 +242,10 @@ vi.mock('./workspace-ports', () => ({
 
 vi.mock('./localhost-worktree-labels', () => ({
   registerLocalhostWorktreeLabelHandlers: registerLocalhostWorktreeLabelHandlersMock
+}))
+
+vi.mock('./editor-format-on-save', () => ({
+  registerEditorFormatOnSaveHandlers: registerEditorFormatOnSaveHandlersMock
 }))
 
 vi.mock('./keybindings', () => ({
@@ -442,6 +448,7 @@ describe('registerCoreHandlers', () => {
     registerWorkspaceSpaceHandlersMock.mockReset()
     registerWorkspacePortHandlersMock.mockReset()
     registerLocalhostWorktreeLabelHandlersMock.mockReset()
+    registerEditorFormatOnSaveHandlersMock.mockReset()
     registerNativeChatHandlersMock.mockReset()
     registerEmulatorFrameStreamHandlersMock.mockReset()
     registerEmulatorVideoStreamHandlersMock.mockReset()
@@ -526,6 +533,7 @@ describe('registerCoreHandlers', () => {
     expect(registerWorkspaceSpaceHandlersMock).toHaveBeenCalledWith(store)
     expect(registerWorkspacePortHandlersMock).toHaveBeenCalledWith(store)
     expect(registerLocalhostWorktreeLabelHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerEditorFormatOnSaveHandlersMock).toHaveBeenCalledWith(store)
     expect(registerTelemetryHandlersMock).toHaveBeenCalledWith(store)
     expect(registerOrcaProfileHandlersMock).toHaveBeenCalledWith(store, { onBeforeRelaunch })
     expect(registerSessionHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -46,6 +46,7 @@ import { registerSkillsHandlers } from './skills'
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
 import { registerWorkspacePortHandlers } from './workspace-ports'
 import { registerLocalhostWorktreeLabelHandlers } from './localhost-worktree-labels'
+import { registerEditorFormatOnSaveHandlers } from './editor-format-on-save'
 import { registerAutomationHandlers } from './automations'
 import { registerKeybindingHandlers } from './keybindings'
 import { registerTelemetryHandlers } from './telemetry'
@@ -206,6 +207,7 @@ export function registerCoreHandlers(
   registerWorkspaceSpaceHandlers(store)
   registerWorkspacePortHandlers(store)
   registerLocalhostWorktreeLabelHandlers(store)
+  registerEditorFormatOnSaveHandlers(store)
   if (commitMessageAgentEnv) {
     registerFilesystemHandlers(store, commitMessageAgentEnv)
   } else {

--- a/src/main/ipc/repo-owned-worktree-path.ts
+++ b/src/main/ipc/repo-owned-worktree-path.ts
@@ -1,0 +1,55 @@
+import { posix, resolve } from 'node:path'
+import type { Repo } from '../../shared/types'
+import type { Store } from '../persistence'
+import { listRepoWorktrees } from '../repo-worktrees'
+import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+import { resolveRegisteredWorktreePath } from './filesystem-auth'
+
+/**
+ * Authorize a caller-supplied worktree path against one repo.
+ *
+ * Why both checks: `resolveRegisteredWorktreePath` only proves the path is a
+ * worktree Orca knows about, not that it belongs to `repo`. Without the second
+ * step a caller can pair one repo's configuration with another repo's worktree.
+ */
+export async function resolveRepoOwnedWorktreePath(
+  repo: Repo,
+  store: Store,
+  worktreePath?: string
+): Promise<string> {
+  if (!worktreePath) {
+    return repo.path
+  }
+  if (repo.connectionId) {
+    const remoteWorktreePath = normalizeRemoteWorktreePath(worktreePath)
+    const repoWorktrees = await listRepoWorktrees(repo)
+    if (
+      !repoWorktrees.some(
+        (worktree) => normalizeRemoteWorktreePath(worktree.path) === remoteWorktreePath
+      )
+    ) {
+      throw new Error('Access denied: worktree does not belong to repository')
+    }
+    return remoteWorktreePath
+  }
+  const resolvedWorktreePath = await resolveRegisteredWorktreePath(worktreePath, store)
+  const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
+  const repoWorktrees =
+    Object.keys(localGitOptions).length > 0
+      ? await listRepoWorktrees(repo, localGitOptions)
+      : await listRepoWorktrees(repo)
+  if (!repoWorktrees.some((worktree) => resolve(worktree.path) === resolvedWorktreePath)) {
+    throw new Error('Access denied: worktree does not belong to repository')
+  }
+  return resolvedWorktreePath
+}
+
+export function normalizeRemoteWorktreePath(remotePath: string): string {
+  if (!remotePath || remotePath.includes('\0')) {
+    throw new Error('Access denied: invalid worktree path')
+  }
+  // Why: SSH worktree paths belong to the remote POSIX host. Local path.resolve
+  // rewrites them on Windows and cannot authorize remote-only paths.
+  const normalized = posix.normalize(remotePath)
+  return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized
+}

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -2082,6 +2082,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
             | 'repoIcon'
             | 'upstream'
             | 'hookSettings'
+            | 'formatOnSave'
             | 'worktreeBaseRef'
             | 'worktreeBasePath'
             | 'kind'

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4547,6 +4547,7 @@ export class Store {
         | 'upstream'
         | 'gitRemoteIdentity'
         | 'hookSettings'
+        | 'formatOnSave'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
         | 'kind'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -17941,6 +17941,7 @@ export class OrcaRuntimeService {
         | 'repoIcon'
         | 'upstream'
         | 'hookSettings'
+        | 'formatOnSave'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
         | 'kind'

--- a/src/main/runtime/rpc/methods/repo-update-schema.ts
+++ b/src/main/runtime/rpc/methods/repo-update-schema.ts
@@ -44,6 +44,7 @@ export function createRepoUpdateSchema<T extends z.ZodRawShape>(
         .optional(),
       upstream: RepoUpstream,
       hookSettings: z.unknown().optional(),
+      formatOnSave: z.unknown().optional(),
       worktreeBaseRef: OptionalString,
       worktreeBasePath: OptionalString,
       kind: z.enum(['git', 'folder']).optional(),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -9,6 +9,7 @@ import type {
   HostedReviewProvider
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
+import type { FormatOnSaveResult } from '../shared/format-on-save-command'
 import type { BrowserFindSource } from '../shared/browser-find-source'
 import type { DashboardSnapshot, DashboardRevealAgentArgs } from '../shared/dashboard-snapshot'
 import type {
@@ -1203,6 +1204,7 @@ export type PreloadApi = {
           | 'repoIcon'
           | 'upstream'
           | 'hookSettings'
+          | 'formatOnSave'
           | 'worktreeBaseRef'
           | 'worktreeBasePath'
           | 'kind'
@@ -2565,6 +2567,13 @@ export type PreloadApi = {
       content: string
       hostId?: ExecutionHostId
     }) => Promise<void>
+  }
+  editor: {
+    formatOnSave: (args: {
+      repoId: string
+      worktreePath: string
+      filePath: string
+    }) => Promise<FormatOnSaveResult>
   }
   ephemeralVm: {
     listRecipes: (args: { repoId: string }) => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,7 @@ import type {
   TerminalPreviewDataPayload
 } from '../shared/terminal-preview'
 import type { CliInstallStatus } from '../shared/cli-install-types'
+import type { FormatOnSaveResult } from '../shared/format-on-save-command'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type { CodexConfigSyncStatus } from '../shared/codex-config-sync-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
@@ -2885,6 +2886,14 @@ const api = {
       content: string
       hostId?: ExecutionHostId
     }): Promise<void> => ipcRenderer.invoke('hooks:writeIssueCommand', args)
+  },
+
+  editor: {
+    formatOnSave: (args: {
+      repoId: string
+      worktreePath: string
+      filePath: string
+    }): Promise<FormatOnSaveResult> => ipcRenderer.invoke('editor:formatOnSave', args)
   },
 
   ephemeralVm: {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3539,3 +3539,39 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
     inset 0 1px 0 0 color-mix(in srgb, var(--foreground) 5%, transparent),
     0 10px 24px rgba(0, 0, 0, 0.18);
 }
+
+/* Why: the format-on-save switch needs a command before it can be turned on;
+   nudging the command field points at what to fill in instead of leaving the
+   user with a switch that springs back. */
+@keyframes format-on-save-command-nudge {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  20% {
+    transform: translateX(-4px);
+  }
+
+  40% {
+    transform: translateX(4px);
+  }
+
+  60% {
+    transform: translateX(-3px);
+  }
+
+  80% {
+    transform: translateX(2px);
+  }
+}
+
+.animate-format-on-save-command-nudge {
+  animation: format-on-save-command-nudge 0.36s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-format-on-save-command-nudge {
+    animation: none;
+  }
+}

--- a/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
@@ -65,13 +65,16 @@ vi.mock('@/lib/lazy-with-retry', async () => {
             }),
             pushEditOperations: (_selections: unknown[], operations: { text: string }[]) => {
               retained.content = operations[0]?.text ?? retained.content
-            }
+            },
+            validatePosition: (position: unknown) => position
           }
           // Why: exercising the real mount reconciler makes outer key ordering
           // observable without replacing Monaco's retained-model semantics.
           syncContentOnMount(
             {
               getModel: () => model,
+              getSelections: () => [],
+              setSelections: () => undefined,
               pushUndoStop: () => {
                 retained.undo.push('unexpected undo stop')
                 return true

--- a/src/renderer/src/components/editor/editor-autosave-controller-test-fixture.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller-test-fixture.ts
@@ -15,14 +15,26 @@ export type EditorWindowStub = {
   api: {
     fs: {
       writeFile: ReturnType<typeof vi.fn>
+      readFile: ReturnType<typeof vi.fn>
+    }
+    editor: {
+      formatOnSave: ReturnType<typeof vi.fn>
     }
   }
 }
 
 /** Stubs the global window with an isolated event target and fs bridge;
- *  returns the writeFile mock for assertions. */
-export function stubEditorWindow(): ReturnType<typeof vi.fn> {
+ *  returns the writeFile mock for assertions. Format-on-save is stubbed as
+ *  "nothing configured" so suites that don't care about it stay unaffected. */
+export function stubEditorWindow(overrides?: {
+  readFile?: ReturnType<typeof vi.fn>
+  formatOnSave?: ReturnType<typeof vi.fn>
+}): ReturnType<typeof vi.fn> {
   const writeFile = vi.fn().mockResolvedValue(undefined)
+  const readFile = overrides?.readFile ?? vi.fn().mockResolvedValue({ content: '' })
+  const formatOnSave =
+    overrides?.formatOnSave ??
+    vi.fn().mockResolvedValue({ status: 'skipped', reason: 'not-configured' })
   const eventTarget = new EventTarget()
   vi.stubGlobal('window', {
     addEventListener: eventTarget.addEventListener.bind(eventTarget),
@@ -32,7 +44,11 @@ export function stubEditorWindow(): ReturnType<typeof vi.fn> {
     clearTimeout: globalThis.clearTimeout.bind(globalThis),
     api: {
       fs: {
-        writeFile
+        writeFile,
+        readFile
+      },
+      editor: {
+        formatOnSave
       }
     }
   } satisfies EditorWindowStub)
@@ -45,7 +61,7 @@ export function createEditorStore(): StoreApi<AppState> {
     activeWorktreeId: 'wt-1',
     repos: [],
     worktreesByRepo: {
-      'repo-1': [{ id: 'wt-1', repoId: 'repo-1', hostId: 'local' }]
+      'repo-1': [{ id: 'wt-1', repoId: 'repo-1', hostId: 'local', path: '/repo' }]
     },
     detectedWorktreesByRepo: {},
     runtimeEnvironments: [],

--- a/src/renderer/src/components/editor/editor-autosave-controller.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.ts
@@ -23,6 +23,7 @@ import {
   type EditorSaveQuiesceDetail
 } from './editor-autosave'
 import { markFileChangedOnDisk } from './editor-changed-on-disk-mark'
+import { maybeFormatSavedFile } from './editor-format-on-save'
 import { flushPendingEditorChange } from './editor-pending-flush'
 import {
   clearSelfWrite,
@@ -120,6 +121,13 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
           throw error
         }
 
+        const formattedContent = await maybeFormatSavedFile({
+          file: liveFile,
+          worktree,
+          fileContext,
+          savedContent: contentToSave
+        })
+
         if ((saveGeneration.get(file.id) ?? 0) !== queuedGeneration) {
           return
         }
@@ -127,12 +135,28 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
         const nextState = store.getState()
         const currentDraft = nextState.editorDrafts[file.id]
         const stillDirty = currentDraft !== undefined && currentDraft !== contentToSave
+        const diskContent = formattedContent ?? contentToSave
+        // Why: the formatter rewrote the file after our stamp, so re-stamp the new
+        // bytes or the watcher reports Orca's own formatting as an external edit.
+        if (formattedContent !== null) {
+          recordSelfWrite(
+            liveFile.filePath,
+            formattedContent,
+            liveFile.runtimeEnvironmentId,
+            connectionId || liveFile.runtimeEnvironmentId?.trim()
+              ? SELF_WRITE_REMOTE_TTL_MS
+              : undefined
+          )
+        }
+        // Why: adopting the formatted text into a buffer the user has typed into
+        // since the save would silently discard those keystrokes.
+        const bufferContent = stillDirty ? contentToSave : diskContent
         nextState.markFileDirty(file.id, stillDirty)
         if (!stillDirty) {
           nextState.clearEditorDraft(file.id)
         }
-        // Why: disk now holds contentToSave — rebaseline so our own save isn't flagged external; drop pending verification.
-        nextState.setLastKnownDiskSignature(file.id, getDiskBaselineSignature(contentToSave))
+        // Why: disk now holds diskContent — rebaseline so our own save isn't flagged external; drop pending verification.
+        nextState.setLastKnownDiskSignature(file.id, getDiskBaselineSignature(diskContent))
         nextState.clearPendingDiskBaselineVerification(file.id)
         // Why: the write made disk match the buffer, so clear any now-stale changed-on-disk conflict.
         const savedFile = nextState.openFiles.find((openFile) => openFile.id === file.id)
@@ -143,7 +167,7 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
 
         window.dispatchEvent(
           new CustomEvent<EditorFileSavedDetail>(ORCA_EDITOR_FILE_SAVED_EVENT, {
-            detail: { fileId: file.id, content: contentToSave }
+            detail: { fileId: file.id, content: bufferContent }
           })
         )
       })

--- a/src/renderer/src/components/editor/editor-autosave-controller.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.ts
@@ -148,9 +148,6 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
               : undefined
           )
         }
-        // Why: adopting the formatted text into a buffer the user has typed into
-        // since the save would silently discard those keystrokes.
-        const bufferContent = stillDirty ? contentToSave : diskContent
         nextState.markFileDirty(file.id, stillDirty)
         if (!stillDirty) {
           nextState.clearEditorDraft(file.id)
@@ -167,7 +164,11 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
 
         window.dispatchEvent(
           new CustomEvent<EditorFileSavedDetail>(ORCA_EDITOR_FILE_SAVED_EVENT, {
-            detail: { fileId: file.id, content: bufferContent }
+            // Why: this event states what is on disk, so it carries the
+            // formatted bytes even when the user has typed since the save. It
+            // updates the disk-side content only — the unsaved draft is kept by
+            // markFileDirty/clearEditorDraft above and still wins in the editor.
+            detail: { fileId: file.id, content: diskContent }
           })
         )
       })

--- a/src/renderer/src/components/editor/editor-autosave-format-on-save.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-format-on-save.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StoreApi } from 'zustand/vanilla'
+import type { AppState } from '@/store'
+import { attachEditorAutosaveController } from './editor-autosave-controller'
+import {
+  ORCA_EDITOR_FILE_SAVED_EVENT,
+  requestEditorFileSave,
+  type EditorFileSavedDetail
+} from './editor-autosave'
+import { createEditorStore, stubEditorWindow } from './editor-autosave-controller-test-fixture'
+import { __clearSelfWriteRegistryForTests, hasRecentSelfWrite } from './editor-self-write-registry'
+
+const UNFORMATTED = 'const a=1'
+const FORMATTED = 'const a = 1\n'
+
+let store: StoreApi<AppState>
+let detach: () => void
+let formatOnSave: ReturnType<typeof vi.fn>
+let readFile: ReturnType<typeof vi.fn>
+let writeFile: ReturnType<typeof vi.fn>
+
+const FILE_ID = '/repo/src/a.ts'
+
+function openEditableFile(): void {
+  store.getState().openFile({
+    filePath: FILE_ID,
+    relativePath: 'src/a.ts',
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    mode: 'edit'
+  } as never)
+}
+
+function savedContents(): string[] {
+  return savedEvents
+}
+
+let savedEvents: string[] = []
+
+beforeEach(() => {
+  savedEvents = []
+  formatOnSave = vi.fn().mockResolvedValue({ status: 'completed' })
+  readFile = vi.fn().mockResolvedValue({ content: FORMATTED })
+  writeFile = stubEditorWindow({ formatOnSave, readFile })
+  store = createEditorStore()
+  openEditableFile()
+  detach = attachEditorAutosaveController(store)
+  window.addEventListener(ORCA_EDITOR_FILE_SAVED_EVENT, ((
+    event: CustomEvent<EditorFileSavedDetail>
+  ) => {
+    savedEvents.push(event.detail.content)
+  }) as EventListener)
+})
+
+afterEach(() => {
+  detach()
+  __clearSelfWriteRegistryForTests()
+  vi.unstubAllGlobals()
+})
+
+describe('format on save through the editor save queue', () => {
+  it('adopts the formatted file into the buffer after the write', async () => {
+    store.getState().setEditorDraft(FILE_ID, UNFORMATTED)
+    await requestEditorFileSave({ fileId: FILE_ID })
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: FILE_ID, content: UNFORMATTED })
+    )
+    expect(formatOnSave).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      worktreePath: '/repo',
+      filePath: FILE_ID
+    })
+    expect(savedContents()).toEqual([FORMATTED])
+    expect(store.getState().openFiles.find((file) => file.id === FILE_ID)?.isDirty).toBe(false)
+  })
+
+  it('suppresses the formatter write as an external change', async () => {
+    store.getState().setEditorDraft(FILE_ID, UNFORMATTED)
+    await requestEditorFileSave({ fileId: FILE_ID })
+
+    // Why: without a re-stamp the watcher reports Orca's own formatting as a
+    // changed-on-disk conflict on the very next event.
+    expect(hasRecentSelfWrite(FILE_ID, undefined)).toBe(true)
+  })
+
+  it('keeps the typed buffer when the user edits while the formatter runs', async () => {
+    let releaseFormat: ((value: { status: string }) => void) | undefined
+    let markFormatStarted: (() => void) | undefined
+    const formatStarted = new Promise<void>((resolve) => {
+      markFormatStarted = resolve
+    })
+    formatOnSave.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseFormat = resolve as (value: { status: string }) => void
+          markFormatStarted?.()
+        })
+    )
+
+    store.getState().setEditorDraft(FILE_ID, UNFORMATTED)
+    const save = requestEditorFileSave({ fileId: FILE_ID })
+    await formatStarted
+
+    store.getState().setEditorDraft(FILE_ID, `${UNFORMATTED}\nconst b=2`)
+    releaseFormat?.({ status: 'completed' })
+    await save
+
+    expect(savedContents()).toEqual([UNFORMATTED])
+    expect(store.getState().editorDrafts[FILE_ID]).toBe(`${UNFORMATTED}\nconst b=2`)
+    expect(store.getState().openFiles.find((file) => file.id === FILE_ID)?.isDirty).toBe(true)
+  })
+
+  it('leaves the saved content alone when the formatter changes nothing', async () => {
+    readFile.mockResolvedValue({ content: UNFORMATTED })
+    store.getState().setEditorDraft(FILE_ID, UNFORMATTED)
+    await requestEditorFileSave({ fileId: FILE_ID })
+
+    expect(savedContents()).toEqual([UNFORMATTED])
+  })
+
+  it('still reports the save as successful when the formatter fails', async () => {
+    formatOnSave.mockResolvedValue({ status: 'failed', message: 'SyntaxError' })
+    store.getState().setEditorDraft(FILE_ID, UNFORMATTED)
+
+    await expect(requestEditorFileSave({ fileId: FILE_ID })).resolves.toBeUndefined()
+    expect(savedContents()).toEqual([UNFORMATTED])
+    expect(readFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/editor-autosave-format-on-save.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-format-on-save.test.ts
@@ -106,7 +106,9 @@ describe('format on save through the editor save queue', () => {
     releaseFormat?.({ status: 'completed' })
     await save
 
-    expect(savedContents()).toEqual([UNFORMATTED])
+    // Why: the event reports what landed on disk, which is the formatted text.
+    // The user's newer keystrokes stay in the draft and still win in the editor.
+    expect(savedContents()).toEqual([FORMATTED])
     expect(store.getState().editorDrafts[FILE_ID]).toBe(`${UNFORMATTED}\nconst b=2`)
     expect(store.getState().openFiles.find((file) => file.id === FILE_ID)?.isDirty).toBe(true)
   })

--- a/src/renderer/src/components/editor/editor-format-on-save.test.ts
+++ b/src/renderer/src/components/editor/editor-format-on-save.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const toastError = vi.fn()
+vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => toastError(...args) } }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('@/runtime/runtime-file-client', () => ({ readRuntimeFileContent: vi.fn() }))
+
+import { formatSavedFile } from './editor-format-on-save'
+
+beforeEach(() => {
+  toastError.mockReset()
+})
+
+function request(overrides: {
+  runFormat: Parameters<typeof formatSavedFile>[0]['runFormat']
+  readSavedContent?: Parameters<typeof formatSavedFile>[0]['readSavedContent']
+  savedContent?: string
+}): Parameters<typeof formatSavedFile>[0] {
+  return {
+    repoId: 'repo-1',
+    worktreePath: '/repo',
+    filePath: '/repo/src/a.ts',
+    savedContent: overrides.savedContent ?? 'const a=1',
+    runFormat: overrides.runFormat,
+    readSavedContent: overrides.readSavedContent ?? (async () => 'const a = 1')
+  }
+}
+
+describe('formatSavedFile', () => {
+  it('returns the reformatted text when the formatter rewrote the file', async () => {
+    await expect(
+      formatSavedFile(request({ runFormat: async () => ({ status: 'completed' }) }))
+    ).resolves.toBe('const a = 1')
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the formatter left the file byte-identical', async () => {
+    await expect(
+      formatSavedFile(
+        request({
+          runFormat: async () => ({ status: 'completed' }),
+          readSavedContent: async () => 'const a=1'
+        })
+      )
+    ).resolves.toBeNull()
+  })
+
+  it('surfaces the formatter error without touching the buffer', async () => {
+    await expect(
+      formatSavedFile(
+        request({
+          runFormat: async () => ({ status: 'failed', message: 'SyntaxError: line 3' })
+        })
+      )
+    ).resolves.toBeNull()
+
+    expect(toastError).toHaveBeenCalledWith(
+      'Formatter failed',
+      expect.objectContaining({ description: 'SyntaxError: line 3' })
+    )
+  })
+
+  it('truncates a runaway formatter error so the toast stays readable', async () => {
+    await expect(
+      formatSavedFile(
+        request({ runFormat: async () => ({ status: 'failed', message: 'x'.repeat(1000) }) })
+      )
+    ).resolves.toBeNull()
+
+    const description = toastError.mock.calls[0][1].description as string
+    expect(description).toHaveLength(301)
+    expect(description.endsWith('…')).toBe(true)
+  })
+
+  it('stays silent for every skip reason', async () => {
+    for (const reason of [
+      'not-configured',
+      'not-included',
+      'outside-worktree',
+      'already-running',
+      'unsupported-host'
+    ] as const) {
+      await expect(
+        formatSavedFile(request({ runFormat: async () => ({ status: 'skipped', reason }) }))
+      ).resolves.toBeNull()
+    }
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('keeps the save successful when the format channel itself throws', async () => {
+    await expect(
+      formatSavedFile(
+        request({
+          runFormat: async () => {
+            throw new Error('ipc down')
+          }
+        })
+      )
+    ).resolves.toBeNull()
+  })
+
+  it('keeps the save successful when re-reading the formatted file fails', async () => {
+    await expect(
+      formatSavedFile(
+        request({
+          runFormat: async () => ({ status: 'completed' }),
+          readSavedContent: async () => {
+            throw new Error('read failed')
+          }
+        })
+      )
+    ).resolves.toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/editor-format-on-save.ts
+++ b/src/renderer/src/components/editor/editor-format-on-save.ts
@@ -62,8 +62,10 @@ export async function formatSavedFile({
   }
 }
 
+// Why: mirrors the fields getEditorFileOperationContext returns that this path
+// needs; typing `settings` off the file client keeps the read call cast-free.
 type EditorFileOperationContext = {
-  settings: unknown
+  settings: Parameters<typeof readRuntimeFileContent>[0]['settings']
   worktreeId: string
   worktreePath: string | null
   connectionId?: string
@@ -106,7 +108,7 @@ export async function maybeFormatSavedFile({
     runFormat: (args) => window.api.editor.formatOnSave(args),
     readSavedContent: async () => {
       const result = await readRuntimeFileContent({
-        settings: fileContext.settings as Parameters<typeof readRuntimeFileContent>[0]['settings'],
+        settings: fileContext.settings,
         filePath: file.filePath,
         relativePath: file.relativePath,
         worktreeId: file.worktreeId

--- a/src/renderer/src/components/editor/editor-format-on-save.ts
+++ b/src/renderer/src/components/editor/editor-format-on-save.ts
@@ -1,0 +1,128 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { readRuntimeFileContent } from '@/runtime/runtime-file-client'
+import type { OpenFile } from '@/store/slices/editor'
+import type { Worktree } from '../../../../shared/types'
+import type { FormatOnSaveResult } from '../../../../shared/format-on-save-command'
+
+export type FormatSavedFileRequest = {
+  repoId: string
+  worktreePath: string
+  filePath: string
+  savedContent: string
+  runFormat: (args: {
+    repoId: string
+    worktreePath: string
+    filePath: string
+  }) => Promise<FormatOnSaveResult>
+  readSavedContent: () => Promise<string | null>
+}
+
+/**
+ * Runs the repo's formatter over a file the editor just wrote, and returns the
+ * reformatted text when the formatter actually changed it. `null` means the
+ * buffer should keep the content it saved.
+ */
+export async function formatSavedFile({
+  repoId,
+  worktreePath,
+  filePath,
+  savedContent,
+  runFormat,
+  readSavedContent
+}: FormatSavedFileRequest): Promise<string | null> {
+  let result: FormatOnSaveResult
+  try {
+    result = await runFormat({ repoId, worktreePath, filePath })
+  } catch (error) {
+    // Why: the file is already on disk; a broken format channel must not turn a
+    // successful save into a failed one.
+    console.error('[editor] format on save failed', error)
+    return null
+  }
+
+  if (result.status === 'failed') {
+    notifyFormatFailure(result.message)
+    return null
+  }
+
+  if (result.status !== 'completed') {
+    return null
+  }
+
+  try {
+    const formatted = await readSavedContent()
+    if (formatted === null || formatted === savedContent) {
+      return null
+    }
+    return formatted
+  } catch (error) {
+    console.error('[editor] reading formatted file failed', error)
+    return null
+  }
+}
+
+type EditorFileOperationContext = {
+  settings: unknown
+  worktreeId: string
+  worktreePath: string | null
+  connectionId?: string
+  expectedExecutionHostId: 'local' | `ssh:${string}`
+}
+
+type MaybeFormatSavedFileArgs = {
+  file: OpenFile
+  worktree: Worktree | null | undefined
+  fileContext: EditorFileOperationContext
+  savedContent: string
+}
+
+/**
+ * Editor-side entry point: decides whether this save is even formattable, then
+ * defers to the main process, which owns the configured command.
+ */
+export async function maybeFormatSavedFile({
+  file,
+  worktree,
+  fileContext,
+  savedContent
+}: MaybeFormatSavedFileArgs): Promise<string | null> {
+  // Why: SSH and runtime hosts expose no generic command channel, so there is
+  // nothing to run there — skip before paying for an IPC round trip per save.
+  if (
+    !worktree?.path ||
+    fileContext.connectionId ||
+    file.runtimeEnvironmentId ||
+    fileContext.expectedExecutionHostId !== 'local'
+  ) {
+    return null
+  }
+
+  return formatSavedFile({
+    repoId: worktree.repoId,
+    worktreePath: worktree.path,
+    filePath: file.filePath,
+    savedContent,
+    runFormat: (args) => window.api.editor.formatOnSave(args),
+    readSavedContent: async () => {
+      const result = await readRuntimeFileContent({
+        settings: fileContext.settings as Parameters<typeof readRuntimeFileContent>[0]['settings'],
+        filePath: file.filePath,
+        relativePath: file.relativePath,
+        worktreeId: file.worktreeId
+      })
+      return typeof result.content === 'string' ? result.content : null
+    }
+  })
+}
+
+function notifyFormatFailure(message: string): void {
+  toast.error(
+    translate('auto.components.editor.formatOnSave.failure.notice.4f2b1c9a7d', 'Formatter failed'),
+    {
+      // Why: a formatter reports the offending line on stderr; truncate so a
+      // stack-trace-sized failure cannot cover the workspace.
+      description: message.length > 300 ? `${message.slice(0, 300)}…` : message
+    }
+  )
+}

--- a/src/renderer/src/components/editor/editor-format-on-save.ts
+++ b/src/renderer/src/components/editor/editor-format-on-save.ts
@@ -89,14 +89,10 @@ export async function maybeFormatSavedFile({
   fileContext,
   savedContent
 }: MaybeFormatSavedFileArgs): Promise<string | null> {
-  // Why: SSH and runtime hosts expose no generic command channel, so there is
-  // nothing to run there — skip before paying for an IPC round trip per save.
-  if (
-    !worktree?.path ||
-    fileContext.connectionId ||
-    file.runtimeEnvironmentId ||
-    fileContext.expectedExecutionHostId !== 'local'
-  ) {
+  // Why: runtime environments have no non-interactive exec channel, so skip them
+  // before paying for an IPC round trip per save. SSH-backed repos do have one
+  // and are handled in the main process.
+  if (!worktree?.path || file.runtimeEnvironmentId) {
     return null
   }
 

--- a/src/renderer/src/components/editor/monaco-content-sync.test.ts
+++ b/src/renderer/src/components/editor/monaco-content-sync.test.ts
@@ -12,6 +12,7 @@ function createHarness(
   applyEdits: ReturnType<typeof vi.fn>
   pushEditOperations: ReturnType<typeof vi.fn>
   pushUndoStop: ReturnType<typeof vi.fn>
+  setSelections: ReturnType<typeof vi.fn>
 } {
   const getValue = vi.fn(() => initialContent)
   const getFullModelRange = vi.fn(() => ({
@@ -27,12 +28,16 @@ function createHarness(
     getEOL: () => eol,
     getFullModelRange,
     pushEditOperations,
-    applyEdits
+    applyEdits,
+    validatePosition: vi.fn((position: { lineNumber: number; column: number }) => position)
   } as unknown as editor.ITextModel
   const pushUndoStop = vi.fn()
+  const setSelections = vi.fn()
   const editorInstance = {
     getModel: () => model,
-    pushUndoStop
+    pushUndoStop,
+    getSelections: vi.fn(() => []),
+    setSelections
   } as unknown as editor.IStandaloneCodeEditor
   return {
     editorInstance,
@@ -40,7 +45,8 @@ function createHarness(
     getFullModelRange,
     applyEdits,
     pushEditOperations,
-    pushUndoStop
+    pushUndoStop,
+    setSelections
   }
 }
 

--- a/src/renderer/src/components/editor/monaco-content-sync.ts
+++ b/src/renderer/src/components/editor/monaco-content-sync.ts
@@ -1,4 +1,4 @@
-import type { editor } from 'monaco-editor'
+import type { editor, ISelection } from 'monaco-editor'
 
 export type MonacoContentSyncMode = 'undoable' | 'read-only-live-tail'
 
@@ -46,7 +46,35 @@ function replaceModelContent(
     return
   }
   const fullRange = model.getFullModelRange()
+  // Why: a full-range replace collapses the cursor to the end of the edit. Format
+  // on save routes through here on every save, so without this the caret jumps to
+  // the bottom of the file mid-edit.
+  const selections = mode === 'undoable' ? editorInstance.getSelections() : null
   applyModelEdit(editorInstance, model, { range: fullRange, text: content }, mode, withUndoStops)
+  if (selections && selections.length > 0) {
+    editorInstance.setSelections(
+      selections.map((selection) => clampSelectionToModel(model, selection))
+    )
+  }
+}
+
+function clampSelectionToModel(model: editor.ITextModel, selection: ISelection): ISelection {
+  // Why: the replacement text can be shorter than what the selection pointed at,
+  // and Monaco throws on out-of-range positions.
+  const anchor = model.validatePosition({
+    lineNumber: selection.selectionStartLineNumber,
+    column: selection.selectionStartColumn
+  })
+  const active = model.validatePosition({
+    lineNumber: selection.positionLineNumber,
+    column: selection.positionColumn
+  })
+  return {
+    selectionStartLineNumber: anchor.lineNumber,
+    selectionStartColumn: anchor.column,
+    positionLineNumber: active.lineNumber,
+    positionColumn: active.column
+  }
 }
 
 /**

--- a/src/renderer/src/components/editor/monaco-content-sync.undo-history.test.ts
+++ b/src/renderer/src/components/editor/monaco-content-sync.undo-history.test.ts
@@ -5,16 +5,26 @@ import { syncContentUpdate } from './monaco-content-sync'
 
 const models: monaco.editor.ITextModel[] = []
 
-function createEditor(initialContent: string): {
+function createEditor(
+  initialContent: string,
+  initialSelections: monaco.ISelection[] = []
+): {
   editorInstance: monaco.editor.IStandaloneCodeEditor
   model: monaco.editor.ITextModel
+  getSelections: () => monaco.ISelection[]
 } {
   const model = monaco.editor.createModel(initialContent, 'plaintext')
   models.push(model)
+  let selections = initialSelections
   return {
     model,
+    getSelections: () => selections,
     editorInstance: {
       getModel: () => model,
+      getSelections: () => selections,
+      setSelections: (next: monaco.ISelection[]) => {
+        selections = next
+      },
       pushUndoStop: () => {
         model.pushStackElement()
         return true
@@ -47,5 +57,73 @@ describe('Monaco external-content undo history', () => {
     expect(model.canUndo()).toBe(true)
     await model.undo()
     expect(model.getValue()).toBe('editable')
+  })
+})
+
+describe('Monaco external-content cursor preservation', () => {
+  it('keeps the caret where it was when a rewrite replaces the whole file', () => {
+    const { editorInstance, getSelections } = createEditor('const a=1\nconst b=2\nconst c=3', [
+      {
+        selectionStartLineNumber: 2,
+        selectionStartColumn: 8,
+        positionLineNumber: 2,
+        positionColumn: 8
+      }
+    ])
+
+    syncContentUpdate(editorInstance, 'const a = 1\nconst b = 2\nconst c = 3')
+
+    expect(getSelections()).toEqual([
+      {
+        selectionStartLineNumber: 2,
+        selectionStartColumn: 8,
+        positionLineNumber: 2,
+        positionColumn: 8
+      }
+    ])
+  })
+
+  it('clamps a caret that the rewrite pushed past the end of the file', () => {
+    const { editorInstance, getSelections } = createEditor('line one\nline two\nline three', [
+      {
+        selectionStartLineNumber: 3,
+        selectionStartColumn: 11,
+        positionLineNumber: 3,
+        positionColumn: 11
+      }
+    ])
+
+    syncContentUpdate(editorInstance, 'line one')
+
+    expect(getSelections()).toEqual([
+      {
+        selectionStartLineNumber: 1,
+        selectionStartColumn: 9,
+        positionLineNumber: 1,
+        positionColumn: 9
+      }
+    ])
+  })
+
+  it('leaves read-only live-tail selections alone', () => {
+    const { editorInstance, getSelections } = createEditor('log line', [
+      {
+        selectionStartLineNumber: 1,
+        selectionStartColumn: 2,
+        positionLineNumber: 1,
+        positionColumn: 2
+      }
+    ])
+
+    syncContentUpdate(editorInstance, 'totally different', 'read-only-live-tail')
+
+    expect(getSelections()).toEqual([
+      {
+        selectionStartLineNumber: 1,
+        selectionStartColumn: 2,
+        positionLineNumber: 1,
+        positionColumn: 2
+      }
+    ])
   })
 })

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
@@ -70,6 +70,49 @@ describe('RepositoryFormatOnSaveSection', () => {
     expect(container.textContent).toContain('Set a formatter command below to turn this on.')
   })
 
+  it('points at the command field when the switch is clicked without one', () => {
+    render()
+    act(() => container.querySelector<HTMLButtonElement>('[role="switch"]')?.click())
+
+    const command = input('format-on-save-command')
+    expect(command.getAttribute('aria-invalid')).toBe('true')
+    expect(command.parentElement?.className).toContain('animate-format-on-save-command-nudge')
+    expect(document.activeElement).toBe(command)
+    // Why: nothing may be written — a command-less enabled config reads back as off.
+    expect(onUpdateFormatOnSave).not.toHaveBeenCalled()
+  })
+
+  it('clears the invalid state as soon as the user types a command', () => {
+    render()
+    act(() => container.querySelector<HTMLButtonElement>('[role="switch"]')?.click())
+    expect(input('format-on-save-command').getAttribute('aria-invalid')).toBe('true')
+
+    typeAndBlur('format-on-save-command', 'prettier --write ${file}')
+    expect(input('format-on-save-command').getAttribute('aria-invalid')).toBeNull()
+  })
+
+  it('turns the feature on when a command is already configured', () => {
+    render({
+      ...baseRepo,
+      formatOnSave: { enabled: false, command: 'prettier --write ${file}', include: [] }
+    })
+    act(() => container.querySelector<HTMLButtonElement>('[role="switch"]')?.click())
+
+    expect(onUpdateFormatOnSave).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+    expect(input('format-on-save-command').getAttribute('aria-invalid')).toBeNull()
+  })
+
+  it('stops nudging once the animation finishes', () => {
+    render()
+    act(() => container.querySelector<HTMLButtonElement>('[role="switch"]')?.click())
+
+    const wrapper = input('format-on-save-command').parentElement
+    act(() => {
+      wrapper?.dispatchEvent(new Event('animationend', { bubbles: true }))
+    })
+    expect(wrapper?.className).not.toContain('animate-format-on-save-command-nudge')
+  })
+
   it('commits a typed command on blur', () => {
     render()
     typeAndBlur('format-on-save-command', '  npx prettier --write ${file}  ')

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
@@ -161,6 +161,13 @@ describe('RepositoryFormatOnSaveSection', () => {
     expect(container.textContent).not.toContain('runtime host')
   })
 
+  it('says nothing for a WSL worktree, which is a local execution host', () => {
+    // Why: WSL repos keep executionHostId 'local' — the formatter runs inside the
+    // distro, so the runtime-host notice must not appear for them.
+    render({ ...baseRepo, path: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo' })
+    expect(container.textContent).not.toContain('runtime host')
+  })
+
   it('warns that a runtime-hosted project is saved unformatted', () => {
     render({ ...baseRepo, executionHostId: 'runtime:env-1' })
     expect(container.textContent).toContain('runtime host')

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { Repo, RepoFormatOnSaveSettings } from '../../../../shared/types'
+import { RepositoryFormatOnSaveSection } from './RepositoryFormatOnSaveSection'
+
+let container: HTMLDivElement
+let root: Root
+let onUpdateFormatOnSave: Mock<(next: RepoFormatOnSaveSettings) => void>
+
+const baseRepo: Repo = {
+  id: 'repo-1',
+  path: '/tmp/repo',
+  displayName: 'Example Repo',
+  badgeColor: '#000000',
+  addedAt: 1,
+  kind: 'git'
+}
+
+function render(repo: Repo = baseRepo): void {
+  act(() => {
+    root.render(
+      React.createElement(RepositoryFormatOnSaveSection, {
+        repo,
+        forceVisible: true,
+        onUpdateFormatOnSave
+      })
+    )
+  })
+}
+
+function input(id: string): HTMLInputElement {
+  const element = container.querySelector<HTMLInputElement>(`#${id}`)
+  if (!element) {
+    throw new Error(`missing input ${id}`)
+  }
+  return element
+}
+
+function typeAndBlur(id: string, value: string): void {
+  const element = input(id)
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    setter?.call(element, value)
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  act(() => {
+    // Why: React delegates blur through the bubbling focusout event.
+    element.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+  })
+}
+
+beforeEach(() => {
+  onUpdateFormatOnSave = vi.fn<(next: RepoFormatOnSaveSettings) => void>()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('RepositoryFormatOnSaveSection', () => {
+  it('tells the user why the toggle cannot be turned on yet', () => {
+    render()
+    expect(container.textContent).toContain('Set a formatter command below to turn this on.')
+  })
+
+  it('commits a typed command on blur', () => {
+    render()
+    typeAndBlur('format-on-save-command', '  npx prettier --write ${file}  ')
+
+    expect(onUpdateFormatOnSave).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'npx prettier --write ${file}' })
+    )
+  })
+
+  it('parses the include field into globs', () => {
+    render({
+      ...baseRepo,
+      formatOnSave: { enabled: true, command: 'prettier --write ${file}', include: [] }
+    })
+    typeAndBlur('format-on-save-include', '**/*.ts, **/*.md')
+
+    expect(onUpdateFormatOnSave).toHaveBeenCalledWith(
+      expect.objectContaining({ include: ['**/*.ts', '**/*.md'] })
+    )
+  })
+
+  it('clearing the command also turns the feature off', () => {
+    render({
+      ...baseRepo,
+      formatOnSave: { enabled: true, command: 'prettier --write ${file}', include: [] }
+    })
+    typeAndBlur('format-on-save-command', '')
+
+    const next = onUpdateFormatOnSave.mock.calls[0][0]
+    expect(next).toEqual(expect.objectContaining({ command: '', enabled: false }))
+  })
+
+  it('does not write back when the field is left unchanged', () => {
+    render({
+      ...baseRepo,
+      formatOnSave: { enabled: true, command: 'prettier --write ${file}', include: ['**/*.ts'] }
+    })
+    typeAndBlur('format-on-save-command', 'prettier --write ${file}')
+    typeAndBlur('format-on-save-include', '**/*.ts')
+
+    expect(onUpdateFormatOnSave).not.toHaveBeenCalled()
+  })
+
+  it('warns that a remote project is saved unformatted', () => {
+    render({ ...baseRepo, connectionId: 'ssh-target-1' })
+    expect(container.textContent).toContain('This project runs on a remote host')
+  })
+
+  it('says nothing about remote hosts for a local project', () => {
+    render()
+    expect(container.textContent).not.toContain('This project runs on a remote host')
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.test.tsx
@@ -156,13 +156,18 @@ describe('RepositoryFormatOnSaveSection', () => {
     expect(onUpdateFormatOnSave).not.toHaveBeenCalled()
   })
 
-  it('warns that a remote project is saved unformatted', () => {
+  it('says nothing extra for an SSH project, which formats through the relay', () => {
     render({ ...baseRepo, connectionId: 'ssh-target-1' })
-    expect(container.textContent).toContain('This project runs on a remote host')
+    expect(container.textContent).not.toContain('runtime host')
   })
 
-  it('says nothing about remote hosts for a local project', () => {
+  it('warns that a runtime-hosted project is saved unformatted', () => {
+    render({ ...baseRepo, executionHostId: 'runtime:env-1' })
+    expect(container.textContent).toContain('runtime host')
+  })
+
+  it('says nothing about hosts for a local project', () => {
     render()
-    expect(container.textContent).not.toContain('This project runs on a remote host')
+    expect(container.textContent).not.toContain('runtime host')
   })
 })

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { Repo, RepoFormatOnSaveSettings } from '../../../../shared/types'
 import {
   formatOnSaveIncludeToInput,
@@ -15,6 +15,7 @@ import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
 
 type RepositoryFormatOnSaveSectionProps = {
   repo: Repo
@@ -49,12 +50,34 @@ export function RepositoryFormatOnSaveSection({
     setIncludeDraft(formatOnSaveIncludeToInput(settings.include))
   }
 
+  const hasCommand = settings.command.trim().length > 0
+  const commandInputRef = useRef<HTMLInputElement>(null)
+  const [needsCommand, setNeedsCommand] = useState(false)
+  const [nudging, setNudging] = useState(false)
+
+  // Why: the switch cannot turn on without a command, so a click points at the
+  // field that is missing instead of springing back with no explanation.
+  const handleToggle = (): void => {
+    if (!hasCommand) {
+      setNeedsCommand(true)
+      setNudging(true)
+      commandInputRef.current?.focus()
+      return
+    }
+    setNeedsCommand(false)
+    onUpdateFormatOnSave(
+      normalizeRepoFormatOnSaveSettings({ ...settings, enabled: !settings.enabled })
+    )
+  }
+
   const commitCommand = (): void => {
     const command = commandDraft.trim()
     if (command === settings.command) {
       return
     }
-    onUpdateFormatOnSave({ ...settings, command, enabled: settings.enabled && command.length > 0 })
+    // Why: normalize on write too, so a command-less config never persists
+    // `enabled: true` — a state the reader would silently correct anyway.
+    onUpdateFormatOnSave(normalizeRepoFormatOnSaveSettings({ ...settings, command }))
   }
 
   const commitInclude = (): void => {
@@ -94,12 +117,10 @@ export function RepositoryFormatOnSaveSection({
           label={enableLabel}
           description={enableDescription}
           checked={settings.enabled}
-          onChange={() => onUpdateFormatOnSave({ ...settings, enabled: !settings.enabled })}
+          onChange={handleToggle}
         />
-        {settings.command.trim().length === 0 ? (
-          // Why: an enabled toggle with no command would run nothing on every save,
-          // so the switch stays off until one is set — say so instead of silently ignoring the click.
-          <p className="text-xs text-muted-foreground">
+        {!hasCommand ? (
+          <p className={cn('text-xs', needsCommand ? 'text-destructive' : 'text-muted-foreground')}>
             {translate(
               'auto.components.settings.RepositoryFormatOnSaveSection.needsCommand',
               'Set a formatter command below to turn this on.'
@@ -127,20 +148,32 @@ export function RepositoryFormatOnSaveSection({
             'Formatter Command'
           )}
         </Label>
-        <Input
-          id="format-on-save-command"
-          value={commandDraft}
-          spellCheck={false}
-          placeholder={SUGGESTED_FORMAT_ON_SAVE_COMMAND}
-          onChange={(event) => setCommandDraft(event.target.value)}
-          onBlur={commitCommand}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              commitCommand()
-            }
-          }}
-          className="font-mono text-xs"
-        />
+        <div
+          className={cn(nudging && 'animate-format-on-save-command-nudge')}
+          onAnimationEnd={() => setNudging(false)}
+        >
+          <Input
+            id="format-on-save-command"
+            ref={commandInputRef}
+            value={commandDraft}
+            spellCheck={false}
+            aria-invalid={needsCommand || undefined}
+            placeholder={SUGGESTED_FORMAT_ON_SAVE_COMMAND}
+            onChange={(event) => {
+              setCommandDraft(event.target.value)
+              if (event.target.value.trim().length > 0) {
+                setNeedsCommand(false)
+              }
+            }}
+            onBlur={commitCommand}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                commitCommand()
+              }
+            }}
+            className="font-mono text-xs"
+          />
+        </div>
         <p className="text-xs text-muted-foreground">
           {translate(
             'auto.components.settings.RepositoryFormatOnSaveSection.commandHint',

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.tsx
@@ -1,0 +1,197 @@
+import type React from 'react'
+import { useState } from 'react'
+import type { Repo, RepoFormatOnSaveSettings } from '../../../../shared/types'
+import {
+  formatOnSaveIncludeToInput,
+  getDefaultRepoFormatOnSaveSettings,
+  normalizeRepoFormatOnSaveSettings,
+  parseFormatOnSaveIncludeInput,
+  SUGGESTED_FORMAT_ON_SAVE_COMMAND,
+  SUGGESTED_FORMAT_ON_SAVE_INCLUDE
+} from '../../../../shared/format-on-save-command'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+
+type RepositoryFormatOnSaveSectionProps = {
+  repo: Repo
+  forceVisible?: boolean
+  onUpdateFormatOnSave: (next: RepoFormatOnSaveSettings) => void
+}
+
+export function RepositoryFormatOnSaveSection({
+  repo,
+  forceVisible = false,
+  onUpdateFormatOnSave
+}: RepositoryFormatOnSaveSectionProps): React.JSX.Element {
+  const settings = normalizeRepoFormatOnSaveSettings(
+    repo.formatOnSave ?? getDefaultRepoFormatOnSaveSettings()
+  )
+  const isRemote =
+    Boolean(repo.connectionId) || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID
+
+  const [commandDraft, setCommandDraft] = useState(settings.command)
+  const [includeDraft, setIncludeDraft] = useState(formatOnSaveIncludeToInput(settings.include))
+  const [committedSettings, setCommittedSettings] = useState(settings)
+
+  // Why: the repo record can change outside this pane (another window, a sync);
+  // reconcile before paint so the inputs never show a stale command.
+  if (
+    committedSettings.command !== settings.command ||
+    formatOnSaveIncludeToInput(committedSettings.include) !==
+      formatOnSaveIncludeToInput(settings.include)
+  ) {
+    setCommittedSettings(settings)
+    setCommandDraft(settings.command)
+    setIncludeDraft(formatOnSaveIncludeToInput(settings.include))
+  }
+
+  const commitCommand = (): void => {
+    const command = commandDraft.trim()
+    if (command === settings.command) {
+      return
+    }
+    onUpdateFormatOnSave({ ...settings, command, enabled: settings.enabled && command.length > 0 })
+  }
+
+  const commitInclude = (): void => {
+    const include = parseFormatOnSaveIncludeInput(includeDraft)
+    if (formatOnSaveIncludeToInput(include) === formatOnSaveIncludeToInput(settings.include)) {
+      return
+    }
+    onUpdateFormatOnSave({ ...settings, include })
+  }
+
+  const enableLabel = translate(
+    'auto.components.settings.RepositoryFormatOnSaveSection.enableTitle',
+    'Format on Save'
+  )
+  const enableDescription = translate(
+    'auto.components.settings.RepositoryFormatOnSaveSection.enableDescription',
+    "Run this project's formatter after Orca saves a file in this repository."
+  )
+
+  return (
+    <section key="format-on-save" className="space-y-4">
+      <SettingsSubsectionHeader
+        title={enableLabel}
+        description={translate(
+          'auto.components.settings.RepositoryFormatOnSaveSection.sectionDescription',
+          'Orca runs the command in the worktree root after each save, so the project’s own formatter config and version apply.'
+        )}
+      />
+
+      <SearchableSetting
+        title={enableLabel}
+        description={enableDescription}
+        keywords={['format', 'formatter', 'prettier', 'biome', 'gofmt', 'rustfmt', 'save']}
+        forceVisible={forceVisible}
+      >
+        <SettingsSwitchRow
+          label={enableLabel}
+          description={enableDescription}
+          checked={settings.enabled}
+          onChange={() => onUpdateFormatOnSave({ ...settings, enabled: !settings.enabled })}
+        />
+        {settings.command.trim().length === 0 ? (
+          // Why: an enabled toggle with no command would run nothing on every save,
+          // so the switch stays off until one is set — say so instead of silently ignoring the click.
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.RepositoryFormatOnSaveSection.needsCommand',
+              'Set a formatter command below to turn this on.'
+            )}
+          </p>
+        ) : null}
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.RepositoryFormatOnSaveSection.commandTitle',
+          'Formatter Command'
+        )}
+        description={translate(
+          'auto.components.settings.RepositoryFormatOnSaveSection.commandDescription',
+          'Shell command run in the worktree root. ${file} and ${relativeFile} expand to the saved file.'
+        )}
+        keywords={['command', 'formatter', 'prettier', 'oxfmt', 'ruff']}
+        forceVisible={forceVisible}
+        className="space-y-2 py-2"
+      >
+        <Label htmlFor="format-on-save-command">
+          {translate(
+            'auto.components.settings.RepositoryFormatOnSaveSection.commandTitle',
+            'Formatter Command'
+          )}
+        </Label>
+        <Input
+          id="format-on-save-command"
+          value={commandDraft}
+          spellCheck={false}
+          placeholder={SUGGESTED_FORMAT_ON_SAVE_COMMAND}
+          onChange={(event) => setCommandDraft(event.target.value)}
+          onBlur={commitCommand}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              commitCommand()
+            }
+          }}
+          className="font-mono text-xs"
+        />
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.RepositoryFormatOnSaveSection.commandHint',
+            'A non-zero exit leaves the saved file untouched and shows the formatter’s error.'
+          )}
+        </p>
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.RepositoryFormatOnSaveSection.includeTitle',
+          'Included Files'
+        )}
+        description={translate(
+          'auto.components.settings.RepositoryFormatOnSaveSection.includeDescription',
+          'Comma-separated globs limiting which saved files run the command. Leave empty to format every saved file.'
+        )}
+        keywords={['glob', 'include', 'files', 'extensions']}
+        forceVisible={forceVisible}
+        className="space-y-2 py-2"
+      >
+        <Label htmlFor="format-on-save-include">
+          {translate(
+            'auto.components.settings.RepositoryFormatOnSaveSection.includeTitle',
+            'Included Files'
+          )}
+        </Label>
+        <Input
+          id="format-on-save-include"
+          value={includeDraft}
+          spellCheck={false}
+          placeholder={SUGGESTED_FORMAT_ON_SAVE_INCLUDE}
+          onChange={(event) => setIncludeDraft(event.target.value)}
+          onBlur={commitInclude}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              commitInclude()
+            }
+          }}
+          className="font-mono text-xs"
+        />
+      </SearchableSetting>
+
+      {isRemote ? (
+        <p className="max-w-3xl text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.RepositoryFormatOnSaveSection.remoteNotice',
+            'This project runs on a remote host. Saves there are written unformatted — Orca only runs the formatter for local and WSL worktrees.'
+          )}
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryFormatOnSaveSection.tsx
@@ -9,7 +9,7 @@ import {
   SUGGESTED_FORMAT_ON_SAVE_COMMAND,
   SUGGESTED_FORMAT_ON_SAVE_INCLUDE
 } from '../../../../shared/format-on-save-command'
-import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared/execution-host'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
@@ -31,8 +31,10 @@ export function RepositoryFormatOnSaveSection({
   const settings = normalizeRepoFormatOnSaveSettings(
     repo.formatOnSave ?? getDefaultRepoFormatOnSaveSettings()
   )
-  const isRemote =
-    Boolean(repo.connectionId) || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID
+  // Why: SSH hosts format through the relay's non-interactive exec channel;
+  // runtime environments have no equivalent, so only those are called out.
+  const executionHost = parseExecutionHostId(getRepoExecutionHostId(repo))
+  const isRuntimeHost = !repo.connectionId && executionHost?.kind === 'runtime'
 
   const [commandDraft, setCommandDraft] = useState(settings.command)
   const [includeDraft, setIncludeDraft] = useState(formatOnSaveIncludeToInput(settings.include))
@@ -217,11 +219,11 @@ export function RepositoryFormatOnSaveSection({
         />
       </SearchableSetting>
 
-      {isRemote ? (
+      {isRuntimeHost ? (
         <p className="max-w-3xl text-xs text-muted-foreground">
           {translate(
-            'auto.components.settings.RepositoryFormatOnSaveSection.remoteNotice',
-            'This project runs on a remote host. Saves there are written unformatted — Orca only runs the formatter for local and WSL worktrees.'
+            'auto.components.settings.RepositoryFormatOnSaveSection.runtimeHostNotice',
+            'This project runs on a runtime host, which has no channel for running the command. Saves there are written unformatted; local, WSL, and SSH worktrees are formatted.'
           )}
         </p>
       ) : null}

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -17,7 +17,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { RepositoryHooksSection } from './RepositoryHooksSection'
 import { RepositoryFormatOnSaveSection } from './RepositoryFormatOnSaveSection'
-import { FORMAT_ON_SAVE_SEARCH_TITLES } from './repository-format-on-save-search-entries'
+import { getFormatOnSaveSearchTitles } from './repository-format-on-save-search-entries'
 import { McpConfigSection } from './McpConfigSection'
 import { WorktreeSymlinksSection } from './WorktreeSymlinksSection'
 import { SparsePresetSettingsSection } from './SparsePresetSettingsSection'
@@ -195,9 +195,8 @@ export function RepositoryPane({
       'Custom GitHub Issue Command'
     ].includes(entry.title)
   )
-  const formatOnSaveEntries = allEntries.filter((entry) =>
-    FORMAT_ON_SAVE_SEARCH_TITLES.includes(entry.title)
-  )
+  const formatOnSaveTitles = new Set(getFormatOnSaveSearchTitles())
+  const formatOnSaveEntries = allEntries.filter((entry) => formatOnSaveTitles.has(entry.title))
   const mcpEntries = allEntries.filter((entry) => entry.title === 'MCP Configs')
   const symlinkEntries = allEntries.filter((entry) => entry.title === 'Worktree Shared Paths')
   const sourceControlAiEntries = allEntries.filter((entry) => entry.title === 'Git AI Author')

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -4,6 +4,7 @@ import type {
   Project,
   ProjectUpdateArgs,
   Repo,
+  RepoFormatOnSaveSettings,
   RepoHookSettings
 } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
@@ -15,6 +16,8 @@ import { Trash2 } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { RepositoryHooksSection } from './RepositoryHooksSection'
+import { RepositoryFormatOnSaveSection } from './RepositoryFormatOnSaveSection'
+import { FORMAT_ON_SAVE_SEARCH_TITLES } from './repository-format-on-save-search-entries'
 import { McpConfigSection } from './McpConfigSection'
 import { WorktreeSymlinksSection } from './WorktreeSymlinksSection'
 import { SparsePresetSettingsSection } from './SparsePresetSettingsSection'
@@ -141,6 +144,12 @@ export function RepositoryPane({
     })
   }
 
+  const updateSelectedRepoFormatOnSave = (nextSettings: RepoFormatOnSaveSettings) => {
+    updateSelectedRepo(repo.id, {
+      formatOnSave: nextSettings
+    })
+  }
+
   const handleCopyTemplate = async () => {
     // Why: the missing-`orca.yaml` state is a migration aid, so copying the shared-template
     // snippet should be one click rather than forcing users to reconstruct the expected shape.
@@ -185,6 +194,9 @@ export function RepositoryPane({
       'When to Run Setup',
       'Custom GitHub Issue Command'
     ].includes(entry.title)
+  )
+  const formatOnSaveEntries = allEntries.filter((entry) =>
+    FORMAT_ON_SAVE_SEARCH_TITLES.includes(entry.title)
   )
   const mcpEntries = allEntries.filter((entry) => entry.title === 'MCP Configs')
   const symlinkEntries = allEntries.filter((entry) => entry.title === 'Worktree Shared Paths')
@@ -360,6 +372,14 @@ export function RepositoryPane({
       </section>
     ) : null,
     hooksSection,
+    forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, formatOnSaveEntries) ? (
+      <RepositoryFormatOnSaveSection
+        key="format-on-save"
+        repo={repo}
+        forceVisible={forceFullPaneForRepoMatch}
+        onUpdateFormatOnSave={updateSelectedRepoFormatOnSave}
+      />
+    ) : null,
     !isFolder &&
     (forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, sourceControlAiEntries)) ? (
       <RepositorySourceControlAiSection

--- a/src/renderer/src/components/settings/repository-format-on-save-search-entries.ts
+++ b/src/renderer/src/components/settings/repository-format-on-save-search-entries.ts
@@ -3,11 +3,18 @@ import type { SettingsSearchEntry } from './settings-search'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
-export const FORMAT_ON_SAVE_SEARCH_TITLES = [
-  'Format on Save',
-  'Formatter Command',
-  'Included Files'
-]
+/**
+ * Why: the pane filters entries by comparing titles, and titles go through
+ * `translate()`. Hardcoding English here hid the section from settings search in
+ * every other locale, so resolve the same translated strings the entries use.
+ */
+export function getFormatOnSaveSearchTitles(): string[] {
+  return [
+    translate('auto.components.settings.repository.search.formatOnSave', 'Format on Save'),
+    translate('auto.components.settings.repository.search.formatterCommand', 'Formatter Command'),
+    translate('auto.components.settings.repository.search.formatIncludedFiles', 'Included Files')
+  ]
+}
 
 export function getRepositoryFormatOnSaveSearchEntries(repo: Repo): SettingsSearchEntry[] {
   return [

--- a/src/renderer/src/components/settings/repository-format-on-save-search-entries.ts
+++ b/src/renderer/src/components/settings/repository-format-on-save-search-entries.ts
@@ -1,0 +1,84 @@
+import type { Repo } from '../../../../shared/types'
+import type { SettingsSearchEntry } from './settings-search'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export const FORMAT_ON_SAVE_SEARCH_TITLES = [
+  'Format on Save',
+  'Formatter Command',
+  'Included Files'
+]
+
+export function getRepositoryFormatOnSaveSearchEntries(repo: Repo): SettingsSearchEntry[] {
+  return [
+    {
+      title: translate('auto.components.settings.repository.search.formatOnSave', 'Format on Save'),
+      description: translate(
+        'auto.components.settings.repository.search.formatOnSaveDescription',
+        "Run this project's formatter after Orca saves a file."
+      ),
+      keywords: [
+        repo.displayName,
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.formatOnSaveKeyword',
+          'format on save'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.formatterKeyword',
+          'formatter'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.prettierKeyword',
+          'prettier'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.biomeKeyword',
+          'biome'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.gofmtKeyword',
+          'gofmt rustfmt ruff'
+        )
+      ]
+    },
+    {
+      title: translate(
+        'auto.components.settings.repository.search.formatterCommand',
+        'Formatter Command'
+      ),
+      description: translate(
+        'auto.components.settings.repository.search.formatterCommandDescription',
+        'Shell command run in the worktree root after each save.'
+      ),
+      keywords: [
+        repo.displayName,
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.formatterCommandKeyword',
+          'formatter command'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.formatOnSaveKeyword',
+          'format on save'
+        )
+      ]
+    },
+    {
+      title: translate(
+        'auto.components.settings.repository.search.formatIncludedFiles',
+        'Included Files'
+      ),
+      description: translate(
+        'auto.components.settings.repository.search.formatIncludedFilesDescription',
+        'Globs limiting which saved files run the formatter.'
+      ),
+      keywords: [
+        repo.displayName,
+        ...translateSearchKeyword('auto.components.settings.repository.search.globKeyword', 'glob'),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.formatIncludeKeyword',
+          'format include'
+        )
+      ]
+    }
+  ]
+}

--- a/src/renderer/src/components/settings/repository-search.ts
+++ b/src/renderer/src/components/settings/repository-search.ts
@@ -7,6 +7,7 @@ import { translateSearchKeyword } from './settings-search-keywords'
 import { getRepositoryGitAuthorSearchEntries } from './repository-git-author-search-entries'
 import { getRepositoryGitHooksSearchEntries } from './repository-git-hooks-search-entries'
 import { getRepositoryGitWorktreeSearchEntries } from './repository-git-worktree-search-entries'
+import { getRepositoryFormatOnSaveSearchEntries } from './repository-format-on-save-search-entries'
 
 type RepositoryPaneSearchOptions = {
   isLocalWindowsProject?: boolean
@@ -220,6 +221,9 @@ export function getRepositoryPaneSearchEntries(
       ]
     },
     ...(isFolder ? [] : getRepositoryGitWorktreeSearchEntries(repo)),
+    // Why: format on save applies to folder workspaces too — it only needs a
+    // save and a root to run in, not a git worktree.
+    ...getRepositoryFormatOnSaveSearchEntries(repo),
     ...(isFolder
       ? []
       : [...getRepositoryGitAuthorSearchEntries(repo), ...getRepositoryGitHooksSearchEntries(repo)])

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8737,7 +8737,13 @@
             "keepForkUpToDate": "Keep Fork Up to Date",
             "keepForkUpToDateDescription": "Safely fast-forward this fork from upstream.",
             "projectRuntime": "Project Runtime",
-            "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL."
+            "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
+            "formatOnSave": "Format on Save",
+            "formatOnSaveDescription": "Run this project's formatter after Orca saves a file.",
+            "formatterCommand": "Formatter Command",
+            "formatterCommandDescription": "Shell command run in the worktree root after each save.",
+            "formatIncludedFiles": "Included Files",
+            "formatIncludedFilesDescription": "Globs limiting which saved files run the formatter."
           }
         },
         "runtime": {
@@ -10072,6 +10078,18 @@
           "setupRecipe": "Set up an environment recipe for your cloud provider.",
           "createWorkspace": "Create a workspace and select that recipe under Run on.",
           "openSetup": "Set up environment recipes"
+        },
+        "RepositoryFormatOnSaveSection": {
+          "enableTitle": "Format on Save",
+          "enableDescription": "Run this project's formatter after Orca saves a file in this repository.",
+          "sectionDescription": "Orca runs the command in the worktree root after each save, so the project’s own formatter config and version apply.",
+          "needsCommand": "Set a formatter command below to turn this on.",
+          "commandTitle": "Formatter Command",
+          "commandDescription": "Shell command run in the worktree root. ${file} and ${relativeFile} expand to the saved file.",
+          "commandHint": "A non-zero exit leaves the saved file untouched and shows the formatter’s error.",
+          "includeTitle": "Included Files",
+          "includeDescription": "Comma-separated globs limiting which saved files run the command. Leave empty to format every saved file.",
+          "remoteNotice": "This project runs on a remote host. Saves there are written unformatted — Orca only runs the formatter for local and WSL worktrees."
         }
       },
       "right": {
@@ -13217,6 +13235,13 @@
               "notice": {
                 "8c59ce5075": "Failed to save the file. Please try again."
               }
+            }
+          }
+        },
+        "formatOnSave": {
+          "failure": {
+            "notice": {
+              "4f2b1c9a7d": "Formatter failed"
             }
           }
         }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10089,7 +10089,8 @@
           "commandHint": "A non-zero exit leaves the saved file untouched and shows the formatter’s error.",
           "includeTitle": "Included Files",
           "includeDescription": "Comma-separated globs limiting which saved files run the command. Leave empty to format every saved file.",
-          "remoteNotice": "This project runs on a remote host. Saves there are written unformatted — Orca only runs the formatter for local and WSL worktrees."
+          "remoteNotice": "This project runs on a remote host. Saves there are written unformatted — Orca only runs the formatter for local and WSL worktrees.",
+          "runtimeHostNotice": "This project runs on a runtime host, which has no channel for running the command. Saves there are written unformatted; local, WSL, and SSH worktrees are formatted."
         }
       },
       "right": {

--- a/src/shared/format-on-save-command.test.ts
+++ b/src/shared/format-on-save-command.test.ts
@@ -109,6 +109,44 @@ describe('format-on-save command expansion', () => {
     ).toBe(`prettier --write '/repo/a b/it'\\''s; rm -rf ~.ts'`)
   })
 
+  it('does not rescan a substituted path, so a token in a filename stays quoted', () => {
+    // Why: `${file}` is a legal POSIX filename. Substituting sequentially spliced
+    // the absolute path inside the already-quoted relative path and broke quoting.
+    const relativePath = 'src/a${file}b.ts'
+    expect(
+      expandFormatOnSaveCommand({
+        command: 'prettier --write ${relativeFile}',
+        absolutePath: `/repo/${relativePath}`,
+        relativePath,
+        platform: 'darwin'
+      })
+    ).toBe("prettier --write 'src/a${file}b.ts'")
+  })
+
+  it('substitutes both tokens independently in one pass', () => {
+    expect(
+      expandFormatOnSaveCommand({
+        command: '${file} ${relativeFile} ${file}',
+        absolutePath: '/repo/a.ts',
+        relativePath: 'a.ts',
+        platform: 'darwin'
+      })
+    ).toBe("'/repo/a.ts' 'a.ts' '/repo/a.ts'")
+  })
+
+  it('treats a dollar-brace sequence in the replacement as literal text', () => {
+    // Why: String.replace expands `$&`-style patterns in a string replacement;
+    // the callback form must not.
+    expect(
+      expandFormatOnSaveCommand({
+        command: 'fmt ${file}',
+        absolutePath: '/repo/$&$`.ts',
+        relativePath: '$&$`.ts',
+        platform: 'darwin'
+      })
+    ).toBe("fmt '/repo/$&$`.ts'")
+  })
+
   it('wraps windows paths in double quotes', () => {
     expect(quoteForShell('C:\\repo\\a b.ts', 'win32')).toBe('"C:\\repo\\a b.ts"')
   })

--- a/src/shared/format-on-save-command.test.ts
+++ b/src/shared/format-on-save-command.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  expandFormatOnSaveCommand,
+  isFormatOnSaveConfigured,
+  matchesFormatOnSaveInclude,
+  normalizeRepoFormatOnSaveSettings,
+  quoteForShell
+} from './format-on-save-command'
+
+describe('format-on-save settings normalization', () => {
+  it('treats an enabled config with a blank command as off', () => {
+    expect(normalizeRepoFormatOnSaveSettings({ enabled: true, command: '   ' })).toEqual({
+      enabled: false,
+      command: '',
+      include: []
+    })
+  })
+
+  it('drops non-string and blank include entries from persisted state', () => {
+    const settings = normalizeRepoFormatOnSaveSettings({
+      enabled: true,
+      command: 'prettier --write ${file}',
+      include: ['**/*.ts', '', '   ', 7, null, '**/*.md']
+    })
+
+    expect(settings.include).toEqual(['**/*.ts', '**/*.md'])
+    expect(settings.enabled).toBe(true)
+  })
+
+  it('reads a missing config as disabled defaults', () => {
+    expect(normalizeRepoFormatOnSaveSettings(undefined)).toEqual({
+      enabled: false,
+      command: '',
+      include: []
+    })
+    expect(isFormatOnSaveConfigured(undefined)).toBe(false)
+  })
+})
+
+describe('format-on-save include matching', () => {
+  it('matches every saved file when no globs are configured', () => {
+    expect(matchesFormatOnSaveInclude('src/a.ts', [])).toBe(true)
+  })
+
+  it('matches nested and root files for a leading double star', () => {
+    expect(matchesFormatOnSaveInclude('src/deep/nested/a.ts', ['**/*.ts'])).toBe(true)
+    expect(matchesFormatOnSaveInclude('a.ts', ['**/*.ts'])).toBe(true)
+  })
+
+  it('expands brace alternatives', () => {
+    const include = ['**/*.{ts,tsx,json}']
+    expect(matchesFormatOnSaveInclude('src/a.tsx', include)).toBe(true)
+    expect(matchesFormatOnSaveInclude('src/a.json', include)).toBe(true)
+    expect(matchesFormatOnSaveInclude('src/a.css', include)).toBe(false)
+  })
+
+  it('keeps a single star from crossing directory boundaries', () => {
+    expect(matchesFormatOnSaveInclude('src/deep/a.ts', ['src/*.ts'])).toBe(false)
+    expect(matchesFormatOnSaveInclude('src/a.ts', ['src/*.ts'])).toBe(true)
+  })
+
+  it('matches a slashless pattern against the basename in any directory', () => {
+    expect(matchesFormatOnSaveInclude('deep/nested/a.ts', ['*.ts'])).toBe(true)
+  })
+
+  it('normalizes windows separators before matching', () => {
+    expect(matchesFormatOnSaveInclude('src\\deep\\a.ts', ['src/**/*.ts'])).toBe(true)
+  })
+
+  it('does not let glob metacharacters in a path widen the match', () => {
+    expect(matchesFormatOnSaveInclude('src/a.ts', ['src/a.t?'])).toBe(true)
+    expect(matchesFormatOnSaveInclude('src/reportx2026.ts', ['src/report.2026.ts'])).toBe(false)
+  })
+})
+
+describe('format-on-save command expansion', () => {
+  it('substitutes absolute and relative tokens', () => {
+    expect(
+      expandFormatOnSaveCommand({
+        command: 'prettier --write ${file} # ${relativeFile}',
+        absolutePath: '/repo/src/a.ts',
+        relativePath: 'src/a.ts',
+        platform: 'darwin'
+      })
+    ).toBe("prettier --write '/repo/src/a.ts' # 'src/a.ts'")
+  })
+
+  it('leaves a token-free command untouched', () => {
+    expect(
+      expandFormatOnSaveCommand({
+        command: 'pnpm format',
+        absolutePath: '/repo/src/a.ts',
+        relativePath: 'src/a.ts',
+        platform: 'linux'
+      })
+    ).toBe('pnpm format')
+  })
+
+  it('quotes paths that would otherwise break out of the argument', () => {
+    expect(
+      expandFormatOnSaveCommand({
+        command: 'prettier --write ${file}',
+        absolutePath: "/repo/a b/it's; rm -rf ~.ts",
+        relativePath: "a b/it's; rm -rf ~.ts",
+        platform: 'darwin'
+      })
+    ).toBe(`prettier --write '/repo/a b/it'\\''s; rm -rf ~.ts'`)
+  })
+
+  it('wraps windows paths in double quotes', () => {
+    expect(quoteForShell('C:\\repo\\a b.ts', 'win32')).toBe('"C:\\repo\\a b.ts"')
+  })
+})

--- a/src/shared/format-on-save-command.test.ts
+++ b/src/shared/format-on-save-command.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   expandFormatOnSaveCommand,
+  formatOnSaveIncludeToInput,
+  parseFormatOnSaveIncludeInput,
   isFormatOnSaveConfigured,
   matchesFormatOnSaveInclude,
   normalizeRepoFormatOnSaveSettings,
@@ -109,5 +111,24 @@ describe('format-on-save command expansion', () => {
 
   it('wraps windows paths in double quotes', () => {
     expect(quoteForShell('C:\\repo\\a b.ts', 'win32')).toBe('"C:\\repo\\a b.ts"')
+  })
+})
+
+describe('format-on-save include input', () => {
+  it('splits on commas and newlines and drops empty entries', () => {
+    expect(parseFormatOnSaveIncludeInput('**/*.ts, **/*.md,\n\n  **/*.css  ,')).toEqual([
+      '**/*.ts',
+      '**/*.md',
+      '**/*.css'
+    ])
+  })
+
+  it('round-trips through the settings input', () => {
+    const include = ['**/*.ts', '**/*.md']
+    expect(parseFormatOnSaveIncludeInput(formatOnSaveIncludeToInput(include))).toEqual(include)
+  })
+
+  it('reads an empty field as no restriction', () => {
+    expect(parseFormatOnSaveIncludeInput('   ')).toEqual([])
   })
 })

--- a/src/shared/format-on-save-command.ts
+++ b/src/shared/format-on-save-command.ts
@@ -8,6 +8,8 @@ export const SUGGESTED_FORMAT_ON_SAVE_COMMAND = 'npx prettier --write ${file}'
 
 export const FORMAT_ON_SAVE_FILE_TOKEN = '${file}'
 export const FORMAT_ON_SAVE_RELATIVE_FILE_TOKEN = '${relativeFile}'
+// Why: relativeFile first so the shared `${file}` prefix cannot win the match.
+const FORMAT_ON_SAVE_TOKEN_PATTERN = /\$\{relativeFile\}|\$\{file\}/g
 
 export type FormatOnSaveSkipReason =
   | 'not-configured'
@@ -164,11 +166,13 @@ export function expandFormatOnSaveCommand({
   const quotedAbsolute = quoteForShell(absolutePath, platform)
   const quotedRelative = quoteForShell(relativePath, platform)
 
-  return command
-    .split(FORMAT_ON_SAVE_RELATIVE_FILE_TOKEN)
-    .join(quotedRelative)
-    .split(FORMAT_ON_SAVE_FILE_TOKEN)
-    .join(quotedAbsolute)
+  // Why: one pass. Substituting sequentially lets the second pass rescan a path
+  // the first pass inserted, so a filename containing the literal text `${file}`
+  // would splice a second quoted path inside the first one and break the quoting
+  // this function exists to guarantee. Filenames come from cloned repositories.
+  return command.replace(FORMAT_ON_SAVE_TOKEN_PATTERN, (token) =>
+    token === FORMAT_ON_SAVE_RELATIVE_FILE_TOKEN ? quotedRelative : quotedAbsolute
+  )
 }
 
 export function quoteForShell(value: string, platform: NodeJS.Platform): string {

--- a/src/shared/format-on-save-command.ts
+++ b/src/shared/format-on-save-command.ts
@@ -1,0 +1,171 @@
+import type { RepoFormatOnSaveSettings } from './types'
+import { normalizeRuntimePathSeparators } from './cross-platform-path'
+
+/** Offered in Settings as a starting point; not applied unless the user saves it. */
+export const SUGGESTED_FORMAT_ON_SAVE_INCLUDE = '**/*.{ts,tsx,js,jsx,json,css,md}'
+
+export const FORMAT_ON_SAVE_FILE_TOKEN = '${file}'
+export const FORMAT_ON_SAVE_RELATIVE_FILE_TOKEN = '${relativeFile}'
+
+export type FormatOnSaveSkipReason =
+  | 'not-configured'
+  | 'not-included'
+  | 'outside-worktree'
+  | 'already-running'
+  /** SSH and runtime hosts expose no generic command channel, so the file is saved unformatted. */
+  | 'unsupported-host'
+
+export type FormatOnSaveResult =
+  | { status: 'completed' }
+  | { status: 'skipped'; reason: FormatOnSaveSkipReason }
+  | { status: 'failed'; message: string }
+
+export function getDefaultRepoFormatOnSaveSettings(): RepoFormatOnSaveSettings {
+  return { enabled: false, command: '', include: [] }
+}
+
+export function normalizeRepoFormatOnSaveSettings(value: unknown): RepoFormatOnSaveSettings {
+  const raw = (value ?? {}) as Partial<RepoFormatOnSaveSettings>
+  const command = typeof raw.command === 'string' ? raw.command.trim() : ''
+  const include = Array.isArray(raw.include)
+    ? raw.include
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    : []
+
+  return {
+    // Why: a command-less config would run nothing every save; treat it as off so callers can skip work early.
+    enabled: raw.enabled === true && command.length > 0,
+    command,
+    include
+  }
+}
+
+export function isFormatOnSaveConfigured(
+  settings: RepoFormatOnSaveSettings | undefined | null
+): boolean {
+  return settings?.enabled === true && settings.command.trim().length > 0
+}
+
+/**
+ * `include` semantics: empty list matches every saved file. A pattern without a
+ * `/` matches the basename in any directory, which is what users reach for when
+ * they type `*.ts`.
+ */
+export function matchesFormatOnSaveInclude(relativePath: string, include: string[]): boolean {
+  if (include.length === 0) {
+    return true
+  }
+
+  const normalized = normalizeRuntimePathSeparators(relativePath).replace(/^\.?\//, '')
+  const basename = normalized.slice(normalized.lastIndexOf('/') + 1)
+
+  return include.some((pattern) => {
+    const normalizedPattern = normalizeRuntimePathSeparators(pattern).replace(/^\.?\//, '')
+    const target = normalizedPattern.includes('/') ? normalized : basename
+    return globToRegExp(normalizedPattern).test(target)
+  })
+}
+
+const globRegExpCache = new Map<string, RegExp>()
+const GLOB_CACHE_LIMIT = 256
+
+function globToRegExp(pattern: string): RegExp {
+  const cached = globRegExpCache.get(pattern)
+  if (cached) {
+    return cached
+  }
+
+  const compiled = new RegExp(`^${compileGlobBody(pattern)}$`)
+  if (globRegExpCache.size >= GLOB_CACHE_LIMIT) {
+    globRegExpCache.clear()
+  }
+  globRegExpCache.set(pattern, compiled)
+  return compiled
+}
+
+function compileGlobBody(pattern: string): string {
+  let source = ''
+
+  for (let index = 0; index < pattern.length; index++) {
+    const char = pattern[index]
+
+    if (char === '*') {
+      const isDoubleStar = pattern[index + 1] === '*'
+      if (isDoubleStar) {
+        index++
+        if (pattern[index + 1] === '/') {
+          index++
+          // Why: `**/x` must also match a root-level `x`, so the directory prefix is optional.
+          source += '(?:.*/)?'
+          continue
+        }
+        source += '.*'
+        continue
+      }
+      source += '[^/]*'
+      continue
+    }
+
+    if (char === '?') {
+      source += '[^/]'
+      continue
+    }
+
+    if (char === '{') {
+      const closingIndex = pattern.indexOf('}', index)
+      if (closingIndex !== -1) {
+        const alternatives = pattern.slice(index + 1, closingIndex).split(',')
+        source += `(?:${alternatives.map((alternative) => compileGlobBody(alternative)).join('|')})`
+        index = closingIndex
+        continue
+      }
+    }
+
+    source += escapeRegExpChar(char)
+  }
+
+  return source
+}
+
+function escapeRegExpChar(char: string): string {
+  return /[.+^${}()|[\]\\]/.test(char) ? `\\${char}` : char
+}
+
+type FormatOnSaveCommandExpansion = {
+  command: string
+  absolutePath: string
+  relativePath: string
+  platform: NodeJS.Platform
+}
+
+/**
+ * Substitutes the path tokens with shell-quoted values. A command without any
+ * token is left alone — some formatters take the whole project.
+ */
+export function expandFormatOnSaveCommand({
+  command,
+  absolutePath,
+  relativePath,
+  platform
+}: FormatOnSaveCommandExpansion): string {
+  const quotedAbsolute = quoteForShell(absolutePath, platform)
+  const quotedRelative = quoteForShell(relativePath, platform)
+
+  return command
+    .split(FORMAT_ON_SAVE_RELATIVE_FILE_TOKEN)
+    .join(quotedRelative)
+    .split(FORMAT_ON_SAVE_FILE_TOKEN)
+    .join(quotedAbsolute)
+}
+
+export function quoteForShell(value: string, platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    // Why: `"` and `<>|&` are already illegal in Windows paths, so wrapping is
+    // enough; a lone `%` only expands as part of a defined `%VAR%` pair.
+    return `"${value}"`
+  }
+
+  return `'${value.split("'").join(`'\\''`)}'`
+}

--- a/src/shared/format-on-save-command.ts
+++ b/src/shared/format-on-save-command.ts
@@ -1,8 +1,9 @@
 import type { RepoFormatOnSaveSettings } from './types'
 import { normalizeRuntimePathSeparators } from './cross-platform-path'
 
-/** Offered in Settings as a starting point; not applied unless the user saves it. */
+/** Shown in Settings as placeholders; these are command/glob syntax, not UI copy. */
 export const SUGGESTED_FORMAT_ON_SAVE_INCLUDE = '**/*.{ts,tsx,js,jsx,json,css,md}'
+export const SUGGESTED_FORMAT_ON_SAVE_COMMAND = 'npx prettier --write ${file}'
 
 export const FORMAT_ON_SAVE_FILE_TOKEN = '${file}'
 export const FORMAT_ON_SAVE_RELATIVE_FILE_TOKEN = '${relativeFile}'
@@ -40,6 +41,18 @@ export function normalizeRepoFormatOnSaveSettings(value: unknown): RepoFormatOnS
     command,
     include
   }
+}
+
+/** Settings shows the globs as one comma-separated line; newlines are accepted for pasted lists. */
+export function parseFormatOnSaveIncludeInput(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+export function formatOnSaveIncludeToInput(include: string[]): string {
+  return include.join(', ')
 }
 
 export function isFormatOnSaveConfigured(

--- a/src/shared/format-on-save-command.ts
+++ b/src/shared/format-on-save-command.ts
@@ -1,5 +1,6 @@
 import type { RepoFormatOnSaveSettings } from './types'
 import { normalizeRuntimePathSeparators } from './cross-platform-path'
+import { escapeRegex } from './string-utils'
 
 /** Shown in Settings as placeholders; these are command/glob syntax, not UI copy. */
 export const SUGGESTED_FORMAT_ON_SAVE_INCLUDE = '**/*.{ts,tsx,js,jsx,json,css,md}'
@@ -13,7 +14,7 @@ export type FormatOnSaveSkipReason =
   | 'not-included'
   | 'outside-worktree'
   | 'already-running'
-  /** SSH and runtime hosts expose no generic command channel, so the file is saved unformatted. */
+  /** Runtime hosts, and SSH hosts whose relay is down, have no exec channel to reach the file. */
   | 'unsupported-host'
 
 export type FormatOnSaveResult =
@@ -136,14 +137,11 @@ function compileGlobBody(pattern: string): string {
       }
     }
 
-    source += escapeRegExpChar(char)
+    // Why: `*` and `?` are consumed above, so whatever reaches here is a literal.
+    source += escapeRegex(char)
   }
 
   return source
-}
-
-function escapeRegExpChar(char: string): string {
-  return /[.+^${}()|[\]\\]/.test(char) ? `\\${char}` : char
 }
 
 type FormatOnSaveCommandExpansion = {
@@ -175,9 +173,9 @@ export function expandFormatOnSaveCommand({
 
 export function quoteForShell(value: string, platform: NodeJS.Platform): string {
   if (platform === 'win32') {
-    // Why: `"` and `<>|&` are already illegal in Windows paths, so wrapping is
-    // enough; a lone `%` only expands as part of a defined `%VAR%` pair.
-    return `"${value}"`
+    // Why: doubling `"` matches how cmd.exe unquotes, and a lone `%` only
+    // expands as part of a defined `%VAR%` pair.
+    return `"${value.split('"').join('""')}"`
   }
 
   return `'${value.split("'").join(`'\\''`)}'`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -254,6 +254,8 @@ export type Repo = {
   /** Optional repo-scoped workspace root override. Relative paths resolve from `path`. */
   worktreeBasePath?: string
   hookSettings?: RepoHookSettings
+  /** Formatter run after editor saves. Absent = never formatted. */
+  formatOnSave?: RepoFormatOnSaveSettings
   /** SSH target ID for remote repos. null/undefined = local. */
   connectionId?: string | null
   /**
@@ -2151,6 +2153,15 @@ export type RepoHookSettings = {
     setup: string
     archive: string
   }
+}
+
+/** Per-repo format-on-save command, run after the editor writes a file to disk. */
+export type RepoFormatOnSaveSettings = {
+  enabled: boolean
+  /** Shell command run in the worktree root. `${file}` / `${relativeFile}` expand to the saved path. */
+  command: string
+  /** Globs limiting which saved files run the command. Empty = every saved file. */
+  include: string[]
 }
 
 export type WorktreeSetupLaunch = {


### PR DESCRIPTION
## Summary

Closes #11494.

Adds a per-project format-on-save command, so a file saved in Orca's editor comes out formatted the same way it would in the editor you left open next to it.

Monaco has no extension host, so `esbenp.prettier-vscode` and its equivalents can't run inside Orca, and Settings exposes nothing about formatting. Files saved here land unformatted while the same files saved in VS Code don't, and the diff picks up whichever editor touched a line last. Bundling formatters or reading their configs is the wrong end of the problem — every project already has a formatter it knows how to run, so Orca shells out to it. One generic hook covers Prettier, Biome, `gofmt`, `rustfmt`, `ruff format`, ktlint, and anything else with a CLI.

The command runs with the worktree root as cwd, so the project's own config and pinned version resolve the way they do in a terminal. `${file}` and `${relativeFile}` expand to the saved path, shell-quoted at substitution time; a command with neither token runs as written, which is what a whole-project formatter wants. Include globs limit which saves trigger it, and an empty list means every saved file. Glob matching is written out in `format-on-save-command.ts` rather than pulling in a matcher — it needs `*`, `**`, `?` and `{a,b}`, and a pattern without a `/` matches the basename, because `*.ts` is what people type when they mean TypeScript files.

Three things worth flagging for review:

**The command never crosses the IPC boundary.** `editor:formatOnSave` takes a repo id, a worktree path and a file path; the handler reads the command off the repo record and authorizes the worktree path through `resolveRegisteredWorktreePath`. If the renderer could supply the command, this channel would be arbitrary command execution wearing a formatter's name. The tests assert that property directly rather than only testing the happy path.

**Adopting formatter output is conditional.** The formatter runs after the write lands and the file is read back, but the result only enters the buffer if the user hasn't typed since the save — otherwise their keystrokes win and the next save reformats. Disk still holds the formatted bytes either way, so the disk-baseline signature tracks the formatted content regardless of which side the buffer took. The formatter's write is also re-stamped in the self-write registry; the stamp taken before the original write covers the pre-format bytes, and without a second one the watcher reports Orca's own formatting as a changed-on-disk conflict.

**A formatter failure never fails the save.** The file is already on disk by then. A non-zero exit surfaces as a non-blocking toast carrying the formatter's stderr, truncated — the actionable line is the parse error, not Node's "Command failed".

Adopting the output replaces the whole model, and that turned up a bug underneath: the caret jumped to the end of the file on every save. It isn't a format-on-save bug. `replaceModelContent` has always done a full-range replace, and `pushEditOperations` collapses selections to the end of the replaced range, so the caret has been dying on every external rewrite of an open file — an agent editing what you're reading, a `git checkout`, a formatter run from a terminal. Fixed in the first commit, selections captured before the edit and restored clamped through `validatePosition`. Read-only live-tail syncs keep their current behavior; those are machine-owned log appends with no caret to save. It's a separate defect and reproduces without any of this — open a file, put the caret mid-document, edit it from a terminal — so it's split out as its own commit and is easy to drop if you'd rather see it on its own.

SSH-backed repos format on the host that owns the file, through `agent.execNonInteractive` — the same relay channel the AI commit-message generator uses to run agent CLIs remotely, and the worktree archive hook uses to run a shell script there. The command is wrapped the way the archive hook wraps its script (`/bin/bash -lc`, or `cmd.exe /d /s /c` when the remote path shape says the host is Windows), and quoting follows the remote platform rather than this one. A dropped relay is a skip, not a failure — the save already landed, so a transport error must not read as the formatter rejecting the file.

Runtime-hosted repos are the one case left out; they have no equivalent non-interactive exec channel, and the Settings notice names that case specifically. Folder workspaces are supported — formatting needs a save and a root to run in, not a git worktree.

## Screenshots

Settings → Projects → Format on Save.

The switch cannot turn on without a command, so clicking it there writes nothing and instead marks the command field invalid, nudges it, and focuses it:

<img width="3456" height="2168" alt="orca-format-on-save-needs-command" src="https://github.com/user-attachments/assets/95eca5a4-435e-4dfd-a336-58d1fca20a52" />

Configured — the command runs in the worktree root, and the globs limit which saved files trigger it:

<img width="3456" height="2168" alt="orca-format-on-save-configured" src="https://github.com/user-attachments/assets/b506cb03-815a-4d52-8371-c407f37b3a0b" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (see note)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

42,104 passing. Eight suites fail on my machine for reasons that predate this branch — I checked by running them on a clean worktree at `a2d0e77`, where exactly the same eight fail. One is the `ko-KR` locale issue already known from #11275: `automation-schedules.test.ts` expects `'Sundays at ...'` and `Intl` on a Korean host returns `'일요일s at ...'`; it passes under `LANG=en_US.UTF-8`. The other seven (`clipboard-ipc-handlers`, `agent-exec-handler`, the three `orchestration` suites, `coordinator`, `codex-fetcher-pty-settle`) fail in isolation too and are unrelated to anything here. My own suites were run repeatedly to confirm they aren't flaky.

102 unit cases across the new surfaces:

- Shared: glob semantics — brace expansion, single-star not crossing directory boundaries, `**/x` matching a root-level `x`, and glob metacharacters *inside a path* not widening the match. Shell quoting of a path containing both a space and a single quote.
- Runner: every skip reason, cwd and token substitution, stderr propagation, in-flight suppression and its release after a failure, the WSL branch, and the remote branch — POSIX and Windows SSH hosts, remote stderr, remote timeout vs spawn failure, a dropped relay degrading to a skip, and per-host in-flight slots for an identical path. The worktree-relative check uses the project's platform-free path helper instead of `path.relative`, which is what lets CI actually cover the WSL case rather than silently skipping it on a POSIX runner.
- IPC: the properties that make the handler safe — command comes from the repo record and not the payload, the path is authorized before anything runs, the *resolved* path is what reaches the runner, and SSH hosts, runtime hosts, unknown repos and malformed payloads are all refused.
- Save queue: adoption into the buffer, the typed-while-formatting case, self-write re-stamping, and a formatter failure still resolving the save.
- Monaco: caret preservation and clamping against a real Monaco model, including a rewrite that pushes the caret past the new end of file.
- Settings: commit-on-blur, glob parsing, the remote notice, and the empty-command interaction.

Beyond the suite I ran the runner against the real `oxfmt` binary, spawning an actual process and asserting the bytes on disk: a successful rewrite, a parse failure leaving the file untouched, a glob-excluded file, and a path containing a space and a quote. That last one is the case unit tests can't really prove, since it's the shell that has to agree with the quoting.

## AI Review Report

Reviewed with an AI coding agent.

- Cross-platform: shell selection follows the existing hook runner — `ComSpec` on Windows, `/bin/bash` elsewhere. Quoting is platform-specific (POSIX single-quote escaping, double quotes on Windows where `"` and `<>|&` are already illegal in paths). No path separator is assumed anywhere; comparisons go through `normalizeRuntimePathForComparison` and `relativePathInsideRoot`. WSL UNC worktrees run inside the distro via `wsl.exe -d <distro> -- bash -c` with Linux-side paths, because a Windows-native run would either miss the toolchain or crawl over the 9P bridge. No new shortcuts or shortcut labels.
- SSH and remote: SSH formats remotely through the existing relay exec channel, with the remote platform deciding the shell and the quoting. The first revision of this PR skipped SSH on the mistaken belief that no such channel existed — `git.exec` allowlists git subcommands, but `agent.execNonInteractive` is general and already in use. Runtime hosts remain unsupported and say so. A relay that is down degrades to a skip rather than an error toast.
- Compatibility: no git command, provider, or agent state is touched, and nothing in the save path changes for a repo that hasn't opted in. `formatOnSave` is optional on `Repo`, so existing records read as "never formatted" with no migration.
- Performance: one IPC and at most one process spawn per save, only for opted-in repos and only for files matching the globs. Compiled globs are cached in a bounded map. Non-matching files and remote saves short-circuit before any work.
- UI: built from the existing settings primitives, no new tokens or one-off styles. Errors surface through `aria-invalid`, which the `Input` primitive already maps to the destructive ring, rather than hand-painted color. The nudge animation is dropped under `prefers-reduced-motion`. All new strings go through `translate()` and are registered in the catalog.

What came out of the review: SSH support was missing because I read the `git.exec` allowlist as the whole story and never looked for a general exec channel; `agent.execNonInteractive` was already there, used by two other features. The first version of the enable switch accepted a click with no command configured, wrote `{ enabled: true, command: '' }`, and then read back as off because normalization treats a command-less config as disabled — the switch looked broken and the stored state meant nothing. Normalization now runs on write as well as read, and the click points at the field that's missing instead of springing back. Two more came from re-reading the runner against how formatters actually behave: Node's 1 MB default `maxBuffer` kills a *successful* `black --verbose` or `prettier --loglevel debug` mid-run and reports it as a failure even though the file was rewritten correctly, and a timed-out process carries no stderr, so it surfaced as a bare "Command failed" that named nothing. The in-flight key was also comparing raw paths, so on Windows two tabs on the same file under differently-cased paths each started a formatter over the other's output; it now uses the comparison form, which folds case for Windows paths only — folding POSIX paths would treat two genuinely different files as one.

## Security Audit

This change executes a user-configured shell command, so the boundary matters more than usual.

The command is never accepted from the renderer. `editor:formatOnSave` carries a repo id, a worktree path and a file path; the handler looks the command up on the repo record. A compromised or buggy renderer can therefore pick *which* repo's configured formatter runs, but cannot introduce a command. The worktree path is authorized through `resolveRegisteredWorktreePath` — the same check the filesystem IPC uses — and the resolved path, not the caller's string, becomes the cwd. A file outside that worktree is refused before anything spawns, and null bytes are rejected at the boundary.

Both path tokens are shell-quoted at substitution time, so a filename containing spaces, quotes or `;` can't break out of its argument; there's a test for exactly that string, and the live run against `oxfmt` confirms the shell agrees. Command text itself is intentionally not escaped — it's the user's own command and `&&` or `|` in it are legitimate.

On SSH hosts the command runs through `agent.execNonInteractive`, which already applies the unattended git-credential prompt guard, so a formatter that shells out to git can't hang on a credential prompt. Remote worktree paths are not run through the local registered-root check — that check resolves against this machine's filesystem and would reject or rewrite a remote path — so the remote path is passed as the caller supplied it, exactly as the existing remote hook and archive paths do.

Configuration is stored in the existing repo record and travels through `updateRepo`, which already validates its payload. No new dependencies, no network, no credentials, no filesystem writes outside what the user's formatter does. The process inherits Orca's environment, so a formatter resolves the same PATH the app already hydrates at startup.

## Notes

- Reused rather than reinvented, after a pass looking for duplicates: `escapeRegex` (`shared/string-utils`), `stableInFlightKey` (`shared/in-flight-promise-dedupe`), `getCmdExePath` (`shared/windows-batch-spawn`), `relativePathInsideRoot` and `normalizeRuntimePathForComparison` (`shared/cross-platform-path`), and `isWindowsAbsolutePathLike` for the remote-Windows check the archive hook already uses. Shell quoting is still local to this module — the codebase has at least six copies of that logic in different shapes (`ai-vault-types`, `setup-runner-command`, `tui-agent-startup-shell`, `wsl-login-shell-command`, `ephemeral-vm-recipe-process`, `terminal-pane/pane-helpers`), none exported in a form this could use. Consolidating them looked like a separate change; happy to do it if you'd like it folded in.
- One command per project, not per language. A project that formats TypeScript with Prettier and Python with Black needs a command that dispatches on the path, or two entries — which the current shape doesn't have. Language-scoped commands would compose with this rather than replace it, but they'd want a real settings surface, so I left them out.
- No E2E spec. Per `tests/e2e/AGENTS.md` the bar is behavior a unit test genuinely can't reach; the pieces here are either pure logic or an IPC handler, both covered directly, and the one thing that isn't — a real formatter rewriting a real file — I verified by running against `oxfmt` rather than pinning CI to a formatter binary. Happy to add one if you'd rather have it in the suite.
- The 20 s timeout kills the formatter but not grandchildren it spawned. Same limitation as the existing hook runner, and fixing it belongs with that code rather than here.
- `already-running` skips rather than queues a trailing run, so back-to-back saves from two tabs on one file can leave the last save unformatted. The save queue already serializes per file, so this only shows up across tabs; queuing seemed worse than skipping for something that runs on every keystroke pause.

## ELI5

You set up "run Prettier when I save" in your other editor. Orca's editor couldn't do that, so files you saved here came out looking different from the rest of the project. Now you can tell Orca, per project, what command to run after a save — and it also stops the cursor from jumping to the bottom of the file when something else edits it.

