### PR TITLE
fix(renderer): refresh runtime project group and folder workspace catalogs on remote repo events

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -9120,6 +9120,112 @@ describe('useIpcEvents agent status snapshot integration', () => {
   })
 })
 
+describe('runtime host catalog refresh on reposChanged', () => {
+  // Why: the host emits one reposChanged for project-group and folder-workspace edits
+  // too, so a repos-only refresh leaves those catalogs stale on every paired client.
+  it('refetches the runtime host project group and folder workspace catalogs', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    try {
+      const calls: string[] = []
+      const fetchRuntimeEnvironmentRepos = vi.fn(() => {
+        calls.push('repos')
+        return Promise.resolve([])
+      })
+      const fetchProjectGroups = vi.fn(() => {
+        calls.push('project-groups')
+        return Promise.resolve()
+      })
+      const fetchFolderWorkspaces = vi.fn(() => {
+        calls.push('folder-workspaces')
+        return Promise.resolve()
+      })
+      const state = {
+        settings: { activeRuntimeEnvironmentId: 'env-1' as string | null },
+        repos: [],
+        worktreesByRepo: {},
+        folderWorkspaces: [],
+        projectGroups: [],
+        runtimeEnvironments: [],
+        runtimeStatusByEnvironmentId: new Map(),
+        tabsByWorktree: {},
+        ptyIdsByTabId: {},
+        remountTerminalTabForRecovery: vi.fn(),
+        markEnvironmentSshStateStale: vi.fn(),
+        fetchRepos: vi.fn(() => Promise.resolve()),
+        fetchRuntimeEnvironmentRepos,
+        fetchProjectGroups,
+        fetchFolderWorkspaces,
+        fetchWorktrees: vi.fn(() => Promise.resolve()),
+        fetchWorktreeLineage: vi.fn(() => Promise.resolve())
+      }
+
+      vi.doMock('react', async () => {
+        const actual = await vi.importActual<typeof ReactModule>('react')
+        return { ...actual, useEffect: (effect: () => void | (() => void)) => void effect() }
+      })
+      vi.doMock('../store', () => ({
+        useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => state }
+      }))
+      const noopListener = (): (() => void) => () => {}
+      const autoStubNamespace = new Proxy(
+        {},
+        {
+          get:
+            () =>
+            (...args: unknown[]) => {
+              if (typeof args[0] === 'function') {
+                return noopListener()
+              }
+              return new Promise(() => {})
+            }
+        }
+      )
+      let runtimeOnResponse: ((response: unknown) => void) | undefined
+      const api = new Proxy(
+        {
+          runtimeEnvironments: {
+            subscribe: async (_args: unknown, callbacks: { onResponse: (r: unknown) => void }) => {
+              runtimeOnResponse = callbacks.onResponse
+              return { unsubscribe: vi.fn(), sendBinary: vi.fn() }
+            }
+          }
+        } as Record<string, unknown>,
+        { get: (target, prop: string) => target[prop] ?? autoStubNamespace }
+      )
+      vi.stubGlobal('window', { api })
+
+      const { useIpcEvents } = await import('./useIpcEvents')
+      useIpcEvents()
+      // Seeded discovery for the connected runtime; drains the scheduler's debounce.
+      await vi.advanceTimersByTimeAsync(300)
+
+      const runtimeOwner = { runtimeEnvironmentId: 'env-1' }
+      expect(fetchProjectGroups).toHaveBeenCalledWith(runtimeOwner)
+      expect(fetchFolderWorkspaces).toHaveBeenCalledWith(runtimeOwner)
+      // Folder workspaces resolve their owning group from projectGroups, so groups must land first.
+      expect(calls).toEqual(['repos', 'project-groups', 'folder-workspaces'])
+
+      calls.length = 0
+      fetchProjectGroups.mockClear()
+      fetchFolderWorkspaces.mockClear()
+      if (!runtimeOnResponse) {
+        throw new Error('Expected runtime client event callbacks')
+      }
+      // Past the scheduler's min interval so the event schedules on the debounce alone.
+      await vi.advanceTimersByTimeAsync(5_000)
+      runtimeOnResponse({ ok: true, result: { type: 'reposChanged' } })
+      await vi.advanceTimersByTimeAsync(300)
+
+      expect(fetchProjectGroups).toHaveBeenCalledWith(runtimeOwner)
+      expect(fetchFolderWorkspaces).toHaveBeenCalledWith(runtimeOwner)
+      expect(calls).toEqual(['repos', 'project-groups', 'folder-workspaces'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
 describe('parked terminal recovery on repos:changed', () => {
   it('remounts a pane that parked on an unresolved host once repos hydrate', async () => {
     vi.resetModules()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -911,6 +911,11 @@ export function useIpcEvents(): void {
         // Why: project events can reveal target CRUD, but known target states already arrive by push.
         void refreshRuntimeEnvironmentSshTargetMetadata(environmentId).catch(() => {})
         const repos = await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
+        // Why: the host emits one reposChanged for group/folder-workspace edits too, so those
+        // catalogs go stale without this; groups first because folder workspaces resolve owners from them.
+        const runtimeOwner = { runtimeEnvironmentId: environmentId }
+        await useAppStore.getState().fetchProjectGroups(runtimeOwner)
+        await useAppStore.getState().fetchFolderWorkspaces(runtimeOwner)
         await refreshRuntimeProjectWorktreesAndLineage(
           environmentId,
           repos,


### PR DESCRIPTION
## Summary

A runtime host emits a single `reposChanged` client event for project-group and folder-workspace mutations as well as repo mutations — `createProjectGroup`, `updateProjectGroup`, `deleteProjectGroup`, `moveProjectToGroup`, `createFolderWorkspace`, `updateFolderWorkspace`, and `deleteFolderWorkspace` all call `notifyReposChanged()` (`src/main/runtime/orca-runtime.ts`), as do the host's own `projectGroups:*` / `folderWorkspaces:*` IPC handlers via `notifyReposChangedForRemoteClients()` (`src/main/ipc/repos.ts`).

The client's handler for that event only refetched the host's **repo** catalog, worktrees, and lineage. Project group and folder workspace rows for a remote runtime therefore stayed stale for the rest of the session — a group created, renamed, moved, or deleted on the host never reached a paired client.

This refetches the environment's project group and folder workspace catalogs in the same scheduled refresh.

### ELI5

Orca's sidebar shows projects from other machines, sorted into folders. When one of those machines said "something about my projects changed", Orca re-read the project list but not the folders they sit in — so a folder renamed on that machine kept its old name here until you restarted. Now it re-reads both.

### Why this is a bug on `main` today

The staleness is only partly masked: an unrelated **local** `repos:changed` runs an all-host sweep (`fetchProjectGroupsForAllHosts` / `fetchFolderWorkspacesForAllHosts`), which happens to repair the remote rows as a side effect. With no local repo activity, remote groups never refresh after startup.

That masking is also exactly what #13632 removes, so this is a prerequisite for that PR — but it stands on its own regardless of whether #13632 ships.

## Implementation notes

- Groups are fetched before folder workspaces: `fetchFolderWorkspaceCatalogForTarget` resolves each workspace's owning group from `get().projectGroups`.
- Both fetches are host-fenced through `claimHostCatalogFence` (keyed `<kind>:<hostId>`), so a per-environment refresh cannot clobber local, direct-SSH, or other runtimes' rows — the merges are `mergeFetchedProjectGroupsForHost` / `mergeFetchedFolderWorkspaceCatalog`, both host-scoped.
- Both fetchers swallow and log their own errors, so an unreachable host cannot break the worktree/lineage refresh that follows.
- Cost is bounded by the existing scheduler: 250 ms debounce, 5 s min interval per environment. Two added RPCs per refresh, and only for environments that actually emitted an event or (re)connected.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.177 pnpm test` — 49,834 passed, 107 skipped

  A first full-suite pass reported 2 failures, both environmental rather than code: `src/relay/agent-exec-handler.test.ts` (my shell exports `GIT_CONFIG_COUNT=2`, so the handler appended its credential entries on top and the test saw 4 — passes 10/10 with those vars unset) and `tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` (the cross-version harness could not resolve its default baseline checkout in this worktree — passes 4/4 with the baseline ref pinned, same as #13632 did).
- [x] New regression in `useIpcEvents.test.ts` covering both the seeded on-connect refresh and the `reposChanged` client-event path, asserting the per-environment owner (`{ runtimeEnvironmentId: 'env-1' }`) and the groups-before-folder-workspaces ordering. Verified it fails on the unpatched hook.

## Notes

- **Remote wire compatibility**: no wire change. `folderWorkspace.list` and the project-group list RPC already exist and are already called by the all-host sweep; this only changes when the client calls them. Nothing new is published by the host, so mixed client/host versions are unaffected.
- **Cross-platform**: renderer state routing only — identical on macOS, Linux, and Windows.
- **Folder workspaces / SSH**: direct-SSH and folder-workspace catalogs remain owned by the local APIs and are untouched here.
- **Security**: no new input handling, IPC surface, paths, or auth. Same already-authorized RPCs, called on a different trigger.

Made with [Orca](https://github.com/stablyai/orca) 🐋

