### PR TITLE
perf(renderer): index the repo catalog compat merge and keep catalog identity

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1416,7 +1416,9 @@ function App(): React.JSX.Element {
         hideWorkspacesFromOtherDevices,
         alwaysShowDefaultBranchWorkspace,
         showDotfilesByWorktree,
-        filterRepoIds,
+        // Why: the store keeps this readonly for identity stability, but PersistedUI crosses to
+        // main, which owns a mutable array — copy at the boundary rather than widening the wire type.
+        filterRepoIds: [...filterRepoIds],
         // Why (#9002): activeView is deliberately NOT included here. It used to
         // ride this same 150ms writer (#8265), which meant every top-level view
         // switch scheduled a full durable-state save. The narrow preference

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -62,7 +62,7 @@ type AutomationEditorDialogProps = {
   canSave: boolean
   createTarget: AutomationCreateTarget
   repos: readonly Repo[]
-  projectHostSetups: ProjectHostSetup[]
+  projectHostSetups: readonly ProjectHostSetup[]
   automationYamlHooksByRepoKey: Record<string, OrcaHooks | null>
   getAutomationHooksCacheKey: (repoId: string) => string
   repoMap: Map<string, Repo>

--- a/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialogFooter.tsx
@@ -32,7 +32,7 @@ type AutomationEditorDialogFooterProps = {
   isSaving: boolean
   canSave: boolean
   repos: readonly Repo[]
-  projectHostSetups: ProjectHostSetup[]
+  projectHostSetups: readonly ProjectHostSetup[]
   automationYamlHooksByRepoKey: Record<string, OrcaHooks | null>
   getAutomationHooksCacheKey: (repoId: string) => string
   repoMap: Map<string, Repo>

--- a/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.ts
@@ -3,7 +3,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
 import type { ProjectHostSetupProjection } from '../../../../shared/project-host-setup-projection'
-import type { Worktree } from '../../../../shared/types'
+import type { ProjectHostSetup, Worktree } from '../../../../shared/types'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree-id'
 
 export function deriveAiVaultWorkspaceScopePaths(
@@ -88,10 +88,10 @@ export function deriveAiVaultScopeSessionPaths(
 
 function buildProjectSetupsByRepoId(
   projection?: ProjectHostSetupProjection
-): Map<string, ProjectHostSetupProjection['setups']> {
-  const setupsByRepoId = new Map<string, ProjectHostSetupProjection['setups']>()
+): Map<string, ProjectHostSetup[]> {
+  const setupsByRepoId = new Map<string, ProjectHostSetup[]>()
   for (const setup of projection?.setups ?? []) {
-    const setups = setupsByRepoId.get(setup.repoId) ?? []
+    const setups: ProjectHostSetup[] = setupsByRepoId.get(setup.repoId) ?? []
     setups.push(setup)
     setupsByRepoId.set(setup.repoId, setups)
   }

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -3,7 +3,7 @@ import { isDefaultBranchWorkspace } from './visible-worktrees'
 
 export type AddRepoSkipFinalizationState = {
   activeRepoId: string | null
-  filterRepoIds: string[]
+  filterRepoIds: readonly string[]
   showActiveOnly: boolean
   hideDefaultBranchWorkspace: boolean
   showSleepingWorkspaces: boolean

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -186,7 +186,7 @@ export function computeVisibleWorktreeIds(
   worktreesByRepo: Record<string, Worktree[]>,
   sortedIds: string[],
   opts: {
-    filterRepoIds: string[]
+    filterRepoIds: readonly string[]
     showSleepingWorkspaces: boolean
     tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
     ptyIdsByTabId: Record<string, string[]> | null

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -40,7 +40,7 @@ type StoreAccessor = () => {
   setActiveWorktree: (worktreeId: string) => void
   createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
   repos?: readonly LocalhostLinkRepo[]
-  projects?: LocalhostLinkProject[]
+  projects?: readonly LocalhostLinkProject[]
   worktreesByRepo?: Record<string, LocalhostLinkWorktree[]>
   allWorktrees?: () => LocalhostLinkWorktree[]
   workspacePortScan?: { result: WorkspacePortScanResult } | null

--- a/src/renderer/src/store/slices/repo-filter-selection.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.ts
@@ -1,0 +1,10 @@
+// Why: catalog refreshes re-filter this on every fetch; six identity-sensitive subscribers
+// (App.tsx at the root among them) re-render on a new array even when nothing was pruned.
+export function retainValidFilterRepoIds(
+  filterRepoIds: readonly string[],
+  validRepoIds: ReadonlySet<string>
+): readonly string[] {
+  return filterRepoIds.every((repoId) => validRepoIds.has(repoId))
+    ? filterRepoIds
+    : filterRepoIds.filter((repoId) => validRepoIds.has(repoId))
+}

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -12,7 +12,7 @@ import { getRepoHostIdentity } from './repo-host-identity'
 // arrays). IPC structured-clone rebuilds those every fetch, and main's hydrateRepo always
 // reconstructs hookSettings — so a reference compare reports every repo as changed and no repo
 // ever reconciles. Compare nested plain values structurally; they are small sanitized records.
-function areValuesEqual(a: unknown, b: unknown): boolean {
+export function areValuesEqual(a: unknown, b: unknown): boolean {
   if (a === b) {
     return true
   }
@@ -28,9 +28,11 @@ function areValuesEqual(a: unknown, b: unknown): boolean {
     )
   }
   // Why: only plain records are safe to walk — anything exotic falls back to reference equality.
+  const aPrototype = Object.getPrototypeOf(a)
+  const bPrototype = Object.getPrototypeOf(b)
   if (
-    Object.getPrototypeOf(a) !== Object.prototype ||
-    Object.getPrototypeOf(b) !== Object.prototype
+    (aPrototype !== Object.prototype && aPrototype !== null) ||
+    (bPrototype !== Object.prototype && bPrototype !== null)
   ) {
     return false
   }
@@ -45,41 +47,35 @@ function areValuesEqual(a: unknown, b: unknown): boolean {
   )
 }
 
-function areReposEqual(a: Repo, b: Repo): boolean {
-  if (a === b) {
-    return true
-  }
-  const keys = Object.keys(a) as (keyof Repo)[]
-  if (keys.length !== Object.keys(b).length) {
-    return false
-  }
-  for (const key of keys) {
-    if (!Object.hasOwn(b, key)) {
-      return false
-    }
-    if (!areValuesEqual(a[key], b[key])) {
-      return false
-    }
-  }
-  return true
-}
-
-export function reconcileFetchedRepos(
-  previous: readonly Repo[],
-  next: readonly Repo[]
-): readonly Repo[] {
-  const previousById = new Map(previous.map((repo) => [getRepoHostIdentity(repo), repo]))
+/**
+ * Reuses equal rows from `previous` — and the whole array when nothing moved — so a refetch that
+ * changed nothing leaves identity-keyed memos and store subscribers untouched. `getIdentity` must
+ * be the key the producing merge already dedups by, so it is unique within `next`.
+ */
+export function reconcileCatalogRows<T>(
+  previous: readonly T[],
+  next: readonly T[],
+  getIdentity: (row: T) => string
+): readonly T[] {
+  const previousByIdentity = new Map(previous.map((row) => [getIdentity(row), row]))
   let identical = next.length === previous.length
-  const reconciled = next.map((repo, index) => {
-    const existing = previousById.get(getRepoHostIdentity(repo))
-    if (existing && areReposEqual(existing, repo)) {
+  const reconciled = next.map((row, index) => {
+    const existing = previousByIdentity.get(getIdentity(row))
+    if (existing !== undefined && areValuesEqual(existing, row)) {
       if (existing !== previous[index]) {
         identical = false
       }
       return existing
     }
     identical = false
-    return repo
+    return row
   })
   return identical ? previous : reconciled
+}
+
+export function reconcileFetchedRepos(
+  previous: readonly Repo[],
+  next: readonly Repo[]
+): readonly Repo[] {
+  return reconcileCatalogRows(previous, next, getRepoHostIdentity)
 }

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Project, Repo } from '../../../../shared/types'
+import { createTestStore } from './store-test-helpers'
+
+// Why: every field here is load-bearing. A scalar-only repo reconciles even when the structural
+// compare is broken, which is exactly how an earlier version of this work shipped green and inert.
+// addedAt must stay non-zero: project-host-setup-projection falls back to `repo.addedAt || now`,
+// so a zero timestamp stamps Date.now() into every projection and nothing ever reconciles.
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repo-1',
+  displayName: 'Repo 1',
+  badgeColor: '#000000',
+  addedAt: 1_700_000_000_000,
+  executionHostId: 'local',
+  kind: 'git',
+  repoIcon: { type: 'lucide', name: 'Box' },
+  upstream: { owner: 'upstream-owner', repo: 'repo-1', host: 'github.com' },
+  gitRemoteIdentity: {
+    canonicalKey: 'github.com/octocat/repo-1',
+    remoteName: 'origin',
+    remoteUrl: 'git@github.com:octocat/repo-1.git'
+  },
+  hookSettings: { mode: 'auto', scripts: { setup: 'echo hi', archive: '' } },
+  symlinkPaths: ['.env', 'node_modules'],
+  importedExternalWorktreePaths: []
+}
+
+const secondRepo: Repo = {
+  ...repo,
+  id: 'repo-2',
+  path: '/repo-2',
+  displayName: 'Repo 2',
+  addedAt: 1_700_000_001_000,
+  upstream: { owner: 'upstream-owner', repo: 'repo-2', host: 'github.com' },
+  gitRemoteIdentity: {
+    canonicalKey: 'github.com/octocat/repo-2',
+    remoteName: 'origin',
+    remoteUrl: 'git@github.com:octocat/repo-2.git'
+  }
+}
+
+const reposList = vi.fn()
+const projectsList = vi.fn()
+const listHostSetups = vi.fn()
+
+// Why: catalogs arrive over IPC, so every fetch must hand back freshly allocated objects —
+// otherwise identity would match by accident and prove nothing.
+function clone<T>(value: T): T {
+  return structuredClone(value)
+}
+
+function mockRepos(...rows: readonly Repo[]): void {
+  reposList.mockImplementation(async () => rows.map(clone))
+}
+
+beforeEach(() => {
+  reposList.mockReset()
+  projectsList.mockReset()
+  listHostSetups.mockReset()
+  mockRepos(repo)
+  projectsList.mockImplementation(async () => [])
+  listHostSetups.mockImplementation(async () => [])
+
+  vi.stubGlobal('window', {
+    api: {
+      repos: { list: reposList },
+      projects: { list: projectsList, listHostSetups }
+    },
+    dispatchEvent: vi.fn()
+  })
+})
+
+describe('repo catalog refresh identity', () => {
+  it('keeps the projects and host setups arrays and entries across a no-op refetch', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+    const setups = store.getState().projectHostSetups
+    expect(projects).toHaveLength(1)
+    expect(setups).toHaveLength(1)
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).toBe(projects)
+    expect(store.getState().projects[0]).toBe(projects[0])
+    expect(store.getState().projectHostSetups).toBe(setups)
+    expect(store.getState().projectHostSetups[0]).toBe(setups[0])
+  })
+
+  it('lets a nested hookSettings change through', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const setups = store.getState().projectHostSetups
+
+    mockRepos({ ...repo, hookSettings: { mode: 'override', scripts: { setup: '', archive: '' } } })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projectHostSetups).not.toBe(setups)
+    expect(store.getState().projectHostSetups[0]?.hookSettings?.mode).toBe('override')
+  })
+
+  it('lets a displayName change through on projects', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+
+    mockRepos({ ...repo, displayName: 'Renamed' })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).not.toBe(projects)
+    expect(store.getState().projects[0]?.displayName).toBe('Renamed')
+  })
+
+  it('lets an array-field change through', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const repos = store.getState().repos
+
+    mockRepos({ ...repo, symlinkPaths: ['.env'] })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).not.toBe(repos)
+    expect(store.getState().repos[0]?.symlinkPaths).toEqual(['.env'])
+  })
+
+  it('lets a nested gitRemoteIdentity change through', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+
+    mockRepos({
+      ...repo,
+      gitRemoteIdentity: { ...repo.gitRemoteIdentity!, remoteName: 'upstream' }
+    })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).not.toBe(projects)
+    expect(store.getState().projects[0]?.gitRemoteIdentity?.remoteName).toBe('upstream')
+  })
+
+  it('treats clearing localWindowsRuntimePreference as a change', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projectId = store.getState().projects[0]!.id
+    const withPreference: Project = {
+      ...store.getState().projects[0]!,
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    }
+    store.setState({ projects: [withPreference] })
+
+    await store.getState().fetchRepos()
+
+    // Why: a local-host refresh is authoritative; an absent key must not read as unchanged.
+    expect(store.getState().projects[0]).not.toBe(withPreference)
+    expect(store.getState().projects[0]?.id).toBe(projectId)
+    expect(store.getState().projects[0]?.localWindowsRuntimePreference).toBeUndefined()
+  })
+
+  it('reuses an unchanged setup element while a sibling changes', async () => {
+    mockRepos(repo, secondRepo)
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const setups = store.getState().projectHostSetups
+    expect(setups).toHaveLength(2)
+
+    mockRepos(repo, { ...secondRepo, displayName: 'Repo 2 renamed' })
+    await store.getState().fetchRepos()
+
+    const next = store.getState().projectHostSetups
+    expect(next).not.toBe(setups)
+    expect(next[0]).toBe(setups[0])
+    expect(next[1]).not.toBe(setups[1])
+  })
+
+  it('does not reuse a setup that moved to a different execution host', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const setups = store.getState().projectHostSetups
+    expect(setups[0]?.hostId).toBe('local')
+
+    // Why: the repo-derived fallback sets setup.id = repo.id, so the same id on a second host is
+    // the case that would silently splice the wrong host's routing metadata into the row.
+    mockRepos({ ...repo, executionHostId: 'ssh:host-a', connectionId: 'host-a' })
+    await store.getState().fetchRepos()
+
+    const next = store.getState().projectHostSetups
+    expect(next[0]).not.toBe(setups[0])
+    expect(next[0]?.hostId).toBe('ssh:host-a')
+  })
+
+  it('reconciles both setups when one repo id exists on two hosts', async () => {
+    // Why: the repo-derived fallback sets setup.id = repo.id, so these two setups share an id and
+    // differ only by host. Keying the reconcile on setup.id instead of the owner key collapses them
+    // onto one slot and one of the two churns on every refresh.
+    const sshRepo: Repo = { ...repo, executionHostId: 'ssh:host-a', connectionId: 'host-a' }
+    mockRepos(repo, sshRepo)
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const setups = store.getState().projectHostSetups
+    expect(setups).toHaveLength(2)
+    expect(new Set(setups.map((setup) => setup.id)).size).toBe(1)
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projectHostSetups).toBe(setups)
+    expect(store.getState().projectHostSetups[0]).toBe(setups[0])
+    expect(store.getState().projectHostSetups[1]).toBe(setups[1])
+  })
+
+  it('drops a project and its setup when its repo disappears', async () => {
+    mockRepos(repo, secondRepo)
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+
+    mockRepos(repo)
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).not.toBe(projects)
+    expect(store.getState().projects).toHaveLength(1)
+    expect(store.getState().projectHostSetups).toHaveLength(1)
+  })
+
+  it('adds a project and its setup when a repo appears', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+
+    mockRepos(repo, secondRepo)
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).not.toBe(projects)
+    expect(store.getState().projects).toHaveLength(2)
+    expect(store.getState().projectHostSetups).toHaveLength(2)
+  })
+})
+
+describe('repo filter identity across catalog refreshes', () => {
+  it('keeps the filterRepoIds array when a refetch prunes nothing', async () => {
+    const store = createTestStore()
+    store.setState({ filterRepoIds: [repo.id] })
+    const first = store.getState().filterRepoIds
+
+    await store.getState().fetchRepos()
+
+    // Why: App.tsx at the root and five sidebar consumers select this array by identity.
+    expect(store.getState().filterRepoIds).toBe(first)
+  })
+
+  it('still prunes a filtered repo id that no longer exists', async () => {
+    const store = createTestStore()
+    store.setState({ filterRepoIds: [repo.id, 'gone'] })
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().filterRepoIds).toEqual([repo.id])
+  })
+
+  it('prunes only the vanished id and reallocates', async () => {
+    mockRepos(repo)
+    const store = createTestStore()
+    store.setState({ filterRepoIds: [repo.id, secondRepo.id] })
+    const first = store.getState().filterRepoIds
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().filterRepoIds).toEqual([repo.id])
+    expect(store.getState().filterRepoIds).not.toBe(first)
+  })
+
+  it('keeps a filtered id whose repo merely moved to another host', async () => {
+    const store = createTestStore()
+    store.setState({ filterRepoIds: [repo.id] })
+    const first = store.getState().filterRepoIds
+
+    // Why: the filter is keyed on repo id, not host identity — a rehomed repo is not pruned.
+    mockRepos({ ...repo, executionHostId: 'ssh:host-a', connectionId: 'host-a' })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().filterRepoIds).toBe(first)
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -48,6 +48,7 @@ import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
 import { reconcileFetchedRepos } from './repo-identity-reconcile'
+import { retainValidFilterRepoIds } from './repo-filter-selection'
 import {
   mergeSshRepoReadoptions,
   reconcileReadoptedSshRepoRows,
@@ -2102,7 +2103,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             ? {}
             : { folderWorkspacePathStatuses: {} }),
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          filterRepoIds: retainValidFilterRepoIds(s.filterRepoIds, validRepoIds),
           setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
             s.setupScriptPromptDismissedRepoIds,
             validRepoHostIdentities
@@ -2186,7 +2187,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ...reconcileReadoptedSshWorktreeState(s, s.pendingSshRepoReadoptions),
           ...mergedProjectCompatibility,
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          filterRepoIds: retainValidFilterRepoIds(s.filterRepoIds, validRepoIds),
           setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
             s.setupScriptPromptDismissedRepoIds,
             validRepoHostIdentities
@@ -2268,7 +2269,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         const validRepoHostIdentities = new Set(s.repos.map(getRepoHostIdentity))
         return {
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          filterRepoIds: retainValidFilterRepoIds(s.filterRepoIds, validRepoIds),
           setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
             s.setupScriptPromptDismissedRepoIds,
             validRepoHostIdentities

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -47,7 +47,11 @@ import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
-import { reconcileFetchedRepos } from './repo-identity-reconcile'
+import {
+  areValuesEqual,
+  reconcileCatalogRows,
+  reconcileFetchedRepos
+} from './repo-identity-reconcile'
 import { retainValidFilterRepoIds } from './repo-filter-selection'
 import {
   mergeSshRepoReadoptions,
@@ -944,50 +948,29 @@ function mergeFetchedProjectCompatibilityForHost({
       !fetchedProjectIds.has(project.id) &&
       (!previousProjectHostIds(project).has(hostId) || projectHasCurrentOwnerOutsideHost(project))
   )
+  // Why: both merges always allocate (sourceRepoIds is rebuilt per project, and fetched setups
+  // arrive freshly cloned over IPC), so reconcile against `previous` to recover identity when a
+  // refresh changed nothing. Each key is what the producing merge already dedups by.
   return {
-    projects: mergeProjectCompatibilityProjects(
-      preservedProjects.map((project) => {
-        const sourceRepoIds = getSourceRepoIdsOutsideHost(project, reposById, hostId)
-        return sourceRepoIds.length === project.sourceRepoIds.length
-          ? project
-          : { ...project, sourceRepoIds }
-      }),
-      fetchedProjects
+    projects: reconcileCatalogRows(
+      previous.projects,
+      mergeProjectCompatibilityProjects(
+        preservedProjects.map((project) => {
+          const sourceRepoIds = getSourceRepoIdsOutsideHost(project, reposById, hostId)
+          return sourceRepoIds.length === project.sourceRepoIds.length
+            ? project
+            : { ...project, sourceRepoIds }
+        }),
+        fetchedProjects
+      ),
+      (project) => project.id
     ),
-    projectHostSetups
-  }
-}
-
-function isPlainCatalogObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null) {
-    return false
-  }
-  const prototype = Object.getPrototypeOf(value)
-  return prototype === Object.prototype || prototype === null
-}
-
-// Why: catalog fetches rebuild every entry from IPC, so identity alone never matches;
-// structural equality is what lets an unchanged refetch stay a no-op.
-function areCatalogEntriesEqual(a: unknown, b: unknown): boolean {
-  if (a === b) {
-    return true
-  }
-  if (Array.isArray(a) || Array.isArray(b)) {
-    return (
-      Array.isArray(a) &&
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((entry, index) => areCatalogEntriesEqual(entry, b[index]))
+    projectHostSetups: reconcileCatalogRows(
+      previous.projectHostSetups,
+      projectHostSetups,
+      getProjectHostSetupOwnerKey
     )
   }
-  if (!isPlainCatalogObject(a) || !isPlainCatalogObject(b)) {
-    return false
-  }
-  const keys = Object.keys(a)
-  if (keys.length !== Object.keys(b).length) {
-    return false
-  }
-  return keys.every((key) => Object.hasOwn(b, key) && areCatalogEntriesEqual(a[key], b[key]))
 }
 
 // Why: returning `base` unchanged keeps referential-equality selectors quiet, so a
@@ -1009,7 +992,7 @@ function mergeByIdentity<T>(
       changed = true
       continue
     }
-    if (areCatalogEntriesEqual(merged[index], entry)) {
+    if (areValuesEqual(merged[index], entry)) {
       continue
     }
     merged[index] = entry
@@ -1300,7 +1283,7 @@ function filterSetupsForPrunedRepoRows(
   setups: readonly ProjectHostSetup[],
   mergedRepos: readonly Repo[],
   reconciledRepos: readonly Repo[]
-): ProjectHostSetup[] {
+): readonly ProjectHostSetup[] {
   const survivingOwners = new Set(
     reconciledRepos.map((repo) => `${getRepoExecutionHostId(repo)}:${repo.id}`)
   )
@@ -1309,12 +1292,15 @@ function filterSetupsForPrunedRepoRows(
       .filter((repo) => !survivingOwners.has(`${getRepoExecutionHostId(repo)}:${repo.id}`))
       .map((repo) => `${getRepoExecutionHostId(repo)}:${repo.id}`)
   )
+  // Why: this result feeds the compat merge as `previous`, so an unconditional copy would discard
+  // the identity that merge is about to try to preserve.
   if (prunedOwners.size === 0) {
-    return [...setups]
+    return setups
   }
-  return setups.filter(
+  const filtered = setups.filter(
     (setup) => !setup.repoId || !prunedOwners.has(`${setup.hostId}:${setup.repoId}`)
   )
+  return filtered.length === setups.length ? setups : filtered
 }
 
 function reconcileReadoptedSshWorktreeState(
@@ -1787,8 +1773,8 @@ function getFolderWorkspacePathStatusRequestSnapshotForRead(
 
 export type RepoSlice = {
   repos: readonly Repo[]
-  projects: Project[]
-  projectHostSetups: ProjectHostSetup[]
+  projects: readonly Project[]
+  projectHostSetups: readonly ProjectHostSetup[]
   projectGroups: readonly ProjectGroup[]
   folderWorkspaces: readonly FolderWorkspace[]
   folderWorkspacePathStatuses: Record<string, FolderWorkspacePathStatusCacheEntry>

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -792,6 +792,81 @@ function getExplicitProjectHostIds(
   return hostIds
 }
 
+function indexProjectHostSetupsByProjectId(
+  setups: readonly ProjectHostSetup[]
+): Map<string, ProjectHostSetup[]> {
+  const setupsByProjectId = new Map<string, ProjectHostSetup[]>()
+  for (const setup of setups) {
+    const existing = setupsByProjectId.get(setup.projectId)
+    if (existing) {
+      existing.push(setup)
+    } else {
+      setupsByProjectId.set(setup.projectId, [setup])
+    }
+  }
+  return setupsByProjectId
+}
+
+function getProjectSourceRepos(
+  project: Project,
+  reposById: ReadonlyMap<string, readonly Repo[]>
+): Repo[] {
+  const sourceRepos: Repo[] = []
+  for (const repoId of project.sourceRepoIds) {
+    for (const repo of reposById.get(repoId) ?? []) {
+      sourceRepos.push(repo)
+    }
+  }
+  return sourceRepos
+}
+
+// Why: the host-id resolvers rescan every setup and repo per project; feeding them the project's own slices keeps a catalog refresh linear.
+function createProjectHostIdIndex(
+  setups: readonly ProjectHostSetup[],
+  reposById: ReadonlyMap<string, readonly Repo[]>,
+  resolveHostIds: (
+    project: Project,
+    setups: readonly ProjectHostSetup[],
+    repos: readonly Repo[]
+  ) => Set<string>
+): (project: Project) => ReadonlySet<string> {
+  const noSetups: readonly ProjectHostSetup[] = []
+  const hostIdsByProject = new Map<Project, ReadonlySet<string>>()
+  let setupsByProjectId: Map<string, ProjectHostSetup[]> | null = null
+  return (project) => {
+    const cached = hostIdsByProject.get(project)
+    if (cached) {
+      return cached
+    }
+    setupsByProjectId ??= indexProjectHostSetupsByProjectId(setups)
+    const hostIds = resolveHostIds(
+      project,
+      setupsByProjectId.get(project.id) ?? noSetups,
+      getProjectSourceRepos(project, reposById)
+    )
+    hostIdsByProject.set(project, hostIds)
+    return hostIds
+  }
+}
+
+// Why: mergePreviousProjectMetadata scans the whole catalog's repo key set; a view holding only this pair's repos keeps that scan per-project.
+function restrictReposToProjectPair(
+  previous: Project,
+  current: Project,
+  reposById: ReadonlyMap<string, readonly Repo[]>
+): Map<string, readonly Repo[]> {
+  const restricted = new Map<string, readonly Repo[]>()
+  for (const project of [previous, current]) {
+    for (const repoId of project.sourceRepoIds) {
+      const matches = reposById.get(repoId)
+      if (matches) {
+        restricted.set(repoId, matches)
+      }
+    }
+  }
+  return restricted
+}
+
 function mergeFetchedProjectCompatibilityForHost({
   previous,
   fetched,
@@ -819,33 +894,54 @@ function mergeFetchedProjectCompatibilityForHost({
   const previousProjectById = new Map(previous.projects.map((project) => [project.id, project]))
   const reposById = getReposById(repos)
   const currentRepoIds = new Set(repos.map((repo) => repo.id))
-  const projectHasHost = (project: Project, setups: readonly ProjectHostSetup[]): boolean =>
-    getProjectHostIds(project, setups, repos).has(hostId)
-  const projectHasCurrentOwnerOutsideHost = (project: Project): boolean =>
-    [...getExplicitProjectHostIds(project, projectHostSetups, repos)].some(
-      (ownerHostId) => ownerHostId !== hostId
-    )
+  const fetchedProjectHostIds = createProjectHostIdIndex(
+    fetched.projectHostSetups,
+    reposById,
+    getProjectHostIds
+  )
+  const previousProjectHostIds = createProjectHostIdIndex(
+    previous.projectHostSetups,
+    reposById,
+    getProjectHostIds
+  )
+  const currentProjectOwnerHostIds = createProjectHostIdIndex(
+    projectHostSetups,
+    reposById,
+    getExplicitProjectHostIds
+  )
+  const projectHasCurrentOwnerOutsideHost = (project: Project): boolean => {
+    for (const ownerHostId of currentProjectOwnerHostIds(project)) {
+      if (ownerHostId !== hostId) {
+        return true
+      }
+    }
+    return false
+  }
   const fetchedProjects = fetched.projects
     .filter((project) => {
       const previousProject = previousProjectById.get(project.id)
       // Why: repo-derived compatibility projects include every host; a one-host refresh should only reconcile or prune that host's ownership.
       return (
-        projectHasHost(project, fetched.projectHostSetups) ||
-        (previousProject ? projectHasHost(previousProject, previous.projectHostSetups) : false)
+        fetchedProjectHostIds(project).has(hostId) ||
+        (previousProject ? previousProjectHostIds(previousProject).has(hostId) : false)
       )
     })
     .map((project) => {
       const previousProject = previousProjectById.get(project.id)
       return previousProject
-        ? mergePreviousProjectMetadata(previousProject, project, reposById, hostId)
+        ? mergePreviousProjectMetadata(
+            previousProject,
+            project,
+            restrictReposToProjectPair(previousProject, project, reposById),
+            hostId
+          )
         : projectWithCurrentSourceRepoIds(project, currentRepoIds)
     })
   const fetchedProjectIds = new Set(fetchedProjects.map((project) => project.id))
   const preservedProjects = previous.projects.filter(
     (project) =>
       !fetchedProjectIds.has(project.id) &&
-      (!getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId) ||
-        projectHasCurrentOwnerOutsideHost(project))
+      (!previousProjectHostIds(project).has(hostId) || projectHasCurrentOwnerOutsideHost(project))
   )
   return {
     projects: mergeProjectCompatibilityProjects(

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -904,8 +904,8 @@ export type UISlice = {
   showDotfilesByWorktree: Record<string, boolean>
   setShowDotfilesForWorktree: (worktreeId: string, showDotfiles: boolean) => void
   toggleShowDotfilesForWorktree: (worktreeId: string) => void
-  filterRepoIds: string[]
-  setFilterRepoIds: (ids: string[]) => void
+  filterRepoIds: readonly string[]
+  setFilterRepoIds: (ids: readonly string[]) => void
   collapsedGroups: Set<string>
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -6080,7 +6080,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const reposChanged = survivingRepos.length !== s.repos.length
 
       // Why: a repoId-less setup on the removed host can still split a surviving project group, so drop every setup it owns.
-      const survivingSetups: AppState['projectHostSetups'] = []
+      const survivingSetups: ProjectHostSetup[] = []
       for (const setup of s.projectHostSetups) {
         if (isRemovedRuntimeHostId(setup.hostId, removed)) {
           if (setup.repoId) {

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -13,8 +13,8 @@ type ProjectAccumulator = {
 }
 
 export type ProjectHostSetupProjection = {
-  projects: Project[]
-  setups: ProjectHostSetup[]
+  projects: readonly Project[]
+  setups: readonly ProjectHostSetup[]
 }
 
 function getProjectProviderIdentity(


### PR DESCRIPTION
## Summary

`mergeFetchedProjectCompatibilityForHost` runs **synchronously inside a zustand `set()` on every repo catalog refresh**, and was O(projects × (setups + repos)). This indexes it, and stops three slices losing their array identity on the same path.

Built on current `main` (it supersedes #13788, which was written pre-#13770 and became conflicting).

| Commit | What |
|---|---|
| `2c464a7` | Index project-host ownership in the compat merge |
| `c3a2da7` | `filterRepoIds` keeps identity when nothing is pruned |
| `7ce561b` | Reconcile `projects` / `projectHostSetups`; **delete the duplicate comparator** |
| `d681dfd` | Refresh-identity tests |

## 1. The quadratic merge

Three per-project rescans: `getProjectHostIds` / `getExplicitProjectHostIds` rescanned all setups and repos once per project, and `mergePreviousProjectMetadata` rebuilt a full repo key-set per project.

Fixed by precomputing indexes once and handing the **existing** ownership helpers pre-sliced inputs. No ownership logic was reimplemented, so the results are provably identical rather than "hopefully equivalent".

## 2. Three slices losing identity

- **`projects` / `projectHostSetups`** — the merge always allocates (`sourceRepoIds` rebuilt per project; setups arrive freshly cloned over IPC), so these now reconcile against `previous`. `filterSetupsForPrunedRepoRows` also had to stop returning `[...setups]`, or the reconcile compares against a throwaway.
- **`filterRepoIds`** — returns the input when nothing is pruned. Note `[].filter(...)` still allocates, so on `main` this churned **even for users with no filter set**.

## 3. Deletes a duplicated comparator

#13744 and #13770 landed near-identical structural deep-equality helpers into this file hours apart, from parallel sessions. This generalizes `reconcileFetchedRepos` into `reconcileCatalogRows<T>` and **deletes** `repos.ts`'s `isPlainCatalogObject` + `areCatalogEntriesEqual`. No third comparator added; `repos.ts` shrinks. It also removes a pre-existing `as (keyof Repo)[]` cast.

(A follow-up PR unifies the remaining copies — see below.)

## Measured — branch tip, not the best commit

The per-commit number for `2c464a7` in isolation is 5.2×/15.3×/26.6×, and two independent reviewers reproduced it. **But that is not what shipping this branch gives you**, because the reconcile in `7ce561b` adds a structural walk back. Branch tip, medians of 40 rounds across 3 fresh node processes, steady-state no-op refresh:

| repos | main | branch tip | speedup |
|---:|---:|---:|---:|
| 10 | 0.023 ms | 0.039 ms | **0.6× (slower)** |
| 50 | 0.121 ms | 0.124 ms | ~parity |
| 200 | 1.12 ms | 0.43 ms | 2.6× |
| 600 | 11.6 ms | 1.32 ms | 8.8× |
| 1200 | 47.4 ms | 2.75 ms | 17.3× |

**Crossover is around 50 repos; below that this is neutral-to-marginally-slower.** The merge also runs **once per host**, so an all-hosts refresh pays the figure N times.

## The consumer win

The strongest effect is one I had originally failed to cite. `project-host-setup-selector.ts` keys a WeakMap chain on `(repos, projects, projectHostSetups)` **array identity**, and `getProjectHostSetupProjectionFromState` is `Object.is`-compared as a zustand selector. Because `projects` and `projectHostSetups` were reallocated every refresh, that cache missed **100% of the time** and every consumer got a fresh projection object: `WorktreeList`, `TerminalPane` (one per pane), `TabBarQuickCommandsButton`, `AiVaultPanel`, plus `computeRenderedSidebarWorktreeOrder`. Verified stable across three identical fetches now.

`filterRepoIds` has six plain-identity subscribers: `App.tsx:698`, `WorktreeList.tsx:5232`, `SidebarFilter.tsx:69`, `SidebarWorkspaceOptionsMenu.tsx:46`, `SidebarRepositoryFilterSection.tsx:42`, `use-visible-workspace-kanban-worktree-ids.ts:45`.

## Known limitation — multi-host array identity

**The array-identity half does not hold when refreshes alternate between different host scopes.** `mergeProjectCompatibilityProjects` orders preserved-before-fetched (`repos.ts:577-584`), so refreshing host A and host B yield different orders and the reconcile correctly returns a new array. Element identity still holds; the WeakMap chain above keys on array identity, so multi-host users get the element benefit but not the projection benefit.

This is pre-existing merge behaviour, not introduced here, and stabilizing that ordering is a separate change. Flagging it rather than letting the headline imply a win it does not deliver for the multi-host case.

Also note: `readonly` caught two array-level accumulators, but it does **not** prevent element-level mutation of a reused `Project` / `ProjectHostSetup`.

## Verification

Adversarial review by four independent agents; **no P0/P1 correctness findings**.

- Differential harness: the indexed rewrite is byte-, order- and **provenance**-identical to `main` across 20,000 randomized catalogs (duplicate repo/project ids, dangling `sourceRepoIds`, empty-string `repoId` setups, local/SSH/runtime mixes, `runtimeOwnerEnvironmentId`, `localWindowsRuntimePreference` absent/undefined/defined). Element provenance diverges only in the intended direction (reusing a previous object where `main` allocated), never toward over-preservation.
- Comparator dedupe: 0/60,000 randomized pairs differ from `areCatalogEntriesEqual`.
- **Six negative controls**, each verified red then restored: removing both reconcile calls; reverting `filterSetupsForPrunedRepoRows`; reverting `retainValidFilterRepoIds`; reducing the compare to `a === b`; forcing it to `true`; switching the setups key to `setup.id`. Reducing to reference-equality turning the tests red is what proves the production-shaped fixture is load-bearing — a scalar-only fixture stays green while the feature is dead, which is exactly how an earlier version of this work shipped inert.
- 2502 store tests / 10,781 across affected scope; `tsc` web + node + cli clean; oxlint, oxfmt, max-lines ratchet clean. No `as` casts, `as unknown as`, `@ts-expect-error`, or lint disables added.

## Follow-ups (not in this PR)

- `mergeProjectHostSetupCompatibility` + `recordSshRepoReadoptions` still spread fresh arrays into `set()` without going through the compat merge. Only fires on SSH re-adoption; ~4 lines now that `filterSetupsForPrunedRepoRows` returns its input.
- Repos with `addedAt === 0`/absent silently never reconcile (`projectHostSetupProjectionFromRepos` uses `repo.addedAt || now`). Degraded-data only, but it turns the optimization off quietly rather than failing loudly.
- The three new index helpers would be a natural extraction into a domain-named module; `repos.ts` is large and already carries a pre-existing `max-lines` suppression.
- Stabilizing cross-host merge ordering, which would make the array-identity half hold for multi-host users.

Made with [Orca](https://github.com/stablyai/orca) 🐋
