### PR TITLE
fix(terminal): retain alt frames through park reveal

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1562,6 +1562,7 @@ function TerminalPane(
         worktreeId,
         cwd,
         startup: CODEX_ACCOUNT_RESTART_STARTUP,
+        mountFollowsTerminalPark: false,
         paneTransportsRef,
         paneMode2031Ref,
         paneKittyKeyboardModesRef,

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -48,7 +48,8 @@ export type PtyConnectionDeps = {
   } | null
   restoredLeafId?: string | null
   restoredPtyIdByLeafId?: Record<string, string>
-  /** Preserves park intent across StrictMode's passive-effect replay. */
+  /** Park intent sampled at render time, before the host disposes the tab's
+   *  watchers; consumed once the restored layout has been replayed. */
   mountFollowsTerminalPark: boolean
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   paneMode2031Ref: React.RefObject<Map<number, boolean>>

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -48,6 +48,8 @@ export type PtyConnectionDeps = {
   } | null
   restoredLeafId?: string | null
   restoredPtyIdByLeafId?: Record<string, string>
+  /** Preserves park intent across StrictMode's passive-effect replay. */
+  mountFollowsTerminalPark: boolean
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   paneMode2031Ref: React.RefObject<Map<number, boolean>>
   /** Per-pane mirror of the kitty keyboard flags the pane's application

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -15501,6 +15501,165 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  // Drives a hidden->visible alt-screen snapshot restore whose captured grid is
+  // 120 cols wide, letting each case control what the pane measures as.
+  async function restoreAltFrameSnapshotForPaneGeometry(options: {
+    frameMarker: string
+    proposeDimensions: () => { cols: number; rows: number } | null
+    measureRect?: () => { width: number; height: number }
+    onWrite?: (data: string) => void
+  }): Promise<{ writes: string; dispose: () => void }> {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    let onData: ConnectCallbacks['onData']
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      onData = callbacks.onData
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    getMainBufferSnapshot.mockResolvedValue({
+      data: options.frameMarker,
+      frameRestoreAnsi: '\x1b[?1004h\x1b[?25l',
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + 1,
+      alternateScreen: true,
+      scrollbackAnsi: 'preserved history'
+    })
+    const pane = createPane(1)
+    ;(
+      pane.fitAddon as unknown as {
+        proposeDimensions: () => { cols: number; rows: number } | null
+      }
+    ).proposeDimensions = vi.fn(options.proposeDimensions)
+    const measureRect = options.measureRect
+    if (measureRect) {
+      Object.defineProperty(pane.container, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => {
+          const { width, height } = measureRect()
+          return { width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0 }
+        }
+      })
+    }
+    const onWrite = options.onWrite
+    if (onWrite) {
+      const originalWrite = pane.terminal.write
+      pane.terminal.write = vi.fn((...args: Parameters<typeof originalWrite>) => {
+        onWrite(args[0])
+        return originalWrite(...args)
+      }) as typeof originalWrite
+    }
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+    onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
+    await flushAsyncTicks(20)
+    const readWrites = (): string =>
+      (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]).join('')
+    // Why real time: an unmeasurable visible pane must burn the whole bounded
+    // safe-fit retry budget (40 ticks of rAF + a 16ms layout settle) before the
+    // deferred repaint decision is made, so "absent" only means absent after it.
+    for (
+      let waited = 0;
+      waited < 2_500 && !readWrites().includes(options.frameMarker);
+      waited += 25
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      await flushAsyncTicks(10)
+    }
+    await flushAsyncTicks(20)
+    return { writes: readWrites(), dispose: () => disposable.dispose() }
+  }
+
+  // Why: the E2E's deepest split pane is ~W/256 x ~H/256 px, so it fails the
+  // 48x24 pixel floor and proposes nothing. It is visible and permanently
+  // unmeasurable: no fit ever lands, the skip's pulse repaint never runs, and
+  // the captured frame is lost unless the deferral repaints it here.
+  it('repaints the alt frame for a visible pane whose box is below the fit pixel floor', async () => {
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'SUB-FLOOR-ALT-FRAME',
+      proposeDimensions: () => null,
+      measureRect: () => ({ width: 4, height: 3 })
+    })
+    expect(writes).toContain('SUB-FLOOR-ALT-FRAME')
+    expect(writes).toContain('preserved history')
+    // The withheld frame arrives after the frame-restore state, not instead of it.
+    expect(writes.indexOf('\x1b[?1004h\x1b[?25l')).toBeLessThan(
+      writes.indexOf('SUB-FLOOR-ALT-FRAME')
+    )
+    dispose()
+  })
+
+  // The 50px divider clamp: measurable box, but the proposal is under the cols floor.
+  it('repaints the alt frame for a visible pane clamped under the fit cols floor', async () => {
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'SLIVER-ALT-FRAME',
+      proposeDimensions: () => ({ cols: 5, rows: 40 }),
+      measureRect: () => ({ width: 50, height: 600 })
+    })
+    expect(writes).toContain('SLIVER-ALT-FRAME')
+    expect(writes).toContain('preserved history')
+    dispose()
+  })
+
+  it('still drops an alt frame captured wider than the grid the fit will land on', async () => {
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'TOO-WIDE-ALT-FRAME',
+      proposeDimensions: () => ({ cols: 64, rows: 40 })
+    })
+    expect(writes).not.toContain('TOO-WIDE-ALT-FRAME')
+    expect(writes).toContain('\x1b[?1004h\x1b[?25l')
+    dispose()
+  })
+
+  // #13014 must survive the deferral: a pane that is only transiently
+  // unmeasurable gets its fit inside the retry budget, and that narrower fit
+  // would clip the captured frame — so the repaint must not fire for it.
+  it('keeps a too-wide alt frame withheld when a transiently unmeasurable pane later fits narrower', async () => {
+    let probes = 0
+    const measured = (): boolean => {
+      probes += 1
+      return probes > 3
+    }
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'NARROWED-ALT-FRAME',
+      proposeDimensions: () => (probes > 3 ? { cols: 64, rows: 40 } : null),
+      measureRect: () => (measured() ? { width: 400, height: 600 } : { width: 4, height: 3 })
+    })
+    expect(writes).not.toContain('NARROWED-ALT-FRAME')
+    expect(writes).toContain('preserved history')
+    expect(writes).toContain('\x1b[?1004h\x1b[?25l')
+    dispose()
+  })
+
+  // Why: the skip is a deferral. If the pane collapses under the fit floor
+  // between the replay and the post-replay fit, no fit and therefore no pulse
+  // repaint ever lands, so the withheld frame must be painted onto the grid the
+  // pane actually kept.
+  it('repaints a skipped alt frame when the post-replay fit never lands', async () => {
+    let collapsed = false
+    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
+      frameMarker: 'COLLAPSED-ALT-FRAME',
+      // The frame was withheld against a 64-col fit; then the divider clamps the pane to a sliver.
+      onWrite: (data) => {
+        collapsed ||= data === '\x1b[?1004h\x1b[?25l'
+      },
+      proposeDimensions: () => (collapsed ? { cols: 5, rows: 40 } : { cols: 64, rows: 40 })
+    })
+    expect(writes).toContain('preserved history')
+    expect(writes.indexOf('\x1b[?1004h\x1b[?25l')).toBeLessThan(
+      writes.indexOf('COLLAPSED-ALT-FRAME')
+    )
+    dispose()
+  })
+
   it('drains foreground output after a renderer-sourced hidden-backlog snapshot without seq', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8791,7 +8791,7 @@ describe('connectPanePty', () => {
     expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
   })
 
-  it('drops a live daemon alt frame until a hidden pane has a final grid', async () => {
+  it('keeps a daemon alt frame at its capture grid while the target grid is unknown', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) =>
@@ -8829,7 +8829,8 @@ describe('connectPanePty', () => {
 
     const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
     expect(writes.join('')).toContain('PREFIX-SCROLLBACK')
-    expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
+    expect(writes.join('')).toContain('ALT-FRAME-BODY')
+    expect(writes.filter((write) => write.includes('ALT-FRAME-BODY'))).toHaveLength(1)
   })
 
   it('falls back to the merged daemon snapshot when split metadata is incomplete', async () => {
@@ -15473,9 +15474,8 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
-  it('pulses a skipped hidden alt frame when reveal keeps the snapshot grid', async () => {
+  it('keeps a hidden-output alt frame at the capture grid below the fit floor', async () => {
     const { connectPanePty } = await import('./pty-connection')
-    const { safeFit } = await import('@/lib/pane-manager/pane-tree-ops')
     const transport = createMockTransport('pty-id')
     let onData: ConnectCallbacks['onData']
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
@@ -15497,200 +15497,36 @@ describe('connectPanePty', () => {
       scrollbackAnsi: 'preserved history'
     })
     const pane = createPane(1)
-    let paneRect = createRect(0, 0)
-    pane.container.getBoundingClientRect = vi.fn(() => paneRect)
-    let xtermContainerDisplay = 'none'
-    const xtermContainer = new EventTarget() as HTMLElement
-    Object.defineProperty(xtermContainer, 'parentElement', { value: null })
-    Object.defineProperty(xtermContainer, 'ownerDocument', {
-      value: { defaultView: { getComputedStyle: () => ({ display: xtermContainerDisplay }) } }
+    pane.terminal.cols = 80
+    pane.terminal.rows = 24
+    const writes: string[] = []
+    pane.terminal.write = vi.fn((data: string, callback?: () => void) => {
+      writes.push(data)
+      callback?.()
     })
-    ;(pane as { xtermContainer?: HTMLElement }).xtermContainer = xtermContainer
+    pane.container.getBoundingClientRect = vi.fn(() => createRect(4, 3))
     const deps = createDeps({ isVisibleRef: { current: false } })
-    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    const binding = connectPanePty(pane as never, createManager(1) as never, deps as never)
     await flushAsyncTicks(6)
     onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    const { _dispatchPtyModelRestoreNeededForTest } = await import('./pty-model-restore-channel')
+    _dispatchPtyModelRestoreNeededForTest({
+      id: 'pty-id',
+      reason: 'hidden-drop',
+      markerSeq: hidden.length + 1
+    })
     ;(deps.isVisibleRef as { current: boolean }).current = true
-    onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
+    const { requestTerminalBacklogRecovery } =
+      await import('@/lib/pane-manager/pane-terminal-output-scheduler')
+    requestTerminalBacklogRecovery(pane.terminal as never)
     await flushAsyncTicks(20)
 
-    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
-      (call) => call[0]
-    )
-    expect(writes.join('')).not.toContain('TOO-WIDE-ALT-FRAME')
-    expect(writes.join('')).toContain('\x1b[?1004h\x1b[?25l')
+    expect(writes.join('')).toContain('TOO-WIDE-ALT-FRAME')
+    expect(writes.join('')).toContain('preserved history')
+    expect(writes.filter((write) => write.includes('TOO-WIDE-ALT-FRAME'))).toHaveLength(1)
+    expect(pane.terminal.resize).toHaveBeenCalledWith(120, 40)
     expect(transport.resize).not.toHaveBeenCalled()
-
-    xtermContainerDisplay = 'block'
-    paneRect = createRect(800, 600)
-    safeFit(pane as never)
-    await flushAsyncTicks(12)
-
-    const pulseStart = transport.resize.mock.calls.findIndex(
-      ([cols, rows]) => cols === 119 && rows === 40
-    )
-    expect(pulseStart).toBeGreaterThanOrEqual(0)
-    expect(transport.resize.mock.calls[pulseStart + 1]).toEqual([120, 40])
-    disposable.dispose()
-  })
-
-  // Drives a hidden->visible alt-screen snapshot restore whose captured grid is
-  // 120 cols wide, letting each case control what the pane measures as.
-  async function restoreAltFrameSnapshotForPaneGeometry(options: {
-    frameMarker: string
-    proposeDimensions: () => { cols: number; rows: number } | null
-    measureRect?: () => { width: number; height: number }
-    onWrite?: (data: string) => void
-  }): Promise<{ writes: string; dispose: () => void }> {
-    const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport('pty-id')
-    let onData: ConnectCallbacks['onData']
-    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-      onData = callbacks.onData
-      return 'pty-id'
-    })
-    transportFactoryQueue.push(transport)
-    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
-      typeof vi.fn
-    >
-    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
-    getMainBufferSnapshot.mockResolvedValue({
-      data: options.frameMarker,
-      frameRestoreAnsi: '\x1b[?1004h\x1b[?25l',
-      cols: 120,
-      rows: 40,
-      seq: hidden.length + 1,
-      alternateScreen: true,
-      scrollbackAnsi: 'preserved history'
-    })
-    const pane = createPane(1)
-    ;(
-      pane.fitAddon as unknown as {
-        proposeDimensions: () => { cols: number; rows: number } | null
-      }
-    ).proposeDimensions = vi.fn(options.proposeDimensions)
-    const measureRect = options.measureRect
-    if (measureRect) {
-      Object.defineProperty(pane.container, 'getBoundingClientRect', {
-        configurable: true,
-        value: () => {
-          const { width, height } = measureRect()
-          return { width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0 }
-        }
-      })
-    }
-    const onWrite = options.onWrite
-    if (onWrite) {
-      const originalWrite = pane.terminal.write
-      pane.terminal.write = vi.fn((...args: Parameters<typeof originalWrite>) => {
-        onWrite(args[0])
-        return originalWrite(...args)
-      }) as typeof originalWrite
-    }
-    const deps = createDeps({ isVisibleRef: { current: false } })
-    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
-    await flushAsyncTicks(6)
-    onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
-    ;(deps.isVisibleRef as { current: boolean }).current = true
-    onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
-    await flushAsyncTicks(20)
-    const readWrites = (): string =>
-      (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]).join('')
-    // Why real time: an unmeasurable visible pane must burn the whole bounded
-    // safe-fit retry budget (40 ticks of rAF + a 16ms layout settle) before the
-    // deferred repaint decision is made, so "absent" only means absent after it.
-    for (
-      let waited = 0;
-      waited < 2_500 && !readWrites().includes(options.frameMarker);
-      waited += 25
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 25))
-      await flushAsyncTicks(10)
-    }
-    await flushAsyncTicks(20)
-    return { writes: readWrites(), dispose: () => disposable.dispose() }
-  }
-
-  // Why: the E2E's deepest split pane is ~W/256 x ~H/256 px, so it fails the
-  // 48x24 pixel floor and proposes nothing. It is visible and permanently
-  // unmeasurable: no fit ever lands, the skip's pulse repaint never runs, and
-  // the captured frame is lost unless the deferral repaints it here.
-  it('repaints the alt frame for a visible pane whose box is below the fit pixel floor', async () => {
-    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
-      frameMarker: 'SUB-FLOOR-ALT-FRAME',
-      proposeDimensions: () => null,
-      measureRect: () => ({ width: 4, height: 3 })
-    })
-    expect(writes).toContain('SUB-FLOOR-ALT-FRAME')
-    expect(writes).toContain('preserved history')
-    // The withheld frame arrives after the frame-restore state, not instead of it.
-    expect(writes.indexOf('\x1b[?1004h\x1b[?25l')).toBeLessThan(
-      writes.indexOf('SUB-FLOOR-ALT-FRAME')
-    )
-    dispose()
-  })
-
-  // The 50px divider clamp: measurable box, but the proposal is under the cols floor.
-  it('repaints the alt frame for a visible pane clamped under the fit cols floor', async () => {
-    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
-      frameMarker: 'SLIVER-ALT-FRAME',
-      proposeDimensions: () => ({ cols: 5, rows: 40 }),
-      measureRect: () => ({ width: 50, height: 600 })
-    })
-    expect(writes).toContain('SLIVER-ALT-FRAME')
-    expect(writes).toContain('preserved history')
-    dispose()
-  })
-
-  it('still drops an alt frame captured wider than the grid the fit will land on', async () => {
-    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
-      frameMarker: 'TOO-WIDE-ALT-FRAME',
-      proposeDimensions: () => ({ cols: 64, rows: 40 })
-    })
-    expect(writes).not.toContain('TOO-WIDE-ALT-FRAME')
-    expect(writes).toContain('\x1b[?1004h\x1b[?25l')
-    dispose()
-  })
-
-  // #13014 must survive the deferral: a pane that is only transiently
-  // unmeasurable gets its fit inside the retry budget, and that narrower fit
-  // would clip the captured frame — so the repaint must not fire for it.
-  it('keeps a too-wide alt frame withheld when a transiently unmeasurable pane later fits narrower', async () => {
-    let probes = 0
-    const measured = (): boolean => {
-      probes += 1
-      return probes > 3
-    }
-    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
-      frameMarker: 'NARROWED-ALT-FRAME',
-      proposeDimensions: () => (probes > 3 ? { cols: 64, rows: 40 } : null),
-      measureRect: () => (measured() ? { width: 400, height: 600 } : { width: 4, height: 3 })
-    })
-    expect(writes).not.toContain('NARROWED-ALT-FRAME')
-    expect(writes).toContain('preserved history')
-    expect(writes).toContain('\x1b[?1004h\x1b[?25l')
-    dispose()
-  })
-
-  // Why: the skip is a deferral. If the pane collapses under the fit floor
-  // between the replay and the post-replay fit, no fit and therefore no pulse
-  // repaint ever lands, so the withheld frame must be painted onto the grid the
-  // pane actually kept.
-  it('repaints a skipped alt frame when the post-replay fit never lands', async () => {
-    let collapsed = false
-    const { writes, dispose } = await restoreAltFrameSnapshotForPaneGeometry({
-      frameMarker: 'COLLAPSED-ALT-FRAME',
-      // The frame was withheld against a 64-col fit; then the divider clamps the pane to a sliver.
-      onWrite: (data) => {
-        collapsed ||= data === '\x1b[?1004h\x1b[?25l'
-      },
-      proposeDimensions: () => (collapsed ? { cols: 5, rows: 40 } : { cols: 64, rows: 40 })
-    })
-    expect(writes).toContain('preserved history')
-    expect(writes.indexOf('\x1b[?1004h\x1b[?25l')).toBeLessThan(
-      writes.indexOf('COLLAPSED-ALT-FRAME')
-    )
-    dispose()
+    binding.dispose()
   })
 
   it('drains foreground output after a renderer-sourced hidden-backlog snapshot without seq', async () => {
@@ -21866,7 +21702,7 @@ describe('connectPanePty', () => {
     expect(transport.getPtyId).toHaveReturnedWith(remotePtyId)
   })
 
-  it('restores a local main-model snapshot after a contentless park reattach', async () => {
+  it('keeps a parked main-model alt frame at its capture grid while hidden', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const localPtyId = 'global-floating-terminal@@terminal-1'
     const transport = createMockTransport(localPtyId)
@@ -21877,11 +21713,14 @@ describe('connectPanePty', () => {
     transportFactoryQueue.push(transport)
     const getMainBufferSnapshot = vi.mocked(window.api.pty.getMainBufferSnapshot)
     getMainBufferSnapshot.mockResolvedValue({
-      data: 'FLOATING-PARK-RESTORE-OK\r\n',
+      data: 'FLOATING-PARK-ALT-FRAME',
+      frameRestoreAnsi: '\x1b[?25l',
       cols: 113,
       rows: 32,
       seq: 558,
-      source: 'headless'
+      source: 'headless',
+      alternateScreen: true,
+      scrollbackAnsi: 'FLOATING-PARK-HISTORY\r\n'
     })
     await parkTabForReveal('tab-1', localPtyId, 'global-floating-terminal')
     mockStoreState = {
@@ -21901,6 +21740,7 @@ describe('connectPanePty', () => {
     }
 
     const pane = createPane(1)
+    pane.container.getBoundingClientRect = vi.fn(() => createRect(0, 0))
     const { parseCallbacks, writes } = captureCallbackTerminalWrites(pane)
     const deps = createDeps({
       worktreeId: 'global-floating-terminal',
@@ -21919,7 +21759,10 @@ describe('connectPanePty', () => {
       expect.objectContaining({ sessionId: localPtyId })
     )
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, localPtyId)
-    expect(writes.join('')).toContain('FLOATING-PARK-RESTORE-OK')
+    expect(writes.join('')).toContain('FLOATING-PARK-HISTORY')
+    expect(writes.join('')).toContain('FLOATING-PARK-ALT-FRAME')
+    expect(writes.filter((write) => write.includes('FLOATING-PARK-ALT-FRAME'))).toHaveLength(1)
+    expect(pane.terminal.resize).toHaveBeenCalledWith(113, 32)
   })
 
   it('falls back to relay replay when the SSH model snapshot stalls', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3148,6 +3148,39 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
   })
 
+  it('routes terminal input through deferPtyInput so the host can withhold it', async () => {
+    // Regression: inlining forwardPtyInput into onData dropped this hop, silently disabling link-click mouse suppression.
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const transport = createMockTransport('pty-1')
+    transportFactoryQueue.push(transport)
+    const deferPtyInput = vi.fn()
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps({ deferPtyInput }) as never)
+    await flushAsyncTicks()
+    sendTerminalInputThroughPane(pane, 'a')
+
+    expect(deferPtyInput).toHaveBeenCalledWith(1, 'a', expect.any(Function))
+    expect(transport.sendInput).not.toHaveBeenCalled()
+
+    const forward = deferPtyInput.mock.calls[0]?.[2] as (data: string) => void
+    forward('a')
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('forwards terminal input directly when the host supplies no deferPtyInput', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const transport = createMockTransport('pty-1')
+    transportFactoryQueue.push(transport)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+    sendTerminalInputThroughPane(pane, 'a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
   it('does not let OpenTUI-style small ANSI redraw bursts monopolize foreground writes', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -62,18 +62,6 @@ async function drainFakeTimerWork(limit = 20): Promise<void> {
   vi.clearAllTimers()
 }
 
-// Why: a reveal remount reads the still-live park watcher entry at connect time to
-// tell itself apart from an in-place reattach; the host disposes it a beat later.
-async function parkTabForReveal(tabId: string, ptyId: string, worktreeId = 'wt-1'): Promise<void> {
-  const { parkedWatchersByTabId } = await import('./terminal-parked-watcher-registry')
-  parkedWatchersByTabId.set(tabId, {
-    worktreeId,
-    tabPtyId: ptyId,
-    paneIdByPtyId: new Map([[ptyId, 1]]),
-    disposersByPtyId: new Map([[ptyId, () => {}]])
-  })
-}
-
 async function drainPendingTimeouts(pendingTimeouts: (() => void)[], limit = 100): Promise<void> {
   let iterations = 0
   while (pendingTimeouts.length > 0) {
@@ -624,6 +612,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     startup: null,
     restoredLeafId: null,
     restoredPtyIdByLeafId: {},
+    mountFollowsTerminalPark: false,
     paneTransportsRef: { current: new Map() },
     paneMode2031Ref: { current: new Map() },
     paneKittyKeyboardModesRef: { current: new Map() },
@@ -21423,7 +21412,6 @@ describe('connectPanePty', () => {
       alternateScreen: true,
       scrollbackAnsi: 'PARKED-SSH-SCROLLBACK\r\n'
     })
-    await parkTabForReveal('tab-1', sshPtyId)
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: sshPtyId }] },
@@ -21441,6 +21429,7 @@ describe('connectPanePty', () => {
       pane as never,
       createManager(1) as never,
       createDeps({
+        mountFollowsTerminalPark: true,
         restoredLeafId: LEAF_1,
         restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
       }) as never
@@ -21486,7 +21475,6 @@ describe('connectPanePty', () => {
     transportFactoryQueue.push(createMockTransport())
     vi.mocked(window.api.pty.getMainBufferSnapshot).mockReturnValue(snapshot.promise)
     vi.mocked(window.api.ssh.connect).mockReturnValue(sshConnect.promise)
-    await parkTabForReveal('tab-1', sshPtyId)
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: sshPtyId, generation: 7 }] },
@@ -21513,6 +21501,7 @@ describe('connectPanePty', () => {
       pane as never,
       createManager(1) as never,
       createDeps({
+        mountFollowsTerminalPark: true,
         restoredLeafId: LEAF_1,
         restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
       }) as never
@@ -21565,7 +21554,6 @@ describe('connectPanePty', () => {
       seq: 125,
       source: 'headless'
     })
-    await parkTabForReveal('tab-1', foreignPtyId)
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: foreignPtyId }] },
@@ -21582,6 +21570,7 @@ describe('connectPanePty', () => {
       pane as never,
       createManager(1) as never,
       createDeps({
+        mountFollowsTerminalPark: true,
         restoredLeafId: LEAF_1,
         restoredPtyIdByLeafId: { [LEAF_1]: foreignPtyId }
       }) as never
@@ -21617,7 +21606,6 @@ describe('connectPanePty', () => {
     })
     transportFactoryQueue.push(transport)
     vi.mocked(window.api.pty.getMainBufferSnapshot).mockReturnValue(snapshot.promise)
-    await parkTabForReveal('tab-1', sshPtyId)
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: sshPtyId }] },
@@ -21634,6 +21622,7 @@ describe('connectPanePty', () => {
       pane as never,
       createManager(1) as never,
       createDeps({
+        mountFollowsTerminalPark: true,
         restoredLeafId: LEAF_1,
         restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
       }) as never
@@ -21671,7 +21660,6 @@ describe('connectPanePty', () => {
       source: 'headless'
     })
     transportFactoryQueue.push(transport)
-    await parkTabForReveal('tab-1', remotePtyId)
     mockStoreState = {
       ...mockStoreState,
       runtimeStatusByEnvironmentId: new Map([
@@ -21687,7 +21675,7 @@ describe('connectPanePty', () => {
 
     const pane = createPane(1)
     const { parseCallbacks, writes } = captureCallbackTerminalWrites(pane)
-    const deps = createDeps()
+    const deps = createDeps({ mountFollowsTerminalPark: true })
 
     connectPanePty(pane as never, createManager(1) as never, deps as never)
     for (let step = 0; step < 30; step += 1) {
@@ -21722,7 +21710,6 @@ describe('connectPanePty', () => {
       alternateScreen: true,
       scrollbackAnsi: 'FLOATING-PARK-HISTORY\r\n'
     })
-    await parkTabForReveal('tab-1', localPtyId, 'global-floating-terminal')
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: {
@@ -21743,6 +21730,7 @@ describe('connectPanePty', () => {
     pane.container.getBoundingClientRect = vi.fn(() => createRect(0, 0))
     const { parseCallbacks, writes } = captureCallbackTerminalWrites(pane)
     const deps = createDeps({
+      mountFollowsTerminalPark: true,
       worktreeId: 'global-floating-terminal',
       restoredLeafId: LEAF_1,
       restoredPtyIdByLeafId: { [LEAF_1]: localPtyId }
@@ -21765,6 +21753,51 @@ describe('connectPanePty', () => {
     expect(pane.terminal.resize).toHaveBeenCalledWith(113, 32)
   })
 
+  it('restores a parked SSH alt frame after StrictMode watcher disposal', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('conn-1', 'relay-pty-static-alt')
+    const transport = createMockTransport(sshPtyId)
+    transport.connect.mockImplementation(async () => {
+      transport.getPtyId.mockReturnValue(sshPtyId)
+      return { id: sshPtyId, isReattach: true, replay: '' }
+    })
+    transportFactoryQueue.push(transport)
+    vi.mocked(window.api.pty.getMainBufferSnapshot).mockResolvedValue({
+      data: '\x1b[0m\x1b[?1049h\x1b[HSTATIC-SSH-ALT-FRAME',
+      frameRestoreAnsi: '\x1b[0m\x1b[?1049h\x1b[?6l\x1b[1;21H',
+      cols: 100,
+      rows: 30,
+      seq: 512,
+      source: 'headless',
+      alternateScreen: true,
+      scrollbackAnsi: 'PRESERVED-SSH-HISTORY\r\n'
+    })
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': sshPtyId }
+    }
+
+    const pane = createPane(1)
+    const { parseCallbacks, writes } = captureCallbackTerminalWrites(pane)
+    const deps = createDeps({
+      mountFollowsTerminalPark: true,
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
+    })
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    for (let step = 0; step < 30; step += 1) {
+      parseCallbacks.shift()?.()
+      await flushAsyncTicks(2)
+    }
+
+    expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalledOnce()
+    expect(writes.join('')).toContain('PRESERVED-SSH-HISTORY')
+    expect(writes.filter((write) => write.includes('STATIC-SSH-ALT-FRAME'))).toHaveLength(1)
+  })
+
   it('falls back to relay replay when the SSH model snapshot stalls', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { SSH_REATTACH_MODEL_SNAPSHOT_TIMEOUT_MS } = await import('./ssh-reattach-model-restore')
@@ -21776,9 +21809,7 @@ describe('connectPanePty', () => {
     })
     transportFactoryQueue.push(transport)
     vi.mocked(window.api.pty.getMainBufferSnapshot).mockReturnValue(new Promise(() => {}))
-    // Why parked: only a reveal remount probes main's model — the pane reads the
-    // still-live park watcher entry at connect time to tell the two apart.
-    await parkTabForReveal('tab-1', sshPtyId)
+    // Why parked: only a reveal remount probes main's model.
 
     mockStoreState = {
       ...mockStoreState,
@@ -21791,6 +21822,7 @@ describe('connectPanePty', () => {
     const pane = createPane(1)
     const { writes } = captureCallbackTerminalWrites(pane)
     const deps = createDeps({
+      mountFollowsTerminalPark: true,
       restoredLeafId: LEAF_1,
       restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
     })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4080,7 +4080,7 @@ export function connectPanePty(
     }
   )
 
-  const onDataDisposable = pane.terminal.onData((data) => {
+  const forwardPtyInput = (data: string): void => {
     // Why: xterm auto-replies to embedded query sequences (DA1, DECRQM,
     // OSC 10/11, focus, CPR) via onData. When we replay recorded PTY bytes
     // into xterm for scrollback/cold-restore/snapshot, those queries would
@@ -4215,6 +4215,13 @@ export function connectPanePty(
       clearPendingTerminalInputIntent()
       requestRecoveryForUndeliverableInput()
     }
+  }
+  const onDataDisposable = pane.terminal.onData((data) => {
+    if (deps.deferPtyInput) {
+      deps.deferPtyInput(pane.id, data, forwardPtyInput)
+      return
+    }
+    forwardPtyInput(data)
   })
   const imeCompositionRouteDisposable = installTerminalImeCompositionRoute({
     terminalElement: pane.terminal.element,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -280,7 +280,6 @@ import {
   setCommandCodeDoneSettleExecutor
 } from './command-code-done-settle'
 import { canCommandCodeOutputOwnPane } from './command-code-output-ownership'
-import { isTerminalTabParked } from './terminal-parked-watcher-registry'
 import {
   getExecutionHostIdForWorktree,
   getSettingsForWorktreeRuntimeOwner
@@ -1107,10 +1106,7 @@ export function connectPanePty(
   // settles after remount must not remount its already-replaced successor.
   const terminalRecoveryGeneration = captureTerminalPaneRecoveryGeneration(deps.tabId)
   const terminalRecoveryInstance = registerTerminalPaneRecoveryInstance(deps.tabId)
-  // Why sampled here: the host disposes this tab's park watcher in the effect
-  // that follows this mount, so connect time is the only moment a pane can tell
-  // a reveal remount from an in-place reattach.
-  let mountFollowsTerminalPark = isTerminalTabParked(deps.tabId)
+  let mountFollowsTerminalPark = deps.mountFollowsTerminalPark
   let authoritativeReattachGeneration = 0
   exposeE2eTerminalPtyOutputDebug()
   let disposed = false

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -261,12 +261,10 @@ import {
 } from './hidden-output-restore-scheduler'
 import { resolveHiddenRestoreScrollbackRows } from './terminal-hidden-restore-scrollback'
 import {
-  buildDeferredAltFrameReplayWrites,
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
   readProposedTerminalCols,
   resolvePositiveTerminalDimensions,
-  shouldRepaintDeferredAltFrame,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
 import {
@@ -7266,9 +7264,7 @@ export function connectPanePty(
             skippedAltFrame =
               snapshot.alternateScreen === true &&
               snapshot.frameRestoreAnsi !== undefined &&
-              shouldSkipAltFrameForWidthMismatch(snapshot.cols, readProposedTerminalCols(pane), {
-                skipIfTargetUnknown: true
-              })
+              shouldSkipAltFrameForWidthMismatch(snapshot.cols, readProposedTerminalCols(pane))
             for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
               skipAltFrame: skippedAltFrame
             })) {
@@ -7347,26 +7343,11 @@ export function connectPanePty(
                 }
               )
               pendingHiddenSnapshotFit = fit
-              let fitCompleted = false
               try {
-                fitCompleted = await fit.completion
+                await fit.completion
               } finally {
                 if (pendingHiddenSnapshotFit === fit) {
                   pendingHiddenSnapshotFit = null
-                }
-              }
-              if (
-                !fitCompleted &&
-                skippedAltFrame &&
-                isCurrentRestore() &&
-                transport.getPtyId() === currentPtyId &&
-                shouldRepaintDeferredAltFrame(pane, snapshot.cols)
-              ) {
-                // Why: the skip is a deferral, not a deletion. No fit landed, and the pulse
-                // repaint lives in that failed continuation, so paint the frame here unless the
-                // pane is hidden (its reveal fit still owes one) or measurably narrower.
-                for (const replayChunk of buildDeferredAltFrameReplayWrites(snapshot)) {
-                  writeReplayData(replayChunk)
                 }
               }
               if (isCurrentRestore()) {
@@ -8228,8 +8209,7 @@ export function connectPanePty(
             typeof snapshotFrameRestoreAnsi === 'string' &&
             shouldSkipAltFrameForWidthMismatch(
               connectResult.snapshotCols,
-              readProposedTerminalCols(pane),
-              { skipIfTargetUnknown: true }
+              readProposedTerminalCols(pane)
             )
           writeReplayData(
             daemonAltFrameSkippable
@@ -8295,10 +8275,7 @@ export function connectPanePty(
             for (const replayChunk of buildMainModelSnapshotReplayWrites(modelSnapshot, {
               skipAltFrame: shouldSkipAltFrameForWidthMismatch(
                 modelCols,
-                readProposedTerminalCols(pane),
-                {
-                  skipIfTargetUnknown: true
-                }
+                readProposedTerminalCols(pane)
               )
             })) {
               writeReplayData(replayChunk)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -261,10 +261,12 @@ import {
 } from './hidden-output-restore-scheduler'
 import { resolveHiddenRestoreScrollbackRows } from './terminal-hidden-restore-scrollback'
 import {
+  buildDeferredAltFrameReplayWrites,
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
   readProposedTerminalCols,
   resolvePositiveTerminalDimensions,
+  shouldRepaintDeferredAltFrame,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
 import {
@@ -4078,7 +4080,7 @@ export function connectPanePty(
     }
   )
 
-  const forwardPtyInput = (data: string): void => {
+  const onDataDisposable = pane.terminal.onData((data) => {
     // Why: xterm auto-replies to embedded query sequences (DA1, DECRQM,
     // OSC 10/11, focus, CPR) via onData. When we replay recorded PTY bytes
     // into xterm for scrollback/cold-restore/snapshot, those queries would
@@ -4213,13 +4215,6 @@ export function connectPanePty(
       clearPendingTerminalInputIntent()
       requestRecoveryForUndeliverableInput()
     }
-  }
-  const onDataDisposable = pane.terminal.onData((data) => {
-    if (deps.deferPtyInput) {
-      deps.deferPtyInput(pane.id, data, forwardPtyInput)
-      return
-    }
-    forwardPtyInput(data)
   })
   const imeCompositionRouteDisposable = installTerminalImeCompositionRoute({
     terminalElement: pane.terminal.element,
@@ -7345,11 +7340,26 @@ export function connectPanePty(
                 }
               )
               pendingHiddenSnapshotFit = fit
+              let fitCompleted = false
               try {
-                await fit.completion
+                fitCompleted = await fit.completion
               } finally {
                 if (pendingHiddenSnapshotFit === fit) {
                   pendingHiddenSnapshotFit = null
+                }
+              }
+              if (
+                !fitCompleted &&
+                skippedAltFrame &&
+                isCurrentRestore() &&
+                transport.getPtyId() === currentPtyId &&
+                shouldRepaintDeferredAltFrame(pane, snapshot.cols)
+              ) {
+                // Why: the skip is a deferral, not a deletion. No fit landed, and the pulse
+                // repaint lives in that failed continuation, so paint the frame here unless the
+                // pane is hidden (its reveal fit still owes one) or measurably narrower.
+                for (const replayChunk of buildDeferredAltFrameReplayWrites(snapshot)) {
+                  writeReplayData(replayChunk)
                 }
               }
               if (isCurrentRestore()) {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
@@ -58,10 +58,10 @@ export function terminalWatcherLiveWorkspaceIds(workspaceIds: Iterable<string>):
 }
 
 /**
- * Whether this tab is parked right now — the reveal remount's own mount effect
- * runs before the host effect that disposes the watcher (child effects first),
- * so a pane reading this at connect time can tell a park-reveal from an
- * in-place reattach. Empty entries are pinned-close tombstones, not live parks.
+ * Whether this tab is parked right now — the reveal remount renders before the
+ * host effect that disposes the watcher, so a pane reading this at render time
+ * can tell a park-reveal from an in-place reattach. Empty entries are
+ * pinned-close tombstones, not live parks.
  */
 export function isTerminalTabParked(tabId: string): boolean {
   return (parkedWatchersByTabId.get(tabId)?.disposersByPtyId.size ?? 0) > 0

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -89,10 +89,6 @@ describe('shouldSkipAltFrameForWidthMismatch', () => {
     expect(shouldSkipAltFrameForWidthMismatch(Number.NaN, 128)).toBe(false)
     expect(shouldSkipAltFrameForWidthMismatch(Number.POSITIVE_INFINITY, 128)).toBe(false)
   })
-
-  it('keeps the capture-grid frame until a real target grid is known', () => {
-    expect(shouldSkipAltFrameForWidthMismatch(135, undefined)).toBe(false)
-  })
 })
 
 describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@xterm/headless'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import {
+  buildDeferredAltFrameReplayWrites,
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
+  shouldRepaintDeferredAltFrame,
   resolvePositiveTerminalDimensions,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
@@ -171,5 +174,110 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
     ).toEqual(['\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
+  })
+})
+
+describe('shouldRepaintDeferredAltFrame', () => {
+  function makePane(args: {
+    rect: { width: number; height: number }
+    proposed: { cols: number; rows: number } | null
+    display?: string
+  }): ManagedPane {
+    const display = args.display ?? 'block'
+    const container = {
+      dataset: {},
+      parentElement: null,
+      ownerDocument: { defaultView: { getComputedStyle: () => ({ display }) } },
+      getBoundingClientRect: () => args.rect
+    }
+    return {
+      id: 1,
+      terminal: { cols: 120, rows: 40, options: {} },
+      container,
+      fitAddon: { proposeDimensions: () => args.proposed }
+    } as unknown as ManagedPane
+  }
+
+  // Why: a visible pane under the 48x24 fit floor (divider clamp, a sliver from
+  // repeated splits) is permanently unmeasurable, so the deferred repaint that
+  // rode the post-replay fit never runs and the frame would be lost for good.
+  it('repaints for a visible pane whose box is below the fit floor', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 4, height: 3 }, proposed: null }),
+        120
+      )
+    ).toBe(true)
+  })
+
+  it('repaints for a visible pane that measures but proposes under the cols floor', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 50, height: 600 }, proposed: { cols: 5, rows: 40 } }),
+        120
+      )
+    ).toBe(true)
+  })
+
+  it('withholds for a display:none pane whose reveal fit still owes the repaint', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 800, height: 600 }, proposed: null, display: 'none' }),
+        120
+      )
+    ).toBe(false)
+  })
+
+  // #13014: a frame wider than the grid a later fit lands on clips instead of reflowing.
+  it('withholds when the pane became measurable and is narrower than the capture grid', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 400, height: 600 }, proposed: { cols: 64, rows: 40 } }),
+        120
+      )
+    ).toBe(false)
+  })
+
+  it('repaints when the measurable grid is at least as wide as the capture grid', () => {
+    expect(
+      shouldRepaintDeferredAltFrame(
+        makePane({ rect: { width: 900, height: 600 }, proposed: { cols: 120, rows: 40 } }),
+        120
+      )
+    ).toBe(true)
+  })
+})
+
+describe('buildDeferredAltFrameReplayWrites', () => {
+  it('repaints only the alt frame, never a second copy of scrollback', () => {
+    expect(
+      buildDeferredAltFrameReplayWrites({
+        data: 'alt-frame'
+      })
+    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
+  })
+
+  it('lands the withheld frame on the alt buffer, leaving normal history intact', async () => {
+    const terminal = new Terminal({ cols: 12, rows: 5, scrollback: 20 })
+    const snapshot = {
+      data: '\x1b[1;1HFRAME',
+      frameRestoreAnsi: '\x1b[?25l',
+      alternateScreen: true,
+      scrollbackAnsi: 'log'
+    }
+    try {
+      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame: true })) {
+        await writeTerminal(terminal, chunk)
+      }
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('')
+      for (const chunk of buildDeferredAltFrameReplayWrites(snapshot)) {
+        await writeTerminal(terminal, chunk)
+      }
+      expect(terminal.buffer.active.type).toBe('alternate')
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('FRAME')
+      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('log')
+    } finally {
+      terminal.dispose()
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@xterm/headless'
-import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import {
-  buildDeferredAltFrameReplayWrites,
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
-  shouldRepaintDeferredAltFrame,
   resolvePositiveTerminalDimensions,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
@@ -93,17 +90,38 @@ describe('shouldSkipAltFrameForWidthMismatch', () => {
     expect(shouldSkipAltFrameForWidthMismatch(Number.POSITIVE_INFINITY, 128)).toBe(false)
   })
 
-  it('can conservatively skip a live frame until a hidden pane has a final grid', () => {
-    expect(shouldSkipAltFrameForWidthMismatch(135, undefined, { skipIfTargetUnknown: true })).toBe(
-      true
-    )
-    expect(
-      shouldSkipAltFrameForWidthMismatch(undefined, undefined, { skipIfTargetUnknown: true })
-    ).toBe(false)
+  it('keeps the capture-grid frame until a real target grid is known', () => {
+    expect(shouldSkipAltFrameForWidthMismatch(135, undefined)).toBe(false)
   })
 })
 
 describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
+  it('restores the exact capture-grid alt frame while the target grid is unknown', async () => {
+    const terminal = new Terminal({ cols: 12, rows: 5, scrollback: 20 })
+    const snapshot = {
+      data: '\x1b[1;1HTOP---------\x1b[2;1HMIDDLE------\x1b[3;1HBOTTOM------',
+      frameRestoreAnsi: '\x1b[?25l',
+      alternateScreen: true,
+      scrollbackAnsi: 'history'
+    }
+
+    try {
+      const skipAltFrame = shouldSkipAltFrameForWidthMismatch(12, undefined)
+      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame })) {
+        await writeTerminal(terminal, chunk)
+      }
+
+      expect(
+        Array.from({ length: 3 }, (_, row) =>
+          terminal.buffer.active.getLine(row)?.translateToString(true)
+        )
+      ).toEqual(['TOP---------', 'MIDDLE------', 'BOTTOM------'])
+      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('history')
+    } finally {
+      terminal.dispose()
+    }
+  })
+
   it('keeps normal history and a clean alt grid through the real resize path', async () => {
     const terminal = new Terminal({ cols: 12, rows: 5, scrollback: 20 })
     const snapshot = {
@@ -174,110 +192,5 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
     ).toEqual(['\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
-  })
-})
-
-describe('shouldRepaintDeferredAltFrame', () => {
-  function makePane(args: {
-    rect: { width: number; height: number }
-    proposed: { cols: number; rows: number } | null
-    display?: string
-  }): ManagedPane {
-    const display = args.display ?? 'block'
-    const container = {
-      dataset: {},
-      parentElement: null,
-      ownerDocument: { defaultView: { getComputedStyle: () => ({ display }) } },
-      getBoundingClientRect: () => args.rect
-    }
-    return {
-      id: 1,
-      terminal: { cols: 120, rows: 40, options: {} },
-      container,
-      fitAddon: { proposeDimensions: () => args.proposed }
-    } as unknown as ManagedPane
-  }
-
-  // Why: a visible pane under the 48x24 fit floor (divider clamp, a sliver from
-  // repeated splits) is permanently unmeasurable, so the deferred repaint that
-  // rode the post-replay fit never runs and the frame would be lost for good.
-  it('repaints for a visible pane whose box is below the fit floor', () => {
-    expect(
-      shouldRepaintDeferredAltFrame(
-        makePane({ rect: { width: 4, height: 3 }, proposed: null }),
-        120
-      )
-    ).toBe(true)
-  })
-
-  it('repaints for a visible pane that measures but proposes under the cols floor', () => {
-    expect(
-      shouldRepaintDeferredAltFrame(
-        makePane({ rect: { width: 50, height: 600 }, proposed: { cols: 5, rows: 40 } }),
-        120
-      )
-    ).toBe(true)
-  })
-
-  it('withholds for a display:none pane whose reveal fit still owes the repaint', () => {
-    expect(
-      shouldRepaintDeferredAltFrame(
-        makePane({ rect: { width: 800, height: 600 }, proposed: null, display: 'none' }),
-        120
-      )
-    ).toBe(false)
-  })
-
-  // #13014: a frame wider than the grid a later fit lands on clips instead of reflowing.
-  it('withholds when the pane became measurable and is narrower than the capture grid', () => {
-    expect(
-      shouldRepaintDeferredAltFrame(
-        makePane({ rect: { width: 400, height: 600 }, proposed: { cols: 64, rows: 40 } }),
-        120
-      )
-    ).toBe(false)
-  })
-
-  it('repaints when the measurable grid is at least as wide as the capture grid', () => {
-    expect(
-      shouldRepaintDeferredAltFrame(
-        makePane({ rect: { width: 900, height: 600 }, proposed: { cols: 120, rows: 40 } }),
-        120
-      )
-    ).toBe(true)
-  })
-})
-
-describe('buildDeferredAltFrameReplayWrites', () => {
-  it('repaints only the alt frame, never a second copy of scrollback', () => {
-    expect(
-      buildDeferredAltFrameReplayWrites({
-        data: 'alt-frame'
-      })
-    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
-  })
-
-  it('lands the withheld frame on the alt buffer, leaving normal history intact', async () => {
-    const terminal = new Terminal({ cols: 12, rows: 5, scrollback: 20 })
-    const snapshot = {
-      data: '\x1b[1;1HFRAME',
-      frameRestoreAnsi: '\x1b[?25l',
-      alternateScreen: true,
-      scrollbackAnsi: 'log'
-    }
-    try {
-      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame: true })) {
-        await writeTerminal(terminal, chunk)
-      }
-      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('')
-      for (const chunk of buildDeferredAltFrameReplayWrites(snapshot)) {
-        await writeTerminal(terminal, chunk)
-      }
-      expect(terminal.buffer.active.type).toBe('alternate')
-      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('FRAME')
-      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('log')
-    } finally {
-      terminal.dispose()
-    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,5 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
+import { isManagedPaneDisplayNone } from '@/lib/pane-manager/pane-display-visibility'
 
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
@@ -40,6 +41,32 @@ export function resolvePositiveTerminalDimensions(
  */
 export function readProposedTerminalCols(pane: ManagedPane): number | undefined {
   return readProposedPaneFitDimensions(pane)?.cols
+}
+
+/**
+ * Whether a withheld alt frame must be painted now, asked once the post-replay
+ * fit has already failed to land.
+ *
+ * Why display:none rather than "is the target still unknown": the skip is a
+ * deferral whose repaint rides that fit continuation, and only a hidden pane
+ * still owes one — its continuation is parked for the reveal (which is also why
+ * its completion resolves false immediately). A visible pane gets no second
+ * chance, so a permanently unmeasurable one (display:none never applied, but a
+ * box under the 48x24 fit floor: the divider clamp, a sliver from repeated
+ * splits) would lose the frame forever.
+ *
+ * The width re-check keeps #13014: if the pane did become measurable and is
+ * genuinely narrower than the capture grid, a later fit would clip the frame,
+ * so leave it withheld.
+ */
+export function shouldRepaintDeferredAltFrame(
+  pane: ManagedPane,
+  snapshotCols: number | undefined
+): boolean {
+  if (isManagedPaneDisplayNone(pane)) {
+    return false
+  }
+  return !shouldSkipAltFrameForWidthMismatch(snapshotCols, readProposedTerminalCols(pane))
 }
 
 export function shouldSkipAltFrameForWidthMismatch(
@@ -104,4 +131,14 @@ export function buildMainModelSnapshotReplayWrites(
   // blank cells; clear the alt buffer so the pre-hide frame can't bleed
   // through blank cells (spares normal-buffer scrollback).
   return ['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', ...altFrame]
+}
+
+/**
+ * Paints a frame a previous skipAltFrame replay withheld, once it is known no
+ * fit will move the grid off the capture grid. Only the alt-screen half: the
+ * normal buffer and its scrollback were already rebuilt by that replay and must
+ * not be replayed a second time.
+ */
+export function buildDeferredAltFrameReplayWrites(snapshot: { data: string }): string[] {
+  return buildMainModelSnapshotReplayWrites({ data: snapshot.data, alternateScreen: true })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,6 +1,5 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
-import { isManagedPaneDisplayNone } from '@/lib/pane-manager/pane-display-visibility'
 
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
@@ -36,50 +35,23 @@ export function resolvePositiveTerminalDimensions(
  * The column count the post-replay fit will land on. Why not terminal.cols: a
  * pane that has not been fitted yet still reads xterm's 80-column default, so
  * comparing against it would drop frames whose width actually matches the
- * container. Returns undefined when the pane cannot be measured; callers with
- * a repaint owner can clear and defer, while offline preconnect paint cannot.
+ * container. Returns undefined when the pane cannot be measured, so replay can
+ * retain the frame at its capture grid until a final fit exists.
  */
 export function readProposedTerminalCols(pane: ManagedPane): number | undefined {
   return readProposedPaneFitDimensions(pane)?.cols
 }
 
-/**
- * Whether a withheld alt frame must be painted now, asked once the post-replay
- * fit has already failed to land.
- *
- * Why display:none rather than "is the target still unknown": the skip is a
- * deferral whose repaint rides that fit continuation, and only a hidden pane
- * still owes one — its continuation is parked for the reveal (which is also why
- * its completion resolves false immediately). A visible pane gets no second
- * chance, so a permanently unmeasurable one (display:none never applied, but a
- * box under the 48x24 fit floor: the divider clamp, a sliver from repeated
- * splits) would lose the frame forever.
- *
- * The width re-check keeps #13014: if the pane did become measurable and is
- * genuinely narrower than the capture grid, a later fit would clip the frame,
- * so leave it withheld.
- */
-export function shouldRepaintDeferredAltFrame(
-  pane: ManagedPane,
-  snapshotCols: number | undefined
-): boolean {
-  if (isManagedPaneDisplayNone(pane)) {
-    return false
-  }
-  return !shouldSkipAltFrameForWidthMismatch(snapshotCols, readProposedTerminalCols(pane))
-}
-
 export function shouldSkipAltFrameForWidthMismatch(
   snapshotCols: number | undefined,
-  targetCols: number | undefined,
-  options: { skipIfTargetUnknown?: boolean } = {}
+  targetCols: number | undefined
 ): boolean {
   if (typeof snapshotCols !== 'number' || !Number.isFinite(snapshotCols) || snapshotCols <= 0) {
     return false
   }
   if (typeof targetCols !== 'number' || !Number.isFinite(targetCols) || targetCols <= 0) {
-    // A hidden pane has no final grid; its live app can repaint after the deferred fit.
-    return options.skipIfTargetUnknown === true
+    // Keep the frame at its capture grid until a real fit can replace that grid.
+    return false
   }
   // Fixed-grid alt rows clip at narrower columns; normal history remains reflowable.
   return snapshotCols > targetCols
@@ -131,14 +103,4 @@ export function buildMainModelSnapshotReplayWrites(
   // blank cells; clear the alt buffer so the pre-hide frame can't bleed
   // through blank cells (spares normal-buffer scrollback).
   return ['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', ...altFrame]
-}
-
-/**
- * Paints a frame a previous skipAltFrame replay withheld, once it is known no
- * fit will move the grid off the capture grid. Only the alt-screen half: the
- * normal buffer and its scrollback were already rebuilt by that replay and must
- * not be replayed a second time.
- */
-export function buildDeferredAltFrameReplayWrites(snapshot: { data: string }): string[] {
-  return buildMainModelSnapshotReplayWrites({ data: snapshot.data, alternateScreen: true })
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   resolvePaneLinkCwd,
   resolvePaneSeedCwd,
   resolveQueuedInitialCwd,
+  replayLayoutWithOneShotParkIntent,
   resetTerminalKeyboardProtocolAfterInterrupt,
   retireMountedTerminalPaneSurface,
   shouldDetachPaneTransportOnUnmount,
@@ -245,6 +246,35 @@ describe('splitPaneWithOneShotStartup', () => {
 
     expect(splitPane).toHaveBeenCalledTimes(1)
     expect(deps.startup).toBeNull()
+  })
+})
+
+describe('replayLayoutWithOneShotParkIntent', () => {
+  it('exposes park intent to replayed panes and clears it before later splits', () => {
+    const deps = { mountFollowsTerminalPark: true }
+    const observedByReplayedPane: boolean[] = []
+
+    const restored = replayLayoutWithOneShotParkIntent(deps, () => {
+      observedByReplayedPane.push(deps.mountFollowsTerminalPark)
+      return 'restored-panes'
+    })
+
+    expect(restored).toBe('restored-panes')
+    expect(observedByReplayedPane).toEqual([true])
+    // A split after replay reads the same deps object, so it must see ordinary reconnect semantics.
+    expect(deps.mountFollowsTerminalPark).toBe(false)
+  })
+
+  it('clears park intent even when layout replay throws', () => {
+    const deps = { mountFollowsTerminalPark: true }
+
+    expect(() =>
+      replayLayoutWithOneShotParkIntent(deps, () => {
+        throw new Error('replay failed')
+      })
+    ).toThrow('replay failed')
+
+    expect(deps.mountFollowsTerminalPark).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -480,6 +480,19 @@ export function splitPaneWithOneShotStartup<TPane>(
   }
 }
 
+/** Scopes `deps.mountFollowsTerminalPark` to the restored-layout replay. */
+export function replayLayoutWithOneShotParkIntent<TRestored>(
+  deps: { mountFollowsTerminalPark: boolean },
+  replayLayout: () => TRestored
+): TRestored {
+  // Why: only panes reconstructed by this replay belong to the park reveal; later splits must use ordinary reconnect semantics.
+  try {
+    return replayLayout()
+  } finally {
+    deps.mountFollowsTerminalPark = false
+  }
+}
+
 export function shouldDetachPaneTransportOnUnmount(args: {
   tabStillExists: boolean
   tabId: string
@@ -1564,9 +1577,9 @@ export function useTerminalPaneLifecycle({
       window.__paneManagers = window.__paneManagers ?? new Map()
       window.__paneManagers.set(tabId, manager)
     }
-    const restoredPaneByLeafId = replayTerminalLayout(manager, initialLayoutRef.current, isActive)
-    // Why: only panes reconstructed by this replay belong to the park reveal; later splits must use ordinary reconnect semantics.
-    ptyDeps.mountFollowsTerminalPark = false
+    const restoredPaneByLeafId = replayLayoutWithOneShotParkIntent(ptyDeps, () =>
+      replayTerminalLayout(manager, initialLayoutRef.current, isActive)
+    )
 
     const restoredBuffers = initialLayoutRef.current.buffersByLeafId
     restoreScrollbackBuffers(

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1565,6 +1565,8 @@ export function useTerminalPaneLifecycle({
       window.__paneManagers.set(tabId, manager)
     }
     const restoredPaneByLeafId = replayTerminalLayout(manager, initialLayoutRef.current, isActive)
+    // Why: only panes reconstructed by this replay belong to the park reveal; later splits must use ordinary reconnect semantics.
+    ptyDeps.mountFollowsTerminalPark = false
 
     const restoredBuffers = initialLayoutRef.current.buffersByLeafId
     restoreScrollbackBuffers(

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -126,6 +126,7 @@ import { markTerminalPinnedViewport } from '@/lib/pane-manager/terminal-scroll-i
 import { syncTerminalScrollIntentSoon } from '@/lib/pane-manager/terminal-scroll-intent-settle'
 import { registerRuntimeTerminalTab, scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { captureParkedTerminalPaneCandidates } from './terminal-parked-tab-watchers'
+import { useTerminalParkMountIntent } from './use-terminal-park-mount-intent'
 import { e2eConfig } from '@/lib/e2e-config'
 import {
   PRIMARY_SELECTION_MAX_LENGTH,
@@ -661,6 +662,7 @@ export function useTerminalPaneLifecycle({
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
   const previousVisibleForReconcileRef = useRef<TerminalPaneVisibilitySnapshot | null>(null)
+  const mountFollowsTerminalPark = useTerminalParkMountIntent(tabId)
   const linkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
   const terminalHandleLinkDisposablesRef = useRef(new Map<number, IDisposable>())
   const linkifierClickPrimingDisposablesRef = useRef(new Map<number, IDisposable>())
@@ -841,6 +843,7 @@ export function useTerminalPaneLifecycle({
       worktreeId,
       cwd: startupCwd,
       startup: startupWithSetupSplitWait,
+      mountFollowsTerminalPark,
       paneTransportsRef,
       paneMode2031Ref,
       paneKittyKeyboardModesRef,

--- a/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.react185.test.tsx
@@ -1,6 +1,5 @@
 /** @vitest-environment happy-dom */
-import { StrictMode, useEffect } from 'react'
-import { act } from 'react'
+import { StrictMode, act, useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it } from 'vitest'
 import { disposeParkedTabWatchers, parkedWatchersByTabId } from './terminal-parked-watcher-registry'

--- a/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.react185.test.tsx
@@ -25,6 +25,15 @@ function Parent() {
   return <Child />
 }
 
+function parkTab(): void {
+  parkedWatchersByTabId.set(TAB_ID, {
+    worktreeId: 'wt-1',
+    tabPtyId: 'pty-1',
+    paneIdByPtyId: new Map([['pty-1', 1]]),
+    disposersByPtyId: new Map([['pty-1', () => {}]])
+  })
+}
+
 afterEach(() => {
   observations.length = 0
   disposeParkedTabWatchers(TAB_ID)
@@ -32,12 +41,7 @@ afterEach(() => {
 
 describe('useTerminalParkMountIntent', () => {
   it('survives StrictMode effect replay after the parent disposes the watcher', () => {
-    parkedWatchersByTabId.set(TAB_ID, {
-      worktreeId: 'wt-1',
-      tabPtyId: 'pty-1',
-      paneIdByPtyId: new Map([['pty-1', 1]]),
-      disposersByPtyId: new Map([['pty-1', () => {}]])
-    })
+    parkTab()
     const container = document.createElement('div')
     const root = createRoot(container)
 
@@ -50,6 +54,23 @@ describe('useTerminalParkMountIntent', () => {
     })
 
     expect(observations).toEqual([true, true])
+    act(() => root.unmount())
+  })
+
+  // Why: the lifecycle effect re-runs on cwd changes for the same component
+  // instance, so intent cached per instance would resupply a stale park reveal.
+  it('re-reads park intent when the same instance re-renders after disposal', () => {
+    parkTab()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => root.render(<Child />))
+    expect(observations).toEqual([true])
+
+    disposeParkedTabWatchers(TAB_ID)
+    act(() => root.render(<Child />))
+
+    expect(observations).toEqual([true, false])
     act(() => root.unmount())
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.react185.test.tsx
@@ -1,0 +1,56 @@
+/** @vitest-environment happy-dom */
+import { StrictMode, useEffect } from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { disposeParkedTabWatchers, parkedWatchersByTabId } from './terminal-parked-watcher-registry'
+import { useTerminalParkMountIntent } from './use-terminal-park-mount-intent'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const TAB_ID = 'strict-park-reveal'
+const observations: boolean[] = []
+
+function Child(): null {
+  const mountFollowsTerminalPark = useTerminalParkMountIntent(TAB_ID)
+  useEffect(() => {
+    observations.push(mountFollowsTerminalPark)
+  }, [mountFollowsTerminalPark])
+  return null
+}
+
+function Parent() {
+  useEffect(() => {
+    disposeParkedTabWatchers(TAB_ID)
+  }, [])
+  return <Child />
+}
+
+afterEach(() => {
+  observations.length = 0
+  disposeParkedTabWatchers(TAB_ID)
+})
+
+describe('useTerminalParkMountIntent', () => {
+  it('survives StrictMode effect replay after the parent disposes the watcher', () => {
+    parkedWatchersByTabId.set(TAB_ID, {
+      worktreeId: 'wt-1',
+      tabPtyId: 'pty-1',
+      paneIdByPtyId: new Map([['pty-1', 1]]),
+      disposersByPtyId: new Map([['pty-1', () => {}]])
+    })
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <StrictMode>
+          <Parent />
+        </StrictMode>
+      )
+    })
+
+    expect(observations).toEqual([true, true])
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.ts
@@ -1,0 +1,10 @@
+import { useRef } from 'react'
+import { isTerminalTabParked } from './terminal-parked-watcher-registry'
+
+export function useTerminalParkMountIntent(tabId: string): boolean {
+  const followsParkRef = useRef<boolean | null>(null)
+  if (followsParkRef.current === null) {
+    followsParkRef.current = isTerminalTabParked(tabId)
+  }
+  return followsParkRef.current
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-park-mount-intent.ts
@@ -1,10 +1,9 @@
-import { useRef } from 'react'
 import { isTerminalTabParked } from './terminal-parked-watcher-registry'
 
+// Why render time: the host effect that disposes the watcher runs after every
+// child render, so reading here — not at connect time — is what lets a reveal
+// remount still see the park. Caching it per instance would instead resupply a
+// stale reveal on later same-instance effect re-runs (cwd change).
 export function useTerminalParkMountIntent(tabId: string): boolean {
-  const followsParkRef = useRef<boolean | null>(null)
-  if (followsParkRef.current === null) {
-    followsParkRef.current = isTerminalTabParked(tabId)
-  }
-  return followsParkRef.current
+  return isTerminalTabParked(tabId)
 }


### PR DESCRIPTION
## Summary

Alternate-screen TUIs could restore blank after a parked terminal remounted into a pane whose final grid was not yet measurable. Deeply split panes below the 48×24px / 8×4 fit floor were the clearest case: the frame was discarded as “target unknown,” but no successful fit remained to trigger the compensating repaint.

This regression was introduced by #13014 and surfaced by the failing pressure scenario split out of #13791.

## Fix

- Replay at the snapshot’s capture grid when the destination width is unknown.
- Skip a captured alt frame only when a confirmed narrower destination exists.
- Apply that rule consistently to hidden-output, daemon-reattach, and parked model-snapshot restore paths.
- Read park/reveal intent at render time, before the host disposes the tab's watchers, so an SSH reattach with empty relay replay still probes the retained headless snapshot.
- Consume that mount-only intent immediately after restored layout replay so later user-created splits keep ordinary reconnect behavior.

The earlier deferred-repaint draft was removed. The final design adds no timer, retry loop, duplicate frame write, wire change, provider branch, or ordinary reconnect probe. Park-intent detection costs one registry `Map` read per `TerminalPane` render.

An intermediate commit in this PR dropped the `deferPtyInput` hop, breaking mouse-report suppression during terminal link clicks; a later commit in the same PR restored it. The hop is therefore unchanged versus the merge base and shows no source hunk in this diff, but both optional-dependency branches now have coverage.

## Regression coverage

- Unknown and sub-floor targets retain their alt frame.
- Known narrower targets still omit the fixed-grid frame and rely on the final fit/repaint.
- All three replay call sites use the same decision.
- Pending escape-tail and post-replay reset ordering remains unchanged.
- StrictMode remount preserves park intent.
- Intent is cleared after restored layout replay so later splits do not inherit park-only snapshot work.
- Ordinary reattach remains free of snapshot probes.

## Validation

- Same-model high-effort review loop: **clean** after the final lifecycle correction.
- Focused terminal suite: **571 passed**.
- Typecheck, oxlint, native static analysis, changed-code quality, React Doctor, formatting, max-lines, and diff checks: passed.
- Exact-head CI: all Node 24/26 shards, compatibility checks, macOS package, Windows package, and verify are green.
- Exact SSH path: disposable Ubuntu 20.04/glibc 2.31 target, real remote repo and PTY, static alt frame ignoring `SIGWINCH`, production cold park/reveal, same remote PID retained, alternate buffer restored. [SSH evidence](https://github.com/stablyai/orca/pull/13882#issuecomment-5261937006)
- Exact final-head Electron QA via Orca-orchestrated Grok: full-width plus 11-pane deep split, including four sub-floor panes; all 11 restored to the alternate buffer with marker-backed and pixel-backed evidence. [Final Electron evidence](https://github.com/stablyai/orca/pull/13882#issuecomment-5262087388)

The full `artificial-opencode-terminal-load` spec was not rerun locally; CI path-skipped E2E because no E2E spec changed. Its core blank-sliver failure mode was exercised directly with static no-repaint frames in both local Electron and real SSH restore paths.

## Scope and compatibility

Renderer-local terminal lifecycle/replay only. No IPC or remote-wire shape changed, and no platform-specific path, shortcut, or shell behavior was added. Folder workspaces, git worktrees, local terminals, and SSH terminals keep their existing ownership boundaries.


