### PR TITLE
fix(commit-message): drop unsupported kimi --quiet flag

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -62,7 +62,8 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     const promptIndex = args.indexOf('--prompt')
     expect(promptIndex).toBeGreaterThanOrEqual(0)
     expect(args[promptIndex + 1]).toBe('Name a branch for adding login')
-    expect(args).toContain('--quiet')
+    // Why: kimi-code 0.34 rejects --quiet (residual after #11674).
+    expect(args).not.toContain('--quiet')
     expect(args).toContain('--thinking')
     expect(args).toEqual(expect.arrayContaining(['--model', 'kimi-code/kimi-for-coding']))
   })

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -571,10 +571,10 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     // Why: kimi-code accepts the generation prompt only via --prompt/-p (Claude's
     // --print is rejected). Deliver on argv so --prompt receives the text (#11669).
     promptDelivery: 'argv',
+    // Why: kimi-code 0.34 rejects --quiet (unknown option); plain --prompt is enough (#11674 residual).
     buildArgs: ({ prompt, model, thinkingLevel }) => [
       '--prompt',
       prompt,
-      '--quiet',
       ...(model && model !== 'default' ? ['--model', model] : []),
       ...(thinkingLevel === 'on'
         ? ['--thinking']


### PR DESCRIPTION
## Problem

After #11674, branch auto-rename / Source Control commit-message generation still fails for Kimi Code users on 1.4.179:

```
Kimi CLI command failed with code 1: error: unknown option '--quiet'
```

Reporter verified on kimi-code **0.34.0** that `kimi --quiet` is rejected; plain `kimi --prompt "<text>"` works end-to-end. Residual noted on #11674.

## Root cause

`COMMIT_MESSAGE_AGENT_SPECS.kimi.buildArgs` still emits `--quiet` after `--prompt`. #11674 only replaced Claude's `--print` with `--prompt`; it did not remove the unsupported quiet flag.

pi/omp reject `--quiet` too, but they never shared this builder path — only the kimi entry is wrong.

## Fix

Drop `--quiet` from the kimi argv builder. Keep `--prompt`, optional `--model`, and thinking flags.

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/commit-message-agent-spec.test.ts src/shared/commit-message-plan.test.ts` (57 tests)
- [x] Spec test asserts `--quiet` is **absent** and `--prompt` still delivers the text
- [ ] Manual: set commit-message agent to Kimi → generate commit message / first-work branch rename succeeds without `unknown option '--quiet'`

## Notes

Shared argv only — same flags on macOS/Linux/Windows. Separate from workspace-agent vs default-agent rename (#11009 / #11147).

Related residual of #11669 / #11674.