### PR TITLE
fix(pty): stop reporting permission-denied worktrees as deleted

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -12527,6 +12527,12 @@ describe('registerPtyHandlers', () => {
       }
       return true
     })
+    statSyncMock.mockImplementation((targetPath: string) => {
+      if (targetPath === '//wsl.localhost/Ubuntu/home/jin/missing') {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      }
+      return { isDirectory: () => true, mode: 0o755 }
+    })
 
     try {
       registerPtyHandlers(mainWindow as never)

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -444,9 +444,27 @@ describe('LocalPtyProvider', () => {
 
     it('throws when cwd does not exist', async () => {
       existsSyncMock.mockImplementation((p: string) => p !== '/nonexistent')
+      statSyncMock.mockImplementation((p: string) => {
+        if (p === '/nonexistent') {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+        }
+        return { isDirectory: () => true, mode: 0o755 }
+      })
       await expect(provider.spawn({ cols: 80, rows: 24, cwd: '/nonexistent' })).rejects.toThrow(
         'does not exist'
       )
+    })
+
+    it('reports an unreadable cwd as inaccessible rather than deleted (#13760)', async () => {
+      statSyncMock.mockImplementation((p: string) => {
+        if (p === '/media/user/volume/repo') {
+          throw Object.assign(new Error('EACCES'), { code: 'EACCES' })
+        }
+        return { isDirectory: () => true, mode: 0o755 }
+      })
+      await expect(
+        provider.spawn({ cols: 80, rows: 24, cwd: '/media/user/volume/repo' })
+      ).rejects.toThrow('cannot be accessed (EACCES)')
     })
 
     it('allows an explicitly requested plain shell at POSIX root', async () => {

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -25,6 +25,12 @@ function dirStats(isDirectory: boolean): Stats {
   return { isDirectory: () => isDirectory } as Stats
 }
 
+function fsError(code: string): NodeJS.ErrnoException {
+  const error = new Error(`${code}: fake fs failure`) as NodeJS.ErrnoException
+  error.code = code
+  return error
+}
+
 vi.mock('../wsl', () => ({
   wslUncDirectoryExists: wslUncDirectoryExistsMock
 }))
@@ -57,52 +63,92 @@ describe('validateWorkingDirectory', () => {
     // Why: the Win32 9P stat is the exact path that falsely reported ENOENT and
     // broke opening WSL worktrees. The distro answer must win.
     wslUncDirectoryExistsMock.mockReturnValue(true)
-    existsSyncMock.mockReturnValue(false)
+    statSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT')
+    })
 
     expect(() => validateWorkingDirectory(WSL_UNC_DIR)).not.toThrow()
     expect(wslUncDirectoryExistsMock).toHaveBeenCalledWith(WSL_UNC_DIR)
     // The fs fallback must not run when the distro confirmed existence.
-    expect(existsSyncMock).not.toHaveBeenCalled()
+    expect(statSyncMock).not.toHaveBeenCalled()
   })
 
   it('rejects a WSL UNC worktree that does not exist inside the distro', () => {
     wslUncDirectoryExistsMock.mockReturnValue(false)
 
     expect(() => validateWorkingDirectory(WSL_UNC_DIR)).toThrow(/does not exist/)
-    expect(existsSyncMock).not.toHaveBeenCalled()
+    expect(statSyncMock).not.toHaveBeenCalled()
   })
 
   it('falls back to the fs check when the distro answer is inconclusive', () => {
     wslUncDirectoryExistsMock.mockReturnValue(null)
-    existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue(dirStats(true))
 
     expect(() => validateWorkingDirectory(WSL_UNC_DIR)).not.toThrow()
     expect(wslUncDirectoryExistsMock).toHaveBeenCalledWith(WSL_UNC_DIR)
-    expect(existsSyncMock).toHaveBeenCalledWith(WSL_UNC_DIR)
+    expect(statSyncMock).toHaveBeenCalledWith(WSL_UNC_DIR)
   })
 
   it('validates native Windows paths via fs without consulting the distro', () => {
-    existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue(dirStats(true))
 
     expect(() => validateWorkingDirectory(NATIVE_DIR)).not.toThrow()
     expect(wslUncDirectoryExistsMock).not.toHaveBeenCalled()
-    expect(existsSyncMock).toHaveBeenCalledWith(NATIVE_DIR)
+    expect(statSyncMock).toHaveBeenCalledWith(NATIVE_DIR)
   })
 
   it('rejects a missing native Windows path', () => {
-    existsSyncMock.mockReturnValue(false)
+    statSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT')
+    })
 
     expect(() => validateWorkingDirectory(NATIVE_DIR)).toThrow(/does not exist/)
     expect(wslUncDirectoryExistsMock).not.toHaveBeenCalled()
   })
 
   it('rejects a native Windows path that exists but is not a directory', () => {
-    existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue(dirStats(false))
 
     expect(() => validateWorkingDirectory(NATIVE_DIR)).toThrow(/is not a directory/)
+  })
+
+  it('reports a permission failure as inaccessible, never as deleted/unmounted (#13760)', () => {
+    // Why: existsSync folded EACCES into "missing", telling users their existing
+    // external-volume worktree had been deleted.
+    statSyncMock.mockImplementation(() => {
+      throw fsError('EACCES')
+    })
+
+    expect(() => validateWorkingDirectory('/media/user/volume/repo')).toThrow(
+      /cannot be accessed \(EACCES\)/
+    )
+    expect(() => validateWorkingDirectory('/media/user/volume/repo')).not.toThrow(/does not exist/)
+  })
+
+  it('reports EPERM the same way as EACCES', () => {
+    statSyncMock.mockImplementation(() => {
+      throw fsError('EPERM')
+    })
+
+    expect(() => validateWorkingDirectory(NATIVE_DIR)).toThrow(/cannot be accessed \(EPERM\)/)
+  })
+
+  it('treats ENOTDIR like a missing directory', () => {
+    statSyncMock.mockImplementation(() => {
+      throw fsError('ENOTDIR')
+    })
+
+    expect(() => validateWorkingDirectory('/work/file.txt/child')).toThrow(/does not exist/)
+  })
+
+  it('surfaces unexpected stat failures verbatim instead of claiming deletion', () => {
+    statSyncMock.mockImplementation(() => {
+      throw fsError('EIO')
+    })
+
+    expect(() => validateWorkingDirectory('/media/user/dying-disk')).toThrow(
+      /could not be verified: EIO/
+    )
   })
 })
 

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,5 +1,12 @@
 import { basename, isAbsolute, join } from 'node:path'
-import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
+import {
+  existsSync,
+  accessSync,
+  statSync,
+  chmodSync,
+  constants as fsConstants,
+  type Stats
+} from 'node:fs'
 import type * as pty from 'node-pty'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { wslUncDirectoryExists } from '../wsl'
@@ -124,10 +131,29 @@ export function validateWorkingDirectory(cwd: string): void {
     }
   }
 
-  if (!existsSync(cwd)) {
-    throwMissingWorkingDirectory(cwd)
+  let stats: Stats
+  try {
+    stats = statSync(cwd)
+  } catch (error) {
+    // Why: existsSync folds every stat failure into "missing", so a directory
+    // Orca merely cannot traverse (EACCES on external volumes, FUSE mounts,
+    // sandbox-hidden paths) was misreported as deleted or unmounted (#13760).
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'EACCES' || code === 'EPERM') {
+      throw new Error(
+        `Working directory "${cwd}" cannot be accessed (${code}). ` +
+          `Check its permissions and the permissions of its parent directories.`
+      )
+    }
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throwMissingWorkingDirectory(cwd)
+    }
+    throw new Error(
+      `Working directory "${cwd}" could not be verified: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+    )
   }
-  if (!statSync(cwd).isDirectory()) {
+  if (!stats.isDirectory()) {
     throw new Error(`Working directory "${cwd}" is not a directory.`)
   }
 }


### PR DESCRIPTION
Fixes #13760

## Summary

When spawning a terminal, `validateWorkingDirectory` decided "missing" with `existsSync`, which returns `false` for **every** stat failure — not just `ENOENT`. An existing directory Orca merely cannot traverse (a Linux external volume mounted under `/media` with restrictive parent permissions, a FUSE mount, a sandbox-hidden path) was reported as:

> Working directory "…" does not exist. It may have been deleted or is on an unmounted volume.

telling the user their intact worktree had been deleted. That is exactly the misdiagnosis in #13760 (`/media/happy/…` on Linux).

Reproduction of the underlying behavior (Node, any POSIX system):

```js
// parent directory chmod 000
existsSync(child)        // -> false        (folds the error away)
statSync(child)          // -> throws EACCES (the real reason)
```

## What changed

`validateWorkingDirectory` now uses a single `statSync` and branches on the real error code:

- `ENOENT` / `ENOTDIR` → the existing "does not exist / deleted or unmounted" message (unchanged wording, so no behavior change for genuinely missing paths).
- `EACCES` / `EPERM` → new message: `Working directory "…" cannot be accessed (EACCES). Check its permissions and the permissions of its parent directories.` It deliberately does not claim the directory exists — an EACCES on a parent means we cannot know.
- Any other code (e.g. `EIO` on a failing disk) → `Working directory "…" could not be verified: <original error>` instead of a fabricated "deleted" claim.

The WSL UNC path (`\\wsl.localhost\…`) keeps its distro-side second opinion unchanged and only reaches the fs check when `wsl.exe` is inconclusive. The double `existsSync` + `statSync` pair also collapses to one syscall, removing a TOCTOU window where the second call could throw raw.

## Testing

- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ · `pnpm build` ✅
- `local-pty-utils.test.ts`: existing cases migrated to the single-stat shape (missing, not-a-directory, WSL UNC accept/reject/inconclusive), plus new regression cases that inject fs errors explicitly — stable on Windows runners, unlike permission-bit fixtures:
  - `EACCES` → "cannot be accessed", and **not** the deleted/unmounted message (the #13760 regression)
  - `EPERM` → same as EACCES
  - `ENOTDIR` → treated as missing
  - `EIO` → surfaced verbatim as "could not be verified"
- `local-pty-provider.test.ts`: adds the caller-level EACCES case (spawn rejects with the inaccessible message).
- Two existing tests mocked *only* `existsSync` to simulate a missing directory, so they silently stopped exercising the guard once it moved to `statSync`. They now throw an `ENOENT`-coded error from `statSyncMock` — the convention already used by the neighbouring cases in the same files (`ipc/pty.test.ts` "keeps a missing cwd unchanged", `local-pty-provider.test.ts`). Full suite: 4661 files / 49853 tests, 0 failures.

No visual change.

## AI Review Report

Reviewed with Claude Code:

- **Cross-platform:** the code-branch set covers POSIX (`EACCES`) and Windows (`EPERM`, and `ENOENT` from ConPTY-relevant preflight); the WSL UNC distro-side check is untouched. Tests inject error objects rather than relying on permission bits, so they run identically on all three OSes.
- **SSH/remote:** this validator runs only in the local PTY spawn paths (`pty-subprocess.ts` preflight, `local-pty-provider.ts`); SSH/remote spawn paths do not route through it. The error text travels over the existing daemon error channel — message-text-only, no wire shape change.
- **Agents/integrations/git providers:** not involved; this is shell/PTY spawn preflight.
- **Performance:** one syscall instead of two on the happy path.
- **Security:** no new inputs; error messages include only the path the caller already supplied.

## Notes

- `getShellValidationError` (same file) still uses `existsSync` for the shell binary; a shell hidden by permissions is a much rarer setup than a worktree on a restricted mount, so it is left out of scope to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
