### PR TITLE
fix(dashboard): keep acknowledged completions in the Done column

### DIFF
--- a/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.test.ts
+++ b/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.test.ts
@@ -99,6 +99,27 @@ describe('patchDashboardSnapshotFromAgentStatus', () => {
     })
   })
 
+  it('keeps a completion the user already saw in the done bucket', () => {
+    const original = snapshot([card({ bucket: 'done', dotState: 'done', stateChangedAt: 250 })])
+    const ping = event({
+      state: 'done',
+      prompt: '',
+      interactivePrompt: undefined,
+      stateStartedAt: 250
+    })
+    const result = patchDashboardSnapshotFromAgentStatus(original, ping)
+
+    // Why statusUpdatedAt: the card already carries these done fields, so
+    // without it an early bail-out would satisfy the assertion.
+    expect(result.matched).toBe(true)
+    expect(result.snapshot.cards[0]).toMatchObject({
+      bucket: 'done',
+      dotState: 'done',
+      unseen: false,
+      statusUpdatedAt: ping.receivedAt
+    })
+  })
+
   it('ignores stale, wrong-workspace, and session-only events', () => {
     const original = snapshot()
     expect(

--- a/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.ts
+++ b/src/renderer/src/components/dashboard-popout/dashboard-agent-status-patch.ts
@@ -1,9 +1,8 @@
 import type { AgentStatusIpcPayload } from '../../../../shared/agent-status-types'
-import {
-  dashboardCardDisplayState,
-  type DashboardCard,
-  type DashboardCardSubagent,
-  type DashboardSnapshot
+import type {
+  DashboardCard,
+  DashboardCardSubagent,
+  DashboardSnapshot
 } from '../../../../shared/dashboard-snapshot'
 import { dashboardBucketForDotState } from '../dashboard/dashboard-card-bucket'
 
@@ -51,9 +50,8 @@ export function patchDashboardSnapshotFromAgentStatus(
   const dotState = event.state
   const workingMode =
     event.state === 'working' && event.workingMode === 'monitoring' ? event.workingMode : undefined
-  const bucket = dashboardBucketForDotState(
-    dashboardCardDisplayState({ dotState, workingMode, unseen })
-  )
+  // Mirrors dashboardRowBucketProjection: the column follows reported state, not seen-ness.
+  const bucket = dashboardBucketForDotState(dotState)
   const nextCard: DashboardCard = {
     ...card,
     ...(event.agentType ? { agentType: event.agentType } : {}),

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot-folder-workspace.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot-folder-workspace.test.ts
@@ -280,6 +280,28 @@ describe('buildDashboardSnapshot folder workspaces', () => {
     ])
   })
 
+  // Why: a group folder is where a user drives several repos from one terminal,
+  // so they sit on that pane while it works — auto-ack marks the run seen the
+  // moment it finishes. The board must still list the completed work.
+  it('keeps a finished group-folder agent on the board after auto-ack', () => {
+    const finishedState = state()
+    finishedState.agentStatusByPaneKey = {
+      [PANE_KEY]: { ...entry(), state: 'done', stateStartedAt: NOW - 60_000 }
+    }
+    finishedState.acknowledgedAgentsByPaneKey = { [PANE_KEY]: NOW - 30_000 }
+
+    const snapshot = buildDashboardSnapshot(finishedState, NOW)
+
+    expect(snapshot.cards).toHaveLength(1)
+    expect(snapshot.cards[0]).toMatchObject({
+      bucket: 'done',
+      dotState: 'done',
+      unseen: false,
+      repoName: 'Documentation',
+      worktreeName: 'Docs workspace'
+    })
+  })
+
   it('classifies a folder workspace from its own runtime host stamp', () => {
     const runtimeState = state()
     runtimeState.folderWorkspaces = [

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -486,7 +486,7 @@ describe('buildDashboardSnapshot', () => {
     expect(snapshot.cards[0].ptyId).toBeNull()
   })
 
-  it('moves an acknowledged completion to idle while retaining its raw done state', () => {
+  it('keeps an acknowledged completion in the done bucket, only muting it', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({
         agentStatusByPaneKey: { [PANE_KEY]: entry({ state: 'done' }) },
@@ -494,10 +494,12 @@ describe('buildDashboardSnapshot', () => {
       }),
       NOW
     )
-    // ack (NOW-1000) is after stateStartedAt (NOW-5000) → seen.
+    // ack (NOW-1000) is after stateStartedAt (NOW-5000) → seen. Auto-ack fires
+    // from merely sitting on the agent's tab, so bucketing on seen-ness erased
+    // every run the user watched finish.
     expect(snapshot.cards[0].unseen).toBe(false)
     expect(snapshot.cards[0].dotState).toBe('done')
-    expect(snapshot.cards[0].bucket).toBe('idle')
+    expect(snapshot.cards[0].bucket).toBe('done')
   })
 
   it('does not mark title-derived rows unseen from synthetic timestamps', () => {

--- a/src/renderer/src/components/dashboard/dashboard-row-bucket.ts
+++ b/src/renderer/src/components/dashboard/dashboard-row-bucket.ts
@@ -1,9 +1,5 @@
 import type { DashboardAgentRow } from './useDashboardData'
-import {
-  dashboardCardDisplayState,
-  type DashboardBucket,
-  type DashboardCardDotState
-} from '../../../../shared/dashboard-snapshot'
+import type { DashboardBucket, DashboardCardDotState } from '../../../../shared/dashboard-snapshot'
 import { dashboardBucketForDotState } from './dashboard-card-bucket'
 import type { AgentRowState } from '@/lib/agent-row-decay-state'
 
@@ -40,9 +36,9 @@ export function dashboardRowBucketProjection(
       : undefined
   const unseen =
     !isTitleDerived && (acknowledgedAgentsByPaneKey?.[row.paneKey] ?? 0) < row.entry.stateStartedAt
-  const bucket = dashboardBucketForDotState(
-    dashboardCardDisplayState({ dotState, workingMode, unseen })
-  )
+  // Bucket on reported state, not seen-ness: routing through
+  // dashboardCardDisplayState hid acknowledged completions in Idle (#12168).
+  const bucket = dashboardBucketForDotState(dotState)
 
   return { isTitleDerived, dotState, workingMode, unseen, bucket }
 }


### PR DESCRIPTION
## Summary

Agents that finish while you are watching them disappear from the Agent Dashboard instead of landing in **Done**.

`buildDashboardSnapshot` chose each card's column with `dashboardBucketForDotState(dashboardCardDisplayState({ dotState, unseen }))`. `dashboardCardDisplayState` folds a *seen* `done` agent into `idle` — it exists to grey the card's dot once you have read it. Feeding it into the **column** decision meant an acknowledged completion landed in the `idle` bucket, which the board hides unless the experimental "show idle" setting is on.

`useAutoAckViewedAgent` acknowledges an agent from merely sitting on its tab (window focused and visible). So any run the user watched finish was already acknowledged by the time it reported `done`: it never reached the Done column at all and vanished from the board outright — no card, and excluded from the `N total` header count. The sidebar kept rendering the same row as a green check, so the two surfaces disagreed about work that had just completed.

This regressed in #12168 (agent map). Before that the board used `bucketForState(row.state)`, where `done` always meant the Done column (#11042).

**Fix:** bucket on the reported `dotState`. Seen-ness still drives the card's dot, tint, mute, and map node colour through `dashboardCardDisplayState`, which is unchanged.

Reproduced against a real profile: a `done` agent in a multi-repo folder workspace produced a card with `bucket: 'done'` while unacknowledged and `bucket: 'idle'` once acknowledged — same card, same agent state, only the ack timestamp differing.

## Screenshots

No layout, styling, or token change — only which column a card lands in.

**Before** — an agent finishes while its terminal is the focused tab:
<img width="3000" height="1880" alt="before" src="https://github.com/user-attachments/assets/a431f6ce-614b-4701-b09f-de3bddc4c12b" />


- Done column reads `None`; the finished agent has no card anywhere on the board.
- The `Agents N total` header count excludes it — the board reads `0 total`.
- The sidebar's **Agent Dashboard** badge shows no emerald `done` dot.
- Meanwhile the sidebar workspace row still lists that agent with its green completion check — the two surfaces contradict each other.

**After** — the same run:
<img width="3000" height="1880" alt="after" src="https://github.com/user-attachments/assets/8da11b0a-79b0-4312-abc2-7568db960cf0" />


- The card sits in **Done**, muted (not bold), because it is still correctly reported as seen.
- The header count includes it — `1 total`.
- The sidebar's **Agent Dashboard** entry gains an emerald `done` badge.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — no regressions; fewer failures than `main` (see below)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Rebased onto `main` (`5a8b4aff7b`). Some suites fail locally on this machine regardless of
this change, so I measured a baseline instead of asserting a clean run:

| | failing files | failing tests |
|---|---|---|
| this branch | 13 | 26 |
| pristine `main` | 17 | 31 |

The set difference — failures present here but not on `main` — is **empty**. They are relay,
PTY, and terminal-IME flakes plus three suites that cannot resolve the Windows-only
`@vscode/windows-process-tree` on macOS. No file this PR touches appears in either failing set.

`dashboard` + `dashboard-popout` + `sidebar`: 335 files / 2,835 tests green.

Each regression test was also re-run against `main`'s version of the two source files, with the
new tests in place, and all three fail — so they genuinely pin the behavior rather than passing
vacuously.

Test changes:

- `build-dashboard-snapshot.test.ts` — the existing case *"moves an acknowledged completion to idle while retaining its raw done state"* pinned the regression. Rewritten to assert the completion **stays in Done** while still reporting `unseen: false`, so the mute signal and the column stay independently covered.
- `build-dashboard-snapshot-folder-workspace.test.ts` — new regression test for the reported scenario: a finished agent in a project-group folder workspace, already auto-acked, must still be on the board.
- `dashboard-agent-status-patch.test.ts` — new test for the pop-out's incremental patch path, which derived the bucket the same way and had no coverage for a seen completion.

## AI Review Report

Reviewed with Claude Opus 5. Risks checked and how they were resolved:

- **Cross-platform (macOS / Linux / Windows).** The diff is renderer-only TypeScript that maps an enum to an enum. No path handling, shell invocation, keyboard shortcut, modifier key (`metaKey` / `ctrlKey`), shortcut label, or Electron platform API is touched, so there is no platform-conditional behavior to guard. The surrounding host-detection code (`clientHost.platform`, `hostPlatform`) is untouched.
- **Both bucket derivations kept in lockstep.** The board builder and the pop-out's incremental hook patch (`dashboard-agent-status-patch.ts`) each computed the bucket independently. Fixing only the builder would have made a live hook ping in the popped-out window re-hide a card that the next full republish restored. Both were changed together and both are covered by tests.
- **SSH / remote / local.** Bucketing runs after host resolution and does not read `hostKind`, `executionHostId`, `connectionId`, or `terminalInput`. The folder-workspace regression test covers an SSH-backed project group, and the existing runtime-host test still passes.
- **Agent- and provider-neutral.** The rule is keyed on `AgentStatusState`, which every agent's hook reports; nothing keys on `agentType`, and no git-provider or review-integration code is involved.
- **Wire compatibility.** `DashboardCard.bucket` was already part of the snapshot contract and its value set is unchanged, so `dashboard-payload-validation.ts` needs no update. Confirmed the dashboard snapshot never crosses the client↔remote-host boundary: it travels main renderer → main → pop-out renderer via `dashboard:publishSnapshot`, both shipped in the same build. It is absent from the runtime RPC surface (`ui-state-schema-parity-checks.ts` carries only `dashboardPopoutBounds`) and from the mobile client, so `docs/reference/remote-wire-compatibility.md` does not apply.
- **No interaction with the new `monitoring` state (#16201).** `monitoring` is derived from `dotState === 'working' && workingMode === 'monitoring'`, and `dashboardBucketForDotState` maps both `'working'` and `'monitoring'` to the `working` bucket — so bucketing on the raw `dotState` lands in the identical column. `workingMode` is still computed and still rides on the card; only the bucket input changed. Upstream's own `keeps monitoring in the working bucket with a passive dot state` passes unchanged, and the pop-out's `patches same-state working into passive monitoring` was kept alongside the new case.
- **Performance.** Strictly cheaper — one fewer function call per card per rebuild, on a path that runs on every agent-status ping. No new allocations, subscriptions, or store reads.
- **UI quality.** Purely which column a card lands in. `dashboardCardDisplayState` still drives every *visual* consumer (`AgentKanbanCard` tint and dot, `AgentTerminalDialog` label, `agent-map-node-metadata`), so a seen completion still reads as muted rather than shouting for attention. No new colors, sizes, or tokens.

**The Agent Map already made this call.** Since this PR was opened, `agent-map-node-metadata.ts`
split an acknowledged finish out of `idle` into its own `done-seen` status, and `agentMapState`
routes it to the **Done** chip. Its rationale is the same one this PR makes for the board:

> Why: an acknowledged finish still paints emerald, so it has to answer the Done chip.
> Filtering it as idle would let "hide idle" blank out visibly green nodes.

Upstream's `counts all four display states` test pins it — `done-new` and `done-seen` both count
as `done: 2`. So the map and the board currently disagree about the same card: emerald and under
Done on the map, hidden in Idle on the board. This change makes the board agree.

One caveat, stated plainly: the docstring on `AgentMapNodeStatus` calls the fold into `idle`
"right for bucket counts", which reads as a deliberate choice for the board. I think the Done
column is the board's Done chip and deserves the same treatment — but that is the call to make
here, and I would rather surface it than let it pass unnoticed.

## Security Audit

Low risk; no new attack surface.

- **Input handling.** No new external input is parsed. The only new data flow is an existing enum (`DashboardCardDotState`) reaching an existing exhaustive `switch` that already handles every member, so a malformed value cannot fall through.
- **IPC.** No IPC channel, handler, or payload shape is added or changed. The main-process validator in `dashboard-payload-validation.ts` still checks `bucket` against `DASHBOARD_BUCKETS` on every publish, and that set is unchanged, so a compromised renderer gains nothing.
- **Command execution / path handling / auth / secrets / dependencies.** None touched. No process spawn, no filesystem access, no credential or token handling, no dependency changes.
- **Disclosure.** The change can surface a card that was previously hidden, but only for an agent already owned and visible to the same user in the same window — card content itself (prompt, last message) is unchanged and was already rendered while the agent was working.

No follow-up needed.

## Notes

- No platform-, remote-, agent-, integration-, or git-provider-specific behavior.
- The Done column can now hold more cards over a long session, since a completion stays until its pane closes or the retained row is dismissed. This is the pre-#12168 behavior and matches the sidebar, which has been showing these same rows all along.
- Users who prefer the old "clear it once I've seen it" board can still get it: an acknowledged completion is muted rather than bold, and the Done column can be worked down by closing the panes.

