### PR TITLE
fix(orchestration): open workers in the coordinator split pane

### DIFF
--- a/docs/superpowers/specs/2026-08-11-orchestration-worker-pane-placement-design.md
+++ b/docs/superpowers/specs/2026-08-11-orchestration-worker-pane-placement-design.md
@@ -1,0 +1,74 @@
+# Orchestration Worker Pane Placement
+
+## Problem
+
+When an agent starts orchestration from a terminal in a secondary split group, a newly created worker session can appear in the first split group. Worker creation carries the workspace but not the coordinator tab that owns the intended group. Background publication and renderer adoption therefore fall back to active-group state, which is not durable evidence of the coordinator's location.
+
+## Goal
+
+An orchestration worker created in an existing workspace must be added to the same outer split group as the coordinator terminal that started it.
+
+The placement must behave consistently for local windows, folder workspaces, SSH/runtime-hosted workspaces, and headless session snapshots. Worker startup must still succeed when placement evidence is unavailable.
+
+## Non-goals
+
+- Moving workers created in a new child or top-level worktree back into the coordinator workspace.
+- Changing terminal-internal leaf splits.
+- Focusing the worker tab or changing orchestration's background surfacing behavior.
+- Reorganizing existing worker tabs.
+
+## Design
+
+### Placement anchor
+
+The worker-start path resolves the coordinator terminal before creating an existing-workspace worker. It passes the coordinator's outer tab ID as an optional placement anchor in terminal creation options.
+
+The anchor identifies intent without exposing renderer-only group IDs to orchestration. Group IDs remain owned by the current session layout, while the stable coordinator tab is already known to local, SSH, and headless runtime paths.
+
+### Runtime publication
+
+Before publishing a new PTY-backed session tab, the runtime looks up the group that owns the anchor tab in the current workspace snapshot. When found, the new worker parent tab is assigned to that group and inserted after the anchor. The active group and active tab are unchanged because orchestration workers remain background sessions.
+
+When no renderer is attached, the same resolved assignment is written into the headless session snapshot. This keeps SSH and folder-workspace behavior aligned with the desktop path.
+
+### Renderer adoption
+
+The terminal reveal request carries the optional placement anchor. The renderer resolves the anchor against unified tabs and uses its group when creating the worker tab. If snapshot publication won the race and the worker tab already exists, adoption verifies its group and moves it to the anchor group without activating it.
+
+The request uses an optional field. Older receivers ignore it, and newer receivers fall back when older senders omit it, so no runtime protocol bump or capability negotiation is required.
+
+### Fallbacks
+
+If the coordinator tab was closed, reminted, belongs to another workspace, or is missing from a partial snapshot, worker creation uses the existing active-group fallback. Placement failure never fails an otherwise valid worker start.
+
+New-worktree workers retain their current behavior because their target workspace has no coordinator tab group to inherit.
+
+## Data flow
+
+1. `orchestration.workerStart` resolves `params.from` to the coordinator terminal.
+2. Existing-workspace worker creation passes the coordinator tab ID as the placement anchor.
+3. `createTerminal` preserves the optional anchor through agent launch resolution.
+4. The runtime assigns the new PTY-backed parent tab to the anchor's snapshot group when available.
+5. Terminal reveal forwards the anchor to the renderer.
+6. The renderer creates or reconciles the worker tab in the anchor's unified-tab group without changing focus.
+
+## Testing
+
+Focused regression coverage will verify:
+
+- Existing-workspace worker creation forwards the coordinator tab ID.
+- A worker started from group B is published into group B while group A remains globally active.
+- Renderer creation uses the anchor group for a fresh tab.
+- Renderer reconciliation moves an already-published worker tab into the anchor group without activating it.
+- A stale or cross-workspace anchor falls back without failing creation.
+- Headless and SSH-compatible snapshot placement preserves multi-group layout.
+- Folder workspaces use the same existing-workspace path.
+- New-worktree workers are unchanged.
+
+## Acceptance criteria
+
+- With two split groups, orchestration started from the second group creates its existing-workspace worker tab in the second group.
+- The first group does not receive the worker tab.
+- The coordinator remains focused and the worker remains a background session.
+- Worker startup succeeds when the placement anchor cannot be resolved.
+- Existing mixed-version behavior remains functional when the optional anchor is absent or ignored.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12490,6 +12490,120 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('publishes background terminals in their anchor tab group without changing focus', async () => {
+    const spawn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'pty-worker' })
+      .mockResolvedValueOnce({ id: 'pty-stale-anchor' })
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-worker' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer:split-layout',
+      snapshotVersion: 1,
+      activeGroupId: 'group-left',
+      activeTabId: `tab-left::${HEADLESS_LEAF_ID}`,
+      activeTabType: 'terminal',
+      tabGroups: [
+        { id: 'group-left', activeTabId: 'tab-left', tabOrder: ['tab-left'] },
+        {
+          id: 'group-right',
+          activeTabId: 'tab-coordinator',
+          tabOrder: ['tab-coordinator', 'tab-peer']
+        }
+      ],
+      tabs: [
+        {
+          type: 'terminal',
+          id: `tab-left::${HEADLESS_LEAF_ID}`,
+          parentTabId: 'tab-left',
+          leafId: HEADLESS_LEAF_ID,
+          ptyId: 'pty-left',
+          title: 'Left',
+          isActive: true
+        },
+        {
+          type: 'terminal',
+          id: `tab-coordinator::${HEADLESS_SECOND_LEAF_ID}`,
+          parentTabId: 'tab-coordinator',
+          leafId: HEADLESS_SECOND_LEAF_ID,
+          ptyId: 'pty-coordinator',
+          title: 'Coordinator',
+          isActive: false
+        },
+        {
+          type: 'terminal',
+          id: `tab-peer::${HEADLESS_THIRD_LEAF_ID}`,
+          parentTabId: 'tab-peer',
+          leafId: HEADLESS_THIRD_LEAF_ID,
+          ptyId: 'pty-peer',
+          title: 'Peer',
+          isActive: false
+        }
+      ]
+    })
+
+    const placed = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      afterTabId: 'tab-coordinator',
+      surfaceOwner: false
+    })
+    const fallback = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      afterTabId: 'tab-missing',
+      surfaceOwner: false
+    })
+
+    const snapshot = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+    expect(snapshot.tabGroups).toEqual([
+      {
+        id: 'group-left',
+        activeTabId: 'tab-left',
+        tabOrder: ['tab-left', fallback.tabId]
+      },
+      {
+        id: 'group-right',
+        activeTabId: 'tab-coordinator',
+        tabOrder: ['tab-coordinator', placed.tabId, 'tab-peer']
+      }
+    ])
+    expect(snapshot).toMatchObject({
+      activeGroupId: 'group-left',
+      activeTabId: `tab-left::${HEADLESS_LEAF_ID}`,
+      activeTabType: 'terminal'
+    })
+    expect(revealTerminalSession).toHaveBeenNthCalledWith(
+      1,
+      TEST_WORKTREE_ID,
+      expect.objectContaining({ afterTabId: 'tab-coordinator', activate: false })
+    )
+    expect(revealTerminalSession).toHaveBeenNthCalledWith(
+      2,
+      TEST_WORKTREE_ID,
+      expect.objectContaining({ afterTabId: 'tab-missing', activate: false })
+    )
+  })
+
   it('retires inherited launch authority when the agent command exits', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-authority', incarnationId: 'process-1' })
     const retireAuthority = vi.fn()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1366,6 +1366,9 @@ type TerminalCreateOptions = {
   // sidebar reveal, no tab focus. Distinct from 'background' presentation,
   // which skips renderer adoption entirely.
   surfaceOwner?: false
+  // Why: background creators can preserve the initiating tab's outer split group
+  // without depending on whichever group is globally active when adoption finishes.
+  afterTabId?: string
   tabId?: string
   leafId?: string
   sessionId?: string
@@ -1874,6 +1877,7 @@ type RuntimeNotifier = {
       activate?: boolean
       presentation?: RuntimeTerminalPresentation
       surfaceOwner?: false
+      afterTabId?: string
       tabId?: string
       leafId?: string
       splitFromLeafId?: string
@@ -6377,9 +6381,19 @@ export class OrcaRuntimeService {
     worktreeId: string,
     groups: readonly RuntimeMobileSessionTabGroup[],
     terminalTabs: readonly RuntimeMobileSessionTerminalTab[],
-    activeTab: RuntimeMobileSessionTerminalTab | null
+    activeTab: RuntimeMobileSessionTerminalTab | null,
+    placement?: { tabId: string; afterTabId: string }
   ): RuntimeMobileSessionTabGroup[] {
     const parentTabOrder = this.collectHeadlessParentTabOrder(terminalTabs)
+    if (placement && placement.tabId !== placement.afterTabId) {
+      const placedIndex = parentTabOrder.indexOf(placement.tabId)
+      const anchorIndex = parentTabOrder.indexOf(placement.afterTabId)
+      if (placedIndex !== -1 && anchorIndex !== -1) {
+        parentTabOrder.splice(placedIndex, 1)
+        const nextAnchorIndex = parentTabOrder.indexOf(placement.afterTabId)
+        parentTabOrder.splice(nextAnchorIndex + 1, 0, placement.tabId)
+      }
+    }
     if (parentTabOrder.length === 0) {
       return [...groups]
     }
@@ -6408,9 +6422,13 @@ export class OrcaRuntimeService {
     const activeParentId = activeTab?.parentTabId ?? null
     const activeGroupId =
       (activeParentId ? ownerGroupId.get(activeParentId) : undefined) ?? nextGroups[0]!.id
+    const placementGroupId = placement ? ownerGroupId.get(placement.afterTabId) : undefined
     const retainedOrder = new Map<string, string[]>(nextGroups.map((group) => [group.id, []]))
     for (const tabId of parentTabOrder) {
-      const groupId = ownerGroupId.get(tabId) ?? activeGroupId
+      const groupId =
+        (tabId === placement?.tabId ? placementGroupId : undefined) ??
+        ownerGroupId.get(tabId) ??
+        activeGroupId
       retainedOrder.get(groupId)?.push(tabId)
     }
     return nextGroups
@@ -6450,6 +6468,7 @@ export class OrcaRuntimeService {
       startupCwd?: string
       viewMode?: 'terminal' | 'chat'
       split?: { splitFromLeafId: string; direction: 'horizontal' | 'vertical' }
+      afterTabId?: string
       notify?: boolean
     }
   ): void {
@@ -6519,7 +6538,7 @@ export class OrcaRuntimeService {
           candidate.leafId === args.leafId
         )
     )
-    const tabs = this.mergeMobileSessionSnapshotTabs(
+    let tabs = this.mergeMobileSessionSnapshotTabs(
       existingTabs.map((candidate) => ({
         ...candidate,
         // Why: the client picks one sibling's parentLayout to render the whole
@@ -6533,6 +6552,26 @@ export class OrcaRuntimeService {
       })),
       [tab]
     )
+    if (args.afterTabId && args.tabId !== args.afterTabId) {
+      // Why: persist parent order so later background publications cannot undo the anchor insertion.
+      const placedSurfaces = tabs.filter(
+        (candidate) => candidate.type === 'terminal' && candidate.parentTabId === args.tabId
+      )
+      const retainedTabs = tabs.filter(
+        (candidate) => candidate.type !== 'terminal' || candidate.parentTabId !== args.tabId
+      )
+      const anchorIndex = retainedTabs.reduce(
+        (lastIndex, candidate, index) =>
+          (candidate.type === 'terminal' ? candidate.parentTabId : candidate.id) === args.afterTabId
+            ? index
+            : lastIndex,
+        -1
+      )
+      if (placedSurfaces.length > 0 && anchorIndex !== -1) {
+        retainedTabs.splice(anchorIndex + 1, 0, ...placedSurfaces)
+        tabs = retainedTabs
+      }
+    }
     const activeTab =
       (tab.isActive ? tab : tabs.find((candidate) => candidate.id === existing?.activeTabId)) ??
       tabs.find((candidate) => candidate.isActive) ??
@@ -6553,7 +6592,8 @@ export class OrcaRuntimeService {
         worktreeId,
         existing?.tabGroups ?? [],
         terminalTabs,
-        activeTab?.type === 'terminal' ? activeTab : null
+        activeTab?.type === 'terminal' ? activeTab : null,
+        args.afterTabId ? { tabId: args.tabId, afterTabId: args.afterTabId } : undefined
       ),
       ...(existing?.tabGroupLayout ? { tabGroupLayout: existing.tabGroupLayout } : {}),
       tabs
@@ -25422,6 +25462,9 @@ export class OrcaRuntimeService {
       }
       const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
       const launchOpts = await this.resolveAgentTerminalCreateOptions(workspace, opts)
+      if (launchOpts.afterTabId) {
+        this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(workspace.id)
+      }
       let ptySpawnCommitReported = false
       const reportPtySpawnCommitted = (): void => {
         if (ptySpawnCommitReported) {
@@ -25692,7 +25735,8 @@ export class OrcaRuntimeService {
             // metadata from an already-owned renderer pane; don't select it on mobile.
             selectIfNoActiveTab: presentation !== 'background',
             ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
-            ...(cwd !== workspace.path ? { startupCwd: cwd } : {})
+            ...(cwd !== workspace.path ? { startupCwd: cwd } : {}),
+            ...(launchOpts.afterTabId ? { afterTabId: launchOpts.afterTabId } : {})
           })
         }
         let surface: RuntimeTerminalCreate['surface'] = 'background'
@@ -25714,6 +25758,7 @@ export class OrcaRuntimeService {
               activate: presentation === 'focused',
               ...(presentation ? { presentation } : {}),
               ...ownerSurfacing(opts.surfaceOwner !== false),
+              ...(launchOpts.afterTabId ? { afterTabId: launchOpts.afterTabId } : {}),
               tabId,
               leafId
             })
@@ -25799,6 +25844,7 @@ export class OrcaRuntimeService {
         ...(launchOpts.launchToken ? { launchToken: launchOpts.launchToken } : {}),
         ...(launchOpts.launchAgent ? { launchAgent: launchOpts.launchAgent } : {}),
         ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
+        ...(launchOpts.afterTabId ? { afterTabId: launchOpts.afterTabId } : {}),
         startupCommandDelivery: launchOpts.startupCommandDelivery,
         title: launchOpts.title,
         activate: presentation === 'focused',

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -59,6 +59,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
   agent: TuiAgent
   launchPreferences?: AgentLaunchPreferences
   taskId: string
+  coordinatorTabId?: string
   effects: WorkerEffect[]
 }): Promise<{ handle: string; warning?: string }> {
   const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
@@ -68,6 +69,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
     startupAgent: args.agent,
     ...(args.launchPreferences ? { launchPreferences: args.launchPreferences } : {}),
     title: `worker-${args.taskId}`,
+    ...(args.coordinatorTabId ? { afterTabId: args.coordinatorTabId } : {}),
     // Why: dispatching a worker is background work; it must not pull the sidebar
     // to the worker's workspace while the user is reading somewhere else.
     surfaceOwner: false

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -1,4 +1,5 @@
 import type { TuiAgent } from '../../../../shared/types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
@@ -28,6 +29,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
     handler: async (params, { runtime, orchestrationMutation }) => {
       const db = runtime.getOrchestrationDb()
       const coordinatorPane = runtime.getTerminalPaneKey(params.from)
+      const coordinatorTabId = coordinatorPane ? parsePaneKey(coordinatorPane)?.tabId : undefined
       const run = coordinatorPane ? db.getCurrentRunForPane(coordinatorPane) : undefined
       if (!run || (params.run && params.run !== run.id)) {
         throw new OrchestrationError(
@@ -164,6 +166,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             agent: agent as TuiAgent,
             launchPreferences: launch.preferences,
             taskId: task.id,
+            coordinatorTabId,
             effects
           })
           terminalHandle = terminal.handle

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -2229,6 +2229,7 @@ describe('orchestration RPC methods', () => {
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
         startupAgent: 'codex',
         title: `worker-${task.id}`,
+        afterTabId: 'tab_coord',
         surfaceOwner: false
       })
       expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledWith(

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -813,6 +813,7 @@ describe('attachMainWindowServices', () => {
           cwd?: string
           viewMode?: 'terminal' | 'chat'
           activate?: boolean
+          afterTabId?: string
         }
       ) => Promise<{ tabId: string; title?: string }>
     }
@@ -820,7 +821,8 @@ describe('attachMainWindowServices', () => {
       ptyId: 'pty-1',
       title: 'SSH tmux',
       cwd: '/repo/packages/web',
-      viewMode: 'chat'
+      viewMode: 'chat',
+      afterTabId: 'tab-coordinator'
     })
     const sentPayload = sendMock.mock.calls.find(
       ([channel]) => channel === 'ui:createTerminal'
@@ -828,7 +830,11 @@ describe('attachMainWindowServices', () => {
     const handler = onMock.mock.calls.find(
       ([channel]) => channel === 'terminal:tabCreateReply'
     )?.[1]
-    expect(sentPayload).toMatchObject({ cwd: '/repo/packages/web', viewMode: 'chat' })
+    expect(sentPayload).toMatchObject({
+      cwd: '/repo/packages/web',
+      viewMode: 'chat',
+      afterTabId: 'tab-coordinator'
+    })
 
     handler?.(
       { sender: { send: vi.fn() } },

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -417,6 +417,7 @@ function registerRuntimeWindowLifecycle(
           activate: opts.activate !== false,
           ...(opts.presentation ? { presentation: opts.presentation } : {}),
           ...(opts.surfaceOwner === false ? { surfaceOwner: false } : {}),
+          ...(opts.afterTabId !== undefined ? { afterTabId: opts.afterTabId } : {}),
           // Why: pre-minted tabId aligns the renderer tab id with the paneKey baked into the PTY env, so hook events route right.
           ...(opts.tabId !== undefined ? { tabId: opts.tabId } : {}),
           ...(opts.leafId !== undefined ? { leafId: opts.leafId } : {}),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3198,6 +3198,7 @@ export type PreloadApi = {
         focus?: boolean
         presentation?: RuntimeTerminalPresentation
         surfaceOwner?: false
+        afterTabId?: string
         tabId?: string
         leafId?: string
         splitFromLeafId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3841,6 +3841,7 @@ const api = {
         focus?: boolean
         presentation?: RuntimeTerminalPresentation
         surfaceOwner?: false
+        afterTabId?: string
         tabId?: string
         leafId?: string
         splitFromLeafId?: string
@@ -3867,6 +3868,7 @@ const api = {
           focus?: boolean
           presentation?: RuntimeTerminalPresentation
           surfaceOwner?: false
+          afterTabId?: string
           tabId?: string
           leafId?: string
           splitFromLeafId?: string

--- a/src/renderer/src/hooks/ipc-events-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-test-harness.ts
@@ -11,6 +11,7 @@ export type CreateTerminalRequest = {
   activate?: boolean
   presentation?: 'background' | 'focused'
   surfaceOwner?: boolean
+  afterTabId?: string
   tabId?: string
   leafId?: string
   splitFromLeafId?: string
@@ -19,6 +20,8 @@ export type CreateTerminalRequest = {
 export type RequestTerminalCreateRequest = {
   requestId: string
   worktreeId?: string
+  afterTabId?: string
+  targetGroupId?: string
   command?: string
   title?: string
   activate?: boolean

--- a/src/renderer/src/hooks/terminal-tab-placement.test.ts
+++ b/src/renderer/src/hooks/terminal-tab-placement.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyTerminalTabPlacement,
+  resolveTerminalTabPlacementGroupId
+} from './terminal-tab-placement'
+
+function createPlacementState(workerGroupId = 'group-left') {
+  return {
+    unifiedTabsByWorktree: {
+      wt: [
+        {
+          id: 'tab-left',
+          entityId: 'tab-left',
+          groupId: 'group-left'
+        },
+        {
+          id: 'tab-coordinator',
+          entityId: 'tab-coordinator',
+          groupId: 'group-right'
+        },
+        {
+          id: 'tab-peer',
+          entityId: 'tab-peer',
+          groupId: 'group-right'
+        },
+        {
+          id: 'tab-worker',
+          entityId: 'tab-worker',
+          groupId: workerGroupId
+        }
+      ]
+    },
+    groupsByWorktree: {
+      wt: [
+        {
+          id: 'group-left',
+          activeTabId: 'tab-left',
+          tabOrder: ['tab-left', ...(workerGroupId === 'group-left' ? ['tab-worker'] : [])]
+        },
+        {
+          id: 'group-right',
+          activeTabId: 'tab-coordinator',
+          tabOrder: [
+            'tab-coordinator',
+            'tab-peer',
+            ...(workerGroupId === 'group-right' ? ['tab-worker'] : [])
+          ]
+        }
+      ]
+    },
+    moveUnifiedTabToGroup: vi.fn(),
+    reorderUnifiedTabs: vi.fn()
+  }
+}
+
+describe('terminal tab placement', () => {
+  it('resolves the split group that owns the anchor tab', () => {
+    const state = createPlacementState()
+
+    expect(
+      resolveTerminalTabPlacementGroupId(state as never, 'wt', {
+        afterTabId: 'tab-coordinator'
+      })
+    ).toBe('group-right')
+  })
+
+  it('moves an already-published worker after its coordinator without activating it', () => {
+    const state = createPlacementState()
+
+    applyTerminalTabPlacement(state as never, 'wt', 'tab-worker', {
+      afterTabId: 'tab-coordinator'
+    })
+
+    expect(state.moveUnifiedTabToGroup).toHaveBeenCalledWith('tab-worker', 'group-right', {
+      index: 1,
+      activate: false,
+      recordInteraction: false
+    })
+    expect(state.reorderUnifiedTabs).not.toHaveBeenCalled()
+  })
+
+  it('orders a fresh worker after its coordinator inside the same group', () => {
+    const state = createPlacementState('group-right')
+
+    applyTerminalTabPlacement(state as never, 'wt', 'tab-worker', {
+      afterTabId: 'tab-coordinator'
+    })
+
+    expect(state.moveUnifiedTabToGroup).not.toHaveBeenCalled()
+    expect(state.reorderUnifiedTabs).toHaveBeenCalledWith(
+      'group-right',
+      ['tab-coordinator', 'tab-worker', 'tab-peer'],
+      { recordInteraction: false }
+    )
+  })
+
+  it('leaves placement unchanged when the anchor is stale or belongs elsewhere', () => {
+    const state = createPlacementState()
+
+    expect(
+      resolveTerminalTabPlacementGroupId(state as never, 'wt', { afterTabId: 'tab-missing' })
+    ).toBeUndefined()
+    expect(
+      resolveTerminalTabPlacementGroupId(state as never, 'other-worktree', {
+        afterTabId: 'tab-coordinator'
+      })
+    ).toBeUndefined()
+    applyTerminalTabPlacement(state as never, 'wt', 'tab-worker', {
+      afterTabId: 'tab-missing'
+    })
+
+    expect(state.moveUnifiedTabToGroup).not.toHaveBeenCalled()
+    expect(state.reorderUnifiedTabs).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/terminal-tab-placement.ts
+++ b/src/renderer/src/hooks/terminal-tab-placement.ts
@@ -1,0 +1,74 @@
+import type { AppState } from '../store/types'
+
+type TerminalTabPlacementState = Pick<
+  AppState,
+  'unifiedTabsByWorktree' | 'groupsByWorktree' | 'moveUnifiedTabToGroup' | 'reorderUnifiedTabs'
+>
+
+type TerminalTabPlacement = {
+  targetGroupId?: string
+  afterTabId?: string
+}
+
+function findUnifiedTab(state: TerminalTabPlacementState, worktreeId: string, tabId: string) {
+  return state.unifiedTabsByWorktree?.[worktreeId]?.find(
+    (tab) => tab.id === tabId || tab.entityId === tabId
+  )
+}
+
+export function resolveTerminalTabPlacementGroupId(
+  state: TerminalTabPlacementState,
+  worktreeId: string,
+  placement: TerminalTabPlacement
+): string | undefined {
+  const groups = state.groupsByWorktree?.[worktreeId] ?? []
+  if (placement.targetGroupId) {
+    return placement.targetGroupId
+  }
+  if (!placement.afterTabId) {
+    return undefined
+  }
+  const anchor = findUnifiedTab(state, worktreeId, placement.afterTabId)
+  return anchor && groups.some((group) => group.id === anchor.groupId) ? anchor.groupId : undefined
+}
+
+export function applyTerminalTabPlacement(
+  state: TerminalTabPlacementState,
+  worktreeId: string,
+  createdTabId: string,
+  placement: TerminalTabPlacement
+): void {
+  const targetGroupId = resolveTerminalTabPlacementGroupId(state, worktreeId, placement)
+  const created = findUnifiedTab(state, worktreeId, createdTabId)
+  if (!targetGroupId || !created || created.id === placement.afterTabId) {
+    return
+  }
+  const targetGroup = state.groupsByWorktree?.[worktreeId]?.find(
+    (group) => group.id === targetGroupId
+  )
+  if (!targetGroup) {
+    return
+  }
+  const anchor = placement.afterTabId
+    ? findUnifiedTab(state, worktreeId, placement.afterTabId)
+    : undefined
+  const order = targetGroup.tabOrder.filter((tabId) => tabId !== created.id)
+  const anchorIndex = anchor?.groupId === targetGroupId ? order.indexOf(anchor.id) : -1
+  const index = anchorIndex === -1 ? order.length : anchorIndex + 1
+  if (created.groupId !== targetGroupId) {
+    state.moveUnifiedTabToGroup(created.id, targetGroupId, {
+      index,
+      activate: false,
+      recordInteraction: false
+    })
+    return
+  }
+  order.splice(index, 0, created.id)
+  if (
+    order.length === targetGroup.tabOrder.length &&
+    order.every((tabId, orderIndex) => targetGroup.tabOrder[orderIndex] === tabId)
+  ) {
+    return
+  }
+  state.reorderUnifiedTabs(targetGroupId, order, { recordInteraction: false })
+}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1964,6 +1964,7 @@ describe('useIpcEvents updater integration', () => {
             activate?: boolean
             focus?: boolean
             presentation?: 'background' | 'focused'
+            afterTabId?: string
             tabId?: string
             leafId?: string
             splitFromLeafId?: string
@@ -2113,6 +2114,7 @@ describe('useIpcEvents updater integration', () => {
               activate?: boolean
               focus?: boolean
               presentation?: 'background' | 'focused'
+              afterTabId?: string
               tabId?: string
               leafId?: string
               splitFromLeafId?: string

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -171,6 +171,10 @@ import {
   type DirectSshPreparationReason
 } from './direct-ssh-reconnect-coordinator'
 import { directSshAuthoritiesEqual } from './direct-ssh-reconnect-tokens'
+import {
+  applyTerminalTabPlacement,
+  resolveTerminalTabPlacementGroupId
+} from './terminal-tab-placement'
 import { createDirectSshHostHydration } from './direct-ssh-host-hydration'
 import { createDirectSshReconnectProductTelemetryAdapter } from '@/lib/direct-ssh-reconnect-product-telemetry'
 import {
@@ -1441,6 +1445,7 @@ export function useIpcEvents(): void {
           focus,
           presentation,
           surfaceOwner,
+          afterTabId,
           tabId,
           leafId,
           splitFromLeafId,
@@ -1483,10 +1488,13 @@ export function useIpcEvents(): void {
               throw new Error(`Terminal tab ${tabId} not found`)
             }
             const reusedTab = existingTab ?? splitTargetTab
+            const targetGroupId = resolveTerminalTabPlacementGroupId(store, worktreeId, {
+              afterTabId
+            })
             const tab =
               reusedTab ??
               (ptyId
-                ? store.createTab(worktreeId, undefined, undefined, {
+                ? store.createTab(worktreeId, targetGroupId, undefined, {
                     initialPtyId: ptyId,
                     activate: shouldActivate,
                     ...(launchAgent
@@ -1510,7 +1518,7 @@ export function useIpcEvents(): void {
                   })
                 : store.createTab(
                     worktreeId,
-                    undefined,
+                    targetGroupId,
                     undefined,
                     shouldActivate
                       ? cwd
@@ -1522,6 +1530,7 @@ export function useIpcEvents(): void {
                           ...(cwd ? { startupCwd: cwd } : {})
                         }
                   ))
+            applyTerminalTabPlacement(useAppStore.getState(), worktreeId, tab.id, { afterTabId })
             // Why: a reused tab whose id differs from the hint breaks the PTY's baked-in paneKey attribution; warn during dev.
             if (tabId !== undefined && tab.id !== tabId) {
               console.warn(
@@ -1737,38 +1746,19 @@ export function useIpcEvents(): void {
                   recordInteraction: false,
                   ...(data.cwd ? { startupCwd: data.cwd } : {})
                 }
-          const tab = store.createTab(worktreeId, data.targetGroupId, undefined, tabOptions)
+          const targetGroupId = resolveTerminalTabPlacementGroupId(store, worktreeId, {
+            targetGroupId: data.targetGroupId,
+            afterTabId: data.afterTabId
+          })
+          const tab = store.createTab(worktreeId, targetGroupId, undefined, tabOptions)
           if (!shouldActivate) {
             // Why: renderer-backed Codex startup must mount its new TerminalPane without switching UI or connecting every saved tab.
             requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [tab.id] })
           }
-          if (data.afterTabId) {
-            const createdUnifiedTab = useAppStore
-              .getState()
-              .unifiedTabsByWorktree[worktreeId]?.find((item) => item.entityId === tab.id)
-            const anchorUnifiedTab = useAppStore
-              .getState()
-              .unifiedTabsByWorktree[worktreeId]?.find((item) => item.id === data.afterTabId)
-            if (
-              createdUnifiedTab &&
-              anchorUnifiedTab &&
-              createdUnifiedTab.groupId === anchorUnifiedTab.groupId
-            ) {
-              const group = useAppStore
-                .getState()
-                .groupsByWorktree[worktreeId]?.find((item) => item.id === createdUnifiedTab.groupId)
-              const order = (group?.tabOrder ?? []).filter((id) => id !== createdUnifiedTab.id)
-              const anchorIndex = order.indexOf(anchorUnifiedTab.id)
-              order.splice(
-                anchorIndex === -1 ? order.length : anchorIndex + 1,
-                0,
-                createdUnifiedTab.id
-              )
-              useAppStore.getState().reorderUnifiedTabs(createdUnifiedTab.groupId, order, {
-                recordInteraction: false
-              })
-            }
-          }
+          applyTerminalTabPlacement(useAppStore.getState(), worktreeId, tab.id, {
+            targetGroupId: data.targetGroupId,
+            afterTabId: data.afterTabId
+          })
           if (shouldActivate) {
             store.setActiveTabType('terminal')
             store.setActiveTab(tab.id)


### PR DESCRIPTION
## Summary
Orchestration workers created in an existing workspace now open in the same split pane as their coordinator, even when another pane is active during startup.

Worker creation remains in the background without stealing focus. New-worktree behavior is unchanged, and stale coordinator anchors fall back safely.

## Screenshots
 No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Validation completed:
  - Focused Vitest run: 5 files and 8 tests passed.
  - Node, renderer, and CLI TypeScript checks passed.
  - Standard and type-aware oxlint checks passed.
  - Max-lines ratchet passed.
  - `git diff --check` passed.
  - Full repository lint, test, and build commands were not run.
  
## AI Review Report

The AI review checked worker routing from orchestration dispatch through runtime publication, Electron IPC, preload types, and renderer tab adoption.

  Main risks reviewed:

  - Coordinator placement context being lost during worker creation.
  - Runtime and renderer placement disagreeing during asynchronous tab adoption.
  - A worker being placed in the active pane instead of the coordinator pane.
  - Placement accidentally activating the worker or changing the focused split.
  - Sequential background publications undoing the anchored tab order.
  - Stale or cross-workspace anchor IDs moving unrelated tabs.
  - Existing explicit target-group behavior regressing.

  The review identified that orchestration retained the coordinator workspace but discarded its tab identity. New terminals consequently fell back to the globally active group. It also found that the previous `afterTabId` behavior could reorder a tab only when it was already in the correct group.

  The implementation now carries the coordinator tab ID through worker creation, applies it to runtime snapshots and renderer adoption, and reconciles tabs published into the wrong group without activating them. Tests cover correct-group placement, ordering, focus preservation, stale anchors, and renderer reconciliation.

  Cross-platform compatibility was explicitly reviewed for macOS, Linux, and Windows:

  - No keyboard shortcuts or platform-specific labels changed.
  - No filesystem path handling changed.
  - No shell commands or shell-selection behavior changed.
  - Placement uses platform-neutral tab and group identifiers.
  - Electron changes only add an optional serializable IPC field.
  - Folder workspaces, local worktrees, headless sessions, and SSH-backed workspaces continue through the same placement path.

  No unresolved code-review findings remain.

## Security Audit

  The audit reviewed input handling, IPC boundaries, command execution, paths, authentication, secrets, and dependencies.

  - `afterTabId` is an optional internal identifier and is not passed to a shell or command executor.
  - Coordinator tab identity is derived from the validated stable pane key.
  - Renderer lookup is scoped to the target workspace.
  - Missing, stale, or cross-workspace anchors safely produce a no-op or existing fallback behavior.
  - No new IPC channel or privileged operation was added.
  - The optional IPC field does not expand renderer capabilities.
  - No authentication, authorization, secret handling, dependency, or filesystem-path behavior changed.
  - No user-controlled value was introduced into command construction.

  No security follow-up is required.

## Notes

  - New-worktree orchestration behavior is unchanged.