### PR TITLE
Fix smart sort ranking of done agents by completion time

### DIFF
--- a/src/renderer/src/components/dashboard/agent-finished-timestamp.test.ts
+++ b/src/renderer/src/components/dashboard/agent-finished-timestamp.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { lastEnteredDoneAt } from './agent-finished-timestamp'
 
@@ -35,5 +36,19 @@ describe('lastEnteredDoneAt session boundaries (STA-3386)', () => {
         )
       )
     ).toBe(1_000)
+  })
+})
+
+describe('lastEnteredDoneAt shares the Smart Sort completion clock', () => {
+  it('times an ordinary completion from stateStartedAt, not updatedAt', () => {
+    const entry = doneEntry({ stateStartedAt: 2_000, updatedAt: 190_000 })
+    expect(lastEnteredDoneAt(row(entry))).toBe(2_000)
+    expect(agentEntryCompletionAt(entry)).toBe(2_000)
+  })
+
+  it('still shows when an interrupted turn stopped, though it never ranks as done', () => {
+    const entry = doneEntry({ interrupted: true, stateStartedAt: 2_000 })
+    expect(lastEnteredDoneAt(row(entry))).toBe(2_000)
+    expect(agentEntryCompletionAt(entry)).toBeNull()
   })
 })

--- a/src/renderer/src/components/dashboard/agent-finished-timestamp.ts
+++ b/src/renderer/src/components/dashboard/agent-finished-timestamp.ts
@@ -1,3 +1,4 @@
+import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
 import type { DashboardAgentRow } from './useDashboardData'
 
 /**
@@ -15,9 +16,15 @@ export function lastEnteredDoneAt(
     return null
   }
   const entry = agent.entry
-  // Why: a session-boundary done means the session connected idle (STA-3386) — nothing
-  // finished; fall through to history (which never records session boundaries).
-  if (entry.state === 'done' && entry.sessionBoundary !== true) {
+  // Why: same primitive Smart Sort ranks on, so the displayed age and Done eligibility share a clock.
+  // (Session-boundary `done` means the session connected idle — STA-3386 — so it resolves to the real
+  // completion it displaced, if any.)
+  const completedAt = agentEntryCompletionAt(entry)
+  if (completedAt !== null) {
+    return completedAt
+  }
+  // Why: display is looser than ranking — an interrupted turn still shows when it stopped.
+  if (entry.state === 'done' && entry.interrupted === true && entry.sessionBoundary !== true) {
     return entry.stateStartedAt
   }
   for (let i = (entry.stateHistory?.length ?? 0) - 1; i >= 0; i--) {

--- a/src/renderer/src/components/sidebar/smart-attention.test.ts
+++ b/src/renderer/src/components/sidebar/smart-attention.test.ts
@@ -195,6 +195,70 @@ describe('resolveAttention', () => {
     })
   })
 
+  it('drops a done pane out of Class 2 once the completion itself ages out', () => {
+    const justInside = makeEntry({
+      paneKey: 't:1',
+      state: 'done',
+      stateStartedAt: NOW - AGENT_STATUS_STALE_AFTER_MS,
+      updatedAt: NOW - 1_000
+    })
+    expect(resolveAttention([hookPane(justInside)], NOW)).toEqual({
+      cls: 2,
+      attentionTimestamp: NOW - AGENT_STATUS_STALE_AFTER_MS
+    })
+
+    const justOutside = makeEntry({
+      paneKey: 't:1',
+      state: 'done',
+      stateStartedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1,
+      updatedAt: NOW - 1_000
+    })
+    expect(resolveAttention([hookPane(justOutside)], NOW)).toEqual(IDLE)
+  })
+
+  it('does not let same-state done writes extend Class 2 eligibility', () => {
+    // The captured regression: updatedAt was 3m04s newer than the completion, keeping a 32m-old
+    // "done" row above two spinners.
+    const entry = makeEntry({
+      paneKey: 't:1',
+      state: 'done',
+      stateStartedAt: NOW - 32 * 60_000,
+      updatedAt: NOW - 29 * 60_000
+    })
+    expect(resolveAttention([hookPane(entry)], NOW)).toEqual(IDLE)
+  })
+
+  it('keeps an expired done pane from masking a live working sibling', () => {
+    const expiredDone = makeEntry({
+      paneKey: 't:1',
+      state: 'done',
+      stateStartedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 60_000,
+      updatedAt: NOW - 1_000
+    })
+    const working = makeEntry({
+      paneKey: 't:2',
+      state: 'working',
+      stateStartedAt: NOW - 10_000,
+      updatedAt: NOW - 1_000
+    })
+    expect(resolveAttention(hookPanes([expiredDone, working]), NOW)).toEqual({
+      cls: 3,
+      attentionTimestamp: NOW - 10_000
+    })
+  })
+
+  it('ages out a session-boundary completion from its real completion time', () => {
+    const boundary = makeEntry({
+      paneKey: 't:1',
+      state: 'done',
+      sessionBoundary: true,
+      stateStartedAt: NOW - 1_000,
+      updatedAt: NOW - 500,
+      stateHistory: [makeHistory('done', NOW - AGENT_STATUS_STALE_AFTER_MS - 1)]
+    })
+    expect(resolveAttention([hookPane(boundary)], NOW)).toEqual(IDLE)
+  })
+
   it('classifies a working pane with prior done as Class 3 with the prior timestamp', () => {
     const entry = makeEntry({
       paneKey: 't:1',

--- a/src/renderer/src/components/sidebar/smart-attention.ts
+++ b/src/renderer/src/components/sidebar/smart-attention.ts
@@ -1,4 +1,5 @@
 import { classifyTitleActivity, isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
+import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafId } from '@/lib/runtime-pane-title-leaf-id'
@@ -15,9 +16,9 @@ import { parsePaneKey } from '../../../../shared/stable-pane-id'
 /**
  * Ordinal class for the "Smart" sort. Lower number = more attention-demanding.
  *   1 — Needs you (`blocked` / `waiting`)
- *   2 — Done (`done`, not interrupted)
+ *   2 — Done (`done`, not interrupted, completed within AGENT_STATUS_STALE_AFTER_MS)
  *   3 — Working (`working`)
- *   4 — Idle (no live entry, stale entry, or interrupted `done`)
+ *   4 — Idle (no live entry, stale entry, interrupted `done`, or an aged-out completion)
  *
  * Primary sort key; ties fall back to the attention timestamp. See docs/smart-worktree-order-redesign.md.
  */
@@ -34,7 +35,7 @@ export type AttentionCause = 'blocked' | 'waiting' | 'title-heuristic'
  * Per-worktree resolution computed once before sorting.
  *
  * `attentionTimestamp` by class:
- *   - Class 1 / 2: `stateStartedAt` of the current entry.
+ *   - Class 1: `stateStartedAt` of the current entry. Class 2: the entry's completion time.
  *   - Class 3: `stateStartedAt` of the most recent prior `done`/`blocked`/`waiting` entry,
  *     falling back to the current `working` `stateStartedAt`.
  *   - Class 4: `0` — comparator drops to `effectiveRecentActivity` for idle ordering.
@@ -98,21 +99,6 @@ export function mostRecentAttentionInHistory(history: AgentStateHistoryEntry[]):
   return max > 0 ? max : null
 }
 
-function mostRecentCompletedTurnInHistory(history: AgentStateHistoryEntry[]): number | null {
-  let max = 0
-  for (const entry of history) {
-    if (
-      entry.state === 'done' &&
-      entry.interrupted !== true &&
-      Number.isFinite(entry.startedAt) &&
-      entry.startedAt > max
-    ) {
-      max = entry.startedAt
-    }
-  }
-  return max > 0 ? max : null
-}
-
 /**
  * One pane's contribution to a worktree's attention class. Fresh hook entries win; hookless
  * panes fall back to the title heuristic (design doc Edge case 9). Authority is per-pane, not per-worktree.
@@ -152,21 +138,19 @@ export function resolveAttention(panes: PaneInput[], now: number): WorktreeAtten
         ts = entry.stateStartedAt
         cause = entry.state
       } else if (entry.state === 'done') {
-        // Why: interrupted `done` (Ctrl+C) means the user is done with the turn; treat as idle, not Class 2.
-        if (entry.interrupted) {
+        // Why: null covers interrupted `done` (Ctrl+C — user is finished with it) and idle session
+        // boundaries; neither is attention.
+        const completedAt = agentEntryCompletionAt(entry)
+        if (completedAt === null) {
+          continue
+        }
+        // Why: same-state `done` writes advance updatedAt without moving the completion, so the hook
+        // freshness gate alone can keep a row in Class 2 long after the UI shows it aged out.
+        if (now - completedAt > AGENT_STATUS_STALE_AFTER_MS) {
           continue
         }
         cls = 2
-        if (entry.sessionBoundary) {
-          // Why: idle connect is not new attention; only preserve a real completion it displaced.
-          const completedAt = mostRecentCompletedTurnInHistory(entry.stateHistory)
-          if (completedAt === null) {
-            continue
-          }
-          ts = completedAt
-        } else {
-          ts = entry.stateStartedAt
-        }
+        ts = completedAt
       } else {
         // working
         cls = 3

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -109,7 +109,8 @@ function ptyMapForTabs(tabsByWorktree: Record<string, TerminalTab[]>): Record<st
  * Sort helper: builds the attention map and runs the smart comparator. Mirrors
  * what callers do in production (visible-worktrees, WorktreeList).
  */
-function sortSmart(
+function sortSmartAt(
+  now: number,
   worktrees: Worktree[],
   tabsByWorktree: Record<string, TerminalTab[]>,
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
@@ -120,9 +121,17 @@ function sortSmart(
     agentStatusByPaneKey,
     {},
     ptyMapForTabs(tabsByWorktree),
-    NOW
+    now
   )
-  return [...worktrees].sort(buildWorktreeComparator('smart', repoMap, NOW, attention))
+  return [...worktrees].sort(buildWorktreeComparator('smart', repoMap, now, attention))
+}
+
+function sortSmart(
+  worktrees: Worktree[],
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+): Worktree[] {
+  return sortSmartAt(NOW, worktrees, tabsByWorktree, agentStatusByPaneKey)
 }
 
 describe('smart sort — class invariants', () => {
@@ -351,6 +360,62 @@ describe('smart sort — interrupted and stale handling', () => {
     const sorted = sortSmart([stale, fresh], tabs, entries)
     // fresh is Class 2; stale falls to Class 4.
     expect(sorted.map((w) => w.id)).toEqual(['fresh', 'stale'])
+  })
+})
+
+describe('smart sort — completed-agent eligibility clock', () => {
+  // Captured regression (docs/smart-sort-agent-activity-findings.md): a `done` row whose
+  // updatedAt was 3m04s newer than its completion outranked two live spinners.
+  const SCREENSHOT_AT = new Date('2026-03-27T21:44:39.000Z').getTime()
+  const at = (hhmmss: string): number => new Date(`2026-03-27T${hhmmss}.000Z`).getTime()
+
+  function capturedFixture(workingUpdatedAt = at('21:44:30')) {
+    const done = makeWorktree({ id: 'fix-linear-persistent', displayName: 'fix-linear-persistent' })
+    const workingA = makeWorktree({ id: 'allow-editing', displayName: 'allow-editing' })
+    const workingB = makeWorktree({ id: 'resume-terminal', displayName: 'resume-terminal' })
+    const tabs = {
+      [done.id]: [makeTab({ id: 'tab-done', worktreeId: done.id })],
+      [workingA.id]: [makeTab({ id: 'tab-a', worktreeId: workingA.id })],
+      [workingB.id]: [makeTab({ id: 'tab-b', worktreeId: workingB.id })]
+    }
+    const entries = {
+      [paneKey('tab-done', '1')]: makeEntry({
+        paneKey: paneKey('tab-done', '1'),
+        state: 'done',
+        stateStartedAt: at('21:12:09'),
+        // Same-state `done` writes pushed updatedAt 3m04s past the completion.
+        updatedAt: at('21:15:13')
+      }),
+      [paneKey('tab-a', '1')]: makeEntry({
+        paneKey: paneKey('tab-a', '1'),
+        state: 'working',
+        stateStartedAt: workingUpdatedAt - 68_000,
+        updatedAt: workingUpdatedAt
+      }),
+      [paneKey('tab-b', '1')]: makeEntry({
+        paneKey: paneKey('tab-b', '1'),
+        state: 'working',
+        stateStartedAt: workingUpdatedAt - 145_000,
+        updatedAt: workingUpdatedAt - 5_000
+      })
+    }
+    return { worktrees: [done, workingA, workingB], tabs, entries }
+  }
+
+  it('ranks the two spinners above the 32-minute-old completion', () => {
+    const { worktrees, tabs, entries } = capturedFixture()
+    const sorted = sortSmartAt(SCREENSHOT_AT, worktrees, tabs, entries)
+    expect(sorted.map((w) => w.id)).toEqual([
+      'allow-editing',
+      'resume-terminal',
+      'fix-linear-persistent'
+    ])
+  })
+
+  it('still ranks that completion above the spinners inside its own window', () => {
+    const { worktrees, tabs, entries } = capturedFixture(at('21:39:50'))
+    const sorted = sortSmartAt(at('21:40:00'), worktrees, tabs, entries)
+    expect(sorted[0].id).toBe('fix-linear-persistent')
   })
 })
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2300,6 +2300,64 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.sortEpoch).toBe((initialState.sortEpoch ?? 0) + 1)
   })
 
+  it('bumps sort epoch when a mirrored same-state done update becomes a completion', () => {
+    const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
+    const initialSnapshot = makeSnapshot([
+      {
+        type: 'terminal',
+        id: HOST_SURFACE_ID,
+        title: 'Codex',
+        parentTabId: 'host-tab-1',
+        leafId: LEAF_ID,
+        isActive: true,
+        status: 'ready',
+        terminal: 'terminal-1',
+        agentStatus: {
+          state: 'done',
+          prompt: 'same prompt',
+          updatedAt: NOW - 1_000,
+          stateStartedAt: NOW - 2_000,
+          agentType: 'codex',
+          paneKey: hostPaneKey,
+          stateHistory: [],
+          interrupted: true
+        }
+      }
+    ])
+    const initialPatch = applyWebSessionTabsSnapshot(
+      makeState(),
+      initialSnapshot,
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+    const initialState = { ...makeState(), ...initialPatch }
+
+    const patch = applyWebSessionTabsSnapshot(
+      initialState,
+      {
+        ...initialSnapshot,
+        snapshotVersion: 2,
+        tabs: initialSnapshot.tabs.map((tab) =>
+          tab.type === 'terminal' && tab.agentStatus
+            ? {
+                ...tab,
+                agentStatus: {
+                  ...tab.agentStatus,
+                  updatedAt: NOW,
+                  interrupted: undefined
+                }
+              }
+            : tab
+        )
+      },
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.agentStatusEpoch).toBe((initialState.agentStatusEpoch ?? 0) + 1)
+    expect(patch.sortEpoch).toBe((initialState.sortEpoch ?? 0) + 1)
+  })
+
   it('hydrates multiple initial host snapshots in one merged patch', () => {
     const secondWorktree = 'repo::/other-worktree'
     const patch = applyWebSessionTabsSnapshots(

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -8,6 +8,7 @@ import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry
 } from '../../../shared/agent-status-types'
+import { agentEntryCompletionAt } from '../../../shared/agent-completion-time'
 import { agentProviderSessionsEqual } from '../../../shared/agent-session-resume'
 import type {
   RuntimeMobileSessionTabsResult,
@@ -1278,12 +1279,17 @@ function buildMirroredAgentStatusPatch(
       existing?.worktreeId !== entry.worktreeId || existing?.tabId !== entry.tabId
     const entryFreshnessChanged =
       !!existing && isAgentStatusFresh(existing, now) !== isAgentStatusFresh(entry, now)
+    const doneAttentionChanged =
+      existing?.state === 'done' &&
+      entry.state === 'done' &&
+      agentEntryCompletionAt(existing) !== agentEntryCompletionAt(entry)
     const entrySortRelevantChange =
       !existing ||
       existing.state !== entry.state ||
       !isAgentStatusFresh(existing, now) ||
       entryFreshnessChanged ||
       entryAttributionChanged ||
+      doneAttentionChanged ||
       isMirroredCommandCodeTurnBump(existing, entry)
     aggregateRelevantChange = aggregateRelevantChange || entrySortRelevantChange
     sortRelevantChange = sortRelevantChange || entrySortRelevantChange

--- a/src/renderer/src/store/slices/agent-status-freshness-scheduler.test.ts
+++ b/src/renderer/src/store/slices/agent-status-freshness-scheduler.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
+
+const NOW = new Date('2026-04-09T12:00:00.000Z').getTime()
+
+function doneEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    paneKey: 'tab-1:11111111-1111-4111-8111-111111111111',
+    state: 'done',
+    prompt: '',
+    updatedAt: NOW,
+    stateStartedAt: NOW,
+    stateHistory: [],
+    agentType: 'claude',
+    ...overrides
+  }
+}
+
+function setup(entries: AgentStatusEntry[]) {
+  const bumpEpochs = vi.fn()
+  const scheduler = createFreshnessScheduler({ getEntries: () => entries, bumpEpochs })
+  return { bumpEpochs, scheduler }
+}
+
+describe('freshness scheduler completion deadlines', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('wakes at the completion deadline even while the hook row stays fresh', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    // Completion is 25m old; same-state `done` writes have kept updatedAt at now.
+    const completedAt = NOW - 25 * 60_000
+    const { bumpEpochs, scheduler } = setup([
+      doneEntry({ stateStartedAt: completedAt, updatedAt: NOW })
+    ])
+
+    scheduler.schedule()
+    vi.advanceTimersByTime(completedAt + AGENT_STATUS_STALE_AFTER_MS - NOW)
+    expect(bumpEpochs).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(bumpEpochs).toHaveBeenCalledTimes(1)
+
+    scheduler.dispose()
+  })
+
+  it('keeps the strict-expiry wake armed when rescheduled exactly at the boundary', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const { bumpEpochs, scheduler } = setup([
+      doneEntry({
+        stateStartedAt: NOW - AGENT_STATUS_STALE_AFTER_MS,
+        updatedAt: NOW
+      })
+    ])
+
+    scheduler.schedule()
+    vi.advanceTimersByTime(1)
+    expect(bumpEpochs).toHaveBeenCalledTimes(1)
+
+    scheduler.dispose()
+  })
+
+  it('does not lose a completion deadline when an overdue timer is rescheduled after sleep', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const completedAt = NOW - 25 * 60_000
+    const entries = [doneEntry({ stateStartedAt: completedAt, updatedAt: NOW })]
+    const { bumpEpochs, scheduler } = setup(entries)
+
+    scheduler.schedule()
+    vi.setSystemTime(completedAt + AGENT_STATUS_STALE_AFTER_MS + 1)
+    entries[0] = doneEntry({ stateStartedAt: completedAt, updatedAt: Date.now() })
+    scheduler.schedule()
+
+    expect(bumpEpochs).toHaveBeenCalledTimes(1)
+    scheduler.schedule()
+    expect(bumpEpochs).toHaveBeenCalledTimes(1)
+    scheduler.dispose()
+  })
+
+  it('does not rearm an expired completion deadline in a zero-delay loop', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const completedAt = NOW - 25 * 60_000
+    const { bumpEpochs, scheduler } = setup([
+      doneEntry({ stateStartedAt: completedAt, updatedAt: NOW })
+    ])
+
+    scheduler.schedule()
+    // Past both the completion deadline and the hook-freshness deadline.
+    vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 60_000)
+
+    // One bump for the completion boundary, one for hook freshness — never a spin.
+    expect(bumpEpochs).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+
+    scheduler.dispose()
+  })
+
+  it('ignores completions that cannot demand attention', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const completedAt = NOW - 25 * 60_000
+    const { bumpEpochs, scheduler } = setup([
+      doneEntry({ stateStartedAt: completedAt, updatedAt: NOW, interrupted: true })
+    ])
+
+    scheduler.schedule()
+    vi.advanceTimersByTime(completedAt + AGENT_STATUS_STALE_AFTER_MS - NOW + 1)
+    expect(bumpEpochs).not.toHaveBeenCalled()
+
+    // Only the hook-freshness deadline remains.
+    vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS)
+    expect(bumpEpochs).toHaveBeenCalledTimes(1)
+
+    scheduler.dispose()
+  })
+
+  it('still arms hook freshness for a working entry', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const { bumpEpochs, scheduler } = setup([
+      doneEntry({ state: 'working', stateStartedAt: NOW, updatedAt: NOW })
+    ])
+
+    scheduler.schedule()
+    vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
+    expect(bumpEpochs).toHaveBeenCalledTimes(1)
+
+    scheduler.dispose()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status-freshness-scheduler.ts
+++ b/src/renderer/src/store/slices/agent-status-freshness-scheduler.ts
@@ -54,14 +54,11 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
       if (expiryAt >= now) {
         nextExpiryAt = Math.min(nextExpiryAt, expiryAt)
       }
-      // Why: Smart Sort drops a completed pane out of the Done class at completion + threshold, which
-      // can land well before hook freshness expires (same-state `done` writes push updatedAt, never the
-      // completion). Already-passed deadlines are skipped for the same anti-spin reason as above.
+      // Completion and hook freshness have independent expiry times.
       const completedAt = agentEntryCompletionAt(entry)
       if (completedAt !== null) {
         const completionExpiryAt = completedAt + AGENT_STATUS_STALE_AFTER_MS
-        // Why: an overdue callback can be cleared by a same-state update after sleep; detect
-        // the crossed stable completion deadline before that update extends hook freshness.
+        // Detect a missed completion expiry before a same-state update extends hook freshness.
         if (
           lastCheckedAt !== null &&
           completionExpiryAt >= lastCheckedAt &&

--- a/src/renderer/src/store/slices/agent-status-freshness-scheduler.ts
+++ b/src/renderer/src/store/slices/agent-status-freshness-scheduler.ts
@@ -1,3 +1,4 @@
+import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 
@@ -21,6 +22,7 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
   // `dispose()` in teardown — otherwise a real 30-minute setTimeout leaks
   // into the test process.
   let timer: ReturnType<typeof setTimeout> | null = null
+  let lastCheckedAt: number | null = null
 
   const clear = (): void => {
     if (timer !== null) {
@@ -33,10 +35,12 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
     clear()
     const entries = deps.getEntries()
     if (entries.length === 0) {
+      lastCheckedAt = null
       return
     }
     const now = Date.now()
     let nextExpiryAt = Number.POSITIVE_INFINITY
+    let crossedCompletionDeadline = false
     // Why: skip entries already past the stale boundary — they each contribute
     // exactly one epoch bump at crossing, and rescheduling on them would spin
     // the timer forever because the bump doesn't clear them from the map
@@ -47,9 +51,32 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
     // freshness-aware selectors can decay them immediately on that render.
     for (const entry of entries) {
       const expiryAt = entry.updatedAt + AGENT_STATUS_STALE_AFTER_MS
-      if (expiryAt > now) {
+      if (expiryAt >= now) {
         nextExpiryAt = Math.min(nextExpiryAt, expiryAt)
       }
+      // Why: Smart Sort drops a completed pane out of the Done class at completion + threshold, which
+      // can land well before hook freshness expires (same-state `done` writes push updatedAt, never the
+      // completion). Already-passed deadlines are skipped for the same anti-spin reason as above.
+      const completedAt = agentEntryCompletionAt(entry)
+      if (completedAt !== null) {
+        const completionExpiryAt = completedAt + AGENT_STATUS_STALE_AFTER_MS
+        // Why: an overdue callback can be cleared by a same-state update after sleep; detect
+        // the crossed stable completion deadline before that update extends hook freshness.
+        if (
+          lastCheckedAt !== null &&
+          completionExpiryAt >= lastCheckedAt &&
+          completionExpiryAt < now
+        ) {
+          crossedCompletionDeadline = true
+        }
+        if (completionExpiryAt >= now) {
+          nextExpiryAt = Math.min(nextExpiryAt, completionExpiryAt)
+        }
+      }
+    }
+    lastCheckedAt = now
+    if (crossedCompletionDeadline) {
+      deps.bumpEpochs()
     }
     if (!Number.isFinite(nextExpiryAt)) {
       return
@@ -62,6 +89,7 @@ export function createFreshnessScheduler(deps: FreshnessSchedulerDeps): Freshnes
     timer = setTimeout(() => {
       timer = null
       deps.bumpEpochs()
+      lastCheckedAt = Date.now()
       schedule()
     }, delayMs)
   }

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -805,6 +805,29 @@ describe('agent status tool + assistant fields', () => {
     expect(store.getState().sortEpoch).toBe(firstSortEpoch)
   })
 
+  it('bumps sort epoch when a same-state done update changes completion eligibility', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:1',
+        { state: 'done', prompt: 'p1', agentType: 'claude', interrupted: true },
+        'claude',
+        { updatedAt: 1_000, stateStartedAt: 1_000 }
+      )
+    const firstSortEpoch = store.getState().sortEpoch
+
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'done', prompt: 'p1', agentType: 'claude' }, 'claude', {
+        updatedAt: 2_000,
+        stateStartedAt: 1_000
+      })
+
+    expect(store.getState().sortEpoch).toBe(firstSortEpoch + 1)
+  })
+
   it('bumps global epochs when a stale same-state entry refreshes', () => {
     vi.useFakeTimers()
     const store = createTestStore()

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -26,6 +26,7 @@ import {
   shouldSuppressInheritedTerminalStatus
 } from '../../../../shared/agent-status-identity'
 import { isCommandCodeNewTurnWhileWorking } from '../../../../shared/command-code-turn-boundary'
+import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
 import type { TerminalPaneLayoutNode, TerminalTab } from '../../../../shared/types'
 import {
   getRepoExecutionHostId,
@@ -1982,13 +1983,18 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           !!existing &&
           existing.state === payload.state &&
           entry.stateStartedAt !== existing.stateStartedAt
+        const sameStateDoneAttentionChanged =
+          existing?.state === 'done' &&
+          entry.state === 'done' &&
+          agentEntryCompletionAt(existing) !== agentEntryCompletionAt(entry)
         const sortRelevantChange =
           !existing ||
           existing.state !== payload.state ||
           !wasFresh ||
           attributionChanged ||
           commandCodeNewTurn ||
-          sameStateStateStartedAtChanged
+          sameStateStateStartedAtChanged ||
+          sameStateDoneAttentionChanged
         const doneRetentionFieldsChanged =
           existing?.state === 'done' &&
           entry.state === 'done' &&

--- a/src/shared/agent-completion-time.ts
+++ b/src/shared/agent-completion-time.ts
@@ -1,0 +1,43 @@
+import type { AgentStateHistoryEntry, AgentStatusEntry } from './agent-status-types'
+
+/** The subset of a hook entry a completion time is derived from. */
+export type AgentCompletionSource = Pick<
+  AgentStatusEntry,
+  'state' | 'stateStartedAt' | 'stateHistory' | 'interrupted' | 'sessionBoundary'
+>
+
+function mostRecentCompletedTurnInHistory(
+  history: readonly AgentStateHistoryEntry[] | undefined
+): number | null {
+  let max = 0
+  for (const row of history ?? []) {
+    if (
+      row.state === 'done' &&
+      row.interrupted !== true &&
+      Number.isFinite(row.startedAt) &&
+      row.startedAt > max
+    ) {
+      max = row.startedAt
+    }
+  }
+  return max > 0 ? max : null
+}
+
+/**
+ * When the entry's agent last actually COMPLETED a turn, or null when nothing qualifies.
+ * One clock for both the displayed completion age and Smart Sort's Done eligibility, so a row
+ * can't rank as freshly done while showing an age past the staleness threshold.
+ *
+ * A completion is only:
+ *   - a non-interrupted `done` (its `stateStartedAt` — unmoved by same-state tool/prompt pings); or
+ *   - for a session-boundary `done` (connected idle, not a turn), the real completion it displaced.
+ */
+export function agentEntryCompletionAt(entry: AgentCompletionSource): number | null {
+  if (entry.state !== 'done' || entry.interrupted === true) {
+    return null
+  }
+  if (entry.sessionBoundary === true) {
+    return mostRecentCompletedTurnInHistory(entry.stateHistory)
+  }
+  return Number.isFinite(entry.stateStartedAt) ? entry.stateStartedAt : null
+}


### PR DESCRIPTION
## Problem

The smart sort was incorrectly ranking old completed agents high in the worktree list. When a `done` agent received same-state updates (tool/prompt changes), the `updatedAt` field advanced but the actual completion time stayed at `stateStartedAt`. The sort logic was using the hook's freshness (based on `updatedAt`) to determine class membership, causing 32-minute-old completions to outrank live spinners if they'd been pinged recently.

## Solution

Extract the actual completion time into a shared, centralized function `agentEntryCompletionAt()` in `src/shared/agent-completion-time.ts`. Use this same primitive for both the displayed completion age and Smart Sort's Done-class eligibility. This ensures completions age out at `AGENT_STATUS_STALE_AFTER_MS` from their actual finish time, not from their last update.

Key changes:
- New file `src/shared/agent-completion-time.ts` with `agentEntryCompletionAt()` — returns the real completion time or null for interrupted/ineligible entries
- Updated `smart-attention.ts` to rank done agents by completion time, not hook freshness; skip eligibility after staleness threshold
- Updated `agent-finished-timestamp.ts` to display the same completion clock
- Updated freshness scheduler to detect completion deadlines separately from hook freshness, so completions age out even when updatedAt is kept fresh
- Updated web-session-tabs-sync to bump sort epoch when a same-state done update changes completion eligibility
- Comprehensive tests covering the regression: a 32-minute-old completion now correctly ranks below two live agents

## Testing

- [x] Added regression tests in `smart-sort.test.ts` capturing the captured screenshot fixture (32-minute-old done vs. two spinners)
- [x] Added tests in `smart-attention.test.ts` for completion aging and session boundaries
- [x] Added new test file `agent-status-freshness-scheduler.test.ts` for completion deadline detection
- [x] Updated `agent-status.test.ts` for same-state done eligibility changes
- [x] Updated `web-session-tabs-sync.test.ts` for sort epoch bumps on completion eligibility change

## Notes

This fix ensures the displayed completion age and sort ranking use the same clock, eliminating the discrepancy where a row could show as "32 minutes old" while still ranking as freshly done.