### PR TITLE
WIP: two real bugs found behind three failing E2E specs (neither fixes its spec)

### DIFF
--- a/src/renderer/src/components/settings/VoicePane.test.tsx
+++ b/src/renderer/src/components/settings/VoicePane.test.tsx
@@ -253,4 +253,74 @@ describe('VoicePane', () => {
 
     expect(recordFeatureInteraction).not.toHaveBeenCalled()
   })
+
+  it('merges an in-flight voice write onto the newest settings, not the render-time snapshot', async () => {
+    const updateSettings = vi.fn()
+    let resolveClear: () => void = () => {}
+    const clearing = new Promise<void>((resolve) => {
+      resolveClear = resolve
+    })
+    useAppStoreMock.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        modelStates: [],
+        refreshModelStates: vi.fn(),
+        markFeatureTipsSeen: vi.fn(),
+        recordFeatureInteraction: vi.fn()
+      })
+    )
+    useShortcutLabelMock.mockReturnValue('Ctrl+Shift+Y')
+    installWindowApi(vi.fn(async () => deniedMicrophoneResult))
+    window.api.speech.getOpenAiApiKeyStatus = vi.fn(async () => ({ configured: true }))
+    window.api.speech.clearOpenAiApiKey = vi.fn(() => clearing)
+
+    const settingsWithKey = (enabled: boolean): GlobalSettings =>
+      ({
+        voice: {
+          ...getDefaultVoiceSettings(),
+          enabled,
+          openAiApiKeyConfigured: true,
+          microphoneDeviceId: 'usb-mic',
+          microphoneDeviceLabel: 'USB Microphone'
+        }
+      }) as GlobalSettings
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(<VoicePane settings={settingsWithKey(true)} updateSettings={updateSettings} />)
+    })
+
+    const disconnect = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Disconnect OpenAI API key"]'
+    )
+    if (!disconnect) {
+      throw new Error('Disconnect OpenAI API key button was not rendered')
+    }
+    await act(async () => {
+      disconnect.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // The user turns dictation off while the clear-key IPC is still in flight.
+    await act(async () => {
+      root.render(<VoicePane settings={settingsWithKey(false)} updateSettings={updateSettings} />)
+    })
+
+    await act(async () => {
+      resolveClear()
+      await clearing
+    })
+    root.unmount()
+
+    expect(updateSettings).toHaveBeenCalledTimes(1)
+    expect(updateSettings).toHaveBeenCalledWith({
+      voice: {
+        ...getDefaultVoiceSettings(),
+        enabled: false,
+        openAiApiKeyConfigured: false,
+        microphoneDeviceId: 'usb-mic',
+        microphoneDeviceLabel: 'USB Microphone'
+      }
+    })
+  })
 })

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -36,6 +36,12 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   const [openAiKeyPending, setOpenAiKeyPending] = useState(false)
   const [pendingCloudModelId, setPendingCloudModelId] = useState<string | null>(null)
   const mountedRef = useRef(true)
+  // Why: every write here is a read-modify-write of the whole voice object, and the
+  // writers are async (key status probe, save/clear key). Merging onto the render-time
+  // snapshot would resurrect settings that changed while the IPC was in flight — e.g.
+  // reverting `enabled` to false and leaving the microphone picker permanently disabled.
+  const voiceSettingsRef = useRef(voiceSettings)
+  voiceSettingsRef.current = voiceSettings
 
   const handlePaneRef = useCallback((node: HTMLDivElement | null): void => {
     mountedRef.current = node !== null
@@ -45,12 +51,12 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
     (updates: Partial<VoiceSettings>): void => {
       updateSettings({
         voice: {
-          ...voiceSettings,
+          ...voiceSettingsRef.current,
           ...updates
         }
       })
     },
-    [updateSettings, voiceSettings]
+    [updateSettings]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -15501,6 +15501,165 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  // Drives a hidden->visible alt-screen snapshot restore whose captured grid is
+  // 120 cols wide, letting each case control what the pane measures as.
+  async function restoreAltFrameSnapshotForPaneGeometry(options: {
+    frameMarker: string
+    proposeDimensions: () => { cols: number; rows: number } | null
+    measureRect?: () => { width: number; height: number }
+    onWrite?: (data: string) => void
+  }): Promise<{ writes: string; dispose: () => void }> {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    let onData: ConnectCallbacks['onData']
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      onData = callbacks.onData
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    getMainBufferSnapshot.mockResolvedValue({
+      data: options.frameMarker,
+      frameRestoreAnsi: '\x1b[?1004h\x1b[?25l',
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + 1,
+      alternateScreen: true,
+      scrollbackAnsi: 'preserved history'
+    })
+    const pane = createPane(1)
+    ;(
+      pane.fitAddon as unknown as {
+        proposeDimensions: () => { cols: number; rows: number } | null
+      }
+    ).proposeDimensions = vi.fn(options.proposeDimensions)
+    const measureRect = options.measureRect
+    if (measureRect) {
+      Object.defineProperty(pane.container, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => {
+          const { width, height } = measureRect()
+          return { width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0 }
+        }
+      })
+    }
+    const onWrite = options.onWrite
+    if (onWrite) {
+      const originalWrite = pane.terminal.write
+      pane.terminal.write = vi.fn((...args: Parameters<typeof originalWrite>) => {
+        onWrite(args[0])
+        return originalWrite(...args)
+      }) as typeof originalWrite
+    }
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+    onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
+    await flushAsyncTicks(20)
+    const readWrites = (): string =>
+      (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]).join('')
+    // Why real time: an unmeasurable visible pane must burn the whole bounded
+    // safe-fit retry budget (40 ticks of rAF + a 16ms layout settle) before the
+    // deferred repaint decision is made, so "absent" only means absent after it.
+    for (
+      let waited = 0;
+      waited < 2_500 && !readWrites().includes(options.frameMarker);
+      waited += 25
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      await flushAsyncTicks(10)
+    }
+    await flushAsyncTicks(20)
+    return { writes: readWrites(), dispose: () => disposable.dispose() }
+  }
+
+  // Why: the E2E's deepest split pane is ~W/256 x ~H/256 px, so it fails the
+  // 48x24 pixel floor and proposes nothing. It is visible and permanently
+  // unmeasurable: no fit ever lands, the skip's pulse repaint never runs, and
+  // the captured frame is lost unless the deferral repaints it here.
+  it('repaints the alt frame for a visible pane whose box is below the fit pixel floor', async () => {
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'SUB-FLOOR-ALT-FRAME',
+      proposeDimensions: () => null,
+      measureRect: () => ({ width: 4, height: 3 })
+    })
+    expect(writes).toContain('SUB-FLOOR-ALT-FRAME')
+    expect(writes).toContain('preserved history')
+    // The withheld frame arrives after the frame-restore state, not instead of it.
+    expect(writes.indexOf('\x1b[?1004h\x1b[?25l')).toBeLessThan(
+      writes.indexOf('SUB-FLOOR-ALT-FRAME')
+    )
+    dispose()
+  })
+
+  // The 50px divider clamp: measurable box, but the proposal is under the cols floor.
+  it('repaints the alt frame for a visible pane clamped under the fit cols floor', async () => {
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'SLIVER-ALT-FRAME',
+      proposeDimensions: () => ({ cols: 5, rows: 40 }),
+      measureRect: () => ({ width: 50, height: 600 })
+    })
+    expect(writes).toContain('SLIVER-ALT-FRAME')
+    expect(writes).toContain('preserved history')
+    dispose()
+  })
+
+  it('still drops an alt frame captured wider than the grid the fit will land on', async () => {
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'TOO-WIDE-ALT-FRAME',
+      proposeDimensions: () => ({ cols: 64, rows: 40 })
+    })
+    expect(writes).not.toContain('TOO-WIDE-ALT-FRAME')
+    expect(writes).toContain('\x1b[?1004h\x1b[?25l')
+    dispose()
+  })
+
+  // #13014 must survive the deferral: a pane that is only transiently
+  // unmeasurable gets its fit inside the retry budget, and that narrower fit
+  // would clip the captured frame — so the repaint must not fire for it.
+  it('keeps a too-wide alt frame withheld when a transiently unmeasurable pane later fits narrower', async () => {
+    let probes = 0
+    const measured = (): boolean => {
+      probes += 1
+      return probes > 3
+    }
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'NARROWED-ALT-FRAME',
+      proposeDimensions: () => (probes > 3 ? { cols: 64, rows: 40 } : null),
+      measureRect: () => (measured() ? { width: 400, height: 600 } : { width: 4, height: 3 })
+    })
+    expect(writes).not.toContain('NARROWED-ALT-FRAME')
+    expect(writes).toContain('preserved history')
+    expect(writes).toContain('\x1b[?1004h\x1b[?25l')
+    dispose()
+  })
+
+  // Why: the skip is a deferral. If the pane collapses under the fit floor
+  // between the replay and the post-replay fit, no fit and therefore no pulse
+  // repaint ever lands, so the withheld frame must be painted onto the grid the
+  // pane actually kept.
+  it('repaints a skipped alt frame when the post-replay fit never lands', async () => {
+    let collapsed = false
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'COLLAPSED-ALT-FRAME',
+      // The frame was withheld against a 64-col fit; then the divider clamps the pane to a sliver.
+      onWrite: (data) => {
+        collapsed ||= data === '\x1b[?1004h\x1b[?25l'
+      },
+      proposeDimensions: () => (collapsed ? { cols: 5, rows: 40 } : { cols: 64, rows: 40 })
+    })
+    expect(writes).toContain('preserved history')
+    expect(writes.indexOf('\x1b[?1004h\x1b[?25l')).toBeLessThan(
+      writes.indexOf('COLLAPSED-ALT-FRAME')
+    )
+    dispose()
+  })
+
   it('drains foreground output after a renderer-sourced hidden-backlog snapshot without seq', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -261,10 +261,12 @@ import {
 } from './hidden-output-restore-scheduler'
 import { resolveHiddenRestoreScrollbackRows } from './terminal-hidden-restore-scrollback'
 import {
+  buildDeferredAltFrameReplayWrites,
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
   readProposedTerminalCols,
   resolvePositiveTerminalDimensions,
+  shouldRepaintDeferredAltFrame,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
 import {
@@ -7338,11 +7340,26 @@ export function connectPanePty(
                 }
               )
               pendingHiddenSnapshotFit = fit
+              let fitCompleted = false
               try {
-                await fit.completion
+                fitCompleted = await fit.completion
               } finally {
                 if (pendingHiddenSnapshotFit === fit) {
                   pendingHiddenSnapshotFit = null
+                }
+              }
+              if (
+                !fitCompleted &&
+                skippedAltFrame &&
+                isCurrentRestore() &&
+                transport.getPtyId() === currentPtyId &&
+                shouldRepaintDeferredAltFrame(pane, snapshot.cols)
+              ) {
+                // Why: the skip is a deferral, not a deletion. No fit landed, and the pulse
+                // repaint lives in that failed continuation, so paint the frame here unless the
+                // pane is hidden (its reveal fit still owes one) or measurably narrower.
+                for (const replayChunk of buildDeferredAltFrameReplayWrites(snapshot)) {
+                  writeReplayData(replayChunk)
                 }
               }
               if (isCurrentRestore()) {

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
@@ -585,6 +585,48 @@ describe('selectColdParkedTerminalTabs', () => {
     expect(selected).toEqual(new Set())
   })
 
+  // Why: tab ids are random UUIDs, so resolving the #8262 exemption by id makes
+  // it a coin flip — and identical hiddenSinceMs is the common case (one pass
+  // stamps every tab a view switch just hid), not a corner.
+  it('resolves an identical-hiddenSinceMs tie by activation order, not by tab id', () => {
+    const hiddenSinceMs = nowMs - TERMINAL_TAB_HOT_RETAIN_MS
+    const selected = selectColdParkedTerminalTabs({
+      worktreeId: 'wt-1',
+      terminalTabs: [
+        { ...localTab('tab-aaa', hiddenSinceMs), lastActivatedSeq: 1 },
+        // Lexicographically last, but the tab the user actually lands on.
+        { ...localTab('tab-zzz', hiddenSinceMs), lastActivatedSeq: 2 }
+      ],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      hotRetainLimit: 0
+    })
+
+    expect(selected).toEqual(new Set(['tab-aaa']))
+  })
+
+  // Why: the cap evicts by the same recency ranking, so a tie there must not be
+  // a coin flip either.
+  it('keeps the most recently activated tab warm when the cap evicts a tie', () => {
+    const hiddenSinceMs = nowMs - TERMINAL_TAB_HOT_RETAIN_MS + 1
+    const selected = selectColdParkedTerminalTabs({
+      worktreeId: 'wt-1',
+      terminalTabs: [
+        { ...localTab('tab-aaa', hiddenSinceMs), lastActivatedSeq: 1 },
+        { ...localTab('tab-bbb', hiddenSinceMs), lastActivatedSeq: 3 },
+        { ...localTab('tab-ccc', hiddenSinceMs), lastActivatedSeq: 2 }
+      ],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      hotRetainLimit: 2
+    })
+
+    // tab-bbb takes the exemption slot, tab-ccc the remaining warm slot.
+    expect(selected).toEqual(new Set(['tab-aaa']))
+  })
+
   it('selects nothing when the settings kill switch disables parking', () => {
     const selected = selectColdParkedTerminalTabs({
       worktreeId: 'wt-1',

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -49,6 +49,9 @@ export type TerminalTabColdParkCandidate = ColdParkableTerminalTab & {
   isVisible: boolean
   hasActivityTerminalPortal: boolean
   hiddenSinceMs: number | null
+  /** Monotonic activation counter (higher = activated more recently); see
+   *  compareColdParkRecencyDesc for why hiddenSinceMs alone cannot rank tabs. */
+  lastActivatedSeq?: number
 }
 
 function getPendingActivationSpawnCount(value: boolean | number | undefined): number {
@@ -198,21 +201,35 @@ export function canParkTerminalTabRenderer(args: {
   return isParkRestorableTerminalPty(tab.ptyId, args.worktreeId, args.restorePolicy)
 }
 
-export type ColdParkRetainCandidate = { id: string; hiddenSinceMs: number }
+export type ColdParkRetainCandidate = {
+  id: string
+  hiddenSinceMs: number
+  lastActivatedSeq?: number
+}
+
+// Why: equal hiddenSinceMs is the common case, not a corner — hiding a view
+// stamps every tab it owns in one pass — and ids are random UUIDs, so ranking
+// recency on them is a coin flip. Recorded activation order decides instead;
+// the id only settles candidates that were never activated (#8262).
+function compareColdParkRecencyDesc(
+  a: ColdParkRetainCandidate,
+  b: ColdParkRetainCandidate
+): number {
+  if (a.hiddenSinceMs !== b.hiddenSinceMs) {
+    return b.hiddenSinceMs - a.hiddenSinceMs
+  }
+  const activationDelta = (b.lastActivatedSeq ?? -1) - (a.lastActivatedSeq ?? -1)
+  return activationDelta === 0 ? a.id.localeCompare(b.id) : activationDelta
+}
 
 // Why: the single most-recently-hidden candidate is the view the user just
 // switched away from; keeping it warm regardless of the TTL or cap means
 // switching back after any absence (a meeting, coffee) is always instant, the
-// remount cost users actually notice. Ties break by id for determinism.
+// remount cost users actually notice.
 function selectLastActiveRetainedId(candidates: ColdParkRetainCandidate[]): string | null {
   let lastActive: ColdParkRetainCandidate | null = null
   for (const candidate of candidates) {
-    if (
-      lastActive === null ||
-      candidate.hiddenSinceMs > lastActive.hiddenSinceMs ||
-      (candidate.hiddenSinceMs === lastActive.hiddenSinceMs &&
-        candidate.id.localeCompare(lastActive.id) < 0)
-    ) {
+    if (lastActive === null || compareColdParkRecencyDesc(candidate, lastActive) < 0) {
       lastActive = candidate
     }
   }
@@ -221,8 +238,7 @@ function selectLastActiveRetainedId(candidates: ColdParkRetainCandidate[]): stri
 
 // Why: hot-retain keeps the most recently hidden ids warm up to the limit;
 // ids hidden past hotRetainMs or beyond the limit cold-park. The last-active
-// id is exempt from both so returning to it never pays a remount. Ties sort by
-// id so the selection is deterministic.
+// id is exempt from both so returning to it never pays a remount.
 export function selectIdsBeyondHotRetain(
   candidates: ColdParkRetainCandidate[],
   args: { nowMs: number; hotRetainMs: number; hotRetainLimit: number }
@@ -240,10 +256,7 @@ export function selectIdsBeyondHotRetain(
       retainedCandidates.push(candidate)
     }
   }
-  retainedCandidates.sort((a, b) => {
-    const recencyDelta = b.hiddenSinceMs - a.hiddenSinceMs
-    return recencyDelta === 0 ? a.id.localeCompare(b.id) : recencyDelta
-  })
+  retainedCandidates.sort(compareColdParkRecencyDesc)
   // Why: the last-active id already holds one slot in the warm working set, so
   // the cap counts it out — the remaining candidates fill hotRetainLimit-1.
   const remainingLimit = lastActiveId === null ? args.hotRetainLimit : args.hotRetainLimit - 1
@@ -322,7 +335,11 @@ export function selectColdParkedTerminalTabs(
     ) {
       continue
     }
-    candidates.push({ id: tab.id, hiddenSinceMs: tab.hiddenSinceMs })
+    candidates.push({
+      id: tab.id,
+      hiddenSinceMs: tab.hiddenSinceMs,
+      lastActivatedSeq: tab.lastActivatedSeq
+    })
   }
   return selectIdsBeyondHotRetain(candidates, {
     nowMs: args.nowMs,

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@xterm/headless'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import {
+  buildDeferredAltFrameReplayWrites,
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
+  shouldRepaintDeferredAltFrame,
   resolvePositiveTerminalDimensions,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
@@ -171,5 +174,110 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
     ).toEqual(['\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
+  })
+})
+
+describe('shouldRepaintDeferredAltFrame', () => {
+  function makePane(args: {
+    rect: { width: number; height: number }
+    proposed: { cols: number; rows: number } | null
+    display?: string
+  }): ManagedPane {
+    const display = args.display ?? 'block'
+    const container = {
+      dataset: {},
+      parentElement: null,
+      ownerDocument: { defaultView: { getComputedStyle: () => ({ display }) } },
+      getBoundingClientRect: () => args.rect
+    }
+    return {
+      id: 1,
+      terminal: { cols: 120, rows: 40, options: {} },
+      container,
+      fitAddon: { proposeDimensions: () => args.proposed }
+    } as unknown as ManagedPane
+  }
+
+  // Why: a visible pane under the 48x24 fit floor (divider clamp, a sliver from
+  // repeated splits) is permanently unmeasurable, so the deferred repaint that
+  // rode the post-replay fit never runs and the frame would be lost for good.
+  it('repaints for a visible pane whose box is below the fit floor', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 4, height: 3 }, proposed: null }),
+        120
+      )
+    ).toBe(true)
+  })
+
+  it('repaints for a visible pane that measures but proposes under the cols floor', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 50, height: 600 }, proposed: { cols: 5, rows: 40 } }),
+        120
+      )
+    ).toBe(true)
+  })
+
+  it('withholds for a display:none pane whose reveal fit still owes the repaint', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 800, height: 600 }, proposed: null, display: 'none' }),
+        120
+      )
+    ).toBe(false)
+  })
+
+  // #13014: a frame wider than the grid a later fit lands on clips instead of reflowing.
+  it('withholds when the pane became measurable and is narrower than the capture grid', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 400, height: 600 }, proposed: { cols: 64, rows: 40 } }),
+        120
+      )
+    ).toBe(false)
+  })
+
+  it('repaints when the measurable grid is at least as wide as the capture grid', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 900, height: 600 }, proposed: { cols: 120, rows: 40 } }),
+        120
+      )
+    ).toBe(true)
+  })
+})
+
+describe('buildDeferredAltFrameReplayWrites', () => {
+  it('repaints only the alt frame, never a second copy of scrollback', () => {
+    expect(
+      buildDeferredAltFrameReplayWrites({
+        data: 'alt-frame'
+      })
+    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
+  })
+
+  it('lands the withheld frame on the alt buffer, leaving normal history intact', async () => {
+    const terminal = new Terminal({ cols: 12, rows: 5, scrollback: 20 })
+    const snapshot = {
+      data: '\x1b[1;1HFRAME',
+      frameRestoreAnsi: '\x1b[?25l',
+      alternateScreen: true,
+      scrollbackAnsi: 'log'
+    }
+    try {
+      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame: true })) {
+        await writeTerminal(terminal, chunk)
+      }
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('')
+      for (const chunk of buildDeferredAltFrameReplayWrites(snapshot)) {
+        await writeTerminal(terminal, chunk)
+      }
+      expect(terminal.buffer.active.type).toBe('alternate')
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('FRAME')
+      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('log')
+    } finally {
+      terminal.dispose()
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,5 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
+import { isManagedPaneDisplayNone } from '@/lib/pane-manager/pane-display-visibility'
 
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
@@ -40,6 +41,32 @@ export function resolvePositiveTerminalDimensions(
  */
 export function readProposedTerminalCols(pane: ManagedPane): number | undefined {
   return readProposedPaneFitDimensions(pane)?.cols
+}
+
+/**
+ * Whether a withheld alt frame must be painted now, asked once the post-replay
+ * fit has already failed to land.
+ *
+ * Why display:none rather than "is the target still unknown": the skip is a
+ * deferral whose repaint rides that fit continuation, and only a hidden pane
+ * still owes one — its continuation is parked for the reveal (which is also why
+ * its completion resolves false immediately). A visible pane gets no second
+ * chance, so a permanently unmeasurable one (display:none never applied, but a
+ * box under the 48x24 fit floor: the divider clamp, a sliver from repeated
+ * splits) would lose the frame forever.
+ *
+ * The width re-check keeps #13014: if the pane did become measurable and is
+ * genuinely narrower than the capture grid, a later fit would clip the frame,
+ * so leave it withheld.
+ */
+export function shouldRepaintDeferredAltFrame(
+  pane: ManagedPane,
+  snapshotCols: number | undefined
+): boolean {
+  if (isManagedPaneDisplayNone(pane)) {
+    return false
+  }
+  return !shouldSkipAltFrameForWidthMismatch(snapshotCols, readProposedTerminalCols(pane))
 }
 
 export function shouldSkipAltFrameForWidthMismatch(
@@ -104,4 +131,14 @@ export function buildMainModelSnapshotReplayWrites(
   // blank cells; clear the alt buffer so the pre-hide frame can't bleed
   // through blank cells (spares normal-buffer scrollback).
   return ['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', ...altFrame]
+}
+
+/**
+ * Paints a frame a previous skipAltFrame replay withheld, once it is known no
+ * fit will move the grid off the capture grid. Only the alt-screen half: the
+ * normal buffer and its scrollback were already rebuilt by that replay and must
+ * not be replayed a second time.
+ */
+export function buildDeferredAltFrameReplayWrites(snapshot: { data: string }): string[] {
+  return buildMainModelSnapshotReplayWrites({ data: snapshot.data, alternateScreen: true })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-tab-activation-order.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-activation-order.ts
@@ -1,0 +1,45 @@
+/**
+ * Monotonic activation order for a worktree's terminal tabs.
+ *
+ * Why: hiddenSince cannot rank tabs that go hidden in the same pass — leaving a
+ * worktree hides every tab it owns against one nowMs — and the tie-break of
+ * last resort is a random-UUID tab id, so the #8262 keep-warm exemption would
+ * be a coin flip. The order the user actually activated tabs in is what tells
+ * the policy which tab they land on when they come back.
+ */
+export type TerminalTabActivationOrder = {
+  recordVisibleTabIds(visibleTabIds: ReadonlySet<string>): void
+  getActivationSeq(tabId: string): number | undefined
+  retainTabIds(liveTabIds: ReadonlySet<string>): void
+}
+
+export function createTerminalTabActivationOrder(): TerminalTabActivationOrder {
+  const activationSeqByTabId = new Map<string, number>()
+  let previouslyVisibleTabIds: ReadonlySet<string> = new Set()
+  let nextActivationSeq = 0
+
+  return {
+    // Why the hidden->visible edge only: a tab that merely stayed visible was
+    // never re-activated, so its rank must not float above tabs activated after
+    // it (splits keep one active tab per group visible across many passes).
+    recordVisibleTabIds(visibleTabIds) {
+      for (const tabId of visibleTabIds) {
+        if (!previouslyVisibleTabIds.has(tabId)) {
+          activationSeqByTabId.set(tabId, nextActivationSeq)
+          nextActivationSeq += 1
+        }
+      }
+      previouslyVisibleTabIds = visibleTabIds
+    },
+    getActivationSeq(tabId) {
+      return activationSeqByTabId.get(tabId)
+    },
+    retainTabIds(liveTabIds) {
+      for (const tabId of Array.from(activationSeqByTabId.keys())) {
+        if (!liveTabIds.has(tabId)) {
+          activationSeqByTabId.delete(tabId)
+        }
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-tab-park-candidates.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-park-candidates.ts
@@ -1,0 +1,52 @@
+/**
+ * Builds the per-tab cold-park candidate list for useTerminalTabColdParking.
+ *
+ * Why separate: the hidden-clock and activation-order bookkeeping that decides
+ * each candidate's park rank is policy, not hook orchestration.
+ */
+import type { TerminalTab } from '../../../../shared/types'
+import type { TerminalTabColdParkCandidate } from './terminal-hidden-view-parking'
+import type { TerminalTabActivationOrder } from './terminal-tab-activation-order'
+
+export function buildTerminalTabColdParkCandidates(args: {
+  terminalTabs: readonly TerminalTab[]
+  assignments: ReadonlyMap<string, { isActiveInGroup: boolean }>
+  isWorktreeActive: boolean
+  portalTabIds: ReadonlySet<string>
+  shouldMeasureHiddenWorktree: boolean
+  /** Mutated in place: the hook owns this clock across passes. */
+  hiddenSinceByTabId: Map<string, number>
+  activationOrder: TerminalTabActivationOrder
+  nowMs: number
+}): TerminalTabColdParkCandidate[] {
+  const visibleTabIds = new Set<string>()
+  for (const terminalTab of args.terminalTabs) {
+    if (args.isWorktreeActive && args.assignments.get(terminalTab.id)?.isActiveInGroup === true) {
+      visibleTabIds.add(terminalTab.id)
+    }
+  }
+  args.activationOrder.recordVisibleTabIds(visibleTabIds)
+
+  return args.terminalTabs.map((terminalTab) => {
+    const isVisible = visibleTabIds.has(terminalTab.id)
+    const hasActivityTerminalPortal = args.portalTabIds.has(terminalTab.id)
+    // Why measuring preserves the clock: the startup probe still needs mounted
+    // panes (the hook's selection + render vetoes), but deleting hiddenSince
+    // would restart the hysteresis AND desync per-tab deadlines from the
+    // worktree retention/TTL clock on every ~3s probe.
+    if (isVisible || hasActivityTerminalPortal) {
+      args.hiddenSinceByTabId.delete(terminalTab.id)
+    } else if (!args.shouldMeasureHiddenWorktree && !args.hiddenSinceByTabId.has(terminalTab.id)) {
+      args.hiddenSinceByTabId.set(terminalTab.id, args.nowMs)
+    }
+    return {
+      id: terminalTab.id,
+      ptyId: terminalTab.ptyId,
+      pendingActivationSpawn: terminalTab.pendingActivationSpawn,
+      isVisible,
+      hasActivityTerminalPortal,
+      hiddenSinceMs: args.hiddenSinceByTabId.get(terminalTab.id) ?? null,
+      lastActivatedSeq: args.activationOrder.getActivationSeq(terminalTab.id)
+    }
+  })
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -97,6 +97,37 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
     mocks.storeState.runtimeStatusByEnvironmentId = new Map()
   })
 
+  // Why: leaving a worktree hides every one of its tabs against a single
+  // nowMs, so the #8262 keep-warm exemption always lands on a hiddenSince tie.
+  // Broken by the id tie-break, the coin flip can park the very tab the user
+  // returns to (a random-UUID id carries no recency), which is the remount the
+  // exemption exists to prevent.
+  it('exempts the tab the worktree was left on when every tab hides in one pass', () => {
+    // tab-2 is active and lexicographically last, so the id tie-break cannot
+    // stumble into the right answer.
+    const assignments = new Map([
+      ['tab-1', { groupId: 'group-1', isActiveInGroup: false }],
+      ['tab-2', { groupId: 'group-1', isActiveInGroup: true }]
+    ])
+    const { result, rerender } = renderHook(
+      (args: ReturnType<typeof hookArgs> & { isWorktreeActive: boolean }) =>
+        useTerminalTabColdParking(args),
+      { initialProps: { ...hookArgs(false), assignments, isWorktreeActive: true } }
+    )
+    expect(result.current.size).toBe(0)
+
+    // The worktree goes hidden with the clock frozen: both tabs are stamped
+    // with the same hiddenSince, exactly as one commit does in the app.
+    act(() => {
+      rerender({ ...hookArgs(false), assignments, isWorktreeActive: false })
+    })
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_HOT_RETAIN_MS + 1)
+    })
+
+    expect(result.current).toEqual(new Set(['tab-1']))
+  })
+
   it('parks paired-runtime tabs only when their exact host advertises restore', () => {
     const environmentId = 'paired-env'
     const remoteArgs = {

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -17,8 +17,7 @@ import { getTerminalTabColdParkRecheckDelayMs } from './terminal-cold-park-reche
 import {
   TERMINAL_TAB_COLD_PARK_DELAY_MS,
   selectPairedRuntimeParkingEnvironmentIds,
-  selectColdParkedTerminalTabs,
-  type TerminalTabColdParkCandidate
+  selectColdParkedTerminalTabs
 } from './terminal-hidden-view-parking'
 import {
   recordParkVerdictFlips,
@@ -32,6 +31,8 @@ import {
 } from './terminal-eviction-exempt-tabs'
 import { selectSleepingRecordParkExemptTabIds } from './sleeping-record-park-exemption'
 import { canWatcherCoverParkedTerminalTab } from './terminal-parked-tab-watchers'
+import { createTerminalTabActivationOrder } from './terminal-tab-activation-order'
+import { buildTerminalTabColdParkCandidates } from './terminal-tab-park-candidates'
 import {
   getTerminalParkingAssignmentsKey,
   getTerminalParkingInputsKey,
@@ -115,6 +116,9 @@ export function useTerminalTabColdParking(args: {
     [sleepingAgentSessionsByPaneKey, worktreeId]
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())
+  // Why: ranks the #8262 keep-warm exemption when hiddenSince ties; see
+  // terminal-tab-activation-order.ts.
+  const terminalTabActivationOrderRef = useRef(createTerminalTabActivationOrder())
   // Why (shared measure-clock contract with Terminal.tsx): tab hiddenSince
   // survives a background-measure window so per-tab park deadlines stay in
   // sync with the worktree retention/TTL clock, and a post-measure cool-down
@@ -161,6 +165,7 @@ export function useTerminalTabColdParking(args: {
         terminalTabHiddenSinceRef.current.delete(tabId)
       }
     }
+    terminalTabActivationOrderRef.current.retainTabIds(currentTerminalTabIds)
 
     // Why: measure end starts the re-park cool-down (worktree measure-clock
     // contract) — hiddenSince is preserved through the window, so without the
@@ -180,30 +185,15 @@ export function useTerminalTabColdParking(args: {
       measureParkCooldownUntilRef.current = null
     }
 
-    const candidates: TerminalTabColdParkCandidate[] = terminalTabs.map((terminalTab) => {
-      const assignment = assignments.get(terminalTab.id)
-      const isVisible = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
-      const hasActivityTerminalPortal = portalTabIds.has(terminalTab.id)
-      // Why measuring preserves the clock: the startup probe still needs
-      // mounted panes (selection + render veto below), but deleting
-      // hiddenSince would restart the hysteresis AND desync per-tab deadlines
-      // from the worktree retention/TTL clock on every ~3s probe.
-      if (isVisible || hasActivityTerminalPortal) {
-        terminalTabHiddenSinceRef.current.delete(terminalTab.id)
-      } else if (
-        !shouldMeasureHiddenWorktree &&
-        !terminalTabHiddenSinceRef.current.has(terminalTab.id)
-      ) {
-        terminalTabHiddenSinceRef.current.set(terminalTab.id, nowMs)
-      }
-      return {
-        id: terminalTab.id,
-        ptyId: terminalTab.ptyId,
-        pendingActivationSpawn: terminalTab.pendingActivationSpawn,
-        isVisible,
-        hasActivityTerminalPortal,
-        hiddenSinceMs: terminalTabHiddenSinceRef.current.get(terminalTab.id) ?? null
-      }
+    const candidates = buildTerminalTabColdParkCandidates({
+      terminalTabs,
+      assignments,
+      isWorktreeActive,
+      portalTabIds,
+      shouldMeasureHiddenWorktree,
+      hiddenSinceByTabId: terminalTabHiddenSinceRef.current,
+      activationOrder: terminalTabActivationOrderRef.current,
+      nowMs
     })
 
     const nextColdParkedTerminalTabIds = selectColdParkedTerminalTabs({

--- a/tests/e2e/browser-local-https-certificate-trust.spec.ts
+++ b/tests/e2e/browser-local-https-certificate-trust.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@stablyai/playwright-test'
+import type { Locator, Page } from '@stablyai/playwright-test'
 
 import { expect, test } from './helpers/orca-app'
 import {
@@ -62,6 +62,12 @@ async function switchToBrowserTab(page: Page, worktreeId: string, browserTabId: 
 
 function browserSlot(page: Page, pageId: string) {
   return page.locator(`[data-browser-overlay-tab-id="${pageId}"]`)
+}
+
+// Why: the toolbar reload button is also named "Retry" once a load fails, so match the
+// overlay's button by its visible label — the toolbar one is icon-only.
+function failureOverlayRetryButton(slot: Locator): Locator {
+  return slot.getByRole('button', { name: 'Retry' }).filter({ hasText: 'Retry' })
 }
 
 async function readBrowserHeading(page: Page, browserTabId: string): Promise<string | null> {
@@ -144,7 +150,7 @@ test.describe('local HTTPS certificate trust', () => {
       // The certificate-failure branch keeps its safe recovery actions and the
       // certificate-specific hint, but never the local-server connectivity hint.
       await expect(firstSlot.getByRole('button', { name: 'Copy Address' })).toBeVisible()
-      await expect(firstSlot.getByRole('button', { name: 'Retry' })).toBeVisible()
+      await expect(failureOverlayRetryButton(firstSlot)).toBeVisible()
       await expect(firstSlot.getByText(/use a trusted local certificate/i)).toBeVisible()
       await expect(firstSlot.getByText(/make sure the server is running/i)).toHaveCount(0)
       await firstSlot.getByRole('button', { name: 'Proceed Anyway (Unsafe)' }).click()

--- a/tests/e2e/floating-tab-rename.spec.ts
+++ b/tests/e2e/floating-tab-rename.spec.ts
@@ -80,7 +80,15 @@ async function openFloatingPanel(page: Page): Promise<void> {
     PANEL_SELECTOR,
     { timeout: 30_000 }
   )
-  await page.evaluate(() => window.dispatchEvent(new Event('orca-toggle-floating-terminal')))
+  // Why: the panel's open flag is persisted (floating-terminal-panel-view-state), so
+  // after a restart it reopens on its own and a blind toggle would close it again.
+  const alreadyOpen = await page.evaluate(
+    (selector) => Boolean(document.querySelector(selector)),
+    OPEN_PANEL_SELECTOR
+  )
+  if (!alreadyOpen) {
+    await page.evaluate(() => window.dispatchEvent(new Event('orca-toggle-floating-terminal')))
+  }
   await expect(page.locator(OPEN_PANEL_SELECTOR)).toBeVisible()
 }
 

--- a/tests/e2e/github-created-issue-start-prefill.spec.ts
+++ b/tests/e2e/github-created-issue-start-prefill.spec.ts
@@ -167,6 +167,17 @@ test('starting a just-created GitHub issue launches Claude with its URL prefille
 
   await orcaPage.getByRole('button', { name: 'Start workspace from issue' }).click()
 
+  // Why: starting a GitHub issue now routes through the quick-create composer,
+  // which carries the linked issue URL into the agent launch command on submit.
+  const composer = orcaPage.getByRole('dialog', { name: /Create (workspace|worktree)/i })
+  await expect(composer).toBeVisible({ timeout: 15_000 })
+  const createWorkspaceButton = composer.getByRole('button', {
+    name: /Create (workspace|worktree)/i
+  })
+  await expect(createWorkspaceButton).toBeEnabled({ timeout: 15_000 })
+  await createWorkspaceButton.click()
+  await expect(composer).toBeHidden({ timeout: 20_000 })
+
   let terminalText = ''
   await expect
     .poll(

--- a/tests/e2e/helpers/source-control-ai-generation.ts
+++ b/tests/e2e/helpers/source-control-ai-generation.ts
@@ -42,12 +42,16 @@ export async function openChecks(page: Page, worktreeId: string): Promise<void> 
       { timeout: 5_000 }
     )
     .toBe(true)
-  const checksButton = page.getByRole('button', { name: 'Checks', exact: true })
+  // Why: the activity-bar label carries an optional shortcut and a failure suffix ("Checks — Error"),
+  // so an exact 'Checks' name silently stops matching once the active branch has failing checks.
+  const checksButton = page.getByRole('button', { name: /^Checks(\s|$)/ })
   await expect
     .poll(
       async () => {
         if ((await page.evaluate(() => window.__store?.getState().rightSidebarTab)) !== 'checks') {
-          await checksButton.click()
+          // Why: the label flips as the checks status arrives; bound the click so the poll retries
+          // instead of hanging on a locator that stopped matching mid-action.
+          await checksButton.click({ timeout: 2_000 }).catch(() => undefined)
         }
         await page.waitForTimeout(250)
         return page.evaluate(() => window.__store?.getState().rightSidebarTab)

--- a/tests/e2e/ssh-config-host-import.spec.ts
+++ b/tests/e2e/ssh-config-host-import.spec.ts
@@ -148,7 +148,7 @@ test.describe('SSH config host import (bulk + settings re-adopt)', () => {
     await expect(
       configHostRow(reopened, hosts.bravo).getByText('In Orca', { exact: true })
     ).toBeVisible()
-    await expect(reopened.getByRole('button', { name: 'All hosts already in Orca' })).toBeDisabled()
+    await expect(reopened.getByRole('button', { name: 'No new hosts to add' })).toBeDisabled()
   })
 
   // ── P7 ─────────────────────────────────────────────────────────────
@@ -164,13 +164,17 @@ test.describe('SSH config host import (bulk + settings re-adopt)', () => {
     )
 
     const picker = await openSshConfigHostPicker(orcaPage)
-    // Suppressed aliases are omitted from the picker entirely.
-    await expect(configHostRow(picker, hosts.alpha)).toHaveCount(0)
+    // Suppressed aliases stay listed (re-pickable) but never count as new.
+    const alphaRow = configHostRow(picker, hosts.alpha)
+    await expect(alphaRow).toBeVisible()
+    await expect(alphaRow).toBeEnabled()
+    await expect(alphaRow.getByText('Removed from Orca', { exact: true })).toBeVisible()
+    await expect(alphaRow.getByText('In Orca', { exact: true })).toHaveCount(0)
     await expect(configHostRow(picker, hosts.bravo)).toBeVisible()
     await expect(
       configHostRow(picker, hosts.bravo).getByText('In Orca', { exact: true })
     ).toBeVisible()
-    await expect(picker.getByRole('button', { name: 'All hosts already in Orca' })).toBeDisabled()
+    await expect(picker.getByRole('button', { name: 'No new hosts to add' })).toBeDisabled()
     await expect(picker.getByRole('button', { name: /Add all \d+ to Orca/ })).toHaveCount(0)
 
     await returnToAppShell(orcaPage)

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -19,9 +19,9 @@ test('new-tab file results prioritize the filename and reveal the full path on h
   await ensureTerminalVisible(orcaPage)
 
   await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
-  const input = orcaPage.getByRole('combobox', {
-    name: 'Open any file, URL, agent, ...'
-  })
+  // Not the placeholder/aria-label: that copy is translated and already drifted
+  // once. aria-controls points at the results listbox id, which is structural.
+  const input = orcaPage.locator('input[role="combobox"][aria-controls="tab-create-entry-results"]')
   await input.fill('secondaryNav')
 
   const row = orcaPage.locator('[role="option"]').filter({ hasText: 'Open file' }).first()

--- a/tests/e2e/voice-microphone-selection.spec.ts
+++ b/tests/e2e/voice-microphone-selection.spec.ts
@@ -89,6 +89,25 @@ async function prepareVoiceSettings(
     await page.getByRole('button', { name: 'Maybe Later' }).click()
   }
   await expect(page.getByRole('heading', { name: 'Voice', exact: true })).toBeVisible()
+  // Why: the microphone Select is disabled until voice.enabled hydrates into the renderer
+  // store, and "System default" renders identically before and after hydration — so the
+  // text assertions below are not a barrier. Wait on the store value the pane actually reads.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const voice = window.__store?.getState().settings?.voice
+          return voice
+            ? {
+                enabled: voice.enabled,
+                deviceId: voice.microphoneDeviceId ?? null,
+                label: voice.microphoneDeviceLabel ?? null
+              }
+            : null
+        }),
+      { message: 'voice settings did not hydrate into the renderer store' }
+    )
+    .toEqual({ enabled: true, deviceId: microphoneDeviceId, label: microphoneDeviceLabel })
 }
 
 async function readMicrophoneSettings(
@@ -116,6 +135,7 @@ test.describe('Voice microphone selection', () => {
 
     const microphone = orcaPage.getByRole('combobox', { name: 'Microphone' })
     await expect(microphone).toHaveText('System default')
+    await expect(microphone).toBeEnabled()
     await microphone.click()
     await expect(orcaPage.getByRole('option', { name: 'USB Microphone' })).toBeVisible()
     await orcaPage.getByRole('option', { name: 'USB Microphone' }).click()
@@ -147,6 +167,7 @@ test.describe('Voice microphone selection', () => {
     await prepareVoiceSettings(orcaPage, 'stale-airpods-id', 'AirPods')
 
     const microphone = orcaPage.getByRole('combobox', { name: 'Microphone' })
+    await expect(microphone).toBeEnabled()
     await microphone.click()
     await expect(orcaPage.getByRole('option', { name: 'AirPods (unavailable)' })).toBeVisible()
     await orcaPage.keyboard.press('Escape')

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -6,6 +6,7 @@ const LOCAL_PROJECT = 'E2E Palette Local Project'
 const REMOTE_PROJECT = 'E2E Palette Remote Project'
 const REMOTE_WORKSPACE = 'E2E Palette Remote Workspace'
 const REMOTE_HOST = 'E2E Palette Builder'
+const SEARCH_PLACEHOLDER = 'Search chats, terminals, worktrees, settings, and actions...'
 
 type PaletteFilterFixture = { localWorktreeId: string; remoteWorktreeId: string }
 
@@ -107,7 +108,7 @@ async function openPalette(page: Page): Promise<void> {
 }
 
 async function searchFixtureWorkspaces(page: Page, fixture: PaletteFilterFixture): Promise<void> {
-  const input = palette(page).getByPlaceholder('Search worktrees, settings, tabs, and actions...')
+  const input = palette(page).getByPlaceholder(SEARCH_PLACEHOLDER)
   await input.fill('E2E Palette')
   await expect(worktreeRow(page, fixture.localWorktreeId)).toBeVisible()
   await expect(worktreeRow(page, fixture.remoteWorktreeId)).toBeVisible()
@@ -115,7 +116,7 @@ async function searchFixtureWorkspaces(page: Page, fixture: PaletteFilterFixture
 
 async function selectRemoteHost(page: Page, useKeyboard = false): Promise<void> {
   if (useKeyboard) {
-    const input = palette(page).getByPlaceholder('Search worktrees, settings, tabs, and actions...')
+    const input = palette(page).getByPlaceholder(SEARCH_PLACEHOLDER)
     await input.press('Tab')
     await expect(filterTrigger(page)).toBeFocused()
     await filterTrigger(page).click()
@@ -152,9 +153,7 @@ test.describe('Worktree jump-palette filters', () => {
     await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toHaveCount(0)
 
     // P2: host and project fields intersect, with the filter-specific empty state.
-    await palette(orcaPage)
-      .getByPlaceholder('Search worktrees, settings, tabs, and actions...')
-      .fill('')
+    await palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER).fill('')
     await filterTrigger(orcaPage).click()
     await palette(orcaPage).getByText('Projects', { exact: true }).click()
     const projects = palette(orcaPage).getByRole('listbox', { name: 'Projects' })


### PR DESCRIPTION
**Draft — not ready to merge.** Every change here is unit-tested and green, and each fixes a defect that is real. **None of them makes the E2E test that led to it pass.** Opening this so the findings are visible and reviewable, not because it is ready.

Context: #13758 restored E2E collection, #13785 fixed 9 of the 11 resulting failures. These are what is left underneath the other three.

## 1. Cold-park exemption ranks recency by random UUID

`terminal-hidden-view-parking.ts:207-220` resolved equal `hiddenSinceMs` with `candidate.id.localeCompare(lastActive.id)`, and tab ids are UUIDv4 — so the keep-warm exemption is decided by a coin flip. The exempt tab is skipped by `selectIdsBeyondHotRetain` and can never cold-park.

Ties are routine, not exotic: `use-terminal-tab-cold-parking.ts:151` takes **one** `Date.now()` per effect pass and `:193-198` stamps every tab first seen hidden in that pass with it. Switching away from a worktree hides all its tabs in one commit, so they all tie.

Fix: rank by an explicit activation sequence recorded on the hidden→visible edge (`compareColdParkRecencyDesc`: `hiddenSinceMs` → `lastActivatedSeq` → id). Unit test added covering the tie; verified red before, green after.

**Does not fix `terminal-hidden-view-parking.spec.ts:467`**, which still fails with the same `did not park` error it fails with on CI.

## 2. Alt-screen frame permanently lost on hidden restore for a sub-floor pane

#13014 (`f2984e2230d`, landed 2026-08-10) skips a too-wide alt frame on snapshot replay and relies on a post-fit repaint. For a pane that is **visible but permanently below the 48x24px fit floor** (`pane-fit-measurability.ts:32-43`), `readProposedTerminalCols` is forever `undefined`, so `skipIfTargetUnknown: true` drops the frame — and the only compensating repaint (`pulseVisibleLocalPtySizeForTuiRepaint`) lives in a safe-fit continuation that is *failed* rather than run for such a pane. The frame is gone until the user widens the pane.

Fix: deferred repaint gated on `display:none` rather than on target-unknown, preserving #13014's no-clip guarantee.

**Does not fix `artificial-opencode-terminal-load.spec.ts:761`.** Two unresolved concerns from review: the repaint waits out the full 40-frame safe-fit retry budget (~1.3s) against the spec's own 2s restore budget, and the cold-park reveal path at `pty-connection.ts:8222/8289` still has no deferral net. Locally that spec fails on a different branch entirely (`main recovery was unavailable`), so a macOS run cannot reproduce CI's empty-alt-buffer failure at all.

## 3. VoicePane stale-closure lost update

`updateVoiceSettings` wrote from a stale closure; switched to the latest-ref pattern already used in `Settings.tsx:405-407`. Incidental — reviewers confirmed this path is not reachable from the failing spec.

## `voice-microphone-selection:107` has no fix and no established root cause

Three theories were proposed and **all three refuted with evidence**:

1. *"Voice settings have not hydrated, so the control is disabled."* The CI accessibility snapshot at the moment of failure shows `switch "Enable Voice Dictation" [checked]` and `combobox "Microphone" [cursor=pointer]` with no disabled marker.
2. *"click({force: true})".* Bypasses the actionability contract rather than fixing it, and would click a control whose wait was the actual signal.
3. *"backgroundThrottling starves rAF in a never-shown window."* A probe against the real app measured 60Hz rAF, `visibilityState: "visible"`, and a rect stable across 240 frames — `rectChangesAcross240Frames: 0` with the spec's fake devices installed.

All probes ran on macOS **without** the Linux-only launch switches (`--no-sandbox --disable-gpu --disable-gpu-compositing --in-process-gpu`, `electron-launch-args.ts:16-24`) and without xvfb. The remaining hypothesis is platform-specific frame production, and it needs an actual Linux runner to settle.

## What would make this mergeable

Each product fix needs to either make its E2E pass or be justified on its own terms as an independent bug fix with the E2E tracked separately. Right now neither is true, and shipping hot-path changes to `pty-connection.ts` and the parking path that do not fix their own acceptance tests would misrepresent what they do.

Made with [Orca](https://github.com/stablyai/orca) 🐋
