### PR TITLE
docs(agent-status): make design references self-contained

### DIFF
--- a/src/main/agent-hooks/installer-utils-remote.ts
+++ b/src/main/agent-hooks/installer-utils-remote.ts
@@ -8,8 +8,6 @@
 // We deliberately keep the JSON merge logic in the existing
 // `installer-utils.ts` and only swap fs primitives — the JSON shape and
 // managed-command matching must stay identical to the local install.
-//
-// See docs/design/agent-status-over-ssh.md §8 (commit #8).
 
 import { randomUUID } from 'node:crypto'
 import type { SFTPWrapper, FileEntryWithStats } from 'ssh2'
@@ -83,9 +81,9 @@ export async function writeHooksJsonRemote(
   }
 }
 
-/** Write the managed hook script to the remote and chmod 0o755. POSIX-only —
- *  the relay deliberately does not support Windows-remote in v1 (see design
- *  doc §3 + §6). */
+/** Write the managed hook script to the remote and chmod 0o755. POSIX-only:
+ *  the payload is a shell script and every path here is POSIX-joined, so a
+ *  Windows SSH target would need a separate installer, not a tweak to this one. */
 export async function writeManagedScriptRemote(
   sftp: SFTPWrapper,
   remotePath: string,

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: this file owns the loopback HTTP adapter, the on-disk last-status persistence layer (hydrate, sanitize, TTL, atomic write, drop), and the relay ingest path in one place so the cache lifecycle (set → schedule → drain) lives next to the surfaces that mutate it. Splitting would force mutual `private` accessor scaffolding for a single class. */
-// Why: this main-process adapter keeps listener internals in shared/ (`src/shared/agent-hook-listener.ts`) so the relay can host the same pipeline without Electron. See docs/design/agent-status-over-ssh.md §5.
+// Why: this main-process adapter keeps listener internals in shared/ (`src/shared/agent-hook-listener.ts`) so the relay can host the same pipeline without Electron; parsing that drifts back into this file stops applying to SSH panes.
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -216,7 +216,7 @@ export class CursorHookService {
     return this.getStatus()
   }
 
-  // Installs managed Cursor hooks on an SSH remote (POSIX-only). See docs/design/agent-status-over-ssh.md §8.
+  // Installs managed Cursor hooks on an SSH remote (POSIX-only); the managed script/JSON shape must match local install() or remote panes report a different status.
   async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
     const remoteConfigPath = `${remoteHome.replace(/\/$/, '')}/.cursor/hooks.json`
     const remoteScriptPath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/cursor-hook.sh`

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -200,7 +200,7 @@ export class GeminiHookService {
     return this.getStatus()
   }
 
-  // POSIX-only remote install mirroring ClaudeHookService.installRemote. See docs/design/agent-status-over-ssh.md §8.
+  // POSIX-only remote install mirroring ClaudeHookService.installRemote; the managed script/JSON shape must match local install() or remote panes report a different status.
   async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
     const remoteConfigPath = `${remoteHome.replace(/\/$/, '')}/.gemini/settings.json`
     const remoteScriptPath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/gemini-hook.sh`

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1436,7 +1436,7 @@ export class SshRelaySession {
     })
   }
 
-  // Why: ship plugin/extension source from Orca so agent-event changes don't force a relay redeploy (agent-status-over-ssh.md §4/§8). Best-effort.
+  // Why: ship plugin/extension source from Orca so agent-event changes don't force a relay redeploy — the relay is versioned independently. Best-effort: failure only costs agent status on this host.
   private async installPluginsOnRelay(mux: SshChannelMultiplexer): Promise<void> {
     if (!isRemoteAgentHooksEnabled() || !this.areAgentStatusHooksEnabled()) {
       return
@@ -1513,7 +1513,7 @@ export class SshRelaySession {
       if (typeof envelope.paneKey !== 'string') {
         return
       }
-      // Why: forward env/version verbatim so cross-build warn-once diagnostics fire on remote events too (agent-status-over-ssh.md §3).
+      // Why: forward the agent CLI's env/version verbatim (not the relay's) so warn-once protocol-mismatch diagnostics fire for remote events too.
       agentHookServer.ingestRemote(
         {
           paneKey: envelope.paneKey,

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -1,8 +1,9 @@
 /* eslint-disable max-lines -- Why: parsing, replay cache, endpoint writing, and retry state are one lifecycle unit; splitting obscures cleanup ordering across reconnects. */
 // Relay-side adapter for the shared agent-hook listener: hosts a loopback HTTP server and
 // forwards each parsed payload via a callback so `relay.ts` re-emits it as an `agent.hook`
-// JSON-RPC notification over the SSH channel. Replay cache is bounded one-entry-per-paneKey —
-// see docs/design/agent-status-over-ssh.md §5 (Path 3, request-driven replay) for the rationale.
+// JSON-RPC notification over the SSH channel. Replay cache is bounded one-entry-per-paneKey: a
+// reattaching Orca only needs each pane's current status, never its history, and the bound keeps a
+// long-lived relay from growing with every event.
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'

--- a/src/relay/plugin-overlay.ts
+++ b/src/relay/plugin-overlay.ts
@@ -4,11 +4,11 @@
 // renderer are meaningless on SSH targets, so the relay performs the remote
 // filesystem work itself.
 //
-// Plugin source strings ship over the JSON-RPC channel at session-ready
-// (commit #7) — they are NOT bundled with the relay binary because the
-// relay is versioned independently from Orca and the plugin source changes
-// frequently as new agent events get added (see docs/design/agent-status-
-// over-ssh.md §4 "Why ship the plugin source over the wire").
+// Plugin source strings ship over the JSON-RPC channel at session-ready —
+// they are NOT bundled with the relay binary because the relay is versioned
+// independently from Orca and the plugin source changes frequently as new
+// agent events get added; bundling would make every such change a relay
+// redeploy, and an old relay would silently serve stale plugin code.
 //
 // We deliberately do not reuse OpenCodeHookService / PiTitlebarExtensionService
 // directly: those modules import `electron` and ride on Orca's userData

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -557,7 +557,7 @@ export class PtyHandler {
   }
 
   /** Register an env augmenter merged into every spawn env *after* process.env and renderer env.
-   *  Used by the relay-hook server to inject ORCA_AGENT_HOOK_* coords. See docs/design/agent-status-over-ssh.md §3. */
+   *  Used by the relay-hook server to inject ORCA_AGENT_HOOK_* coords: evaluated per spawn (not captured once), so a late or restarted hook-server bind still reaches the next PTY. */
   addEnvAugmenter(augmenter: PtyEnvAugmenter): () => void {
     this.envAugmenters.push(augmenter)
     return () => {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -780,7 +780,7 @@ async function main(): Promise<void> {
   )
 
   // ── Agent-hook server ─────────────────────────────────────────────
-  // Why: loopback HTTP receiver so remote-PTY agent CLIs post hook events locally, forwarded to Orca as agent.hook notifications. See docs/design/agent-status-over-ssh.md §2-§5.
+  // Why: loopback HTTP receiver so remote-PTY agent CLIs post hook events to a local port (they can't reach Orca's host); the relay forwards them as agent.hook notifications.
   const hookServer = new RelayAgentHookServer({
     // Why: scope endpoint.env/cmd by socket path so multiple relay daemons on one account can't overwrite each other's hook tokens.
     endpointDir: endpointDir ?? endpointDirForRelaySocket(sockPath),
@@ -870,7 +870,7 @@ async function main(): Promise<void> {
     return env
   })
 
-  // Why: evict pane status cache + overlay dirs on PTY exit so panes don't ghost after reconnect (§5 Path 3) or leak dirs.
+  // Why: evict pane status cache + overlay dirs on PTY exit, else the next reconnect replays a dead pane's last status (ghost row) and overlay dirs leak.
   ptyHandler.setExitListener(({ paneKey, id }) => {
     if (paneKey) {
       hookServer.clearPaneState(paneKey)
@@ -878,7 +878,7 @@ async function main(): Promise<void> {
     pluginOverlay.clearOverlay(paneKey ?? id)
   })
 
-  // Why: forward cached entries as notifications before returning so the response trails all replays, closing a reconnect race. See docs/design/agent-status-over-ssh.md §5 Path 3.
+  // Why: forward cached entries as notifications before returning, so the response trails every replay and Orca can't treat replay as done while frames are still in flight.
   dispatcher.onRequest(AGENT_HOOK_REQUEST_REPLAY_METHOD, async () => {
     const replayed = hookServer.replayCachedPayloadsForPanes()
     return { replayed }
@@ -887,7 +887,7 @@ async function main(): Promise<void> {
   // Why: relay-local installers collapse hundreds of SFTP request/response RTTs to one RPC.
   registerManagedHookInstaller(dispatcher)
 
-  // Why: plugin sources ship over the wire so an Orca update doesn't force a relay redeploy; cache them per spawn. See docs/design/agent-status-over-ssh.md §4.
+  // Why: plugin sources ship over the wire — the relay is versioned independently of Orca, so bundling them would make every agent-event change a relay redeploy.
   // Why: bound per-source size so a buggy/hostile Orca can't OOM the relay by pushing a giant string.
   dispatcher.onRequest(AGENT_HOOK_INSTALL_PLUGINS_METHOD, async (params) => {
     const opencode = params.opencodePluginSource

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: canonical transport-agnostic listener; parser, normalizer, per-CLI extractors, and endpoint writer share invariants that must not drift between Orca's main process and the relay. */
 
-// Why: extracted from src/main/agent-hooks/server.ts so the relay can host the pipeline without Electron (Node builtins only). See docs/design/agent-status-over-ssh.md §3.
+// Why: extracted from src/main/agent-hooks/server.ts so the relay can host the same pipeline without Electron — this file must stay on Node builtins and other shared/ modules, or the relay bundle breaks.
 import type { IncomingMessage } from 'node:http'
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
@@ -323,7 +323,8 @@ export type AgentHookEventPayload = {
   launchToken?: string
   tabId?: string
   worktreeId?: string
-  /** SSH connection the event arrived on, or null for local (only ingestRemote stamps it; the HTTP path can't know the mux). See docs/design/agent-status-over-ssh.md §5. */
+  /** SSH connection the event arrived on, or null for local. Only `ingestRemote` can stamp it — the loopback HTTP path has no mux identity — and receivers key off it to drop
+   *  in-flight events from a superseded connection after an SSH reconnect. */
   connectionId: string | null
   /** True when the event carried prompt text directly, not the listener's cached prompt from an earlier event in the pane. */
   hasExplicitPrompt?: boolean
@@ -4361,7 +4362,6 @@ export function normalizeHookPayload(
       break
   }
 
-  // Why: connectionId is null here; ingestRemote stamps it from mux identity on receive. See docs/design/agent-status-over-ssh.md §5.
   const providerSessionOnly =
     (source === 'pi' || source === 'prime-agent') &&
     eventName === 'session_start' &&
@@ -4379,6 +4379,7 @@ export function normalizeHookPayload(
         launchToken,
         tabId,
         worktreeId,
+        // Why: normalization is transport-agnostic — only ingestRemote knows the mux identity to stamp here.
         connectionId: null,
         hasExplicitPrompt:
           source === 'amp'

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -8,7 +8,7 @@
 // the renderer-bound IPC + installer contract; this module is the wire envelope
 // between Orca's main process and the remote relay.
 //
-// Per the design doc:
+// Invariants both ends rely on:
 // - The relay normalizes; Orca routes. The envelope's `payload` field has
 //   already been through `normalizeHookPayload` (which calls
 //   `parseAgentStatusPayload` → `normalizeAgentStatusObject`) on the relay
@@ -194,8 +194,9 @@ export function restoreShedStatusFields(
 }
 
 /** JSON-RPC request method Orca issues after `--connect` reattach to ask the
- *  relay to replay its per-paneKey last-payload cache. See §5 Path 3 of the
- *  design doc for the race that ruled out push-on-`setWrite`. */
+ *  relay to replay its per-paneKey last-payload cache. Pull, not push: a relay
+ *  that pushed on `setWrite` can emit before Orca has wired its `agent.hook`
+ *  handler, and those notifications are dropped silently. */
 export const AGENT_HOOK_REQUEST_REPLAY_METHOD = 'agent_hook.requestReplay' as const
 
 /** JSON-RPC request method Orca issues at session-ready to ship the


### PR DESCRIPTION
## Summary

`docs/design/agent-status-over-ssh.md` is cited from 17 places across `src/` as the authority for why per-pane agent-status replay works the way it does. **That file does not exist** — there is no `docs/design/` directory in this repo. Reviewers have been pointed at a document nobody can open.

We are deliberately not checking design docs into version control, so this replaces each pointer with the invariant the code actually relies on, keeping the knowledge without the doc.

## Scope

Comment/JSDoc only — no executable statement, type, signature, or string literal changed.

Fixes 14 of the 17 citations. The remaining 3 (`useIpcEvents.ts:3177`, `useIpcEvents.ts:3737`, `agent-status-types.ts:229`) are owned by the concurrent agent-status batching change and are scrubbed there, to avoid a conflict.

Went slightly past a literal grep to catch bare section-number references (`relay.ts:873` "(§5 Path 3)", `agent-hook-relay.ts:11/197`, `installer-utils-remote.ts:88`) and removed stale "(commit #7/#8)" pointers.

## Validation

`typecheck:tsc:node` and `typecheck:tsc:web` clean. 471 tests across 14 files (shared + relay + main-process), 0 failures. `check:code-quality:changed` reports 0 new findings.

## Note for a follow-up

~20 *other* phantom design-doc citations exist in this repo (`docs/design/github-project-view-tasks.md`, `DESIGN_DOC_TERMINAL_HISTORY_FIX_V2.md`, `telemetry-plan.md`, `terminal-query-authority.md`, `docs/upstream-base-ref-design.md`). Out of scope here; worth a triage ticket so it isn't rediscovered.

Made with [Orca](https://github.com/stablyai/orca) 🐋
