### PR TITLE
fix(native-chat): let the model picker clear the persisted launch override

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -2,8 +2,26 @@
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import type * as ReactModule from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  PersistedNativeChatSessionOptions,
+  SessionOptionDescriptor
+} from '../../../../shared/native-chat-session-options'
+
+const mocks = vi.hoisted(() => ({
+  storeState: {
+    settings: {} as { nativeChatSessionOptions?: PersistedNativeChatSessionOptions }
+  },
+  clearPersistedNativeChatModel: vi.fn()
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof mocks.storeState) => unknown) => selector(mocks.storeState)
+}))
+
+vi.mock('./use-native-chat-session-options', () => ({
+  clearPersistedNativeChatModel: mocks.clearPersistedNativeChatModel
+}))
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string, values?: Record<string, string | number>) => {
@@ -135,6 +153,7 @@ vi.mock('@/components/ui/dropdown-menu', () => {
 import { NativeChatSessionOptionPickers } from './NativeChatSessionOptionPickers'
 
 const surface = {
+  agent: 'claude',
   getSnapshot: vi.fn(() => []),
   setOption: vi.fn(),
   invokeAction: vi.fn(),
@@ -186,6 +205,11 @@ const fast: SessionOptionDescriptor = {
 }
 
 afterEach(() => cleanup())
+
+beforeEach(() => {
+  mocks.storeState.settings = {}
+  mocks.clearPersistedNativeChatModel.mockReset().mockResolvedValue(undefined)
+})
 
 describe('NativeChatSessionOptionPickers', () => {
   it('prefers collision-aware upward placement for model and option menus', () => {
@@ -456,5 +480,41 @@ describe('NativeChatSessionOptionPickers', () => {
       />
     )
     expect(screen.getByText('Sent to the agent — not confirmed')).not.toBeNull()
+  })
+
+  it('offers a Use CLI default action only while a launch override is persisted', () => {
+    mocks.storeState.settings = { nativeChatSessionOptions: { claude: { model: 'haiku' } } }
+    const { rerender } = render(
+      <NativeChatSessionOptionPickers surface={surface} snapshot={[model()]} isWorking={false} />
+    )
+    // An action row, not a radio — the radios state the session's tracked model.
+    const row = screen.getByRole('button', { name: /Use CLI default/ })
+    expect(row.getAttribute('role')).not.toBe('radio')
+    expect(
+      screen.getByText('New sessions use the model configured in the agent CLI')
+    ).not.toBeNull()
+
+    mocks.storeState.settings = { nativeChatSessionOptions: { claude: {} } }
+    rerender(
+      <NativeChatSessionOptionPickers surface={surface} snapshot={[model()]} isWorking={false} />
+    )
+    expect(screen.queryByText('Use CLI default')).toBeNull()
+  })
+
+  it('clears the persisted override for the surface agent without touching the surface', async () => {
+    mocks.storeState.settings = { nativeChatSessionOptions: { claude: { model: 'haiku' } } }
+    const setOption = vi.fn().mockResolvedValue({ snapshot: [] })
+    const invokeAction = vi.fn().mockResolvedValue({ snapshot: [] })
+    render(
+      <NativeChatSessionOptionPickers
+        surface={{ ...surface, setOption, invokeAction }}
+        snapshot={[model()]}
+        isWorking={false}
+      />
+    )
+    screen.getByRole('button', { name: /Use CLI default/ }).click()
+    await waitFor(() => expect(mocks.clearPersistedNativeChatModel).toHaveBeenCalledWith('claude'))
+    expect(setOption).not.toHaveBeenCalled()
+    expect(invokeAction).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '../../store'
+import { clearPersistedNativeChatModel } from './use-native-chat-session-options'
 import { sortNativeChatSessionOptions } from '../../../../shared/native-chat-session-option-snapshot'
 import type {
   SessionOptionDescriptor,
@@ -210,6 +212,11 @@ function NativeChatSessionOptionPickersInner({
   isWorking
 }: NativeChatSessionOptionPickersProps): React.JSX.Element | null {
   const [pendingId, setPendingId] = useState<string | null>(null)
+  // Why: the launch override lives in settings, not the session record — read it
+  // here so the "Use CLI default" row reacts without agent-keyed prop drilling (#13794).
+  const persistedLaunchModelId = useAppStore((store) =>
+    surface ? (store.settings?.nativeChatSessionOptions?.[surface.agent]?.model ?? null) : null
+  )
   const model = snapshot.find((descriptor) => descriptor.category === 'model')
   const options = sortNativeChatSessionOptions(snapshot)
   if (!surface || !model) {
@@ -282,6 +289,32 @@ function NativeChatSessionOptionPickersInner({
             setValue={(value) => setOption(model, value)}
             invokeAction={() => invokeAction(model)}
           />
+          {/* Why: not a radio choice — the radios state the session's tracked model,
+              while this action deletes the persisted launch override (#13794). */}
+          {persistedLaunchModelId ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={pendingId !== null}
+                onSelect={() =>
+                  runSurfaceCall('model-launch-default', setPendingId, () =>
+                    clearPersistedNativeChatModel(surface.agent)
+                  )
+                }
+              >
+                <ChoiceBody
+                  label={translate(
+                    'components.native-chat.composer.useCliDefault',
+                    'Use CLI default'
+                  )}
+                  description={translate(
+                    'components.native-chat.composer.useCliDefaultDescription',
+                    'New sessions use the model configured in the agent CLI'
+                  )}
+                />
+              </DropdownMenuItem>
+            </>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/renderer/src/components/native-chat/native-chat-clear-persisted-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-clear-persisted-model.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
+
+const mocks = vi.hoisted(() => ({
+  storeState: {
+    settings: {} as { nativeChatSessionOptions?: PersistedNativeChatSessionOptions },
+    updateSettings: vi.fn()
+  },
+  createNativeChatPtySessionOptions: vi.fn(),
+  discoverNativeChatCatalogModels: vi.fn()
+}))
+
+vi.mock('../../store', () => ({ useAppStore: { getState: () => mocks.storeState } }))
+
+vi.mock('./native-chat-pty-session-options', () => ({
+  createNativeChatPtySessionOptions: mocks.createNativeChatPtySessionOptions
+}))
+
+vi.mock('./native-chat-session-option-discovery', () => ({
+  resolveNativeChatModelDiscoveryContext: () => ({ hostKey: 'local', runtime: {} }),
+  discoverNativeChatCatalogModels: mocks.discoverNativeChatCatalogModels
+}))
+
+const { clearPersistedNativeChatModel } = await import('./use-native-chat-session-options')
+
+function persist(options: PersistedNativeChatSessionOptions): void {
+  mocks.storeState.settings = { nativeChatSessionOptions: options }
+}
+
+/** The "Use CLI default" picker row: deleting the persisted model must restore
+ *  launches that inherit the agent CLI's own configured default (#13794). */
+describe('clearPersistedNativeChatModel', () => {
+  beforeEach(() => {
+    mocks.storeState.updateSettings.mockReset().mockResolvedValue(undefined)
+    mocks.storeState.settings = {}
+  })
+
+  it('drops only the model, keeping per-model values for a later reselect', async () => {
+    persist({ claude: { model: 'haiku', valuesByModel: { haiku: { effort: 'high' } } } })
+    await clearPersistedNativeChatModel('claude')
+    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
+      nativeChatSessionOptions: { claude: { valuesByModel: { haiku: { effort: 'high' } } } }
+    })
+  })
+
+  it('clears only the named agent, leaving other agents’ picks intact', async () => {
+    persist({ claude: { model: 'haiku' }, codex: { model: 'gpt-5.5-codex' } })
+    await clearPersistedNativeChatModel('claude')
+    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
+      nativeChatSessionOptions: { claude: {}, codex: { model: 'gpt-5.5-codex' } }
+    })
+  })
+
+  it('writes nothing when no model is persisted', async () => {
+    persist({ claude: { valuesByModel: { haiku: { effort: 'high' } } } })
+    await clearPersistedNativeChatModel('claude')
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('survives settings that were never written', async () => {
+    await expect(clearPersistedNativeChatModel('claude')).resolves.toBeUndefined()
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('re-reads live settings at apply so a clear landing after another write is not stale', async () => {
+    persist({ claude: { model: 'haiku' } })
+    const pending = clearPersistedNativeChatModel('claude')
+    persist({})
+    await pending
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -173,6 +173,7 @@ export function createNativeChatPtySessionOptions(
   })
 
   return {
+    agent: args.agent,
     getSnapshot: () => snapshot,
     setOption: appliers.setOption,
     invokeAction: appliers.invokeAction,

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -83,6 +83,21 @@ export async function retirePersistedModelMissingFromDiscovery(
   })
 }
 
+/**
+ * Why: once persisted, `model` is re-emitted as a launch flag forever and only ever
+ * overwritten by another pick — the user has no way back to the agent CLI's own
+ * configured default. Dropping just `model` keeps the per-model option values for a
+ * later reselect, mirroring probe retirement.
+ */
+export function clearPersistedNativeChatModel(agent: AgentType): Promise<void> {
+  return enqueueSessionOptionSettingsWrite((persisted) => {
+    const modelId = persisted?.[agent]?.model
+    return typeof modelId === 'string' && modelId
+      ? clearNativeChatSessionOptionModel(persisted, agent)
+      : null
+  })
+}
+
 export function useNativeChatSessionOptions(args: {
   agent: AgentType
   terminalTabId: string

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15089,7 +15089,9 @@
           "max": "Max",
           "on": "On",
           "off": "Off"
-        }
+        },
+        "useCliDefault": "Use CLI default",
+        "useCliDefaultDescription": "New sessions use the model configured in the agent CLI"
       },
       "tool": {
         "running": "Running…",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14305,6 +14305,8 @@
         "pillAccessibleName": "{{value0}} {{value1}}",
         "valueUnknown": "Valor actual desconocido — elige Activado o Desactivado",
         "sentNotConfirmed": "Enviado al agente — sin confirmar",
+        "useCliDefault": "Usar el valor predeterminado de la CLI",
+        "useCliDefaultDescription": "Las nuevas sesiones usan el modelo configurado en la CLI del agente",
         "setWhenSessionStarts": "Configúralo al iniciar la sesión.",
         "availableAfterSessionStarts": "Disponible después de iniciar la sesión.",
         "optionUpdateFailed": "No se pudo actualizar la opción",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14305,6 +14305,8 @@
         "pillAccessibleName": "{{value0}} {{value1}}",
         "valueUnknown": "現在の値が不明です — オンまたはオフを選んでください",
         "sentNotConfirmed": "Agent に送信済み — 未確認",
+        "useCliDefault": "CLI のデフォルトを使用",
+        "useCliDefaultDescription": "新規セッションは Agent CLI で設定されたモデルを使用します",
         "setWhenSessionStarts": "セッション開始時に設定してください。",
         "availableAfterSessionStarts": "セッション開始後に利用できます。",
         "optionUpdateFailed": "オプションを更新できませんでした",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14316,6 +14316,8 @@
         "pillAccessibleName": "{{value0}} {{value1}}",
         "valueUnknown": "현재 값을 알 수 없음 — 켜짐 또는 꺼짐을 선택하세요",
         "sentNotConfirmed": "에이전트에 전송됨 — 확인되지 않음",
+        "useCliDefault": "CLI 기본값 사용",
+        "useCliDefaultDescription": "새 세션은 에이전트 CLI에 설정된 모델을 사용합니다",
         "setWhenSessionStarts": "세션을 시작할 때 설정하세요.",
         "availableAfterSessionStarts": "세션이 시작된 후 사용할 수 있습니다.",
         "optionUpdateFailed": "옵션을 업데이트하지 못했습니다",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14325,6 +14325,8 @@
         "pillAccessibleName": "{{value0}} {{value1}}",
         "valueUnknown": "当前值未知 — 请选择开或关",
         "sentNotConfirmed": "已发送给代理 — 尚未确认",
+        "useCliDefault": "使用 CLI 默认值",
+        "useCliDefaultDescription": "新会话将使用代理 CLI 中配置的模型",
         "setWhenSessionStarts": "请在会话开始时设置。",
         "availableAfterSessionStarts": "会话开始后可用。",
         "optionUpdateFailed": "无法更新选项",

--- a/src/renderer/src/i18n/native-chat-locales.test.ts
+++ b/src/renderer/src/i18n/native-chat-locales.test.ts
@@ -37,7 +37,9 @@ describe('native chat locale copy', () => {
         'chooseInAgentPicker',
         'toggleOption',
         'valueUnknown',
-        'sentNotConfirmed'
+        'sentNotConfirmed',
+        'useCliDefault',
+        'useCliDefaultDescription'
       ] as const) {
         expect(composer[key].trim()).not.toBe('')
         expect(composer[key]).not.toBe(englishComposer[key])

--- a/src/shared/native-chat-session-options.ts
+++ b/src/shared/native-chat-session-options.ts
@@ -1,3 +1,5 @@
+import type { AgentType } from './agent-status-types'
+
 export type SessionOptionValue = string | boolean
 
 export type SessionOptionSelectChoice = {
@@ -56,6 +58,9 @@ export type PersistedNativeChatSessionOptions = Partial<
 >
 
 export type SessionOptionsSurface = {
+  /** The agent this surface scopes options for — lets consumers resolve
+   *  agent-keyed state (e.g. the persisted launch default) without prop drilling. */
+  agent: AgentType
   getSnapshot(): SessionOptionDescriptor[]
   /** Apply an absolute target; known flip-only options use their tracked baseline. */
   setOption(id: string, value: SessionOptionValue): Promise<SessionOptionSetResult>


### PR DESCRIPTION
Fixes #13794

## Summary

Once a model is picked in the native Chat composer, Orca persists it as `nativeChatSessionOptions.<agent>.model` and passes `--model` to every new launch — permanently overriding the model configured in the agent CLI (e.g. `~/.claude/settings.json`), with no way back: picking another model only replaces the override.

The unset path already existed end to end — a missing `model` key emits no launch flag (`native-chat-session-option-defaults.ts`), and `clearNativeChatSessionOptionModel` already drops the key (it was only reachable from automatic probe retirement). What was missing was a user-facing action that calls it.

This PR adds a **Use CLI default** row to the model dropdown:

- Shown only while a launch override is persisted for the agent — when there is nothing to clear, the row disappears.
- It is a plain action row below the model radios, **not** a radio choice: the radios state the session's tracked model (which stays truthful — the live session keeps running its current model), while this action deletes the persisted launch override so **new sessions** inherit the CLI's configured default. This also avoids the trap noted in the issue discussion where a sentinel choice value would be persisted as a literal `--model __default__`.
- Clearing keeps `valuesByModel` (per-model effort/options survive a later reselect), mirroring probe retirement.
- Agent-generic: works for any agent whose picker persists a launch default, not just Claude.

Implementation shape: `SessionOptionsSurface` now carries the `agent` it scopes (set by its single producer, `createNativeChatPtySessionOptions`), and the pickers component reads the persisted override with a narrow `useAppStore` selector keyed by `surface.agent`. This keeps the change out of `NativeChatComposer.tsx` entirely — that file sits exactly at the `max-lines` ratchet, and threading two props through Composer → Field → Actions would either trip the ratchet or force an unrelated refactor.

## Screenshots

Same seeded state in all three shots (`nativeChatSessionOptions.claude.model = "haiku"` persisted), captured from the real app via the repo's Playwright E2E harness:

| Before (no way back to the CLI default) | After (override persisted → row shown) | After clicking (override cleared → row gone) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/tnqls0624/orca/assets/13794-model-default-reset/before-dropdown.png) | ![after](https://raw.githubusercontent.com/tnqls0624/orca/assets/13794-model-default-reset/after-dropdown.png) | ![cleared](https://raw.githubusercontent.com/tnqls0624/orca/assets/13794-model-default-reset/after-cleared-dropdown.png) |

## Testing

- `pnpm lint` ✅ (including the three localization gates) · `pnpm typecheck` ✅ · `pnpm test` ✅ · `pnpm build` ✅
- New unit tests:
  - `native-chat-clear-persisted-model.test.ts` — clears only the agent's `model` and keeps `valuesByModel`; leaves other agents' picks intact; writes nothing when no override exists; re-reads live settings at apply time (serialized write queue) so a concurrent write is not clobbered.
  - `NativeChatSessionOptionPickers.test.tsx` — the row renders only while an override is persisted; clicking clears the override for the surface's agent and never touches the session-options surface.
- Verified in the real app via the Playwright E2E harness (screenshots above): with `nativeChatSessionOptions.claude.model = "haiku"` seeded, the row shows; clicking it empties `settings.nativeChatSessionOptions.claude.model` (asserted through `window.api.settings.get`) and the row disappears.

## AI Review Report

Reviewed with Claude Code:

- **Cross-platform (macOS/Linux/Windows):** renderer-only change (settings write + dropdown row); no keyboard, path, shell, or Electron-API differences.
- **SSH/remote & workspace types:** `nativeChatSessionOptions` is a local `GlobalSettings` slice consumed at launch-command assembly; no RPC/stream changes, so remote wire compatibility is unaffected. Folder workspaces and worktrees behave identically.
- **Agents/integrations:** the row is gated on a persisted override for the specific agent; agents without one (or whose catalog shows the CLI default, e.g. grok's `defaultModelIsCliDefault`) simply never show it. Existing behavior for picking concrete models is untouched.
- **Performance:** the new store selector returns a primitive (`string | null`), so the memoized pickers component re-renders only when the override actually changes. The settings write goes through the existing serialized write queue (`enqueueSessionOptionSettingsWrite`), so it cannot clobber a concurrent pick.
- **UI quality:** shadcn `DropdownMenuItem` + existing `ChoiceBody`/separator primitives; strings localized (en/es/ja/ko/zh) and covered by `native-chat-locales.test.ts`.
- **Security:** no new IPC, no input parsing; the write path is the existing settings queue.

## Notes

An adversarial multi-agent review of this diff confirmed three interplays worth disclosing — all rooted in pre-existing semantics rather than introduced by this change:

- **Re-adoption on later option writes.** After clearing, changing a *persisting* per-model option in the same session (e.g. Claude's effort) re-establishes the override: `updateNativeChatSessionOptionDefaults` deliberately adopts the model on every option write ("without a `model` no launch resolves the value at all" — its documented contract). If maintainers would rather an explicit clear suppress re-adoption until the next explicit model pick, that needs a persisted marker and feels like a follow-up with product input.
- **Write-failure feedback.** Settings writes flow through `updateSettings`, which logs-and-swallows IPC failures, so the row's error toast fires only for queue-level failures — identical semantics to every existing picker persist (the override simply survives and the row reappears).
- **In-flight pick vs clear.** A pick whose persist lands after the clear (e.g. its `/model` confirmation arrives later, possibly from another pane) re-writes the override — inherent last-writer-wins on the existing serialized settings queue.

Other notes:

- The live session intentionally keeps its current model when the override is cleared — the row's description says "New sessions use the model configured in the agent CLI". Dispatching a mid-session model change to the CLI's default is not attempted because agents don't expose a reliable "switch to your configured default" command.
- The ja description uses Latin "Agent" per the catalog's generic-term convention (`verify:localization-catalog` enforces it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
