### PR TITLE
fix(e2e): repair seven specs whose assertions drifted from shipped behavior

### DIFF
--- a/tests/e2e/browser-local-https-certificate-trust.spec.ts
+++ b/tests/e2e/browser-local-https-certificate-trust.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@stablyai/playwright-test'
+import type { Locator, Page } from '@stablyai/playwright-test'
 
 import { expect, test } from './helpers/orca-app'
 import {
@@ -62,6 +62,12 @@ async function switchToBrowserTab(page: Page, worktreeId: string, browserTabId: 
 
 function browserSlot(page: Page, pageId: string) {
   return page.locator(`[data-browser-overlay-tab-id="${pageId}"]`)
+}
+
+// Why: the toolbar reload button is also named "Retry" once a load fails, so match the
+// overlay's button by its visible label — the toolbar one is icon-only.
+function failureOverlayRetryButton(slot: Locator): Locator {
+  return slot.getByRole('button', { name: 'Retry' }).filter({ hasText: 'Retry' })
 }
 
 async function readBrowserHeading(page: Page, browserTabId: string): Promise<string | null> {
@@ -144,7 +150,7 @@ test.describe('local HTTPS certificate trust', () => {
       // The certificate-failure branch keeps its safe recovery actions and the
       // certificate-specific hint, but never the local-server connectivity hint.
       await expect(firstSlot.getByRole('button', { name: 'Copy Address' })).toBeVisible()
-      await expect(firstSlot.getByRole('button', { name: 'Retry' })).toBeVisible()
+      await expect(failureOverlayRetryButton(firstSlot)).toBeVisible()
       await expect(firstSlot.getByText(/use a trusted local certificate/i)).toBeVisible()
       await expect(firstSlot.getByText(/make sure the server is running/i)).toHaveCount(0)
       await firstSlot.getByRole('button', { name: 'Proceed Anyway (Unsafe)' }).click()

--- a/tests/e2e/floating-tab-rename.spec.ts
+++ b/tests/e2e/floating-tab-rename.spec.ts
@@ -80,7 +80,15 @@ async function openFloatingPanel(page: Page): Promise<void> {
     PANEL_SELECTOR,
     { timeout: 30_000 }
   )
-  await page.evaluate(() => window.dispatchEvent(new Event('orca-toggle-floating-terminal')))
+  // Why: the panel's open flag is persisted (floating-terminal-panel-view-state), so
+  // after a restart it reopens on its own and a blind toggle would close it again.
+  const alreadyOpen = await page.evaluate(
+    (selector) => Boolean(document.querySelector(selector)),
+    OPEN_PANEL_SELECTOR
+  )
+  if (!alreadyOpen) {
+    await page.evaluate(() => window.dispatchEvent(new Event('orca-toggle-floating-terminal')))
+  }
   await expect(page.locator(OPEN_PANEL_SELECTOR)).toBeVisible()
 }
 

--- a/tests/e2e/github-created-issue-start-prefill.spec.ts
+++ b/tests/e2e/github-created-issue-start-prefill.spec.ts
@@ -119,11 +119,17 @@ function configureGitHubRemote(repoPath: string): void {
   })
 }
 
-test('starting a just-created GitHub issue launches Claude with its URL prefilled', async ({
-  orcaPage,
-  testRepoPath
-}) => {
+// Why: the remote must exist before Electron launches. `repos.add` probes the
+// remote once, and a settled "no remote" both makes the repo ineligible for the
+// tasks page (disabling "New GitHub issue") and suppresses re-probes for five
+// minutes — so adding origin inside the test body can never recover.
+test.beforeAll(({ testRepoPath }) => {
   configureGitHubRemote(testRepoPath)
+})
+
+test('starting a just-created GitHub issue launches Claude with its URL prefilled', async ({
+  orcaPage
+}) => {
   await waitForSessionReady(orcaPage)
   await waitForActiveWorktree(orcaPage)
 

--- a/tests/e2e/github-created-issue-start-prefill.spec.ts
+++ b/tests/e2e/github-created-issue-start-prefill.spec.ts
@@ -167,6 +167,17 @@ test('starting a just-created GitHub issue launches Claude with its URL prefille
 
   await orcaPage.getByRole('button', { name: 'Start workspace from issue' }).click()
 
+  // Why: starting a GitHub issue now routes through the quick-create composer,
+  // which carries the linked issue URL into the agent launch command on submit.
+  const composer = orcaPage.getByRole('dialog', { name: /Create (workspace|worktree)/i })
+  await expect(composer).toBeVisible({ timeout: 15_000 })
+  const createWorkspaceButton = composer.getByRole('button', {
+    name: /Create (workspace|worktree)/i
+  })
+  await expect(createWorkspaceButton).toBeEnabled({ timeout: 15_000 })
+  await createWorkspaceButton.click()
+  await expect(composer).toBeHidden({ timeout: 20_000 })
+
   let terminalText = ''
   await expect
     .poll(

--- a/tests/e2e/helpers/source-control-ai-generation.ts
+++ b/tests/e2e/helpers/source-control-ai-generation.ts
@@ -42,12 +42,16 @@ export async function openChecks(page: Page, worktreeId: string): Promise<void> 
       { timeout: 5_000 }
     )
     .toBe(true)
-  const checksButton = page.getByRole('button', { name: 'Checks', exact: true })
+  // Why: the activity-bar label carries an optional shortcut and a failure suffix ("Checks — Error"),
+  // so an exact 'Checks' name silently stops matching once the active branch has failing checks.
+  const checksButton = page.getByRole('button', { name: /^Checks(\s|$)/ })
   await expect
     .poll(
       async () => {
         if ((await page.evaluate(() => window.__store?.getState().rightSidebarTab)) !== 'checks') {
-          await checksButton.click()
+          // Why: the label flips as the checks status arrives; bound the click so the poll retries
+          // instead of hanging on a locator that stopped matching mid-action.
+          await checksButton.click({ timeout: 2_000 }).catch(() => undefined)
         }
         await page.waitForTimeout(250)
         return page.evaluate(() => window.__store?.getState().rightSidebarTab)

--- a/tests/e2e/ssh-config-host-import.spec.ts
+++ b/tests/e2e/ssh-config-host-import.spec.ts
@@ -148,7 +148,7 @@ test.describe('SSH config host import (bulk + settings re-adopt)', () => {
     await expect(
       configHostRow(reopened, hosts.bravo).getByText('In Orca', { exact: true })
     ).toBeVisible()
-    await expect(reopened.getByRole('button', { name: 'All hosts already in Orca' })).toBeDisabled()
+    await expect(reopened.getByRole('button', { name: 'No new hosts to add' })).toBeDisabled()
   })
 
   // ── P7 ─────────────────────────────────────────────────────────────
@@ -164,13 +164,17 @@ test.describe('SSH config host import (bulk + settings re-adopt)', () => {
     )
 
     const picker = await openSshConfigHostPicker(orcaPage)
-    // Suppressed aliases are omitted from the picker entirely.
-    await expect(configHostRow(picker, hosts.alpha)).toHaveCount(0)
+    // Suppressed aliases stay listed (re-pickable) but never count as new.
+    const alphaRow = configHostRow(picker, hosts.alpha)
+    await expect(alphaRow).toBeVisible()
+    await expect(alphaRow).toBeEnabled()
+    await expect(alphaRow.getByText('Removed from Orca', { exact: true })).toBeVisible()
+    await expect(alphaRow.getByText('In Orca', { exact: true })).toHaveCount(0)
     await expect(configHostRow(picker, hosts.bravo)).toBeVisible()
     await expect(
       configHostRow(picker, hosts.bravo).getByText('In Orca', { exact: true })
     ).toBeVisible()
-    await expect(picker.getByRole('button', { name: 'All hosts already in Orca' })).toBeDisabled()
+    await expect(picker.getByRole('button', { name: 'No new hosts to add' })).toBeDisabled()
     await expect(picker.getByRole('button', { name: /Add all \d+ to Orca/ })).toHaveCount(0)
 
     await returnToAppShell(orcaPage)

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -19,9 +19,9 @@ test('new-tab file results prioritize the filename and reveal the full path on h
   await ensureTerminalVisible(orcaPage)
 
   await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
-  const input = orcaPage.getByRole('combobox', {
-    name: 'Open any file, URL, agent, ...'
-  })
+  // Not the placeholder/aria-label: that copy is translated and already drifted
+  // once. aria-controls points at the results listbox id, which is structural.
+  const input = orcaPage.locator('input[role="combobox"][aria-controls="tab-create-entry-results"]')
   await input.fill('secondaryNav')
 
   const row = orcaPage.locator('[role="option"]').filter({ hasText: 'Open file' }).first()

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -6,6 +6,7 @@ const LOCAL_PROJECT = 'E2E Palette Local Project'
 const REMOTE_PROJECT = 'E2E Palette Remote Project'
 const REMOTE_WORKSPACE = 'E2E Palette Remote Workspace'
 const REMOTE_HOST = 'E2E Palette Builder'
+const SEARCH_PLACEHOLDER = 'Search chats, terminals, worktrees, settings, and actions...'
 
 type PaletteFilterFixture = { localWorktreeId: string; remoteWorktreeId: string }
 
@@ -107,7 +108,7 @@ async function openPalette(page: Page): Promise<void> {
 }
 
 async function searchFixtureWorkspaces(page: Page, fixture: PaletteFilterFixture): Promise<void> {
-  const input = palette(page).getByPlaceholder('Search worktrees, settings, tabs, and actions...')
+  const input = palette(page).getByPlaceholder(SEARCH_PLACEHOLDER)
   await input.fill('E2E Palette')
   await expect(worktreeRow(page, fixture.localWorktreeId)).toBeVisible()
   await expect(worktreeRow(page, fixture.remoteWorktreeId)).toBeVisible()
@@ -115,7 +116,7 @@ async function searchFixtureWorkspaces(page: Page, fixture: PaletteFilterFixture
 
 async function selectRemoteHost(page: Page, useKeyboard = false): Promise<void> {
   if (useKeyboard) {
-    const input = palette(page).getByPlaceholder('Search worktrees, settings, tabs, and actions...')
+    const input = palette(page).getByPlaceholder(SEARCH_PLACEHOLDER)
     await input.press('Tab')
     await expect(filterTrigger(page)).toBeFocused()
     await filterTrigger(page).click()
@@ -152,9 +153,7 @@ test.describe('Worktree jump-palette filters', () => {
     await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toHaveCount(0)
 
     // P2: host and project fields intersect, with the filter-specific empty state.
-    await palette(orcaPage)
-      .getByPlaceholder('Search worktrees, settings, tabs, and actions...')
-      .fill('')
+    await palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER).fill('')
     await filterTrigger(orcaPage).click()
     await palette(orcaPage).getByText('Projects', { exact: true }).click()
     const projects = palette(orcaPage).getByRole('listbox', { name: 'Projects' })


### PR DESCRIPTION
Follow-up to #13758, which restored E2E collection. With the suite able to run again, eleven tests across ten specs were failing. **Seven of those specs are fixed here.** The other three are not, for reasons documented at the bottom — they turned out to be real product bugs, and the obvious test-side fix for each would have hidden one.

## The seven

Each was verified against `src/` to confirm the test had drifted, rather than by making the assertion pass.

| Spec | Cause |
|---|---|
| `worktree-jump-palette-filter` | palette placeholder gained chats + terminals |
| `tab-create-entry-file-paths` | matched the omnibox by its translated `aria-label` |
| `browser-local-https-certificate-trust` | strict-mode violation: two buttons named "Retry" |
| `repro-7732-gitlab-checks-job-details` | activity-bar label gains an "— Error" suffix |
| `floating-tab-rename` | panel open flag is persisted; a blind toggle closed it |
| `github-created-issue-start-prefill` | Start now routes through the quick-create composer |
| `ssh-config-host-import` (×2) | assertions contradicted deliberate, unit-tested behavior |

Three are worth calling out because the test was wrong in an instructive way:

- **`browser-local-https-certificate-trust`** — once a load failure settles, the toolbar reload button relabels itself "Retry" (`Stop` → `Retry` → `Reload` per `resolveBrowserReloadButtonLabelKind`), colliding with the failure overlay's own Retry. The test only ever passed inside the transient window where the toolbar still read "Stop". Narrowed by visible text; the toolbar button is icon-only.
- **`repro-7732-gitlab-checks-job-details`** — the label carries a failure suffix, so an exact-name match stops matching *precisely when the checks under test fail*. Anchored regex, plus a bounded click so the poll retries rather than hanging on a label that flips mid-action.
- **`ssh-config-host-import`** — P6 waited on `"All hosts already in Orca"`, a string that exists **nowhere in `src/`** and never could have matched. P7 required the tombstoned host to be *absent*, but listing it behind a "Removed from Orca" badge is deliberate: see the rationale at `ssh-config-host-picker.ts:54` and the unit test at `AddRemoteHostDialog.config-picker.test.tsx:171` already pinning it. P7 still proves the host is excluded from bulk re-adoption, which is what it was for.

## Verification

All seven pass locally. One caveat: `github-created-issue-start-prefill` cannot be verified on a machine whose `gh` resolves to an Orca terminal-attribution shim, because `hydrateShellPath` puts that ahead of the fixture's fake `gh`. CI has no shim.

## What is deliberately NOT here

`artificial-opencode-terminal-load:761`, `terminal-hidden-view-parking:467`, and `voice-microphone-selection:107` are still failing.

Adversarial review found the first-pass fix for each was masking a real defect — retargeting the assertion to a pane where the broken path is never entered, inverting a suppression assertion, and `click({force: true})` on a control whose actionability wait was the actual signal. Those were reverted.

The real bugs found underneath are on `nwparker/e2e-product-findings`, unit-tested and green, **explicitly not proposed for merge**: the cold-park exemption ranks equal `hiddenSince` values by random UUID, and #13014 permanently drops an alternate-screen frame for a pane below the fit floor. Neither fix makes its E2E pass, so neither is claimed as one. The voice failure has no established root cause — three theories were proposed and all three refuted with evidence, the last by a probe measuring 60Hz rAF and a rect stable across 240 frames in a never-shown window.

Net: 11 failures → 4. This PR is test-only and touches no `src/`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
