### PR TITLE
fix(cmd-j): improve keyboard selection visibility in light mode

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -67,9 +67,9 @@ A common point of drift. Use these conventions for any list-style row (worktrees
 
 - **Idle:** transparent background.
 - **Hover:** `bg-accent` (in the worktree sidebar, `bg-sidebar-accent`).
-- **Keyboard-selected (cmdk highlight):** `data-[selected=true]:bg-accent` plus a `border-border` outline so the active row stays visible while the user types. The `data-selected` attribute is set by `cmdk` automatically.
+- **Keyboard-selected (cmdk highlight):** do **not** rely on flat `bg-accent` alone on light popover/dialog surfaces — `--accent` (#f5f5f5) is nearly identical to `--background` (#fff), so the cursor vanishes. Use the jump-palette recipe in `main.css` (`.jump-palette-item[data-selected='true']`): `color-mix` foreground into background (~12%) plus an inset ring. Expose the mix as `--jump-palette-selection-surface` when nested cutouts (status pips) must match. The `data-selected` attribute is set by `cmdk` automatically.
 - **Persistent "current" / "active" row** (e.g. the worktree the user is viewing): also `bg-accent`, _plus_ a `data-current="true"` attribute so CSS or future styling can distinguish it from the cmdk highlight.
-- **Don't:** hardcode `bg-[#ededed]` / `bg-[#333333]` or invent a "selected" color. The accent token already adapts to light/dark and matches the rest of the app.
+- **Don't:** hardcode `bg-[#ededed]` / `bg-[#333333]` or invent a "selected" color. Mix from existing tokens (`foreground`/`background`/`accent`) so light/dark stay aligned.
 
 ### Color mixing
 

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1121,6 +1121,31 @@ html.native-shell .app-layout {
   overflow: hidden;
 }
 
+/* ── Jump palette (Cmd+J) ─────────────────────────────── */
+
+/* Why the data-slot qualifier: CommandItem also sets data-[selected=true]:bg-accent;
+   this selector must beat that utility so light-mode selection is actually visible. */
+[data-slot='command-item'].jump-palette-item[data-selected='true'] {
+  /* Why: flat --accent (#f5f5f5) on the palette surface (#fff) is nearly invisible
+     in light mode — the keyboard cursor has to read as a solid selected row.
+     Mix foreground into background and draw an inset ring; expose the surface
+     as a var so status-pip cutouts can match without hardcoding. */
+  --jump-palette-selection-surface: color-mix(in srgb, var(--foreground) 12%, var(--background));
+  background: var(--jump-palette-selection-surface);
+  border-color: transparent;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--foreground) 18%, transparent);
+  color: var(--foreground);
+}
+
+.dark [data-slot='command-item'].jump-palette-item[data-selected='true'] {
+  /* Why accent, not the light-mode mix: --accent (#404040) already reads clearly on
+     dark surfaces; a low-%% foreground mix was a visible step down from the old row. */
+  --jump-palette-selection-surface: var(--accent);
+  background: var(--jump-palette-selection-surface);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--foreground) 16%, transparent);
+  color: var(--accent-foreground);
+}
+
 /* ── Sidebar ─────────────────────────────────────────── */
 
 [data-file-explorer-row][data-selected='true'] {

--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -315,6 +315,28 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     expect(getCommandValue()).toBe('workspace-tab:tab-host')
   })
 
+  // Why: after typing, arrow moves must stick. Dropping onValueChange while cmdk already
+  // advanced its internal cursor made the next ArrowDown a no-op (Object.is short-circuit).
+  it('keeps arrow selection after the typed query ranking has committed', async () => {
+    await renderPalette(makeTypedRelevanceState())
+
+    await act(async () => {
+      setCommandQuery?.('perf')
+    })
+    await flushEffects()
+    expect(getCommandValue()).toBe('workspace-tab:tab-host')
+
+    const rows = getRenderedRowIds().filter((id) => id.length > 0)
+    expect(rows.length).toBeGreaterThan(1)
+
+    await act(async () => {
+      setCommandSelection?.(rows[1])
+    })
+    await flushEffects()
+
+    expect(getCommandValue()).toBe(rows[1])
+  })
+
   it('keeps worktrees ahead of tabs when a worktree holds the stronger match', async () => {
     await renderPalette({
       ...makeTypedRelevanceState(),

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -270,6 +270,9 @@ const CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID = `quick-action:${CREATE_WORKSPACE_Q
 
 // Why: outlast the CommandDialog close animation so its rows do not disappear mid-fade.
 const PALETTE_CLOSE_LINGER_MS = 300
+// Why `jump-palette-item`: selection chrome lives in main.css — flat accent is invisible on light popovers.
+const JUMP_PALETTE_ITEM_CLASSNAME =
+  'jump-palette-item group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 text-left outline-none transition-[background-color,box-shadow]'
 
 type OpenTabPaletteItem = BrowserPaletteItem | SimulatorPaletteItem | WorkspaceTabPaletteItem
 
@@ -637,7 +640,6 @@ function WorktreeJumpPaletteContent({
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
   const [selectedItemId, setSelectedItemId] = useState('')
-  const latestQueryRef = useRef('')
   // Why: the id cmdk auto-selected for the last committed list, so a late recent-order snapshot can
   // tell "nobody has moved the highlight yet" from "the user arrowed somewhere deliberately".
   const autoSelectedItemIdRef = useRef<string | null>(null)
@@ -1871,7 +1873,6 @@ function WorktreeJumpPaletteContent({
           ? document.activeElement
           : null
       skipRestoreFocusRef.current = false
-      latestQueryRef.current = ''
       setQuery('')
       setSelectedItemId('')
       // Why: reset on open, not on close — closing races the fade-out, and a
@@ -1908,16 +1909,23 @@ function WorktreeJumpPaletteContent({
     showCreateAction
   })
 
-  const handleCommandSelectionChange = useCallback(
-    (nextItemId: string) => {
-      // Why: cmdk can report the old list head before the deferred query commits its new ranking.
-      if (latestQueryRef.current !== deferredQuery) {
-        return
-      }
-      setSelectedItemId(nextItemId)
-    },
-    [deferredQuery]
-  )
+  // Why: cmdk writes its internal cursor *before* calling onValueChange. Dropping that
+  // callback (e.g. while deferredQuery lags the keystroke) leaves internal state advanced
+  // while the controlled `value` prop stays put — the next ArrowDown/Up then no-ops on
+  // cmdk's Object.is guard, so keyboard navigation dies after typing. Always accept the
+  // report so the cursor stays aligned; the deferred-commit effect below re-auto-selects
+  // the new ranking head once the list the user sees actually changes.
+  const handleCommandSelectionChange = useCallback((nextItemId: string) => {
+    setSelectedItemId(nextItemId)
+  }, [])
+
+  // Why: while query is mid-deferral, cmdk (and mid-lag arrows) can latch a selection
+  // against the previous ranking. When the deferred list commits, snap Enter back to the
+  // new head — matching handleQueryChange's clear, but covering selection that landed
+  // after the keystroke and before this commit.
+  useLayoutEffect(() => {
+    setSelectedItemId('')
+  }, [deferredQuery])
 
   useEffect(() => {
     const isCreateWorkspaceHighlighted =
@@ -1931,7 +1939,6 @@ function WorktreeJumpPaletteContent({
   }, [commandSelectedItemId, prefetchCreateWorkspaceBaseForComposer, visible])
 
   const handleQueryChange = useCallback((nextQuery: string) => {
-    latestQueryRef.current = nextQuery
     setQuery(nextQuery)
     setSelectedItemId('')
     listRef.current?.scrollTo(0, 0)
@@ -2587,7 +2594,7 @@ function WorktreeJumpPaletteContent({
                     key={entry.id}
                     value={CREATE_WORKTREE_ITEM_ID}
                     onSelect={handleCreateWorktree}
-                    className="group mx-0.5 mt-1 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-1.5 text-left outline-none transition-[background-color,border-color,box-shadow] data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground"
+                    className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'mt-1 py-1.5')}
                   >
                     <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-dashed border-border/60 bg-muted/25 text-muted-foreground/70">
                       <Plus size={13} aria-hidden="true" />
@@ -2631,10 +2638,7 @@ function WorktreeJumpPaletteContent({
                     value={entry.id}
                     onSelect={() => handleSelectItem(entry)}
                     data-current={isCurrentWorktree ? 'true' : undefined}
-                    className={cn(
-                      'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
-                      'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
-                    )}
+                    className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
                     <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start">
                       <PaletteWorktreeStatusDot worktree={worktree} />
@@ -2760,10 +2764,7 @@ function WorktreeJumpPaletteContent({
                     key={entry.id}
                     value={entry.id}
                     onSelect={() => handleSelectItem(entry)}
-                    className={cn(
-                      'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
-                      'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
-                    )}
+                    className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
                     <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <FolderTree className="size-3.5" aria-hidden="true" />
@@ -2807,10 +2808,7 @@ function WorktreeJumpPaletteContent({
                     key={entry.id}
                     value={entry.id}
                     onSelect={() => handleSelectItem(entry)}
-                    className={cn(
-                      'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
-                      'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
-                    )}
+                    className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
                     <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <Icon className="size-3.5" aria-hidden="true" />
@@ -2855,10 +2853,7 @@ function WorktreeJumpPaletteContent({
                     key={entry.id}
                     value={entry.id}
                     onSelect={() => handleSelectItem(entry)}
-                    className={cn(
-                      'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
-                      'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
-                    )}
+                    className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
                     <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <PaletteRecentTabStatusDot
@@ -2940,10 +2935,7 @@ function WorktreeJumpPaletteContent({
                     key={entry.id}
                     value={entry.id}
                     onSelect={() => handleSelectItem(entry)}
-                    className={cn(
-                      'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
-                      'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
-                    )}
+                    className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
                     <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <Smartphone className="size-3.5" aria-hidden="true" />
@@ -3019,10 +3011,7 @@ function WorktreeJumpPaletteContent({
                   key={entry.id}
                   value={entry.id}
                   onSelect={() => handleSelectItem(entry)}
-                  className={cn(
-                    'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
-                    'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
-                  )}
+                  className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                 >
                   <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                     <Globe className="size-3.5" aria-hidden="true" />

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -411,7 +411,11 @@ describe('palette live status', () => {
     expect(pip?.className).toContain('bg-popover')
     expect(pip?.className).toContain('ring-popover')
     expect(pip?.className).not.toContain('bg-background')
-    expect(pip?.className).toContain('group-data-[selected=true]:bg-accent')
-    expect(pip?.className).toContain('group-data-[selected=true]:ring-accent')
+    expect(pip?.className).toContain(
+      'group-data-[selected=true]:bg-[var(--jump-palette-selection-surface)]'
+    )
+    expect(pip?.className).toContain(
+      'group-data-[selected=true]:ring-[var(--jump-palette-selection-surface)]'
+    )
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-live-status.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.tsx
@@ -216,10 +216,11 @@ export function PaletteRecentTabStatusDot({
         className={cn(
           // Why popover, not background: the dialog surface is --popover (#171717 in dark), while
           // --background is the app canvas (#0a0a0a) — using it punched a dark halo through every
-          // dark-mode row. Selected rows swap to accent so the cutout stays invisible there too.
+          // dark-mode row. Selected rows use --jump-palette-selection-surface so the cutout tracks
+          // the stronger keyboard highlight from main.css.
           'pointer-events-none absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full',
           'bg-popover ring-2 ring-popover',
-          'group-data-[selected=true]:bg-accent group-data-[selected=true]:ring-accent'
+          'group-data-[selected=true]:bg-[var(--jump-palette-selection-surface)] group-data-[selected=true]:ring-[var(--jump-palette-selection-surface)]'
         )}
         aria-hidden="true"
       >


### PR DESCRIPTION
## Problem

In light mode, the Cmd+J palette's keyboard selection highlight was nearly invisible because the flat `--accent` color (#f5f5f5) is nearly identical to the dialog background (#fff), making the cursor disappear while typing.

## Solution

The selection now uses a `color-mix` recipe that blends the foreground color (~12%) into the background with an inset ring for clarity, creating visible contrast in both light and dark modes. The selection surface is exposed as a CSS variable (`--jump-palette-selection-surface`) so nested elements like status pips can match it automatically.

Also fixed a keyboard navigation bug where arrow keys stopped working after typing: cmdk advances its internal cursor before calling callbacks, so dropping the callback (while deferred query lags) left the cursor and controlled value out of sync. Now the component always accepts selection reports and re-auto-selects the new list head once the deferred query commits.

## Screenshots

No visual change from the user's perspective—the fix restores visibility of the keyboard selection highlight that should have always been visible in light mode.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions (palette-live-status.test.tsx and recent-tabs.test.tsx updated to verify selection and arrow navigation)

## AI Review Report

TODO

## Security Audit

TODO

## Notes

This is a styling and behavior fix with no breaking changes. The CSS recipe is platform-agnostic and applies across macOS, Linux, and Windows.