### PR TITLE
fix(worktrees): stop deleting the branch a worktree drifted onto

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename-test-harness.ts
+++ b/src/main/agent-hooks/first-work-branch-rename-test-harness.ts
@@ -54,11 +54,13 @@ export function makeBranchRenameDeps(
   deps: FirstWorkBranchRenameDeps
   onRenamed: VitestMock
   setDisplayName: VitestMock
+  recordRenamedBranch: VitestMock
   renameWorktreeFolder: VitestMock
   setRenameError: VitestMock
 } {
   const onRenamed = mockFn()
   const setDisplayName = mockFn()
+  const recordRenamedBranch = mockFn()
   const renameWorktreeFolder = mockFn(async () => false)
   const setRenameError = mockFn()
   const settings = { autoRenameBranchFromWork: true } as unknown as GlobalSettings
@@ -66,6 +68,7 @@ export function makeBranchRenameDeps(
   return {
     onRenamed,
     setDisplayName,
+    recordRenamedBranch,
     renameWorktreeFolder,
     setRenameError,
     deps: {
@@ -75,6 +78,7 @@ export function makeBranchRenameDeps(
       getCurrentDisplayName: () => 'Nautilus-8',
       canRenameOrcaCreatedBranch: () => true,
       setDisplayName,
+      recordRenamedBranch,
       renameWorktreeFolder,
       setRenameError,
       resolveWorktreeIdForTab: () => WORKTREE_ID,

--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -105,6 +105,12 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     expect(renameWorktreeFolder).toHaveBeenCalledWith(WORKTREE_ID, 'fix-auth')
   })
 
+  it('records the renamed branch so delete-time cleanup still matches it', async () => {
+    const { deps, recordRenamedBranch } = makeDeps()
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+    expect(recordRenamedBranch).toHaveBeenCalledWith(WORKTREE_ID, 'you/fix-auth')
+  })
+
   it('keeps branch and display rename working when folder rename is disabled', async () => {
     const { deps, onRenamed, setDisplayName } = makeDeps({ renameWorktreeFolder: undefined })
     await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -53,6 +53,8 @@ export type FirstWorkBranchRenameDeps = {
   canRenameOrcaCreatedBranch: (worktreeId: string) => boolean
   /** Persist a new sidebar display name for the worktree. */
   setDisplayName: (worktreeId: string, displayName: string) => void
+  /** Keep meta.createdBranch in sync so delete-time branch cleanup still recognizes Orca's branch. */
+  recordRenamedBranch: (worktreeId: string, newBranch: string) => void
   /** Align the on-disk folder with the new branch leaf (best-effort, local-only). */
   renameWorktreeFolder?: (worktreeId: string, newLeaf: string) => Promise<boolean>
   /** Record (or clear with null) an auto-rename failure for the sidebar "rename failed" badge; `failureOutput` carries bounded CLI output for on-demand display. */
@@ -278,6 +280,7 @@ async function runAutoRename(
   await (provider
     ? provider.renameCurrentBranch(worktreePath, newBranch)
     : renameCurrentBranch(exec, newBranch))
+  deps.recordRenamedBranch(worktreeId, newBranch)
 
   // resolveUniqueBranchName may append a collision suffix (`-2`, …), so derive names from the resolved leaf, not the slug.
   const newBranchLeaf = newBranch.slice(newBranch.lastIndexOf('/') + 1)

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -198,13 +198,117 @@ branch refs/heads/feature/test
       }
     })
 
-    await removeWorktree('/repo', '/repo-feature', false, { deleteBranch: false })
+    await removeWorktree('/repo', '/repo-feature', false, { branchRetention: 'preexisting-branch' })
 
     const calls = getGitCalls()
     expect(calls).toContain('git worktree remove /repo-feature')
     expect(calls).not.toContain('git worktree prune')
     expect(calls).not.toContain('git branch -d -- feature/test')
     expect(calls).not.toContain('git branch -D -- feature/test')
+  })
+
+  it('never deletes a trunk branch the removed worktree drifted onto', async () => {
+    // The primary checkout sits on a feature branch, so nothing would stop
+    // `git branch -d main` after removal — the protected-branch guard must.
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/dev_charles
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/main
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/dev_charles
+`
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({
+      preservedBranch: { branchName: 'main', head: 'def456', reason: 'default-branch' }
+    })
+
+    const calls = getGitCalls()
+    expect(calls).toContain('git worktree remove /repo-feature')
+    expect(calls).not.toContain('git branch -d -- main')
+    expect(calls).not.toContain('git branch -D -- main')
+  })
+
+  it('reports the kept branch when the checkout drifted off the branch Orca created', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/dev_charles
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/release/1.2
+`
+      }
+    })
+
+    await expect(
+      removeWorktree('/repo', '/repo-feature', false, { branchRetention: 'checkout-drift' })
+    ).resolves.toEqual({
+      preservedBranch: { branchName: 'release/1.2', head: 'def456', reason: 'checkout-drift' }
+    })
+
+    const calls = getGitCalls()
+    expect(calls).toContain('git worktree remove /repo-feature')
+    expect(calls).not.toContain('git branch -d -- release/1.2')
+    // Why: drift is decided from metadata, so it must not pay for the default-branch probes.
+    expect(calls).not.toContain('git symbolic-ref --quiet refs/remotes/origin/HEAD')
+  })
+
+  it('still force-deletes the just-created branch when creation rollback names a trunk', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/dev_charles
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/main
+`
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature', true, { forceBranchDelete: true })
+
+    // Rollback owns the branch it just created; the guard must not strand it.
+    expect(getGitCalls()).toContain('git branch -D -- main')
+  })
+
+  it('never deletes the origin/HEAD default branch after removing its worktree', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/dev_charles
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/develop
+`
+      },
+      'git symbolic-ref --quiet refs/remotes/origin/HEAD': {
+        stdout: 'refs/remotes/origin/develop\n'
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature')
+
+    const calls = getGitCalls()
+    expect(calls).toContain('git worktree remove /repo-feature')
+    expect(calls).not.toContain('git branch -d -- develop')
+    expect(calls).not.toContain('git branch -D -- develop')
   })
 
   it('skips branch deletion when another worktree still points at the branch', async () => {
@@ -298,6 +402,8 @@ branch refs/heads/main
       // The cleanliness probe that decides whether the checkout may be renamed aside.
       'git status --porcelain --untracked-files=all',
       'git worktree remove /repo-feature',
+      'git symbolic-ref --quiet refs/remotes/origin/HEAD',
+      'git rev-parse --verify --quiet refs/remotes/origin/main',
       'git branch -d -- feature/test',
       'git worktree prune',
       'git branch -d -- feature/test'

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -10,6 +10,16 @@ import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
 import { buildHostedRemoteCommitUrl, buildHostedRemoteFileUrl } from './hosted-remote-url'
 import { getLocalGitCapabilityCache } from './git-capability-state'
+import {
+  DEFAULT_BASE_REF_PROBES,
+  gitRefToDefaultBaseRef,
+  resolveDefaultBaseRefViaExec,
+  type GitExec
+} from '../../shared/git-default-base-ref'
+
+// Why re-export: the relay bundle can't import from src/main, so the resolution moved to
+// shared. Main-side importers (and their module mocks) keep addressing it through this file.
+export { DEFAULT_BASE_REF_PROBES, resolveDefaultBaseRefViaExec, type GitExec }
 
 type LocalGitExecOptions = {
   wslDistro?: string
@@ -30,33 +40,6 @@ function gitExecOptions(
   options: LocalGitExecOptions = {}
 ): { cwd: string; wslDistro?: string } {
   return options.wslDistro ? { cwd, wslDistro: options.wslDistro } : { cwd }
-}
-
-/**
- * Ordered probe list for a repo's default base ref when no origin/HEAD symbolic-ref is set.
- * `returnAs` is the short-name format the UI expects (as `for-each-ref --format=%(refname:short)` renders it).
- * Shared local/SSH so both resolve identical defaults.
- */
-export const DEFAULT_BASE_REF_PROBES: readonly { ref: string; returnAs: string }[] = [
-  { ref: 'refs/remotes/origin/main', returnAs: 'origin/main' },
-  { ref: 'refs/remotes/origin/master', returnAs: 'origin/master' },
-  { ref: 'refs/heads/main', returnAs: 'main' },
-  { ref: 'refs/heads/master', returnAs: 'master' }
-]
-
-/**
- * Walk DEFAULT_BASE_REF_PROBES in order, returning the first ref `hasRef` confirms, or null.
- * Abstracts the existence test so local and SSH paths share one authoritative probe ordering.
- */
-async function resolveDefaultBaseRefFromProbes(
-  hasRef: (ref: string) => Promise<boolean>
-): Promise<string | null> {
-  for (const { ref, returnAs } of DEFAULT_BASE_REF_PROBES) {
-    if (await hasRef(ref)) {
-      return returnAs
-    }
-  }
-  return null
 }
 
 /** Check if a path is a valid git repository (regular or bare). */
@@ -489,10 +472,6 @@ function hasGitRef(path: string, ref: string): boolean {
   }
 }
 
-function gitRefToDefaultBaseRef(ref: string): string {
-  return ref.replace(/^refs\/remotes\//, '')
-}
-
 function getVerifiedOriginHeadBaseRef(path: string): string | null {
   try {
     const ref = gitExecFileSync(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], {
@@ -601,45 +580,6 @@ export async function getRemoteCount(path: string): Promise<number> {
     console.warn('[getRemoteCount] git remote failed', { path, err })
     return 0
   }
-}
-
-/** Callback shape for a git exec function that yields stdout. */
-export type GitExec = (argv: string[]) => Promise<{ stdout: string }>
-
-async function hasGitRefViaExec(exec: GitExec, ref: string): Promise<boolean> {
-  try {
-    await exec(['rev-parse', '--verify', '--quiet', ref])
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function resolveVerifiedOriginHeadBaseRefViaExec(exec: GitExec): Promise<string | null> {
-  try {
-    const { stdout } = await exec(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
-    const ref = stdout.trim()
-    if (!ref || !(await hasGitRefViaExec(exec, ref))) {
-      return null
-    }
-    return gitRefToDefaultBaseRef(ref)
-  } catch {
-    return null
-  }
-}
-
-/**
- * Resolve the default base ref via a git exec callback: prefer origin/HEAD's symbolic-ref target,
- * else fall back to DEFAULT_BASE_REF_PROBES. Shared local/SSH so both transports agree.
- *
- * Why swallow symbolic-ref's error: a non-zero exit is the expected "origin/HEAD unset" signal, not a failure.
- */
-export async function resolveDefaultBaseRefViaExec(exec: GitExec): Promise<string | null> {
-  const originHeadBaseRef = await resolveVerifiedOriginHeadBaseRefViaExec(exec)
-  if (originHeadBaseRef) {
-    return originHeadBaseRef
-  }
-  return resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
 }
 
 export function resolveDefaultBaseRefWithLocalGit(

--- a/src/main/git/worktree-deferred-removal-real-git.test.ts
+++ b/src/main/git/worktree-deferred-removal-real-git.test.ts
@@ -58,7 +58,7 @@ describe('deferred worktree removal against the real Git binary', () => {
   it('clears the registration and deletes the renamed checkout in the background', async () => {
     const trashRoot = getWorktreeTrashRoot(worktreePath)
 
-    await removeWorktree(repoPath, worktreePath, false, { deleteBranch: false })
+    await removeWorktree(repoPath, worktreePath, false, { branchRetention: 'preexisting-branch' })
 
     // The user-visible removal is complete: nothing on disk, nothing registered.
     expect(existsSync(worktreePath)).toBe(false)
@@ -75,7 +75,7 @@ describe('deferred worktree removal against the real Git binary', () => {
     const siblingPath = join(workspaceRoot, 'repo', 'sibling')
     await git(['worktree', 'add', '-q', siblingPath, '-b', 'sibling'], repoPath)
 
-    await removeWorktree(repoPath, worktreePath, false, { deleteBranch: false })
+    await removeWorktree(repoPath, worktreePath, false, { branchRetention: 'preexisting-branch' })
 
     expect(await git(['worktree', 'list'], repoPath)).toContain(siblingPath)
     expect(existsSync(siblingPath)).toBe(true)

--- a/src/main/git/worktree-removal-large-tree.bench.test.ts
+++ b/src/main/git/worktree-removal-large-tree.bench.test.ts
@@ -63,7 +63,7 @@ describeBench('worktree removal on a large checkout', () => {
 
   it('returns from removeWorktree without waiting for the recursive delete', async () => {
     const startedAt = Date.now()
-    await removeWorktree(repoPath, worktreePath, false, { deleteBranch: false })
+    await removeWorktree(repoPath, worktreePath, false, { branchRetention: 'preexisting-branch' })
     const userVisibleMs = Date.now() - startedAt
 
     const trashRoot = getWorktreeTrashRoot(worktreePath)

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -1805,6 +1805,8 @@ describe('removeWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // symbolic-ref origin/HEAD (protected-branch probe)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // rev-parse origin/main (protected-branch probe)
     // Git refuses to delete an unmerged branch with `-d`.
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not fully merged')) // branch -d
 
@@ -1837,6 +1839,8 @@ describe('removeWorktree', () => {
   it('reuses known removed worktree metadata instead of relisting before removal', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // symbolic-ref origin/HEAD (protected-branch probe)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // rev-parse origin/main (protected-branch probe)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d succeeds
 
     await removeWorktree('/repo', '/repo-feature', false, {
@@ -1849,6 +1853,8 @@ describe('removeWorktree', () => {
     expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
       ['status', '--porcelain', '--untracked-files=all'],
       ['worktree', 'remove', '/repo-feature'],
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
       ['branch', '-d', '--', 'feature/test']
     ])
   })
@@ -1857,6 +1863,8 @@ describe('removeWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // symbolic-ref origin/HEAD (protected-branch probe)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // rev-parse origin/main (protected-branch probe)
     gitExecFileAsyncMock.mockRejectedValueOnce(
       new Error("error: cannot delete branch 'feature/test' used by worktree at '/repo-stale'")
     ) // branch -d hits stale worktree metadata
@@ -1869,6 +1877,8 @@ describe('removeWorktree', () => {
       ['worktree', 'list', '--porcelain', '-z'],
       ['status', '--porcelain', '--untracked-files=all'],
       ['worktree', 'remove', '/repo-feature'],
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
       ['branch', '-d', '--', 'feature/test'],
       ['worktree', 'prune'],
       ['branch', '-d', '--', 'feature/test']

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -18,9 +18,12 @@ import type {
   GitWorktreeInfo,
   LocalBaseRefRefreshResult,
   LocalBaseRefUpdateSuggestion,
+  PreservedWorktreeBranch,
   RemoveWorktreeResult
 } from '../../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../../shared/worktree-removal'
+import { isRepoDefaultBranch, normalizeLocalBranchRef } from '../../shared/git-default-base-ref'
+import type { WorktreeBranchRetention } from '../../shared/worktree-branch-deletion-policy'
 import { isSubmoduleWorktreeRemovalRefusal } from '../../shared/worktree-submodule-removal'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
@@ -65,7 +68,7 @@ export type AddWorktreeOptions = GitWorktreeExecOptions & {
 }
 
 export type RemoveWorktreeOptions = GitWorktreeExecOptions & {
-  deleteBranch?: boolean
+  branchRetention?: WorktreeBranchRetention
   forceBranchDelete?: boolean
   knownRemovedWorktree?: Pick<GitWorktreeInfo, 'branch' | 'head' | 'locked' | 'lockReason'>
 }
@@ -138,10 +141,6 @@ function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
   return /cannot delete branch .*(?:used by worktree|checked out)|branch .*is checked out/i.test(
     getErrorText(error)
   )
-}
-
-function normalizeLocalBranchRef(branch: string): string {
-  return branch.replace(/^refs\/heads\//, '')
 }
 
 function parseRemoteTrackingLocalBaseRef(
@@ -1071,7 +1070,7 @@ export async function addSparseWorktree(
       }
       try {
         await removeWorktree(repoPath, worktreePath, true, {
-          deleteBranch: !options.checkoutExistingBranch,
+          branchRetention: options.checkoutExistingBranch ? 'preexisting-branch' : 'delete',
           // Why: failed-creation rollback — the fresh branch has no user commits, so force-delete rather than orphan it.
           forceBranchDelete: !options.checkoutExistingBranch,
           ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
@@ -1168,8 +1167,13 @@ async function performRemoveWorktree(
   if (!branchName) {
     return {}
   }
-  if (options.deleteBranch === false) {
+  const retention = options.branchRetention ?? 'delete'
+  if (retention === 'preexisting-branch') {
+    // Orca never owned this branch, and the user knows it pre-existed — keeping it needs no notice.
     return {}
+  }
+  if (retention === 'checkout-drift') {
+    return preservedBranchResult(branchName, branchHead, 'checkout-drift')
   }
 
   // Why its own span: branch cleanup can reach the network (`fetch --prune`), so a stall here reads as
@@ -1255,12 +1259,35 @@ async function clearGitRegistrationForMissingWorktree(
   }
 }
 
+function preservedBranchResult(
+  branchName: string,
+  branchHead: string,
+  reason: NonNullable<PreservedWorktreeBranch['reason']>
+): RemoveWorktreeResult {
+  return {
+    preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}), reason }
+  }
+}
+
 async function deleteBranchAfterWorktreeRemoval(
   repoPath: string,
   branchName: string,
   branchHead: string,
   options: RemoveWorktreeOptions
 ): Promise<RemoveWorktreeResult> {
+  // Last line of defense: metadata-level checks can be bypassed (external worktrees have no
+  // meta), and deleting a shared trunk is never recoverable UX. Skipped for failed-creation
+  // rollback, which must be able to drop the branch it just created.
+  if (
+    !options.forceBranchDelete &&
+    (await isRepoDefaultBranch(
+      (argv) => gitExecFileAsync(argv, gitExecOptions(repoPath, options)),
+      branchName
+    ))
+  ) {
+    console.warn(`[git] Kept default branch "${branchName}" after removing its worktree`)
+    return preservedBranchResult(branchName, branchHead, 'default-branch')
+  }
   try {
     // Why: also drop the now-orphaned branch so delete-worktree leaves none; `-d` (not `-D`) preserves
     // unmerged work, and forceBranchDelete opts into `-D` for failed-creation rollback.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -565,6 +565,9 @@ function maybeAutoRenameBranchOnFirstWorkFromHook(event: {
         // Why: a user branch could coincidentally match a creature name; only Orca-stamped worktrees are safe to auto-rename.
         return !!meta?.orcaCreationSource && meta.preserveBranchOnDelete !== true
       },
+      recordRenamedBranch: (worktreeId, newBranch) => {
+        currentStore.setWorktreeMeta(worktreeId, { createdBranch: newBranch })
+      },
       setDisplayName: (worktreeId, displayName) => {
         rememberBranchRenameFailureOutput(worktreeId, null)
         const scope = parseWorkspaceKey(worktreeId)

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1789,6 +1789,7 @@ export async function createRemoteWorktree(
     ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
     ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {}),
     baseRef: metadataBaseRef,
+    createdBranch: branchName,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
     ...(requestedDisplayName
@@ -2398,6 +2399,7 @@ export async function createLocalWorktree(
     ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
     ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {}),
     baseRef: metadataBaseRef,
+    createdBranch: branchName,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
     ...(requestedDisplayName

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -9521,7 +9521,7 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/feature-wt',
       false,
       expect.objectContaining({
-        deleteBranch: false,
+        branchRetention: 'preexisting-branch',
         knownRemovedWorktree: expect.objectContaining({
           branch: 'feature',
           head: 'feature',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -10,6 +10,7 @@ import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
 import { planWorktreeSortOrderUpdates } from '../../shared/worktree-sort-order-update'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
+import { resolveWorktreeBranchRetention } from '../../shared/worktree-branch-deletion-policy'
 import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
 import { WorkspaceLinkedItemSchema } from '../../shared/workspace-linked-item-schema'
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-linked-item-source-context'
@@ -2629,7 +2630,10 @@ export function registerWorktreeHandlers(
             throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
           }
           const canonicalWorktreePath = registeredWorktree.path
-          const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+          const branchRetention = resolveWorktreeBranchRetention(
+            removedMeta,
+            registeredWorktree.branch
+          )
 
           // Why: a Git lock must block before archive hooks or linked-path cleanup mutate the workspace; dirty-file force is separate.
           try {
@@ -2659,7 +2663,7 @@ export function registerWorktreeHandlers(
               repoPath: repo.path,
               localWorktreeGitOptions,
               registeredWorktree,
-              deleteBranch
+              branchRetention
             })
             await cleanupUnusedWorktreePushTargetRemote(
               repo.path,
@@ -2723,7 +2727,10 @@ export function registerWorktreeHandlers(
               }
             }
 
-            const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
+            // Why both keys: `deleteBranch` is what older relays understand; `branchRetention` adds
+            // the reason newer ones report back. An old relay ignores it and still keeps the branch.
+            const remoteRemoveOptions =
+              branchRetention === 'delete' ? {} : { deleteBranch: false, branchRetention }
             const removalGate = await withWorktreeRemoveStageSpan(
               'watcher_gate',
               'remote',
@@ -2853,7 +2860,7 @@ export function registerWorktreeHandlers(
 
             try {
               const removeOptions = {
-                ...(!deleteBranch ? { deleteBranch } : {}),
+                ...(branchRetention === 'delete' ? {} : { branchRetention }),
                 // Why: reuse the authoritative worktree list already computed here instead of rescanning siblings on the hot delete path.
                 knownRemovedWorktree: refreshedRegisteredWorktree,
                 ...(hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {})
@@ -2878,7 +2885,7 @@ export function registerWorktreeHandlers(
                 repoPath: repo.path,
                 localWorktreeGitOptions,
                 registeredWorktree: refreshedRegisteredWorktree,
-                deleteBranch,
+                branchRetention,
                 closeWatcher: (worktreePath) => runtime.closeFileWatchersForRemoval(worktreePath)
               })
               if (recoveredRemovalResult) {

--- a/src/main/local-worktree-removal-recovery-live.test.ts
+++ b/src/main/local-worktree-removal-recovery-live.test.ts
@@ -114,7 +114,7 @@ describe('local Windows worktree removal recovery (live Git)', () => {
             repoPath,
             localWorktreeGitOptions: {},
             registeredWorktree: { branch: 'refs/heads/feature/churn', head },
-            deleteBranch: false,
+            branchRetention: 'preexisting-branch',
             closeWatcher: async () => {}
           })
         ).resolves.toEqual({})

--- a/src/main/local-worktree-removal-recovery.test.ts
+++ b/src/main/local-worktree-removal-recovery.test.ts
@@ -62,7 +62,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
         repoPath: 'C:/repo',
         localWorktreeGitOptions: {},
         registeredWorktree: { branch: 'refs/heads/delete-e2e-held-cwd', head: 'abc123' },
-        deleteBranch: true,
+        branchRetention: 'delete',
         closeWatcher: vi.fn().mockResolvedValue(undefined)
       })
 
@@ -96,7 +96,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
         repoPath: 'C:/repo',
         localWorktreeGitOptions: {},
         registeredWorktree: { branch: 'refs/heads/delete-e2e-held-cwd', head: 'abc123' },
-        deleteBranch: true,
+        branchRetention: 'delete',
         closeWatcher: vi.fn().mockResolvedValue(undefined)
       })
 
@@ -128,7 +128,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
           repoPath: 'C:/repo',
           localWorktreeGitOptions: {},
           registeredWorktree: { branch: 'refs/heads/feature', head: 'abc123' },
-          deleteBranch: true,
+          branchRetention: 'delete',
           closeWatcher: vi.fn().mockRejectedValue(watcherError)
         })
       ).rejects.toBe(watcherError)
@@ -149,7 +149,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
         repoPath: 'C:/repo',
         localWorktreeGitOptions: {},
         registeredWorktree: { branch: 'refs/heads/feature', head: 'abc123' },
-        deleteBranch: false,
+        branchRetention: 'preexisting-branch',
         closeWatcher: vi.fn().mockResolvedValue(undefined)
       })
 
@@ -180,7 +180,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
           repoPath: 'C:/repo',
           localWorktreeGitOptions: {},
           registeredWorktree: { branch: 'refs/heads/feature', head: 'abc123' },
-          deleteBranch: false,
+          branchRetention: 'preexisting-branch',
           closeWatcher: vi.fn().mockResolvedValue(undefined)
         })
       ).resolves.toBeUndefined()
@@ -202,7 +202,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
           repoPath: 'C:/repo',
           localWorktreeGitOptions: {},
           registeredWorktree: { branch: 'refs/heads/delete-e2e-held-cwd', head: 'abc123' },
-          deleteBranch: true,
+          branchRetention: 'delete',
           closeWatcher: vi.fn().mockResolvedValue(undefined)
         })
       ).resolves.toBeUndefined()
@@ -230,7 +230,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
           repoPath: 'C:/repo',
           localWorktreeGitOptions: {},
           registeredWorktree,
-          deleteBranch: true,
+          branchRetention: 'delete',
           closeWatcher
         })
       ).rejects.toThrow('Worktree is locked by Git. Lock reason: active agent')
@@ -268,7 +268,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
             repoPath: 'C:/repo',
             localWorktreeGitOptions: { wslDistro: 'Ubuntu' },
             registeredWorktree: { branch: 'refs/heads/feature', head: 'abc123' },
-            deleteBranch: true,
+            branchRetention: 'delete',
             closeWatcher
           })
         ).resolves.toBeUndefined()
@@ -295,7 +295,7 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
           repoPath: 'C:/repo',
           localWorktreeGitOptions: {},
           registeredWorktree: { branch: 'refs/heads/feature', head: 'abc123' },
-          deleteBranch: true,
+          branchRetention: 'delete',
           closeWatcher
         })
       ).resolves.toBeUndefined()
@@ -326,7 +326,7 @@ describe('removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval', () => {
           locked: true,
           lockReason: 'active agent'
         },
-        deleteBranch: true
+        branchRetention: 'delete'
       })
     ).rejects.toThrow('Worktree is locked by Git')
 
@@ -350,7 +350,7 @@ describe('removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval', () => {
         repoPath: 'C:/repo',
         localWorktreeGitOptions: {},
         registeredWorktree: { branch: 'refs/heads/feature', head: 'abc123' },
-        deleteBranch: true
+        branchRetention: 'delete'
       })
     ).rejects.toThrow('Git still has stale worktree registration')
   })

--- a/src/main/local-worktree-removal-recovery.ts
+++ b/src/main/local-worktree-removal-recovery.ts
@@ -1,5 +1,6 @@
 import type { GitWorktreeInfo, RemoveWorktreeResult } from '../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree-removal'
+import type { WorktreeBranchRetention } from '../shared/worktree-branch-deletion-policy'
 import { areWorktreePathsEqual, formatWorktreeRemovalError } from './ipc/worktree-logic'
 import { gitExecFileAsync } from './git/runner'
 import { listWorktreesStrict, type GitWorktreeExecOptions } from './git/worktree'
@@ -12,7 +13,7 @@ type LocalWindowsRemovalRecoveryArgs = {
   repoPath: string
   localWorktreeGitOptions: GitWorktreeExecOptions
   registeredWorktree: Pick<GitWorktreeInfo, 'branch' | 'head' | 'locked' | 'lockReason'>
-  deleteBranch: boolean
+  branchRetention: WorktreeBranchRetention
   closeWatcher: (worktreePath: string) => Promise<void>
 }
 
@@ -23,9 +24,9 @@ type StaleLocalWorktreeRegistrationArgs = Omit<
 
 function preservedBranchResult(
   registeredWorktree: Pick<GitWorktreeInfo, 'branch' | 'head'>,
-  deleteBranch: boolean
+  branchRetention: WorktreeBranchRetention
 ): RemoveWorktreeResult {
-  if (!deleteBranch || !registeredWorktree.branch || !registeredWorktree.head) {
+  if (branchRetention !== 'delete' || !registeredWorktree.branch || !registeredWorktree.head) {
     return {}
   }
   return {
@@ -83,7 +84,7 @@ async function removeRequiredGitWorktreeRegistration(
       cwd: args.repoPath,
       ...args.localWorktreeGitOptions
     })
-    result = preservedBranchResult(args.registeredWorktree, args.deleteBranch)
+    result = preservedBranchResult(args.registeredWorktree, args.branchRetention)
   } catch (error) {
     removalError = error
   }
@@ -104,7 +105,7 @@ async function removeRequiredGitWorktreeRegistration(
   }
   // Why: if Git detached the row before reporting its filesystem error, keep
   // the branch rather than guessing whether the normal branch cleanup ran.
-  return result ?? preservedBranchResult(args.registeredWorktree, args.deleteBranch)
+  return result ?? preservedBranchResult(args.registeredWorktree, args.branchRetention)
 }
 
 export async function recoverLocalWindowsWorktreeRemoval(

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../shared/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
 import type { CommitMessageDraftContext } from '../../shared/commit-message-generation'
+import type { WorktreeBranchRetention } from '../../shared/worktree-branch-deletion-policy'
 import type { GitProviderStatusOptions } from './git-provider-status-options'
 
 export type { GitProviderStatusOptions } from './git-provider-status-options'
@@ -82,7 +83,11 @@ export type IGitProvider = {
   removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
+    options?: {
+      deleteBranch?: boolean
+      branchRetention?: WorktreeBranchRetention
+      forceBranchDelete?: boolean
+    }
   ): Promise<RemoveWorktreeResult>
   renameCurrentBranch?(worktreePath: string, newBranch: string): Promise<void>
   forceDeletePreservedBranch?(

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -32,6 +32,7 @@ import {
 } from '../git/max-buffer-overflow'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
+import type { WorktreeBranchRetention } from '../../shared/worktree-branch-deletion-policy'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -740,7 +741,11 @@ export class SshGitProvider implements IGitProvider {
   async removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
+    options?: {
+      deleteBranch?: boolean
+      branchRetention?: WorktreeBranchRetention
+      forceBranchDelete?: boolean
+    }
   ): Promise<RemoveWorktreeResult> {
     return this.runWithDiffDedupeClear(
       async () =>

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -386,6 +386,7 @@ import {
   getProjectHostSetupWorktreeMeta
 } from '../../shared/project-host-setup-projection'
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
+import { resolveWorktreeBranchRetention } from '../../shared/worktree-branch-deletion-policy'
 import { clampLinearIssueListLimit } from '../../shared/linear-issue-read-limits'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
@@ -22384,6 +22385,7 @@ export class OrcaRuntimeService {
       orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
       ...displayNameMeta,
       baseRef: metadataBaseRef,
+      createdBranch: branchName,
       ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
       ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
       ...(sparseDirectories.length > 0
@@ -24597,7 +24599,10 @@ export class OrcaRuntimeService {
           throw new Error(`Refusing to delete unregistered worktree path: ${removalTarget.path}`)
         }
         const canonicalWorktreePath = registeredWorktree.path
-        const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+        const branchRetention = resolveWorktreeBranchRetention(
+          removedMeta,
+          registeredWorktree.branch
+        )
 
         // Why: a Git lock must block before archive hooks or linked-path cleanup
         // mutate the workspace; dirty-file force is a separate permission.
@@ -24623,7 +24628,7 @@ export class OrcaRuntimeService {
             repoPath: repo.path,
             localWorktreeGitOptions,
             registeredWorktree,
-            deleteBranch
+            branchRetention
           })
           await cleanupUnusedWorktreePushTargetRemote(
             repo.path,
@@ -24648,7 +24653,10 @@ export class OrcaRuntimeService {
           return removalResult ?? {}
         }
         if (repo.connectionId) {
-          const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
+          // Why both keys: older relays only understand `deleteBranch`; `branchRetention` adds the
+          // reason newer ones report back. An old relay ignores it and still keeps the branch.
+          const remoteRemoveOptions =
+            branchRetention === 'delete' ? {} : { deleteBranch: false, branchRetention }
           const removalGate = await this.acquireFileWatcherRemoval(
             canonicalWorktreePath,
             repo.connectionId
@@ -24781,7 +24789,7 @@ export class OrcaRuntimeService {
 
           try {
             const removeOptions = {
-              ...(!deleteBranch ? { deleteBranch } : {}),
+              ...(branchRetention === 'delete' ? {} : { branchRetention }),
               // Why: removal already validated the Git row under the selected
               // project runtime; keep branch cleanup on that same canonical row.
               knownRemovedWorktree: refreshedRegisteredWorktree,
@@ -24801,7 +24809,7 @@ export class OrcaRuntimeService {
               repoPath: repo.path,
               localWorktreeGitOptions,
               registeredWorktree: refreshedRegisteredWorktree,
-              deleteBranch,
+              branchRetention,
               closeWatcher: (worktreePath) => this.closeFileWatchersForRemoval(worktreePath)
             })
             if (recoveredRemovalResult) {

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -24,7 +24,9 @@ const ORCA_OWNED_PROVENANCE_META_KEYS = [
   'orcaCreationWorkspaceLayout',
   'automationProvenance',
   'cliProvenance',
-  'creatorProvenance'
+  'creatorProvenance',
+  // Why: a spoofed createdBranch could re-enable branch deletion for a drifted checkout.
+  'createdBranch'
 ] as const
 type UnregisteredOrcaCleanupMeta = Pick<
   WorktreeMeta,

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -192,6 +192,8 @@ describe('removeWorktreeOp', () => {
       '/repo-feature$ rev-parse --git-common-dir',
       `${resolvedRepoPath()}$ worktree list --porcelain -z`,
       `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      `${resolvedRepoPath()}$ symbolic-ref --quiet refs/remotes/origin/HEAD`,
+      `${resolvedRepoPath()}$ rev-parse --verify --quiet refs/remotes/origin/main`,
       `${resolvedRepoPath()}$ branch -d -- feature/test`
     ])
   })
@@ -233,6 +235,8 @@ describe('removeWorktreeOp', () => {
       `${resolvedRepoPath()}$ worktree remove /repo-feature`,
       '/repo-feature$ status --porcelain --untracked-files=all',
       `${resolvedRepoPath()}$ worktree remove --force /repo-feature`,
+      `${resolvedRepoPath()}$ symbolic-ref --quiet refs/remotes/origin/HEAD`,
+      `${resolvedRepoPath()}$ rev-parse --verify --quiet refs/remotes/origin/main`,
       `${resolvedRepoPath()}$ branch -d -- feature/test`
     ])
   })
@@ -435,6 +439,132 @@ describe('removeWorktreeOp', () => {
       `${resolvedRepoPath()}$ worktree list --porcelain -z`,
       `${resolvedRepoPath()}$ worktree remove /repo-feature`
     ])
+  })
+
+  it('never deletes a trunk branch the removed worktree drifted onto', async () => {
+    const calls: string[] = []
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(`${cwd}$ ${args.join(' ')}`)
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'dev_charles' },
+                  { path: '/repo-feature', branch: 'main' }
+                )
+              : worktreeList({ path: '/repo', branch: 'dev_charles' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).resolves.toEqual({
+      preservedBranch: { branchName: 'main', head: '1', reason: 'default-branch' }
+    })
+
+    expect(calls).toContain(`${resolvedRepoPath()}$ worktree remove /repo-feature`)
+    expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'main'], expect.any(String))
+    expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'main'], expect.any(String))
+  })
+
+  it('reports the kept branch when the desktop flags a drifted checkout', async () => {
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'dev_charles' },
+                  { path: '/repo-feature', branch: 'release/1.2' }
+                )
+              : worktreeList({ path: '/repo', branch: 'dev_charles' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, {
+        worktreePath: '/repo-feature',
+        deleteBranch: false,
+        branchRetention: 'checkout-drift'
+      })
+    ).resolves.toEqual({
+      preservedBranch: { branchName: 'release/1.2', head: '1', reason: 'checkout-drift' }
+    })
+    expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'release/1.2'], expect.any(String))
+  })
+
+  it('keeps an older desktop deleteBranch:false silent, with no drift reason', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, {
+        worktreePath: '/repo-feature',
+        deleteBranch: false
+      })
+    ).resolves.toEqual({})
+  })
+
+  it('never deletes the origin/HEAD default branch after removing its worktree', async () => {
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args, _cwd) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'refs/remotes/origin/develop\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'dev_charles' },
+                  { path: '/repo-feature', branch: 'develop' }
+                )
+              : worktreeList({ path: '/repo', branch: 'dev_charles' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+
+    expect(git).toHaveBeenCalledWith(['worktree', 'remove', '/repo-feature'], expect.any(String))
+    expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'develop'], expect.any(String))
+    expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'develop'], expect.any(String))
   })
 
   it('keeps the branch when Git reports another SSH worktree still uses it', async () => {

--- a/src/relay/git-handler-worktree-paths.test.ts
+++ b/src/relay/git-handler-worktree-paths.test.ts
@@ -105,6 +105,8 @@ describe('relay worktree path parsing', () => {
       `${resolvedRepoPath()}$ worktree list --porcelain -z`,
       `${resolvedRepoPath()}$ worktree list --porcelain`,
       `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      `${resolvedRepoPath()}$ symbolic-ref --quiet refs/remotes/origin/HEAD`,
+      `${resolvedRepoPath()}$ rev-parse --verify --quiet refs/remotes/origin/main`,
       `${resolvedRepoPath()}$ branch -d -- feature/test`
     ])
   })

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path'
-import type { RemoveWorktreeResult } from '../shared/types'
+import type { PreservedWorktreeBranch, RemoveWorktreeResult } from '../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree-removal'
+import { isRepoDefaultBranch, normalizeLocalBranchRef } from '../shared/git-default-base-ref'
+import type { WorktreeBranchRetention } from '../shared/worktree-branch-deletion-policy'
 import { isSubmoduleWorktreeRemovalRefusal } from '../shared/worktree-submodule-removal'
 import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-handler-branch-cleanup'
 import type { GitExec } from './git-handler-ops'
@@ -30,8 +32,14 @@ function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
   )
 }
 
-function normalizeLocalBranchRef(branch: string): string {
-  return branch.replace(/^refs\/heads\//, '')
+function preservedBranchResult(
+  branchName: string,
+  branchHead: string,
+  reason: NonNullable<PreservedWorktreeBranch['reason']>
+): RemoveWorktreeResult {
+  return {
+    preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}), reason }
+  }
 }
 
 function isPosixAbsolutePath(value: string): boolean {
@@ -122,6 +130,20 @@ async function deleteRelayBranchAfterWorktreeRemoval(
   }
 }
 
+// Why not a plain param read: older desktops send only `deleteBranch`, so the retention
+// reason has to degrade to the boolean both sides have always understood.
+function readBranchRetention(params: Record<string, unknown>): WorktreeBranchRetention {
+  const retention = params.branchRetention
+  if (
+    retention === 'delete' ||
+    retention === 'preexisting-branch' ||
+    retention === 'checkout-drift'
+  ) {
+    return retention
+  }
+  return params.deleteBranch === false ? 'preexisting-branch' : 'delete'
+}
+
 export async function removeWorktreeOp(
   git: GitExec,
   params: Record<string, unknown>,
@@ -129,7 +151,7 @@ export async function removeWorktreeOp(
 ): Promise<RemoveWorktreeResult> {
   const worktreePath = params.worktreePath as string
   const force = params.force as boolean | undefined
-  const deleteBranch = params.deleteBranch !== false
+  const branchRetention = readBranchRetention(params)
   const forceBranchDelete = params.forceBranchDelete === true
 
   let repoPath = worktreePath
@@ -178,8 +200,21 @@ export async function removeWorktreeOp(
   if (!branchName) {
     return {}
   }
-  if (!deleteBranch) {
+  if (branchRetention === 'preexisting-branch') {
     return {}
+  }
+  if (branchRetention === 'checkout-drift') {
+    return preservedBranchResult(branchName, branchHead, 'checkout-drift')
+  }
+  // Mirrors the local guard in deleteBranchAfterWorktreeRemoval: never prune a trunk.
+  if (
+    !forceBranchDelete &&
+    (await isRepoDefaultBranch((argv) => git(argv, repoPath), branchName))
+  ) {
+    console.warn(
+      `relay removeWorktree: kept default branch "${branchName}" after removing its worktree`
+    )
+    return preservedBranchResult(branchName, branchHead, 'default-branch')
   }
 
   // Why: SSH worktree deletion should mirror local deletion. Dropping the

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
@@ -3,10 +3,29 @@ import { LoaderCircle } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import type { Worktree } from '../../../../shared/types'
 import { DeleteWorktreeDirtyChangeHint } from './DeleteWorktreeDirtyChangeHint'
+import { translate } from '@/i18n/i18n'
 
 type DeleteState = {
   isDeleting?: boolean
   error?: string | null
+}
+
+// Why: the card name can drift from the actual checkout (e.g. an agent switched
+// the worktree onto another branch), and delete prunes the checked-out branch.
+function CheckedOutBranchLine({ branch }: { branch: string }): JSX.Element | null {
+  const shortBranch = branch.replace(/^refs\/heads\//, '')
+  if (!shortBranch) {
+    return null
+  }
+  return (
+    <div className="mt-0.5 break-all text-muted-foreground">
+      {translate(
+        'auto.components.sidebar.DeleteWorktreeTargetPreview.checkedOutBranch',
+        'Branch: {{value0}}',
+        { value0: shortBranch }
+      )}
+    </div>
+  )
 }
 
 export function DeleteWorktreeTargetPreview({
@@ -34,6 +53,7 @@ export function DeleteWorktreeTargetPreview({
                   <div className="min-w-0 flex-1">
                     <div className="break-all font-medium text-foreground">{item.displayName}</div>
                     <div className="mt-0.5 break-all text-muted-foreground">{item.path}</div>
+                    <CheckedOutBranchLine branch={item.branch} />
                     <DeleteWorktreeDirtyChangeHint
                       changeCount={dirtyChangeCountsByWorktreeId.get(item.id)}
                     />
@@ -59,6 +79,7 @@ export function DeleteWorktreeTargetPreview({
     <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
       <div className="break-all font-medium text-foreground">{worktree.displayName}</div>
       <div className="mt-1 break-all text-muted-foreground">{worktree.path}</div>
+      <CheckedOutBranchLine branch={worktree.branch} />
       <DeleteWorktreeDirtyChangeHint changeCount={dirtyChangeCountsByWorktreeId.get(worktree.id)} />
     </div>
   ) : null

--- a/src/renderer/src/components/sidebar/preserved-branch-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-toast.test.tsx
@@ -86,6 +86,41 @@ describe('showPreservedBranchToast', () => {
     )
   })
 
+  it('explains a kept default branch and offers no one-click trunk deletion', () => {
+    const result: RemoveWorktreeResult = {
+      preservedBranch: { branchName: 'main', head: 'abc123', reason: 'default-branch' }
+    }
+
+    showPreservedBranchToast(result, { displayName: 'Fix auth', isMainWorktree: false }, vi.fn())
+    const body = renderToastBody()
+
+    expect(body.textContent).toContain("this repository's default branch")
+    expect(body.textContent).not.toContain('Force Delete Branch')
+    expect(toast.warning).toHaveBeenCalledWith(
+      'Worktree deleted, branch kept',
+      expect.not.objectContaining({ duration: Infinity })
+    )
+  })
+
+  it('names the drifted checkout and still offers recovery', () => {
+    const onForceDelete = vi.fn()
+    const result: RemoveWorktreeResult = {
+      preservedBranch: { branchName: 'develop', head: 'def456', reason: 'checkout-drift' }
+    }
+
+    showPreservedBranchToast(
+      result,
+      { displayName: 'Fix auth', isMainWorktree: false },
+      onForceDelete
+    )
+    const body = renderToastBody()
+
+    expect(body.textContent).toContain('not the branch Orca created')
+    expect(body.textContent).toContain('develop')
+    clickButton(body, 'Force Delete Branch')
+    expect(onForceDelete).toHaveBeenCalledWith('develop', 'def456')
+  })
+
   it('does not show the force-delete action without the preserved head', () => {
     const result: RemoveWorktreeResult = {
       preservedBranch: {

--- a/src/renderer/src/components/sidebar/preserved-branch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-toast.tsx
@@ -1,10 +1,15 @@
 import { Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
-import type { RemoveWorktreeResult, Worktree } from '../../../../shared/types'
+import type {
+  PreservedWorktreeBranch,
+  RemoveWorktreeResult,
+  Worktree
+} from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import { Button } from '../ui/button'
 
 type PreservedBranchWorktree = Pick<Worktree, 'displayName' | 'isMainWorktree'>
+type PreservedBranchReason = PreservedWorktreeBranch['reason']
 
 type PreservedBranchToastBodyProps = {
   description: string
@@ -25,8 +30,31 @@ function getPreservedBranchTitle(isWorkspace: boolean): string {
 function getPreservedBranchDescription(
   branch: string,
   targetName: string | undefined,
-  isWorkspace: boolean
+  isWorkspace: boolean,
+  reason: PreservedBranchReason
 ): string {
+  // Why separate copy: Git refusing an unmerged delete and Orca declining to touch a branch
+  // are different events, and the unmerged wording would misinform in the other two cases.
+  if (reason === 'default-branch') {
+    return translate(
+      'auto.components.sidebar.preserved.branch.toast.defaultBranchKept',
+      'Branch "{{value0}}" is this repository\'s default branch, so Orca kept it.',
+      { value0: branch }
+    )
+  }
+  if (reason === 'checkout-drift') {
+    return targetName
+      ? translate(
+          'auto.components.sidebar.preserved.branch.toast.driftedBranchKeptNamed',
+          'Workspace "{{value1}}" had branch "{{value0}}" checked out, which is not the branch Orca created for it, so Orca kept the branch.',
+          { value0: branch, value1: targetName }
+        )
+      : translate(
+          'auto.components.sidebar.preserved.branch.toast.driftedBranchKept',
+          'Branch "{{value0}}" is not the branch Orca created for this workspace, so Orca kept it.',
+          { value0: branch }
+        )
+  }
   if (!targetName) {
     return translate(
       'auto.store.slices.worktrees.78e08cd877',
@@ -92,16 +120,25 @@ export function showPreservedBranchToast(
   const targetName = worktree?.displayName?.trim()
   const expectedHead = preservedBranch.head
   const toastId = preservedBranchToastId(branch, expectedHead)
-  const forceDeleteLabel = expectedHead
+  // Why no force button for the default branch: one click away from the exact trunk deletion
+  // this guard exists to prevent. Deleting it stays a deliberate act outside Orca.
+  const offerForceDelete = !!expectedHead && preservedBranch.reason !== 'default-branch'
+  const forceDeleteLabel = offerForceDelete
     ? translate('auto.store.slices.worktrees.e50495aae6', 'Force Delete Branch')
     : undefined
-  const description = getPreservedBranchDescription(branch, targetName, isWorkspace)
-  const forceDelete = expectedHead
-    ? (): void => {
-        onForceDelete(branch, expectedHead)
-        toast.dismiss(toastId)
-      }
-    : undefined
+  const description = getPreservedBranchDescription(
+    branch,
+    targetName,
+    isWorkspace,
+    preservedBranch.reason
+  )
+  const forceDelete =
+    offerForceDelete && expectedHead
+      ? (): void => {
+          onForceDelete(branch, expectedHead)
+          toast.dismiss(toastId)
+        }
+      : undefined
 
   toast.warning(getPreservedBranchTitle(isWorkspace), {
     id: toastId,
@@ -113,6 +150,7 @@ export function showPreservedBranchToast(
       />
     ),
     dismissible: true,
-    ...(expectedHead ? { duration: Infinity } : {})
+    // Why: only a toast carrying an action may not auto-dismiss before it is used.
+    ...(offerForceDelete ? { duration: Infinity } : {})
   })
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5372,6 +5372,11 @@
                 "d42f1f14e0_one": "Retry {{count}} Branch",
                 "d42f1f14e0_other": "Retry {{count}} Branches"
               }
+            },
+            "toast": {
+              "defaultBranchKept": "Branch \"{{value0}}\" is this repository's default branch, so Orca kept it.",
+              "driftedBranchKeptNamed": "Workspace \"{{value1}}\" had branch \"{{value0}}\" checked out, which is not the branch Orca created for it, so Orca kept the branch.",
+              "driftedBranchKept": "Branch \"{{value0}}\" is not the branch Orca created for this workspace, so Orca kept it."
             }
           }
         },
@@ -5386,6 +5391,9 @@
           "a0f9863597": "Force Delete {{count}} Branches",
           "a0f9863597_one": "Force Delete {{count}} Branch",
           "a0f9863597_other": "Force Delete {{count}} Branches"
+        },
+        "DeleteWorktreeTargetPreview": {
+          "checkedOutBranch": "Branch: {{value0}}"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5122,6 +5122,14 @@
           "3b7ea51793": "清除搜索",
           "7f1c2e94a5": "搜索文本过长 — 看板未被筛选",
           "9a4d0f6b21": "过长"
+        },
+        "DeleteWorktreeTargetPreview": {
+          "checkedOutBranch": "分支：{{value0}}"
+        },
+        "preserved.branch.toast": {
+          "defaultBranchKept": "分支「{{value0}}」是本仓库的默认分支,Orca 已保留它。",
+          "driftedBranchKeptNamed": "工作区「{{value1}}」当时检出的是分支「{{value0}}」,而非 Orca 为它创建的分支,因此 Orca 保留了该分支。",
+          "driftedBranchKept": "分支「{{value0}}」不是 Orca 为该工作区创建的分支,因此已保留。"
         }
       },
       "shared": {

--- a/src/shared/git-default-base-ref.test.ts
+++ b/src/shared/git-default-base-ref.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isRepoDefaultBranch, resolveDefaultBaseRefViaExec } from './git-default-base-ref'
+
+function gitWith(outputs: Record<string, string | Error>) {
+  return vi.fn(async (argv: string[]) => {
+    const value = outputs[argv.join(' ')]
+    if (value instanceof Error) {
+      throw value
+    }
+    if (value === undefined) {
+      throw new Error(`unmocked: ${argv.join(' ')}`)
+    }
+    return { stdout: value }
+  })
+}
+
+const NO_REFS = {
+  'symbolic-ref --quiet refs/remotes/origin/HEAD': new Error('not a symbolic ref'),
+  'rev-parse --verify --quiet refs/remotes/origin/main': new Error('missing'),
+  'rev-parse --verify --quiet refs/remotes/origin/master': new Error('missing'),
+  'rev-parse --verify --quiet refs/heads/main': new Error('missing'),
+  'rev-parse --verify --quiet refs/heads/master': new Error('missing')
+}
+
+describe('resolveDefaultBaseRefViaExec', () => {
+  it('prefers a verified origin/HEAD target', async () => {
+    const git = gitWith({
+      'symbolic-ref --quiet refs/remotes/origin/HEAD': 'refs/remotes/origin/develop\n',
+      'rev-parse --verify --quiet refs/remotes/origin/develop': 'abc123\n'
+    })
+    await expect(resolveDefaultBaseRefViaExec(git)).resolves.toBe('origin/develop')
+  })
+
+  it('falls back to the probe order when origin/HEAD is unset', async () => {
+    const git = gitWith({
+      ...NO_REFS,
+      'rev-parse --verify --quiet refs/heads/main': 'abc123\n'
+    })
+    await expect(resolveDefaultBaseRefViaExec(git)).resolves.toBe('main')
+  })
+})
+
+describe('isRepoDefaultBranch', () => {
+  it('protects the branch origin/HEAD points at', async () => {
+    const git = gitWith({
+      'symbolic-ref --quiet refs/remotes/origin/HEAD': 'refs/remotes/origin/develop\n',
+      'rev-parse --verify --quiet refs/remotes/origin/develop': 'abc123\n'
+    })
+    await expect(isRepoDefaultBranch(git, 'develop')).resolves.toBe(true)
+    await expect(isRepoDefaultBranch(git, 'refs/heads/develop')).resolves.toBe(true)
+  })
+
+  it('does not protect a branch merely named main when the default is another branch', async () => {
+    // Why: hardcoding main/master would make an ordinary workspace branch undeletable.
+    const git = gitWith({
+      'symbolic-ref --quiet refs/remotes/origin/HEAD': 'refs/remotes/origin/develop\n',
+      'rev-parse --verify --quiet refs/remotes/origin/develop': 'abc123\n'
+    })
+    await expect(isRepoDefaultBranch(git, 'main')).resolves.toBe(false)
+  })
+
+  it('protects main when it is what the probes resolve', async () => {
+    const git = gitWith({
+      ...NO_REFS,
+      'rev-parse --verify --quiet refs/remotes/origin/main': 'abc123\n'
+    })
+    await expect(isRepoDefaultBranch(git, 'main')).resolves.toBe(true)
+  })
+
+  it('falls back to init.defaultBranch when no ref resolves', async () => {
+    const git = gitWith({ ...NO_REFS, 'config --get init.defaultBranch': 'trunk\n' })
+    await expect(isRepoDefaultBranch(git, 'trunk')).resolves.toBe(true)
+    await expect(isRepoDefaultBranch(git, 'feature/x')).resolves.toBe(false)
+  })
+
+  it('protects nothing when every probe fails', async () => {
+    const git = gitWith({ ...NO_REFS, 'config --get init.defaultBranch': new Error('unset') })
+    await expect(isRepoDefaultBranch(git, 'feature/x')).resolves.toBe(false)
+  })
+
+  it('never protects an empty branch name', async () => {
+    const git = gitWith({})
+    await expect(isRepoDefaultBranch(git, '')).resolves.toBe(false)
+    expect(git).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/git-default-base-ref.ts
+++ b/src/shared/git-default-base-ref.ts
@@ -1,0 +1,95 @@
+/** Callback shape for a git exec function that yields stdout. */
+export type GitExec = (argv: string[]) => Promise<{ stdout: string }>
+
+/**
+ * Ordered probe list for a repo's default base ref when no origin/HEAD symbolic-ref is set.
+ * `returnAs` is the short-name format the UI expects (as `for-each-ref --format=%(refname:short)` renders it).
+ * Shared local/SSH so both resolve identical defaults.
+ */
+export const DEFAULT_BASE_REF_PROBES: readonly { ref: string; returnAs: string }[] = [
+  { ref: 'refs/remotes/origin/main', returnAs: 'origin/main' },
+  { ref: 'refs/remotes/origin/master', returnAs: 'origin/master' },
+  { ref: 'refs/heads/main', returnAs: 'main' },
+  { ref: 'refs/heads/master', returnAs: 'master' }
+]
+
+export function gitRefToDefaultBaseRef(ref: string): string {
+  return ref.replace(/^refs\/remotes\//, '')
+}
+
+export function normalizeLocalBranchRef(branch: string): string {
+  return branch.replace(/^refs\/heads\//, '')
+}
+
+/**
+ * Walk DEFAULT_BASE_REF_PROBES in order, returning the first ref `hasRef` confirms, or null.
+ * Abstracts the existence test so local and SSH paths share one authoritative probe ordering.
+ */
+export async function resolveDefaultBaseRefFromProbes(
+  hasRef: (ref: string) => Promise<boolean>
+): Promise<string | null> {
+  for (const { ref, returnAs } of DEFAULT_BASE_REF_PROBES) {
+    if (await hasRef(ref)) {
+      return returnAs
+    }
+  }
+  return null
+}
+
+async function hasGitRefViaExec(exec: GitExec, ref: string): Promise<boolean> {
+  try {
+    await exec(['rev-parse', '--verify', '--quiet', ref])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveVerifiedOriginHeadBaseRefViaExec(exec: GitExec): Promise<string | null> {
+  try {
+    const { stdout } = await exec(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
+    const ref = stdout.trim()
+    if (!ref || !(await hasGitRefViaExec(exec, ref))) {
+      return null
+    }
+    return gitRefToDefaultBaseRef(ref)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the default base ref via a git exec callback: prefer origin/HEAD's symbolic-ref target,
+ * else fall back to DEFAULT_BASE_REF_PROBES. Shared local/SSH so both transports agree.
+ *
+ * Why swallow symbolic-ref's error: a non-zero exit is the expected "origin/HEAD unset" signal, not a failure.
+ */
+export async function resolveDefaultBaseRefViaExec(exec: GitExec): Promise<string | null> {
+  const originHeadBaseRef = await resolveVerifiedOriginHeadBaseRefViaExec(exec)
+  if (originHeadBaseRef) {
+    return originHeadBaseRef
+  }
+  return resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
+}
+
+/**
+ * Whether `branchName` is this repo's default branch, per the same resolution every
+ * other Orca surface uses. `init.defaultBranch` is a last resort for repos where no
+ * ref resolves at all (no remote, no main/master).
+ */
+export async function isRepoDefaultBranch(exec: GitExec, branchName: string): Promise<boolean> {
+  const branch = normalizeLocalBranchRef(branchName)
+  if (!branch) {
+    return false
+  }
+  const defaultBaseRef = await resolveDefaultBaseRefViaExec(exec)
+  if (defaultBaseRef) {
+    return defaultBaseRef.replace(/^origin\//, '') === branch
+  }
+  try {
+    const { stdout } = await exec(['config', '--get', 'init.defaultBranch'])
+    return stdout.trim() === branch
+  } catch {
+    return false
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -674,6 +674,8 @@ export type WorktreeMeta = {
   baseRef?: string
   /** True when Orca checked out a pre-existing local branch that delete must not prune. */
   preserveBranchOnDelete?: boolean
+  /** Branch Orca created, kept in sync by auto-rename. Delete prunes the checkout only while it still matches. */
+  createdBranch?: string
   /** See {@link Worktree.pushTarget}. Persisted so refreshed worktree lists keep the target. */
   pushTarget?: GitPushTarget
   /** Explicit marker stamped when Orca creates the worktree. */
@@ -2381,6 +2383,8 @@ export type WorktreeCreateBaseFallback = {
 export type PreservedWorktreeBranch = {
   branchName: string
   head?: string
+  /** Why Orca kept it. Absent means Git refused a safe delete (unmerged work). */
+  reason?: 'default-branch' | 'checkout-drift'
 }
 
 export type RemoveWorktreeResult = {

--- a/src/shared/worktree-branch-deletion-policy.test.ts
+++ b/src/shared/worktree-branch-deletion-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeBranchRetention } from './worktree-branch-deletion-policy'
+
+describe('resolveWorktreeBranchRetention', () => {
+  it('deletes the branch for a worktree without metadata', () => {
+    expect(resolveWorktreeBranchRetention(undefined, 'refs/heads/feature/x')).toBe('delete')
+    expect(resolveWorktreeBranchRetention(null, 'feature/x')).toBe('delete')
+  })
+
+  it('reports a pre-existing branch checkout Orca never owned', () => {
+    expect(
+      resolveWorktreeBranchRetention(
+        { preserveBranchOnDelete: true, createdBranch: 'feature/x' },
+        'refs/heads/feature/x'
+      )
+    ).toBe('preexisting-branch')
+  })
+
+  it('deletes the branch while the checkout still matches the created branch', () => {
+    expect(
+      resolveWorktreeBranchRetention({ createdBranch: 'feature/x' }, 'refs/heads/feature/x')
+    ).toBe('delete')
+    expect(
+      resolveWorktreeBranchRetention({ createdBranch: 'refs/heads/feature/x' }, 'feature/x')
+    ).toBe('delete')
+  })
+
+  it('reports drift when the checkout moved off the created branch', () => {
+    // The reported bug: an agent ran `git checkout main && git merge` inside the worktree.
+    expect(resolveWorktreeBranchRetention({ createdBranch: 'feature/x' }, 'refs/heads/main')).toBe(
+      'checkout-drift'
+    )
+  })
+
+  it('deletes the branch when either side of the comparison is unknown', () => {
+    // Detached HEAD reports no branch; legacy metadata predates createdBranch.
+    expect(resolveWorktreeBranchRetention({ createdBranch: 'feature/x' }, '')).toBe('delete')
+    expect(resolveWorktreeBranchRetention({}, 'refs/heads/feature/x')).toBe('delete')
+  })
+})

--- a/src/shared/worktree-branch-deletion-policy.ts
+++ b/src/shared/worktree-branch-deletion-policy.ts
@@ -1,0 +1,22 @@
+import type { WorktreeMeta } from './types'
+import { normalizeLocalBranchRef } from './git-default-base-ref'
+
+/** `checkout-drift`: the checkout moved off the branch Orca created, so the branch isn't Orca's to delete. */
+export type WorktreeBranchRetention = 'delete' | 'preexisting-branch' | 'checkout-drift'
+
+export function resolveWorktreeBranchRetention(
+  meta: Pick<WorktreeMeta, 'preserveBranchOnDelete' | 'createdBranch'> | null | undefined,
+  currentBranch: string | null | undefined
+): WorktreeBranchRetention {
+  if (meta?.preserveBranchOnDelete === true) {
+    return 'preexisting-branch'
+  }
+  const createdBranch = meta?.createdBranch ? normalizeLocalBranchRef(meta.createdBranch) : ''
+  const checkedOutBranch = normalizeLocalBranchRef(currentBranch ?? '')
+  // Both sides must be known: detached HEAD reports no branch, and metadata predating
+  // createdBranch would otherwise preserve every branch it can't verify.
+  if (createdBranch && checkedOutBranch && createdBranch !== checkedOutBranch) {
+    return 'checkout-drift'
+  }
+  return 'delete'
+}


### PR DESCRIPTION
## Problem

Deleting a worktree pruned whatever branch it had checked out, and nothing in the local, relay, or runtime paths refused to prune the repo's default branch.

That is reachable through an ordinary workflow. Ask an agent to merge your work into the trunk and it runs `git checkout main && git merge <branch>` inside the worktree, so the checkout silently becomes `main` while the sidebar card still shows the workspace name. Right-click → Delete then ran `git worktree remove` followed by `git branch -d main`, which succeeds whenever the primary checkout sits elsewhere and `main` is merged. The worktree's own branch was never touched.

`preserveBranchOnDelete` did not help: it is a snapshot of how the worktree was *created* and is never updated when the checkout moves.

## Fix

Three independent layers now stand between a delete and the branch:

1. **Default-branch guard.** Removal refuses to prune the repo's default branch, resolved the same way every other Orca surface resolves it (verified `origin/HEAD`, then the shared probe order, with `init.defaultBranch` as a last resort). Failed-creation rollback still force-deletes the branch it just created, so a partially created worktree is not stranded.
2. **Created-branch comparison.** Worktree metadata records the branch Orca created, kept current by the auto-rename hook, and removal keeps the branch whenever the checkout no longer matches — trunk or not, so drifting onto `develop` or `release/*` is equally safe.
3. **Visible before confirming.** The delete dialog shows the checked-out branch, so drift is apparent before the click rather than after the branch is gone.

Branch retention is now an explicit reason rather than a boolean, so a kept branch reports *why* through `preservedBranch` instead of returning silently. The toast explains which case it hit, and the default branch deliberately gets no one-click force delete — that is precisely the deletion the guard exists to prevent.

The first commit is a pure move: the relay ships as its own bundle and cannot import from `src/main`, so the exec-based default-base-ref resolution moved to `shared` and `git/repo.ts` re-exports it. Every existing importer and module mock keeps addressing the same path, and main and relay can no longer disagree about what the default branch is.

## Compatibility

- **SSH / relay:** the desktop still sends the `deleteBranch` flag older relays understand, alongside the new `branchRetention` reason newer ones report back. An older relay ignores the new field and still keeps the branch.
- **Git baseline:** `symbolic-ref`, `rev-parse --verify`, and `config --get` all predate 2.25; no new capability probe is needed.
- **Folder workspaces** have no branch and are unaffected; detached HEAD reports no branch and degrades to today's behaviour.

## Testing

`pnpm typecheck`, oxlint, oxfmt, and the localization gates pass. 26k+ tests green across `src/main`, `src/shared`, `src/relay`, and the renderer sidebar/store/i18n suites.

New coverage: default-branch resolution (including *not* protecting a branch merely named `main` when the default is another branch), retention resolution, local and relay "kept the trunk / kept the drifted branch / older desktop stays silent / rollback can still force-delete", and the three toast variants.

## Known gaps

- Worktrees created before this change carry no `createdBranch`, so they rely on layer 1 only. Backfilling from the current checkout would freeze an already-drifted checkout in as "Orca's branch", which is worse than leaving it unset.
- Users with `skipDeleteWorktreeConfirm` never see the dialog, though the post-delete toast still reports what was kept.
- `es` / `ja` / `ko` copy for the new strings falls back to English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)