### PR TITLE
fix(shell): preserve zsh wrapper re-entry across exec

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -512,6 +512,50 @@ describePosix('daemon shell-ready launch config', () => {
   )
 
   itWithZsh(
+    're-enters the wrapper when a user startup file replaces zsh with exec',
+    async () => {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      const tempHome = mkdtempSync(join(tmpdir(), 'orca-zsh-exec-'))
+      const redirectOutput = 'ORCA-EXEC-REDIRECT-PRESERVED'
+      const userTrapOutput = 'ORCA-USER-DEBUG-TRAP-PRESERVED'
+      writeFileSync(
+        join(tempHome, '.zshenv'),
+        `unsetopt DEBUG_BEFORE_CMD
+TRAPDEBUG() {
+  [[ "$ZSH_DEBUG_CMD" == *ORCA-USER-DEBUG-COMMAND* ]] && printf "${userTrapOutput}\\n"
+  return 0
+}
+`
+      )
+      writeFileSync(
+        join(tempHome, '.zprofile'),
+        `if [[ -z "\${ORCA_EXEC_REPRO_DONE:-}" ]]; then
+  export ORCA_EXEC_REPRO_DONE=1
+  exec 3>&1
+  printf "${redirectOutput}:%s\\n" "$ZDOTDIR" >&3
+  exec zsh -o noglobalrcs -l -i
+fi
+`
+      )
+      writeFileSync(join(tempHome, '.zlogin'), 'print -r -- ORCA-USER-DEBUG-COMMAND\n')
+      try {
+        const output = await runInteractiveZshLogin({
+          tempHome,
+          wrapperZdotdir: config.env.ZDOTDIR,
+          isDone: (current) => current.includes(SHELL_READY_MARKER_OUTPUT)
+        })
+        expect(output).toContain(`${redirectOutput}:${tempHome}`)
+        expect(output).toContain(userTrapOutput)
+        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
+      } finally {
+        rmSync(tempHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
+
+  itWithZsh(
     'still runs user add-zle-hook-widget line-init hooks after the marker',
     async () => {
       const { getShellReadyLaunchConfig } = await importFreshShellReady()

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -114,10 +114,51 @@ case "\${_orca_home%/}" in
 esac
 if [[ ${checks.join(' && ')} ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
+  # Why: an exec never returns to the source call, so restore the wrapper dir
+  # immediately before process replacement and let the replacement re-enter it.
+  _orca_previous_trapdebug_body="\${functions[TRAPDEBUG]-}"
+  _orca_debug_before_cmd_was_set="\${options[debugbeforecmd]}"
+  setopt DEBUG_BEFORE_CMD
+  if [[ -n "$_orca_previous_trapdebug_body" ]]; then
+    functions[__orca_previous_startup_trapdebug]="$_orca_previous_trapdebug_body"
+  fi
+  TRAPDEBUG() {
+    local _orca_trapdebug_status=0
+    if [[ "\${_orca_exec_restore_pending:-0}" == "1" ]]; then
+      export ZDOTDIR="$_orca_exec_user_zdotdir"
+      unset _orca_exec_user_zdotdir _orca_exec_restore_pending
+    fi
+    if (( \${+functions[__orca_previous_startup_trapdebug]} )); then
+      __orca_previous_startup_trapdebug "$@" || _orca_trapdebug_status=$?
+    fi
+    if (( _orca_trapdebug_status == 0 )); then
+      case "$ZSH_DEBUG_CMD" in
+        exec|exec\\ *|builtin\\ exec|builtin\\ exec\\ *|command\\ exec|command\\ exec\\ *)
+          _orca_exec_user_zdotdir="$ZDOTDIR"
+          export ZDOTDIR="$_orca_wrapper_zdotdir"
+          _orca_exec_restore_pending=1
+          ;;
+      esac
+    fi
+    return $_orca_trapdebug_status
+  }
+  _orca_startup_trapdebug_body="\${functions[TRAPDEBUG]}"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
   # Orca restores its wrapper dir afterward so zsh still loads wrapper files.
   export ZDOTDIR="$_orca_home"
   source "$_orca_home/${options.fileName}"
+  if [[ "\${functions[TRAPDEBUG]-}" == "$_orca_startup_trapdebug_body" ]]; then
+    if [[ -n "$_orca_previous_trapdebug_body" ]]; then
+      functions[TRAPDEBUG]="$_orca_previous_trapdebug_body"
+    else
+      unfunction TRAPDEBUG
+    fi
+  fi
+  unfunction __orca_previous_startup_trapdebug 2>/dev/null
+  if [[ "$_orca_debug_before_cmd_was_set" != "on" ]]; then
+    unsetopt DEBUG_BEFORE_CMD
+  fi
+  unset _orca_previous_trapdebug_body _orca_startup_trapdebug_body _orca_debug_before_cmd_was_set
   export ZDOTDIR="$_orca_wrapper_zdotdir"
   unset _orca_wrapper_zdotdir
 fi


### PR DESCRIPTION
## Summary

Preserve Orca's zsh wrapper re-entry when a sourced user startup file replaces the shell process with `exec`.

The wrapper temporarily points `ZDOTDIR` at the user's startup directory while sourcing each file. If that file calls `exec`, control never returns to the restore that selects Orca's remaining wrapper files, so the shell-ready marker and OSC 133 hooks are never installed. This change restores the wrapper `ZDOTDIR` immediately before process replacement, while preserving redirection-only `exec`, an existing user `TRAPDEBUG`, and the user's initial `DEBUG_BEFORE_CMD` state.

Scope is deliberately zsh-only. Bash reaches the same symptom through a different `--rcfile` mechanism and is not changed here.

Addresses #13767.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused checks run on macOS arm64:

- `src/main/daemon/shell-ready.test.ts`: 28 passed, 1 skipped
- focused `oxfmt --check` and `oxlint`
- max-lines ratchet, root-directory guard, and `git diff --check`

Repeated runtime evidence on the same host (behavior proof, not a cross-platform performance benchmark):

- baseline helper at `d6e1d842351c` (byte-identical through the PR base): 5/5 control trials emitted the marker; 0/5 exec trials emitted it within 3 seconds
- patched real PTY: 10/10 trials emitted the marker and preserved fd redirection plus the user's DEBUG trap; median completion 0.102s, range 0.076-1.110s
- installed Orca 1.4.176: control marker 0.113s; exec path emitted no marker within 3 seconds

The full `pnpm` gates are intentionally left unchecked. A complete Orca Electron/native install has a material multi-GiB peak on the current executor; the Draft PR's CI is the full-matrix executor rather than claiming unrun local checks.

## AI Review Report

The review checked the generated zsh wrapper, the real-PTY regression, and all call surfaces of the shared startup-file source block.

- **macOS/Linux/Windows:** runtime RED-to-GREEN was run on macOS arm64 with zsh 5.9. The change is emitted only for zsh wrappers and uses zsh-native state; Windows shell paths are unchanged. Linux and WSL runtime execution are not claimed and remain for CI/maintainer review.
- **local/daemon/SSH/remote:** the fix lives in the shared zsh startup source block used by the wrapper generators, without adding local-only paths or transport state. The focused regression exercises the daemon wrapper boundary; live SSH/remote execution was not run.
- **agents/integrations:** no agent- or vendor-specific behavior is added. The patch preserves wrapper re-entry for an exec-based startup integration, but individual agent/integration matrices were not run.
- **performance:** the DEBUG trap exists only while a user startup file is being sourced and is removed or restored afterward. Same-host repeated PTY evidence showed a 0.102s median, with one 1.110s scheduling outlier; no persistent prompt-time hook is added.
- **UI:** not applicable; there is no renderer or interaction change.
- **flagged residuals:** an rc file that deliberately rewrites `TRAPDEBUG` or `DEBUG_BEFORE_CMD` immediately before its own `exec` is not exhaustively covered. Bash has a distinct equivalent failure and remains out of scope.

## Security Audit

The review covered user-controlled startup content, command matching, path state, and process replacement:

- `ZSH_DEBUG_CMD` is matched as data in a shell `case`; it is never evaluated.
- The patch introduces no dependency, file write, network, auth, secret, or IPC surface.
- The existing user `TRAPDEBUG` body is preserved in zsh's function table and invoked directly; it is not logged or passed through a new `eval`.
- `ZDOTDIR` continues to alternate only between the already-established user and wrapper directories. The new behavior changes when the wrapper value is restored across `exec`, not how either path is constructed.
- Redirection-only `exec` is covered so the temporary restore does not change persistent-fd semantics.

No new security blocker was found. The main residual risk is compatibility with unusually self-modifying zsh startup traps/options, called out above for review.

## Notes

- Draft until the full CI matrix and maintainer architecture review complete.
- Bash is intentionally not included; merging this PR should not be treated as resolving the bash half of #13767.
- No release, dependency, or changelog change.
- X handle: N/A — no X account
