### PR TITLE
fix(worktree-poller): sample the scan gate before its listing

### DIFF
--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { writeFileSync } from 'node:fs'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -263,6 +263,44 @@ describe('worktree base directory poller', () => {
     expect(
       events.filter((event) => event.type === 'create' && event.path === markerPath)
     ).toHaveLength(2)
+  })
+
+  it('rescans on the next tick when a write races an in-flight full scan', async () => {
+    const root = await makeRoot()
+    const worktree = join(root, 'raced')
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    const snapshotTicks: number[] = []
+    let raced = false
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      {
+        pollIntervalMs: 0,
+        onSnapshotTaken: (tick) => {
+          snapshotTicks.push(tick)
+          if (raced) {
+            return
+          }
+          raced = true
+          mkdirSync(worktree)
+          writeFileSync(join(worktree, '.git'), 'gitdir: elsewhere')
+        }
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+
+    // A write landing after a scan's listings must leave the gate stale, so the
+    // next tick rescans instead of deferring the create to the backstop.
+    expect(snapshotTicks.slice(0, 2)).toEqual([
+      WORKTREE_BASE_BACKSTOP_TICKS,
+      WORKTREE_BASE_BACKSTOP_TICKS + 1
+    ])
   })
 
   it('parks base scans while hidden and losslessly detects changes on resume', async () => {

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -65,6 +65,8 @@ export type WorktreeBasePollerOptions = {
   onFullScan?: () => void
   /** Test hook: called before a pending `.git` marker stat. */
   onPendingMarkerProbe?: (path: string) => void
+  /** Test hook: awaited with the tick after a full scan's listings, to land a racing write. */
+  onSnapshotTaken?: (tick: number) => void | Promise<void>
   /** Test hook: overrides the fast-probe window. */
   pendingMarkerMaxTicks?: number
 }
@@ -117,6 +119,8 @@ type BaseSnapshot = {
   // dirs whose listing determines the candidate set: the root plus any
   // nested repo containers. Their stat signatures gate the next full scan.
   gateDirs: string[]
+  // index-aligned with gateDirs, each sampled *before* that dir's listing
+  gateSignatures: string[]
 }
 
 // Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
@@ -128,6 +132,10 @@ async function snapshotBase(
 ): Promise<BaseSnapshot> {
   const markers = new Map<string, boolean>()
   const gateDirs = [rootPath]
+  // Why: sampling the signature before the listing makes a write that races the
+  // scan look stale next tick (one redundant rescan) instead of invisible until
+  // the backstop, which is up to 15 ticks of missed creates/deletes.
+  const gateSignatures = [await dirSignature(rootPath)]
   const configs = [...repos.values()]
   const includeFlat = configs.some((config) => !config.nestWorkspaces)
   const nestedRepoNames = new Set(
@@ -142,7 +150,7 @@ async function snapshotBase(
   } catch {
     // Root vanished: an empty snapshot diffs into delete events for every
     // previously-known worktree dir, matching the old watcher's error path.
-    return { markers, gateDirs }
+    return { markers, gateDirs, gateSignatures }
   }
 
   const candidates: string[] = []
@@ -156,6 +164,7 @@ async function snapshotBase(
     }
     if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
       gateDirs.push(entryPath)
+      gateSignatures.push(await dirSignature(entryPath))
       let subEntries
       try {
         subEntries = await readdir(entryPath, { withFileTypes: true })
@@ -173,7 +182,7 @@ async function snapshotBase(
   for (const dir of candidates) {
     markers.set(dir, await hasGitMarker(dir))
   }
-  return { markers, gateDirs }
+  return { markers, gateDirs, gateSignatures }
 }
 
 function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent[] {
@@ -203,7 +212,6 @@ async function startBasePoller(
   let ticking = false
   let tickCount = 0
   let snapshot = await snapshotBase(target.path, getRepos())
-  let gateSignatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
   const pendingMarkerMaxTicks = options.pendingMarkerMaxTicks ?? PENDING_MARKER_MAX_TICKS
@@ -218,7 +226,7 @@ async function startBasePoller(
   const fullScan = async (): Promise<void> => {
     options.onFullScan?.()
     const next = await snapshotBase(target.path, getRepos())
-    const nextSignatures = await Promise.all(next.gateDirs.map(dirSignature))
+    await options.onSnapshotTaken?.(tickCount)
     if (disposed) {
       return
     }
@@ -236,7 +244,6 @@ async function startBasePoller(
       }
     }
     snapshot = next
-    gateSignatures = nextSignatures
     if (events.length > 0) {
       onEvents(events)
     }
@@ -274,8 +281,8 @@ async function startBasePoller(
     // are untouched, skip the readdir + per-candidate stat fan-out entirely.
     const signatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
     const gateChanged =
-      signatures.length !== gateSignatures.length ||
-      signatures.some((sig, index) => sig !== gateSignatures[index])
+      signatures.length !== snapshot.gateSignatures.length ||
+      signatures.some((sig, index) => sig !== snapshot.gateSignatures[index])
     if (gateChanged) {
       await fullScan()
       return


### PR DESCRIPTION
## Summary

Fixes a latent race in the worktree base-directory poller that lets a filesystem change go undetected until the backstop fires (~30s at the production 2s tick).

`fullScan()` sampled each gate directory's signature **after** the directory listing:

```ts
const next = await snapshotBase(target.path, getRepos())
const nextSignatures = await Promise.all(next.gateDirs.map(dirSignature))
```

Any write landing between the listing and that stat gets baked into the recorded signature. The next tick then compares against a state the snapshot never actually saw, the gate reads "clean", and detection is deferred to the backstop — up to 15 ticks.

`BaseSnapshot` now carries `gateSignatures`, each stat'd **before** that gate dir's `readdir`. A racing write therefore reads as stale on the next tick and forces one redundant rescan instead of going invisible. Stat count per scan is unchanged.

### ELI5

Orca watches a folder by taking a photo of it, then writing down a "has this changed?" fingerprint. It was taking the photo first and the fingerprint second — so anything that happened in between got recorded as if it had always been there, and Orca never noticed it. Now the fingerprint is taken first.

## How this was found

CI on #13622 failed with:

```
FAIL src/main/ipc/worktree-base-directory-poller.test.ts > retires stale marker probes while preserving backstop detection and path reuse
AssertionError: expected 43 to be less than or equal to 30
```

That failure was unrelated to #13622 — the branch does not touch this file. In the spec, `rm -r ordinary-folder` races the scan; the snapshot catches the directory with `.git` already unlinked, opening a pending-marker window, and the swallowed gate change keeps that window alive for the whole backstop gap, burning one probe per tick. Baseline probes are 29 (28 phase-1 + 1 phase-3); +14 stale-window probes = 43, against a budget of 30.

Split out of #13622 so it lands on its own merits.

## Testing

- [x] New spec `rescans on the next tick when a write races an in-flight full scan`, with a narrow `onSnapshotTaken(tick)` hook alongside the file's existing `onFullScan` / `onPendingMarkerProbe` hooks.
- [x] Verified the new spec **discriminates**: reverting only the ordering (keeping the hook) fails with `expected [ 15, 30 ] to deeply equal [ 15, 16 ]`; it passes with the fix.
- [x] `worktree-base-directory-poller.test.ts` — 23/23 passing, x6 consecutive runs on the source branch, and re-verified 23/23 after cherry-picking onto current `main`.
- [x] `worktree-git-common-watch.test.ts` — 49 passing.
- [x] oxlint clean; no lint suppressions added.

The existing `pendingMarkerProbes <= pendingMarkerMaxTicks` assertion was **not** touched. With the fix the transient window costs 0 probes — a changed gate returns from `poll()` before `checkPendingMarkers()` runs — so the count stays at 29.

## Notes

- No wire, IPC shape, persistence, or renderer change. Main-process polling only.
- Applies equally to local, SSH, and folder workspaces; no git-worktree-specific assumption.

Made with [Orca](https://github.com/stablyai/orca) 🐋
