### PR TITLE
fix(agent-status): treat Claude 2.1.228 quarter-circle busy titles as working

### DIFF
--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -81,6 +81,26 @@ describe('OSC title extraction', () => {
   })
 })
 
+describe('Claude Code 2.1.228+ quarter-circle busy titles (#13889)', () => {
+  it.each(['◐ Claude Code', '◑ Claude Code', '◒ Claude Code', '◓ Claude Code'] as const)(
+    'classifies %s as working Claude Code',
+    (title) => {
+      expect(detectAgentStatusFromTitle(title)).toBe('working')
+      expect(getAgentLabel(title)).toBe('Claude Code')
+    }
+  )
+
+  it('still treats the idle ✳ prefix as idle Claude Code', () => {
+    expect(detectAgentStatusFromTitle('✳ Claude Code')).toBe('idle')
+    expect(getAgentLabel('✳ Claude Code')).toBe('Claude Code')
+  })
+
+  it('does not treat Gemini idle ◇ as Claude busy', () => {
+    expect(detectAgentStatusFromTitle('◇ Gemini CLI')).toBe('idle')
+    expect(getAgentLabel('◇ Gemini CLI')).toBe('Gemini CLI')
+  })
+})
+
 describe('MiMo title detection', () => {
   it.each([
     ['MiMo Code', 'idle'],

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -83,6 +83,15 @@ export function containsBrailleSpinner(title: string): boolean {
   return false
 }
 
+// Why: Claude Code 2.1.228+ replaced braille busy titles with quarter-circle
+// glyphs (◐/◑; reserve the full U+25D0–U+25D3 set). A leading glyph + space is
+// the same prefix shape as `. ` / `* `.
+export const CLAUDE_BUSY_GLYPH_PREFIX_RE = /^[\u25d0-\u25d3] /u
+
+export function hasClaudeBusyGlyphPrefix(title: string): boolean {
+  return CLAUDE_BUSY_GLYPH_PREFIX_RE.test(title)
+}
+
 export function containsLegacyAgentName(title: string): boolean {
   return titleHasAnyLegacyAgentName(title)
 }

--- a/src/shared/agent-title-decoration.test.ts
+++ b/src/shared/agent-title-decoration.test.ts
@@ -18,6 +18,11 @@ describe('stripLeadingAgentTitleDecoration', () => {
     expect(stripLeadingAgentTitleDecoration('⠋ Pi')).toBe('Pi')
   })
 
+  it('strips Claude 2.1.228+ quarter-circle busy glyphs', () => {
+    expect(stripLeadingAgentTitleDecoration('◐ Claude Code')).toBe('Claude Code')
+    expect(stripLeadingAgentTitleDecoration('◑ Claude Code')).toBe('Claude Code')
+  })
+
   it('leaves an undecorated title untouched', () => {
     expect(stripLeadingAgentTitleDecoration('Dolphin-2')).toBe('Dolphin-2')
     expect(stripLeadingAgentTitleDecoration('npm run dev')).toBe('npm run dev')

--- a/src/shared/agent-title-decoration.ts
+++ b/src/shared/agent-title-decoration.ts
@@ -5,7 +5,8 @@
 // displayed title. Scoped to titles we already know belong to an agent.
 const LEADING_AGENT_TITLE_DECORATION_RE =
   // eslint-disable-next-line no-control-regex -- intentional unicode status-glyph ranges
-  /^(?:[✳✦⏲◇✋⠀-⣿]+|[.*]\s)\s*/
+  // Why: Claude 2.1.228+ busy titles use ◐–◓ (U+25D0–U+25D3) instead of braille.
+  /^(?:[✳✦⏲◇✋◐-◓⠀-⣿]+|[.*]\s)\s*/
 
 export function stripLeadingAgentTitleDecorationOrEmpty(title: string): string {
   return title.replace(LEADING_AGENT_TITLE_DECORATION_RE, '').trimStart()

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -4,6 +4,7 @@ import {
   DROID_AGENT_NAME_RE,
   HERMES_AGENT_NAME_RE,
   containsBrailleSpinner,
+  hasClaudeBusyGlyphPrefix,
   isClaudeManagementTitle,
   isCursorAgentTitle,
   isGeminiTerminalTitle,
@@ -28,7 +29,7 @@ export function isClaudeAgent(title: string): boolean {
   if (title.startsWith(`${CLAUDE_IDLE} `) || title === CLAUDE_IDLE) {
     return true
   }
-  if (title.startsWith('. ') || title.startsWith('* ')) {
+  if (title.startsWith('. ') || title.startsWith('* ') || hasClaudeBusyGlyphPrefix(title)) {
     return true
   }
   if (containsBrailleSpinner(title)) {
@@ -58,7 +59,8 @@ export function getAgentLabel(title: string): string | null {
     title.startsWith(`${CLAUDE_IDLE} `) ||
     title === CLAUDE_IDLE ||
     title.startsWith('. ') ||
-    title.startsWith('* ')
+    title.startsWith('* ') ||
+    hasClaudeBusyGlyphPrefix(title)
   ) {
     return 'Claude Code'
   }

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -15,6 +15,7 @@ import {
   containsAgentName,
   containsAny,
   containsBrailleSpinner,
+  hasClaudeBusyGlyphPrefix,
   containsLegacyAgentName,
   isClaudeManagementTitle,
   isGeminiTerminalTitle,
@@ -181,7 +182,7 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   if (isPiTerminalTitle(title)) {
     return 'idle'
   }
-  if (containsBrailleSpinner(title)) {
+  if (containsBrailleSpinner(title) || hasClaudeBusyGlyphPrefix(title)) {
     return 'working'
   }
 

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -166,4 +166,9 @@ describe('isClaudeAgent', () => {
     expect(isClaudeAgent('⠋ preserve cursor visibility across replays')).toBe(true)
     expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
   })
+
+  it('recognizes Claude Code 2.1.228+ quarter-circle busy titles', () => {
+    expect(isClaudeAgent('◐ Claude Code')).toBe(true)
+    expect(isClaudeAgent('◑ fixing the auth flow')).toBe(true)
+  })
 })

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -33,6 +33,11 @@ export function containsBrailleSpinner(title: string): boolean {
   return false
 }
 
+// Keep in sync with agent-title-core.hasClaudeBusyGlyphPrefix (Claude Code 2.1.228+).
+export function hasClaudeBusyGlyphPrefix(title: string): boolean {
+  return /^[\u25d0-\u25d3] /u.test(title)
+}
+
 export function isGeminiTerminalTitle(title: string): boolean {
   // Why: Gemini OSC glyphs are stronger evidence than any cwd/session text.
   if (
@@ -93,7 +98,8 @@ export function isClaudeAgent(title: string): boolean {
   // Why: ". " (working) and "* " (idle) are Claude Code title conventions.
   // Other supported agents do not use them, and rejecting titles that mention
   // another agent in the task text caused false negatives for real Claude tabs.
-  if (title.startsWith('. ') || title.startsWith('* ')) {
+  // Claude Code 2.1.228+ busy titles use quarter-circle glyphs (◐/◑) the same way.
+  if (title.startsWith('. ') || title.startsWith('* ') || hasClaudeBusyGlyphPrefix(title)) {
     return true
   }
   if (containsBrailleSpinner(title)) {
@@ -134,7 +140,8 @@ export function getAgentLabel(title: string): string | null {
     title.startsWith(`${CLAUDE_IDLE} `) ||
     title === CLAUDE_IDLE ||
     title.startsWith('. ') ||
-    title.startsWith('* ')
+    title.startsWith('* ') ||
+    hasClaudeBusyGlyphPrefix(title)
   ) {
     return 'Claude Code'
   }
@@ -232,6 +239,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
 function hasGenericClaudeStatusPrefix(title: string): boolean {
   return (
     containsBrailleSpinner(title) ||
+    hasClaudeBusyGlyphPrefix(title) ||
     title.startsWith('✳ ') ||
     title === '✳' ||
     title.startsWith('. ') ||


### PR DESCRIPTION
## Summary
- Claude Code 2.1.228 changed busy OSC titles from braille to ◐/◑; Orca only treated braille as `working`, so idle→busy looked like agent exit and Chat UI flipped to the terminal view on every message (#13889).
- Accept U+25D0–U+25D3 busy prefixes for status, Claude identity, and leading decoration strip (shared `agent-title-*` + parallel `terminal-title-agent-type` copy).

## Test plan
- [x] `vitest run src/shared/agent-detection.test.ts src/shared/agent-title-decoration.test.ts src/shared/terminal-title-agent-type.test.ts` (87 tests)
- [x] `detectAgentStatusFromTitle('◐ Claude Code') === 'working'`; idle ✳ and Gemini ◇ unchanged

Fixes #13889