### PR TITLE
fix(editor): keep an invalidated diff visible until its reload lands

### DIFF
--- a/src/renderer/src/components/editor/editor-panel-content-types.ts
+++ b/src/renderer/src/components/editor/editor-panel-content-types.ts
@@ -29,4 +29,7 @@ export type FileContent = {
   isStale?: boolean
 }
 
-export type DiffContent = GitDiffResult
+export type DiffContent = GitDiffResult & {
+  /** Superseded by an external change; still rendered until the lazy reload lands. */
+  isStale?: boolean
+}

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -187,8 +187,11 @@ export function useEditorPanelContentState({
       const next = { ...prev }
       let changed = false
       for (const fileId of uniqueIds) {
-        if (fileId in next) {
-          delete next[fileId]
+        const existing = next[fileId]
+        // Why: keep the last-known diff rendered and swap it when the lazy
+        // reload lands — dropping it flashes "Loading diff…" on every reveal.
+        if (existing && existing.isStale !== true) {
+          next[fileId] = { ...existing, isStale: true }
           changed = true
         }
       }
@@ -525,9 +528,13 @@ export function useEditorPanelContentState({
       !hasLiveRead(fileReadGenerationRef.current, outstandingFileReadsRef.current, fileId)
     )
   }
-  const needsDiffRead = (fileId: string): boolean =>
-    !diffContents[fileId] &&
-    !hasLiveRead(diffReadGenerationRef.current, outstandingDiffReadsRef.current, fileId)
+  const needsDiffRead = (fileId: string): boolean => {
+    const cached = diffContents[fileId]
+    return (
+      (!cached || cached.isStale === true) &&
+      !hasLiveRead(diffReadGenerationRef.current, outstandingDiffReadsRef.current, fileId)
+    )
+  }
 
   useEffect(() => {
     if (!isVisible) {
@@ -643,9 +650,10 @@ export function useEditorPanelContentState({
       invalidateDiffContent([current.id])
       return
     }
-    // Why: the lazy-load effect already fetches on first open; forcing here
-    // races a duplicate git-diff RPC for the same tab.
-    if (!diffContentsRef.current[current.id]) {
+    // Why: the lazy-load effect already fetches on first open and on a retained
+    // stale entry; forcing here races a duplicate git-diff RPC for the same tab.
+    const cachedDiff = diffContentsRef.current[current.id]
+    if (!cachedDiff || cachedDiff.isStale === true) {
       return
     }
     void loadDiffContent(current, { force: true })

--- a/src/renderer/src/components/editor/useEditorPanelVisibilityContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelVisibilityContentState.test.tsx
@@ -387,6 +387,40 @@ describe('useEditorPanelContentState visibility', () => {
     expect(mocks.getRuntimeGitDiff).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps an invalidated diff on screen until the reveal read lands', async () => {
+    const file = makeFile('diff-no-flash', { mode: 'diff', diffSource: 'unstaged' })
+    const freshDiff = createDeferred<DiffContent>()
+    mocks.getRuntimeGitDiff
+      .mockResolvedValueOnce(textDiff('old diff'))
+      .mockReturnValueOnce(freshDiff.promise)
+
+    await act(async () => root.render(<Probe activeFile={file} />))
+    await vi.waitFor(() =>
+      expect(snapshots.get('main')?.diffContents[file.id]?.modifiedContent).toBe('old diff')
+    )
+
+    await act(async () => root.render(<Probe activeFile={file} isVisible={false} />))
+    dispatchExternalChange(file)
+    // Why: the viewers render "Loading diff…" purely on a missing entry, so a
+    // retained (stale-marked) entry is what keeps the pane painted.
+    expect(snapshots.get('main')?.diffContents[file.id]?.modifiedContent).toBe('old diff')
+    expect(snapshots.get('main')?.diffContents[file.id]?.isStale).toBe(true)
+    expect(mocks.getRuntimeGitDiff).toHaveBeenCalledOnce()
+
+    await act(async () => root.render(<Probe activeFile={file} />))
+    await vi.waitFor(() => expect(mocks.getRuntimeGitDiff).toHaveBeenCalledTimes(2))
+    expect(snapshots.get('main')?.diffContents[file.id]?.modifiedContent).toBe('old diff')
+
+    await act(async () => {
+      freshDiff.resolve(textDiff('fresh diff'))
+      await freshDiff.promise
+    })
+    await vi.waitFor(() =>
+      expect(snapshots.get('main')?.diffContents[file.id]).toEqual(textDiff('fresh diff'))
+    )
+    expect(mocks.getRuntimeGitDiff).toHaveBeenCalledTimes(2)
+  })
+
   it('invalidates a hidden Git-status diff without reading until reveal', async () => {
     const file = makeFile('status', { mode: 'diff', diffSource: 'unstaged' })
     const status: GitStatusEntry[] = [
@@ -401,7 +435,7 @@ describe('useEditorPanelContentState visibility', () => {
     await act(async () =>
       root.render(<Probe activeFile={file} gitStatusEntries={status} isVisible={false} />)
     )
-    expect(snapshots.get('main')?.diffContents[file.id]).toBeUndefined()
+    expect(snapshots.get('main')?.diffContents[file.id]?.isStale).toBe(true)
     expect(mocks.getRuntimeGitDiff).toHaveBeenCalledOnce()
 
     await act(async () => root.render(<Probe activeFile={file} gitStatusEntries={status} />))
@@ -430,7 +464,7 @@ describe('useEditorPanelContentState visibility', () => {
     dispatchExternalChange(file)
     await vi.waitFor(() => expect(mocks.readRuntimeFileContent).toHaveBeenCalledTimes(2))
     expect(mocks.getRuntimeGitDiff).toHaveBeenCalledOnce()
-    expect(snapshots.get('main')?.diffContents[file.id]).toBeUndefined()
+    expect(snapshots.get('main')?.diffContents[file.id]?.isStale).toBe(true)
 
     await act(async () =>
       root.render(<Probe activeFile={file} editorViewMode={changesMode} isChangesMode />)


### PR DESCRIPTION
Deferred follow-up to #13634.

That PR made `invalidateFileContent` mark cache entries **stale** instead of deleting them, so revealing a hidden editor panel swaps bytes in place rather than flashing `Loading…`. `invalidateDiffContent` was left deleting its entry, so revealing a hidden/inactive **diff** still flashed `Loading diff...`. Two reviewers raised it separately; it was out of scope at the time.

## Safety: the diff path has its own generation fence

Verified before mirroring the change — the diff read is fenced identically to the file read:

- `diffReadGenerationRef` is bumped by `invalidateDiffContent` (`useEditorPanelContentState.ts`), exactly as `fileReadGenerationRef` is by `invalidateFileContent`.
- `loadDiffContent` captures its generation before any `await` and re-checks `diffReadGenerationRef.current[file.id] !== generation` on **both** the success and the error path before calling `setDiffContents`.

So a superseded in-flight diff read can never write back over fresh content, which is what makes retaining the bytes safe. (Covered by the pre-existing test `invalidates a hidden diff nonce without reading until reveal`, which still asserts the stale read is dropped.)

## Changes

- `DiffContent` gains an optional `isStale` flag (renderer-local extension of the shared `GitDiffResult` wire type — no wire change, so no remote-compat impact).
- `invalidateDiffContent` marks the entry stale instead of deleting it.
- `needsDiffRead` treats a stale entry as needing a read, so the lazy reveal effect still refetches exactly once (same RPC count as before).
- The git-status reload effect's "the lazy-load effect already fetches this" guard now treats a stale entry like a missing one. Without this, a status change arriving in the same commit as a reveal would fire both the lazy read and a forced read — a double RPC that the delete-based code avoided.

Fresh reads and error results overwrite the whole entry, so `isStale` clears naturally.

## Test

New: `keeps an invalidated diff on screen until the reveal read lands` in `useEditorPanelVisibilityContentState.test.tsx` — asserts the diff is still `'old diff'` (not undefined, which is the only thing `EditorContent`/`ChangesModeView` key their `Loading diff...` placeholder on) both right after invalidation and while the reveal read is in flight, then that the fresh read replaces it with `isStale` gone, in exactly 2 RPCs.

Proven discriminating: reverting only the `invalidateDiffContent` body back to `delete` fails 3 tests —

```
× keeps an invalidated diff on screen until the reveal read lands
× invalidates a hidden Git-status diff without reading until reveal
× invalidates an inactive cached Changes diff after an external edit
AssertionError: expected undefined to be 'old diff'
```

The latter two are existing tests updated from `toBeUndefined()` to asserting the retained stale entry.

## Verification

- `vitest run src/renderer/src/components/editor/` — 167 files, 1123 tests passed
- `tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- oxlint clean on touched files

No `max-lines` disables added or bumped. No UI/token changes (the fix is purely that the existing viewer keeps rendering). Behavior is host-agnostic — it lives in renderer cache bookkeeping, so SSH hosts and folder workspaces are covered identically.

## Not done

- `reloadContent`'s diff branch still deletes before force-loading. That is the explicit user-initiated Reload button, where showing a loading state is legitimate feedback, and #13634 left the equivalent file-content branch deleting too. Out of scope.

Made with [Orca](https://github.com/stablyai/orca) 🐋
