### PR TITLE
fix(skills): retry past a dead version-manager shim on exit 126

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../shared/skill-freshness'
 import { inventorySkillFreshness } from '../skills/skill-freshness-inventory'
 import { SkillUpdateRunner } from '../skills/skill-update-run'
+import { resolveCliCommandCandidates } from '../codex-cli/command'
 import { skillUpdateFailedNames } from '../skills/skill-update-outcome'
 import { readGloballyUpdatableSkillLocks } from '../skills/skill-update-registration'
 import {
@@ -40,6 +41,10 @@ export function registerSkillsHandlers(store: Store): void {
       ])
       return skillUpdateFailedNames(names, inventory.installations, globalSkillLocks)
     },
+    // Why: asdf/mise shims pass the X_OK probe but exit 126 when their declared
+    // node version is missing; the runner retries the next candidate (issue
+    // #13807).
+    resolveCommandCandidates: (name) => resolveCliCommandCandidates(name),
     onState: (run: SkillUpdateRun) => {
       for (const window of BrowserWindow.getAllWindows()) {
         if (!window.isDestroyed()) {

--- a/src/main/skills/skill-update-run.test.ts
+++ b/src/main/skills/skill-update-run.test.ts
@@ -400,7 +400,45 @@ describe('SkillUpdateRunner', () => {
 
     const run = runner.getState()
     expect(run.state).toBe('error')
-    expect(run.state === 'error' && run.message).toBe('skills update exited with code 126')
+    expect(run.state === 'error' && run.message).toContain('skills update exited with code 126')
+    // The final message must name the binary and suggest a version-manager fix.
+    expect(run.state === 'error' && run.message).toContain('/usr/local/bin/npx')
+    expect(run.state === 'error' && run.message).toMatch(/asdf install|mise install/)
+  })
+
+  it('only retries once — a third candidate is never spawned after two 126s', async () => {
+    const children: FakeChild[] = []
+    const spawnCalls: { command: string }[] = []
+    const runner = new SkillUpdateRunner({
+      now: () => 1000,
+      resolveCommandCandidates: () => [
+        '/home/user/.asdf/shims/npx',
+        '/usr/local/bin/npx',
+        '/opt/homebrew/bin/npx'
+      ],
+      rescanOutdatedNames: async () => ['orca-cli'],
+      killTree: async (_pid, killRoot) => killRoot(),
+      onState: () => {},
+      spawnProcess: ((command: string) => {
+        spawnCalls.push({ command })
+        const child = new FakeChild()
+        children.push(child)
+        return child as never
+      }) as never
+    })
+
+    runner.start(['orca-cli'])
+    children[0].emit('close', 126)
+    await flush()
+    children[1].emit('close', 126)
+    await flush()
+
+    // Exactly one fallback: the third candidate must never be spawned.
+    expect(spawnCalls.map((call) => call.command)).toEqual([
+      '/home/user/.asdf/shims/npx',
+      '/usr/local/bin/npx'
+    ])
+    expect(runner.getState().state).toBe('error')
   })
 
   it('uses the single resolveCommand result when no candidates are injected', () => {

--- a/src/main/skills/skill-update-run.test.ts
+++ b/src/main/skills/skill-update-run.test.ts
@@ -346,4 +346,66 @@ describe('SkillUpdateRunner', () => {
     runner.acknowledge()
     expect(runner.getState()).toEqual({ state: 'idle' })
   })
+
+  it('falls back to the next npx candidate when the first dies with 126', async () => {
+    // A dead asdf/mise shim (missing declared node version) exits 126 after
+    // passing the X_OK probe; the runner must retry the next PATH candidate.
+    const children: FakeChild[] = []
+    const spawnCalls: { command: string }[] = []
+    const runner = new SkillUpdateRunner({
+      now: () => 1000,
+      resolveCommandCandidates: () => ['/home/user/.asdf/shims/npx', '/usr/local/bin/npx'],
+      rescanOutdatedNames: async () => [],
+      killTree: async (_pid, killRoot) => killRoot(),
+      onState: () => {},
+      spawnProcess: ((command: string) => {
+        spawnCalls.push({ command })
+        const child = new FakeChild()
+        children.push(child)
+        return child as never
+      }) as never
+    })
+
+    runner.start(['orca-cli'])
+    children[0].emit('close', 126)
+    await flush()
+
+    expect(spawnCalls.map((call) => call.command)).toEqual([
+      '/home/user/.asdf/shims/npx',
+      '/usr/local/bin/npx'
+    ])
+    expect(runner.getState().state).toBe('running')
+  })
+
+  it('settles as an error when the last npx candidate also exits 126', async () => {
+    const children: FakeChild[] = []
+    const runner = new SkillUpdateRunner({
+      now: () => 1000,
+      resolveCommandCandidates: () => ['/home/user/.asdf/shims/npx', '/usr/local/bin/npx'],
+      rescanOutdatedNames: async () => ['orca-cli'],
+      killTree: async (_pid, killRoot) => killRoot(),
+      onState: () => {},
+      spawnProcess: (() => {
+        const child = new FakeChild()
+        children.push(child)
+        return child as never
+      }) as never
+    })
+
+    runner.start(['orca-cli'])
+    children[0].emit('close', 126)
+    await flush()
+    children[1].emit('close', 126)
+    await flush()
+
+    const run = runner.getState()
+    expect(run.state).toBe('error')
+    expect(run.state === 'error' && run.message).toBe('skills update exited with code 126')
+  })
+
+  it('uses the single resolveCommand result when no candidates are injected', () => {
+    const { runner, spawnCalls } = makeRunner({ resolveCommand: () => '/usr/local/bin/npx' })
+    runner.start(['orca-cli'])
+    expect(spawnCalls[0].command).toBe('/usr/local/bin/npx')
+  })
 })

--- a/src/main/skills/skill-update-run.ts
+++ b/src/main/skills/skill-update-run.ts
@@ -29,6 +29,10 @@ export const CANCEL_RELEASE_TIMEOUT_MS = 12_000
 export type SkillUpdateRunnerDeps = {
   spawnProcess?: typeof spawn
   resolveCommand?: (commandName: string) => string
+  /** Ordered fallback list for a command; tried in order when the previous
+   *  candidate dies with exit 126 (a version-manager shim whose declared
+   *  node version is not installed). */
+  resolveCommandCandidates?: (commandName: string) => string[]
   /** Returns the subset of `names` that did not land, re-read from disk. */
   rescanOutdatedNames?: (names: string[]) => Promise<string[]>
   killTree?: (pid: number, killRoot: () => void) => Promise<void>
@@ -37,6 +41,12 @@ export type SkillUpdateRunnerDeps = {
   now?: () => number
   onState?: (run: SkillUpdateRun) => void
 }
+
+// Why: asdf/mise shims pass an accessSync(X_OK) probe but exec their declared
+// node version on launch; when that version is not installed the shim exits
+// 126. Retrying the next PATH candidate once turns a permanently broken
+// update into a working one (issue #13807).
+const DEAD_SHIM_EXIT_CODE = 126
 
 function stripAnsi(value: string): string {
   return value.replace(ANSI_RE, '').replace(/\r(?!\n)/g, '\n')
@@ -90,19 +100,20 @@ export class SkillUpdateRunner {
     }
 
     const resolveCommand = this.deps.resolveCommand ?? ((name: string) => resolveCliCommand(name))
-    const spawnProcess = this.deps.spawnProcess ?? spawn
-    const npxCommand = resolveCommand('npx')
+    const candidates =
+      this.deps.resolveCommandCandidates?.(canonicalNames[0] ? 'npx' : 'npx') ??
+      [resolveCommand('npx')]
     const npxArgs = ['--yes', 'skills', 'update', ...canonicalNames, '--global', '-y']
 
-    let spawnCmd: string
-    let spawnArgs: string[]
+    // Why: the first candidate is validated synchronously so the caller keeps
+    // the `started: false, reason: 'unsafe-command-path'` contract instead of
+    // learning about a bad path only after the run has already been published
+    // as running (the cmd.exe rail rejects paths containing &, ^, etc.).
+    let firstSpawn: { spawnCmd: string; spawnArgs: string[] } | null = null
     try {
       const buildSpawnArgs = this.deps.buildSpawnArgs ?? getSpawnArgsForWindows
-      ;({ spawnCmd, spawnArgs } = buildSpawnArgs(npxCommand, npxArgs))
+      firstSpawn = buildSpawnArgs(candidates[0] ?? 'npx', npxArgs)
     } catch {
-      // Why: the names are already canonical here, so this is the cmd.exe rail
-      // rejecting the resolved npx *path*. Publishing the failure keeps the dialog
-      // honest; a bare `started: false` would leave the button dead and silent.
       this.runToken += 1
       this.settling = false
       this.publish({
@@ -112,8 +123,8 @@ export class SkillUpdateRunner {
         output: '',
         failedNames: canonicalNames,
         message:
-          `Could not run ${npxCommand} safely from this location: its path contains one of ` +
-          `${WINDOWS_BATCH_UNSAFE_CHARACTERS_LABEL}, which cmd.exe would reinterpret.`
+          `Could not run ${candidates[0] ?? 'npx'} safely from this location: its path contains ` +
+          `one of ${WINDOWS_BATCH_UNSAFE_CHARACTERS_LABEL}, which cmd.exe would reinterpret.`
       })
       return { started: false, reason: 'unsafe-command-path' }
     }
@@ -122,6 +133,39 @@ export class SkillUpdateRunner {
     const token = ++this.runToken
     this.settling = false
     this.publish({ state: 'running', names: canonicalNames, startedAt, output: '' })
+    this.spawnAttempt(token, canonicalNames, candidates, 0, npxArgs, firstSpawn)
+    return { started: true }
+  }
+
+  private spawnAttempt(
+    token: number,
+    canonicalNames: string[],
+    candidates: string[],
+    index: number,
+    npxArgs: string[],
+    prebuilt?: { spawnCmd: string; spawnArgs: string[] }
+  ): void {
+    if (token !== this.runToken || this.run.state !== 'running') {
+      return
+    }
+    const spawnProcess = this.deps.spawnProcess ?? spawn
+    const npxCommand = candidates[index] ?? candidates.at(-1) ?? 'npx'
+
+    let spawnCmd: string
+    let spawnArgs: string[]
+    if (prebuilt) {
+      ;({ spawnCmd, spawnArgs } = prebuilt)
+    } else {
+      try {
+        const buildSpawnArgs = this.deps.buildSpawnArgs ?? getSpawnArgsForWindows
+        ;({ spawnCmd, spawnArgs } = buildSpawnArgs(npxCommand, npxArgs))
+      } catch {
+        // A later candidate hitting the cmd.exe rail is a hard failure — the
+        // first one already passed, so this is an unusual path; surface it.
+        this.settle(token, canonicalNames, `Could not run ${npxCommand} safely from this location`)
+        return
+      }
+    }
 
     const child = spawnProcess(spawnCmd, spawnArgs, {
       // Why: stdin ignored keeps `process.stdin.isTTY` falsy in the child, which
@@ -173,14 +217,21 @@ export class SkillUpdateRunner {
     })
     child.on('close', (code) => {
       drain()
+      // Why: 126 is the POSIX "found but not executable" exit — version-manager
+      // shims (asdf/mise) with a missing declared node version die with it. The
+      // shim passed our X_OK probe, so the only way to recover is to try the
+      // next PATH candidate once (issue #13807).
+      if (code === DEAD_SHIM_EXIT_CODE && index + 1 < candidates.length) {
+        this.child = null
+        this.spawnAttempt(token, canonicalNames, candidates, index + 1, npxArgs)
+        return
+      }
       this.settle(
         token,
         canonicalNames,
         code === 0 ? null : `skills update exited with code ${code}`
       )
     })
-
-    return { started: true }
   }
 
   private settle(token: number, names: string[], spawnError: string | null): void {

--- a/src/main/skills/skill-update-run.ts
+++ b/src/main/skills/skill-update-run.ts
@@ -220,17 +220,22 @@ export class SkillUpdateRunner {
       // Why: 126 is the POSIX "found but not executable" exit — version-manager
       // shims (asdf/mise) with a missing declared node version die with it. The
       // shim passed our X_OK probe, so the only way to recover is to try the
-      // next PATH candidate once (issue #13807).
-      if (code === DEAD_SHIM_EXIT_CODE && index + 1 < candidates.length) {
+      // next PATH candidate once (issue #13807). Deliberately a single fallback:
+      // more attempts would mask genuinely broken installs.
+      if (code === DEAD_SHIM_EXIT_CODE && index === 0 && index + 1 < candidates.length) {
         this.child = null
         this.spawnAttempt(token, canonicalNames, candidates, index + 1, npxArgs)
         return
       }
-      this.settle(
-        token,
-        canonicalNames,
-        code === 0 ? null : `skills update exited with code ${code}`
-      )
+      const exitMessage =
+        code === DEAD_SHIM_EXIT_CODE && code !== 0
+          ? `skills update exited with code ${code} — ${npxCommand} looks like a version-manager ` +
+            `shim whose declared runtime is not installed. Check or install the configured node ` +
+            `version (e.g. 'asdf install' or 'mise install') or fix PATH so a working npx comes first.`
+          : code === 0
+            ? null
+            : `skills update exited with code ${code}`
+      this.settle(token, canonicalNames, exitMessage)
     })
   }
 

--- a/src/shared/node-cli-command-resolution.test.ts
+++ b/src/shared/node-cli-command-resolution.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveCliCommand, resolveCliCommandCandidates } from './node-cli-command-resolution'
+
+function makeFakeBin(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'npx-resolve-'))
+  const bin = join(dir, 'bin')
+  mkdirSync(bin)
+  const shim = join(bin, 'npx')
+  writeFileSync(shim, '#!/usr/bin/env sh\nexit 126\n')
+  chmodSync(shim, 0o755)
+  return bin
+}
+
+describe('resolveCliCommandCandidates', () => {
+  it('returns every runnable candidate in PATH order', () => {
+    const first = makeFakeBin()
+    const second = makeFakeBin()
+    const path = [first, second].join(':')
+
+    const candidates = resolveCliCommandCandidates('npx', { pathEnv: path, platform: 'linux' })
+
+    expect(candidates).toEqual([join(first, 'npx'), join(second, 'npx')])
+  })
+
+  it('falls back to version-manager shims when PATH has no candidate', () => {
+    const home = mkdtempSync(join(tmpdir(), 'npx-home-'))
+    const shims = join(home, '.asdf', 'shims')
+    mkdirSync(shims, { recursive: true })
+    const shim = join(shims, 'npx')
+    writeFileSync(shim, '#!/usr/bin/env sh\nexit 126\n')
+    chmodSync(shim, 0o755)
+
+    const candidates = resolveCliCommandCandidates('npx', {
+      pathEnv: '/usr/bin:/bin',
+      platform: 'linux',
+      homePath: home
+    })
+
+    expect(candidates).toContain(join(shims, 'npx'))
+  })
+
+  it('resolveCliCommand keeps returning the first candidate', () => {
+    const first = makeFakeBin()
+    const second = makeFakeBin()
+    const path = [first, second].join(':')
+
+    expect(resolveCliCommand('npx', { pathEnv: path, platform: 'linux' })).toBe(
+      join(first, 'npx')
+    )
+  })
+
+  it('deduplicates a candidate that appears both in PATH and version-manager dirs', () => {
+    const home = mkdtempSync(join(tmpdir(), 'npx-home2-'))
+    const shims = join(home, '.asdf', 'shims')
+    mkdirSync(shims, { recursive: true })
+    const shim = join(shims, 'npx')
+    writeFileSync(shim, '#!/usr/bin/env sh\nexit 126\n')
+    chmodSync(shim, 0o755)
+
+    const candidates = resolveCliCommandCandidates('npx', {
+      pathEnv: shims,
+      platform: 'linux',
+      homePath: home
+    })
+
+    // The shim dir is in PATH AND in the asdf shims list — must appear once.
+    expect(candidates.filter((c) => c === shim)).toHaveLength(1)
+  })
+})

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -152,28 +152,63 @@ export function resolveCliCommand(
   commandName: string,
   options: ResolveCommandOptions = {}
 ): string {
+  return resolveCliCommandCandidates(commandName, options)[0] ?? commandName
+}
+
+/**
+ * All runnable candidates for a command, in PATH order then version-manager
+ * install dirs. Used by the skill-update runner to retry past a dead
+ * version-manager shim (asdf/mise shims pass the X_OK probe but exit 126
+ * when their declared node version is not installed — issue #13807).
+ */
+export function resolveCliCommandCandidates(
+  commandName: string,
+  options: ResolveCommandOptions = {}
+): string[] {
   const platform = options.platform ?? process.platform
   const executableNames = getExecutableNames(platform, commandName)
   const pathEnv = options.pathEnv ?? process.env.PATH ?? process.env.Path ?? null
-  const pathCandidate = findFirstExecutable(platform, splitPath(pathEnv), executableNames)
-  if (pathCandidate) {
-    return pathCandidate
+  const homePath = options.homePath ?? homedir()
+
+  const candidates: string[] = []
+  const seen = new Set<string>()
+  const pushUnique = (candidate: string | null): void => {
+    if (candidate && !seen.has(candidate)) {
+      seen.add(candidate)
+      candidates.push(candidate)
+    }
   }
 
-  const homePath = options.homePath ?? homedir()
-  const nvmCandidate = findFirstExecutable(
-    platform,
-    getNvmVersionDirectories(homePath),
-    executableNames
-  )
-  const versionManagerCandidate =
-    nvmCandidate ??
-    findFirstExecutable(
-      platform,
-      getBaseVersionManagerDirectories(platform, homePath),
-      executableNames
-    )
-  return versionManagerCandidate ?? commandName
+  // PATH order first — the user's own ordering is the primary intent.
+  for (const directory of splitPath(pathEnv)) {
+    for (const executableName of executableNames) {
+      const candidate = join(directory, executableName)
+      if (isRunnableCommand(platform, candidate)) {
+        pushUnique(candidate)
+      }
+    }
+  }
+
+  // Then the version-manager install dirs (nvm, volta, fnm, asdf, mise, ...),
+  // deduplicated against PATH hits.
+  for (const directory of getNvmVersionDirectories(homePath)) {
+    for (const executableName of executableNames) {
+      const candidate = join(directory, executableName)
+      if (isRunnableCommand(platform, candidate)) {
+        pushUnique(candidate)
+      }
+    }
+  }
+  for (const directory of getBaseVersionManagerDirectories(platform, homePath)) {
+    for (const executableName of executableNames) {
+      const candidate = join(directory, executableName)
+      if (isRunnableCommand(platform, candidate)) {
+        pushUnique(candidate)
+      }
+    }
+  }
+
+  return candidates
 }
 
 export function resolveCliCommands(


### PR DESCRIPTION
## Summary

Fixes skill updates being permanently blocked when `resolveCliCommand('npx')` picks a version-manager shim (asdf/mise) whose declared node version is not installed. The shim passes the `accessSync(X_OK)` probe but exits **126** on launch, so the update fails even though a working `npx` exists later in PATH. The runner now retries the next PATH candidate once, and the final error names the binary and suggests the version-manager fix.

Closes #13807

## Screenshots

No visual change — this is a background runner/CLI resolution fix.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test` — `vitest run` on the touched files: **27/27 pass** (`node-cli-command-resolution.test.ts` 4, `skill-update-run.test.ts` 23); **168 pass** across the files importing the resolver
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions: 4 new resolver tests (PATH ordering, version-manager fallback, first-candidate compat, dedup) + 4 new runner tests (fallback on 126, single-retry boundary — third candidate never spawned, final-error content, single-command compat)

## AI Review Report

Reviewed by CodeRabbit (Pro) and iterated:
- **Major — retry scope**: the fallback originally tried every remaining candidate; CodeRabbit flagged that the issue's "retry once" contract was violated. Fixed to fire only at `index === 0`; added a three-candidate test proving the third is never spawned.
- **Minor — error UX**: the final 126 error now includes the resolved binary path and version-manager guidance (`asdf install` / `mise install` / fix PATH order).
- Cross-platform: the fix is POSIX-specific by construction (126 is a POSIX exit code; Windows shims resolve to `.cmd` and are not affected). The Windows cmd.exe rail contract (`unsafe-command-path`) is preserved and covered by the existing test. No shortcuts, labels, paths or Electron-specific behavior changed.

## Security Audit

- **Command execution**: the runner spawns `npx` with canonicalized skill names (existing guard, unchanged); the new code only changes *which* npx path is spawned (candidate list from PATH + version-manager dirs), never the arguments.
- **Path handling**: candidates come from the user's own PATH and standard version-manager dirs; deduplicated. The existing Windows unsafe-character rail still applies to every candidate.
- **No auth, secrets, dependencies or IPC surface changed.**

## Notes

- The repo template requires AI-review/security sections, so this description follows the template (the earlier draft was a plain summary).
- On a VPS the full `tsc -p config/tsconfig.node.json` run exceeds available memory; the project CI runs the canonical typecheck/lint, and all touched-file tests pass locally.
