### PR TITLE
fix(automations): give list table more breathing room

### DIFF
--- a/src/renderer/src/components/automations/AutomationsListPanel.tsx
+++ b/src/renderer/src/components/automations/AutomationsListPanel.tsx
@@ -153,7 +153,7 @@ export function AutomationsListPanel({
           </div>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
           <div className="flex shrink-0 items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-2">
               <AutomationListSearchField

--- a/src/renderer/src/components/automations/AutomationsPageSkeleton.tsx
+++ b/src/renderer/src/components/automations/AutomationsPageSkeleton.tsx
@@ -25,7 +25,7 @@ function TableRowSkeleton({
   statusWidthClass: string
 }): React.JSX.Element {
   return (
-    <div className={cn(AUTOMATIONS_TABLE_GRID_CLASS, 'items-center gap-3 px-3 py-2')}>
+    <div className={cn(AUTOMATIONS_TABLE_GRID_CLASS, 'min-h-11 items-center gap-3 px-3 py-3')}>
       <SkeletonBar className={cn('h-3.5', nameWidthClass)} />
       <SkeletonBar className={cn('h-3.5', scheduleWidthClass)} />
       <SkeletonBar className={cn('h-3.5', projectWidthClass)} />
@@ -91,7 +91,7 @@ const TABLE_ROW_SKELETONS = [
 export function AutomationsPageSkeleton(): React.JSX.Element {
   return (
     <div
-      className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden px-3 pb-4 md:px-5"
+      className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden px-3 pb-4 md:px-5"
       aria-busy="true"
       aria-label={translate(
         'auto.components.automations.AutomationsPageSkeleton.55527b7bcf',

--- a/src/renderer/src/components/automations/automations-table-layout.ts
+++ b/src/renderer/src/components/automations/automations-table-layout.ts
@@ -10,6 +10,6 @@ export const AUTOMATIONS_TABLE_HEADER_CLASS =
   'sticky top-0 z-10 h-8 items-center gap-3 border-b border-border/50 bg-muted/25 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground'
 
 export const AUTOMATIONS_TABLE_ROW_CLASS =
-  'w-full cursor-pointer items-center gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+  'w-full min-h-11 cursor-pointer items-center gap-3 px-3 py-3 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
 
 export const AUTOMATIONS_TABLE_ROW_SELECTED_CLASS = 'bg-accent text-accent-foreground'


### PR DESCRIPTION
## Summary
- Increase automations table row height (`min-h-11`, `py-3`) so list rows feel less dense
- Widen the gap between the search toolbar and the table header
- Keep the loading skeleton aligned with the new spacing

## Test plan
- [ ] Open Automations and confirm rows have more vertical padding
- [ ] Confirm search → table gap looks slightly roomier
- [ ] Confirm loading skeleton matches the table spacing