### PR TITLE
feat(tasks): show PR line totals in detail header

### DIFF
--- a/src/renderer/src/components/PullRequestChangeSummary.test.ts
+++ b/src/renderer/src/components/PullRequestChangeSummary.test.ts
@@ -1,0 +1,41 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { PullRequestChangeSummary } from './PullRequestChangeSummary'
+
+function renderSummary(props: {
+  readonly additions?: number
+  readonly deletions?: number
+}): string {
+  return renderToStaticMarkup(React.createElement(PullRequestChangeSummary, props))
+}
+
+describe('PullRequestChangeSummary', () => {
+  it('renders added and deleted line totals with git decoration colors', () => {
+    const markup = renderSummary({ additions: 128, deletions: 34 })
+
+    expect(markup).toContain('128 lines added')
+    expect(markup).toContain('34 lines deleted')
+    expect(markup).toContain('var(--git-decoration-added)')
+    expect(markup).toContain('var(--git-decoration-deleted)')
+  })
+
+  it('keeps explicit zero totals visible', () => {
+    const markup = renderSummary({ additions: 0, deletions: 0 })
+
+    expect(markup).toContain('0 lines added')
+    expect(markup).toContain('0 lines deleted')
+  })
+
+  it('renders the available total when GitHub omits the other one', () => {
+    const markup = renderSummary({ additions: 12 })
+
+    expect(markup).toContain('+12')
+    expect(markup).not.toContain('git-decoration-deleted')
+  })
+
+  it('renders nothing when GitHub provides no change totals', () => {
+    expect(renderSummary({})).toBe('')
+  })
+})

--- a/src/renderer/src/components/PullRequestChangeSummary.test.ts
+++ b/src/renderer/src/components/PullRequestChangeSummary.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 
 import { PullRequestChangeSummary } from './PullRequestChangeSummary'
+import { getIntlLocale } from '@/i18n/i18n'
 
 function renderSummary(props: {
   readonly additions?: number
@@ -33,6 +34,20 @@ describe('PullRequestChangeSummary', () => {
 
     expect(markup).toContain('+12')
     expect(markup).not.toContain('git-decoration-deleted')
+  })
+
+  it('renders a deletion-only total without the added decoration', () => {
+    const markup = renderSummary({ deletions: 12 })
+
+    expect(markup).toContain('-12')
+    expect(markup).not.toContain('git-decoration-added')
+  })
+
+  it('formats large totals with the current locale', () => {
+    const additions = 12_345
+    const markup = renderSummary({ additions })
+
+    expect(markup).toContain(`+${additions.toLocaleString(getIntlLocale())}`)
   })
 
   it('renders nothing when GitHub provides no change totals', () => {

--- a/src/renderer/src/components/PullRequestChangeSummary.tsx
+++ b/src/renderer/src/components/PullRequestChangeSummary.tsx
@@ -1,0 +1,58 @@
+import type { JSX } from 'react'
+import { getIntlLocale, translate } from '@/i18n/i18n'
+
+type PullRequestChangeSummaryProps = {
+  readonly additions?: number
+  readonly deletions?: number
+}
+
+export function PullRequestChangeSummary({
+  additions,
+  deletions
+}: PullRequestChangeSummaryProps): JSX.Element | null {
+  const hasAdditions = typeof additions === 'number'
+  const hasDeletions = typeof deletions === 'number'
+  if (!hasAdditions && !hasDeletions) {
+    return null
+  }
+
+  const accessibleLabel =
+    hasAdditions && hasDeletions
+      ? translate(
+          'auto.components.right.sidebar.source.control.branch.line.total.chip.daa8e8e59b',
+          '{{value0}} lines added, {{value1}} lines deleted',
+          { value0: additions, value1: deletions }
+        )
+      : hasAdditions
+        ? translate(
+            'auto.components.right.sidebar.source.control.branch.line.total.chip.8a9b97b666',
+            '{{value0}} lines added',
+            { value0: additions }
+          )
+        : translate(
+            'auto.components.right.sidebar.source.control.branch.line.total.chip.52c366d88d',
+            '{{value0}} lines deleted',
+            { value0: deletions }
+          )
+  const locale = getIntlLocale()
+
+  return (
+    <span
+      role="group"
+      data-pull-request-change-summary
+      className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap tabular-nums"
+      aria-label={accessibleLabel}
+    >
+      {hasAdditions ? (
+        <span className="text-[color:var(--git-decoration-added)]" aria-hidden="true">
+          +{additions.toLocaleString(locale)}
+        </span>
+      ) : null}
+      {hasDeletions ? (
+        <span className="text-[color:var(--git-decoration-deleted)]" aria-hidden="true">
+          -{deletions.toLocaleString(locale)}
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -167,6 +167,7 @@ import {
   getGitHubSourceRuntimeHost
 } from '@/lib/github-source-runtime-context'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
+import { PullRequestChangeSummary } from '@/components/PullRequestChangeSummary'
 import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
@@ -5332,6 +5333,8 @@ export default function PullRequestPage({
     }
     return { ...workItem, ...details.item, repoId: workItem.repoId }
   }, [details?.item, workItem])
+  const summaryAdditions = displayWorkItem?.additions ?? workItem?.additions
+  const summaryDeletions = displayWorkItem?.deletions ?? workItem?.deletions
 
   useEffect(() => {
     if (!workItem || details?.item.reviewRequests === undefined) {
@@ -5704,6 +5707,7 @@ export default function PullRequestPage({
               </span>
             )}
           </span>
+          <PullRequestChangeSummary additions={summaryAdditions} deletions={summaryDeletions} />
           <span className="text-muted-foreground/40">·</span>
           <span className="text-muted-foreground/80">
             {translate('auto.components.PullRequestPage.dd5d9a4f17', 'updated {{value0}}', {

--- a/tests/e2e/pull-request-change-summary.spec.ts
+++ b/tests/e2e/pull-request-change-summary.spec.ts
@@ -1,0 +1,144 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const PR_TITLE = 'Improve pull request review header'
+
+const PR_DETAILS = {
+  item: {
+    id: 'pr:13773',
+    type: 'pr',
+    number: 13773,
+    title: PR_TITLE,
+    state: 'open',
+    url: 'https://github.com/stablyai/orca/pull/13773',
+    labels: ['enhancement'],
+    updatedAt: '2026-08-11T00:00:00Z',
+    author: 'orca-contributor',
+    branchName: 'feat/pr-change-summary',
+    baseRefName: 'main',
+    additions: 128,
+    deletions: 34,
+    changedFiles: 5
+  },
+  body: '',
+  comments: [],
+  checks: [],
+  files: []
+} as const
+
+async function installGitHubDetailsBackend(electronApp: ElectronApplication): Promise<void> {
+  await electronApp.evaluate(({ ipcMain }, details) => {
+    ipcMain.removeHandler('gh:workItemDetails')
+    ipcMain.handle('gh:workItemDetails', async () => details)
+  }, PR_DETAILS)
+}
+
+async function openMockedPullRequest(page: Page): Promise<void> {
+  await page.evaluate((title) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    const activeWorktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((worktree) => worktree.id === state.activeWorktreeId)
+    const repo = state.repos.find((candidate) => candidate.id === activeWorktree?.repoId)
+    if (!repo || !state.settings) {
+      throw new Error('Pull request summary fixture requires a ready repository')
+    }
+
+    const pullRequest = {
+      id: 'pr:13773',
+      type: 'pr' as const,
+      number: 13773,
+      title,
+      state: 'open' as const,
+      url: 'https://github.com/stablyai/orca/pull/13773',
+      labels: ['enhancement'],
+      updatedAt: '2026-08-11T00:00:00Z',
+      author: 'orca-contributor',
+      branchName: 'feat/pr-change-summary',
+      baseRefName: 'main',
+      repoId: repo.id
+    }
+
+    store.setState({
+      repos: state.repos.map((candidate) =>
+        candidate.id === repo.id
+          ? { ...candidate, upstream: { owner: 'stablyai', repo: 'orca' } }
+          : candidate
+      ),
+      settings: {
+        ...state.settings,
+        theme: 'light',
+        defaultTaskSource: 'github',
+        defaultTaskViewPreset: 'prs',
+        visibleTaskProviders: ['github']
+      },
+      taskResumeState: {
+        ...state.taskResumeState,
+        githubItemsPreset: 'prs',
+        githubItemsQuery: 'is:pr is:open',
+        githubMode: 'items'
+      },
+      prefetchWorkItems: () => undefined,
+      fetchWorkItemsAcrossRepos: async () => ({
+        items: [pullRequest],
+        failedCount: 0,
+        githubUnavailable: false
+      }),
+      countWorkItemsAcrossRepos: async () => ({ totalCount: 1, totalPages: 1 })
+    })
+    store
+      .getState()
+      .openTaskPage(
+        { taskSource: 'github', preselectedRepoId: repo.id },
+        { recordTasksInteraction: false }
+      )
+  }, PR_TITLE)
+
+  await expect(page.getByText(PR_TITLE, { exact: true })).toBeVisible()
+  await page.getByText(PR_TITLE, { exact: true }).click()
+}
+
+test('shows PR line totals in the detail header and captures both themes', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => {
+  await orcaPage.setViewportSize({ width: 1440, height: 900 })
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await installGitHubDetailsBackend(electronApp)
+  await openMockedPullRequest(orcaPage)
+
+  const heading = orcaPage.getByRole('heading', {
+    name: new RegExp(`${PR_TITLE}\\s*#13773`)
+  })
+  const summary = orcaPage.locator('[data-pull-request-change-summary]')
+  await expect(heading).toBeVisible()
+  await expect(summary).toHaveAccessibleName('128 lines added, 34 lines deleted')
+  await expect(summary).toContainText('+128')
+  await expect(summary).toContainText('-34')
+
+  const titleBlock = heading.locator('..').locator('..')
+  await expect(orcaPage.locator('html')).not.toHaveClass(/dark/)
+  await titleBlock.screenshot({
+    path: testInfo.outputPath('pull-request-change-summary-light.png')
+  })
+
+  await orcaPage.evaluate(() => {
+    const store = window.__store
+    const settings = store?.getState().settings
+    if (!store || !settings) {
+      throw new Error('Settings unavailable while switching visual QA theme')
+    }
+    store.setState({ settings: { ...settings, theme: 'dark' } })
+  })
+  await expect(orcaPage.locator('html')).toHaveClass(/dark/)
+  await titleBlock.screenshot({
+    path: testInfo.outputPath('pull-request-change-summary-dark.png')
+  })
+})


### PR DESCRIPTION
## Summary

- Show GitHub-like `+additions` and `-deletions` totals beside the base/head branch pair in the pull request detail header.
- Hydrate totals from the existing PR detail response, with the list item retained as a fallback and no RPC or wire-contract change.
- Reuse Orca's git decoration tokens, localized accessible labels, locale-aware number grouping, and explicit zero/partial/missing-value behavior.

Closes #13773

## Screenshots

### Light

![Pull request line totals in Orca light theme](https://raw.githubusercontent.com/sionic-khope/orca/assets/pr-13773/.github/pr-assets/13773/pull-request-change-summary-light.png)

### Dark

![Pull request line totals in Orca dark theme](https://raw.githubusercontent.com/sionic-khope/orca/assets/pr-13773/.github/pr-assets/13773/pull-request-change-summary-dark.png)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (4,644 files / 49,670 tests passed)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional focused validation:

- `PullRequestChangeSummary.test.ts`: 4/4 passed, covering full, zero, partial, and missing totals.
- Electron Playwright: 1/1 passed after opening a list item with no totals and hydrating them through a mocked `gh:workItemDetails` main-process IPC response.
- Changed-code quality, type-aware quality, React Doctor, Oxfmt, localization catalog, extraction, and coverage gates passed.
- Manual Electron QA and independent visual reviews passed in light and dark themes at a 1440x900 viewport.

## AI Review Report

Five independent post-implementation review lanes covered goal/constraint compliance, code quality, security, hands-on Electron QA, and repository/GitHub context. Two additional visual reviewers inspected both screenshots.

The main issue found was that PR list queries intentionally omit additions/deletions. The implementation was changed to read the merged `displayWorkItem` detail response, and the Electron E2E was strengthened so the list fixture omits totals and the existing `gh:workItemDetails` IPC supplies them. Review also aligned the component with Orca's existing branch line-total convention: shared localization keys, locale-grouped display digits, `role="group"`, tabular numbers, no wrapping, and page-owned separators.

Cross-platform review explicitly checked macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, Electron boundaries, local folders, SSH hosts, and remote Orca connections. This is renderer-only display logic using an existing optional model and RPC; it adds no platform-specific shortcut, path, shell, Git command, native module, or wire-contract behavior.

## Security Audit

- No new dependency, command execution, filesystem/path handling, auth flow, preload API, IPC channel, or remote-wire shape was added.
- The displayed values are finite numeric fields normalized by the existing main-process GitHub mapper; React renders them as escaped text.
- Accessible labels interpolate numbers only, and the visible spans remain hidden from assistive technology to avoid duplicate announcements.
- E2E data and screenshots are synthetic and contain no credentials, cookies, private paths, or tokens.
- Untracked `.omo/` agent artifacts were deliberately excluded by staging the four implementation files explicitly.

No security follow-up is required for this change.

## Notes

- X: [@rlaope](https://x.com/rlaope)
- The dark-theme deleted-line color uses Orca's existing canonical git-deleted token. A visual reviewer noted its contrast is marginally below strict AA at small text; changing that shared token is broader than this PR and should be handled app-wide if desired.
- The reused accessible-label translations currently fall back to English in non-English catalogs, matching the existing source-control line-total chip.
