### PR TITLE
feat(rate-limits): add API-key-based ClinePass usage tracking

### DIFF
--- a/src/main/clinepass/clinepass-api-key-store.test.ts
+++ b/src/main/clinepass/clinepass-api-key-store.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClinePassApiKeyStore from './clinepass-api-key-store'
+
+const safeStorageMock = vi.hoisted(() => ({
+  isEncryptionAvailable: vi.fn(() => true),
+  encryptString: vi.fn((value: string) => Buffer.from(value)),
+  decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
+  getSelectedStorageBackend: vi.fn(() => 'gnome_libsecret')
+}))
+
+const electronMock = vi.hoisted(() => ({
+  safeStorage: safeStorageMock
+}))
+
+vi.mock('electron', () => electronMock)
+
+const existsSyncMock = vi.fn()
+const readFileSyncMock = vi.fn()
+const rmSyncMock = vi.fn()
+const hardenExistingSecureFileMock = vi.fn()
+const writeSecureFileMock = vi.fn()
+const homedirMock = vi.fn(() => '/home/test')
+
+vi.mock('node:fs', () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+  rmSync: rmSyncMock
+}))
+
+vi.mock('node:os', () => ({
+  homedir: homedirMock
+}))
+
+vi.mock('node:path', () => ({
+  join: (...parts: string[]) => parts.join('/')
+}))
+
+vi.mock('../../shared/secure-file', () => ({
+  hardenExistingSecureFile: hardenExistingSecureFileMock,
+  writeSecureFile: writeSecureFileMock
+}))
+
+const storePath = '/home/test/.orca/clinepass-api-key.enc'
+const envelope = (value: string): string =>
+  `orca-clinepass-api-key:v1:encrypted:${Buffer.from(value, 'utf8').toString('base64')}`
+
+async function loadStore(): Promise<typeof ClinePassApiKeyStore> {
+  return await import('./clinepass-api-key-store')
+}
+
+describe('clinepass-api-key-store', () => {
+  const originalEnv = process.env.CLINE_API_KEY
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    delete process.env.CLINE_API_KEY
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    existsSyncMock.mockReset()
+    readFileSyncMock.mockReset()
+    rmSyncMock.mockReset()
+    hardenExistingSecureFileMock.mockReset()
+    writeSecureFileMock.mockReset()
+    safeStorageMock.isEncryptionAvailable.mockReset()
+    safeStorageMock.encryptString.mockReset()
+    safeStorageMock.decryptString.mockReset()
+    safeStorageMock.getSelectedStorageBackend.mockReset()
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+    safeStorageMock.encryptString.mockImplementation((value: string) => Buffer.from(value))
+    safeStorageMock.decryptString.mockImplementation((value: Buffer) => value.toString('utf8'))
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue('gnome_libsecret')
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CLINE_API_KEY
+    } else {
+      process.env.CLINE_API_KEY = originalEnv
+    }
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    vi.resetModules()
+  })
+
+  it('returns none status when no stored key or environment key exists', async () => {
+    existsSyncMock.mockReturnValue(false)
+    const store = await loadStore()
+    expect(store.getClinePassCredentialsStatus()).toEqual({ configured: false, source: 'none' })
+    expect(store.hasClinePassApiKey()).toBe(false)
+    expect(store.readClinePassApiKey()).toBeNull()
+    expect(hardenExistingSecureFileMock).not.toHaveBeenCalled()
+  })
+
+  it('hardens the key file when checking stored status', async () => {
+    existsSyncMock.mockReturnValue(true)
+    const store = await loadStore()
+    expect(store.getClinePassCredentialsStatus()).toEqual({ configured: true, source: 'stored' })
+    expect(store.hasClinePassApiKey()).toBe(true)
+    expect(hardenExistingSecureFileMock).toHaveBeenCalledWith(storePath)
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+  })
+
+  it('still reports a stored key when status-path hardening fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    existsSyncMock.mockReturnValue(true)
+    hardenExistingSecureFileMock.mockImplementation(() => {
+      throw new Error('permission denied')
+    })
+    const store = await loadStore()
+    expect(store.getClinePassCredentialsStatus()).toEqual({ configured: true, source: 'stored' })
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to harden ClinePass API key file'),
+      expect.any(Error)
+    )
+    warn.mockRestore()
+  })
+
+  it('prefers stored source over environment when both are present', async () => {
+    process.env.CLINE_API_KEY = 'env-key'
+    existsSyncMock.mockReturnValue(true)
+    const store = await loadStore()
+    expect(store.getClinePassCredentialsStatus()).toEqual({ configured: true, source: 'stored' })
+  })
+
+  it('reports environment source when only CLINE_API_KEY is set', async () => {
+    process.env.CLINE_API_KEY = '  env-only-key  '
+    existsSyncMock.mockReturnValue(false)
+    const store = await loadStore()
+    expect(store.getClinePassCredentialsStatus()).toEqual({
+      configured: true,
+      source: 'environment'
+    })
+    expect(store.hasClinePassApiKey()).toBe(true)
+    expect(store.readClinePassApiKey()).toBe('env-only-key')
+  })
+
+  it('ignores blank environment keys', async () => {
+    process.env.CLINE_API_KEY = '   '
+    existsSyncMock.mockReturnValue(false)
+    const store = await loadStore()
+    expect(store.getClinePassCredentialsStatus()).toEqual({ configured: false, source: 'none' })
+    expect(store.readClinePassApiKey()).toBeNull()
+  })
+
+  it('writes the key using safeStorage when encryption is available', async () => {
+    existsSyncMock.mockReturnValue(false)
+    const store = await loadStore()
+    store.saveClinePassApiKey(' cp_live_abc ')
+    expect(safeStorageMock.encryptString).toHaveBeenCalledWith('cp_live_abc')
+    expect(writeSecureFileMock).toHaveBeenCalledWith(storePath, envelope('cp_live_abc'))
+    expect(store.readClinePassApiKey()).toBe('cp_live_abc')
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+  })
+
+  it('refuses to persist when safeStorage encryption is unavailable', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    existsSyncMock.mockReturnValue(false)
+    const store = await loadStore()
+    expect(() => store.saveClinePassApiKey('cp_live_plain')).toThrow(/CLINE_API_KEY/)
+    expect(writeSecureFileMock).not.toHaveBeenCalled()
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled()
+  })
+
+  it('refuses to persist on Linux when safeStorage backend is basic_text', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue('basic_text')
+    existsSyncMock.mockReturnValue(false)
+    const store = await loadStore()
+    expect(() => store.saveClinePassApiKey('cp_live_basic')).toThrow(/CLINE_API_KEY/)
+    expect(writeSecureFileMock).not.toHaveBeenCalled()
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled()
+  })
+
+  it('refuses empty API keys', async () => {
+    const store = await loadStore()
+    expect(() => store.saveClinePassApiKey('   ')).toThrow(/required/)
+  })
+
+  it('reads decrypted key from disk and caches it', async () => {
+    existsSyncMock.mockReturnValue(true)
+    readFileSyncMock.mockReturnValue(Buffer.from(envelope('encrypted-payload')))
+    safeStorageMock.decryptString.mockReturnValue('cp_live_cached')
+    const store = await loadStore()
+    const first = store.readClinePassApiKey()
+    const second = store.readClinePassApiKey()
+    expect(first).toBe('cp_live_cached')
+    expect(second).toBe(first)
+    expect(hardenExistingSecureFileMock).toHaveBeenCalledTimes(1)
+    expect(hardenExistingSecureFileMock).toHaveBeenCalledWith(storePath)
+    expect(safeStorageMock.decryptString).toHaveBeenCalledTimes(1)
+    expect(safeStorageMock.decryptString).toHaveBeenCalledWith(Buffer.from('encrypted-payload'))
+  })
+
+  it('prefers stored key over environment when reading', async () => {
+    process.env.CLINE_API_KEY = 'env-key'
+    existsSyncMock.mockReturnValue(true)
+    readFileSyncMock.mockReturnValue(Buffer.from(envelope('encrypted-payload')))
+    safeStorageMock.decryptString.mockReturnValue('stored-key')
+    const store = await loadStore()
+    expect(store.readClinePassApiKey()).toBe('stored-key')
+  })
+
+  it('fails closed when reading a stored key without secure storage', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    existsSyncMock.mockReturnValue(true)
+    readFileSyncMock.mockReturnValue(Buffer.from(envelope('encrypted-payload')))
+    const store = await loadStore()
+    expect(() => store.readClinePassApiKey()).toThrow(/could not be decrypted/)
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when reading a stored key on Linux basic_text backend', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue('basic_text')
+    existsSyncMock.mockReturnValue(true)
+    readFileSyncMock.mockReturnValue(Buffer.from(envelope('encrypted-payload')))
+    const store = await loadStore()
+    expect(() => store.readClinePassApiKey()).toThrow(/could not be decrypted/)
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+  })
+
+  it('throws when decryption fails', async () => {
+    existsSyncMock.mockReturnValue(true)
+    readFileSyncMock.mockReturnValue(Buffer.from(envelope('encrypted-payload')))
+    safeStorageMock.decryptString.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    const store = await loadStore()
+    expect(() => store.readClinePassApiKey()).toThrow(/could not be decrypted/)
+  })
+
+  it('clears the cached key and removes the file', async () => {
+    existsSyncMock.mockReturnValueOnce(true)
+    readFileSyncMock.mockReturnValueOnce(Buffer.from(envelope('encrypted-payload')))
+    safeStorageMock.decryptString.mockReturnValueOnce('cp_live_preclear')
+    const store = await loadStore()
+    expect(store.readClinePassApiKey()).toBe('cp_live_preclear')
+    store.clearClinePassApiKey()
+    expect(rmSyncMock).toHaveBeenCalledWith(storePath, { force: true })
+    existsSyncMock.mockReturnValue(false)
+    expect(store.readClinePassApiKey()).toBeNull()
+    expect(store.getClinePassCredentialsStatus()).toEqual({ configured: false, source: 'none' })
+  })
+})

--- a/src/main/clinepass/clinepass-api-key-store.ts
+++ b/src/main/clinepass/clinepass-api-key-store.ts
@@ -1,0 +1,157 @@
+import { safeStorage } from 'electron'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { ClinePassCredentialsStatus } from '../../shared/clinepass-credentials'
+import { hardenExistingSecureFile, writeSecureFile } from '../../shared/secure-file'
+
+const CLINEPASS_API_KEY_FILE = 'clinepass-api-key.enc'
+const API_KEY_ENVELOPE_PREFIX = 'orca-clinepass-api-key:v1:encrypted:'
+const CLINE_API_KEY_ENV = 'CLINE_API_KEY'
+const SECURE_STORAGE_UNAVAILABLE_ERROR =
+  'ClinePass API key cannot be stored securely on this system. Set the CLINE_API_KEY environment variable instead.'
+
+let cachedClinePassApiKey: string | null = null
+let warnedClinePassStatusHardenFailure = false
+
+function getOrcaDir(): string {
+  return join(homedir(), '.orca')
+}
+
+function getClinePassApiKeyPath(): string {
+  return join(getOrcaDir(), CLINEPASS_API_KEY_FILE)
+}
+
+function isClinePassSecureStorageAvailable(): boolean {
+  if (!safeStorage.isEncryptionAvailable()) {
+    return false
+  }
+  // Why: Electron's Linux basic_text backend only obscures bytes; treat it as
+  // unavailable so we never persist a recoverable API key to disk.
+  if (process.platform === 'linux') {
+    const backend =
+      typeof safeStorage.getSelectedStorageBackend === 'function'
+        ? safeStorage.getSelectedStorageBackend()
+        : null
+    if (backend === 'basic_text') {
+      return false
+    }
+  }
+  return true
+}
+
+function encodeEncryptedApiKeyEnvelope(encrypted: Buffer): string {
+  return `${API_KEY_ENVELOPE_PREFIX}${encrypted.toString('base64')}`
+}
+
+function decodeEncryptedApiKeyEnvelope(raw: Buffer): Buffer {
+  const text = raw.toString('utf8')
+  if (!text.startsWith(API_KEY_ENVELOPE_PREFIX)) {
+    throw new Error('ClinePass API key could not be decrypted')
+  }
+  const payload = Buffer.from(text.slice(API_KEY_ENVELOPE_PREFIX.length), 'base64')
+  if (payload.length === 0) {
+    throw new Error('ClinePass API key could not be decrypted')
+  }
+  return payload
+}
+
+function readEnvironmentClinePassApiKey(): string | null {
+  const value = process.env[CLINE_API_KEY_ENV]?.trim()
+  return value ? value : null
+}
+
+function hasStoredClinePassApiKey(): boolean {
+  const keyPath = getClinePassApiKeyPath()
+  if (!existsSync(keyPath)) {
+    return false
+  }
+  // Why: Settings/status polls should not decrypt (and prompt the keychain) just to know a key is on disk.
+  try {
+    hardenExistingSecureFile(keyPath)
+  } catch (error) {
+    if (!warnedClinePassStatusHardenFailure) {
+      warnedClinePassStatusHardenFailure = true
+      console.warn(
+        '[clinepass] Failed to harden ClinePass API key file while checking status',
+        error
+      )
+    }
+  }
+  return true
+}
+
+function readStoredClinePassApiKey(): string | null {
+  if (cachedClinePassApiKey !== null) {
+    return cachedClinePassApiKey
+  }
+  const keyPath = getClinePassApiKeyPath()
+  if (!existsSync(keyPath)) {
+    return null
+  }
+  // Why: keep hardening out of the decode/decrypt try so a chmod/ACL failure
+  // isn't misreported as a decrypt failure (matches hasStoredClinePassApiKey).
+  try {
+    hardenExistingSecureFile(keyPath)
+  } catch (error) {
+    console.warn('[clinepass] Failed to harden ClinePass API key file while reading', error)
+  }
+  if (!isClinePassSecureStorageAvailable()) {
+    throw new Error('ClinePass API key could not be decrypted')
+  }
+  try {
+    const encrypted = decodeEncryptedApiKeyEnvelope(readFileSync(keyPath))
+    const value = safeStorage.decryptString(encrypted).trim()
+    if (!value) {
+      throw new Error('ClinePass API key could not be decrypted')
+    }
+    cachedClinePassApiKey = value
+    return cachedClinePassApiKey
+  } catch (error) {
+    console.error('[clinepass] failed to decode/decrypt API key', error)
+    throw new Error('ClinePass API key could not be decrypted')
+  }
+}
+
+export function hasClinePassApiKey(): boolean {
+  return hasStoredClinePassApiKey() || readEnvironmentClinePassApiKey() !== null
+}
+
+export function getClinePassCredentialsStatus(): ClinePassCredentialsStatus {
+  if (hasStoredClinePassApiKey()) {
+    return { configured: true, source: 'stored' }
+  }
+  if (readEnvironmentClinePassApiKey() !== null) {
+    return { configured: true, source: 'environment' }
+  }
+  return { configured: false, source: 'none' }
+}
+
+export function saveClinePassApiKey(apiKey: string): void {
+  const trimmed = apiKey.trim()
+  if (!trimmed) {
+    throw new Error('ClinePass API key is required')
+  }
+  if (!isClinePassSecureStorageAvailable()) {
+    throw new Error(SECURE_STORAGE_UNAVAILABLE_ERROR)
+  }
+  writeSecureFile(
+    getClinePassApiKeyPath(),
+    encodeEncryptedApiKeyEnvelope(safeStorage.encryptString(trimmed))
+  )
+  cachedClinePassApiKey = trimmed
+}
+
+/** Prefer the securely stored key; fall back to official `CLINE_API_KEY`. Never returns the key over IPC. */
+export function readClinePassApiKey(): string | null {
+  const stored = readStoredClinePassApiKey()
+  if (stored) {
+    return stored
+  }
+  return readEnvironmentClinePassApiKey()
+}
+
+export function clearClinePassApiKey(): void {
+  cachedClinePassApiKey = null
+  rmSync(getClinePassApiKeyPath(), { force: true })
+}

--- a/src/main/ipc/clinepass-credentials.test.ts
+++ b/src/main/ipc/clinepass-credentials.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ClinePassCredentialsStatus } from '../../shared/clinepass-credentials'
+import type { RateLimitState } from '../../shared/rate-limit-types'
+import type { RateLimitService } from '../rate-limits/service'
+
+const ipcState = vi.hoisted(() => ({
+  handleHandlers: new Map<string, (event: unknown, ...args: unknown[]) => unknown>()
+}))
+
+const isTrustedUIRendererMock = vi.hoisted(() => vi.fn(() => true))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+      ipcState.handleHandlers.set(channel, handler)
+    }
+  }
+}))
+
+vi.mock('./ui', () => ({
+  isTrustedUIRenderer: isTrustedUIRendererMock
+}))
+
+const saveClinePassApiKeyMock = vi.hoisted(() => vi.fn())
+const clearClinePassApiKeyMock = vi.hoisted(() => vi.fn())
+const getClinePassCredentialsStatusMock = vi.hoisted(() =>
+  vi.fn((): ClinePassCredentialsStatus => ({ configured: false, source: 'none' }))
+)
+
+vi.mock('../clinepass/clinepass-api-key-store', () => ({
+  saveClinePassApiKey: saveClinePassApiKeyMock,
+  clearClinePassApiKey: clearClinePassApiKeyMock,
+  getClinePassCredentialsStatus: getClinePassCredentialsStatusMock
+}))
+
+import { registerClinePassCredentialsHandlers } from './clinepass-credentials'
+
+function makeRefreshMock(): {
+  refresh: ReturnType<typeof vi.fn>
+  invalidateClinePassCredentialState: ReturnType<typeof vi.fn>
+  service: Pick<RateLimitService, 'refresh' | 'invalidateClinePassCredentialState'>
+} {
+  const refresh = vi.fn(() => Promise.resolve({} as RateLimitState))
+  const invalidateClinePassCredentialState = vi.fn()
+  return {
+    refresh,
+    invalidateClinePassCredentialState,
+    service: { refresh, invalidateClinePassCredentialState }
+  }
+}
+
+const trustedEvent = { sender: { id: 1 } }
+const untrustedEvent = { sender: { id: 99 } }
+
+async function invokeWithEvent<T>(
+  channel: string,
+  event: { sender: { id: number } },
+  ...args: unknown[]
+): Promise<T> {
+  const handler = ipcState.handleHandlers.get(channel)
+  if (!handler) {
+    throw new Error(`No handler registered for ${channel}`)
+  }
+  return (await handler(event, ...args)) as T
+}
+
+async function invokeTrusted<T>(channel: string, ...args: unknown[]): Promise<T> {
+  isTrustedUIRendererMock.mockReturnValue(true)
+  return invokeWithEvent<T>(channel, trustedEvent, ...args)
+}
+
+describe('registerClinePassCredentialsHandlers', () => {
+  beforeEach(() => {
+    ipcState.handleHandlers.clear()
+    saveClinePassApiKeyMock.mockReset()
+    clearClinePassApiKeyMock.mockReset()
+    getClinePassCredentialsStatusMock.mockReset()
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: false, source: 'none' })
+    isTrustedUIRendererMock.mockReset()
+    isTrustedUIRendererMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('registers the three ClinePass credential channels', () => {
+    registerClinePassCredentialsHandlers(null)
+    expect(ipcState.handleHandlers.has('clinePassCredentials:getStatus')).toBe(true)
+    expect(ipcState.handleHandlers.has('clinePassCredentials:saveApiKey')).toBe(true)
+    expect(ipcState.handleHandlers.has('clinePassCredentials:clearApiKey')).toBe(true)
+  })
+
+  it('returns status on getStatus without exposing the key', async () => {
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: true, source: 'environment' })
+    registerClinePassCredentialsHandlers(null)
+    const status = await invokeTrusted<ClinePassCredentialsStatus>('clinePassCredentials:getStatus')
+    expect(status).toEqual({ configured: true, source: 'environment' })
+    expect(status).not.toHaveProperty('apiKey')
+    expect(isTrustedUIRendererMock).toHaveBeenCalledWith(trustedEvent.sender)
+  })
+
+  it('persists the key and reports stored status after saveApiKey', async () => {
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: true, source: 'stored' })
+    registerClinePassCredentialsHandlers(null)
+    const status = await invokeTrusted<ClinePassCredentialsStatus>(
+      'clinePassCredentials:saveApiKey',
+      'cp_live_abc'
+    )
+    expect(saveClinePassApiKeyMock).toHaveBeenCalledWith('cp_live_abc')
+    expect(status).toEqual({ configured: true, source: 'stored' })
+    expect(status).not.toHaveProperty('apiKey')
+  })
+
+  it('rejects non-string saveApiKey arguments', async () => {
+    registerClinePassCredentialsHandlers(null)
+    await expect(invokeTrusted('clinePassCredentials:saveApiKey', 42)).rejects.toThrow(
+      /must be a string/
+    )
+    expect(saveClinePassApiKeyMock).not.toHaveBeenCalled()
+  })
+
+  it('triggers invalidate + background refresh after saveApiKey when a service is provided', async () => {
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: true, source: 'stored' })
+    const { refresh, invalidateClinePassCredentialState, service } = makeRefreshMock()
+    registerClinePassCredentialsHandlers(service as RateLimitService)
+    await invokeTrusted('clinePassCredentials:saveApiKey', 'cp_live_abc')
+    // Why: the save handler is fire-and-forget — wait a microtask cycle so
+    // the queued `void rateLimits?.refresh()` resolves before we assert.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(invalidateClinePassCredentialState).toHaveBeenCalledTimes(1)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when saveApiKey runs without a rate-limit service', async () => {
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: true, source: 'stored' })
+    registerClinePassCredentialsHandlers(null)
+    await expect(
+      invokeTrusted('clinePassCredentials:saveApiKey', 'cp_live_abc')
+    ).resolves.toBeDefined()
+  })
+
+  it('clears the key and triggers a refresh on clearApiKey', async () => {
+    const { refresh, invalidateClinePassCredentialState, service } = makeRefreshMock()
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: false, source: 'none' })
+    registerClinePassCredentialsHandlers(service as RateLimitService)
+    const status = await invokeTrusted<ClinePassCredentialsStatus>(
+      'clinePassCredentials:clearApiKey'
+    )
+    expect(clearClinePassApiKeyMock).toHaveBeenCalledTimes(1)
+    expect(invalidateClinePassCredentialState).toHaveBeenCalledTimes(1)
+    expect(status).toEqual({ configured: false, source: 'none' })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs but does not throw when the post-save rate-limit refresh rejects', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    getClinePassCredentialsStatusMock.mockReturnValue({ configured: true, source: 'stored' })
+    const refresh = vi.fn(() => Promise.reject(new Error('refresh boom')))
+    const invalidateClinePassCredentialState = vi.fn()
+    registerClinePassCredentialsHandlers({
+      refresh,
+      invalidateClinePassCredentialState
+    } as Pick<
+      RateLimitService,
+      'refresh' | 'invalidateClinePassCredentialState'
+    > as RateLimitService)
+    await invokeTrusted('clinePassCredentials:saveApiKey', 'cp_live_abc')
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(invalidateClinePassCredentialState).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('failed to trigger rate-limit refresh after save'),
+      expect.any(Error)
+    )
+  })
+
+  it.each([
+    ['clinePassCredentials:getStatus', [] as unknown[]],
+    ['clinePassCredentials:saveApiKey', ['cp_live_abc'] as unknown[]],
+    ['clinePassCredentials:clearApiKey', [] as unknown[]]
+  ] as const)(
+    'rejects untrusted senders on %s without touching credentials or refresh',
+    async (channel, args) => {
+      const { refresh, invalidateClinePassCredentialState, service } = makeRefreshMock()
+      registerClinePassCredentialsHandlers(service as RateLimitService)
+      isTrustedUIRendererMock.mockReturnValue(false)
+
+      await expect(invokeWithEvent(channel, untrustedEvent, ...args)).rejects.toThrow(
+        /Unauthorized ClinePass credentials sender/
+      )
+
+      expect(isTrustedUIRendererMock).toHaveBeenCalledWith(untrustedEvent.sender)
+      expect(getClinePassCredentialsStatusMock).not.toHaveBeenCalled()
+      expect(saveClinePassApiKeyMock).not.toHaveBeenCalled()
+      expect(clearClinePassApiKeyMock).not.toHaveBeenCalled()
+      expect(invalidateClinePassCredentialState).not.toHaveBeenCalled()
+      expect(refresh).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/main/ipc/clinepass-credentials.ts
+++ b/src/main/ipc/clinepass-credentials.ts
@@ -1,0 +1,54 @@
+import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+import type { ClinePassCredentialsStatus } from '../../shared/clinepass-credentials'
+import {
+  clearClinePassApiKey,
+  getClinePassCredentialsStatus,
+  saveClinePassApiKey
+} from '../clinepass/clinepass-api-key-store'
+import type { RateLimitService } from '../rate-limits/service'
+import { isTrustedUIRenderer } from './ui'
+
+function assertTrustedClinePassCredentialsSender(event: IpcMainInvokeEvent): void {
+  if (!isTrustedUIRenderer(event.sender)) {
+    throw new Error('Unauthorized ClinePass credentials sender')
+  }
+}
+
+// Why: fire-and-forget — callers get the persisted credential status immediately;
+// the rate-limit refresh runs in the background and only logs on failure.
+function refreshAfterClinePassCredentialChange(
+  rateLimits: RateLimitService | null,
+  action: 'save' | 'clear'
+): void {
+  rateLimits?.invalidateClinePassCredentialState()
+  void rateLimits?.refresh().catch((error: unknown) => {
+    console.error(`[clinepass] failed to trigger rate-limit refresh after ${action}:`, error)
+  })
+}
+
+export function registerClinePassCredentialsHandlers(rateLimits: RateLimitService | null): void {
+  ipcMain.handle('clinePassCredentials:getStatus', (event): ClinePassCredentialsStatus => {
+    assertTrustedClinePassCredentialsSender(event)
+    return getClinePassCredentialsStatus()
+  })
+  ipcMain.handle(
+    'clinePassCredentials:saveApiKey',
+    (event, apiKey: unknown): ClinePassCredentialsStatus => {
+      assertTrustedClinePassCredentialsSender(event)
+      // Validate the IPC argument in the main process; the renderer-declared type
+      // is compile-time only and the value arrives as unknown over IPC.
+      if (typeof apiKey !== 'string') {
+        throw new Error('ClinePass API key must be a string')
+      }
+      saveClinePassApiKey(apiKey)
+      refreshAfterClinePassCredentialChange(rateLimits, 'save')
+      return getClinePassCredentialsStatus()
+    }
+  )
+  ipcMain.handle('clinePassCredentials:clearApiKey', (event): ClinePassCredentialsStatus => {
+    assertTrustedClinePassCredentialsSender(event)
+    clearClinePassApiKey()
+    refreshAfterClinePassCredentialChange(rateLimits, 'clear')
+    return getClinePassCredentialsStatus()
+  })
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -36,6 +36,7 @@ const {
   registerAgentTrustHandlersMock,
   registerClaudeAccountHandlersMock,
   registerMiniMaxCredentialsHandlersMock,
+  registerClinePassCredentialsHandlersMock,
   registerGrokAccountHandlersMock,
   registerClipboardHandlersMock,
   setTrustedClipboardRendererWebContentsIdMock,
@@ -101,6 +102,7 @@ const {
   registerAgentTrustHandlersMock: vi.fn(),
   registerClaudeAccountHandlersMock: vi.fn(),
   registerMiniMaxCredentialsHandlersMock: vi.fn(),
+  registerClinePassCredentialsHandlersMock: vi.fn(),
   registerGrokAccountHandlersMock: vi.fn(),
   registerClipboardHandlersMock: vi.fn(),
   setTrustedClipboardRendererWebContentsIdMock: vi.fn(),
@@ -327,6 +329,10 @@ vi.mock('./minimax-credentials', () => ({
   registerMiniMaxCredentialsHandlers: registerMiniMaxCredentialsHandlersMock
 }))
 
+vi.mock('./clinepass-credentials', () => ({
+  registerClinePassCredentialsHandlers: registerClinePassCredentialsHandlersMock
+}))
+
 vi.mock('./grok-accounts', () => ({
   registerGrokAccountHandlers: registerGrokAccountHandlersMock
 }))
@@ -422,6 +428,7 @@ describe('registerCoreHandlers', () => {
     registerAgentTrustHandlersMock.mockReset()
     registerClaudeAccountHandlersMock.mockReset()
     registerMiniMaxCredentialsHandlersMock.mockReset()
+    registerClinePassCredentialsHandlersMock.mockReset()
     registerClipboardHandlersMock.mockReset()
     setTrustedClipboardRendererWebContentsIdMock.mockReset()
     registerUpdaterHandlersMock.mockReset()
@@ -509,6 +516,7 @@ describe('registerCoreHandlers', () => {
     expect(registerPetHandlersMock).toHaveBeenCalled()
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)
+    expect(registerClinePassCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGrokAccountHandlersMock).toHaveBeenCalled()
     expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits, codexAccounts)
     expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -61,6 +61,7 @@ import { getPtyIdForPaneKey } from './pty'
 import { registerAgentTrustHandlers } from './agent-trust'
 import { registerClaudeAccountHandlers } from './claude-accounts'
 import { registerMiniMaxCredentialsHandlers } from './minimax-credentials'
+import { registerClinePassCredentialsHandlers } from './clinepass-credentials'
 import { registerGrokAccountHandlers } from './grok-accounts'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
 import {
@@ -146,6 +147,7 @@ export function registerCoreHandlers(
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerMiniMaxCredentialsHandlers(rateLimits)
+  registerClinePassCredentialsHandlers(rateLimits)
   registerGrokAccountHandlers()
   registerRateLimitHandlers(rateLimits, codexAccounts)
   registerGitHubHandlers(store, stats)

--- a/src/main/rate-limits/clinepass-fetcher.test.ts
+++ b/src/main/rate-limits/clinepass-fetcher.test.ts
@@ -259,7 +259,9 @@ describe('fetchClinePassRateLimits', () => {
     const result = await fetchClinePassRateLimits(API_KEY, { signal: controller.signal })
 
     expect(timeoutSpy).toHaveBeenCalledWith(15_000)
-    expect(anySpy).toHaveBeenCalled()
+    expect(anySpy.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining([controller.signal, timeoutSignal])
+    )
     expect(result.status).toBe('error')
     expect(result.usageMetadata?.failureKind).toBe('network')
   })

--- a/src/main/rate-limits/clinepass-fetcher.test.ts
+++ b/src/main/rate-limits/clinepass-fetcher.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+import { fetchClinePassRateLimits } from './clinepass-fetcher'
+
+const USAGE_URL = 'https://api.cline.bot/api/v1/users/me/plan/usage-limits'
+const API_KEY = 'cpk-test-secret-key'
+
+const SESSION_RESET = '2026-08-11T18:00:00.000Z'
+const WEEKLY_RESET = '2026-08-18T12:00:00.000Z'
+const MONTHLY_RESET = '2026-09-01T00:00:00.000Z'
+
+function makeOkPayload(limits: { type: string; percentUsed: number; resetsAt: string }[]): unknown {
+  return {
+    success: true,
+    data: { limits }
+  }
+}
+
+const FULL_LIMITS = [
+  { type: 'five_hour', percentUsed: 42.5, resetsAt: SESSION_RESET },
+  { type: 'weekly', percentUsed: 10, resetsAt: WEEKLY_RESET },
+  { type: 'monthly', percentUsed: 3, resetsAt: MONTHLY_RESET }
+]
+
+function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      ...headers
+    }
+  })
+}
+
+describe('fetchClinePassRateLimits', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-11T12:00:00.000Z'))
+    netFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns unavailable with missing-credentials when the key is blank', async () => {
+    for (const key of ['', '   ']) {
+      const result = await fetchClinePassRateLimits(key)
+      expect(result).toMatchObject({
+        provider: 'clinepass',
+        status: 'unavailable',
+        session: null,
+        weekly: null,
+        error: expect.stringMatching(/not configured/i),
+        usageMetadata: { failureKind: 'missing-credentials', source: 'web' }
+      })
+    }
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('requests the usage-limits URL with a bearer Authorization header', async () => {
+    netFetchMock.mockResolvedValueOnce(jsonResponse(makeOkPayload(FULL_LIMITS)))
+
+    await fetchClinePassRateLimits(API_KEY)
+
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = netFetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(USAGE_URL)
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${API_KEY}`)
+    expect((init.headers as Record<string, string>).Accept).toBe('application/json')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('maps five_hour, weekly, and monthly windows with reset timestamps', async () => {
+    netFetchMock.mockResolvedValueOnce(jsonResponse(makeOkPayload(FULL_LIMITS)))
+
+    const result = await fetchClinePassRateLimits(API_KEY)
+
+    expect(result.status).toBe('ok')
+    expect(result.provider).toBe('clinepass')
+    expect(result.error).toBeNull()
+    expect(result.usageMetadata).toEqual({ source: 'web' })
+    expect(result.session).toEqual({
+      usedPercent: 42.5,
+      windowMinutes: 300,
+      resetsAt: Date.parse(SESSION_RESET),
+      resetDescription: expect.any(String)
+    })
+    expect(result.weekly).toEqual({
+      usedPercent: 10,
+      windowMinutes: 10_080,
+      resetsAt: Date.parse(WEEKLY_RESET),
+      resetDescription: expect.any(String)
+    })
+    expect(result.monthly).toEqual({
+      usedPercent: 3,
+      windowMinutes: 43_200,
+      resetsAt: Date.parse(MONTHLY_RESET),
+      resetDescription: expect.any(String)
+    })
+  })
+
+  it('clamps percentUsed into the 0..100 range', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        makeOkPayload([
+          { type: 'five_hour', percentUsed: -12, resetsAt: SESSION_RESET },
+          { type: 'weekly', percentUsed: 150, resetsAt: WEEKLY_RESET }
+        ])
+      )
+    )
+
+    const result = await fetchClinePassRateLimits(API_KEY)
+
+    expect(result.status).toBe('ok')
+    expect(result.session?.usedPercent).toBe(0)
+    expect(result.weekly?.usedPercent).toBe(100)
+  })
+
+  it('classifies 401 and 403 as stale-token auth errors', async () => {
+    for (const status of [401, 403]) {
+      netFetchMock.mockResolvedValueOnce(jsonResponse({}, status))
+      const result = await fetchClinePassRateLimits(API_KEY)
+      expect(result.status).toBe('error')
+      expect(result.usageMetadata?.failureKind).toBe('stale-token')
+      expect(result.usageMetadata?.source).toBe('web')
+      expect(result.error).toMatch(new RegExp(`unauthorized.*${status}`, 'i'))
+      expect(result.error).not.toContain(API_KEY)
+    }
+  })
+
+  it('classifies 429 as rate-limited and honors parseable Retry-After', async () => {
+    netFetchMock.mockResolvedValueOnce(jsonResponse({}, 429, { 'retry-after': '120' }))
+
+    const before = Date.now()
+    const result = await fetchClinePassRateLimits(API_KEY)
+
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('rate-limited')
+    expect(result.usageMetadata?.source).toBe('web')
+    expect(result.error).toMatch(/rate limited/i)
+    expect(result.usageMetadata?.retryAtMs).toBeGreaterThanOrEqual(before + 120_000)
+    expect(result.usageMetadata?.retryAtMs).toBeLessThanOrEqual(Date.now() + 120_000)
+  })
+
+  it('omits retryAtMs when a 429 has no parseable Retry-After', async () => {
+    netFetchMock.mockResolvedValueOnce(jsonResponse({}, 429))
+
+    const result = await fetchClinePassRateLimits(API_KEY)
+
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('rate-limited')
+    expect(result.usageMetadata?.retryAtMs).toBeUndefined()
+  })
+
+  it('classifies 5xx responses as server errors', async () => {
+    netFetchMock.mockResolvedValueOnce(jsonResponse({}, 503))
+
+    const result = await fetchClinePassRateLimits(API_KEY)
+
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('server')
+    expect(result.error).toMatch(/503/)
+    expect(result.error).not.toContain(API_KEY)
+  })
+
+  it('classifies thrown fetch failures as network errors without leaking the key', async () => {
+    netFetchMock.mockRejectedValueOnce(new Error(`connect failed for ${API_KEY}`))
+
+    const result = await fetchClinePassRateLimits(API_KEY)
+
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('network')
+    expect(result.error).toMatch(/connect failed/)
+    expect(result.error).not.toContain(API_KEY)
+    expect(result.error).toContain('[redacted]')
+  })
+
+  it('classifies malformed success bodies as parse errors', async () => {
+    const cases: unknown[] = [
+      null,
+      { success: false, data: { limits: FULL_LIMITS } },
+      { success: true, data: null },
+      { success: true, data: {} },
+      { success: true, data: { limits: 'nope' } },
+      {
+        success: true,
+        data: { limits: [{ type: 'five_hour', percentUsed: 'x', resetsAt: SESSION_RESET }] }
+      },
+      {
+        success: true,
+        data: {
+          limits: [{ type: 'five_hour', percentUsed: 10, resetsAt: 'not-a-date' }]
+        }
+      }
+    ]
+
+    for (const body of cases) {
+      netFetchMock.mockResolvedValueOnce(jsonResponse(body))
+      const result = await fetchClinePassRateLimits(API_KEY)
+      expect(result.status).toBe('error')
+      expect(result.usageMetadata?.failureKind).toBe('parse')
+      expect(result.session).toBeNull()
+      expect(result.weekly).toBeNull()
+    }
+  })
+
+  it('ignores unknown window types and requires at least one known valid window', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        makeOkPayload([
+          { type: 'daily', percentUsed: 50, resetsAt: SESSION_RESET },
+          { type: 'five_hour', percentUsed: 22, resetsAt: SESSION_RESET }
+        ])
+      )
+    )
+    const ok = await fetchClinePassRateLimits(API_KEY)
+    expect(ok.status).toBe('ok')
+    expect(ok.session?.usedPercent).toBe(22)
+    expect(ok.weekly).toBeNull()
+    expect(ok.monthly).toBeNull()
+
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse(makeOkPayload([{ type: 'daily', percentUsed: 50, resetsAt: SESSION_RESET }]))
+    )
+    const onlyUnknown = await fetchClinePassRateLimits(API_KEY)
+    expect(onlyUnknown.status).toBe('error')
+    expect(onlyUnknown.usageMetadata?.failureKind).toBe('parse')
+  })
+
+  it('composes the caller AbortSignal with the 15s timeout', async () => {
+    const timeoutSignal = AbortSignal.abort(
+      new DOMException('The operation timed out.', 'TimeoutError')
+    )
+    const anySpy = vi.spyOn(AbortSignal, 'any').mockReturnValue(timeoutSignal)
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+
+    const controller = new AbortController()
+    netFetchMock.mockImplementation((_url: string, init: { signal: AbortSignal }) => {
+      const { promise, reject } = Promise.withResolvers<Response>()
+      const abort = (): void => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'))
+      }
+      if (init.signal.aborted) {
+        abort()
+      } else {
+        init.signal.addEventListener('abort', abort, { once: true })
+      }
+      return promise
+    })
+
+    const result = await fetchClinePassRateLimits(API_KEY, { signal: controller.signal })
+
+    expect(timeoutSpy).toHaveBeenCalledWith(15_000)
+    expect(anySpy).toHaveBeenCalled()
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('network')
+  })
+})

--- a/src/main/rate-limits/clinepass-fetcher.ts
+++ b/src/main/rate-limits/clinepass-fetcher.ts
@@ -1,0 +1,217 @@
+import { net } from 'electron'
+import type {
+  ProviderRateLimits,
+  RateLimitWindow,
+  UsageRateLimitFailureKind,
+  UsageRateLimitMetadata
+} from '../../shared/rate-limit-types'
+
+// Why: ClinePass plan usage is a single bearer-auth JSON endpoint — no scraping or OAuth refresh.
+const USAGE_LIMITS_URL = 'https://api.cline.bot/api/v1/users/me/plan/usage-limits'
+const API_TIMEOUT_MS = 15_000
+// Why: a hostile Retry-After must not gate refreshes for days.
+const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000
+
+const WINDOW_MINUTES = {
+  five_hour: 300,
+  weekly: 10_080,
+  monthly: 43_200
+} as const
+
+type ClinePassLimitType = keyof typeof WINDOW_MINUTES
+
+const PROVIDER: ProviderRateLimits['provider'] = 'clinepass'
+
+function result(
+  status: ProviderRateLimits['status'],
+  error: string | null,
+  usageMetadata?: UsageRateLimitMetadata,
+  windows?: {
+    session?: RateLimitWindow | null
+    weekly?: RateLimitWindow | null
+    monthly?: RateLimitWindow | null
+  }
+): ProviderRateLimits {
+  return {
+    provider: PROVIDER,
+    session: windows?.session ?? null,
+    weekly: windows?.weekly ?? null,
+    monthly: windows?.monthly ?? null,
+    updatedAt: Date.now(),
+    error,
+    status,
+    ...(usageMetadata ? { usageMetadata } : {})
+  }
+}
+
+function makeError(
+  error: string,
+  failureKind: UsageRateLimitFailureKind,
+  extra?: Pick<UsageRateLimitMetadata, 'retryAtMs'>
+): ProviderRateLimits {
+  return result('error', error, { failureKind, source: 'web', ...extra })
+}
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) {
+    return null
+  }
+  const seconds = Number(header)
+  if (Number.isFinite(seconds)) {
+    return seconds > 0 ? Math.min(seconds * 1000, MAX_RETRY_AFTER_MS) : null
+  }
+  // Why: Retry-After may also be an HTTP-date (RFC 9110).
+  const dateMs = Date.parse(header)
+  if (!Number.isFinite(dateMs)) {
+    return null
+  }
+  const delta = dateMs - Date.now()
+  return delta > 0 ? Math.min(delta, MAX_RETRY_AFTER_MS) : null
+}
+
+function parseResetDescription(isoString: string): string | null {
+  const date = new Date(isoString)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  const isToday = date.toDateString() === new Date().toDateString()
+  return isToday
+    ? date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+    : date.toLocaleDateString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
+}
+
+function isKnownLimitType(type: unknown): type is ClinePassLimitType {
+  return type === 'five_hour' || type === 'weekly' || type === 'monthly'
+}
+
+function parseLimit(entry: unknown): { type: ClinePassLimitType; window: RateLimitWindow } | null {
+  if (typeof entry !== 'object' || entry === null) {
+    return null
+  }
+  const record = entry as Record<string, unknown>
+  if (!isKnownLimitType(record.type)) {
+    return null
+  }
+  const percentUsed = record.percentUsed
+  if (typeof percentUsed !== 'number' || !Number.isFinite(percentUsed)) {
+    return null
+  }
+  const resetsAtRaw = record.resetsAt
+  if (typeof resetsAtRaw !== 'string' || !resetsAtRaw.trim()) {
+    return null
+  }
+  const resetsAt = Date.parse(resetsAtRaw)
+  if (!Number.isFinite(resetsAt)) {
+    return null
+  }
+  return {
+    type: record.type,
+    window: {
+      usedPercent: Math.max(0, Math.min(100, percentUsed)),
+      windowMinutes: WINDOW_MINUTES[record.type],
+      resetsAt,
+      resetDescription: parseResetDescription(resetsAtRaw)
+    }
+  }
+}
+
+function redactApiKey(message: string, apiKey: string): string {
+  return apiKey && message.includes(apiKey) ? message.split(apiKey).join('[redacted]') : message
+}
+
+/**
+ * Read-only ClinePass subscription quota via the plan usage-limits API.
+ *
+ * Never throws for expected provider failures — always returns ProviderRateLimits.
+ */
+export async function fetchClinePassRateLimits(
+  apiKey: string,
+  options?: { signal?: AbortSignal }
+): Promise<ProviderRateLimits> {
+  const key = apiKey.trim()
+  if (!key) {
+    return result('unavailable', 'ClinePass API key not configured', {
+      failureKind: 'missing-credentials',
+      source: 'web'
+    })
+  }
+
+  try {
+    const requestSignal = options?.signal
+      ? AbortSignal.any([options.signal, AbortSignal.timeout(API_TIMEOUT_MS)])
+      : AbortSignal.timeout(API_TIMEOUT_MS)
+    const res = await net.fetch(USAGE_LIMITS_URL, {
+      headers: {
+        Authorization: `Bearer ${key}`,
+        Accept: 'application/json'
+      },
+      signal: requestSignal
+    })
+
+    if (res.status === 401 || res.status === 403) {
+      return makeError(`ClinePass usage request unauthorized (HTTP ${res.status})`, 'stale-token')
+    }
+    if (res.status === 429) {
+      const retryAfterMs = parseRetryAfterMs(res.headers.get('retry-after'))
+      return makeError(
+        'ClinePass usage is rate limited right now.',
+        'rate-limited',
+        retryAfterMs ? { retryAtMs: Date.now() + retryAfterMs } : undefined
+      )
+    }
+    if (!res.ok) {
+      return makeError(`ClinePass usage fetch failed (HTTP ${res.status})`, 'server')
+    }
+
+    let payload: unknown
+    try {
+      payload = await res.json()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid ClinePass usage response'
+      return makeError(redactApiKey(message, key), 'parse')
+    }
+
+    if (typeof payload !== 'object' || payload === null) {
+      return makeError('ClinePass usage response was malformed', 'parse')
+    }
+    const body = payload as Record<string, unknown>
+    if (body.success !== true) {
+      return makeError('ClinePass usage response was malformed', 'parse')
+    }
+    const data = body.data
+    if (typeof data !== 'object' || data === null) {
+      return makeError('ClinePass usage response was malformed', 'parse')
+    }
+    const limits = (data as Record<string, unknown>).limits
+    if (!Array.isArray(limits)) {
+      return makeError('ClinePass usage response was malformed', 'parse')
+    }
+
+    let session: RateLimitWindow | null = null
+    let weekly: RateLimitWindow | null = null
+    let monthly: RateLimitWindow | null = null
+    let knownValid = 0
+    for (const entry of limits) {
+      const parsed = parseLimit(entry)
+      if (!parsed) {
+        continue
+      }
+      knownValid += 1
+      if (parsed.type === 'five_hour') {
+        session = parsed.window
+      } else if (parsed.type === 'weekly') {
+        weekly = parsed.window
+      } else {
+        monthly = parsed.window
+      }
+    }
+    if (knownValid === 0) {
+      return makeError('ClinePass usage response did not include quota windows', 'parse')
+    }
+
+    return result('ok', null, { source: 'web' }, { session, weekly, monthly })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ClinePass usage request failed'
+    return makeError(redactApiKey(message, key), 'network')
+  }
+}

--- a/src/main/rate-limits/service-clinepass-usage.test.ts
+++ b/src/main/rate-limits/service-clinepass-usage.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits } from '../../shared/rate-limit-types'
+import { RateLimitService } from './service'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { fetchClinePassRateLimits } from './clinepass-fetcher'
+import { hasClinePassApiKey, readClinePassApiKey } from '../clinepass/clinepass-api-key-store'
+import {
+  deferred,
+  okProvider,
+  resetRateLimitProviderMocks,
+  unavailableProvider
+} from './rate-limit-service-test-harness'
+
+vi.mock('./claude-fetcher', () => ({
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
+}))
+
+vi.mock('./codex-fetcher', () => ({
+  consumeCodexRateLimitResetCredit: vi.fn(),
+  fetchCodexRateLimits: vi.fn()
+}))
+
+vi.mock('./gemini-usage-fetcher', () => ({
+  fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./kimi-fetcher', () => ({
+  fetchKimiRateLimits: vi.fn()
+}))
+
+vi.mock('./opencode-go-usage-fetcher', () => ({
+  fetchOpenCodeGoRateLimits: vi.fn()
+}))
+
+vi.mock('./minimax-fetcher', () => ({
+  fetchMiniMaxRateLimits: vi.fn()
+}))
+
+vi.mock('./clinepass-fetcher', () => ({
+  fetchClinePassRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-fetcher', () => ({
+  fetchGrokRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-auth', () => ({
+  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+}))
+
+vi.mock('../minimax/minimax-cookie-store', () => ({
+  hasMiniMaxSessionCookie: vi.fn(() => false)
+}))
+
+vi.mock('../clinepass/clinepass-api-key-store', () => ({
+  hasClinePassApiKey: vi.fn(() => false),
+  readClinePassApiKey: vi.fn(() => null)
+}))
+
+describe('RateLimitService', () => {
+  beforeEach(() => {
+    resetRateLimitProviderMocks()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
+    vi.mocked(fetchClinePassRateLimits).mockResolvedValue(
+      unavailableProvider('clinepass', 'ClinePass API key not configured')
+    )
+    vi.mocked(hasClinePassApiKey).mockReturnValue(false)
+    vi.mocked(readClinePassApiKey).mockReturnValue(null)
+  })
+
+  it('reports clinePassApiKeyConfigured from the credential store', () => {
+    const service = new RateLimitService()
+    vi.mocked(hasClinePassApiKey).mockReturnValue(true)
+    expect(service.getState().clinePassApiKeyConfigured).toBe(true)
+  })
+
+  it('fetches ClinePass alongside other providers when an API key is configured', async () => {
+    const service = new RateLimitService()
+    vi.mocked(hasClinePassApiKey).mockReturnValue(true)
+    vi.mocked(readClinePassApiKey).mockReturnValue('cp-test-key')
+    vi.mocked(fetchClinePassRateLimits).mockResolvedValueOnce(
+      okProvider('clinepass', 42, Date.now())
+    )
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+
+    await service.refresh()
+
+    expect(fetchClinePassRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchClinePassRateLimits).toHaveBeenCalledWith('cp-test-key', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+
+    const state = service.getState()
+    expect(state.clinePass?.status).toBe('ok')
+    expect(state.clinePass?.session?.usedPercent).toBe(42)
+    expect(state.claude?.status).toBe('ok')
+    expect(state.clinePassApiKeyConfigured).toBe(true)
+  })
+
+  it('surfaces missing ClinePass credentials without blocking other providers', async () => {
+    const service = new RateLimitService()
+    vi.mocked(hasClinePassApiKey).mockReturnValue(false)
+    vi.mocked(readClinePassApiKey).mockReturnValue(null)
+    vi.mocked(fetchClinePassRateLimits).mockResolvedValueOnce(
+      unavailableProvider('clinepass', 'ClinePass API key not configured')
+    )
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+
+    await service.refresh()
+
+    expect(fetchClinePassRateLimits).toHaveBeenCalledWith('', {
+      signal: expect.any(AbortSignal)
+    })
+    const state = service.getState()
+    expect(state.clinePass?.status).toBe('unavailable')
+    expect(state.claude?.status).toBe('ok')
+    expect(state.clinePassApiKeyConfigured).toBe(false)
+  })
+
+  it('isolates ClinePass credential-read failures from other providers', async () => {
+    const service = new RateLimitService()
+    vi.mocked(hasClinePassApiKey).mockReturnValue(true)
+    vi.mocked(readClinePassApiKey).mockImplementation(() => {
+      throw new Error('ClinePass API key could not be decrypted')
+    })
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+
+    await service.refresh()
+
+    const state = service.getState()
+    expect(fetchClinePassRateLimits).not.toHaveBeenCalled()
+    expect(state.clinePass?.status).toBe('error')
+    expect(state.clinePass?.error).toBe('ClinePass API key could not be decrypted')
+    expect(state.claude?.status).toBe('ok')
+  })
+
+  it('discards the previous ClinePass snapshot when the API key changes', async () => {
+    const service = new RateLimitService()
+    let apiKey = 'cp-key-a'
+    vi.mocked(hasClinePassApiKey).mockReturnValue(true)
+    vi.mocked(readClinePassApiKey).mockImplementation(() => apiKey)
+    vi.mocked(fetchClinePassRateLimits)
+      .mockResolvedValueOnce(okProvider('clinepass', 40, Date.now()))
+      .mockResolvedValueOnce(okProvider('clinepass', 10, Date.now()))
+
+    await service.refresh()
+    expect(service.getState().clinePass?.session?.usedPercent).toBe(40)
+
+    apiKey = 'cp-key-b'
+    await service.refresh()
+
+    const state = service.getState()
+    expect(fetchClinePassRateLimits).toHaveBeenCalledTimes(2)
+    expect(fetchClinePassRateLimits).toHaveBeenNthCalledWith(1, 'cp-key-a', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(fetchClinePassRateLimits).toHaveBeenNthCalledWith(2, 'cp-key-b', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(state.clinePass?.session?.usedPercent).toBe(10)
+  })
+
+  it('does not apply an in-flight ClinePass result after credential invalidation', async () => {
+    const service = new RateLimitService()
+    const firstClinePass = deferred<ProviderRateLimits>()
+    const secondClinePass = deferred<ProviderRateLimits>()
+    vi.mocked(hasClinePassApiKey).mockReturnValue(true)
+    vi.mocked(readClinePassApiKey).mockReturnValue('cp-test-key')
+    vi.mocked(fetchClinePassRateLimits)
+      .mockImplementationOnce(() => firstClinePass.promise)
+      .mockImplementationOnce(() => secondClinePass.promise)
+
+    const firstRefresh = service.refresh()
+    await Promise.resolve()
+
+    service.invalidateClinePassCredentialState()
+    const queuedRefresh = service.refresh()
+    await Promise.resolve()
+
+    firstClinePass.resolve(okProvider('clinepass', 50, Date.now()))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(service.getState().clinePass?.status).toBe('fetching')
+    expect(service.getState().clinePass?.session).toBeNull()
+
+    secondClinePass.resolve(okProvider('clinepass', 10, Date.now()))
+    await firstRefresh
+    await queuedRefresh
+
+    const state = service.getState()
+    expect(fetchClinePassRateLimits).toHaveBeenCalledTimes(2)
+    expect(state.clinePass?.session?.usedPercent).toBe(10)
+  })
+
+  it('isolates ClinePass fetch failures from other providers', async () => {
+    const service = new RateLimitService()
+    vi.mocked(hasClinePassApiKey).mockReturnValue(true)
+    vi.mocked(readClinePassApiKey).mockReturnValue('cp-test-key')
+    vi.mocked(fetchClinePassRateLimits).mockRejectedValueOnce(new Error('clinepass down'))
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+
+    await service.refresh()
+
+    const state = service.getState()
+    expect(state.clinePass?.status).toBe('error')
+    expect(state.clinePass?.error).toBe('clinepass down')
+    expect(state.claude?.status).toBe('ok')
+  })
+})

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -26,6 +26,8 @@ import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
+import { hasClinePassApiKey, readClinePassApiKey } from '../clinepass/clinepass-api-key-store'
+import { fetchClinePassRateLimits } from './clinepass-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
 import {
   normalizeCodexAccountSelectionTarget,
@@ -58,6 +60,11 @@ type MiniMaxRateLimitConfig = {
 
 type MiniMaxResolvedConfig = {
   config: MiniMaxRateLimitConfig
+  error: string | null
+}
+
+type ClinePassResolvedApiKey = {
+  apiKey: string | null
   error: string | null
 }
 
@@ -109,6 +116,7 @@ type InternalRateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  clinePass: ProviderRateLimits | null
 }
 
 function normalizePollingInterval(ms: number): number {
@@ -175,7 +183,8 @@ export class RateLimitService {
     kimi: null,
     antigravity: null,
     minimax: null,
-    grok: null
+    grok: null,
+    clinePass: null
   }
   private grokAuthConfigured = readGrokAuthSession().status === 'ok'
   private pollInterval: number = DEFAULT_POLL_MS
@@ -190,7 +199,8 @@ export class RateLimitService {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    clinepass: 0
   }
   // Why: consecutive failures drive exponential backoff of the fast activation-retry lane; reset on any success/unavailable result.
   private activeFailureStreakByProvider: Record<ActiveRateLimitProvider, number> = {
@@ -201,7 +211,8 @@ export class RateLimitService {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    clinepass: 0
   }
   private mainWindow: BrowserWindow | null = null
   private detachWindowListeners: (() => void) | null = null
@@ -218,8 +229,10 @@ export class RateLimitService {
   private lastClaudeAuthSnapshot: { configDir: string | null; provenance: string } | null = null
   private opencodeFetchGeneration = 0
   private minimaxFetchGeneration = 0
+  private clinePassFetchGeneration = 0
   private lastOpencodeConfigHash = ''
   private lastMiniMaxConfigHash = ''
+  private lastClinePassApiKeyFingerprint = ''
   private codexHomePathResolver: CodexHomePathResolver | null = null
   private codexFetchTarget: NormalizedCodexAccountSelectionTarget = {
     runtime: 'host',
@@ -388,6 +401,7 @@ export class RateLimitService {
       // Why: the cookie lives on the filesystem, not GlobalSettings; surface its presence so the renderer keeps the MiniMax bar across reloads.
       minimaxCookieConfigured: hasMiniMaxSessionCookie(),
       grokAuthConfigured: this.grokAuthConfigured,
+      clinePassApiKeyConfigured: hasClinePassApiKey(),
       claudeTarget: this.claudeFetchTarget,
       codexTarget: this.codexFetchTarget,
       inactiveClaudeAccounts: this.buildInactiveArray(
@@ -425,6 +439,15 @@ export class RateLimitService {
     this.updateState({
       ...this.state,
       minimax: this.withFetchingStatus(null, 'minimax')
+    })
+  }
+
+  invalidateClinePassCredentialState(): void {
+    this.clinePassFetchGeneration += 1
+    // Why: save/clear races an in-flight usage fetch; drop the visible snapshot before any old-key result returns.
+    this.updateState({
+      ...this.state,
+      clinePass: this.withFetchingStatus(null, 'clinepass')
     })
   }
 
@@ -871,7 +894,8 @@ export class RateLimitService {
       kimi: this.state.kimi,
       minimax: this.state.minimax,
       grok: this.state.grok,
-      antigravity: this.state.antigravity
+      antigravity: this.state.antigravity,
+      clinepass: this.state.clinePass
     }
     return Object.entries(byProvider).map(([provider, limits]) => ({
       provider: provider as ActiveRateLimitProvider,
@@ -1438,6 +1462,27 @@ export class RateLimitService {
     }
   }
 
+  private resolveClinePassApiKey(): ClinePassResolvedApiKey {
+    try {
+      return { apiKey: readClinePassApiKey(), error: null }
+    } catch (error) {
+      // Why: a decrypt/keychain failure must not abort every provider's refresh.
+      return { apiKey: null, error: toErrorMessage(error) }
+    }
+  }
+
+  private getClinePassCredentialError(message: string): ProviderRateLimits {
+    return {
+      provider: 'clinepass',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: message,
+      status: 'error',
+      usageMetadata: { failureKind: 'keychain-unavailable', source: 'web' }
+    }
+  }
+
   // Why: hitting a usage endpoint before its Retry-After expires burns the budget for nothing and keeps the 429 window alive.
   private isRetryAfterActive(limits: ProviderRateLimits | null): boolean {
     return Boolean(
@@ -1578,6 +1623,7 @@ export class RateLimitService {
       | 'minimax'
       | 'grok'
       | 'antigravity'
+      | 'clinepass'
   ): ProviderRateLimits {
     if (!current) {
       return {
@@ -1632,6 +1678,8 @@ export class RateLimitService {
     const miniMaxCookie = miniMaxConfigResult.config.sessionCookie
     const miniMaxGroupId = miniMaxConfigResult.config.groupId
     const miniMaxModels = miniMaxConfigResult.config.models
+    const clinePassResolved = this.resolveClinePassApiKey()
+    const clinePassApiKey = clinePassResolved.apiKey ?? ''
     const geminiCliOAuthEnabled = this.geminiCliOAuthEnabledResolver?.() ?? false
     // Why: getState() is hot (renderer pushes + mobile snapshots); keep Grok's sync auth-file probe on fetch cycles instead.
     const grokAuthReadResult = readGrokAuthSession()
@@ -1654,6 +1702,15 @@ export class RateLimitService {
     }
     const miniMaxGeneration = this.minimaxFetchGeneration
 
+    const currentClinePassApiKeyFingerprint = `${clinePassApiKey}|${clinePassResolved.error ?? ''}`
+    const clinePassConfigChanged =
+      currentClinePassApiKeyFingerprint !== this.lastClinePassApiKeyFingerprint
+    if (clinePassConfigChanged) {
+      this.lastClinePassApiKeyFingerprint = currentClinePassApiKeyFingerprint
+      this.clinePassFetchGeneration += 1
+    }
+    const clinePassGeneration = this.clinePassFetchGeneration
+
     // Mark all providers fetching while keeping previous data visible (Codex is cleared separately on account change).
     this.updateState({
       ...previousState,
@@ -1671,7 +1728,10 @@ export class RateLimitService {
       minimax: miniMaxConfigChanged
         ? this.withFetchingStatus(null, 'minimax')
         : this.withFetchingStatus(previousState.minimax, 'minimax'),
-      grok: this.withFetchingStatus(previousState.grok, 'grok')
+      grok: this.withFetchingStatus(previousState.grok, 'grok'),
+      clinePass: clinePassConfigChanged
+        ? this.withFetchingStatus(null, 'clinepass')
+        : this.withFetchingStatus(previousState.clinePass, 'clinepass')
     })
 
     const missingWslCodexHome =
@@ -1688,40 +1748,50 @@ export class RateLimitService {
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
 
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
-      await Promise.allSettled([
-        claudeFetchGated
-          ? Promise.resolve(previousState.claude as ProviderRateLimits)
-          : fetchClaudeRateLimits({
-              authPreparation: claudeAuthPreparation,
-              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-              networkProxySettings: this.networkProxySettingsResolver?.(),
-              signal
-            }),
-        codexFetchGated
-          ? Promise.resolve(previousState.codex as ProviderRateLimits)
-          : (missingWslCodexHome ??
-            fetchCodexRateLimits({
-              codexHomePath,
-              allowPtyFallback: this.shouldAllowCodexPtyFallback(),
-              signal
-            })),
-        fetchGeminiRateLimits(geminiCliOAuthEnabled),
-        fetchOpenCodeGoRateLimits(
-          cookie,
-          workspaceIdOverride || undefined,
-          this.networkProxySettingsResolver?.()
-        ),
-        this.fetchKimiWithResolvedHome(),
-        miniMaxConfigResult.error
-          ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
-          : fetchMiniMaxRateLimits({
-              cookie: miniMaxCookie,
-              groupId: miniMaxGroupId,
-              models: miniMaxModels
-            })
-      ])
+    const [
+      claudeResult,
+      codexResult,
+      geminiResult,
+      opencodeGoResult,
+      kimiResult,
+      miniMaxResult,
+      clinePassResult
+    ] = await Promise.allSettled([
+      claudeFetchGated
+        ? Promise.resolve(previousState.claude as ProviderRateLimits)
+        : fetchClaudeRateLimits({
+            authPreparation: claudeAuthPreparation,
+            allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+            allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
+            signal
+          }),
+      codexFetchGated
+        ? Promise.resolve(previousState.codex as ProviderRateLimits)
+        : (missingWslCodexHome ??
+          fetchCodexRateLimits({
+            codexHomePath,
+            allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            signal
+          })),
+      fetchGeminiRateLimits(geminiCliOAuthEnabled),
+      fetchOpenCodeGoRateLimits(
+        cookie,
+        workspaceIdOverride || undefined,
+        this.networkProxySettingsResolver?.()
+      ),
+      this.fetchKimiWithResolvedHome(),
+      miniMaxConfigResult.error
+        ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
+        : fetchMiniMaxRateLimits({
+            cookie: miniMaxCookie,
+            groupId: miniMaxGroupId,
+            models: miniMaxModels
+          }),
+      clinePassResolved.error
+        ? Promise.resolve(this.getClinePassCredentialError(clinePassResolved.error))
+        : fetchClinePassRateLimits(clinePassApiKey, { signal })
+    ])
 
     if (signal.aborted) {
       return
@@ -1815,6 +1885,21 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
+    const clinePass =
+      clinePassResult.status === 'fulfilled'
+        ? clinePassResult.value
+        : ({
+            provider: 'clinepass',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error:
+              clinePassResult.reason instanceof Error
+                ? clinePassResult.reason.message
+                : 'Unknown error',
+            status: 'error'
+          } satisfies ProviderRateLimits)
+
     const latestCodexHome = this.resolveCodexHome(codexTarget)
     const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     if (signal.aborted) {
@@ -1838,6 +1923,7 @@ export class RateLimitService {
       this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
     const shouldApplyOpencode = opencodeGeneration === this.opencodeFetchGeneration
     const shouldApplyMiniMax = miniMaxGeneration === this.minimaxFetchGeneration
+    const shouldApplyClinePass = clinePassGeneration === this.clinePassFetchGeneration
 
     if (shouldApplyClaude) {
       this.trackActiveFailureStreak('claude', claude)
@@ -1853,6 +1939,9 @@ export class RateLimitService {
     this.trackActiveFailureStreak('kimi', kimi)
     if (shouldApplyMiniMax) {
       this.trackActiveFailureStreak('minimax', miniMax)
+    }
+    if (shouldApplyClinePass) {
+      this.trackActiveFailureStreak('clinepass', clinePass)
     }
 
     // Why: apply a Codex result only when provenance and generation still match, else a raced in-flight fetch overwrites the new account.
@@ -1878,7 +1967,12 @@ export class RateLimitService {
         ? miniMaxConfigChanged
           ? miniMax
           : this.applyStalePolicy(miniMax, previousState.minimax)
-        : this.state.minimax
+        : this.state.minimax,
+      clinePass: shouldApplyClinePass
+        ? clinePassConfigChanged
+          ? clinePass
+          : this.applyStalePolicy(clinePass, previousState.clinePass)
+        : this.state.clinePass
     })
 
     const grokResult = await grokResultPromise

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -69,6 +69,7 @@ const StatusBarItem = z.enum([
   'kimi',
   'minimax',
   'grok',
+  'clinepass',
   'ssh',
   'resource-usage',
   'ports'
@@ -229,6 +230,7 @@ const UiUpdateFields = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _clinePassStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1,6 +1,7 @@
 import type { ElectronAPI } from '@electron-toolkit/preload'
 import type {
   ClaudeAccountsApi,
+  ClinePassCredentialsApi,
   CodexAccountsApi,
   CodexConfigSyncApi,
   GrokAccountsApi,
@@ -138,6 +139,7 @@ export type PreloadApi = {
   runtime: RuntimeApi['runtime']
   runtimeEnvironments: RuntimeApi['runtimeEnvironments']
   rateLimits: RateLimitsApi
+  clinePassCredentials: ClinePassCredentialsApi
   minimaxCredentials: MinimaxCredentialsApi
   grokAccounts: GrokAccountsApi
   ssh: SshApi

--- a/src/preload/api/agent-account-api.ts
+++ b/src/preload/api/agent-account-api.ts
@@ -4,6 +4,7 @@ import type {
 } from '../../shared/managed-account-types'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 import type { GrokAccountStatus } from '../../shared/rate-limit-types'
+import type { ClinePassCredentialsStatus } from '../../shared/clinepass-credentials'
 
 export type CodexAccountsApi = {
   list: () => Promise<CodexRateLimitAccountsState>
@@ -57,6 +58,12 @@ export type ClaudeAccountsApi = {
 export type GrokAccountsApi = {
   getStatus: () => Promise<GrokAccountStatus>
 }
+export type ClinePassCredentialsApi = {
+  getStatus: () => Promise<ClinePassCredentialsStatus>
+  saveApiKey: (apiKey: string) => Promise<ClinePassCredentialsStatus>
+  clearApiKey: () => Promise<ClinePassCredentialsStatus>
+}
+
 
 export type MinimaxCredentialsApi = {
   getStatus: () => Promise<{ configured: boolean }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -338,6 +338,7 @@ import {
   prepareAndInvokeUpdaterInstall,
   registerRendererRestartIpcRelays
 } from './renderer-restart-wiring'
+import type { ClinePassCredentialsStatus } from '../shared/clinepass-credentials'
 
 // Why: the sync checkpoint only stages; this joins its durable write so a
 // navigating path can abort instead of losing the staged session.
@@ -4652,6 +4653,15 @@ const api = {
       ipcRenderer.invoke('minimaxCredentials:saveCookie', cookie),
     clearCookie: (): Promise<{ configured: boolean }> =>
       ipcRenderer.invoke('minimaxCredentials:clearCookie')
+  },
+
+  clinePassCredentials: {
+    getStatus: (): Promise<ClinePassCredentialsStatus> =>
+      ipcRenderer.invoke('clinePassCredentials:getStatus'),
+    saveApiKey: (apiKey: string): Promise<ClinePassCredentialsStatus> =>
+      ipcRenderer.invoke('clinePassCredentials:saveApiKey', apiKey),
+    clearApiKey: (): Promise<ClinePassCredentialsStatus> =>
+      ipcRenderer.invoke('clinePassCredentials:clearApiKey')
   },
 
   grokAccounts: {

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -43,6 +43,7 @@ import {
 } from '../status-bar/icons'
 import { toast } from 'sonner'
 import {
+  getAccountsClinePassSearchEntries,
   getAccountsClaudeSearchEntries,
   getAccountsCodexSearchEntries,
   getAccountsGeminiSearchEntries,
@@ -52,6 +53,7 @@ import {
   getAccountsOpencodeSearchEntries,
   getAccountsPaneSearchEntries
 } from './accounts-search'
+import { ClinePassAccountsSection } from './ClinePassAccountsSection'
 import { GrokAccountsSection } from './GrokAccountsSection'
 import { getRemoteAccountsPaneScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
@@ -1982,6 +1984,9 @@ export function AccountsPane({
           </SearchableSetting>
         </div>
       </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, getAccountsClinePassSearchEntries()) ? (
+      <ClinePassAccountsSection key="clinepass" />
     ) : null,
     matchesSettingsSearch(searchQuery, getAccountsGrokSearchEntries()) ? (
       <GrokAccountsSection key="grok" />

--- a/src/renderer/src/components/settings/ClinePassAccountsSection.test.tsx
+++ b/src/renderer/src/components/settings/ClinePassAccountsSection.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import React from 'react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+  saveApiKey: vi.fn(),
+  clearApiKey: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn()
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  AgentIcon: ({ agent }: { agent: string }) =>
+    React.createElement('span', { 'data-testid': 'agent-icon' }, agent)
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess }
+}))
+
+vi.mock('./SearchableSetting', () => ({
+  SearchableSetting: ({ children }: { children: React.ReactNode }) => children
+}))
+
+import { ClinePassAccountsSection } from './ClinePassAccountsSection'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+describe('ClinePassAccountsSection', () => {
+  beforeEach(() => {
+    mocks.getStatus.mockResolvedValue({ configured: false, source: 'none' })
+    mocks.saveApiKey.mockResolvedValue({ configured: true, source: 'stored' })
+    mocks.clearApiKey.mockResolvedValue({ configured: false, source: 'none' })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        clinePassCredentials: {
+          getStatus: mocks.getStatus,
+          saveApiKey: mocks.saveApiKey,
+          clearApiKey: mocks.clearApiKey
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('shows the unconfigured subscription quota state', async () => {
+    render(<ClinePassAccountsSection />)
+
+    expect(await screen.findByText('API key not configured')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.queryByRole('button', { name: 'Forget API key' })).not.toBeInTheDocument()
+    expect(screen.getByText(/5-hour, weekly, and monthly windows/i)).toBeInTheDocument()
+    expect(screen.getByTestId('agent-icon')).toHaveTextContent('cline')
+  })
+
+  it('shows a stored credential without loading or echoing its secret', async () => {
+    const storedSecret = 'cline-stored-secret-that-must-not-render'
+    mocks.getStatus.mockResolvedValue({
+      configured: true,
+      source: 'stored',
+      apiKey: storedSecret
+    })
+
+    render(<ClinePassAccountsSection />)
+
+    expect(await screen.findByText('API key saved in Orca')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Replace' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Forget API key' })).toBeEnabled()
+    expect(screen.getByLabelText('ClinePass API key')).toHaveValue('')
+    expect(document.body.textContent).not.toContain(storedSecret)
+  })
+
+  it('explains environment configuration and does not offer to clear it', async () => {
+    mocks.getStatus.mockResolvedValue({ configured: true, source: 'environment' })
+
+    render(<ClinePassAccountsSection />)
+
+    expect(await screen.findByText('Configured by CLINE_API_KEY')).toBeInTheDocument()
+    expect(screen.getByText(/cannot be cleared here/i)).toBeInTheDocument()
+    expect(screen.getByText(/saved key overrides the environment/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Forget API key' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('link', { name: 'API key docs' })).toHaveAttribute(
+      'href',
+      'https://docs.cline.bot/api/authentication'
+    )
+  })
+
+  it.each([
+    { source: 'none', action: 'Save' },
+    { source: 'stored', action: 'Replace' }
+  ] as const)(
+    '$action stores a trimmed local draft and clears it on success',
+    async ({ source, action }) => {
+      mocks.getStatus.mockResolvedValue({ configured: source === 'stored', source })
+      render(<ClinePassAccountsSection />)
+      const input = screen.getByLabelText('ClinePass API key')
+      await screen.findByRole('button', { name: action })
+
+      fireEvent.change(input, { target: { value: '  cline-test-key  ' } })
+      fireEvent.click(screen.getByRole('button', { name: action }))
+
+      await waitFor(() => expect(mocks.saveApiKey).toHaveBeenCalledWith('cline-test-key'))
+      expect(input).toHaveValue('')
+      expect(screen.getByRole('button', { name: 'Replace' })).toBeEnabled()
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('ClinePass API key saved.')
+    }
+  )
+
+  it('forgets only the stored credential and adopts the returned status', async () => {
+    mocks.getStatus.mockResolvedValue({ configured: true, source: 'stored' })
+    render(<ClinePassAccountsSection />)
+    const forget = await screen.findByRole('button', { name: 'Forget API key' })
+
+    fireEvent.click(forget)
+
+    await waitFor(() => expect(mocks.clearApiKey).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('API key not configured')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Forget API key' })).not.toBeInTheDocument()
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Stored ClinePass API key forgotten.')
+  })
+
+  it('validates an empty draft before calling the credential API', async () => {
+    render(<ClinePassAccountsSection />)
+    const save = await screen.findByRole('button', { name: 'Save' })
+
+    fireEvent.click(save)
+
+    expect(mocks.saveApiKey).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('ClinePass API key')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByRole('alert')).toHaveTextContent('ClinePass API key is required.')
+    expect(mocks.toastError).toHaveBeenCalledWith('ClinePass API key is required.')
+  })
+
+  it('blocks duplicate saves, retains the draft on failure, and does not echo error secrets', async () => {
+    const pending = deferred<{ configured: boolean; source: 'stored' }>()
+    const draft = 'cline-private-draft'
+    mocks.saveApiKey.mockReturnValue(pending.promise)
+    render(<ClinePassAccountsSection />)
+    const save = await screen.findByRole('button', { name: 'Save' })
+    const input = screen.getByLabelText('ClinePass API key')
+    fireEvent.change(input, { target: { value: draft } })
+
+    fireEvent.click(save)
+    fireEvent.click(save)
+
+    expect(mocks.saveApiKey).toHaveBeenCalledTimes(1)
+    expect(save).toBeDisabled()
+    expect(input).toBeDisabled()
+
+    await act(async () => {
+      pending.reject(new Error(`request failed for ${draft}`))
+    })
+
+    expect(input).toHaveValue(draft)
+    expect(save).toBeEnabled()
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'ClinePass API key could not be saved. Check the key and try again.'
+    )
+    expect(JSON.stringify(mocks.toastError.mock.calls)).not.toContain(draft)
+  })
+
+  it('blocks duplicate forget actions and keeps stored status on failure', async () => {
+    const pending = deferred<{ configured: boolean; source: 'none' }>()
+    mocks.getStatus.mockResolvedValue({ configured: true, source: 'stored' })
+    mocks.clearApiKey.mockReturnValue(pending.promise)
+    render(<ClinePassAccountsSection />)
+    const forget = await screen.findByRole('button', { name: 'Forget API key' })
+
+    fireEvent.click(forget)
+    fireEvent.click(forget)
+
+    expect(mocks.clearApiKey).toHaveBeenCalledTimes(1)
+    expect(forget).toBeDisabled()
+
+    await act(async () => {
+      pending.reject(new Error('storage unavailable'))
+    })
+
+    expect(screen.getByText('API key saved in Orca')).toBeInTheDocument()
+    expect(forget).toBeEnabled()
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Stored ClinePass API key could not be forgotten. Try again.'
+    )
+  })
+
+  it('reports status load failures without exposing an API value', async () => {
+    mocks.getStatus.mockRejectedValue(new Error('cline-secret-from-error'))
+    render(<ClinePassAccountsSection />)
+
+    expect(await screen.findByText('Credential status unavailable')).toBeInTheDocument()
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'ClinePass credential status could not be loaded.'
+    )
+    expect(document.body.textContent).not.toContain('cline-secret-from-error')
+  })
+
+  it('recovers from an initial status error after a successful save', async () => {
+    mocks.getStatus.mockRejectedValue(new Error('status unavailable'))
+    render(<ClinePassAccountsSection />)
+    expect(await screen.findByText('Credential status unavailable')).toBeInTheDocument()
+    const input = screen.getByLabelText('ClinePass API key')
+    fireEvent.change(input, { target: { value: 'cline-recovery-key' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('API key saved in Orca')).toBeInTheDocument()
+    expect(screen.queryByText('Credential status unavailable')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Replace' })).toBeEnabled()
+  })
+})

--- a/src/renderer/src/components/settings/ClinePassAccountsSection.test.tsx
+++ b/src/renderer/src/components/settings/ClinePassAccountsSection.test.tsx
@@ -217,6 +217,12 @@ describe('ClinePassAccountsSection', () => {
     render(<ClinePassAccountsSection />)
 
     expect(await screen.findByText('Credential status unavailable')).toBeInTheDocument()
+    expect(
+      screen.getByText('Orca could not check whether a Cline API key is configured. Try again.')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Add a Cline API key to read your ClinePass subscription quota.')
+    ).not.toBeInTheDocument()
     expect(mocks.toastError).toHaveBeenCalledWith(
       'ClinePass credential status could not be loaded.'
     )

--- a/src/renderer/src/components/settings/ClinePassAccountsSection.test.tsx
+++ b/src/renderer/src/components/settings/ClinePassAccountsSection.test.tsx
@@ -105,7 +105,7 @@ describe('ClinePassAccountsSection', () => {
 
     expect(await screen.findByText('Configured by CLINE_API_KEY')).toBeInTheDocument()
     expect(screen.getByText(/cannot be cleared here/i)).toBeInTheDocument()
-    expect(screen.getByText(/saved key overrides the environment/i)).toBeInTheDocument()
+    expect(screen.getByText(/saved key overrides the environment variable/i)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Forget API key' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
     expect(screen.getByRole('link', { name: 'API key docs' })).toHaveAttribute(

--- a/src/renderer/src/components/settings/ClinePassAccountsSection.tsx
+++ b/src/renderer/src/components/settings/ClinePassAccountsSection.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from 'react'
+import { ExternalLink } from 'lucide-react'
+import { toast } from 'sonner'
+import type { ClinePassCredentialsStatus } from '../../../../shared/clinepass-credentials'
+import { translate } from '@/i18n/i18n'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { ClinePassApiKeyForm } from './ClinePassApiKeyForm'
+import { ClinePassCredentialStatus } from './ClinePassCredentialStatus'
+
+const CLINE_API_AUTH_DOCS_URL = 'https://docs.cline.bot/api/authentication'
+
+export function ClinePassAccountsSection(): React.JSX.Element {
+  const [status, setStatus] = useState<ClinePassCredentialsStatus | null>(null)
+  const [statusLoading, setStatusLoading] = useState(true)
+  const [statusLoadFailed, setStatusLoadFailed] = useState(false)
+  const [apiKeyDraft, setApiKeyDraft] = useState('')
+  const [draftInvalid, setDraftInvalid] = useState(false)
+  const [credentialBusy, setCredentialBusy] = useState(false)
+  const credentialBusyRef = useRef(false)
+
+  useEffect(() => {
+    let active = true
+    void window.api.clinePassCredentials
+      .getStatus()
+      .then(({ configured, source }) => {
+        if (active) {
+          setStatus({ configured, source })
+        }
+      })
+      .catch(() => {
+        if (!active) {
+          return
+        }
+        setStatusLoadFailed(true)
+        toast.error(
+          translate(
+            'auto.components.settings.ClinePassAccountsSection.3f06b1e71d',
+            'ClinePass credential status could not be loaded.'
+          )
+        )
+      })
+      .finally(() => {
+        if (active) {
+          setStatusLoading(false)
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const beginCredentialAction = (): boolean => {
+    if (credentialBusyRef.current) {
+      return false
+    }
+    credentialBusyRef.current = true
+    setCredentialBusy(true)
+    return true
+  }
+
+  const endCredentialAction = (): void => {
+    credentialBusyRef.current = false
+    setCredentialBusy(false)
+  }
+
+  const saveApiKey = async (): Promise<void> => {
+    const apiKey = apiKeyDraft.trim()
+    if (!apiKey) {
+      setDraftInvalid(true)
+      toast.error(
+        translate(
+          'auto.components.settings.ClinePassAccountsSection.f036f412e9',
+          'ClinePass API key is required.'
+        )
+      )
+      return
+    }
+    if (!beginCredentialAction()) {
+      return
+    }
+
+    try {
+      const next = await window.api.clinePassCredentials.saveApiKey(apiKey)
+      if (!next.configured || next.source !== 'stored') {
+        throw new Error('save failed')
+      }
+      setStatus({ configured: next.configured, source: next.source })
+      setStatusLoadFailed(false)
+      setApiKeyDraft('')
+      setDraftInvalid(false)
+      toast.success(
+        translate(
+          'auto.components.settings.ClinePassAccountsSection.738e1fe094',
+          'ClinePass API key saved.'
+        )
+      )
+    } catch {
+      toast.error(
+        translate(
+          'auto.components.settings.ClinePassAccountsSection.d8358b48f6',
+          'ClinePass API key could not be saved. Check the key and try again.'
+        )
+      )
+    } finally {
+      endCredentialAction()
+    }
+  }
+
+  const clearApiKey = async (): Promise<void> => {
+    if (status?.source !== 'stored' || !beginCredentialAction()) {
+      return
+    }
+
+    try {
+      const next = await window.api.clinePassCredentials.clearApiKey()
+      if (next.source === 'stored') {
+        throw new Error('clear failed')
+      }
+      setStatus({ configured: next.configured, source: next.source })
+      setStatusLoadFailed(false)
+      toast.success(
+        translate(
+          'auto.components.settings.ClinePassAccountsSection.902abdf7f8',
+          'Stored ClinePass API key forgotten.'
+        )
+      )
+    } catch {
+      toast.error(
+        translate(
+          'auto.components.settings.ClinePassAccountsSection.8c8eb65703',
+          'Stored ClinePass API key could not be forgotten. Try again.'
+        )
+      )
+    } finally {
+      endCredentialAction()
+    }
+  }
+
+  const handleDraftChange = (value: string): void => {
+    setApiKeyDraft(value)
+    if (draftInvalid && value.trim()) {
+      setDraftInvalid(false)
+    }
+  }
+
+  const source = status?.source ?? 'none'
+
+  return (
+    <section id="accounts-clinepass" className="space-y-4 scroll-mt-6">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <AgentIcon agent="cline" size={16} />
+            {translate('auto.components.settings.ClinePassAccountsSection.02498819c4', 'ClinePass')}
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.ClinePassAccountsSection.71c914cff5',
+              'Track included ClinePass subscription quota across 5-hour, weekly, and monthly windows.'
+            )}
+          </p>
+        </div>
+        <a
+          href={CLINE_API_AUTH_DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          {translate(
+            'auto.components.settings.ClinePassAccountsSection.7b9e5f6452',
+            'API key docs'
+          )}
+          <ExternalLink className="size-3" />
+        </a>
+      </div>
+
+      <ClinePassCredentialStatus
+        status={status}
+        loading={statusLoading}
+        loadFailed={statusLoadFailed}
+      />
+
+      <ClinePassApiKeyForm
+        source={source}
+        draft={apiKeyDraft}
+        draftInvalid={draftInvalid}
+        busy={credentialBusy}
+        statusLoading={statusLoading}
+        onDraftChange={handleDraftChange}
+        onSave={saveApiKey}
+        onClear={clearApiKey}
+      />
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/ClinePassApiKeyForm.tsx
+++ b/src/renderer/src/components/settings/ClinePassApiKeyForm.tsx
@@ -66,8 +66,8 @@ export function ClinePassApiKeyForm({
         {isEnvironment ? (
           <span className="text-[11px] text-muted-foreground">
             {translate(
-              'auto.components.settings.ClinePassAccountsSection.7e87f4df2a',
-              'A saved key overrides the environment'
+              'auto.components.settings.ClinePassApiKeyForm.3c8f8283c8',
+              'A saved key overrides the environment variable.'
             )}
           </span>
         ) : null}

--- a/src/renderer/src/components/settings/ClinePassApiKeyForm.tsx
+++ b/src/renderer/src/components/settings/ClinePassApiKeyForm.tsx
@@ -1,0 +1,142 @@
+import { Loader2 } from 'lucide-react'
+import type { ClinePassCredentialsStatus } from '../../../../shared/clinepass-credentials'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+
+type ClinePassApiKeyFormProps = {
+  source: ClinePassCredentialsStatus['source']
+  draft: string
+  draftInvalid: boolean
+  busy: boolean
+  statusLoading: boolean
+  onDraftChange: (value: string) => void
+  onSave: () => Promise<void>
+  onClear: () => Promise<void>
+}
+
+export function ClinePassApiKeyForm({
+  source,
+  draft,
+  draftInvalid,
+  busy,
+  statusLoading,
+  onDraftChange,
+  onSave,
+  onClear
+}: ClinePassApiKeyFormProps): React.JSX.Element {
+  const isStored = source === 'stored'
+  const isEnvironment = source === 'environment'
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.ClinePassAccountsSection.c89556fc40',
+        'ClinePass API key'
+      )}
+      description={translate(
+        'auto.components.settings.ClinePassAccountsSection.3d738f9c5f',
+        'Authenticate quota refreshes with an official Cline API key.'
+      )}
+      keywords={[
+        'clinepass',
+        'cline',
+        'subscription',
+        'quota',
+        'api key',
+        'CLINE_API_KEY',
+        '5-hour',
+        'weekly',
+        'monthly',
+        'rate limit',
+        'status bar'
+      ]}
+      className="space-y-2"
+      forceVisible
+    >
+      <div className="flex items-center justify-between gap-2">
+        <Label htmlFor="clinepass-api-key">
+          {translate(
+            'auto.components.settings.ClinePassAccountsSection.c89556fc40',
+            'ClinePass API key'
+          )}
+        </Label>
+        {isEnvironment ? (
+          <span className="text-[11px] text-muted-foreground">
+            {translate(
+              'auto.components.settings.ClinePassAccountsSection.7e87f4df2a',
+              'A saved key overrides the environment'
+            )}
+          </span>
+        ) : null}
+      </div>
+      <form
+        className="flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault()
+          void onSave()
+        }}
+      >
+        <Input
+          id="clinepass-api-key"
+          type="password"
+          value={draft}
+          onChange={(event) => onDraftChange(event.target.value)}
+          placeholder={translate(
+            'auto.components.settings.ClinePassAccountsSection.ce12d5e9c6',
+            'Paste a Cline API key'
+          )}
+          spellCheck={false}
+          autoCapitalize="none"
+          autoCorrect="off"
+          autoComplete="off"
+          aria-invalid={draftInvalid}
+          disabled={busy}
+          className="flex-1 text-xs"
+        />
+        <Button
+          type="submit"
+          size="xs"
+          disabled={busy || statusLoading}
+          className="h-7 shrink-0 text-xs"
+        >
+          {busy ? <Loader2 className="size-3 animate-spin" /> : null}
+          {isStored
+            ? translate('auto.components.settings.ClinePassAccountsSection.61a2148925', 'Replace')
+            : translate('auto.components.settings.ClinePassAccountsSection.3fc8e072dc', 'Save')}
+        </Button>
+        {isStored ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => void onClear()}
+            disabled={busy}
+            className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {translate(
+              'auto.components.settings.ClinePassAccountsSection.535a2c9a19',
+              'Forget API key'
+            )}
+          </Button>
+        ) : null}
+      </form>
+      {draftInvalid ? (
+        <p role="alert" className="text-xs text-destructive">
+          {translate(
+            'auto.components.settings.ClinePassAccountsSection.f036f412e9',
+            'ClinePass API key is required.'
+          )}
+        </p>
+      ) : null}
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.ClinePassAccountsSection.a11dc5b121',
+          'Create an API key in your Cline account, then paste it here. Orca never displays a saved key.'
+        )}
+      </p>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/ClinePassCredentialStatus.tsx
+++ b/src/renderer/src/components/settings/ClinePassCredentialStatus.tsx
@@ -65,20 +65,25 @@ export function ClinePassCredentialStatus({
                     )}
         </p>
         <p className="text-xs text-muted-foreground">
-          {isStored
+          {loadFailed
             ? translate(
-                'auto.components.settings.ClinePassAccountsSection.20e3fe7fe6',
-                'Stored locally and sent only to api.cline.bot to read your ClinePass subscription quota.'
+                'auto.components.settings.ClinePassCredentialStatus.4df8f88808',
+                'Orca could not check whether a Cline API key is configured. Try again.'
               )
-            : isEnvironment
+            : isStored
               ? translate(
-                  'auto.components.settings.ClinePassAccountsSection.933597b6ca',
-                  'CLINE_API_KEY configures Orca and cannot be cleared here. Save a key below to override it.'
+                  'auto.components.settings.ClinePassAccountsSection.20e3fe7fe6',
+                  'Stored locally and sent only to api.cline.bot to read your ClinePass subscription quota.'
                 )
-              : translate(
-                  'auto.components.settings.ClinePassAccountsSection.0571590443',
-                  'Add a Cline API key to read your ClinePass subscription quota.'
-                )}
+              : isEnvironment
+                ? translate(
+                    'auto.components.settings.ClinePassAccountsSection.933597b6ca',
+                    'CLINE_API_KEY configures Orca and cannot be cleared here. Save a key below to override it.'
+                  )
+                : translate(
+                    'auto.components.settings.ClinePassAccountsSection.0571590443',
+                    'Add a Cline API key to read your ClinePass subscription quota.'
+                  )}
         </p>
       </div>
       {!loading && !loadFailed ? (

--- a/src/renderer/src/components/settings/ClinePassCredentialStatus.tsx
+++ b/src/renderer/src/components/settings/ClinePassCredentialStatus.tsx
@@ -1,0 +1,105 @@
+import { Loader2, Lock, LockOpen, ShieldCheck } from 'lucide-react'
+import type { ClinePassCredentialsStatus } from '../../../../shared/clinepass-credentials'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { Badge } from '../ui/badge'
+
+type ClinePassCredentialStatusProps = {
+  status: ClinePassCredentialsStatus | null
+  loading: boolean
+  loadFailed: boolean
+}
+
+export function ClinePassCredentialStatus({
+  status,
+  loading,
+  loadFailed
+}: ClinePassCredentialStatusProps): React.JSX.Element {
+  const source = status?.source ?? 'none'
+  const isStored = source === 'stored'
+  const isEnvironment = source === 'environment'
+
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        'flex items-start gap-3 rounded-lg border bg-muted/20 p-3',
+        isStored || isEnvironment ? 'border-border/60' : 'border-border/40'
+      )}
+    >
+      {loading ? (
+        <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-muted-foreground" />
+      ) : (
+        <ShieldCheck
+          className={cn(
+            'mt-0.5 size-4 shrink-0',
+            isStored || isEnvironment ? 'text-foreground' : 'text-muted-foreground'
+          )}
+        />
+      )}
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <p className="text-xs font-medium">
+          {loading
+            ? translate(
+                'auto.components.settings.ClinePassAccountsSection.f0fcb3c84e',
+                'Checking API key…'
+              )
+            : loadFailed
+              ? translate(
+                  'auto.components.settings.ClinePassAccountsSection.139c527c90',
+                  'Credential status unavailable'
+                )
+              : isStored
+                ? translate(
+                    'auto.components.settings.ClinePassAccountsSection.a59efe5917',
+                    'API key saved in Orca'
+                  )
+                : isEnvironment
+                  ? translate(
+                      'auto.components.settings.ClinePassAccountsSection.76d85f70af',
+                      'Configured by CLINE_API_KEY'
+                    )
+                  : translate(
+                      'auto.components.settings.ClinePassAccountsSection.d6d08ab7ba',
+                      'API key not configured'
+                    )}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {isStored
+            ? translate(
+                'auto.components.settings.ClinePassAccountsSection.20e3fe7fe6',
+                'Stored locally and sent only to api.cline.bot to read your ClinePass subscription quota.'
+              )
+            : isEnvironment
+              ? translate(
+                  'auto.components.settings.ClinePassAccountsSection.933597b6ca',
+                  'CLINE_API_KEY configures Orca and cannot be cleared here. Save a key below to override it.'
+                )
+              : translate(
+                  'auto.components.settings.ClinePassAccountsSection.0571590443',
+                  'Add a Cline API key to read your ClinePass subscription quota.'
+                )}
+        </p>
+      </div>
+      {!loading && !loadFailed ? (
+        <Badge
+          variant={status?.configured ? 'secondary' : 'outline'}
+          className="h-5 gap-1 rounded-full px-2 text-[10px] font-medium text-muted-foreground"
+        >
+          {status?.configured ? <Lock className="size-3" /> : <LockOpen className="size-3" />}
+          {isStored
+            ? translate('auto.components.settings.ClinePassAccountsSection.fac44d3a91', 'Saved')
+            : isEnvironment
+              ? translate(
+                  'auto.components.settings.ClinePassAccountsSection.b1866729fa',
+                  'Environment'
+                )
+              : translate(
+                  'auto.components.settings.ClinePassAccountsSection.d9ea8a4643',
+                  'Not saved'
+                )}
+        </Badge>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/accounts-search.test.ts
+++ b/src/renderer/src/components/settings/accounts-search.test.ts
@@ -15,7 +15,11 @@ vi.mock('./settings-search-keywords', () => ({
   translateSearchKeyword: (_key: string, fallback: string) => [fallback]
 }))
 
-import { getAccountsMiniMaxSearchEntries, getAccountsPaneSearchEntries } from './accounts-search'
+import {
+  getAccountsClinePassSearchEntries,
+  getAccountsMiniMaxSearchEntries,
+  getAccountsPaneSearchEntries
+} from './accounts-search'
 
 describe('getAccountsMiniMaxSearchEntries', () => {
   it('returns a single entry that targets the MiniMax session cookie flow', () => {
@@ -40,5 +44,37 @@ describe('getAccountsMiniMaxSearchEntries', () => {
     const allEntries = getAccountsPaneSearchEntries()
     const titles = allEntries.map((entry) => entry.title)
     expect(titles).toContain('MiniMax Usage')
+  })
+})
+
+describe('getAccountsClinePassSearchEntries', () => {
+  it('indexes ClinePass subscription quota and API-key configuration', () => {
+    const entries = getAccountsClinePassSearchEntries()
+    expect(entries).toHaveLength(1)
+    const [entry] = entries
+
+    expect(entry.title).toBe('ClinePass Subscription Quota')
+    expect(entry.description).toContain('5-hour, weekly, and monthly')
+    expect(entry.keywords).toEqual(
+      expect.arrayContaining([
+        'clinepass',
+        'cline',
+        'subscription',
+        'quota',
+        'api key',
+        'CLINE_API_KEY',
+        '5-hour',
+        'weekly',
+        'monthly',
+        'rate limit',
+        'status bar'
+      ])
+    )
+  })
+
+  it('includes ClinePass in the rolled-up pane search entries', () => {
+    expect(getAccountsPaneSearchEntries().map((entry) => entry.title)).toContain(
+      'ClinePass Subscription Quota'
+    )
   })
 })

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -191,6 +191,41 @@ export const getAccountsMiniMaxSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getAccountsClinePassSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.accounts.search.cfe73344d1',
+      'ClinePass Subscription Quota'
+    ),
+    description: translate(
+      'auto.components.settings.accounts.search.7a55b8bad9',
+      'Add a Cline API key to track ClinePass 5-hour, weekly, and monthly subscription quota.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.308f59fef5', 'clinepass'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.cbd82de6ed', 'cline'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.bb02af14f0',
+        'subscription'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.c759741d77', 'quota'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.6820f493db', 'api key'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.7fdd7b176f',
+        'CLINE_API_KEY'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.c0fb8c7458', '5-hour'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.fc6394b24b', 'weekly'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.777e4e05e8', 'monthly'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.e949b08ffb',
+        'rate limit'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.86edc96bc9', 'status bar')
+    ]
+  }
+])
+
 export const getAccountsGrokSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate('auto.components.settings.accounts.search.f4a8c2e1b7', 'Grok (xAI) Usage'),
@@ -219,5 +254,6 @@ export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsS
   ...getAccountsGeminiSearchEntries(),
   ...getAccountsOpencodeSearchEntries(),
   ...getAccountsMiniMaxSearchEntries(),
+  ...getAccountsClinePassSearchEntries(),
   ...getAccountsGrokSearchEntries()
 ])

--- a/src/renderer/src/components/settings/appearance-status-bar-search.test.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.test.ts
@@ -43,4 +43,17 @@ describe('getStatusBarToggles', () => {
       expect.arrayContaining(['status bar', 'minimax', 'usage', 'subscription', 'cookie'])
     )
   })
+
+  it('includes ClinePass quota so Appearance can toggle the default-on status item', () => {
+    const clinePassToggle = getStatusBarToggles().find((entry) => entry.id === 'clinepass')
+
+    expect(clinePassToggle).toMatchObject({
+      title: 'ClinePass Usage',
+      description: 'Show ClinePass subscription quota in the status bar.',
+      toggleDescription: 'Show ClinePass 5-hour, weekly, and monthly subscription quota.'
+    })
+    expect(clinePassToggle?.keywords).toEqual(
+      expect.arrayContaining(['status bar', 'clinepass', 'cline', 'usage', 'subscription', 'quota'])
+    )
+  })
 })

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -201,6 +201,39 @@ export const getStatusBarToggles = createLocalizedCatalog(
     },
     getGrokStatusBarToggleSearchEntry(),
     {
+      id: 'clinepass',
+      title: translate('auto.components.settings.appearance.search.6c82e7d14f', 'ClinePass Usage'),
+      description: translate(
+        'auto.components.settings.appearance.search.df7ae25c91',
+        'Show ClinePass subscription quota in the status bar.'
+      ),
+      keywords: [
+        ...translateSearchKeyword(
+          'auto.components.settings.appearance.search.896eb53fd4',
+          'status bar'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.appearance.search.93a7f4026d',
+          'clinepass'
+        ),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.ac8d39e715', 'cline'),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+        ...translateSearchKeyword(
+          'auto.components.settings.appearance.search.de586def95',
+          'subscription'
+        ),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.83f2db601a', 'quota'),
+        ...translateSearchKeyword(
+          'auto.components.settings.appearance.search.4bbef739a2',
+          'api key'
+        )
+      ],
+      toggleDescription: translate(
+        'settings.appearance.statusBar.clinePassToggleDescription',
+        'Show ClinePass 5-hour, weekly, and monthly subscription quota.'
+      )
+    },
+    {
       id: 'ssh',
       title: translate('auto.components.settings.appearance.search.57fb424c56', 'Remote Hosts'),
       description: translate(

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -2481,10 +2481,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             }}
           >
             <AgentIcon agent="cline" size={14} />
-            {translate(
-              'auto.components.status.bar.StatusBar.clinePassUsageMenu',
-              'ClinePass Usage'
-            )}
+            {translate('auto.components.status.bar.StatusBar.029230c95c', 'ClinePass Usage')}
           </DropdownMenuCheckboxItem>
           {isStatusBarItemAvailable('codex', detectedAgentIds) && (
             <DropdownMenuCheckboxItem

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1148,6 +1148,8 @@ function getProviderLetter(provider: ProviderRateLimits['provider']): string {
   switch (provider) {
     case 'claude':
       return 'C'
+    case 'clinepass':
+      return 'P'
     case 'gemini':
       return 'G'
     case 'opencode-go':
@@ -2106,7 +2108,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const { claude, clinePass, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } =
+    rateLimits
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -2119,9 +2122,11 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     ...settings,
     antigravityUsageConfigured,
     minimaxCookieConfigured: rateLimits.minimaxCookieConfigured,
+    clinePassApiKeyConfigured: rateLimits.clinePassApiKeyConfigured,
     grokAuthConfigured: rateLimits.grokAuthConfigured
   }
   const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
+  const visibleClinePass = getVisibleUsageProvider('clinepass', clinePass, usageSettings)
   const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)
   const visibleGemini = getVisibleUsageProvider('gemini', gemini, usageSettings)
   const visibleKimi = getVisibleUsageProvider('kimi', kimi, usageSettings)
@@ -2132,6 +2137,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
     isStatusBarItemAvailable('claude', detectedAgentIds)
+  // Why: ClinePass uses an API key, not Cline CLI authentication or PATH detection.
+  const showClinePass = visibleClinePass !== null && statusBarItems.includes('clinepass')
   const showCodex =
     visibleCodex !== null &&
     statusBarItems.includes('codex') &&
@@ -2165,6 +2172,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   // Why: meter-only children (excludes resource-usage) so the % display callout anchors to a real meter cluster.
   const hasVisibleUsageMeters =
     showClaude ||
+    showClinePass ||
     showCodex ||
     showGemini ||
     showOpencodeGo ||
@@ -2175,13 +2183,14 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: include Settings so durable managed accounts count — a configured user isn't shown the empty state while snapshots hydrate.
   const isEmptyUsageState = isUsageEmptyState(
-    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
+    { claude, clinePass, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
     usageSettings
   )
   // Why: one-time nudge — once dismissed, stays hidden even if providers reconnect later.
   const showEmptyUsageCta = isEmptyUsageState && !usageEmptyStateDismissed
   const anyFetching =
     claude?.status === 'fetching' ||
+    clinePass?.status === 'fetching' ||
     codex?.status === 'fetching' ||
     gemini?.status === 'fetching' ||
     opencodeGo?.status === 'fetching' ||
@@ -2201,6 +2210,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   // otherwise an empty trigger would bypass those visibility controls.
   const rosterProviders = [
     showClaude ? visibleClaude : null,
+    showClinePass ? visibleClinePass : null,
     showCodex ? visibleCodex : null,
     showGemini ? visibleGemini : null,
     showAntigravity ? visibleAntigravity : null,
@@ -2463,6 +2473,19 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.3885eb74d8', 'Claude Usage')}
             </DropdownMenuCheckboxItem>
           )}
+          <DropdownMenuCheckboxItem
+            checked={statusBarItems.includes('clinepass')}
+            onCheckedChange={() => {
+              recordFeatureInteraction('usage-tracking')
+              toggleStatusBarItem('clinepass')
+            }}
+          >
+            <AgentIcon agent="cline" size={14} />
+            {translate(
+              'auto.components.status.bar.StatusBar.clinePassUsageMenu',
+              'ClinePass Usage'
+            )}
+          </DropdownMenuCheckboxItem>
           {isStatusBarItemAvailable('codex', detectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('codex')}

--- a/src/renderer/src/components/status-bar/StatusBarUsageEmptyCta.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarUsageEmptyCta.tsx
@@ -100,6 +100,7 @@ export function StatusBarUsageEmptyCta(): React.JSX.Element {
               )}
             </span>
             <ClaudeIcon size={13} />
+            <AgentIcon agent="cline" size={13} />
             <OpenAIIcon size={13} />
             <GeminiIcon size={13} />
             <OpenCodeGoIcon size={13} />

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -10,6 +10,7 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('resource-usage', [])).toBe(true)
     expect(isStatusBarItemAvailable('ports', [])).toBe(true)
     expect(isStatusBarItemAvailable('opencode-go', [])).toBe(true)
+    expect(isStatusBarItemAvailable('clinepass', [])).toBe(true)
   })
 
   it('keeps CLI items visible while detection is in flight', () => {

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -74,6 +74,7 @@ function usageSettings(overrides: Partial<UsageProviderSettings> = {}): UsagePro
     antigravityUsageConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
+    clinePassApiKeyConfigured: false,
     ...overrides
   }
 }
@@ -128,6 +129,7 @@ describe('hasUsageProviderSettings', () => {
     )
     expect(hasUsageProviderSettings(usageSettings({ minimaxCookieConfigured: true }))).toBe(true)
     expect(hasUsageProviderSettings(usageSettings({ grokAuthConfigured: true }))).toBe(true)
+    expect(hasUsageProviderSettings(usageSettings({ clinePassApiKeyConfigured: true }))).toBe(true)
   })
 
   it('does not treat empty or unloaded settings as configured', () => {
@@ -203,6 +205,17 @@ describe('hasUsageProviderSettingsForProvider', () => {
     expect(hasUsageProviderSettingsForProvider('grok', usageSettings())).toBe(false)
     expect(hasUsageProviderSettingsForProvider('grok', null)).toBe(false)
   })
+
+  it('treats the ClinePass API key flag as the durable ClinePass signal', () => {
+    expect(
+      hasUsageProviderSettingsForProvider(
+        'clinepass',
+        usageSettings({ clinePassApiKeyConfigured: true })
+      )
+    ).toBe(true)
+    expect(hasUsageProviderSettingsForProvider('clinepass', usageSettings())).toBe(false)
+    expect(hasUsageProviderSettingsForProvider('clinepass', null)).toBe(false)
+  })
 })
 
 describe('getVisibleUsageProvider', () => {
@@ -263,12 +276,50 @@ describe('getVisibleUsageProvider', () => {
     expect(getVisibleUsageProvider('codex', null, usageSettings())).toBe(null)
     expect(getVisibleUsageProvider('grok', undefined, usageSettings())).toBe(null)
     expect(getVisibleUsageProvider('gemini', provider('fetching'), usageSettings())).toBe(null)
+    expect(getVisibleUsageProvider('clinepass', undefined, usageSettings())).toBe(null)
   })
 
   it('creates a pending snapshot when an older main process omits a configured provider', () => {
     expect(
       getVisibleUsageProvider('grok', undefined, usageSettings({ grokAuthConfigured: true }))
     ).toMatchObject({ provider: 'grok', status: 'fetching' })
+  })
+
+  it('keeps configured ClinePass visible with a complete pending quota shape', () => {
+    expect(
+      getVisibleUsageProvider(
+        'clinepass',
+        undefined,
+        usageSettings({ clinePassApiKeyConfigured: true })
+      )
+    ).toMatchObject({
+      provider: 'clinepass',
+      status: 'fetching',
+      session: null,
+      weekly: null,
+      monthly: null
+    })
+  })
+
+  it('keeps live ClinePass quota windows distinct from Cline CLI usage', () => {
+    const live = provider('ok', {
+      provider: 'clinepass',
+      session: { usedPercent: 10, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      weekly: {
+        usedPercent: 20,
+        windowMinutes: 10080,
+        resetsAt: null,
+        resetDescription: null
+      },
+      monthly: {
+        usedPercent: 30,
+        windowMinutes: 43200,
+        resetsAt: null,
+        resetDescription: null
+      }
+    })
+
+    expect(getVisibleUsageProvider('clinepass', live, usageSettings())).toBe(live)
   })
 
   it('keeps MiniMax visible while the snapshot is pending when a cookie is configured', () => {

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -17,10 +17,12 @@ export type UsageProviderSettings = Pick<
   // Why: MiniMax/Grok sign-in live on disk, not in settings; main sets these each poll.
   minimaxCookieConfigured: boolean
   grokAuthConfigured: boolean
+  clinePassApiKeyConfigured?: boolean
 }
 
 type UsageProviderSnapshots = {
   claude: ProviderRateLimits | null | undefined
+  clinePass?: ProviderRateLimits | null
   codex: ProviderRateLimits | null | undefined
   gemini: ProviderRateLimits | null | undefined
   opencodeGo: ProviderRateLimits | null | undefined
@@ -70,6 +72,7 @@ export function hasUsageProviderSettings(
   settings: Partial<UsageProviderSettings> | null | undefined
 ): boolean {
   return Boolean(
+    settings?.clinePassApiKeyConfigured === true ||
     (settings?.codexManagedAccounts?.length ?? 0) > 0 ||
     (settings?.claudeManagedAccounts?.length ?? 0) > 0 ||
     settings?.geminiCliOAuthEnabled === true ||
@@ -90,6 +93,9 @@ export function hasUsageProviderSettingsForProvider(
   }
   if (providerId === 'claude') {
     return (settings.claudeManagedAccounts?.length ?? 0) > 0
+  }
+  if (providerId === 'clinepass') {
+    return settings.clinePassApiKeyConfigured === true
   }
   if (providerId === 'codex') {
     return (settings.codexManagedAccounts?.length ?? 0) > 0
@@ -120,7 +126,7 @@ function createPendingProviderSnapshot(providerId: UsageProviderId): ProviderRat
     provider: providerId,
     session: null,
     weekly: null,
-    ...(providerId === 'opencode-go' ? { monthly: null } : {}),
+    ...(providerId === 'opencode-go' || providerId === 'clinepass' ? { monthly: null } : {}),
     ...(providerId === 'gemini' ? { buckets: [] } : {}),
     updatedAt: 0,
     error: null,
@@ -157,8 +163,12 @@ export function isUsageEmptyState(
   const antigravitySnapshotPending =
     hasUsageProviderSettingsForProvider('antigravity', settings) &&
     isProviderSnapshotPending(providers.antigravity)
+  const clinePassSnapshotPending =
+    hasUsageProviderSettingsForProvider('clinepass', settings) &&
+    isProviderSnapshotPending(providers.clinePass)
   if (
     isProviderSnapshotPending(providers.claude) ||
+    clinePassSnapshotPending ||
     isProviderSnapshotPending(providers.codex) ||
     isProviderSnapshotPending(providers.gemini) ||
     isProviderSnapshotPending(providers.opencodeGo) ||
@@ -172,6 +182,7 @@ export function isUsageEmptyState(
   return (
     !hasUsageProviderSettings(settings) &&
     !isProviderConfigured(providers.claude) &&
+    !isProviderConfigured(providers.clinePass) &&
     !isProviderConfigured(providers.codex) &&
     !isProviderConfigured(providers.gemini) &&
     !isProviderConfigured(providers.opencodeGo) &&

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -47,6 +47,7 @@ function provider(overrides: Partial<ProviderRateLimits> = {}): ProviderRateLimi
 
 const PROVIDER_IDS: ProviderRateLimits['provider'][] = [
   'claude',
+  'clinepass',
   'codex',
   'gemini',
   'antigravity',
@@ -94,6 +95,18 @@ describe('provider usage error copy', () => {
     expect(getProviderUsageStatusLabel(p)).toBe('Refresh failed')
     expect(getProviderUsageErrorMessage(p)).toBe(
       'Claude usage could not be refreshed. Agent sessions may still be signed in.'
+    )
+  })
+
+  it('routes ClinePass API key failures to Settings without implying Cline CLI sign-in', () => {
+    const clinePass = provider({
+      provider: 'clinepass',
+      error: 'Unauthorized API key'
+    })
+
+    expect(getProviderUsageStatusLabel(clinePass)).toBe('Check API key')
+    expect(getProviderUsageErrorMessage(clinePass)).toBe(
+      'ClinePass usage could not be refreshed. Update the API key in Settings, then retry.'
     )
   })
 
@@ -342,6 +355,34 @@ describe('getWindowSections', () => {
     ])
   })
 
+  it('returns the complete ClinePass subscription quota roster', () => {
+    const p: ProviderRateLimits = {
+      provider: 'clinepass',
+      session: { usedPercent: 10, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      weekly: {
+        usedPercent: 20,
+        windowMinutes: 10080,
+        resetsAt: null,
+        resetDescription: null
+      },
+      monthly: {
+        usedPercent: 30,
+        windowMinutes: 43200,
+        resetsAt: null,
+        resetDescription: null
+      },
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+
+    expect(getWindowSections(p)).toEqual([
+      { label: 'Session', window: p.session },
+      { label: 'Weekly', window: p.weekly },
+      { label: 'Monthly', window: p.monthly }
+    ])
+  })
+
   it('returns a separate Fable section when Claude reports Fable weekly usage', () => {
     const p: ProviderRateLimits = {
       provider: 'claude',
@@ -580,6 +621,11 @@ describe('ProviderIcon', () => {
   it('renders the Antigravity agent icon for the antigravity provider', () => {
     const markup = renderToStaticMarkup(ProviderIcon({ provider: 'antigravity' }))
     expect(markup).toContain('data-agent-icon="antigravity"')
+  })
+
+  it('reuses the Cline agent icon for the ClinePass provider', () => {
+    const markup = renderToStaticMarkup(ProviderIcon({ provider: 'clinepass' }))
+    expect(markup).toContain('data-agent-icon="cline"')
   })
 
   it('renders the official MiniMax icon asset for the minimax provider', () => {

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -75,6 +75,9 @@ export function formatResetCreditExpiry(
 // ---------------------------------------------------------------------------
 
 export function ProviderIcon({ provider }: { provider: string }): React.JSX.Element {
+  if (provider === 'clinepass') {
+    return <AgentIcon agent="cline" size={13} />
+  }
   if (provider === 'codex') {
     return <OpenAIIcon size={13} />
   }

--- a/src/renderer/src/components/status-bar/usage-error-copy.test.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.test.ts
@@ -17,6 +17,7 @@ describe('getProviderDisplayName', () => {
 
   it('returns the existing provider brand names', () => {
     expect(getProviderDisplayName('claude')).toBe('Claude')
+    expect(getProviderDisplayName('clinepass')).toBe('ClinePass')
     expect(getProviderDisplayName('codex')).toBe('Codex')
     expect(getProviderDisplayName('gemini')).toBe('Gemini')
     expect(getProviderDisplayName('opencode-go')).toBe('OpenCode Go')

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -5,6 +5,9 @@ export function getProviderDisplayName(provider: ProviderRateLimits['provider'])
   if (provider === 'claude') {
     return 'Claude'
   }
+  if (provider === 'clinepass') {
+    return 'ClinePass'
+  }
   if (provider === 'codex') {
     return 'Codex'
   }
@@ -83,6 +86,9 @@ export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
   if (delegatedCliProvider === 'kimi') {
     return translate('auto.components.status.bar.tooltip.f90b3d7a16', 'Run Kimi to refresh')
   }
+  if (p.provider === 'clinepass' && isUsageAuthError(p.error)) {
+    return translate('auto.components.status.bar.tooltip.clinePassApiKeyError', 'Check API key')
+  }
   if (p.provider === 'claude') {
     switch (p.usageMetadata?.failureKind) {
       case 'deferred-by-live-session':
@@ -136,6 +142,12 @@ export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
     return translate(
       'auto.components.status.bar.tooltip.a37e8c15d4',
       'Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.'
+    )
+  }
+  if (p.provider === 'clinepass' && isUsageAuthError(p.error)) {
+    return translate(
+      'auto.components.status.bar.tooltip.clinePassApiKeyRecovery',
+      'ClinePass usage could not be refreshed. Update the API key in Settings, then retry.'
     )
   }
   if (p.provider === 'claude') {

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -87,7 +87,7 @@ export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
     return translate('auto.components.status.bar.tooltip.f90b3d7a16', 'Run Kimi to refresh')
   }
   if (p.provider === 'clinepass' && isUsageAuthError(p.error)) {
-    return translate('auto.components.status.bar.tooltip.clinePassApiKeyError', 'Check API key')
+    return translate('auto.components.status.bar.usage.error.copy.3a5a07c3c3', 'Check API key')
   }
   if (p.provider === 'claude') {
     switch (p.usageMetadata?.failureKind) {
@@ -146,7 +146,7 @@ export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
   }
   if (p.provider === 'clinepass' && isUsageAuthError(p.error)) {
     return translate(
-      'auto.components.status.bar.tooltip.clinePassApiKeyRecovery',
+      'auto.components.status.bar.usage.error.copy.edeabb5cc7',
       'ClinePass usage could not be refreshed. Update the API key in Settings, then retry.'
     )
   }

--- a/src/renderer/src/components/status-bar/usage-provider-settings-target.test.ts
+++ b/src/renderer/src/components/status-bar/usage-provider-settings-target.test.ts
@@ -4,6 +4,7 @@ import { getUsageProviderAccountsSectionId } from './usage-provider-settings-tar
 describe('getUsageProviderAccountsSectionId', () => {
   it('routes providers only to settings sections that exist', () => {
     expect(getUsageProviderAccountsSectionId('claude')).toBe('accounts-claude')
+    expect(getUsageProviderAccountsSectionId('clinepass')).toBe('accounts-clinepass')
     expect(getUsageProviderAccountsSectionId('codex')).toBe('accounts-codex')
     expect(getUsageProviderAccountsSectionId('gemini')).toBe('accounts-gemini')
     expect(getUsageProviderAccountsSectionId('antigravity')).toBe('accounts-gemini')

--- a/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
+++ b/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
@@ -6,6 +6,8 @@ export function getUsageProviderAccountsSectionId(
   switch (provider) {
     case 'claude':
       return 'accounts-claude'
+    case 'clinepass':
+      return 'accounts-clinepass'
     case 'codex':
       return 'accounts-codex'
     case 'gemini':

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3493,7 +3493,7 @@
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
             "codexSignInError": "Codex sign-in failed. Please try again.",
-            "clinePassUsageMenu": "ClinePass Usage"
+            "029230c95c": "ClinePass Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3672,9 +3672,7 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
-            "clinePassApiKeyError": "Check API key",
-            "clinePassApiKeyRecovery": "ClinePass usage could not be refreshed. Update the API key in Settings, then retry."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
@@ -3749,6 +3747,14 @@
             "onDescription": "Keep this computer awake continuously",
             "autoDescription": "Stay awake while an agent is working",
             "offDescription": "Allow normal system sleep behavior"
+          },
+          "usage": {
+            "error": {
+              "copy": {
+                "3a5a07c3c3": "Check API key",
+                "edeabb5cc7": "ClinePass usage could not be refreshed. Update the API key in Settings, then retry."
+              }
+            }
           }
         }
       },
@@ -11296,6 +11302,9 @@
           "3fc8e072dc": "Save",
           "535a2c9a19": "Forget API key",
           "a11dc5b121": "Create an API key in your Cline account, then paste it here. Orca never displays a saved key."
+        },
+        "ClinePassCredentialStatus": {
+          "4df8f88808": "Orca could not check whether a Cline API key is configured. Try again."
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11296,7 +11296,6 @@
           "d9ea8a4643": "Not saved",
           "c89556fc40": "ClinePass API key",
           "3d738f9c5f": "Authenticate quota refreshes with an official Cline API key.",
-          "7e87f4df2a": "A saved key overrides the environment",
           "ce12d5e9c6": "Paste a Cline API key",
           "61a2148925": "Replace",
           "3fc8e072dc": "Save",
@@ -11305,6 +11304,9 @@
         },
         "ClinePassCredentialStatus": {
           "4df8f88808": "Orca could not check whether a Cline API key is configured. Try again."
+        },
+        "ClinePassApiKeyForm": {
+          "3c8f8283c8": "A saved key overrides the environment variable."
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -60,7 +60,8 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "clinePassToggleDescription": "Show ClinePass 5-hour, weekly, and monthly subscription quota."
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
@@ -3491,7 +3492,8 @@
             "grokUsageMenu": "Grok Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
-            "codexSignInError": "Codex sign-in failed. Please try again."
+            "codexSignInError": "Codex sign-in failed. Please try again.",
+            "clinePassUsageMenu": "ClinePass Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3670,7 +3672,9 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "clinePassApiKeyError": "Check API key",
+            "clinePassApiKeyRecovery": "ClinePass usage could not be refreshed. Update the API key in Settings, then retry."
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
@@ -8480,7 +8484,9 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "oauth",
-            "a9f3d7b5c8": "login"
+            "a9f3d7b5c8": "login",
+            "cfe73344d1": "ClinePass Subscription Quota",
+            "7a55b8bad9": "Add a Cline API key to track ClinePass 5-hour, weekly, and monthly subscription quota."
           }
         },
         "advanced": {
@@ -8707,7 +8713,9 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "6c82e7d14f": "ClinePass Usage",
+            "df7ae25c91": "Show ClinePass subscription quota in the status bar."
           }
         },
         "auto": {
@@ -11258,6 +11266,36 @@
           "cancel": "Keep cleaning",
           "stopping": "Stopping…",
           "confirm": "Stop cleanup"
+        },
+        "ClinePassAccountsSection": {
+          "3f06b1e71d": "ClinePass credential status could not be loaded.",
+          "f036f412e9": "ClinePass API key is required.",
+          "738e1fe094": "ClinePass API key saved.",
+          "d8358b48f6": "ClinePass API key could not be saved. Check the key and try again.",
+          "902abdf7f8": "Stored ClinePass API key forgotten.",
+          "8c8eb65703": "Stored ClinePass API key could not be forgotten. Try again.",
+          "02498819c4": "ClinePass",
+          "71c914cff5": "Track included ClinePass subscription quota across 5-hour, weekly, and monthly windows.",
+          "7b9e5f6452": "API key docs",
+          "f0fcb3c84e": "Checking API key…",
+          "139c527c90": "Credential status unavailable",
+          "a59efe5917": "API key saved in Orca",
+          "76d85f70af": "Configured by CLINE_API_KEY",
+          "d6d08ab7ba": "API key not configured",
+          "20e3fe7fe6": "Stored locally and sent only to api.cline.bot to read your ClinePass subscription quota.",
+          "933597b6ca": "CLINE_API_KEY configures Orca and cannot be cleared here. Save a key below to override it.",
+          "0571590443": "Add a Cline API key to read your ClinePass subscription quota.",
+          "fac44d3a91": "Saved",
+          "b1866729fa": "Environment",
+          "d9ea8a4643": "Not saved",
+          "c89556fc40": "ClinePass API key",
+          "3d738f9c5f": "Authenticate quota refreshes with an official Cline API key.",
+          "7e87f4df2a": "A saved key overrides the environment",
+          "ce12d5e9c6": "Paste a Cline API key",
+          "61a2148925": "Replace",
+          "3fc8e072dc": "Save",
+          "535a2c9a19": "Forget API key",
+          "a11dc5b121": "Create an API key in your Cline account, then paste it here. Orca never displays a saved key."
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."

--- a/src/renderer/src/store/slices/rate-limits.test.ts
+++ b/src/renderer/src/store/slices/rate-limits.test.ts
@@ -16,4 +16,11 @@ describe('createRateLimitSlice', () => {
 
     expect(store.getState().rateLimits.antigravity).toBeNull()
   })
+
+  it('initializes ClinePass as an unconfigured optional provider', () => {
+    const store = createRateLimitStore()
+
+    expect(store.getState().rateLimits.clinePass).toBeNull()
+    expect(store.getState().rateLimits.clinePassApiKeyConfigured).toBe(false)
+  })
 })

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -18,6 +18,7 @@ export type RateLimitSlice = {
 export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice> = (set, get) => ({
   rateLimits: {
     claude: null,
+    clinePass: null,
     codex: null,
     gemini: null,
     opencodeGo: null,
@@ -25,6 +26,7 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     antigravity: null,
     minimax: null,
     grok: null,
+    clinePassApiKeyConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -120,6 +120,12 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().worktreeCardProperties).toEqual(['status', 'unread', 'inline-agents'])
   })
 
+  it('enables ClinePass usage for new profiles', () => {
+    const store = createUIStore()
+
+    expect(store.getState().statusBarItems).toContain('clinepass')
+  })
+
   it('adds default-on status items once for older persisted UI', () => {
     const setUI = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal('window', { api: { ui: { set: setUI } } })
@@ -139,7 +145,8 @@ describe('createUISlice hydratePersistedUI', () => {
       'kimi',
       'minimax',
       'antigravity',
-      'grok'
+      'grok',
+      'clinepass'
     ])
     expect(setUI).toHaveBeenCalledWith({
       statusBarItems: [
@@ -149,13 +156,15 @@ describe('createUISlice hydratePersistedUI', () => {
         'kimi',
         'minimax',
         'antigravity',
-        'grok'
+        'grok',
+        'clinepass'
       ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
-      _grokStatusBarDefaultAdded: true
+      _grokStatusBarDefaultAdded: true,
+      _clinePassStatusBarDefaultAdded: true
     })
   })
 
@@ -171,7 +180,8 @@ describe('createUISlice hydratePersistedUI', () => {
         _kimiStatusBarDefaultAdded: true,
         _minimaxStatusBarDefaultAdded: true,
         _antigravityStatusBarDefaultAdded: true,
-        _grokStatusBarDefaultAdded: true
+        _grokStatusBarDefaultAdded: true,
+        _clinePassStatusBarDefaultAdded: true
       })
     )
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -285,6 +285,7 @@ const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
 const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
 const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
 const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
+const DEFAULT_ON_CLINEPASS_STATUS_BAR_ITEM: StatusBarItem = 'clinepass'
 
 function normalizeHydratedVisibleWorkspaceHostIds(ui: PersistedUIState): VisibleWorkspaceHostIds {
   const visibleHostIds = normalizeVisibleExecutionHostIds(ui.visibleWorkspaceHostIds)
@@ -2461,22 +2462,28 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ui._grokStatusBarDefaultAdded || statusBarItemsWithAntigravity.includes('grok')
           ? statusBarItemsWithAntigravity
           : [...statusBarItemsWithAntigravity, DEFAULT_ON_GROK_STATUS_BAR_ITEM]
+      const statusBarItemsWithClinePass =
+        ui._clinePassStatusBarDefaultAdded || statusBarItemsWithGrok.includes('clinepass')
+          ? statusBarItemsWithGrok
+          : [...statusBarItemsWithGrok, DEFAULT_ON_CLINEPASS_STATUS_BAR_ITEM]
       if (
         (!ui._portsStatusBarDefaultAdded ||
           !ui._kimiStatusBarDefaultAdded ||
           !ui._minimaxStatusBarDefaultAdded ||
           !ui._antigravityStatusBarDefaultAdded ||
-          !ui._grokStatusBarDefaultAdded) &&
+          !ui._grokStatusBarDefaultAdded ||
+          !ui._clinePassStatusBarDefaultAdded) &&
         typeof window !== 'undefined'
       ) {
         window.api.ui
           .set({
-            statusBarItems: statusBarItemsWithGrok,
+            statusBarItems: statusBarItemsWithClinePass,
             _portsStatusBarDefaultAdded: true,
             _kimiStatusBarDefaultAdded: true,
             _minimaxStatusBarDefaultAdded: true,
             _antigravityStatusBarDefaultAdded: true,
-            _grokStatusBarDefaultAdded: true
+            _grokStatusBarDefaultAdded: true,
+            _clinePassStatusBarDefaultAdded: true
           })
           .catch(console.error)
       }
@@ -2547,7 +2554,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
         syncTaskStatusFromWorkspaceBoard: ui.syncTaskStatusFromWorkspaceBoard === true,
-        statusBarItems: statusBarItemsWithGrok,
+        statusBarItems: statusBarItemsWithClinePass,
         statusBarVisible: ui.statusBarVisible ?? true,
         usagePercentageDisplay: normalizeUsagePercentageDisplay(ui.usagePercentageDisplay),
         statusBarUsageMode: normalizeStatusBarUsageMode(ui.statusBarUsageMode),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -900,6 +900,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     notifications: createNotificationsApi(),
     rateLimits: createRateLimitsApi(),
     minimaxCredentials: createMiniMaxCredentialsApi(),
+    clinePassCredentials: createClinePassCredentialsApi(),
     grokAccounts: createGrokAccountsApi(),
     codexAccounts: createAccountsApi(),
     claudeAccounts: createAccountsApi(),
@@ -3186,6 +3187,7 @@ function createNotificationsApi(): NonNullable<Partial<PreloadApi>['notification
 function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimits']> {
   const empty: RateLimitState = {
     claude: null,
+    clinePass: null,
     codex: null,
     gemini: null,
     opencodeGo: null,
@@ -3193,6 +3195,7 @@ function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimits']> {
     antigravity: null,
     minimax: null,
     grok: null,
+    clinePassApiKeyConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },
@@ -3223,6 +3226,18 @@ function createMiniMaxCredentialsApi(): NonNullable<Partial<PreloadApi>['minimax
     getStatus: () => Promise.resolve(notConfigured),
     saveCookie: () => Promise.reject(unsupportedError),
     clearCookie: () => Promise.resolve(notConfigured)
+  }
+}
+
+function createClinePassCredentialsApi(): NonNullable<Partial<PreloadApi>['clinePassCredentials']> {
+  const notConfigured = { configured: false, source: 'none' as const }
+  const unsupportedError = new Error(
+    'ClinePass API key storage is only available in the desktop app.'
+  )
+  return {
+    getStatus: () => Promise.resolve(notConfigured),
+    saveApiKey: () => Promise.reject(unsupportedError),
+    clearApiKey: () => Promise.reject(unsupportedError)
   }
 }
 

--- a/src/shared/clinepass-credentials.ts
+++ b/src/shared/clinepass-credentials.ts
@@ -1,0 +1,6 @@
+export type ClinePassCredentialsSource = 'stored' | 'environment' | 'none'
+
+export type ClinePassCredentialsStatus = {
+  configured: boolean
+  source: ClinePassCredentialsSource
+}

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -99,6 +99,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on ClinePass status item. */
+  _clinePassStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */

--- a/src/shared/rate-limit-types.test.ts
+++ b/src/shared/rate-limit-types.test.ts
@@ -16,8 +16,10 @@ describe('RateLimitState', () => {
       antigravity: null,
       minimax: null,
       grok: null,
+      clinePass: null,
       minimaxCookieConfigured: false,
       grokAuthConfigured: false,
+      clinePassApiKeyConfigured: false,
       claudeTarget: { runtime: 'host', wslDistro: null },
       codexTarget: { runtime: 'host', wslDistro: null },
       inactiveClaudeAccounts: [],
@@ -26,6 +28,8 @@ describe('RateLimitState', () => {
 
     expect(state.antigravity).toBeNull()
     expect(state.minimax).toBeNull()
+    expect(state.clinePass).toBeNull()
     expect(state.minimaxCookieConfigured).toBe(false)
+    expect(state.clinePassApiKeyConfigured).toBe(false)
   })
 })

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -55,13 +55,14 @@ export type ProviderRateLimits = {
     | 'minimax'
     | 'grok'
     | 'antigravity'
+    | 'clinepass'
   /** 5-hour session window, null if not available. */
   session: RateLimitWindow | null
   /** 7-day weekly window, null if not available. */
   weekly: RateLimitWindow | null
   /** Claude Fable 7-day weekly window, null if not available. */
   fableWeekly?: RateLimitWindow | null
-  /** 30-day monthly window (OpenCode Go, Grok unified billing), null if not available. */
+  /** 30-day monthly window (OpenCode Go, Grok unified billing, ClinePass), null if not available. */
   monthly?: RateLimitWindow | null
   /** Named per-model buckets (Gemini only). */
   buckets?: RateLimitBucket[]
@@ -125,6 +126,11 @@ export type RateLimitState = {
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
   /**
+   * Optional for mixed-version remote compatibility. Present when this build
+   * tracks ClinePass plan usage; older peers may omit the field entirely.
+   */
+  clinePass?: ProviderRateLimits | null
+  /**
    * True when a MiniMax session cookie is persisted on disk. The cookie lives
    * outside GlobalSettings, so this flag is the durable signal that the
    * status bar uses to keep the MiniMax provider visible across reloads and
@@ -133,6 +139,11 @@ export type RateLimitState = {
   minimaxCookieConfigured: boolean
   /** True when main finds a Grok CLI session file (~/.grok/auth.json or GROK_HOME). */
   grokAuthConfigured: boolean
+  /**
+   * Optional for mixed-version remote compatibility. True when a ClinePass API
+   * key is stored or `CLINE_API_KEY` is set; older peers may omit the field.
+   */
+  clinePassApiKeyConfigured?: boolean
   claudeTarget: RateLimitRuntimeTarget
   codexTarget: RateLimitRuntimeTarget
   inactiveClaudeAccounts: InactiveAccountUsage[]

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -2,6 +2,7 @@ import type { StatusBarItem } from './ui-chrome-types'
 
 export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'claude',
+  'clinepass',
   'codex',
   'gemini',
   'antigravity',

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -51,6 +51,7 @@ export type AgentActivityDisplayMode = 'compact' | 'full'
 
 export type StatusBarItem =
   | 'claude'
+  | 'clinepass'
   | 'codex'
   | 'gemini'
   | 'antigravity'


### PR DESCRIPTION
## Scope

This is an API-key-based implementation related to #13032. It supports Windows + WSL setups through an Orca-owned credential: the user enters the key once in Settings, the Windows Orca process stores it and queries the quota API directly, and the Cline agent can continue running in WSL. No WSL-specific credential access is required for this flow.

Automatic import of an environment variable or CLI session that exists exclusively inside a WSL distribution is not included. This PR therefore does not claim WSL credential auto-discovery and does not close #13032.

## Summary

- Add API-key-based ClinePass subscription quota tracking to the Usage status bar and AI Provider Accounts.
- Fetch the 5-hour, weekly, and monthly windows from Cline's account usage API with explicit auth, rate-limit, network, server, and parse failure states.
- Support either a stored API key or `CLINE_API_KEY` from the Orca process environment; stored keys use Electron `safeStorage`, fail closed when secure storage is unavailable (including Linux `basic_text`), and never cross into renderer state.
- Keep ClinePass subscription quota distinct from Cline PAYG/BYOK usage.

Related to #13032 (explicit API-key path; does not close it).

## Screenshots

Screenshots are not attached because the local end-to-end smoke used live account/quota data. I visually verified both the Usage roster and the ClinePass Accounts section without publishing private account values.

## Testing

- [ ] `pnpm lint` — not run project-wide; `check-changed-code-quality.mjs` passed with 0 new code-quality, type-aware, or React Doctor errors across 43 changed files.
- [x] `pnpm typecheck` — node, web, and CLI TypeScript targets passed independently; the review-fix commit also passed the web target again.
- [ ] `pnpm test` — not run project-wide; 16 focused suites passed locally (401 tests). The review-fix commit additionally passed the two affected UI suites (15 tests). Upstream CI has not independently run the full focused set yet.
- [ ] `pnpm build` — not run as a production build; Electron dev runtime launched successfully.
- [x] Added or updated high-quality tests for credential storage/IPC trust, response mapping and errors, service races/stale state, status visibility/migrations, search/toggles, Settings recovery states, and failure-specific credential guidance.
- [x] Localization catalog and extraction verification passed locally.
- [x] `check-max-lines-ratchet.mjs` passed locally.
- [x] Live smoke: a real ClinePass account rendered 5h, weekly, and monthly quota plus reset data in the Usage roster; Accounts showed the environment credential source without exposing the key.

## AI Review Report

Reviewed the full credential → IPC/preload → rate-limit service → shared state → renderer path. The review checked provider exhaustiveness, account-key generation races, stale-snapshot policy, optional mixed-version state, status-item migrations, Settings search/toggle coverage, loading/error recovery, and test contracts. It found two UI omissions before the PR was opened; both were fixed and covered by focused tests. CodeRabbit subsequently found misleading secondary copy after a credential-status load failure and three noncanonical localization keys; both findings were fixed in `eec5ab02b` and reverified.

Cross-platform review covered macOS, Linux, and Windows storage/path behavior, Electron renderer trust boundaries, old main/remote payload fallback, and the SSH/folder-workspace case. Explicit API-key entry works when Cline runs in WSL because Orca owns the credential and performs the quota request. The remaining convenience gap is automatic import of credentials that exist only inside WSL.

## Security Audit

The security review checked secret-at-rest handling, environment precedence, IPC sender authorization, renderer/remote exposure, auth-header/error leakage, redirect/proxy behavior, and save/clear/fetch races. It found and fixed two blocking issues before this PR was opened:

- credential persistence now fails closed instead of degrading to plaintext when `safeStorage` is unavailable or Linux selects `basic_text`; users can use `CLINE_API_KEY` instead;
- every `clinePassCredentials:*` handler now rejects untrusted renderers before reading, writing, clearing, or refreshing credentials.

The key is sent only as a fixed HTTPS Bearer header to `api.cline.bot`, is never returned to the renderer, and is never included in rate-limit state or logs.

## Notes

- Cline documents API-key authentication: https://docs.cline.bot/api/authentication
- The quota endpoint is used by Cline's dashboard but is not currently documented as a stable public quota API. CodexBar uses the same endpoint as prior art: https://github.com/steipete/CodexBar/blob/main/Sources/CodexBarCore/Resources/Plugins/clinepass.ts
- This intentionally does not read or refresh Cline CLI OAuth tokens and does not automatically import credentials from a configured WSL runtime.
- X handle: not provided.