### PR TITLE
fix(settings): read voice settings from a ref, not a stale closure

### DIFF
--- a/src/renderer/src/components/settings/VoicePane.test.tsx
+++ b/src/renderer/src/components/settings/VoicePane.test.tsx
@@ -257,8 +257,8 @@ describe('VoicePane', () => {
   it('merges an in-flight voice write onto the newest settings, not the render-time snapshot', async () => {
     const updateSettings = vi.fn()
     let resolveClear: () => void = () => {}
-    const clearing = new Promise<void>((resolve) => {
-      resolveClear = resolve
+    const clearing = new Promise<{ configured: boolean }>((resolve) => {
+      resolveClear = () => resolve({ configured: false })
     })
     useAppStoreMock.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
       selector({

--- a/src/renderer/src/components/settings/VoicePane.test.tsx
+++ b/src/renderer/src/components/settings/VoicePane.test.tsx
@@ -253,4 +253,74 @@ describe('VoicePane', () => {
 
     expect(recordFeatureInteraction).not.toHaveBeenCalled()
   })
+
+  it('merges an in-flight voice write onto the newest settings, not the render-time snapshot', async () => {
+    const updateSettings = vi.fn()
+    let resolveClear: () => void = () => {}
+    const clearing = new Promise<void>((resolve) => {
+      resolveClear = resolve
+    })
+    useAppStoreMock.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        modelStates: [],
+        refreshModelStates: vi.fn(),
+        markFeatureTipsSeen: vi.fn(),
+        recordFeatureInteraction: vi.fn()
+      })
+    )
+    useShortcutLabelMock.mockReturnValue('Ctrl+Shift+Y')
+    installWindowApi(vi.fn(async () => deniedMicrophoneResult))
+    window.api.speech.getOpenAiApiKeyStatus = vi.fn(async () => ({ configured: true }))
+    window.api.speech.clearOpenAiApiKey = vi.fn(() => clearing)
+
+    const settingsWithKey = (enabled: boolean): GlobalSettings =>
+      ({
+        voice: {
+          ...getDefaultVoiceSettings(),
+          enabled,
+          openAiApiKeyConfigured: true,
+          microphoneDeviceId: 'usb-mic',
+          microphoneDeviceLabel: 'USB Microphone'
+        }
+      }) as GlobalSettings
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(<VoicePane settings={settingsWithKey(true)} updateSettings={updateSettings} />)
+    })
+
+    const disconnect = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Disconnect OpenAI API key"]'
+    )
+    if (!disconnect) {
+      throw new Error('Disconnect OpenAI API key button was not rendered')
+    }
+    await act(async () => {
+      disconnect.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // The user turns dictation off while the clear-key IPC is still in flight.
+    await act(async () => {
+      root.render(<VoicePane settings={settingsWithKey(false)} updateSettings={updateSettings} />)
+    })
+
+    await act(async () => {
+      resolveClear()
+      await clearing
+    })
+    root.unmount()
+
+    expect(updateSettings).toHaveBeenCalledTimes(1)
+    expect(updateSettings).toHaveBeenCalledWith({
+      voice: {
+        ...getDefaultVoiceSettings(),
+        enabled: false,
+        openAiApiKeyConfigured: false,
+        microphoneDeviceId: 'usb-mic',
+        microphoneDeviceLabel: 'USB Microphone'
+      }
+    })
+  })
 })

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -36,6 +36,12 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   const [openAiKeyPending, setOpenAiKeyPending] = useState(false)
   const [pendingCloudModelId, setPendingCloudModelId] = useState<string | null>(null)
   const mountedRef = useRef(true)
+  // Why: every write here is a read-modify-write of the whole voice object, and the
+  // writers are async (key status probe, save/clear key). Merging onto the render-time
+  // snapshot would resurrect settings that changed while the IPC was in flight — e.g.
+  // reverting `enabled` to false and leaving the microphone picker permanently disabled.
+  const voiceSettingsRef = useRef(voiceSettings)
+  voiceSettingsRef.current = voiceSettings
 
   const handlePaneRef = useCallback((node: HTMLDivElement | null): void => {
     mountedRef.current = node !== null
@@ -45,12 +51,12 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
     (updates: Partial<VoiceSettings>): void => {
       updateSettings({
         voice: {
-          ...voiceSettings,
+          ...voiceSettingsRef.current,
           ...updates
         }
       })
     },
-    [updateSettings, voiceSettings]
+    [updateSettings]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -40,8 +40,11 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   // writers are async (key status probe, save/clear key). Merging onto the render-time
   // snapshot would resurrect settings that changed while the IPC was in flight — e.g.
   // reverting `enabled` to false and leaving the microphone picker permanently disabled.
+  // Written in an effect, not during render: the async writers all run post-commit.
   const voiceSettingsRef = useRef(voiceSettings)
-  voiceSettingsRef.current = voiceSettings
+  useEffect(() => {
+    voiceSettingsRef.current = voiceSettings
+  }, [voiceSettings])
 
   const handlePaneRef = useCallback((node: HTMLDivElement | null): void => {
     mountedRef.current = node !== null

--- a/tests/e2e/voice-microphone-selection.spec.ts
+++ b/tests/e2e/voice-microphone-selection.spec.ts
@@ -89,25 +89,6 @@ async function prepareVoiceSettings(
     await page.getByRole('button', { name: 'Maybe Later' }).click()
   }
   await expect(page.getByRole('heading', { name: 'Voice', exact: true })).toBeVisible()
-  // Why: the microphone Select is disabled until voice.enabled hydrates into the renderer
-  // store, and "System default" renders identically before and after hydration — so the
-  // text assertions below are not a barrier. Wait on the store value the pane actually reads.
-  await expect
-    .poll(
-      () =>
-        page.evaluate(() => {
-          const voice = window.__store?.getState().settings?.voice
-          return voice
-            ? {
-                enabled: voice.enabled,
-                deviceId: voice.microphoneDeviceId ?? null,
-                label: voice.microphoneDeviceLabel ?? null
-              }
-            : null
-        }),
-      { message: 'voice settings did not hydrate into the renderer store' }
-    )
-    .toEqual({ enabled: true, deviceId: microphoneDeviceId, label: microphoneDeviceLabel })
 }
 
 async function readMicrophoneSettings(
@@ -135,7 +116,6 @@ test.describe('Voice microphone selection', () => {
 
     const microphone = orcaPage.getByRole('combobox', { name: 'Microphone' })
     await expect(microphone).toHaveText('System default')
-    await expect(microphone).toBeEnabled()
     await microphone.click()
     await expect(orcaPage.getByRole('option', { name: 'USB Microphone' })).toBeVisible()
     await orcaPage.getByRole('option', { name: 'USB Microphone' }).click()
@@ -167,7 +147,6 @@ test.describe('Voice microphone selection', () => {
     await prepareVoiceSettings(orcaPage, 'stale-airpods-id', 'AirPods')
 
     const microphone = orcaPage.getByRole('combobox', { name: 'Microphone' })
-    await expect(microphone).toBeEnabled()
     await microphone.click()
     await expect(orcaPage.getByRole('option', { name: 'AirPods (unavailable)' })).toBeVisible()
     await orcaPage.keyboard.press('Escape')

--- a/tests/e2e/voice-microphone-selection.spec.ts
+++ b/tests/e2e/voice-microphone-selection.spec.ts
@@ -89,6 +89,25 @@ async function prepareVoiceSettings(
     await page.getByRole('button', { name: 'Maybe Later' }).click()
   }
   await expect(page.getByRole('heading', { name: 'Voice', exact: true })).toBeVisible()
+  // Why: the microphone Select is disabled until voice.enabled hydrates into the renderer
+  // store, and "System default" renders identically before and after hydration — so the
+  // text assertions below are not a barrier. Wait on the store value the pane actually reads.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const voice = window.__store?.getState().settings?.voice
+          return voice
+            ? {
+                enabled: voice.enabled,
+                deviceId: voice.microphoneDeviceId ?? null,
+                label: voice.microphoneDeviceLabel ?? null
+              }
+            : null
+        }),
+      { message: 'voice settings did not hydrate into the renderer store' }
+    )
+    .toEqual({ enabled: true, deviceId: microphoneDeviceId, label: microphoneDeviceLabel })
 }
 
 async function readMicrophoneSettings(
@@ -116,6 +135,7 @@ test.describe('Voice microphone selection', () => {
 
     const microphone = orcaPage.getByRole('combobox', { name: 'Microphone' })
     await expect(microphone).toHaveText('System default')
+    await expect(microphone).toBeEnabled()
     await microphone.click()
     await expect(orcaPage.getByRole('option', { name: 'USB Microphone' })).toBeVisible()
     await orcaPage.getByRole('option', { name: 'USB Microphone' }).click()
@@ -147,6 +167,7 @@ test.describe('Voice microphone selection', () => {
     await prepareVoiceSettings(orcaPage, 'stale-airpods-id', 'AirPods')
 
     const microphone = orcaPage.getByRole('combobox', { name: 'Microphone' })
+    await expect(microphone).toBeEnabled()
     await microphone.click()
     await expect(orcaPage.getByRole('option', { name: 'AirPods (unavailable)' })).toBeVisible()
     await orcaPage.keyboard.press('Escape')


### PR DESCRIPTION
Split out of #13791. **Draft — incidental fix, unrelated to any failing E2E.**

No owner to point at; this is a latent stale-closure bug, not a regression from a specific PR.

## Bug

`updateVoiceSettings` wrote from a closure captured at mount, so an async continuation could clobber a newer value. Switched to the latest-ref pattern already used in `Settings.tsx:405-407`. Unit test verified red before / green after; whole settings dir green (149 files / 1007 tests).

## Honest status

Found while investigating `voice-microphone-selection.spec.ts:107` and **confirmed not to be its cause**. That failure still has **no established root cause** — three theories proposed, all three refuted with evidence:

1. *"Settings have not hydrated, so the control is disabled."* The CI a11y snapshot at failure shows `switch "Enable Voice Dictation" [checked]` and `combobox "Microphone" [cursor=pointer]`, no disabled marker.
2. *"click({force: true})".* Bypasses the actionability contract rather than fixing it.
3. *"backgroundThrottling starves rAF in a never-shown window."* A probe against the real app measured 60Hz rAF and `rectChangesAcross240Frames: 0`.

All probes ran on macOS without the Linux-only launch switches (`--no-sandbox --disable-gpu --in-process-gpu`) and without xvfb. Remaining hypothesis is platform-specific frame production; needs a real Linux runner.

The spec also gains a hydration barrier and `toBeEnabled()` assertions here. Those improve the failure message; they do not fix it.

Made with [Orca](https://github.com/stablyai/orca) 🐋
