### PR TITLE
perf(renderer): cut repo-refresh work in the repos slice

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1413,7 +1413,8 @@ function App(): React.JSX.Element {
         hideDetachedHeadWorkspaces,
         alwaysShowDefaultBranchWorkspace,
         showDotfilesByWorktree,
-        filterRepoIds,
+        // Why: the store keeps this array readonly for identity stability; persistence serializes it.
+        filterRepoIds: [...filterRepoIds],
         // Why (#9002): activeView is deliberately NOT included here. It used to
         // ride this same 150ms writer (#8265), which meant every top-level view
         // switch scheduled a full durable-state save. The narrow preference

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -62,7 +62,7 @@ type AutomationEditorDialogProps = {
   canSave: boolean
   createTarget: AutomationCreateTarget
   repos: readonly Repo[]
-  projectHostSetups: ProjectHostSetup[]
+  projectHostSetups: readonly ProjectHostSetup[]
   automationYamlHooksByRepoKey: Record<string, OrcaHooks | null>
   getAutomationHooksCacheKey: (repoId: string) => string
   repoMap: Map<string, Repo>

--- a/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
@@ -32,7 +32,7 @@ type AutomationEditorDialogFooterProps = {
   isSaving: boolean
   canSave: boolean
   repos: readonly Repo[]
-  projectHostSetups: ProjectHostSetup[]
+  projectHostSetups: readonly ProjectHostSetup[]
   automationYamlHooksByRepoKey: Record<string, OrcaHooks | null>
   getAutomationHooksCacheKey: (repoId: string) => string
   repoMap: Map<string, Repo>

--- a/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.ts
@@ -3,7 +3,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
 import type { ProjectHostSetupProjection } from '../../../../shared/project-host-setup-projection'
-import type { Worktree } from '../../../../shared/types'
+import type { ProjectHostSetup, Worktree } from '../../../../shared/types'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree-id'
 
 export function deriveAiVaultWorkspaceScopePaths(
@@ -88,8 +88,8 @@ export function deriveAiVaultScopeSessionPaths(
 
 function buildProjectSetupsByRepoId(
   projection?: ProjectHostSetupProjection
-): Map<string, ProjectHostSetupProjection['setups']> {
-  const setupsByRepoId = new Map<string, ProjectHostSetupProjection['setups']>()
+): Map<string, ProjectHostSetup[]> {
+  const setupsByRepoId = new Map<string, ProjectHostSetup[]>()
   for (const setup of projection?.setups ?? []) {
     const setups = setupsByRepoId.get(setup.repoId) ?? []
     setups.push(setup)

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -3,7 +3,7 @@ import { isDefaultBranchWorkspace } from './visible-worktrees'
 
 export type AddRepoSkipFinalizationState = {
   activeRepoId: string | null
-  filterRepoIds: string[]
+  filterRepoIds: readonly string[]
   showActiveOnly: boolean
   hideDefaultBranchWorkspace: boolean
   showSleepingWorkspaces: boolean

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -177,7 +177,7 @@ export function computeVisibleWorktreeIds(
   worktreesByRepo: Record<string, Worktree[]>,
   sortedIds: string[],
   opts: {
-    filterRepoIds: string[]
+    filterRepoIds: readonly string[]
     showSleepingWorkspaces: boolean
     tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
     ptyIdsByTabId: Record<string, string[]> | null

--- a/src/renderer/src/hooks/useAgentDetectionTarget.test.ts
+++ b/src/renderer/src/hooks/useAgentDetectionTarget.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { Repo } from '../../../shared/types'
+import type { FolderWorkspace, ProjectGroup, Repo } from '../../../shared/types'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { getAgentDetectionTargetKeyForWorktree } from './useAgentDetectionTarget'
 
@@ -25,22 +25,43 @@ describe('getAgentDetectionTargetKeyForWorktree', () => {
       })
       return repo
     })
+    const projectGroups: ProjectGroup[] = [
+      {
+        id: 'runtime-group',
+        name: 'workspace',
+        parentPath: '/workspace',
+        connectionId: null,
+        executionHostId: 'runtime:owner-env',
+        parentGroupId: null,
+        createdFrom: 'folder-scan',
+        tabOrder: 0,
+        isCollapsed: false,
+        color: null,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const folderWorkspaces: FolderWorkspace[] = [
+      {
+        id: 'runtime-folder',
+        projectGroupId: 'runtime-group',
+        name: 'workspace',
+        folderPath: '/workspace',
+        linkedTask: null,
+        comment: '',
+        isArchived: false,
+        isUnread: false,
+        isPinned: false,
+        sortOrder: 0,
+        lastActivityAt: 1,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
     const state = {
       settings: { activeRuntimeEnvironmentId: 'focused-env' },
-      folderWorkspaces: [
-        {
-          id: 'runtime-folder',
-          projectGroupId: 'runtime-group',
-          folderPath: '/workspace'
-        }
-      ],
-      projectGroups: [
-        {
-          id: 'runtime-group',
-          connectionId: null,
-          executionHostId: 'runtime:owner-env'
-        }
-      ],
+      folderWorkspaces,
+      projectGroups,
       repos,
       worktreesByRepo: {}
     } as Parameters<typeof getAgentDetectionTargetKeyForWorktree>[0]

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -36,7 +36,7 @@ type StoreAccessor = () => {
   setActiveWorktree: (worktreeId: string) => void
   createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
   repos?: readonly LocalhostLinkRepo[]
-  projects?: LocalhostLinkProject[]
+  projects?: readonly LocalhostLinkProject[]
   worktreesByRepo?: Record<string, LocalhostLinkWorktree[]>
   allWorktrees?: () => LocalhostLinkWorktree[]
   workspacePortScan?: { result: WorkspacePortScanResult } | null

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -47,11 +47,13 @@ function areValuesEqual(a: unknown, b: unknown): boolean {
   )
 }
 
-function areReposEqual(a: Repo, b: Repo): boolean {
+// Why: own-key-count equality distinguishes an absent optional key from one present-and-undefined,
+// which callers rely on to detect a cleared field (e.g. a dropped runtime preference).
+function areEntriesEqual<T extends object>(a: T, b: T): boolean {
   if (a === b) {
     return true
   }
-  const keys = Object.keys(a) as (keyof Repo)[]
+  const keys = Object.keys(a) as (keyof T)[]
   if (keys.length !== Object.keys(b).length) {
     return false
   }
@@ -66,22 +68,34 @@ function areReposEqual(a: Repo, b: Repo): boolean {
   return true
 }
 
-export function reconcileFetchedRepos(
-  previous: readonly Repo[],
-  next: readonly Repo[]
-): readonly Repo[] {
-  const previousById = new Map(previous.map((repo) => [getRepoHostIdentity(repo), repo]))
+/**
+ * Reuses equal entries from `previous` — and the whole array when nothing moved — so a refetch
+ * that changed nothing leaves identity-keyed memos and store subscribers untouched.
+ */
+export function reconcileFetchedEntries<T extends object>(
+  previous: readonly T[],
+  next: readonly T[],
+  getIdentity: (entry: T) => string
+): readonly T[] {
+  const previousByIdentity = new Map(previous.map((entry) => [getIdentity(entry), entry]))
   let identical = next.length === previous.length
-  const reconciled = next.map((repo, index) => {
-    const existing = previousById.get(getRepoHostIdentity(repo))
-    if (existing && areReposEqual(existing, repo)) {
+  const reconciled = next.map((entry, index) => {
+    const existing = previousByIdentity.get(getIdentity(entry))
+    if (existing && areEntriesEqual(existing, entry)) {
       if (existing !== previous[index]) {
         identical = false
       }
       return existing
     }
     identical = false
-    return repo
+    return entry
   })
   return identical ? previous : reconciled
+}
+
+export function reconcileFetchedRepos(
+  previous: readonly Repo[],
+  next: readonly Repo[]
+): readonly Repo[] {
+  return reconcileFetchedEntries(previous, next, getRepoHostIdentity)
 }

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import type { FolderWorkspacePathStatusCacheEntry } from './repos'
+import type { Repo } from '../../../../shared/types'
+import {
+  installReposRuntimeRoutingHarness,
+  localRepo,
+  reposList
+} from './repos-runtime-routing-fixture'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() }
+}))
+
+installReposRuntimeRoutingHarness()
+
+// Why: a catalog refresh that changes nothing must leave every slice referentially stable —
+// identity-keyed memos and store subscribers key off these arrays. Fixtures here are
+// production-shaped on purpose; scalar-only repos reconcile even when the compare is broken.
+describe('repo catalog refresh identity', () => {
+  it('keeps the repos array identity across a refetch that changes nothing', async () => {
+    // Why: main rebuilds nested records (hookSettings et al) per list and IPC clones them, so a
+    // production-shaped repo — not a scalar-only fixture — is what proves reconciliation works.
+    const hydrated = (): Repo => ({
+      ...localRepo,
+      kind: 'git',
+      gitUsername: 'octocat',
+      hookSettings: { mode: 'auto', scripts: { setup: 'echo hi', archive: '' } },
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/octocat/local',
+        remoteName: 'origin',
+        remoteUrl: 'git@github.com:octocat/local.git'
+      },
+      importedExternalWorktreePaths: ['/local/wt']
+    })
+    reposList.mockImplementation(async () => [hydrated()])
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const reposRef = store.getState().repos
+
+    await store.getState().fetchRepos()
+
+    // Why: identity-keyed renderer memos (repo lookup index, selectors) rebuild on a new array.
+    expect(store.getState().repos).toBe(reposRef)
+    expect(store.getState().repos[0]).toBe(reposRef[0])
+  })
+
+  it('keeps projects and host setups identity across a refetch that changes nothing', async () => {
+    // Why: the compat merge rebuilds sourceRepoIds per project and setups arrive freshly cloned,
+    // so only a structural reconcile recovers identity — a scalar-only fixture would pass anyway.
+    const hydrated = (): Repo => ({
+      ...localRepo,
+      kind: 'git',
+      hookSettings: { mode: 'auto', scripts: { setup: 'echo hi', archive: '' } },
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/octocat/local',
+        remoteName: 'origin',
+        remoteUrl: 'git@github.com:octocat/local.git'
+      }
+    })
+    reposList.mockImplementation(async () => [hydrated()])
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projectsRef = store.getState().projects
+    const setupsRef = store.getState().projectHostSetups
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).toBe(projectsRef)
+    expect(store.getState().projects[0]).toBe(projectsRef[0])
+    expect(store.getState().projectHostSetups).toBe(setupsRef)
+    expect(store.getState().projectHostSetups[0]).toBe(setupsRef[0])
+  })
+
+  it('replaces projects and host setups identity when a refetch adds a repo', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projectsRef = store.getState().projects
+    const setupsRef = store.getState().projectHostSetups
+    reposList.mockResolvedValue([localRepo, { ...localRepo, id: 'second', path: '/second' }])
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).not.toBe(projectsRef)
+    expect(store.getState().projectHostSetups).not.toBe(setupsRef)
+    expect(store.getState().projects).toHaveLength(2)
+  })
+
+  it('keeps the repo filter array identity when a refetch prunes nothing', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    store.setState({ filterRepoIds: [localRepo.id] })
+    const filterRef = store.getState().filterRepoIds
+
+    await store.getState().fetchRepos()
+
+    // Why: App.tsx and five sidebar consumers select this array by identity.
+    expect(store.getState().filterRepoIds).toBe(filterRef)
+  })
+
+  it('still prunes filtered repo ids that no longer exist', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    store.setState({ filterRepoIds: [localRepo.id, 'gone'] })
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().filterRepoIds).toEqual([localRepo.id])
+  })
+
+  it('keeps the folder workspace path status map identity when there is nothing to drop', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    const statusesRef = store.getState().folderWorkspacePathStatuses
+
+    await store.getState().fetchRepos()
+
+    // Why: sidebar rows shallow-select this map, so a fresh {} re-renders the whole list.
+    expect(store.getState().folderWorkspacePathStatuses).toBe(statusesRef)
+  })
+
+  it('still drops cached folder workspace path statuses on a catalog fetch', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    const stale: Record<string, FolderWorkspacePathStatusCacheEntry> = {
+      stale: {
+        status: { path: '/gone', exists: false },
+        checkedAt: 1,
+        requestSnapshot: 'old'
+      }
+    }
+    store.setState({ folderWorkspacePathStatuses: stale })
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().folderWorkspacePathStatuses).toEqual({})
+  })
+
+  it('replaces the repos array identity when a refetch adds a repo', async () => {
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const reposRef = store.getState().repos
+    reposList.mockResolvedValue([localRepo, { ...localRepo, id: 'second', path: '/second' }])
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).not.toBe(reposRef)
+    expect(store.getState().repos).toHaveLength(2)
+  })
+})

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createTestStore, makeWorktree } from './store-test-helpers'
 import { workItemsCacheKey } from './github'
-import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
+import type { Project, ProjectHostSetup } from '../../../../shared/types'
 import { toast } from 'sonner'
 import {
   installReposRuntimeRoutingHarness,
@@ -50,46 +50,6 @@ describe('repo slice runtime routing', () => {
     ])
     expect(reposList).toHaveBeenCalled()
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
-  })
-
-  it('keeps the repos array identity across a refetch that changes nothing', async () => {
-    // Why: main rebuilds nested records (hookSettings et al) per list and IPC clones them, so a
-    // production-shaped repo — not a scalar-only fixture — is what proves reconciliation works.
-    const hydrated = (): Repo => ({
-      ...localRepo,
-      kind: 'git',
-      gitUsername: 'octocat',
-      hookSettings: { mode: 'auto', scripts: { setup: 'echo hi', archive: '' } },
-      gitRemoteIdentity: {
-        canonicalKey: 'github.com/octocat/local',
-        remoteName: 'origin',
-        remoteUrl: 'git@github.com:octocat/local.git'
-      },
-      importedExternalWorktreePaths: ['/local/wt']
-    })
-    reposList.mockImplementation(async () => [hydrated()])
-    const store = createTestStore()
-    await store.getState().fetchRepos()
-    const reposRef = store.getState().repos
-
-    await store.getState().fetchRepos()
-
-    // Why: identity-keyed renderer memos (repo lookup index, selectors) rebuild on a new array.
-    expect(store.getState().repos).toBe(reposRef)
-    expect(store.getState().repos[0]).toBe(reposRef[0])
-  })
-
-  it('replaces the repos array identity when a refetch adds a repo', async () => {
-    reposList.mockResolvedValue([localRepo])
-    const store = createTestStore()
-    await store.getState().fetchRepos()
-    const reposRef = store.getState().repos
-    reposList.mockResolvedValue([localRepo, { ...localRepo, id: 'second', path: '/second' }])
-
-    await store.getState().fetchRepos()
-
-    expect(store.getState().repos).not.toBe(reposRef)
-    expect(store.getState().repos).toHaveLength(2)
   })
 
   it('fetches repos from the active remote runtime environment', async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -47,7 +47,7 @@ import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
-import { reconcileFetchedRepos } from './repo-identity-reconcile'
+import { reconcileFetchedEntries, reconcileFetchedRepos } from './repo-identity-reconcile'
 import {
   mergeSshRepoReadoptions,
   reconcileReadoptedSshRepoRows,
@@ -741,7 +741,7 @@ function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {
 function mergeProjectHostSetupsByOwner(
   base: readonly ProjectHostSetup[],
   overlay: readonly ProjectHostSetup[]
-): ProjectHostSetup[] {
+): readonly ProjectHostSetup[] {
   const merged = [...base]
   const indexByOwner = new Map(
     merged.map((entry, index) => [getProjectHostSetupOwnerKey(entry), index])
@@ -790,6 +790,81 @@ function getExplicitProjectHostIds(
   return hostIds
 }
 
+function indexProjectHostSetupsByProjectId(
+  setups: readonly ProjectHostSetup[]
+): Map<string, ProjectHostSetup[]> {
+  const setupsByProjectId = new Map<string, ProjectHostSetup[]>()
+  for (const setup of setups) {
+    const existing = setupsByProjectId.get(setup.projectId)
+    if (existing) {
+      existing.push(setup)
+    } else {
+      setupsByProjectId.set(setup.projectId, [setup])
+    }
+  }
+  return setupsByProjectId
+}
+
+function getProjectSourceRepos(
+  project: Project,
+  reposById: ReadonlyMap<string, readonly Repo[]>
+): Repo[] {
+  const sourceRepos: Repo[] = []
+  for (const repoId of project.sourceRepoIds) {
+    for (const repo of reposById.get(repoId) ?? []) {
+      sourceRepos.push(repo)
+    }
+  }
+  return sourceRepos
+}
+
+// Why: the host-id resolvers rescan every setup and repo per project; feeding them the project's own slices keeps a catalog refresh linear.
+function createProjectHostIdIndex(
+  setups: readonly ProjectHostSetup[],
+  reposById: ReadonlyMap<string, readonly Repo[]>,
+  resolveHostIds: (
+    project: Project,
+    setups: readonly ProjectHostSetup[],
+    repos: readonly Repo[]
+  ) => Set<string>
+): (project: Project) => ReadonlySet<string> {
+  const noSetups: readonly ProjectHostSetup[] = []
+  const hostIdsByProject = new Map<Project, ReadonlySet<string>>()
+  let setupsByProjectId: Map<string, ProjectHostSetup[]> | null = null
+  return (project) => {
+    const cached = hostIdsByProject.get(project)
+    if (cached) {
+      return cached
+    }
+    setupsByProjectId ??= indexProjectHostSetupsByProjectId(setups)
+    const hostIds = resolveHostIds(
+      project,
+      setupsByProjectId.get(project.id) ?? noSetups,
+      getProjectSourceRepos(project, reposById)
+    )
+    hostIdsByProject.set(project, hostIds)
+    return hostIds
+  }
+}
+
+// Why: mergePreviousProjectMetadata reads the whole catalog's key set; a view holding only this pair's repos keeps that scan per-project.
+function restrictReposToProjectPair(
+  previous: Project,
+  current: Project,
+  reposById: ReadonlyMap<string, readonly Repo[]>
+): Map<string, readonly Repo[]> {
+  const restricted = new Map<string, readonly Repo[]>()
+  for (const project of [previous, current]) {
+    for (const repoId of project.sourceRepoIds) {
+      const matches = reposById.get(repoId)
+      if (matches) {
+        restricted.set(repoId, matches)
+      }
+    }
+  }
+  return restricted
+}
+
 function mergeFetchedProjectCompatibilityForHost({
   previous,
   fetched,
@@ -817,45 +892,77 @@ function mergeFetchedProjectCompatibilityForHost({
   const previousProjectById = new Map(previous.projects.map((project) => [project.id, project]))
   const reposById = getReposById(repos)
   const currentRepoIds = new Set(repos.map((repo) => repo.id))
-  const projectHasHost = (project: Project, setups: readonly ProjectHostSetup[]): boolean =>
-    getProjectHostIds(project, setups, repos).has(hostId)
-  const projectHasCurrentOwnerOutsideHost = (project: Project): boolean =>
-    [...getExplicitProjectHostIds(project, projectHostSetups, repos)].some(
-      (ownerHostId) => ownerHostId !== hostId
-    )
+  const fetchedProjectHostIds = createProjectHostIdIndex(
+    fetched.projectHostSetups,
+    reposById,
+    getProjectHostIds
+  )
+  const previousProjectHostIds = createProjectHostIdIndex(
+    previous.projectHostSetups,
+    reposById,
+    getProjectHostIds
+  )
+  const currentProjectOwnerHostIds = createProjectHostIdIndex(
+    projectHostSetups,
+    reposById,
+    getExplicitProjectHostIds
+  )
+  const projectHasCurrentOwnerOutsideHost = (project: Project): boolean => {
+    for (const ownerHostId of currentProjectOwnerHostIds(project)) {
+      if (ownerHostId !== hostId) {
+        return true
+      }
+    }
+    return false
+  }
   const fetchedProjects = fetched.projects
     .filter((project) => {
       const previousProject = previousProjectById.get(project.id)
       // Why: repo-derived compatibility projects include every host; a one-host refresh should only reconcile or prune that host's ownership.
       return (
-        projectHasHost(project, fetched.projectHostSetups) ||
-        (previousProject ? projectHasHost(previousProject, previous.projectHostSetups) : false)
+        fetchedProjectHostIds(project).has(hostId) ||
+        (previousProject ? previousProjectHostIds(previousProject).has(hostId) : false)
       )
     })
     .map((project) => {
       const previousProject = previousProjectById.get(project.id)
       return previousProject
-        ? mergePreviousProjectMetadata(previousProject, project, reposById, hostId)
+        ? mergePreviousProjectMetadata(
+            previousProject,
+            project,
+            restrictReposToProjectPair(previousProject, project, reposById),
+            hostId
+          )
         : projectWithCurrentSourceRepoIds(project, currentRepoIds)
     })
   const fetchedProjectIds = new Set(fetchedProjects.map((project) => project.id))
   const preservedProjects = previous.projects.filter(
     (project) =>
       !fetchedProjectIds.has(project.id) &&
-      (!getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId) ||
-        projectHasCurrentOwnerOutsideHost(project))
+      (!previousProjectHostIds(project).has(hostId) || projectHasCurrentOwnerOutsideHost(project))
   )
+  // Why: the merges above always allocate (sourceRepoIds is rebuilt per project, and fetched setups
+  // arrive freshly cloned over IPC), so reconcile against `previous` to recover identity when a
+  // refresh changed nothing. Keys match what each merge already dedups by.
   return {
-    projects: mergeProjectCompatibilityProjects(
-      preservedProjects.map((project) => {
-        const sourceRepoIds = getSourceRepoIdsOutsideHost(project, reposById, hostId)
-        return sourceRepoIds.length === project.sourceRepoIds.length
-          ? project
-          : { ...project, sourceRepoIds }
-      }),
-      fetchedProjects
+    projects: reconcileFetchedEntries(
+      previous.projects,
+      mergeProjectCompatibilityProjects(
+        preservedProjects.map((project) => {
+          const sourceRepoIds = getSourceRepoIdsOutsideHost(project, reposById, hostId)
+          return sourceRepoIds.length === project.sourceRepoIds.length
+            ? project
+            : { ...project, sourceRepoIds }
+        }),
+        fetchedProjects
+      ),
+      (project) => project.id
     ),
-    projectHostSetups
+    projectHostSetups: reconcileFetchedEntries(
+      previous.projectHostSetups,
+      projectHostSetups,
+      getProjectHostSetupOwnerKey
+    )
   }
 }
 
@@ -1134,7 +1241,7 @@ function filterSetupsForPrunedRepoRows(
   setups: readonly ProjectHostSetup[],
   mergedRepos: readonly Repo[],
   reconciledRepos: readonly Repo[]
-): ProjectHostSetup[] {
+): readonly ProjectHostSetup[] {
   const survivingOwners = new Set(
     reconciledRepos.map((repo) => `${getRepoExecutionHostId(repo)}:${repo.id}`)
   )
@@ -1143,12 +1250,15 @@ function filterSetupsForPrunedRepoRows(
       .filter((repo) => !survivingOwners.has(`${getRepoExecutionHostId(repo)}:${repo.id}`))
       .map((repo) => `${getRepoExecutionHostId(repo)}:${repo.id}`)
   )
+  // Why: this result feeds the compat merge as `previous`, so an unconditional copy here would
+  // discard the identity that merge is about to try to preserve.
   if (prunedOwners.size === 0) {
-    return [...setups]
+    return setups
   }
-  return setups.filter(
+  const filtered = setups.filter(
     (setup) => !setup.repoId || !prunedOwners.has(`${setup.hostId}:${setup.repoId}`)
   )
+  return filtered.length === setups.length ? setups : filtered
 }
 
 function reconcileReadoptedSshWorktreeState(
@@ -1612,6 +1722,25 @@ function getFreshFolderWorkspacePathStatusFromCache(args: {
   return Date.now() - entry.checkedAt < FOLDER_WORKSPACE_PATH_STATUS_TTL_MS ? entry.status : null
 }
 
+// Why: catalog fetches drop this cache defensively, but entries already self-invalidate on
+// requestSnapshot drift and TTL. Keep the identity when there is nothing to drop, so a no-op
+// refresh stops re-rendering every sidebar row that shallow-selects this map.
+function clearedFolderWorkspacePathStatuses(
+  current: Record<string, FolderWorkspacePathStatusCacheEntry>
+): Record<string, FolderWorkspacePathStatusCacheEntry> {
+  return Object.keys(current).length === 0 ? current : {}
+}
+
+// Why: App.tsx and five other components select this array by identity, so a refresh that prunes
+// nothing must hand back the input rather than an equal copy.
+function pruneFilterRepoIds(
+  filterRepoIds: readonly string[],
+  validRepoIds: ReadonlySet<string>
+): readonly string[] {
+  const pruned = filterRepoIds.filter((projectId) => validRepoIds.has(projectId))
+  return pruned.length === filterRepoIds.length ? filterRepoIds : pruned
+}
+
 function getFolderWorkspacePathStatusRequestSnapshotForRead(
   state: AppState,
   request: FolderWorkspacePathStatusRequest
@@ -1621,8 +1750,8 @@ function getFolderWorkspacePathStatusRequestSnapshotForRead(
 
 export type RepoSlice = {
   repos: readonly Repo[]
-  projects: Project[]
-  projectHostSetups: ProjectHostSetup[]
+  projects: readonly Project[]
+  projectHostSetups: readonly ProjectHostSetup[]
   projectGroups: ProjectGroup[]
   folderWorkspaces: FolderWorkspace[]
   folderWorkspacePathStatuses: Record<string, FolderWorkspacePathStatusCacheEntry>
@@ -1933,9 +2062,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           pendingSshRepoReadoptions: reconciliation.pendingReadoptions,
           ...reconcileReadoptedSshWorktreeState(s, s.pendingSshRepoReadoptions),
           ...mergedProjectCompatibility,
-          folderWorkspacePathStatuses: {},
+          folderWorkspacePathStatuses: clearedFolderWorkspacePathStatuses(
+            s.folderWorkspacePathStatuses
+          ),
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          filterRepoIds: pruneFilterRepoIds(s.filterRepoIds, validRepoIds),
           setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
             s.setupScriptPromptDismissedRepoIds,
             validRepoHostIdentities
@@ -2019,7 +2150,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ...reconcileReadoptedSshWorktreeState(s, s.pendingSshRepoReadoptions),
           ...mergedProjectCompatibility,
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          filterRepoIds: pruneFilterRepoIds(s.filterRepoIds, validRepoIds),
           setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
             s.setupScriptPromptDismissedRepoIds,
             validRepoHostIdentities
@@ -2084,7 +2215,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           pendingSshRepoReadoptions: reconciliation.pendingReadoptions,
           ...reconcileReadoptedSshWorktreeState(s, s.pendingSshRepoReadoptions),
           ...mergedProjectCompatibility,
-          folderWorkspacePathStatuses: {},
+          folderWorkspacePathStatuses: clearedFolderWorkspacePathStatuses(
+            s.folderWorkspacePathStatuses
+          ),
           activeRepoId: s.activeRepoId,
           filterRepoIds: s.filterRepoIds,
           setupScriptPromptDismissedRepoIds: s.setupScriptPromptDismissedRepoIds
@@ -2099,7 +2232,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         const validRepoHostIdentities = new Set(s.repos.map(getRepoHostIdentity))
         return {
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          filterRepoIds: pruneFilterRepoIds(s.filterRepoIds, validRepoIds),
           setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
             s.setupScriptPromptDismissedRepoIds,
             validRepoHostIdentities
@@ -2171,7 +2304,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ? {
               projectGroups: mergeFetchedProjectGroupCatalog(catalog, current.projectGroups)
                 .projectGroups,
-              folderWorkspacePathStatuses: {}
+              folderWorkspacePathStatuses: clearedFolderWorkspacePathStatuses(
+                current.folderWorkspacePathStatuses
+              )
             }
           : current
       )
@@ -2191,7 +2326,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ? {
               projectGroups: mergeFetchedProjectGroupCatalog(catalog, s.projectGroups)
                 .projectGroups,
-              folderWorkspacePathStatuses: {}
+              folderWorkspacePathStatuses: clearedFolderWorkspacePathStatuses(
+                s.folderWorkspacePathStatuses
+              )
             }
           : s
       )
@@ -2252,7 +2389,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           current.folderWorkspaces,
           current.projectGroups
         )
-        return { folderWorkspaces, folderWorkspacePathStatuses: {} }
+        return {
+          folderWorkspaces,
+          folderWorkspacePathStatuses: clearedFolderWorkspacePathStatuses(
+            current.folderWorkspacePathStatuses
+          )
+        }
       })
     } catch (err) {
       console.error('Failed to fetch folder workspaces:', err)
@@ -2286,7 +2428,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             current.folderWorkspaces,
             current.projectGroups
           ).folderWorkspaces,
-          folderWorkspacePathStatuses: {}
+          folderWorkspacePathStatuses: clearedFolderWorkspacePathStatuses(
+            current.folderWorkspacePathStatuses
+          )
         }
       })
     }

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -902,7 +902,7 @@ export type UISlice = {
   showDotfilesByWorktree: Record<string, boolean>
   setShowDotfilesForWorktree: (worktreeId: string, showDotfiles: boolean) => void
   toggleShowDotfilesForWorktree: (worktreeId: string) => void
-  filterRepoIds: string[]
+  filterRepoIds: readonly string[]
   setFilterRepoIds: (ids: string[]) => void
   collapsedGroups: Set<string>
   toggleCollapsedGroup: (key: string) => void

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -6080,7 +6080,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const reposChanged = survivingRepos.length !== s.repos.length
 
       // Why: a repoId-less setup on the removed host can still split a surviving project group, so drop every setup it owns.
-      const survivingSetups: AppState['projectHostSetups'] = []
+      const survivingSetups: ProjectHostSetup[] = []
       for (const setup of s.projectHostSetups) {
         if (isRemovedRuntimeHostId(setup.hostId, removed)) {
           if (setup.repoId) {

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -13,8 +13,8 @@ type ProjectAccumulator = {
 }
 
 export type ProjectHostSetupProjection = {
-  projects: Project[]
-  setups: ProjectHostSetup[]
+  projects: readonly Project[]
+  setups: readonly ProjectHostSetup[]
 }
 
 function getProjectProviderIdentity(


### PR DESCRIPTION
## Summary

Follow-up to #13744. Profiling the leftovers from that PR surfaced something much bigger than the identity work it was chasing: a quadratic merge running synchronously inside a zustand `set()` on every repo catalog refresh.

| Commit | What |
|---|---|
| `bb8ca45` | Index the compat merge (**up to 27.8×**) + stop three slices losing array identity |
| `0754aaa` | Generalize the identity reconciler; widen catalog types to `readonly` |
| `033d4ac` | Refresh-identity tests; complete two incomplete fixtures |

## 1. The quadratic merge — the headline

`mergeFetchedProjectCompatibilityForHost` runs **synchronously inside a zustand `set()`** on every repo refresh (`fetchRepos`, `fetchRuntimeEnvironmentRepos`, `fetchReposForAllHosts`). It was O(projects × (setups + repos)):

- `getProjectHostIds` / `getExplicitProjectHostIds` rescanned **all** setups and repos, once per project
- `mergePreviousProjectMetadata` rebuilt a full repo key-set (`new Set(reposById.keys())`) **per project** — a hidden quadratic term

At 1200 repos that is ~200 ms of main-thread work — roughly a dozen dropped frames — inside a store write.

The fix precomputes the indexes once and hands each helper only its own project's slice. **No ownership logic was reimplemented**; the existing helpers are called verbatim with pre-sliced inputs, so the results are provably identical rather than "hopefully equivalent".

Warm refresh (previous state already holds the catalog — the steady-state case):

| repos | before | after | speedup |
|---|---:|---:|---:|
| 200 | 7.7 ms | 1.0 ms | **7.8×** |
| 600 | 33.2 ms | 1.2 ms | **27.8×** |
| 1200 | 202.2 ms | 8.3 ms | **24.3×** |

Growth is now roughly linear rather than quadratic. Absolute numbers are noisy run-to-run (the 1200 baseline ranged 156–473 ms); the ratio was stable.

## 2. Three slices that lost array identity every refresh

Same class of bug #13744 fixed for `repos`, in the slices next to it:

- **`projects` / `projectHostSetups`** — the merge always allocates (`sourceRepoIds` is rebuilt per project; setups arrive freshly cloned over IPC), so these now reconcile against `previous`. `filterSetupsForPrunedRepoRows` also had to stop copying unconditionally — otherwise the reconcile compares against a throwaway copy and achieves nothing.
- **`filterRepoIds`** — returns the input when nothing was pruned. This one has the widest reach of the three: **six identity-sensitive subscribers including `App.tsx` at the root**.
- **`folderWorkspacePathStatuses`** — keeps identity when already empty, at all six catalog-fetch sites (`useIpcEvents` fires `fetchRepos` + `fetchProjectGroups` + `fetchFolderWorkspaces` together, so fixing only the repo sites would leave the sidebar churning).

On that last one I checked whether the reset was load-bearing before touching it. It isn't: entries already self-invalidate via a `requestSnapshot` check on **read** (`repos.ts:1609`) and **write** (`:2377`), plus a 10s TTL and a component-level force-refetch on membership change. Two things settled it — `fetchRuntimeEnvironmentRepos` already mutates `repos` *without* clearing this cache (so it would be a live bug if the reset were required), and the only test asserting a clear covers a mutation site, using identity-agnostic `toEqual({})`.

## 3. `readonly` types

Following the `RepoSlice['repos']` precedent — returning live store state behind a mutable type is the footgun that PR called out. `RepoSlice['projects']`, `['projectHostSetups']`, `UISlice['filterRepoIds']`, and `ProjectHostSetupProjection` are now `readonly`. Local accumulators are annotated mutable and built from copies. **No `as` casts, `as unknown as`, or `@ts-expect-error` added.**

At the persisted-UI IPC boundary (`App.tsx`) I copy rather than widen a shared main-process type — that call is debounced and serializes anyway.

## Honest accounting of the payoff

The identity half is **not** a CPU win. Measured: the projection WeakMap hit saves ~2 µs at 200 repos and ~0 at 1200, because the selector's expensive prologue (`normalizeHydratedProjectHostSetupProjection`) is uncached and runs before any cache lookup. Reconciliation also makes the write path slightly slower.

What it actually buys is **render churn**: `useProjectHostSetupProjection` goes from "new object every refresh" to reference-stable, which stops ~24 component re-renders (mostly per-pane `TerminalPane`) plus the `buildRows` sidebar-tree rebuild in `WorktreeList`, and two spurious effect re-runs (`AiVaultPanel` scope paths, native-chat skill rescan).

**The speedup in §1 is the real win here.** I have also posted a correction on #13744, whose cache claims that profiling falsified.

## Testing

Refresh-identity cases live in a new `repos-refresh-identity.test.ts` (`repos.test.ts` crossed the 800-line limit, and these are a distinct concern — no `max-lines` disable added).

**Every identity assertion was verified to fail against a reverted source.** Fixtures are production-shaped on purpose: a scalar-only repo reconciles even when the compare is broken, which is exactly how an earlier version of this work shipped green while being completely inert.

- [x] 20,504 main-process tests
- [x] 13,869 component tests
- [x] 11,264 store / shared / lib / hooks tests
- [x] `tsc` web + node + cli — zero errors
- [x] oxlint, oxfmt, max-lines ratchet

## Residual risk

- Remaining cost in the merge after indexing is `getProjectHostSetupOwnerKey` (three `JSON.stringify` calls per setup) and object spreads in `mergeProjectCompatibilityProject` — together ~40% of what's left. A non-JSON owner key is a cheap follow-up.
- `projectHostSetupProjectionFromRepos` sets `createdAt: repo.addedAt || now`, so a repo with `addedAt === 0` would get a drifting timestamp and never reconcile. `addedAt` is required and real repos have it, so this is no worse than today — but it is why a fixture missing `addedAt` would make the fix look broken.
- Removing the `folderWorkspacePathStatuses` reset entirely (rather than guarding it) is defensible on the evidence above and would close a window where the folder-path guard is briefly un-gated, but that is a real behavior change and deserves its own PR.

Made with [Orca](https://github.com/stablyai/orca) 🐋
