### PR TITLE
fix(omp): handle static WSL titles and clear stale spinners

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -319,6 +319,7 @@ import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-r
 import { resolveExpectedTeardownScope } from './crash-reporting/expected-teardown-state'
 import {
   advanceSyntheticTitleSpinnerEntries,
+  stopSyntheticTitleSpinnerOnStatusClear,
   type SyntheticTitleSpinnerEntry
 } from './synthetic-title-spinner'
 import { shouldSendSyntheticTitleFrame } from './synthetic-title-visibility'
@@ -1594,6 +1595,7 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     }
   )
   agentHookServer.setPaneStatusClearListener((clear) => {
+    stopSyntheticTitleSpinnerOnStatusClear(clear, stopSyntheticTitleSpinner)
     if (mainWindow?.isDestroyed()) {
       return
     }

--- a/src/main/synthetic-title-spinner.test.ts
+++ b/src/main/synthetic-title-spinner.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   advanceSyntheticTitleSpinnerEntries,
+  stopSyntheticTitleSpinnerOnStatusClear,
   type SyntheticTitleSpinnerEntry
 } from './synthetic-title-spinner'
 
@@ -42,5 +43,24 @@ describe('advanceSyntheticTitleSpinnerEntries', () => {
     ])
     expect(entries.has('live-pane')).toBe(true)
     expect(entries.has('stale-pane')).toBe(false)
+  })
+
+  it('stops the pane spinner when its ordinary status is cleared', () => {
+    const stop = vi.fn()
+
+    expect(stopSyntheticTitleSpinnerOnStatusClear({ paneKey: 'pane-a' }, stop)).toBe(true)
+    expect(stop).toHaveBeenCalledExactlyOnceWith('pane-a')
+  })
+
+  it('keeps pane spinners on connection-scoped transient clears', () => {
+    const stop = vi.fn()
+
+    expect(
+      stopSyntheticTitleSpinnerOnStatusClear(
+        { transient: true, connectionId: 'ssh-a', clearedAt: 42 },
+        stop
+      )
+    ).toBe(false)
+    expect(stop).not.toHaveBeenCalled()
   })
 })

--- a/src/main/synthetic-title-spinner.ts
+++ b/src/main/synthetic-title-spinner.ts
@@ -1,3 +1,5 @@
+import type { AgentStatusClearIpcPayload } from '../shared/agent-status-types'
+
 export type SyntheticTitleSpinnerEntry<TProfile> = {
   frame: number
   profile: TProfile
@@ -8,6 +10,16 @@ export type SyntheticTitleSpinnerTick<TProfile> = {
   ptyId: string
   frame: number
   profile: TProfile
+}
+export function stopSyntheticTitleSpinnerOnStatusClear(
+  clear: AgentStatusClearIpcPayload,
+  stop: (paneKey: string) => void
+): boolean {
+  if (!('paneKey' in clear)) {
+    return false
+  }
+  stop(clear.paneKey)
+  return true
 }
 
 export function advanceSyntheticTitleSpinnerEntries<TProfile>(args: {

--- a/src/main/synthetic-title-spinner.ts
+++ b/src/main/synthetic-title-spinner.ts
@@ -11,6 +11,10 @@ export type SyntheticTitleSpinnerTick<TProfile> = {
   frame: number
   profile: TProfile
 }
+/**
+ * Stop a pane spinner for an ordinary pane-scoped clear.
+ * Connection-scoped transient clears intentionally carry no pane key.
+ */
 export function stopSyntheticTitleSpinnerOnStatusClear(
   clear: AgentStatusClearIpcPayload,
   stop: (paneKey: string) => void

--- a/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
@@ -119,6 +119,16 @@ describe('main title tracker parity with the renderer transport processor', () =
     expect(kinds.indexOf('became-working')).toBeLessThan(kinds.indexOf('became-idle'))
   })
 
+  it('derives working and idle facts from static OMP WSL titles', () => {
+    const chunk = `${ESC}]0;zsh | π : cwd${BEL}response text\r\n` + `${ESC}]0;zsh | π > cwd${BEL}`
+    feedBoth(paths, chunk)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    const kinds = paths.main.events.map((event) => event.kind)
+    expect(kinds).toContain('became-working')
+    expect(kinds.indexOf('became-working')).toBeLessThan(kinds.indexOf('became-idle'))
+  })
+
   it('derives identical facts from BEL- and ST-terminated titles', () => {
     feedBoth(paths, `${ESC}]2;Codex working${ST}body bytes`)
     feedBoth(paths, `${ESC}]0;Codex done${BEL}`)

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -167,6 +167,19 @@ describe('Pi-compatible title detection', () => {
     expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
   })
 
+  it.each([
+    ['π : my-project', 'working'],
+    ['π > my-project', 'idle'],
+    ['π ! my-project', 'permission'],
+    // The no-space legacy title is OMP's disabled state, not a working delimiter.
+    ['π: my-project', 'idle'],
+    ['zsh | π : wrapped-project', 'working'],
+    ['zsh | tmux | π > wrapped-project', 'idle'],
+    ['zsh | π ! wrapped-project', 'permission']
+  ] as const)('classifies native OMP title %s', (title, expectedStatus) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
   it('re-detects status after display-title normalization for Pi idle frames', () => {
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
     expect(detectAgentStatusFromTitle(normalizeTerminalTitle('π - my-project'))).toBe('idle')

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -25,7 +25,10 @@ import {
 } from './agent-title-core'
 import type { AgentStatus } from './agent-title-core'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
-import { getPiCompatibleSyntheticAgentStatus } from './pi-compatible-synthetic-title'
+import {
+  getPiCompatibleNativeTitleStatus,
+  getPiCompatibleSyntheticAgentStatus
+} from './pi-compatible-synthetic-title'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
 
 /**
@@ -174,6 +177,11 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   if (title.includes(GEMINI_IDLE)) {
     return 'idle'
+  }
+
+  const piCompatibleNativeStatus = getPiCompatibleNativeTitleStatus(title)
+  if (piCompatibleNativeStatus) {
+    return piCompatibleNativeStatus
   }
 
   // Why: resolve synthetic Pi/OMP permission/idle labels before the broader

--- a/src/shared/pi-compatible-synthetic-title.ts
+++ b/src/shared/pi-compatible-synthetic-title.ts
@@ -30,6 +30,10 @@ export function getPiCompatibleSyntheticAgentLabel(
   }
   return match[1].toLowerCase() === 'omp' ? 'OMP' : 'Pi'
 }
+/**
+ * Classify OMP's native π state-title protocol, including wrapper-prefixed titles.
+ * Whitespace before the delimiter keeps the legacy disabled `π: cwd` title idle.
+ */
 export function getPiCompatibleNativeTitleStatus(
   title: string
 ): PiCompatibleSyntheticAgentStatus | null {

--- a/src/shared/pi-compatible-synthetic-title.ts
+++ b/src/shared/pi-compatible-synthetic-title.ts
@@ -1,3 +1,5 @@
+import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
+
 export type PiCompatibleSyntheticAgentLabel = 'Pi' | 'OMP'
 export type PiCompatibleSyntheticAgentStatus = 'working' | 'permission' | 'idle'
 
@@ -5,6 +7,9 @@ const PI_COMPATIBLE_SYNTHETIC_TITLE_RE =
   /^\s*(?:[\u2800-\u28ff]\s+)?(pi|omp)(?:\s+-\s+action required|\s+(?:ready|idle|done))?\s*$/i
 // Why: legacy Pi/OMP-compatible shells can emit the delimiter before cwd text exists.
 const LEGACY_PI_COMPATIBLE_TITLE_RE = /^\s*(?:[\u2800-\u28ff]\s+)?π(?:\s*[-:]|\s)\s*.*$/u
+// OMP 17.2.12+ uses static state delimiters on WSL/ConPTY instead of braille frames.
+// Require whitespace before the delimiter so the legacy disabled title `π: cwd` stays idle.
+const PI_COMPATIBLE_NATIVE_STATE_TITLE_RE = /^\s*π\s+([:>!])(?:\s+.*)?$/u
 
 function containsBrailleSpinner(title: string): boolean {
   for (const char of title) {
@@ -24,6 +29,23 @@ export function getPiCompatibleSyntheticAgentLabel(
     return null
   }
   return match[1].toLowerCase() === 'omp' ? 'OMP' : 'Pi'
+}
+export function getPiCompatibleNativeTitleStatus(
+  title: string
+): PiCompatibleSyntheticAgentStatus | null {
+  for (const segment of getWrapperTitleSegments(title)) {
+    const stateDelimiter = PI_COMPATIBLE_NATIVE_STATE_TITLE_RE.exec(segment)?.[1]
+    if (stateDelimiter === ':') {
+      return 'working'
+    }
+    if (stateDelimiter === '!') {
+      return 'permission'
+    }
+    if (stateDelimiter === '>') {
+      return 'idle'
+    }
+  }
+  return null
 }
 
 export function getPiCompatibleSyntheticAgentStatus(


### PR DESCRIPTION
## Summary

- Classify bare and wrapper-prefixed OMP 17.2.12+ WSL/ConPTY titles as `working`, `idle`, or `permission`.
- Preserve the legacy no-space `π:` title as idle.
- Stop a pane's synthetic title spinner when its ordinary hook status is cleared.
- Leave connection-scoped transient clears isolated from pane spinner state.
- Document the native-title and status-clear invariants on the new exported functions.

Closes #13890

## Screenshots

No screenshots attached. The fix changes terminal-title-derived status rather than layout or styling. The live smoke was verified through Orca's terminal and worktree APIs without publishing local workspace or session data.

## Testing

- [ ] `pnpm lint` — not run project-wide; the pre-commit `oxlint`, React Doctor lint, and `oxfmt` tasks passed for all changed files.
- [x] `pnpm typecheck` — `pnpm run typecheck:node` and `pnpm run typecheck:web` passed.
- [ ] `pnpm test` — not run project-wide; 3 focused suites passed locally (95 tests).
- [ ] `pnpm build` — not run as a production build; the Electron dev runtime launched successfully.
- [x] Added regression coverage for bare and wrapper-prefixed native OMP states, main/renderer working-to-idle parity, ordinary pane clear cleanup, and transient connection-clear isolation.
- [x] A/B runtime validation on Windows + WSL2:
  - OMP 17.2.11: three consecutive standard-launcher turns ended in `done` with no stuck spinner.
  - Isolated OMP 17.2.14 under the patched Orca dev runtime: the static working title normalized to `⠋ Pi`, then returned to `Pi` after completion.

## AI Review Report

Reviewed the native OMP title → shared status classifier → main/renderer title tracker path and the hook clear → synthetic spinner lifecycle. The review covered delimiter precedence, the legacy no-space `π:` title, nested wrapper prefixes, working-to-idle ordering, ordinary pane clears, and connection-scoped transient clears.

An independent review found that the first parser version missed wrapper-prefixed titles such as `zsh | π : cwd`. The parser was updated to use the repository's existing `getWrapperTitleSegments` convention, bare and nested-wrapper regression cases were added, and the follow-up review returned `APPROVE` with no remaining actionable findings.

Cross-platform scope was checked explicitly: the new state-title protocol is used for WSL/ConPTY, existing animated Pi-compatible titles remain unchanged, and the shared parser behavior stays identical between main and renderer paths.

## Security Audit

This change adds no network requests, credentials, persistence, renderer IPC surface, or privilege boundary. Native title parsing is bounded to existing terminal-title strings and requires an explicit π state delimiter. The no-space legacy `π:` form remains idle to avoid broadening the working match.

Pane-scoped clears stop only the addressed spinner. Connection-scoped transient clears carry no pane key and are intentionally ignored, preserving the existing cross-connection isolation contract.

## Notes

- OMP's WSL/ConPTY title behavior changed in can1357/oh-my-pi#8014.
- #13749 / #13776 cover stale identity after an agent exits back to a shell; this PR covers an OMP process that remains inside its TUI and transitions between working and idle.
- The two new exported lifecycle/parser functions now document their invariants for generated docstring coverage.
- X handle: not provided.
