### PR TITLE
fix(bitbucket): persist and prioritize created pull requests

### DIFF
--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -144,22 +144,24 @@ describe('Bitbucket client', () => {
     ).resolves.toBeNull()
   })
 
-  it('keeps a MERGED PR on a feature branch when it is the explicitly linked review', async () => {
+  it('fetches an explicitly linked DECLINED PR before the branch index', async () => {
     const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/pullrequests/7')) {
+        return Response.json({ ...bitbucketPr(7), state: 'DECLINED' })
+      }
       if (url.includes('/statuses/build')) {
         return Response.json({ values: [] })
       }
-      return Response.json({
-        values: [
-          { ...bitbucketPr(7), state: 'MERGED', source: { branch: { name: 'feature/login' } } }
-        ]
-      })
+      return new Response('branch index unavailable', { status: 503 })
     })
     vi.stubGlobal('fetch', fetchMock)
 
     await expect(
-      getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/login', 7)
-    ).resolves.toMatchObject({ number: 7, state: 'merged' })
+      getBitbucketPullRequestForBranchOrThrow('/repo', 'refs/heads/feature/login', 7)
+    ).resolves.toMatchObject({ number: 7, state: 'closed' })
+    expect(fetchMock.mock.calls.map(([url]) => url)).not.toContainEqual(
+      expect.stringContaining('/pullrequests?')
+    )
   })
 
   it('fetches a branch pull request and commit build status', async () => {

--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -164,6 +164,31 @@ describe('Bitbucket client', () => {
     )
   })
 
+  it('falls back to the branch index when a linked PR number is stale', async () => {
+    const branchPR = bitbucketPr(7)
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/pullrequests/99')) {
+        return new Response('not found', { status: 404 })
+      }
+      if (url.includes('/statuses/build')) {
+        return Response.json({ values: [] })
+      }
+      return Response.json({
+        values: [{ ...branchPR, source: { ...branchPR.source, branch: { name: 'feature/login' } } }]
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getBitbucketPullRequestForBranchOrThrow('/repo', 'refs/heads/feature/login', 99)
+    ).resolves.toMatchObject({ number: 7, state: 'open' })
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      expect.stringContaining('/pullrequests/99'),
+      expect.stringContaining('/pullrequests?'),
+      expect.stringContaining('/statuses/build')
+    ])
+  })
+
   it('fetches a branch pull request and commit build status', async () => {
     const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
       if (url.includes('/statuses/build')) {

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -205,6 +205,17 @@ export async function getBitbucketPullRequestForBranch(
     return null
   }
 
+  if (typeof linkedPRNumber === 'number') {
+    const raw = await requestJson<RawBitbucketPullRequest>(
+      `/repositories/${encodedRepoPath(repo)}/pullrequests/${encodeURIComponent(String(linkedPRNumber))}`,
+      {},
+      throwOnFailure
+    )
+    if (raw) {
+      return normalizePullRequest(repo, raw)
+    }
+  }
+
   if (branchName) {
     const query = [
       `source.branch.name = "${escapeBitbucketQueryString(branchName)}"`,
@@ -237,15 +248,7 @@ export async function getBitbucketPullRequestForBranch(
     }
   }
 
-  if (typeof linkedPRNumber !== 'number') {
-    return null
-  }
-  const raw = await requestJson<RawBitbucketPullRequest>(
-    `/repositories/${encodedRepoPath(repo)}/pullrequests/${encodeURIComponent(String(linkedPRNumber))}`,
-    {},
-    throwOnFailure
-  )
-  return raw ? normalizePullRequest(repo, raw) : null
+  return null
 }
 
 /**

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -68,7 +68,8 @@ async function requestJson<T>(
   // Why: the existing-review lookup behind Create must distinguish a real
   // transport/auth failure from an accepted "no PR". When true, a failed request
   // throws instead of collapsing to null so callers never report false not_found.
-  throwOnFailure = false
+  throwOnFailure = false,
+  notFoundIsNull = false
 ): Promise<T | null> {
   const config = resolveBitbucketAuthConfig()
   try {
@@ -81,6 +82,9 @@ async function requestJson<T>(
     })
     if (!response.ok) {
       await cancelUnreadResponseBody(response)
+      if (response.status === 404 && notFoundIsNull) {
+        return null
+      }
       if (throwOnFailure) {
         throw new Error(`Bitbucket request failed: HTTP ${response.status}`)
       }
@@ -209,7 +213,8 @@ export async function getBitbucketPullRequestForBranch(
     const raw = await requestJson<RawBitbucketPullRequest>(
       `/repositories/${encodedRepoPath(repo)}/pullrequests/${encodeURIComponent(String(linkedPRNumber))}`,
       {},
-      throwOnFailure
+      throwOnFailure,
+      true
     )
     if (raw) {
       return normalizePullRequest(repo, raw)

--- a/src/main/source-control/forge-provider.test.ts
+++ b/src/main/source-control/forge-provider.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   createGitHubPullRequestMock,
+  createBitbucketPullRequestMock,
   createGitLabMergeRequestMock,
   createAzureDevOpsPullRequestMock,
   createGiteaPullRequestMock,
@@ -17,6 +18,7 @@ const {
   getEnterpriseGitHubRepoSlugMock
 } = vi.hoisted(() => ({
   createGitHubPullRequestMock: vi.fn(),
+  createBitbucketPullRequestMock: vi.fn(),
   createGitLabMergeRequestMock: vi.fn(),
   createAzureDevOpsPullRequestMock: vi.fn(),
   createGiteaPullRequestMock: vi.fn(),
@@ -61,6 +63,10 @@ vi.mock('../bitbucket/client', () => ({
   getBitbucketPullRequest: vi.fn()
 }))
 
+vi.mock('../bitbucket/pull-request-creation', () => ({
+  createBitbucketPullRequest: createBitbucketPullRequestMock
+}))
+
 vi.mock('../azure-devops/client', () => ({
   getAzureDevOpsRepoSlug: getAzureDevOpsRepoSlugMock,
   getAzureDevOpsPullRequestForBranch: vi.fn(),
@@ -100,6 +106,7 @@ describe('forge provider interface', () => {
   beforeEach(() => {
     createGitHubPullRequestMock.mockReset()
     createGitLabMergeRequestMock.mockReset()
+    createBitbucketPullRequestMock.mockReset()
     createAzureDevOpsPullRequestMock.mockReset()
     createGiteaPullRequestMock.mockReset()
     getAzureDevOpsRepoSlugMock.mockReset()
@@ -206,6 +213,28 @@ describe('forge provider interface', () => {
       head: 'feature/provider-interface',
       title: 'Add provider interface'
     })
+  })
+
+  it('routes Bitbucket review creation through the shared provider contract', async () => {
+    createBitbucketPullRequestMock.mockResolvedValue({
+      ok: true,
+      number: 23,
+      url: 'https://bitbucket.org/team/orca/pull-requests/23'
+    })
+
+    const provider = getForgeProviderById('bitbucket')
+    const input = {
+      provider: 'bitbucket' as const,
+      base: 'main',
+      head: 'feature/provider-interface',
+      title: 'Add provider interface'
+    }
+    await expect(provider.createReview?.('/repo', input)).resolves.toEqual({
+      ok: true,
+      number: 23,
+      url: 'https://bitbucket.org/team/orca/pull-requests/23'
+    })
+    expect(createBitbucketPullRequestMock).toHaveBeenCalledWith('/repo', input)
   })
 
   it('routes GitLab review creation through the shared provider contract', async () => {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -189,6 +189,7 @@ import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { CreateHostedReviewComposer } from './CreateHostedReviewComposer'
+import { resolveCreatedHostedReviewLink } from './source-control-created-review-link'
 import { formatCreateError } from './create-pull-request-review-copy'
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { localizedHostedReviewCopy } from '@/i18n/hosted-review-localized-copy'
@@ -3907,26 +3908,18 @@ export default function ChecksPanel(): React.JSX.Element {
       setRightSidebarOpen(true)
       setRightSidebarTab('checks')
       try {
-        if (activeWorktreeId && result.provider === 'github') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedPR: result.number })
-        }
-        if (activeWorktreeId && result.provider === 'gitlab') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedGitLabMR: result.number })
-        }
-        if (activeWorktreeId && result.provider === 'azure-devops') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedAzureDevOpsPR: result.number })
-        }
-        if (activeWorktreeId && result.provider === 'gitea') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedGiteaPR: result.number })
+        const createdLink = resolveCreatedHostedReviewLink(result.provider, result.number)
+        if (activeWorktreeId && result.provider !== 'unsupported') {
+          await updateWorktreeMeta(activeWorktreeId, createdLink.worktree)
         }
         const linkedReviewNumbers = {
-          linkedGitHubPR: result.provider === 'github' ? result.number : linkedPR,
+          linkedGitHubPR: linkedPR,
           fallbackGitHubPR: fallbackGitHubPRNumber,
-          linkedGitLabMR: result.provider === 'gitlab' ? result.number : linkedGitLabMR,
+          linkedGitLabMR,
           linkedBitbucketPR,
-          linkedAzureDevOpsPR:
-            result.provider === 'azure-devops' ? result.number : linkedAzureDevOpsPR,
-          linkedGiteaPR: result.provider === 'gitea' ? result.number : linkedGiteaPR
+          linkedAzureDevOpsPR,
+          linkedGiteaPR,
+          ...createdLink.lookup
         }
         if (result.provider === 'gitlab') {
           const refreshedReview = await refreshHostedReviewCard(fetchHostedReviewForBranch, {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -246,6 +246,7 @@ import {
 } from './source-control-pull-policy-error-notice'
 import { SourceControlTextGenerationDialog } from './SourceControlTextGenerationDialog'
 import { CreateHostedReviewComposer } from './CreateHostedReviewComposer'
+import { resolveCreatedHostedReviewLink } from './source-control-created-review-link'
 import {
   hasConfiguredCommitMessageGenerationDefaults,
   hasConfiguredSourceControlTextGenerationDefaults
@@ -2753,26 +2754,18 @@ function SourceControlInner(): React.JSX.Element {
         setRightSidebarTab('checks')
       }
       try {
-        if (worktreeId && result.provider === 'github') {
-          await updateWorktreeMeta(worktreeId, { linkedPR: result.number })
-        }
-        if (worktreeId && result.provider === 'gitlab') {
-          await updateWorktreeMeta(worktreeId, { linkedGitLabMR: result.number })
-        }
-        if (worktreeId && result.provider === 'azure-devops') {
-          await updateWorktreeMeta(worktreeId, { linkedAzureDevOpsPR: result.number })
-        }
-        if (worktreeId && result.provider === 'gitea') {
-          await updateWorktreeMeta(worktreeId, { linkedGiteaPR: result.number })
+        const createdLink = resolveCreatedHostedReviewLink(result.provider, result.number)
+        if (worktreeId && result.provider !== 'unsupported') {
+          await updateWorktreeMeta(worktreeId, createdLink.worktree)
         }
         const linkedReviewNumbers = {
-          linkedGitHubPR: result.provider === 'github' ? result.number : linkedGitHubPR,
+          linkedGitHubPR,
           fallbackGitHubPR: fallbackGitHubPRNumber,
-          linkedGitLabMR: result.provider === 'gitlab' ? result.number : linkedGitLabMR,
+          linkedGitLabMR,
           linkedBitbucketPR,
-          linkedAzureDevOpsPR:
-            result.provider === 'azure-devops' ? result.number : linkedAzureDevOpsPR,
-          linkedGiteaPR: result.provider === 'gitea' ? result.number : linkedGiteaPR
+          linkedAzureDevOpsPR,
+          linkedGiteaPR,
+          ...createdLink.lookup
         }
         if (result.provider === 'gitlab') {
           await fetchHostedReviewForBranch(repoPath, branch, {

--- a/src/renderer/src/components/right-sidebar/source-control-created-review-link.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-created-review-link.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { HostedReviewProvider } from '../../../../shared/hosted-review'
+import { resolveCreatedHostedReviewLink } from './source-control-created-review-link'
+
+describe('resolveCreatedHostedReviewLink', () => {
+  it.each([
+    ['github', { linkedPR: 42 }, { linkedGitHubPR: 42 }],
+    ['gitlab', { linkedGitLabMR: 42 }, { linkedGitLabMR: 42 }],
+    ['bitbucket', { linkedBitbucketPR: 42 }, { linkedBitbucketPR: 42 }],
+    ['azure-devops', { linkedAzureDevOpsPR: 42 }, { linkedAzureDevOpsPR: 42 }],
+    ['gitea', { linkedGiteaPR: 42 }, { linkedGiteaPR: 42 }]
+  ] as const)('links a created %s review by number', (provider, worktree, lookup) => {
+    expect(resolveCreatedHostedReviewLink(provider as HostedReviewProvider, 42)).toEqual({
+      worktree,
+      lookup
+    })
+  })
+
+  it('does not link an unsupported review provider', () => {
+    expect(resolveCreatedHostedReviewLink('unsupported', 42)).toEqual({
+      worktree: {},
+      lookup: {}
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
@@ -1,0 +1,45 @@
+import type { HostedReviewProvider } from '../../../../shared/hosted-review'
+
+type WorktreeReviewLink = Partial<{
+  linkedPR: number
+  linkedGitLabMR: number
+  linkedBitbucketPR: number
+  linkedAzureDevOpsPR: number
+  linkedGiteaPR: number
+}>
+
+type HostedReviewLookupLink = Partial<{
+  linkedGitHubPR: number
+  linkedGitLabMR: number
+  linkedBitbucketPR: number
+  linkedAzureDevOpsPR: number
+  linkedGiteaPR: number
+}>
+
+export type CreatedHostedReviewLink = {
+  worktree: WorktreeReviewLink
+  lookup: HostedReviewLookupLink
+}
+
+export function resolveCreatedHostedReviewLink(
+  provider: HostedReviewProvider,
+  number: number
+): CreatedHostedReviewLink {
+  switch (provider) {
+    case 'github':
+      return { worktree: { linkedPR: number }, lookup: { linkedGitHubPR: number } }
+    case 'gitlab':
+      return { worktree: { linkedGitLabMR: number }, lookup: { linkedGitLabMR: number } }
+    case 'azure-devops':
+      return {
+        worktree: { linkedAzureDevOpsPR: number },
+        lookup: { linkedAzureDevOpsPR: number }
+      }
+    case 'gitea':
+      return { worktree: { linkedGiteaPR: number }, lookup: { linkedGiteaPR: number } }
+    case 'bitbucket':
+      return { worktree: { linkedBitbucketPR: number }, lookup: { linkedBitbucketPR: number } }
+    case 'unsupported':
+      return { worktree: {}, lookup: {} }
+  }
+}

--- a/src/renderer/src/components/settings/integrations-search.ts
+++ b/src/renderer/src/components/settings/integrations-search.ts
@@ -56,7 +56,7 @@ export const getIntegrationsPaneSearchEntries = createLocalizedCatalog(() => [
       'Bitbucket Integration'
     ),
     description: translate(
-      'auto.components.settings.integrations.search.bitbucketDescription',
+      'auto.components.settings.integrations.search.760e2446e0',
       'Bitbucket Cloud authentication with a saved API token or environment variables.'
     ),
     keywords: [
@@ -89,7 +89,7 @@ export const getIntegrationsPaneSearchEntries = createLocalizedCatalog(() => [
         'credentials'
       ),
       ...translateSearchKeyword(
-        'auto.components.settings.integrations.search.bitbucketAccessToken',
+        'auto.components.settings.integrations.search.af5ae87847',
         'access token'
       )
     ]

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8723,8 +8723,8 @@
             "b79c21bd42": "github",
             "7166b9090c": "GitHub authentication via the gh CLI.",
             "f16e41cc72": "GitHub Integration",
-            "bitbucketDescription": "Bitbucket Cloud authentication with a saved API token or environment variables.",
-            "bitbucketAccessToken": "access token"
+            "760e2446e0": "Bitbucket Cloud authentication with a saved API token or environment variables.",
+            "af5ae87847": "access token"
           }
         },
         "jira": {


### PR DESCRIPTION
## Summary

- persist a newly created Bitbucket PR number in worktree metadata on both creation surfaces
- use that linked PR number for the immediate hosted-review refresh
- fetch an explicitly linked Bitbucket PR by number before the branch index, so transient index failures and terminal states do not hide it
- replace temporary Bitbucket localization keys with generated IDs
- add direct forge-creation delegation coverage requested in review

## Regression covered

Immediately after creation, Bitbucket's branch-index endpoint can fail or lag while `GET /pullrequests/{id}` already succeeds. The new client test makes the branch index return HTTP 503 and verifies the explicitly linked PR is returned without consulting the index. The shared link-mapping test covers Bitbucket persistence in both renderer callbacks.

## Verification

- 137 focused Bitbucket/provider/renderer tests passed
- full TypeScript typecheck passed
- localization catalog and extraction checks passed

Commits are intentionally separated by concern so they can be reviewed or cherry-picked independently.