### PR TITLE
fix(terminal): restore the shell icon after an agent exits

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
@@ -330,6 +330,165 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
   })
 
+  it('confirms shell foreground for a sleeping-only pane identity', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('powershell.exe')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-droid-sleeping-only'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'droid',
+      providerSession: { key: 'session_id', id: 'droid-session-1' },
+      state: 'done',
+      capturedAt: 1,
+      updatedAt: 1
+    }
+
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    await vi.advanceTimersByTimeAsync(350)
+
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: null,
+      shellForeground: true
+    })
+  })
+
+  it('clears same-tab legacy aliases while preserving another tab', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('powershell.exe')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-droid-legacy-sleeping-only'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const legacyPaneKey = 'tab-1:1'
+    const duplicateLegacyPaneKey = 'tab-1:2'
+    const otherTabLegacyPaneKey = 'tab-2:1'
+    const providerSession = { key: 'session_id' as const, id: 'droid-session-1' }
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.sleepingAgentSessionsByPaneKey = {
+      [legacyPaneKey]: {
+        paneKey: legacyPaneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'droid',
+        providerSession,
+        state: 'done',
+        capturedAt: 1,
+        updatedAt: 1
+      },
+      [duplicateLegacyPaneKey]: {
+        paneKey: duplicateLegacyPaneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'droid',
+        providerSession,
+        state: 'done',
+        capturedAt: 2,
+        updatedAt: 2
+      },
+      [otherTabLegacyPaneKey]: {
+        paneKey: otherTabLegacyPaneKey,
+        tabId: 'tab-2',
+        worktreeId: 'wt-1',
+        agent: 'droid',
+        providerSession,
+        state: 'done',
+        capturedAt: 3,
+        updatedAt: 3
+      }
+    }
+
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    await vi.advanceTimersByTimeAsync(350)
+
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[legacyPaneKey]).toBeUndefined()
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[duplicateLegacyPaneKey]).toBeUndefined()
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[otherTabLegacyPaneKey]).toBeDefined()
+  })
+
+  it('does not clear legacy identity when same-tab provider sessions differ', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('powershell.exe')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const transport = createMockTransport('pty-ambiguous-legacy-sleeping')
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: 'pty-ambiguous-legacy-sleeping' }
+    })
+    transportFactoryQueue.push(transport)
+    const exactLegacyPaneKey = 'tab-1:1'
+    const siblingLegacyPaneKey = 'tab-1:2'
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.sleepingAgentSessionsByPaneKey = {
+      [exactLegacyPaneKey]: {
+        paneKey: exactLegacyPaneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'droid',
+        providerSession: { key: 'session_id', id: 'droid-session-1' },
+        state: 'done',
+        capturedAt: 1,
+        updatedAt: 1
+      },
+      [siblingLegacyPaneKey]: {
+        paneKey: siblingLegacyPaneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'droid',
+        providerSession: { key: 'session_id', id: 'droid-session-2' },
+        state: 'done',
+        capturedAt: 2,
+        updatedAt: 2
+      }
+    }
+
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    await vi.advanceTimersByTimeAsync(350)
+
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[exactLegacyPaneKey]).toBeDefined()
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[siblingLegacyPaneKey]).toBeDefined()
+  })
+
   it('disarms stale TUI modes in the emulator after a confirmed return to shell', async () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2079,6 +2079,7 @@ export function connectPanePty(
     return (
       Boolean(state.paneForegroundAgentByPaneKey[cacheKey]?.agent) ||
       paneHasLiveHookAgentIcon(state) ||
+      Boolean(state.sleepingAgentSessionsByPaneKey[cacheKey]?.agent) ||
       isTuiAgent(registeredLaunchAgent)
     )
   }
@@ -2139,6 +2140,7 @@ export function connectPanePty(
     publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry),
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
+      useAppStore.getState().clearSleepingAgentSession(cacheKey)
       clearStaleAgentTabTitleOnConfirmedShell()
       // Why: a hard-killed agent leaves mouse/focus/kitty modes armed, and the
       // surviving shell then receives pointer moves as typed SGR reports; the

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1312,6 +1312,25 @@ export function connectPanePty(
       }
     }
   }
+  const clearShellOwnedSleepingRecord = (
+    state: ReturnType<typeof useAppStore.getState>,
+    consumed: { paneKey: string; record: SleepingAgentSessionRecord }
+  ): void => {
+    state.clearSleepingAgentSession(consumed.paneKey)
+    const consumedClaimKey = getProviderSessionClaimKey(consumed.record)
+    for (const [paneKey, record] of Object.entries(state.sleepingAgentSessionsByPaneKey)) {
+      const legacy = parseLegacyNumericPaneKey(paneKey)
+      if (
+        paneKey !== consumed.paneKey &&
+        legacy?.tabId === deps.tabId &&
+        (!record.tabId || record.tabId === deps.tabId) &&
+        getProviderSessionClaimKey(record) === consumedClaimKey
+      ) {
+        // Why: shell confirmation owns this tab, not another tab with the same provider metadata.
+        state.clearSleepingAgentSession(paneKey)
+      }
+    }
+  }
   const launchToken = paneStartup?.launchConfig
     ? (paneStartup.launchToken ?? createBrowserUuid())
     : undefined
@@ -2166,7 +2185,7 @@ export function connectPanePty(
       const state = useAppStore.getState()
       const sleepingRecord = getShellOwnedSleepingRecordForPane(state)
       if (sleepingRecord) {
-        clearSleepingRecordProviderDuplicates(state, sleepingRecord)
+        clearShellOwnedSleepingRecord(state, sleepingRecord)
       }
       clearStaleAgentTabTitleOnConfirmedShell()
       // Why: a hard-killed agent leaves mouse/focus/kitty modes armed, and the

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1264,6 +1264,29 @@ export function connectPanePty(
     const [paneKey, record] = selectedLegacyMatch
     return { paneKey, record }
   }
+  const getShellOwnedSleepingRecordForPane = (
+    state: ReturnType<typeof useAppStore.getState>
+  ): { paneKey: string; record: SleepingAgentSessionRecord } | null => {
+    const matchedRecord = getSleepingRecordForPane(state)
+    if (!matchedRecord || matchedRecord.paneKey === cacheKey) {
+      return matchedRecord
+    }
+    const matchedClaimKey = getProviderSessionClaimKey(matchedRecord.record)
+    const hasConflictingLegacySession = Object.entries(state.sleepingAgentSessionsByPaneKey).some(
+      ([paneKey, record]) => {
+        const legacy = parseLegacyNumericPaneKey(paneKey)
+        return (
+          legacy?.tabId === deps.tabId &&
+          record.worktreeId === deps.worktreeId &&
+          (!record.tabId || record.tabId === deps.tabId) &&
+          getProviderSessionClaimKey(record) !== matchedClaimKey
+        )
+      }
+    )
+    // Why: renderer-local numeric pane IDs can be reused, so shell cleanup
+    // requires every same-tab legacy row to identify one provider session.
+    return hasConflictingLegacySession ? null : matchedRecord
+  }
   const isLegacyWorkerAutomaticResumeBlocked = (): boolean =>
     getSleepingRecordForPane(useAppStore.getState())?.record.automaticResumeBlockedBy ===
     'legacy-orchestration-worker'
@@ -2079,7 +2102,7 @@ export function connectPanePty(
     return (
       Boolean(state.paneForegroundAgentByPaneKey[cacheKey]?.agent) ||
       paneHasLiveHookAgentIcon(state) ||
-      Boolean(getSleepingRecordForPane(state)?.record.agent) ||
+      Boolean(getShellOwnedSleepingRecordForPane(state)?.record.agent) ||
       isTuiAgent(registeredLaunchAgent)
     )
   }
@@ -2141,7 +2164,7 @@ export function connectPanePty(
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       const state = useAppStore.getState()
-      const sleepingRecord = getSleepingRecordForPane(state)
+      const sleepingRecord = getShellOwnedSleepingRecordForPane(state)
       if (sleepingRecord) {
         clearSleepingRecordProviderDuplicates(state, sleepingRecord)
       }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2079,7 +2079,7 @@ export function connectPanePty(
     return (
       Boolean(state.paneForegroundAgentByPaneKey[cacheKey]?.agent) ||
       paneHasLiveHookAgentIcon(state) ||
-      Boolean(state.sleepingAgentSessionsByPaneKey[cacheKey]?.agent) ||
+      Boolean(getSleepingRecordForPane(state)?.record.agent) ||
       isTuiAgent(registeredLaunchAgent)
     )
   }
@@ -2140,7 +2140,11 @@ export function connectPanePty(
     publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry),
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
-      useAppStore.getState().clearSleepingAgentSession(cacheKey)
+      const state = useAppStore.getState()
+      const sleepingRecord = getSleepingRecordForPane(state)
+      if (sleepingRecord) {
+        clearSleepingRecordProviderDuplicates(state, sleepingRecord)
+      }
       clearStaleAgentTabTitleOnConfirmedShell()
       // Why: a hard-killed agent leaves mouse/focus/kitty modes armed, and the
       // surviving shell then receives pointer moves as typed SGR reports; the

--- a/src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts
@@ -110,6 +110,24 @@ describe('manual sleep agent session capture', () => {
     expect(records['tab-1:stale']).toMatchObject({ state: 'working', updatedAt: NOW })
   })
 
+  it('does not recreate a completed session after shell foreground is confirmed', () => {
+    const store = createTestStore()
+    seedTabs(store)
+    const paneKey = 'tab-1:leaf-1'
+    store.setState({
+      agentStatusByPaneKey: {
+        [paneKey]: makeAgentEntry({ paneKey, state: 'done' })
+      },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: { agent: null, shellForeground: true }
+      }
+    } as Partial<AppState>)
+
+    store.getState().captureSleepingAgentSessionsByWorktree('wt-1')
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+  })
+
   it('marks finished panes for tab-open-only restore so a mobile wake cannot respawn them all', () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)

--- a/src/renderer/src/store/slices/agent-status-provider-session.test.ts
+++ b/src/renderer/src/store/slices/agent-status-provider-session.test.ts
@@ -69,6 +69,41 @@ describe('recordAgentProviderSession', () => {
     )
   })
 
+  it('does not recreate sleeping identity from a late done after shell foreground', () => {
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-1'
+    const providerSession = { key: 'session_id' as const, id: 'claude-session-1' }
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+
+    store
+      .getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'working', prompt: '', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession }
+      )
+    store.getState().setPaneForegroundAgent(paneKey, { agent: null, shellForeground: true })
+    store
+      .getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'done', prompt: '', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 20, stateStartedAt: 20 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession }
+      )
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+  })
+
   // Why: `done` is the resting state, and both OSC 9999 repaints and reconnect snapshot
   // replays re-deliver a metadata-less `done` onto an already-done row. Retaining only the
   // first one still blanked the chat the moment a second landed (#10630).

--- a/src/renderer/src/store/slices/agent-status-provider-session.test.ts
+++ b/src/renderer/src/store/slices/agent-status-provider-session.test.ts
@@ -90,6 +90,8 @@ describe('recordAgentProviderSession', () => {
         { providerSession }
       )
     store.getState().setPaneForegroundAgent(paneKey, { agent: null, shellForeground: true })
+    store.getState().clearSleepingAgentSession(paneKey)
+    expect(store.getState().sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
     store
       .getState()
       .setAgentStatus(

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -823,6 +823,15 @@ export function collectSleepingAgentSessionRecordsForWorktree(
     }
   }
 
+  for (const [paneKey, record] of Object.entries(records)) {
+    if (
+      record.state === 'done' &&
+      state.paneForegroundAgentByPaneKey[paneKey]?.shellForeground === true
+    ) {
+      delete records[paneKey]
+    }
+  }
+
   return records
 }
 

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -2087,6 +2087,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         // the pane to a bare shell instead of `--resume`-ing the agent logged in.
         const retainsResumableRecoveryIdentity =
           payload.state === 'done' &&
+          s.paneForegroundAgentByPaneKey[paneKey]?.shellForeground !== true &&
           isResumableTuiAgent(identity.agentType) &&
           providerSession !== undefined &&
           getAgentResumeArgv(identity.agentType, providerSession) !== null


### PR DESCRIPTION
## Summary

- Restore the terminal icon after a completed agent exits to the shell.
- Clear resumable **sleeping identity** only after fresh foreground-process confirmation.
- Resolve legacy numeric pane keys while preserving other tabs and ambiguous provider sessions.
- Prevent late `done` hooks and later workspace sleep from rebuilding the exited identity.

Fixes #13749

## Screenshots

<img width="1000" height="850" alt="orca-agent-icon-before-after-v3" src="https://github.com/user-attachments/assets/d98ac5fc-7b15-40b2-9847-531a160cbc09" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused PTY coverage: 570 tests passed. Full suite: 49,652 passed, 102 skipped.

## AI Review Report

Exact-SHA five-lane review passed for `23fe4a056d9b119f6b36705b72897c1670696d80`: goal/constraints, runtime QA, code quality, security, and history/context.

The review explicitly checked macOS, Linux, and Windows behavior, plus SSH and folder workspaces. This change introduces no shortcuts, labels, paths, shell commands, or Electron platform branches; remote PTYs remain excluded from local foreground-process confirmation.

## Security Audit

Passed. Cleanup requires fresh pane/PTY-bound shell confirmation. Legacy aliases are limited to the same tab and provider claim; mixed-provider rows fail closed, other tabs are preserved, and provider claims include worktree identity. No command execution, path handling, authentication, secrets, dependencies, or IPC contracts changed.

## Notes

Manual macOS dev-app QA confirmed `Claude` → `/exit` restores the terminal identity.
