### PR TITLE
fix(e2e): restore the helpers the macOS key-remap spec imports

### DIFF
--- a/tests/e2e/terminal-ime-cdp-composition.ts
+++ b/tests/e2e/terminal-ime-cdp-composition.ts
@@ -1,0 +1,89 @@
+import type { CDPSession } from '@stablyai/playwright-test'
+
+/**
+ * Dispatches the key shapes an input source or a system text substitution produces, through CDP.
+ *
+ * Driving these from the browser protocol rather than a native input source is what removes the
+ * accessibility grant and the system input source that would otherwise force a `@headful`,
+ * macOS-only gate, so the specs they feed run in the normal headless project on CI.
+ */
+export type ImeKeyIdentity = {
+  key: string
+  code: string
+  keyCode: number
+}
+
+/**
+ * A printable keydown whose `key` the input source has already rewritten to the glyph it will
+ * commit — the shape a CJK source produces for punctuation and full-width digits, which arrive
+ * with no composition session at all.
+ */
+export async function dispatchImeRewrittenPrintableKey(
+  session: CDPSession,
+  identity: ImeKeyIdentity
+): Promise<void> {
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode,
+    text: identity.key,
+    unmodifiedText: identity.key
+  })
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode
+  })
+}
+
+/**
+ * A printable keydown that still carries the **physical layout key**, followed by the substituted
+ * glyph arriving through the text system.
+ *
+ * This is the macOS shape for full-width punctuation and digits, and for a
+ * `DefaultKeyBinding.dict` remap: the substitution happens inside `insertText:`, not on the
+ * keydown, so the keydown Chromium delivers is the plain layout character and the substituted one
+ * only ever appears in the `input` event. Anything that produces terminal bytes from the keydown
+ * emits the layout form and destroys the real one.
+ */
+export async function dispatchImeSubstitutedTextKey(
+  session: CDPSession,
+  identity: ImeKeyIdentity,
+  committedText: string
+): Promise<void> {
+  // rawKeyDown carries no `text`, so Chromium generates no character of its own and the only
+  // committed text is the one the text system supplies below.
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'rawKeyDown',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode,
+    text: '',
+    unmodifiedText: ''
+  })
+  await session.send('Input.insertText', { text: committedText })
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode
+  })
+}
+
+export async function dispatchPlainEnter(session: CDPSession): Promise<void> {
+  for (const type of ['rawKeyDown', 'keyUp'] as const) {
+    await session.send('Input.dispatchKeyEvent', {
+      type,
+      key: 'Enter',
+      code: 'Enter',
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13
+    })
+  }
+}

--- a/tests/e2e/terminal-ime-pane-arena.ts
+++ b/tests/e2e/terminal-ime-pane-arena.ts
@@ -1,0 +1,50 @@
+import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  attachTerminalImeBoundaryEvidence,
+  disposeTerminalImeBoundaryProbe,
+  installTerminalImeBoundaryProbe
+} from './terminal-ime-boundary-probe'
+
+/** A focused terminal pane with a CDP session and the boundary probe already attached. */
+export type TerminalImePaneArena = {
+  page: Page
+  session: CDPSession
+  ptyId: string
+}
+
+export async function openTerminalImePaneArena(page: Page): Promise<TerminalImePaneArena> {
+  await waitForSessionReady(page)
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  const ptyId = await waitForActivePanePtyId(page)
+  const session = await page.context().newCDPSession(page)
+  await focusActiveTerminalInput(page)
+  await installTerminalImeBoundaryProbe(page)
+  return { page, session, ptyId }
+}
+
+/**
+ * `interrupt` sends Ctrl+C only when the test did not reach its end, so a spec that failed
+ * mid-composition cannot leave a byte reader holding the pane for the next test in the worker.
+ */
+export async function closeTerminalImePaneArena(
+  arena: TerminalImePaneArena,
+  testInfo: TestInfo,
+  evidenceName: string,
+  interrupt: boolean
+): Promise<void> {
+  await attachTerminalImeBoundaryEvidence(arena.page, testInfo, evidenceName).catch(() => undefined)
+  await disposeTerminalImeBoundaryProbe(arena.page).catch(() => undefined)
+  await arena.session.detach().catch(() => undefined)
+  if (interrupt) {
+    await sendToTerminal(arena.page, arena.ptyId, '\x03').catch(() => undefined)
+  }
+}

--- a/tests/e2e/terminal-ime-platform-policy.ts
+++ b/tests/e2e/terminal-ime-platform-policy.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@stablyai/playwright-test'
+
+/**
+ * Pins the renderer's IME ownership policy to one platform, from any runner.
+ *
+ * Every platform-dependent IME decision in the terminal reads `navigator.userAgent` and nothing
+ * else — the forwarder that owns printable keydowns installs only when the UA reports macOS, the
+ * candidate-key guards only when it reports desktop Linux, and the standalone `keyCode 229`
+ * keydown reaches xterm on macOS and Linux but not on Windows. Overriding the UA is therefore the
+ * whole platform decision, which is what lets the Windows and Linux shapes run headless on the
+ * Linux CI shards instead of needing three runners.
+ *
+ * What it does NOT simulate is the input framework itself. That comes from the recorded traces
+ * replayed against the pinned policy, because the frameworks disagree on ordering in ways no
+ * hand-authored sequence would have predicted.
+ */
+export type ImePlatformPolicy = 'mac' | 'windows' | 'linux'
+
+const USER_AGENT_BY_POLICY: Record<ImePlatformPolicy, string> = {
+  mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/146 Safari/537.36',
+  windows: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/146 Safari/537.36',
+  // X11 rather than Wayland in the UA string: Chromium reports the same token for both, so the
+  // Wayland traces run under this policy too.
+  linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/146 Safari/537.36'
+}
+
+export async function applyImePlatformPolicy(page: Page, policy: ImePlatformPolicy): Promise<void> {
+  await page.addInitScript((userAgent) => {
+    Object.defineProperty(navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true
+    })
+  }, USER_AGENT_BY_POLICY[policy])
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })
+}
+
+/** Fails loudly if the override did not take, so a policy-scoped spec cannot pass on the wrong one. */
+export async function expectImePlatformPolicy(
+  page: Page,
+  policy: ImePlatformPolicy
+): Promise<void> {
+  const observed = await page.evaluate(() => ({
+    mac: navigator.userAgent.includes('Mac'),
+    windows: navigator.userAgent.includes('Windows'),
+    linux: navigator.userAgent.includes('Linux') && !/Android|CrOS/.test(navigator.userAgent)
+  }))
+  if (!observed[policy] || (policy !== 'mac' && observed.mac)) {
+    throw new Error(`IME platform policy '${policy}' did not take: ${JSON.stringify(observed)}`)
+  }
+}


### PR DESCRIPTION
## What

`tests/e2e/terminal-macos-system-key-remap.spec.ts` imports three modules that are not in the repo:

- `./terminal-ime-pane-arena`
- `./terminal-ime-cdp-composition`
- `./terminal-ime-platform-policy`

#13314 added the spec, and its final commit — `chore: drop non-mergeable IME e2e scratch files` — deleted the three helpers. The spec was left behind.

## Why it matters more than one spec

Playwright resolves every spec before running any of them, so an unresolved import is fatal for the entire run rather than for the one file. On `main` today:

```
$ npx playwright test --config tests/playwright.config.ts --project=electron-headless --list
Error: Cannot find module './terminal-ime-pane-arena'
   at terminal-macos-system-key-remap.spec.ts:37
Total: 0 tests in 0 files
```

`playwright.config.ts` matches `**/*.spec.ts` with no `testIgnore`, so all ten scheduled E2E shards have been failing at collection since #13314 merged, and the macOS system-key-remap coverage the PR existed for has never run.

It stayed invisible because no `tsconfig` project includes `tests/`, so `pnpm run typecheck` never sees these imports, and PR E2E is advisory (`e2e` is deliberately absent from `verify`'s `needs`).

## Change

Restored from `56bf4a24758^`, the commit before the drop:

- `terminal-ime-pane-arena.ts` and `terminal-ime-platform-policy.ts` — verbatim; every export is used by the surviving spec.
- `terminal-ime-cdp-composition.ts` — only the four entry points this spec imports (`ImeKeyIdentity`, `dispatchImeRewrittenPrintableKey`, `dispatchImeSubstitutedTextKey`, `dispatchPlainEnter`). The dropped exports drove composition sessions for specs that were never merged, so bringing them back would be dead code. The module doc is retargeted to what remains.

All dependencies (`helpers/store`, `helpers/terminal`, `terminal-ime-boundary-probe`, `terminal-ime-byte-reader`) are already on `main`.

## Verification

Collection restored:

```
Total: 528 tests in 222 files
```

The spec itself, run locally on macOS:

```
Running 6 tests using 1 worker
  ✓ sends ` for the 두벌식 backquote key when a system remap rewrites it to a backquote (6.7s)
  ✓ sends ₩ for the 두벌식 backquote key when no remap is installed (6.2s)
  ✓ sends ₩ for the 두벌식 backquote key when a system remap substitutes it for itself (5.2s)
  ✓ sends ` for the 세벌식 최종 backquote key when a system remap rewrites it to a backquote (6.1s)
  ✓ sends * for the 세벌식 최종 backquote key when no remap is installed (5.2s)
  ✓ sends * for the 세벌식 최종 backquote key when a system remap substitutes it for itself (5.3s)
  6 passed (42.2s)
```

`oxlint tests/` and `check:reliability-gates` are clean.

Note: this PR touches no `*.spec.ts`, so `e2e-paths` in `pr.yml` will skip the advisory E2E job. A full `e2e.yml` run is dispatched against this branch separately to confirm collection and these six tests on the Linux runners.

## Scope

This restores collection. It does not claim the full suite is green — `pr.yml` records that it is red on `main` for other reasons, and flipping the merge gate on is a separate call.

Made with [Orca](https://github.com/stablyai/orca) 🐋
