### PR TITLE
fix(feedback): pre-include Orca version and OS in errors and feedback

### DIFF
--- a/src/main/daemon/node-pty-error-hints.test.ts
+++ b/src/main/daemon/node-pty-error-hints.test.ts
@@ -50,7 +50,7 @@ describe('node-pty diagnostic error hints', () => {
 
   it('hints local wrapped spawn errors from pty allocation failures', () => {
     const message =
-      'Failed to spawn shell "/bin/zsh": node-pty: open_slave failed: EMFILE (errno 24, Too many open files) - slave=\'/dev/ttys003\' (shell: /bin/zsh, cwd: /tmp, arch: arm64, platform: darwin 25.0.0). If this persists, please file an issue.'
+      'Failed to spawn shell "/bin/zsh": node-pty: open_slave failed: EMFILE (errno 24, Too many open files) - slave=\'/dev/ttys003\' (shell: /bin/zsh, cwd: /tmp, arch: arm64, platform: darwin 25.0.0, orca: 1.4.178). If this persists, please file an issue.'
 
     expect(addNodePtyRecoveryHint(message)).toBe(`${PTY_ALLOCATION_HINT} ${message}`)
   })

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -2613,6 +2613,8 @@ describe('createPtySubprocess', () => {
     spawnMock.mockImplementation(() => {
       throw new Error('File not found: ')
     })
+    const previousVersion = process.env.ORCA_APP_VERSION
+    process.env.ORCA_APP_VERSION = '1.4.178-test'
 
     try {
       expect(() =>
@@ -2623,9 +2625,14 @@ describe('createPtySubprocess', () => {
           shellOverride: 'not-a-real-shell.exe'
         })
       ).toThrow(
-        /Daemon failed to spawn shell "not-a-real-shell\.exe" with cwd ".+": File not found:/
+        /Daemon failed to spawn shell "not-a-real-shell\.exe" with cwd ".+": File not found:.*orca: 1\.4\.178-test/
       )
     } finally {
+      if (previousVersion === undefined) {
+        delete process.env.ORCA_APP_VERSION
+      } else {
+        process.env.ORCA_APP_VERSION = previousVersion
+      }
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: daemon PTY spawning must keep platform launch setup, preflight, and lifecycle guards in one execution path. */
 import * as pty from 'node-pty'
 import { statSync } from 'node:fs'
+import { release } from 'node:os'
 import { delimiter, win32 as pathWin32 } from 'node:path'
 import type { SubprocessHandle } from './session'
 import { DaemonProtocolError } from './types'
@@ -246,16 +247,25 @@ function removeInheritedElectronRunAsNode(env: Record<string, string>): void {
   delete env.ELECTRON_RUN_AS_NODE
 }
 
+function daemonEnvironmentDiagSuffix(): string {
+  const orca = process.env.ORCA_APP_VERSION?.trim() || '0.0.0-dev'
+  const systemVersion =
+    (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ||
+    release()
+  const platform = `${process.platform} ${systemVersion}`
+  return ` (orca: ${orca}, arch: ${process.arch}, platform: ${platform})`
+}
+
 /**
  * Formats a daemon preflight failure with the same ENOENT details node-pty exposes.
  */
 function formatMissingDaemonPathError(kind: 'helper' | 'cwd', path: string): DaemonProtocolError {
   const detailName = kind === 'helper' ? 'helper' : 'cwd'
   const step = kind === 'helper' ? 'posix_spawn' : 'daemon_cwd'
+  const missingTarget = kind === 'helper' ? 'node-pty install' : 'working directory'
+  const diag = daemonEnvironmentDiagSuffix()
   return new DaemonProtocolError(
-    `Daemon's ${kind === 'helper' ? 'node-pty install' : 'working directory'} is gone ` +
-      `(worktree deleted?). Restart Orca. node-pty: ${step} failed: ENOENT ` +
-      `(errno 2, No such file or directory) - ${detailName}='${path}'`
+    `Daemon's ${missingTarget} is gone (worktree deleted?). Restart Orca. node-pty: ${step} failed: ENOENT (errno 2, No such file or directory) - ${detailName}='${path}'${diag}`
   )
 }
 
@@ -399,8 +409,9 @@ function preflightPosixPtySpawnEnvironment(validationCwd: string): void {
  */
 function formatPtySpawnError(err: unknown, shellPath: string, spawnCwd: string): Error {
   const message = err instanceof Error ? err.message : String(err)
+  const diag = daemonEnvironmentDiagSuffix()
   const formatted = new DaemonProtocolError(
-    `Daemon failed to spawn shell "${shellPath}" with cwd "${spawnCwd}": ${message}`
+    `Daemon failed to spawn shell "${shellPath}" with cwd "${spawnCwd}": ${message}${diag}`
   )
   if (err instanceof Error && err.stack) {
     formatted.stack = err.stack

--- a/src/main/providers/local-pty-utils-windows-fallback.test.ts
+++ b/src/main/providers/local-pty-utils-windows-fallback.test.ts
@@ -133,18 +133,28 @@ describe('spawnShellWithFallback on Windows', () => {
     const ptySpawn = vi.fn(() => {
       throw new Error(ACCESS_DENIED_5)
     }) as unknown as typeof pty.spawn
+    const previousVersion = process.env.ORCA_APP_VERSION
+    process.env.ORCA_APP_VERSION = '1.4.178-test'
 
-    expect(() =>
-      spawnShellWithFallback({
-        shellPath: PWSH7,
-        shellArgs: attempts[0].shellArgs,
-        cols: 80,
-        rows: 24,
-        cwd: 'C:\\repo',
-        env: {},
-        ptySpawn,
-        windowsFallbackAttempts: attempts
-      })
-    ).toThrow(/Failed to spawn shell/)
+    try {
+      expect(() =>
+        spawnShellWithFallback({
+          shellPath: PWSH7,
+          shellArgs: attempts[0].shellArgs,
+          cols: 80,
+          rows: 24,
+          cwd: 'C:\\repo',
+          env: {},
+          ptySpawn,
+          windowsFallbackAttempts: attempts
+        })
+      ).toThrow(/Failed to spawn shell.*orca: 1\.4\.178-test/)
+    } finally {
+      if (previousVersion === undefined) {
+        delete process.env.ORCA_APP_VERSION
+      } else {
+        process.env.ORCA_APP_VERSION = previousVersion
+      }
+    }
   })
 })

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -93,9 +93,21 @@ describe('validateWorkingDirectory', () => {
 
   it('rejects a missing native Windows path', () => {
     existsSyncMock.mockReturnValue(false)
+    const previousVersion = process.env.ORCA_APP_VERSION
+    process.env.ORCA_APP_VERSION = '1.4.178-test'
 
-    expect(() => validateWorkingDirectory(NATIVE_DIR)).toThrow(/does not exist/)
-    expect(wslUncDirectoryExistsMock).not.toHaveBeenCalled()
+    try {
+      expect(() => validateWorkingDirectory(NATIVE_DIR)).toThrow(
+        /does not exist.*orca: 1\.4\.178-test/
+      )
+      expect(wslUncDirectoryExistsMock).not.toHaveBeenCalled()
+    } finally {
+      if (previousVersion === undefined) {
+        delete process.env.ORCA_APP_VERSION
+      } else {
+        process.env.ORCA_APP_VERSION = previousVersion
+      }
+    }
   })
 
   it('rejects a native Windows path that exists but is not a directory', () => {

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,5 +1,6 @@
 import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
+import { release } from 'node:os'
 import type * as pty from 'node-pty'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { wslUncDirectoryExists } from '../wsl'
@@ -99,10 +100,26 @@ export function ensureNodePtySpawnHelperExecutable(): void {
   }
 }
 
+function formatLocalPtyEnvironmentDiag(extra: Record<string, string> = {}): string {
+  const systemVersion =
+    (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ||
+    release()
+  const parts = {
+    ...extra,
+    arch: process.arch,
+    platform: `${process.platform} ${systemVersion}`,
+    orca: process.env.ORCA_APP_VERSION?.trim() || '0.0.0-dev'
+  }
+  return Object.entries(parts)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ')
+}
+
 function throwMissingWorkingDirectory(cwd: string): never {
   throw new Error(
     `Working directory "${cwd}" does not exist. ` +
-      `It may have been deleted or is on an unmounted volume.`
+      `It may have been deleted or is on an unmounted volume ` +
+      `(${formatLocalPtyEnvironmentDiag({ cwd })}).`
   )
 }
 
@@ -305,12 +322,7 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
     }
   }
 
-  const diag = [
-    `shell: ${shellPath}`,
-    `cwd: ${cwd}`,
-    `arch: ${process.arch}`,
-    `platform: ${process.platform} ${process.getSystemVersion?.() ?? ''}`
-  ].join(', ')
+  const diag = formatLocalPtyEnvironmentDiag({ shell: shellPath, cwd })
   throw new Error(
     `Failed to spawn shell "${shellPath}": ${primaryError ?? 'unknown error'} (${diag}). ` +
       `If this persists, please file an issue.`

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1146,6 +1146,9 @@ export type PreloadApi = {
     get: () => {
       platform: NodeJS.Platform
       osRelease: string
+      arch: string
+      /** Login shell or ComSpec when available. */
+      shell: string
       displayServer: 'wayland' | 'x11' | null
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: preload is the audited renderer/Electron IPC contract; co-locating the surface eases security and type-drift review. */
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import { release as getOsRelease } from 'node:os'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
@@ -570,11 +569,14 @@ const api = {
   platform: {
     get: () => ({
       platform: process.platform,
+      // Why: sandboxed preload cannot require node:os; Electron exposes the OS
+      // version on process.getSystemVersion when available.
       osRelease:
-        (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ||
-        getOsRelease(),
+        (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ??
+        '',
       arch: process.arch,
       // Why: these identify the default shell without probing user config files.
+      // process.env is available in the sandboxed preload; node:os is not.
       shell: process.env.SHELL?.trim() || process.env.ComSpec?.trim() || '',
       displayServer: getLinuxDisplayServer()
     })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: preload is the audited renderer/Electron IPC contract; co-locating the surface eases security and type-drift review. */
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import { release as getOsRelease } from 'node:os'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
@@ -570,8 +571,11 @@ const api = {
     get: () => ({
       platform: process.platform,
       osRelease:
-        (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ??
-        '',
+        (process as NodeJS.Process & { getSystemVersion?: () => string }).getSystemVersion?.() ||
+        getOsRelease(),
+      arch: process.arch,
+      // Why: these identify the default shell without probing user config files.
+      shell: process.env.SHELL?.trim() || process.env.ComSpec?.trim() || '',
       displayServer: getLinuxDisplayServer()
     })
   } satisfies PreloadApi['platform'],

--- a/src/renderer/src/components/sidebar/SidebarFeedbackDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFeedbackDialog.test.tsx
@@ -138,13 +138,25 @@ describe('SidebarFeedbackDialog environment prefill', () => {
     expect(textarea.selectionStart).toBe('Typed before loading'.length)
   })
 
-  it('requires user text above the footer after values are edited or moved', async () => {
+  it('enables Send when the user types below the prefilled footer', async () => {
     render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
     const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
     await waitFor(() => expect(textarea.value).toContain('Orca: 1.4.178-rc.2'))
 
     fireEvent.change(textarea, {
-      target: { value: '---\nOrca: custom build\nOS: edited\nText below footer' }
+      target: { value: `${textarea.value.trim()}\nText below footer` }
+    })
+
+    expect((screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('keeps Send disabled for an edited footer with no user text', async () => {
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+    await waitFor(() => expect(textarea.value).toContain('Orca: 1.4.178-rc.2'))
+
+    fireEvent.change(textarea, {
+      target: { value: '---\nOrca: custom build\nOS: edited' }
     })
 
     expect((screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement).disabled).toBe(true)

--- a/src/renderer/src/components/sidebar/SidebarFeedbackDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFeedbackDialog.test.tsx
@@ -5,6 +5,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  getPlatform: vi.fn(),
+  getVersion: vi.fn(),
   readFeedbackImageFiles: vi.fn(),
   submit: vi.fn(),
   toastWarning: vi.fn()
@@ -57,20 +59,122 @@ beforeEach(() => {
   mocks.readFeedbackImageFiles.mockReset()
   mocks.submit.mockReset()
   mocks.toastWarning.mockReset()
+  mocks.getPlatform.mockReset()
+  mocks.getVersion.mockReset()
   mocks.submit.mockResolvedValue({ ok: true })
+  mocks.getPlatform.mockReturnValue({
+    platform: 'darwin',
+    osRelease: '25.0.0',
+    arch: 'arm64',
+    shell: '/bin/zsh',
+    displayServer: null
+  })
+  mocks.getVersion.mockResolvedValue('1.4.178-rc.2')
   URL.revokeObjectURL = vi.fn()
   Object.defineProperty(window, 'api', {
     configurable: true,
     value: {
       feedback: { submit: mocks.submit },
       gh: { viewer: vi.fn().mockResolvedValue(null) },
-      shell: { openUrl: vi.fn() }
+      shell: { openUrl: vi.fn() },
+      platform: {
+        get: mocks.getPlatform
+      },
+      updater: { getVersion: mocks.getVersion }
     }
   })
 })
 
 afterEach(() => {
   cleanup()
+})
+
+describe('SidebarFeedbackDialog environment prefill', () => {
+  it('pre-inserts Orca version and OS info when the dialog opens', async () => {
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+
+    await waitFor(() => {
+      expect(textarea.value).toContain('Orca: 1.4.178-rc.2')
+      expect(textarea.value).toContain('OS: darwin 25.0.0 (arm64)')
+      expect(textarea.value).toContain('Shell: /bin/zsh')
+    })
+    expect((screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('keeps version info when the user types above the prefilled block', async () => {
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+    await waitFor(() => expect(textarea.value).toContain('Orca: 1.4.178-rc.2'))
+
+    fireEvent.change(textarea, {
+      target: { value: `Tabs feel slow\n\n${textarea.value.trim()}` }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => expect(mocks.submit).toHaveBeenCalledTimes(1))
+    const submitted = mocks.submit.mock.calls[0]?.[0].feedback as string
+    expect(submitted).toContain('Tabs feel slow')
+    expect(submitted).toContain('Orca: 1.4.178-rc.2')
+  })
+
+  it('preserves early typing and appends the footer after version loading finishes', async () => {
+    let finishVersion: ((version: string) => void) | undefined
+    mocks.getVersion.mockReturnValue(
+      new Promise((resolve) => {
+        finishVersion = resolve
+      })
+    )
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+
+    fireEvent.change(textarea, { target: { value: 'Typed before loading' } })
+    textarea.focus()
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+    await act(async () => finishVersion?.('1.4.178-rc.2'))
+
+    await waitFor(() => expect(textarea.value).toContain('Orca: 1.4.178-rc.2'))
+    expect(textarea.value).toContain('Typed before loading')
+    expect(textarea.selectionStart).toBe('Typed before loading'.length)
+  })
+
+  it('requires user text above the footer after values are edited or moved', async () => {
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+    await waitFor(() => expect(textarea.value).toContain('Orca: 1.4.178-rc.2'))
+
+    fireEvent.change(textarea, {
+      target: { value: '---\nOrca: custom build\nOS: edited\nText below footer' }
+    })
+
+    expect((screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('allows a real report after the prefilled footer is deleted', async () => {
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+    await waitFor(() => expect(textarea.value).toContain('Orca: 1.4.178-rc.2'))
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement
+
+    fireEvent.change(textarea, { target: { value: '' } })
+    expect(send.disabled).toBe(true)
+    fireEvent.change(textarea, { target: { value: 'Tabs hang after waking the laptop.' } })
+    expect(send.disabled).toBe(false)
+  })
+
+  it('still prefills best-effort details when preload lookups fail', async () => {
+    mocks.getPlatform.mockImplementation(() => {
+      throw new Error('platform unavailable')
+    })
+    mocks.getVersion.mockRejectedValue(new Error('version unavailable'))
+
+    render(<SidebarFeedbackDialog open onOpenChange={vi.fn()} />)
+
+    await waitFor(() => {
+      const textarea = screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+      expect(textarea.value).toContain('Orca: unknown')
+    })
+  })
 })
 
 describe('SidebarFeedbackDialog image submission', () => {

--- a/src/renderer/src/components/sidebar/SidebarFeedbackDialog.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFeedbackDialog.tsx
@@ -17,13 +17,12 @@ import type { GitHubViewer } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import {
   extractImageFilesFromDataTransfer,
-  hasAttachableFeedbackImage,
-  readFeedbackImageFiles,
-  releaseFeedbackImageDraft,
-  type FeedbackImageDraft
+  hasAttachableFeedbackImage
 } from '@/lib/feedback-image-attachments'
+import { stripClientEnvironmentFooter } from '../../../../shared/client-environment-info'
 import { SidebarFeedbackImageAttachments } from './SidebarFeedbackImageAttachments'
-import { useFeedbackImageDrop } from './use-feedback-image-drop'
+import { useSidebarFeedbackEnvironmentPrefill } from './use-sidebar-feedback-environment-prefill'
+import { useSidebarFeedbackImages } from './use-sidebar-feedback-images'
 
 const GITHUB_ISSUES_URL = 'https://github.com/stablyai/orca/issues/'
 const DISCORD_URL = 'https://discord.gg/fzjDKHxv8Q'
@@ -66,98 +65,28 @@ export function SidebarFeedbackDialog({
   const [viewer, setViewer] = useState<GitHubViewer | null>(null)
   const [isViewerLoading, setIsViewerLoading] = useState(false)
   const [submitAnonymously, setSubmitAnonymously] = useState(false)
-  const [images, setImages] = useState<FeedbackImageDraft[]>([])
-  const [pendingImageReadCount, setPendingImageReadCount] = useState(0)
   const mountedRef = useMountedRef()
   const feedbackTextareaRef = useRef<HTMLTextAreaElement>(null)
-  const liveImageDraftsRef = useRef<FeedbackImageDraft[]>([])
+  const {
+    images,
+    pendingImageReadCount,
+    isDragActive,
+    contentRef,
+    dragHandlers,
+    handleAddFiles,
+    handleRemoveImage,
+    clearImages,
+    hasPendingImageReads,
+    getReservedImageSlots
+  } = useSidebarFeedbackImages({ open, isSubmitting, mountedRef })
 
-  const clearImages = React.useCallback(() => {
-    liveImageDraftsRef.current.forEach(releaseFeedbackImageDraft)
-    liveImageDraftsRef.current = []
-    setImages([])
-  }, [])
-
-  // Why: object URLs for the thumbnails leak until revoked, so drop them when
-  // the dialog unmounts as well as when an attachment is removed.
-  React.useEffect(
-    () => () => {
-      liveImageDraftsRef.current.forEach(releaseFeedbackImageDraft)
-      liveImageDraftsRef.current = []
-    },
-    []
-  )
-
-  const imageCount = images.length
-
-  // Why: committed state lags the in-flight reads, so batches still being read
-  // count against capacity — otherwise two quick pastes both see room for four.
-  const pendingImageReadsRef = useRef(0)
-
-  const handleAddFiles = React.useCallback(
-    (files: readonly File[]) => {
-      if (files.length === 0) {
-        return
-      }
-      if (isSubmitting) {
-        toast.warning(
-          translate(
-            'auto.components.sidebar.SidebarFeedbackDialog.attachWhileSending',
-            'Wait for the current feedback to finish sending before attaching more images.'
-          )
-        )
-        return
-      }
-      // Why: read the committed count from the closure rather than a ref. A ref
-      // synced in an effect can still be stale-low right after an add, which
-      // over-accepts and gets the whole submission rejected by the main process.
-      const existingCount = imageCount + pendingImageReadsRef.current
-      pendingImageReadsRef.current += files.length
-      setPendingImageReadCount((current) => current + files.length)
-      void readFeedbackImageFiles(files, existingCount).then(
-        ({ images: added, errors }) => {
-          pendingImageReadsRef.current -= files.length
-          if (!mountedRef.current) {
-            added.forEach(releaseFeedbackImageDraft)
-            return
-          }
-          setPendingImageReadCount((current) => Math.max(0, current - files.length))
-          if (added.length > 0) {
-            liveImageDraftsRef.current = [...liveImageDraftsRef.current, ...added]
-            setImages((existing) => [...existing, ...added])
-          }
-          // Why: never drop an attachment without telling the user — that
-          // silence is what made screenshots vanish in the first place.
-          errors.forEach((error) => toast.warning(error))
-        },
-        (error: unknown) => {
-          pendingImageReadsRef.current -= files.length
-          console.error('Failed to read feedback image attachments:', error)
-          if (mountedRef.current) {
-            setPendingImageReadCount((current) => Math.max(0, current - files.length))
-            toast.error(
-              translate(
-                'auto.components.sidebar.SidebarFeedbackDialog.imageReadFailed',
-                'Could not read the attached images. Try attaching them again.'
-              )
-            )
-          }
-        }
-      )
-    },
-    [imageCount, isSubmitting, mountedRef]
-  )
-
-  const handleRemoveImage = React.useCallback((id: string) => {
-    const removed = liveImageDraftsRef.current.find((image) => image.id === id)
-    if (removed) {
-      releaseFeedbackImageDraft(removed)
-      liveImageDraftsRef.current = liveImageDraftsRef.current.filter((image) => image.id !== id)
-    }
-    setImages((current) => current.filter((image) => image.id !== id))
-  }, [])
-
-  const { isDragActive, contentRef, dragHandlers } = useFeedbackImageDrop(open, handleAddFiles)
+  useSidebarFeedbackEnvironmentPrefill({
+    open,
+    feedback,
+    setFeedback,
+    textareaRef: feedbackTextareaRef,
+    mountedRef
+  })
 
   React.useEffect(() => {
     if (!open) {
@@ -191,11 +120,12 @@ export function SidebarFeedbackDialog({
   }, [open])
 
   const handleSubmit = async (): Promise<void> => {
-    if (isSubmitting || pendingImageReadsRef.current > 0) {
+    if (isSubmitting || hasPendingImageReads()) {
       return
     }
     const trimmed = feedback.trim()
-    if (!trimmed) {
+    const userText = stripClientEnvironmentFooter(feedback).trim()
+    if (!trimmed || !userText) {
       toast.warning(
         translate(
           'auto.components.sidebar.SidebarFeedbackDialog.a2fd890d9e',
@@ -287,7 +217,7 @@ export function SidebarFeedbackDialog({
           // Why: consume the paste only when something is actually attachable.
           // An unsupported image still routes through for its rejection toast,
           // but preventing default there would silently eat co-pasted text.
-          if (hasAttachableFeedbackImage(pasted, imageCount + pendingImageReadsRef.current)) {
+          if (hasAttachableFeedbackImage(pasted, getReservedImageSlots())) {
             event.preventDefault()
           }
           handleAddFiles(pasted)
@@ -430,7 +360,11 @@ export function SidebarFeedbackDialog({
           </Button>
           <Button
             onClick={() => void handleSubmit()}
-            disabled={isSubmitting || pendingImageReadCount > 0 || !feedback.trim()}
+            disabled={
+              isSubmitting ||
+              pendingImageReadCount > 0 ||
+              stripClientEnvironmentFooter(feedback).trim() === ''
+            }
           >
             {isSubmitting
               ? translate('auto.components.sidebar.SidebarFeedbackDialog.69969ba364', 'Sending…')

--- a/src/renderer/src/components/sidebar/use-sidebar-feedback-environment-prefill.ts
+++ b/src/renderer/src/components/sidebar/use-sidebar-feedback-environment-prefill.ts
@@ -1,0 +1,83 @@
+import { useLayoutEffect, useEffect, useRef, type RefObject } from 'react'
+import { resolveClientEnvironmentInfo } from '@/lib/client-environment-info'
+import {
+  appendClientEnvironmentFooter,
+  type ClientEnvironmentInfo
+} from '../../../../shared/client-environment-info'
+
+type FeedbackSelection = {
+  feedback: string
+  start: number
+  end: number
+  direction: 'forward' | 'backward' | 'none'
+}
+
+function insertClientEnvironmentFooter(params: {
+  feedback: string
+  environmentInfo: ClientEnvironmentInfo
+}): string {
+  const withFooter = appendClientEnvironmentFooter({
+    message: params.feedback,
+    info: params.environmentInfo
+  })
+  return params.feedback.trim() === '' ? `\n\n${withFooter}` : withFooter
+}
+
+/** Prefill version/OS footer without stealing caret while the user is typing. */
+export function useSidebarFeedbackEnvironmentPrefill(params: {
+  open: boolean
+  feedback: string
+  setFeedback: (updater: (current: string) => string) => void
+  textareaRef: RefObject<HTMLTextAreaElement | null>
+  mountedRef: RefObject<boolean>
+}): void {
+  const pendingFeedbackSelectionRef = useRef<FeedbackSelection | null>(null)
+
+  useLayoutEffect(() => {
+    const pending = pendingFeedbackSelectionRef.current
+    if (!pending) {
+      return
+    }
+    pendingFeedbackSelectionRef.current = null
+    if (pending.feedback !== params.feedback) {
+      return
+    }
+    const textarea = params.textareaRef.current
+    if (textarea && document.activeElement === textarea) {
+      textarea.setSelectionRange(pending.start, pending.end, pending.direction)
+    }
+  }, [params.feedback, params.textareaRef])
+
+  // Why: copied feedback does not include the structured IPC metadata.
+  useEffect(() => {
+    if (!params.open) {
+      return
+    }
+
+    let cancelled = false
+    void resolveClientEnvironmentInfo().then((environmentInfo) => {
+      if (cancelled || !params.mountedRef.current) {
+        return
+      }
+      const textarea = params.textareaRef.current
+      if (textarea && document.activeElement === textarea) {
+        pendingFeedbackSelectionRef.current = {
+          feedback: insertClientEnvironmentFooter({
+            feedback: textarea.value,
+            environmentInfo
+          }),
+          start: textarea.selectionStart,
+          end: textarea.selectionEnd,
+          direction: textarea.selectionDirection
+        }
+      }
+      params.setFeedback((current) =>
+        insertClientEnvironmentFooter({ feedback: current, environmentInfo })
+      )
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [params.open, params.mountedRef, params.setFeedback, params.textareaRef])
+}

--- a/src/renderer/src/components/sidebar/use-sidebar-feedback-environment-prefill.ts
+++ b/src/renderer/src/components/sidebar/use-sidebar-feedback-environment-prefill.ts
@@ -31,6 +31,7 @@ export function useSidebarFeedbackEnvironmentPrefill(params: {
   textareaRef: RefObject<HTMLTextAreaElement | null>
   mountedRef: RefObject<boolean>
 }): void {
+  const { open, feedback, setFeedback, textareaRef, mountedRef } = params
   const pendingFeedbackSelectionRef = useRef<FeedbackSelection | null>(null)
 
   useLayoutEffect(() => {
@@ -39,27 +40,27 @@ export function useSidebarFeedbackEnvironmentPrefill(params: {
       return
     }
     pendingFeedbackSelectionRef.current = null
-    if (pending.feedback !== params.feedback) {
+    if (pending.feedback !== feedback) {
       return
     }
-    const textarea = params.textareaRef.current
+    const textarea = textareaRef.current
     if (textarea && document.activeElement === textarea) {
       textarea.setSelectionRange(pending.start, pending.end, pending.direction)
     }
-  }, [params.feedback, params.textareaRef])
+  }, [feedback, textareaRef])
 
   // Why: copied feedback does not include the structured IPC metadata.
   useEffect(() => {
-    if (!params.open) {
+    if (!open) {
       return
     }
 
     let cancelled = false
     void resolveClientEnvironmentInfo().then((environmentInfo) => {
-      if (cancelled || !params.mountedRef.current) {
+      if (cancelled || !mountedRef.current) {
         return
       }
-      const textarea = params.textareaRef.current
+      const textarea = textareaRef.current
       if (textarea && document.activeElement === textarea) {
         pendingFeedbackSelectionRef.current = {
           feedback: insertClientEnvironmentFooter({
@@ -71,7 +72,7 @@ export function useSidebarFeedbackEnvironmentPrefill(params: {
           direction: textarea.selectionDirection
         }
       }
-      params.setFeedback((current) =>
+      setFeedback((current) =>
         insertClientEnvironmentFooter({ feedback: current, environmentInfo })
       )
     })
@@ -79,5 +80,5 @@ export function useSidebarFeedbackEnvironmentPrefill(params: {
     return () => {
       cancelled = true
     }
-  }, [params.open, params.mountedRef, params.setFeedback, params.textareaRef])
+  }, [open, mountedRef, setFeedback, textareaRef])
 }

--- a/src/renderer/src/components/sidebar/use-sidebar-feedback-images.ts
+++ b/src/renderer/src/components/sidebar/use-sidebar-feedback-images.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import {
+  readFeedbackImageFiles,
+  releaseFeedbackImageDraft,
+  type FeedbackImageDraft
+} from '@/lib/feedback-image-attachments'
+import { useFeedbackImageDrop } from './use-feedback-image-drop'
+
+export function useSidebarFeedbackImages(params: {
+  open: boolean
+  isSubmitting: boolean
+  mountedRef: RefObject<boolean>
+}): {
+  images: FeedbackImageDraft[]
+  pendingImageReadCount: number
+  isDragActive: boolean
+  contentRef: ReturnType<typeof useFeedbackImageDrop>['contentRef']
+  dragHandlers: ReturnType<typeof useFeedbackImageDrop>['dragHandlers']
+  handleAddFiles: (files: readonly File[]) => void
+  handleRemoveImage: (id: string) => void
+  clearImages: () => void
+  hasPendingImageReads: () => boolean
+  /** Live committed+pending count for paste capacity checks. */
+  getReservedImageSlots: () => number
+} {
+  const [images, setImages] = useState<FeedbackImageDraft[]>([])
+  const [pendingImageReadCount, setPendingImageReadCount] = useState(0)
+  const liveImageDraftsRef = useRef<FeedbackImageDraft[]>([])
+  // Why: committed state lags in-flight reads, so batches still being read count
+  // against capacity — otherwise two quick pastes both see room for four.
+  const pendingImageReadsRef = useRef(0)
+  const imageCount = images.length
+
+  const clearImages = useCallback(() => {
+    liveImageDraftsRef.current.forEach(releaseFeedbackImageDraft)
+    liveImageDraftsRef.current = []
+    setImages([])
+  }, [])
+
+  // Why: object URLs for the thumbnails leak until revoked.
+  useEffect(
+    () => () => {
+      liveImageDraftsRef.current.forEach(releaseFeedbackImageDraft)
+      liveImageDraftsRef.current = []
+    },
+    []
+  )
+
+  const handleAddFiles = useCallback(
+    (files: readonly File[]) => {
+      if (files.length === 0) {
+        return
+      }
+      if (params.isSubmitting) {
+        toast.warning(
+          translate(
+            'auto.components.sidebar.SidebarFeedbackDialog.attachWhileSending',
+            'Wait for the current feedback to finish sending before attaching more images.'
+          )
+        )
+        return
+      }
+      // Why: read the committed count from the closure rather than a ref. A ref
+      // synced in an effect can still be stale-low right after an add.
+      const existingCount = imageCount + pendingImageReadsRef.current
+      pendingImageReadsRef.current += files.length
+      setPendingImageReadCount((current) => current + files.length)
+      void readFeedbackImageFiles(files, existingCount).then(
+        ({ images: added, errors }) => {
+          pendingImageReadsRef.current -= files.length
+          if (!params.mountedRef.current) {
+            added.forEach(releaseFeedbackImageDraft)
+            return
+          }
+          setPendingImageReadCount((current) => Math.max(0, current - files.length))
+          if (added.length > 0) {
+            liveImageDraftsRef.current = [...liveImageDraftsRef.current, ...added]
+            setImages((existing) => [...existing, ...added])
+          }
+          // Why: never drop an attachment without telling the user.
+          errors.forEach((error) => toast.warning(error))
+        },
+        (error: unknown) => {
+          pendingImageReadsRef.current -= files.length
+          console.error('Failed to read feedback image attachments:', error)
+          if (params.mountedRef.current) {
+            setPendingImageReadCount((current) => Math.max(0, current - files.length))
+            toast.error(
+              translate(
+                'auto.components.sidebar.SidebarFeedbackDialog.imageReadFailed',
+                'Could not read the attached images. Try attaching them again.'
+              )
+            )
+          }
+        }
+      )
+    },
+    [imageCount, params.isSubmitting, params.mountedRef]
+  )
+
+  const handleRemoveImage = useCallback((id: string) => {
+    const removed = liveImageDraftsRef.current.find((image) => image.id === id)
+    if (removed) {
+      releaseFeedbackImageDraft(removed)
+      liveImageDraftsRef.current = liveImageDraftsRef.current.filter((image) => image.id !== id)
+    }
+    setImages((current) => current.filter((image) => image.id !== id))
+  }, [])
+
+  const { isDragActive, contentRef, dragHandlers } = useFeedbackImageDrop(
+    params.open,
+    handleAddFiles
+  )
+
+  return {
+    images,
+    pendingImageReadCount,
+    isDragActive,
+    contentRef,
+    dragHandlers,
+    handleAddFiles,
+    handleRemoveImage,
+    clearImages,
+    hasPendingImageReads: () => pendingImageReadsRef.current > 0,
+    getReservedImageSlots: () => liveImageDraftsRef.current.length + pendingImageReadsRef.current
+  }
+}

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -1,10 +1,35 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+
+import React from 'react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const environmentMocks = vi.hoisted(() => ({
+  resolveFooter: vi.fn()
+}))
+
+vi.mock('@/lib/client-environment-info', () => ({
+  resolveClientEnvironmentFooter: environmentMocks.resolveFooter
+}))
+
 import {
+  TerminalErrorToast,
   humanizeTerminalError,
   isSshReconnectOwnedTerminalError,
   shouldOfferDaemonRestart,
   stripSshReconnectOwnedErrorLines
 } from './TerminalErrorToast'
+
+beforeEach(() => {
+  environmentMocks.resolveFooter.mockReset()
+  environmentMocks.resolveFooter.mockResolvedValue(
+    ['---', 'Orca: 1.4.178-rc.2', 'OS: darwin 25.0.0 (arm64)', 'Shell: /bin/zsh'].join('\n')
+  )
+})
+
+afterEach(() => {
+  cleanup()
+})
 
 const SSH_FAILURE =
   "SSH connection failed: Error invoking remote method 'ssh:connect': Error: Relay package for linux-x64 not found locally."
@@ -106,5 +131,49 @@ describe('shouldOfferDaemonRestart', () => {
   it('does not match unrelated terminal spawn errors', () => {
     expect(shouldOfferDaemonRestart('SSH connection is not active.')).toBe(false)
     expect(shouldOfferDaemonRestart('node-pty: open_slave failed: EMFILE (errno 24)')).toBe(false)
+  })
+})
+
+describe('TerminalErrorToast environment footer', () => {
+  it('appends client environment details to local errors', async () => {
+    const view = render(
+      React.createElement(TerminalErrorToast, {
+        error: 'Paste failed.',
+        onDismiss: vi.fn()
+      })
+    )
+
+    await waitFor(() => expect(view.container.textContent).toContain('Orca: 1.4.178-rc.2'))
+  })
+
+  it('does not retain a prior async footer when the next error already has one', async () => {
+    const view = render(
+      React.createElement(TerminalErrorToast, {
+        error: 'First failure.',
+        onDismiss: vi.fn()
+      })
+    )
+    await waitFor(() => expect(view.container.textContent).toContain('Orca: 1.4.178-rc.2'))
+
+    view.rerender(
+      React.createElement(TerminalErrorToast, {
+        error: 'Second failure.\n\n---\nOrca: embedded\nOS: linux 6.8 (x64)',
+        onDismiss: vi.fn()
+      })
+    )
+
+    expect(view.container.textContent).toContain('Orca: embedded')
+    expect(view.container.textContent).not.toContain('Orca: 1.4.178-rc.2')
+  })
+
+  it('omits client details for every SSH reconnect-owned error', async () => {
+    render(
+      React.createElement(TerminalErrorToast, {
+        error: SSH_FAILURE,
+        onDismiss: vi.fn()
+      })
+    )
+
+    await waitFor(() => expect(environmentMocks.resolveFooter).not.toHaveBeenCalled())
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useState } from 'react'
 import { translate } from '@/i18n/i18n'
+import { resolveClientEnvironmentFooter } from '@/lib/client-environment-info'
+import { hasClientEnvironmentFooter } from '../../../../shared/client-environment-info'
+
 const SSH_PREFIX = 'SSH connection is not active'
 // Produced by pty-connection.ts reportError() when a PTY reattach can't reach its SSH host.
 const SSH_CONNECT_FAILURE_PREFIX = 'SSH connection failed'
@@ -16,7 +20,7 @@ const STALE_DAEMON_CWD_MARKERS = [
 const PANE_OWNER_UNVERIFIED_MARKER = 'terminal_pane_owner_unverified'
 
 function isSshError(error: string): boolean {
-  return error.startsWith(SSH_PREFIX) || error.includes(SSH_RELAY_LOST_MARKER)
+  return isSshReconnectOwnedTerminalError(error)
 }
 
 /** A single error line the SSH reconnect banner already covers — hide instead of stacking under/over it. */
@@ -70,6 +74,28 @@ export function TerminalErrorToast({
   const ssh = isSshError(error)
   const showDaemonRestart = !ssh && onRestartDaemon && shouldOfferDaemonRestart(error)
   const displayError = humanizeTerminalError(error)
+  const [environmentFooter, setEnvironmentFooter] = useState<{
+    error: string
+    footer: string
+  } | null>(null)
+
+  // Why: a select-all copy should carry details loaded asynchronously from preload.
+  useEffect(() => {
+    if (ssh || hasClientEnvironmentFooter(displayError)) {
+      return
+    }
+    let cancelled = false
+    void resolveClientEnvironmentFooter().then((footer) => {
+      if (!cancelled) {
+        setEnvironmentFooter({ error: displayError, footer })
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [displayError, ssh])
+
+  const footer = environmentFooter?.error === displayError ? environmentFooter.footer : ''
 
   return (
     <div
@@ -120,6 +146,7 @@ export function TerminalErrorToast({
               .
             </>
           ) : null}
+          {!ssh && footer ? `\n\n${footer}` : null}
         </span>
         {showDaemonRestart ? (
           <button

--- a/src/renderer/src/hooks/useUnreadDockBadge.test.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.test.ts
@@ -63,6 +63,12 @@ describe('useUnreadDockBadge', () => {
     expect(setUnreadDockBadgeCount).toHaveBeenCalledWith(0)
   })
 
+  it('no-ops when the preload API is unavailable', () => {
+    vi.stubGlobal('window', {})
+
+    expect(() => clearUnreadDockBadgeCount()).not.toThrow()
+  })
+
   it('does not rescan workspaces for unrelated remote activity or parent renders', () => {
     const worktrees = Array.from({ length: 100 }, (_, index) =>
       makeWorktree({ id: `repo::worktree-${index}`, repoId: 'repo' })

--- a/src/renderer/src/hooks/useUnreadDockBadge.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.ts
@@ -4,7 +4,11 @@ import { getUnreadBadgeCount } from '@/lib/unread-badge-count'
 import { useAppStore } from '@/store'
 
 function setUnreadDockBadgeCountBestEffort(count: number): void {
-  void window.api.app.setUnreadDockBadgeCount(count).catch(() => {
+  const setBadge = window.api?.app?.setUnreadDockBadgeCount
+  if (!setBadge) {
+    return
+  }
+  void setBadge(count).catch(() => {
     // Dock sync is best-effort chrome; stale badge state should not affect app use.
   })
 }

--- a/src/renderer/src/lib/client-environment-info.ts
+++ b/src/renderer/src/lib/client-environment-info.ts
@@ -1,0 +1,50 @@
+import {
+  formatClientEnvironmentFooter,
+  type ClientEnvironmentInfo
+} from '../../../shared/client-environment-info'
+import { getRendererAppPlatform } from './renderer-app-platform'
+
+/** Resolve trusted desktop env details (or browser best-effort) for bug reports. */
+export async function resolveClientEnvironmentInfo(): Promise<ClientEnvironmentInfo> {
+  const platformInfo = resolvePlatformInfo()
+  const appVersion = await resolveAppVersion()
+  return {
+    appVersion,
+    platform: platformInfo?.platform ?? resolveFallbackPlatform(),
+    osRelease: platformInfo?.osRelease ?? '',
+    arch: platformInfo?.arch ?? '',
+    ...(platformInfo?.shell ? { shell: platformInfo.shell } : {})
+  }
+}
+
+function resolvePlatformInfo(): ReturnType<NonNullable<typeof window.api.platform>['get']> | null {
+  try {
+    return window.api?.platform?.get?.() ?? null
+  } catch {
+    return null
+  }
+}
+
+function resolveFallbackPlatform(): NodeJS.Platform | 'unknown' {
+  try {
+    return getRendererAppPlatform()
+  } catch {
+    return 'unknown'
+  }
+}
+
+export async function resolveClientEnvironmentFooter(): Promise<string> {
+  return formatClientEnvironmentFooter(await resolveClientEnvironmentInfo())
+}
+
+async function resolveAppVersion(): Promise<string> {
+  try {
+    const version = await window.api?.updater?.getVersion?.()
+    if (typeof version === 'string' && version.trim()) {
+      return version.trim()
+    }
+  } catch {
+    // Best-effort: feedback/error copy should still show OS details.
+  }
+  return 'unknown'
+}

--- a/src/renderer/src/store/slices/preflight.ts
+++ b/src/renderer/src/store/slices/preflight.ts
@@ -90,10 +90,13 @@ export const createPreflightSlice: StateCreator<AppState, [], [], PreflightSlice
       preflightStatusError: null
     })
 
+    const localPreflightCheck = window.api?.preflight?.check
     const request = (
       runtimeTarget.kind === 'environment'
         ? callRuntimeRpc<PreflightStatus>(runtimeTarget, 'preflight.check', force ? { force } : {})
-        : window.api.preflight.check(preflightArgs)
+        : localPreflightCheck
+          ? localPreflightCheck(preflightArgs)
+          : Promise.reject(new Error('Desktop preflight API is unavailable.'))
     )
       .then((status) => {
         if (requestId !== latestPreflightRequestId) {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -603,6 +603,8 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       get: () => ({
         platform: getBrowserPlatform(),
         osRelease: '',
+        arch: '',
+        shell: '',
         displayServer: null
       })
     },

--- a/src/shared/client-environment-info.test.ts
+++ b/src/shared/client-environment-info.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendClientEnvironmentFooter,
+  formatClientEnvironmentFooter,
+  formatClientEnvironmentInfo,
+  hasClientEnvironmentFooter,
+  stripClientEnvironmentFooter
+} from './client-environment-info'
+
+const SAMPLE = {
+  appVersion: '1.4.178-rc.2',
+  platform: 'win32',
+  osRelease: '10.0.22631',
+  arch: 'x64',
+  shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+} as const
+
+describe('formatClientEnvironmentInfo', () => {
+  it('formats version, OS, and optional shell for copy-paste', () => {
+    expect(formatClientEnvironmentInfo(SAMPLE)).toBe(
+      [
+        'Orca: 1.4.178-rc.2',
+        'OS: win32 10.0.22631 (x64)',
+        'Shell: C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+      ].join('\n')
+    )
+  })
+
+  it('omits shell when unset and falls back unknown fields', () => {
+    expect(
+      formatClientEnvironmentInfo({
+        appVersion: '',
+        platform: 'darwin',
+        osRelease: '',
+        arch: 'arm64'
+      })
+    ).toBe(['Orca: unknown', 'OS: darwin (arm64)'].join('\n'))
+  })
+
+  it('keeps environment-controlled values on one line', () => {
+    expect(
+      formatClientEnvironmentInfo({
+        appVersion: '1.2.3\nInjected: value',
+        platform: 'linux',
+        osRelease: '6.8\r\nExtra',
+        arch: 'x64',
+        shell: '/bin/zsh\nMore: data'
+      })
+    ).toBe(
+      [
+        'Orca: 1.2.3 Injected: value',
+        'OS: linux 6.8 Extra (x64)',
+        'Shell: /bin/zsh More: data'
+      ].join('\n')
+    )
+  })
+})
+
+describe('environment footer helpers', () => {
+  it('builds a marked footer and detects when one is already present', () => {
+    const footer = formatClientEnvironmentFooter(SAMPLE)
+    expect(footer.startsWith('---\nOrca:')).toBe(true)
+    expect(hasClientEnvironmentFooter(`oops\n\n${footer}`)).toBe(true)
+    expect(hasClientEnvironmentFooter('oops')).toBe(false)
+  })
+
+  it('appends a footer once and leaves existing footers alone', () => {
+    const withFooter = appendClientEnvironmentFooter({
+      message: 'Working directory missing.',
+      info: SAMPLE
+    })
+    expect(withFooter).toContain('Working directory missing.')
+    expect(withFooter).toContain('Orca: 1.4.178-rc.2')
+    expect(appendClientEnvironmentFooter({ message: withFooter, info: SAMPLE })).toBe(withFooter)
+  })
+
+  it('treats footer-only text as empty user feedback', () => {
+    const footer = formatClientEnvironmentFooter(SAMPLE)
+    expect(stripClientEnvironmentFooter(`\n\n${footer}\n`).trim()).toBe('')
+    expect(stripClientEnvironmentFooter(`please fix tabs\n\n${footer}`).trimEnd()).toBe(
+      'please fix tabs'
+    )
+    expect(stripClientEnvironmentFooter(footer).trim()).toBe('')
+  })
+
+  it('recognizes edited footer values and ignores text moved below the footer', () => {
+    const editedFooter = ['---', 'Orca: locally-built', 'OS: edited by user', 'notes below'].join(
+      '\n'
+    )
+
+    expect(hasClientEnvironmentFooter(editedFooter)).toBe(true)
+    expect(stripClientEnvironmentFooter(editedFooter)).toBe('')
+    expect(stripClientEnvironmentFooter(`actual report\n\n${editedFooter}`).trim()).toBe(
+      'actual report'
+    )
+  })
+
+  it('treats a report as user text after the footer is deleted', () => {
+    const withoutFooter = 'Tabs hang after waking the laptop.'
+
+    expect(hasClientEnvironmentFooter(withoutFooter)).toBe(false)
+    expect(stripClientEnvironmentFooter(withoutFooter)).toBe(withoutFooter)
+  })
+})

--- a/src/shared/client-environment-info.test.ts
+++ b/src/shared/client-environment-info.test.ts
@@ -83,16 +83,21 @@ describe('environment footer helpers', () => {
     expect(stripClientEnvironmentFooter(footer).trim()).toBe('')
   })
 
-  it('recognizes edited footer values and ignores text moved below the footer', () => {
-    const editedFooter = ['---', 'Orca: locally-built', 'OS: edited by user', 'notes below'].join(
-      '\n'
-    )
+  it('counts authored text above or below the footer as user feedback', () => {
+    const footer = formatClientEnvironmentFooter(SAMPLE)
+    expect(hasClientEnvironmentFooter(`\n\n${footer}\ntyped below`)).toBe(true)
+    expect(stripClientEnvironmentFooter(`\n\n${footer}\ntyped below`).trim()).toBe('typed below')
+    expect(stripClientEnvironmentFooter(`actual report\n\n${footer}`).trim()).toBe('actual report')
+    expect(
+      stripClientEnvironmentFooter(`above\n\n${footer}\nbelow`).replace(/\n+/g, ' ').trim()
+    ).toBe('above below')
+  })
+
+  it('still detects an edited footer block', () => {
+    const editedFooter = ['---', 'Orca: locally-built', 'OS: edited by user'].join('\n')
 
     expect(hasClientEnvironmentFooter(editedFooter)).toBe(true)
-    expect(stripClientEnvironmentFooter(editedFooter)).toBe('')
-    expect(stripClientEnvironmentFooter(`actual report\n\n${editedFooter}`).trim()).toBe(
-      'actual report'
-    )
+    expect(stripClientEnvironmentFooter(editedFooter).trim()).toBe('')
   })
 
   it('treats a report as user text after the footer is deleted', () => {

--- a/src/shared/client-environment-info.ts
+++ b/src/shared/client-environment-info.ts
@@ -11,6 +11,12 @@ export type ClientEnvironmentInfo = {
 const FOOTER_MARKER = '---'
 const ORCA_LINE_PREFIX = 'Orca:'
 
+// Why: match the whole prefilled block (optional Shell line included) so strip
+// keeps authored text both above and below — users who click past the footer
+// and type must still be able to send.
+const CLIENT_ENVIRONMENT_FOOTER_BLOCK =
+  /(^|\r?\n)---\r?\nOrca:[^\r\n]*\r?\nOS:[^\r\n]*(?:\r?\nShell:[^\r\n]*)?/
+
 function normalizeEnvironmentValue(value: string): string {
   return value.trim().replace(/[\r\n]+/g, ' ')
 }
@@ -34,19 +40,13 @@ export function formatClientEnvironmentFooter(info: ClientEnvironmentInfo): stri
   return `${FOOTER_MARKER}\n${formatClientEnvironmentInfo(info)}`
 }
 
-function findClientEnvironmentFooterIndex(text: string): number | null {
-  const match = /(^|\r?\n)---\r?\nOrca:[^\r\n]*\r?\nOS:[^\r\n]*/.exec(text)
-  return match ? match.index + match[1].length : null
-}
-
 export function hasClientEnvironmentFooter(text: string): boolean {
-  return findClientEnvironmentFooterIndex(text) !== null
+  return CLIENT_ENVIRONMENT_FOOTER_BLOCK.test(text)
 }
 
-/** Keep only text above the footer so validation requires a user-authored report. */
+/** Drop only the env footer block; keep user text above and below it. */
 export function stripClientEnvironmentFooter(text: string): string {
-  const footerIndex = findClientEnvironmentFooterIndex(text)
-  return footerIndex === null ? text : text.slice(0, footerIndex)
+  return text.replace(CLIENT_ENVIRONMENT_FOOTER_BLOCK, '$1')
 }
 
 export function appendClientEnvironmentFooter(params: {

--- a/src/shared/client-environment-info.ts
+++ b/src/shared/client-environment-info.ts
@@ -1,0 +1,62 @@
+/** Copy-pasteable client environment fields for bug reports and feedback. */
+export type ClientEnvironmentInfo = {
+  appVersion: string
+  platform: string
+  osRelease: string
+  arch: string
+  /** Login/default shell path when known (e.g. SHELL / ComSpec / spawn shell). */
+  shell?: string
+}
+
+const FOOTER_MARKER = '---'
+const ORCA_LINE_PREFIX = 'Orca:'
+
+function normalizeEnvironmentValue(value: string): string {
+  return value.trim().replace(/[\r\n]+/g, ' ')
+}
+
+export function formatClientEnvironmentInfo(info: ClientEnvironmentInfo): string {
+  const version = normalizeEnvironmentValue(info.appVersion) || 'unknown'
+  const platform = normalizeEnvironmentValue(info.platform) || 'unknown'
+  const osRelease = normalizeEnvironmentValue(info.osRelease)
+  const arch = normalizeEnvironmentValue(info.arch)
+  const osParts = [platform, osRelease, arch ? `(${arch})` : ''].filter(Boolean)
+  const lines = [`${ORCA_LINE_PREFIX} ${version}`, `OS: ${osParts.join(' ')}`]
+  const shell = info.shell ? normalizeEnvironmentValue(info.shell) : ''
+  if (shell) {
+    lines.push(`Shell: ${shell}`)
+  }
+  return lines.join('\n')
+}
+
+/** Block appended under error/feedback bodies so reporters always paste env details. */
+export function formatClientEnvironmentFooter(info: ClientEnvironmentInfo): string {
+  return `${FOOTER_MARKER}\n${formatClientEnvironmentInfo(info)}`
+}
+
+function findClientEnvironmentFooterIndex(text: string): number | null {
+  const match = /(^|\r?\n)---\r?\nOrca:[^\r\n]*\r?\nOS:[^\r\n]*/.exec(text)
+  return match ? match.index + match[1].length : null
+}
+
+export function hasClientEnvironmentFooter(text: string): boolean {
+  return findClientEnvironmentFooterIndex(text) !== null
+}
+
+/** Keep only text above the footer so validation requires a user-authored report. */
+export function stripClientEnvironmentFooter(text: string): string {
+  const footerIndex = findClientEnvironmentFooterIndex(text)
+  return footerIndex === null ? text : text.slice(0, footerIndex)
+}
+
+export function appendClientEnvironmentFooter(params: {
+  message: string
+  info: ClientEnvironmentInfo
+}): string {
+  if (hasClientEnvironmentFooter(params.message)) {
+    return params.message
+  }
+  const footer = formatClientEnvironmentFooter(params.info)
+  const base = params.message.trimEnd()
+  return base.length > 0 ? `${base}\n\n${footer}` : footer
+}


### PR DESCRIPTION
## Summary
- Terminal error toasts and main/daemon spawn/cwd failures now include easy-to-copy **Orca version + OS (+ shell when known)** so users pasting errors into GitHub/Discord don't forget env details.
- **Send Feedback** pre-inserts the same environment footer into the textarea (caret preserved while the async version load finishes), and blocks send until the user writes real feedback above it.
- Shared pure formatter (`src/shared/client-environment-info.ts`) keeps the copy format consistent; preload exposes `arch`/`shell` for desktop, with safe web fallbacks.

## Codex review (gpt-5.6 high)
Orchestrated review+fix pass tightened:
- async feedback prefill without clobbering early typing / caret
- footer-only validation and robust footer strip/detect
- toast footer keyed to current error (no stale footer)
- full SSH reconnect-owned exclusion from env footer
- newline sanitization of environment values
- `os.release()` fallback when `getSystemVersion` is unavailable

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts` on client-environment, SidebarFeedbackDialog, TerminalErrorToast, local-pty-utils, node-pty-error-hints suites
- [ ] Open Send Feedback → confirm footer prefill with version/OS/shell; typing above it still enables Send; footer-only does not
- [ ] Force a local terminal cwd/spawn error → toast shows env footer; select-all copy includes it
- [ ] SSH reconnect errors → no env footer / no "file an issue" noise