### PR TITLE
feat(pr-comments): sort grouped PR comment sections newest-first

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -78,7 +78,7 @@ import {
   getPRCommentGroupActionState,
   isPRCommentGroupQueueableForAI,
   partitionPRCommentGroupsForTriage,
-  sortPRCommentGroupsForTimeline,
+  sortPRCommentGroupsByRecency,
   type PRCommentGroupActionState
 } from '@/lib/pr-comment-action-state'
 import { formatPrCommentRelativeTime } from '../../../../shared/pr-comment-time'
@@ -2477,9 +2477,13 @@ export function PRCommentsList({
     [botAuthorOverrides, commentFilter, comments]
   )
   const groups = React.useMemo(() => groupPRComments(visibleComments), [visibleComments])
-  const triageGroups = React.useMemo(() => partitionPRCommentGroupsForTriage(groups), [groups])
-  // Why: triage mode prioritizes actionability; timeline restores the host discussion history.
-  const timelineGroups = React.useMemo(() => sortPRCommentGroupsForTimeline(groups), [groups])
+  const triageGroups = React.useMemo(
+    // Why: grouped sections read newest-first so recent discussion surfaces at the top.
+    () => partitionPRCommentGroupsForTriage(sortPRCommentGroupsByRecency(groups, 'newest-first')),
+    [groups]
+  )
+  // Why: timeline reads oldest-first so the discussion history unfolds in order.
+  const timelineGroups = React.useMemo(() => sortPRCommentGroupsByRecency(groups), [groups])
   const canShowResolveWithAI = Boolean(
     onResolveSelectedCommentsWithAI && selectableGroups.length > 0
   )

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
@@ -7,44 +7,64 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
-vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({
-    children,
-    onSelect
-  }: {
-    children: ReactNode
-    onSelect?: (event: Event) => void
-  }) => (
-    <button
-      type="button"
-      role="menuitem"
-      onClick={() => onSelect?.({ preventDefault: () => {} } as unknown as Event)}
-    >
-      {children}
-    </button>
-  ),
-  DropdownMenuRadioGroup: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuRadioItem: ({
-    children,
-    onSelect
-  }: {
-    children: ReactNode
-    onSelect?: (event: Event) => void
-  }) => (
-    <button
-      type="button"
-      role="menuitemradio"
-      onClick={() => onSelect?.({ preventDefault: () => {} } as unknown as Event)}
-    >
-      {children}
-    </button>
-  ),
-  DropdownMenuSeparator: () => <hr />,
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
-}))
+vi.mock('@/components/ui/dropdown-menu', () => {
+  // Radix keeps the selection callback on the group, so the mocked items need it too.
+  let onRadioValueChange: ((value: string) => void) | undefined
+  return {
+    DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuItem: ({
+      children,
+      onSelect
+    }: {
+      children: ReactNode
+      onSelect?: (event: Event) => void
+    }) => (
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => onSelect?.({ preventDefault: () => {} } as unknown as Event)}
+      >
+        {children}
+      </button>
+    ),
+    DropdownMenuRadioGroup: ({
+      children,
+      onValueChange
+    }: {
+      children: ReactNode
+      onValueChange?: (value: string) => void
+    }) => {
+      onRadioValueChange = onValueChange
+      return <>{children}</>
+    },
+    DropdownMenuRadioItem: ({
+      children,
+      value,
+      onSelect
+    }: {
+      children: ReactNode
+      value?: string
+      onSelect?: (event: Event) => void
+    }) => (
+      <button
+        type="button"
+        role="menuitemradio"
+        onClick={() => {
+          onSelect?.({ preventDefault: () => {} } as unknown as Event)
+          if (value !== undefined) {
+            onRadioValueChange?.(value)
+          }
+        }}
+      >
+        {children}
+      </button>
+    ),
+    DropdownMenuSeparator: () => <hr />,
+    DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+  }
+})
 import type { PRComment } from '../../../../shared/types'
 import type { PRCommentGroup } from '../../../../shared/pr-comment-groups'
 import {
@@ -167,6 +187,24 @@ function hasButton(label: string): boolean {
   )
 }
 
+function selectDisplayMode(label: string): void {
+  const item = [...container.querySelectorAll('[role="menuitemradio"]')].find(
+    (candidate) => candidate.textContent === label
+  )
+  if (!item) {
+    throw new Error(`Display mode not found: ${label}`)
+  }
+  act(() => {
+    item.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+function renderedGroupOrder(labels: readonly string[]): string[] {
+  return [...container.querySelectorAll('[data-testid="pr-comment-group"]')].map(
+    (row) => labels.find((label) => row.textContent?.includes(label)) ?? '<unmatched>'
+  )
+}
+
 function clickMenuItem(label: string): void {
   clickButton('More comment actions')
   const menuItem =
@@ -256,12 +294,20 @@ describe('PRCommentsList comment resolution selection', () => {
   it('lets a user queue one eligible comment thread for the agent from the visible row action', () => {
     const onResolveSelectedCommentsWithAI = vi.fn()
     renderList({
+      // Why: distinct timestamps pin thread-1 to the first row under the newest-first grouped order.
       comments: [
-        comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts', isResolved: false }),
+        comment({
+          id: 1,
+          createdAt: '2026-05-15T00:00:00Z',
+          threadId: 'thread-1',
+          path: 'src/a.ts',
+          isResolved: false
+        }),
         comment({
           id: 2,
           author: 'bob',
           body: 'Second thread.',
+          createdAt: '2026-05-14T00:00:00Z',
           threadId: 'thread-2',
           path: 'src/b.ts',
           isResolved: false
@@ -497,5 +543,64 @@ describe('PRCommentsList comment resolution selection', () => {
 
     renderList({ comments, contextKey: 'review:keep' })
     expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+  })
+})
+
+describe('PRCommentsList comment ordering', () => {
+  const labels = ['Oldest note.', 'Middle note.', 'Newest note.']
+
+  it('reads newest-first in grouped mode and oldest-first in timeline mode', () => {
+    renderList({
+      comments: [
+        comment({ id: 1, body: 'Middle note.', createdAt: '2026-05-14T00:00:00Z' }),
+        comment({ id: 2, body: 'Newest note.', createdAt: '2026-05-15T00:00:00Z' }),
+        comment({ id: 3, body: 'Oldest note.', createdAt: '2026-05-13T00:00:00Z' })
+      ]
+    })
+
+    expect(renderedGroupOrder(labels)).toEqual(['Newest note.', 'Middle note.', 'Oldest note.'])
+
+    selectDisplayMode('Timeline')
+
+    expect(renderedGroupOrder(labels)).toEqual(['Oldest note.', 'Middle note.', 'Newest note.'])
+  })
+
+  it('ranks a replied-to thread by its fresh reply in grouped mode only', () => {
+    const threadLabels = ['Replied thread.', 'Quiet thread.']
+    renderList({
+      comments: [
+        comment({
+          id: 1,
+          body: 'Replied thread.',
+          createdAt: '2026-05-14T00:00:00Z',
+          threadId: 'thread-1',
+          path: 'src/a.ts',
+          isResolved: false
+        }),
+        comment({
+          id: 2,
+          body: 'Quiet thread.',
+          createdAt: '2026-05-13T00:00:00Z',
+          threadId: 'thread-2',
+          path: 'src/b.ts',
+          isResolved: false
+        }),
+        comment({
+          id: 3,
+          body: 'Fresh reply.',
+          createdAt: '2026-05-16T00:00:00Z',
+          threadId: 'thread-1',
+          path: 'src/a.ts',
+          isResolved: false
+        })
+      ]
+    })
+
+    expect(renderedGroupOrder(threadLabels)).toEqual(['Replied thread.', 'Quiet thread.'])
+
+    // Why: timeline ranks by when a thread started, so the quiet older root leads again.
+    selectDisplayMode('Timeline')
+
+    expect(renderedGroupOrder(threadLabels)).toEqual(['Quiet thread.', 'Replied thread.'])
   })
 })

--- a/src/renderer/src/lib/pr-comment-action-state.test.ts
+++ b/src/renderer/src/lib/pr-comment-action-state.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { PRComment } from '../../../shared/types'
-import { groupPRComments } from '../../../shared/pr-comment-groups'
+import { groupPRComments, type PRCommentGroup } from '../../../shared/pr-comment-groups'
 import {
   getPRCommentGroupActionState,
   isPRCommentGroupQueueableForAI,
   partitionPRCommentGroupsForTriage,
-  sortPRCommentGroupsForTimeline
+  sortPRCommentGroupsByRecency
 } from './pr-comment-action-state'
 
 function comment(overrides: Partial<PRComment> & { id: number }): PRComment {
@@ -17,6 +17,10 @@ function comment(overrides: Partial<PRComment> & { id: number }): PRComment {
     url: '',
     ...overrides
   }
+}
+
+function bodies(groups: readonly PRCommentGroup[]): string[] {
+  return groups.map((group) => (group.kind === 'standalone' ? group.comment.body : group.root.body))
 }
 
 describe('pr-comment-action-state', () => {
@@ -57,15 +61,120 @@ describe('pr-comment-action-state', () => {
       comment({ id: 1, createdAt: '2026-06-16T10:00:00Z', body: 'first' }),
       comment({ id: 2, createdAt: '2026-06-16T11:00:00Z', body: 'second' })
     ])
-    const sorted = sortPRCommentGroupsForTimeline(groups)
+    const sorted = sortPRCommentGroupsByRecency(groups)
 
     expect(sorted.map((group) => getPRCommentGroupActionState(group))).toEqual([
       'conversation',
       'conversation',
       'conversation'
     ])
-    expect(
-      sorted.map((group) => (group.kind === 'standalone' ? group.comment.body : group.root.body))
-    ).toEqual(['first', 'second', 'third'])
+    expect(bodies(sorted)).toEqual(['first', 'second', 'third'])
+  })
+
+  it('sorts each triage section newest-first for grouped mode', () => {
+    const groups = groupPRComments([
+      comment({ id: 1, createdAt: '2026-06-16T10:00:00Z', body: 'first' }),
+      comment({ id: 2, createdAt: '2026-06-16T11:00:00Z', body: 'second' }),
+      comment({
+        id: 3,
+        createdAt: '2026-06-16T09:00:00Z',
+        body: 'older open',
+        threadId: 't-open-old',
+        path: 'src/a.ts',
+        isResolved: false
+      }),
+      comment({
+        id: 4,
+        createdAt: '2026-06-16T12:00:00Z',
+        body: 'newer open',
+        threadId: 't-open-new',
+        path: 'src/b.ts',
+        isResolved: false
+      })
+    ])
+    const partitioned = partitionPRCommentGroupsForTriage(
+      sortPRCommentGroupsByRecency(groups, 'newest-first')
+    )
+
+    expect(bodies(partitioned.conversation)).toEqual(['second', 'first'])
+    expect(bodies(partitioned.open)).toEqual(['newer open', 'older open'])
+    expect(partitioned.resolved).toEqual([])
+  })
+
+  it('ranks a stale thread by its newest reply under newest-first only', () => {
+    const groups = groupPRComments([
+      comment({
+        id: 1,
+        createdAt: '2026-06-13T09:00:00Z',
+        body: 'stale root',
+        threadId: 't-stale',
+        path: 'src/a.ts',
+        isResolved: false
+      }),
+      comment({
+        id: 2,
+        createdAt: '2026-06-16T12:00:00Z',
+        body: 'fresh reply',
+        threadId: 't-stale',
+        path: 'src/a.ts',
+        isResolved: false
+      }),
+      comment({ id: 3, createdAt: '2026-06-16T11:00:00Z', body: 'newer standalone' }),
+      comment({
+        id: 4,
+        createdAt: '2026-06-14T09:00:00Z',
+        body: 'mid root',
+        threadId: 't-mid',
+        path: 'src/b.ts',
+        isResolved: false
+      }),
+      comment({
+        id: 5,
+        createdAt: '2026-06-14T10:00:00Z',
+        body: 'mid reply',
+        threadId: 't-mid',
+        path: 'src/b.ts',
+        isResolved: false
+      })
+    ])
+
+    expect(bodies(sortPRCommentGroupsByRecency(groups, 'newest-first'))).toEqual([
+      'stale root',
+      'newer standalone',
+      'mid root'
+    ])
+    expect(bodies(sortPRCommentGroupsByRecency(groups))).toEqual([
+      'stale root',
+      'mid root',
+      'newer standalone'
+    ])
+  })
+
+  it('inverts the id tiebreaker numerically when groups share a timestamp', () => {
+    const groups = groupPRComments([
+      comment({ id: 9, createdAt: '2026-06-16T12:00:00Z', body: 'batch a' }),
+      comment({ id: 10, createdAt: '2026-06-16T12:00:00Z', body: 'batch b' })
+    ])
+
+    expect(bodies(sortPRCommentGroupsByRecency(groups))).toEqual(['batch a', 'batch b'])
+    expect(bodies(sortPRCommentGroupsByRecency(groups, 'newest-first'))).toEqual([
+      'batch b',
+      'batch a'
+    ])
+  })
+
+  it('sinks groups with an unparseable timestamp to the bottom in both orders', () => {
+    const groups = groupPRComments([
+      comment({ id: 1, createdAt: '', body: 'unknown time' }),
+      comment({ id: 2, createdAt: '2026-06-16T10:00:00Z', body: 'older' }),
+      comment({ id: 3, createdAt: '2026-06-16T11:00:00Z', body: 'newer' })
+    ])
+
+    expect(bodies(sortPRCommentGroupsByRecency(groups))).toEqual(['older', 'newer', 'unknown time'])
+    expect(bodies(sortPRCommentGroupsByRecency(groups, 'newest-first'))).toEqual([
+      'newer',
+      'older',
+      'unknown time'
+    ])
   })
 })

--- a/src/renderer/src/lib/pr-comment-action-state.ts
+++ b/src/renderer/src/lib/pr-comment-action-state.ts
@@ -1,8 +1,5 @@
-import {
-  getPRCommentGroupId,
-  getPRCommentGroupRoot,
-  type PRCommentGroup
-} from '../../../shared/pr-comment-groups'
+import { getPRCommentGroupRoot, type PRCommentGroup } from '../../../shared/pr-comment-groups'
+import type { PRComment } from '../../../shared/types'
 
 /** How a comment group should read in the PR sidebar triage UI. */
 export type PRCommentGroupActionState = 'open' | 'conversation' | 'resolved'
@@ -45,17 +42,58 @@ export function partitionPRCommentGroupsForTriage(groups: readonly PRCommentGrou
   return { open, conversation, resolved }
 }
 
-function groupTimelineMs(group: PRCommentGroup): number {
-  const ts = Date.parse(getPRCommentGroupRoot(group).createdAt)
-  return Number.isNaN(ts) ? 0 : ts
+/** Null when the host sent an unparseable (often empty) `createdAt`. */
+function commentMs(comment: PRComment): number | null {
+  const ts = Date.parse(comment.createdAt)
+  return Number.isNaN(ts) ? null : ts
 }
 
-export function sortPRCommentGroupsForTimeline(
-  groups: readonly PRCommentGroup[]
+function groupStartMs(group: PRCommentGroup): number | null {
+  return commentMs(getPRCommentGroupRoot(group))
+}
+
+/** Newest comment anywhere in the group, so a fresh reply refreshes an old thread. */
+function groupLatestActivityMs(group: PRCommentGroup): number | null {
+  if (group.kind !== 'thread') {
+    return commentMs(group.comment)
+  }
+  return group.replies.reduce<number | null>((latest, reply) => {
+    const ts = commentMs(reply)
+    if (ts === null) {
+      return latest
+    }
+    return latest === null ? ts : Math.max(latest, ts)
+  }, commentMs(group.root))
+}
+
+/**
+ * Orders comment groups by time. The two orders use different keys, not just opposite
+ * directions: `newest-first` ranks by last activity anywhere in the thread, while
+ * `oldest-first` ranks by when the thread started. Groups whose timestamp is unknown
+ * sort last in both orders.
+ */
+export function sortPRCommentGroupsByRecency(
+  groups: readonly PRCommentGroup[],
+  order: 'oldest-first' | 'newest-first' = 'oldest-first'
 ): PRCommentGroup[] {
-  return [...groups].sort(
-    (left, right) =>
-      groupTimelineMs(left) - groupTimelineMs(right) ||
-      getPRCommentGroupId(left).localeCompare(getPRCommentGroupId(right))
-  )
+  const newestFirst = order === 'newest-first'
+  const multiplier = newestFirst ? -1 : 1
+  const timestampOf = newestFirst ? groupLatestActivityMs : groupStartMs
+  // Why: decorate first so each group parses its dates once, not once per comparison.
+  return groups
+    .map((group) => ({ group, ts: timestampOf(group), id: getPRCommentGroupRoot(group).id }))
+    .sort((left, right) => {
+      if (left.ts === null || right.ts === null) {
+        if (left.ts !== null) {
+          return -1
+        }
+        if (right.ts !== null) {
+          return 1
+        }
+        return multiplier * (left.id - right.id)
+      }
+      // Why: ids break the ties GitHub creates by stamping a whole review batch identically.
+      return multiplier * (left.ts - right.ts || left.id - right.id)
+    })
+    .map((entry) => entry.group)
 }


### PR DESCRIPTION
## Summary

- Grouped/triage sections now rank newest-first for recent discussion visibility, while Timeline maintains its oldest-first history order
- Threads are ranked by their latest activity under newest-first, ensuring a fresh reply refreshes an old thread to the top
- GitHub review batches sharing a timestamp are ordered correctly via numeric comment ID tiebreaker
- Groups with unparseable `createdAt` sink to the bottom in both sort orders

## Test plan

- 8 lib tests in `pr-comment-action-state.test.ts` verify sorting logic for both orders
- New component-level ordering tests in `pr-comments-list-selection.test.tsx` (verified load-bearing by mutation)
- Full right-sidebar suite: 197 files / 1788 tests passing
- Typecheck and oxlint clean

Made with [Orca](https://github.com/stablyai/orca) 🐋
