### PR TITLE
fix(renderer): keep authored commit-message line breaks in the history tooltip

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -94,7 +94,13 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
                 {item.subject}
               </span>
             </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+            {/* Why: fit conventional 72-char commit lines; text-wrap stops the
+                primitive's text-balance from re-breaking authored lines. */}
+            <TooltipContent
+              side="bottom"
+              sideOffset={6}
+              className="max-w-[min(76ch,calc(100vw-2rem))] text-wrap whitespace-pre-wrap"
+            >
               {rowTooltip}
             </TooltipContent>
           </Tooltip>


### PR DESCRIPTION
Fixes #13793

## What changed

The commit-message tooltip in Source Control → Commits wrapped lines at `max-w-96` (384px ≈ 55–60 chars at `text-xs`), so commit bodies authored to the conventional 72-character limit were re-broken mid-line. The tooltip primitive's `text-balance` made it worse by redistributing the soft-wrapped lines even earlier.

This PR widens the commit tooltip to `max-w-[min(76ch,calc(100vw-2rem))]` and overrides `text-balance` with `text-wrap`:

- `76ch` scales with the tooltip's own font, so conventional 72-char lines stay on one visual line (with slack for wide glyphs).
- The `min(…, calc(100vw-2rem))` guard keeps the tooltip inside narrow windows, where Radix shifts position but never shrinks content.
- `text-wrap` (plain wrapping) stops `text-balance` from re-breaking lines the author deliberately kept short; explicit newlines were already preserved via `whitespace-pre-wrap`.

Scope is intentionally limited to the commit-message tooltip in `GitHistoryRow.tsx` — the ref-badge and “+N” tooltips render single-line labels and keep `max-w-72`.

## Screenshots

Same multi-line commit message (72-char-convention body), macOS:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/tnqls0624/orca/assets/13793-tooltip/before-closeup.png) | ![after](https://raw.githubusercontent.com/tnqls0624/orca/assets/13793-tooltip/after-closeup.png) |

## Checks

`pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass locally (macOS, arm64). Screenshots were captured from the real app driven through the repo's Playwright E2E harness.

## Notes

- **Why no dedicated test:** this is a pure presentation (CSS class) change; the existing `GitHistoryPanel.test.tsx` mocks the tooltip primitives entirely, and a class-string assertion would not catch a real regression. Message content/newline preservation is already covered by the parser path.
- The `max-w-96` value came from an unrelated tab-overflow fix (#5415), not a deliberate width decision for commit messages.

## AI code review summary

Reviewed with Claude Code:

- **Cross-platform:** class-only change in shared renderer CSS; no platform APIs, no keyboard/path logic. Behavior identical on macOS/Linux/Windows.
- **SSH/remote & workspace types:** the tooltip renders already-fetched history items; no change to data fetching, so SSH worktrees and folder workspaces are unaffected.
- **Agents/integrations/git providers:** none touched; the panel is provider-neutral git log data.
- **Performance:** no new work in render path; `cn()`/tailwind-merge already ran on this element.
- **UI quality:** verified in the running app (screenshots above); `whitespace-pre-wrap` retained so authored line breaks render as-is; viewport guard prevents overflow on narrow windows. STYLEGUIDE has no tooltip-width token, so an arbitrary value mirrors existing usage in this file (`max-w-[8rem]`).
- **Security:** none — no input handling or IPC changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
