### PR TITLE
test: new-stack fixture parent

### DIFF
--- a/newstack-parent.txt
+++ b/newstack-parent.txt
@@ -1,0 +1,1 @@
+new-stack fixture parent 20260811175603


### PR DESCRIPTION
Disposable fixture for validating Orca's stacked-PR creation when the parent is not yet in a stack. Safe to close.