### PR TITLE
fix(rate-limits): resolve Grok auth from configured WSL runtime

### DIFF
--- a/src/main/grok-accounts/status.test.ts
+++ b/src/main/grok-accounts/status.test.ts
@@ -1,22 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { getGrokAccountStatus } from './status'
-import { isGrokAccessTokenFresh, readGrokAuthSession } from '../rate-limits/grok-auth'
+import { isGrokAccessTokenFresh } from '../rate-limits/grok-auth'
 
 vi.mock('../rate-limits/grok-auth', () => ({
-  isGrokAccessTokenFresh: vi.fn(),
-  readGrokAuthSession: vi.fn()
+  isGrokAccessTokenFresh: vi.fn()
 }))
 
 describe('getGrokAccountStatus', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    vi.mocked(isGrokAccessTokenFresh).mockReturnValue(true)
-  })
-
   it('reports unsigned status when the Grok auth file is missing', () => {
-    vi.mocked(readGrokAuthSession).mockReturnValue({ status: 'missing' })
-
-    expect(getGrokAccountStatus()).toEqual({
+    expect(getGrokAccountStatus({ status: 'missing' })).toEqual({
       signedIn: false,
       email: null,
       teamId: null,
@@ -26,12 +18,12 @@ describe('getGrokAccountStatus', () => {
   })
 
   it('reports auth read errors without exposing token fields', () => {
-    vi.mocked(readGrokAuthSession).mockReturnValue({
-      status: 'error',
-      error: 'Grok auth file is invalid'
-    })
-
-    expect(getGrokAccountStatus()).toEqual({
+    expect(
+      getGrokAccountStatus({
+        status: 'error',
+        error: 'Grok auth file is invalid'
+      })
+    ).toEqual({
       signedIn: false,
       email: null,
       teamId: null,
@@ -41,7 +33,8 @@ describe('getGrokAccountStatus', () => {
   })
 
   it('returns non-secret signed-in metadata and freshness', () => {
-    vi.mocked(readGrokAuthSession).mockReturnValue({
+    vi.mocked(isGrokAccessTokenFresh).mockReturnValue(false)
+    const status = getGrokAccountStatus({
       status: 'ok',
       session: {
         accessToken: 'secret-token',
@@ -52,9 +45,6 @@ describe('getGrokAccountStatus', () => {
         oidcClientId: 'client-1'
       }
     })
-    vi.mocked(isGrokAccessTokenFresh).mockReturnValue(false)
-
-    const status = getGrokAccountStatus()
 
     expect(status).toEqual({
       signedIn: true,

--- a/src/main/grok-accounts/status.ts
+++ b/src/main/grok-accounts/status.ts
@@ -1,8 +1,7 @@
 import type { GrokAccountStatus } from '../../shared/rate-limit-types'
-import { isGrokAccessTokenFresh, readGrokAuthSession } from '../rate-limits/grok-auth'
+import { isGrokAccessTokenFresh, type GrokAuthReadResult } from '../rate-limits/grok-auth'
 
-export function getGrokAccountStatus(): GrokAccountStatus {
-  const readResult = readGrokAuthSession()
+export function getGrokAccountStatus(readResult: GrokAuthReadResult): GrokAccountStatus {
   if (readResult.status === 'missing') {
     return {
       signedIn: false,

--- a/src/main/grok-accounts/status.ts
+++ b/src/main/grok-accounts/status.ts
@@ -1,6 +1,7 @@
 import type { GrokAccountStatus } from '../../shared/rate-limit-types'
 import { isGrokAccessTokenFresh, type GrokAuthReadResult } from '../rate-limits/grok-auth'
 
+/** Convert an auth-file read into renderer-safe Grok account metadata. */
 export function getGrokAccountStatus(readResult: GrokAuthReadResult): GrokAccountStatus {
   if (readResult.status === 'missing') {
     return {

--- a/src/main/grok/grok-runtime-home.test.ts
+++ b/src/main/grok/grok-runtime-home.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wslMocks = vi.hoisted(() => ({
+  listWslDistrosAsync: vi.fn<() => Promise<string[]>>(),
+  getWslHomeAsync: vi.fn<(distro: string) => Promise<string | null>>()
+}))
+
+vi.mock('../wsl', () => wslMocks)
+vi.mock('node:os', () => ({ homedir: () => 'C:\\Users\\neil' }))
+
+import { getGrokRuntimeTarget, getHostGrokHome, resolveGrokHome } from './grok-runtime-home'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+
+function settings(overrides: Partial<GlobalSettings>): GlobalSettings {
+  return overrides as GlobalSettings
+}
+
+describe('getGrokRuntimeTarget', () => {
+  it('follows the configured WSL runtime on Windows', () => {
+    expect(
+      getGrokRuntimeTarget(
+        settings({ localAccountRuntime: 'wsl', localAccountWslDistro: ' Ubuntu ' }),
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+  })
+
+  it('pins to host off Windows even when the setting says wsl', () => {
+    expect(
+      getGrokRuntimeTarget(
+        settings({ localAccountRuntime: 'wsl', localAccountWslDistro: 'Ubuntu' }),
+        'darwin'
+      )
+    ).toEqual({ runtime: 'host', wslDistro: null })
+  })
+
+  it('follows the Windows runtime default when the policy is auto', () => {
+    expect(
+      getGrokRuntimeTarget(
+        settings({
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Debian' }
+        }),
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Debian' })
+  })
+})
+
+describe('resolveGrokHome', () => {
+  const originalGrokHome = process.env.GROK_HOME
+
+  beforeEach(() => {
+    delete process.env.GROK_HOME
+    wslMocks.listWslDistrosAsync.mockReset().mockResolvedValue(['Ubuntu'])
+    wslMocks.getWslHomeAsync.mockReset().mockResolvedValue('\\\\wsl.localhost\\Ubuntu\\home\\neil')
+  })
+
+  afterEach(() => {
+    if (originalGrokHome === undefined) {
+      delete process.env.GROK_HOME
+    } else {
+      process.env.GROK_HOME = originalGrokHome
+    }
+  })
+
+  it('resolves the host Grok home for a host target', async () => {
+    expect(await resolveGrokHome({ runtime: 'host', wslDistro: null }, 'win32')).toEqual({
+      runtime: 'host',
+      wslDistro: null,
+      path: getHostGrokHome()
+    })
+    expect(wslMocks.getWslHomeAsync).not.toHaveBeenCalled()
+  })
+
+  it('honors host GROK_HOME for a host target', async () => {
+    process.env.GROK_HOME = 'D:\\grok-home'
+
+    expect((await resolveGrokHome({ runtime: 'host', wslDistro: null }, 'win32')).path).toBe(
+      'D:\\grok-home'
+    )
+  })
+
+  it('resolves the selected WSL distro home', async () => {
+    expect(await resolveGrokHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.grok'
+    })
+  })
+
+  it('ignores the host GROK_HOME when reading a WSL home', async () => {
+    process.env.GROK_HOME = 'D:\\grok-home'
+
+    expect((await resolveGrokHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).path).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.grok'
+    )
+  })
+
+  it('falls back to the default distro when none is configured', async () => {
+    expect(await resolveGrokHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toMatchObject({
+      wslDistro: 'Ubuntu'
+    })
+    expect(wslMocks.getWslHomeAsync).toHaveBeenCalledWith('Ubuntu')
+  })
+
+  it('reports no path when the distro home cannot be probed', async () => {
+    wslMocks.getWslHomeAsync.mockResolvedValue(null)
+
+    expect(await resolveGrokHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      path: null
+    })
+  })
+
+  it('reports no path when no WSL distro exists', async () => {
+    wslMocks.listWslDistrosAsync.mockResolvedValue([])
+
+    expect(await resolveGrokHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toEqual({
+      runtime: 'wsl',
+      wslDistro: null,
+      path: null
+    })
+  })
+
+  it('never probes WSL off Windows', async () => {
+    expect(await resolveGrokHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'linux')).toEqual({
+      runtime: 'host',
+      wslDistro: null,
+      path: getHostGrokHome()
+    })
+    expect(wslMocks.listWslDistrosAsync).not.toHaveBeenCalled()
+    expect(wslMocks.getWslHomeAsync).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/grok/grok-runtime-home.ts
+++ b/src/main/grok/grok-runtime-home.ts
@@ -1,0 +1,56 @@
+import { join, win32 as pathWin32 } from 'node:path'
+import { resolveGrokHomeDir } from '../../shared/grok-session-paths'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  resolveLocalAccountRuntimeTarget,
+  type LocalAccountRuntimeTarget
+} from '../../shared/local-account-runtime'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
+
+export type GrokHomeResolution = LocalAccountRuntimeTarget & {
+  /** null when the WSL distro's home could not be probed. */
+  path: string | null
+}
+
+export type GrokHomeResolver = (target: LocalAccountRuntimeTarget) => Promise<GrokHomeResolution>
+
+/** Match Grok CLI's `GROK_HOME ?? ~/.grok` resolution on the host. */
+export function getHostGrokHome(): string {
+  return resolveGrokHomeDir()
+}
+
+/** Grok follows the local-account runtime policy on Windows. */
+export function getGrokRuntimeTarget(
+  settings: GlobalSettings,
+  platform: NodeJS.Platform = process.platform
+): LocalAccountRuntimeTarget {
+  if (platform !== 'win32') {
+    return { runtime: 'host', wslDistro: null }
+  }
+  return resolveLocalAccountRuntimeTarget(settings, platform)
+}
+
+/** Resolve the Grok home Orca should read, using a UNC path for WSL. */
+export async function resolveGrokHome(
+  target: LocalAccountRuntimeTarget,
+  platform: NodeJS.Platform = process.platform
+): Promise<GrokHomeResolution> {
+  if (target.runtime !== 'wsl' || platform !== 'win32') {
+    return { runtime: 'host', wslDistro: null, path: getHostGrokHome() }
+  }
+  const distro = target.wslDistro?.trim() || (await listWslDistrosAsync())[0] || null
+  if (!distro) {
+    return { runtime: 'wsl', wslDistro: null, path: null }
+  }
+  const home = await getWslHomeAsync(distro)
+  return {
+    runtime: 'wsl',
+    wslDistro: distro,
+    path: home ? joinGrokHome(home) : null
+  }
+}
+
+function joinGrokHome(home: string): string {
+  return parseWslUncPath(home) ? pathWin32.join(home, '.grok') : join(home, '.grok')
+}

--- a/src/main/grok/grok-runtime-home.ts
+++ b/src/main/grok/grok-runtime-home.ts
@@ -51,6 +51,7 @@ export async function resolveGrokHome(
   }
 }
 
+/** Append Grok CLI's data directory without breaking WSL UNC semantics. */
 function joinGrokHome(home: string): string {
   return parseWslUncPath(home) ? pathWin32.join(home, '.grok') : join(home, '.grok')
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -201,6 +201,7 @@ import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
 import { getKimiRuntimeTarget, resolveKimiHome } from './kimi/kimi-runtime-home'
+import { getGrokRuntimeTarget, resolveGrokHome } from './grok/grok-runtime-home'
 import { createAccountRuntimeTargetSettingsSync } from './rate-limits/account-runtime-target-sync'
 import {
   attachMainWindowServices,
@@ -2463,6 +2464,8 @@ void app.whenReady().then(async () => {
   // Why: Kimi's CLI refreshes its OAuth token in whichever runtime it runs in, so the
   // usage fetch must read the WSL-side credentials when that's the configured runtime (#12370).
   rateLimits.setKimiHomeResolver(() => resolveKimiHome(getKimiRuntimeTarget(store!.getSettings())))
+  rateLimits.setGrokFetchTarget(getGrokRuntimeTarget(store.getSettings()))
+  rateLimits.setGrokHomeResolver((target) => resolveGrokHome(target))
   rateLimits.setClaudeFetchTarget(getInitialClaudeRateLimitTarget(store.getSettings()))
   const syncAccountRuntimeTargets = createAccountRuntimeTargetSettingsSync(
     rateLimits,

--- a/src/main/ipc/grok-accounts.ts
+++ b/src/main/ipc/grok-accounts.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
-import { getGrokAccountStatus } from '../grok-accounts/status'
+import type { RateLimitService } from '../rate-limits/service'
 
-export function registerGrokAccountHandlers(): void {
-  ipcMain.handle('grokAccounts:getStatus', () => getGrokAccountStatus())
+export function registerGrokAccountHandlers(rateLimits: RateLimitService): void {
+  ipcMain.handle('grokAccounts:getStatus', () => rateLimits.getGrokAccountStatus())
 }

--- a/src/main/ipc/grok-accounts.ts
+++ b/src/main/ipc/grok-accounts.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import type { RateLimitService } from '../rate-limits/service'
 
+/** Register Grok account status IPC against the runtime-aware rate-limit service. */
 export function registerGrokAccountHandlers(rateLimits: RateLimitService): void {
   ipcMain.handle('grokAccounts:getStatus', () => rateLimits.getGrokAccountStatus())
 }

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -509,7 +509,7 @@ describe('registerCoreHandlers', () => {
     expect(registerPetHandlersMock).toHaveBeenCalled()
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)
-    expect(registerGrokAccountHandlersMock).toHaveBeenCalled()
+    expect(registerGrokAccountHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits, codexAccounts)
     expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)
     expect(registerLinearHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -146,7 +146,7 @@ export function registerCoreHandlers(
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerMiniMaxCredentialsHandlers(rateLimits)
-  registerGrokAccountHandlers()
+  registerGrokAccountHandlers(rateLimits)
   registerRateLimitHandlers(rateLimits, codexAccounts)
   registerGitHubHandlers(store, stats)
   registerGitLabHandlers(store)

--- a/src/main/rate-limits/account-runtime-target-sync.test.ts
+++ b/src/main/rate-limits/account-runtime-target-sync.test.ts
@@ -11,12 +11,13 @@ function createServiceTargets(
   return {
     getState: vi.fn(() => state),
     refreshClaudeForTarget: vi.fn(async () => state),
-    refreshCodexForTarget: vi.fn(async () => state)
+    refreshCodexForTarget: vi.fn(async () => state),
+    refreshGrokForTarget: vi.fn(async () => state)
   }
 }
 
 describe('createAccountRuntimeTargetSettingsSync', () => {
-  it('retargets only Claude and Codex when auto changes to WSL', async () => {
+  it('retargets Claude, Codex, and Grok when auto changes to WSL', async () => {
     const service = createServiceTargets(
       { runtime: 'host', wslDistro: null },
       { runtime: 'host', wslDistro: null }
@@ -42,6 +43,7 @@ describe('createAccountRuntimeTargetSettingsSync', () => {
     expect(service.refreshClaudeForTarget).toHaveBeenCalledWith(expectedTarget)
     expect(service.refreshCodexForTarget).toHaveBeenCalledOnce()
     expect(service.refreshCodexForTarget).toHaveBeenCalledWith(expectedTarget)
+    expect(service.refreshGrokForTarget).toHaveBeenCalledWith(expectedTarget)
   })
 
   it('does no work for unrelated settings updates', async () => {
@@ -57,6 +59,7 @@ describe('createAccountRuntimeTargetSettingsSync', () => {
     expect(service.getState).not.toHaveBeenCalled()
     expect(service.refreshClaudeForTarget).not.toHaveBeenCalled()
     expect(service.refreshCodexForTarget).not.toHaveBeenCalled()
+    expect(service.refreshGrokForTarget).not.toHaveBeenCalled()
   })
 
   it('preserves a manual runtime when the settings-derived policy does not change', async () => {
@@ -82,6 +85,7 @@ describe('createAccountRuntimeTargetSettingsSync', () => {
     expect(service.getState).not.toHaveBeenCalled()
     expect(service.refreshClaudeForTarget).not.toHaveBeenCalled()
     expect(service.refreshCodexForTarget).not.toHaveBeenCalled()
+    expect(service.refreshGrokForTarget).not.toHaveBeenCalled()
   })
 
   it('refreshes only the provider whose current target differs', async () => {
@@ -104,5 +108,9 @@ describe('createAccountRuntimeTargetSettingsSync', () => {
     expect(service.refreshClaudeForTarget).not.toHaveBeenCalled()
     expect(service.refreshCodexForTarget).toHaveBeenCalledOnce()
     expect(service.refreshCodexForTarget).toHaveBeenCalledWith({ runtime: 'host' })
+    expect(service.refreshGrokForTarget).toHaveBeenCalledWith({
+      runtime: 'host',
+      wslDistro: null
+    })
   })
 })

--- a/src/main/rate-limits/account-runtime-target-sync.ts
+++ b/src/main/rate-limits/account-runtime-target-sync.ts
@@ -3,10 +3,11 @@ import type { RateLimitState } from '../../shared/rate-limit-types'
 import type { RateLimitService } from './service'
 import { getInitialClaudeRateLimitTarget } from './claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './codex-rate-limit-target'
+import { getGrokRuntimeTarget } from '../grok/grok-runtime-home'
 
 type AccountRuntimeRateLimitService = Pick<
   RateLimitService,
-  'getState' | 'refreshClaudeForTarget' | 'refreshCodexForTarget'
+  'getState' | 'refreshClaudeForTarget' | 'refreshCodexForTarget' | 'refreshGrokForTarget'
 >
 
 type RuntimeTarget = {
@@ -29,8 +30,9 @@ export function createAccountRuntimeTargetSettingsSync(
     const nextSettingsTargets = getSettingsTargets(settings, platform)
     const claudePolicyChanged = !isSameTarget(settingsTargets.claude, nextSettingsTargets.claude)
     const codexPolicyChanged = !isSameTarget(settingsTargets.codex, nextSettingsTargets.codex)
+    const grokPolicyChanged = !isSameTarget(settingsTargets.grok, nextSettingsTargets.grok)
     settingsTargets = nextSettingsTargets
-    if (!claudePolicyChanged && !codexPolicyChanged) {
+    if (!claudePolicyChanged && !codexPolicyChanged && !grokPolicyChanged) {
       return
     }
 
@@ -42,6 +44,9 @@ export function createAccountRuntimeTargetSettingsSync(
     if (codexPolicyChanged && !isSameTarget(current.codexTarget, nextSettingsTargets.codex)) {
       refreshes.push(rateLimits.refreshCodexForTarget(nextSettingsTargets.codex))
     }
+    if (grokPolicyChanged) {
+      refreshes.push(rateLimits.refreshGrokForTarget(nextSettingsTargets.grok))
+    }
 
     await Promise.all(refreshes)
   }
@@ -50,7 +55,8 @@ export function createAccountRuntimeTargetSettingsSync(
 function getSettingsTargets(settings: GlobalSettings, platform: NodeJS.Platform) {
   return {
     claude: getInitialClaudeRateLimitTarget(settings, platform),
-    codex: getInitialCodexRateLimitTarget(settings, platform)
+    codex: getInitialCodexRateLimitTarget(settings, platform),
+    grok: getGrokRuntimeTarget(settings, platform)
   }
 }
 

--- a/src/main/rate-limits/account-runtime-target-sync.ts
+++ b/src/main/rate-limits/account-runtime-target-sync.ts
@@ -15,6 +15,7 @@ type RuntimeTarget = {
   wslDistro?: string | null
 }
 
+/** Build a settings listener that refreshes providers when their local runtime changes. */
 export function createAccountRuntimeTargetSettingsSync(
   rateLimits: AccountRuntimeRateLimitService,
   initialSettings: GlobalSettings,
@@ -52,6 +53,7 @@ export function createAccountRuntimeTargetSettingsSync(
   }
 }
 
+/** Resolve effective local-account targets for every runtime-aware provider. */
 function getSettingsTargets(settings: GlobalSettings, platform: NodeJS.Platform) {
   return {
     claude: getInitialClaudeRateLimitTarget(settings, platform),
@@ -60,6 +62,7 @@ function getSettingsTargets(settings: GlobalSettings, platform: NodeJS.Platform)
   }
 }
 
+/** Detect settings patches that can change an effective local-account target. */
 function containsAccountRuntimeTargetUpdate(updates: Partial<GlobalSettings>): boolean {
   return (
     'localAccountRuntime' in updates ||
@@ -68,6 +71,7 @@ function containsAccountRuntimeTargetUpdate(updates: Partial<GlobalSettings>): b
   )
 }
 
+/** Compare normalized host or WSL target identity. */
 function isSameTarget(current: RuntimeTarget, next: RuntimeTarget): boolean {
   return (
     (current.runtime ?? 'host') === (next.runtime ?? 'host') &&

--- a/src/main/rate-limits/grok-auth.test.ts
+++ b/src/main/rate-limits/grok-auth.test.ts
@@ -1,46 +1,56 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMocks = vi.hoisted(() => ({ readFile: vi.fn() }))
+
+vi.mock('node:fs/promises', () => fsMocks)
+
+import { readGrokAuthSession } from './grok-auth'
 
 describe('readGrokAuthSession', () => {
+  beforeEach(() => {
+    fsMocks.readFile.mockReset()
+  })
+
   afterEach(() => {
-    vi.resetModules()
-    vi.doUnmock('node:fs')
+    vi.restoreAllMocks()
   })
 
   it('redacts filesystem paths from auth read failures', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() => {
-        throw new Error(
-          'EACCES: permission denied, open /Users/brennanbenson/private/.grok/auth.json'
-        )
-      })
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+    fsMocks.readFile.mockRejectedValueOnce(
+      Object.assign(
+        new Error('EACCES: permission denied, open /Users/brennanbenson/private/.grok/auth.json'),
+        { code: 'EACCES' }
+      )
+    )
 
-    expect(readGrokAuthSession()).toEqual({
+    expect(await readGrokAuthSession({ home: '/Users/brennanbenson/private/.grok' })).toEqual({
       status: 'error',
       error: 'Unable to read Grok auth file'
     })
   })
 
-  it('treats a token-less auth file as signed out, not an error', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() => JSON.stringify({ 'https://auth.x.ai::client': { user_id: 'u1' } }))
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('reports a missing auth file as signed out', async () => {
+    fsMocks.readFile.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }))
 
-    expect(readGrokAuthSession()).toEqual({ status: 'missing' })
+    expect(await readGrokAuthSession({ home: '/tmp/missing-grok-home' })).toEqual({
+      status: 'missing'
+    })
+  })
+
+  it('treats a token-less auth file as signed out, not an error', async () => {
+    fsMocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({ 'https://auth.x.ai::client': { user_id: 'u1' } })
+    )
+
+    expect(await readGrokAuthSession({ home: '/tmp/tokenless-grok-home' })).toEqual({
+      status: 'missing'
+    })
   })
 
   it('reports malformed auth JSON without parser details', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() => '{')
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+    fsMocks.readFile.mockResolvedValueOnce('{')
 
-    expect(readGrokAuthSession()).toEqual({
+    expect(await readGrokAuthSession({ home: '/tmp/malformed-grok-home' })).toEqual({
       status: 'error',
       error: 'Grok auth file is invalid'
     })
@@ -49,30 +59,28 @@ describe('readGrokAuthSession', () => {
   it.each(['https://auth.x.ai', 'https://auth.x.ai::client'])(
     'prefers the %s issuer entry over an earlier alternate issuer',
     async (preferredIssuer) => {
-      vi.doMock('node:fs', () => ({
-        existsSync: vi.fn(() => true),
-        readFileSync: vi.fn(() =>
-          JSON.stringify({
-            'https://stale.example.com::client': {
-              key: 'stale-token',
-              user_id: 'stale-user',
-              email: 'stale@example.com',
-              expires_at: '2099-01-01T00:00:00.000Z'
-            },
-            [preferredIssuer]: {
-              key: 'live-token',
-              user_id: 'live-user',
-              email: 'live@example.com',
-              team_id: 'team-1',
-              expires_at: '2099-06-01T00:00:00.000Z',
-              oidc_client_id: 'client-1'
-            }
-          })
-        )
-      }))
-      const { readGrokAuthSession } = await import('./grok-auth')
+      fsMocks.readFile.mockResolvedValueOnce(
+        JSON.stringify({
+          'https://stale.example.com::client': {
+            key: 'stale-token',
+            user_id: 'stale-user',
+            email: 'stale@example.com',
+            expires_at: '2099-01-01T00:00:00.000Z'
+          },
+          [preferredIssuer]: {
+            key: 'live-token',
+            user_id: 'live-user',
+            email: 'live@example.com',
+            team_id: 'team-1',
+            expires_at: '2099-06-01T00:00:00.000Z',
+            oidc_client_id: 'client-1'
+          }
+        })
+      )
 
-      expect(readGrokAuthSession()).toEqual({
+      expect(
+        await readGrokAuthSession({ home: `/tmp/preferred-${preferredIssuer.length}` })
+      ).toEqual({
         status: 'ok',
         session: {
           accessToken: 'live-token',
@@ -87,22 +95,18 @@ describe('readGrokAuthSession', () => {
   )
 
   it('falls back to the first tokenized entry when no auth.x.ai key exists', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() =>
-        JSON.stringify({
-          'https://alternate.example.com::client': {
-            key: 'alt-token',
-            user_id: 'alt-user',
-            email: 'alt@example.com',
-            expires_at: '2099-01-01T00:00:00.000Z'
-          }
-        })
-      )
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+    fsMocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        'https://alternate.example.com::client': {
+          key: 'alt-token',
+          user_id: 'alt-user',
+          email: 'alt@example.com',
+          expires_at: '2099-01-01T00:00:00.000Z'
+        }
+      })
+    )
 
-    expect(readGrokAuthSession()).toEqual({
+    expect(await readGrokAuthSession({ home: '/tmp/alternate-grok-home' })).toEqual({
       status: 'ok',
       session: {
         accessToken: 'alt-token',
@@ -116,41 +120,66 @@ describe('readGrokAuthSession', () => {
   })
 
   it('skips an expired auth.x.ai client entry when a fresh one follows it', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() =>
-        JSON.stringify({
-          'https://auth.x.ai::old-client': {
-            key: 'expired-token',
-            expires_at: '2020-01-01T00:00:00.000Z'
-          },
-          'https://auth.x.ai::current-client': {
-            key: 'fresh-token',
-            expires_at: '2099-01-01T00:00:00.000Z'
-          }
-        })
-      )
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+    fsMocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        'https://auth.x.ai::old-client': {
+          key: 'expired-token',
+          expires_at: '2020-01-01T00:00:00.000Z'
+        },
+        'https://auth.x.ai::current-client': {
+          key: 'fresh-token',
+          expires_at: '2099-01-01T00:00:00.000Z'
+        }
+      })
+    )
 
-    expect(readGrokAuthSession()).toMatchObject({
+    expect(await readGrokAuthSession({ home: '/tmp/fresh-grok-home' })).toMatchObject({
       status: 'ok',
       session: { accessToken: 'fresh-token' }
     })
   })
 
   it('does not resurrect an alternate issuer when an auth.x.ai entry is tokenless', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() =>
-        JSON.stringify({
-          'https://alternate.example.com::client': { key: 'stale-token' },
-          'https://auth.x.ai::client': { user_id: 'signed-out-user' }
-        })
-      )
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+    fsMocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        'https://alternate.example.com::client': { key: 'stale-token' },
+        'https://auth.x.ai::client': { user_id: 'signed-out-user' }
+      })
+    )
 
-    expect(readGrokAuthSession()).toEqual({ status: 'missing' })
+    expect(await readGrokAuthSession({ home: '/tmp/signed-out-grok-home' })).toEqual({
+      status: 'missing'
+    })
+  })
+
+  it('reads auth.json from a resolved WSL UNC home', async () => {
+    fsMocks.readFile.mockResolvedValueOnce('{}')
+
+    await readGrokAuthSession({ home: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.grok' })
+
+    expect(fsMocks.readFile).toHaveBeenCalledWith(
+      '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.grok\\auth.json',
+      'utf-8'
+    )
+  })
+
+  it('fails closed when the WSL home cannot be resolved', async () => {
+    expect(await readGrokAuthSession({ home: null })).toEqual({
+      status: 'error',
+      error: 'Unable to resolve Grok auth home'
+    })
+    expect(fsMocks.readFile).not.toHaveBeenCalled()
+  })
+
+  it('bounds a stalled auth read', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort(new DOMException('The operation timed out.', 'TimeoutError'))
+    )
+
+    expect(await readGrokAuthSession({ home: '/tmp/stalled-grok-home', timeoutMs: 1 })).toEqual({
+      status: 'error',
+      error: 'Unable to read Grok auth file'
+    })
+    expect(fsMocks.readFile).not.toHaveBeenCalled()
   })
 })

--- a/src/main/rate-limits/grok-auth.ts
+++ b/src/main/rate-limits/grok-auth.ts
@@ -7,11 +7,12 @@ import {
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
 
-// Why: when GROK_HOME is set, auth.json must be the same path Grok CLI uses.
+/** Resolve the Grok home exactly as Grok CLI does, including `GROK_HOME`. */
 export function getGrokHome(): string {
   return resolveGrokHomeDir()
 }
 
+/** Locate `auth.json` under an explicit host or WSL Grok home. */
 export function getGrokAuthPath(home: string = getGrokHome()): string {
   return parseWslUncPath(home) ? pathWin32.join(home, 'auth.json') : join(home, 'auth.json')
 }
@@ -50,6 +51,7 @@ type GrokAuthReadOptions = {
   timeoutMs?: number
 }
 
+/** Sanitize auth read failures before they reach renderer-visible account state. */
 function getGrokAuthReadError(err: unknown): string {
   if (err instanceof SyntaxError) {
     return 'Grok auth file is invalid'
@@ -59,6 +61,7 @@ function getGrokAuthReadError(err: unknown): string {
   return 'Unable to read Grok auth file'
 }
 
+/** Validate and narrow one unknown `auth.json` entry that carries an access token. */
 function parseAuthEntry(value: unknown): TokenizedGrokAuthEntry | null {
   if (typeof value !== 'object' || value === null) {
     return null
@@ -70,6 +73,7 @@ function parseAuthEntry(value: unknown): TokenizedGrokAuthEntry | null {
   return entry as TokenizedGrokAuthEntry
 }
 
+/** Parse an optional ISO expiry without letting malformed metadata reject the file. */
 function parseExpiresAtMs(iso: string | undefined): number | null {
   if (!iso) {
     return null
@@ -81,6 +85,7 @@ function parseExpiresAtMs(iso: string | undefined): number | null {
 // Why: stale alternate issuers can precede the default xAI OAuth session in auth.json.
 const PREFERRED_GROK_AUTH_ISSUER = 'https://auth.x.ai'
 
+/** Convert Grok CLI's auth entry shape into Orca's normalized session contract. */
 function sessionFromAuthEntry(authEntry: TokenizedGrokAuthEntry): GrokAuthSession {
   return {
     accessToken: authEntry.key,
@@ -92,10 +97,12 @@ function sessionFromAuthEntry(authEntry: TokenizedGrokAuthEntry): GrokAuthSessio
   }
 }
 
+/** Identify xAI's preferred issuer while accepting its scoped session keys. */
 function isPreferredGrokAuthKey(key: string): boolean {
   return key === PREFERRED_GROK_AUTH_ISSUER || key.startsWith(`${PREFERRED_GROK_AUTH_ISSUER}::`)
 }
 
+/** Parse Grok CLI auth contents and select the preferred usable session. */
 function parseGrokAuthContents(raw: string): GrokAuthReadResult {
   try {
     const parsed: unknown = JSON.parse(raw)
@@ -133,11 +140,13 @@ function parseGrokAuthContents(raw: string): GrokAuthReadResult {
   }
 }
 
+/** Treat absent files and absent parent directories as a signed-out state. */
 function isMissingPathError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | null)?.code
   return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
+/** Share one bounded filesystem read per auth path until the native read settles. */
 function getGrokAuthRead(path: string): SharedAuthFilesystemOperation<GrokAuthReadResult> {
   const existing = authReadByPath.get(path)
   if (existing) {
@@ -163,6 +172,7 @@ function getGrokAuthRead(path: string): SharedAuthFilesystemOperation<GrokAuthRe
   return read
 }
 
+/** Read Grok authentication from a resolved home with timeout and abort support. */
 export async function readGrokAuthSession(
   options: GrokAuthReadOptions = {}
 ): Promise<GrokAuthReadResult> {
@@ -181,6 +191,7 @@ export async function readGrokAuthSession(
 
 const TOKEN_SKEW_MS = 5 * 60 * 1000
 
+/** Report whether a token remains usable beyond the refresh safety margin. */
 export function isGrokAccessTokenFresh(session: GrokAuthSession): boolean {
   if (session.expiresAtMs === null) {
     // Why: auth.json may lack expiry; a bad token still surfaces as billing HTTP 401.

--- a/src/main/rate-limits/grok-auth.ts
+++ b/src/main/rate-limits/grok-auth.ts
@@ -1,14 +1,19 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { join, win32 as pathWin32 } from 'node:path'
 import { resolveGrokHomeDir } from '../../shared/grok-session-paths'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  createAuthFilesystemOperation,
+  type SharedAuthFilesystemOperation
+} from './auth-filesystem-operation'
 
 // Why: when GROK_HOME is set, auth.json must be the same path Grok CLI uses.
 export function getGrokHome(): string {
   return resolveGrokHomeDir()
 }
 
-export function getGrokAuthPath(): string {
-  return join(getGrokHome(), 'auth.json')
+export function getGrokAuthPath(home: string = getGrokHome()): string {
+  return parseWslUncPath(home) ? pathWin32.join(home, 'auth.json') : join(home, 'auth.json')
 }
 
 export type GrokAuthSession = {
@@ -35,6 +40,15 @@ export type GrokAuthReadResult =
   | { status: 'missing' }
   | { status: 'error'; error: string }
   | { status: 'ok'; session: GrokAuthSession }
+
+const AUTH_READ_TIMEOUT_MS = 5_000
+const authReadByPath = new Map<string, SharedAuthFilesystemOperation<GrokAuthReadResult>>()
+
+type GrokAuthReadOptions = {
+  home?: string | null
+  signal?: AbortSignal
+  timeoutMs?: number
+}
 
 function getGrokAuthReadError(err: unknown): string {
   if (err instanceof SyntaxError) {
@@ -82,13 +96,9 @@ function isPreferredGrokAuthKey(key: string): boolean {
   return key === PREFERRED_GROK_AUTH_ISSUER || key.startsWith(`${PREFERRED_GROK_AUTH_ISSUER}::`)
 }
 
-export function readGrokAuthSession(): GrokAuthReadResult {
-  const path = getGrokAuthPath()
-  if (!existsSync(path)) {
-    return { status: 'missing' }
-  }
+function parseGrokAuthContents(raw: string): GrokAuthReadResult {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+    const parsed: unknown = JSON.parse(raw)
     if (typeof parsed !== 'object' || parsed === null) {
       return { status: 'error', error: 'Grok auth file is invalid' }
     }
@@ -110,23 +120,62 @@ export function readGrokAuthSession(): GrokAuthReadResult {
         expiredPreferred ??= session
         continue
       }
-      if (!fallback) {
-        fallback = session
-      }
+      fallback ??= session
     }
     // Why: alternate issuers are compatibility fallbacks only when no default entry exists.
     const selectedSession = expiredPreferred ?? (preferredKeySeen ? null : fallback)
     if (selectedSession) {
       return { status: 'ok', session: selectedSession }
     }
-    // Why: a token-less file (e.g. after grok logout) means signed out, not a
-    // failure — 'error' would keep a status-bar alert visible for that user.
     return { status: 'missing' }
-  } catch (err) {
-    return {
-      status: 'error',
-      error: getGrokAuthReadError(err)
+  } catch (error) {
+    return { status: 'error', error: getGrokAuthReadError(error) }
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+function getGrokAuthRead(path: string): SharedAuthFilesystemOperation<GrokAuthReadResult> {
+  const existing = authReadByPath.get(path)
+  if (existing) {
+    return existing
+  }
+  // Why: a timed-out UNC read can keep a native thread occupied; share it until settlement.
+  const read = createAuthFilesystemOperation(path, async (): Promise<GrokAuthReadResult> => {
+    try {
+      return parseGrokAuthContents(await readFile(path, 'utf-8'))
+    } catch (error) {
+      return isMissingPathError(error)
+        ? { status: 'missing' }
+        : { status: 'error', error: getGrokAuthReadError(error) }
     }
+  })
+  authReadByPath.set(path, read)
+  const clearRead = (): void => {
+    if (authReadByPath.get(path) === read) {
+      authReadByPath.delete(path)
+    }
+  }
+  void read.result.then(clearRead, clearRead)
+  return read
+}
+
+export async function readGrokAuthSession(
+  options: GrokAuthReadOptions = {}
+): Promise<GrokAuthReadResult> {
+  const home = options.home === undefined ? getGrokHome() : options.home
+  if (!home) {
+    return { status: 'error', error: 'Unable to resolve Grok auth home' }
+  }
+  const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? AUTH_READ_TIMEOUT_MS)
+  const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal
+  try {
+    return await getGrokAuthRead(getGrokAuthPath(home)).wait(signal)
+  } catch (error) {
+    return { status: 'error', error: getGrokAuthReadError(error) }
   }
 }
 

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -10,14 +10,13 @@ vi.mock('electron', () => ({
   net: { fetch: netFetchMock }
 }))
 
-vi.mock('node:fs', () => ({
-  existsSync: () => authState.file !== null,
-  readFileSync: () => {
+vi.mock('node:fs/promises', () => ({
+  readFile: async () => {
     if (authState.readError) {
       throw authState.readError
     }
     if (authState.file === null) {
-      throw new Error('ENOENT')
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     }
     return authState.file
   }
@@ -246,8 +245,7 @@ describe('fetchGrokRateLimits', () => {
     })
 
     const resultPromise = fetchGrokRateLimits({ signal: controller.signal })
-    await Promise.resolve()
-
+    await vi.waitFor(() => expect(requestSignal).toBeDefined())
     expect(requestSignal?.aborted).toBe(false)
     controller.abort()
     expect(requestSignal?.aborted).toBe(true)

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -242,7 +242,8 @@ async function fetchMonthlyUsageFallback(
 export async function fetchGrokRateLimits(
   options: { signal?: AbortSignal; authReadResult?: GrokAuthReadResult } = {}
 ): Promise<ProviderRateLimits> {
-  const readResult = options.authReadResult ?? readGrokAuthSession()
+  const readResult =
+    options.authReadResult ?? (await readGrokAuthSession({ signal: options.signal }))
   if (readResult.status === 'missing') {
     return result('unavailable', 'Not signed in to Grok — run grok login')
   }

--- a/src/main/rate-limits/rate-limit-service-test-harness.ts
+++ b/src/main/rate-limits/rate-limit-service-test-harness.ts
@@ -107,7 +107,7 @@ export function resetRateLimitProviderMocks(): void {
     status: 'unavailable'
   })
   vi.mocked(hasMiniMaxSessionCookie).mockReturnValue(false)
-  vi.mocked(readGrokAuthSession).mockReturnValue({ status: 'missing' })
+  vi.mocked(readGrokAuthSession).mockResolvedValue({ status: 'missing' })
 }
 
 type RateLimitWindow = Parameters<RateLimitService['attach']>[0]

--- a/src/main/rate-limits/service-account-target-selection.test.ts
+++ b/src/main/rate-limits/service-account-target-selection.test.ts
@@ -41,7 +41,8 @@ vi.mock('./grok-fetcher', () => ({
 }))
 
 vi.mock('./grok-auth', () => ({
-  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+  isGrokAccessTokenFresh: vi.fn(() => true),
+  readGrokAuthSession: vi.fn(async () => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({

--- a/src/main/rate-limits/service-inactive-account-previews.test.ts
+++ b/src/main/rate-limits/service-inactive-account-previews.test.ts
@@ -48,7 +48,8 @@ vi.mock('./grok-fetcher', () => ({
 }))
 
 vi.mock('./grok-auth', () => ({
-  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+  isGrokAccessTokenFresh: vi.fn(() => true),
+  readGrokAuthSession: vi.fn(async () => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({

--- a/src/main/rate-limits/service-live-claude-usage.test.ts
+++ b/src/main/rate-limits/service-live-claude-usage.test.ts
@@ -45,7 +45,8 @@ vi.mock('./grok-fetcher', () => ({
 }))
 
 vi.mock('./grok-auth', () => ({
-  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+  isGrokAccessTokenFresh: vi.fn(() => true),
+  readGrokAuthSession: vi.fn(async () => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({

--- a/src/main/rate-limits/service-minimax-usage.test.ts
+++ b/src/main/rate-limits/service-minimax-usage.test.ts
@@ -42,7 +42,8 @@ vi.mock('./grok-fetcher', () => ({
 }))
 
 vi.mock('./grok-auth', () => ({
-  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+  isGrokAccessTokenFresh: vi.fn(() => true),
+  readGrokAuthSession: vi.fn(async () => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -49,7 +49,8 @@ vi.mock('./grok-fetcher', () => ({
 }))
 
 vi.mock('./grok-auth', () => ({
-  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+  isGrokAccessTokenFresh: vi.fn(() => true),
+  readGrokAuthSession: vi.fn(async () => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({
@@ -65,8 +66,8 @@ describe('RateLimitService', () => {
     resetRateLimitProviderMocks()
   })
 
-  it('does not reread Grok auth when callers read state snapshots', () => {
-    vi.mocked(readGrokAuthSession).mockReturnValue({
+  it('does not reread Grok auth when callers read state snapshots', async () => {
+    vi.mocked(readGrokAuthSession).mockResolvedValue({
       status: 'ok',
       session: {
         accessToken: 'token',
@@ -78,6 +79,7 @@ describe('RateLimitService', () => {
       }
     })
     const service = new RateLimitService()
+    await service.refreshGrok()
     vi.mocked(readGrokAuthSession).mockClear()
 
     expect(service.getState().grokAuthConfigured).toBe(true)
@@ -98,15 +100,22 @@ describe('RateLimitService', () => {
         oidcClientId: null
       }
     }
-    vi.mocked(readGrokAuthSession).mockReturnValue(authReadResult)
+    vi.mocked(readGrokAuthSession).mockResolvedValue(authReadResult)
     vi.mocked(fetchGrokRateLimits).mockResolvedValueOnce(okProvider('grok', 42))
     const service = new RateLimitService()
+    const home = '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.grok'
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+    service.setGrokHomeResolver(async () => ({ runtime: 'wsl', wslDistro: 'Ubuntu', path: home }))
 
     await service.refreshGrok()
 
     expect(fetchGrokRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchGrokRateLimits).toHaveBeenCalledWith({
       authReadResult,
+      signal: expect.any(AbortSignal)
+    })
+    expect(readGrokAuthSession).toHaveBeenCalledWith({
+      home,
       signal: expect.any(AbortSignal)
     })
     expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
@@ -117,6 +126,139 @@ describe('RateLimitService', () => {
     expect(fetchMiniMaxRateLimits).not.toHaveBeenCalled()
     expect(service.getState().grokAuthConfigured).toBe(true)
     expect(service.getState().grok?.status).toBe('ok')
+  })
+
+  it('discards a Grok result when the runtime changes during fetch', async () => {
+    const authReadResult = {
+      status: 'ok' as const,
+      session: {
+        accessToken: 'token',
+        userId: null,
+        email: null,
+        teamId: null,
+        expiresAtMs: null,
+        oidcClientId: null
+      }
+    }
+    const ubuntuFetch = deferred<ProviderRateLimits>()
+    vi.mocked(readGrokAuthSession).mockResolvedValue(authReadResult)
+    vi.mocked(fetchGrokRateLimits)
+      .mockImplementationOnce(() => ubuntuFetch.promise)
+      .mockResolvedValueOnce(okProvider('grok', 22))
+    const service = new RateLimitService()
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+    service.setGrokHomeResolver(async (target) => ({
+      ...target,
+      path: `\\\\wsl.localhost\\${target.wslDistro}\\home\\dev\\.grok`
+    }))
+
+    const ubuntuRefresh = service.refreshGrok()
+    await vi.waitFor(() => expect(fetchGrokRateLimits).toHaveBeenCalledOnce())
+    const debianRefresh = service.refreshGrokForTarget({
+      runtime: 'wsl',
+      wslDistro: 'Debian'
+    })
+    ubuntuFetch.resolve(okProvider('grok', 11))
+
+    await Promise.all([ubuntuRefresh, debianRefresh])
+    expect(fetchGrokRateLimits).toHaveBeenCalledTimes(2)
+    expect(service.getState().grok?.session?.usedPercent).toBe(22)
+  })
+
+  it('uses the resolved WSL home for Grok account status', async () => {
+    const home = '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.grok'
+    vi.mocked(readGrokAuthSession).mockResolvedValue({
+      status: 'ok',
+      session: {
+        accessToken: 'secret-token',
+        userId: null,
+        email: 'dev@example.com',
+        teamId: 'team-1',
+        expiresAtMs: null,
+        oidcClientId: null
+      }
+    })
+    const service = new RateLimitService()
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+    service.setGrokHomeResolver(async () => ({ runtime: 'wsl', wslDistro: 'Ubuntu', path: home }))
+
+    await expect(service.getGrokAccountStatus()).resolves.toEqual({
+      signedIn: true,
+      email: 'dev@example.com',
+      teamId: 'team-1',
+      tokenFresh: true,
+      error: null
+    })
+    expect(readGrokAuthSession).toHaveBeenCalledWith({ home, signal: undefined })
+    expect(fetchGrokRateLimits).not.toHaveBeenCalled()
+  })
+
+  it('publishes the initial Grok auth presence after installing the resolver', async () => {
+    vi.mocked(readGrokAuthSession).mockResolvedValue({
+      status: 'ok',
+      session: {
+        accessToken: 'secret-token',
+        userId: null,
+        email: null,
+        teamId: null,
+        expiresAtMs: null,
+        oidcClientId: null
+      }
+    })
+    const service = new RateLimitService()
+    const listener = vi.fn()
+    service.onStateChange(listener)
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+    service.setGrokHomeResolver(async (target) => ({
+      ...target,
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.grok'
+    }))
+
+    await vi.waitFor(() => expect(service.getState().grokAuthConfigured).toBe(true))
+    expect(listener).toHaveBeenCalled()
+  })
+
+  it('retries account status when the Grok runtime changes during resolution', async () => {
+    const ubuntuResolution = deferred<{
+      runtime: 'wsl'
+      wslDistro: string
+      path: string
+    }>()
+    vi.mocked(readGrokAuthSession).mockImplementation(async (options) => ({
+      status: 'ok',
+      session: {
+        accessToken: 'secret-token',
+        userId: null,
+        email: options?.home?.includes('Debian') ? 'debian@example.com' : 'ubuntu@example.com',
+        teamId: null,
+        expiresAtMs: null,
+        oidcClientId: null
+      }
+    }))
+    const service = new RateLimitService()
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+    service.setGrokHomeResolver((target) =>
+      target.wslDistro === 'Ubuntu'
+        ? ubuntuResolution.promise
+        : Promise.resolve({
+            runtime: 'wsl',
+            wslDistro: 'Debian',
+            path: '\\\\wsl.localhost\\Debian\\home\\dev\\.grok'
+          })
+    )
+
+    const status = service.getGrokAccountStatus()
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Debian' })
+    ubuntuResolution.resolve({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.grok'
+    })
+
+    await expect(status).resolves.toMatchObject({
+      signedIn: true,
+      email: 'debian@example.com'
+    })
   })
 
   it('does not refetch Claude when a Codex account switch is queued during fetchAll', async () => {
@@ -341,8 +483,7 @@ describe('RateLimitService', () => {
     )
 
     const activeFetch = serviceInternals(service).fetchAll()
-    await Promise.resolve()
-    await Promise.resolve()
+    await vi.waitFor(() => expect(fetchGrokRateLimits).toHaveBeenCalledOnce())
 
     const queuedRefresh = service.refresh()
     await Promise.resolve()

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -218,6 +218,27 @@ describe('RateLimitService', () => {
     expect(listener).toHaveBeenCalled()
   })
 
+  it('contains Grok home resolver failures as auth read errors', async () => {
+    const service = new RateLimitService()
+    service.setGrokFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+    service.setGrokHomeResolver(async () => {
+      throw new Error('spawn wsl.exe ENOENT')
+    })
+
+    await expect(service.refreshGrok()).resolves.toMatchObject({
+      grok: { status: 'unavailable' }
+    })
+    expect(fetchGrokRateLimits).toHaveBeenCalledWith({
+      authReadResult: {
+        status: 'error',
+        error: 'Unable to resolve Grok auth home'
+      },
+      signal: expect.any(AbortSignal)
+    })
+    expect(readGrokAuthSession).not.toHaveBeenCalled()
+    expect(service.getState().grok?.status).not.toBe('fetching')
+  })
+
   it('retries account status when the Grok runtime changes during resolution', async () => {
     const ubuntuResolution = deferred<{
       runtime: 'wsl'

--- a/src/main/rate-limits/service-window-activation.test.ts
+++ b/src/main/rate-limits/service-window-activation.test.ts
@@ -50,7 +50,8 @@ vi.mock('./grok-fetcher', () => ({
 }))
 
 vi.mock('./grok-auth', () => ({
-  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+  isGrokAccessTokenFresh: vi.fn(() => true),
+  readGrokAuthSession: vi.fn(async () => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -170,12 +170,14 @@ function isSameUsageWindow(
   return a.usedPercent === b.usedPercent && a.resetsAt === b.resetsAt
 }
 
+/** Normalize Grok runtime identity so target comparisons remain stable. */
 function normalizeGrokFetchTarget(target: LocalAccountRuntimeTarget): LocalAccountRuntimeTarget {
   return target.runtime === 'wsl'
     ? { runtime: 'wsl', wslDistro: target.wslDistro?.trim() || null }
     : { runtime: 'host', wslDistro: null }
 }
 
+/** Compare the runtime identity that scopes a Grok credential and quota result. */
 function isSameGrokTarget(
   current: LocalAccountRuntimeTarget,
   next: LocalAccountRuntimeTarget
@@ -321,6 +323,7 @@ export class RateLimitService {
     this.claudeAuthPreparationResolver = resolver
   }
 
+  /** Replace the Grok runtime target and invalidate credentials from the prior target. */
   setGrokFetchTarget(target: LocalAccountRuntimeTarget): void {
     const nextTarget = normalizeGrokFetchTarget(target)
     if (isSameGrokTarget(this.grokFetchTarget, nextTarget)) {
@@ -331,11 +334,13 @@ export class RateLimitService {
     this.grokAuthConfigured = false
   }
 
+  /** Install runtime home resolution and prime Grok's configured-credential state. */
   setGrokHomeResolver(resolver: GrokHomeResolver): void {
     this.grokHomeResolver = resolver
     void this.refreshGrokAuthConfigured()
   }
 
+  /** Resolve and read Grok auth while containing WSL probe failures as account state. */
   private async readResolvedGrokAuthSession(
     target: LocalAccountRuntimeTarget,
     signal?: AbortSignal
@@ -349,10 +354,12 @@ export class RateLimitService {
     return readGrokAuthSession({ home: resolution?.path, signal })
   }
 
+  /** Reject work captured before the current Grok runtime generation. */
   private isCurrentGrokTarget(generation: number, target: LocalAccountRuntimeTarget): boolean {
     return generation === this.grokFetchGeneration && isSameGrokTarget(target, this.grokFetchTarget)
   }
 
+  /** Refresh credential presence without issuing a Grok quota request. */
   private async refreshGrokAuthConfigured(): Promise<void> {
     const generation = this.grokFetchGeneration
     const target = this.grokFetchTarget
@@ -368,6 +375,7 @@ export class RateLimitService {
     this.updateState({ ...this.state })
   }
 
+  /** Read current Grok account metadata, retrying once across a concurrent target switch. */
   async getGrokAccountStatus(): Promise<GrokAccountStatus> {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const generation = this.grokFetchGeneration
@@ -504,6 +512,7 @@ export class RateLimitService {
     return this.getState()
   }
 
+  /** Switch Grok runtime and force an isolated quota refresh for the new target. */
   async refreshGrokForTarget(target: LocalAccountRuntimeTarget): Promise<RateLimitState> {
     const nextTarget = normalizeGrokFetchTarget(target)
     const targetChanged = !isSameGrokTarget(this.grokFetchTarget, nextTarget)

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -2,11 +2,13 @@
 import type { BrowserWindow } from 'electron'
 import type {
   CodexRateLimitResetResult,
+  GrokAccountStatus,
   RateLimitState,
   ProviderRateLimits,
   InactiveAccountUsage,
   RateLimitRuntimeTarget
 } from '../../shared/rate-limit-types'
+import type { LocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
 import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import type { InactiveClaudeAccountInfo } from './claude-fetcher'
 import { mapClaudeUsageWindow } from './claude-usage-window'
@@ -22,8 +24,10 @@ import {
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
+import type { GrokHomeResolver } from '../grok/grok-runtime-home'
+import { getGrokAccountStatus as buildGrokAccountStatus } from '../grok-accounts/status'
 import { fetchGrokRateLimits } from './grok-fetcher'
-import { readGrokAuthSession } from './grok-auth'
+import { readGrokAuthSession, type GrokAuthReadResult } from './grok-auth'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
@@ -166,6 +170,19 @@ function isSameUsageWindow(
   return a.usedPercent === b.usedPercent && a.resetsAt === b.resetsAt
 }
 
+function normalizeGrokFetchTarget(target: LocalAccountRuntimeTarget): LocalAccountRuntimeTarget {
+  return target.runtime === 'wsl'
+    ? { runtime: 'wsl', wslDistro: target.wslDistro?.trim() || null }
+    : { runtime: 'host', wslDistro: null }
+}
+
+function isSameGrokTarget(
+  current: LocalAccountRuntimeTarget,
+  next: LocalAccountRuntimeTarget
+): boolean {
+  return current.runtime === next.runtime && current.wslDistro === next.wslDistro
+}
+
 export class RateLimitService {
   private state: InternalRateLimitState = {
     claude: null,
@@ -177,7 +194,7 @@ export class RateLimitService {
     minimax: null,
     grok: null
   }
-  private grokAuthConfigured = readGrokAuthSession().status === 'ok'
+  private grokAuthConfigured = false
   private pollInterval: number = DEFAULT_POLL_MS
   private timer: ReturnType<typeof setInterval> | null = null
   private deferredStartupRefreshTimer: ReturnType<typeof setTimeout> | null = null
@@ -214,6 +231,7 @@ export class RateLimitService {
   private fetchIdleResolvers: (() => void)[] = []
   private codexFetchGeneration = 0
   private claudeFetchGeneration = 0
+  private grokFetchGeneration = 0
   // Why: statusline ingest must attribute live windows to the selected account without re-running the side-effectful auth sync per post.
   private lastClaudeAuthSnapshot: { configDir: string | null; provenance: string } | null = null
   private opencodeFetchGeneration = 0
@@ -227,6 +245,11 @@ export class RateLimitService {
   }
   // Why: resolved per cycle — the local-account runtime policy can flip between fetches.
   private kimiHomeResolver: KimiHomeResolver | null = null
+  private grokHomeResolver: GrokHomeResolver | null = null
+  private grokFetchTarget: LocalAccountRuntimeTarget = {
+    runtime: 'host',
+    wslDistro: null
+  }
   private claudeAuthPreparationResolver: ClaudeAuthPreparationResolver | null = null
   private claudeFetchTarget: NormalizedClaudeAccountSelectionTarget = {
     runtime: 'host',
@@ -296,6 +319,63 @@ export class RateLimitService {
 
   setClaudeAuthPreparationResolver(resolver: ClaudeAuthPreparationResolver): void {
     this.claudeAuthPreparationResolver = resolver
+  }
+
+  setGrokFetchTarget(target: LocalAccountRuntimeTarget): void {
+    const nextTarget = normalizeGrokFetchTarget(target)
+    if (isSameGrokTarget(this.grokFetchTarget, nextTarget)) {
+      return
+    }
+    this.grokFetchTarget = nextTarget
+    this.grokFetchGeneration += 1
+    this.grokAuthConfigured = false
+  }
+
+  setGrokHomeResolver(resolver: GrokHomeResolver): void {
+    this.grokHomeResolver = resolver
+    void this.refreshGrokAuthConfigured()
+  }
+
+  private async readResolvedGrokAuthSession(
+    target: LocalAccountRuntimeTarget,
+    signal?: AbortSignal
+  ): Promise<GrokAuthReadResult> {
+    const resolution = await this.grokHomeResolver?.(target)
+    return readGrokAuthSession({ home: resolution?.path, signal })
+  }
+
+  private isCurrentGrokTarget(generation: number, target: LocalAccountRuntimeTarget): boolean {
+    return generation === this.grokFetchGeneration && isSameGrokTarget(target, this.grokFetchTarget)
+  }
+
+  private async refreshGrokAuthConfigured(): Promise<void> {
+    const generation = this.grokFetchGeneration
+    const target = this.grokFetchTarget
+    const readResult = await this.readResolvedGrokAuthSession(target)
+    if (!this.isCurrentGrokTarget(generation, target)) {
+      return
+    }
+    const configured = readResult.status === 'ok'
+    if (configured === this.grokAuthConfigured) {
+      return
+    }
+    this.grokAuthConfigured = configured
+    this.updateState({ ...this.state })
+  }
+
+  async getGrokAccountStatus(): Promise<GrokAccountStatus> {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const generation = this.grokFetchGeneration
+      const target = this.grokFetchTarget
+      const readResult = await this.readResolvedGrokAuthSession(target)
+      if (this.isCurrentGrokTarget(generation, target)) {
+        return buildGrokAccountStatus(readResult)
+      }
+    }
+    return buildGrokAccountStatus({
+      status: 'error',
+      error: 'Grok runtime changed while reading account status'
+    })
   }
 
   setClaudeFetchTarget(target?: ClaudeAccountSelectionTarget): void {
@@ -415,6 +495,19 @@ export class RateLimitService {
   }
 
   async refreshGrok(): Promise<RateLimitState> {
+    await this.fetchGrokOnly({ force: true })
+    return this.getState()
+  }
+
+  async refreshGrokForTarget(target: LocalAccountRuntimeTarget): Promise<RateLimitState> {
+    const nextTarget = normalizeGrokFetchTarget(target)
+    const targetChanged = !isSameGrokTarget(this.grokFetchTarget, nextTarget)
+    this.setGrokFetchTarget(nextTarget)
+    this.activeFailureStreakByProvider.grok = 0
+    this.updateState({
+      ...this.state,
+      grok: this.withFetchingStatus(targetChanged ? null : this.state.grok, 'grok')
+    })
     await this.fetchGrokOnly({ force: true })
     return this.getState()
   }
@@ -1633,9 +1726,10 @@ export class RateLimitService {
     const miniMaxGroupId = miniMaxConfigResult.config.groupId
     const miniMaxModels = miniMaxConfigResult.config.models
     const geminiCliOAuthEnabled = this.geminiCliOAuthEnabledResolver?.() ?? false
-    // Why: getState() is hot (renderer pushes + mobile snapshots); keep Grok's sync auth-file probe on fetch cycles instead.
-    const grokAuthReadResult = readGrokAuthSession()
-    this.grokAuthConfigured = grokAuthReadResult.status === 'ok'
+    const grokTarget = this.grokFetchTarget
+    const grokGeneration = this.grokFetchGeneration
+    // Why: start the async WSL probe before other providers so it runs concurrently.
+    const grokAuthReadPromise = this.readResolvedGrokAuthSession(grokTarget, signal)
 
     // Discard stale data on config change — it belongs to a different session/workspace.
     const currentConfigHash = `${cookie}|${workspaceIdOverride}`
@@ -1676,13 +1770,18 @@ export class RateLimitService {
 
     const missingWslCodexHome =
       codexFetchGated || codexHomePath ? null : this.getMissingWslCodexHomeResult(codexTarget)
-    const grokResultPromise = fetchGrokRateLimits({
-      signal,
-      authReadResult: grokAuthReadResult
-    }).then(
-      (value) => ({ status: 'fulfilled', value }) as const,
-      (reason) => ({ status: 'rejected', reason }) as const
-    )
+    const grokResultPromise = grokAuthReadPromise
+      .then((authReadResult) => {
+        if (signal.aborted || !this.isCurrentGrokTarget(grokGeneration, grokTarget)) {
+          throw new Error('Stale Grok fetch target')
+        }
+        this.grokAuthConfigured = authReadResult.status === 'ok'
+        return fetchGrokRateLimits({ signal, authReadResult })
+      })
+      .then(
+        (value) => ({ status: 'fulfilled', value }) as const,
+        (reason) => ({ status: 'rejected', reason }) as const
+      )
 
     // Why: skip automated Claude fetches while a Retry-After window is open or a live session feed is fresher than the OAuth poll would be.
     const claudeFetchGated =
@@ -1896,6 +1995,9 @@ export class RateLimitService {
             error: grokResult.reason instanceof Error ? grokResult.reason.message : 'Unknown error',
             status: 'error'
           } satisfies ProviderRateLimits)
+    if (!this.isCurrentGrokTarget(grokGeneration, grokTarget)) {
+      return
+    }
     this.trackActiveFailureStreak('grok', grok)
     this.updateState({
       ...this.state,
@@ -2051,13 +2153,19 @@ export class RateLimitService {
       return
     }
     const previousState = this.state
-    const grokAuthReadResult = readGrokAuthSession()
-    this.grokAuthConfigured = grokAuthReadResult.status === 'ok'
+    const grokTarget = this.grokFetchTarget
+    const grokGeneration = this.grokFetchGeneration
 
     this.updateState({
       ...previousState,
       grok: this.withFetchingStatus(previousState.grok, 'grok')
     })
+
+    const grokAuthReadResult = await this.readResolvedGrokAuthSession(grokTarget, signal)
+    if (signal.aborted || !this.isCurrentGrokTarget(grokGeneration, grokTarget)) {
+      return
+    }
+    this.grokAuthConfigured = grokAuthReadResult.status === 'ok'
 
     const grok = await fetchGrokRateLimits({
       signal,
@@ -2073,7 +2181,7 @@ export class RateLimitService {
       })
     )
 
-    if (signal.aborted) {
+    if (signal.aborted || !this.isCurrentGrokTarget(grokGeneration, grokTarget)) {
       return
     }
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -24,7 +24,7 @@ import {
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
-import type { GrokHomeResolver } from '../grok/grok-runtime-home'
+import type { GrokHomeResolution, GrokHomeResolver } from '../grok/grok-runtime-home'
 import { getGrokAccountStatus as buildGrokAccountStatus } from '../grok-accounts/status'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession, type GrokAuthReadResult } from './grok-auth'
@@ -340,7 +340,12 @@ export class RateLimitService {
     target: LocalAccountRuntimeTarget,
     signal?: AbortSignal
   ): Promise<GrokAuthReadResult> {
-    const resolution = await this.grokHomeResolver?.(target)
+    let resolution: GrokHomeResolution | undefined
+    try {
+      resolution = await this.grokHomeResolver?.(target)
+    } catch {
+      return { status: 'error', error: 'Unable to resolve Grok auth home' }
+    }
     return readGrokAuthSession({ home: resolution?.path, signal })
   }
 


### PR DESCRIPTION
## Summary

- Resolve Grok authentication from Orca's configured local account runtime.
- Preserve host `GROK_HOME`; on Windows with a WSL runtime, resolve the selected or default distro home and read `.grok/auth.json` through its UNC path.
- Use the same bounded asynchronous auth read for account status, full rate-limit refreshes, and Grok-only refreshes.
- Refresh Grok after runtime changes and discard stale target results before credentials can be sent or attributed to the new target.

Fixes #13784

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — not run project-wide; changed-code quality passed with 0 new native, type-aware, or React Doctor findings across 16 changed files.
- [x] `pnpm typecheck` — the affected Node TypeScript target passed with `pnpm typecheck:node`.
- [ ] `pnpm test` — not run project-wide; 7 focused suites passed locally (123 tests). The resolver-failure follow-up additionally passed 3 affected suites (103 tests).
- [ ] `pnpm build` — not run; this is a main-process behavior change with no renderer or bundle changes.
- [x] Added or updated high-quality tests for runtime selection, UNC auth paths, bounded async auth reads, target-change races, account status, refresh synchronization, and WSL resolver failure containment.

## AI Review Report

The full runtime target → home resolution → auth read → account status/rate-limit refresh path was reviewed. The review checked selected/default WSL distro behavior, host fallback, stale-target races, account cross-attribution, resolver failures, abort/timeout handling, full versus Grok-only refreshes, and IPC status reuse. It found stale-target races and an uncontained WSL resolver rejection; both were fixed and covered by regression tests. The final independent code and security re-reviews found no remaining actionable blockers.

Cross-platform compatibility was checked explicitly: macOS and Linux remain on the host runtime and preserve `GROK_HOME`/`~/.grok`; Windows host behavior is unchanged; Windows WSL uses a normalized `\\wsl.localhost\<distro>\...\.grok` path. A real Windows Node + `wsl.exe` smoke against Ubuntu 24.04 resolved the WSL home and read a fresh auth session without printing token or account metadata.

## Security Audit

The security review checked credential path selection, token exposure, error sanitization, filesystem timeouts, abort handling, shared-read behavior, and runtime-switch races. Grok tokens remain in the Electron main process and are not added to renderer state or logs. Resolver failures become a sanitized auth error rather than an unhandled rejection. Generation/target checks run before the Grok network request and again before applying results, preventing an old runtime credential from being sent or attributed after a target switch.

## Notes

- WSL home resolution is enabled only for Windows local-account runtime selection; SSH/remote behavior is unchanged.
- Grok hook discovery is unrelated to quota authentication and is intentionally unchanged.
- Real smoke result: `{"runtime":"wsl","wslDistro":"Ubuntu-24.04","homeResolved":true,"authStatus":"ok","tokenFresh":true}`.