### PR TITLE
fix(sidebar): stop reorder drags from selecting header labels

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -829,7 +829,8 @@ function HostSectionHeader({
         aria-expanded={!row.collapsed}
         className={cn(
           'group/host-header flex h-8 w-full cursor-pointer items-center gap-2 rounded-md border px-2 text-left transition-all',
-          onDragPointerDown && 'cursor-grab active:cursor-grabbing',
+          // select-none only when draggable: same reorder-drag selection anchor as repo/group headers.
+          onDragPointerDown && 'cursor-grab active:cursor-grabbing select-none',
           isBlocked
             ? 'border-destructive/40 bg-destructive/10'
             : isDisconnected
@@ -4273,6 +4274,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       // actions use cursor-pointer so … / + never look reorderable.
                       'group relative flex h-7 w-full items-center gap-1.5 pr-2 text-left transition-all',
                       !(isDraggableRepoHeader || isDraggableProjectGroupHeader) && 'cursor-pointer',
+                      // Why: pointerdown arms drag without preventDefault and body user-select only
+                      // lands once the 4px threshold promotes, so the label anchors a selection that
+                      // resurfaces on pointerup. Non-draggable rows have no such gap — keep them
+                      // selectable rather than removing copyable text for free.
+                      (isDraggableRepoHeader || isDraggableProjectGroupHeader) && 'select-none',
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
                       (isDraggingThis || isDraggingThisProjectGroup) &&
@@ -4365,7 +4371,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
                       <div className="min-w-0 flex-1">
                         <div className="flex min-w-0 items-center gap-1.5">
-                          <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
+                          <div
+                            data-repo-header-title=""
+                            className="min-w-0 truncate text-[13px] font-semibold leading-none"
+                          >
                             {row.label}
                           </div>
                           <RepoForkIndicator upstream={row.repo?.upstream} />

--- a/src/renderer/src/components/sidebar/project-group-header-dom.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-dom.test.ts
@@ -47,4 +47,23 @@ describe('Project Group header drag DOM source', () => {
       /isDraggableRepoHeader \|\| isDraggableProjectGroupHeader\s*\?\s*'cursor-grab/
     )
   })
+
+  it('scopes select-none to headers that can arm a reorder drag', () => {
+    // Why: behavior lives in project-group-manual-sort.spec.ts; this only guards the scoping,
+    // so an unconditional select-none cannot creep back and strip copyable text from rows
+    // (lone projects, Pinned, workspace-status) that never had the selection-anchor bug.
+    const source = readWorktreeListSource()
+
+    expect(source).toMatch(
+      /\(isDraggableRepoHeader \|\| isDraggableProjectGroupHeader\) && 'select-none'/
+    )
+    expect(source).toMatch(/onDragPointerDown && '[^']*\bselect-none\b/)
+    // Base row classes must stay selectable; only the guarded entries may add select-none.
+    for (const base of [
+      /'group relative flex h-7 w-full[^']*'/,
+      /'group\/host-header flex h-8 w-full[^']*'/
+    ]) {
+      expect(source.match(base)?.[0]).not.toContain('select-none')
+    }
+  })
 })

--- a/tests/e2e/project-group-manual-sort.spec.ts
+++ b/tests/e2e/project-group-manual-sort.spec.ts
@@ -244,6 +244,35 @@ async function dragProjectIntoProjectBody(args: {
   await args.page.mouse.up()
 }
 
+async function dragProjectLabelBefore(args: {
+  page: Page
+  draggedProjectId: string
+  targetProjectId: string
+}): Promise<string> {
+  const label = args.page
+    .locator(`[data-repo-header-id="${args.draggedProjectId}"] [data-repo-header-title]`)
+    .first()
+  const target = args.page.locator(`[data-repo-header-id="${args.targetProjectId}"]`)
+  await label.scrollIntoViewIfNeeded()
+  await target.scrollIntoViewIfNeeded()
+  const labelBox = await label.boundingBox()
+  const targetBox = await target.boundingBox()
+  if (!labelBox || !targetBox) {
+    throw new Error('Project header label bounding box was not available')
+  }
+
+  // Why: press mid-label, not row center — the regression anchored the selection at the
+  // pressed character, so how much text highlighted depended on the grab point.
+  await args.page.mouse.move(labelBox.x + labelBox.width / 2, labelBox.y + labelBox.height / 2)
+  await args.page.mouse.down()
+  await args.page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 3, { steps: 8 })
+  await args.page.mouse.up()
+
+  // Why: read after pointerup — body user-select only hides the range during the drag, so
+  // the stale selection resurfaces here once the drag styles are torn down.
+  return await args.page.evaluate(() => window.getSelection()?.toString() ?? '')
+}
+
 async function dragProjectGroupBefore(args: {
   page: Page
   draggedGroupId: string
@@ -357,5 +386,36 @@ test.describe('Project Group manual sorting', () => {
         message: 'Dragged Project Group header did not persist the requested visible order'
       })
       .toEqual([groups.alphaId, groups.bravoId, groups.deltaId, groups.charlieId])
+  })
+
+  test('dragging a project header by its label leaves no text selection behind', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const repoPaths = await createProjectHeaderSortFixture()
+    const projects = await seedProjectHeaderSortScenario(orcaPage, repoPaths)
+
+    await expect
+      .poll(() => getProjectHeaderOrder(orcaPage, projects), {
+        timeout: 12_000,
+        message: 'Project headers did not render in manual order'
+      })
+      .toEqual([projects.alphaId, projects.bravoId, projects.charlieId])
+
+    const selectionAfterDrag = await dragProjectLabelBefore({
+      page: orcaPage,
+      draggedProjectId: projects.charlieId,
+      targetProjectId: projects.bravoId
+    })
+
+    expect(selectionAfterDrag).toBe('')
+
+    // Why: the reorder must still work — a fix that killed the drag would also pass above.
+    await expect
+      .poll(() => getProjectHeaderOrder(orcaPage, projects), {
+        timeout: 12_000,
+        message: 'Label-initiated drag did not persist the requested visible order'
+      })
+      .toEqual([projects.alphaId, projects.charlieId, projects.bravoId])
   })
 })


### PR DESCRIPTION
## Summary

Dragging a project header in the sidebar to reorder it left the project's name partially
highlighted, with the amount of text selected depending on where in the label you grabbed it.

The three reorderable sidebar header tiers — project, project group, and host — arm their
pointer drag in `onPointerDown` without calling `preventDefault()`, so the browser proceeds
with its default action and anchors a native text selection at the pressed character. The
`user-select: none` guard is applied to `document.body` only once the drag *promotes* past the
4px threshold (`project-header-drag.ts:291-304`, threshold at lines 219-237). In the gap
between pointerdown and promotion, a selection has already been anchored and extended.

The body style then only *hides* that range for the duration of the drag — it does not clear
it — so the selection resurfaces on pointerup and the label is left visibly half-selected.
That is why the artifact appears after you release the drag rather than during it.

Worktree cards never showed this because `worktree-card-surface.tsx:122` already carries
`select-none`. The header rows did not.

**Fix:** mark the header rows `select-none`, matching the worktree cards. Scoped to rows that
can actually arm a reorder drag — a lone project in its bucket, Pinned, and workspace-status
sections share this markup but have no such gap, and keep their labels selectable and
copyable.

## Screenshots

**Before** — grabbing `agentbrain` mid-label leaves it partially selected after the drop:

![before](https://raw.githubusercontent.com/possibilities/orca/assets/sidebar-drag-selection/before.gif)

**After** — same gesture, no selection, reorder still lands:

![after](https://raw.githubusercontent.com/possibilities/orca/assets/sidebar-drag-selection/after.gif)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Added an e2e test in `tests/e2e/project-group-manual-sort.spec.ts` that presses **mid-label**
(the regression anchored the selection at the pressed character, so a row-center press could
miss it), drags past the promotion threshold, releases, and asserts `window.getSelection()` is
empty. It also re-asserts the reorder still lands, so a change that simply broke dragging
cannot pass it.

That test was negative-controlled: with the fix removed it fails with

```
Expected: ""
Received: "e2e-manual-p"
```

— a project label selected partway through its name, which is the reported bug reproduced as
an assertion. The accompanying DOM test guards the *scoping* (rather than asserting full
Tailwind class strings, which would be brittle to class reordering); it was likewise confirmed
to fail when `select-none` is re-broadened to all header rows.

**Also validated on CI runners before opening this PR.** I ran the full `pr.yml` matrix on a
fork PR (`possibilities/orca#1`): **45 checks passed**, including the 16-way sharded Node 24
test matrix, `package` on macOS *and* Windows, static analysis, git compatibility, shell
contracts, cross-version wire, managed hooks on Node 18, and the root directory guard. The
only failure was `track-community-pr`, which needs a `stablyai`-owned GitHub App private key
that a fork cannot access — infrastructure, not code.

The e2e job was correctly detected (`Changed E2E specs:
["tests/e2e/project-group-manual-sort.spec.ts"]`) but skipped on the fork because `e2e.yml` is
`disabled_fork`; it should run here. That spec passes locally, 4/4.

Note on local `pnpm test`: a handful of failures on my machine are environmental and reproduce
identically on a clean `main` — two in `src/relay/agent-exec-handler.test.ts` (my shell exports
`GIT_CONFIG_COUNT=2`, so the handler's own two entries make four) and one in
`src/shared/posix-command-path-lookup.test.ts` (resolves Homebrew's node where it expects
nvm's). I verified the same 18 files on this branch vs. clean `main` under matched load and got
identical results, with the sole difference being a wall-clock perf budget in
`ai-vault-session-worktree-map` that passes 3/3 in isolation. None are related to this change,
and CI above is green regardless.

## AI Review Report

Reviewed with Claude (implementation) and an adversarial review pass by **Codex (gpt-5.6,
high effort)**, which was explicitly briefed to find what was wrong rather than validate the
change, and to treat a clean result as a failed review absent proof of correctness.

**Verified empirically, not just by reading code.** The reviewer built a standalone probe
against this repo's Electron 43.1.0 runtime with real pointer input, and confirmed the
mechanism: a selectable label acquires a selection before promotion; body `user-select: none`
hides it; restoring the style after pointerup makes the same selection reappear. With
row-level `select-none`, no range is anchored, and dragging from the row into a selectable
neighbouring row still produces no selection.

**It returned two findings, both of which are fixed in this PR:**

1. `select-none` was initially applied unconditionally, including to header rows that can
   never arm a drag (a single project in its bucket, Pinned, workspace-status sections). That
   removed copyable text from rows that never had the bug. Now gated on
   `isDraggableRepoHeader || isDraggableProjectGroupHeader`, mirroring the `cursor-pointer`
   conditional already on that row; the host row is gated on `onDragPointerDown`.
2. The original regression test asserted exact Tailwind class-string literals from source — it
   would have passed on dead code and failed on harmless class reordering, while never
   exercising the behavior. Replaced with the real Electron pointer/selection e2e above, plus
   a narrowed scoping guard.

**Completeness audit:** no other draggable sidebar surface is affected — worktree cards and
kanban cards (which render the same `WorktreeCard`) already carry `select-none`, and host
drag does suppress body selection at promotion via `setSidebarPointerDragDocumentStyles`. No
second rendering path exists for these headers.

**Accessibility:** `user-select` removes neither DOM text nor accessible names. The probe's
accessibility snapshot still exposed the project label and `window.find()` still matched it,
so screen readers and AX-based computer-use scraping are unaffected. Mouse text selection is
affected — which is precisely why the scope is now limited to draggable rows.

**Cross-platform — reviewed for macOS, Linux, and Windows.** The fix uses Chromium's standard
`user-select` behavior with no OS-specific shortcut, event modifier, path, or native API, and
Electron uses the same Chromium selection engine on all three targets. Evidence: the unit and
type/lint matrix ran green on CI's Linux runners and `package` passed on both macOS and
Windows. The *behavioral* selection probe and the e2e drag were run on macOS only, so the
claim that the drag artifact is gone specifically on Linux and Windows rests on the shared
Chromium selection engine rather than three native interactive runs.

**SSH / remote / local, agents, integrations, git providers:** renderer-only CSS plus tests.
No execution routing, RPC, stream frame, filesystem path, remote-wire payload, or host-version
behavior changed, so local, SSH, and folder workspaces are equally affected. No agent, CLI,
integration, or provider-specific code is touched, so there is no GitHub/GitLab asymmetry.

**Performance:** negligible — two conditional CSS classes on rows that already recompute their
class list per render.

## Security Audit

No security regression. The change introduces no input parsing, command execution, path
handling, IPC, secrets, privilege boundary, HTML injection, or remote content handling.
`select-none` affects presentation and selection only, and the added `data-repo-header-title`
attribute is an inert test hook carrying no data. The e2e test writes only to a `mkdtemp`
scratch directory that it cleans up. No dependencies added or changed. No follow-up needed.

## Notes

- No platform-specific behavior is introduced; see the cross-platform note above on where the
  evidence is macOS-only.
- The underlying timing gap (pointerdown arming without `preventDefault`, body `user-select`
  landing only at promotion) still exists in all three drag hooks. This PR closes the symptom
  at the surfaces that show it rather than changing the shared drag lifecycle, which would be
  a broader and riskier change. Calling it out explicitly in case maintainers would prefer the
  fix at that altitude instead — happy to rework it that way.
- Reported by / X handle: **@possibilities**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML3nvoBBKfv9Rx9D58VbXP
