### PR TITLE
fix(codex): use a codex-specific 3s managed hook timeout, and cover the EOF pipe-break signature in the Windows hook lifecycle tests

### DIFF
--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -361,12 +361,13 @@ describe('Windows managed hook stdin structure', () => {
           const result = await runHookProcess(executable, args, hookEnvironment())
           expect(result.exitCode, `${fileName} exit code`).toBe(0)
           // Why (#11549 class): every Windows-local hook exits before owning stdin when the
-          // Orca env is missing, so the writer may break — EPIPE, or ECONNRESET when Windows
-          // tears the pipe down first. hookEnvironment() strips every ORCA_* var, so this
+          // Orca env is missing, so the writer may break — EPIPE, ECONNRESET, or EOF (libuv's
+          // UV_EOF) when Windows tears the pipe down first — all three are valid pipe-break
+          // signatures of the missing-env fast exit. hookEnvironment() strips every ORCA_* var, so this
           // relaxation only ever covers the missing-env path — a happy-path case added to
           // this loop must not reuse it.
           for (const error of result.stdinErrors) {
-            expect(['EPIPE', 'ECONNRESET'], `${fileName} stdin error`).toContain(error.code)
+            expect(['EPIPE', 'ECONNRESET', 'EOF'], `${fileName} stdin error`).toContain(error.code)
           }
         }
 

--- a/src/main/codex/codex-hook-trust-grant.test.ts
+++ b/src/main/codex/codex-hook-trust-grant.test.ts
@@ -66,7 +66,7 @@ function managedEntry(eventLabel: CodexTrustEntry['eventLabel']): CodexTrustEntr
     groupIndex: 0,
     handlerIndex: 0,
     command: MANAGED_COMMAND,
-    timeoutSec: 10
+    timeoutSec: 3
   }
 }
 

--- a/src/main/codex/codex-real-home-hook-install.test.ts
+++ b/src/main/codex/codex-real-home-hook-install.test.ts
@@ -497,7 +497,7 @@ describe('ensureRealHomeCodexHookState (opt-out sweep)', () => {
               {
                 hooks: [
                   { type: 'command', command: userCommand },
-                  { type: 'command', command: material.command, timeout: 10 }
+                  { type: 'command', command: material.command, timeout: 3 }
                 ]
               }
             ]
@@ -522,7 +522,7 @@ describe('ensureRealHomeCodexHookState (opt-out sweep)', () => {
         groupIndex: 0,
         handlerIndex: 1,
         command: material.command,
-        timeoutSec: 10
+        timeoutSec: 3
       }
     ]
     writeFileSync(getRealConfigTomlPath(), upsertHookTrustEntriesInContent('', entries), 'utf-8')

--- a/src/main/codex/codex-real-home-hook-install.ts
+++ b/src/main/codex/codex-real-home-hook-install.ts
@@ -4,7 +4,6 @@ import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
-  MANAGED_HOOK_TIMEOUT_SECONDS,
   readHooksJsonWithRaw,
   removeManagedCommands,
   writeHooksJson,
@@ -25,6 +24,9 @@ import { getSystemCodexHomePath } from './codex-home-paths'
 import type { CodexTrustEntry } from './config-toml-trust'
 import { restoreCodexTrustConfig } from './codex-trust-config-rollback'
 import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+
+// Why: keep Codex on a tighter hook timeout than the cross-agent default without changing the shared constant.
+const CODEX_MANAGED_HOOK_TIMEOUT_SECONDS = 3
 
 /**
  * Real-home Codex hook lane for the system-default selection (flag ON).
@@ -154,7 +156,7 @@ function installRealHomeCodexHook(userDataPath: string): RealHomeCodexHookLane {
       groupIndex: reconciled.groupIndex,
       handlerIndex: reconciled.handlerIndex,
       command: material.command,
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+      timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
     })
   }
   // Why: sweep stale Orca entries out of events the managed lane no longer
@@ -331,7 +333,7 @@ function sweepRealHomeCodexHook(): RealHomeCodexHookLane {
         sourcePath: hooksJsonPath,
         command: material.command,
         managedEventLabels: new Set(Object.values(material.eventLabel)),
-        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+        timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
       })
     } catch (error) {
       console.warn('[codex-real-home-hooks] failed to drop Orca trust entries:', error)

--- a/src/main/codex/hook-service-trust-grant.test.ts
+++ b/src/main/codex/hook-service-trust-grant.test.ts
@@ -171,7 +171,7 @@ describe('CodexHookService app-server trust grant lane', () => {
       groupIndex: 0,
       handlerIndex: 0,
       command: wrapPosixHookCommand(join(tmpHome, '.orca', 'agent-hooks', 'codex-hook.sh')),
-      timeoutSec: 10
+      timeoutSec: 3
     })
     expect(trustConfig).not.toContain(selfComputed)
     expect(Object.keys(readCodexTrustGrantLedgerHome(managedHome)!.entries)).toHaveLength(8)
@@ -206,7 +206,7 @@ describe('CodexHookService app-server trust grant lane', () => {
       groupIndex: 0,
       handlerIndex: 0,
       command: material.command,
-      timeoutSec: 10,
+      timeoutSec: 3,
       trustedHash
     }
     const trustKey = computeTrustKey(entry)

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -4,7 +4,6 @@ import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { dirname, join, win32 as pathWin32 } from 'node:path'
 
-import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
 import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from '../agent-hooks/hook-stdin-contract'
 import {
   computeTrustKey,
@@ -73,7 +72,7 @@ function getManagedTrustEntry(
     groupIndex: 0,
     handlerIndex: 0,
     command,
-    timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    timeoutSec: 3
   }
 }
 

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -9,7 +9,6 @@ import {
   buildWindowsAgentHookCurlPostCommand,
   getSharedManagedScriptPath,
   hookDefinitionHasManagedCommand,
-  MANAGED_HOOK_TIMEOUT_SECONDS,
   readHooksJson,
   readHooksJsonWithRaw,
   removeManagedCommands,
@@ -35,6 +34,8 @@ import {
   buildWindowsHookStdinDrainEpilogue,
   POSIX_HOOK_STDIN_DRAIN_COMMAND
 } from '../agent-hooks/hook-stdin-contract'
+// Why: keep Codex on a tighter hook timeout than the cross-agent default without changing the shared constant.
+const CODEX_MANAGED_HOOK_TIMEOUT_SECONDS = 3
 import {
   codexHookSourcePathsEqual,
   computeTrustKey,
@@ -576,7 +577,7 @@ function removeSystemManagedHookTrustEntries(systemHomePath: string, hooksJsonPa
     sourcePath: hooksJsonPath,
     command: getManagedCommand(getManagedScriptPath()),
     managedEventLabels: CODEX_MANAGED_EVENT_LABELS,
-    timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
   })
 }
 
@@ -722,7 +723,7 @@ function removeRuntimeManagedHookTrustEntries(configPath: string): void {
       sourcePath: configPath,
       command: getManagedCommand(getManagedScriptPath()),
       managedEventLabels: CODEX_MANAGED_EVENT_LABELS,
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS,
+      timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS,
       sourceUsesExplicitCodexHome: true
     })
   } catch (error) {
@@ -739,7 +740,7 @@ function removeWslRuntimeManagedHookTrustEntries(plan: CodexWslRuntimeHookInstal
       sourcePath: plan.trustConfigPath,
       command: wrapReadablePosixHookCommand(plan.commandScriptPath),
       managedEventLabels: CODEX_MANAGED_EVENT_LABELS,
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+      timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
     })
   } catch (error) {
     // Why: best-effort like host cleanup; stale trust is inert once hooks.json no longer points at us.
@@ -757,7 +758,7 @@ function removeStaleWslRuntimeManagedHookTrustEntries(
     runtimeHomePath: pathWin32.dirname(tomlPath),
     desiredEntries,
     managedEventLabels: CODEX_MANAGED_EVENT_LABELS,
-    timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS,
+    timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS,
     buildManagedCommand: (linuxRuntimeHome) =>
       wrapReadablePosixHookCommand(`${linuxRuntimeHome}/.orca/agent-hooks/codex-hook.sh`),
     priorLedgerHomes
@@ -891,7 +892,7 @@ function installManagedHooksIntoWslRuntime(
       groupIndex: 0,
       handlerIndex: 0,
       command,
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+      timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
     })
   }
 
@@ -1202,7 +1203,7 @@ export class CodexHookService {
         groupIndex: foundGroupIndex,
         handlerIndex: foundHandlerIndex,
         command,
-        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+        timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
       }
       const trustKey = computeTrustKey(trustInput)
       const validHashes = new Set([computeTrustedHash(trustInput)])
@@ -1331,7 +1332,7 @@ export class CodexHookService {
         groupIndex: 0,
         handlerIndex: 0,
         command,
-        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+        timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
       })
     }
     const trustEntries: CodexTrustEntry[] = [...mirroredTrustEntries, ...managedTrustEntries]
@@ -1456,7 +1457,7 @@ export class CodexHookService {
           groupIndex: cleaned.length,
           handlerIndex: 0,
           command,
-          timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+          timeoutSec: CODEX_MANAGED_HOOK_TIMEOUT_SECONDS
         })
       }
 


### PR DESCRIPTION
### Summary

Two focused improvements on top of the recently merged missing-env guard fix (#11549):

1. **Codex-specific hook timeout.** All agents currently share `MANAGED_HOOK_TIMEOUT_SECONDS = 10`. Codex now uses its own `CODEX_MANAGED_HOOK_TIMEOUT_SECONDS = 3`, applied across installation, cleanup, reconciliation, and status validation in codex-only files. The shared 10s constant for other agents is untouched.

2. **EOF in the pipe-break whitelist.** The lifecycle test for the missing-env fast exit allows `EPIPE` and `ECONNRESET` as valid writer-side break signatures, but Windows libuv also reports `UV_EOF` when the reader closes the pipe first — a third signature of the same path. It is now covered, with a comment explaining why.

### Why

- A single shared timeout forces every agent to fit one budget. Codex's Windows hook process tree has tighter resource semantics; a dedicated shorter timeout keeps the shared default conservative for other agents.
- The test whitelist previously missed `EOF`, so a real `UV_EOF` break would have failed CI on Windows even though it is the expected behavior of the fast exit.

### Tests

- `tsc` typecheck (`config/tsconfig.node.json`, `config/tsconfig.tc.cli.json`): clean.
- `vitest`: codex hook suites pass; the Windows lifecycle suite passes locally with `KIMI_SHELL_PATH` set (Git Bash requirement; the suite is skipped otherwise).

### Screenshots

No visual change — this is a runtime constant and test-only change.

### AI Review Report

Reviewed by CodeRabbit on the earlier revision (walkthrough + pre-merge checks); this revision narrows the change to the two increments above and was re-verified by typecheck and targeted vitest.

### Security Audit

No new surface: the change alters a timeout constant used by an existing managed-hook invocation path and a test assertion whitelist. No credentials, network endpoints, or file access are introduced or modified.

### Notes

The missing-env guard fast-exit itself was already merged upstream in #11549; this PR intentionally does not re-implement it and only carries the two increments above.
