### PR TITLE
fix(terminal): rank cold-park recency by activation order, not random UUID

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -389,6 +389,7 @@ export function FloatingTerminalPanel({
     terminalTabs: tabs,
     assignments: terminalAssignments,
     isWorktreeActive: open,
+    activeTerminalTabId: activeTerminalId,
     coldParkTerminalPanes: false,
     shouldMeasureHiddenWorktree: false,
     activityTerminalPortals: NO_ACTIVITY_TERMINAL_PORTALS

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -100,11 +100,24 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
     return entries
   }, [groupActiveTabById, unifiedTabs])
 
+  const activeTerminalTabId = useMemo(() => {
+    if (!activeGroupId) {
+      return null
+    }
+    for (const [terminalTabId, assignment] of assignments) {
+      if (assignment.groupId === activeGroupId && assignment.isActiveInGroup) {
+        return terminalTabId
+      }
+    }
+    return null
+  }, [activeGroupId, assignments])
+
   const parkedTerminalTabIds = useTerminalTabColdParking({
     worktreeId,
     terminalTabs,
     assignments,
     isWorktreeActive,
+    activeTerminalTabId,
     coldParkTerminalPanes,
     isForceParked,
     shouldMeasureHiddenWorktree,

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
@@ -154,6 +154,7 @@ function OverlayHost(): React.JSX.Element | null {
     terminalTabs,
     assignments: EMPTY_ASSIGNMENTS,
     isWorktreeActive: false,
+    activeTerminalTabId: null,
     coldParkTerminalPanes: false,
     shouldMeasureHiddenWorktree: false,
     activityTerminalPortals: EMPTY_PORTALS,

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
@@ -585,16 +585,13 @@ describe('selectColdParkedTerminalTabs', () => {
     expect(selected).toEqual(new Set())
   })
 
-  // Why: tab ids are random UUIDs, so resolving the #8262 exemption by id makes
-  // it a coin flip — and identical hiddenSinceMs is the common case (one pass
-  // stamps every tab a view switch just hid), not a corner.
+  // Why: view switches stamp every tab together, so UUID order cannot express recency.
   it('resolves an identical-hiddenSinceMs tie by activation order, not by tab id', () => {
     const hiddenSinceMs = nowMs - TERMINAL_TAB_HOT_RETAIN_MS
     const selected = selectColdParkedTerminalTabs({
       worktreeId: 'wt-1',
       terminalTabs: [
         { ...localTab('tab-aaa', hiddenSinceMs), lastActivatedSeq: 1 },
-        // Lexicographically last, but the tab the user actually lands on.
         { ...localTab('tab-zzz', hiddenSinceMs), lastActivatedSeq: 2 }
       ],
       pendingStartupByTabId: {},
@@ -606,8 +603,7 @@ describe('selectColdParkedTerminalTabs', () => {
     expect(selected).toEqual(new Set(['tab-aaa']))
   })
 
-  // Why: the cap evicts by the same recency ranking, so a tie there must not be
-  // a coin flip either.
+  // Why: the cap and exemption must share one recency ranking.
   it('keeps the most recently activated tab warm when the cap evicts a tie', () => {
     const hiddenSinceMs = nowMs - TERMINAL_TAB_HOT_RETAIN_MS + 1
     const selected = selectColdParkedTerminalTabs({
@@ -623,7 +619,6 @@ describe('selectColdParkedTerminalTabs', () => {
       hotRetainLimit: 2
     })
 
-    // tab-bbb takes the exemption slot, tab-ccc the remaining warm slot.
     expect(selected).toEqual(new Set(['tab-aaa']))
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
@@ -585,6 +585,48 @@ describe('selectColdParkedTerminalTabs', () => {
     expect(selected).toEqual(new Set())
   })
 
+  // Why: tab ids are random UUIDs, so resolving the #8262 exemption by id makes
+  // it a coin flip — and identical hiddenSinceMs is the common case (one pass
+  // stamps every tab a view switch just hid), not a corner.
+  it('resolves an identical-hiddenSinceMs tie by activation order, not by tab id', () => {
+    const hiddenSinceMs = nowMs - TERMINAL_TAB_HOT_RETAIN_MS
+    const selected = selectColdParkedTerminalTabs({
+      worktreeId: 'wt-1',
+      terminalTabs: [
+        { ...localTab('tab-aaa', hiddenSinceMs), lastActivatedSeq: 1 },
+        // Lexicographically last, but the tab the user actually lands on.
+        { ...localTab('tab-zzz', hiddenSinceMs), lastActivatedSeq: 2 }
+      ],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      hotRetainLimit: 0
+    })
+
+    expect(selected).toEqual(new Set(['tab-aaa']))
+  })
+
+  // Why: the cap evicts by the same recency ranking, so a tie there must not be
+  // a coin flip either.
+  it('keeps the most recently activated tab warm when the cap evicts a tie', () => {
+    const hiddenSinceMs = nowMs - TERMINAL_TAB_HOT_RETAIN_MS + 1
+    const selected = selectColdParkedTerminalTabs({
+      worktreeId: 'wt-1',
+      terminalTabs: [
+        { ...localTab('tab-aaa', hiddenSinceMs), lastActivatedSeq: 1 },
+        { ...localTab('tab-bbb', hiddenSinceMs), lastActivatedSeq: 3 },
+        { ...localTab('tab-ccc', hiddenSinceMs), lastActivatedSeq: 2 }
+      ],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      hotRetainLimit: 2
+    })
+
+    // tab-bbb takes the exemption slot, tab-ccc the remaining warm slot.
+    expect(selected).toEqual(new Set(['tab-aaa']))
+  })
+
   it('selects nothing when the settings kill switch disables parking', () => {
     const selected = selectColdParkedTerminalTabs({
       worktreeId: 'wt-1',

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -49,8 +49,7 @@ export type TerminalTabColdParkCandidate = ColdParkableTerminalTab & {
   isVisible: boolean
   hasActivityTerminalPortal: boolean
   hiddenSinceMs: number | null
-  /** Monotonic activation counter (higher = activated more recently); see
-   *  compareColdParkRecencyDesc for why hiddenSinceMs alone cannot rank tabs. */
+  /** Higher means activated more recently; breaks same-pass hidden-time ties. */
   lastActivatedSeq?: number
 }
 
@@ -207,10 +206,8 @@ export type ColdParkRetainCandidate = {
   lastActivatedSeq?: number
 }
 
-// Why: equal hiddenSinceMs is the common case, not a corner — hiding a view
-// stamps every tab it owns in one pass — and ids are random UUIDs, so ranking
-// recency on them is a coin flip. Recorded activation order decides instead;
-// the id only settles candidates that were never activated (#8262).
+// Why: a view switch stamps every owned tab at once, so activation order must
+// break the routine hidden-time tie before the deterministic UUID fallback.
 function compareColdParkRecencyDesc(
   a: ColdParkRetainCandidate,
   b: ColdParkRetainCandidate

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -49,6 +49,9 @@ export type TerminalTabColdParkCandidate = ColdParkableTerminalTab & {
   isVisible: boolean
   hasActivityTerminalPortal: boolean
   hiddenSinceMs: number | null
+  /** Monotonic activation counter (higher = activated more recently); see
+   *  compareColdParkRecencyDesc for why hiddenSinceMs alone cannot rank tabs. */
+  lastActivatedSeq?: number
 }
 
 function getPendingActivationSpawnCount(value: boolean | number | undefined): number {
@@ -198,21 +201,35 @@ export function canParkTerminalTabRenderer(args: {
   return isParkRestorableTerminalPty(tab.ptyId, args.worktreeId, args.restorePolicy)
 }
 
-export type ColdParkRetainCandidate = { id: string; hiddenSinceMs: number }
+export type ColdParkRetainCandidate = {
+  id: string
+  hiddenSinceMs: number
+  lastActivatedSeq?: number
+}
+
+// Why: equal hiddenSinceMs is the common case, not a corner — hiding a view
+// stamps every tab it owns in one pass — and ids are random UUIDs, so ranking
+// recency on them is a coin flip. Recorded activation order decides instead;
+// the id only settles candidates that were never activated (#8262).
+function compareColdParkRecencyDesc(
+  a: ColdParkRetainCandidate,
+  b: ColdParkRetainCandidate
+): number {
+  if (a.hiddenSinceMs !== b.hiddenSinceMs) {
+    return b.hiddenSinceMs - a.hiddenSinceMs
+  }
+  const activationDelta = (b.lastActivatedSeq ?? -1) - (a.lastActivatedSeq ?? -1)
+  return activationDelta === 0 ? a.id.localeCompare(b.id) : activationDelta
+}
 
 // Why: the single most-recently-hidden candidate is the view the user just
 // switched away from; keeping it warm regardless of the TTL or cap means
 // switching back after any absence (a meeting, coffee) is always instant, the
-// remount cost users actually notice. Ties break by id for determinism.
+// remount cost users actually notice.
 function selectLastActiveRetainedId(candidates: ColdParkRetainCandidate[]): string | null {
   let lastActive: ColdParkRetainCandidate | null = null
   for (const candidate of candidates) {
-    if (
-      lastActive === null ||
-      candidate.hiddenSinceMs > lastActive.hiddenSinceMs ||
-      (candidate.hiddenSinceMs === lastActive.hiddenSinceMs &&
-        candidate.id.localeCompare(lastActive.id) < 0)
-    ) {
+    if (lastActive === null || compareColdParkRecencyDesc(candidate, lastActive) < 0) {
       lastActive = candidate
     }
   }
@@ -221,8 +238,7 @@ function selectLastActiveRetainedId(candidates: ColdParkRetainCandidate[]): stri
 
 // Why: hot-retain keeps the most recently hidden ids warm up to the limit;
 // ids hidden past hotRetainMs or beyond the limit cold-park. The last-active
-// id is exempt from both so returning to it never pays a remount. Ties sort by
-// id so the selection is deterministic.
+// id is exempt from both so returning to it never pays a remount.
 export function selectIdsBeyondHotRetain(
   candidates: ColdParkRetainCandidate[],
   args: { nowMs: number; hotRetainMs: number; hotRetainLimit: number }
@@ -240,10 +256,7 @@ export function selectIdsBeyondHotRetain(
       retainedCandidates.push(candidate)
     }
   }
-  retainedCandidates.sort((a, b) => {
-    const recencyDelta = b.hiddenSinceMs - a.hiddenSinceMs
-    return recencyDelta === 0 ? a.id.localeCompare(b.id) : recencyDelta
-  })
+  retainedCandidates.sort(compareColdParkRecencyDesc)
   // Why: the last-active id already holds one slot in the warm working set, so
   // the cap counts it out — the remaining candidates fill hotRetainLimit-1.
   const remainingLimit = lastActiveId === null ? args.hotRetainLimit : args.hotRetainLimit - 1
@@ -322,7 +335,11 @@ export function selectColdParkedTerminalTabs(
     ) {
       continue
     }
-    candidates.push({ id: tab.id, hiddenSinceMs: tab.hiddenSinceMs })
+    candidates.push({
+      id: tab.id,
+      hiddenSinceMs: tab.hiddenSinceMs,
+      lastActivatedSeq: tab.lastActivatedSeq
+    })
   }
   return selectIdsBeyondHotRetain(candidates, {
     nowMs: args.nowMs,

--- a/src/renderer/src/components/terminal-pane/terminal-tab-activation-order.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-activation-order.ts
@@ -1,40 +1,30 @@
-/**
- * Monotonic activation order for a worktree's terminal tabs.
- *
- * Why: hiddenSince cannot rank tabs that go hidden in the same pass — leaving a
- * worktree hides every tab it owns against one nowMs — and the tie-break of
- * last resort is a random-UUID tab id, so the #8262 keep-warm exemption would
- * be a coin flip. The order the user actually activated tabs in is what tells
- * the policy which tab they land on when they come back.
- */
+/** Ranks tabs hidden in the same pass by the user's activation order. */
 export type TerminalTabActivationOrder = {
-  recordVisibleTabIds(visibleTabIds: ReadonlySet<string>): void
+  recordActiveTabId(activeTabId: string | null): void
   getActivationSeq(tabId: string): number | undefined
   retainTabIds(liveTabIds: ReadonlySet<string>): void
 }
 
 export function createTerminalTabActivationOrder(): TerminalTabActivationOrder {
   const activationSeqByTabId = new Map<string, number>()
-  let previouslyVisibleTabIds: ReadonlySet<string> = new Set()
+  let previousActiveTabId: string | null = null
   let nextActivationSeq = 0
 
   return {
-    // Why the hidden->visible edge only: a tab that merely stayed visible was
-    // never re-activated, so its rank must not float above tabs activated after
-    // it (splits keep one active tab per group visible across many passes).
-    recordVisibleTabIds(visibleTabIds) {
-      for (const tabId of visibleTabIds) {
-        if (!previouslyVisibleTabIds.has(tabId)) {
-          activationSeqByTabId.set(tabId, nextActivationSeq)
-          nextActivationSeq += 1
-        }
+    recordActiveTabId(activeTabId) {
+      if (activeTabId !== null && activeTabId !== previousActiveTabId) {
+        activationSeqByTabId.set(activeTabId, nextActivationSeq)
+        nextActivationSeq += 1
       }
-      previouslyVisibleTabIds = visibleTabIds
+      previousActiveTabId = activeTabId
     },
     getActivationSeq(tabId) {
       return activationSeqByTabId.get(tabId)
     },
     retainTabIds(liveTabIds) {
+      if (previousActiveTabId !== null && !liveTabIds.has(previousActiveTabId)) {
+        previousActiveTabId = null
+      }
       for (const tabId of Array.from(activationSeqByTabId.keys())) {
         if (!liveTabIds.has(tabId)) {
           activationSeqByTabId.delete(tabId)

--- a/src/renderer/src/components/terminal-pane/terminal-tab-activation-order.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-activation-order.ts
@@ -1,0 +1,45 @@
+/**
+ * Monotonic activation order for a worktree's terminal tabs.
+ *
+ * Why: hiddenSince cannot rank tabs that go hidden in the same pass — leaving a
+ * worktree hides every tab it owns against one nowMs — and the tie-break of
+ * last resort is a random-UUID tab id, so the #8262 keep-warm exemption would
+ * be a coin flip. The order the user actually activated tabs in is what tells
+ * the policy which tab they land on when they come back.
+ */
+export type TerminalTabActivationOrder = {
+  recordVisibleTabIds(visibleTabIds: ReadonlySet<string>): void
+  getActivationSeq(tabId: string): number | undefined
+  retainTabIds(liveTabIds: ReadonlySet<string>): void
+}
+
+export function createTerminalTabActivationOrder(): TerminalTabActivationOrder {
+  const activationSeqByTabId = new Map<string, number>()
+  let previouslyVisibleTabIds: ReadonlySet<string> = new Set()
+  let nextActivationSeq = 0
+
+  return {
+    // Why the hidden->visible edge only: a tab that merely stayed visible was
+    // never re-activated, so its rank must not float above tabs activated after
+    // it (splits keep one active tab per group visible across many passes).
+    recordVisibleTabIds(visibleTabIds) {
+      for (const tabId of visibleTabIds) {
+        if (!previouslyVisibleTabIds.has(tabId)) {
+          activationSeqByTabId.set(tabId, nextActivationSeq)
+          nextActivationSeq += 1
+        }
+      }
+      previouslyVisibleTabIds = visibleTabIds
+    },
+    getActivationSeq(tabId) {
+      return activationSeqByTabId.get(tabId)
+    },
+    retainTabIds(liveTabIds) {
+      for (const tabId of Array.from(activationSeqByTabId.keys())) {
+        if (!liveTabIds.has(tabId)) {
+          activationSeqByTabId.delete(tabId)
+        }
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-tab-park-candidates.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-park-candidates.ts
@@ -1,0 +1,52 @@
+/**
+ * Builds the per-tab cold-park candidate list for useTerminalTabColdParking.
+ *
+ * Why separate: the hidden-clock and activation-order bookkeeping that decides
+ * each candidate's park rank is policy, not hook orchestration.
+ */
+import type { TerminalTab } from '../../../../shared/types'
+import type { TerminalTabColdParkCandidate } from './terminal-hidden-view-parking'
+import type { TerminalTabActivationOrder } from './terminal-tab-activation-order'
+
+export function buildTerminalTabColdParkCandidates(args: {
+  terminalTabs: readonly TerminalTab[]
+  assignments: ReadonlyMap<string, { isActiveInGroup: boolean }>
+  isWorktreeActive: boolean
+  portalTabIds: ReadonlySet<string>
+  shouldMeasureHiddenWorktree: boolean
+  /** Mutated in place: the hook owns this clock across passes. */
+  hiddenSinceByTabId: Map<string, number>
+  activationOrder: TerminalTabActivationOrder
+  nowMs: number
+}): TerminalTabColdParkCandidate[] {
+  const visibleTabIds = new Set<string>()
+  for (const terminalTab of args.terminalTabs) {
+    if (args.isWorktreeActive && args.assignments.get(terminalTab.id)?.isActiveInGroup === true) {
+      visibleTabIds.add(terminalTab.id)
+    }
+  }
+  args.activationOrder.recordVisibleTabIds(visibleTabIds)
+
+  return args.terminalTabs.map((terminalTab) => {
+    const isVisible = visibleTabIds.has(terminalTab.id)
+    const hasActivityTerminalPortal = args.portalTabIds.has(terminalTab.id)
+    // Why measuring preserves the clock: the startup probe still needs mounted
+    // panes (the hook's selection + render vetoes), but deleting hiddenSince
+    // would restart the hysteresis AND desync per-tab deadlines from the
+    // worktree retention/TTL clock on every ~3s probe.
+    if (isVisible || hasActivityTerminalPortal) {
+      args.hiddenSinceByTabId.delete(terminalTab.id)
+    } else if (!args.shouldMeasureHiddenWorktree && !args.hiddenSinceByTabId.has(terminalTab.id)) {
+      args.hiddenSinceByTabId.set(terminalTab.id, args.nowMs)
+    }
+    return {
+      id: terminalTab.id,
+      ptyId: terminalTab.ptyId,
+      pendingActivationSpawn: terminalTab.pendingActivationSpawn,
+      isVisible,
+      hasActivityTerminalPortal,
+      hiddenSinceMs: args.hiddenSinceByTabId.get(terminalTab.id) ?? null,
+      lastActivatedSeq: args.activationOrder.getActivationSeq(terminalTab.id)
+    }
+  })
+}

--- a/src/renderer/src/components/terminal-pane/terminal-tab-park-candidates.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-park-candidates.ts
@@ -1,9 +1,4 @@
-/**
- * Builds the per-tab cold-park candidate list for useTerminalTabColdParking.
- *
- * Why separate: the hidden-clock and activation-order bookkeeping that decides
- * each candidate's park rank is policy, not hook orchestration.
- */
+/** Builds the stateful per-tab cold-park candidate list. */
 import type { TerminalTab } from '../../../../shared/types'
 import type { TerminalTabColdParkCandidate } from './terminal-hidden-view-parking'
 import type { TerminalTabActivationOrder } from './terminal-tab-activation-order'
@@ -12,28 +7,24 @@ export function buildTerminalTabColdParkCandidates(args: {
   terminalTabs: readonly TerminalTab[]
   assignments: ReadonlyMap<string, { isActiveInGroup: boolean }>
   isWorktreeActive: boolean
+  activeTerminalTabId: string | null
   portalTabIds: ReadonlySet<string>
   shouldMeasureHiddenWorktree: boolean
-  /** Mutated in place: the hook owns this clock across passes. */
   hiddenSinceByTabId: Map<string, number>
   activationOrder: TerminalTabActivationOrder
   nowMs: number
 }): TerminalTabColdParkCandidate[] {
+  args.activationOrder.recordActiveTabId(args.isWorktreeActive ? args.activeTerminalTabId : null)
   const visibleTabIds = new Set<string>()
   for (const terminalTab of args.terminalTabs) {
     if (args.isWorktreeActive && args.assignments.get(terminalTab.id)?.isActiveInGroup === true) {
       visibleTabIds.add(terminalTab.id)
     }
   }
-  args.activationOrder.recordVisibleTabIds(visibleTabIds)
-
   return args.terminalTabs.map((terminalTab) => {
     const isVisible = visibleTabIds.has(terminalTab.id)
     const hasActivityTerminalPortal = args.portalTabIds.has(terminalTab.id)
-    // Why measuring preserves the clock: the startup probe still needs mounted
-    // panes (the hook's selection + render vetoes), but deleting hiddenSince
-    // would restart the hysteresis AND desync per-tab deadlines from the
-    // worktree retention/TTL clock on every ~3s probe.
+    // Why: measure probes need mounted panes without restarting the park clock.
     if (isVisible || hasActivityTerminalPortal) {
       args.hiddenSinceByTabId.delete(terminalTab.id)
     } else if (!args.shouldMeasureHiddenWorktree && !args.hiddenSinceByTabId.has(terminalTab.id)) {

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -74,6 +74,7 @@ function hookArgs(shouldMeasureHiddenWorktree: boolean) {
     terminalTabs: [terminalTab('tab-1'), terminalTab('tab-2')],
     assignments: new Map<string, { groupId: string; isActiveInGroup: boolean }>(),
     isWorktreeActive: false,
+    activeTerminalTabId: null as string | null,
     coldParkTerminalPanes: false,
     shouldMeasureHiddenWorktree,
     activityTerminalPortals: [],
@@ -97,14 +98,8 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
     mocks.storeState.runtimeStatusByEnvironmentId = new Map()
   })
 
-  // Why: leaving a worktree hides every one of its tabs against a single
-  // nowMs, so the #8262 keep-warm exemption always lands on a hiddenSince tie.
-  // Broken by the id tie-break, the coin flip can park the very tab the user
-  // returns to (a random-UUID id carries no recency), which is the remount the
-  // exemption exists to prevent.
+  // Why: leaving a worktree gives every tab the same hidden time.
   it('exempts the tab the worktree was left on when every tab hides in one pass', () => {
-    // tab-2 is active and lexicographically last, so the id tie-break cannot
-    // stumble into the right answer.
     const assignments = new Map([
       ['tab-1', { groupId: 'group-1', isActiveInGroup: false }],
       ['tab-2', { groupId: 'group-1', isActiveInGroup: true }]
@@ -112,14 +107,69 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
     const { result, rerender } = renderHook(
       (args: ReturnType<typeof hookArgs> & { isWorktreeActive: boolean }) =>
         useTerminalTabColdParking(args),
-      { initialProps: { ...hookArgs(false), assignments, isWorktreeActive: true } }
+      {
+        initialProps: {
+          ...hookArgs(false),
+          assignments,
+          isWorktreeActive: true,
+          activeTerminalTabId: 'tab-2'
+        }
+      }
     )
     expect(result.current.size).toBe(0)
 
-    // The worktree goes hidden with the clock frozen: both tabs are stamped
-    // with the same hiddenSince, exactly as one commit does in the app.
     act(() => {
-      rerender({ ...hookArgs(false), assignments, isWorktreeActive: false })
+      rerender({
+        ...hookArgs(false),
+        assignments,
+        isWorktreeActive: false,
+        activeTerminalTabId: 'tab-2'
+      })
+    })
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_HOT_RETAIN_MS + 1)
+    })
+
+    expect(result.current).toEqual(new Set(['tab-1']))
+  })
+
+  it('records focused split changes when the visible tab set does not change', () => {
+    const assignments = new Map([
+      ['tab-1', { groupId: 'group-1', isActiveInGroup: true }],
+      ['tab-2', { groupId: 'group-2', isActiveInGroup: true }]
+    ])
+    const { result, rerender } = renderHook(
+      (
+        args: ReturnType<typeof hookArgs> & {
+          activeTerminalTabId: string | null
+          isWorktreeActive: boolean
+        }
+      ) => useTerminalTabColdParking(args),
+      {
+        initialProps: {
+          ...hookArgs(false),
+          assignments,
+          isWorktreeActive: true,
+          activeTerminalTabId: 'tab-1'
+        }
+      }
+    )
+
+    act(() => {
+      rerender({
+        ...hookArgs(false),
+        assignments,
+        isWorktreeActive: true,
+        activeTerminalTabId: 'tab-2'
+      })
+    })
+    act(() => {
+      rerender({
+        ...hookArgs(false),
+        assignments,
+        isWorktreeActive: false,
+        activeTerminalTabId: 'tab-2'
+      })
     })
     act(() => {
       vi.advanceTimersByTime(TERMINAL_TAB_HOT_RETAIN_MS + 1)

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -97,6 +97,37 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
     mocks.storeState.runtimeStatusByEnvironmentId = new Map()
   })
 
+  // Why: leaving a worktree hides every one of its tabs against a single
+  // nowMs, so the #8262 keep-warm exemption always lands on a hiddenSince tie.
+  // Broken by the id tie-break, the coin flip can park the very tab the user
+  // returns to (a random-UUID id carries no recency), which is the remount the
+  // exemption exists to prevent.
+  it('exempts the tab the worktree was left on when every tab hides in one pass', () => {
+    // tab-2 is active and lexicographically last, so the id tie-break cannot
+    // stumble into the right answer.
+    const assignments = new Map([
+      ['tab-1', { groupId: 'group-1', isActiveInGroup: false }],
+      ['tab-2', { groupId: 'group-1', isActiveInGroup: true }]
+    ])
+    const { result, rerender } = renderHook(
+      (args: ReturnType<typeof hookArgs> & { isWorktreeActive: boolean }) =>
+        useTerminalTabColdParking(args),
+      { initialProps: { ...hookArgs(false), assignments, isWorktreeActive: true } }
+    )
+    expect(result.current.size).toBe(0)
+
+    // The worktree goes hidden with the clock frozen: both tabs are stamped
+    // with the same hiddenSince, exactly as one commit does in the app.
+    act(() => {
+      rerender({ ...hookArgs(false), assignments, isWorktreeActive: false })
+    })
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_HOT_RETAIN_MS + 1)
+    })
+
+    expect(result.current).toEqual(new Set(['tab-1']))
+  })
+
   it('parks paired-runtime tabs only when their exact host advertises restore', () => {
     const environmentId = 'paired-env'
     const remoteArgs = {

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -17,8 +17,7 @@ import { getTerminalTabColdParkRecheckDelayMs } from './terminal-cold-park-reche
 import {
   TERMINAL_TAB_COLD_PARK_DELAY_MS,
   selectPairedRuntimeParkingEnvironmentIds,
-  selectColdParkedTerminalTabs,
-  type TerminalTabColdParkCandidate
+  selectColdParkedTerminalTabs
 } from './terminal-hidden-view-parking'
 import {
   recordParkVerdictFlips,
@@ -32,6 +31,8 @@ import {
 } from './terminal-eviction-exempt-tabs'
 import { selectSleepingRecordParkExemptTabIds } from './sleeping-record-park-exemption'
 import { canWatcherCoverParkedTerminalTab } from './terminal-parked-tab-watchers'
+import { createTerminalTabActivationOrder } from './terminal-tab-activation-order'
+import { buildTerminalTabColdParkCandidates } from './terminal-tab-park-candidates'
 import {
   getTerminalParkingAssignmentsKey,
   getTerminalParkingInputsKey,
@@ -115,6 +116,9 @@ export function useTerminalTabColdParking(args: {
     [sleepingAgentSessionsByPaneKey, worktreeId]
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())
+  // Why: ranks the #8262 keep-warm exemption when hiddenSince ties; see
+  // terminal-tab-activation-order.ts.
+  const terminalTabActivationOrderRef = useRef(createTerminalTabActivationOrder())
   // Why (shared measure-clock contract with Terminal.tsx): tab hiddenSince
   // survives a background-measure window so per-tab park deadlines stay in
   // sync with the worktree retention/TTL clock, and a post-measure cool-down
@@ -161,6 +165,7 @@ export function useTerminalTabColdParking(args: {
         terminalTabHiddenSinceRef.current.delete(tabId)
       }
     }
+    terminalTabActivationOrderRef.current.retainTabIds(currentTerminalTabIds)
 
     // Why: measure end starts the re-park cool-down (worktree measure-clock
     // contract) — hiddenSince is preserved through the window, so without the
@@ -180,30 +185,15 @@ export function useTerminalTabColdParking(args: {
       measureParkCooldownUntilRef.current = null
     }
 
-    const candidates: TerminalTabColdParkCandidate[] = terminalTabs.map((terminalTab) => {
-      const assignment = assignments.get(terminalTab.id)
-      const isVisible = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
-      const hasActivityTerminalPortal = portalTabIds.has(terminalTab.id)
-      // Why measuring preserves the clock: the startup probe still needs
-      // mounted panes (selection + render veto below), but deleting
-      // hiddenSince would restart the hysteresis AND desync per-tab deadlines
-      // from the worktree retention/TTL clock on every ~3s probe.
-      if (isVisible || hasActivityTerminalPortal) {
-        terminalTabHiddenSinceRef.current.delete(terminalTab.id)
-      } else if (
-        !shouldMeasureHiddenWorktree &&
-        !terminalTabHiddenSinceRef.current.has(terminalTab.id)
-      ) {
-        terminalTabHiddenSinceRef.current.set(terminalTab.id, nowMs)
-      }
-      return {
-        id: terminalTab.id,
-        ptyId: terminalTab.ptyId,
-        pendingActivationSpawn: terminalTab.pendingActivationSpawn,
-        isVisible,
-        hasActivityTerminalPortal,
-        hiddenSinceMs: terminalTabHiddenSinceRef.current.get(terminalTab.id) ?? null
-      }
+    const candidates = buildTerminalTabColdParkCandidates({
+      terminalTabs,
+      assignments,
+      isWorktreeActive,
+      portalTabIds,
+      shouldMeasureHiddenWorktree,
+      hiddenSinceByTabId: terminalTabHiddenSinceRef.current,
+      activationOrder: terminalTabActivationOrderRef.current,
+      nowMs
     })
 
     const nextColdParkedTerminalTabIds = selectColdParkedTerminalTabs({

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -63,6 +63,7 @@ export function useTerminalTabColdParking(args: {
   terminalTabs: readonly TerminalTab[]
   assignments: ReadonlyMap<string, TerminalOverlayTabAssignment>
   isWorktreeActive: boolean
+  activeTerminalTabId: string | null
   /** Worktree-level park verdict from Terminal.tsx. */
   coldParkTerminalPanes: boolean
   /** Retention-budget force-park (C1 slice B): unlike ordinary parks, the
@@ -82,6 +83,7 @@ export function useTerminalTabColdParking(args: {
     terminalTabs,
     assignments,
     isWorktreeActive,
+    activeTerminalTabId,
     coldParkTerminalPanes,
     isForceParked = false,
     shouldMeasureHiddenWorktree,
@@ -116,8 +118,7 @@ export function useTerminalTabColdParking(args: {
     [sleepingAgentSessionsByPaneKey, worktreeId]
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())
-  // Why: ranks the #8262 keep-warm exemption when hiddenSince ties; see
-  // terminal-tab-activation-order.ts.
+  // Why: view switches hide every tab at once, so the park clock cannot rank them.
   const terminalTabActivationOrderRef = useRef(createTerminalTabActivationOrder())
   // Why (shared measure-clock contract with Terminal.tsx): tab hiddenSince
   // survives a background-measure window so per-tab park deadlines stay in
@@ -189,6 +190,7 @@ export function useTerminalTabColdParking(args: {
       terminalTabs,
       assignments,
       isWorktreeActive,
+      activeTerminalTabId,
       portalTabIds,
       shouldMeasureHiddenWorktree,
       hiddenSinceByTabId: terminalTabHiddenSinceRef.current,
@@ -249,6 +251,7 @@ export function useTerminalTabColdParking(args: {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- semantic keys own the tab and assignment dependencies.
   }, [
     activityTerminalPortals,
+    activeTerminalTabId,
     isWorktreeActive,
     pendingStartupByTabId,
     runtimeStatusByEnvironmentId,


### PR DESCRIPTION
## Summary

Fix terminal cold-parking ties so the actually focused terminal stays warm instead of choosing a winner by random UUID order.

Tabs hidden in the same render pass share `hiddenSinceMs`. The renderer now records a monotonic activation sequence from focused-tab changes, including focus moves between simultaneously visible split panes, and uses it to break those ties. UUID ordering remains only as a deterministic fallback for tabs without observed activation history. Floating terminals use the same active-terminal signal.

## Screenshots

No visual change. Electron validation covered two simultaneously visible terminal groups: after focusing Terminal 2 and hiding the worktree, Terminal 1 parked while Terminal 2 retained its pane manager; returning reattached Terminal 1 without remounting Terminal 2.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — all Node 24 and Node 26 CI shards passed
- [x] `pnpm build` — `pnpm run build:electron-vite:parallel` passed
- [x] Added high-quality regression coverage for tied timestamps, active-tab retention, split focus changes, retain-cap eviction, and null active-tab input

Focused validation: 7 test files, 152 tests passed. Independent review runs also passed 56 parking/verdict tests and 127 floating-terminal tests. Linux and Windows packaging, static analysis, compatibility checks, and aggregate `verify` are green.

## AI Review Report

The review checked whether activation order reflects real focus across regular, split, and floating terminals; whether deleted tab IDs are pruned; whether unchanged verdicts preserve state identity; and whether UUID fallback remains deterministic. It also checked SSH, paired runtime, folder workspace, provider neutrality, remote-wire compatibility, and macOS/Linux/Windows behavior.

The first implementation tracked hidden-to-visible edges, which missed focus changes between simultaneously visible split panes. Review replaced that with a renderer-local active-terminal signal derived from the active group. Architecture, reproduction, performance, and elegance reviews found no remaining actionable issues. CodeRabbit generated no actionable code comments.

## Security Audit

This change introduces no user input handling, command execution, path handling, authentication, secrets, dependencies, IPC, subprocesses, or remote-wire changes. Activation history is renderer-local, bounded to live terminal IDs, and pruned when tabs disappear. No security follow-up is needed.

## Notes

The behavior is provider-neutral and applies without assuming a local git worktree, so SSH, paired runtimes, and folder workspaces retain the existing parking policy. No protocol or persisted-state migration is required because clients and remote hosts exchange no new fields or opcodes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
