### PR TITLE
Make OpenCode agent session discoverable - Unpack OpenCode SQLite worker entry from asar

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -166,6 +166,12 @@ module.exports = {
   // Why: sherpa-onnx native bindings (platform-specific subpackages) must be
   // unpacked because they ship .node addons + .dylib/.so files that cannot be
   // dlopen()'d from inside the asar archive.
+  // Why: the OpenCode SQLite worker entry is also spawned by the scanner
+  // service, which runs under ELECTRON_RUN_AS_NODE and so cannot see into
+  // app.asar. Left packed, that spawn fails closed and every OpenCode session
+  // disappears from Agent Session History in packaged builds only. Worker
+  // entries reached solely from the Electron main process stay packed, since
+  // asar redirects their app.asar paths.
   asarUnpack: [
     'out/package.json',
     'out/cli/**',
@@ -183,6 +189,7 @@ module.exports = {
     'out/main/hermes/**',
     'out/main/daemon-entry.js',
     'out/main/session-scanner-service-entry.js',
+    'out/main/session-scanner-opencode-sqlite-worker-entry.js',
     'out/main/plugin-host-entry.js',
     'out/main/computer-sidecar.js',
     'out/main/parcel-watcher-process-entry.js',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -4,6 +4,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
+const REPO_ROOT = join(import.meta.dirname, '..', '..')
+const SRC_MAIN_DIR = join(REPO_ROOT, 'src', 'main')
+
 const require = createRequire(import.meta.url)
 const electronBuilderConfig = require('../electron-builder.config.cjs')
 const { FileMatcher } = require('app-builder-lib/out/fileMatcher')
@@ -169,6 +172,29 @@ describe('electron-builder config', () => {
     expect(electronBuilderConfig.asarUnpack).toEqual(
       expect.arrayContaining(['out/main/parcel-watcher-process-entry.js'])
     )
+  })
+
+  // Why: the scanner service is forked with ELECTRON_RUN_AS_NODE, so asar is
+  // invisible to it and a packed worker entry fails closed — dropping every
+  // OpenCode session in packaged builds while dev stays green. Three legs must
+  // agree on the filename, so all three are read rather than hardcoded.
+  it('unpacks the OpenCode SQLite worker entry the scanner service forks', async () => {
+    const spawnSource = await readFile(
+      join(SRC_MAIN_DIR, 'ai-vault', 'session-scanner-opencode-sqlite-worker-spawn.ts'),
+      'utf8'
+    )
+    const entryFilename = spawnSource.match(/WORKER_ENTRY_FILENAME = '([^']+)'/)?.[1]
+
+    expect(entryFilename).toBeDefined()
+    expect(electronBuilderConfig.asarUnpack).toContain(`out/main/${entryFilename}`)
+
+    // Why: the emitted path comes from the rollup input key under
+    // entryFileNames '[name].js', not from the source filename — renaming the
+    // key alone would leave the other two legs agreeing on a file that no
+    // longer exists.
+    const viteConfig = await readFile(join(REPO_ROOT, 'electron.vite.config.ts'), 'utf8')
+    expect(viteConfig).toContain("entryFileNames: '[name].js'")
+    expect(viteConfig).toMatch(new RegExp(`'${entryFilename.replace(/\.js$/, '')}':\\s*resolve\\(`))
   })
 
   it('keeps the worker-thread hang watchdog inside app.asar', () => {


### PR DESCRIPTION
## Problem

The OpenCode SQLite worker entry was packed inside the app.asar archive in built/packaged releases. However, the scanner service runs under `ELECTRON_RUN_AS_NODE` and cannot access files inside asar. This caused worker spawn failures in packaged builds only, making every OpenCode session disappear from Agent Session History while dev builds worked fine.

## Solution

Unpack the OpenCode SQLite worker entry by adding `'out/main/session-scanner-opencode-sqlite-worker-entry.js'` to the `asarUnpack` array in the electron-builder config. Added a test that verifies the worker entry filename is consistently referenced across three config files: the spawn source, the builder config, and the vite config.

## Screenshots

No visual change.

## Testing

- [x] Added test `unpacks the OpenCode SQLite worker entry the scanner service forks` that validates the filename matches across all three config sources
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- Manual verification: packaged build should show OpenCode sessions in Agent Session History (previously disappeared)

## AI Review Report

TODO: Run code review

## Security Audit

TODO: Run security audit

## Notes

This is a build configuration fix specific to packaged (non-dev) releases. The test prevents accidental drift between the three points that must agree on the worker entry filename.