### PR TITLE
fix(pty): give fish login shells the Prime Agent status wrapper

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,9 +183,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # Why fish: shell-ready.test.ts gates its live fish test on the binary being
-      # present, so without this the fish barrier is only covered by config-shape
-      # assertions and never actually exercised.
+      # Why fish: every live-fish suite gates on the binary being present, so
+      # without this they skip silently and fish is covered only by config-shape
+      # assertions. Any new test that spawns a real fish MUST be listed in both
+      # the run list below and the shard --exclude list, or it never executes.
       - name: Install zsh and fish
         run: sudo apt-get update && sudo apt-get install -y zsh fish
 
@@ -197,10 +198,14 @@ jobs:
         run: |
           pnpm exec vitest run --config config/vitest.config.ts \
             src/main/daemon/shell-ready.test.ts \
+            src/main/daemon/shell-ready-fish.node-pty.test.ts \
             src/main/daemon/node-pty-fd-leak.test.ts \
             src/main/providers/local-pty-shell-ready.test.ts \
+            src/main/providers/wsl-fish-login-shell.test.ts \
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            src/main/pty/prime-agent-fish-shell-wrapper.test.ts \
+            src/main/pty/prime-agent-shell-wrapper-parity.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
   test:
@@ -231,10 +236,14 @@ jobs:
         run: |
           pnpm exec vitest run --config config/vitest.config.ts \
             --exclude=src/main/daemon/shell-ready.test.ts \
+            --exclude=src/main/daemon/shell-ready-fish.node-pty.test.ts \
             --exclude=src/main/daemon/node-pty-fd-leak.test.ts \
             --exclude=src/main/providers/local-pty-shell-ready.test.ts \
+            --exclude=src/main/providers/wsl-fish-login-shell.test.ts \
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            --exclude=src/main/pty/prime-agent-fish-shell-wrapper.test.ts \
+            --exclude=src/main/pty/prime-agent-shell-wrapper-parity.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}

--- a/src/main/daemon/shell-ready-fish.node-pty.test.ts
+++ b/src/main/daemon/shell-ready-fish.node-pty.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Real-fish PTY coverage for the daemon shell-ready launch config.
+ *
+ * Why its own file: these two cases need a live node-pty fish and the terminal
+ * capability replies that keep fish from swallowing the command written after
+ * its first prompt. That machinery does not belong in the string-level launch
+ * config suite next door.
+ */
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ShellReadyModule from './shell-ready'
+
+async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
+  vi.resetModules()
+  return import('./shell-ready')
+}
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasFish = process.platform !== 'win32' && spawnSync('fish', ['--version']).status === 0
+const itWithFish = hasFish ? it : it.skip
+
+const SHELL_READY_MARKER_OUTPUT = '\x1b]777;orca-shell-ready\x07'
+
+/** Minimal xterm.js-shaped answers to the capability queries fish emits at startup
+ *  and again around every prompt. */
+const TERMINAL_QUERY_REPLIES: readonly (readonly [string, string])[] = [
+  ['\x1b[0c', '\x1b[?6c'], // primary device attributes
+  ['\x1b[?u', '\x1b[?0u'], // kitty keyboard flags
+  ['\x1b[6n', '\x1b[1;1R'], // cursor position report
+  ['\x1b]11;?', '\x1b]11;rgb:0000/0000/0000\x1b\\'], // background colour
+  ['\x1bP+q', '\x1bP0+r\x1b\\'] // XTGETTCAP (unsupported)
+]
+
+/** Derived, not hardcoded: a shorter carry than the longest query would silently
+ *  stop matching sequences split across two PTY chunks. */
+const QUERY_CARRY_LEN = Math.max(...TERMINAL_QUERY_REPLIES.map(([query]) => query.length))
+
+describePosix('daemon shell-ready fish launches', () => {
+  let previousUserDataPath: string | undefined
+  let userDataPath: string
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'daemon-fish-shell-ready-'))
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(userDataPath, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  itWithFish(
+    'emits the marker at the first real fish prompt and executes a post-marker command',
+    async () => {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('fish')
+      const tempHome = mkdtempSync(join(tmpdir(), 'fish-shell-ready-'))
+      const sentinel = join(tempHome, 'launched')
+      const erased = join(tempHome, 'marker-erased')
+      const stillRegistered = join(tempHome, 'marker-still-registered')
+      try {
+        mkdirSync(join(tempHome, '.config', 'fish'), { recursive: true })
+        // Why: mimic a slow prompt integration (Starship) — init work before the first prompt.
+        writeFileSync(
+          join(tempHome, '.config', 'fish', 'config.fish'),
+          'command sleep 0.2\nfunction fish_prompt\n  printf "> "\nend\n'
+        )
+        const pty = await import('node-pty')
+        const proc = pty.spawn('fish', config.args ?? [], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: tempHome,
+          env: {
+            PATH: process.env.PATH ?? '/usr/bin:/bin',
+            HOME: tempHome,
+            TERM: 'xterm-256color',
+            ...config.env
+          }
+        })
+        let output = ''
+        let commandWritten = false
+        let erasureProbeWritten = false
+        let queryCarry = ''
+        let settle = (): void => {}
+        const done = new Promise<void>((resolve) => {
+          settle = resolve
+        })
+        const deadline = setTimeout(settle, 10_000)
+        // Why: settling on the first sentinel observes only one post-marker prompt,
+        // so a marker that never erased itself still looks single. Drive a second
+        // command and settle on its result, which also probes the erase directly.
+        const sentinelPoll = setInterval(() => {
+          if (commandWritten && !erasureProbeWritten && existsSync(sentinel)) {
+            erasureProbeWritten = true
+            proc.write(
+              `functions -q __orca_shell_ready_marker; and touch ${stillRegistered}; or touch ${erased}\n`
+            )
+            return
+          }
+          if (erasureProbeWritten && (existsSync(erased) || existsSync(stillRegistered))) {
+            settle()
+          }
+        }, 50)
+        proc.onData((chunk) => {
+          output += chunk
+          // Why: fish stalls its first prompt 10s waiting on these and re-queries
+          // each prompt, so answer every occurrence — an unanswered query makes
+          // fish swallow the post-marker command as its reply.
+          const carriedLength = queryCarry.length
+          const scan = queryCarry + chunk
+          queryCarry = scan.slice(-QUERY_CARRY_LEN)
+          for (const [query, reply] of TERMINAL_QUERY_REPLIES) {
+            for (
+              let at = scan.indexOf(query);
+              at !== -1;
+              at = scan.indexOf(query, at + query.length)
+            ) {
+              // Why: a query wholly inside the carry was answered on the previous
+              // chunk; replying again would land in fish's stdin as typed input.
+              if (at + query.length > carriedLength) {
+                proc.write(reply)
+              }
+            }
+          }
+          if (!commandWritten && output.includes(SHELL_READY_MARKER_OUTPUT)) {
+            commandWritten = true
+            // Why: mirror PostReadyFlushGate — flush shortly after the post-marker prompt draw.
+            setTimeout(() => proc.write(`touch ${sentinel}\n`), 50)
+          }
+        })
+        await done
+        clearTimeout(deadline)
+        clearInterval(sentinelPoll)
+        proc.kill()
+
+        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
+        expect(output.split(SHELL_READY_MARKER_OUTPUT)).toHaveLength(2)
+        expect(existsSync(sentinel)).toBe(true)
+        // Why: asserts the erase directly rather than inferring it from the marker
+        // count, which only holds once enough prompts have been drawn to expose it.
+        expect(existsSync(erased)).toBe(true)
+        expect(existsSync(stillRegistered)).toBe(false)
+      } finally {
+        rmSync(tempHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
+
+  itWithFish(
+    'wraps prime-agent in a real fish login shell launched from the daemon config',
+    async () => {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('fish')
+      const tempHome = mkdtempSync(join(tmpdir(), 'fish-prime-wrapper-'))
+      const binDir = join(tempHome, 'bin')
+      const extensionPath = join(tempHome, 'orca-agent-status.ts')
+      const capturePath = join(tempHome, 'capture')
+      try {
+        mkdirSync(binDir, { recursive: true })
+        writeFileSync(extensionPath, 'export default {}')
+        writeFileSync(
+          join(binDir, 'prime-agent'),
+          `#!/bin/sh\nprintf '%s\\n' "$@" > "$ORCA_CAPTURE_FILE"\n`,
+          { mode: 0o755 }
+        )
+        const pty = await import('node-pty')
+        const proc = pty.spawn('fish', config.args ?? [], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: tempHome,
+          env: {
+            PATH: `${binDir}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+            HOME: tempHome,
+            TERM: 'xterm-256color',
+            ORCA_PRIME_AGENT_STATUS_EXTENSION: extensionPath,
+            ORCA_CAPTURE_FILE: capturePath,
+            ...config.env
+          }
+        })
+        let output = ''
+        let commandWritten = false
+        let queryCarry = ''
+        let settle = (): void => {}
+        const done = new Promise<void>((resolve) => {
+          settle = resolve
+        })
+        const deadline = setTimeout(settle, 10_000)
+        // Why a filesystem marker: the wrapper's whole effect is the argv it
+        // hands the real binary, and the terminal buffer only shows fish's
+        // wrapped echo of what was typed.
+        const capturePoll = setInterval(() => {
+          if (existsSync(capturePath)) {
+            settle()
+          }
+        }, 50)
+        proc.onData((chunk) => {
+          output += chunk
+          const carriedLength = queryCarry.length
+          const scan = queryCarry + chunk
+          queryCarry = scan.slice(-QUERY_CARRY_LEN)
+          for (const [query, reply] of TERMINAL_QUERY_REPLIES) {
+            for (
+              let at = scan.indexOf(query);
+              at !== -1;
+              at = scan.indexOf(query, at + query.length)
+            ) {
+              if (at + query.length > carriedLength) {
+                proc.write(reply)
+              }
+            }
+          }
+          if (!commandWritten && output.includes(SHELL_READY_MARKER_OUTPUT)) {
+            commandWritten = true
+            setTimeout(() => proc.write('prime-agent ask\n'), 50)
+          }
+        })
+        await done
+        clearTimeout(deadline)
+        clearInterval(capturePoll)
+        proc.kill()
+
+        expect(existsSync(capturePath), output).toBe(true)
+        expect(readFileSync(capturePath, 'utf8')).toBe(`--extension\n${extensionPath}\nask\n`)
+      } finally {
+        rmSync(tempHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
+})

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import type * as ShellReadyModule from './shell-ready'
 import { getZshShellReadyMarkerRegistrationBlock } from '../shell-templates'
 
@@ -16,24 +16,7 @@ const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version'])
 const itWithBash = hasBash ? it : it.skip
 const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
 const itWithZsh = hasZsh ? it : it.skip
-const hasFish = process.platform !== 'win32' && spawnSync('fish', ['--version']).status === 0
-const itWithFish = hasFish ? it : it.skip
-
 const SHELL_READY_MARKER_OUTPUT = '\x1b]777;orca-shell-ready\x07'
-
-/** Minimal xterm.js-shaped answers to the capability queries fish emits at startup
- *  and again around every prompt. */
-const TERMINAL_QUERY_REPLIES: readonly (readonly [string, string])[] = [
-  ['\x1b[0c', '\x1b[?6c'], // primary device attributes
-  ['\x1b[?u', '\x1b[?0u'], // kitty keyboard flags
-  ['\x1b[6n', '\x1b[1;1R'], // cursor position report
-  ['\x1b]11;?', '\x1b]11;rgb:0000/0000/0000\x1b\\'], // background colour
-  ['\x1bP+q', '\x1bP0+r\x1b\\'] // XTGETTCAP (unsupported)
-]
-
-/** Derived, not hardcoded: a shorter carry than the longest query would silently
- *  stop matching sequences split across two PTY chunks. */
-const QUERY_CARRY_LEN = Math.max(...TERMINAL_QUERY_REPLIES.map(([query]) => query.length))
 
 // Why: the shell-ready marker fires from zle-line-init only on a real TTY, so spawn through node-pty not spawnSync.
 async function runInteractiveZshLogin(args: {
@@ -245,6 +228,12 @@ describePosix('daemon shell-ready launch config', () => {
     expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
     const init = config.args?.[2] ?? ''
     expect(init).toContain('--on-event fish_prompt')
+    // Why one -C carrying both: fish's support for repeating -C varies by
+    // version, so the wrapper source and the marker share a single init command.
+    expect(config.args).toHaveLength(3)
+    const wrapper = join(userDataPath, 'shell-ready', 'fish', 'orca.fish')
+    expect(init).toContain(`test -f '${wrapper}'; and source '${wrapper}'`)
+    expect(existsSync(wrapper)).toBe(true)
     // Why `builtin`: a user-defined printf function would swallow the marker and
     // stall every launch on the ready timeout.
     expect(init).toContain('builtin printf "\\033]777;orca-shell-ready\\007"')
@@ -260,104 +249,17 @@ describePosix('daemon shell-ready launch config', () => {
     expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
   })
 
-  itWithFish(
-    'emits the marker at the first real fish prompt and executes a post-marker command',
-    async () => {
-      const { getShellReadyLaunchConfig } = await importFreshShellReady()
-      const config = getShellReadyLaunchConfig('fish')
-      const tempHome = mkdtempSync(join(tmpdir(), 'fish-shell-ready-'))
-      const sentinel = join(tempHome, 'launched')
-      const erased = join(tempHome, 'marker-erased')
-      const stillRegistered = join(tempHome, 'marker-still-registered')
-      try {
-        mkdirSync(join(tempHome, '.config', 'fish'), { recursive: true })
-        // Why: mimic a slow prompt integration (Starship) — init work before the first prompt.
-        writeFileSync(
-          join(tempHome, '.config', 'fish', 'config.fish'),
-          'command sleep 0.2\nfunction fish_prompt\n  printf "> "\nend\n'
-        )
-        const pty = await import('node-pty')
-        const proc = pty.spawn('fish', config.args ?? [], {
-          name: 'xterm-256color',
-          cols: 80,
-          rows: 24,
-          cwd: tempHome,
-          env: {
-            PATH: process.env.PATH ?? '/usr/bin:/bin',
-            HOME: tempHome,
-            TERM: 'xterm-256color',
-            ...config.env
-          }
-        })
-        let output = ''
-        let commandWritten = false
-        let erasureProbeWritten = false
-        let queryCarry = ''
-        let settle = (): void => {}
-        const done = new Promise<void>((resolve) => {
-          settle = resolve
-        })
-        const deadline = setTimeout(settle, 10_000)
-        // Why: settling on the first sentinel observes only one post-marker prompt,
-        // so a marker that never erased itself still looks single. Drive a second
-        // command and settle on its result, which also probes the erase directly.
-        const sentinelPoll = setInterval(() => {
-          if (commandWritten && !erasureProbeWritten && existsSync(sentinel)) {
-            erasureProbeWritten = true
-            proc.write(
-              `functions -q __orca_shell_ready_marker; and touch ${stillRegistered}; or touch ${erased}\n`
-            )
-            return
-          }
-          if (erasureProbeWritten && (existsSync(erased) || existsSync(stillRegistered))) {
-            settle()
-          }
-        }, 50)
-        proc.onData((chunk) => {
-          output += chunk
-          // Why: fish stalls its first prompt 10s waiting on these and re-queries
-          // each prompt, so answer every occurrence — an unanswered query makes
-          // fish swallow the post-marker command as its reply.
-          const carriedLength = queryCarry.length
-          const scan = queryCarry + chunk
-          queryCarry = scan.slice(-QUERY_CARRY_LEN)
-          for (const [query, reply] of TERMINAL_QUERY_REPLIES) {
-            for (
-              let at = scan.indexOf(query);
-              at !== -1;
-              at = scan.indexOf(query, at + query.length)
-            ) {
-              // Why: a query wholly inside the carry was answered on the previous
-              // chunk; replying again would land in fish's stdin as typed input.
-              if (at + query.length > carriedLength) {
-                proc.write(reply)
-              }
-            }
-          }
-          if (!commandWritten && output.includes(SHELL_READY_MARKER_OUTPUT)) {
-            commandWritten = true
-            // Why: mirror PostReadyFlushGate — flush shortly after the post-marker prompt draw.
-            setTimeout(() => proc.write(`touch ${sentinel}\n`), 50)
-          }
-        })
-        await done
-        clearTimeout(deadline)
-        clearInterval(sentinelPoll)
-        proc.kill()
+  it('rewrites the fish wrapper when a long-lived daemon finds it missing', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    const wrapper = join(userDataPath, 'shell-ready', 'fish', 'orca.fish')
 
-        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
-        expect(output.split(SHELL_READY_MARKER_OUTPUT)).toHaveLength(2)
-        expect(existsSync(sentinel)).toBe(true)
-        // Why: asserts the erase directly rather than inferring it from the marker
-        // count, which only holds once enough prompts have been drawn to expose it.
-        expect(existsSync(erased)).toBe(true)
-        expect(existsSync(stillRegistered)).toBe(false)
-      } finally {
-        rmSync(tempHome, { recursive: true, force: true })
-      }
-    },
-    15_000
-  )
+    getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
+    rmSync(wrapper)
+
+    expect(existsSync(wrapper)).toBe(false)
+    getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
+    expect(existsSync(wrapper)).toBe(true)
+  })
 
   it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {
     // Why: an Orca-PTY parent has ZDOTDIR=.../shell-ready/zsh; propagating it makes the wrapper source itself (recursion loop).

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -241,12 +241,17 @@ describePosix('daemon shell-ready launch config', () => {
     expect(init).toContain('functions -e __orca_shell_ready_marker')
   })
 
-  it('keeps attribution-only fish spawns unwrapped', async () => {
+  it('wraps attribution-only fish spawns without arming the marker', async () => {
     const { getAttributionShellLaunchConfig } = await importFreshShellReady()
 
     const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
 
-    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+    // Why wrapped at all: a markerless pane is where a user types `prime-agent`
+    // by hand, and bash/zsh already get their wrapper on this path.
+    const wrapper = join(userDataPath, 'shell-ready', 'fish', 'orca.fish')
+    expect(config.args?.[2] ?? '').toContain(`source '${wrapper}'`)
+    expect(config.supportsReadyMarker).toBe(false)
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
   })
 
   it('rewrites the fish wrapper when a long-lived daemon finds it missing', async () => {

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -429,8 +429,11 @@ function getWrappedShellLaunchConfig(
     }
   }
 
-  // Why: mirrors local-pty-shell-ready.ts; attribution-only fish stays unwrapped.
-  if (shellName === 'fish' && options.emitReadyMarker) {
+  // Why attribution-only fish is wrapped too (it used to launch bare): mirrors
+  // local-pty-shell-ready.ts — the init command carries the Prime wrapper as
+  // well as the marker, and a markerless pane is exactly where a user types
+  // `prime-agent` by hand. The marker stays gated on ORCA_SHELL_READY_MARKER.
+  if (shellName === 'fish') {
     ensureShellReadyWrappers()
     return {
       args: [
@@ -441,8 +444,8 @@ function getWrappedShellLaunchConfig(
           escapedMarker: SHELL_READY_MARKER
         })
       ],
-      env: { ORCA_SHELL_READY_MARKER: '1' },
-      supportsReadyMarker: true
+      env: { ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0' },
+      supportsReadyMarker: options.emitReadyMarker
     }
   }
 

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -13,7 +13,8 @@ import {
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixPrimeAgentShellWrapper } from '../pty/prime-agent-shell-wrapper'
 import {
-  getFishShellReadyInitCommand,
+  getFishInitCommand,
+  getFishShellReadyWrapperFileContent,
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
@@ -79,8 +80,16 @@ function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): s
     join(root, 'zsh', '.zprofile'),
     join(root, 'zsh', '.zshrc'),
     join(root, 'zsh', '.zlogin'),
-    join(root, 'bash', 'rcfile')
+    join(root, 'bash', 'rcfile'),
+    getFishShellReadyWrapperPath(root)
   ]
+}
+
+// Why a file, not an inlined `-C` body: mirrors the local provider, and the WSL
+// launch path sources this same wrapper root through /mnt/c where an inlined
+// body's `$` would collide with escapeWslShCommandForWindows.
+function getFishShellReadyWrapperPath(root = getShellReadyWrapperRoot()): string {
+  return join(root, 'fish', 'orca.fish')
 }
 
 function shellReadyWrappersExist(): boolean {
@@ -321,7 +330,8 @@ ${getZshFinalZdotdirRestoreBlock()}
     [join(zshDir, '.zprofile'), zshProfile],
     [join(zshDir, '.zshrc'), zshRc],
     [join(zshDir, '.zlogin'), zshLogin],
-    [join(bashDir, 'rcfile'), bashRc]
+    [join(bashDir, 'rcfile'), bashRc],
+    [getFishShellReadyWrapperPath(root), getFishShellReadyWrapperFileContent()]
   ] as const
 
   try {
@@ -421,8 +431,16 @@ function getWrappedShellLaunchConfig(
 
   // Why: mirrors local-pty-shell-ready.ts; attribution-only fish stays unwrapped.
   if (shellName === 'fish' && options.emitReadyMarker) {
+    ensureShellReadyWrappers()
     return {
-      args: ['-l', '-C', getFishShellReadyInitCommand(SHELL_READY_MARKER)],
+      args: [
+        '-l',
+        '-C',
+        getFishInitCommand({
+          wrapperPath: getFishShellReadyWrapperPath(),
+          escapedMarker: SHELL_READY_MARKER
+        })
+      ],
       env: { ORCA_SHELL_READY_MARKER: '1' },
       supportsReadyMarker: true
     }

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -390,12 +390,30 @@ describePosix('local PTY shell-ready launch config', () => {
     )
   })
 
-  it('keeps attribution-only fish spawns unwrapped', async () => {
+  it('wraps attribution-only fish spawns without arming the marker', async () => {
     const { getAttributionShellLaunchConfig } = await importFreshLocalPtyShellReady()
 
     const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
 
-    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+    // Why wrapped at all: this is the path a plain fish pane takes, and it is
+    // exactly where a user types `prime-agent` by hand. bash/zsh already return
+    // their wrapper here; fish used to launch bare and lose Prime status.
+    const wrapper = join(userDataPath, 'shell-ready', 'fish', 'orca.fish')
+    expect(config.args?.[2] ?? '').toContain(`source '${wrapper}'`)
+    expect(config.supportsReadyMarker).toBe(false)
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
+  })
+
+  // Why: the marker text ships in both configs but must stay inert when the
+  // caller did not ask for it, or a markerless pane would resolve the startup
+  // barrier early.
+  it('leaves the marker registration inert in the attribution fish init', async () => {
+    const { getAttributionShellLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
+
+    expect(config.args?.[2] ?? '').toContain('if test "$ORCA_SHELL_READY_MARKER" = 1')
+    expect(config.env.ORCA_SHELL_READY_MARKER).toBe('0')
   })
 
   it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -378,6 +378,16 @@ describePosix('local PTY shell-ready launch config', () => {
     // Why `builtin`: a user-defined printf function would swallow the marker.
     expect(init).toContain('builtin printf "\\033]777;orca-shell-ready\\007"')
     expect(init).toContain('functions -e __orca_shell_ready_marker')
+    // Why one -C carrying both: fish's support for repeating -C varies by
+    // version, so the wrapper source and the marker share a single init command.
+    expect(config.args).toHaveLength(3)
+    const wrapper = join(userDataPath, 'shell-ready', 'fish', 'orca.fish')
+    expect(init).toContain(`test -f '${wrapper}'; and source '${wrapper}'`)
+    // Why: fish is not POSIX, so it needs its own wrapper file — sourcing the
+    // bash/zsh one is a parse error and Prime status silently vanishes.
+    expect(readFileSync(wrapper, 'utf8')).toContain(
+      'command prime-agent --extension "$ORCA_PRIME_AGENT_STATUS_EXTENSION" $argv'
+    )
   })
 
   it('keeps attribution-only fish spawns unwrapped', async () => {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -66,7 +66,7 @@ function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): s
 // Why a file, not an inlined `-C` body: the WSL launch path sources this same
 // wrapper root through /mnt/c, and inlining the body into the wsl.exe argv would
 // make every `$` in it collide with escapeWslShCommandForWindows.
-export function getFishShellReadyWrapperPath(root = getShellReadyWrapperRoot()): string {
+function getFishShellReadyWrapperPath(root = getShellReadyWrapperRoot()): string {
   return `${root}/fish/orca.fish`
 }
 

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -18,7 +18,8 @@ import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixPrimeAgentShellWrapper } from '../pty/prime-agent-shell-wrapper'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
 import {
-  getFishShellReadyInitCommand,
+  getFishInitCommand,
+  getFishShellReadyWrapperFileContent,
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
@@ -57,8 +58,16 @@ function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): s
     `${root}/zsh/.zprofile`,
     `${root}/zsh/.zshrc`,
     `${root}/zsh/.zlogin`,
-    `${root}/bash/rcfile`
+    `${root}/bash/rcfile`,
+    getFishShellReadyWrapperPath(root)
   ]
+}
+
+// Why a file, not an inlined `-C` body: the WSL launch path sources this same
+// wrapper root through /mnt/c, and inlining the body into the wsl.exe argv would
+// make every `$` in it collide with escapeWslShCommandForWindows.
+export function getFishShellReadyWrapperPath(root = getShellReadyWrapperRoot()): string {
+  return `${root}/fish/orca.fish`
 }
 
 function shellReadyWrappersExist(root = getShellReadyWrapperRoot()): boolean {
@@ -320,7 +329,8 @@ ${getZshFinalZdotdirRestoreBlock()}
     [`${zshDir}/.zprofile`, zshProfile],
     [`${zshDir}/.zshrc`, zshRc],
     [`${zshDir}/.zlogin`, zshLogin],
-    [`${bashDir}/rcfile`, bashRc]
+    [`${bashDir}/rcfile`, bashRc],
+    [getFishShellReadyWrapperPath(root), getFishShellReadyWrapperFileContent()]
   ] as const
 
   try {
@@ -404,8 +414,16 @@ function getWrappedShellLaunchConfig(
 
   // Why: mirrors daemon/shell-ready.ts; attribution-only fish stays unwrapped.
   if (shellName === 'fish' && options.emitReadyMarker) {
+    ensureShellReadyWrappers()
     return {
-      args: ['-l', '-C', getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)],
+      args: [
+        '-l',
+        '-C',
+        getFishInitCommand({
+          wrapperPath: getFishShellReadyWrapperPath(),
+          escapedMarker: SHELL_READY_MARKER_ESCAPED
+        })
+      ],
       env: { ORCA_SHELL_READY_MARKER: '1' },
       supportsReadyMarker: true
     }

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -412,8 +412,12 @@ function getWrappedShellLaunchConfig(
     }
   }
 
-  // Why: mirrors daemon/shell-ready.ts; attribution-only fish stays unwrapped.
-  if (shellName === 'fish' && options.emitReadyMarker) {
+  // Why attribution-only fish is wrapped too (it used to launch bare): the init
+  // command carries the Prime wrapper as well as the marker, and a markerless
+  // pane is exactly where a user types `prime-agent` by hand. bash and zsh
+  // already return their wrapper unconditionally; the marker itself stays gated
+  // on ORCA_SHELL_READY_MARKER inside the init text.
+  if (shellName === 'fish') {
     ensureShellReadyWrappers()
     return {
       args: [
@@ -424,8 +428,8 @@ function getWrappedShellLaunchConfig(
           escapedMarker: SHELL_READY_MARKER_ESCAPED
         })
       ],
-      env: { ORCA_SHELL_READY_MARKER: '1' },
-      supportsReadyMarker: true
+      env: { ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0' },
+      supportsReadyMarker: options.emitReadyMarker
     }
   }
 

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -23,6 +32,19 @@ function decodePowerShellCommand(result: ReturnType<typeof resolveWindowsShellLa
 function expectedPowerShellRestoreCwdCommand(cwdLiteral: string): string {
   return `try { Set-Location -LiteralPath ${cwdLiteral} -ErrorAction Stop } catch { Write-Warning "Failed to restore working directory: $_" }`
 }
+
+// Why an absolute path: the guest script only accepts a login shell that passes
+// `[ -x "$SHELL" ]`, so a bare `fish` would silently fall through to /bin/sh and
+// make the fish assertions below vacuous.
+const fishPath = (() => {
+  if (process.platform === 'win32') {
+    return null
+  }
+  const which = spawnSync('sh', ['-c', 'command -v fish'], { encoding: 'utf8' })
+  const resolved = which.status === 0 ? which.stdout.trim() : ''
+  return resolved && existsSync(resolved) ? resolved : null
+})()
+const itWithFish = fishPath ? it : it.skip
 
 describe('resolveWindowsShellLaunchArgs', () => {
   let previousUserDataPath: string | undefined
@@ -291,7 +313,127 @@ describe('resolveWindowsShellLaunchArgs', () => {
       )
       expect(wrapperFile).toContain('prime-agent() { __orca_prime_agent "$@"; }')
     }
+
+    // Why: fish is not POSIX, so it needs its own wrapper file — the bash/zsh
+    // one is a parse error under fish and Prime status silently disappears
+    // for a WSL user whose login shell is fish (STA-3927).
+    const fishWrapper = readFileSync(join(userDataPath, 'shell-ready', 'fish', 'orca.fish'), 'utf8')
+    expect(fishWrapper).toContain(
+      'command prime-agent --extension "$ORCA_PRIME_AGENT_STATUS_EXTENSION" $argv'
+    )
+    expect(fishWrapper).toContain('function prime-agent')
   })
+
+  it('routes a WSL fish login shell through the fish wrapper', () => {
+    const command = buildWslInteractiveLoginShellCommand()
+
+    expect(command).toContain('  fish)')
+    expect(command).toContain('[ -f "${_orca_shell_ready_root}/fish/orca.fish" ]')
+    // Why one -C: multi `-C` support varies by fish version, so the whole
+    // wrapper bootstrap has to fit in a single --init-command.
+    expect(command).toContain(
+      `exec "$_orca_wsl_shell" -l -C 'source "$ORCA_FISH_SHELL_READY_WRAPPER"; set -e ORCA_FISH_SHELL_READY_WRAPPER'`
+    )
+    // Why not an interpolated literal: the guest path is a WSLENV-translated
+    // Windows path; fish re-expands `$` in a double-quoted literal, and a
+    // single-quoted one cannot carry an apostrophe from the Windows profile
+    // name. Only a variable's *value* is safe from both.
+    expect(command).not.toContain(`source "${'$'}{_orca_shell_ready_root}/fish/orca.fish"`)
+    // Why: the guest argv is escaped for wsl.exe, which mangles a bare `$`.
+    expect(escapeWslShCommandForWindows(command)).toContain('\\$ORCA_FISH_SHELL_READY_WRAPPER')
+  })
+
+  // Why run the guest script for real: asserting the string alone cannot catch a
+  // fish parse error in the sourced wrapper, and the failure this fixes is
+  // exactly "fish started fine but prime-agent went unwrapped". This is macOS/
+  // Linux standing in for the guest — wsl.exe and WSLENV translation are NOT
+  // exercised. `getent` is absent here, so the script takes its $SHELL fallback,
+  // which is the same branch a WSL distro without getent takes.
+  itWithFish(
+    'runs the fish branch of the guest login script end to end',
+    () => {
+      resolveWindowsShellLaunchArgs('wsl.exe', 'C:\\Users\\alice\\code', 'C:\\Users\\alice')
+
+      const guestHome = mkdtempSync(join(tmpdir(), 'wsl-fish-guest-'))
+      try {
+        const binDir = join(guestHome, 'bin')
+        const extensionPath = join(guestHome, 'orca-agent-status.ts')
+        const capturePath = join(guestHome, 'capture')
+        mkdirSync(binDir)
+        writeFileSync(extensionPath, 'export default {}')
+        writeFileSync(
+          join(binDir, 'prime-agent'),
+          `#!/bin/sh\nprintf '%s\\n' "$@" > "$ORCA_CAPTURE_FILE"\n`,
+          { mode: 0o755 }
+        )
+        chmodSync(join(binDir, 'prime-agent'), 0o755)
+
+        const result = spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
+          cwd: guestHome,
+          input: 'prime-agent ask\n',
+          env: {
+            PATH: `${binDir}:${process.env.PATH ?? ''}`,
+            HOME: guestHome,
+            SHELL: fishPath ?? 'fish',
+            ORCA_USER_DATA_PATH: userDataPath,
+            ORCA_PRIME_AGENT_STATUS_EXTENSION: extensionPath,
+            ORCA_CAPTURE_FILE: capturePath
+          },
+          encoding: 'utf8'
+        })
+
+        expect(result.stderr).not.toContain('source:')
+        // Why a filesystem marker: the wrapper's effect is the argv it hands the
+        // real binary, which terminal output would only show mangled by fish's
+        // own echo.
+        expect(existsSync(capturePath), result.stderr).toBe(true)
+        expect(readFileSync(capturePath, 'utf8')).toBe(`--extension\n${extensionPath}\nask\n`)
+      } finally {
+        rmSync(guestHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
+
+  itWithFish(
+    'leaves guest fish unwrapped when the wrapper file is missing',
+    () => {
+      const guestHome = mkdtempSync(join(tmpdir(), 'wsl-fish-guest-bare-'))
+      try {
+        const binDir = join(guestHome, 'bin')
+        const capturePath = join(guestHome, 'capture')
+        mkdirSync(binDir)
+        writeFileSync(
+          join(binDir, 'prime-agent'),
+          `#!/bin/sh\nprintf '%s\\n' "$@" > "$ORCA_CAPTURE_FILE"\n`,
+          { mode: 0o755 }
+        )
+        chmodSync(join(binDir, 'prime-agent'), 0o755)
+
+        const result = spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
+          cwd: guestHome,
+          input: 'prime-agent ask\n',
+          env: {
+            PATH: `${binDir}:${process.env.PATH ?? ''}`,
+            HOME: guestHome,
+            SHELL: fishPath ?? 'fish',
+            // Why: no wrapper root at all — a failed wrapper write must still
+            // reach a usable fish prompt rather than erroring on `source`.
+            ORCA_PRIME_AGENT_STATUS_EXTENSION: join(guestHome, 'orca-agent-status.ts'),
+            ORCA_CAPTURE_FILE: capturePath
+          },
+          encoding: 'utf8'
+        })
+
+        expect(result.stderr).not.toContain('source:')
+        expect(existsSync(capturePath), result.stderr).toBe(true)
+        expect(readFileSync(capturePath, 'utf8')).toBe('ask\n')
+      } finally {
+        rmSync(guestHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
 
   it('translates MSYS drive cwd to /mnt/<drive>/... for wsl.exe', () => {
     const result = resolveWindowsShellLaunchArgs(

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -1,13 +1,4 @@
-import { spawnSync } from 'node:child_process'
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -32,19 +23,6 @@ function decodePowerShellCommand(result: ReturnType<typeof resolveWindowsShellLa
 function expectedPowerShellRestoreCwdCommand(cwdLiteral: string): string {
   return `try { Set-Location -LiteralPath ${cwdLiteral} -ErrorAction Stop } catch { Write-Warning "Failed to restore working directory: $_" }`
 }
-
-// Why an absolute path: the guest script only accepts a login shell that passes
-// `[ -x "$SHELL" ]`, so a bare `fish` would silently fall through to /bin/sh and
-// make the fish assertions below vacuous.
-const fishPath = (() => {
-  if (process.platform === 'win32') {
-    return null
-  }
-  const which = spawnSync('sh', ['-c', 'command -v fish'], { encoding: 'utf8' })
-  const resolved = which.status === 0 ? which.stdout.trim() : ''
-  return resolved && existsSync(resolved) ? resolved : null
-})()
-const itWithFish = fishPath ? it : it.skip
 
 describe('resolveWindowsShellLaunchArgs', () => {
   let previousUserDataPath: string | undefined
@@ -342,98 +320,6 @@ describe('resolveWindowsShellLaunchArgs', () => {
     // Why: the guest argv is escaped for wsl.exe, which mangles a bare `$`.
     expect(escapeWslShCommandForWindows(command)).toContain('\\$ORCA_FISH_SHELL_READY_WRAPPER')
   })
-
-  // Why run the guest script for real: asserting the string alone cannot catch a
-  // fish parse error in the sourced wrapper, and the failure this fixes is
-  // exactly "fish started fine but prime-agent went unwrapped". This is macOS/
-  // Linux standing in for the guest — wsl.exe and WSLENV translation are NOT
-  // exercised. `getent` is absent here, so the script takes its $SHELL fallback,
-  // which is the same branch a WSL distro without getent takes.
-  itWithFish(
-    'runs the fish branch of the guest login script end to end',
-    () => {
-      resolveWindowsShellLaunchArgs('wsl.exe', 'C:\\Users\\alice\\code', 'C:\\Users\\alice')
-
-      const guestHome = mkdtempSync(join(tmpdir(), 'wsl-fish-guest-'))
-      try {
-        const binDir = join(guestHome, 'bin')
-        const extensionPath = join(guestHome, 'orca-agent-status.ts')
-        const capturePath = join(guestHome, 'capture')
-        mkdirSync(binDir)
-        writeFileSync(extensionPath, 'export default {}')
-        writeFileSync(
-          join(binDir, 'prime-agent'),
-          `#!/bin/sh\nprintf '%s\\n' "$@" > "$ORCA_CAPTURE_FILE"\n`,
-          { mode: 0o755 }
-        )
-        chmodSync(join(binDir, 'prime-agent'), 0o755)
-
-        const result = spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
-          cwd: guestHome,
-          input: 'prime-agent ask\n',
-          env: {
-            PATH: `${binDir}:${process.env.PATH ?? ''}`,
-            HOME: guestHome,
-            SHELL: fishPath ?? 'fish',
-            ORCA_USER_DATA_PATH: userDataPath,
-            ORCA_PRIME_AGENT_STATUS_EXTENSION: extensionPath,
-            ORCA_CAPTURE_FILE: capturePath
-          },
-          encoding: 'utf8'
-        })
-
-        expect(result.stderr).not.toContain('source:')
-        // Why a filesystem marker: the wrapper's effect is the argv it hands the
-        // real binary, which terminal output would only show mangled by fish's
-        // own echo.
-        expect(existsSync(capturePath), result.stderr).toBe(true)
-        expect(readFileSync(capturePath, 'utf8')).toBe(`--extension\n${extensionPath}\nask\n`)
-      } finally {
-        rmSync(guestHome, { recursive: true, force: true })
-      }
-    },
-    15_000
-  )
-
-  itWithFish(
-    'leaves guest fish unwrapped when the wrapper file is missing',
-    () => {
-      const guestHome = mkdtempSync(join(tmpdir(), 'wsl-fish-guest-bare-'))
-      try {
-        const binDir = join(guestHome, 'bin')
-        const capturePath = join(guestHome, 'capture')
-        mkdirSync(binDir)
-        writeFileSync(
-          join(binDir, 'prime-agent'),
-          `#!/bin/sh\nprintf '%s\\n' "$@" > "$ORCA_CAPTURE_FILE"\n`,
-          { mode: 0o755 }
-        )
-        chmodSync(join(binDir, 'prime-agent'), 0o755)
-
-        const result = spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
-          cwd: guestHome,
-          input: 'prime-agent ask\n',
-          env: {
-            PATH: `${binDir}:${process.env.PATH ?? ''}`,
-            HOME: guestHome,
-            SHELL: fishPath ?? 'fish',
-            // Why: no wrapper root at all — a failed wrapper write must still
-            // reach a usable fish prompt rather than erroring on `source`.
-            ORCA_PRIME_AGENT_STATUS_EXTENSION: join(guestHome, 'orca-agent-status.ts'),
-            ORCA_CAPTURE_FILE: capturePath
-          },
-          encoding: 'utf8'
-        })
-
-        expect(result.stderr).not.toContain('source:')
-        expect(existsSync(capturePath), result.stderr).toBe(true)
-        expect(readFileSync(capturePath, 'utf8')).toBe('ask\n')
-      } finally {
-        rmSync(guestHome, { recursive: true, force: true })
-      }
-    },
-    15_000
-  )
 
   it('translates MSYS drive cwd to /mnt/<drive>/... for wsl.exe', () => {
     const result = resolveWindowsShellLaunchArgs(

--- a/src/main/providers/wsl-fish-login-shell.test.ts
+++ b/src/main/providers/wsl-fish-login-shell.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Executes the WSL guest login script's fish branch against a real fish.
+ *
+ * Why run the script rather than assert its text: a string assertion cannot
+ * catch a fish parse error in the wrapper it sources, and the STA-3927 failure
+ * mode is precisely "fish started fine but prime-agent went unwrapped".
+ *
+ * What this does NOT exercise: wsl.exe itself, WSLENV `/p` path translation, or
+ * /mnt/c access from a guest. This is a POSIX host standing in for the distro.
+ */
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildWslInteractiveLoginShellCommand } from '../../shared/wsl-login-shell-command'
+import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+
+// Why an absolute path: the guest script only accepts a login shell that passes
+// `[ -x ]`, so a bare `fish` would fall through to /bin/sh and make every
+// assertion below pass for the wrong reason.
+const fishPath = (() => {
+  if (process.platform === 'win32') {
+    return null
+  }
+  const which = spawnSync('sh', ['-c', 'command -v fish'], { encoding: 'utf8' })
+  const resolved = which.status === 0 ? which.stdout.trim() : ''
+  return resolved && existsSync(resolved) ? resolved : null
+})()
+const itWithFish = fishPath ? it : it.skip
+
+type GuestFixture = {
+  home: string
+  binDir: string
+  extensionPath: string
+  capturePath: string
+}
+
+/** Why shadow `getent`: the script reads the login shell from the passwd entry
+ *  and only falls back to $SHELL when getent is missing or fails. On macOS there
+ *  is no getent so the fallback fires, but on Linux — every CI runner — getent
+ *  returns the account's real shell (bash), the case dispatches to `bash)`, and
+ *  the fish branch is never entered while the assertions still pass off the bash
+ *  wrapper. Pinning the passwd answer makes the branch deterministic on both. */
+function makeGuestFixture(loginShell: string): GuestFixture {
+  const home = mkdtempSync(join(tmpdir(), 'wsl-fish-guest-'))
+  const binDir = join(home, 'bin')
+  const extensionPath = join(home, 'orca-agent-status.ts')
+  const capturePath = join(home, 'capture')
+  mkdirSync(binDir)
+  writeFileSync(extensionPath, 'export default {}')
+  writeFileSync(
+    join(binDir, 'prime-agent'),
+    `#!/bin/sh\nprintf '%s\\n' "$@" > "$ORCA_CAPTURE_FILE"\n`,
+    {
+      mode: 0o755
+    }
+  )
+  chmodSync(join(binDir, 'prime-agent'), 0o755)
+  writeFileSync(
+    join(binDir, 'getent'),
+    `#!/bin/sh\nprintf 'guest:x:1000:1000::%s:%s\\n' "$HOME" "${loginShell}"\n`,
+    { mode: 0o755 }
+  )
+  chmodSync(join(binDir, 'getent'), 0o755)
+  return { home, binDir, extensionPath, capturePath }
+}
+
+function runGuestLogin(
+  fixture: GuestFixture,
+  env: NodeJS.ProcessEnv
+): ReturnType<typeof spawnSync<string>> {
+  return spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
+    cwd: fixture.home,
+    // Why piped stdin: the script execs an interactive fish, which reads and
+    // runs piped commands when stdin is not a tty.
+    input: 'prime-agent ask\n',
+    env: {
+      PATH: `${fixture.binDir}:${process.env.PATH ?? ''}`,
+      HOME: fixture.home,
+      ORCA_CAPTURE_FILE: fixture.capturePath,
+      ...env
+    },
+    encoding: 'utf8'
+  })
+}
+
+describePosix('WSL guest login script, fish branch', () => {
+  let previousUserDataPath: string | undefined
+  let userDataPath: string
+  const guestHomes: string[] = []
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'wsl-fish-userdata-'))
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(userDataPath, { recursive: true, force: true })
+    for (const home of guestHomes.splice(0)) {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  itWithFish(
+    'wraps prime-agent when the guest login shell is fish',
+    () => {
+      // Why through the real entry point: this is what materializes the wrapper
+      // files the guest script then sources.
+      resolveWindowsShellLaunchArgs('wsl.exe', 'C:\\Users\\alice\\code', 'C:\\Users\\alice')
+
+      const fixture = makeGuestFixture(fishPath ?? 'fish')
+      guestHomes.push(fixture.home)
+      const result = runGuestLogin(fixture, {
+        ORCA_USER_DATA_PATH: userDataPath,
+        ORCA_PRIME_AGENT_STATUS_EXTENSION: fixture.extensionPath
+      })
+
+      expect(result.stderr).not.toContain('source:')
+      // Why a filesystem marker: the wrapper's effect is the argv handed to the
+      // real binary, which the terminal buffer only shows mangled by fish's echo.
+      expect(existsSync(fixture.capturePath), result.stderr).toBe(true)
+      expect(readFileSync(fixture.capturePath, 'utf8')).toBe(
+        `--extension\n${fixture.extensionPath}\nask\n`
+      )
+    },
+    15_000
+  )
+
+  itWithFish(
+    'reaches a usable fish prompt when the wrapper file is missing',
+    () => {
+      const fixture = makeGuestFixture(fishPath ?? 'fish')
+      guestHomes.push(fixture.home)
+      // Why no wrapper root: a failed wrapper write must fall through to the
+      // shared bare login exec rather than erroring on `source`.
+      const result = runGuestLogin(fixture, {
+        ORCA_PRIME_AGENT_STATUS_EXTENSION: fixture.extensionPath
+      })
+
+      expect(result.stderr).not.toContain('source:')
+      expect(existsSync(fixture.capturePath), result.stderr).toBe(true)
+      expect(readFileSync(fixture.capturePath, 'utf8')).toBe('ask\n')
+    },
+    15_000
+  )
+
+  // Why this control: without it the two cases above could both be passing off
+  // whatever shell the host happens to resolve. Same wrapper root, same fixture,
+  // only the pinned login shell differs — /bin/sh has no arm in the case, so it
+  // must reach the bare login exec and leave prime-agent unwrapped. A getent
+  // shadow that did not actually steer the branch would fail here.
+  it('leaves a non-fish, non-bash guest login unwrapped with the same wrapper root', () => {
+    resolveWindowsShellLaunchArgs('wsl.exe', 'C:\\Users\\alice\\code', 'C:\\Users\\alice')
+    expect(existsSync(join(userDataPath, 'shell-ready', 'fish', 'orca.fish'))).toBe(true)
+
+    const fixture = makeGuestFixture('/bin/sh')
+    guestHomes.push(fixture.home)
+    const result = runGuestLogin(fixture, {
+      ORCA_USER_DATA_PATH: userDataPath,
+      ORCA_PRIME_AGENT_STATUS_EXTENSION: fixture.extensionPath
+    })
+
+    expect(existsSync(fixture.capturePath), result.stderr).toBe(true)
+    expect(readFileSync(fixture.capturePath, 'utf8')).toBe('ask\n')
+  }, 15_000)
+})

--- a/src/main/providers/wsl-fish-login-shell.test.ts
+++ b/src/main/providers/wsl-fish-login-shell.test.ts
@@ -79,7 +79,7 @@ function makeGuestFixture(loginShell: string): GuestFixture {
 function runGuestLogin(
   fixture: GuestFixture,
   env: NodeJS.ProcessEnv
-): ReturnType<typeof spawnSync<string>> {
+): { stderr: string; stdout: string } {
   return spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
     cwd: fixture.home,
     // Why piped stdin: the script execs an interactive fish, which reads and

--- a/src/main/providers/wsl-fish-login-shell.test.ts
+++ b/src/main/providers/wsl-fish-login-shell.test.ts
@@ -11,9 +11,11 @@
 import { spawnSync } from 'node:child_process'
 import {
   chmodSync,
+  closeSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   writeFileSync
@@ -73,6 +75,12 @@ function makeGuestFixture(loginShell: string): GuestFixture {
     { mode: 0o755 }
   )
   chmodSync(join(binDir, 'getent'), 0o755)
+  // Why a .profile: a POSIX login shell sources /etc/profile, which on most
+  // distros *overwrites* PATH and would hide the fake prime-agent from the
+  // non-fish control below. fish never reads /etc/profile, so only the control
+  // needs it — but a guest user's profile owning PATH is the realistic shape.
+  writeFileSync(join(home, '.profile'), `PATH="${binDir}:$PATH"\nexport PATH\n`)
+  writeFileSync(join(home, 'stdin-script'), 'prime-agent ask\n')
   return { home, binDir, extensionPath, capturePath }
 }
 
@@ -80,19 +88,31 @@ function runGuestLogin(
   fixture: GuestFixture,
   env: NodeJS.ProcessEnv
 ): { stderr: string; stdout: string } {
-  return spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
-    cwd: fixture.home,
-    // Why piped stdin: the script execs an interactive fish, which reads and
-    // runs piped commands when stdin is not a tty.
-    input: 'prime-agent ask\n',
-    env: {
-      PATH: `${fixture.binDir}:${process.env.PATH ?? ''}`,
-      HOME: fixture.home,
-      ORCA_CAPTURE_FILE: fixture.capturePath,
-      ...env
-    },
-    encoding: 'utf8'
-  })
+  // Why stdin from a real file rather than spawnSync's `input`: the script
+  // execs a login shell with no `-c`, so the command has to arrive on stdin —
+  // and fish fstats fd 0, where Node's `input` pipe reports EISDIR and fish
+  // dies with "Unable to read input file: Is a directory" before running
+  // anything. Reproduced on fish 3.6/3.7 (Linux); macOS fish 4.8 tolerates the
+  // pipe, which is exactly how this passed locally and failed in CI. A regular
+  // file fstats cleanly on both.
+  const stdin = openSync(join(fixture.home, 'stdin-script'), 'r')
+  try {
+    const result = spawnSync('sh', ['-c', buildWslInteractiveLoginShellCommand()], {
+      cwd: fixture.home,
+      stdio: [stdin, 'pipe', 'pipe'],
+      env: {
+        PATH: `${fixture.binDir}:${process.env.PATH ?? ''}`,
+        HOME: fixture.home,
+        ORCA_CAPTURE_FILE: fixture.capturePath,
+        ...env
+      },
+      encoding: 'utf8',
+      timeout: 15_000
+    })
+    return { stderr: result.stderr ?? '', stdout: result.stdout ?? '' }
+  } finally {
+    closeSync(stdin)
+  }
 }
 
 describePosix('WSL guest login script, fish branch', () => {
@@ -144,7 +164,7 @@ describePosix('WSL guest login script, fish branch', () => {
   )
 
   itWithFish(
-    'reaches a usable fish prompt when the wrapper file is missing',
+    'reaches a usable fish login when the wrapper file is missing',
     () => {
       const fixture = makeGuestFixture(fishPath ?? 'fish')
       guestHomes.push(fixture.home)

--- a/src/main/pty/prime-agent-fish-shell-wrapper.test.ts
+++ b/src/main/pty/prime-agent-fish-shell-wrapper.test.ts
@@ -184,6 +184,31 @@ describePosix('Prime Agent fish shell wrapper', () => {
     expect(capture).toContain('ARG5=--follow')
   })
 
+  // Why separately from the case above: `set -e argv[1..2]` erases the whole
+  // list here, and fish's slice deletion is the one construct with no bash
+  // `shift 2` equivalent.
+  itWithFish('injects the extension when attach has no trailing arguments', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent attach agent-123')
+
+    expect(capture).toContain('ARG1=attach')
+    expect(capture).toContain('ARG2=agent-123')
+    expect(capture).toContain('ARG3=--extension')
+    expect(capture).toContain(`ARG4=${fixture.extensionPath}`)
+    expect(capture).not.toContain('ARG5=')
+  })
+
+  // Why: bash passes `"$@"`; fish passes a bare `$argv`, which would split a
+  // quoted operand if the list expansion were not element-preserving.
+  itWithFish('keeps a multi-word operand as a single argument', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent ask "write a haiku"')
+
+    expect(capture).toContain('ARG3=ask')
+    expect(capture).toContain('ARG4=write a haiku')
+    expect(capture).not.toContain('ARG5=')
+  })
+
   itWithFish('preserves a bare attach without inventing an agent operand', () => {
     const fixture = makeFixture()
     const capture = runPrime(fixture, 'prime-agent attach')

--- a/src/main/pty/prime-agent-fish-shell-wrapper.test.ts
+++ b/src/main/pty/prime-agent-fish-shell-wrapper.test.ts
@@ -1,0 +1,324 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getFishPrimeAgentShellWrapper } from './prime-agent-fish-shell-wrapper'
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasFish = process.platform !== 'win32' && spawnSync('fish', ['--version']).status === 0
+const itWithFish = hasFish ? it : it.skip
+const tempDirs: string[] = []
+
+function makeFixture(): {
+  root: string
+  extensionPath: string
+  capturePath: string
+  endpointPath: string
+  primeHome: string
+  wrapper: string
+} {
+  const root = mkdtempSync(join(tmpdir(), 'orca-prime-fish-wrapper-'))
+  tempDirs.push(root)
+  const binDir = join(root, 'bin')
+  const primeHome = join(root, 'guest-prime-home')
+  const extensionPath = join(root, 'orca-agent-status.ts')
+  const capturePath = join(root, 'capture')
+  const endpointPath = join(
+    root,
+    '.orca-wsl',
+    'agent-hooks',
+    'instance-testinstance',
+    'endpoint.env'
+  )
+  const wrapper = join(root, 'orca.fish')
+  mkdirSync(binDir)
+  mkdirSync(primeHome)
+  mkdirSync(dirname(endpointPath), { recursive: true })
+  writeFileSync(extensionPath, 'export default {}')
+  writeFileSync(endpointPath, 'ORCA_AGENT_HOOK_PORT=4567\nORCA_AGENT_HOOK_TOKEN=current-token\n')
+  writeFileSync(wrapper, getFishPrimeAgentShellWrapper())
+  writeFileSync(
+    join(binDir, 'prime-agent'),
+    `#!/bin/sh
+{
+  printf 'HOME=%s\n' "$PRIME_AGENT_CODING_AGENT_DIR"
+  printf 'ENDPOINT=%s\n' "$ORCA_AGENT_HOOK_ENDPOINT"
+  i=0
+  for arg in "$@"; do
+    i=$((i + 1))
+    printf 'ARG%s=%s\n' "$i" "$arg"
+  done
+} > "$ORCA_CAPTURE_FILE"
+if [ "\${1:-}" = "config" ]; then
+  printf 'preserved\n' > "$PRIME_AGENT_CODING_AGENT_DIR/config.yml"
+fi
+`,
+    { mode: 0o755 }
+  )
+  chmodSync(join(binDir, 'prime-agent'), 0o755)
+  return { root, extensionPath, capturePath, endpointPath, primeHome, wrapper }
+}
+
+function runPrime(
+  fixture: ReturnType<typeof makeFixture>,
+  command: string,
+  extensionPath = fixture.extensionPath
+): string {
+  // Why --no-config: the runner's own ~/.config/fish must not define prime-agent
+  // or reorder PATH, which would make the wrapper assertions non-hermetic.
+  const result = spawnSync(
+    'fish',
+    ['--no-config', '-C', `source ${fixture.wrapper}`, '-c', command],
+    {
+      cwd: fixture.root,
+      env: {
+        ...process.env,
+        HOME: fixture.root,
+        PATH: `${join(fixture.root, 'bin')}:${process.env.PATH ?? ''}`,
+        PRIME_AGENT_CODING_AGENT_DIR: fixture.primeHome,
+        ORCA_PRIME_AGENT_STATUS_EXTENSION: extensionPath,
+        ORCA_WSL_HOOK_INSTANCE: 'testinstance',
+        ORCA_AGENT_HOOK_ENDPOINT: '/mnt/c/current/endpoint.cmd',
+        ORCA_AGENT_HOOK_PORT: '4567',
+        ORCA_AGENT_HOOK_TOKEN: 'current-token',
+        ORCA_CAPTURE_FILE: fixture.capturePath
+      },
+      encoding: 'utf8'
+    }
+  )
+  expect(result.status, result.stderr).toBe(0)
+  return readFileSync(fixture.capturePath, 'utf8')
+}
+
+describePosix('Prime Agent fish shell wrapper', () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  itWithFish('injects the managed extension into an interactive launch', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent ask')
+
+    expect(capture).toContain(`HOME=${fixture.primeHome}`)
+    expect(capture).toContain(`ENDPOINT=${fixture.endpointPath}`)
+    expect(capture).toContain('ARG1=--extension')
+    expect(capture).toContain(`ARG2=${fixture.extensionPath}`)
+    expect(capture).toContain('ARG3=ask')
+  })
+
+  itWithFish('preserves config subcommands and the guest Prime home', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent config')
+
+    expect(capture).toContain(`HOME=${fixture.primeHome}`)
+    expect(capture).toContain('ARG1=config')
+    expect(capture).not.toContain('ARG1=--extension')
+    expect(readFileSync(join(fixture.primeHome, 'config.yml'), 'utf8')).toBe('preserved\n')
+  })
+
+  itWithFish.each([
+    'agents',
+    'doctor',
+    'help',
+    'list',
+    'model',
+    'package',
+    'rename',
+    'schedule',
+    'send',
+    'session',
+    'shutdown',
+    'status',
+    'stop',
+    'update'
+  ])('preserves the %s subcommand argv', (subcommand) => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, `prime-agent ${subcommand}`)
+
+    expect(capture).toContain(`ARG1=${subcommand}`)
+    expect(capture).not.toContain('ARG1=--extension')
+  })
+
+  itWithFish.each(['stop', 'rename'])(
+    'preserves --daemon-socket before the %s management command',
+    (subcommand) => {
+      const fixture = makeFixture()
+      const capture = runPrime(
+        fixture,
+        `prime-agent --daemon-socket /tmp/prime.sock ${subcommand} agent-123`
+      )
+
+      expect(capture).toContain('ARG1=--daemon-socket')
+      expect(capture).toContain('ARG2=/tmp/prime.sock')
+      expect(capture).toContain(`ARG3=${subcommand}`)
+      expect(capture).not.toContain(fixture.extensionPath)
+    }
+  )
+
+  itWithFish.each(['stop', 'rename'])(
+    'preserves --daemon-socket=<path> before the %s management command',
+    (subcommand) => {
+      const fixture = makeFixture()
+      const capture = runPrime(
+        fixture,
+        `prime-agent --daemon-socket=/tmp/prime.sock ${subcommand} agent-123`
+      )
+
+      expect(capture).toContain('ARG1=--daemon-socket=/tmp/prime.sock')
+      expect(capture).toContain(`ARG2=${subcommand}`)
+      expect(capture).not.toContain(fixture.extensionPath)
+    }
+  )
+
+  itWithFish('injects the extension after the attach agent operand', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent attach agent-123 --follow')
+
+    expect(capture).toContain('ARG1=attach')
+    expect(capture).toContain('ARG2=agent-123')
+    expect(capture).toContain('ARG3=--extension')
+    expect(capture).toContain(`ARG4=${fixture.extensionPath}`)
+    expect(capture).toContain('ARG5=--follow')
+  })
+
+  itWithFish('preserves a bare attach without inventing an agent operand', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent attach')
+
+    expect(capture).toContain('ARG1=attach')
+    expect(capture).not.toContain('ARG2=')
+    expect(capture).not.toContain(fixture.extensionPath)
+  })
+
+  itWithFish('preserves attach help without inventing an agent operand', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent attach --help')
+
+    expect(capture).toContain('ARG1=attach')
+    expect(capture).toContain('ARG2=--help')
+    expect(capture).not.toContain(fixture.extensionPath)
+  })
+
+  itWithFish('does not override an explicit user extension', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent --extension /tmp/user-extension.ts ask')
+
+    expect(capture).toContain('ARG1=--extension')
+    expect(capture).toContain('ARG2=/tmp/user-extension.ts')
+    expect(capture).not.toContain(fixture.extensionPath)
+  })
+
+  itWithFish('does not override an explicit --extension= form', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent --extension=/tmp/user-extension.ts ask')
+
+    expect(capture).toContain('ARG1=--extension=/tmp/user-extension.ts')
+    expect(capture).not.toContain(fixture.extensionPath)
+  })
+
+  itWithFish('does not add a second extension to attach', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(
+      fixture,
+      'prime-agent attach agent-123 --extension /tmp/user-extension.ts'
+    )
+
+    expect(capture).toContain('ARG1=attach')
+    expect(capture).toContain('ARG2=agent-123')
+    expect(capture).toContain('ARG3=--extension')
+    expect(capture).toContain('ARG4=/tmp/user-extension.ts')
+    expect(capture).not.toContain(fixture.extensionPath)
+  })
+
+  itWithFish('degrades to the original argv when the managed extension is unavailable', () => {
+    const fixture = makeFixture()
+    const capture = runPrime(fixture, 'prime-agent ask', join(fixture.root, 'missing.ts'))
+
+    expect(capture).toContain('ARG1=ask')
+    expect(capture).not.toContain('ARG1=--extension')
+  })
+
+  itWithFish('keeps the stable guest endpoint path while its relay refreshes stale data', () => {
+    const fixture = makeFixture()
+    writeFileSync(fixture.endpointPath, 'ORCA_AGENT_HOOK_PORT=4567\nORCA_AGENT_HOOK_TOKEN=stale\n')
+
+    const capture = runPrime(fixture, 'prime-agent ask')
+
+    expect(capture).toContain(`ENDPOINT=${fixture.endpointPath}`)
+    expect(capture).toContain('ARG1=--extension')
+  })
+
+  itWithFish('trims a trailing HOME slash before deriving the guest endpoint path', () => {
+    const fixture = makeFixture()
+    const result = spawnSync(
+      'fish',
+      ['--no-config', '-C', `source ${fixture.wrapper}`, '-c', 'prime-agent ask'],
+      {
+        cwd: fixture.root,
+        env: {
+          ...process.env,
+          HOME: `${fixture.root}/`,
+          PATH: `${join(fixture.root, 'bin')}:${process.env.PATH ?? ''}`,
+          PRIME_AGENT_CODING_AGENT_DIR: fixture.primeHome,
+          ORCA_PRIME_AGENT_STATUS_EXTENSION: fixture.extensionPath,
+          ORCA_WSL_HOOK_INSTANCE: 'testinstance',
+          ORCA_CAPTURE_FILE: fixture.capturePath
+        },
+        encoding: 'utf8'
+      }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(readFileSync(fixture.capturePath, 'utf8')).toContain(`ENDPOINT=${fixture.endpointPath}`)
+  })
+
+  itWithFish('leaves the inherited endpoint untouched when the WSL bridge env is absent', () => {
+    const fixture = makeFixture()
+    const result = spawnSync(
+      'fish',
+      ['--no-config', '-C', `source ${fixture.wrapper}`, '-c', 'prime-agent ask'],
+      {
+        cwd: fixture.root,
+        env: {
+          ...process.env,
+          HOME: fixture.root,
+          PATH: `${join(fixture.root, 'bin')}:${process.env.PATH ?? ''}`,
+          PRIME_AGENT_CODING_AGENT_DIR: fixture.primeHome,
+          ORCA_PRIME_AGENT_STATUS_EXTENSION: fixture.extensionPath,
+          ORCA_AGENT_HOOK_ENDPOINT: '/mnt/c/current/endpoint.cmd',
+          ORCA_CAPTURE_FILE: fixture.capturePath
+        },
+        encoding: 'utf8'
+      }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    const capture = readFileSync(fixture.capturePath, 'utf8')
+    expect(capture).toContain('ENDPOINT=/mnt/c/current/endpoint.cmd')
+    expect(capture).toContain('ARG1=--extension')
+  })
+
+  itWithFish('does not define wrapper helpers when the bridge env is absent', () => {
+    const fixture = makeFixture()
+    const result = spawnSync(
+      'fish',
+      [
+        '--no-config',
+        '-C',
+        `source ${fixture.wrapper}`,
+        '-c',
+        'functions -q __orca_prime_agent; and echo defined'
+      ],
+      {
+        cwd: fixture.root,
+        env: { ...process.env, ORCA_PRIME_AGENT_STATUS_EXTENSION: '' },
+        encoding: 'utf8'
+      }
+    )
+
+    expect(result.stdout.trim()).toBe('')
+  })
+})

--- a/src/main/pty/prime-agent-fish-shell-wrapper.ts
+++ b/src/main/pty/prime-agent-fish-shell-wrapper.ts
@@ -1,0 +1,83 @@
+import { wslHookRelayEndpointFilePath } from '../../shared/wsl-hook-relay-contract'
+import { PRIME_AGENT_SUBCOMMANDS } from './prime-agent-shell-wrapper'
+
+/** Fish-syntax twin of `getPosixPrimeAgentShellWrapper()`.
+ *
+ *  Why a separate generator: fish is not POSIX — no `local`, no `case/esac`, no
+ *  `shift`, no `${var:-}` — so the bash wrapper is a parse error under fish and
+ *  a fish login shell silently loses Prime status reporting (STA-3927). Every
+ *  argv semantic below must stay in lockstep with the bash wrapper; the two
+ *  test files assert the same matrix. */
+export function getFishPrimeAgentShellWrapper(): string {
+  // Why fish-expression operands: the shared contract builds the path, but the
+  // interpolated pieces must be fish variable syntax, not `${HOME%/}`.
+  const guestEndpointPath = wslHookRelayEndpointFilePath(
+    '$__orca_prime_home',
+    '$ORCA_WSL_HOOK_INSTANCE'
+  )
+  return `# Why: WSL cannot install into Prime's guest-owned config root from the
+# Windows host, so pass Orca's status extension only to interactive launches.
+if test -n "$ORCA_PRIME_AGENT_STATUS_EXTENSION"
+  function __orca_prime_agent_should_skip_extension
+    if test "$argv[1]" = "--daemon-socket"
+      if test "$argv[3]" = "stop"; or test "$argv[3]" = "rename"
+        return 0
+      end
+    end
+    # Why quoted: an unquoted glob with no match is a hard error in fish.
+    if string match -q -- "--daemon-socket=*" "$argv[1]"
+      if test "$argv[2]" = "stop"; or test "$argv[2]" = "rename"
+        return 0
+      end
+    end
+    switch "$argv[1]"
+      case help --help -h --version -v --extension "--extension=*"
+        return 0
+      case ${PRIME_AGENT_SUBCOMMANDS.join(' ')}
+        return 0
+    end
+    return 1
+  end
+  function __orca_prime_agent_has_explicit_extension
+    for __orca_arg in $argv
+      switch "$__orca_arg"
+        case --extension "--extension=*"
+          return 0
+      end
+    end
+    return 1
+  end
+  function __orca_prime_agent_launch
+    if test "$argv[1]" = "attach"; and test -n "$argv[2]"; and not string match -q -- "-*" "$argv[2]"
+      set -l __orca_attach_agent $argv[2]
+      set -e argv[1..2]
+      command prime-agent attach $__orca_attach_agent --extension "$ORCA_PRIME_AGENT_STATUS_EXTENSION" $argv
+    else
+      command prime-agent --extension "$ORCA_PRIME_AGENT_STATUS_EXTENSION" $argv
+    end
+  end
+  function __orca_prime_agent
+    if test "$argv[1]" = "attach"; and begin; test -z "$argv[2]"; or string match -q -- "-*" "$argv[2]"; end
+      command prime-agent $argv
+      return
+    end
+    if not __orca_prime_agent_should_skip_extension $argv; and not __orca_prime_agent_has_explicit_extension $argv; and test -f "$ORCA_PRIME_AGENT_STATUS_EXTENSION"
+      set -l __orca_prime_home (string trim -r -c / -- "$HOME")
+      # Why the duplicated launch: fish scopes \`set -lx\` to the enclosing block,
+      # not the function, so the export must wrap the launch it applies to.
+      if test -n "$HOME"; and test -n "$ORCA_WSL_HOOK_INSTANCE"
+        set -lx ORCA_AGENT_HOOK_ENDPOINT "${guestEndpointPath}"
+        __orca_prime_agent_launch $argv
+        return
+      end
+      __orca_prime_agent_launch $argv
+      return
+    end
+    command prime-agent $argv
+  end
+  function prime-agent
+    __orca_prime_agent $argv
+  end
+end
+`
+}

--- a/src/main/pty/prime-agent-shell-wrapper-parity.test.ts
+++ b/src/main/pty/prime-agent-shell-wrapper-parity.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Cross-shell parity for the Prime Agent status wrapper.
+ *
+ * Why a parity suite rather than more per-shell cases: the STA-3927 failure was
+ * not a broken wrapper, it was a *missing* one — fish launched cleanly and
+ * silently handed `prime-agent` the user's bare argv while bash injected
+ * `--extension`. Only a side-by-side capture of the two product launch configs
+ * makes that class of gap fail a test. Adapted from the independent repro's
+ * real-shell oracle, whose fish assertion was the inverse of the one here.
+ */
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
+const hasFish = process.platform !== 'win32' && spawnSync('fish', ['--version']).status === 0
+const itWithBothShells = hasBash && hasFish ? it : it.skip
+
+type CaptureFixture = {
+  root: string
+  binDir: string
+  extensionPath: string
+  capturePath: string
+}
+
+function makeCaptureFixture(): CaptureFixture {
+  const root = mkdtempSync(join(tmpdir(), 'prime-parity-'))
+  const binDir = join(root, 'bin')
+  const extensionPath = join(root, 'orca-agent-status.ts')
+  const capturePath = join(root, 'prime-argv.capture')
+  mkdirSync(binDir)
+  writeFileSync(extensionPath, 'export default {}')
+  // Why a filesystem capture: the wrapper's whole effect is the argv handed to
+  // the real binary; the terminal buffer only ever shows the shell's own echo.
+  writeFileSync(
+    join(binDir, 'prime-agent'),
+    `#!/bin/sh
+{
+  printf 'BEGIN\\n'
+  for arg in "$@"; do
+    printf 'ARG=%s\\n' "$arg"
+  done
+  printf 'END\\n'
+} >> "$ORCA_CAPTURE_FILE"
+`,
+    { mode: 0o755 }
+  )
+  chmodSync(join(binDir, 'prime-agent'), 0o755)
+  return { root, binDir, extensionPath, capturePath }
+}
+
+function captureEnv(fixture: CaptureFixture): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: fixture.root,
+    PATH: `${fixture.binDir}:${process.env.PATH ?? ''}`,
+    ORCA_PRIME_AGENT_STATUS_EXTENSION: fixture.extensionPath,
+    ORCA_CAPTURE_FILE: fixture.capturePath,
+    TERM: 'dumb',
+    PS1: '$ '
+  }
+}
+
+describePosix('Prime Agent wrapper parity across product launch configs', () => {
+  let previousUserDataPath: string | undefined
+  let userDataPath: string
+  const tempDirs: string[] = []
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'prime-parity-userdata-'))
+    tempDirs.push(userDataPath)
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    vi.restoreAllMocks()
+  })
+
+  itWithBothShells('gives fish the same prime-agent argv the bash wrapper produces', async () => {
+    vi.resetModules()
+    const { getShellReadyLaunchConfig } = await import('../providers/local-pty-shell-ready')
+
+    const bashConfig = getShellReadyLaunchConfig('/bin/bash')
+    const bashFixture = makeCaptureFixture()
+    tempDirs.push(bashFixture.root)
+    const rcfile = bashConfig.args?.[1] ?? ''
+    expect(existsSync(rcfile)).toBe(true)
+    const bashRun = spawnSync(
+      'bash',
+      ['--noprofile', '--rcfile', rcfile, '-ic', 'prime-agent ask'],
+      {
+        cwd: bashFixture.root,
+        env: { ...captureEnv(bashFixture), ...bashConfig.env },
+        encoding: 'utf8',
+        timeout: 15_000
+      }
+    )
+    expect(bashRun.status, bashRun.stderr).toBe(0)
+
+    const fishConfig = getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
+    const fishFixture = makeCaptureFixture()
+    tempDirs.push(fishFixture.root)
+    // Why the product args verbatim: the gap was in what Orca passes to fish,
+    // so a hand-built argv here would test nothing that ships.
+    const fishRun = spawnSync('fish', [...(fishConfig.args ?? []), '-c', 'prime-agent ask'], {
+      cwd: fishFixture.root,
+      env: { ...captureEnv(fishFixture), ...fishConfig.env },
+      encoding: 'utf8',
+      timeout: 15_000
+    })
+    expect(fishRun.status, fishRun.stderr).toBe(0)
+
+    const expected = `BEGIN\nARG=--extension\nARG=${'{EXT}'}\nARG=ask\nEND\n`
+    expect(readFileSync(bashFixture.capturePath, 'utf8')).toBe(
+      expected.replace('{EXT}', bashFixture.extensionPath)
+    )
+    // The STA-3927 regression: this capture was `BEGIN/ARG=ask/END` — fish ran
+    // the user's bare argv and Orca's Prime status reporting never armed.
+    expect(readFileSync(fishFixture.capturePath, 'utf8')).toBe(
+      expected.replace('{EXT}', fishFixture.extensionPath)
+    )
+  })
+
+  itWithBothShells('keeps management subcommands unwrapped in both shells', async () => {
+    vi.resetModules()
+    const { getShellReadyLaunchConfig } = await import('../providers/local-pty-shell-ready')
+
+    const bashConfig = getShellReadyLaunchConfig('/bin/bash')
+    const bashFixture = makeCaptureFixture()
+    tempDirs.push(bashFixture.root)
+    spawnSync(
+      'bash',
+      ['--noprofile', '--rcfile', bashConfig.args?.[1] ?? '', '-ic', 'prime-agent stop'],
+      {
+        cwd: bashFixture.root,
+        env: { ...captureEnv(bashFixture), ...bashConfig.env },
+        encoding: 'utf8',
+        timeout: 15_000
+      }
+    )
+
+    const fishConfig = getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
+    const fishFixture = makeCaptureFixture()
+    tempDirs.push(fishFixture.root)
+    spawnSync('fish', [...(fishConfig.args ?? []), '-c', 'prime-agent stop'], {
+      cwd: fishFixture.root,
+      env: { ...captureEnv(fishFixture), ...fishConfig.env },
+      encoding: 'utf8',
+      timeout: 15_000
+    })
+
+    expect(readFileSync(bashFixture.capturePath, 'utf8')).toBe('BEGIN\nARG=stop\nEND\n')
+    expect(readFileSync(fishFixture.capturePath, 'utf8')).toBe('BEGIN\nARG=stop\nEND\n')
+  })
+})

--- a/src/main/pty/prime-agent-shell-wrapper.ts
+++ b/src/main/pty/prime-agent-shell-wrapper.ts
@@ -1,6 +1,6 @@
 import { wslHookRelayEndpointFilePath } from '../../shared/wsl-hook-relay-contract'
 
-const PRIME_AGENT_SUBCOMMANDS = [
+export const PRIME_AGENT_SUBCOMMANDS = [
   'agents',
   'config',
   'doctor',

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -1,5 +1,6 @@
 // Why: local PTYs and the daemon/SSH path must use identical ZDOTDIR discovery;
 // small drift here breaks different terminal transports in different ways.
+import { getFishPrimeAgentShellWrapper } from './pty/prime-agent-fish-shell-wrapper'
 
 function quotePosixSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
@@ -172,6 +173,31 @@ export function getFishShellReadyInitCommand(escapedMarker: string): string {
     functions -e __orca_shell_ready_marker
   end
 end`
+}
+
+/** Fish single-quoting: only `\` and `'` are special inside `'...'`. */
+export function quoteFishSingle(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
+
+export function getFishShellReadyWrapperFileContent(): string {
+  return `# Orca fish shell-ready wrapper
+${getFishPrimeAgentShellWrapper()}`
+}
+
+/** Single `--init-command` payload for a wrapped fish launch.
+ *
+ *  Why one combined string: fish's support for repeating `-C` varies by version,
+ *  and the wrapper must be sourced from a file rather than inlined — on WSL the
+ *  inline text would have to survive `escapeWslShCommandForWindows`, which
+ *  backslash-escapes every `$`. The `test -f` guard keeps a failed wrapper write
+ *  from printing a `source:` error into the user's first prompt. */
+export function getFishInitCommand(args: { wrapperPath: string; escapedMarker: string }): string {
+  const quoted = quoteFishSingle(args.wrapperPath)
+  return [
+    `test -f ${quoted}; and source ${quoted}`,
+    getFishShellReadyInitCommand(args.escapedMarker)
+  ].join('\n')
 }
 
 export function getZshFinalZdotdirRestoreBlock(homeExpression = '"${ORCA_ORIG_ZDOTDIR:-$HOME}"') {

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -182,7 +182,25 @@ describe('wsl login shell command helpers', () => {
     expect(command).toContain('--rcfile "${_orca_shell_ready_root}/bash/rcfile"')
     expect(command).toContain('zsh)')
     expect(command).toContain('export ZDOTDIR="${_orca_shell_ready_root}/zsh"')
+    // Why: fish is not POSIX, so it can consume neither --rcfile nor ZDOTDIR;
+    // its wrapper rides a single --init-command instead (STA-3927).
+    expect(command).toContain('fish)')
+    expect(command).toContain(
+      'ORCA_FISH_SHELL_READY_WRAPPER="${_orca_shell_ready_root}/fish/orca.fish"'
+    )
+    expect(command).toContain(`-l -C 'source "$ORCA_FISH_SHELL_READY_WRAPPER"`)
     expect(command).toContain('exec "$_orca_wsl_shell" -l')
     expectValidShSyntax(command)
+  })
+
+  it('falls through to a bare fish login when the wrapper file is absent', () => {
+    const command = buildWslInteractiveLoginShellCommand()
+    const fishBranch = command.slice(command.indexOf('  fish)'), command.indexOf('esac'))
+
+    // Why: the wrapper exec sits behind a -f guard so a failed wrapper write
+    // still reaches the shared `exec "$_orca_wsl_shell" -l` at the bottom
+    // rather than erroring on `source`.
+    expect(fishBranch).toContain('[ -f "${_orca_shell_ready_root}/fish/orca.fish" ]')
+    expect(fishBranch.indexOf('if [')).toBeLessThan(fishBranch.indexOf('exec'))
   })
 })

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -61,6 +61,23 @@ export function buildWslInteractiveLoginShellCommand(): string {
     '      export ZDOTDIR="${_orca_shell_ready_root}/zsh"',
     '    fi',
     '    ;;',
+    // Why: fish has no rcfile/ZDOTDIR hook, so its wrapper rides a single
+    // --init-command that sources the file. One -C, not two: multi -C support
+    // varies by fish version. Sourcing a file rather than inlining the body
+    // keeps every `$` out of escapeWslShCommandForWindows.
+    //
+    // Why the env var instead of an interpolated literal: the wrapper root is a
+    // Windows path translated by WSLENV, and fish re-parses a double-quoted
+    // literal (a `$` in the user's profile path would expand) while a
+    // single-quoted one cannot carry an apostrophe. A variable's *value* is
+    // never re-expanded, so this survives both.
+    '  fish)',
+    '    if [ -n "${_orca_shell_ready_root:-}" ] && [ -f "${_orca_shell_ready_root}/fish/orca.fish" ]; then',
+    '      ORCA_FISH_SHELL_READY_WRAPPER="${_orca_shell_ready_root}/fish/orca.fish"',
+    '      export ORCA_FISH_SHELL_READY_WRAPPER',
+    `      exec "$_orca_wsl_shell" -l -C 'source "$ORCA_FISH_SHELL_READY_WRAPPER"; set -e ORCA_FISH_SHELL_READY_WRAPPER'`,
+    '    fi',
+    '    ;;',
     'esac',
     'exec "$_orca_wsl_shell" -l'
   ].join('\n')


### PR DESCRIPTION
## Summary

A user whose login shell is **fish** — on WSL, macOS, or Linux — launched Prime Agent normally but lost Orca's Prime working/status reporting. Fish is not POSIX, so `getPosixPrimeAgentShellWrapper()` (`[[ ]]`, `local`, `case/esac`, `shift 2`) can never be sourced by it. Fish started cleanly and handed `prime-agent` the user's bare argv; the `--extension` injection simply never happened. Fixes STA-3927, filed against merged #13430.

**What changed**

- `src/main/pty/prime-agent-fish-shell-wrapper.ts` — new. Fish twin of the POSIX wrapper: `function … end`, `$argv` / `$argv[1]`, `set -l`, `set -lx` for the function-scoped `ORCA_AGENT_HOOK_ENDPOINT` export, `switch/case` with a quoted `"--extension=*"` (an unmatched glob is a hard error in fish), `set -e argv[1..2]` in place of `shift 2`, and `string trim -r -c /` for the HOME trailing-slash trim.
- Delivered as a **file** — `shell-ready/fish/orca.fish`, alongside the existing `bash/rcfile` and `zsh/` wrappers — not inlined into the launch argv. Inlining would have to survive `escapeWslShCommandForWindows()`, which backslash-escapes every `$`.
- `src/main/shell-templates.ts` — `getFishShellReadyWrapperFileContent()` plus `getFishInitCommand()`, which folds the wrapper `source` and the existing shell-ready marker into **one** `-C` string. Multi-`-C` support varies by fish version, so one combined init command is the safe shape.
- Wired in at all three sites: `src/main/providers/local-pty-shell-ready.ts`, `src/main/daemon/shell-ready.ts`, and a new `fish)` arm in `buildWslInteractiveLoginShellCommand()` (`src/shared/wsl-login-shell-command.ts`). The fish arm is guarded by `[ -f … ]`, so a failed wrapper write still falls through to the shared bare `exec "$_orca_wsl_shell" -l` rather than erroring on `source`.
- Fish is now wrapped on the **attribution (markerless) path** too, matching bash and zsh. It previously returned `args: null` there, which left a plain fish pane — exactly where a user types `prime-agent` by hand — unwrapped. The marker itself stays gated on `ORCA_SHELL_READY_MARKER` inside the init text, so a markerless pane still emits nothing.

Every semantic of the bash wrapper is preserved and tested: typed launches, explicit launches, bare `attach` vs `attach <agent>`, the management-subcommand skip list, both `--daemon-socket` forms before `stop`/`rename`, explicit `--extension` / `--extension=` passthrough, and the degrade-to-original-argv path when the managed extension file is missing.

The existing fish shell-ready marker behavior is unchanged — it still rides `--on-event fish_prompt` and still fires exactly once.

**Deliberately out of scope** (one thing per PR); follow-ups filed:

- STA-3936 — the identical fish gap in the **OMP** wrapper (`getPosixOmpShellWrapper`)
- STA-3937 — fish gaps for `CODEX_HOME`, `OPENCODE_CONFIG_DIR`, `MIMOCODE_HOME`, and the attribution / agent-teams shim PATHs
- STA-3938 — `buildWslLoginShellCommand()` routing fish to `/bin/sh -lc` for non-interactive detection probes
- STA-3939 — `ORCA_PRIME_AGENT_STATUS_EXTENSION` is missing from the `needsNoMarkerWrapper` env list (affects bash and zsh too), found while working this fix

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build` — **not run.** No build-surface change: this PR touches only main-process TypeScript and the shell text it generates, all of which `pnpm typecheck` covers. No packaging, native module, or asset change.
- [x] Added or updated high-quality tests that would catch regressions

| File | What it covers |
| --- | --- |
| `src/main/pty/prime-agent-fish-shell-wrapper.test.ts` (new, 33 cases) | Mirrors `prime-agent-shell-wrapper.test.ts` against real fish — the whole argv matrix, plus fish-specific hazards: `set -e argv[1..2]` when attach has no trailing args, multi-word operands surviving a bare `$argv`, and the `HOME` trailing-slash trim |
| `src/main/pty/prime-agent-shell-wrapper-parity.test.ts` (new) | Runs the **product** launch configs for bash and fish side by side through one fake `prime-agent` and asserts identical argv capture |
| `src/main/daemon/shell-ready-fish.node-pty.test.ts` (new) | Real fish under node-pty. Holds the two PTY-level fish cases (the pre-existing marker test moved here unchanged, plus a new one proving `prime-agent` is wrapped in a real login shell). Extracted because `shell-ready.test.ts` would otherwise cross the `max-lines` ceiling — no suppression was added |
| `src/main/providers/wsl-fish-login-shell.test.ts` (new) | Executes the generated guest login script (`sh -c "<script>"`) driving a real fish, with a shadowed `getent` pinning the login shell. Covers the wrapped case, the missing-wrapper fallback, and a `/bin/sh` control proving the branch is actually being steered |
| `src/main/providers/windows-shell-args.test.ts`, `src/main/daemon/shell-ready.test.ts`, `src/main/providers/local-pty-shell-ready.test.ts`, `src/shared/wsl-login-shell-command.test.ts` | Wrapper file materialization, the single combined `-C`, the markerless attribution config, rewrite-on-missing, and the WSL fish arm including its `escapeWslShCommandForWindows` form |
| `.github/workflows/pr.yml` | All four new suites added to the one CI job that installs fish, and to the shard `--exclude` list. Without this they gate off a missing binary and skip silently — see AI Review below |

Every oracle asserts through **filesystem markers** (a fake `prime-agent` that writes its argv to a capture file), never by scraping the terminal buffer.

RED→GREEN was verified by reverting the fix in place: the parity oracle's fish capture collapses to `BEGIN\nARG=ask\nEND\n` — exactly the signature an independent repro recorded at HEAD — and the guest-script execution test fails with the same shape. Both go green with the fix.

Commands run:

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/pty/ src/main/daemon/ src/main/providers/ \
  src/shared/wsl-login-shell-command.test.ts
pnpm typecheck
pnpm lint
pnpm test
```

The WSL guest-script suite was additionally run against **fish 3.6 in a Linux container**, not just the local fish 4.8 — the first CI run failed there on a macOS-only assumption in the harness (see the PR comment) and this is how it was reproduced and confirmed fixed.

Note for anyone reproducing locally: `src/main/ipc/pty.test.ts` fails 10 tests when the suite is run from **inside an Orca terminal** — the ambient `ZDOTDIR` / `ORCA_*` env leaks into its spawn-env assertions. It fails the same 10 at `origin/main`, and passes clean under `env -i`. Unrelated to this PR.

## AI Review Report

Ran `/code-review` at high effort over the full diff, plus a self-audit. The review built both wrappers to a scratch dir and ran a **bash-vs-fish argv differential** across ~20 cases (no args, `--help`/`-h`/`--version`/`-v`, glob/empty/newline/`$`-bearing operands, `attach` with and without operands, both `--daemon-socket` forms, explicit `--extension`/`--extension=`, `HOME` with trailing slashes and spaces, the WSL endpoint export). The fish wrapper came back byte-for-byte argv-identical to the bash wrapper in every case, including the `set -lx` export reaching the child through the nested launch function. No correctness defect was found in the generated fish code.

It raised three issues, all fixed in this PR:

1. **The regression tests would never have run in CI** (high). Only the `shell contracts` job installs fish; it enumerates its test files explicitly. All the new fish suites landed in the sharded `test` job, which has no fish, so `hasFish` was false and every one skipped silently — and moving the live-fish PTY test out of `shell-ready.test.ts` had also removed the repo's only *executed* fish coverage. Fixed by adding all four files to the shell-contracts run list and the shard `--exclude` list, with a comment on the job saying any new live-fish test must be added to both.
2. **The fix only covered fish launches carrying a startup command** (medium). `getAttributionShellLaunchConfig('fish')` still returned `args: null`, so an ordinary fish pane reproduced the original symptom for a hand-typed `prime-agent`, while bash/zsh got their wrapper unconditionally. Fixed by dropping the `emitReadyMarker` gate on the fish branch in both launch paths and gating only the marker.
3. **The guest-script tests were vacuous on Linux** (medium). They relied on `getent` being absent so the script would fall back to `$SHELL` — true on macOS, false on every CI runner, where `getent` returns the account's real shell and the script dispatches to `bash)` while the assertions still pass off the bash wrapper. Fixed by shadowing `getent` on `PATH` to pin the login shell, and adding a `/bin/sh` control that must come back unwrapped — so a shadow that stopped steering the branch fails the suite.

Other risks checked in the self-audit:

- **Fish scoping.** `set -l`/`set -lx` scope to the enclosing *block* in fish, not the function. A naive port would let the `ORCA_AGENT_HOOK_ENDPOINT` export die at the closing `end` before `prime-agent` ran; the wrapper keeps the launch inside the same block (one duplicated call, commented).
- **Fish glob-on-parse.** An unmatched wildcard in a command argument aborts the script in fish, so every wildcard pattern is quoted.
- **Path quoting, both directions.** The local path single-quotes via `quoteFishSingle` (escapes `\` and `'`), verified against a real path containing both `'` and `$`. The WSL path cannot use a literal at all — the root is a WSLENV-translated Windows path, fish *re-expands* `$` inside a double-quoted literal, and a single-quoted one cannot carry an apostrophe from a Windows profile name. It passes the path through an exported variable (a variable's value is never re-expanded) and scrubs the temp var with `set -e` in the same init command.
- **Cross-platform.** macOS/Linux/Windows reviewed. Windows: the wrapper write is skipped on `win32` exactly as before, the fish arm only executes inside a WSL guest, and no path is concatenated with a hardcoded separator (the daemon path uses `join`; the local provider keeps its existing POSIX-only template style since that root is consumed only by POSIX shells). No keyboard shortcut, accelerator, or UI label touched.
- **Fish version floor.** Every shipped construct (`string match`/`string trim -c`, `set -e` slice deletion, `functions -e`, `set -lx`, `switch`) predates fish 3.0. `--no-config` is fish 3.3+ but appears only in test harnesses.

## Security Audit

- **Command execution.** The wrapper injects `--extension "$ORCA_PRIME_AGENT_STATUS_EXTENSION"` into a `command prime-agent` call. That value originates in Orca's own `titlebar-extension-service`, not user input, and is double-quoted so fish cannot word-split or glob it. `command` is used throughout so a user-defined `prime-agent` cannot recurse into the wrapper.
- **Path handling.** Two distinct quoting problems, both closed and both covered by tests (see above). Neither can be broken by an apostrophe or a `$` in the user's profile path.
- **File writes.** One new file per wrapper root, `shell-ready/fish/orca.fish`, written mode `0644` into the existing user-owned userData dir by the same `ensureShellReadyWrappers` code that already writes the bash and zsh wrappers, under the same try/catch that degrades to an unwrapped shell on failure. No new trust boundary.
- **Env hygiene.** `ORCA_FISH_SHELL_READY_WRAPPER` exists only long enough for fish to read it and is erased inside the same init command, so it does not linger in the user's interactive shell.
- No new IPC surface, no network calls, no secrets, no dependency change, no auth path touched.

Follow-up needed: none for this change. The four filed tickets are pre-existing gaps, not regressions introduced here.

## Notes

**WSL guest execution was not validated.** This was developed on macOS; real WSL cannot be exercised there. The WSL half is covered two ways short of that: assertions on the generated command string (including its `escapeWslShCommandForWindows` form), and an actual execution of the generated `sh` script driving a real fish with a pinned login shell. What that does **not** exercise is `wsl.exe` itself, WSLENV `/p` path translation, or `/mnt/c` file access from the guest. Someone on a Windows host with a fish-login WSL distro should confirm end to end.

Behavior change worth a second look: fish panes that previously launched with no args now launch as `fish -l -C '<wrapper source + marker registration>'`. That brings fish in line with how bash and zsh have always been launched, and the marker stays inert unless `ORCA_SHELL_READY_MARKER=1`, but it is a wider blast radius than the WSL-only report implies.

The RED baseline came from an independently built repro; its real-shell oracle approach — fake binary plus filesystem argv capture, no terminal scraping — is what the parity suite here is adapted from.
