### PR TITLE
fix(wsl): preserve single-letter POSIX terminal cwd

### DIFF
--- a/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
+++ b/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
@@ -3,7 +3,7 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 
 describe('foreground-confirmation daemon protocol', () => {
   it('rejects daemons from before the fresh-confirmation RPC', () => {
-    expect(PROTOCOL_VERSION).toBe(32)
+    expect(PROTOCOL_VERSION).toBe(33)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(19)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(23)
@@ -15,5 +15,6 @@ describe('foreground-confirmation daemon protocol', () => {
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(29)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(30)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(31)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(32)
   })
 })

--- a/src/main/daemon/daemon-protocol-version.test.ts
+++ b/src/main/daemon/daemon-protocol-version.test.ts
@@ -8,6 +8,7 @@ import {
   MODE_2031_UNSUBSCRIBE_FACT_PROTOCOL_VERSION,
   SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION,
   STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION,
+  WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION,
   PREVIOUS_DAEMON_PROTOCOL_VERSIONS,
   PROTOCOL_VERSION,
   supportsMode2031UnsubscribeFact
@@ -15,7 +16,8 @@ import {
 
 describe('daemon protocol version', () => {
   it('ships bounded history transfer after the 2031-unsubscribe fact', () => {
-    expect(PROTOCOL_VERSION).toBe(32)
+    expect(PROTOCOL_VERSION).toBe(33)
+    expect(WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION).toBe(33)
     expect(SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION).toBe(32)
     expect(STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION).toBe(31)
     expect(HISTORY_SEED_TRANSFER_PROTOCOL_VERSION).toBe(30)
@@ -25,7 +27,7 @@ describe('daemon protocol version', () => {
     expect(AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
-      Array.from({ length: 31 }, (_, index) => index + 1)
+      Array.from({ length: 32 }, (_, index) => index + 1)
     )
   })
 

--- a/src/main/daemon/daemon-protocol-version.ts
+++ b/src/main/daemon/daemon-protocol-version.ts
@@ -1,6 +1,7 @@
 // Why: daemons survive app updates, so wire behavior must be version-gated.
-// v32 carries the corrected terminal snapshot serializer; older owners remain attachable.
-export const PROTOCOL_VERSION = 32
+// v33 preserves selected-WSL POSIX cwd semantics; older owners remain attachable.
+export const PROTOCOL_VERSION = 33
+export const WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION = 33
 export const SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION = 32
 export const STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION = 31
 export const HISTORY_SEED_TRANSFER_PROTOCOL_VERSION = 30
@@ -26,7 +27,7 @@ export const CLEAN_DISCONNECT_PROTOCOL_VERSION = 24
 export const MODE_2031_UNSUBSCRIBE_FACT_PROTOCOL_VERSION = 29
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-  28, 29, 30, 31
+  28, 29, 30, 31, 32
 ] as const
 
 export function supportsPtyStartupIngress(protocolVersion: number): boolean {

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -433,6 +433,7 @@ describe('DaemonPtyRouter', () => {
     const fresh = await router.spawn({ cols: 80, rows: 24 })
     router.write('v30-session', 'old-v30\n')
     router.write('v31-session', 'old-v31\n')
+    router.write('v32-session', 'old-v32\n')
     router.write(fresh.id, 'new\n')
 
     expect(legacyV30.spawn).toHaveBeenCalledWith({ sessionId: 'v30-session', cols: 80, rows: 24 })
@@ -441,6 +442,7 @@ describe('DaemonPtyRouter', () => {
     expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
     expect(legacyV30.write).toHaveBeenCalledWith('v30-session', 'old-v30\n')
     expect(legacyV31.write).toHaveBeenCalledWith('v31-session', 'old-v31\n')
+    expect(legacyV32.write).toHaveBeenCalledWith('v32-session', 'old-v32\n')
     expect(current.write).toHaveBeenCalledWith(fresh.id, 'new\n')
   })
 

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -408,7 +408,7 @@ describe('DaemonPtyRouter', () => {
     expect(current.confirmForegroundProcess).toHaveBeenCalledWith('current-session')
   })
 
-  it('preserves v30/v31 session owners and routes new sessions to v32', async () => {
+  it('preserves older session owners and routes new sessions to v33', async () => {
     const current = createAdapter('current', [], undefined, PROTOCOL_VERSION)
     const legacyV30 = createAdapter(
       'v30',
@@ -422,12 +422,14 @@ describe('DaemonPtyRouter', () => {
       undefined,
       STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION
     )
-    const router = new DaemonPtyRouter({ current, legacy: [legacyV30, legacyV31] })
+    const legacyV32 = createAdapter('v32', ['v32-session'], undefined, 32)
+    const router = new DaemonPtyRouter({ current, legacy: [legacyV30, legacyV31, legacyV32] })
 
     await router.discoverLegacySessions()
 
     await router.spawn({ sessionId: 'v30-session', cols: 80, rows: 24 })
     await router.spawn({ sessionId: 'v31-session', cols: 80, rows: 24 })
+    await router.spawn({ sessionId: 'v32-session', cols: 80, rows: 24 })
     const fresh = await router.spawn({ cols: 80, rows: 24 })
     router.write('v30-session', 'old-v30\n')
     router.write('v31-session', 'old-v31\n')
@@ -435,6 +437,7 @@ describe('DaemonPtyRouter', () => {
 
     expect(legacyV30.spawn).toHaveBeenCalledWith({ sessionId: 'v30-session', cols: 80, rows: 24 })
     expect(legacyV31.spawn).toHaveBeenCalledWith({ sessionId: 'v31-session', cols: 80, rows: 24 })
+    expect(legacyV32.spawn).toHaveBeenCalledWith({ sessionId: 'v32-session', cols: 80, rows: 24 })
     expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
     expect(legacyV30.write).toHaveBeenCalledWith('v30-session', 'old-v30\n')
     expect(legacyV31.write).toHaveBeenCalledWith('v31-session', 'old-v31\n')

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -2965,36 +2965,39 @@ describe('createPtySubprocess', () => {
     expect(spawnCall[2].env.WSLENV ?? '').not.toContain(POWERLEVEL10K_WIZARD_DISABLE_ENV)
   })
 
-  it('keeps daemon WSL split panes in their distro when cwd is already POSIX', () => {
-    const proc = mockPtyProcess()
-    spawnMock.mockReturnValue(proc)
-    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+  it.each(['/home/jin/repo/subdir', '/a', '/c'])(
+    'keeps daemon WSL split panes in their distro when cwd is POSIX (%s)',
+    (cwd) => {
+      const proc = mockPtyProcess()
+      spawnMock.mockReturnValue(proc)
+      const platform = Object.getOwnPropertyDescriptor(process, 'platform')
 
-    Object.defineProperty(process, 'platform', { value: 'win32' })
+      Object.defineProperty(process, 'platform', { value: 'win32' })
 
-    try {
-      createPtySubprocess({
-        sessionId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo@@deadbeef',
-        cols: 80,
-        rows: 24,
-        cwd: '/home/jin/repo/subdir',
-        shellOverride: 'wsl.exe'
-      })
-    } finally {
-      if (platform) {
-        Object.defineProperty(process, 'platform', platform)
+      try {
+        createPtySubprocess({
+          sessionId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo@@deadbeef',
+          cols: 80,
+          rows: 24,
+          cwd,
+          shellOverride: 'wsl.exe'
+        })
+      } finally {
+        if (platform) {
+          Object.defineProperty(process, 'platform', platform)
+        }
       }
-    }
 
-    expect(validateWorkingDirectoryMock).toHaveBeenCalledWith(
-      '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\subdir'
-    )
-    expect(spawnMock).toHaveBeenCalledWith(
-      'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringContaining("cd '/home/jin/repo/subdir'")],
-      expect.objectContaining({ cwd: expect.any(String) })
-    )
-  })
+      expect(validateWorkingDirectoryMock).toHaveBeenCalledWith(
+        `\\\\wsl.localhost\\Ubuntu${cwd.replaceAll('/', '\\')}`
+      )
+      expect(spawnMock).toHaveBeenCalledWith(
+        'wsl.exe',
+        ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringContaining(`cd '${cwd}'`)],
+        expect.objectContaining({ cwd: expect.any(String) })
+      )
+    }
+  )
 
   // Why: node-pty's UnixTerminal.destroy() registers _socket.once('close', () =>
   // this.kill('SIGHUP')), and the socket 'close' event can fire concurrently

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -9261,13 +9261,26 @@ describe('registerPtyHandlers', () => {
       store.persistPtyBinding.mockClear()
       mainWindow.webContents.send.mockClear()
 
+      wslUncDirectoryExistsAsyncMock.mockClear()
       const mountArgs = {
         cols: 120,
         rows: 40,
-        cwd,
+        cwd: '/a',
+        cwdFallback: 'worktree',
         command: 'claude --resume provider-session',
         launchAgent: 'claude',
         worktreeId,
+        projectRuntime: {
+          status: 'resolved',
+          runtime: {
+            kind: 'wsl',
+            hostPlatform: 'wsl',
+            projectId: 'repo-1',
+            distro: 'Ubuntu-24.04',
+            reason: 'project-override',
+            cacheKey: 'repo-1:wsl'
+          }
+        },
         tabId,
         leafId,
         env: {
@@ -9300,6 +9313,7 @@ describe('registerPtyHandlers', () => {
         sessionId: 'pty-live-owner'
       })
       expect(providerSpawn.mock.calls[1]?.[0].command).toBeUndefined()
+      expect(wslUncDirectoryExistsAsyncMock).not.toHaveBeenCalled()
       expect(runtime.createPreAllocatedTerminalHandle).not.toHaveBeenCalled()
       expect(prepareClaudeAuth).not.toHaveBeenCalled()
       expect(runtime.registerPreAllocatedHandleForPty).not.toHaveBeenCalled()
@@ -12180,51 +12194,60 @@ describe('registerPtyHandlers', () => {
     expect(result.startupCwdFallback).toEqual({ kind: 'worktree', cwd: worktreePath })
   })
 
-  it('keeps an existing POSIX startup cwd for the selected WSL runtime', async () => {
-    const originalPlatform = process.platform
-    const providerSpawn = vi.fn().mockResolvedValue({ id: 'pty-wsl-cwd' })
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    wslUncDirectoryExistsAsyncMock.mockResolvedValue(true)
-    statSyncMock.mockImplementation((target: string) => {
-      if (target === '/home/alice/repo') {
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      }
-      return { isDirectory: () => true, mode: 0o755 }
-    })
-
-    try {
-      installDaemonTestProvider({ spawn: providerSpawn })
-      registerPtyHandlers(mainWindow as never)
-      await handlers.get('pty:spawn')!(null, {
-        cols: 80,
-        rows: 24,
-        cwd: '/home/alice/repo',
-        cwdFallback: 'worktree',
-        worktreeId: 'repo-1::C:\\Users\\alice\\repo',
-        projectRuntime: {
-          status: 'resolved',
-          runtime: {
-            kind: 'wsl',
-            hostPlatform: 'wsl',
-            projectId: 'repo-1',
-            distro: 'Ubuntu-24.04',
-            reason: 'project-override',
-            cacheKey: 'repo-1:wsl'
-          }
+  it.each(['/home/alice/repo', '/a', '/c'])(
+    'keeps an existing POSIX startup cwd for the selected WSL runtime (%s)',
+    async (startupCwd) => {
+      const originalPlatform = process.platform
+      const providerSpawn = vi.fn().mockResolvedValue({ id: 'pty-wsl-cwd' })
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      wslUncDirectoryExistsAsyncMock.mockResolvedValue(true)
+      statSyncMock.mockImplementation((target: string) => {
+        if (target === startupCwd) {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
         }
+        return { isDirectory: () => true, mode: 0o755 }
       })
 
-      expect(statSyncMock).not.toHaveBeenCalledWith('/home/alice/repo')
-      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledWith(
-        '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\repo'
-      )
-      expect(providerSpawn).toHaveBeenCalledWith(
-        expect.objectContaining({ cwd: '/home/alice/repo', shellOverride: 'wsl.exe' })
-      )
-    } finally {
-      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+      try {
+        installDaemonTestProvider({ spawn: providerSpawn })
+        registerPtyHandlers(mainWindow as never)
+        await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: startupCwd,
+          cwdFallback: 'worktree',
+          worktreeId: 'repo-1::C:\\Users\\alice\\repo',
+          projectRuntime: {
+            status: 'resolved',
+            runtime: {
+              kind: 'wsl',
+              hostPlatform: 'wsl',
+              projectId: 'repo-1',
+              distro: 'Ubuntu-24.04',
+              reason: 'project-override',
+              cacheKey: 'repo-1:wsl'
+            }
+          }
+        })
+
+        const expectedValidationCwd = `\\\\wsl.localhost\\Ubuntu-24.04${startupCwd.replaceAll('/', '\\')}`
+        expect(statSyncMock).not.toHaveBeenCalledWith(startupCwd)
+        expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(1)
+        expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledWith(expectedValidationCwd)
+        expect(providerSpawn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cwd: startupCwd,
+            shellOverride: 'wsl.exe'
+          })
+        )
+        expect(providerSpawn).toHaveBeenCalledWith(
+          expect.not.objectContaining({ prevalidatedCwd: expect.anything() })
+        )
+      } finally {
+        Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+      }
     }
-  })
+  )
 
   it('falls back when the selected WSL runtime reports a POSIX cwd missing', async () => {
     const originalPlatform = process.platform
@@ -12239,7 +12262,7 @@ describe('registerPtyHandlers', () => {
       const result = (await handlers.get('pty:spawn')!(null, {
         cols: 80,
         rows: 24,
-        cwd: '/home/alice/deleted',
+        cwd: '/a',
         cwdFallback: 'worktree',
         worktreeId: `repo-1::${worktreePath}`,
         projectRuntime: {
@@ -12255,11 +12278,69 @@ describe('registerPtyHandlers', () => {
         }
       })) as { startupCwdFallback?: { kind: string; cwd: string } }
 
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(1)
       expect(providerSpawn).toHaveBeenCalledWith(expect.objectContaining({ cwd: worktreePath }))
+      expect(providerSpawn).toHaveBeenCalledWith(
+        expect.not.objectContaining({ prevalidatedCwd: expect.anything() })
+      )
       expect(result.startupCwdFallback).toEqual({ kind: 'worktree', cwd: worktreePath })
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
+  })
+
+  it('does not probe or forward local WSL cwd evidence for SSH fallback spawns', async () => {
+    const sshSpawn = vi.fn(async () => ({ id: 'ssh-wsl-looking-cwd' }))
+    registerSshPtyProvider('ssh-1', {
+      spawn: sshSpawn,
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerPtyHandlers(mainWindow as never)
+
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      cwd: '/a',
+      cwdFallback: 'worktree',
+      connectionId: 'ssh-1',
+      worktreeId: 'repo-1::C:\\Users\\alice\\repo',
+      shellOverride: 'wsl.exe',
+      projectRuntime: {
+        status: 'resolved',
+        runtime: {
+          kind: 'wsl',
+          hostPlatform: 'wsl',
+          projectId: 'repo-1',
+          distro: 'Ubuntu-24.04',
+          reason: 'project-override',
+          cacheKey: 'repo-1:wsl'
+        }
+      }
+    })
+
+    expect(wslUncDirectoryExistsAsyncMock).not.toHaveBeenCalled()
+    expect(sshSpawn).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/a' }))
+    expect(sshSpawn).toHaveBeenCalledWith(
+      expect.not.objectContaining({ prevalidatedCwd: expect.anything() })
+    )
   })
 
   it('preserves a POSIX WSL cwd when the distro probe is inconclusive', async () => {
@@ -12274,15 +12355,13 @@ describe('registerPtyHandlers', () => {
       const result = (await handlers.get('pty:spawn')!(null, {
         cols: 80,
         rows: 24,
-        cwd: '/home/alice/repo',
+        cwd: '/a',
         cwdFallback: 'worktree',
         worktreeId: 'repo-1::C:/Users/alice/repo',
         shellOverride: 'wsl.exe'
       })) as { startupCwdFallback?: unknown }
 
-      expect(providerSpawn).toHaveBeenCalledWith(
-        expect.objectContaining({ cwd: '/home/alice/repo' })
-      )
+      expect(providerSpawn).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/a' }))
       expect(result.startupCwdFallback).toBeUndefined()
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
@@ -12301,17 +12380,15 @@ describe('registerPtyHandlers', () => {
       const result = (await handlers.get('pty:spawn')!(null, {
         cols: 80,
         rows: 24,
-        cwd: '/home/alice/repo',
+        cwd: '/c',
         cwdFallback: 'worktree',
         worktreeId: 'repo-1::C:/Users/alice/repo',
         shellOverride: 'wsl.exe'
       })) as { startupCwdFallback?: unknown }
 
-      expect(statSyncMock).not.toHaveBeenCalledWith('/home/alice/repo')
+      expect(statSyncMock).not.toHaveBeenCalledWith('/c')
       expect(wslUncDirectoryExistsAsyncMock).not.toHaveBeenCalled()
-      expect(providerSpawn).toHaveBeenCalledWith(
-        expect.objectContaining({ cwd: '/home/alice/repo' })
-      )
+      expect(providerSpawn).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/c' }))
       expect(result.startupCwdFallback).toBeUndefined()
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
@@ -12319,7 +12396,11 @@ describe('registerPtyHandlers', () => {
   })
 
   it.each([
-    { exists: true, expectedCwd: '/home/alice/repo', expectedFallback: undefined },
+    {
+      exists: true,
+      expectedCwd: '/home/alice/repo',
+      expectedFallback: undefined
+    },
     {
       exists: false,
       expectedCwd: '\\\\wsl.localhost\\Ubuntu\\home\\alice',
@@ -12348,8 +12429,12 @@ describe('registerPtyHandlers', () => {
         worktreeId: 'repo-1::\\\\wsl.localhost\\Ubuntu\\home\\alice'
       })) as { startupCwdFallback?: { kind: string; cwd: string } }
 
+      expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(testCase.exists ? 1 : 2)
       expect(providerSpawn).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: testCase.expectedCwd })
+      )
+      expect(providerSpawn).toHaveBeenCalledWith(
+        expect.not.objectContaining({ prevalidatedCwd: expect.anything() })
       )
       expect(result.startupCwdFallback).toEqual(testCase.expectedFallback)
     } finally {
@@ -12369,15 +12454,16 @@ describe('registerPtyHandlers', () => {
       const result = (await handlers.get('pty:spawn')!(null, {
         cols: 80,
         rows: 24,
-        cwd: '/home/alice/deleted',
+        cwd: '/c',
         cwdFallback: 'worktree',
         worktreeId: 'repo-1::\\\\wsl.localhost\\Ubuntu\\home\\alice'
       })) as { startupCwdFallback?: unknown }
 
       expect(wslUncDirectoryExistsAsyncMock).toHaveBeenCalledTimes(2)
       expect(providerSpawn).toHaveBeenCalledWith(
-        expect.objectContaining({ cwd: '/home/alice/deleted' })
+        expect.not.objectContaining({ prevalidatedCwd: expect.anything() })
       )
+      expect(providerSpawn).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/c' }))
       expect(result.startupCwdFallback).toBeUndefined()
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
@@ -12440,7 +12526,41 @@ describe('registerPtyHandlers', () => {
       expect(providerSpawn).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: worktreePath, shellOverride: 'wsl.exe' })
       )
+      expect(wslUncDirectoryExistsAsyncMock).not.toHaveBeenCalled()
       expect(result.startupCwdFallback).toEqual({ kind: 'worktree', cwd: worktreePath })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('probes Git Bash /c as its existing native drive root without falling back', async () => {
+    const originalPlatform = process.platform
+    const providerSpawn = vi.fn().mockResolvedValue({ id: 'pty-git-bash-cwd' })
+    const worktreePath = 'C:/Users/alice/repo'
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      installDaemonTestProvider({ spawn: providerSpawn })
+      registerPtyHandlers(mainWindow as never)
+      const result = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/c',
+        cwdFallback: 'worktree',
+        worktreeId: `repo-1::${worktreePath}`,
+        shellOverride: 'C:\\Program Files\\Git\\bin\\bash.exe'
+      })) as { startupCwdFallback?: { kind: string; cwd: string } }
+
+      expect(wslUncDirectoryExistsAsyncMock).not.toHaveBeenCalled()
+      expect(statSyncMock).toHaveBeenCalledWith('C:\\')
+      expect(statSyncMock).not.toHaveBeenCalledWith('/c')
+      expect(providerSpawn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/c',
+          shellOverride: expect.stringContaining('bash')
+        })
+      )
+      expect(result.startupCwdFallback).toBeUndefined()
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -70,6 +70,7 @@ import {
 } from '../../shared/pi-agent-kind'
 import { isPwshAvailableAsync } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
+import { normalizeWindowsTerminalCwd } from '../providers/windows-shell-args'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import { isPtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import {
@@ -5862,83 +5863,9 @@ export function registerPtyHandlers(
       if (startupPromise) {
         await startupPromise
       }
-      // Why: honor the fallback only for fresh local spawns — reattach needs exact cwd and SSH can't probe the local filesystem.
-      const requestedMissingCwdFallback =
-        !args.connectionId && !args.sessionId && args.cwdFallback === 'worktree'
-      const isWslOwnedPosixCwd =
-        args.cwd?.startsWith('/') === true && !/^\/[A-Za-z](?:\/|$)/.test(args.cwd)
-      const startupWorkspaceCwd =
-        requestedMissingCwdFallback && isWslOwnedPosixCwd
-          ? resolvePtySpawnStartupCwd(args.worktreeId, '.')
-          : undefined
-      const initiallyResolvedStartupCwd =
-        requestedMissingCwdFallback && isWslOwnedPosixCwd
-          ? resolvePtySpawnStartupCwd(args.worktreeId, args.cwd)
-          : undefined
-      const startupTerminalRuntimeOptions =
-        requestedMissingCwdFallback && process.platform === 'win32'
-          ? resolveLocalWindowsTerminalRuntimeOptions({
-              requestedShellOverride: args.shellOverride,
-              settings: getSettings?.(),
-              projectRuntime: args.projectRuntime,
-              fallbackHostShell: process.env.COMSPEC || 'powershell.exe'
-            })
-          : undefined
-      const wslRuntimeOwnsStartupCwd =
-        requestedMissingCwdFallback &&
-        isWslOwnedPosixCwd &&
-        (isWslShellName(startupTerminalRuntimeOptions?.shellOverride) ||
-          isWslUncPath(startupWorkspaceCwd ?? ''))
-      const startupWslContext = wslRuntimeOwnsStartupCwd
-        ? resolveWslSessionContext({
-            cwd: startupWorkspaceCwd,
-            shellOverride: startupTerminalRuntimeOptions?.shellOverride,
-            terminalWindowsWslDistro: startupTerminalRuntimeOptions?.terminalWindowsWslDistro
-          })
-        : undefined
-      let wslStartupCwdExists: boolean | null = null
-      let wslWorkspaceCwdExists: boolean | null = null
-      if (startupWslContext && initiallyResolvedStartupCwd) {
-        const validationCwd = toWindowsWslPath(
-          initiallyResolvedStartupCwd,
-          startupWslContext.distro
-        )
-        wslStartupCwdExists = isWslUncPath(validationCwd)
-          ? await wslUncDirectoryExistsAsync(validationCwd)
-          : localStartupCwdDirectoryExists(validationCwd)
-        if (wslStartupCwdExists === false && startupWorkspaceCwd) {
-          wslWorkspaceCwdExists = isWslUncPath(startupWorkspaceCwd)
-            ? await wslUncDirectoryExistsAsync(startupWorkspaceCwd)
-            : localStartupCwdDirectoryExists(startupWorkspaceCwd)
-        }
-      }
-      const allowMissingCwdFallback =
-        requestedMissingCwdFallback &&
-        (!wslRuntimeOwnsStartupCwd ||
-          (wslStartupCwdExists === false && wslWorkspaceCwdExists === true))
-      let didFallbackToWorkspaceRootCwd = false
-      const cwd = resolvePtySpawnStartupCwd(
-        args.worktreeId,
-        args.cwd,
-        allowMissingCwdFallback
-          ? {
-              directoryExists: (path) =>
-                startupWslContext &&
-                wslStartupCwdExists === false &&
-                path === initiallyResolvedStartupCwd
-                  ? false
-                  : startupWslContext && path === startupWorkspaceCwd
-                    ? wslWorkspaceCwdExists === true
-                    : localStartupCwdDirectoryExists(path),
-              onFallbackToWorkspaceRoot: () => {
-                didFallbackToWorkspaceRootCwd = true
-              }
-            }
-          : undefined
-      )
-      const startupCwdFallback =
-        didFallbackToWorkspaceRootCwd && cwd ? ({ kind: 'worktree', cwd } as const) : undefined
-      spawnTiming.mark('preflight')
+      let cwd = resolvePtySpawnStartupCwd(args.worktreeId, args.cwd)
+      let prevalidatedCwd: string | undefined
+      let startupCwdFallback: { kind: 'worktree'; cwd: string } | undefined
       const earlyLeafId =
         typeof args.leafId === 'string' && isTerminalLeafId(args.leafId) ? args.leafId : null
       const earlyPaneKey =
@@ -5989,6 +5916,7 @@ export function registerPtyHandlers(
           await assertFolderWorkspacePtyPathUsable(args.worktreeId)
         }
         const provider = getProvider(args.connectionId)
+        spawnTiming.mark('stable_adoption_setup')
         const preAdoptedStablePane =
           earlyStablePaneOwner && earlyWorktreeId
             ? await adoptStablePane({
@@ -6002,9 +5930,97 @@ export function registerPtyHandlers(
                 ownsPaneSpawnReservation: true
               })
             : null
+        spawnTiming.mark('stable_adoption')
         if (earlyStablePaneOwner && !preAdoptedStablePane) {
           await assertFolderWorkspacePtyPathUsable(args.worktreeId)
         }
+        if (!preAdoptedStablePane) {
+          // Why: reattach needs exact cwd, SSH cannot probe locally, and successful stable-pane adoption needs no launch preflight.
+          const requestedMissingCwdFallback =
+            !args.connectionId && !args.sessionId && args.cwdFallback === 'worktree'
+          const isPosixStartupCwd = args.cwd?.startsWith('/') === true
+          const startupWorkspaceCwd =
+            requestedMissingCwdFallback && isPosixStartupCwd
+              ? resolvePtySpawnStartupCwd(args.worktreeId, '.')
+              : undefined
+          const initiallyResolvedStartupCwd =
+            requestedMissingCwdFallback && isPosixStartupCwd ? cwd : undefined
+          const startupTerminalRuntimeOptions =
+            requestedMissingCwdFallback && process.platform === 'win32'
+              ? resolveLocalWindowsTerminalRuntimeOptions({
+                  requestedShellOverride: args.shellOverride,
+                  settings: getSettings?.(),
+                  projectRuntime: args.projectRuntime,
+                  fallbackHostShell: process.env.COMSPEC || 'powershell.exe'
+                })
+              : undefined
+          const wslRuntimeOwnsStartupCwd =
+            requestedMissingCwdFallback &&
+            isPosixStartupCwd &&
+            (isWslShellName(startupTerminalRuntimeOptions?.shellOverride) ||
+              isWslUncPath(startupWorkspaceCwd ?? ''))
+          const startupWslContext = wslRuntimeOwnsStartupCwd
+            ? resolveWslSessionContext({
+                cwd: startupWorkspaceCwd,
+                shellOverride: startupTerminalRuntimeOptions?.shellOverride,
+                terminalWindowsWslDistro: startupTerminalRuntimeOptions?.terminalWindowsWslDistro
+              })
+            : undefined
+          let wslStartupCwdExists: boolean | null = null
+          let wslWorkspaceCwdExists: boolean | null = null
+          if (startupWslContext && initiallyResolvedStartupCwd) {
+            const validationCwd = toWindowsWslPath(
+              initiallyResolvedStartupCwd,
+              startupWslContext.distro
+            )
+            wslStartupCwdExists = isWslUncPath(validationCwd)
+              ? await wslUncDirectoryExistsAsync(validationCwd)
+              : localStartupCwdDirectoryExists(validationCwd)
+            if (wslStartupCwdExists === true) {
+              prevalidatedCwd = validationCwd
+            }
+            if (wslStartupCwdExists === false && startupWorkspaceCwd) {
+              wslWorkspaceCwdExists = isWslUncPath(startupWorkspaceCwd)
+                ? await wslUncDirectoryExistsAsync(startupWorkspaceCwd)
+                : localStartupCwdDirectoryExists(startupWorkspaceCwd)
+              if (wslWorkspaceCwdExists === true) {
+                prevalidatedCwd = startupWorkspaceCwd
+              }
+            }
+          }
+          const allowMissingCwdFallback =
+            requestedMissingCwdFallback &&
+            (!wslRuntimeOwnsStartupCwd ||
+              (wslStartupCwdExists === false && wslWorkspaceCwdExists === true))
+          let didFallbackToWorkspaceRootCwd = false
+          cwd = resolvePtySpawnStartupCwd(
+            args.worktreeId,
+            args.cwd,
+            allowMissingCwdFallback
+              ? {
+                  directoryExists: (path) =>
+                    startupWslContext &&
+                    wslStartupCwdExists === false &&
+                    path === initiallyResolvedStartupCwd
+                      ? false
+                      : startupWslContext && path === startupWorkspaceCwd
+                        ? wslWorkspaceCwdExists === true
+                        : localStartupCwdDirectoryExists(
+                            process.platform === 'win32' ? normalizeWindowsTerminalCwd(path) : path
+                          ),
+                  onFallbackToWorkspaceRoot: () => {
+                    didFallbackToWorkspaceRootCwd = true
+                  }
+                }
+              : undefined
+          )
+          if (didFallbackToWorkspaceRootCwd && wslWorkspaceCwdExists === true && cwd) {
+            prevalidatedCwd = cwd
+          }
+          startupCwdFallback =
+            didFallbackToWorkspaceRootCwd && cwd ? { kind: 'worktree', cwd } : undefined
+        }
+        spawnTiming.mark('preflight')
         const freshSpawnRecovery = preAdoptedStablePane
           ? undefined
           : recoverFreshSpawnProviderRouting(provider, args.connectionId, args.sessionId)
@@ -6343,6 +6359,7 @@ export function registerPtyHandlers(
           cols: args.cols,
           rows: args.rows,
           cwd,
+          ...(prevalidatedCwd && !isDaemonHostSpawn ? { prevalidatedCwd } : {}),
           env: spawnEnv,
           ...(isMintedSessionId ? { isNewSession: true } : {})
         }

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -14,7 +14,8 @@ const {
   resolveAgentForegroundProcessMock,
   readWindowsConptyProcessIdsMock,
   killWithDescendantSweepMock,
-  isWslAvailableAsyncMock
+  isWslAvailableAsyncMock,
+  wslUncDirectoryExistsMock
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
@@ -26,7 +27,8 @@ const {
   resolveAgentForegroundProcessMock: vi.fn(),
   readWindowsConptyProcessIdsMock: vi.fn(),
   killWithDescendantSweepMock: vi.fn(),
-  isWslAvailableAsyncMock: vi.fn()
+  isWslAvailableAsyncMock: vi.fn(),
+  wslUncDirectoryExistsMock: vi.fn()
 }))
 
 vi.mock('fs', () => ({
@@ -102,7 +104,7 @@ vi.mock('../wsl', () => ({
   isWslAvailableAsync: () => isWslAvailableAsyncMock(),
   // Why: WSL worktree validation now asks the distro; these tests use WSL UNC
   // cwds that are meant to exist, so report them present without spawning wsl.exe.
-  wslUncDirectoryExists: () => true
+  wslUncDirectoryExists: (...args: unknown[]) => wslUncDirectoryExistsMock(...args)
 }))
 
 import {
@@ -170,6 +172,8 @@ describe('LocalPtyProvider', () => {
     readWindowsConptyProcessIdsMock.mockResolvedValue(null)
     isWslAvailableAsyncMock.mockReset()
     isWslAvailableAsyncMock.mockResolvedValue(true)
+    wslUncDirectoryExistsMock.mockReset()
+    wslUncDirectoryExistsMock.mockReturnValue(true)
 
     exitCb = undefined
     mockProc = {
@@ -978,29 +982,50 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.HISTFILE).toContain('terminal-history-wsl/Debian')
     })
 
-    it('translates a POSIX cwd through the preferred WSL distro', async () => {
+    it.each(['/home/jin/repo', '/a', '/c'])(
+      'preserves a POSIX cwd through the preferred WSL distro (%s)',
+      async (cwd) => {
+        Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+        await provider.spawn({
+          cols: 80,
+          rows: 24,
+          worktreeId: 'repo-1::C:\\Users\\jin\\repo',
+          cwd,
+          prevalidatedCwd: `\\\\wsl.localhost\\Debian${cwd.replaceAll('/', '\\')}`,
+          shellOverride: 'wsl.exe',
+          terminalWindowsWslDistro: 'Debian'
+        })
+
+        const spawnCall = spawnMock.mock.calls.at(-1)!
+        expect(spawnCall[0]).toBe('wsl.exe')
+        expect(spawnCall[1]).toEqual([
+          '-d',
+          'Debian',
+          '--',
+          'sh',
+          '-c',
+          expect.stringContaining(`cd '${cwd}'`)
+        ])
+        expect(spawnCall[2].cwd).not.toBe(cwd)
+        expect(wslUncDirectoryExistsMock).not.toHaveBeenCalled()
+      }
+    )
+
+    it('revalidates when cwd evidence does not exactly match the resolved WSL path', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
 
       await provider.spawn({
         cols: 80,
         rows: 24,
         worktreeId: 'repo-1::C:\\Users\\jin\\repo',
-        cwd: '/home/jin/repo',
+        cwd: '/a',
+        prevalidatedCwd: '\\\\wsl.localhost\\Debian\\c',
         shellOverride: 'wsl.exe',
         terminalWindowsWslDistro: 'Debian'
       })
 
-      const spawnCall = spawnMock.mock.calls.at(-1)!
-      expect(spawnCall[0]).toBe('wsl.exe')
-      expect(spawnCall[1]).toEqual([
-        '-d',
-        'Debian',
-        '--',
-        'sh',
-        '-c',
-        expect.stringContaining("cd '/home/jin/repo'")
-      ])
-      expect(spawnCall[2].cwd).not.toBe('/home/jin/repo')
+      expect(wslUncDirectoryExistsMock).toHaveBeenCalledWith('\\\\wsl.localhost\\Debian\\a')
     })
 
     it('resolves and persists the default distro for Windows cwd WSL terminals', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -670,7 +670,9 @@ export class LocalPtyProvider implements IPtyProvider {
     }
 
     ensureNodePtySpawnHelperExecutable()
-    validateWorkingDirectory(validationCwd)
+    if (args.prevalidatedCwd !== validationCwd) {
+      validateWorkingDirectory(validationCwd)
+    }
 
     const spawnEnv: Record<string, string> = {
       ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), args.env),

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -38,6 +38,8 @@ export type PtySpawnOptions = {
   cols: number
   rows: number
   cwd?: string
+  /** Exact per-spawn cwd already proven by main; providers validate any other resolved path. */
+  prevalidatedCwd?: string
   env?: Record<string, string>
   envToDelete?: string[]
   /** Main-validated home provenance for an automatic Codex session resume. */

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -219,7 +219,7 @@ describe('resolveWindowsShellLaunchArgs', () => {
   it('starts Git Bash as an interactive login shell with UTF-8 console setup', () => {
     const result = resolveWindowsShellLaunchArgs(
       'C:\\Program Files\\Git\\bin\\bash.exe',
-      'C:\\Users\\alice\\code',
+      '/c',
       'C:\\Users\\alice'
     )
 
@@ -237,8 +237,8 @@ describe('resolveWindowsShellLaunchArgs', () => {
     // Must stay fail-open: `;` (not `&&`) so a missing chcp.com can't abort the
     // exec and kill the terminal on startup.
     expect(bashCommand).not.toContain('&&')
-    expect(result.effectiveCwd).toBe('C:\\Users\\alice\\code')
-    expect(result.validationCwd).toBe('C:\\Users\\alice\\code')
+    expect(result.effectiveCwd).toBe('C:\\')
+    expect(result.validationCwd).toBe('C:\\')
   })
 
   it('does not apply Git Bash launch args to unrelated bash.exe paths', () => {
@@ -307,17 +307,15 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(result.validationCwd).toBe('C:\\Users\\alice\\project')
   })
 
-  it('does not treat MSYS drive cwd as a WSL POSIX cwd', () => {
-    const result = resolveWindowsShellLaunchArgs(
-      'wsl.exe',
-      '/c/Users/alice/project',
-      'C:\\Users\\alice',
-      { distro: 'Ubuntu', treatPosixCwdAsWsl: true }
-    )
+  it.each(['/a', '/c'])('keeps a selected WSL runtime single-letter cwd exact (%s)', (cwd) => {
+    const result = resolveWindowsShellLaunchArgs('wsl.exe', cwd, 'C:\\Users\\alice', {
+      distro: 'Ubuntu',
+      treatPosixCwdAsWsl: true
+    })
 
-    expect(result.shellArgs).toEqual(expectedWslArgs('/mnt/c/Users/alice/project', 'Ubuntu'))
+    expect(result.shellArgs).toEqual(expectedWslArgs(cwd, 'Ubuntu'))
     expect(result.effectiveCwd).toBe('C:\\Users\\alice')
-    expect(result.validationCwd).toBe('C:\\Users\\alice\\project')
+    expect(result.validationCwd).toBe(`\\\\wsl.localhost\\Ubuntu\\${cwd.slice(1)}`)
   })
 
   it('escapes single quotes when translating a WSL cwd', () => {

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -131,7 +131,7 @@ function buildWslShellArgs(linuxCwd: string, distro?: string): string[] {
   return distro ? ['-d', distro, ...shellArgs] : shellArgs
 }
 
-function normalizeMsysDrivePath(cwd: string): string {
+export function normalizeWindowsTerminalCwd(cwd: string): string {
   const match = cwd.match(/^\/([A-Za-z])(?:\/(.*))?$/)
   if (!match) {
     return cwd
@@ -161,8 +161,7 @@ export function resolveWindowsShellLaunchArgs(
   startupCommand?: string
 ): WindowsShellLaunchArgs {
   const shellBasename = pathWin32.basename(shellPath).toLowerCase()
-  const nativeCwd = normalizeMsysDrivePath(cwd)
-  const isMsysDriveCwd = nativeCwd !== cwd
+  const nativeCwd = normalizeWindowsTerminalCwd(cwd)
 
   if (shellBasename === 'cmd.exe') {
     const shellArgStartupCommand = getCmdShellArgStartupCommand(startupCommand)
@@ -210,7 +209,7 @@ export function resolveWindowsShellLaunchArgs(
         validationCwd: cwd
       }
     }
-    if (wslContext?.treatPosixCwdAsWsl && cwd.startsWith('/') && !isMsysDriveCwd) {
+    if (wslContext?.treatPosixCwdAsWsl && cwd.startsWith('/')) {
       return {
         shellArgs: buildWslShellArgs(cwd, wslContext.distro),
         effectiveCwd: defaultCwd,

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -131,6 +131,7 @@ function buildWslShellArgs(linuxCwd: string, distro?: string): string[] {
   return distro ? ['-d', distro, ...shellArgs] : shellArgs
 }
 
+/** Converts an MSYS drive spelling to the native cwd used by Windows terminal processes. */
 export function normalizeWindowsTerminalCwd(cwd: string): string {
   const match = cwd.match(/^\/([A-Za-z])(?:\/(.*))?$/)
   if (!match) {

--- a/src/shared/local-build-compatibility-contract.json
+++ b/src/shared/local-build-compatibility-contract.json
@@ -3,9 +3,9 @@
   "appId": "com.stablyai.orca",
   "stateSchemaVersion": 1,
   "readableStateSchemaVersions": [1],
-  "daemonProtocolVersion": 32,
+  "daemonProtocolVersion": 33,
   "attachableDaemonProtocolVersions": [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32
+    27, 28, 29, 30, 31, 32, 33
   ]
 }

--- a/src/shared/local-build-compatibility-contract.ts
+++ b/src/shared/local-build-compatibility-contract.ts
@@ -3,9 +3,9 @@ export const LOCAL_BUILD_COMPATIBILITY_CONTRACT = {
   appId: 'com.stablyai.orca',
   stateSchemaVersion: 1,
   readableStateSchemaVersions: [1],
-  daemonProtocolVersion: 32,
+  daemonProtocolVersion: 33,
   attachableDaemonProtocolVersions: [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32
+    27, 28, 29, 30, 31, 32, 33
   ]
 } as const


### PR DESCRIPTION
## Summary

- Preserve exact absolute POSIX cwd paths, including `/a` and `/c`, when the selected Windows runtime is WSL.
- Fall back to the workspace root only after WSL proves the requested cwd is missing and the root exists.
- Keep native/MSYS launch semantics aligned, avoid probes for SSH and successful stable-pane adoption, and route fresh spawns through daemon protocol v33 while preserving older daemon-owned sessions.

This is the latest-main release audit follow-up for historical PR #13420.

Linear: STA-3925

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Completed proportional validation:

- Deterministic oracle on final `origin/main`: baseline RED, candidate GREEN, in-memory revert RED for both `/a` and `/c`.
- Physical Windows 2 / WSL2 (`Ubuntu-24.04`) proof: exact `/a` and `/c`; missing `wsl.exe --cd /q` warns, returns `/`, and exits 0; inode-guarded cleanup verified.
- Native Windows: `/a` -> `C:\a`, `/c` -> `C:\c`; Git Bash/MSYS: `/a` -> `A:\`, `/c` -> `C:\`.
- Focused IPC/provider/daemon/protocol tests, plus SSH and folder-workspace cwd tests.
- Node typecheck; Oxlint default/type-aware/React Doctor with denied warnings; formatting; max-lines ratchet; diff check.

## AI Review Report

Fresh adversarial, performance, and internal reviews are clean. Review explicitly covered macOS, Linux, and Windows path/shell behavior; WSL vs native/MSYS authority; SSH and folder workspaces; stable-pane probe cost; daemon generation skew; test quality; and Electron main/daemon boundaries.

Review findings addressed:

- Removed caller-asserted daemon cwd prevalidation and retained daemon-side validation.
- Added daemon protocol v33 so a surviving v32 daemon cannot reinterpret fresh `/a` or `/c` spawns.
- Deferred WSL probes until stable-pane adoption fails and pinned SSH zero-probe behavior.
- Aligned non-WSL MSYS existence checks with native launch normalization.
- Added mismatch, daemon `/a`/`/c`, timing attribution, and local-build compatibility coverage.

## Security Audit

Reviewed cwd input handling, path normalization, WSL command construction/quoting, IPC/provider trust boundaries, SSH isolation, and daemon protocol skew. The exact-path prevalidation hint remains in-process only and must equal the provider’s independently resolved path; it is not sent over daemon or SSH RPC. No auth, secret, dependency, or new external-command surface was added.

## Notes

- Daemon v1-v32 sessions remain attachable; fresh sessions route to v33.
- Full local `pty.test.ts` has three unchanged Windows host-coupling failures, and full `pty-subprocess.test.ts` has two unchanged default-distro expectation failures. Focused changed contracts pass.
- The local cross-version harness cannot extract its release checkout through Git Bash when given a native Windows staging path; the Linux CI cross-version lane is the authoritative run.
- Do not merge as part of this audit.