### PR TITLE
fix(bitbucket): commit credentials atomically and stop blaming the token for network faults

### DIFF
--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -223,6 +223,28 @@ describe('Bitbucket client', () => {
     ])
   })
 
+  it('does not report an unreachable host as an auth failure (STA-3944)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      })
+    )
+    await expect(getBitbucketAuthStatus()).resolves.toMatchObject({
+      configured: true,
+      authenticated: true
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 401 }))
+    )
+    await expect(getBitbucketAuthStatus()).resolves.toMatchObject({
+      configured: true,
+      authenticated: false
+    })
+  })
+
   it('fetches a branch pull request and commit build status', async () => {
     const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
       if (url.includes('/statuses/build')) {

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -15,7 +15,7 @@ import {
 } from '../source-control/hosted-review-git-options'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 import { authHeaders, getEnvAuthConfig, hasAuth } from './bitbucket-auth-config'
-import { accountNameFromUser, fetchBitbucketUser } from './user-request'
+import { accountNameFromUser, fetchBitbucketUserResult } from './user-request'
 import {
   getStoredBitbucketCredentialError,
   getStoredBitbucketMetadata,
@@ -154,11 +154,14 @@ async function normalizePullRequest(
 export async function getBitbucketAuthStatus(): Promise<BitbucketAuthStatus> {
   const env = getEnvAuthConfig()
   if (hasAuth(env)) {
-    const user = await fetchBitbucketUser(env)
+    const result = await fetchBitbucketUserResult(env)
     return {
       configured: true,
-      authenticated: user !== null,
-      account: accountNameFromUser(user)
+      // Why (STA-3944): only a rejection means the credential is bad. An
+      // unreachable host must not render as "Auth failed" and send the user
+      // off to regenerate a token that still works.
+      authenticated: result.ok || result.reason === 'unreachable',
+      account: result.ok ? accountNameFromUser(result.user) : null
     }
   }
   const metadata = getStoredBitbucketMetadata()
@@ -170,11 +173,11 @@ export async function getBitbucketAuthStatus(): Promise<BitbucketAuthStatus> {
     if (!cached) {
       return { configured: true, authenticated: true, account: metadata.account }
     }
-    const user = await fetchBitbucketUser(storedAuthConfig(metadata, cached))
+    const result = await fetchBitbucketUserResult(storedAuthConfig(metadata, cached))
     return {
       configured: true,
-      authenticated: user !== null,
-      account: accountNameFromUser(user) ?? metadata.account
+      authenticated: result.ok || result.reason === 'unreachable',
+      account: (result.ok ? accountNameFromUser(result.user) : null) ?? metadata.account
     }
   }
   return { configured: false, authenticated: false, account: null }

--- a/src/main/bitbucket/credential-connection.test.ts
+++ b/src/main/bitbucket/credential-connection.test.ts
@@ -95,6 +95,30 @@ describe('Bitbucket credential connection', () => {
     expect(conn.getBitbucketConnectionStatus().source).toBe('none')
   })
 
+  it('separates a rejected credential from an unreachable host (STA-3944)', async () => {
+    const conn = await loadModule()
+
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 401 })
+    ) as unknown as typeof fetch
+    const rejected = await conn.connectBitbucket({ authMode: 'token', accessToken: 'bad' })
+    expect(!rejected.ok && rejected.error).toMatch(/rejected these credentials/i)
+
+    // Why: a timeout or 5xx says nothing about the token; calling it invalid
+    // sends the user off to regenerate a credential that still works.
+    for (const failure of [
+      async () => {
+        throw new Error('network down')
+      },
+      async () => new Response(null, { status: 503 })
+    ]) {
+      globalThis.fetch = vi.fn(failure) as unknown as typeof fetch
+      const unreachable = await conn.connectBitbucket({ authMode: 'token', accessToken: 'good' })
+      expect(!unreachable.ok && unreachable.error).toMatch(/could not reach bitbucket/i)
+    }
+    expect(conn.getBitbucketConnectionStatus().source).toBe('none')
+  })
+
   it('rejects an incomplete basic-auth credential before making a request', async () => {
     const conn = await loadModule()
     const fetchSpy = vi.fn()

--- a/src/main/bitbucket/credential-connection.ts
+++ b/src/main/bitbucket/credential-connection.ts
@@ -5,7 +5,7 @@ import {
   hasAuth,
   type BitbucketAuthConfig
 } from './bitbucket-auth-config'
-import { accountNameFromUser, fetchBitbucketUser } from './user-request'
+import { accountNameFromUser, fetchBitbucketUserResult } from './user-request'
 import {
   clearStoredBitbucketCredential,
   getStoredBitbucketMetadata,
@@ -51,14 +51,19 @@ export async function connectBitbucket(
           : 'Enter both an email and an API token.'
     }
   }
-  const user = await fetchBitbucketUser(config, VERIFY_TIMEOUT_MS)
-  if (!user) {
+  const result = await fetchBitbucketUserResult(config, VERIFY_TIMEOUT_MS)
+  if (!result.ok) {
     return {
       ok: false,
-      error: 'Could not authenticate with Bitbucket. Check the credentials and try again.'
+      // Why (STA-3944): telling someone their token is invalid when the network
+      // is down sends them to regenerate a credential that was fine.
+      error:
+        result.reason === 'rejected'
+          ? 'Bitbucket rejected these credentials. Check the email and token, then try again.'
+          : 'Could not reach Bitbucket. Check your connection or the API base URL, then try again.'
     }
   }
-  const account = accountNameFromUser(user)
+  const account = accountNameFromUser(result.user)
   saveBitbucketCredential({
     authMode: input.authMode,
     email: config.email,

--- a/src/main/bitbucket/credential-store.test.ts
+++ b/src/main/bitbucket/credential-store.test.ts
@@ -8,8 +8,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 let tempHome = ''
 const decryptStringMock = vi.fn((value: Buffer) => value.toString('utf-8'))
 
-async function loadStore(options: { unlinkError?: NodeJS.ErrnoException } = {}) {
+async function loadStore(
+  options: { unlinkError?: NodeJS.ErrnoException; writeError?: Error } = {}
+) {
   vi.resetModules()
+  // Why: doMock registrations outlive resetModules, so an injected failure from
+  // one case would leak into every later one in this file.
+  vi.doUnmock('node:fs')
   vi.doMock('electron', () => ({
     safeStorage: {
       isEncryptionAvailable: () => true,
@@ -21,6 +26,18 @@ async function loadStore(options: { unlinkError?: NodeJS.ErrnoException } = {}) 
     const actual = await vi.importActual<typeof Os>('node:os')
     return { ...actual, homedir: () => tempHome }
   })
+  if (options.writeError) {
+    const error = options.writeError
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof Fs>('node:fs')
+      return {
+        ...actual,
+        writeSync: () => {
+          throw error
+        }
+      }
+    })
+  }
   if (options.unlinkError) {
     // Why mocked: chmod-based failure injection is not portable — Windows has no
     // POSIX modes and a root/elevated runner can unlink through a 0500 directory.
@@ -61,9 +78,13 @@ describe('Bitbucket credential store', () => {
       email: 'ada@example.com',
       account: 'ada'
     })
-    expect(store.loadStoredBitbucketSecret()).toEqual({
+    expect(store.loadStoredBitbucketSecret()).toMatchObject({
       accessToken: null,
-      apiToken: 'secret-token'
+      apiToken: 'secret-token',
+      // Why (STA-3941): auth fields live in the envelope so a torn write cannot
+      // pair a new secret with a stale email.
+      authMode: 'basic',
+      email: 'ada@example.com'
     })
   })
 
@@ -131,9 +152,10 @@ describe('Bitbucket credential store', () => {
     expect(decryptStringMock).not.toHaveBeenCalled()
 
     // Forcing the load decrypts exactly once, then caches.
-    expect(store.loadStoredBitbucketSecret({ force: true })).toEqual({
+    expect(store.loadStoredBitbucketSecret({ force: true })).toMatchObject({
       accessToken: 'access-secret',
-      apiToken: null
+      apiToken: null,
+      authMode: 'token'
     })
     expect(decryptStringMock).toHaveBeenCalledTimes(1)
     expect(store.loadStoredBitbucketSecret()).not.toBeNull()
@@ -163,9 +185,101 @@ describe('Bitbucket credential store', () => {
     store._resetBitbucketCredentialCache()
 
     expect(store.getStoredBitbucketMetadata()).toMatchObject({ email: null, account: null })
-    expect(store.loadStoredBitbucketSecret({ force: true })).toEqual({
+    expect(store.loadStoredBitbucketSecret({ force: true })).toMatchObject({
       accessToken: null,
       apiToken: null
+    })
+  })
+
+  it('keeps the previous credential intact when the secret write fails (STA-3941)', async () => {
+    const store = await loadStore()
+    store.saveBitbucketCredential({
+      authMode: 'basic',
+      email: 'ada@example.com',
+      baseUrl: null,
+      account: 'ada',
+      accessToken: null,
+      apiToken: 'first-token'
+    })
+    const { readFileSync } = await import('node:fs')
+    const before = readFileSync(join(tempHome, '.orca', 'bitbucket-credential.enc'))
+
+    // Why: a direct write truncates in place, so a failure mid-write used to
+    // destroy the only working credential. The temp+rename path cannot.
+    const failing = await loadStore({ writeError: new Error('disk full') })
+    expect(() =>
+      failing.saveBitbucketCredential({
+        authMode: 'basic',
+        email: 'grace@example.com',
+        baseUrl: null,
+        account: 'grace',
+        accessToken: null,
+        apiToken: 'second-token'
+      })
+    ).toThrow(/disk full/)
+
+    expect(readFileSync(join(tempHome, '.orca', 'bitbucket-credential.enc'))).toEqual(before)
+    expect(existsSync(join(tempHome, '.orca', 'bitbucket-credential.enc.tmp'))).toBe(false)
+  })
+
+  it('authenticates from the envelope when metadata is stale (STA-3941)', async () => {
+    const store = await loadStore()
+    store.saveBitbucketCredential({
+      authMode: 'basic',
+      email: 'grace@example.com',
+      baseUrl: null,
+      account: 'grace',
+      accessToken: null,
+      apiToken: 'second-token'
+    })
+
+    // Simulate an interrupt between publishing the secret and the metadata:
+    // metadata still describes the previous connection.
+    const { writeFileSync } = await import('node:fs')
+    writeFileSync(
+      join(tempHome, '.orca', 'bitbucket-credential.json'),
+      JSON.stringify({
+        version: 1,
+        authMode: 'basic',
+        email: 'ada@example.com',
+        baseUrl: null,
+        account: 'ada',
+        updatedAt: ''
+      })
+    )
+    store._resetBitbucketCredentialCache()
+
+    const { resolveBitbucketAuthConfig } = await import('./resolve-auth')
+    // Auth follows the envelope, so the pair stays usable; only the displayed
+    // account is stale until the next status refresh.
+    expect(resolveBitbucketAuthConfig()).toMatchObject({
+      email: 'grace@example.com',
+      apiToken: 'second-token'
+    })
+  })
+
+  it('still authenticates a credential saved before the envelope carried auth fields', async () => {
+    const store = await loadStore()
+    store.saveBitbucketCredential({
+      authMode: 'basic',
+      email: 'ada@example.com',
+      baseUrl: null,
+      account: 'ada',
+      accessToken: null,
+      apiToken: 'legacy-token'
+    })
+    const { writeFileSync } = await import('node:fs')
+    // Legacy envelopes held only the two tokens.
+    writeFileSync(
+      join(tempHome, '.orca', 'bitbucket-credential.enc'),
+      JSON.stringify({ accessToken: null, apiToken: 'legacy-token' })
+    )
+    store._resetBitbucketCredentialCache()
+
+    const { resolveBitbucketAuthConfig } = await import('./resolve-auth')
+    expect(resolveBitbucketAuthConfig()).toMatchObject({
+      email: 'ada@example.com',
+      apiToken: 'legacy-token'
     })
   })
 

--- a/src/main/bitbucket/credential-store.test.ts
+++ b/src/main/bitbucket/credential-store.test.ts
@@ -9,7 +9,11 @@ let tempHome = ''
 const decryptStringMock = vi.fn((value: Buffer) => value.toString('utf-8'))
 
 async function loadStore(
-  options: { unlinkError?: NodeJS.ErrnoException; writeError?: Error } = {}
+  options: {
+    unlinkError?: NodeJS.ErrnoException
+    writeError?: Error
+    shortWrites?: boolean
+  } = {}
 ) {
   vi.resetModules()
   // Why: doMock registrations outlive resetModules, so an injected failure from
@@ -26,6 +30,18 @@ async function loadStore(
     const actual = await vi.importActual<typeof Os>('node:os')
     return { ...actual, homedir: () => tempHome }
   })
+  if (options.shortWrites) {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof Fs>('node:fs')
+      return {
+        ...actual,
+        // Why: write(2) may return a short count; publishing without looping
+        // would rename a truncated credential into place.
+        writeSync: (fd: number, data: Buffer, offset = 0, length = data.length) =>
+          actual.writeSync(fd, data, offset, Math.min(1, length))
+      }
+    })
+  }
   if (options.writeError) {
     const error = options.writeError
     vi.doMock('node:fs', async () => {
@@ -281,6 +297,25 @@ describe('Bitbucket credential store', () => {
       email: 'ada@example.com',
       apiToken: 'legacy-token'
     })
+  })
+
+  it('writes the whole credential even when the filesystem short-writes (STA-3941)', async () => {
+    const store = await loadStore({ shortWrites: true })
+    store.saveBitbucketCredential({
+      authMode: 'basic',
+      email: 'ada@example.com',
+      baseUrl: null,
+      account: 'ada',
+      accessToken: null,
+      apiToken: 'a-token-long-enough-to-need-several-writes'
+    })
+    store._resetBitbucketCredentialCache()
+
+    expect(store.loadStoredBitbucketSecret({ force: true })).toMatchObject({
+      apiToken: 'a-token-long-enough-to-need-several-writes',
+      email: 'ada@example.com'
+    })
+    expect(store.getStoredBitbucketMetadata()?.account).toBe('ada')
   })
 
   it('clears both files and in-memory state on disconnect', async () => {

--- a/src/main/bitbucket/credential-store.ts
+++ b/src/main/bitbucket/credential-store.ts
@@ -1,11 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import {
   CredentialDecryptionError,
   credentialFileHasContent,
   readStoredCredentialToken,
-  restrictCredentialFileToOwner,
+  writeCredentialFileAtomic,
   writeEncryptedCredential
 } from '../integration-credential-file'
 import type { BitbucketAuthMode } from '../../shared/bitbucket-credentials'
@@ -22,9 +22,16 @@ export type BitbucketStoredMetadata = {
   updatedAt: string
 }
 
+// Why (STA-3941): the envelope carries everything auth needs, so a torn write
+// between the two files can only leave stale display metadata — never a new
+// secret paired with an old email that cannot authenticate. Fields are optional
+// because credentials saved before this change hold only the two tokens.
 export type BitbucketStoredSecret = {
   accessToken: string | null
   apiToken: string | null
+  authMode?: BitbucketAuthMode
+  email?: string | null
+  baseUrl?: string | null
 }
 
 export type BitbucketCredentialSaveInput = {
@@ -131,7 +138,12 @@ export function loadStoredBitbucketSecret(
     const parsed = JSON.parse(token) as Partial<BitbucketStoredSecret>
     cachedSecret = {
       accessToken: asOptionalString(parsed.accessToken),
-      apiToken: asOptionalString(parsed.apiToken)
+      apiToken: asOptionalString(parsed.apiToken),
+      ...(parsed.authMode === 'token' || parsed.authMode === 'basic'
+        ? { authMode: parsed.authMode }
+        : {}),
+      email: asOptionalString(parsed.email),
+      baseUrl: asOptionalString(parsed.baseUrl)
     }
     credentialError = null
     return cachedSecret
@@ -148,7 +160,10 @@ export function saveBitbucketCredential(input: BitbucketCredentialSaveInput): vo
   ensureOrcaDir()
   const secret: BitbucketStoredSecret = {
     accessToken: input.accessToken,
-    apiToken: input.apiToken
+    apiToken: input.apiToken,
+    authMode: input.authMode,
+    email: input.email,
+    baseUrl: input.baseUrl
   }
   writeEncryptedCredential('Bitbucket', getSecretPath(), JSON.stringify(secret))
   const metadata: BitbucketStoredMetadata = {
@@ -159,11 +174,10 @@ export function saveBitbucketCredential(input: BitbucketCredentialSaveInput): vo
     account: input.account,
     updatedAt: new Date().toISOString()
   }
-  writeFileSync(getMetadataPath(), JSON.stringify(metadata, null, 2), {
-    encoding: 'utf-8',
-    mode: 0o600
-  })
-  restrictCredentialFileToOwner(getMetadataPath())
+  writeCredentialFileAtomic(
+    getMetadataPath(),
+    Buffer.from(JSON.stringify(metadata, null, 2), 'utf-8')
+  )
   cachedMetadata = metadata
   metadataLoadedFromDisk = true
   cachedSecret = secret

--- a/src/main/bitbucket/pull-request-creation.ts
+++ b/src/main/bitbucket/pull-request-creation.ts
@@ -8,8 +8,9 @@ import {
   requestHostedReviewJson
 } from '../source-control/hosted-review-api-request'
 import { readHostedPullRequestTemplate } from '../source-control/pull-request-template'
-import { authHeaders, hasAuth } from './bitbucket-auth-config'
+import { authHeaders, getEnvAuthConfig, hasAuth } from './bitbucket-auth-config'
 import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { hasStoredBitbucketCredential } from './credential-store'
 import { getBitbucketPullRequestForBranch } from './client'
 import { mapBitbucketPullRequest, type RawBitbucketPullRequest } from './pull-request-mappers'
 import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
@@ -18,8 +19,12 @@ import { getHostedReviewLocalGitOptions } from '../source-control/hosted-review-
 
 const CREATE_REQUEST_TIMEOUT_MS = 60_000
 
+// Why: eligibility is evaluated proactively for the sidebar, so this must not
+// decrypt — forcing the secret open here would pop an OS keychain prompt just
+// from opening a worktree. Presence is enough; the create call itself still
+// fails closed if the credential turns out to be unusable.
 export function isBitbucketReviewCreationAuthenticated(): boolean {
-  return hasAuth(resolveBitbucketAuthConfig())
+  return hasAuth(getEnvAuthConfig()) || hasStoredBitbucketCredential()
 }
 
 function encodedRepoPath(repo: BitbucketRepoRef): string {

--- a/src/main/bitbucket/resolve-auth.ts
+++ b/src/main/bitbucket/resolve-auth.ts
@@ -12,17 +12,26 @@ import {
   type BitbucketStoredSecret
 } from './credential-store'
 
+/**
+ * Why (STA-3941): the encrypted envelope is authoritative for auth. Plaintext
+ * metadata is only consulted for credentials written before the envelope
+ * carried these fields, so a torn write between the two files degrades to stale
+ * display data rather than a secret paired with the wrong email.
+ */
 export function storedAuthConfig(
-  metadata: BitbucketStoredMetadata,
+  metadata: BitbucketStoredMetadata | null,
   secret: BitbucketStoredSecret
 ): BitbucketAuthConfig {
+  const authMode = secret.authMode ?? metadata?.authMode ?? null
+  const email = secret.authMode ? (secret.email ?? null) : (metadata?.email ?? null)
+  const baseUrl = secret.authMode ? (secret.baseUrl ?? null) : (metadata?.baseUrl ?? null)
   return {
     // Why: an explicit ORCA_BITBUCKET_API_BASE_URL still wins even when the
     // credential itself is stored — env precedence is per-setting, not all-or-nothing.
-    baseUrl: envValue('ORCA_BITBUCKET_API_BASE_URL') ?? metadata.baseUrl ?? DEFAULT_API_BASE_URL,
-    accessToken: metadata.authMode === 'token' ? secret.accessToken : null,
-    email: metadata.authMode === 'basic' ? metadata.email : null,
-    apiToken: metadata.authMode === 'basic' ? secret.apiToken : null
+    baseUrl: envValue('ORCA_BITBUCKET_API_BASE_URL') ?? baseUrl ?? DEFAULT_API_BASE_URL,
+    accessToken: authMode === 'token' ? secret.accessToken : null,
+    email: authMode === 'basic' ? email : null,
+    apiToken: authMode === 'basic' ? secret.apiToken : null
   }
 }
 
@@ -34,13 +43,9 @@ export function resolveBitbucketAuthConfig(): BitbucketAuthConfig {
   if (hasAuth(env)) {
     return env
   }
-  const metadata = getStoredBitbucketMetadata()
-  if (!metadata) {
-    return env
-  }
   try {
     const secret = loadStoredBitbucketSecret({ force: true })
-    return secret ? storedAuthConfig(metadata, secret) : env
+    return secret ? storedAuthConfig(getStoredBitbucketMetadata(), secret) : env
   } catch {
     // Decryption denied or unavailable: fall through as unauthenticated.
     return env

--- a/src/main/bitbucket/user-request.ts
+++ b/src/main/bitbucket/user-request.ts
@@ -9,31 +9,57 @@ export type RawBitbucketUser = {
   account_id?: string | null
 }
 
+/**
+ * Why (STA-3944): a timeout, DNS failure, 5xx, or unparseable body says nothing
+ * about the credential. Collapsing those to the same miss as a 401 told users
+ * their token was invalid when the network was simply unreachable.
+ */
+export type BitbucketUserResult =
+  | { ok: true; user: RawBitbucketUser }
+  | { ok: false; reason: 'rejected' | 'unreachable' }
+
 export function accountNameFromUser(user: RawBitbucketUser | null): string | null {
   return user?.username ?? user?.display_name ?? user?.account_id ?? null
 }
 
 // Shared by live env-var status checks and by connect-time verification, so a
 // credential is proven against `/user` before it is ever persisted.
-export async function fetchBitbucketUser(
+export async function fetchBitbucketUserResult(
   config: BitbucketAuthConfig,
   timeoutMs: number = USER_REQUEST_TIMEOUT_MS
-): Promise<RawBitbucketUser | null> {
+): Promise<BitbucketUserResult> {
+  let response: Response
   try {
     const base = config.baseUrl.replace(/\/+$/, '')
-    const response = await fetch(`${base}/user`, {
+    response = await fetch(`${base}/user`, {
       headers: {
         Accept: 'application/json',
         ...authHeaders(config)
       },
       signal: AbortSignal.timeout(timeoutMs)
     })
-    if (!response.ok) {
-      await cancelUnreadResponseBody(response)
-      return null
-    }
-    return (await response.json()) as RawBitbucketUser
   } catch {
-    return null
+    return { ok: false, reason: 'unreachable' }
   }
+  if (!response.ok) {
+    await cancelUnreadResponseBody(response)
+    // Only the credential-bearing statuses are the credential's fault; 5xx and
+    // the rest are the server or the path in between.
+    const rejected = response.status === 401 || response.status === 403
+    return { ok: false, reason: rejected ? 'rejected' : 'unreachable' }
+  }
+  try {
+    return { ok: true, user: (await response.json()) as RawBitbucketUser }
+  } catch {
+    return { ok: false, reason: 'unreachable' }
+  }
+}
+
+/** Convenience for callers that only need the account, not the failure reason. */
+export async function fetchBitbucketUser(
+  config: BitbucketAuthConfig,
+  timeoutMs: number = USER_REQUEST_TIMEOUT_MS
+): Promise<RawBitbucketUser | null> {
+  const result = await fetchBitbucketUserResult(config, timeoutMs)
+  return result.ok ? result.user : null
 }

--- a/src/main/integration-credential-file.ts
+++ b/src/main/integration-credential-file.ts
@@ -50,7 +50,16 @@ export function writeCredentialFileAtomic(path: string, data: Buffer): void {
   let handle: number | null = null
   try {
     handle = openSync(tempPath, 'w', 0o600)
-    writeSync(handle, data)
+    // Why: write(2) is allowed to return a short count, so a single writeSync
+    // could publish a truncated credential — the very corruption this avoids.
+    let written = 0
+    while (written < data.length) {
+      const bytes = writeSync(handle, data, written, data.length - written)
+      if (bytes <= 0) {
+        throw new Error(`Credential write stalled at ${written}/${data.length} bytes`)
+      }
+      written += bytes
+    }
     fsyncSync(handle)
     closeSync(handle)
     handle = null

--- a/src/main/integration-credential-file.ts
+++ b/src/main/integration-credential-file.ts
@@ -1,4 +1,13 @@
-import { chmodSync, statSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeSync
+} from 'node:fs'
 import { safeStorage } from 'electron'
 import {
   credentialDecryptionMessage,
@@ -23,15 +32,45 @@ export function writeEncryptedCredential(
   value: string
 ): void {
   if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(path, safeStorage.encryptString(value), { mode: 0o600 })
-    restrictCredentialFileToOwner(path)
+    writeCredentialFileAtomic(path, safeStorage.encryptString(value))
     return
   }
   console.warn(
     `[${service.toLowerCase()}] safeStorage encryption unavailable — storing credential in plaintext`
   )
-  writeFileSync(path, value, { encoding: 'utf-8', mode: 0o600 })
-  restrictCredentialFileToOwner(path)
+  writeCredentialFileAtomic(path, Buffer.from(value, 'utf-8'))
+}
+
+// Why (STA-3941): a direct write can truncate the previous credential if it
+// fails or the app dies mid-write, leaving nothing to authenticate with. Write
+// a sibling temp file, fsync it, then rename — readers only ever observe the
+// old bytes or the complete new ones.
+export function writeCredentialFileAtomic(path: string, data: Buffer): void {
+  const tempPath = `${path}.tmp`
+  let handle: number | null = null
+  try {
+    handle = openSync(tempPath, 'w', 0o600)
+    writeSync(handle, data)
+    fsyncSync(handle)
+    closeSync(handle)
+    handle = null
+    renameSync(tempPath, path)
+    restrictCredentialFileToOwner(path)
+  } catch (error) {
+    if (handle !== null) {
+      try {
+        closeSync(handle)
+      } catch {
+        // Already closed or invalid; the unlink below is what matters.
+      }
+    }
+    try {
+      unlinkSync(tempPath)
+    } catch {
+      // Nothing to clean up.
+    }
+    throw error
+  }
 }
 
 // Why: writeFileSync's `mode` only applies when it creates the file, so


### PR DESCRIPTION
Fixes [STA-3941](https://linear.app/stably/issue/STA-3941) (P0) and [STA-3944](https://linear.app/stably/issue/STA-3944) (P2), both from continuous readiness against #5832.

## STA-3941 — a credential edit could destroy the last working pair

Two independent problems, same write path:

**Non-atomic replace.** `writeEncryptedCredential` used `writeFileSync`, which truncates in place. A failure or crash mid-write left the previous secret truncated — nothing to authenticate with, and nothing to roll back to.

**Torn pair.** The secret and the plaintext metadata were published as two separate writes. A crash between them left a *new* secret paired with the *old* email and auth mode. On restart the two files load independently, so basic auth sends the new token with the previous email and fails, with no way for the user to tell why.

### Fix

- **Atomic publish** — credential files are written to a sibling temp file, fsynced, then renamed over the target. A reader sees either the old bytes or the complete new ones. The temp file is cleaned up on failure.
- **Envelope owns auth** — `authMode`, `email` and `baseUrl` now live inside the encrypted envelope, and the plaintext metadata becomes display-only. Auth resolves from the single atomically-replaced file, so a torn write can only leave a stale *displayed* account, never an unusable credential. This preserves the no-decrypt-on-status property, since status still reads only the plaintext file.

Credentials written before this change hold only the two tokens; those fall back to metadata, so existing connections keep working without a reconnect.

## STA-3944 — network faults reported as bad credentials

`fetchBitbucketUser` returned `null` for everything: 401, timeout, DNS failure, 5xx, unparseable body. Connect then said *"Could not authenticate with Bitbucket. Check the credentials and try again."* for all of them, and the Settings card rendered "Auth failed" — sending users to regenerate a token that was fine.

`/user` now reports `rejected` (401/403) vs `unreachable` (everything else). Connect explains which happened, and an unreachable host no longer flips the card to "Auth failed".

## Testing

Failure-injection coverage as the P0 ticket asks for:

- partial secret write → previous credential byte-identical, no temp file left behind
- interrupt between publishing secret and metadata → auth still resolves from the envelope
- legacy envelope without auth fields → still resolves via metadata
- rejected vs unreachable at connect (throw, and 503) and in status

`pnpm lint`, both typechecks, and 25,188 main/shared/preload tests pass.

## Risk

Storage-format change, but additive and backward compatible — new fields are optional and old envelopes take the metadata path. Reverting is safe: envelopes written by this build carry extra fields the old reader ignores.
