### PR TITLE
fix(runtime): cap git.diff at the transport boundary, fail oversized replies per-request

### DIFF
--- a/mobile/src/files/mobile-file-tab-doc.test.ts
+++ b/mobile/src/files/mobile-file-tab-doc.test.ts
@@ -138,6 +138,24 @@ describe('resolveMobileFileTabDoc', () => {
     })
   })
 
+  // Why: the host caps oversized diffs and previews with an error envelope, so an old client that
+  // knows nothing about the codes must still surface the message instead of an empty or binary doc.
+  it('propagates a host diff_too_large failure instead of rendering an empty diff', async () => {
+    const client = clientOf({
+      'git.diff': fail('diff_too_large', 'This diff is too large to open over a remote connection.')
+    })
+    await expect(
+      resolveMobileFileTabDoc(client, { ...WT, relativePath: 'a.ts', diffSource: 'staged' })
+    ).rejects.toThrow('This diff is too large to open over a remote connection.')
+  })
+
+  it('propagates a capped image preview instead of rendering a broken image', async () => {
+    const client = clientOf({ 'files.readPreview': fail('runtime_error', 'file_too_large') })
+    await expect(
+      resolveMobileFileTabDoc(client, { ...WT, relativePath: 'logo.png' })
+    ).rejects.toThrow('file_too_large')
+  })
+
   it('propagates the RPC error message when a read fails', async () => {
     const client = clientOf({ 'files.read': fail('EIO', 'file_too_large') })
     await expect(

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -104,7 +104,15 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
     'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
 }))
 
-import { awaitRuntimeFileWatcherUnsubscribes, RuntimeFileCommands } from './orca-runtime-files'
+import {
+  awaitRuntimeFileWatcherUnsubscribes,
+  RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES,
+  RuntimeFileCommands
+} from './orca-runtime-files'
+import {
+  REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES,
+  REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+} from '../../shared/remote-runtime-capacity-limits'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   resetSshConnectionGenerations,
@@ -2314,6 +2322,61 @@ describe('RuntimeFileCommands', () => {
       await expect(commands.resolveTerminalPath('id:wt-1', 'src/x.ts')).rejects.toThrow(
         'Remote connection dropped'
       )
+    })
+  })
+  // Why: mobile-file-tab-doc.ts calls files.readPreview for every image tab, so this constant is
+  // the most reachable way to overflow the outbound envelope and kill the socket.
+  describe('previewable binary budget', () => {
+    const previewTempDirs: string[] = []
+
+    afterEach(async () => {
+      await Promise.all(previewTempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+      previewTempDirs.length = 0
+    })
+
+    async function previewFixture(): Promise<string> {
+      const dir = await mkdtemp(join(tmpdir(), 'orca-preview-budget-'))
+      previewTempDirs.push(dir)
+      await writeFile(join(dir, 'logo.png'), 'fake-png')
+      return dir
+    }
+
+    it('stays inside the outbound JSON envelope once base64-inflated', () => {
+      const base64Bytes = Math.ceil(RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES / 3) * 4
+
+      expect(base64Bytes).toBeLessThanOrEqual(REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES)
+      expect(base64Bytes).toBeLessThan(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES)
+    })
+
+    it('rejects a previewable image one byte above the cap', async () => {
+      const dir = await previewFixture()
+      const { commands } = createRuntimeFileCommands({ path: dir })
+      resolveAuthorizedPathMock.mockImplementation(async (p: string) => p)
+      statMock.mockResolvedValue({
+        isDirectory: () => false,
+        size: RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES + 1
+      })
+
+      await expect(commands.readFileExplorerPreview('id:wt-1', 'logo.png')).rejects.toThrow(
+        'file_too_large'
+      )
+    })
+
+    it('returns full base64 for a previewable image at the cap', async () => {
+      const dir = await previewFixture()
+      const { commands } = createRuntimeFileCommands({ path: dir })
+      resolveAuthorizedPathMock.mockImplementation(async (p: string) => p)
+      statMock.mockResolvedValue({
+        isDirectory: () => false,
+        size: RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES
+      })
+
+      await expect(commands.readFileExplorerPreview('id:wt-1', 'logo.png')).resolves.toEqual({
+        content: Buffer.from('fake-png').toString('base64'),
+        isBinary: true,
+        isImage: true,
+        mimeType: 'image/png'
+      })
     })
   })
 })

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -37,6 +37,7 @@ import {
   relativePathInsideRoot,
   resolveRuntimePath
 } from '../../shared/cross-platform-path'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES } from '../../shared/remote-runtime-capacity-limits'
 import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { sortDirEntries } from '../../shared/file-name-sort'
 import type {
@@ -101,7 +102,11 @@ const MOBILE_FILE_PATH_SEARCH_CACHE_LIMIT = 20_000
 const MOBILE_FILE_PATH_SEARCH_CACHE_ENTRIES = 8
 const MOBILE_FILE_PATH_SEARCH_CACHE_TTL_MS = 30_000
 const MOBILE_FILE_READ_MAX_BYTES = 512 * 1024
-const RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES = 10 * 1024 * 1024
+// Why: previews are reachable only over RPC, and base64 inflates them 4/3, so derive the cap from
+// the outbound envelope — a hardcoded 10 MiB serializes past it and kills the socket instead.
+export const RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES = Math.floor(
+  (REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES * 3) / 4
+)
 const WINDOWS_RUNTIME_FILE_WATCH_DEBOUNCE_MS = 150
 export const WINDOWS_RUNTIME_FILE_WATCH_CLOSE_DEADLINE_MS = 10_000
 const TERMINAL_FILE_GRANT_TTL_MS = 10 * 60 * 1000

--- a/src/main/runtime/orca-runtime-git-diff-budget.test.ts
+++ b/src/main/runtime/orca-runtime-git-diff-budget.test.ts
@@ -1,0 +1,224 @@
+// Why: the cap lives in orca-runtime-git.ts so both branches of all three diff readers are covered —
+// an SSH relay forwards its payload verbatim, so an older host cannot be relied on to clamp it.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES } from '../../shared/git-diff-transport-budget'
+import type { GitDiffResult, GlobalSettings } from '../../shared/types'
+import type * as GitStatusModule from '../git/status'
+import { RuntimeGitCommands, type ResolvedRuntimeGitWorktree } from './orca-runtime-git'
+
+const mocks = vi.hoisted(() => ({
+  getSshGitProvider: vi.fn(),
+  getDiff: vi.fn(),
+  getBranchDiff: vi.fn(),
+  getCommitDiff: vi.fn()
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: mocks.getSshGitProvider
+}))
+
+vi.mock('../git/status', async () => ({
+  ...(await vi.importActual<typeof GitStatusModule>('../git/status')),
+  getDiff: mocks.getDiff,
+  getBranchDiff: mocks.getBranchDiff,
+  getCommitDiff: mocks.getCommitDiff
+}))
+
+const OVERSIZED_BASE64 = 'A'.repeat(GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES + 1)
+const BRANCH_COMPARE = { mergeBase: 'base-oid', headOid: 'head-oid' }
+const COMMIT_ARGS = {
+  commitOid: 'commit-oid',
+  parentOid: 'parent-oid',
+  filePath: 'assets/logo.png'
+}
+const TOO_LARGE = {
+  code: 'diff_too_large',
+  data: { maxBytes: GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES }
+}
+
+function oversizedResult(): GitDiffResult {
+  return {
+    kind: 'binary',
+    originalContent: '',
+    modifiedContent: OVERSIZED_BASE64,
+    originalIsBinary: false,
+    modifiedIsBinary: true
+  }
+}
+
+function commands(connectionId?: string): RuntimeGitCommands {
+  const worktree = {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/remote/repo',
+    git: { path: '/remote/repo', branch: 'main', isBare: false, isMainWorktree: false }
+  } as unknown as ResolvedRuntimeGitWorktree
+  return new RuntimeGitCommands({
+    resolveRuntimeGitTarget: async () => ({
+      worktree,
+      ...(connectionId ? { connectionId } : {})
+    }),
+    getRuntimeSettings: () => ({}) as GlobalSettings
+  })
+}
+
+function sshProvider(): {
+  getDiff: ReturnType<typeof vi.fn>
+  getBranchDiff: ReturnType<typeof vi.fn>
+  getCommitDiff: ReturnType<typeof vi.fn>
+} {
+  return {
+    getDiff: vi.fn().mockResolvedValue(oversizedResult()),
+    getBranchDiff: vi.fn().mockResolvedValue([oversizedResult()]),
+    getCommitDiff: vi.fn().mockResolvedValue(oversizedResult())
+  }
+}
+
+describe('remote git diff transport budget', () => {
+  beforeEach(() => {
+    mocks.getSshGitProvider.mockReset()
+    mocks.getDiff.mockReset().mockResolvedValue(oversizedResult())
+    mocks.getBranchDiff.mockReset().mockResolvedValue(oversizedResult())
+    mocks.getCommitDiff.mockReset().mockResolvedValue(oversizedResult())
+  })
+
+  it('caps an SSH-forwarded diff that exceeds the budget', async () => {
+    const provider = sshProvider()
+    mocks.getSshGitProvider.mockReturnValue(provider)
+
+    await expect(
+      commands('conn-1').getRuntimeGitDiff(
+        'id:wt-1',
+        'assets/logo.png',
+        false,
+        undefined,
+        GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+      )
+    ).rejects.toMatchObject(TOO_LARGE)
+    expect(provider.getDiff).toHaveBeenCalledWith(
+      '/remote/repo',
+      'assets/logo.png',
+      false,
+      undefined
+    )
+    expect(mocks.getDiff).not.toHaveBeenCalled()
+  })
+
+  it('leaves an SSH-forwarded diff uncapped when no budget is supplied', async () => {
+    mocks.getSshGitProvider.mockReturnValue(sshProvider())
+
+    await expect(
+      commands('conn-1').getRuntimeGitDiff('id:wt-1', 'assets/logo.png', false)
+    ).resolves.toMatchObject({ modifiedContent: OVERSIZED_BASE64 })
+  })
+
+  it('caps a local-repo diff that exceeds the budget', async () => {
+    await expect(
+      commands().getRuntimeGitDiff(
+        'id:wt-1',
+        'assets/logo.png',
+        false,
+        undefined,
+        GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+      )
+    ).rejects.toMatchObject(TOO_LARGE)
+    expect(mocks.getDiff).toHaveBeenCalledWith(
+      '/remote/repo',
+      'assets/logo.png',
+      false,
+      undefined,
+      {}
+    )
+    expect(mocks.getSshGitProvider).not.toHaveBeenCalled()
+  })
+
+  it('leaves a local-repo diff uncapped when no budget is supplied', async () => {
+    await expect(
+      commands().getRuntimeGitDiff('id:wt-1', 'assets/logo.png', false)
+    ).resolves.toMatchObject({ modifiedContent: OVERSIZED_BASE64 })
+  })
+
+  it('caps an SSH-forwarded branch diff that exceeds the budget', async () => {
+    const provider = sshProvider()
+    mocks.getSshGitProvider.mockReturnValue(provider)
+
+    await expect(
+      commands('conn-1').getRuntimeGitBranchDiff(
+        'id:wt-1',
+        BRANCH_COMPARE,
+        'assets/logo.png',
+        undefined,
+        GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+      )
+    ).rejects.toMatchObject(TOO_LARGE)
+    expect(provider.getBranchDiff).toHaveBeenCalled()
+  })
+
+  it('caps a local-repo branch diff that exceeds the budget', async () => {
+    await expect(
+      commands().getRuntimeGitBranchDiff(
+        'id:wt-1',
+        BRANCH_COMPARE,
+        'assets/logo.png',
+        undefined,
+        GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+      )
+    ).rejects.toMatchObject(TOO_LARGE)
+    expect(mocks.getBranchDiff).toHaveBeenCalledWith(
+      '/remote/repo',
+      {
+        mergeBase: 'base-oid',
+        headOid: 'head-oid',
+        filePath: 'assets/logo.png',
+        oldPath: undefined
+      },
+      {}
+    )
+  })
+
+  it('leaves a local-repo branch diff uncapped when no budget is supplied', async () => {
+    await expect(
+      commands().getRuntimeGitBranchDiff('id:wt-1', BRANCH_COMPARE, 'assets/logo.png')
+    ).resolves.toMatchObject({ modifiedContent: OVERSIZED_BASE64 })
+  })
+
+  it('caps an SSH-forwarded commit diff that exceeds the budget', async () => {
+    const provider = sshProvider()
+    mocks.getSshGitProvider.mockReturnValue(provider)
+
+    await expect(
+      commands('conn-1').getRuntimeGitCommitDiff(
+        'id:wt-1',
+        COMMIT_ARGS,
+        GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+      )
+    ).rejects.toMatchObject(TOO_LARGE)
+    expect(provider.getCommitDiff).toHaveBeenCalled()
+  })
+
+  it('caps a local-repo commit diff that exceeds the budget', async () => {
+    await expect(
+      commands().getRuntimeGitCommitDiff(
+        'id:wt-1',
+        COMMIT_ARGS,
+        GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+      )
+    ).rejects.toMatchObject(TOO_LARGE)
+    expect(mocks.getCommitDiff).toHaveBeenCalledWith(
+      '/remote/repo',
+      {
+        commitOid: 'commit-oid',
+        parentOid: 'parent-oid',
+        filePath: 'assets/logo.png',
+        oldPath: undefined
+      },
+      {}
+    )
+  })
+
+  it('leaves a local-repo commit diff uncapped when no budget is supplied', async () => {
+    await expect(commands().getRuntimeGitCommitDiff('id:wt-1', COMMIT_ARGS)).resolves.toMatchObject(
+      { modifiedContent: OVERSIZED_BASE64 }
+    )
+  })
+})

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -17,6 +17,7 @@ import type {
   Worktree
 } from '../../shared/types'
 import type { CommitMessageDraftContext } from '../../shared/commit-message-generation'
+import { assertGitDiffWithinTransportBudget } from '../../shared/git-diff-transport-budget'
 import { getCommitMessageModelDiscoveryHostKey } from '../../shared/commit-message-host-key'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
 import {
@@ -345,11 +346,15 @@ export class RuntimeGitCommands {
     return listLocalBranches(target.worktree.path, localGitOptionsForTarget(target))
   }
 
+  // Why: the budget is enforced here, after both branches and after the read dedupe, so an SSH
+  // payload forwarded verbatim from an older relay is capped too and a concurrent uncapped local
+  // caller can still share the in-flight read.
   async getRuntimeGitDiff(
     worktreeSelector: string,
     filePath: string,
     staged: boolean,
-    compareAgainstHead?: boolean
+    compareAgainstHead?: boolean,
+    maxContentBytes?: number
   ): Promise<GitDiffResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const relativePath = normalizeRuntimeGitRelativePath(filePath)
@@ -358,14 +363,20 @@ export class RuntimeGitCommands {
       if (!provider) {
         throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      return provider.getDiff(target.worktree.path, relativePath, staged, compareAgainstHead)
+      return assertGitDiffWithinTransportBudget(
+        await provider.getDiff(target.worktree.path, relativePath, staged, compareAgainstHead),
+        maxContentBytes
+      )
     }
-    return getDiff(
-      target.worktree.path,
-      relativePath,
-      staged,
-      compareAgainstHead,
-      localGitOptionsForTarget(target)
+    return assertGitDiffWithinTransportBudget(
+      await getDiff(
+        target.worktree.path,
+        relativePath,
+        staged,
+        compareAgainstHead,
+        localGitOptionsForTarget(target)
+      ),
+      maxContentBytes
     )
   }
 
@@ -526,7 +537,8 @@ export class RuntimeGitCommands {
     worktreeSelector: string,
     compare: { mergeBase: string; headOid: string },
     filePath: string,
-    oldPath?: string
+    oldPath?: string,
+    maxContentBytes?: number
   ): Promise<GitDiffResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const relativePath = normalizeRuntimeGitRelativePath(filePath)
@@ -541,31 +553,36 @@ export class RuntimeGitCommands {
         filePath: relativePath,
         oldPath: oldRelativePath
       })
-      return (
+      return assertGitDiffWithinTransportBudget(
         results[0] ?? {
           kind: 'text',
           originalContent: '',
           modifiedContent: '',
           originalIsBinary: false,
           modifiedIsBinary: false
-        }
+        },
+        maxContentBytes
       )
     }
-    return getBranchDiff(
-      target.worktree.path,
-      {
-        mergeBase: compare.mergeBase,
-        headOid: compare.headOid,
-        filePath: relativePath,
-        oldPath: oldRelativePath
-      },
-      localGitOptionsForTarget(target)
+    return assertGitDiffWithinTransportBudget(
+      await getBranchDiff(
+        target.worktree.path,
+        {
+          mergeBase: compare.mergeBase,
+          headOid: compare.headOid,
+          filePath: relativePath,
+          oldPath: oldRelativePath
+        },
+        localGitOptionsForTarget(target)
+      ),
+      maxContentBytes
     )
   }
 
   async getRuntimeGitCommitDiff(
     worktreeSelector: string,
-    args: { commitOid: string; parentOid?: string | null; filePath: string; oldPath?: string }
+    args: { commitOid: string; parentOid?: string | null; filePath: string; oldPath?: string },
+    maxContentBytes?: number
   ): Promise<GitDiffResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const relativePath = normalizeRuntimeRelativePath(args.filePath)
@@ -575,22 +592,28 @@ export class RuntimeGitCommands {
       if (!provider) {
         throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      return provider.getCommitDiff(target.worktree.path, {
-        commitOid: args.commitOid,
-        parentOid: args.parentOid,
-        filePath: relativePath,
-        oldPath: oldRelativePath
-      })
+      return assertGitDiffWithinTransportBudget(
+        await provider.getCommitDiff(target.worktree.path, {
+          commitOid: args.commitOid,
+          parentOid: args.parentOid,
+          filePath: relativePath,
+          oldPath: oldRelativePath
+        }),
+        maxContentBytes
+      )
     }
-    return getCommitDiff(
-      target.worktree.path,
-      {
-        commitOid: args.commitOid,
-        parentOid: args.parentOid,
-        filePath: relativePath,
-        oldPath: oldRelativePath
-      },
-      localGitOptionsForTarget(target)
+    return assertGitDiffWithinTransportBudget(
+      await getCommitDiff(
+        target.worktree.path,
+        {
+          commitOid: args.commitOid,
+          parentOid: args.parentOid,
+          filePath: relativePath,
+          oldPath: oldRelativePath
+        },
+        localGitOptionsForTarget(target)
+      ),
+      maxContentBytes
     )
   }
 

--- a/src/main/runtime/rpc/dispatcher-outbound-reply-limit.test.ts
+++ b/src/main/runtime/rpc/dispatcher-outbound-reply-limit.test.ts
@@ -50,43 +50,64 @@ describe('RpcDispatcher outbound reply limit', () => {
     expect(onOutboundReplyOverflow).not.toHaveBeenCalled()
   })
 
-  it('rejects a one-shot response one byte above the serialized envelope limit', async () => {
+  it('fails a one-shot response one byte above the limit without closing the socket', async () => {
     const replies: string[] = []
     const onOutboundReplyOverflow = vi.fn()
+    const onOutboundReplyTooLarge = vi.fn()
+    const oversized = asciiResultForEnvelopeBytes(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES + 1)
     const dispatcher = new RpcDispatcher({
       runtime: stubRuntime(),
       methods: [
-        defineMethod({
-          name: REQUEST.method,
-          params: null,
-          handler: async () =>
-            asciiResultForEnvelopeBytes(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES + 1)
-        })
+        defineMethod({ name: REQUEST.method, params: null, handler: async () => oversized })
       ]
     })
 
     await dispatcher.dispatchStreaming(REQUEST, (reply) => replies.push(reply), {
-      onOutboundReplyOverflow
+      onOutboundReplyOverflow,
+      onOutboundReplyTooLarge
     })
 
-    expect(replies).toEqual([])
-    expect(onOutboundReplyOverflow).toHaveBeenCalledExactlyOnceWith({ method: REQUEST.method })
+    expect(replies).toHaveLength(1)
+    expect(JSON.parse(replies[0]!)).toEqual({
+      id: REQUEST.id,
+      ok: false,
+      error: {
+        code: 'response_too_large',
+        message: expect.any(String),
+        data: {
+          byteLength: REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES + 1,
+          maxBytes: REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+        }
+      },
+      _meta: { runtimeId: 'test-runtime' }
+    })
+    expect(onOutboundReplyOverflow).not.toHaveBeenCalled()
+    // Exact key set: a future field must not leak params, filePath or worktree into telemetry.
+    expect(onOutboundReplyTooLarge).toHaveBeenCalledExactlyOnceWith({
+      method: REQUEST.method,
+      byteLength: REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES + 1,
+      streaming: false
+    })
   })
 
   it('reports an unregistered method as "unknown" so a client string cannot reach telemetry', async () => {
-    const onOutboundReplyOverflow = vi.fn()
+    const onOutboundReplyTooLarge = vi.fn()
     const dispatcher = new RpcDispatcher({ runtime: stubRuntime(), methods: [] })
 
     await dispatcher.dispatchStreaming(
       { ...REQUEST, method: 'x'.repeat(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) },
       vi.fn(),
-      { onOutboundReplyOverflow }
+      { onOutboundReplyOverflow: vi.fn(), onOutboundReplyTooLarge }
     )
 
-    expect(onOutboundReplyOverflow).toHaveBeenCalledExactlyOnceWith({ method: 'unknown' })
+    expect(onOutboundReplyTooLarge).toHaveBeenCalledExactlyOnceWith({
+      method: 'unknown',
+      byteLength: expect.any(Number),
+      streaming: false
+    })
   })
 
-  it('rejects an oversized error response without emitting a replacement reply', async () => {
+  it('replaces an oversized error response with the same failure envelope', async () => {
     const replies: string[] = []
     const onOutboundReplyOverflow = vi.fn()
     const dispatcher = new RpcDispatcher({
@@ -106,13 +127,40 @@ describe('RpcDispatcher outbound reply limit', () => {
       onOutboundReplyOverflow
     })
 
+    expect(replies).toHaveLength(1)
+    expect(JSON.parse(replies[0]!)).toMatchObject({
+      ok: false,
+      error: { code: 'response_too_large' }
+    })
+    expect(onOutboundReplyOverflow).not.toHaveBeenCalled()
+  })
+
+  it('closes the socket when the replacement envelope itself cannot fit', async () => {
+    const replies: string[] = []
+    const onOutboundReplyOverflow = vi.fn()
+    const onOutboundReplyTooLarge = vi.fn()
+    const dispatcher = new RpcDispatcher({
+      runtime: stubRuntime(),
+      methods: [defineMethod({ name: REQUEST.method, params: null, handler: async () => 'small' })]
+    })
+
+    await dispatcher.dispatchStreaming(
+      { ...REQUEST, id: 'x'.repeat(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) },
+      (reply) => replies.push(reply),
+      { onOutboundReplyOverflow, onOutboundReplyTooLarge }
+    )
+
     expect(replies).toEqual([])
+    expect(onOutboundReplyTooLarge).not.toHaveBeenCalled()
     expect(onOutboundReplyOverflow).toHaveBeenCalledOnce()
   })
 
+  // Why: a subscription handler resolves through registerSubscriptionCleanup, not the abort
+  // signal, so failing the request in place would leak its runtime listener.
   it('closes a synchronous stream once and suppresses later emits after overflow', async () => {
     const replies: string[] = []
     const onOutboundReplyOverflow = vi.fn()
+    const onOutboundReplyTooLarge = vi.fn()
     const dispatcher = new RpcDispatcher({
       runtime: stubRuntime(),
       methods: [
@@ -128,11 +176,17 @@ describe('RpcDispatcher outbound reply limit', () => {
     })
 
     await dispatcher.dispatchStreaming(REQUEST, (reply) => replies.push(reply), {
-      onOutboundReplyOverflow
+      onOutboundReplyOverflow,
+      onOutboundReplyTooLarge
     })
 
     expect(replies).toEqual([])
-    expect(onOutboundReplyOverflow).toHaveBeenCalledOnce()
+    expect(onOutboundReplyTooLarge).not.toHaveBeenCalled()
+    expect(onOutboundReplyOverflow).toHaveBeenCalledExactlyOnceWith({
+      method: REQUEST.method,
+      byteLength: expect.any(Number),
+      streaming: true
+    })
   })
 
   it('does not throw or repeat cleanup for late stream emits after overflow', async () => {
@@ -227,7 +281,7 @@ describe('RpcDispatcher outbound reply limit', () => {
 
   it('measures UTF-8 bytes, not string length', async () => {
     const replies: string[] = []
-    const onOutboundReplyOverflow = vi.fn()
+    const onOutboundReplyTooLarge = vi.fn()
     // 3 UTF-8 bytes each, so `.length` stays far below the limit the byte count blows past.
     const result = '€'.repeat(2 * 1024 * 1024)
     const dispatcher = new RpcDispatcher({
@@ -237,11 +291,16 @@ describe('RpcDispatcher outbound reply limit', () => {
 
     expect(result.length).toBeLessThan(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES)
     await dispatcher.dispatchStreaming(REQUEST, (reply) => replies.push(reply), {
-      onOutboundReplyOverflow
+      onOutboundReplyOverflow: vi.fn(),
+      onOutboundReplyTooLarge
     })
 
-    expect(replies).toEqual([])
-    expect(onOutboundReplyOverflow).toHaveBeenCalledOnce()
+    expect(replies).toHaveLength(1)
+    expect(JSON.parse(replies[0]!)).toMatchObject({
+      ok: false,
+      error: { code: 'response_too_large' }
+    })
+    expect(onOutboundReplyTooLarge).toHaveBeenCalledOnce()
   })
 
   it('agrees with the E2EE channel admission at the byte boundary', async () => {
@@ -267,10 +326,15 @@ describe('RpcDispatcher outbound reply limit', () => {
     await dispatcher(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES + 1).dispatchStreaming(
       REQUEST,
       (reply) => replies.push(reply),
-      { onOutboundReplyOverflow: () => rejected.push('overflow') }
+      {
+        onOutboundReplyOverflow: vi.fn(),
+        onOutboundReplyTooLarge: () => rejected.push('too_large')
+      }
     )
 
     expect(isMobileE2EETextPayloadWithinLimit(replies[0]!)).toBe(true)
+    // The replacement envelope must itself pass the same channel admission.
+    expect(isMobileE2EETextPayloadWithinLimit(replies[1]!)).toBe(true)
     expect(rejected).toHaveLength(1)
     expect(
       isMobileE2EETextPayloadWithinLimit(

--- a/src/main/runtime/rpc/dispatcher-stream-options.ts
+++ b/src/main/runtime/rpc/dispatcher-stream-options.ts
@@ -1,6 +1,7 @@
 import type { RuntimeCapability } from '../../../shared/protocol-version'
 import type { TerminalStreamFrame } from '../../../shared/terminal-stream-protocol'
 import type { PairingRpcContext } from './core'
+import type { OversizedReplyReport } from './oversized-reply-report'
 
 export type RpcDispatchStreamingOptions = {
   connectionId?: string
@@ -9,7 +10,10 @@ export type RpcDispatchStreamingOptions = {
   pairedDeviceId?: string
   clientKind?: 'mobile' | 'runtime'
   clientCapabilities?: readonly RuntimeCapability[]
-  onOutboundReplyOverflow?: (context: { method: string }) => void
+  /** The reply cannot be replaced in place; the caller is expected to kill the socket. */
+  onOutboundReplyOverflow?: (report: OversizedReplyReport) => void
+  /** The reply was replaced by a response_too_large envelope; the socket stays up. */
+  onOutboundReplyTooLarge?: (report: OversizedReplyReport) => void
   // Why: socket-terminal conditions only — keying this off signal.aborted would silently
   // swallow the reply for any future per-request cancel and hang the caller.
   shouldSuppressReplies?: () => boolean

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -10,7 +10,6 @@ import {
 } from './core'
 
 import type { FeatureInteractionId } from '../../../shared/feature-interactions'
-import { REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES } from '../../../shared/remote-runtime-capacity-limits'
 import { errorResponse, successResponse } from './errors'
 import { ALL_RPC_METHODS } from './methods'
 import { emulatorProbe, emulatorProbeError } from '../../emulator/emulator-probe'
@@ -26,6 +25,7 @@ import { recordRuntimeFeatureInteraction } from './runtime-feature-interaction'
 import { OrchestrationLegacyCompatibility } from './orchestration-legacy-compatibility'
 import type { RpcDispatchStreamingOptions } from './dispatcher-stream-options'
 import { invalidArgumentResponse, mapDispatcherError } from './dispatcher-error-response'
+import { createBoundedReplyChannel } from './outbound-reply-admission'
 
 export type DispatcherOptions = { runtime: OrcaRuntimeService; methods?: readonly RpcAnyMethod[] }
 
@@ -140,32 +140,13 @@ export class RpcDispatcher {
     options?: RpcDispatchStreamingOptions
   ): Promise<void> {
     const meta = this.meta()
-    let outboundReplyOverflowed = false
-    const repliesSuppressed = (): boolean =>
-      outboundReplyOverflowed || options?.shouldSuppressReplies?.() === true
-    const replyResponse = (response: RpcResponse): void => {
-      if (repliesSuppressed()) {
-        return
-      }
-      const serialized = JSON.stringify(response)
-      // Why: same constant and UTF-8 measure as the channel's size admission
-      // (mobile-e2ee-outbound-admission.ts), so the two size checks cannot disagree. This is a
-      // backstop — producers cap themselves — so it favours a fast admit over a bounded reject.
-      if (Buffer.byteLength(serialized, 'utf8') > REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) {
-        if (!options?.onOutboundReplyOverflow) {
-          throw new Error(
-            `Outbound RPC reply exceeds ${REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES} bytes`
-          )
-        }
-        outboundReplyOverflowed = true
-        // Why: an unregistered method name is client-supplied; keep it out of logs and telemetry.
-        options.onOutboundReplyOverflow({
-          method: this.registry.get(request.method) ? request.method : 'unknown'
-        })
-        return
-      }
-      reply(serialized)
-    }
+    const { replyResponse, repliesSuppressed } = createBoundedReplyChannel({
+      reply,
+      meta,
+      // Why: an unregistered method name is client-supplied; keep it out of logs and telemetry.
+      method: this.registry.get(request.method) ? request.method : 'unknown',
+      options
+    })
     const method = this.registry.get(request.method)
     if (!method) {
       replyResponse(

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -8,6 +8,7 @@ import { COMPUTER_ERROR_CODES } from '../../../shared/runtime-types'
 import { LINEAR_ERROR_CODES } from '../../../shared/linear-agent-access'
 import { AGENT_SESSION_RPC_ERROR_CODES } from '../../../shared/agent-session-host-authority'
 import { ARTIFACT_SHARING_DISABLED_CODE } from '../../../shared/artifact-sharing-gate'
+import { GIT_DIFF_TOO_LARGE_CODE } from '../../../shared/git-diff-transport-budget'
 
 export function successResponse(id: string, meta: RpcEnvelopeMeta, result: unknown): RpcSuccess {
   return {
@@ -98,6 +99,7 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'stale_delivery',
   'waiter_exists',
   'invalid_argument',
+  GIT_DIFF_TOO_LARGE_CODE,
   ARTIFACT_SHARING_DISABLED_CODE
 ])
 

--- a/src/main/runtime/rpc/methods/git-diff-transport-budget.test.ts
+++ b/src/main/runtime/rpc/methods/git-diff-transport-budget.test.ts
@@ -1,0 +1,131 @@
+// Why: git.diff, git.branchDiff and git.commitDiff share one buildDiffResult/bufferToBlob pair, so
+// capping only the first would leave the other two able to kill a remote socket.
+import { describe, expect, it, vi } from 'vitest'
+import {
+  GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES,
+  assertGitDiffWithinTransportBudget
+} from '../../../../shared/git-diff-transport-budget'
+import type { GitDiffResult } from '../../../../shared/types'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcRequest, RpcResponse } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { GIT_METHODS } from './git'
+
+const OVERSIZED_BASE64 = 'A'.repeat(GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES + 1024)
+
+const OVERSIZED_DIFF: GitDiffResult = {
+  kind: 'binary',
+  originalContent: '',
+  modifiedContent: OVERSIZED_BASE64,
+  isImage: true,
+  mimeType: 'image/png',
+  originalIsBinary: false,
+  modifiedIsBinary: true
+}
+
+const CASES: readonly { method: string; runtimeMethod: string; params: Record<string, unknown> }[] =
+  [
+    {
+      method: 'git.diff',
+      runtimeMethod: 'getRuntimeGitDiff',
+      params: { worktree: 'id:wt-1', filePath: 'assets/logo.png', staged: false }
+    },
+    {
+      method: 'git.branchDiff',
+      runtimeMethod: 'getRuntimeGitBranchDiff',
+      params: {
+        worktree: 'id:wt-1',
+        compare: { mergeBase: 'a'.repeat(40), headOid: 'b'.repeat(40) },
+        filePath: 'assets/logo.png'
+      }
+    },
+    {
+      method: 'git.commitDiff',
+      runtimeMethod: 'getRuntimeGitCommitDiff',
+      params: { worktree: 'id:wt-1', commitOid: 'c'.repeat(40), filePath: 'assets/logo.png' }
+    }
+  ]
+
+/** Stands in for orca-runtime-git.ts, which enforces the budget it is handed as its last argument. */
+function stubRuntime(runtimeMethod: string): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'test-runtime',
+    [runtimeMethod]: vi.fn(async (...args: unknown[]) => {
+      const maxContentBytes = args.at(-1)
+      return assertGitDiffWithinTransportBudget(
+        OVERSIZED_DIFF,
+        typeof maxContentBytes === 'number' ? maxContentBytes : undefined
+      )
+    })
+  } as unknown as OrcaRuntimeService
+}
+
+function budgetArgument(runtime: OrcaRuntimeService, runtimeMethod: string): unknown {
+  const spy = (runtime as unknown as Record<string, ReturnType<typeof vi.fn>>)[runtimeMethod]!
+  return spy.mock.calls[0]!.at(-1)
+}
+
+function makeRequest(method: string, params: Record<string, unknown>): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+async function dispatchRemote(
+  runtime: OrcaRuntimeService,
+  method: string,
+  params: Record<string, unknown>,
+  clientKind: 'mobile' | 'runtime'
+): Promise<RpcResponse> {
+  const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+  const replies: string[] = []
+  await dispatcher.dispatchStreaming(makeRequest(method, params), (reply) => replies.push(reply), {
+    clientKind,
+    onOutboundReplyOverflow: vi.fn(),
+    onOutboundReplyTooLarge: vi.fn()
+  })
+  return JSON.parse(replies[0]!) as RpcResponse
+}
+
+describe('remote git diff transport budget', () => {
+  it.each(CASES)('caps $method for a mobile client', async ({ method, runtimeMethod, params }) => {
+    const runtime = stubRuntime(runtimeMethod)
+
+    const response = await dispatchRemote(runtime, method, params, 'mobile')
+
+    expect(budgetArgument(runtime, runtimeMethod)).toBe(GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES)
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'diff_too_large',
+        data: { maxBytes: GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES }
+      }
+    })
+  })
+
+  it.each(CASES)(
+    'caps $method for a remote desktop client',
+    async ({ method, runtimeMethod, params }) => {
+      const runtime = stubRuntime(runtimeMethod)
+
+      const response = await dispatchRemote(runtime, method, params, 'runtime')
+
+      expect(response).toMatchObject({ ok: false, error: { code: 'diff_too_large' } })
+    }
+  )
+
+  // Why: the in-process/Unix-socket context sets no clientKind, so desktop-local diffs keep full fidelity.
+  it.each(CASES)(
+    'leaves $method uncapped for a local caller',
+    async ({ method, runtimeMethod, params }) => {
+      const runtime = stubRuntime(runtimeMethod)
+      const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+      const response = await dispatcher.dispatch(makeRequest(method, params))
+
+      expect(budgetArgument(runtime, runtimeMethod)).toBeUndefined()
+      expect(response).toMatchObject({
+        ok: true,
+        result: { kind: 'binary', modifiedContent: OVERSIZED_BASE64 }
+      })
+    }
+  )
+})

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -179,7 +179,14 @@ describe('git RPC methods', () => {
       })
     )
 
-    expect(runtime.getRuntimeGitDiff).toHaveBeenCalledWith('id:wt-1', 'src/index.ts', false, true)
+    // No clientKind on the in-process dispatch path, so the diff stays uncapped.
+    expect(runtime.getRuntimeGitDiff).toHaveBeenCalledWith(
+      'id:wt-1',
+      'src/index.ts',
+      false,
+      true,
+      undefined
+    )
     expect(response).toMatchObject({
       ok: true,
       result: { kind: 'text', modifiedContent: 'hello' }

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this table is the runtime git RPC contract; splitting it would make method coverage harder to audit. */
 import { defineMethod, type RpcMethod } from '../core'
+import { GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES } from '../../../../shared/git-diff-transport-budget'
 import type { GlobalSettings } from '../../../../shared/types'
 import type { ResolvedSourceControlAiGenerationParams } from '../../../../shared/source-control-ai'
 import {
@@ -27,6 +28,12 @@ import {
   GitTargetedRemote,
   WorktreeSelector
 } from './git-params'
+
+// Why: clientKind is set only for WebSocket-transported requests, so desktop-local and
+// in-process callers keep uncapped full-fidelity diffs.
+function remoteDiffContentBudget(clientKind: 'mobile' | 'runtime' | undefined): number | undefined {
+  return clientKind ? GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES : undefined
+}
 
 type CommitMessageGenerationOverride = {
   commitMessageAi?: GlobalSettings['commitMessageAi']
@@ -164,12 +171,13 @@ export const GIT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'git.diff',
     params: GitDiff,
-    handler: async (params, { runtime }) =>
+    handler: async (params, { runtime, clientKind }) =>
       runtime.getRuntimeGitDiff(
         params.worktree,
         params.filePath,
         params.staged,
-        params.compareAgainstHead
+        params.compareAgainstHead,
+        remoteDiffContentBudget(clientKind)
       )
   }),
   defineMethod({
@@ -242,24 +250,29 @@ export const GIT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'git.branchDiff',
     params: GitBranchDiff,
-    handler: async (params, { runtime }) =>
+    handler: async (params, { runtime, clientKind }) =>
       runtime.getRuntimeGitBranchDiff(
         params.worktree,
         params.compare,
         params.filePath,
-        params.oldPath
+        params.oldPath,
+        remoteDiffContentBudget(clientKind)
       )
   }),
   defineMethod({
     name: 'git.commitDiff',
     params: GitCommitDiff,
-    handler: async (params, { runtime }) =>
-      runtime.getRuntimeGitCommitDiff(params.worktree, {
-        commitOid: params.commitOid,
-        parentOid: params.parentOid,
-        filePath: params.filePath,
-        oldPath: params.oldPath
-      })
+    handler: async (params, { runtime, clientKind }) =>
+      runtime.getRuntimeGitCommitDiff(
+        params.worktree,
+        {
+          commitOid: params.commitOid,
+          parentOid: params.parentOid,
+          filePath: params.filePath,
+          oldPath: params.oldPath
+        },
+        remoteDiffContentBudget(clientKind)
+      )
   }),
   defineMethod({
     name: 'git.commit',

--- a/src/main/runtime/rpc/outbound-reply-admission.ts
+++ b/src/main/runtime/rpc/outbound-reply-admission.ts
@@ -1,0 +1,94 @@
+import { REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES } from '../../../shared/remote-runtime-capacity-limits'
+import type { RpcEnvelopeMeta, RpcResponse } from './core'
+import type { RpcDispatchStreamingOptions } from './dispatcher-stream-options'
+import { errorResponse } from './errors'
+import {
+  RESPONSE_TOO_LARGE_CODE,
+  RESPONSE_TOO_LARGE_MESSAGE,
+  type OversizedReplyReport
+} from './oversized-reply-report'
+
+type OutboundReplyAdmission =
+  | { serialized: string; report?: undefined; replacement?: undefined }
+  /** No replacement means the reply cannot be failed in place; the socket has to go. */
+  | { serialized?: undefined; report: OversizedReplyReport; replacement?: string }
+
+export type BoundedReplyChannel = {
+  replyResponse: (response: RpcResponse) => void
+  repliesSuppressed: () => boolean
+}
+
+type BoundedReplyChannelInput = {
+  reply: (response: string) => void
+  meta: RpcEnvelopeMeta
+  /** Registry-validated, so a client-supplied name cannot reach logs or telemetry. */
+  method: string
+  options?: Pick<
+    RpcDispatchStreamingOptions,
+    'shouldSuppressReplies' | 'onOutboundReplyOverflow' | 'onOutboundReplyTooLarge'
+  >
+}
+
+function admitOutboundReply(
+  response: RpcResponse,
+  meta: RpcEnvelopeMeta,
+  method: string
+): OutboundReplyAdmission {
+  const serialized = JSON.stringify(response)
+  // Why: same constant and UTF-8 measure as the channel's size admission
+  // (mobile-e2ee-outbound-admission.ts), so the two size checks cannot disagree. This is a
+  // backstop — producers cap themselves — so it favours a fast admit over a bounded reject.
+  const byteLength = Buffer.byteLength(serialized, 'utf8')
+  if (byteLength <= REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) {
+    return { serialized }
+  }
+  const report = { method, byteLength, streaming: response.ok && response.streaming === true }
+  // Why: a mid-stream emit cannot be replaced by a terminal error. Subscription handlers resolve
+  // through registerSubscriptionCleanup and never read the abort signal, so failing the request
+  // would leak the runtime listener while the client resubscribes.
+  if (report.streaming) {
+    return { report }
+  }
+  const replacement = JSON.stringify(
+    errorResponse(response.id, meta, RESPONSE_TOO_LARGE_CODE, RESPONSE_TOO_LARGE_MESSAGE, {
+      byteLength,
+      maxBytes: REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+    })
+  )
+  // A pathological request id can push even the replacement over the limit.
+  return Buffer.byteLength(replacement, 'utf8') <= REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+    ? { report, replacement }
+    : { report }
+}
+
+/** One dispatch's outbound replies: size admission plus the latch that silences what follows. */
+export function createBoundedReplyChannel(input: BoundedReplyChannelInput): BoundedReplyChannel {
+  const { reply, meta, method, options } = input
+  let overflowed = false
+  const repliesSuppressed = (): boolean => overflowed || options?.shouldSuppressReplies?.() === true
+  return {
+    repliesSuppressed,
+    replyResponse: (response) => {
+      if (repliesSuppressed()) {
+        return
+      }
+      const admission = admitOutboundReply(response, meta, method)
+      if (admission.serialized !== undefined) {
+        reply(admission.serialized)
+        return
+      }
+      if (!admission.replacement && !options?.onOutboundReplyOverflow) {
+        throw new Error(
+          `Outbound RPC reply exceeds ${REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES} bytes`
+        )
+      }
+      overflowed = true
+      if (admission.replacement) {
+        options?.onOutboundReplyTooLarge?.(admission.report)
+        reply(admission.replacement)
+        return
+      }
+      options?.onOutboundReplyOverflow?.(admission.report)
+    }
+  }
+}

--- a/src/main/runtime/rpc/oversized-reply-report.test.ts
+++ b/src/main/runtime/rpc/oversized-reply-report.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES } from '../../../shared/remote-runtime-capacity-limits'
+import { oversizedReplySizeBucket } from './oversized-reply-report'
+
+const MIB = 1024 * 1024
+
+describe('oversizedReplySizeBucket', () => {
+  it.each([
+    [REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES + 1, '4_8mb'],
+    [8 * MIB, '4_8mb'],
+    [8 * MIB + 1, '8_16mb'],
+    [16 * MIB, '8_16mb'],
+    [16 * MIB + 1, '16_32mb'],
+    [32 * MIB, '16_32mb'],
+    [32 * MIB + 1, '32_64mb'],
+    [64 * MIB, '32_64mb'],
+    [64 * MIB + 1, '64mb_plus']
+  ])('buckets %i bytes as %s', (byteLength, bucket) => {
+    expect(oversizedReplySizeBucket(byteLength)).toBe(bucket)
+  })
+})

--- a/src/main/runtime/rpc/oversized-reply-report.ts
+++ b/src/main/runtime/rpc/oversized-reply-report.ts
@@ -1,0 +1,29 @@
+export const RESPONSE_TOO_LARGE_CODE = 'response_too_large'
+// Why: no path, method or user content — this string reaches every paired client verbatim.
+export const RESPONSE_TOO_LARGE_MESSAGE =
+  'The response is too large to send over a remote connection.'
+
+export type OversizedReplyReport = {
+  /** Registry-validated method name, or 'unknown' — never the raw client-supplied string. */
+  method: string
+  byteLength: number
+  streaming: boolean
+}
+
+export type OversizedReplySizeBucket = '4_8mb' | '8_16mb' | '16_32mb' | '32_64mb' | '64mb_plus'
+
+const MIB = 1024 * 1024
+
+// Why: buckets, not raw byte counts, cross the telemetry boundary — a payload size is user data.
+export function oversizedReplySizeBucket(byteLength: number): OversizedReplySizeBucket {
+  if (byteLength <= 8 * MIB) {
+    return '4_8mb'
+  }
+  if (byteLength <= 16 * MIB) {
+    return '8_16mb'
+  }
+  if (byteLength <= 32 * MIB) {
+    return '16_32mb'
+  }
+  return byteLength <= 64 * MIB ? '32_64mb' : '64mb_plus'
+}

--- a/src/main/runtime/runtime-rpc-outbound-overflow.test.ts
+++ b/src/main/runtime/runtime-rpc-outbound-overflow.test.ts
@@ -49,7 +49,11 @@ describe('runtime RPC outbound overflow', () => {
       dispatchStreaming: vi.fn(async (_request, _reply, options) => {
         dispatchSignal = options?.signal
         expect(dispatchSignal?.aborted).toBe(false)
-        options?.onOutboundReplyOverflow?.({ method: 'status.get' })
+        options?.onOutboundReplyOverflow?.({
+          method: 'status.get',
+          byteLength: 9 * 1024 * 1024,
+          streaming: true
+        })
         expect(dispatchSignal?.aborted).toBe(true)
       })
     }
@@ -75,7 +79,78 @@ describe('runtime RPC outbound overflow', () => {
       expect(trackMock.mock.calls.filter(([event]) => event === 'remote_reply_overflow')).toEqual([
         [
           'remote_reply_overflow',
-          { method: 'status.get', transport: 'direct', client_kind: 'runtime' }
+          {
+            method: 'status.get',
+            transport: 'direct',
+            client_kind: 'runtime',
+            outcome: 'socket_closed',
+            size_bucket: '8_16mb'
+          }
+        ]
+      ])
+    } finally {
+      await server.stop()
+      await rm(userDataPath, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a replaced one-shot reply as request_failed and leaves the socket up', async () => {
+    trackMock.mockClear()
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-too-large-'))
+    const runtime = { getRuntimeId: () => 'test-runtime' } as OrcaRuntimeService
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath, enableWebSocket: false })
+    const registry = new DeviceRegistry(userDataPath)
+    const device = registry.addDevice('mobile-test', 'mobile')
+    const ws = new FakeWebSocket()
+    const closeForOutboundReplyOverflow = vi.fn()
+    server['deviceRegistry'] = registry
+    server['mobileSocketWiring'] = {
+      closeForOutboundReplyOverflow,
+      getConnectionId: () => 'connection-1'
+    } as unknown as NonNullable<(typeof server)['mobileSocketWiring']>
+    let dispatchSignal: AbortSignal | undefined
+    ;(
+      server as unknown as {
+        dispatcher: {
+          dispatchStreaming: (
+            request: unknown,
+            reply: (response: string) => void,
+            options?: RpcDispatchStreamingOptions
+          ) => Promise<void>
+        }
+      }
+    ).dispatcher = {
+      dispatchStreaming: vi.fn(async (_request, _reply, options) => {
+        dispatchSignal = options?.signal
+        options?.onOutboundReplyTooLarge?.({
+          method: 'git.diff',
+          byteLength: 5 * 1024 * 1024,
+          streaming: false
+        })
+      })
+    }
+
+    try {
+      await server['handleWebSocketMessage'](
+        JSON.stringify({ id: 'request-1', method: 'git.diff', deviceToken: device.token }),
+        vi.fn(),
+        vi.fn(),
+        undefined,
+        ws as unknown as WebSocket
+      )
+
+      expect(dispatchSignal?.aborted).toBe(false)
+      expect(closeForOutboundReplyOverflow).not.toHaveBeenCalled()
+      expect(trackMock.mock.calls.filter(([event]) => event === 'remote_reply_overflow')).toEqual([
+        [
+          'remote_reply_overflow',
+          {
+            method: 'git.diff',
+            transport: 'direct',
+            client_kind: 'mobile',
+            outcome: 'request_failed',
+            size_bucket: '4_8mb'
+          }
         ]
       ])
     } finally {

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -13,6 +13,7 @@ import { OrchestrationDb } from './orchestration/db'
 import * as runtimeMetadataModule from './runtime-metadata'
 import { readRuntimeMetadata, writeRuntimeMetadata } from './runtime-metadata'
 import { createRuntimeTransportMetadata, OrcaRuntimeRpcServer } from './runtime-rpc'
+import { GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES } from '../../shared/git-diff-transport-budget'
 import { parsePairingCode } from '../../shared/pairing'
 import { subscribeRemoteRuntimeRequest } from '../../shared/remote-runtime-client'
 import {
@@ -3342,7 +3343,14 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(abortRuntimeGitRebase).toHaveBeenCalledWith('id:wt-1')
     expect(bulkUnstageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['c.ts'])
     expect(openMobileDiff).toHaveBeenCalledWith('id:wt-1', 'docs/readme.md', true)
-    expect(getRuntimeGitDiff).toHaveBeenCalledWith('id:wt-1', 'docs/readme.md', false, undefined)
+    // A mobile WebSocket request carries clientKind, so the diff is capped at the transport budget.
+    expect(getRuntimeGitDiff).toHaveBeenCalledWith(
+      'id:wt-1',
+      'docs/readme.md',
+      false,
+      undefined,
+      GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+    )
     expect(browserTabCreate).toHaveBeenCalledWith({ worktree: 'id:wt-1', url: 'about:blank' })
     expect(browserSetViewport).toHaveBeenCalledWith({
       worktree: 'id:wt-1',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -53,6 +53,7 @@ import {
   type TerminalStreamFrame
 } from '../../shared/terminal-stream-protocol'
 import { track } from '../telemetry/client'
+import { oversizedReplySizeBucket, type OversizedReplyReport } from './rpc/oversized-reply-report'
 
 const DEFAULT_WS_PORT = 6768
 
@@ -1709,6 +1710,7 @@ export class OrcaRuntimeRpcServer {
               )
           }
         : undefined
+    const replyTransport = authenticatedSocket?.transport.transport === 'relay' ? 'relay' : 'direct'
     try {
       await this.dispatcher.dispatchStreaming(request, replyForRequest, {
         connectionId,
@@ -1719,18 +1721,16 @@ export class OrcaRuntimeRpcServer {
         clientCapabilities: authenticatedSocket?.clientCapabilities,
         ...(ws
           ? {
-              onOutboundReplyOverflow: ({ method }) => {
+              onOutboundReplyOverflow: (report) => {
                 console.warn(
-                  `[runtime-rpc] outbound reply exceeded the remote JSON limit for ${method}; closing socket`
+                  `[runtime-rpc] outbound reply exceeded the remote JSON limit for ${report.method}; closing socket`
                 )
-                track('remote_reply_overflow', {
-                  method,
-                  transport:
-                    authenticatedSocket?.transport.transport === 'relay' ? 'relay' : 'direct',
-                  client_kind: device.scope
-                })
+                this.reportOversizedReply(report, 'socket_closed', device.scope, replyTransport)
                 this.abortWebSocketDispatches(ws)
                 this.mobileSocketWiring?.closeForOutboundReplyOverflow(ws)
+              },
+              onOutboundReplyTooLarge: (report) => {
+                this.reportOversizedReply(report, 'request_failed', device.scope, replyTransport)
               },
               // Why: the only abort sources are socket close/error and overflow, so "not OPEN" is
               // the condition we actually mean; see registerWebSocketDispatchAbort.
@@ -1747,6 +1747,23 @@ export class OrcaRuntimeRpcServer {
       abortRegistration?.dispose()
       this.releaseLongPoll(longPoll)
     }
+  }
+
+  // Why: one event for both outcomes so the ratio of failed requests to killed sessions is
+  // readable without joining two series.
+  private reportOversizedReply(
+    report: OversizedReplyReport,
+    outcome: 'request_failed' | 'socket_closed',
+    clientKind: 'mobile' | 'runtime',
+    transport: 'relay' | 'direct'
+  ): void {
+    track('remote_reply_overflow', {
+      method: report.method,
+      transport,
+      client_kind: clientKind,
+      outcome,
+      size_bucket: oversizedReplySizeBucket(report.byteLength)
+    })
   }
 
   private buildError(id: string, code: string, message: string): RpcResponse {

--- a/src/shared/git-diff-envelope-ceiling.test.ts
+++ b/src/shared/git-diff-envelope-ceiling.test.ts
@@ -1,0 +1,77 @@
+// Why: the invariant the whole cap rests on — a diff that exactly fills the content budget must
+// still serialize inside the outbound JSON limit once wrapped in an RPC reply. A base64-only
+// version of this passes trivially; the newline and control-char fixtures are the load-bearing ones.
+import { describe, expect, it } from 'vitest'
+import type { GitDiffResult } from './types'
+import { GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES } from './git-diff-transport-budget'
+import {
+  REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES,
+  REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES,
+  REMOTE_RUNTIME_OUTBOUND_ENVELOPE_RESERVE_BYTES
+} from './remote-runtime-capacity-limits'
+
+const BUDGET = GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+
+function sideOfJsonBytes(unit: string, jsonBytes: number): string {
+  const unitCost = Buffer.byteLength(JSON.stringify(unit), 'utf8') - 2
+  const count = Math.floor((jsonBytes - 2) / unitCost)
+  return unit.repeat(count) + 'x'.repeat(jsonBytes - 2 - count * unitCost)
+}
+
+function replyBytes(result: GitDiffResult): number {
+  return Buffer.byteLength(
+    JSON.stringify({
+      id: 'req_0123456789abcdef',
+      ok: true,
+      result,
+      _meta: { runtimeId: '00000000-0000-4000-8000-000000000000' }
+    }),
+    'utf8'
+  )
+}
+
+describe('git diff envelope ceiling', () => {
+  it.each([
+    ['ascii', 'a'],
+    ['newline-dense text', '\n'],
+    ['control-char text (0x01)', '\u0001'],
+    ['base64', 'QUJD'],
+    ['cjk', '漢'],
+    ['lone surrogate', '\ud800']
+  ])('keeps a %s diff at the budget inside the outbound JSON limit', (_name, unit) => {
+    const result: GitDiffResult = {
+      kind: 'binary',
+      originalContent: sideOfJsonBytes(unit, Math.floor(BUDGET / 2)),
+      modifiedContent: sideOfJsonBytes(unit, BUDGET - Math.floor(BUDGET / 2)),
+      isImage: true,
+      mimeType: 'image/png',
+      originalIsBinary: true,
+      modifiedIsBinary: true
+    }
+
+    expect(replyBytes(result)).toBeLessThanOrEqual(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES)
+  })
+
+  it('derives the budget from the outbound JSON limit', () => {
+    expect(BUDGET).toBe(REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES)
+    expect(BUDGET).toBeLessThan(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES)
+  })
+
+  // Why: every reserved byte is content that transferred before this cap existed, so the reserve
+  // must stay close to the real envelope overhead. Fails if someone inflates it "just to be safe".
+  it('keeps the envelope reserve within 64x the real overhead it covers', () => {
+    const atBudget: GitDiffResult = {
+      kind: 'binary',
+      originalContent: sideOfJsonBytes('a', Math.floor(BUDGET / 2)),
+      modifiedContent: sideOfJsonBytes('a', BUDGET - Math.floor(BUDGET / 2)),
+      isImage: true,
+      mimeType: 'image/png',
+      originalIsBinary: true,
+      modifiedIsBinary: true
+    }
+    const overhead = replyBytes(atBudget) - BUDGET
+
+    expect(overhead).toBeLessThan(REMOTE_RUNTIME_OUTBOUND_ENVELOPE_RESERVE_BYTES)
+    expect(REMOTE_RUNTIME_OUTBOUND_ENVELOPE_RESERVE_BYTES).toBeLessThan(overhead * 64)
+  })
+})

--- a/src/shared/git-diff-transport-budget.test.ts
+++ b/src/shared/git-diff-transport-budget.test.ts
@@ -1,0 +1,123 @@
+// Why: a raw-byte cap is not enough. JSON escaping expands a control character sixfold and
+// binary-buffer.ts sniffs only for NUL, so control-dense content is classified as text; these
+// fixtures pin every branch of the measurement to native JSON.stringify.
+import { describe, expect, it } from 'vitest'
+import type { GitDiffResult } from './types'
+import {
+  GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES,
+  assertGitDiffWithinTransportBudget,
+  gitDiffTransportContentBytes
+} from './git-diff-transport-budget'
+
+const BUDGET = GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES
+
+/** Native reference: the bytes the two content sides occupy once JSON-encoded. */
+function referenceContentBytes(result: GitDiffResult): number {
+  return (
+    Buffer.byteLength(JSON.stringify(result.originalContent), 'utf8') +
+    Buffer.byteLength(JSON.stringify(result.modifiedContent), 'utf8')
+  )
+}
+
+/** Content whose JSON encoding, quotes included, is exactly `jsonBytes`. */
+function sideOfJsonBytes(unit: string, jsonBytes: number): string {
+  const unitCost = Buffer.byteLength(JSON.stringify(unit), 'utf8') - 2
+  const count = Math.floor((jsonBytes - 2) / unitCost)
+  return unit.repeat(count) + 'x'.repeat(jsonBytes - 2 - count * unitCost)
+}
+
+function textDiff(modifiedContent: string): GitDiffResult {
+  return {
+    kind: 'text',
+    originalContent: '',
+    modifiedContent,
+    originalIsBinary: false,
+    modifiedIsBinary: false
+  }
+}
+
+function budgetError(result: GitDiffResult): { code?: string; data?: unknown } {
+  try {
+    assertGitDiffWithinTransportBudget(result, BUDGET)
+  } catch (error) {
+    return error as { code?: string; data?: unknown }
+  }
+  throw new Error('expected the transport budget assertion to throw')
+}
+
+const UNITS: readonly { name: string; unit: string; expansion: number }[] = [
+  { name: 'ascii', unit: 'a', expansion: 1 },
+  { name: 'newline-dense text', unit: '\n', expansion: 2 },
+  { name: 'control-char text (0x01)', unit: '\u0001', expansion: 6 },
+  { name: 'base64', unit: 'QUJD', expansion: 1 },
+  { name: 'cjk', unit: '漢', expansion: 1 },
+  { name: 'lone surrogate', unit: '\ud800', expansion: 2 }
+]
+
+describe('gitDiffTransportContentBytes', () => {
+  it.each(UNITS)('pins the JSON expansion assumed for $name', ({ unit, expansion }) => {
+    const jsonBytes = Buffer.byteLength(JSON.stringify(unit), 'utf8') - 2
+    expect(jsonBytes / Buffer.byteLength(unit, 'utf8')).toBe(expansion)
+  })
+
+  it.each(UNITS)('admits $name exactly at the budget', ({ unit }) => {
+    const result = textDiff(sideOfJsonBytes(unit, BUDGET - 2))
+
+    expect(referenceContentBytes(result)).toBe(BUDGET)
+    expect(gitDiffTransportContentBytes(result, BUDGET)).toBe(BUDGET)
+    expect(assertGitDiffWithinTransportBudget(result, BUDGET)).toBe(result)
+  })
+
+  it.each(UNITS)('rejects $name one byte above the budget', ({ unit }) => {
+    const result = textDiff(sideOfJsonBytes(unit, BUDGET - 1))
+
+    expect(referenceContentBytes(result)).toBe(BUDGET + 1)
+    expect(gitDiffTransportContentBytes(result, BUDGET)).toBeGreaterThan(BUDGET)
+    expect(budgetError(result).code).toBe('diff_too_large')
+  })
+
+  it.each(UNITS)('agrees with native JSON.stringify across the boundary for $name', ({ unit }) => {
+    for (const jsonBytes of [BUDGET - 3, BUDGET - 2, BUDGET - 1]) {
+      const result = textDiff(sideOfJsonBytes(unit, jsonBytes))
+      expect(gitDiffTransportContentBytes(result, BUDGET) <= BUDGET).toBe(
+        referenceContentBytes(result) <= BUDGET
+      )
+    }
+  })
+
+  // Why: this is the case a raw-byte budget silently lets through into the 1013 close.
+  it('rejects control-dense content whose raw bytes are far under the budget', () => {
+    const result = textDiff(sideOfJsonBytes('\u0001', BUDGET - 1))
+
+    expect(Buffer.byteLength(result.modifiedContent, 'utf8')).toBeLessThan(BUDGET / 5)
+    expect(budgetError(result).data).toEqual({ byteLength: BUDGET + 1, maxBytes: BUDGET })
+  })
+
+  it('splits the budget across both sides', () => {
+    const half = Math.floor(BUDGET / 2)
+    const overBudget: GitDiffResult = {
+      kind: 'binary',
+      originalContent: sideOfJsonBytes('Q', half),
+      modifiedContent: sideOfJsonBytes('Q', BUDGET - half + 1),
+      originalIsBinary: true,
+      modifiedIsBinary: true
+    }
+
+    expect(referenceContentBytes(overBudget)).toBe(BUDGET + 1)
+    expect(budgetError(overBudget).code).toBe('diff_too_large')
+  })
+
+  // The fast path returns the raw sum, which omits the quote bytes the exact scan counts.
+  it('admits small content without an escape-aware scan', () => {
+    const result = textDiff('hello')
+
+    expect(gitDiffTransportContentBytes(result, BUDGET)).toBe(5)
+    expect(referenceContentBytes(result)).toBe(9)
+  })
+
+  it('leaves local callers uncapped', () => {
+    const result = textDiff('x'.repeat(BUDGET + 1))
+
+    expect(assertGitDiffWithinTransportBudget(result, undefined)).toBe(result)
+  })
+})

--- a/src/shared/git-diff-transport-budget.ts
+++ b/src/shared/git-diff-transport-budget.ts
@@ -1,0 +1,64 @@
+import { jsonStringBytes } from './node-json-byte-measurement'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES } from './remote-runtime-capacity-limits'
+import type { GitDiffResult } from './types'
+
+export const GIT_DIFF_MAX_TRANSPORT_CONTENT_BYTES = REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES
+
+export const GIT_DIFF_TOO_LARGE_CODE = 'diff_too_large'
+export const GIT_DIFF_TOO_LARGE_MESSAGE = 'This diff is too large to open over a remote connection.'
+
+// Why: JSON escaping turns one control byte into six (\u00XX), and binary-buffer.ts sniffs only for
+// NUL in the first 8 KiB, so control-dense content is classified as text — a raw-byte cap would
+// admit it and the serialized reply would then blow the envelope.
+const MAX_JSON_ESCAPE_EXPANSION = 6
+const JSON_QUOTE_BYTES_PER_SIDE = 2
+
+/**
+ * Bytes the diff's content sides occupy once JSON-encoded. The value crosses `maxBytes` exactly
+ * when the encoded content does; it is only exact when the escape-aware scan runs.
+ */
+export function gitDiffTransportContentBytes(result: GitDiffResult, maxBytes: number): number {
+  // Why: the SSH provider casts a relay payload to GitDiffResult without validating it, so a
+  // skewed relay version can omit a side; treat a missing one as empty rather than throwing here.
+  const sides = [result.originalContent, result.modifiedContent].filter(
+    (side): side is string => typeof side === 'string'
+  )
+  let rawBytes = 0
+  for (const side of sides) {
+    rawBytes += Buffer.byteLength(side, 'utf8')
+  }
+  // Why: escaping never shrinks and never grows past 6x, so both bounds settle the verdict
+  // without walking multi-megabyte strings; only the band between them needs the exact count.
+  if (
+    rawBytes * MAX_JSON_ESCAPE_EXPANSION + sides.length * JSON_QUOTE_BYTES_PER_SIDE <= maxBytes ||
+    rawBytes > maxBytes
+  ) {
+    return rawBytes
+  }
+  let bytes = 0
+  for (const side of sides) {
+    bytes += jsonStringBytes(side, maxBytes - bytes)
+    if (bytes > maxBytes) {
+      return bytes
+    }
+  }
+  return bytes
+}
+
+/** `maxBytes === undefined` means uncapped: local and in-process callers keep full fidelity. */
+export function assertGitDiffWithinTransportBudget<T extends GitDiffResult>(
+  result: T,
+  maxBytes: number | undefined
+): T {
+  if (maxBytes === undefined) {
+    return result
+  }
+  const byteLength = gitDiffTransportContentBytes(result, maxBytes)
+  if (byteLength <= maxBytes) {
+    return result
+  }
+  throw Object.assign(new Error(GIT_DIFF_TOO_LARGE_MESSAGE), {
+    code: GIT_DIFF_TOO_LARGE_CODE,
+    data: { byteLength, maxBytes }
+  })
+}

--- a/src/shared/remote-runtime-capacity-limits.ts
+++ b/src/shared/remote-runtime-capacity-limits.ts
@@ -11,3 +11,12 @@ export const REMOTE_RUNTIME_MAX_PROCESS_PENDING_RPC_BYTES = REMOTE_RUNTIME_MAX_P
 export const REMOTE_RUNTIME_MAX_READY_WAITERS =
   REMOTE_RUNTIME_MAX_PENDING_REQUESTS + REMOTE_RUNTIME_MAX_SUBSCRIPTIONS
 export const REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES = 8 * 1024 * 1024
+// Why: headroom for everything an RPC reply wraps around its payload — request id, _meta.runtimeId,
+// result keys — so a producer that fills its budget still fits inside the outbound JSON limit.
+// Measured overhead is 181 B (text) to 243 B (binary with isImage/mimeType); the rest is margin.
+// It is deliberately not sized for a pathological client-supplied request id — inbound frames allow
+// up to 1 MiB, so no reserve could cover that and the dispatcher backstop owns it instead. Every
+// byte here is content that transferred before this cap existed, so keep it tight.
+export const REMOTE_RUNTIME_OUTBOUND_ENVELOPE_RESERVE_BYTES = 8 * 1024
+export const REMOTE_RUNTIME_MAX_OUTBOUND_CONTENT_BYTES =
+  REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES - REMOTE_RUNTIME_OUTBOUND_ENVELOPE_RESERVE_BYTES

--- a/src/shared/telemetry-events.test.ts
+++ b/src/shared/telemetry-events.test.ts
@@ -612,3 +612,39 @@ describe('exported enum schemas', () => {
     }
   })
 })
+
+describe('remote_reply_overflow schema', () => {
+  const payload = {
+    method: 'git.diff',
+    transport: 'direct',
+    client_kind: 'mobile',
+    outcome: 'request_failed',
+    size_bucket: '4_8mb'
+  }
+
+  it('round-trips both outcomes', () => {
+    for (const outcome of ['request_failed', 'socket_closed']) {
+      expect(eventSchemas.remote_reply_overflow.safeParse({ ...payload, outcome }).success).toBe(
+        true
+      )
+    }
+  })
+
+  it('rejects a raw byte count or any other extra key', () => {
+    expect(
+      eventSchemas.remote_reply_overflow.safeParse({ ...payload, byte_length: 4194305 }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.remote_reply_overflow.safeParse({ ...payload, file_path: '/tmp/a.png' }).success
+    ).toBe(false)
+  })
+
+  it('rejects an unknown outcome or bucket', () => {
+    expect(
+      eventSchemas.remote_reply_overflow.safeParse({ ...payload, outcome: 'ignored' }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.remote_reply_overflow.safeParse({ ...payload, size_bucket: '2_4mb' }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -393,11 +393,15 @@ const runtimeRpcStartFailedSchema = z
 // Why: the 1013 overflow close kills a remote user's whole session, and no emission site is
 // instrumented today — incidence is unmeasurable, so producer caps have no acceptance signal.
 // `method` is a developer-defined RPC identifier: closed set, no paths or user content.
+// `outcome` separates the recoverable per-request failure from the session-killing close, and
+// `size_bucket` is bucketed because a payload size is user data.
 const remoteReplyOverflowSchema = z
   .object({
     method: z.string().max(64),
     transport: z.enum(['relay', 'direct']),
-    client_kind: z.enum(['mobile', 'runtime'])
+    client_kind: z.enum(['mobile', 'runtime']),
+    outcome: z.enum(['request_failed', 'socket_closed']),
+    size_bucket: z.enum(['4_8mb', '8_16mb', '16_32mb', '32_64mb', '64mb_plus'])
   })
   .strict()
 


### PR DESCRIPTION
> Stacked on #13774. Review that first; this PR's diff is against its branch.

## The bug

A remote or mobile user who opens the diff of a large image loses **their whole WebSocket**, not just that request. `e2ee-channel.ts` closes with `1013` when a reply exceeds the 4 MiB outbound envelope, and two producers can exceed it on their own — no adversary required.

| Producer | Cap today | Worst case in one envelope |
|---|---|---|
| `git.diff` text | `MAX_RENDERED_DIFF_COMBINED_CHARACTERS` = 6M chars | ~6.3 MiB |
| `git.diff` previewable binary | `MAX_GIT_SHOW_BYTES` = 10 MiB per side | ~26.7 MiB (base64 both sides) |
| `files.readPreview` | `RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES` = 10 MiB | ~13.3 MiB |

The text cap is a *renderer* budget picked for render cost, and it sits **above** the transport limit. Contrast `files.read`, which caps at 512 KiB and returns `{content, truncated, byteLength}` — `git.diff` had no equivalent and no mobile payload diet.

## The fix

**Cap the producers.** The budget is applied in `orca-runtime-git.ts`, which is downstream of the dedupe and of *both* the SSH-provider and local branches — so a payload forwarded by an old relay is covered by the same check and `src/relay/` needs no change. Local and in-process callers pass no budget and keep full fidelity; desktop-local diffs are untouched.

**Measurement is escape-aware, and that is the whole difficulty.** A raw `Buffer.byteLength` budget is wrong twice over:
- JSON expands one control byte into six (`\u00XX`), so worst-case expansion is 6x, not the 2x an earlier draft assumed.
- `binary-buffer.ts` sniffs **only for NUL** in the first 8 KiB, so a NUL-free file of `0x01`–`0x1f` bytes is classified as **text**, passes a raw budget, and blows the envelope — the exact `1013` this PR exists to prevent.

A three-branch fast path keeps normal diffs at two native `byteLength` calls (`raw * 6 <= budget` → admit, `raw > budget` → reject) and runs the exact escape-aware scan only in the ambiguous band.

**Contain what is left.** An over-budget reply now fails that request with a `response_too_large` envelope and leaves the socket up.

This deliberately does **not** apply to streaming emits. `accounts.subscribe`, `notifications.subscribe`, `runtime.clientEvents.subscribe` and `session.tabs.subscribe*` never destructure their `signal`; their handler promise resolves only via `registerSubscriptionCleanup`. Failing them in place would leave `dispatchStreaming` unresolved, skip the `finally`, and leak the runtime listener while the client resubscribes. Oversized streaming emits keep the socket close, which *does* clean up. `git.diff` and `files.readPreview` are both one-shot, so the motivating bug is fully covered.

## Wire compatibility

**No success-path wire change.** `GitDiffResult` is untouched — no third `kind`, no new optional field, nothing changed about what the host publishes on success. That is the point of choosing an error envelope over a blanked success payload, and it removes the Rule 3 surface entirely.

`diff_too_large` joins `STRUCTURED_RUNTIME_PASSTHROUGH_CODES`, so it arrives as `{code, message, data}` on the existing failure shape. Verified it reaches an already-correct arm in every consumer:

| Consumer | Behavior |
|---|---|
| `mobile-diff-review-loaders.ts:136` | throws `response.error.message` → existing review error state |
| `mobile-file-tab-doc.ts:38` | throws `response.error.message` → existing error doc |
| Desktop remote (`remote-runtime-client.ts`) | rejects into the diff-load error UI already used for timeouts |
| Old client / new host | sees an error for one request instead of a dropped connection |
| New client / old host | nothing to negotiate; unchanged behavior |

A blanked *success* payload was considered and rejected: `mobile-diff-review-rpc.ts:210` reconstructs from `{kind, originalContent, modifiedContent}` and drops `largeDiffRenderLimit`, so it would render a **silently empty diff**; and a blanked `kind:'binary'` renders "Text diff is unavailable for this file", a false statement about a PNG.

## Telemetry

Extends #13774's `remote_reply_overflow` with `outcome` (`request_failed` | `socket_closed`) and `size_bucket` rather than adding a second overlapping event, so socket kills and per-request failures are directly comparable. No paths or user content; the method name is registry-validated.

## Accepted regression

Remote image previews between ~3.096 MB and ~3.146 MB now return `file_too_large`. They only *intermittently* worked before — above ~3.0 MB they killed the socket — so this trades intermittent connection loss for a consistent, explained error. Flagging it explicitly rather than burying it.

## Testing

- **10014 passed** across `src/main/runtime` + `src/shared` + `src/main/git`.
- Each of the six budget-enforcement sites is **independently mutation-killed** — verified by neutering one `assertGitDiffWithinTransportBudget` call at a time and confirming a distinct test fails each time. An earlier revision passed its whole suite with five of six sites neutered; that gap is closed.
- Envelope-ceiling invariant tested on newline-dense, control-char, CJK and lone-surrogate **text** fixtures, not just base64 — a base64-only version of that test passes trivially and proves nothing.
- SSH-provider path covered with an unclamped forwarded payload; local/in-process asserted **uncapped**.
- `tsc` clean for node, web and cli; `oxlint` and `oxfmt` clean.
- **Mobile suite verified**: 3410 passed / 434 files, `tsc --noEmit` clean. `mobile/` is a separate pnpm workspace whose deps were simply not installed locally; once installed the `diff_too_large` and capped-preview cases run green.

## Out of scope

- **Binary-channel routing for large diffs.** Costed and rejected: the shared control connection has no binary handling, 13.3 MiB exceeds the 8 MiB frame limit so chunking and flow control become mandatory, a new opcode needs capability negotiation, and you would still need this PR's cap for every non-advertising client. A chunked `git.diffBinaryChunk` RPC is the right shape if large binary diffs are ever wanted, and needs no negotiation — this PR is a prerequisite either way.
- **Lowering `MAX_RENDERED_DIFF_COMBINED_CHARACTERS`.** Tempting one-liner, but it counts UTF-16 units so a CJK diff at the cap is still ~18 MiB of UTF-8, and it does nothing for the base64 path. The byte-measured transport cap supersedes it.
- **Four residual 1013 sites** that never reach the dispatcher: outbound queue overflow, oversized binary frames, and `injectDeviceScope` re-serializing `status.get` after the admission check. All narrow; the new telemetry will show whether any fire.

Made with [Orca](https://github.com/stablyai/orca) 🐋

