### PR TITLE
fix(settings): show relay grace period in two units

### DIFF
--- a/src/renderer/src/components/settings/SshHostAdvancedFields.tsx
+++ b/src/renderer/src/components/settings/SshHostAdvancedFields.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
 import { SettingsSwitch } from './SettingsFormControls'
+import { formatSshRelayGraceDuration } from './ssh-relay-grace-duration'
 import type { EditingTarget } from './ssh-target-draft'
 import { translate } from '@/i18n/i18n'
 
@@ -29,6 +30,11 @@ export function SshHostAdvancedFields({
   disabled: boolean
   onFormChange: (updater: (prev: EditingTarget) => EditingTarget) => void
 }): React.JSX.Element {
+  // Why: the field takes seconds, so a milliseconds-shaped entry stays inside the
+  // 60..604800 bounds and reads as an ordinary number until it is spelled out.
+  const graceDuration = form.relayKeepAliveUntilReset
+    ? null
+    : formatSshRelayGraceDuration(Number(form.relayGracePeriodSeconds.trim() || Number.NaN))
   return (
     <Collapsible open={open} onOpenChange={onOpenChange} className="col-span-2 sm:col-span-2">
       <CollapsibleTrigger asChild>
@@ -167,6 +173,7 @@ export function SshHostAdvancedFields({
               max={MAX_SSH_RELAY_GRACE_PERIOD_SECONDS}
             />
             <p className="text-[11px] text-muted-foreground">
+              {graceDuration ? `≈ ${graceDuration} · ` : ''}
               {translate(
                 'auto.components.settings.SshTargetForm.1b19b00e93',
                 'Bounded timeouts must be between 60 seconds and 7 days.'

--- a/src/renderer/src/components/settings/SshTargetCard.tsx
+++ b/src/renderer/src/components/settings/SshTargetCard.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { isSshTargetConnecting, type SshTargetBusyAction } from './ssh-target-action-state'
+import { formatSshRelayGraceDuration } from './ssh-relay-grace-duration'
 import { translate } from '@/i18n/i18n'
 
 // ── Shared status helpers ────────────────────────────────────────────
@@ -52,19 +53,6 @@ export function statusColor(status: SshConnectionStatus): string {
   }
 }
 
-function formatGraceDuration(seconds: number): string {
-  if (seconds % 86_400 === 0) {
-    return `${seconds / 86_400}d`
-  }
-  if (seconds % 3_600 === 0) {
-    return `${seconds / 3_600}h`
-  }
-  if (seconds % 60 === 0) {
-    return `${seconds / 60}m`
-  }
-  return `${seconds}s`
-}
-
 function formatTerminalPersistence(target: SshTarget): string {
   const graceSeconds = target.relayGracePeriodSeconds ?? DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS
   if (graceSeconds === 0) {
@@ -73,7 +61,7 @@ function formatTerminalPersistence(target: SshTarget): string {
   return translate(
     'auto.components.settings.SshTargetCard.a883f5a00f',
     'terminal timeout: {{value0}}',
-    { value0: formatGraceDuration(graceSeconds) }
+    { value0: formatSshRelayGraceDuration(graceSeconds) ?? `${graceSeconds}s` }
   )
 }
 

--- a/src/renderer/src/components/settings/ssh-relay-grace-duration.test.ts
+++ b/src/renderer/src/components/settings/ssh-relay-grace-duration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatSshRelayGraceDuration } from './ssh-relay-grace-duration'
+
+describe('formatSshRelayGraceDuration', () => {
+  it('keeps a single unit when the value divides evenly', () => {
+    expect(formatSshRelayGraceDuration(86_400)).toBe('1d')
+    expect(formatSshRelayGraceDuration(604_800)).toBe('7d')
+    expect(formatSshRelayGraceDuration(10_800)).toBe('3h')
+    expect(formatSshRelayGraceDuration(60)).toBe('1m')
+  })
+
+  it('adds the next unit down instead of falling back to a huge count', () => {
+    // 600000s is the shape of a milliseconds-for-seconds typo: it passes the
+    // 60..604800 bounds, and the single-unit format rendered it as "10000m".
+    expect(formatSshRelayGraceDuration(600_000)).toBe('6d 22h')
+    expect(formatSshRelayGraceDuration(5_400)).toBe('1h 30m')
+    expect(formatSshRelayGraceDuration(90)).toBe('1m 30s')
+  })
+
+  it('never reports a larger unit than the value holds', () => {
+    expect(formatSshRelayGraceDuration(59)).toBe('59s')
+    expect(formatSshRelayGraceDuration(0)).toBe('0s')
+  })
+
+  it('rejects values that are not a usable second count', () => {
+    expect(formatSshRelayGraceDuration(-1)).toBe(null)
+    expect(formatSshRelayGraceDuration(Number.NaN)).toBe(null)
+    expect(formatSshRelayGraceDuration(1.5)).toBe(null)
+  })
+})

--- a/src/renderer/src/components/settings/ssh-relay-grace-duration.ts
+++ b/src/renderer/src/components/settings/ssh-relay-grace-duration.ts
@@ -1,0 +1,32 @@
+const UNITS = [
+  ['d', 86_400],
+  ['h', 3_600],
+  ['m', 60],
+  ['s', 1]
+] as const
+
+/**
+ * Renders an SSH relay grace period as at most two units, largest first.
+ *
+ * Why two units: the single-unit form only held when the value divided evenly, so an
+ * off-by-1000 entry like 600000s rendered as "10000m" and read as a plausible number
+ * rather than the week it actually is.
+ */
+export function formatSshRelayGraceDuration(seconds: number): string | null {
+  if (!Number.isInteger(seconds) || seconds < 0) {
+    return null
+  }
+  const headIndex = UNITS.findIndex(([, size]) => seconds >= size)
+  if (headIndex === -1) {
+    return '0s'
+  }
+  const [headSuffix, headSize] = UNITS[headIndex]
+  const head = Math.floor(seconds / headSize)
+  const tailUnit = UNITS[headIndex + 1]
+  if (!tailUnit) {
+    return `${head}${headSuffix}`
+  }
+  const [tailSuffix, tailSize] = tailUnit
+  const tail = Math.floor((seconds - head * headSize) / tailSize)
+  return tail === 0 ? `${head}${headSuffix}` : `${head}${headSuffix} ${tail}${tailSuffix}`
+}


### PR DESCRIPTION
## Problem

The SSH relay grace period is entered in **seconds**. A milliseconds-shaped entry stays inside the `MIN_SSH_RELAY_GRACE_PERIOD_SECONDS`..`MAX_SSH_RELAY_GRACE_PERIOD_SECONDS` bounds, so nothing rejects it — and `formatGraceDuration` only emitted a single unit when the count divided evenly:

| seconds | before | after |
|---|---|---|
| `600000` | `10000m` | `6d 22h` |
| `5400` | `90m` | `1h 30m` |
| `86400` | `1d` | `1d` |
| `10800` | `3h` | `3h` |

`10000m` reads as an ordinary number. The host card was the only place the value was ever spelled out, so a `600000` entry could sit unnoticed — in the case that prompted this, a relay held its whole PTY fleet for ~2 days after the client disconnected, and the setting looked unremarkable the entire time.

## Change

- Extract the formatter to `ssh-relay-grace-duration.ts`, next to the other SSH settings modules, and compose the two largest units.
- Reuse it in `SshTargetCard` (behavior unchanged for evenly-dividing values).
- Echo the same label under the add-host input, so the value is legible while it is being typed.

No new localization keys — the formatter output is already interpolated into the existing `terminal timeout: {{value0}}` entry, and the form reuses its existing helper line.

## Test plan

- [x] `npx vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-relay-grace-duration.test.ts` — 4 new cases; written first and confirmed red before the module existed
- [x] `npx vitest run --config config/vitest.config.ts src/renderer/src/components/settings/` — 150 files / 1010 tests pass
- [x] `pnpm run typecheck:web`
- [x] `pnpm run lint` (plus `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:max-lines-ratchet`, `verify:localization-catalog`, `verify:localization-extraction` individually — all exit 0)

## Compatibility

Renderer-only display change. No wire format, no RPC params, no stored value semantics — `relayGracePeriodSeconds` is read and rendered, never rewritten. No paths, accelerators, or `metaKey` usage; nothing provider-specific. The relay's own grace behavior is untouched: an explicitly configured window is still honored verbatim.