### PR TITLE
Fix remote-runtime terminal pane split authority

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -8658,6 +8658,86 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('shuts down a split PTY when its expected source binding was retired', async () => {
+    type RuntimeSpawnController = {
+      spawn(args: {
+        cols: number
+        rows: number
+        worktreeId: string
+        tabId: string
+        leafId: string
+        persistHostSessionBinding: boolean
+        expectedSourceBinding: {
+          worktreeId: string
+          tabId: string
+          leafId: string
+          ptyId: string
+        }
+      }): Promise<{ id: string }>
+    }
+    const proc = {
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      process: 'zsh',
+      pid: 12345
+    }
+    spawnMock.mockReturnValue(proc)
+    const store = { persistPtyBinding: vi.fn(() => false) }
+    let controller: RuntimeSpawnController | null = null
+    const runtime = {
+      setPtyController: vi.fn((value) => {
+        controller = value
+      }),
+      preAllocateHandleForPty: vi.fn(() => 'term_expected'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    const leafId = '22222222-2222-4222-8222-222222222222'
+    const expectedSourceBinding = {
+      worktreeId: 'wt-1',
+      tabId: 'tab-headless',
+      leafId: '11111111-1111-4111-8111-111111111111',
+      ptyId: 'pty-source'
+    }
+
+    try {
+      await expect(
+        (controller as unknown as RuntimeSpawnController).spawn({
+          cols: 80,
+          rows: 24,
+          worktreeId: 'wt-1',
+          tabId: 'tab-headless',
+          leafId,
+          persistHostSessionBinding: true,
+          expectedSourceBinding
+        })
+      ).rejects.toThrow('terminal_split_source_not_found')
+    } finally {
+      error.mockRestore()
+    }
+
+    expect(store.persistPtyBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedSourceBinding })
+    )
+    expect(proc.kill).toHaveBeenCalledOnce()
+  })
+
   it('reports lower-owner commit before rejecting an early-exited runtime incarnation', async () => {
     const persistPtyBinding = vi.fn()
     const onPtySpawnCommitted = vi.fn()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -13,7 +13,7 @@ import {
 } from 'electron'
 export { getBashShellReadyRcfileContent } from '../providers/local-pty-shell-ready'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
-import type { Store } from '../persistence'
+import type { PtyBindingSourceExpectation, Store } from '../persistence'
 import { retireTerminalSurfaceFromPersistence } from '../runtime/mobile-session-terminal-persistence-retirement'
 import type { GlobalSettings, TuiAgent } from '../../shared/types'
 import { toSshExecutionHostId } from '../../shared/execution-host'
@@ -4587,6 +4587,7 @@ export function registerPtyHandlers(
         worktreeId: string
         tabId: string
         leafId: string
+        expectedSourceBinding?: PtyBindingSourceExpectation
       } | null = null
       if (shouldPersistHostSessionBinding) {
         if (
@@ -4605,7 +4606,10 @@ export function registerPtyHandlers(
           store,
           worktreeId: args.worktreeId,
           tabId: args.tabId,
-          leafId: args.leafId
+          leafId: args.leafId,
+          ...(args.expectedSourceBinding
+            ? { expectedSourceBinding: args.expectedSourceBinding }
+            : {})
         }
       }
       const sshScopedEnv = stripRemotePaneEnvWhenHooksDisabled(args.connectionId, args.env)
@@ -5225,15 +5229,19 @@ export function registerPtyHandlers(
               leafId: hostSessionBinding.leafId,
               ptyId: result.id,
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
-              ...(cwd ? { startupCwd: cwd } : {})
+              ...(cwd ? { startupCwd: cwd } : {}),
+              ...(hostSessionBinding.expectedSourceBinding
+                ? { expectedSourceBinding: hostSessionBinding.expectedSourceBinding }
+                : {})
             }
-            if (args.connectionId) {
-              hostSessionBinding.store.persistPtyBinding(
-                binding,
-                toSshExecutionHostId(args.connectionId)
-              )
-            } else {
-              hostSessionBinding.store.persistPtyBinding(binding)
+            const persisted = args.connectionId
+              ? hostSessionBinding.store.persistPtyBinding(
+                  binding,
+                  toSshExecutionHostId(args.connectionId)
+                )
+              : hostSessionBinding.store.persistPtyBinding(binding)
+            if (persisted === false) {
+              throw new Error('terminal_split_source_not_found')
             }
           } catch (err) {
             console.error('[pty] failed to persist runtime PTY binding after spawn:', err)
@@ -5245,6 +5253,9 @@ export function registerPtyHandlers(
                 console.warn('[pty] failed to clean up PTY after persistence failure:', shutdownErr)
               }
               clearProviderPtyState(result.id)
+            }
+            if (err instanceof Error && err.message === 'terminal_split_source_not_found') {
+              throw err
             }
             throw Object.assign(new Error(createTerminalSessionStateSaveFailureMessage()), {
               agentSessionOperationOutcome: 'unknown' as const

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -9201,6 +9201,29 @@ describe('Store', () => {
       expect(
         store.persistPtyBinding(
           {
+            worktreeId: 'wt1',
+            tabId: 'different-target-tab',
+            leafId: TEST_LEAF_2,
+            ptyId: 'pty-split',
+            expectedSourceBinding: {
+              worktreeId: 'wt1',
+              tabId: 'tab1',
+              leafId: TEST_LEAF_1,
+              ptyId: 'pty-source'
+            }
+          },
+          hostId
+        )
+      ).toBe(false)
+      expect(
+        store
+          .getWorkspaceSession(hostId)
+          .tabsByWorktree.wt1.some((tab) => tab.id === 'different-target-tab')
+      ).toBe(false)
+
+      expect(
+        store.persistPtyBinding(
+          {
             worktreeId: 'wt-canonical',
             tabId: 'tab1',
             leafId: TEST_LEAF_2,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -9176,6 +9176,126 @@ describe('Store', () => {
     )
   })
 
+  it('admits a split binding only while the exact source still owns its layout leaf', async () => {
+    for (const hostId of [undefined, 'ssh:ssh-1']) {
+      const store = await createStore()
+      store.setWorkspaceSession(
+        {
+          ...getDefaultWorkspaceSession(),
+          tabsByWorktree: {
+            wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: 'pty-source' })]
+          },
+          terminalLayoutsByTabId: {
+            tab1: {
+              root: { type: 'leaf', leafId: TEST_LEAF_1 },
+              activeLeafId: TEST_LEAF_1,
+              expandedLeafId: null,
+              ptyIdsByLeafId: { [TEST_LEAF_1]: 'pty-source' }
+            }
+          }
+        },
+        hostId
+      )
+      const staleRendererSession = structuredClone(store.getWorkspaceSession(hostId))
+
+      expect(
+        store.persistPtyBinding(
+          {
+            worktreeId: 'wt-canonical',
+            tabId: 'tab1',
+            leafId: TEST_LEAF_2,
+            ptyId: 'pty-split',
+            expectedSourceBinding: {
+              worktreeId: 'wt1',
+              tabId: 'tab1',
+              leafId: TEST_LEAF_1,
+              ptyId: 'pty-source'
+            }
+          },
+          hostId
+        )
+      ).toBe(true)
+      const admitted = store.getWorkspaceSession(hostId)
+      expect(admitted.terminalTopologyRevisionByRepoId?.wt1).toBe(1)
+      expect(admitted.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toMatchObject({
+        [TEST_LEAF_1]: 'pty-source',
+        [TEST_LEAF_2]: 'pty-split'
+      })
+
+      store.setWorkspaceSession(staleRendererSession, hostId)
+      expect(
+        store.getWorkspaceSession(hostId).terminalLayoutsByTabId.tab1.ptyIdsByLeafId
+      ).toMatchObject({
+        [TEST_LEAF_1]: 'pty-source',
+        [TEST_LEAF_2]: 'pty-split'
+      })
+
+      expect(
+        store.persistPtyBinding(
+          {
+            worktreeId: 'wt1',
+            tabId: 'rejected-tab',
+            leafId: TEST_LEAF_2,
+            ptyId: 'pty-rejected',
+            expectedSourceBinding: {
+              worktreeId: 'wt1',
+              tabId: 'missing-source-tab',
+              leafId: TEST_LEAF_1,
+              ptyId: 'pty-source'
+            }
+          },
+          hostId
+        )
+      ).toBe(false)
+      expect(
+        store
+          .getWorkspaceSession(hostId)
+          .tabsByWorktree.wt1.some((tab) => tab.id === 'rejected-tab')
+      ).toBe(false)
+      expect(
+        store.getWorkspaceSession(hostId).terminalLayoutsByTabId['rejected-tab']
+      ).toBeUndefined()
+    }
+  })
+
+  it('rejects a split source incarnation mismatch', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        wt1: [makeTerminalTab({ id: 'tab1', worktreeId: 'wt1', ptyId: 'pty-source' })]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'pty-source' }
+        }
+      },
+      terminalPtyIncarnationsByPaneKey: { [`tab1:${TEST_LEAF_1}`]: 'persisted-incarnation' }
+    })
+
+    expect(
+      store.persistPtyBinding({
+        worktreeId: 'wt1',
+        tabId: 'tab1',
+        leafId: TEST_LEAF_2,
+        ptyId: 'pty-split',
+        expectedSourceBinding: {
+          tabId: 'tab1',
+          leafId: TEST_LEAF_1,
+          ptyId: 'pty-source',
+          incarnationId: 'different-incarnation'
+        }
+      })
+    ).toBe(false)
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId.tab1.root).toEqual({
+      type: 'leaf',
+      leafId: TEST_LEAF_1
+    })
+  })
+
   it('rejects competing PTY and incarnation changes during reconciliation', async () => {
     const store = await createStore()
     const paneKey = `tab1:${TEST_LEAF_1}`

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2780,6 +2780,14 @@ export type StoreOptions = {
   dataFile?: string
 }
 
+export type PtyBindingSourceExpectation = {
+  worktreeId?: string
+  tabId: string
+  leafId: string
+  ptyId: string
+  incarnationId?: string
+}
+
 export class Store {
   private state: PersistedState
   private readonly dataFile: string
@@ -6770,15 +6778,34 @@ export class Store {
       incarnationId?: string
       startupCwd?: string
       expectedBinding?: { ptyId: string; incarnationId?: string }
+      expectedSourceBinding?: PtyBindingSourceExpectation
     },
     hostId?: string | null
   ): boolean {
     const resolvedHostId = this.resolveHostId(hostId)
     const session = this.getWorkspaceSession(resolvedHostId)
     const paneKey = `${args.tabId}:${args.leafId}`
+    const bindingWorktreeId = args.expectedSourceBinding?.worktreeId ?? args.worktreeId
+    if (args.expectedSourceBinding) {
+      const expected = args.expectedSourceBinding
+      const sourceTab = session.tabsByWorktree?.[bindingWorktreeId]?.find(
+        (candidate) => candidate.id === expected.tabId && candidate.worktreeId === bindingWorktreeId
+      )
+      const sourceLayout = session.terminalLayoutsByTabId?.[expected.tabId]
+      const sourcePaneKey = `${expected.tabId}:${expected.leafId}`
+      if (
+        !sourceTab ||
+        sourceLayout?.ptyIdsByLeafId?.[expected.leafId] !== expected.ptyId ||
+        !layoutContainsLeafId(sourceLayout.root, expected.leafId) ||
+        (expected.incarnationId !== undefined &&
+          session.terminalPtyIncarnationsByPaneKey?.[sourcePaneKey] !== expected.incarnationId)
+      ) {
+        return false
+      }
+    }
     if (args.expectedBinding) {
-      const tab = session.tabsByWorktree?.[args.worktreeId]?.find(
-        (candidate) => candidate.id === args.tabId && candidate.worktreeId === args.worktreeId
+      const tab = session.tabsByWorktree?.[bindingWorktreeId]?.find(
+        (candidate) => candidate.id === args.tabId && candidate.worktreeId === bindingWorktreeId
       )
       const boundPtyId = session.terminalLayoutsByTabId?.[args.tabId]?.ptyIdsByLeafId?.[args.leafId]
       if (
@@ -6801,9 +6828,13 @@ export class Store {
       args.incarnationId !== args.expectedBinding.incarnationId
     let terminalMembershipChanged = false
     const advanceTopologyFence = (): void => {
-      const repoId = getRepoIdFromWorktreeId(args.worktreeId)
+      const repoId = getRepoIdFromWorktreeId(bindingWorktreeId)
       const currentRevision = session.terminalTopologyRevisionByRepoId?.[repoId] ?? 0
-      if (!reconciledIncarnation && (!terminalMembershipChanged || currentRevision <= 0)) {
+      const establishesSplitAuthority = args.expectedSourceBinding !== undefined
+      if (
+        !reconciledIncarnation &&
+        (!terminalMembershipChanged || (currentRevision <= 0 && !establishesSplitAuthority))
+      ) {
         return
       }
       // Why: host-admitted membership or incarnation changes must outrank a stale renderer replay.
@@ -6834,7 +6865,7 @@ export class Store {
         delete session.terminalSurfaceTombstonesByPaneKey[paneKey]
       }
     }
-    const tabs = session.tabsByWorktree?.[args.worktreeId]
+    const tabs = session.tabsByWorktree?.[bindingWorktreeId]
     const tab = tabs?.find((t) => t.id === args.tabId)
     if (tab) {
       tab.ptyId = args.ptyId
@@ -6845,18 +6876,19 @@ export class Store {
         ...(tabs ?? []),
         createMinimalPersistedTerminalTab({
           ...args,
+          worktreeId: bindingWorktreeId,
           existingTabCount: tabs?.length ?? 0
         })
       ]
       session.tabsByWorktree = {
         ...session.tabsByWorktree,
-        [args.worktreeId]: nextTabs
+        [bindingWorktreeId]: nextTabs
       }
-      session.activeWorktreeId ??= args.worktreeId
+      session.activeWorktreeId ??= bindingWorktreeId
       session.activeTabId ??= args.tabId
       session.activeTabIdByWorktree = {
         ...session.activeTabIdByWorktree,
-        [args.worktreeId]: session.activeTabIdByWorktree?.[args.worktreeId] ?? args.tabId
+        [bindingWorktreeId]: session.activeTabIdByWorktree?.[bindingWorktreeId] ?? args.tabId
       }
     }
     if (!isTerminalLeafId(args.leafId)) {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -6788,6 +6788,9 @@ export class Store {
     const bindingWorktreeId = args.expectedSourceBinding?.worktreeId ?? args.worktreeId
     if (args.expectedSourceBinding) {
       const expected = args.expectedSourceBinding
+      if (expected.tabId !== args.tabId) {
+        return false
+      }
       const sourceTab = session.tabsByWorktree?.[bindingWorktreeId]?.find(
         (candidate) => candidate.id === expected.tabId && candidate.worktreeId === bindingWorktreeId
       )

--- a/src/main/runtime/headless-terminal-split-layout.test.ts
+++ b/src/main/runtime/headless-terminal-split-layout.test.ts
@@ -153,7 +153,11 @@ describe('buildHeadlessTerminalSplitLayout (headless split persistence)', () => 
     )
 
     expect(countTerminalLayoutLeaves(next.root)).toBe(3)
-    expect(Object.keys(next.ptyIdsByLeafId!)).toEqual(['leaf-a', 'leaf-b', 'leaf-c'])
+    expect(next.ptyIdsByLeafId).toEqual({
+      'leaf-a': 'pty-a',
+      'leaf-b': 'pty-b',
+      'leaf-c': 'pty-c'
+    })
   })
 
   it('does not collapse — the persisted layout keeps both leaves (regression guard)', () => {

--- a/src/main/runtime/headless-terminal-split-layout.test.ts
+++ b/src/main/runtime/headless-terminal-split-layout.test.ts
@@ -2,8 +2,26 @@ import { describe, expect, it } from 'vitest'
 import type { TerminalLayoutSnapshot } from '../../shared/types'
 import {
   buildHeadlessTerminalSplitLayout,
-  countTerminalLayoutLeaves
+  countTerminalLayoutLeaves,
+  terminalLayoutContainsLeaf
 } from './headless-terminal-split-layout'
+
+describe('terminalLayoutContainsLeaf', () => {
+  it('requires the leaf in the layout tree', () => {
+    expect(
+      terminalLayoutContainsLeaf(
+        {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: 'leaf-a' },
+          second: { type: 'leaf', leafId: 'leaf-b' }
+        },
+        'leaf-b'
+      )
+    ).toBe(true)
+    expect(terminalLayoutContainsLeaf({ type: 'leaf', leafId: 'leaf-a' }, 'leaf-b')).toBe(false)
+  })
+})
 
 describe('buildHeadlessTerminalSplitLayout (headless split persistence)', () => {
   it('splits a single-leaf tab into a 2-leaf split tree', () => {
@@ -82,6 +100,60 @@ describe('buildHeadlessTerminalSplitLayout (headless split persistence)', () => 
       first: { type: 'leaf', leafId: 'leaf-a' },
       second: { type: 'leaf', leafId: 'leaf-b' }
     })
+  })
+
+  it('replaces the provisional admission leaf with the requested split direction', () => {
+    const next = buildHeadlessTerminalSplitLayout(
+      {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: 'leaf-a' },
+          second: { type: 'leaf', leafId: 'leaf-c' }
+        },
+        activeLeafId: 'leaf-c',
+        expandedLeafId: null,
+        ptyIdsByLeafId: { 'leaf-a': 'pty-a', 'leaf-c': 'provisional-pty' }
+      },
+      { leafId: 'leaf-c', ptyId: 'pty-c', splitFromLeafId: 'leaf-a', direction: 'horizontal' }
+    )
+
+    expect(next.root).toEqual({
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', leafId: 'leaf-a' },
+      second: { type: 'leaf', leafId: 'leaf-c' }
+    })
+    expect(next.ptyIdsByLeafId).toEqual({ 'leaf-a': 'pty-a', 'leaf-c': 'pty-c' })
+  })
+
+  it('preserves a sibling committed by a concurrent split', () => {
+    const next = buildHeadlessTerminalSplitLayout(
+      {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf-a' },
+            second: { type: 'leaf', leafId: 'leaf-b' }
+          },
+          second: { type: 'leaf', leafId: 'leaf-c' }
+        },
+        activeLeafId: 'leaf-c',
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          'leaf-a': 'pty-a',
+          'leaf-b': 'pty-b',
+          'leaf-c': 'provisional-pty'
+        }
+      },
+      { leafId: 'leaf-c', ptyId: 'pty-c', splitFromLeafId: 'leaf-a', direction: 'vertical' }
+    )
+
+    expect(countTerminalLayoutLeaves(next.root)).toBe(3)
+    expect(Object.keys(next.ptyIdsByLeafId!)).toEqual(['leaf-a', 'leaf-b', 'leaf-c'])
   })
 
   it('does not collapse — the persisted layout keeps both leaves (regression guard)', () => {

--- a/src/main/runtime/headless-terminal-split-layout.ts
+++ b/src/main/runtime/headless-terminal-split-layout.ts
@@ -1,5 +1,18 @@
 import type { TerminalLayoutSnapshot, TerminalPaneLayoutNode } from '../../shared/types'
 
+export function terminalLayoutContainsLeaf(
+  node: TerminalPaneLayoutNode | null | undefined,
+  leafId: string
+): boolean {
+  if (!node) {
+    return false
+  }
+  return node.type === 'leaf'
+    ? node.leafId === leafId
+    : terminalLayoutContainsLeaf(node.first, leafId) ||
+        terminalLayoutContainsLeaf(node.second, leafId)
+}
+
 /**
  * Insert a newly split-off leaf into a terminal tab's persisted layout tree.
  *
@@ -17,7 +30,23 @@ export function buildHeadlessTerminalSplitLayout(
     direction: 'horizontal' | 'vertical'
   }
 ): TerminalLayoutSnapshot {
-  const existingRoot: TerminalPaneLayoutNode = existing?.root ?? {
+  const removeProvisionalLeaf = (node: TerminalPaneLayoutNode): TerminalPaneLayoutNode | null => {
+    if (node.type === 'leaf') {
+      return node.leafId === args.leafId ? null : node
+    }
+    const first = removeProvisionalLeaf(node.first)
+    const second = removeProvisionalLeaf(node.second)
+    if (!first) {
+      return second
+    }
+    if (!second) {
+      return first
+    }
+    return { ...node, first, second }
+  }
+  // Why: PTY admission durably appends a fallback vertical leaf before this exact-direction commit.
+  const currentRoot = existing?.root ? removeProvisionalLeaf(existing.root) : null
+  const existingRoot: TerminalPaneLayoutNode = currentRoot ?? {
     type: 'leaf',
     leafId: args.splitFromLeafId
   }
@@ -35,13 +64,15 @@ export function buildHeadlessTerminalSplitLayout(
     }
     return { ...node, first: insertSplit(node.first), second: insertSplit(node.second) }
   }
+  const ptyIdsByLeafId = { ...existing?.ptyIdsByLeafId }
+  delete ptyIdsByLeafId[args.leafId]
   return {
     ...existing,
     root: insertSplit(existingRoot),
     activeLeafId: args.leafId,
     expandedLeafId: existing?.expandedLeafId ?? null,
     ptyIdsByLeafId: {
-      ...existing?.ptyIdsByLeafId,
+      ...ptyIdsByLeafId,
       [args.leafId]: args.ptyId
     }
   }

--- a/src/main/runtime/orca-runtime-terminal-split-authority.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-split-authority.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import type { TerminalLayoutSnapshot, WorkspaceSessionState } from '../../shared/types'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const REPO_ID = 'repo-1'
+const WORKTREE_ID = `${REPO_ID}::/workspace`
+const TAB_ID = 'tab-remote'
+const SOURCE_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const SOURCE_PTY_ID = 'pty-source'
+const SPLIT_PTY_ID = 'pty-split'
+
+function sourceLayout(): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId: SOURCE_LEAF_ID },
+    activeLeafId: SOURCE_LEAF_ID,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [SOURCE_LEAF_ID]: SOURCE_PTY_ID }
+  }
+}
+
+function persistedSession(includeSource = true): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: includeSource
+      ? {
+          [WORKTREE_ID]: [
+            {
+              id: TAB_ID,
+              ptyId: SOURCE_PTY_ID,
+              worktreeId: WORKTREE_ID,
+              title: 'Remote terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        }
+      : {},
+    terminalLayoutsByTabId: includeSource ? { [TAB_ID]: sourceLayout() } : {}
+  }
+}
+
+function remoteSnapshot(): RuntimeMobileSessionTabsSnapshot {
+  const layout = sourceLayout()
+  return {
+    worktree: WORKTREE_ID,
+    publicationEpoch: 'remote-viewer',
+    snapshotVersion: 1,
+    activeGroupId: 'group-1',
+    activeTabId: `${TAB_ID}::${SOURCE_LEAF_ID}`,
+    activeTabType: 'terminal',
+    tabGroups: [{ id: 'group-1', activeTabId: TAB_ID, tabOrder: [TAB_ID] }],
+    tabs: [
+      {
+        type: 'terminal',
+        id: `${TAB_ID}::${SOURCE_LEAF_ID}`,
+        parentTabId: TAB_ID,
+        leafId: SOURCE_LEAF_ID,
+        ptyId: SOURCE_PTY_ID,
+        title: 'Remote terminal',
+        parentLayout: layout,
+        isActive: true
+      }
+    ]
+  }
+}
+
+function createHarness(includeSource = true) {
+  let session = persistedSession(includeSource)
+  const repo = {
+    id: REPO_ID,
+    path: '/workspace',
+    displayName: 'repo',
+    badgeColor: 'blue',
+    addedAt: 1
+  }
+  const store = {
+    getRepos: () => [repo],
+    getRepo: (id: string) => (id === REPO_ID ? repo : undefined),
+    getWorkspaceSession: () => session,
+    setWorkspaceSession: (next: WorkspaceSessionState) => {
+      session = next
+    },
+    persistPtyBinding: () => true
+  }
+  const spawn = vi.fn(async () => ({ id: SPLIT_PTY_ID }))
+  const kill = vi.fn(() => true)
+  const revealTerminalSession = vi
+    .fn()
+    .mockRejectedValue(new Error(`Terminal tab ${TAB_ID} not found`))
+  const runtime = new OrcaRuntimeService(store as never)
+  Object.assign(runtime, {
+    resolveTerminalWorkspaceLaunchScope: vi.fn(async () => ({
+      id: WORKTREE_ID,
+      path: '/workspace',
+      connectionId: null,
+      repo,
+      folderWorkspace: null
+    }))
+  })
+  runtime.setPtyController({
+    spawn,
+    write: () => true,
+    kill,
+    getForegroundProcess: async () => null
+  })
+  runtime.setNotifier({ revealTerminalSession } as never)
+  runtime.syncWindowGraph(1, {
+    tabs: [],
+    leaves: [],
+    mobileSessionTabs: includeSource ? [remoteSnapshot()] : []
+  })
+  runtime.registerPty(SOURCE_PTY_ID, WORKTREE_ID, null, {
+    tabId: TAB_ID,
+    leafId: SOURCE_LEAF_ID
+  })
+  const internals = runtime as unknown as {
+    getTerminalHandleForPaneKey: (paneKey: string) => string | null
+    issuePtyHandle: (pty: unknown) => string
+    mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+    ptysById: Map<string, unknown>
+  }
+  const handle =
+    internals.getTerminalHandleForPaneKey(makePaneKey(TAB_ID, SOURCE_LEAF_ID)) ??
+    internals.issuePtyHandle(internals.ptysById.get(SOURCE_PTY_ID))
+  return {
+    runtime,
+    handle,
+    spawn,
+    kill,
+    revealTerminalSession,
+    getSession: () => session,
+    getSnapshot: () => internals.mobileSessionTabsByWorktree.get(WORKTREE_ID)
+  }
+}
+
+describe('remote runtime terminal split authority', () => {
+  it('splits a persisted tab without consulting an unmounted host renderer', async () => {
+    const harness = createHarness()
+
+    const outcome = await harness.runtime
+      .splitTerminal(harness.handle, { direction: 'vertical' })
+      .then((split) => ({ ok: true as const, split }))
+      .catch((error: unknown) => ({ ok: false as const, error }))
+
+    expect.soft(outcome).toMatchObject({
+      ok: true,
+      split: { tabId: TAB_ID, handle: expect.stringMatching(/^term_/) }
+    })
+    expect.soft(harness.spawn).toHaveBeenCalledTimes(1)
+    expect.soft(harness.kill).not.toHaveBeenCalled()
+    expect.soft(harness.revealTerminalSession).not.toHaveBeenCalled()
+    const persistedLayout = harness.getSession().terminalLayoutsByTabId[TAB_ID]
+    expect(persistedLayout).toMatchObject({
+      root: { type: 'split', direction: 'vertical' },
+      ptyIdsByLeafId: {
+        [SOURCE_LEAF_ID]: SOURCE_PTY_ID
+      }
+    })
+    expect(Object.values(persistedLayout!.ptyIdsByLeafId!)).toContain(SPLIT_PTY_ID)
+    const siblingSurfaces = harness
+      .getSnapshot()!
+      .tabs.filter(
+        (tab): tab is Extract<typeof tab, { type: 'terminal' }> =>
+          tab.type === 'terminal' && tab.parentTabId === TAB_ID
+      )
+    expect(siblingSurfaces).toHaveLength(2)
+    expect(siblingSurfaces.every((tab) => tab.parentLayout?.root?.type === 'split')).toBe(true)
+  })
+
+  it('rejects an unowned split source before spawning a PTY', async () => {
+    const harness = createHarness(false)
+
+    const outcome = await harness.runtime
+      .splitTerminal(harness.handle, { direction: 'vertical' })
+      .then(() => 'resolved')
+      .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
+
+    expect.soft(outcome).toBe('terminal_split_source_not_found')
+    expect.soft(harness.spawn).not.toHaveBeenCalled()
+    expect.soft(harness.kill).not.toHaveBeenCalled()
+    expect.soft(harness.revealTerminalSession).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1525,6 +1525,7 @@ function makeRuntimeStoreWithWorkspaceSession(
             }
           }
         }
+        return true
       }
     )
   }
@@ -14757,6 +14758,172 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('keeps a persisted split when mounted renderer adoption rejects', async () => {
+    const tabId = 'persisted-mounted-tab'
+    const ptyId = 'persisted-mounted-pty'
+    const splitPtyId = 'persisted-mounted-split-pty'
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: tabId,
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          [tabId]: makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    const revealTerminalSession = vi.fn().mockRejectedValue(new Error('renderer rejected'))
+    const kill = vi.fn(() => true)
+    let resolveSpawn!: (result: { id: string }) => void
+    const spawn = vi.fn(
+      (_args: unknown) =>
+        new Promise<{ id: string }>((resolve) => {
+          resolveSpawn = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({ revealTerminalSession } as never)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId,
+      leafId: HEADLESS_LEAF_ID,
+      incarnationId: 'live-source-incarnation'
+    })
+    const internals = runtime as unknown as {
+      issuePtyHandle: (pty: unknown) => string
+      ptysById: Map<string, unknown>
+    }
+    const handle = internals.issuePtyHandle(internals.ptysById.get(ptyId))
+    const split = runtime.splitTerminal(handle, { direction: 'horizontal' })
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce())
+    const splitSpawn = spawn.mock.calls[0]?.[0] as
+      | { expectedSourceBinding?: { incarnationId?: string } }
+      | undefined
+    expect(splitSpawn?.expectedSourceBinding).not.toHaveProperty('incarnationId')
+
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Persisted terminal',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: { type: 'leaf', leafId: HEADLESS_LEAF_ID }
+        }
+      ],
+      leaves: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId
+        }
+      ]
+    })
+    resolveSpawn({ id: splitPtyId })
+
+    await expect(split).resolves.toMatchObject({
+      tabId,
+      handle: expect.stringMatching(/^term_/)
+    })
+
+    expect(revealTerminalSession).toHaveBeenCalledOnce()
+    expect(kill).not.toHaveBeenCalled()
+    expect(getSession().terminalLayoutsByTabId[tabId]?.root).toMatchObject({
+      type: 'split',
+      direction: 'horizontal'
+    })
+  })
+
+  it('rejects a persisted split closed during spawn without recreating its tab', async () => {
+    const tabId = 'closing-persisted-tab'
+    const ptyId = 'closing-persisted-pty'
+    const { runtimeStore, getSession, setSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: tabId,
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Closing terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          [tabId]: makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    let resolveSpawn!: (result: { id: string }) => void
+    const spawn = vi.fn(
+      (_args: unknown) =>
+        new Promise<{ id: string }>((resolve) => {
+          resolveSpawn = resolve
+        })
+    )
+    const kill = vi.fn(() => false)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId,
+      leafId: HEADLESS_LEAF_ID
+    })
+    const internals = runtime as unknown as {
+      issuePtyHandle: (pty: unknown) => string
+      ptysById: Map<string, unknown>
+    }
+    const handle = internals.issuePtyHandle(internals.ptysById.get(ptyId))
+    const split = runtime.splitTerminal(handle, { direction: 'vertical' })
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce())
+
+    setSession(getDefaultWorkspaceSession())
+    runtimeStore.persistPtyBinding.mockReturnValue(false)
+    resolveSpawn({ id: 'rejected-split-pty' })
+
+    await expect(split).rejects.toThrow('terminal_split_source_not_found')
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({
+      persistHostSessionBinding: true,
+      expectedSourceBinding: {
+        worktreeId: TEST_WORKTREE_ID,
+        tabId,
+        leafId: HEADLESS_LEAF_ID,
+        ptyId
+      }
+    })
+    expect(kill).toHaveBeenCalledWith('rejected-split-pty')
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toBeUndefined()
+    expect(getSession().terminalLayoutsByTabId[tabId]).toBeUndefined()
+  })
+
   it('splits folder workspace pty-backed terminal sessions with folder cwd and env', async () => {
     const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-split-'))
     const spawn = vi
@@ -14832,6 +14999,80 @@ describe('OrcaRuntimeService', () => {
       leafId: splitLeafId,
       splitFromLeafId: sourceLeafId,
       splitDirection: 'vertical'
+    })
+  })
+
+  it('atomically admits persisted SSH splits in the SSH host partition', async () => {
+    const tabId = 'ssh-split-tab'
+    const sourcePtyId = 'ssh:ssh-1@@source-pty'
+    const splitPtyId = 'ssh:ssh-1@@split-pty'
+    const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: tabId,
+              ptyId: sourcePtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'SSH terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          [tabId]: makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: sourcePtyId })
+        }
+      }),
+      'ssh:ssh-1'
+    )
+    const spawn = vi.fn().mockResolvedValue({ id: splitPtyId })
+    const runtime = new OrcaRuntimeService({
+      ...runtimeStore,
+      getRepos: () => [remoteRepo],
+      getRepo: (id: string) => (id === TEST_REPO_ID ? remoteRepo : undefined)
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty(sourcePtyId, TEST_WORKTREE_ID, 'ssh-1', {
+      tabId,
+      leafId: HEADLESS_LEAF_ID
+    })
+    const internals = runtime as unknown as {
+      issuePtyHandle: (pty: unknown) => string
+      ptysById: Map<string, unknown>
+    }
+    const handle = internals.issuePtyHandle(internals.ptysById.get(sourcePtyId))
+
+    await expect(runtime.splitTerminal(handle, { direction: 'vertical' })).resolves.toMatchObject({
+      tabId,
+      handle: expect.stringMatching(/^term_/)
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        worktreeId: TEST_WORKTREE_ID,
+        persistHostSessionBinding: true,
+        expectedSourceBinding: expect.objectContaining({
+          worktreeId: TEST_WORKTREE_ID,
+          tabId,
+          leafId: HEADLESS_LEAF_ID,
+          ptyId: sourcePtyId
+        })
+      })
+    )
+    expect(getSession().terminalLayoutsByTabId[tabId]?.root).toMatchObject({
+      type: 'split',
+      direction: 'vertical'
     })
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3325,6 +3325,37 @@ describe('OrcaRuntimeService', () => {
     expect(split.tabs.filter((tab) => tab.type === 'terminal')).toHaveLength(2)
   })
 
+  it('resolves projected split authority from the parent layout PTY binding', () => {
+    const runtime = createRuntime()
+    const tabId = 'projected-parent-tab'
+    const leafId = 'projected-leaf'
+    const ptyId = 'projected-pty'
+    const internals = runtime as unknown as {
+      mobileSessionTabsByWorktree: Map<string, unknown>
+      resolveTerminalSplitSourceAuthority: (
+        worktreeId: string,
+        tabId: string,
+        leafId: string,
+        ptyId: string
+      ) => { persisted: boolean; rendererMounted: boolean } | null
+    }
+    internals.mobileSessionTabsByWorktree.set(TEST_WORKTREE_ID, {
+      tabs: [
+        {
+          type: 'terminal',
+          parentTabId: tabId,
+          leafId,
+          ptyId: null,
+          parentLayout: { ptyIdsByLeafId: { [leafId]: ptyId } }
+        }
+      ]
+    })
+
+    expect(
+      internals.resolveTerminalSplitSourceAuthority(TEST_WORKTREE_ID, tabId, leafId, ptyId)
+    ).toMatchObject({ persisted: false, rendererMounted: false })
+  })
+
   it('keeps targeted terminal lists from adopting controller PTYs for other worktrees', async () => {
     vi.mocked(listWorktrees).mockResolvedValue([
       ...MOCK_GIT_WORKTREES,
@@ -14922,6 +14953,39 @@ describe('OrcaRuntimeService', () => {
     expect(kill).toHaveBeenCalledWith('rejected-split-pty')
     expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toBeUndefined()
     expect(getSession().terminalLayoutsByTabId[tabId]).toBeUndefined()
+  })
+
+  it('rejects a projected split retired during spawn before publishing the new pane', async () => {
+    let resolveSplitSpawn!: (result: { id: string }) => void
+    const spawn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'projected-source-pty' })
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }>((resolve) => {
+            resolveSplitSpawn = resolve
+          })
+      )
+    const kill = vi.fn(() => true)
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    const split = runtime.splitTerminal(handle, { direction: 'vertical' })
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2))
+
+    runtime['mobileSessionTabsByWorktree'].delete(TEST_WORKTREE_ID)
+    resolveSplitSpawn({ id: 'retired-projected-split-pty' })
+
+    await expect(split).rejects.toThrow('terminal_split_source_not_found')
+    expect(kill).toHaveBeenCalledWith('retired-projected-split-pty')
+    expect(runtime['mobileSessionTabsByWorktree'].has(TEST_WORKTREE_ID)).toBe(false)
   })
 
   it('splits folder workspace pty-backed terminal sessions with folder cwd and env', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -27361,15 +27361,13 @@ export class OrcaRuntimeService {
     }
 
     try {
-      if (
-        sourceAuthority.persisted &&
-        !this.resolveTerminalSplitSourceAuthority(
-          workspace.id,
-          parentTabId,
-          parsedPaneKey.leafId,
-          pty.ptyId
-        )?.persisted
-      ) {
+      const revalidatedAuthority = this.resolveTerminalSplitSourceAuthority(
+        workspace.id,
+        parentTabId,
+        parsedPaneKey.leafId,
+        pty.ptyId
+      )
+      if (!revalidatedAuthority || (sourceAuthority.persisted && !revalidatedAuthority.persisted)) {
         throw new Error('terminal_split_source_not_found')
       }
       if (!sourceAuthority.persisted) {
@@ -27476,7 +27474,7 @@ export class OrcaRuntimeService {
             tab.type === 'terminal' &&
             tab.parentTabId === tabId &&
             tab.leafId === leafId &&
-            tab.ptyId === ptyId
+            (tab.ptyId === ptyId || tab.parentLayout?.ptyIdsByLeafId?.[leafId] === ptyId)
         )
     )
     if (!rendererMounted && !projected) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -527,7 +527,8 @@ import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-termina
 import { deriveRemoteRuntimeTerminalCreateHandle } from './remote-runtime-terminal-create-identity'
 import {
   buildHeadlessTerminalSplitLayout,
-  countTerminalLayoutLeaves
+  countTerminalLayoutLeaves,
+  terminalLayoutContainsLeaf
 } from './headless-terminal-split-layout'
 import { RECENT_PTY_OUTPUT_LIMIT, RecentPtyOutputBuffer } from './recent-pty-output-buffer'
 import {
@@ -922,7 +923,7 @@ import {
   WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS
 } from '../worktree-create-candidates'
 import { normalizeSparseDirectories } from '../ipc/sparse-checkout-directories'
-import type { Store } from '../persistence'
+import type { PtyBindingSourceExpectation, Store } from '../persistence'
 import type { StatsCollector } from '../stats/collector'
 import { AgentDetector } from '../stats/agent-detector'
 import {
@@ -1677,6 +1678,7 @@ type RuntimePtyController = {
     sessionId?: string
     isNewSession?: boolean
     persistHostSessionBinding?: boolean
+    expectedSourceBinding?: PtyBindingSourceExpectation
     terminalColorQueryReplies?: { foreground?: string; background?: string }
     agentSessionEnsure?: {
       claim: AgentSessionExecutionClaim
@@ -7662,10 +7664,10 @@ export class OrcaRuntimeService {
     ptyId: string
     splitFromLeafId: string
     direction: 'horizontal' | 'vertical'
-  }): void {
+  }): boolean {
     const session = this.getWorkspaceSessionForWorktree(args.worktreeId)
     if (!session || !this.store?.setWorkspaceSession) {
-      return
+      return false
     }
     const existing = session.terminalLayoutsByTabId?.[args.tabId]
     const nextLayout = buildHeadlessTerminalSplitLayout(
@@ -7679,6 +7681,7 @@ export class OrcaRuntimeService {
         [args.tabId]: nextLayout
       }
     })
+    return true
   }
 
   private persistHeadlessTerminalActiveLeaf(
@@ -27285,6 +27288,15 @@ export class OrcaRuntimeService {
     }
     const direction = opts.direction ?? 'horizontal'
     const workspace = await this.resolveTerminalWorkspaceLaunchScope(`id:${pty.worktreeId}`)
+    const sourceAuthority = this.resolveTerminalSplitSourceAuthority(
+      workspace.id,
+      parentTabId,
+      parsedPaneKey.leafId,
+      pty.ptyId
+    )
+    if (!sourceAuthority) {
+      throw new Error('terminal_split_source_not_found')
+    }
     const leafId = randomUUID()
     const preAllocatedHandle = this.createPreAllocatedTerminalHandle()
     const paneKey = makePaneKey(parentTabId, leafId)
@@ -27301,7 +27313,22 @@ export class OrcaRuntimeService {
       preAllocatedHandle,
       tabId: parentTabId,
       leafId,
-      persistHostSessionBinding: true
+      persistHostSessionBinding: true,
+      ...(sourceAuthority.persisted
+        ? {
+            expectedSourceBinding: {
+              ...(sourceAuthority.persistedWorktreeId
+                ? { worktreeId: sourceAuthority.persistedWorktreeId }
+                : {}),
+              tabId: parentTabId,
+              leafId: parsedPaneKey.leafId,
+              ptyId: pty.ptyId,
+              ...(sourceAuthority.persistedIncarnationId
+                ? { incarnationId: sourceAuthority.persistedIncarnationId }
+                : {})
+            }
+          }
+        : {})
     })
     this.registerPreAllocatedHandleForPty(result.id, preAllocatedHandle)
     if (result.wslDistro) {
@@ -27319,7 +27346,7 @@ export class OrcaRuntimeService {
       )
     }
 
-    try {
+    const revealSplit = async (): Promise<void> => {
       await this.notifier?.revealTerminalSession?.(workspace.id, {
         ptyId: result.id,
         title: null,
@@ -27331,31 +27358,136 @@ export class OrcaRuntimeService {
         splitDirection: direction,
         splitTelemetrySource: opts.telemetrySource
       })
+    }
+
+    try {
+      if (
+        sourceAuthority.persisted &&
+        !this.resolveTerminalSplitSourceAuthority(
+          workspace.id,
+          parentTabId,
+          parsedPaneKey.leafId,
+          pty.ptyId
+        )?.persisted
+      ) {
+        throw new Error('terminal_split_source_not_found')
+      }
+      if (!sourceAuthority.persisted) {
+        await revealSplit()
+      }
+      if (createdPty) {
+        const persisted = this.persistHeadlessTerminalSplit({
+          worktreeId: workspace.id,
+          tabId: parentTabId,
+          leafId,
+          ptyId: createdPty.ptyId,
+          splitFromLeafId: parsedPaneKey.leafId,
+          direction
+        })
+        if (sourceAuthority.persisted && !persisted) {
+          throw new Error('workspace_session_unavailable')
+        }
+        this.publishPtyBackedMobileSessionTerminal(workspace.id, createdPty, {
+          tabId: parentTabId,
+          leafId,
+          title: null,
+          activate: opts.activate !== false,
+          split: { splitFromLeafId: parsedPaneKey.leafId, direction }
+        })
+      }
     } catch (error) {
       this.setPairedRendererSessionOwnership(result.id, false)
       this.ptyController.kill?.(result.id)
       throw error
     }
-    if (createdPty) {
-      this.publishPtyBackedMobileSessionTerminal(workspace.id, createdPty, {
-        tabId: parentTabId,
-        leafId,
-        title: null,
-        activate: opts.activate !== false,
-        split: { splitFromLeafId: parsedPaneKey.leafId, direction }
-      })
-      // Why: persist the split so a later snapshot rebuild keeps it instead of collapsing to a single pane.
-      this.persistHeadlessTerminalSplit({
-        worktreeId: workspace.id,
-        tabId: parentTabId,
-        leafId,
-        ptyId: createdPty.ptyId,
-        splitFromLeafId: parsedPaneKey.leafId,
-        direction
-      })
+    const committedSourceAuthority = sourceAuthority.persisted
+      ? this.resolveTerminalSplitSourceAuthority(
+          workspace.id,
+          parentTabId,
+          parsedPaneKey.leafId,
+          pty.ptyId
+        )
+      : null
+    if (sourceAuthority.persisted && committedSourceAuthority?.rendererMounted) {
+      // Why: renderer adoption is a projection after the durable main commit; rejection cannot undo it.
+      void revealSplit().catch(() => undefined)
     }
 
     return { handle: this.issuePtyHandle(createdPty ?? pty), tabId: parentTabId, paneRuntimeId: -1 }
+  }
+
+  private resolveTerminalSplitSourceAuthority(
+    worktreeId: string,
+    tabId: string,
+    leafId: string,
+    ptyId: string
+  ): {
+    persisted: boolean
+    rendererMounted: boolean
+    persistedWorktreeId: string | null
+    persistedIncarnationId: string | null
+  } | null {
+    const session = this.getWorkspaceSessionForWorktree(worktreeId)
+    const sessionWorktreeId = session ? resolveTerminalSessionWorktreeId(session, worktreeId) : null
+    const persistedTab = sessionWorktreeId
+      ? session?.tabsByWorktree[sessionWorktreeId]?.find(
+          (tab) => tab.id === tabId && runtimeWorktreeIdsEqual(tab.worktreeId, worktreeId)
+        )
+      : undefined
+    const persistedLayout = session?.terminalLayoutsByTabId?.[tabId]
+    const persistedIncarnationId =
+      session?.terminalPtyIncarnationsByPaneKey?.[makePaneKey(tabId, leafId)] ?? null
+    const liveIncarnationId = this.ptysById.get(ptyId)?.incarnationId ?? null
+    if (
+      persistedIncarnationId &&
+      liveIncarnationId &&
+      persistedIncarnationId !== liveIncarnationId
+    ) {
+      return null
+    }
+    const persisted = Boolean(
+      persistedTab &&
+      persistedLayout?.ptyIdsByLeafId?.[leafId] === ptyId &&
+      terminalLayoutContainsLeaf(persistedLayout.root, leafId)
+    )
+    const rendererTab = this.tabs.get(tabId)
+    const rendererLeaf = this.leaves.get(this.getLeafKey(tabId, leafId))
+    const rendererMounted = Boolean(
+      rendererTab &&
+      rendererLeaf &&
+      runtimeWorktreeIdsEqual(rendererTab.worktreeId, worktreeId) &&
+      runtimeWorktreeIdsEqual(rendererLeaf.worktreeId, worktreeId) &&
+      rendererLeaf.ptyId === ptyId
+    )
+    if (persisted && persistedLayout) {
+      return {
+        persisted: true,
+        rendererMounted,
+        persistedWorktreeId: sessionWorktreeId,
+        persistedIncarnationId
+      }
+    }
+    // Why: renderer adoption can precede graph sync; this path still requires reveal success before commit.
+    const projected = [...this.mobileSessionTabsByWorktree.entries()].some(
+      ([candidateWorktreeId, snapshot]) =>
+        runtimeWorktreeIdsEqual(candidateWorktreeId, worktreeId) &&
+        snapshot.tabs.some(
+          (tab) =>
+            tab.type === 'terminal' &&
+            tab.parentTabId === tabId &&
+            tab.leafId === leafId &&
+            tab.ptyId === ptyId
+        )
+    )
+    if (!rendererMounted && !projected) {
+      return null
+    }
+    return {
+      persisted: false,
+      rendererMounted,
+      persistedWorktreeId: null,
+      persistedIncarnationId: null
+    }
   }
 
   async handleAgentTeamsTmuxCompat(


### PR DESCRIPTION
Fixes #13743

## Problem and invariant

A live terminal pane owned by the host's persisted workspace session must be splittable even when the host renderer has not mounted that tab. Conversely, a source pane that is not authoritatively owned must be rejected before a replacement PTY is spawned.

The remote-runtime CLI path previously spawned the new PTY and asked the host renderer to reveal/apply the split. For workspaces absent from that renderer's in-memory tab graph, the renderer rejected the tab lookup, causing the new PTY to be killed. A later stale one-leaf renderer replay could also overwrite an accepted main-process layout.

Although the report was captured on Windows, the failure is platform-neutral: it is a main/renderer ownership mismatch, not a Windows, ConPTY, filesystem, or window-lifecycle primitive.

## Reproduction evidence

The same byte-identical authority test was run in all three states:

| State | Result |
| --- | --- |
| Affected latest-main behavior | RED, 2/2 failed |
| Candidate fix | GREEN, 2/2 passed |
| Candidate with source-authority fix disabled | RED, 2/2 failed |

On the final rebase onto `origin/main` at `444638d96b`, the fix-disabled run again failed 2/2: the persisted-but-unmounted split consulted the renderer and spawned then killed its PTY, while the unowned source also spawned before rejection. Restoring the candidate returned the oracle to GREEN 2/2.

Command:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime-terminal-split-authority.test.ts
```

## Design

- Preflight the exact source authority in main from the persisted tab/layout/PTy binding, falling back to the mounted renderer graph or exact mobile projection only where appropriate.
- Thread an expected source binding through PTY spawn and atomically CAS-check it in persistence before synchronously flushing the new binding.
- Clean up the provider PTY if that CAS loses a concurrent close or identity change.
- Commit persisted, unmounted splits in main without requiring renderer reveal; renderer adoption after commit is best-effort.
- Advance terminal topology authority on split admission so stale one-leaf renderer snapshots cannot erase the committed split.
- Replace the provisional admission leaf with the requested split direction without discarding concurrent sibling splits.

This keeps authoritative truth in the main-process session/persistence boundary, preserves the existing crash-ordering guarantee, and avoids a remote wire or persistence-schema change. A renderer-only patch would retain the spawn-before-validation race; routing every split through a transient mobile projection would use a non-authoritative surface and broaden coupling.

## Risk and compatibility

The main risks are concurrent source close, persisted/live incarnation skew, normalized worktree keys, SSH host partitioning, and stale renderer replay. Tests cover those cases, including legacy sessions without a persisted incarnation. No remote protocol opcode/field, storage schema, Git behavior, provider-specific behavior, or UI styling changes are introduced. Folder workspaces, git worktrees, local hosts, SSH hosts, Windows/macOS/Linux behavior, and mixed client/server versions retain their existing interfaces.

## Validation

On the final merge base:

- Authority oracle: 2 passed; fix-disabled leg 2 failed as expected
- Focused main-process suite: 2,032 passed, 1 skipped across 5 files
- Electron Playwright CDP split right/down/persisted-binding scenarios: 3 passed
- `pnpm run typecheck:node`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- `git diff --check`

Fresh architecture/adversarial, platform/performance/security, and readiness/UX reviews completed cleanly after addressing source CAS/crash ordering, renderer-mount adoption, legacy-incarnation compatibility, and stale-replay fencing.
