### PR TITLE
feat(jira): link a Jira issue from Edit Worktree Details

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeIssueLinkField.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeIssueLinkField.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { LinearIcon } from '@/components/icons/LinearIcon'
+import { JiraIcon } from '@/components/icons/JiraIcon'
 import { ChevronDown, ExternalLink, Github, LoaderCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -32,9 +33,13 @@ export function issueAdornmentReserve(providerLabel: string): string {
 }
 
 function providerLabel(provider: IssueLinkProvider): string {
-  return provider === 'linear'
-    ? translate('auto.components.sidebar.WorktreeIssueLinkField.25852bfc59', 'Linear')
-    : translate('auto.components.sidebar.WorktreeIssueLinkField.5b440069e6', 'GitHub')
+  if (provider === 'linear') {
+    return translate('auto.components.sidebar.WorktreeIssueLinkField.25852bfc59', 'Linear')
+  }
+  if (provider === 'jira') {
+    return translate('auto.components.sidebar.WorktreeIssueLinkField.d83b054c9c', 'Jira')
+  }
+  return translate('auto.components.sidebar.WorktreeIssueLinkField.5b440069e6', 'GitHub')
 }
 
 function ProviderIcon({
@@ -44,11 +49,13 @@ function ProviderIcon({
   provider: IssueLinkProvider
   className?: string
 }): React.JSX.Element {
-  return provider === 'linear' ? (
-    <LinearIcon className={className} />
-  ) : (
-    <Github className={className} />
-  )
+  if (provider === 'linear') {
+    return <LinearIcon className={className} />
+  }
+  if (provider === 'jira') {
+    return <JiraIcon className={className} />
+  }
+  return <Github className={className} />
 }
 
 export type WorktreeIssueLinkFieldProps = {
@@ -115,28 +122,42 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
       )
     }
     if (isInvalid) {
-      return provider === 'linear'
-        ? translate(
-            'auto.components.sidebar.WorktreeIssueLinkField.964d9bc00a',
-            'Not a Linear issue key or linear.app issue URL.'
-          )
-        : translate(
-            'auto.components.sidebar.WorktreeIssueLinkField.0a7a2c6efd',
-            'Not a GitHub issue number or issue URL.'
-          )
+      if (provider === 'linear') {
+        return translate(
+          'auto.components.sidebar.WorktreeIssueLinkField.964d9bc00a',
+          'Not a Linear issue key or linear.app issue URL.'
+        )
+      }
+      if (provider === 'jira') {
+        return translate(
+          'auto.components.sidebar.WorktreeIssueLinkField.c587107e21',
+          'Not a Jira issue key or issue URL.'
+        )
+      }
+      return translate(
+        'auto.components.sidebar.WorktreeIssueLinkField.0a7a2c6efd',
+        'Not a GitHub issue number or issue URL.'
+      )
     }
     // Why: ranked above displacement because it answers the click the user just
     // made, and it clears as soon as they edit the value that caused it.
     if (openIssueFailed) {
-      return provider === 'linear'
-        ? translate(
-            'auto.components.sidebar.WorktreeIssueLinkField.d8c8a30d1f',
-            "Couldn't open that issue. Check the identifier and your Linear connection."
-          )
-        : translate(
-            'auto.components.sidebar.WorktreeIssueLinkField.269198eeda',
-            "Couldn't open that issue. Check the number and your GitHub connection."
-          )
+      if (provider === 'linear') {
+        return translate(
+          'auto.components.sidebar.WorktreeIssueLinkField.d8c8a30d1f',
+          "Couldn't open that issue. Check the identifier and your Linear connection."
+        )
+      }
+      if (provider === 'jira') {
+        return translate(
+          'auto.components.sidebar.WorktreeIssueLinkField.59aa1044bb',
+          "Couldn't open that issue. Check the key and your Jira connection."
+        )
+      }
+      return translate(
+        'auto.components.sidebar.WorktreeIssueLinkField.269198eeda',
+        "Couldn't open that issue. Check the number and your GitHub connection."
+      )
     }
     // Whole sentences per arity rather than a joined list: a translated " and "
     // fragment would not survive languages that order or punctuate lists differently.
@@ -155,8 +176,8 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
       )
     }
     return translate(
-      'auto.components.sidebar.WorktreeIssueLinkField.f047887705',
-      'Paste a GitHub or Linear URL, or enter a number. Leave blank to remove the link.'
+      'auto.components.sidebar.WorktreeIssueLinkField.95d9f8f997',
+      'Paste a GitHub, Linear, or Jira URL, or enter a number. Leave blank to remove the link.'
     )
   }, [displacedLinkLabels, isInvalid, isReadOnly, openIssueFailed, provider])
 
@@ -176,8 +197,8 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
           disabled={isReadOnly}
           aria-invalid={isInvalid || undefined}
           placeholder={translate(
-            'auto.components.sidebar.WorktreeIssueLinkField.662ae142f8',
-            'Issue #, or a GitHub or Linear URL'
+            'auto.components.sidebar.WorktreeIssueLinkField.0ee31ebf7b',
+            'Issue #, or a GitHub, Linear, or Jira URL'
           )}
           className="h-8 text-xs"
           style={{ paddingRight: issueAdornmentReserve(label) }}

--- a/src/renderer/src/components/sidebar/WorktreeIssueLinkField.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeIssueLinkField.tsx
@@ -68,6 +68,8 @@ export type WorktreeIssueLinkFieldProps = {
   displacedLinkLabels: string[] | null
   /** Folder workspaces have no persisted link slots — see the design doc. */
   isReadOnly: boolean
+  /** True while a save is in flight, so edits cannot race the async Jira lookup. */
+  disabled?: boolean
   canOpenIssue: boolean
   openingIssue: boolean
   /** The last open attempt resolved to nothing — see useWorktreeIssueLink. */
@@ -86,6 +88,7 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
     isInvalid,
     displacedLinkLabels,
     isReadOnly,
+    disabled = false,
     canOpenIssue,
     openingIssue,
     openIssueFailed,
@@ -161,6 +164,17 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
     }
     // Whole sentences per arity rather than a joined list: a translated " and "
     // fragment would not survive languages that order or punctuate lists differently.
+    if (displacedLinkLabels && displacedLinkLabels.length > 2) {
+      return translate(
+        'auto.components.sidebar.WorktreeIssueLinkField.5089993940',
+        'Saving unlinks {{first}}, {{second}}, and {{third}}. A workspace tracks one issue.',
+        {
+          first: displacedLinkLabels[0],
+          second: displacedLinkLabels[1],
+          third: displacedLinkLabels[2]
+        }
+      )
+    }
     if (displacedLinkLabels && displacedLinkLabels.length > 1) {
       return translate(
         'auto.components.sidebar.WorktreeIssueLinkField.72486800ff',
@@ -194,7 +208,7 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
           value={value}
           onChange={(e) => onValueChange(e.target.value)}
           onKeyDown={onKeyDown}
-          disabled={isReadOnly}
+          disabled={isReadOnly || disabled}
           aria-invalid={isInvalid || undefined}
           placeholder={translate(
             'auto.components.sidebar.WorktreeIssueLinkField.0ee31ebf7b',
@@ -212,7 +226,7 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
                 type="button"
                 variant="ghost"
                 size="xs"
-                disabled={isReadOnly}
+                disabled={isReadOnly || disabled}
                 aria-label={translate(
                   'auto.components.sidebar.WorktreeIssueLinkField.929c98d05a',
                   'Issue provider'
@@ -242,7 +256,7 @@ export function WorktreeIssueLinkField(props: WorktreeIssueLinkFieldProps): Reac
                 variant="ghost"
                 size="icon-xs"
                 aria-label={openIssueLabel}
-                disabled={!canOpenIssue || openingIssue}
+                disabled={!canOpenIssue || openingIssue || disabled}
                 onClick={onOpenIssue}
                 className="text-muted-foreground"
               >

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.test.tsx
@@ -184,7 +184,7 @@ function openDialog(
 }
 
 function issueInput(): HTMLInputElement {
-  return screen.getByPlaceholderText('Issue #, or a GitHub or Linear URL')
+  return screen.getByPlaceholderText('Issue #, or a GitHub, Linear, or Jira URL')
 }
 
 function providerChip(): HTMLButtonElement {
@@ -313,6 +313,81 @@ describe('WorktreeMetaDialog issue link row', () => {
     const updates = updateWorktreeMeta.mock.calls[0]?.[1] ?? {}
     expect(updates.linkedLinearIssue).toBe('STA-335')
     expect(updates.linkedIssue).toBeNull()
+  })
+
+  // The Jira link's title and URL are resolved from the connected site at save
+  // time, and writing it clears the GitHub slot the workspace held.
+  it('resolves a Jira link against the active site and clears the GitHub link', async () => {
+    const readJiraStatus = vi.fn().mockResolvedValue({
+      connected: true,
+      viewer: null,
+      sites: [
+        {
+          id: 'site-1',
+          siteUrl: 'https://acme.atlassian.net',
+          email: 'a@b.co',
+          displayName: 'Acme',
+          accountId: 'acc'
+        }
+      ],
+      activeSiteId: 'site-1'
+    })
+    const lookupJiraIssueSummary = vi.fn().mockResolvedValue({
+      id: '1',
+      key: 'PROJ-9',
+      title: 'A ticket',
+      url: 'https://acme.atlassian.net/browse/PROJ-9',
+      project: { key: 'PROJ' }
+    })
+    openDialog({ worktree: { linkedIssue: 42 } })
+    useAppStore.setState({
+      readJiraStatus: readJiraStatus as unknown as ReturnType<
+        typeof useAppStore.getState
+      >['readJiraStatus'],
+      lookupJiraIssueSummary: lookupJiraIssueSummary as unknown as ReturnType<
+        typeof useAppStore.getState
+      >['lookupJiraIssueSummary']
+    })
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Jira' }))
+    fireEvent.change(issueInput(), { target: { value: 'PROJ-9' } })
+    await act(async () => {
+      fireEvent.click(saveButton())
+    })
+
+    await waitFor(() => expect(updateWorktreeMeta).toHaveBeenCalledTimes(1))
+    expect(lookupJiraIssueSummary).toHaveBeenCalledWith(expect.anything(), 'PROJ-9', 'site-1')
+    const updates = updateWorktreeMeta.mock.calls[0]?.[1] ?? {}
+    expect(updates.linkedWorkItem).toMatchObject({
+      provider: 'jira',
+      type: 'issue',
+      jiraIdentifier: 'PROJ-9',
+      url: 'https://acme.atlassian.net/browse/PROJ-9'
+    })
+    expect(updates.linkedIssue).toBeNull()
+  })
+
+  // A resolution failure must block the save and explain itself rather than
+  // writing a partial link or silently dropping the existing one.
+  it('shows an error and does not save when Jira is not connected', async () => {
+    const readJiraStatus = vi.fn().mockResolvedValue({ connected: false, viewer: null })
+    openDialog({ worktree: { linkedIssue: 42 } })
+    useAppStore.setState({
+      readJiraStatus: readJiraStatus as unknown as ReturnType<
+        typeof useAppStore.getState
+      >['readJiraStatus']
+    })
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Jira' }))
+    fireEvent.change(issueInput(), { target: { value: 'PROJ-9' } })
+    await act(async () => {
+      fireEvent.click(saveButton())
+    })
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain('Connect Jira in Settings')
+    )
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
   })
 
   // A GitHub-only save must carry no Linear keys: persistence gates the remote

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.test.tsx
@@ -315,8 +315,6 @@ describe('WorktreeMetaDialog issue link row', () => {
     expect(updates.linkedIssue).toBeNull()
   })
 
-  // The Jira link's title and URL are resolved from the connected site at save
-  // time, and writing it clears the GitHub slot the workspace held.
   it('resolves a Jira link against the active site and clears the GitHub link', async () => {
     const readJiraStatus = vi.fn().mockResolvedValue({
       connected: true,
@@ -367,8 +365,6 @@ describe('WorktreeMetaDialog issue link row', () => {
     expect(updates.linkedIssue).toBeNull()
   })
 
-  // A resolution failure must block the save and explain itself rather than
-  // writing a partial link or silently dropping the existing one.
   it('shows an error and does not save when Jira is not connected', async () => {
     const readJiraStatus = vi.fn().mockResolvedValue({ connected: false, viewer: null })
     openDialog({ worktree: { linkedIssue: 42 } })

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { getDisplacedLinkLabels } from './worktree-issue-displacement'
 import {
   buildWorktreeMetaUpdates,
+  isIssueFieldDirty,
   parseGitHubWorkItemNumberForMetaField,
   type WorktreeMetaDraft,
   type WorktreeMetaSavedPayload,
@@ -20,6 +21,7 @@ import {
 } from './worktree-meta-updates'
 import { useWorktreeIssueLink } from './use-worktree-issue-link'
 import { useWorktreeMetaWorkspace } from './use-worktree-meta-workspace'
+import { useWorktreeMetaJiraLink } from './use-worktree-meta-jira-link'
 import { WorktreeIssueLinkField } from './WorktreeIssueLinkField'
 import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -73,11 +75,17 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     worktree,
     linkedIssue,
     linkedLinearIssue,
+    linkedJiraIssue,
     currentIssue,
     currentProvider,
     isFolderWorkspace,
     liveLinks
   } = useWorktreeMetaWorkspace({ worktreeId, ownerRepoId })
+  const { resolveJiraIssueLinkUpdates } = useWorktreeMetaJiraLink({
+    worktreeId,
+    ownerRepoId,
+    worktree
+  })
   // Why: ChecksPanel seeds the PR it is looking at, which may not be linked yet.
   const currentPR =
     typeof modalData.currentPR === 'number'
@@ -199,9 +207,10 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
         snapshot,
         isFolderWorkspace,
         linkedIssue,
-        linkedLinearIssue
+        linkedLinearIssue,
+        linkedJiraIssue
       }),
-    [draft, snapshot, isFolderWorkspace, linkedIssue, linkedLinearIssue]
+    [draft, snapshot, isFolderWorkspace, linkedIssue, linkedLinearIssue, linkedJiraIssue]
   )
 
   const handleOpenChange = useCallback(
@@ -222,7 +231,25 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     // spinner for the whole in-flight save.
     setSaveError(null)
     try {
-      const updates = buildWorktreeMetaUpdates(draft, snapshot, liveLinks)
+      let updates = buildWorktreeMetaUpdates(draft, snapshot, liveLinks)
+
+      // Why: a Jira link carries a title and URL that only a connected-site
+      // lookup can supply, so the synchronous builder deferred it to the hook.
+      const jiraOutcome = await resolveJiraIssueLinkUpdates({
+        issueProvider,
+        issueInput,
+        isDirty: isIssueFieldDirty(draft, snapshot),
+        live: liveLinks
+      })
+      if (jiraOutcome.kind === 'error') {
+        if (mountedRef.current) {
+          setSaveError(jiraOutcome.error)
+        }
+        return
+      }
+      if (jiraOutcome.kind === 'updates') {
+        updates = { ...updates, ...jiraOutcome.updates }
+      }
 
       const result = await updateWorktreeMeta(worktreeId, updates)
       // Why: a failed save refetches and reverts the optimistic write. Closing
@@ -253,6 +280,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     draft,
     snapshot,
     liveLinks,
+    issueProvider,
+    issueInput,
+    resolveJiraIssueLinkUpdates,
     updateWorktreeMeta,
     closeModal,
     afterSave,

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -23,6 +23,7 @@ import { useWorktreeIssueLink } from './use-worktree-issue-link'
 import { useWorktreeMetaWorkspace } from './use-worktree-meta-workspace'
 import { useWorktreeMetaJiraLink } from './use-worktree-meta-jira-link'
 import { WorktreeIssueLinkField } from './WorktreeIssueLinkField'
+import { resizeCommentTextarea } from './comment-textarea-autosize'
 import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
@@ -33,11 +34,6 @@ import {
   type IssueLinkProvider
 } from '../../../../shared/issue-link-input'
 import { WorktreeDisplayNameField } from './WorktreeDisplayNameField'
-
-function resizeCommentTextarea(textarea: HTMLTextAreaElement): void {
-  textarea.style.height = 'auto'
-  textarea.style.height = `${textarea.scrollHeight}px`
-}
 
 /** Only read before the first open, when nothing can be saved yet. */
 const EMPTY_SNAPSHOT: WorktreeMetaSnapshot = {
@@ -223,7 +219,10 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   )
 
   const handleSave = useCallback(async () => {
-    if (!canSave) {
+    // Why: reject re-entry while a save is in flight. The Jira lookup is async, so
+    // a second Enter would capture a newer draft and could persist it over the one
+    // being resolved.
+    if (!canSave || saving) {
       return
     }
     setSaving(true)
@@ -277,6 +276,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   }, [
     worktreeId,
     canSave,
+    saving,
     draft,
     snapshot,
     liveLinks,
@@ -361,6 +361,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
             isInvalid={issueInvalid}
             displacedLinkLabels={displacedLinkLabels}
             isReadOnly={isFolderWorkspace}
+            disabled={saving}
             canOpenIssue={canOpenIssue}
             openingIssue={openingIssue}
             openIssueFailed={openIssueFailed}
@@ -379,6 +380,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
               value={prInput}
               onChange={(e) => setPrInput(e.target.value)}
               onKeyDown={handleIssueKeyDown}
+              disabled={saving}
               placeholder={translate(
                 'auto.components.sidebar.WorktreeMetaDialog.077a4f7b5c',
                 'PR # or GitHub URL'
@@ -402,6 +404,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
               value={commentInput}
               onChange={handleCommentChange}
               onKeyDown={handleCommentKeyDown}
+              disabled={saving}
               placeholder={translate(
                 'auto.components.sidebar.WorktreeMetaDialog.030d484fc0',
                 'Notes about this worktree...'

--- a/src/renderer/src/components/sidebar/comment-textarea-autosize.ts
+++ b/src/renderer/src/components/sidebar/comment-textarea-autosize.ts
@@ -1,0 +1,6 @@
+/** Grows the comment textarea to fit its content in the same input event, so a
+ *  passive effect cannot leave a stale height between keystrokes. */
+export function resizeCommentTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.style.height = 'auto'
+  textarea.style.height = `${textarea.scrollHeight}px`
+}

--- a/src/renderer/src/components/sidebar/use-worktree-issue-link.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-issue-link.ts
@@ -5,6 +5,7 @@ import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { findIndexedWorktreeOwner } from '@/lib/worktree-runtime-owner-index'
 import { buildLinearIssueUrl, parseLinearIssueInput } from '../../../../shared/linear-links'
+import { parseJiraIssueUrl } from '../../../../shared/jira-issue-url'
 import type { IssueLinkProvider } from '../../../../shared/issue-link-input'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
 import { parseExplicitGitHubIssueUrl } from './worktree-meta-updates'
@@ -70,6 +71,7 @@ export function useWorktreeIssueLink(args: {
     linearSourceContext
   } = args
   const isLinear = issueProvider === 'linear'
+  const isJira = issueProvider === 'jira'
   const fetchIssue = useAppStore((s) => s.fetchIssue)
   const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
   const [openingIssue, setOpeningIssue] = useState(false)
@@ -92,17 +94,26 @@ export function useWorktreeIssueLink(args: {
   )
 
   const issueNumber = useMemo(
-    () => (isLinear ? null : parseGitHubIssueOrPRNumber(boundedInput)),
-    [isLinear, boundedInput]
+    () => (isLinear || isJira ? null : parseGitHubIssueOrPRNumber(boundedInput)),
+    [isLinear, isJira, boundedInput]
   )
   const issueUrlFromInput = useMemo(
-    () => (isLinear ? null : parseExplicitGitHubIssueUrl(boundedInput)),
-    [isLinear, boundedInput]
+    () => (isLinear || isJira ? null : parseExplicitGitHubIssueUrl(boundedInput)),
+    [isLinear, isJira, boundedInput]
   )
   const issueInputLooksLikeUrl = useMemo(
     () => /^https?:\/\//i.test(boundedInput.trim()),
     [boundedInput]
   )
+  // Why: a bare Jira key can't build a URL without resolving its site, so only a
+  // full Jira issue URL (the stored link seeds one) is directly openable here.
+  const jiraIssueUrl = useMemo(() => {
+    if (!isJira) {
+      return null
+    }
+    const trimmed = boundedInput.trim()
+    return parseJiraIssueUrl(trimmed) ? trimmed : null
+  }, [isJira, boundedInput])
   const parsedLinearIssue = useMemo(
     () => (isLinear ? parseLinearIssueInput(boundedInput) : null),
     [isLinear, boundedInput]
@@ -149,11 +160,13 @@ export function useWorktreeIssueLink(args: {
       ]?.data?.url ?? null
     )
   })
-  const canOpenIssue = isLinear
-    ? Boolean(parsedLinearIssue)
-    : issueInputLooksLikeUrl
-      ? Boolean(issueUrlFromInput)
-      : Boolean(cachedIssueUrl || (issueRepo && issueNumber))
+  const canOpenIssue = isJira
+    ? Boolean(jiraIssueUrl)
+    : isLinear
+      ? Boolean(parsedLinearIssue)
+      : issueInputLooksLikeUrl
+        ? Boolean(issueUrlFromInput)
+        : Boolean(cachedIssueUrl || (issueRepo && issueNumber))
 
   const handleOpenIssue = useCallback(async () => {
     if (openingIssue) {
@@ -168,6 +181,15 @@ export function useWorktreeIssueLink(args: {
       mountedRef.current &&
       openRequestRef.current === generation &&
       latestRequestKeyRef.current === requestKey
+
+    if (isJira) {
+      // Why: opening is synchronous — a valid Jira issue URL is the only openable
+      // shape here, so there is no lookup to race or report a failure for.
+      if (jiraIssueUrl) {
+        void window.api.shell.openUrl(jiraIssueUrl)
+      }
+      return
+    }
 
     if (isLinear) {
       if (!parsedLinearIssue) {
@@ -246,12 +268,14 @@ export function useWorktreeIssueLink(args: {
     cachedIssueUrl,
     fetchIssue,
     fetchLinearIssue,
+    isJira,
     isLinear,
     issueInput,
     issueInputLooksLikeUrl,
     issueNumber,
     issueRepo,
     issueUrlFromInput,
+    jiraIssueUrl,
     linearIssueUrl,
     linearSourceContext,
     mountedRef,

--- a/src/renderer/src/components/sidebar/use-worktree-meta-jira-link.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-meta-jira-link.ts
@@ -101,16 +101,29 @@ export function useWorktreeMetaJiraLink(args: {
       if (parsed?.provider !== 'jira' || !jiraSourceContext) {
         return { kind: 'error', error: jiraLinkErrorMessage('not-connected') }
       }
-      const resolved = await resolveJiraIssueLink({
-        parsed,
-        sourceContext: jiraSourceContext,
-        readStatus: readJiraStatus,
-        lookupSummary: lookupJiraIssueSummary
-      })
-      if (!resolved.ok) {
-        return { kind: 'error', error: jiraLinkErrorMessage(resolved.errorKind) }
+      try {
+        const resolved = await resolveJiraIssueLink({
+          parsed,
+          sourceContext: jiraSourceContext,
+          readStatus: readJiraStatus,
+          lookupSummary: lookupJiraIssueSummary
+        })
+        if (!resolved.ok) {
+          return { kind: 'error', error: jiraLinkErrorMessage(resolved.errorKind) }
+        }
+        return { kind: 'updates', updates: buildResolvedJiraIssueLinkUpdates(resolved, input.live) }
+      } catch {
+        // Why: the Jira reads can reject on a dead runtime or transport fault.
+        // Without this the rejection escapes handleSave's finally as an unhandled
+        // rejection and the user is left without an error.
+        return {
+          kind: 'error',
+          error: translate(
+            'auto.components.sidebar.WorktreeMetaDialog.a3d824d1b8',
+            'Could not link the Jira issue. Check your Jira connection and try again.'
+          )
+        }
       }
-      return { kind: 'updates', updates: buildResolvedJiraIssueLinkUpdates(resolved, input.live) }
     },
     [jiraSourceContext, readJiraStatus, lookupJiraIssueSummary]
   )

--- a/src/renderer/src/components/sidebar/use-worktree-meta-jira-link.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-meta-jira-link.ts
@@ -1,0 +1,119 @@
+import { useCallback, useMemo } from 'react'
+import { useAppStore } from '@/store'
+import { findIndexedWorktreeOwner } from '@/lib/worktree-runtime-owner-index'
+import { translate } from '@/i18n/i18n'
+import { buildTaskSourceContextFromRepo } from '../../../../shared/task-source-context'
+import { parseIssueLinkInput, type IssueLinkProvider } from '../../../../shared/issue-link-input'
+import type { Worktree, WorktreeMeta } from '../../../../shared/types'
+import {
+  buildResolvedJiraIssueLinkUpdates,
+  type WorktreeMetaLiveLinks
+} from './worktree-meta-updates'
+import { resolveJiraIssueLink, type JiraIssueLinkErrorKind } from './worktree-jira-issue-link'
+
+/** Maps a Jira link resolution failure to a message that tells the user what to
+ *  fix — a bare API toast would only echo a status code. */
+function jiraLinkErrorMessage(kind: JiraIssueLinkErrorKind): string {
+  switch (kind) {
+    case 'not-connected':
+      return translate(
+        'auto.components.sidebar.WorktreeMetaDialog.136795efad',
+        'Connect Jira in Settings before linking an issue.'
+      )
+    case 'site-not-connected':
+      return translate(
+        'auto.components.sidebar.WorktreeMetaDialog.9c3e2078a4',
+        "That Jira site isn't connected. Connect it, or enter a bare issue key to use the active site."
+      )
+    case 'ambiguous-site':
+      return translate(
+        'auto.components.sidebar.WorktreeMetaDialog.764b478e40',
+        'Several Jira sites are connected. Paste a full Jira issue URL so the site is unambiguous.'
+      )
+    case 'not-found':
+      return translate(
+        'auto.components.sidebar.WorktreeMetaDialog.9560604f22',
+        'That Jira issue was not found. Check the key and your access.'
+      )
+  }
+}
+
+export type JiraIssueLinkSaveOutcome =
+  | { kind: 'not-jira' }
+  | { kind: 'updates'; updates: Partial<WorktreeMeta> }
+  | { kind: 'error'; error: string }
+
+/** Owns the async half of the meta dialog's issue field: a Jira link needs its
+ *  title and URL resolved from the connected site before it can be persisted, so
+ *  the synchronous update builder defers to this. Returns the updates to merge, a
+ *  user-facing error, or `not-jira` when the field is not a Jira write. */
+export function useWorktreeMetaJiraLink(args: {
+  worktreeId: string
+  ownerRepoId: string | null
+  worktree: Worktree | undefined
+}): {
+  resolveJiraIssueLinkUpdates: (input: {
+    issueProvider: IssueLinkProvider
+    issueInput: string
+    isDirty: boolean
+    live: WorktreeMetaLiveLinks
+  }) => Promise<JiraIssueLinkSaveOutcome>
+} {
+  const { worktreeId, ownerRepoId, worktree } = args
+  const repos = useAppStore((s) => s.repos)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const readJiraStatus = useAppStore((s) => s.readJiraStatus)
+  const lookupJiraIssueSummary = useAppStore((s) => s.lookupJiraIssueSummary)
+
+  const issueRepo = useMemo(() => {
+    const repoId = ownerRepoId ?? findIndexedWorktreeOwner(worktreesByRepo, worktreeId)?.repoId
+    return repoId ? repos.find((repo) => repo.id === repoId) : undefined
+  }, [ownerRepoId, repos, worktreesByRepo, worktreeId])
+
+  // Why: the lookup runs against the worktree's repo runtime. Prefer a stored
+  // Jira source context (a workspace opened from a Jira task carries the right
+  // project scope); otherwise derive one from the repo like the composer fallback.
+  const jiraSourceContext = useMemo(() => {
+    const stored = worktree?.linkedTaskSourceContext
+    if (stored?.provider === 'jira') {
+      return stored
+    }
+    return issueRepo
+      ? buildTaskSourceContextFromRepo({
+          provider: 'jira',
+          projectId: issueRepo.id,
+          repo: issueRepo
+        })
+      : null
+  }, [issueRepo, worktree?.linkedTaskSourceContext])
+
+  const resolveJiraIssueLinkUpdates = useCallback(
+    async (input: {
+      issueProvider: IssueLinkProvider
+      issueInput: string
+      isDirty: boolean
+      live: WorktreeMetaLiveLinks
+    }): Promise<JiraIssueLinkSaveOutcome> => {
+      if (input.issueProvider !== 'jira' || input.issueInput.trim() === '' || !input.isDirty) {
+        return { kind: 'not-jira' }
+      }
+      const parsed = parseIssueLinkInput(input.issueInput.trim(), 'jira')
+      if (parsed?.provider !== 'jira' || !jiraSourceContext) {
+        return { kind: 'error', error: jiraLinkErrorMessage('not-connected') }
+      }
+      const resolved = await resolveJiraIssueLink({
+        parsed,
+        sourceContext: jiraSourceContext,
+        readStatus: readJiraStatus,
+        lookupSummary: lookupJiraIssueSummary
+      })
+      if (!resolved.ok) {
+        return { kind: 'error', error: jiraLinkErrorMessage(resolved.errorKind) }
+      }
+      return { kind: 'updates', updates: buildResolvedJiraIssueLinkUpdates(resolved, input.live) }
+    },
+    [jiraSourceContext, readJiraStatus, lookupJiraIssueSummary]
+  )
+
+  return { resolveJiraIssueLinkUpdates }
+}

--- a/src/renderer/src/components/sidebar/use-worktree-meta-workspace.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-meta-workspace.ts
@@ -19,6 +19,8 @@ export function useWorktreeMetaWorkspace(args: {
   worktree: Worktree | undefined
   linkedIssue: number | null
   linkedLinearIssue: string | null
+  /** The Jira key of a linked Jira issue, for save-time displacement warnings. */
+  linkedJiraIssue: string | null
   /** The persisted value and its provider, from one source so they cannot drift. */
   currentIssue: string
   currentProvider: IssueLinkProvider
@@ -59,16 +61,34 @@ export function useWorktreeMetaWorkspace(args: {
   )
   const linkedIssue = worktree?.linkedIssue ?? null
   const linkedLinearIssue = worktree?.linkedLinearIssue ?? null
+  const linkedWorkItem = worktree?.linkedWorkItem ?? null
+  // Why: Jira issues live in the shared linkedWorkItem slot, not a dedicated
+  // column, so the provider/type gate keeps a linked PR or MR from seeding the
+  // issue field.
+  const jiraWorkItem =
+    linkedWorkItem?.provider === 'jira' && linkedWorkItem.type === 'issue' ? linkedWorkItem : null
+  const linkedJiraIssue = jiraWorkItem?.jiraIdentifier ?? null
   // Why: `typeof` rather than a null check — an unhydrated projection can leave
   // linkedIssue undefined, which `!== null` would read as a GitHub link.
   const currentProvider: IssueLinkProvider =
-    typeof linkedIssue === 'number' ? 'github' : linkedLinearIssue ? 'linear' : 'github'
+    typeof linkedIssue === 'number'
+      ? 'github'
+      : linkedLinearIssue
+        ? 'linear'
+        : jiraWorkItem
+          ? 'jira'
+          : 'github'
   const currentIssue =
     currentProvider === 'linear'
       ? (linkedLinearIssue ?? '')
-      : typeof linkedIssue === 'number'
-        ? String(linkedIssue)
-        : ''
+      : currentProvider === 'jira'
+        ? // Why: seed the stored URL, not the bare key. It opens directly and pins
+          // the site, so an untouched re-save never re-resolves against the wrong
+          // instance; the identity still normalizes it back to the key.
+          jiraWorkItem?.url || linkedJiraIssue || ''
+        : typeof linkedIssue === 'number'
+          ? String(linkedIssue)
+          : ''
   // Why: displacement is decided against live state, not the frozen snapshot —
   // the dialog's warning reads the same values, so a link added by the CLI while
   // the dialog was open cannot outlive a save that promised to displace it.
@@ -78,7 +98,8 @@ export function useWorktreeMetaWorkspace(args: {
       linkedLinearIssue,
       linkedLinearIssueOrganizationUrlKey: worktree?.linkedLinearIssueOrganizationUrlKey ?? null,
       linkedWorkItemProvider: worktree?.linkedWorkItem?.provider ?? null,
-      linkedWorkItemType: worktree?.linkedWorkItem?.type ?? null
+      linkedWorkItemType: worktree?.linkedWorkItem?.type ?? null,
+      linkedWorkItemJiraIdentifier: worktree?.linkedWorkItem?.jiraIdentifier ?? null
     }),
     [
       linkedIssue,
@@ -92,6 +113,7 @@ export function useWorktreeMetaWorkspace(args: {
     worktree,
     linkedIssue,
     linkedLinearIssue,
+    linkedJiraIssue,
     currentIssue,
     currentProvider,
     // Why: folder workspaces persist links only through their creation-time

--- a/src/renderer/src/components/sidebar/worktree-issue-displacement.ts
+++ b/src/renderer/src/components/sidebar/worktree-issue-displacement.ts
@@ -7,17 +7,25 @@ import {
 } from './worktree-meta-updates'
 
 function formatLinkLabel(provider: IssueLinkProvider, value: string): string {
-  return provider === 'linear'
-    ? translate(
-        'auto.components.sidebar.worktreeIssueDisplacement.3f61c0a8d2',
-        'Linear {{value}}',
-        { value }
-      )
-    : translate(
-        'auto.components.sidebar.worktreeIssueDisplacement.9c4b7e1f60',
-        'GitHub #{{value}}',
-        { value }
-      )
+  if (provider === 'linear') {
+    return translate(
+      'auto.components.sidebar.worktreeIssueDisplacement.3f61c0a8d2',
+      'Linear {{value}}',
+      { value }
+    )
+  }
+  if (provider === 'jira') {
+    return translate(
+      'auto.components.sidebar.worktreeIssueDisplacement.91421aa60e',
+      'Jira {{value}}',
+      { value }
+    )
+  }
+  return translate(
+    'auto.components.sidebar.worktreeIssueDisplacement.9c4b7e1f60',
+    'GitHub #{{value}}',
+    { value }
+  )
 }
 
 /** Names the persisted links a save would drop. A workspace tracks one issue, so
@@ -30,8 +38,10 @@ export function getDisplacedLinkLabels(args: {
   isFolderWorkspace: boolean
   linkedIssue: number | null
   linkedLinearIssue: string | null
+  linkedJiraIssue: string | null
 }): string[] | null {
-  const { draft, snapshot, isFolderWorkspace, linkedIssue, linkedLinearIssue } = args
+  const { draft, snapshot, isFolderWorkspace, linkedIssue, linkedLinearIssue, linkedJiraIssue } =
+    args
   if (isFolderWorkspace || !isIssueFieldDirty(draft, snapshot)) {
     return null
   }
@@ -40,6 +50,9 @@ export function getDisplacedLinkLabels(args: {
   const displaced: string[] = []
   if (keeping !== 'linear' && linkedLinearIssue) {
     displaced.push(formatLinkLabel('linear', linkedLinearIssue))
+  }
+  if (keeping !== 'jira' && linkedJiraIssue) {
+    displaced.push(formatLinkLabel('jira', linkedJiraIssue))
   }
   if (keeping !== 'github' && typeof linkedIssue === 'number') {
     displaced.push(formatLinkLabel('github', String(linkedIssue)))

--- a/src/renderer/src/components/sidebar/worktree-jira-issue-link.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-jira-issue-link.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildJiraLinkedWorkItem,
+  resolveJiraIssueLink,
+  selectJiraSiteForLink,
+  type ParsedJiraIssueLink
+} from './worktree-jira-issue-link'
+import type { JiraConnectionStatus, JiraIssue, JiraSite } from '../../../../shared/jira-types'
+import type { TaskSourceContext } from '../../../../shared/task-source-context'
+
+const site = (id: string, siteUrl: string): JiraSite => ({ id, siteUrl }) as JiraSite
+
+function status(sites: JiraSite[], activeSiteId: string | null = null): JiraConnectionStatus {
+  return { connected: sites.length > 0, viewer: null, sites, activeSiteId }
+}
+
+const bareKey: ParsedJiraIssueLink = { provider: 'jira', issueKey: 'PROJ-9' }
+const pinnedUrl: ParsedJiraIssueLink = {
+  provider: 'jira',
+  issueKey: 'PROJ-9',
+  siteOrigin: 'https://acme.atlassian.net',
+  sitePath: ''
+}
+
+const context = {
+  kind: 'task-source',
+  provider: 'jira',
+  projectId: 'p1',
+  hostId: 'local'
+} as unknown as TaskSourceContext
+
+const issue = (key: string): JiraIssue =>
+  ({
+    key,
+    title: `Ticket ${key}`,
+    url: `https://acme.atlassian.net/browse/${key}`,
+    project: { key: 'PROJ' }
+  }) as JiraIssue
+
+describe('selectJiraSiteForLink', () => {
+  it('reports not-connected when the status is disconnected or has no sites', () => {
+    expect(selectJiraSiteForLink(bareKey, status([]))).toEqual({ errorKind: 'not-connected' })
+    expect(
+      selectJiraSiteForLink(bareKey, { connected: false, viewer: null, sites: [site('1', 'x')] })
+    ).toEqual({ errorKind: 'not-connected' })
+  })
+
+  it('pins the site a URL names by exact origin', () => {
+    const resolved = selectJiraSiteForLink(
+      pinnedUrl,
+      status([site('1', 'https://acme.atlassian.net'), site('2', 'https://other.atlassian.net')])
+    )
+    expect(resolved).toEqual({ site: site('1', 'https://acme.atlassian.net') })
+  })
+
+  it('does not match a host that merely starts with the pinned origin', () => {
+    const resolved = selectJiraSiteForLink(
+      pinnedUrl,
+      status([site('1', 'https://acme.atlassian.net.evil.example')])
+    )
+    expect(resolved).toEqual({ errorKind: 'site-not-connected' })
+  })
+
+  it('uses the active site for a bare key', () => {
+    const resolved = selectJiraSiteForLink(
+      bareKey,
+      status(
+        [site('1', 'https://acme.atlassian.net'), site('2', 'https://other.atlassian.net')],
+        '2'
+      )
+    )
+    expect(resolved).toEqual({ site: site('2', 'https://other.atlassian.net') })
+  })
+
+  it('uses the only connected site for a bare key when none is active', () => {
+    expect(
+      selectJiraSiteForLink(bareKey, status([site('1', 'https://acme.atlassian.net')]))
+    ).toEqual({ site: site('1', 'https://acme.atlassian.net') })
+  })
+
+  it('refuses to guess when several sites are connected and none is active', () => {
+    const resolved = selectJiraSiteForLink(
+      bareKey,
+      status([site('1', 'https://acme.atlassian.net'), site('2', 'https://other.atlassian.net')])
+    )
+    expect(resolved).toEqual({ errorKind: 'ambiguous-site' })
+  })
+})
+
+describe('buildJiraLinkedWorkItem', () => {
+  it('stores the identifier in the Jira field and zeroes the numeric one', () => {
+    expect(buildJiraLinkedWorkItem(issue('PROJ-9'))).toEqual({
+      provider: 'jira',
+      type: 'issue',
+      number: 0,
+      title: 'Ticket PROJ-9',
+      url: 'https://acme.atlassian.net/browse/PROJ-9',
+      jiraIdentifier: 'PROJ-9'
+    })
+  })
+})
+
+describe('resolveJiraIssueLink', () => {
+  it('resolves a bare key against the active site', async () => {
+    const result = await resolveJiraIssueLink({
+      parsed: bareKey,
+      sourceContext: context,
+      readStatus: async () => status([site('1', 'https://acme.atlassian.net')], '1'),
+      lookupSummary: async () => issue('PROJ-9')
+    })
+    expect(result).toMatchObject({ ok: true, linkedWorkItem: { jiraIdentifier: 'PROJ-9' } })
+  })
+
+  it('looks the issue up against the site a URL pins', async () => {
+    let requestedSiteId: string | null = null
+    const result = await resolveJiraIssueLink({
+      parsed: pinnedUrl,
+      sourceContext: context,
+      readStatus: async () =>
+        status(
+          [site('1', 'https://acme.atlassian.net'), site('2', 'https://other.atlassian.net')],
+          '2'
+        ),
+      lookupSummary: async (_ctx, _key, siteId) => {
+        requestedSiteId = siteId
+        return issue('PROJ-9')
+      }
+    })
+    expect(result).toMatchObject({ ok: true })
+    expect(requestedSiteId).toBe('1')
+  })
+
+  it('fails with not-found when the lookup returns nothing', async () => {
+    const result = await resolveJiraIssueLink({
+      parsed: bareKey,
+      sourceContext: context,
+      readStatus: async () => status([site('1', 'https://acme.atlassian.net')], '1'),
+      lookupSummary: async () => null
+    })
+    expect(result).toEqual({ ok: false, errorKind: 'not-found' })
+  })
+
+  it('does not look up an issue when no site resolves', async () => {
+    let lookedUp = false
+    const result = await resolveJiraIssueLink({
+      parsed: bareKey,
+      sourceContext: context,
+      readStatus: async () => status([]),
+      lookupSummary: async () => {
+        lookedUp = true
+        return issue('PROJ-9')
+      }
+    })
+    expect(result).toEqual({ ok: false, errorKind: 'not-connected' })
+    expect(lookedUp).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-jira-issue-link.ts
+++ b/src/renderer/src/components/sidebar/worktree-jira-issue-link.ts
@@ -20,9 +20,10 @@ type JiraSiteResolution =
   | { errorKind: Exclude<JiraIssueLinkErrorKind, 'not-found'> }
 
 /** Picks the Jira site a link resolves against: a URL pins the site it names, a
- *  bare key uses the active (or single) connection, and several sites with none
- *  active is ambiguous — the same key can exist on two instances, so guessing
- *  would link the wrong ticket. Mirrors the CLI `worktree set --jira` contract. */
+ *  bare key uses the active site, then the selected site, then the only connected
+ *  site. Several connected sites with none active or selected is ambiguous: the
+ *  same key can exist on two instances, so guessing would link the wrong ticket.
+ *  Mirrors the CLI `worktree set --jira` contract. */
 export function selectJiraSiteForLink(
   parsed: Pick<ParsedJiraIssueLink, 'siteOrigin' | 'sitePath'>,
   status: JiraConnectionStatus
@@ -67,6 +68,9 @@ export function buildJiraLinkedWorkItem(issue: JiraIssue): WorkspaceLinkedItem {
   }
 }
 
+/** Binds the resolved site and issue into a Jira task-source context so the card
+ *  can scope reads and match the link. Reuses the base context's project, host,
+ *  and repo, and normalizes to null when those are incomplete. */
 export function buildJiraLinkedTaskSourceContext(
   base: TaskSourceContext,
   site: JiraSite,

--- a/src/renderer/src/components/sidebar/worktree-jira-issue-link.ts
+++ b/src/renderer/src/components/sidebar/worktree-jira-issue-link.ts
@@ -1,0 +1,136 @@
+import { getMatchingJiraSites } from '../../../../shared/jira-issue-url'
+import {
+  normalizeTaskSourceContext,
+  type TaskSourceContext
+} from '../../../../shared/task-source-context'
+import type { ParsedIssueLinkInput } from '../../../../shared/issue-link-input'
+import type { JiraConnectionStatus, JiraIssue, JiraSite } from '../../../../shared/jira-types'
+import type { WorkspaceLinkedItem } from '../../../../shared/types'
+
+export type ParsedJiraIssueLink = Extract<ParsedIssueLinkInput, { provider: 'jira' }>
+
+export type JiraIssueLinkErrorKind =
+  | 'not-connected'
+  | 'site-not-connected'
+  | 'ambiguous-site'
+  | 'not-found'
+
+type JiraSiteResolution =
+  | { site: JiraSite }
+  | { errorKind: Exclude<JiraIssueLinkErrorKind, 'not-found'> }
+
+/** Picks the Jira site a link resolves against: a URL pins the site it names, a
+ *  bare key uses the active (or single) connection, and several sites with none
+ *  active is ambiguous — the same key can exist on two instances, so guessing
+ *  would link the wrong ticket. Mirrors the CLI `worktree set --jira` contract. */
+export function selectJiraSiteForLink(
+  parsed: Pick<ParsedJiraIssueLink, 'siteOrigin' | 'sitePath'>,
+  status: JiraConnectionStatus
+): JiraSiteResolution {
+  const sites = status.sites ?? []
+  if (!status.connected || sites.length === 0) {
+    return { errorKind: 'not-connected' }
+  }
+
+  if (parsed.siteOrigin) {
+    const pinned = getMatchingJiraSites(
+      { issueKey: '', origin: parsed.siteOrigin, sitePath: parsed.sitePath ?? '' },
+      sites
+    )[0]
+    return pinned ? { site: pinned } : { errorKind: 'site-not-connected' }
+  }
+
+  const active = sites.find((site) => site.id === status.activeSiteId)
+  if (active) {
+    return { site: active }
+  }
+  const selected =
+    typeof status.selectedSiteId === 'string'
+      ? sites.find((site) => site.id === status.selectedSiteId)
+      : undefined
+  if (selected) {
+    return { site: selected }
+  }
+  return sites.length > 1 ? { errorKind: 'ambiguous-site' } : { site: sites[0] }
+}
+
+/** Jira keys are not numeric, so the shared numeric field carries no meaning; the
+ *  identifier is what the card renders. Matches the CLI-built work item shape. */
+export function buildJiraLinkedWorkItem(issue: JiraIssue): WorkspaceLinkedItem {
+  return {
+    provider: 'jira',
+    type: 'issue',
+    number: 0,
+    title: issue.title,
+    url: issue.url,
+    jiraIdentifier: issue.key
+  }
+}
+
+export function buildJiraLinkedTaskSourceContext(
+  base: TaskSourceContext,
+  site: JiraSite,
+  issue: JiraIssue
+): TaskSourceContext | null {
+  return normalizeTaskSourceContext({
+    provider: 'jira',
+    projectId: base.projectId,
+    hostId: base.hostId,
+    projectHostSetupId: base.projectHostSetupId,
+    repoId: base.repoId,
+    providerIdentity: {
+      provider: 'jira',
+      siteId: site.id,
+      siteUrl: site.siteUrl,
+      projectKey: issue.project.key
+    },
+    accountLabel: site.email || site.displayName
+  })
+}
+
+export type JiraIssueLinkResult =
+  | {
+      ok: true
+      linkedWorkItem: WorkspaceLinkedItem
+      linkedTaskSourceContext: TaskSourceContext | null
+    }
+  | { ok: false; errorKind: JiraIssueLinkErrorKind }
+
+/** Resolves a typed Jira input into the `linkedWorkItem` the workspace stores.
+ *  Failing to resolve is a hard error rather than a partial link: a card showing
+ *  a key with no title or URL is worse than no link, and the renderer expects both. */
+export async function resolveJiraIssueLink(args: {
+  parsed: ParsedJiraIssueLink
+  sourceContext: TaskSourceContext
+  readStatus: (context: TaskSourceContext) => Promise<JiraConnectionStatus>
+  lookupSummary: (
+    context: TaskSourceContext,
+    key: string,
+    siteId: string
+  ) => Promise<JiraIssue | null>
+}): Promise<JiraIssueLinkResult> {
+  const status = await args.readStatus(args.sourceContext)
+  const resolution = selectJiraSiteForLink(args.parsed, status)
+  if ('errorKind' in resolution) {
+    return { ok: false, errorKind: resolution.errorKind }
+  }
+
+  const issue = await args.lookupSummary(
+    args.sourceContext,
+    args.parsed.issueKey,
+    resolution.site.id
+  )
+  if (!issue) {
+    return { ok: false, errorKind: 'not-found' }
+  }
+
+  return {
+    ok: true,
+    linkedWorkItem: buildJiraLinkedWorkItem(issue),
+    linkedTaskSourceContext: buildJiraLinkedTaskSourceContext(
+      args.sourceContext,
+      resolution.site,
+      issue
+    )
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-meta-updates.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-meta-updates.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { WorktreeMeta } from '../../../../shared/types'
 import {
   buildWorktreeMetaUpdates,
+  isIssueFieldDirty,
   type WorktreeMetaDraft,
   type WorktreeMetaLiveLinks,
   type WorktreeMetaSnapshot
@@ -377,5 +378,43 @@ describe('buildWorktreeMetaUpdates', () => {
 
   it('clears a comment with empty string, never a present-undefined key', () => {
     expect(buildUpdates({ commentInput: '  ' }, { comment: 'old note' }).comment).toBe('')
+  })
+})
+
+describe('isIssueFieldDirty Jira site identity', () => {
+  // The same key on two Jira instances is two different links, so re-pointing a
+  // URL at another site must resolve and persist rather than read as untouched.
+  it('treats the same key on two Jira sites as a change', () => {
+    expect(
+      isIssueFieldDirty(
+        makeDraft({
+          issueProvider: 'jira',
+          issueInput: 'https://site-b.atlassian.net/browse/PROJ-9'
+        }),
+        makeSnapshot({
+          issueProvider: 'jira',
+          issueInput: 'https://site-a.atlassian.net/browse/PROJ-9'
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('treats an unchanged Jira URL as clean', () => {
+    const url = 'https://acme.atlassian.net/browse/PROJ-9'
+    expect(
+      isIssueFieldDirty(
+        makeDraft({ issueProvider: 'jira', issueInput: url }),
+        makeSnapshot({ issueProvider: 'jira', issueInput: url })
+      )
+    ).toBe(false)
+  })
+
+  it('treats a respelled bare Jira key as clean', () => {
+    expect(
+      isIssueFieldDirty(
+        makeDraft({ issueProvider: 'jira', issueInput: 'proj-9' }),
+        makeSnapshot({ issueProvider: 'jira', issueInput: 'PROJ-9' })
+      )
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-meta-updates.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-meta-updates.test.ts
@@ -153,6 +153,21 @@ describe('buildWorktreeMetaUpdates', () => {
     expect(updates).toHaveProperty('linkedTaskSourceContext', null)
   })
 
+  it('displaces a Jira linked work item when the issue field changes', () => {
+    const updates = buildUpdates(
+      { issueInput: '12' },
+      {},
+      {
+        linkedWorkItemProvider: 'jira',
+        linkedWorkItemType: 'issue',
+        linkedWorkItemJiraIdentifier: 'PROJ-9'
+      }
+    )
+
+    expect(updates).toHaveProperty('linkedWorkItem', null)
+    expect(updates).toHaveProperty('linkedTaskSourceContext', null)
+  })
+
   // linkedWorkItem also records the PR or MR a workspace was created from, which
   // the Issue row does not own and must not drop.
   it('leaves a PR-typed work item alone', () => {
@@ -166,10 +181,10 @@ describe('buildWorktreeMetaUpdates', () => {
     expect(updates).not.toHaveProperty('linkedTaskSourceContext')
   })
 
-  // The row cannot render a GitLab or Jira issue, so clearing one would destroy a
-  // link the user was never shown — and neither has another editor to restore it.
+  // The row cannot render a GitLab issue, so clearing one would destroy a link
+  // the user was never shown, and it has no other editor to restore it from.
   it('leaves work items owned by other providers alone', () => {
-    for (const provider of ['jira', 'gitlab'] as const) {
+    for (const provider of ['gitlab'] as const) {
       const updates = buildUpdates(
         { issueInput: '12' },
         {},

--- a/src/renderer/src/components/sidebar/worktree-meta-updates.ts
+++ b/src/renderer/src/components/sidebar/worktree-meta-updates.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../shared/linear-links'
 import { parseIssueLinkInput, type IssueLinkProvider } from '../../../../shared/issue-link-input'
 import type { WorkspaceSourceProvider } from '../../../../shared/new-workspace/workspace-source'
+import type { TaskSourceContext } from '../../../../shared/task-source-context'
 import type { WorkspaceLinkedItem, WorktreeMeta } from '../../../../shared/types'
 
 export type WorktreeMetaSavedPayload = {
@@ -46,6 +47,9 @@ export type WorktreeMetaLiveLinks = {
   linkedWorkItemProvider?: WorkspaceSourceProvider | null
   /** `linkedWorkItem` also describes PRs and MRs, which this row does not own. */
   linkedWorkItemType?: WorkspaceLinkedItem['type'] | null
+  /** The Jira key `linkedWorkItem` carries, so a re-save of the same issue is
+   *  recognized rather than displaced. */
+  linkedWorkItemJiraIdentifier?: string | null
 }
 
 export function parseExplicitGitHubIssueUrl(input: string): string | null {
@@ -117,6 +121,9 @@ function issueLinkIdentity(
   if (parsed.provider === 'github') {
     return `github:${parsed.number}`
   }
+  if (parsed.provider === 'jira') {
+    return `jira:${parsed.issueKey.toUpperCase()}`
+  }
   const organizationUrlKey = parsed.organizationUrlKey ?? storedLinearOrganizationUrlKey ?? ''
   return `linear:${parsed.identifier}:${organizationUrlKey.trim().toLowerCase()}`
 }
@@ -153,6 +160,12 @@ function keepsLinkedWorkItem(
   if (parsed.provider === 'github') {
     return live.linkedWorkItemProvider === 'github' && parsed.number === live.linkedIssue
   }
+  if (parsed.provider === 'jira') {
+    return (
+      live.linkedWorkItemProvider === 'jira' &&
+      parsed.issueKey.toUpperCase() === live.linkedWorkItemJiraIdentifier?.trim().toUpperCase()
+    )
+  }
   if (
     live.linkedWorkItemProvider !== 'linear' ||
     parsed.identifier.toUpperCase() !== live.linkedLinearIssue?.trim().toUpperCase()
@@ -183,17 +196,18 @@ function buildIssueLinkUpdates(
 
   const trimmed = draft.issueInput.trim()
   // Why: the linked work item and its source context describe the issue being
-  // replaced. Leaving them would keep a stale title badge and mis-scope Linear
-  // reads — but only when the save names a *different* issue: a value that
-  // re-states the same one, such as a URL adding an org key, must keep its own
-  // title and SSH/runtime routing context. Narrow on purpose: `type` because the
-  // field also records the PR or MR a workspace was created from, and provider
-  // because GitLab and Jira issues have no slot in this row — displacing what it
-  // cannot display would destroy a link the user was never shown and has no
-  // other editor to restore it from.
+  // replaced. Leaving them would keep a stale title badge and mis-scope reads —
+  // but only when the save names a *different* issue: a value that re-states the
+  // same one, such as a URL adding an org key, must keep its own title and
+  // SSH/runtime routing context. Narrow on `type` because the field also records
+  // the PR or MR a workspace was created from. GitLab issues have no editor here,
+  // so they are left untouched; GitHub, Linear and Jira each own a slot in this
+  // field and so displace cleanly.
   const displacedWorkItem: Partial<WorktreeMeta> =
     !keepsLinkedWorkItem(trimmed, draft.issueProvider, live) &&
-    (live.linkedWorkItemProvider === 'github' || live.linkedWorkItemProvider === 'linear') &&
+    (live.linkedWorkItemProvider === 'github' ||
+      live.linkedWorkItemProvider === 'linear' ||
+      live.linkedWorkItemProvider === 'jira') &&
     live.linkedWorkItemType === 'issue'
       ? { linkedWorkItem: null, linkedTaskSourceContext: null }
       : {}
@@ -215,6 +229,14 @@ function buildIssueLinkUpdates(
     }
   }
 
+  // Why: a Jira link carries a title and URL that only an async site lookup can
+  // supply, so the dialog resolves it and writes through
+  // buildResolvedJiraIssueLinkUpdates. The synchronous builder leaves every slot
+  // untouched for a non-empty Jira value rather than persisting a partial link.
+  if (draft.issueProvider === 'jira') {
+    return {}
+  }
+
   const parsed = parseIssueLinkInput(trimmed, draft.issueProvider)
   if (!parsed) {
     // Why: unparseable input leaves every link untouched. `canSave` already
@@ -232,6 +254,25 @@ function buildIssueLinkUpdates(
 
   const linearUpdates = buildLinearIssueLinkUpdates(trimmed)
   return linearUpdates ? { linkedIssue: null, ...linearUpdates, ...displacedWorkItem } : {}
+}
+
+/** Persists a Jira link the dialog resolved asynchronously. Writing the Jira
+ *  work item clears the GitHub and Linear slots so the workspace still tracks
+ *  one issue; the Linear clear is emitted only when a Linear link is live, since
+ *  persistence gates that remote capability on key presence, not value. */
+export function buildResolvedJiraIssueLinkUpdates(
+  resolved: {
+    linkedWorkItem: WorkspaceLinkedItem
+    linkedTaskSourceContext: TaskSourceContext | null
+  },
+  live: WorktreeMetaLiveLinks
+): Partial<WorktreeMeta> {
+  return {
+    linkedIssue: null,
+    ...(live.linkedLinearIssue ? LINEAR_ISSUE_LINK_CLEARED : {}),
+    linkedWorkItem: resolved.linkedWorkItem,
+    linkedTaskSourceContext: resolved.linkedTaskSourceContext
+  }
 }
 
 // Requires the dialog to seed `prInput` from the persisted `linkedPR`: the blank

--- a/src/renderer/src/components/sidebar/worktree-meta-updates.ts
+++ b/src/renderer/src/components/sidebar/worktree-meta-updates.ts
@@ -122,7 +122,13 @@ function issueLinkIdentity(
     return `github:${parsed.number}`
   }
   if (parsed.provider === 'jira') {
-    return `jira:${parsed.issueKey.toUpperCase()}`
+    // Why: a URL pins its site, so the same key on two Jira instances must read
+    // as two different links; a bare key omits the site and stays comparable
+    // across a respelling that resolves to the active site.
+    const site = parsed.siteOrigin
+      ? `${parsed.siteOrigin}${parsed.sitePath ?? ''}`.toLowerCase()
+      : ''
+    return `jira:${parsed.issueKey.toUpperCase()}:${site}`
   }
   const organizationUrlKey = parsed.organizationUrlKey ?? storedLinearOrganizationUrlKey ?? ''
   return `linear:${parsed.identifier}:${organizationUrlKey.trim().toLowerCase()}`

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4846,7 +4846,11 @@
           "382fd11a3e": "Edit Worktree Details",
           "2174f17011": "Save",
           "61d6f612cf": "Saving...",
-          "a0d191b7a7": "Edit issue links, pull request links, and notes for this workspace."
+          "a0d191b7a7": "Edit issue links, pull request links, and notes for this workspace.",
+          "136795efad": "Connect Jira in Settings before linking an issue.",
+          "9c3e2078a4": "That Jira site isn't connected. Connect it, or enter a bare issue key to use the active site.",
+          "764b478e40": "Several Jira sites are connected. Paste a full Jira issue URL so the site is unambiguous.",
+          "9560604f22": "That Jira issue was not found. Check the key and your access."
         },
         "WorktreeOpenInMenu": {
           "localOnly": "Local only",
@@ -5321,14 +5325,18 @@
           "2c245ac134": "Saving unlinks {{link}} — a workspace tracks one issue.",
           "d8c8a30d1f": "Couldn't open that issue. Check the identifier and your Linear connection.",
           "269198eeda": "Couldn't open that issue. Check the number and your GitHub connection.",
-          "f047887705": "Paste a GitHub or Linear URL, or enter a number. Leave blank to remove the link.",
           "ad78f9bee2": "Issue",
-          "662ae142f8": "Issue #, or a GitHub or Linear URL",
-          "929c98d05a": "Issue provider"
+          "929c98d05a": "Issue provider",
+          "d83b054c9c": "Jira",
+          "c587107e21": "Not a Jira issue key or issue URL.",
+          "59aa1044bb": "Couldn't open that issue. Check the key and your Jira connection.",
+          "95d9f8f997": "Paste a GitHub, Linear, or Jira URL, or enter a number. Leave blank to remove the link.",
+          "0ee31ebf7b": "Issue #, or a GitHub, Linear, or Jira URL"
         },
         "worktreeIssueDisplacement": {
           "3f61c0a8d2": "Linear {{value}}",
-          "9c4b7e1f60": "GitHub #{{value}}"
+          "9c4b7e1f60": "GitHub #{{value}}",
+          "91421aa60e": "Jira {{value}}"
         },
         "WorktreeCardSshHostControl": {
           "connectFailed": "SSH connection failed",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4850,7 +4850,8 @@
           "136795efad": "Connect Jira in Settings before linking an issue.",
           "9c3e2078a4": "That Jira site isn't connected. Connect it, or enter a bare issue key to use the active site.",
           "764b478e40": "Several Jira sites are connected. Paste a full Jira issue URL so the site is unambiguous.",
-          "9560604f22": "That Jira issue was not found. Check the key and your access."
+          "9560604f22": "That Jira issue was not found. Check the key and your access.",
+          "a3d824d1b8": "Could not link the Jira issue. Check your Jira connection and try again."
         },
         "WorktreeOpenInMenu": {
           "localOnly": "Local only",
@@ -5331,7 +5332,8 @@
           "c587107e21": "Not a Jira issue key or issue URL.",
           "59aa1044bb": "Couldn't open that issue. Check the key and your Jira connection.",
           "95d9f8f997": "Paste a GitHub, Linear, or Jira URL, or enter a number. Leave blank to remove the link.",
-          "0ee31ebf7b": "Issue #, or a GitHub, Linear, or Jira URL"
+          "0ee31ebf7b": "Issue #, or a GitHub, Linear, or Jira URL",
+          "5089993940": "Saving unlinks {{first}}, {{second}}, and {{third}}. A workspace tracks one issue."
         },
         "worktreeIssueDisplacement": {
           "3f61c0a8d2": "Linear {{value}}",

--- a/src/shared/issue-link-input.test.ts
+++ b/src/shared/issue-link-input.test.ts
@@ -22,6 +22,14 @@ describe('getIssueLinkProviderFromUrl', () => {
     expect(getIssueLinkProviderFromUrl('https://linear.app/acme/team/ENG/all')).toBeNull()
   })
 
+  it('detects Jira issue browse URLs', () => {
+    expect(getIssueLinkProviderFromUrl('https://acme.atlassian.net/browse/PROJ-9')).toBe('jira')
+  })
+
+  it('ignores non-issue paths on a Jira host', () => {
+    expect(getIssueLinkProviderFromUrl('https://acme.atlassian.net/projects/PROJ')).toBeNull()
+  })
+
   it('rejects hosts that merely contain linear.app', () => {
     expect(getIssueLinkProviderFromUrl('https://linear.app.evil.com/acme/issue/STA-335')).toBeNull()
   })
@@ -113,6 +121,48 @@ describe('parseIssueLinkInput', () => {
     it('rejects junk and empty input', () => {
       expect(parseIssueLinkInput('not an issue', 'linear')).toBeNull()
       expect(parseIssueLinkInput('   ', 'linear')).toBeNull()
+    })
+  })
+
+  describe('jira provider', () => {
+    it('accepts bare issue keys and normalizes case', () => {
+      expect(parseIssueLinkInput('PROJ-9', 'jira')).toEqual({
+        provider: 'jira',
+        issueKey: 'PROJ-9'
+      })
+      expect(parseIssueLinkInput('proj-9', 'jira')).toEqual({
+        provider: 'jira',
+        issueKey: 'PROJ-9'
+      })
+    })
+
+    it('omits site pinning for bare keys', () => {
+      expect(parseIssueLinkInput('PROJ-9', 'jira')).not.toHaveProperty('siteOrigin')
+    })
+
+    it('accepts issue URLs and pins the site', () => {
+      expect(parseIssueLinkInput('https://acme.atlassian.net/browse/PROJ-9', 'jira')).toEqual({
+        provider: 'jira',
+        issueKey: 'PROJ-9',
+        siteOrigin: 'https://acme.atlassian.net',
+        sitePath: ''
+      })
+    })
+
+    it('carries the site path for Jira Server instances behind a base path', () => {
+      expect(parseIssueLinkInput('https://jira.example.com/jira/browse/PROJ-9', 'jira')).toEqual({
+        provider: 'jira',
+        issueKey: 'PROJ-9',
+        siteOrigin: 'https://jira.example.com',
+        sitePath: '/jira'
+      })
+    })
+
+    it('rejects GitHub and Linear URLs, junk, and empty input', () => {
+      expect(parseIssueLinkInput('https://github.com/o/r/issues/12', 'jira')).toBeNull()
+      expect(parseIssueLinkInput('https://linear.app/acme/issue/STA-335', 'jira')).toBeNull()
+      expect(parseIssueLinkInput('not an issue', 'jira')).toBeNull()
+      expect(parseIssueLinkInput('   ', 'jira')).toBeNull()
     })
   })
 })

--- a/src/shared/issue-link-input.ts
+++ b/src/shared/issue-link-input.ts
@@ -1,12 +1,14 @@
 import { parseGitHubIssueOrPRLink } from './github-links'
 import { parseLinearIssueInput } from './linear-links'
+import { JIRA_ISSUE_KEY_PATTERN, parseJiraIssueUrl } from './jira-issue-url'
 import type { WorkspaceSourceProvider } from './new-workspace/workspace-source'
 
 // Why: narrows the canonical provider union instead of minting a parallel one,
-// so adding Jira here is a one-entry change rather than a new axis.
+// so adding a provider here is a one-entry change rather than a new axis.
 export const ISSUE_LINK_PROVIDERS = [
   'github',
-  'linear'
+  'linear',
+  'jira'
 ] as const satisfies readonly WorkspaceSourceProvider[]
 
 export type IssueLinkProvider = (typeof ISSUE_LINK_PROVIDERS)[number]
@@ -32,12 +34,18 @@ export function getIssueLinkProviderFromUrl(input: string): IssueLinkProvider | 
   if (parseLinearIssueInput(trimmed)) {
     return 'linear'
   }
+  // Why: a Jira issue URL is `.../browse/KEY`; its host is distinct from GitHub
+  // and linear.app, so this cannot steal a link the other parsers already claim.
+  if (parseJiraIssueUrl(trimmed)) {
+    return 'jira'
+  }
   return null
 }
 
 export type ParsedIssueLinkInput =
   | { provider: 'github'; number: number }
   | { provider: 'linear'; identifier: string; organizationUrlKey?: string }
+  | { provider: 'jira'; issueKey: string; siteOrigin?: string; sitePath?: string }
 
 /**
  * Single parse shared by the dialog's save gate and its payload builder, so a
@@ -55,6 +63,23 @@ export function parseIssueLinkInput(
   if (provider === 'linear') {
     const parsed = parseLinearIssueInput(trimmed)
     return parsed ? { provider: 'linear', ...parsed } : null
+  }
+
+  if (provider === 'jira') {
+    // Why: a URL pins the site it names; a bare key leaves the site to resolve
+    // against the active connection at save time (see worktree-jira-issue-link).
+    const fromUrl = parseJiraIssueUrl(trimmed)
+    if (fromUrl) {
+      return {
+        provider: 'jira',
+        issueKey: fromUrl.issueKey,
+        siteOrigin: fromUrl.origin,
+        sitePath: fromUrl.sitePath
+      }
+    }
+    return JIRA_ISSUE_KEY_PATTERN.test(trimmed)
+      ? { provider: 'jira', issueKey: trimmed.toUpperCase() }
+      : null
   }
 
   const link = parseGitHubIssueOrPRLink(trimmed)


### PR DESCRIPTION
## Summary

Fixes #12899.

The worktree issue-link field in **Edit Worktree Details** only offered GitHub and Linear, so pasting a Jira issue URL was rejected with "Not a GitHub issue number or issue URL." Jira is a first-class task provider elsewhere in Orca, but it had no slot in this dialog.

This adds **Jira** as a selectable provider in that field:

- The provider dropdown now lists GitHub, Linear, and Jira, with the Jira product icon.
- Pasting a Jira issue URL auto-selects the Jira provider. The field also accepts a bare issue key such as `PROJ-123`.
- On save, the value is resolved against the connected Jira site and stored as the workspace's `linkedWorkItem`. This mirrors the `orca worktree set --jira` contract from #11659: a URL pins its site, a bare key uses the active site, and several connected sites with none active is reported rather than guessed.
- Writing a Jira link clears the GitHub and Linear slots so a workspace still tracks one issue. Switching away from Jira, or clearing the field, displaces the Jira link too.
- Resolution failures (not connected, unknown site, ambiguous site, issue not found) show an actionable message instead of writing a partial link.

The async resolution lives in a dedicated hook (`use-worktree-meta-jira-link.ts`) so the dialog stays within the `max-lines` budget. The site-selection and work-item-building logic is a pure, unit-tested module (`worktree-jira-issue-link.ts`).

## Screenshots

<img width="570" height="657" alt="Screenshot 2026-08-11 at 17 05 01" src="https://github.com/user-attachments/assets/eb2ed9ce-b52b-4ddb-82af-0d07c6d83116" />

## Testing

- `pnpm typecheck`
- `pnpm lint` (oxlint, native and type-aware audits, reliability gates, max-lines ratchet, localization catalog/extraction/coverage)
- `pnpm exec vitest run` for the touched suites, including new tests:
  - `worktree-jira-issue-link.test.ts`: site selection (URL pin, active/single/ambiguous), not-found, and no lookup without a site.
  - `issue-link-input.test.ts`: Jira URL detection and key/URL parsing.
  - `WorktreeMetaDialog.test.tsx`: resolves and saves a Jira link (clearing the GitHub slot), and shows an error without saving when Jira is not connected.
- Manual: ran `pnpm dev`, selected Jira in Edit Worktree Details, confirmed a Jira issue URL is accepted (no more "Not a GitHub issue" error) and saved as a linked Jira work item.

## Notes

- Folder workspaces stay read-only for issue links, as before.
- No wire or protocol changes: Jira links use the existing `linkedWorkItem` and `linkedTaskSourceContext` fields.