### PR TITLE
fix(relay): bound remote workspace file listing to the quick-open cap

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -73,6 +73,7 @@ import {
   registerWorktreeRootsForRepo,
   invalidateAuthorizedRootsCache
 } from './registered-worktree-roots-cache'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../shared/quick-open-listing-limits'
 
 describe('registerFilesystemHandlers', () => {
   beforeEach(() => {
@@ -542,7 +543,10 @@ describe('registerFilesystemHandlers', () => {
   // provider saw them. This test guards the second half: regardless of
   // relay behavior, a new linked worktree under the root must be forwarded
   // so the remote scan can prune it. See docs/design/share-quick-open-file-listing.md.
-  it('fs:listFiles forwards excludePaths to the SSH filesystem provider', async () => {
+  // It also guards the result cap: an unbounded listing over the relay overflows
+  // the 2 MiB per-response frame on workspaces that vendor 100k+ gitignored
+  // files, so the handler bounds the scan to QUICK_OPEN_LISTING_MAX_RESULTS.
+  it('fs:listFiles forwards excludePaths and the result cap to the SSH filesystem provider', async () => {
     const listFilesMock = vi.fn().mockResolvedValue([])
     getSshFilesystemProviderMock.mockReturnValue({ listFiles: listFilesMock })
 
@@ -555,7 +559,8 @@ describe('registerFilesystemHandlers', () => {
     })
 
     expect(listFilesMock).toHaveBeenCalledWith('/home/user/repo', {
-      excludePaths: ['/home/user/repo/worktrees/feature']
+      excludePaths: ['/home/user/repo/worktrees/feature'],
+      maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
     })
   })
 

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -94,6 +94,7 @@ import { resolveAuthorizedPath, authorizeExternalPath } from './filesystem-auth'
 import { resolveRegisteredWorktreePath } from './registered-worktree-roots-cache'
 import { validateGitRelativeFilePath, isENOENT } from './filesystem-path-containment'
 import { listQuickOpenFiles } from './filesystem-list-files'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../shared/quick-open-listing-limits'
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
 import { searchWithGitGrep } from './filesystem-search-git'
 import {
@@ -1126,12 +1127,22 @@ export function registerFilesystemHandlers(
             return []
           }
           // Why: forward excludePaths or nested linked worktrees get double-scanned over SSH, causing timeout-induced partial results.
+          // Why: bound the result count so a workspace with 100k+ (often
+          // gitignored) files doesn't overflow the relay's per-response frame
+          // cap, which would replace the whole list with a capacity error.
           return await provider.listFiles(args.rootPath, {
             excludePaths: args.excludePaths,
-            signal: controller?.signal
+            signal: controller?.signal,
+            maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
           })
         }
-        return await listQuickOpenFiles(args.rootPath, store, args.excludePaths, controller?.signal)
+        return await listQuickOpenFiles(
+          args.rootPath,
+          store,
+          args.excludePaths,
+          controller?.signal,
+          QUICK_OPEN_LISTING_MAX_RESULTS
+        )
       } finally {
         listFilesCancellations.finish(event, args.requestToken, controller)
       }

--- a/src/main/runtime/orca-runtime-files-preview-budget.test.ts
+++ b/src/main/runtime/orca-runtime-files-preview-budget.test.ts
@@ -11,6 +11,7 @@ import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES } from './orca-runtime-files'
 import { REMOTE_RPC_MAX_CONTENT_BYTES } from '../../shared/remote-rpc-content-budget'
 import { FileReadCapExceededError, StreamProtocolError } from '../ssh/ssh-filesystem-stream-reader'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../shared/quick-open-listing-limits'
 
 vi.mock('fs', async () => (await import('./orca-runtime-files-mock-registry')).fsModuleMock())
 vi.mock('fs/promises', async () =>
@@ -228,6 +229,29 @@ describe('RuntimeFileCommands', () => {
       await expect(commands.readFileExplorerPreview('id:wt-1', 'logo.png', 128)).rejects.toThrow(
         'file_too_large'
       )
+    })
+  })
+
+  // Why: over the relay a single fs.listFiles response frame is capped (2 MiB
+  // producer queue). A workspace that vendors gitignored repo clones enumerates
+  // 100k+ paths; the unbounded array overflows the cap and the relay replaces
+  // the whole list with a capacity error, so the Files panel and Quick Open
+  // list nothing. Bounding the scan to QUICK_OPEN_LISTING_MAX_RESULTS keeps the
+  // response inside the frame. This test fails if listRuntimeFiles stops
+  // forwarding the cap.
+  describe('remote listing budget', () => {
+    it('bounds a remote runtime file listing to the quick-open result cap', async () => {
+      const listFiles = vi.fn().mockResolvedValue([])
+      const { commands, store } = createRuntimeFileCommands({ path: '/remote/repo' })
+      store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
+      vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles } as never)
+
+      await commands.listRuntimeFiles('id:wt-1', { excludePaths: ['/remote/repo/nested'] })
+
+      expect(listFiles).toHaveBeenCalledWith('/remote/repo', {
+        excludePaths: ['/remote/repo/nested'],
+        maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
+      })
     })
   })
 })

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -54,6 +54,7 @@ import { parseWslPath, toWindowsWslPath } from '../wsl'
 import { resolveAuthorizedPath } from '../ipc/filesystem-auth'
 import { isENOENT } from '../ipc/filesystem-path-containment'
 import { listQuickOpenFiles } from '../ipc/filesystem-list-files'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../shared/quick-open-listing-limits'
 import { searchWithGitGrep } from '../ipc/filesystem-search-git'
 import { getLocalGitOptionsForRegisteredWorktree } from '../ipc/local-worktree-runtime-options'
 import { checkRgAvailable } from '../ipc/rg-availability'
@@ -2051,9 +2052,24 @@ export class RuntimeFileCommands {
       if (!provider) {
         return []
       }
-      return provider.listFiles(target.worktree.path, { excludePaths: options.excludePaths })
+      // Why: unlike local IPC, the relay caps a single response frame (2 MiB
+      // producer queue). A workspace that vendors ignored repo clones enumerates
+      // 100k+ paths (the --no-ignore-vcs pass is deliberate — users open ignored
+      // files), overflowing the cap so the relay substitutes a ResponseOverCapacity
+      // error and the Files panel/Quick Open list nothing. Bound the scan to the
+      // limit the readdir fallback and mobile listing already use.
+      return provider.listFiles(target.worktree.path, {
+        excludePaths: options.excludePaths,
+        maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
+      })
     }
-    return listQuickOpenFiles(target.worktree.path, this.host.requireStore(), options.excludePaths)
+    return listQuickOpenFiles(
+      target.worktree.path,
+      this.host.requireStore(),
+      options.excludePaths,
+      undefined,
+      QUICK_OPEN_LISTING_MAX_RESULTS
+    )
   }
 
   async listRuntimeMarkdownDocuments(worktreeSelector: string): Promise<MarkdownDocument[]> {

--- a/src/relay/fs-list-files-response-capacity.integration.test.ts
+++ b/src/relay/fs-list-files-response-capacity.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * End-to-end in-process regression test for the remote workspace listing that
+ * overflowed the relay's bounded transport.
+ *
+ * Wires the client-side SshChannelMultiplexer to the relay-side
+ * RelayDispatcher + FsHandler through an in-memory pipe (no SSH), exactly like
+ * fs-list-files-cancel.integration.test.ts. The scan body is a fake that
+ * honours maxResults the way the real fs-handler clamp does, so the test can
+ * show both halves of the bug:
+ *   - an unbounded fs.listFiles result (100k+ paths on a workspace that vendors
+ *     gitignored repo clones) exceeds the 2 MiB producer-queue frame cap, so
+ *     the dispatcher substitutes ResponseOverCapacity and the client sees an
+ *     error instead of the file list, and
+ *   - the same workspace bounded to QUICK_OPEN_LISTING_MAX_RESULTS stays inside
+ *     the cap and the list is delivered.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+const { fakeListFiles } = vi.hoisted(() => {
+  // Why: 68-char paths make the arithmetic explicit — 20_001 of them serialise
+  // to ~1.35 MiB (inside the 2 MiB cap) and 120_000 to ~8.13 MiB (over it).
+  const buildPath = (index: number): string =>
+    `projects/vendored-clone/packages/app/src/generated/file-${String(index).padStart(9, '0')}.ts`
+  const fakeListFiles = Object.assign(
+    vi.fn(
+      (
+        _rootPath: string,
+        _excludes: readonly string[] = [],
+        options: { signal?: AbortSignal; maxResults?: number } = {}
+      ): Promise<string[]> => {
+        // Mirror the real scanners: the caller-supplied cap decides how many
+        // paths the enumeration returns. Without a cap the whole tree comes
+        // back; with one, only that many paths.
+        const total = options.maxResults ?? 120_000
+        return Promise.resolve(Array.from({ length: total }, (_, index) => buildPath(index)))
+      }
+    ),
+    { buildPath }
+  )
+  return { fakeListFiles }
+})
+
+vi.mock('./fs-handler-utils', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...original,
+    listFilesWithRg: fakeListFiles
+  }
+})
+
+import {
+  SshChannelMultiplexer,
+  type MultiplexerTransport
+} from '../main/ssh/ssh-channel-multiplexer'
+import { RelayDispatcher } from './dispatcher'
+import { RelayContext } from './context'
+import { FsHandler } from './fs-handler'
+import { RelayErrorCode } from './protocol'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../shared/quick-open-listing-limits'
+
+async function flushPipe(): Promise<void> {
+  // The in-memory pipe defers each hop with setImmediate; a few macrotask
+  // turns guarantee request/response frames have crossed both directions.
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+}
+
+describe('Integration: fs.listFiles bounded-transport capacity', () => {
+  let mux: SshChannelMultiplexer
+  let dispatcher: RelayDispatcher
+  let fsHandler: FsHandler
+
+  beforeEach(() => {
+    fakeListFiles.mockClear()
+
+    let relayFeedFn: (data: Buffer) => void
+    const clientDataCallbacks: ((data: Buffer) => void)[] = []
+    const clientTransport: MultiplexerTransport = {
+      write: (data: Buffer) => {
+        setImmediate(() => relayFeedFn?.(data))
+      },
+      onData: (cb) => {
+        clientDataCallbacks.push(cb)
+      },
+      onClose: () => {}
+    }
+    dispatcher = new RelayDispatcher((data: Buffer) => {
+      setImmediate(() => {
+        for (const cb of clientDataCallbacks) {
+          cb(data)
+        }
+      })
+    })
+    relayFeedFn = (data: Buffer) => dispatcher.feed(data)
+    fsHandler = new FsHandler(dispatcher, new RelayContext())
+    mux = new SshChannelMultiplexer(clientTransport)
+  })
+
+  afterEach(() => {
+    mux.dispose()
+    dispatcher.dispose()
+    fsHandler.dispose()
+  })
+
+  it('overflows the transport when the listing is unbounded (the bug)', async () => {
+    // No maxResults: the whole 120k-path tree is enumerated and the ~8 MiB
+    // response cannot fit the relay's 2 MiB producer frame, so the dispatcher
+    // replaces the result with a capacity error rather than closing the client.
+    const outcome = mux.request('fs.listFiles', { rootPath: '/remote/firstmate' }).then(
+      () => ({ ok: true as const }),
+      (error: Error & { code?: number }) => ({ ok: false as const, error })
+    )
+    await flushPipe()
+
+    const result = await outcome
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe('Relay response exceeded the bounded transport capacity')
+      expect(result.error.code).toBe(RelayErrorCode.ResponseOverCapacity)
+    }
+  })
+
+  it('delivers the listing when bounded to QUICK_OPEN_LISTING_MAX_RESULTS (the fix)', async () => {
+    // The main-side callers now forward this cap; the relay clamps to it and
+    // stops enumerating, so the ~1.35 MiB response fits and crosses the wire.
+    const paths = (await mux.request('fs.listFiles', {
+      rootPath: '/remote/firstmate',
+      maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
+    })) as string[]
+
+    expect(paths).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+    expect(paths[0]).toBe(fakeListFiles.buildPath(0))
+    // The cap was honoured end-to-end: the scan received the bounded count.
+    expect(fakeListFiles).toHaveBeenCalledWith(
+      '/remote/firstmate',
+      expect.anything(),
+      expect.objectContaining({ maxResults: QUICK_OPEN_LISTING_MAX_RESULTS })
+    )
+  })
+})


### PR DESCRIPTION
Fixes #12547
Refs #11884

## What

Bound the two main-side callers that enumerate a workspace's files — `RuntimeFileCommands.listRuntimeFiles` and the `fs:listFiles` IPC handler — to the existing `QUICK_OPEN_LISTING_MAX_RESULTS` (20,001) limit. Over a relay, an unbounded listing on a large remote workspace previously overflowed the transport and returned an error instead of any files; the cap keeps the response inside the relay's per-frame budget.

No relay protocol, wire format, or shared-transport behavior changes — the cap is passed as the existing per-call `maxResults` param that the relay already clamps.

## Why

On a remote (SSH/relay) workspace, the sidebar **Files** panel name filter and **Cmd+P** Quick Open both failed with only one line — `Relay response exceeded the bounded transport capacity` — and listed nothing.

Root cause, split into the three parts that were conflated in the symptom:

- **Trigger.** Both the name filter and Quick Open call `runtime.listRuntimeFiles` → `files.listAll` RPC → over a remote host, `SshFilesystemProvider.listFiles` → relay `fs.listFiles` (`src/relay/fs-handler.ts`). That handler runs a ripgrep scan with a deliberate `--no-ignore-vcs` pass (feat #1130 — users legitimately open gitignored files) and returns the whole tree as one unbounded `string[]`.
- **Masking condition.** The failure is a *size* overflow, not a timeout. On the affected workspace the ignore-respecting pass returns ~332 files but the `--no-ignore-vcs` union is ~126k files serializing to ~10.8 MiB, because ~125k of them are gitignored vendored repo clones under one directory. The relay caps a single response frame at `DEFAULT_PRODUCER_QUEUE_MAX_BYTES = 2 MiB` (`src/relay/dispatcher-writer-admission.ts`); when the frame does not fit, `RelayDispatcher.sendResponse` substitutes a `ResponseOverCapacity` error rather than closing the client (closing would kill every pane on that host — `src/relay/dispatcher.ts`). Local workspaces are unaffected because Electron IPC has no per-frame cap, so the identical 126k-path list is delivered locally.
- **Visible symptom.** The name filter and Quick Open share the same `files.listAll` path, so both surface the substituted capacity error. (The default Files tree uses per-directory `fs.readDir`, a separate cheap path, which is why the tree root still rendered.)

Rejected alternatives:
- **Drop the `--no-ignore-vcs` pass / respect ignore rules** — would defeat the user's own goal: the file they were trying to open (`data/…/report.md`) is itself gitignored, so it would never appear.
- **Raise the 2 MiB cap** — a band-aid that weakens the shared transport's protection for every panel and does not bound growth.
- **Stream / paginate / push the filter down to the remote** — a relay-protocol change; over-reach for this bug and it touches behavior other panels depend on.

The chosen fix reuses the cap the readdir fallback (`src/shared/quick-open-readdir-budget.ts`) and mobile listing already apply, so listing behavior is now consistent across code paths and the fix is contained to two call sites.

## How this was proven

- **Reproduction as a regression test.** `src/relay/fs-list-files-response-capacity.integration.test.ts` wires the client `SshChannelMultiplexer` to a real `RelayDispatcher` + `FsHandler` over an in-memory pipe (same harness as the existing `fs-list-files-cancel.integration.test.ts`). An unbounded ~8 MiB listing (120k paths) reproduces the failure — the client receives `ResponseOverCapacity` / `Relay response exceeded the bounded transport capacity`; a bounded ~1.35 MiB listing (`maxResults = QUICK_OPEN_LISTING_MAX_RESULTS`) is delivered intact. Both payloads sit under the client decoder's 16 MiB `MAX_MESSAGE_SIZE`, so the failure is specifically the relay's 2 MiB producer-queue admission, not the decoder.
- **Wiring guards.** `src/main/runtime/orca-runtime-files.test.ts` and `src/main/ipc/filesystem.test.ts` assert both callers now forward `maxResults: QUICK_OPEN_LISTING_MAX_RESULTS` to the provider.
- **Reverse verification.** With the two source edits reverted (test files kept), both wiring guards fail (`maxResults` absent from the provider call); with the fix applied all three files pass (207 passed, 1 skipped across the three files). The counterfactual is also built into the integration test itself: the only difference between the failing and passing cases is whether the cap is present.
- Targeted `oxlint` and `tsc --noEmit` (node + CLI projects) are clean for all changed files.

## Repo-side follow-up

- None required to ship this fix. Optionally, a future enhancement could push the name filter down to the remote so very large workspaces return only matches rather than a capped prefix — but that is a relay-protocol change and out of scope here.

## What was not verified

- **The client↔host connection was not exercised end-to-end against a real Mac client.** The reproduction runs the relay path in-process (in-memory pipe), which is where the overflow originates; the physical SSH/relay link between the client and host was intentionally not touched.
- **The full test suite did not run to completion in this environment.** The Electron binary could not be downloaded here, so two suites that import `electron` at load time (`src/main/runtime/rpc/methods/files.test.ts`, `src/relay/agent-hook-integration.test.ts`) fail to load — unrelated to this change (1336 unrelated tests pass). One pre-existing, order-dependent flake in `orca-runtime-files.test.ts` (`rejects stale absolute terminal artifact previews`, terminal-artifact grants — unrelated to file listing) reproduces on the unmodified base file as well.
- **The exact 20,001 cap is a policy inherited from existing quick-open limits, not tuned for this workspace.** With ~68-char paths, 20,001 entries serialize to ~1.35 MiB, comfortably under the 2 MiB frame; workspaces with unusually long paths could approach the cap, though the relay's own `Math.min(maxResults, 20_001)` clamp bounds the count regardless. See Notes for the byte-vs-count trade-off measured on the real workspace.

## Screenshots

No visual change. This fixes a data path (remote workspace file enumeration); the only user-visible difference is that the Files panel filter and Quick Open now list files instead of showing `Relay response exceeded the bounded transport capacity`.

## AI Review Report

Reviewed with an AI coding agent. The review focused on:

- **Blast radius of the transport.** Confirmed the change does not touch the relay protocol, wire format, opcodes, or any shared-transport behavior — it only passes the existing per-call `maxResults` param, which the relay already clamps via `Math.min(maxResults, 20_001)`. Closing the client (which would kill every pane on the host) is explicitly avoided; that path is untouched.
- **Cross-platform compatibility (macOS / Linux / Windows).** No keyboard shortcuts, shortcut labels, path separators, shell invocation, or Electron-specific platform branches are added or changed. The two edits only add a numeric argument to existing calls; behavior is platform-independent. The remote (SSH) and local (IPC) branches are both covered.
- **Remote wire compatibility.** No new fields on the wire that a peer must understand — `maxResults` is an already-supported optional param on `fs.listFiles`, so mixed client/host versions are unaffected.
- **Consistency.** The cap reuses `QUICK_OPEN_LISTING_MAX_RESULTS`, the same limit the readdir fallback and mobile listing already apply, rather than introducing a new constant.

What it flagged / what I verified as a result: the agent noted the cap is by **count**, not **bytes**, while the failure is a byte-size limit. I measured this on the real large workspace (see Notes): 20,001 real paths serialize to 1.327 MiB today (0.67 MiB under the 2 MiB frame), but a worst-case set of the 20,001 longest real paths would reach ~2.52 MiB. The count cap fixes the reported case with a wide margin and matches existing repo policy; a hard byte-bound guarantee would require a follow-up (documented in Notes and left for the maintainer to decide).

## Security Audit

Basic AI-assisted security review:

- **Input handling.** No new untrusted input is parsed. `maxResults` is a compile-time constant supplied by our own code, not caller-controlled input; the relay already validates and clamps it (`typeof === 'number' && Number.isInteger && > 0`, then `Math.min(…, 20_001)`).
- **Command execution / path handling.** No change to how ripgrep/git are spawned or how paths are built or resolved; `excludePaths` handling is unchanged.
- **DoS / resource exhaustion.** The change strictly *reduces* the maximum work and payload size for a remote listing (bounded enumeration instead of whole-tree), so it narrows an availability risk rather than widening one.
- **Auth / secrets / IPC.** No auth, secret, or IPC-surface changes; the `fs:listFiles` IPC contract is unchanged apart from an internally-supplied bound.
- No new dependencies. Follow-up: only the count-vs-byte trade-off in Notes; no security follow-up required.

## Notes

- **Count cap vs. byte cap (measured on the real workspace, read-only).** The rejecting threshold is 2 MiB (`DEFAULT_PRODUCER_QUEUE_MAX_BYTES`), not the 1 MiB `DISPATCHER_CONTROL_QUEUE_MAX_BYTES` — the latter only routes frames > 1 MiB onto the `legacy-response` lane; the 2 MiB producer-queue admission is what substitutes `ResponseOverCapacity`. Under concurrent producer traffic the effective headroom can be less than 2 MiB. On the affected workspace (134,004 paths, avg 86 chars, max 226): the first 20,001 paths in rg native order serialize to **1.327 MiB** (✅, 0.67 MiB headroom); the 20,001 *longest* real paths would serialize to **~2.52 MiB** (❌); break-even average path length for 20,001 entries to hit 2 MiB is ~102 chars. So this fix resolves the reported case by a wide margin but does not *guarantee* the byte bound for pathological path-length distributions. If a hard guarantee is preferred over a data-dependent margin, the cap should be made byte-aware (bound the serialized response size / clamp `maxResults` against a byte budget) — flagged for maintainer decision.
- **Platform-specific behavior:** none. **Follow-up:** the count-vs-byte decision above; optional remote-side filter push-down remains out of scope.
