### PR TITLE
perf(renderer): drop redundant worktree card cache-TTL subscription

### DIFF
--- a/src/renderer/src/components/sidebar/use-worktree-card-controller.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-controller.ts
@@ -135,7 +135,8 @@ export function useWorktreeCardController(props: ResolvedWorktreeCardProps) {
     agentActivityDisplayMode: foundation.agentActivityDisplayMode,
     workspacePorts: foundation.workspacePorts,
     openTaskPage: foundation.openTaskPage,
-    updateWorktreeMeta: foundation.updateWorktreeMeta
+    updateWorktreeMeta: foundation.updateWorktreeMeta,
+    settings: foundation.settings
   })
 
   return {

--- a/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.store-subscriptions.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.store-subscriptions.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { readStoreListenerCount } from '@/store/store-listener-census'
+import type { GlobalSettings, Worktree } from '../../../../shared/types'
+import { usePromptCacheCountdownStartedAt } from './CacheTimer'
+import { useWorktreeCardSecondaryDetails } from './use-worktree-card-secondary-details'
+import { useWorktreeAgentRows } from './useWorktreeAgentRows'
+
+const WORKTREE_ID = 'repo-1::/repo/worktrees/card'
+const originalState = useAppStore.getState()
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function mount(node: ReactNode): void {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(node))
+}
+
+function unmount(): void {
+  if (root) {
+    act(() => root?.unmount())
+  }
+  root = null
+  container?.remove()
+  container = null
+}
+
+function listenerCount(): number {
+  const count = readStoreListenerCount()
+  if (count === null) {
+    throw new Error('store listener census unavailable')
+  }
+  return count
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: WORKTREE_ID,
+    repoId: 'repo-1',
+    path: '/repo/worktrees/card',
+    displayName: 'Card',
+    branch: 'feature/card',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1
+  }
+}
+
+function makeSettings(promptCacheTtlMs: number): GlobalSettings {
+  return { promptCacheTimerEnabled: true, promptCacheTtlMs } as GlobalSettings
+}
+
+function secondaryDetailsArgs(settings: GlobalSettings) {
+  return {
+    worktree: makeWorktree(),
+    repo: undefined,
+    statusPrDisplay: null,
+    showStatus: false,
+    showIssue: false,
+    showLinearIssue: false,
+    showJiraIssue: false,
+    showPR: false,
+    showAutomation: false,
+    showCli: false,
+    showComment: false,
+    showPorts: false,
+    issueDisplay: null,
+    linearIssue: null,
+    linearIssueDisplay: null,
+    jiraIssueDisplay: null,
+    prDisplay: null,
+    linkedGitLabMR: null,
+    linkedBitbucketPR: null,
+    linkedAzureDevOpsPR: null,
+    linkedGiteaPR: null,
+    cardProps: [] as never,
+    newCardStyle: false,
+    compactCards: false,
+    agentActivityDisplayMode: 'compact' as const,
+    workspacePorts: [],
+    openTaskPage: (() => {}) as never,
+    updateWorktreeMeta: (() => {}) as never,
+    settings
+  }
+}
+
+afterEach(() => {
+  unmount()
+  useAppStore.setState(originalState, true)
+})
+
+describe('useWorktreeCardSecondaryDetails store subscriptions', () => {
+  it('adds no store listener of its own beyond the hooks it composes', () => {
+    const settings = makeSettings(300_000)
+
+    // Baseline: the two hooks it composes, mounted on their own.
+    const composedBaseline = listenerCount()
+    function ComposedProbe(): null {
+      useWorktreeAgentRows(WORKTREE_ID, false)
+      usePromptCacheCountdownStartedAt(WORKTREE_ID, true)
+      return null
+    }
+    mount(<ComposedProbe />)
+    const composedListeners = listenerCount() - composedBaseline
+    unmount()
+
+    const baseline = listenerCount()
+    function Probe(): null {
+      useWorktreeCardSecondaryDetails(secondaryDetailsArgs(settings))
+      return null
+    }
+    mount(<Probe />)
+
+    // Why: promptCacheTtlMs comes from the settings the card already subscribes to,
+    // so this hook must not open a third subscription for the same field.
+    expect(listenerCount() - baseline).toBe(composedListeners)
+
+    unmount()
+    expect(listenerCount()).toBe(baseline)
+  })
+
+  it('reads the cache TTL from the passed settings', () => {
+    let cacheTtlMs = -1
+    function Probe({ ttl }: { ttl: number }): null {
+      cacheTtlMs = useWorktreeCardSecondaryDetails(
+        secondaryDetailsArgs(makeSettings(ttl))
+      ).cacheTtlMs
+      return null
+    }
+
+    mount(<Probe ttl={300_000} />)
+    expect(cacheTtlMs).toBe(300_000)
+
+    act(() => root?.render(<Probe ttl={120_000} />))
+    expect(cacheTtlMs).toBe(120_000)
+  })
+
+  it('reports no TTL while the aggregate cache timer is suppressed', () => {
+    let cacheTtlMs = -1
+    function Probe(): null {
+      // compactCards suppresses the aggregate timer row.
+      cacheTtlMs = useWorktreeCardSecondaryDetails({
+        ...secondaryDetailsArgs(makeSettings(300_000)),
+        compactCards: true
+      }).cacheTtlMs
+      return null
+    }
+
+    mount(<Probe />)
+    expect(cacheTtlMs).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.ts
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 
 import type { GitHubWorkItem } from '../../../../shared/types'
-import { useAppStore } from '@/store'
 import { hasWorktreeCardDetails } from './WorktreeCardMeta'
 import { usePromptCacheCountdownStartedAt } from './CacheTimer'
 import { useWorktreeAgentRows } from './useWorktreeAgentRows'
@@ -42,7 +41,8 @@ export function useWorktreeCardSecondaryDetails({
   agentActivityDisplayMode,
   workspacePorts,
   openTaskPage,
-  updateWorktreeMeta
+  updateWorktreeMeta,
+  settings
 }: Pick<WorktreeCardProps, 'worktree' | 'repo' | 'statusPrDisplay'> &
   Pick<
     Foundation,
@@ -53,6 +53,7 @@ export function useWorktreeCardSecondaryDetails({
     | 'workspacePorts'
     | 'openTaskPage'
     | 'updateWorktreeMeta'
+    | 'settings'
   > &
   Pick<LinkedDetails, 'issueDisplay' | 'linearIssue' | 'linearIssueDisplay' | 'jiraIssueDisplay'> &
   Pick<
@@ -190,9 +191,9 @@ export function useWorktreeCardSecondaryDetails({
   })
   const hasPorts = showPorts && workspacePorts.length > 0
   const cacheStartedAt = usePromptCacheCountdownStartedAt(worktree.id, showAggregateCacheTimer)
-  const cacheTtlMs = useAppStore((s) =>
-    showAggregateCacheTimer ? (s.settings?.promptCacheTtlMs ?? 0) : 0
-  )
+  // Why: derived from the settings the card already subscribes to — a third store
+  // subscription for this one field costs a listener per card on every store write.
+  const cacheTtlMs = showAggregateCacheTimer ? (settings?.promptCacheTtlMs ?? 0) : 0
 
   return {
     showUnreadEmphasis,


### PR DESCRIPTION
## The finding matters more than the code

This PR was originally scoped to bundle `use-worktree-card-foundation.ts`'s 26 store subscriptions into one `useShallow` projection — 26 listeners per card down to 1, across ~100 mounted cards.

**I measured it before writing it. It is a 4× pessimization. So this PR does not do it.**

150 cards x 400 unrelated store writes, median of 5 runs, real store + React:

| Approach | Time |
| --- | ---: |
| 26 separate `useAppStore` hooks (today) | **100.7 ms** |
| 1 hook + `useShallow` bundle | **402.5 ms** (4.00x worse) |
| 1 hook + non-allocating keyed compare | **141.5 ms** (1.41x worse) |

A vanilla-zustand sweep at 2/5/8/12/20/26 keys showed `useShallow` losing at **every** key count. There is no crossover to aim for.

**Mechanism** — zustand v5's `shallow()` on plain objects falls through to `compareEntries`, which allocates two `Object.entries()` arrays *and two `Map`s* per comparison, per subscriber, per store write:

```js
// node_modules/zustand/vanilla/shallow.js:9
const mapA = valueA instanceof Map ? valueA : new Map(valueA.entries())
const mapB = valueB instanceof Map ? valueB : new Map(valueB.entries())
```

Measured in isolation against zustand 5.0.14: 721 ns for a 2-key bundle, 2,152 ns for 9-key — versus ~1-5 ns for the equivalent `Object.is` sweep. Even a perfect zero-allocation compare still loses, because the bundle must rebuild the whole projection on every notification while separate selectors short-circuit on the first `Object.is` hit.

**Listener count is the wrong metric.** It would have improved 26 -> 1 here while the hot path got 4x slower. Two sibling branches that did land this transform measured 1.3-1.4x regressions on their own target metric; both are being dropped on the strength of this result.

## What actually ships

`use-worktree-card-secondary-details.ts` no longer opens its own subscription for `promptCacheTtlMs` — it derives it from `foundation.settings`, which the same component already subscribes to. 11 -> 10 listeners per card.

Staleness is impossible via two independent paths: `use-worktree-card-foundation.ts:36` subscribes `s.settings` unconditionally, and `usePromptCacheCountdownStartedAt`'s `useShallow` tuple already includes `ttlMs`. `settings` identity always changes on write — no in-place mutation at `settings.ts:133/160` or `ui.ts:2155`.

Honestly: this is ~1 listener out of ~30 per card, well under 1% of sidebar notification cost. **The measurement is the deliverable.**

## Validation

`typecheck:tsc:web` exit 0 (confirmed via `--listFilesOnly` that the new test is inside the web tsconfig program, so its casts are genuinely typechecked). Sidebar suite: 225 files / 2,049 tests pass. `check:code-quality:changed` 0 new findings. `check:zustand-selector-fanout`: 0.0146 ms/write, 0 render invalidations.

Guard proven to bite by double revert: reverting the change fails 1 test in hybrid form and 2 of 3 in pure form.

One caveat: the third test ("reports no TTL while suppressed") passes identically on `main` — it's a harmless behavior lock, not a regression guard.

## Caveat on the numbers

Taken on macOS at load average ~24. Ratios and the deterministic sweep survive that; absolute milliseconds are inflated and shouldn't be quoted as app-level figures.

Made with [Orca](https://github.com/stablyai/orca) 🐋
