### PR TITLE
fix(terminal): stop background panes rendering blank after a system wake

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager-atlas-invalidation.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-atlas-invalidation.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * Pins the hidden-atlas debt contract without standing up a full PaneManager
+ * (which needs real DOM panes and xterm instances).
+ *
+ * The shared glyph atlas is module-global, so a wipe run for the visible
+ * workspace invalidates every hidden workspace's glyph coordinates too. Hidden
+ * managers are skipped deliberately — they cannot be measured — so the debt has
+ * to be settled the moment they become visible. Field logs over 8 days showed
+ * 2526/2621 (96%) of atlas resets were partial, so this path is the norm.
+ */
+
+type AtlasVisibilityHost = {
+  atlasRecoveryVisible: boolean
+  atlasInvalidatedWhileHidden: boolean
+  refreshAllPanes: () => void
+  setAtlasRecoveryVisible: (visible: boolean) => void
+  markAtlasInvalidatedWhileHidden: () => void
+}
+
+// Mirrors PaneManager.setAtlasRecoveryVisible / markAtlasInvalidatedWhileHidden.
+function createHost(initiallyVisible: boolean): AtlasVisibilityHost {
+  const host: AtlasVisibilityHost = {
+    atlasRecoveryVisible: initiallyVisible,
+    atlasInvalidatedWhileHidden: false,
+    refreshAllPanes: vi.fn(),
+    setAtlasRecoveryVisible(visible: boolean) {
+      const wasHidden = !host.atlasRecoveryVisible
+      host.atlasRecoveryVisible = visible
+      if (visible && wasHidden && host.atlasInvalidatedWhileHidden) {
+        host.atlasInvalidatedWhileHidden = false
+        host.refreshAllPanes()
+      }
+    },
+    markAtlasInvalidatedWhileHidden() {
+      host.atlasInvalidatedWhileHidden = true
+    }
+  }
+  return host
+}
+
+describe('hidden atlas invalidation debt', () => {
+  it('repaints on reveal when a wipe ran while hidden', () => {
+    const host = createHost(false)
+
+    host.markAtlasInvalidatedWhileHidden()
+    host.setAtlasRecoveryVisible(true)
+
+    expect(host.refreshAllPanes).toHaveBeenCalledOnce()
+  })
+
+  it('does not repaint on reveal when no wipe ran while hidden', () => {
+    // Why: reveal already has its own repaint path; an unconditional refresh
+    // here would re-rasterize every workspace switch.
+    const host = createHost(false)
+
+    host.setAtlasRecoveryVisible(true)
+
+    expect(host.refreshAllPanes).not.toHaveBeenCalled()
+  })
+
+  it('settles the debt once, not on every later visibility change', () => {
+    const host = createHost(false)
+
+    host.markAtlasInvalidatedWhileHidden()
+    host.setAtlasRecoveryVisible(true)
+    host.setAtlasRecoveryVisible(false)
+    host.setAtlasRecoveryVisible(true)
+
+    expect(host.refreshAllPanes).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the debt while still hidden', () => {
+    // A wipe can land while hidden and be followed by more hidden-state churn;
+    // the repaint must wait for actual visibility.
+    const host = createHost(false)
+
+    host.markAtlasInvalidatedWhileHidden()
+    host.setAtlasRecoveryVisible(false)
+
+    expect(host.refreshAllPanes).not.toHaveBeenCalled()
+    expect(host.atlasInvalidatedWhileHidden).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-manager-atlas-invalidation.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-atlas-invalidation.test.ts
@@ -1,86 +1,56 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest'
+import { PaneManager } from './pane-manager'
 
-/**
- * Pins the hidden-atlas debt contract without standing up a full PaneManager
- * (which needs real DOM panes and xterm instances).
- *
- * The shared glyph atlas is module-global, so a wipe run for the visible
- * workspace invalidates every hidden workspace's glyph coordinates too. Hidden
- * managers are skipped deliberately — they cannot be measured — so the debt has
- * to be settled the moment they become visible. Field logs over 8 days showed
- * 2526/2621 (96%) of atlas resets were partial, so this path is the norm.
- */
-
-type AtlasVisibilityHost = {
-  atlasRecoveryVisible: boolean
-  atlasInvalidatedWhileHidden: boolean
-  refreshAllPanes: () => void
-  setAtlasRecoveryVisible: (visible: boolean) => void
-  markAtlasInvalidatedWhileHidden: () => void
-}
-
-// Mirrors PaneManager.setAtlasRecoveryVisible / markAtlasInvalidatedWhileHidden.
-function createHost(initiallyVisible: boolean): AtlasVisibilityHost {
-  const host: AtlasVisibilityHost = {
-    atlasRecoveryVisible: initiallyVisible,
-    atlasInvalidatedWhileHidden: false,
-    refreshAllPanes: vi.fn(),
-    setAtlasRecoveryVisible(visible: boolean) {
-      const wasHidden = !host.atlasRecoveryVisible
-      host.atlasRecoveryVisible = visible
-      if (visible && wasHidden && host.atlasInvalidatedWhileHidden) {
-        host.atlasInvalidatedWhileHidden = false
-        host.refreshAllPanes()
-      }
-    },
-    markAtlasInvalidatedWhileHidden() {
-      host.atlasInvalidatedWhileHidden = true
-    }
-  }
-  return host
+function createManager(initiallyVisible: boolean): PaneManager {
+  const manager = new PaneManager(document.createElement('div'), {
+    linkOpenHint: () => '',
+    initialRenderingSuspended: !initiallyVisible
+  })
+  vi.spyOn(manager, 'refreshAllPanes').mockImplementation(() => {})
+  return manager
 }
 
 describe('hidden atlas invalidation debt', () => {
   it('repaints on reveal when a wipe ran while hidden', () => {
-    const host = createHost(false)
+    const manager = createManager(false)
 
-    host.markAtlasInvalidatedWhileHidden()
-    host.setAtlasRecoveryVisible(true)
+    manager.markAtlasInvalidatedWhileHidden()
+    manager.setAtlasRecoveryVisible(true)
 
-    expect(host.refreshAllPanes).toHaveBeenCalledOnce()
+    expect(manager.refreshAllPanes).toHaveBeenCalledOnce()
   })
 
   it('does not repaint on reveal when no wipe ran while hidden', () => {
-    // Why: reveal already has its own repaint path; an unconditional refresh
-    // here would re-rasterize every workspace switch.
-    const host = createHost(false)
+    // Why: reveal has its own repaint path; an unconditional refresh here
+    // would re-rasterize on every workspace switch.
+    const manager = createManager(false)
 
-    host.setAtlasRecoveryVisible(true)
+    manager.setAtlasRecoveryVisible(true)
 
-    expect(host.refreshAllPanes).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
   })
 
   it('settles the debt once, not on every later visibility change', () => {
-    const host = createHost(false)
+    const manager = createManager(false)
 
-    host.markAtlasInvalidatedWhileHidden()
-    host.setAtlasRecoveryVisible(true)
-    host.setAtlasRecoveryVisible(false)
-    host.setAtlasRecoveryVisible(true)
+    manager.markAtlasInvalidatedWhileHidden()
+    manager.setAtlasRecoveryVisible(true)
+    manager.setAtlasRecoveryVisible(false)
+    manager.setAtlasRecoveryVisible(true)
 
-    expect(host.refreshAllPanes).toHaveBeenCalledOnce()
+    expect(manager.refreshAllPanes).toHaveBeenCalledOnce()
   })
 
   it('keeps the debt while still hidden', () => {
-    // A wipe can land while hidden and be followed by more hidden-state churn;
-    // the repaint must wait for actual visibility.
-    const host = createHost(false)
+    const manager = createManager(false)
 
-    host.markAtlasInvalidatedWhileHidden()
-    host.setAtlasRecoveryVisible(false)
+    manager.markAtlasInvalidatedWhileHidden()
+    manager.setAtlasRecoveryVisible(false)
 
-    expect(host.refreshAllPanes).not.toHaveBeenCalled()
-    expect(host.atlasInvalidatedWhileHidden).toBe(true)
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
+
+    manager.setAtlasRecoveryVisible(true)
+    expect(manager.refreshAllPanes).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -113,6 +113,86 @@ describe('pane manager registry', () => {
     expect(hidden.every((manager) => manager.refreshAllPanes.mock.calls.length === 0)).toBe(true)
   })
 
+  it('marks skipped hidden managers so their reveal can repaint', () => {
+    // Why: the atlas is module-global, so a wipe invalidates hidden managers'
+    // glyph coordinates too. Skipping their repaint is correct (they cannot be
+    // measured while hidden), but leaving no record made them paint garbled
+    // glyphs on reveal — 96% of field resets were partial like this.
+    const visible = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => true,
+      markAtlasInvalidatedWhileHidden: vi.fn<() => void>()
+    }
+    const hidden = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => false,
+      markAtlasInvalidatedWhileHidden: vi.fn<() => void>()
+    }
+    for (const manager of [visible, hidden]) {
+      registerLivePaneManager(manager)
+      registeredManagers.push(manager)
+    }
+
+    resetAndRefreshAllTerminalWebglAtlases()
+
+    expect(hidden.markAtlasInvalidatedWhileHidden).toHaveBeenCalledOnce()
+    expect(hidden.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    // The visible manager repaints now, so it carries no debt.
+    expect(visible.markAtlasInvalidatedWhileHidden).not.toHaveBeenCalled()
+    expect(visible.refreshAllPanes).toHaveBeenCalledOnce()
+  })
+
+  it('rebuilds hidden managers too after a context loss', () => {
+    // Why: the visibility filter assumes a hidden pane's GPU texture survives
+    // until reveal, which holds for tab switches but not for a system resume —
+    // that destroys every context at once. A skipped manager then keeps a glyph
+    // renderer pointed at a generation its rebuilt atlas no longer has and
+    // paints a blank canvas (field capture: 1949/1998 cells blank, #7951).
+    const visible = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => true,
+      markAtlasInvalidatedWhileHidden: vi.fn<() => void>()
+    }
+    const hidden = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => false,
+      markAtlasInvalidatedWhileHidden: vi.fn<() => void>()
+    }
+    for (const manager of [visible, hidden]) {
+      registerLivePaneManager(manager)
+      registeredManagers.push(manager)
+    }
+
+    resetAndRefreshAllTerminalWebglAtlases('system-resume')
+
+    expect(hidden.resetWebglTextureAtlases).toHaveBeenCalledOnce()
+    expect(hidden.refreshAllPanes).toHaveBeenCalledOnce()
+    // Rebuilt now, so there is no debt left to settle on reveal.
+    expect(hidden.markAtlasInvalidatedWhileHidden).not.toHaveBeenCalled()
+  })
+
+  it('still skips hidden managers for ordinary visibility-driven resets', () => {
+    // The context survives a tab switch, so re-rasterizing every hidden pane
+    // there would trade a rare bug for a constant cost.
+    const hidden = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => false,
+      markAtlasInvalidatedWhileHidden: vi.fn<() => void>()
+    }
+    registerLivePaneManager(hidden)
+    registeredManagers.push(hidden)
+
+    resetAndRefreshAllTerminalWebglAtlases('visibility-resume')
+
+    expect(hidden.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(hidden.markAtlasInvalidatedWhileHidden).toHaveBeenCalledOnce()
+  })
+
   it('continues reset-and-refresh recovery when one manager throws', () => {
     const broken = {
       resetWebglTextureAtlases: vi.fn<() => void>(() => {

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -114,10 +114,8 @@ describe('pane manager registry', () => {
   })
 
   it('marks skipped hidden managers so their reveal can repaint', () => {
-    // Why: the atlas is module-global, so a wipe invalidates hidden managers'
-    // glyph coordinates too. Skipping their repaint is correct (they cannot be
-    // measured while hidden), but leaving no record made them paint garbled
-    // glyphs on reveal — 96% of field resets were partial like this.
+    // Why: skipping the repaint is correct, but leaving no record made the
+    // reveal paint stale coordinates.
     const visible = {
       resetWebglTextureAtlases: vi.fn<() => void>(),
       refreshAllPanes: vi.fn<() => void>(),
@@ -145,11 +143,8 @@ describe('pane manager registry', () => {
   })
 
   it('rebuilds hidden managers too after a context loss', () => {
-    // Why: the visibility filter assumes a hidden pane's GPU texture survives
-    // until reveal, which holds for tab switches but not for a system resume —
-    // that destroys every context at once. A skipped manager then keeps a glyph
-    // renderer pointed at a generation its rebuilt atlas no longer has and
-    // paints a blank canvas (field capture: 1949/1998 cells blank, #7951).
+    // Why: a system resume destroys every context at once, so the visibility
+    // filter's survives-until-reveal assumption does not hold here.
     const visible = {
       resetWebglTextureAtlases: vi.fn<() => void>(),
       refreshAllPanes: vi.fn<() => void>(),

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -11,6 +11,8 @@ type RegisteredPaneManager = {
   getPaneCount?: () => number
   isVisibleForAtlasRecovery?: () => boolean
   scheduleRevealPresent?: () => void
+  /** Records that a shared-atlas wipe ran while this manager was hidden. */
+  markAtlasInvalidatedWhileHidden?: () => void
 }
 
 const liveManagers = new Set<RegisteredPaneManager>()
@@ -48,17 +50,49 @@ export function resetAllTerminalWebglAtlases(): void {
   }
 }
 
+/**
+ * Reasons where the GPU context itself died, not just a surface being hidden.
+ *
+ * Why they cannot skip hidden managers: the visibility filter assumes a hidden
+ * pane's texture survives until it is revealed, which holds for tab switches.
+ * A system resume destroys every context at once, so a skipped manager keeps a
+ * glyph renderer pointing at a generation its rebuilt atlas no longer has —
+ * captured in the field as clearModelGeneration=undefined against
+ * glyphLastSeenClearModelGeneration=17, painting a blank canvas with a full
+ * vertex buffer (#7951).
+ */
+const CONTEXT_LOSS_REASONS = new Set(['system-resume', 'render-desync'])
+
 export function resetAndRefreshAllTerminalWebglAtlases(reason?: string): void {
   // Why: the atlas wipe is the heavy recovery path; recording it lets a freeze
   // report show whether a post-wake repaint actually ran. Silent breadcrumb.
-  const recoveryManagers = Array.from(liveManagers).filter(
-    (manager) => manager.isVisibleForAtlasRecovery?.() !== false
-  )
+  const afterContextLoss = reason !== undefined && CONTEXT_LOSS_REASONS.has(reason)
+  const recoveryManagers: RegisteredPaneManager[] = []
+  const skippedManagers: RegisteredPaneManager[] = []
+  for (const manager of liveManagers) {
+    if (!afterContextLoss && manager.isVisibleForAtlasRecovery?.() === false) {
+      skippedManagers.push(manager)
+    } else {
+      recoveryManagers.push(manager)
+    }
+  }
+  // Why: the atlas is module-global across same-font terminals, so this wipe
+  // invalidates the glyph coordinates of the hidden managers too — but skipping
+  // their repaint is deliberate (they cannot be measured while hidden). Mark
+  // them instead so their reveal repaints from the rebuilt atlas; without this
+  // they paint garbled glyphs with stale coordinates. Field logs showed 96% of
+  // resets are partial, so this is the common case, not an edge case.
+  for (const manager of skippedManagers) {
+    manager.markAtlasInvalidatedWhileHidden?.()
+  }
   recordTerminalWebglDiagnostic('webgl-atlas-reset', {
     managers: recoveryManagers.length,
     mountedManagers: liveManagers.size,
+    invalidatedHidden: skippedManagers.length,
+    afterContextLoss,
     ...(reason ? { reason } : {})
   })
+
   const resetManagers: RegisteredPaneManager[] = []
   for (const manager of recoveryManagers) {
     try {

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -11,7 +11,6 @@ type RegisteredPaneManager = {
   getPaneCount?: () => number
   isVisibleForAtlasRecovery?: () => boolean
   scheduleRevealPresent?: () => void
-  /** Records that a shared-atlas wipe ran while this manager was hidden. */
   markAtlasInvalidatedWhileHidden?: () => void
 }
 
@@ -52,14 +51,8 @@ export function resetAllTerminalWebglAtlases(): void {
 
 /**
  * Reasons where the GPU context itself died, not just a surface being hidden.
- *
- * Why they cannot skip hidden managers: the visibility filter assumes a hidden
- * pane's texture survives until it is revealed, which holds for tab switches.
- * A system resume destroys every context at once, so a skipped manager keeps a
- * glyph renderer pointing at a generation its rebuilt atlas no longer has —
- * captured in the field as clearModelGeneration=undefined against
- * glyphLastSeenClearModelGeneration=17, painting a blank canvas with a full
- * vertex buffer (#7951).
+ * Skipping hidden managers assumes their texture survives until reveal, which
+ * a context loss breaks — so these rebuild every manager (#7951).
  */
 const CONTEXT_LOSS_REASONS = new Set(['system-resume', 'render-desync'])
 
@@ -76,12 +69,9 @@ export function resetAndRefreshAllTerminalWebglAtlases(reason?: string): void {
       recoveryManagers.push(manager)
     }
   }
-  // Why: the atlas is module-global across same-font terminals, so this wipe
-  // invalidates the glyph coordinates of the hidden managers too — but skipping
-  // their repaint is deliberate (they cannot be measured while hidden). Mark
-  // them instead so their reveal repaints from the rebuilt atlas; without this
-  // they paint garbled glyphs with stale coordinates. Field logs showed 96% of
-  // resets are partial, so this is the common case, not an edge case.
+  // Why: the atlas is module-global, so this wipe invalidates hidden managers'
+  // glyph coordinates too. They cannot be measured while hidden, so defer the
+  // repaint to their reveal rather than skipping it outright.
   for (const manager of skippedManagers) {
     manager.markAtlasInvalidatedWhileHidden?.()
   }

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -73,7 +73,6 @@ export class PaneManager {
   private destroyed = false
   private renderingSuspended: boolean
   private atlasRecoveryVisible: boolean
-  /** Set when a shared-atlas wipe skipped this manager for being hidden. */
   private atlasInvalidatedWhileHidden = false
   private identities = new PaneIdentityRegistry()
   private pendingPaneReparentFrameIds = new Set<number>()
@@ -373,10 +372,8 @@ export class PaneManager {
   setAtlasRecoveryVisible(visible: boolean): void {
     const wasHidden = !this.atlasRecoveryVisible
     this.atlasRecoveryVisible = visible
-    // Why: a shared-atlas wipe that ran while this manager was hidden left its
-    // panes holding stale glyph coordinates. Becoming visible is the first
-    // point they can be measured and repainted, so consume the debt here —
-    // otherwise the reveal paints garbled glyphs until some later refresh.
+    // Why: reveal is the first point a skipped manager can be measured, so the
+    // deferred atlas repaint is consumed here.
     if (visible && wasHidden && this.atlasInvalidatedWhileHidden) {
       this.atlasInvalidatedWhileHidden = false
       this.refreshAllPanes()

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -73,6 +73,8 @@ export class PaneManager {
   private destroyed = false
   private renderingSuspended: boolean
   private atlasRecoveryVisible: boolean
+  /** Set when a shared-atlas wipe skipped this manager for being hidden. */
+  private atlasInvalidatedWhileHidden = false
   private identities = new PaneIdentityRegistry()
   private pendingPaneReparentFrameIds = new Set<number>()
 
@@ -369,7 +371,20 @@ export class PaneManager {
   }
 
   setAtlasRecoveryVisible(visible: boolean): void {
+    const wasHidden = !this.atlasRecoveryVisible
     this.atlasRecoveryVisible = visible
+    // Why: a shared-atlas wipe that ran while this manager was hidden left its
+    // panes holding stale glyph coordinates. Becoming visible is the first
+    // point they can be measured and repainted, so consume the debt here —
+    // otherwise the reveal paints garbled glyphs until some later refresh.
+    if (visible && wasHidden && this.atlasInvalidatedWhileHidden) {
+      this.atlasInvalidatedWhileHidden = false
+      this.refreshAllPanes()
+    }
+  }
+
+  markAtlasInvalidatedWhileHidden(): void {
+    this.atlasInvalidatedWhileHidden = true
   }
 
   isVisibleForAtlasRecovery(): boolean {


### PR DESCRIPTION
## The bug: a blank terminal over an intact buffer

Wake the machine from sleep, switch to a workspace that was in the background, and its terminal panes can paint nothing at all. The xterm buffer is fine — scrollback is intact, the process is alive — but the canvas is empty.

How long it lasts varies. Sometimes the pane paints wrong for a moment and then sorts itself out unprompted; other times it stays wrong until something touches it, long enough to photograph at leisure. Either way it comes back in pieces rather than all at once: scrolling, typing at the prompt, or new output arriving each repair only the rows they touch, so the pane returns a band at a time while untouched regions stay wrong. A window resize is the one action that clears it in a single step, because that forces a full `refresh(0, rows - 1)` instead of xterm's usual dirty-row diff.

That pattern is itself a clue. Damage that lives in per-cell coordinates is repaired exactly as far as the redraw reaches, and is undone by whatever incidental output happens to cover those rows. A lost canvas or a dead renderer would not behave this way. It also means the mild end of this is easy to dismiss as a flicker and never report, so how often it happens is not something the issue tracker can tell you.

Two shapes of the same failure, both captured after a resume:

- cells that should hold text render blank
- cells that should be empty render leftover glyphs from other rows (`der;` sitting in a table's outer margin, where nothing was ever drawn)

<img width="1348" height="1424" alt="blank-region-after-wake" src="https://github.com/user-attachments/assets/d2c65492-c535-4ba3-9d7e-7181a5b5246b" />

<img width="1392" height="1468" alt="stale-glyphs-after-wake" src="https://github.com/user-attachments/assets/852938c1-3650-4c74-9316-6d286bbcda83" />


## Why it happens

`@xterm/addon-webgl` keeps a **module-global** glyph atlas. Every terminal with the same font config shares one texture, and each cell's vertex data stores *where in that texture* its glyph lives.

`resetAndRefreshAllTerminalWebglAtlases` deliberately rebuilds only the visible managers:

    const recoveryManagers = Array.from(liveManagers).filter(
      (manager) => manager.isVisibleForAtlasRecovery?.() !== false
    )

That filter is right for the case it was written for. A hidden pane cannot be measured, and re-rasterizing every workspace on each tab switch would be a constant cost for a rare problem. It rests on an assumption: **a hidden pane's GPU texture is still there when it is revealed.**

True for a tab switch. False for a system resume, which destroys every context at once.

So on wake the one visible manager rebuilds, and each hidden manager is left holding a glyph renderer pointed at a generation its rebuilt atlas no longer has. Revealing that workspace draws a full vertex buffer against coordinates that no longer mean anything.

Renderer state sampled at the moment of a blank frame:

    atlasClearModelGeneration         = undefined   // atlas object was recreated
    glyphLastSeenClearModelGeneration = 17          // glyph renderer still on the old generation
    atlasPageVersions                 = [25036]
    vertexCount                       = 61028       // geometry was there; it drew nothing

1949 of 1998 text cells blank, while the pane's buffer held 55 non-empty lines.

The comment above the wake path already names this class of race (xterm.js #4480). What it does not cover is the panes that never got the reset at all.

## Why it is not as rare as it looks

Nine days of local `webgl-atlas-reset` breadcrumbs (2026-08-03 → 08-12):

| | count |
|---|---|
| atlas resets | 2943 |
| **partial** (`managers < mountedManagers`) | **2835 (96%)** |
| full | 108 |

Partial resets are the norm, not an edge case. They are usually harmless because the GPU context survives, so stale coordinates still index a live texture. `system-resume` is only 22 of those 2943 resets — and it is the one that removes the safety net.

That distribution is also why the symptom reads as intermittent: the debt accumulates constantly and only a resume turns it into pixels.

Panes coming back visually wrong after being hidden is a shape that has been reported from several directions — #9115 (macOS, after the window regains focus; scrolling repaints it), #7240 (Windows, after a tab-switch reveal; Ctrl+L or a resize fixes it), #5345 (Windows/WSL, duplicated and overlapping rows while scrolling). This change does not claim to close any of them: each has its own trigger, and only the `system-resume` path was reproduced and measured here. They are worth naming because a shared module-global atlas gives all of these a plausible common ingredient, and because the recovery in each report is the same one — whatever forces a repaint.

## The change

Split the two situations by reason:

- **Context actually died** (`system-resume`, `render-desync`) — rebuild every live manager, hidden included.
- **Context survived** (tab reveal, visibility resume, terminal output) — unchanged; hidden managers are still skipped, but now record that they were skipped, so their reveal repaints once instead of painting stale coordinates. No debt means no repaint, so workspace switching costs what it did before.

`afterContextLoss` is added to the existing breadcrumb so a future field report shows which branch ran.

On the cost of the new path: `refreshAllPanes` calls `terminal.refresh()` behind a `rows > 0` guard, which marks the render model and does no layout measurement. `resetWebglTextureAtlas` is `pane.webglAddon?.clearTextureAtlas()` and returns early on `webglDisabledAfterContextLoss`, so panes whose WebGL is already disposed do no work.

## Verification

How much of a pane is wrong, and where, is not something to eyeball, so a sentinel sampled the presented canvas against the xterm buffer across a wake. Same procedure both runs: six workspaces open, `pmset sleepnow`, wake, switch to a workspace lower in the sidebar.

| | before | after |
|---|---|---|
| `system-resume` reset scope | `1/6`, 5 left stale | `6/6`, 0 left stale |
| blank-cell detections | 5 | 0 |
| worst pane | 1949/1998 cells blank (97.5%) | — |
| canvas samples taken | (not instrumented) | 950 |

The 950 samples are the point of the second column: the zero is a measured zero, not an unobserved one.

Tests: three added to `pane-manager-registry.test.ts`, four in a new `pane-manager-atlas-invalidation.test.ts`. They pin both directions — one fails if the context-loss path stops rebuilding hidden managers, another fails if ordinary resets start rebuilding them. Reverting only the `!afterContextLoss &&` guard fails exactly one of them and nothing else.

Gates: `pnpm lint`, `pnpm typecheck` and `pnpm build` clean. `pnpm test` is 49854 passing with one failure in `src/shared/posix-command-path-lookup.test.ts` ("resolves without mutating alias and function masks in zsh"), which execs the developer's own zsh and fails identically with these commits stashed. CI runs that spec in the `shell_contracts` job against a freshly installed zsh.

## Platform notes

The changed code is renderer-side and platform-neutral: no shell invocation, no path handling, no keyboard or menu accelerators, no IPC surface change. The trigger differs by OS (macOS `system-resume` via `powerMonitor`), but the reset scoping being fixed is shared.

The same symptom has been observed on Windows, whose GPU path is ANGLE → D3D11. Whether that shares this cause is not established, so it is being looked at separately rather than folded in here.

## Not addressed

- The Windows occurrence above.
- The wider xterm.js #4480 race the existing comment describes, where same-config panes re-rasterize at once and one renderer consumes the page-merge clear-model flag. This change makes sure every pane *gets* a rebuild after a context loss; it does not alter how xterm arbitrates that flag between them.