### PR TITLE
fix(editor): unify local WSL terminal and watcher paths

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -258,4 +258,20 @@ describe('getOpenFilesForExternalFileChange', () => {
       }).map((file) => file.id)
     ).toEqual(['runtime-edit', 'runtime-diff'])
   })
+  it('matches WSL edit tabs opened from a forward-slash UNC terminal link', () => {
+    // Why: terminal links use //wsl.localhost/Distro/... while file watchers emit \\wsl.localhost\Distro\...
+    const terminalLinkTab = makeOpenFile({
+      id: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
+      filePath: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
+      worktreeId: 'wt-wsl'
+    })
+
+    expect(
+      getOpenFilesForExternalFileChange([terminalLinkTab], {
+        worktreeId: 'wt-wsl',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
+        relativePath: 'file.ts'
+      }).map((file) => file.id)
+    ).toEqual(['//wsl.localhost/Ubuntu/workspace/repo/file.ts'])
+  })
 })

--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -258,8 +258,8 @@ describe('getOpenFilesForExternalFileChange', () => {
       }).map((file) => file.id)
     ).toEqual(['runtime-edit', 'runtime-diff'])
   })
-  it('matches WSL edit tabs opened from a forward-slash UNC terminal link', () => {
-    // Why: terminal links use //wsl.localhost/Distro/... while file watchers emit \\wsl.localhost\Distro\...
+  it('matches restored WSL aliases only for a proven local Windows watcher', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
     const terminalLinkTab = makeOpenFile({
       id: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
       filePath: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
@@ -270,8 +270,42 @@ describe('getOpenFilesForExternalFileChange', () => {
       getOpenFilesForExternalFileChange([terminalLinkTab], {
         worktreeId: 'wt-wsl',
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
-        relativePath: 'file.ts'
+        relativePath: 'file.ts',
+        runtimeEnvironmentId: null,
+        allowLocalWindowsWslAliases: true
       }).map((file) => file.id)
     ).toEqual(['//wsl.localhost/Ubuntu/workspace/repo/file.ts'])
+
+    expect(
+      getOpenFilesForExternalFileChange([terminalLinkTab], {
+        worktreeId: 'wt-wsl',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
+        relativePath: 'file.ts',
+        runtimeEnvironmentId: null
+      })
+    ).toEqual([])
+
+    vi.stubGlobal('navigator', { userAgent: 'Linux' })
+    expect(
+      getOpenFilesForExternalFileChange([terminalLinkTab], {
+        worktreeId: 'wt-wsl',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
+        relativePath: 'file.ts',
+        runtimeEnvironmentId: null,
+        allowLocalWindowsWslAliases: true
+      })
+    ).toEqual([])
+
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    expect(
+      getOpenFilesForExternalFileChange([terminalLinkTab], {
+        worktreeId: 'wt-wsl',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
+        relativePath: 'file.ts',
+        runtimeEnvironmentId: null,
+        allowLocalWindowsWslAliases: true
+      })
+    ).toEqual([])
   })
 })

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -1,5 +1,6 @@
 import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
+import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
 import {
   DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
   MAX_EDITOR_AUTO_SAVE_DELAY_MS,
@@ -138,7 +139,9 @@ export function getOpenFilesForExternalFileChange(
       return false
     }
     if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-      return file.filePath === absolutePath
+      // Why: WSL UNC paths from terminal links (//wsl.localhost/...) and file
+      // watchers (\\wsl.localhost\...) must fold to the same form before comparing.
+      return normalizeRuntimePathForComparison(file.filePath) === normalizeRuntimePathForComparison(absolutePath)
     }
     if (file.mode === 'diff') {
       return (

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -1,6 +1,7 @@
 import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
-import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
+import { areLocalWindowsWslPathAliases } from '../../../../shared/cross-platform-path'
+import { isLocalWindowsDesktopClient } from '@/lib/desktop-window-chrome'
 import {
   DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
   MAX_EDITOR_AUTO_SAVE_DELAY_MS,
@@ -21,6 +22,7 @@ export type EditorPathMutationTarget = {
   worktreePath: string
   relativePath: string
   runtimeEnvironmentId?: string | null
+  allowLocalWindowsWslAliases?: true
 }
 
 export type EditorSaveQuiesceTarget = { fileId: string } | EditorPathMutationTarget
@@ -139,9 +141,12 @@ export function getOpenFilesForExternalFileChange(
       return false
     }
     if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-      // Why: WSL UNC paths from terminal links (//wsl.localhost/...) and file
-      // watchers (\\wsl.localhost\...) must fold to the same form before comparing.
-      return normalizeRuntimePathForComparison(file.filePath) === normalizeRuntimePathForComparison(absolutePath)
+      return (
+        file.filePath === absolutePath ||
+        (target.allowLocalWindowsWslAliases === true &&
+          isLocalWindowsDesktopClient() &&
+          areLocalWindowsWslPathAliases(file.filePath, absolutePath))
+      )
     }
     if (file.mode === 'diff') {
       return (

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -58,16 +58,19 @@ export function mapTerminalFilePath(
   worktreePath: string,
   wslDistro?: string | null
 ): string {
+  // Why: //wsl.localhost/... and \\wsl.localhost\... are the same file. Keep the
+  // backslash form so open tabs and file watchers match the Files sidebar (#13349).
+  const alreadyUnc = parseWslUncPath(filePath)
+  if (alreadyUnc) {
+    return toWindowsWslPath(alreadyUnc.linuxPath, alreadyUnc.distro)
+  }
   const distro = wslDistro?.trim() || parseWslUncPath(worktreePath)?.distro
-  if (!distro || !filePath.startsWith('/') || filePath.startsWith('//')) {
+  if (!distro || !filePath.startsWith('/')) {
     return filePath
   }
   // Why: /mnt/<drive> is a Windows drive mounted into WSL — reach it directly
   // instead of routing a native file back through the 9P share.
-  if (/^\/mnt\/[a-z](\/|$)/.test(filePath)) {
-    return toWindowsWslPath(filePath, distro)
-  }
-  return `//wsl.localhost/${distro}${filePath}`
+  return toWindowsWslPath(filePath, distro)
 }
 
 // Why: remote-runtime panes print the remote host's POSIX paths; the local WSL

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -58,14 +58,17 @@ export function mapTerminalFilePath(
   worktreePath: string,
   wslDistro?: string | null
 ): string {
-  // Why: //wsl.localhost/... and \\wsl.localhost\... are the same file. Keep the
-  // backslash form so open tabs and file watchers match the Files sidebar (#13349).
+  const distro =
+    wslDistro === null ? null : wslDistro?.trim() || parseWslUncPath(worktreePath)?.distro
+  if (!distro || !filePath.startsWith('/')) {
+    return filePath
+  }
+  // Why: only a proven local WSL pane may reinterpret this POSIX-looking path; SSH/runtime paths stay literal.
   const alreadyUnc = parseWslUncPath(filePath)
   if (alreadyUnc) {
     return toWindowsWslPath(alreadyUnc.linuxPath, alreadyUnc.distro)
   }
-  const distro = wslDistro?.trim() || parseWslUncPath(worktreePath)?.distro
-  if (!distro || !filePath.startsWith('/')) {
+  if (filePath.startsWith('//')) {
     return filePath
   }
   // Why: /mnt/<drive> is a Windows drive mounted into WSL — reach it directly
@@ -78,8 +81,8 @@ export function mapTerminalFilePath(
 export function terminalLinkWslDistro(
   wslDistro: string | null | undefined,
   runtimeEnvironmentId: string | null | undefined
-): string | null {
-  return runtimeEnvironmentId ? null : (wslDistro ?? null)
+): string | null | undefined {
+  return runtimeEnvironmentId ? null : wslDistro
 }
 
 export function shouldOpenTerminalFileWithSystemDefault(

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -785,17 +785,17 @@ describe('handleOscLink', () => {
     await flushDoubleRaf()
 
     expect(authorizeExternalPathMock).toHaveBeenCalledWith({
-      targetPath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      targetPath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     })
     expect(openFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+        filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
       }),
       { forceContentReload: true }
     )
     expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
-      fileId: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
+      fileId: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
       line: 5,
       column: 3,
       matchLength: 0
@@ -817,17 +817,17 @@ describe('handleOscLink', () => {
     await flushDoubleRaf()
 
     expect(authorizeExternalPathMock).toHaveBeenCalledWith({
-      targetPath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      targetPath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     })
     expect(openFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+        filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
       }),
       { forceContentReload: true }
     )
     expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
-      fileId: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
+      fileId: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
       line: 5,
       column: 3,
       matchLength: 0
@@ -1666,7 +1666,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
         runtimeEnvironmentId: null,
         pathExistsCache: new Map([
-          ['active\0//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md', true]
+          ['active\0\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md', true]
         ])
       }
     )
@@ -1675,17 +1675,17 @@ describe('createFilePathLinkProvider range bounds', () => {
 
     expect(opened).toBe(true)
     expect(statMock).toHaveBeenCalledWith({
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     })
     expect(openFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+        filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
       }),
       { forceContentReload: true }
     )
     expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
-      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
-      fileId: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      filePath: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
+      fileId: '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md',
       line: 5,
       column: 3,
       matchLength: 0
@@ -1873,7 +1873,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     ['modern', '\\\\wsl.localhost\\Ubuntu\\home\\repo'],
     ['legacy', '\\\\wsl$\\Ubuntu\\home\\repo']
   ])('maps POSIX terminal links for a %s WSL worktree', async (_label, worktreePath) => {
-    const mappedPath = '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    const mappedPath = '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     vi.mocked(window.api.shell.pathExists).mockImplementation(
       async (pathValue) => pathValue === mappedPath
     )
@@ -1912,7 +1912,7 @@ describe('createFilePathLinkProvider range bounds', () => {
   })
 
   it('resolves relative POSIX terminal links against the pane cwd before mapping', async () => {
-    const mappedPath = '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    const mappedPath = '\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md'
     vi.mocked(window.api.shell.pathExists).mockImplementation(
       async (pathValue) => pathValue === mappedPath
     )
@@ -1930,10 +1930,16 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(window.api.shell.pathExists).toHaveBeenCalledWith(mappedPath)
   })
 
-  it('preserves existing UNC and native paths', () => {
+  it('canonicalizes WSL UNC to the Windows backslash form', () => {
     expect(
       mapTerminalFilePath('//wsl.localhost/Ubuntu/root/file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
-    ).toBe('//wsl.localhost/Ubuntu/root/file.md')
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\root\\file.md')
+    expect(
+      mapTerminalFilePath(
+        '\\\\wsl.localhost\\Ubuntu\\root\\file.md',
+        '\\\\wsl.localhost\\Ubuntu\\repo'
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\root\\file.md')
     expect(
       mapTerminalFilePath('\\\\server\\share\\file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
     ).toBe('\\\\server\\share\\file.md')
@@ -1949,7 +1955,7 @@ describe('createFilePathLinkProvider range bounds', () => {
 
   it('maps POSIX paths with the pane WSL distro when the worktree is on a Windows drive', () => {
     expect(mapTerminalFilePath('/home/alice/notes.md', 'C:\\repo', 'Ubuntu')).toBe(
-      '//wsl.localhost/Ubuntu/home/alice/notes.md'
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\notes.md'
     )
     expect(mapTerminalFilePath('/mnt/c/repo/README.md', 'C:\\repo', 'Ubuntu')).toBe(
       'C:\\repo\\README.md'

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -778,7 +778,8 @@ describe('handleOscLink', () => {
       {
         ...deps,
         startupCwd: '/root/workspace/myrepo',
-        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo'
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
+        wslDistro: 'Ubuntu'
       }
     )
     await flushAsyncWork()
@@ -810,7 +811,8 @@ describe('handleOscLink', () => {
       { metaKey: false, ctrlKey: true },
       {
         ...deps,
-        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo'
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
+        wslDistro: 'Ubuntu'
       }
     )
     await flushAsyncWork()
@@ -952,6 +954,24 @@ describe('handleOscLink', () => {
     )
   })
 
+  it('keeps WSL-looking paths literal for a direct SSH pane', async () => {
+    setPlatform('Windows')
+    vi.mocked(getConnectionId).mockReturnValue('ssh-1')
+    const literalPath = '//wsl.localhost/Ubuntu/repo/file.ts'
+
+    openDetectedFilePath(literalPath, null, null, {
+      worktreeId: 'wt-1',
+      worktreePath: '//wsl.localhost/Ubuntu/repo',
+      wslDistro: null
+    })
+    await flushAsyncWork()
+
+    expect(statMock).toHaveBeenCalledWith({ filePath: literalPath, connectionId: 'ssh-1' })
+    expect(openFileMock).toHaveBeenCalledWith(expect.objectContaining({ filePath: literalPath }), {
+      forceContentReload: true
+    })
+  })
+
   it('pins SSH links outside the worktree to their target host', async () => {
     setPlatform('Macintosh')
     vi.mocked(getConnectionId).mockReturnValue('ssh-1')
@@ -994,6 +1014,12 @@ describe('handleOscLink', () => {
     })
     await flushAsyncWork()
 
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '//wsl.localhost/ubuntu/home/Alice/repo/src/main.ts'
+      }),
+      { forceContentReload: true }
+    )
     expect(openFileMock).toHaveBeenCalledWith(
       expect.not.objectContaining({ externalSshTargetId: expect.anything() }),
       { forceContentReload: true }
@@ -1665,6 +1691,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
         runtimeEnvironmentId: null,
+        wslDistro: 'Ubuntu',
         pathExistsCache: new Map([
           ['active\0\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md', true]
         ])
@@ -1880,7 +1907,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     const { provider, linkTooltip } = createProviderSetup(
       [makeBufferLine('/root/workspace/myrepo/README.md:5:3')],
       new Map(),
-      { worktreePath, startupCwd: '/root/workspace/myrepo' }
+      { worktreePath, wslDistro: 'Ubuntu', startupCwd: '/root/workspace/myrepo' }
     )
 
     const links = await new Promise<ILink[]>((resolve) => {
@@ -1918,6 +1945,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     )
     const { provider } = createProviderSetup([makeBufferLine('README.md:5')], new Map(), {
       worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
+      wslDistro: 'Ubuntu',
       startupCwd: '/stale',
       getPaneLinkCwd: () => '/root/workspace/myrepo'
     })
@@ -1943,6 +1971,9 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(
       mapTerminalFilePath('\\\\server\\share\\file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
     ).toBe('\\\\server\\share\\file.md')
+    expect(mapTerminalFilePath('//server/share/file.md', '\\\\wsl.localhost\\Ubuntu\\repo')).toBe(
+      '//server/share/file.md'
+    )
     expect(mapTerminalFilePath('C:/repo/file.md', '\\\\wsl.localhost\\Ubuntu\\repo')).toBe(
       'C:/repo/file.md'
     )
@@ -1951,6 +1982,19 @@ describe('createFilePathLinkProvider range bounds', () => {
   it('does not map POSIX paths for a native Windows worktree', () => {
     expect(mapTerminalFilePath('/repo/file.md', 'C:\\repo')).toBe('/repo/file.md')
     expect(mapTerminalFilePath('/mnt/c/repo/file.md', '/Users/a/repo')).toBe('/mnt/c/repo/file.md')
+  })
+
+  it('keeps WSL-looking paths literal without a local WSL owner', () => {
+    expect(mapTerminalFilePath('//wsl.localhost/Ubuntu/repo/file.md', '/remote/repo')).toBe(
+      '//wsl.localhost/Ubuntu/repo/file.md'
+    )
+    expect(
+      mapTerminalFilePath(
+        '//wsl.localhost/Ubuntu/repo/file.md',
+        '\\\\wsl.localhost\\Ubuntu\\repo',
+        null
+      )
+    ).toBe('//wsl.localhost/Ubuntu/repo/file.md')
   })
 
   it('maps POSIX paths with the pane WSL distro when the worktree is on a Windows drive', () => {

--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -104,6 +104,63 @@ describe('getEditorExternalWatchTargets', () => {
     ])
   })
 
+  it('enables WSL aliases for a proven-local Windows drive watcher', () => {
+    const repo = makeRepo('repo-local-drive')
+    const worktree = makeWorktree(repo.id, 'wt-local-drive')
+    worktree.path = 'C:\\repo'
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+      ).targets
+    ).toEqual([
+      {
+        worktreeId: 'wt-local-drive',
+        worktreePath: 'C:\\repo',
+        connectionId: undefined,
+        runtimeEnvironmentId: null,
+        allowLocalWindowsWslAliases: true
+      }
+    ])
+  })
+
+  it('does not infer a local alias owner while repo metadata is missing', () => {
+    const repo = makeRepo('repo-unresolved')
+    const worktree = makeWorktree(repo.id, 'wt-unresolved')
+    worktree.path = 'C:\\repo'
+    const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+    state.repos = []
+
+    expect(getEditorExternalWatchTargets(state).targets).toEqual([
+      {
+        worktreeId: 'wt-unresolved',
+        worktreePath: 'C:\\repo',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it.each(['worktree', 'repo'] as const)(
+    'does not grant local aliases for an unknown %s host stamp',
+    (stampOwner) => {
+      const repo = makeRepo('repo-unknown-host')
+      const worktree = makeWorktree(repo.id, 'wt-unknown-host')
+      worktree.path = 'C:\\repo'
+      if (stampOwner === 'worktree') {
+        worktree.hostId = 'future:host' as never
+      } else {
+        repo.executionHostId = 'future:host' as never
+      }
+
+      const target = getEditorExternalWatchTargets(
+        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+      ).targets[0]
+
+      expect(target).not.toHaveProperty('allowLocalWindowsWslAliases')
+    }
+  )
+
   it('does not watch the active worktree while the sidebar is hidden', () => {
     const repo = makeRepo('repo-active')
     const worktree = makeWorktree(repo.id, 'wt-active')

--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -109,12 +109,10 @@ describe('getEditorExternalWatchTargets', () => {
     const worktree = makeWorktree(repo.id, 'wt-local-drive')
     worktree.path = 'C:\\repo'
     worktree.hostId = 'local'
+    const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+    state.repos = [makeRepo(repo.id, 'ssh-1', 'ssh:ssh-1'), repo]
 
-    expect(
-      getEditorExternalWatchTargets(
-        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
-      ).targets
-    ).toEqual([
+    expect(getEditorExternalWatchTargets(state).targets).toEqual([
       {
         worktreeId: 'wt-local-drive',
         worktreePath: 'C:\\repo',
@@ -183,6 +181,82 @@ describe('getEditorExternalWatchTargets', () => {
       ).targets[0]
 
       expect(target).not.toHaveProperty('allowLocalWindowsWslAliases')
+    }
+  )
+
+  it('enables WSL aliases for a proven-local folder workspace', () => {
+    const repo = makeRepo('unused', null, 'local')
+    const worktree = makeWorktree(repo.id)
+    const folderWorkspaceId = 'folder-local'
+    const workspaceKey = `folder:${folderWorkspaceId}`
+    const state = makeState({
+      repo,
+      worktree,
+      openFiles: [makeOpenFile(workspaceKey)]
+    })
+    state.folderWorkspaces = [
+      {
+        id: folderWorkspaceId,
+        projectGroupId: 'group-local',
+        folderPath: 'C:\\folder',
+        executionHostId: 'local'
+      } as EditorExternalWatchTargetState['folderWorkspaces'][number]
+    ]
+    state.projectGroups = [
+      {
+        id: 'group-local',
+        executionHostId: 'runtime:env-1'
+      } as EditorExternalWatchTargetState['projectGroups'][number],
+      {
+        id: 'group-local',
+        executionHostId: 'local'
+      } as EditorExternalWatchTargetState['projectGroups'][number]
+    ]
+
+    expect(getEditorExternalWatchTargets(state).targets).toEqual([
+      {
+        worktreeId: workspaceKey,
+        worktreePath: 'C:\\folder',
+        connectionId: undefined,
+        runtimeEnvironmentId: null,
+        allowLocalWindowsWslAliases: true
+      }
+    ])
+  })
+
+  it.each(['ssh', 'missing-group'] as const)(
+    'does not grant local aliases for a %s folder workspace owner',
+    (ownerCase) => {
+      const repo = makeRepo('unused', null, 'local')
+      const worktree = makeWorktree(repo.id)
+      const folderWorkspaceId = `folder-${ownerCase}`
+      const workspaceKey = `folder:${folderWorkspaceId}`
+      const state = makeState({
+        repo,
+        worktree,
+        openFiles: [makeOpenFile(workspaceKey)]
+      })
+      state.folderWorkspaces = [
+        {
+          id: folderWorkspaceId,
+          projectGroupId: `group-${ownerCase}`,
+          folderPath: 'C:\\folder',
+          executionHostId: ownerCase === 'ssh' ? 'ssh:target-1' : 'local'
+        } as EditorExternalWatchTargetState['folderWorkspaces'][number]
+      ]
+      state.projectGroups =
+        ownerCase === 'ssh'
+          ? [
+              {
+                id: 'group-ssh',
+                executionHostId: 'ssh:target-1'
+              } as EditorExternalWatchTargetState['projectGroups'][number]
+            ]
+          : []
+
+      expect(getEditorExternalWatchTargets(state).targets[0]).not.toHaveProperty(
+        'allowLocalWindowsWslAliases'
+      )
     }
   )
 
@@ -319,6 +393,32 @@ describe('getEditorExternalWatchTargets', () => {
         worktreePath: '/repo-source-control-ssh-connected/worktree',
         connectionId: 'ssh-1',
         runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('keeps a paired runtime SSH Source Control watcher routed through its runtime repo', () => {
+    const repo = makeRepo('repo-paired', null, 'runtime:env-1')
+    const worktree = makeWorktree(repo.id, 'wt-paired')
+    worktree.hostId = 'ssh:private-target'
+    worktree.runtimeOwnerEnvironmentId = 'env-1'
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          activeWorktreeId: worktree.id,
+          rightSidebarOpen: true,
+          rightSidebarTab: 'source-control'
+        })
+      ).targets
+    ).toEqual([
+      {
+        worktreeId: 'wt-paired',
+        worktreePath: '/repo-paired/worktree',
+        connectionId: undefined,
+        runtimeEnvironmentId: 'env-1'
       }
     ])
   })

--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -105,9 +105,10 @@ describe('getEditorExternalWatchTargets', () => {
   })
 
   it('enables WSL aliases for a proven-local Windows drive watcher', () => {
-    const repo = makeRepo('repo-local-drive')
+    const repo = makeRepo('repo-local-drive', null, 'local')
     const worktree = makeWorktree(repo.id, 'wt-local-drive')
     worktree.path = 'C:\\repo'
+    worktree.hostId = 'local'
 
     expect(
       getEditorExternalWatchTargets(
@@ -125,9 +126,10 @@ describe('getEditorExternalWatchTargets', () => {
   })
 
   it('does not infer a local alias owner while repo metadata is missing', () => {
-    const repo = makeRepo('repo-unresolved')
+    const repo = makeRepo('repo-unresolved', null, 'local')
     const worktree = makeWorktree(repo.id, 'wt-unresolved')
     worktree.path = 'C:\\repo'
+    worktree.hostId = 'local'
     const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
     state.repos = []
 
@@ -142,11 +144,34 @@ describe('getEditorExternalWatchTargets', () => {
   })
 
   it.each(['worktree', 'repo'] as const)(
+    'does not grant local aliases while the %s host stamp is missing',
+    (stampOwner) => {
+      const repo = makeRepo('repo-missing-host', null, 'local')
+      const worktree = makeWorktree(repo.id, 'wt-missing-host')
+      worktree.path = 'C:\\repo'
+      worktree.hostId = 'local'
+      if (stampOwner === 'worktree') {
+        worktree.hostId = undefined
+      } else {
+        repo.executionHostId = undefined
+      }
+
+      const target = getEditorExternalWatchTargets(
+        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+      ).targets[0]
+
+      expect(target).not.toHaveProperty('allowLocalWindowsWslAliases')
+    }
+  )
+
+  it.each(['worktree', 'repo'] as const)(
     'does not grant local aliases for an unknown %s host stamp',
     (stampOwner) => {
       const repo = makeRepo('repo-unknown-host')
       const worktree = makeWorktree(repo.id, 'wt-unknown-host')
       worktree.path = 'C:\\repo'
+      worktree.hostId = 'local'
+      repo.executionHostId = 'local'
       if (stampOwner === 'worktree') {
         worktree.hostId = 'future:host' as never
       } else {

--- a/src/renderer/src/hooks/useEditorExternalWatch-wsl-repro.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-wsl-repro.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as EditorAutosaveModule from '@/components/editor/editor-autosave'
+import type { FsChangedPayload } from '../../../shared/types'
+
+vi.mock('@/store', () => ({ useAppStore: { getState: vi.fn() } }))
+vi.mock('@/components/editor/editor-autosave', async (importOriginal) => {
+  const actual = await importOriginal<typeof EditorAutosaveModule>()
+  return { ...actual, notifyEditorExternalFileChange: vi.fn() }
+})
+
+import { useAppStore } from '@/store'
+import { notifyEditorExternalFileChange } from '@/components/editor/editor-autosave'
+import { createExternalWatchEventHandler } from './useEditorExternalWatch'
+
+const worktreePath = '\\\\wsl.localhost\\Ubuntu\\workspace\\repo'
+const restoredPath = '//wsl.localhost/Ubuntu/workspace/repo/file.ts'
+
+function payload(): FsChangedPayload {
+  return {
+    worktreePath,
+    events: [
+      { kind: 'update', absolutePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo\\file.ts' }
+    ]
+  }
+}
+
+describe('WSL watcher stale-refresh reproduction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() })
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [
+        {
+          id: restoredPath,
+          filePath: restoredPath,
+          relativePath: 'file.ts',
+          worktreeId: 'wt-wsl',
+          mode: 'edit',
+          isDirty: false
+        }
+      ],
+      setExternalMutation: vi.fn()
+    } as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reloads a restored forward-UNC tab from a local backslash watcher event', () => {
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
+      worktreeId: 'wt-wsl',
+      worktreePath,
+      connectionId: undefined,
+      runtimeEnvironmentId: null,
+      allowLocalWindowsWslAliases: true
+    }))
+
+    handleFsChanged(payload())
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).toHaveBeenCalledWith({
+      worktreeId: 'wt-wsl',
+      worktreePath,
+      relativePath: 'file.ts',
+      runtimeEnvironmentId: null,
+      allowLocalWindowsWslAliases: true
+    })
+    dispose()
+  })
+
+  it('keeps update aliases distinct for an SSH watcher', () => {
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
+      worktreeId: 'wt-wsl',
+      worktreePath,
+      connectionId: 'ssh-1',
+      runtimeEnvironmentId: null
+    }))
+
+    handleFsChanged(payload())
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).not.toHaveBeenCalled()
+    dispose()
+  })
+
+  it('keeps the same aliases distinct on a POSIX desktop', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Linux' })
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
+      worktreeId: 'wt-wsl',
+      worktreePath,
+      connectionId: undefined,
+      runtimeEnvironmentId: null,
+      allowLocalWindowsWslAliases: true
+    }))
+
+    handleFsChanged(payload())
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).not.toHaveBeenCalled()
+    dispose()
+  })
+
+  it('reloads a restored /mnt drive alias from a native-drive watcher event', () => {
+    const driveRoot = 'C:\\workspace\\repo'
+    const mountedPath = '//wsl.localhost/Ubuntu/mnt/c/workspace/repo/file.ts'
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [
+        {
+          id: mountedPath,
+          filePath: mountedPath,
+          relativePath: 'file.ts',
+          worktreeId: 'wt-wsl',
+          mode: 'edit',
+          isDirty: false
+        }
+      ],
+      setExternalMutation: vi.fn()
+    } as never)
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
+      worktreeId: 'wt-wsl',
+      worktreePath: driveRoot,
+      connectionId: undefined,
+      runtimeEnvironmentId: null,
+      allowLocalWindowsWslAliases: true
+    }))
+
+    handleFsChanged({
+      worktreePath: driveRoot,
+      events: [{ kind: 'update', absolutePath: 'C:\\workspace\\repo\\file.ts' }]
+    })
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).toHaveBeenCalledWith({
+      worktreeId: 'wt-wsl',
+      worktreePath: driveRoot,
+      relativePath: 'file.ts',
+      runtimeEnvironmentId: null,
+      allowLocalWindowsWslAliases: true
+    })
+    dispose()
+  })
+})

--- a/src/renderer/src/hooks/useEditorExternalWatch-wsl-repro.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-wsl-repro.test.ts
@@ -143,4 +143,46 @@ describe('WSL watcher stale-refresh reproduction', () => {
     })
     dispose()
   })
+
+  it('tombstones and restores a /mnt alias from native-drive watcher events', () => {
+    const driveRoot = 'C:\\workspace\\repo'
+    const mountedPath = '//wsl.localhost/Ubuntu/mnt/c/workspace/repo/file.ts'
+    const file = {
+      id: mountedPath,
+      filePath: mountedPath,
+      relativePath: 'file.ts',
+      worktreeId: 'wt-wsl',
+      mode: 'edit' as const,
+      isDirty: false,
+      externalMutation: null as 'deleted' | null
+    }
+    const setExternalMutation = vi.fn((_id: string, mutation: 'deleted' | null) => {
+      file.externalMutation = mutation
+    })
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [file],
+      setExternalMutation
+    } as never)
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
+      worktreeId: 'wt-wsl',
+      worktreePath: driveRoot,
+      connectionId: undefined,
+      runtimeEnvironmentId: null,
+      allowLocalWindowsWslAliases: true
+    }))
+
+    handleFsChanged({
+      worktreePath: driveRoot,
+      events: [{ kind: 'delete', absolutePath: 'C:\\workspace\\repo\\file.ts' }]
+    })
+    vi.advanceTimersByTime(100)
+    expect(setExternalMutation).toHaveBeenCalledWith(mountedPath, 'deleted')
+
+    handleFsChanged({
+      worktreePath: driveRoot,
+      events: [{ kind: 'create', absolutePath: 'C:\\workspace\\repo\\file.ts' }]
+    })
+    expect(setExternalMutation).toHaveBeenLastCalledWith(mountedPath, null)
+    dispose()
+  })
 })

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -4,6 +4,7 @@ import { useAppStore, type AppState } from '@/store'
 import { basename, joinPath } from '@/lib/path'
 import { getExternalFileChangeRelativePath } from '@/components/right-sidebar/useFileExplorerWatch'
 import {
+  areLocalWindowsWslPathAliases,
   isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison
 } from '../../../shared/cross-platform-path'
@@ -39,6 +40,7 @@ import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
 import { isLocalWindowsDesktopClient } from '@/lib/desktop-window-chrome'
 import { parseExecutionHostId } from '../../../shared/execution-host'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
 
 // Why: atomic writes burst same-path events; one reload dispatch each fans out into N EditorPanel rebuilds that can wedge the renderer (issue #826), so debounce per (worktreeId+path).
 const EXTERNAL_RELOAD_DEBOUNCE_MS = 75
@@ -93,6 +95,26 @@ function localWslAliasOption(
   return isLocalWindowsDesktopClient() && target.allowLocalWindowsWslAliases === true
     ? { allowLocalWindowsWslAliases: true }
     : {}
+}
+
+function findMatchingWatchedPath(
+  watchedPaths: ReadonlyMap<string, string>,
+  filePath: string,
+  allowLocalWslAliases?: true
+): string | undefined {
+  const directMatch = watchedPaths.get(normalizeRuntimePathForComparison(filePath))
+  if (directMatch !== undefined) {
+    return directMatch
+  }
+  if (allowLocalWslAliases !== true || !isLocalWindowsDesktopClient()) {
+    return undefined
+  }
+  for (const watchedPath of watchedPaths.values()) {
+    if (areLocalWindowsWslPathAliases(filePath, watchedPath)) {
+      return watchedPath
+    }
+  }
+  return undefined
 }
 
 function isLocalHostStamp(value: string | null | undefined): boolean {
@@ -210,8 +232,13 @@ export function getEditorExternalWatchTargets(
   const activeWorktree = activeWorktreeId
     ? findWorktreeById(state.worktreesByRepo, activeWorktreeId)
     : undefined
+  const activeWorktreeHost = parseExecutionHostId(activeWorktree?.hostId)
   const activeRepo = activeWorktree
-    ? state.repos.find((repo) => repo.id === activeWorktree.repoId)
+    ? activeWorktreeHost?.kind === 'local'
+      ? (findRepoForHost(state.repos, activeWorktree.repoId, {
+          hostId: activeWorktreeHost.id
+        }) ?? undefined)
+      : state.repos.find((repo) => repo.id === activeWorktree.repoId)
     : undefined
   const sourceControlCanConsumeWatch =
     !!activeWorktreeId &&
@@ -251,9 +278,19 @@ export function getEditorExternalWatchTargets(
     if (!wt && !folderWorkspace) {
       continue
     }
-    const repo = wt ? state.repos.find((r) => r.id === wt.repoId) : undefined
+    const worktreeHost = parseExecutionHostId(wt?.hostId)
+    const repo = wt
+      ? worktreeHost?.kind === 'local'
+        ? (findRepoForHost(state.repos, wt.repoId, { hostId: worktreeHost.id }) ?? undefined)
+        : state.repos.find((r) => r.id === wt.repoId)
+      : undefined
+    const folderHostId = parseExecutionHostId(folderWorkspace?.executionHostId)?.id
     const projectGroup = folderWorkspace
-      ? state.projectGroups.find((group) => group.id === folderWorkspace.projectGroupId)
+      ? state.projectGroups.find(
+          (group) =>
+            group.id === folderWorkspace.projectGroupId &&
+            parseExecutionHostId(group.executionHostId)?.id === folderHostId
+        )
       : undefined
     const connectionId = folderWorkspace
       ? getFolderWorkspaceConnectionId(state, folderWorkspace.id)
@@ -489,16 +526,19 @@ export function createExternalWatchEventHandler(
     }
 
     // Why: collect create/update paths first to cancel any pending same-path delete — this absorbs the macOS atomic-write delete→create split across two payloads.
-    const createOrUpdatePaths = new Set<string>()
+    const createOrUpdatePaths = new Map<string, string>()
     for (const evt of payload.events) {
       if (evt.isDirectory === true) {
         continue
       }
       if (evt.kind === 'create' || evt.kind === 'update') {
-        createOrUpdatePaths.add(normalizeRuntimePathForComparison(evt.absolutePath))
+        createOrUpdatePaths.set(
+          normalizeRuntimePathForComparison(evt.absolutePath),
+          evt.absolutePath
+        )
       }
     }
-    for (const createdPath of createOrUpdatePaths) {
+    for (const createdPath of createOrUpdatePaths.keys()) {
       const key = pendingKey(target.worktreeId, target.runtimeEnvironmentId, createdPath)
       const existing = pendingDeletes.get(key)
       if (existing) {
@@ -514,7 +554,8 @@ export function createExternalWatchEventHandler(
       payload,
       target.worktreeId,
       target.runtimeEnvironmentId,
-      openFilesAtStart
+      openFilesAtStart,
+      target.allowLocalWindowsWslAliases
     )
     // Only pay the per-id lookup to suppress a move's own source-delete while a move is live; else the batch stays O(deletes).
     const deletedOpenEditorIds = hasActiveEditorPathMoves()
@@ -544,7 +585,8 @@ export function createExternalWatchEventHandler(
           target.worktreeId,
           target.runtimeEnvironmentId,
           deletedOpenEditorIds,
-          openFilesAtStart
+          openFilesAtStart,
+          target.allowLocalWindowsWslAliases
         )
         for (const fileId of deletedOpenEditorIds) {
           const absolutePath = deletePathByFileId.get(fileId)
@@ -580,7 +622,11 @@ export function createExternalWatchEventHandler(
           openFileRuntimeOwner(file) === target.runtimeEnvironmentId &&
           (file.mode === 'edit' || file.mode === 'markdown-preview') &&
           (file.externalMutation === 'deleted' || file.externalMutation === 'renamed') &&
-          createOrUpdatePaths.has(normalizeRuntimePathForComparison(file.filePath))
+          findMatchingWatchedPath(
+            createOrUpdatePaths,
+            file.filePath,
+            target.allowLocalWindowsWslAliases
+          ) !== undefined
         ) {
           state.setExternalMutation(file.id, null)
         }
@@ -992,12 +1038,13 @@ function buildDeletePathByFileId(
   worktreeId: string,
   runtimeEnvironmentId: string | null,
   deletedOpenEditorIds: string[],
-  openFiles: OpenFile[]
+  openFiles: OpenFile[],
+  allowLocalWindowsWslAliases?: true
 ): Map<string, string> {
-  const deletePaths = new Set<string>()
+  const deletePaths = new Map<string, string>()
   for (const evt of payload.events) {
     if (evt.kind === 'delete') {
-      deletePaths.add(normalizeRuntimePathForComparison(evt.absolutePath))
+      deletePaths.set(normalizeRuntimePathForComparison(evt.absolutePath), evt.absolutePath)
     }
   }
   const result = new Map<string, string>()
@@ -1013,9 +1060,13 @@ function buildDeletePathByFileId(
     ) {
       continue
     }
-    const normalized = normalizeRuntimePathForComparison(file.filePath)
-    if (deletePaths.has(normalized)) {
-      result.set(file.id, normalized)
+    const deletePath = findMatchingWatchedPath(
+      deletePaths,
+      file.filePath,
+      allowLocalWindowsWslAliases
+    )
+    if (deletePath) {
+      result.set(file.id, normalizeRuntimePathForComparison(deletePath))
     }
   }
   return result
@@ -1025,12 +1076,13 @@ function collectDeletedOpenEditorIds(
   payload: FsChangedPayload,
   worktreeId: string,
   runtimeEnvironmentId: string | null,
-  openFiles: OpenFile[]
+  openFiles: OpenFile[],
+  allowLocalWindowsWslAliases?: true
 ): string[] {
-  const deletePaths = new Set<string>()
+  const deletePaths = new Map<string, string>()
   for (const evt of payload.events) {
     if (evt.kind === 'delete') {
-      deletePaths.add(normalizeRuntimePathForComparison(evt.absolutePath))
+      deletePaths.set(normalizeRuntimePathForComparison(evt.absolutePath), evt.absolutePath)
     }
   }
   if (deletePaths.size === 0) {
@@ -1045,7 +1097,9 @@ function collectDeletedOpenEditorIds(
     ) {
       continue
     }
-    if (deletePaths.has(normalizeRuntimePathForComparison(file.filePath))) {
+    if (
+      findMatchingWatchedPath(deletePaths, file.filePath, allowLocalWindowsWslAliases) !== undefined
+    ) {
       result.push(file.id)
     }
   }

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -3,7 +3,10 @@ import { useEffect, useRef } from 'react'
 import { useAppStore, type AppState } from '@/store'
 import { basename, joinPath } from '@/lib/path'
 import { getExternalFileChangeRelativePath } from '@/components/right-sidebar/useFileExplorerWatch'
-import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import {
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathForComparison
+} from '../../../shared/cross-platform-path'
 import {
   canAutoSaveOpenFile,
   getOpenFilesForExternalFileChange,
@@ -34,6 +37,8 @@ import { markFileChangedOnDisk } from '@/components/editor/editor-changed-on-dis
 import { getDiskBaselineSignature } from '@/components/editor/diff-content-signature'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
+import { isLocalWindowsDesktopClient } from '@/lib/desktop-window-chrome'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 
 // Why: atomic writes burst same-path events; one reload dispatch each fans out into N EditorPanel rebuilds that can wedge the renderer (issue #826), so debounce per (worktreeId+path).
 const EXTERNAL_RELOAD_DEBOUNCE_MS = 75
@@ -71,6 +76,7 @@ type WatchedTarget = {
   worktreePath: string
   connectionId: string | undefined
   runtimeEnvironmentId: string | null
+  allowLocalWindowsWslAliases?: true
 }
 
 type ExternalWatchNotification = {
@@ -78,6 +84,53 @@ type ExternalWatchNotification = {
   worktreePath: string
   relativePath: string
   runtimeEnvironmentId: string | null
+  allowLocalWindowsWslAliases?: true
+}
+
+function localWslAliasOption(
+  target: Pick<WatchedTarget, 'allowLocalWindowsWslAliases'>
+): Pick<ExternalWatchNotification, 'allowLocalWindowsWslAliases'> {
+  return isLocalWindowsDesktopClient() && target.allowLocalWindowsWslAliases === true
+    ? { allowLocalWindowsWslAliases: true }
+    : {}
+}
+
+function isLocalHostStamp(value: string | null | undefined): boolean {
+  if (!value?.trim()) {
+    return true
+  }
+  return parseExecutionHostId(value)?.kind === 'local'
+}
+
+function canWatchLocalWindowsWslAliases(args: {
+  worktreePath: string
+  runtimeEnvironmentId: string | null
+  connectionId: string | null | undefined
+  worktree: AppState['worktreesByRepo'][string][number] | undefined
+  repo: AppState['repos'][number] | undefined
+  folderWorkspace: AppState['folderWorkspaces'][number] | undefined
+  projectGroup: AppState['projectGroups'][number] | undefined
+}): boolean {
+  if (
+    args.runtimeEnvironmentId !== null ||
+    args.connectionId !== null ||
+    !isWindowsAbsolutePathLike(args.worktreePath)
+  ) {
+    return false
+  }
+  if (args.worktree) {
+    return (
+      !!args.repo &&
+      !args.worktree.runtimeOwnerEnvironmentId?.trim() &&
+      isLocalHostStamp(args.worktree.hostId) &&
+      isLocalHostStamp(args.repo.executionHostId)
+    )
+  }
+  return (
+    !!args.folderWorkspace &&
+    isLocalHostStamp(args.folderWorkspace.executionHostId) &&
+    isLocalHostStamp(args.projectGroup?.executionHostId)
+  )
 }
 
 type WatchedTargetsSnapshot = {
@@ -117,7 +170,7 @@ let cachedWatchedTargetsSnapshot: WatchedTargetsSnapshot = { targets: [], target
 
 export function getWatchedTargetKey(target: WatchedTarget): string {
   // Why: include connectionId so a local placeholder watch is replaced by the real SSH watch once an SSH worktree's provider metadata hydrates.
-  return `${target.worktreeId}::${target.worktreePath}::${target.connectionId ?? 'local'}::${target.runtimeEnvironmentId ?? 'client'}`
+  return `${target.worktreeId}::${target.worktreePath}::${target.connectionId ?? 'local'}::${target.runtimeEnvironmentId ?? 'client'}::${target.allowLocalWindowsWslAliases === true ? 'wsl-aliases' : 'literal'}`
 }
 
 function openFileRuntimeOwner(file: Pick<OpenFile, 'runtimeEnvironmentId'>): string | null {
@@ -202,9 +255,14 @@ export function getEditorExternalWatchTargets(
       continue
     }
     const repo = wt ? state.repos.find((r) => r.id === wt.repoId) : undefined
+    const projectGroup = folderWorkspace
+      ? state.projectGroups.find((group) => group.id === folderWorkspace.projectGroupId)
+      : undefined
     const connectionId = folderWorkspace
       ? getFolderWorkspaceConnectionId(state, folderWorkspace.id)
-      : repo?.connectionId
+      : repo
+        ? (repo.connectionId ?? null)
+        : undefined
     if (connectionId === undefined && folderWorkspace) {
       continue
     }
@@ -216,7 +274,18 @@ export function getEditorExternalWatchTargets(
         worktreeId: id,
         worktreePath: wt?.path ?? folderWorkspace!.folderPath,
         connectionId: connectionId ?? undefined,
-        runtimeEnvironmentId: owner
+        runtimeEnvironmentId: owner,
+        ...(canWatchLocalWindowsWslAliases({
+          worktreePath: wt?.path ?? folderWorkspace!.folderPath,
+          runtimeEnvironmentId: owner,
+          connectionId,
+          worktree: wt,
+          repo,
+          folderWorkspace,
+          projectGroup
+        })
+          ? { allowLocalWindowsWslAliases: true as const }
+          : {})
       }
       nextTargets.push(target)
       parts.push(getWatchedTargetKey(target))
@@ -569,7 +638,8 @@ export function createExternalWatchEventHandler(
         worktreeId: target.worktreeId,
         worktreePath: target.worktreePath,
         relativePath,
-        runtimeEnvironmentId: target.runtimeEnvironmentId
+        runtimeEnvironmentId: target.runtimeEnvironmentId,
+        ...localWslAliasOption(target)
       }
       const absolutePath = joinPath(notification.worktreePath, notification.relativePath)
       const matching = getOpenFilesForExternalFileChange(openFilesSnapshot, notification)
@@ -885,7 +955,9 @@ function hasCleanExternalReloadTarget(notification: ExternalWatchNotification): 
 
 export function getOverflowExternalReloadTargets(
   target: Pick<WatchedTarget, 'worktreeId' | 'worktreePath'> & {
+    connectionId?: string
     runtimeEnvironmentId?: string | null
+    allowLocalWindowsWslAliases?: true
   }
 ): ExternalWatchNotification[] {
   const state = useAppStore.getState()
@@ -908,7 +980,10 @@ export function getOverflowExternalReloadTargets(
       worktreeId: target.worktreeId,
       worktreePath: target.worktreePath,
       relativePath: file.relativePath,
-      runtimeEnvironmentId: target.runtimeEnvironmentId ?? null
+      runtimeEnvironmentId: target.runtimeEnvironmentId ?? null,
+      ...localWslAliasOption({
+        allowLocalWindowsWslAliases: target.allowLocalWindowsWslAliases
+      })
     })
   }
 

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -96,9 +96,6 @@ function localWslAliasOption(
 }
 
 function isLocalHostStamp(value: string | null | undefined): boolean {
-  if (!value?.trim()) {
-    return true
-  }
   return parseExecutionHostId(value)?.kind === 'local'
 }
 

--- a/src/renderer/src/lib/desktop-window-chrome.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.ts
@@ -7,6 +7,14 @@ export function isPairedWebClientWindow(): boolean {
   return (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true
 }
 
+export function isLocalWindowsDesktopClient(): boolean {
+  return (
+    !isPairedWebClientWindow() &&
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent.includes('Windows')
+  )
+}
+
 export function shouldRenderDesktopWindowChrome({
   platform,
   isWebClient

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -713,6 +713,136 @@ describe('createEditorSlice openDiff', () => {
     expect(store.getState().openFiles[0]?.fileContentReloadNonce).toBe(2)
   })
 
+  it('reuses a restored local WSL alias without folding the Linux path tail', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
+    const store = createEditorStore()
+    const restoredPath = '//wsl.localhost/Ubuntu/home/Alice/repo/file.ts'
+    store.setState({
+      openFiles: [
+        {
+          id: restoredPath,
+          filePath: restoredPath,
+          relativePath: 'file.ts',
+          worktreeId: 'wt-1',
+          runtimeEnvironmentId: null,
+          language: 'typescript',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ]
+    })
+
+    expect(
+      store.getState().openFile(
+        {
+          filePath: '\\\\wsl.localhost\\ubuntu\\home\\Alice\\repo\\file.ts',
+          relativePath: 'file.ts',
+          worktreeId: 'wt-1',
+          runtimeEnvironmentId: null,
+          language: 'typescript',
+          mode: 'edit'
+        },
+        { suppressActiveRuntimeFallback: true }
+      )
+    ).toBe(restoredPath)
+    expect(store.getState().openFiles).toHaveLength(1)
+
+    store.getState().openFile(
+      {
+        filePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo\\file.ts',
+        relativePath: 'file.ts',
+        worktreeId: 'wt-1',
+        runtimeEnvironmentId: null,
+        language: 'typescript',
+        mode: 'edit'
+      },
+      { suppressActiveRuntimeFallback: true }
+    )
+    expect(store.getState().openFiles).toHaveLength(2)
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps local WSL-looking aliases distinct on POSIX clients', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Linux' })
+    const store = createEditorStore()
+    store.setState({
+      openFiles: [
+        {
+          id: 'forward',
+          filePath: '//wsl.localhost/Ubuntu/repo/file.ts',
+          relativePath: 'file.ts',
+          worktreeId: 'wt-1',
+          runtimeEnvironmentId: null,
+          language: 'typescript',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ]
+    })
+
+    store.getState().openFile(
+      {
+        filePath: '\\\\wsl.localhost\\Ubuntu\\repo\\file.ts',
+        relativePath: 'file.ts',
+        worktreeId: 'wt-1',
+        runtimeEnvironmentId: null,
+        language: 'typescript',
+        mode: 'edit'
+      },
+      { suppressActiveRuntimeFallback: true }
+    )
+
+    expect(store.getState().openFiles).toHaveLength(2)
+    vi.unstubAllGlobals()
+  })
+
+  it('does not reuse WSL aliases for SSH-owned tabs', () => {
+    const store = createEditorStore()
+    store.setState({
+      repos: [{ id: 'repo-1', path: '/repo', connectionId: 'ssh-1' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/repo', hostId: 'ssh:ssh-1' }]
+      },
+      sshConnectionStates: new Map([
+        [
+          'ssh-1',
+          {
+            targetId: 'ssh-1',
+            status: 'connected',
+            error: null,
+            reconnectAttempt: 0,
+            connectionGeneration: 1
+          }
+        ]
+      ]),
+      openFiles: [
+        {
+          id: 'ssh-forward',
+          filePath: '//wsl.localhost/Ubuntu/repo/file.ts',
+          relativePath: 'file.ts',
+          worktreeId: 'wt-1',
+          runtimeEnvironmentId: null,
+          externalSshTargetId: 'ssh-1',
+          language: 'typescript',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ]
+    } as never)
+
+    store.getState().openFile({
+      filePath: '\\\\wsl.localhost\\Ubuntu\\repo\\file.ts',
+      relativePath: 'file.ts',
+      worktreeId: 'wt-1',
+      runtimeEnvironmentId: null,
+      externalSshTargetId: 'ssh-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+
+    expect(store.getState().openFiles).toHaveLength(2)
+  })
+
   it('rebinds an existing external tab when it is reopened from a new SSH host', () => {
     const store = createEditorStore()
     const file = {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -10,7 +10,10 @@ import {
 import type { RecentlyClosedTabPosition } from './recently-closed-tabs'
 import { joinPath } from '@/lib/path'
 import { toast } from 'sonner'
-import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
+import {
+  areLocalWindowsWslPathAliases,
+  isPathInsideOrEqual
+} from '../../../../shared/cross-platform-path'
 import { resolveMarkdownLinkTarget } from '@/components/editor/markdown-internal-links'
 import {
   buildCheckRunDetailsTabId,
@@ -107,6 +110,7 @@ import {
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { pruneTabGroupLayoutForGroups } from './tabs-hydration'
 import { sanitizeRecentTabIds } from './tab-group-state'
+import { isLocalWindowsDesktopClient } from '@/lib/desktop-window-chrome'
 
 export type {
   ActiveRightSidebarTab,
@@ -1027,6 +1031,23 @@ function isSameEditorOwner(
   )
 }
 
+function canReuseLocalWslAlias(
+  state: AppState,
+  existing: OpenFile,
+  file: Pick<OpenFile, 'filePath' | 'worktreeId' | 'runtimeEnvironmentId' | 'externalSshTargetId'>,
+  runtimeEnvironmentId: string | null | undefined
+): boolean {
+  return (
+    isLocalWindowsDesktopClient() &&
+    runtimeOwnerKey(runtimeEnvironmentId) === null &&
+    !existing.externalSshTargetId?.trim() &&
+    !file.externalSshTargetId?.trim() &&
+    getConnectionIdForFileFromState(state, file.worktreeId, file.filePath) === null &&
+    getConnectionIdForFileFromState(state, existing.worktreeId, existing.filePath) === null &&
+    areLocalWindowsWslPathAliases(existing.filePath, file.filePath)
+  )
+}
+
 export function buildOwnedEditorFileId(
   filePath: string,
   worktreeId: string,
@@ -1745,9 +1766,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const reusableOpenFileModes = getReusableOpenFileModes(file.mode)
       const existing = s.openFiles.find(
         (f) =>
-          f.filePath === file.filePath &&
           matchesEditorMode(f, reusableOpenFileModes) &&
-          isSameEditorOwner(f, worktreeId, runtimeEnvironmentId)
+          isSameEditorOwner(f, worktreeId, runtimeEnvironmentId) &&
+          (f.filePath === file.filePath || canReuseLocalWslAlias(s, f, file, runtimeEnvironmentId))
       )
       // Why: a snapshot's reopenId can be a stale shape — the same path is bare in whichever worktree opened it first and namespaced elsewhere — so honoring it while this owner's tab is already open would strand activeFileId and the unified tab on an id no OpenFile has.
       const id = existing

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1042,9 +1042,9 @@ function canReuseLocalWslAlias(
     runtimeOwnerKey(runtimeEnvironmentId) === null &&
     !existing.externalSshTargetId?.trim() &&
     !file.externalSshTargetId?.trim() &&
+    areLocalWindowsWslPathAliases(existing.filePath, file.filePath) &&
     getConnectionIdForFileFromState(state, file.worktreeId, file.filePath) === null &&
-    getConnectionIdForFileFromState(state, existing.worktreeId, existing.filePath) === null &&
-    areLocalWindowsWslPathAliases(existing.filePath, file.filePath)
+    getConnectionIdForFileFromState(state, existing.worktreeId, existing.filePath) === null
   )
 }
 

--- a/src/shared/cross-platform-path.test.ts
+++ b/src/shared/cross-platform-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  areLocalWindowsWslPathAliases,
   isCaseInsensitiveRuntimeRoot,
   isPathInsideOrEqual,
   isRuntimePathAbsolute,
@@ -7,6 +8,32 @@ import {
   relativePathInsideRoot,
   resolveRuntimePath
 } from './cross-platform-path'
+
+describe('local Windows WSL aliases', () => {
+  it('matches UNC aliases and mounted drives without folding Linux path case', () => {
+    expect(
+      areLocalWindowsWslPathAliases(
+        '//wsl.localhost/Ubuntu/home/Alice/file.ts',
+        '\\\\wsl$\\ubuntu\\home\\Alice\\file.ts'
+      )
+    ).toBe(true)
+    expect(
+      areLocalWindowsWslPathAliases(
+        '//wsl.localhost/Ubuntu/home/Alice/file.ts',
+        '\\\\wsl.localhost\\Ubuntu\\home\\alice\\file.ts'
+      )
+    ).toBe(false)
+    expect(
+      areLocalWindowsWslPathAliases(
+        '//wsl.localhost/Ubuntu/mnt/c/repo/file.ts',
+        'C:\\repo\\file.ts'
+      )
+    ).toBe(true)
+    expect(
+      areLocalWindowsWslPathAliases('//server/share/file.ts', '\\\\server\\share\\file.ts')
+    ).toBe(false)
+  })
+})
 
 describe('isCaseInsensitiveRuntimeRoot', () => {
   it('folds Windows drive and plain UNC roots', () => {

--- a/src/shared/cross-platform-path.ts
+++ b/src/shared/cross-platform-path.ts
@@ -1,4 +1,4 @@
-import { isWslUncPath } from './wsl-paths'
+import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from './wsl-paths'
 
 const SLASH_CHAR_CODE = '/'.charCodeAt(0)
 
@@ -54,6 +54,21 @@ export function normalizeRuntimePathForComparison(rawValue: string): string {
     return `//wsl/${wslUnc[1].toLowerCase()}${wslUnc[2] ?? ''}`
   }
   return isWindowsPath ? normalized.toLowerCase() : normalized
+}
+
+export function areLocalWindowsWslPathAliases(left: string, right: string): boolean {
+  const leftWslPath = parseWslUncPath(left)
+  const rightWslPath = parseWslUncPath(right)
+  if (!leftWslPath && !rightWslPath) {
+    return false
+  }
+  const normalize = (value: string): string => {
+    const wslPath = parseWslUncPath(value)
+    return normalizeRuntimePathForComparison(
+      wslPath ? toWindowsWslPath(wslPath.linuxPath, wslPath.distro) : value
+    )
+  }
+  return normalize(left) === normalize(right)
 }
 
 export function isRuntimePathAbsolute(


### PR DESCRIPTION
## Summary  WSL can spell the same local file as `//wsl.localhost/Ubuntu/...`, `\\wsl.localhost\Ubuntu\...`, or (for mounted drives) `C:\...`. A terminal-opened tab could therefore stop refreshing because the watcher and editor compared different spellings.  This PR combines the strongest parts of the related fixes:  - canonicalize new local WSL terminal links at open time - retain a guarded watcher fallback for restored forward-UNC tabs - reuse restored local aliases instead of opening duplicate tabs - keep SSH, paired runtimes, POSIX desktops, paired-web clients, and non-WSL UNC paths literal - fail closed while ownership metadata is missing, ambiguous, malformed, or future-versioned  Closes #13349. Supersedes #13423, #13692, and #13605; they should not merge independently.  Credit:  - @bbingz authored the terminal canonicalization; that authored commit is preserved in this branch. - @Pr1p authored the watcher slash-matching fix; that authored commit is preserved in this branch. - @manuaudio contributed the diagnosis and control-case design that shaped the final guarded implementation.  ## Screenshots  No visual change.  ## Testing  - [x] `pnpm lint` (equivalent strict native and type-aware lint commands run with warnings denied) - [x] `pnpm typecheck` - [x] Focused test suite: 8 files / 380 tests - [x] CI unit-test matrix on Node 24 and Node 26 - [x] CI package checks, including Windows - [x] Added deterministic regression and negative-control tests
- [x] Live Windows/WSL Electron E2E through the real watcher/editor pipeline  The deterministic reproduction drives the real watcher event handler with a restored forward-UNC editor tab, emits the backslash/native Windows watcher event, advances the debounce clock deterministically, and proves the reload notification reaches that tab. It also covers restored `/mnt/c` tabs receiving native-drive events and negative controls for SSH and POSIX owners.

Live Electron E2E opened `//wsl.localhost/Ubuntu-24.04/.../watched.txt` in a local folder workspace, then changed the same file through `\\wsl.localhost\Ubuntu-24.04\...\watched.txt`. The rendered editor changed from the before marker to the after marker, the original forward-UNC tab stayed clean and received a new disk signature, and the console reported zero errors.

A live `/mnt/c` fixture could not be exercised because Windows rejected UNC access to that mount with `EPERM`; `/mnt/c` to drive-letter identity remains covered by deterministic integration tests.  ## AI Review Report  Three independent review agents checked correctness, host ownership/isolation, tests, and performance after iterative fixes. The original broad implementation was rejected because it introduced incomplete parallel host routing; this focused implementation was rebuilt around the terminal-open and watcher boundaries. Final internal review was clean before the CodeRabbit pass.  CodeRabbit then identified that missing host stamps were still treated as local. Catalog hydration was traced end-to-end, the guard was changed to require explicit `local` stamps, and missing-worktree/missing-repo regression tests were added.  The post-implementation review then found avoidable owner-resolution work, missing folder-workspace coverage, and a /mnt/c delete/recreate tombstone gap. The final delta moves the cheap alias check first, preserves O(1) literal matching, covers local/SSH/missing/duplicate folder ownership, and applies the validated alias capability consistently across update, delete, and recreate handling. A paired runtime + SSH control test prevents dual-owner routing regressions.  Cross-platform review explicitly covered Windows, WSL UNC and drive aliases, macOS/Linux literal path semantics, paired web, Electron desktop detection, SSH, runtime ownership, and folder workspaces. No shortcuts, labels, or shell behavior changed.  ## Security Audit  Path aliasing is opt-in only for explicit local ownership and a local Windows desktop. Missing, blank, malformed, future, SSH, runtime, paired-web, POSIX, and non-WSL UNC cases fail closed. No commands are executed, no auth/secrets/dependencies change, and no IPC or remote-wire payload changes were introduced. Alias parsing is limited to recognized WSL/local-drive forms and cannot redirect SSH or runtime reads/writes.  ## Notes  - The watcher carries one extra internal snapshot capability bit and performs alias parsing only for opted-in local Windows candidates. - Restored legacy tabs keep their existing persisted ID/path until reopened; compatibility matching remains for them. - Ownership-uncertain tabs intentionally stay literal until catalog hydration proves they are local. - CodeRabbit's generic docstring-coverage warning was not addressed with boilerplate; repository style requires concise, non-obvious comments and the changed code is already documented where the reasoning is not evident. 