### PR TITLE
fix(daemon): bound shell-ready when an exec strips the wrapper

### DIFF
--- a/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
+++ b/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Session } from './session'
 import { PROMPT_READINESS_PROBE_GRACE_MS } from '../../shared/pty-prompt-readiness-probe'
-import type { PtySlaveLineDisciplineEcho } from '../../shared/pty-slave-line-discipline-echo'
+import type { PtySlaveLineEditorState } from '../../shared/pty-slave-line-discipline-echo'
 import type { ShellReadyState } from './types'
 
 // Why this repro exists: an `exec` in a user rc file (Kiro CLI / Amazon Q / Fig / Warp)
@@ -9,10 +9,11 @@ import type { ShellReadyState } from './types'
 // and the shell-ready marker is never printed. The barrier then waited out its full
 // 15s on every spawn (#13767). The slave's line discipline still reports the prompt.
 
-const echoStateRef = vi.hoisted(() => ({ current: 'echoing' as PtySlaveLineDisciplineEcho }))
+const ttyStateRef = vi.hoisted(() => ({ current: 'cooked' as PtySlaveLineEditorState }))
 vi.mock('../../shared/pty-slave-line-discipline-echo', () => ({
-  createPtySlaveEchoProbe: (ptsName: string | undefined) =>
-    ptsName ? async () => echoStateRef.current : undefined
+  createPtySlaveEchoProbe: () => undefined,
+  createPtySlaveLineEditorProbe: (ptsName: string | undefined) =>
+    ptsName ? async () => ttyStateRef.current : undefined
 }))
 
 vi.mock('../pty-descendant-termination', () => ({ killWithDescendantSweep: vi.fn() }))
@@ -55,7 +56,7 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
 
   beforeEach(() => {
     vi.useFakeTimers()
-    echoStateRef.current = 'echoing'
+    ttyStateRef.current = 'cooked'
   })
 
   afterEach(() => {
@@ -86,7 +87,7 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
     expect(s.shellState).toBe('pending' satisfies ShellReadyState)
 
     // The replacement shell draws its prompt: zle/readline clear ECHO on the slave.
-    echoStateRef.current = 'quiet'
+    ttyStateRef.current = 'line-editor'
     await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS)
 
     expect(s.shellState).toBe('ready' satisfies ShellReadyState)
@@ -98,7 +99,7 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
     s.write('claude\r')
     expect(subprocess.written).toEqual([])
 
-    echoStateRef.current = 'quiet'
+    ttyStateRef.current = 'line-editor'
     await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 100)
 
     expect(subprocess.written).toEqual(['claude\r'])
@@ -108,7 +109,7 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     createSession()
 
-    echoStateRef.current = 'quiet'
+    ttyStateRef.current = 'line-editor'
     await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 500)
 
     const messages = warn.mock.calls.map((call) => String(call[0]))
@@ -119,11 +120,23 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
   it('keeps waiting while the shell is still running its startup files', async () => {
     const { session: s } = createSession()
 
-    // A slow rc (oh-my-zsh, nvm) leaves the slave echoing until the first prompt.
-    echoStateRef.current = 'echoing'
+    // A slow rc (oh-my-zsh, nvm) leaves the slave in cooked mode until the first prompt.
+    ttyStateRef.current = 'cooked'
     await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 3_000)
 
     expect(s.shellState).toBe('pending' satisfies ShellReadyState)
+  })
+
+  it('does not flush a startup command into a password read during startup', async () => {
+    const { session: s, subprocess } = createSession()
+    s.write('claude\r')
+
+    // `read -s` in an rc file clears ECHO but stays canonical, so it reports `cooked`.
+    ttyStateRef.current = 'cooked'
+    await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 2_000)
+
+    expect(s.shellState).toBe('pending' satisfies ShellReadyState)
+    expect(subprocess.written).toEqual([])
   })
 
   it('lets the real marker win when the wrapper survived', async () => {
@@ -136,7 +149,7 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
 
     expect(s.shellState).toBe('ready' satisfies ShellReadyState)
 
-    echoStateRef.current = 'quiet'
+    ttyStateRef.current = 'line-editor'
     await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 500)
 
     expect(warn.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain(
@@ -147,7 +160,7 @@ describe('#13767 — shell-ready marker stripped by an exec in user rc files', (
   it('still times out when the slave cannot be probed', async () => {
     const { session: s } = createSession(null)
 
-    echoStateRef.current = 'quiet'
+    ttyStateRef.current = 'line-editor'
     await vi.advanceTimersByTimeAsync(SHELL_READY_TIMEOUT_MS - 1)
     expect(s.shellState).toBe('pending' satisfies ShellReadyState)
 

--- a/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
+++ b/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Session } from './session'
+import { PROMPT_READINESS_PROBE_GRACE_MS } from '../../shared/pty-prompt-readiness-probe'
+import type { PtySlaveLineDisciplineEcho } from '../../shared/pty-slave-line-discipline-echo'
+import type { ShellReadyState } from './types'
+
+// Why this repro exists: an `exec` in a user rc file (Kiro CLI / Amazon Q / Fig / Warp)
+// replaces the shell, dropping ZDOTDIR/--rcfile, so Orca's wrapper is never read again
+// and the shell-ready marker is never printed. The barrier then waited out its full
+// 15s on every spawn (#13767). The slave's line discipline still reports the prompt.
+
+const echoStateRef = vi.hoisted(() => ({ current: 'echoing' as PtySlaveLineDisciplineEcho }))
+vi.mock('../../shared/pty-slave-line-discipline-echo', () => ({
+  createPtySlaveEchoProbe: (ptsName: string | undefined) =>
+    ptsName ? async () => echoStateRef.current : undefined
+}))
+
+vi.mock('../pty-descendant-termination', () => ({ killWithDescendantSweep: vi.fn() }))
+
+const SHELL_READY_TIMEOUT_MS = 15_000
+
+function createMockSubprocess(slavePath: string | undefined) {
+  const written: string[] = []
+  let onData: ((data: string) => void) | null = null
+  let onExit: ((code: number) => void) | null = null
+  return {
+    written,
+    slavePath,
+    pid: 4242,
+    getForegroundProcess: () => null,
+    write: (data: string) => {
+      written.push(data)
+    },
+    resize() {},
+    pause() {},
+    resume() {},
+    clear() {},
+    kill() {},
+    forceKill() {},
+    signal() {},
+    onData(cb: (data: string) => void) {
+      onData = cb
+    },
+    onExit(cb: (code: number) => void) {
+      onExit = cb
+    },
+    dispose() {},
+    simulateData: (data: string) => onData?.(data),
+    simulateExit: (code: number) => onExit?.(code)
+  }
+}
+
+describe('#13767 — shell-ready marker stripped by an exec in user rc files', () => {
+  let session: Session | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    echoStateRef.current = 'echoing'
+  })
+
+  afterEach(() => {
+    session?.dispose()
+    session = null
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function createSession(slavePath: string | null = '/dev/ttys004'): {
+    session: Session
+    subprocess: ReturnType<typeof createMockSubprocess>
+  } {
+    const subprocess = createMockSubprocess(slavePath ?? undefined)
+    session = new Session({
+      sessionId: 'repro-13767',
+      cols: 80,
+      rows: 24,
+      subprocess,
+      shellReadySupported: true
+    })
+    return { session, subprocess }
+  }
+
+  it('reaches ready from the line discipline when the marker never arrives', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { session: s } = createSession()
+    expect(s.shellState).toBe('pending' satisfies ShellReadyState)
+
+    // The replacement shell draws its prompt: zle/readline clear ECHO on the slave.
+    echoStateRef.current = 'quiet'
+    await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS)
+
+    expect(s.shellState).toBe('ready' satisfies ShellReadyState)
+  })
+
+  it('delivers a queued startup command instead of burning the full timeout', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { session: s, subprocess } = createSession()
+    s.write('claude\r')
+    expect(subprocess.written).toEqual([])
+
+    echoStateRef.current = 'quiet'
+    await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 100)
+
+    expect(subprocess.written).toEqual(['claude\r'])
+  })
+
+  it('warns once that shell integration is likely inactive', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    createSession()
+
+    echoStateRef.current = 'quiet'
+    await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 500)
+
+    const messages = warn.mock.calls.map((call) => String(call[0]))
+    expect(messages.filter((message) => message.includes('shell-ready marker'))).toHaveLength(1)
+    expect(messages.join('\n')).toContain('OSC 133')
+  })
+
+  it('keeps waiting while the shell is still running its startup files', async () => {
+    const { session: s } = createSession()
+
+    // A slow rc (oh-my-zsh, nvm) leaves the slave echoing until the first prompt.
+    echoStateRef.current = 'echoing'
+    await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 3_000)
+
+    expect(s.shellState).toBe('pending' satisfies ShellReadyState)
+  })
+
+  it('lets the real marker win when the wrapper survived', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { session: s, subprocess } = createSession()
+
+    s.write('claude\r')
+    // Healthy wrapper: the marker lands well inside the probe's grace window.
+    subprocess.simulateData('\x1b]777;orca-shell-ready\x07user@host % ')
+
+    expect(s.shellState).toBe('ready' satisfies ShellReadyState)
+
+    echoStateRef.current = 'quiet'
+    await vi.advanceTimersByTimeAsync(PROMPT_READINESS_PROBE_GRACE_MS + 500)
+
+    expect(warn.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain(
+      'shell-ready marker never arrived'
+    )
+  })
+
+  it('still times out when the slave cannot be probed', async () => {
+    const { session: s } = createSession(null)
+
+    echoStateRef.current = 'quiet'
+    await vi.advanceTimersByTimeAsync(SHELL_READY_TIMEOUT_MS - 1)
+    expect(s.shellState).toBe('pending' satisfies ShellReadyState)
+
+    await vi.advanceTimersByTimeAsync(2)
+    expect(s.shellState).toBe('timed_out' satisfies ShellReadyState)
+  })
+})

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -33,7 +33,10 @@ import type {
   TerminalSnapshot
 } from './types'
 import type { PtyOwnerBackend } from '../../shared/pty-owner-backend'
-import { createPtySlaveEchoProbe } from '../../shared/pty-slave-line-discipline-echo'
+import {
+  createPtySlaveEchoProbe,
+  createPtySlaveLineEditorProbe
+} from '../../shared/pty-slave-line-discipline-echo'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
 // Why: Codex skips marker-gated command delivery; this only bounds older daemon/local paths that still report shell-ready for Codex.
@@ -192,9 +195,10 @@ export class Session {
     const echoProbe = createPtySlaveEchoProbe(this.subprocess.slavePath)
     // Why: an `exec` in the user's rc files strips the wrapper that prints the marker,
     // so without this the barrier burns its full timeout on every spawn (#13767).
-    if (this._shellState === 'pending' && echoProbe) {
+    const lineEditorProbe = createPtySlaveLineEditorProbe(this.subprocess.slavePath)
+    if (this._shellState === 'pending' && lineEditorProbe) {
       this.stopPromptReadinessProbe = startPtyPromptReadinessProbe({
-        probe: echoProbe,
+        probe: lineEditorProbe,
         onPromptReady: () => this.onPromptReadinessDetected()
       })
     }

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -24,6 +24,7 @@ import {
   type PtyStartupIngressIntent
 } from '../../shared/pty-startup-ingress'
 import { extractOnlyCookedEchoSafeQueryReplies } from '../../shared/terminal-query-reply'
+import { startPtyPromptReadinessProbe } from '../../shared/pty-prompt-readiness-probe'
 import type {
   PendingOutputRecord,
   SessionState,
@@ -126,6 +127,7 @@ export class Session {
   private startupDeviceAttributesQueryFilter: StartupDeviceAttributesQueryFilter | null = null
   private shellReadyScanState: ShellReadyScanState | null = null
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
+  private stopPromptReadinessProbe: (() => void) | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
   private postReadyFlushGate: PostReadyFlushGate
   private pendingOutputRecords: PendingOutputRecord[] = []
@@ -188,6 +190,14 @@ export class Session {
 
     this.postReadyFlushGate = new PostReadyFlushGate(() => this.flushPreReadyQueue())
     const echoProbe = createPtySlaveEchoProbe(this.subprocess.slavePath)
+    // Why: an `exec` in the user's rc files strips the wrapper that prints the marker,
+    // so without this the barrier burns its full timeout on every spawn (#13767).
+    if (this._shellState === 'pending' && echoProbe) {
+      this.stopPromptReadinessProbe = startPtyPromptReadinessProbe({
+        probe: echoProbe,
+        onPromptReady: () => this.onPromptReadinessDetected()
+      })
+    }
     this.startupIngress = new PtyStartupIngress({
       ...(opts.startupIngress ? { intent: opts.startupIngress } : {}),
       ...(opts.ownerBackend ? { ownerBackend: opts.ownerBackend } : {}),
@@ -595,6 +605,7 @@ export class Session {
     this._disposed = true
     // Why: never leave a paused fd behind on teardown; the handle's dead-guard makes this a no-op once the child is reaped.
     this.releaseProducerPause({ resume: true })
+    this.clearPromptReadinessProbe()
     if (this.killTimer) {
       clearTimeout(this.killTimer)
       this.killTimer = null
@@ -712,6 +723,7 @@ export class Session {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null
     }
+    this.clearPromptReadinessProbe()
     this.postReadyFlushGate.clear()
 
     // Why: release the ptmx fd here or node-pty's _socket leaks the master fd until GC (docs/fix-pty-fd-leak.md).
@@ -756,9 +768,36 @@ export class Session {
     }
   }
 
+  /** Readiness proven by the slave's line discipline rather than the marker — the only
+   *  signal an `exec` in the user's rc files cannot strip (#13767). */
+  private onPromptReadinessDetected(): void {
+    this.stopPromptReadinessProbe = null
+    if (this._shellState !== 'pending') {
+      return
+    }
+    // Why warn: a marker that never arrives also means the wrapper's OSC 133 hooks are
+    // gone, and that half of the failure stays silent even once the wait is short.
+    console.warn(
+      `[Session] ${this.sessionId}: shell-ready marker never arrived; fell back to line-discipline prompt detection. Shell integration (OSC 133) is likely inactive — an \`exec\` in a shell startup file strips Orca's wrapper.`
+    )
+    // Why before the transition: transitionToReady drops the scan state, and any held
+    // partial-marker prefix must still reach the client.
+    this.releaseHeldShellReadyBytes()
+    // Why `true`: the line editor already owns the tty — that is what was just measured —
+    // so the gate's wait-for-raw-mode fallback would only add latency.
+    this.transitionToReady(true)
+    this.releaseStartupDeviceAttributes()
+  }
+
+  private clearPromptReadinessProbe(): void {
+    this.stopPromptReadinessProbe?.()
+    this.stopPromptReadinessProbe = null
+  }
+
   private transitionToReady(postMarkerBytesObserved = false): void {
     this._shellState = 'ready'
     this.shellReadyScanState = null
+    this.clearPromptReadinessProbe()
     if (this.shellReadyTimer) {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null
@@ -771,6 +810,7 @@ export class Session {
 
   private onShellReadyTimeout(): void {
     this.shellReadyTimer = null
+    this.clearPromptReadinessProbe()
     if (this._shellState !== 'pending') {
       return
     }

--- a/src/shared/pty-prompt-readiness-probe.test.ts
+++ b/src/shared/pty-prompt-readiness-probe.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startPtyPromptReadinessProbe } from './pty-prompt-readiness-probe'
+
+const GRACE_MS = 500
+const INTERVAL_MS = 100
+
+describe('startPtyPromptReadinessProbe', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function start(probe: () => Promise<'echoing' | 'quiet' | 'unknown'>) {
+    const onPromptReady = vi.fn()
+    const stop = startPtyPromptReadinessProbe({
+      probe,
+      onPromptReady,
+      graceMs: GRACE_MS,
+      intervalMs: INTERVAL_MS
+    })
+    return { onPromptReady, stop }
+  }
+
+  it('does not probe at all during the grace window', async () => {
+    const probe = vi.fn().mockResolvedValue('quiet')
+    const { onPromptReady } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS - 1)
+
+    expect(probe).not.toHaveBeenCalled()
+    expect(onPromptReady).not.toHaveBeenCalled()
+  })
+
+  it('reports ready once the line editor has taken the tty', async () => {
+    const probe = vi.fn().mockResolvedValue('quiet')
+    const { onPromptReady } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+
+    expect(onPromptReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps polling while the slave is still echoing', async () => {
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce('echoing')
+      .mockResolvedValueOnce('echoing')
+      .mockResolvedValue('quiet')
+    const { onPromptReady } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+    expect(onPromptReady).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 2)
+    expect(onPromptReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('never reports ready on an undetermined probe', async () => {
+    const probe = vi.fn().mockResolvedValue('unknown')
+    const { onPromptReady } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS + INTERVAL_MS * 10)
+
+    expect(probe.mock.calls.length).toBeGreaterThan(1)
+    expect(onPromptReady).not.toHaveBeenCalled()
+  })
+
+  it('fires only once even as polling continues', async () => {
+    const probe = vi.fn().mockResolvedValue('quiet')
+    const { onPromptReady } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS + INTERVAL_MS * 10)
+
+    expect(onPromptReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops polling after stop()', async () => {
+    const probe = vi.fn().mockResolvedValue('echoing')
+    const { onPromptReady, stop } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+    const callsBeforeStop = probe.mock.calls.length
+    stop()
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 10)
+
+    expect(probe.mock.calls.length).toBe(callsBeforeStop)
+    expect(onPromptReady).not.toHaveBeenCalled()
+  })
+
+  it('does not report ready when stopped while a probe is in flight', async () => {
+    const pending: { resolve?: (state: 'quiet') => void } = {}
+    const probe = vi.fn(
+      () =>
+        new Promise<'quiet'>((resolve) => {
+          pending.resolve = resolve
+        })
+    )
+    const { onPromptReady, stop } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+    expect(pending.resolve).toBeDefined()
+
+    stop()
+    pending.resolve?.('quiet')
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+
+    expect(onPromptReady).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/pty-prompt-readiness-probe.test.ts
+++ b/src/shared/pty-prompt-readiness-probe.test.ts
@@ -13,7 +13,7 @@ describe('startPtyPromptReadinessProbe', () => {
     vi.useRealTimers()
   })
 
-  function start(probe: () => Promise<'echoing' | 'quiet' | 'unknown'>) {
+  function start(probe: () => Promise<'line-editor' | 'cooked' | 'unknown'>) {
     const onPromptReady = vi.fn()
     const stop = startPtyPromptReadinessProbe({
       probe,
@@ -25,7 +25,7 @@ describe('startPtyPromptReadinessProbe', () => {
   }
 
   it('does not probe at all during the grace window', async () => {
-    const probe = vi.fn().mockResolvedValue('quiet')
+    const probe = vi.fn().mockResolvedValue('line-editor')
     const { onPromptReady } = start(probe)
 
     await vi.advanceTimersByTimeAsync(GRACE_MS - 1)
@@ -35,7 +35,7 @@ describe('startPtyPromptReadinessProbe', () => {
   })
 
   it('reports ready once the line editor has taken the tty', async () => {
-    const probe = vi.fn().mockResolvedValue('quiet')
+    const probe = vi.fn().mockResolvedValue('line-editor')
     const { onPromptReady } = start(probe)
 
     await vi.advanceTimersByTimeAsync(GRACE_MS)
@@ -43,12 +43,12 @@ describe('startPtyPromptReadinessProbe', () => {
     expect(onPromptReady).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps polling while the slave is still echoing', async () => {
+  it('keeps polling while the slave is still in cooked mode', async () => {
     const probe = vi
       .fn()
-      .mockResolvedValueOnce('echoing')
-      .mockResolvedValueOnce('echoing')
-      .mockResolvedValue('quiet')
+      .mockResolvedValueOnce('cooked')
+      .mockResolvedValueOnce('cooked')
+      .mockResolvedValue('line-editor')
     const { onPromptReady } = start(probe)
 
     await vi.advanceTimersByTimeAsync(GRACE_MS)
@@ -69,7 +69,7 @@ describe('startPtyPromptReadinessProbe', () => {
   })
 
   it('fires only once even as polling continues', async () => {
-    const probe = vi.fn().mockResolvedValue('quiet')
+    const probe = vi.fn().mockResolvedValue('line-editor')
     const { onPromptReady } = start(probe)
 
     await vi.advanceTimersByTimeAsync(GRACE_MS + INTERVAL_MS * 10)
@@ -77,8 +77,38 @@ describe('startPtyPromptReadinessProbe', () => {
     expect(onPromptReady).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps polling instead of crashing when the probe rejects', async () => {
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('stty: fork failed'))
+      .mockResolvedValue('line-editor')
+    const { onPromptReady } = start(probe)
+
+    await vi.advanceTimersByTimeAsync(GRACE_MS)
+    expect(onPromptReady).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+    expect(onPromptReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not raise an unhandled rejection when onPromptReady throws', async () => {
+    const probe = vi.fn().mockResolvedValue('line-editor')
+    const onPromptReady = vi.fn(() => {
+      throw new Error('teardown raced the probe')
+    })
+    startPtyPromptReadinessProbe({
+      probe,
+      onPromptReady,
+      graceMs: GRACE_MS,
+      intervalMs: INTERVAL_MS
+    })
+
+    await expect(vi.advanceTimersByTimeAsync(GRACE_MS + INTERVAL_MS * 2)).resolves.not.toThrow()
+    expect(onPromptReady).toHaveBeenCalledTimes(1)
+  })
+
   it('stops polling after stop()', async () => {
-    const probe = vi.fn().mockResolvedValue('echoing')
+    const probe = vi.fn().mockResolvedValue('cooked')
     const { onPromptReady, stop } = start(probe)
 
     await vi.advanceTimersByTimeAsync(GRACE_MS)
@@ -91,10 +121,10 @@ describe('startPtyPromptReadinessProbe', () => {
   })
 
   it('does not report ready when stopped while a probe is in flight', async () => {
-    const pending: { resolve?: (state: 'quiet') => void } = {}
+    const pending: { resolve?: (state: 'line-editor') => void } = {}
     const probe = vi.fn(
       () =>
-        new Promise<'quiet'>((resolve) => {
+        new Promise<'line-editor'>((resolve) => {
           pending.resolve = resolve
         })
     )
@@ -104,7 +134,7 @@ describe('startPtyPromptReadinessProbe', () => {
     expect(pending.resolve).toBeDefined()
 
     stop()
-    pending.resolve?.('quiet')
+    pending.resolve?.('line-editor')
     await vi.advanceTimersByTimeAsync(INTERVAL_MS)
 
     expect(onPromptReady).not.toHaveBeenCalled()

--- a/src/shared/pty-prompt-readiness-probe.ts
+++ b/src/shared/pty-prompt-readiness-probe.ts
@@ -1,0 +1,68 @@
+import type { PtySlaveEchoProbe } from './pty-slave-line-discipline-echo'
+
+// Why this exists: the shell-ready marker is printed by Orca's own wrapper, so it is
+// only as durable as the wrapper. An `exec` in a user rc file — what every
+// figterm-style integration does (Kiro CLI, Amazon Q, Fig, Warp) — replaces the process
+// image, dropping ZDOTDIR/--rcfile, so no wrapper file is ever read again and the marker
+// never arrives (#13767). The line discipline cannot be lost that way: zle/readline
+// clear ECHO on the slave exactly when the line editor takes the tty at the first
+// prompt — after a slow rc, and after an exec. Polling it turns a stripped wrapper into
+// a short wait instead of the full shell-ready timeout.
+
+/** Why: a healthy wrapper marks ready far inside this, so the normal path never spawns
+ *  an `stty` — and a shell that legitimately reads input during startup is past that
+ *  window before the fallback can mistake its raw mode for a prompt. */
+export const PROMPT_READINESS_PROBE_GRACE_MS = 750
+export const PROMPT_READINESS_PROBE_INTERVAL_MS = 250
+
+export type PtyPromptReadinessProbeOptions = {
+  probe: PtySlaveEchoProbe
+  /** Fired at most once, when the slave's line editor has taken the tty. */
+  onPromptReady: () => void
+  graceMs?: number
+  intervalMs?: number
+}
+
+/** Returns a stop function; safe to call after the probe has already fired. */
+export function startPtyPromptReadinessProbe(options: PtyPromptReadinessProbeOptions): () => void {
+  const graceMs = options.graceMs ?? PROMPT_READINESS_PROBE_GRACE_MS
+  const intervalMs = options.intervalMs ?? PROMPT_READINESS_PROBE_INTERVAL_MS
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const schedule = (delayMs: number): void => {
+    timer = setTimeout(() => {
+      timer = null
+      void tick()
+    }, delayMs)
+  }
+
+  const tick = async (): Promise<void> => {
+    if (stopped) {
+      return
+    }
+    const state = await options.probe()
+    // Why re-check: the probe awaits a child process, so a stop can land mid-flight.
+    if (stopped) {
+      return
+    }
+    // Why only 'quiet': `unknown` means the probe could not read the slave, and reading
+    // that as ready would flush a startup command into a shell that cannot take it.
+    if (state === 'quiet') {
+      stopped = true
+      options.onPromptReady()
+      return
+    }
+    schedule(intervalMs)
+  }
+
+  schedule(graceMs)
+
+  return () => {
+    stopped = true
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+}

--- a/src/shared/pty-prompt-readiness-probe.ts
+++ b/src/shared/pty-prompt-readiness-probe.ts
@@ -1,22 +1,24 @@
-import type { PtySlaveEchoProbe } from './pty-slave-line-discipline-echo'
+import type {
+  PtySlaveLineEditorProbe,
+  PtySlaveLineEditorState
+} from './pty-slave-line-discipline-echo'
 
 // Why this exists: the shell-ready marker is printed by Orca's own wrapper, so it is
 // only as durable as the wrapper. An `exec` in a user rc file — what every
 // figterm-style integration does (Kiro CLI, Amazon Q, Fig, Warp) — replaces the process
 // image, dropping ZDOTDIR/--rcfile, so no wrapper file is ever read again and the marker
-// never arrives (#13767). The line discipline cannot be lost that way: zle/readline
-// clear ECHO on the slave exactly when the line editor takes the tty at the first
+// never arrives (#13767). The line discipline cannot be lost that way: zle/readline take
+// the slave out of canonical mode exactly when the line editor owns the tty at the first
 // prompt — after a slow rc, and after an exec. Polling it turns a stripped wrapper into
 // a short wait instead of the full shell-ready timeout.
 
 /** Why: a healthy wrapper marks ready far inside this, so the normal path never spawns
- *  an `stty` — and a shell that legitimately reads input during startup is past that
- *  window before the fallback can mistake its raw mode for a prompt. */
+ *  an `stty` at all. */
 export const PROMPT_READINESS_PROBE_GRACE_MS = 750
 export const PROMPT_READINESS_PROBE_INTERVAL_MS = 250
 
 export type PtyPromptReadinessProbeOptions = {
-  probe: PtySlaveEchoProbe
+  probe: PtySlaveLineEditorProbe
   /** Fired at most once, when the slave's line editor has taken the tty. */
   onPromptReady: () => void
   graceMs?: number
@@ -33,7 +35,10 @@ export function startPtyPromptReadinessProbe(options: PtyPromptReadinessProbeOpt
   const schedule = (delayMs: number): void => {
     timer = setTimeout(() => {
       timer = null
-      void tick()
+      // Why catch: this is fire-and-forget off a timer, so a throwing onPromptReady
+      // would otherwise surface as an unhandled rejection and take the daemon down.
+      // Readiness then degrades to the shell-ready timeout, which is the old behavior.
+      void tick().catch(() => {})
     }, delayMs)
   }
 
@@ -41,14 +46,22 @@ export function startPtyPromptReadinessProbe(options: PtyPromptReadinessProbeOpt
     if (stopped) {
       return
     }
-    const state = await options.probe()
+    let state: PtySlaveLineEditorState
+    try {
+      state = await options.probe()
+    } catch {
+      // Why: a probe that rejects is no evidence of a prompt — keep polling, and let the
+      // shell-ready timeout remain the backstop.
+      state = 'unknown'
+    }
     // Why re-check: the probe awaits a child process, so a stop can land mid-flight.
     if (stopped) {
       return
     }
-    // Why only 'quiet': `unknown` means the probe could not read the slave, and reading
-    // that as ready would flush a startup command into a shell that cannot take it.
-    if (state === 'quiet') {
+    // Why only 'line-editor': `unknown` means the probe could not read the slave, and
+    // `cooked` covers a startup file's own `read` — flushing into either would push a
+    // startup command at a shell that cannot take it (or into a password prompt).
+    if (state === 'line-editor') {
       stopped = true
       options.onPromptReady()
       return

--- a/src/shared/pty-slave-line-discipline-echo.test.ts
+++ b/src/shared/pty-slave-line-discipline-echo.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 const execFileMock = vi.hoisted(() => vi.fn())
 vi.mock('node:child_process', () => ({ execFile: execFileMock }))
 
-import { createPtySlaveEchoProbe, readPtySlavePath } from './pty-slave-line-discipline-echo'
+import {
+  createPtySlaveEchoProbe,
+  createPtySlaveLineEditorProbe,
+  readPtySlavePath
+} from './pty-slave-line-discipline-echo'
 
 /** Replies to the next stty call with the given output, or an error when `output` is null. */
 function answerStty(output: string | null): void {
@@ -130,5 +134,39 @@ describe('createPtySlaveEchoProbe', () => {
     answerStty(RAW)
     await createPtySlaveEchoProbe('/dev/pts/3', 'linux')?.()
     expect(execFileMock.mock.calls[1]?.[1]).toEqual(['-a', '-F', '/dev/pts/3'])
+  })
+})
+
+describe('createPtySlaveLineEditorProbe', () => {
+  it('has no probe to offer when there is no POSIX slave to read', () => {
+    expect(createPtySlaveLineEditorProbe('/dev/ttys048', 'win32')).toBeUndefined()
+    expect(createPtySlaveLineEditorProbe(undefined, 'darwin')).toBeUndefined()
+  })
+
+  it('reports a line editor only when the tty is both silent and raw', async () => {
+    const probe = createPtySlaveLineEditorProbe('/dev/ttys048', 'darwin')
+    answerStty(RAW)
+    await expect(probe?.()).resolves.toBe('line-editor')
+    answerStty(COOKED)
+    await expect(probe?.()).resolves.toBe('cooked')
+  })
+
+  it('does not mistake a password-style read for a prompt', async () => {
+    const probe = createPtySlaveLineEditorProbe('/dev/ttys048', 'darwin')
+    // Why: `read -s` in a startup file clears ECHO but stays canonical (measured on
+    // zsh 5.9 and bash 3.2.57). Reading that as ready flushes a queued startup command
+    // into the user's password prompt (#13767 review).
+    answerStty('lflags: icanon isig iexten -echo echoe echok echoctl\n')
+    await expect(probe?.()).resolves.toBe('cooked')
+  })
+
+  it('reports unknown rather than a prompt when the slave cannot be read', async () => {
+    const probe = createPtySlaveLineEditorProbe('/dev/ttys048', 'darwin')
+    answerStty(null)
+    await expect(probe?.()).resolves.toBe('unknown')
+    const partial = createPtySlaveLineEditorProbe('/dev/ttys049', 'darwin')
+    // A tty report with no icanon token at all must not be read as a prompt.
+    answerStty('lflags: -echo\n')
+    await expect(partial?.()).resolves.toBe('unknown')
   })
 })

--- a/src/shared/pty-slave-line-discipline-echo.ts
+++ b/src/shared/pty-slave-line-discipline-echo.ts
@@ -10,10 +10,17 @@ export type PtySlaveLineDisciplineEcho = 'echoing' | 'quiet' | 'unknown'
 
 export type PtySlaveEchoProbe = () => Promise<PtySlaveLineDisciplineEcho>
 
+/** Whether a line editor (zle/readline) currently owns the slave. `cooked` covers
+ *  both a shell still running startup files and a plain canonical-mode read. */
+export type PtySlaveLineEditorState = 'line-editor' | 'cooked' | 'unknown'
+
+export type PtySlaveLineEditorProbe = () => Promise<PtySlaveLineEditorState>
+
 const STTY_TIMEOUT_MS = 2_000
 // `stty -a` prints the lflags as a space-separated list where a disabled flag is
 // prefixed with `-`, so `echo` and `-echo` are the two tokens that matter.
 const ECHO_FLAG = /(?:^|\s)(-?)echo(?:\s|$)/
+const ICANON_FLAG = /(?:^|\s)(-?)icanon(?:\s|$)/
 
 function sttyArgs(ptsName: string, platform: NodeJS.Platform): readonly string[] {
   // BSD/macOS take `-f`; Linux (GNU coreutils) takes `-F`.
@@ -30,7 +37,23 @@ function parseEchoFlag(sttyOutput: string): PtySlaveLineDisciplineEcho {
   return match[1] === '-' ? 'quiet' : 'echoing'
 }
 
-type SttyProbeResult = { state: PtySlaveLineDisciplineEcho; permanent: boolean }
+/**
+ * Why both flags: ECHO alone does not mean "at a prompt". A password-style `read -s`
+ * in a startup file clears ECHO while leaving the line discipline canonical, so echo
+ * state on its own reports a prompt that is not there (measured: `-echo icanon` at
+ * 0.02s for `read -s`, vs `-echo -icanon` for a real prompt). zle and readline take
+ * the tty out of canonical mode; requiring both is what separates the two.
+ */
+function parseLineEditorState(sttyOutput: string): PtySlaveLineEditorState {
+  const echo = ECHO_FLAG.exec(sttyOutput)
+  const icanon = ICANON_FLAG.exec(sttyOutput)
+  if (!echo || !icanon) {
+    return 'unknown'
+  }
+  return echo[1] === '-' && icanon[1] === '-' ? 'line-editor' : 'cooked'
+}
+
+type SttyProbeResult = { stdout: string | null; permanent: boolean }
 
 /**
  * A spawn that never ran (`stty` absent) or a device that answered non-zero (reaped,
@@ -54,8 +77,8 @@ function runStty(ptsName: string, platform: NodeJS.Platform): Promise<SttyProbeR
       (error, stdout) => {
         resolve(
           error
-            ? { state: 'unknown', permanent: isPermanentSttyFailure(error) }
-            : { state: parseEchoFlag(stdout), permanent: false }
+            ? { stdout: null, permanent: isPermanentSttyFailure(error) }
+            : { stdout, permanent: false }
         )
       }
     )
@@ -83,6 +106,30 @@ export function createPtySlaveEchoProbe(
   ptsName: string | undefined,
   platform: NodeJS.Platform = process.platform
 ): PtySlaveEchoProbe | undefined {
+  return createSttyFlagProbe(ptsName, platform, parseEchoFlag)
+}
+
+/**
+ * Probe for whether a line editor owns the slave right now — i.e. the shell has
+ * reached an interactive prompt. Unlike the shell-ready marker this cannot be lost to
+ * an `exec` in a user rc file (#13767), because it is kernel state on the pty rather
+ * than something Orca's wrapper has to print.
+ *
+ * Same undefined/`unknown` contract as createPtySlaveEchoProbe: callers must never
+ * read `unknown` as `line-editor`.
+ */
+export function createPtySlaveLineEditorProbe(
+  ptsName: string | undefined,
+  platform: NodeJS.Platform = process.platform
+): PtySlaveLineEditorProbe | undefined {
+  return createSttyFlagProbe(ptsName, platform, parseLineEditorState)
+}
+
+function createSttyFlagProbe<T extends string>(
+  ptsName: string | undefined,
+  platform: NodeJS.Platform,
+  parse: (sttyOutput: string) => T | 'unknown'
+): (() => Promise<T | 'unknown'>) | undefined {
   if (platform === 'win32' || !ptsName) {
     return undefined
   }
@@ -101,6 +148,6 @@ export function createPtySlaveEchoProbe(
     })
     const result = await inFlight
     unavailable = result.permanent
-    return result.state
+    return result.stdout === null ? 'unknown' : parse(result.stdout)
   }
 }


### PR DESCRIPTION
## Summary

Fixes the ~15s stall on every terminal/agent spawn reported in #13767.

**The bug in one sentence:** Orca's shell-ready marker is printed by Orca's own wrapper files, so when a user's rc file calls `exec`, the wrapper is thrown away and the marker never arrives — and the daemon then sits and waits out its entire 15s timeout, every single spawn.

**The fix in one sentence:** stop relying only on a signal the shell can lose — also watch the PTY's line discipline, which tells us when the shell reaches its prompt no matter what the rc files did.

This is direction #1 from the issue ("don't make readiness depend on an in-shell marker surviving"), built on machinery Orca already has (`createPtySlaveEchoProbe`).

Addresses #13767.

---

## Explainer: why an `exec` kills the marker

Orca starts zsh with `ZDOTDIR` pointed at its own wrapper directory. The wrapper sources the user's real startup file, and to do that it briefly points `ZDOTDIR` back at the user's home so the user's plugins resolve their own paths:

```sh
export ZDOTDIR="$_orca_home"      # 1. point at the user's home
source "$_orca_home/.zprofile"    # 2. run the user's file
export ZDOTDIR="$_orca_wrapper_zdotdir"   # 3. put ours back
```

Step 3 only happens if step 2 **returns**. If the user's file calls `exec` — which every figterm-style shell integration does (Kiro CLI, Amazon Q, Fig, Warp) — the process is replaced on the spot. Step 3 never runs, `ZDOTDIR` stays pinned at `$HOME`, and the replacement shell never reads an Orca wrapper file again. The marker lives in `.zlogin`, last in the login sequence, so it is the most `exec`-exposed line we have.

Bash gets to the same place by a shorter route: it's launched with `--rcfile <wrapper>`, and `exec bash -l -i` simply doesn't carry that flag.

Two things break, and only one of them is visible:

1. **The 15s stall.** No marker → the barrier waits out `SHELL_READY_TIMEOUT_MS` in full.
2. **OSC 133 goes silently dead.** No prompt boundaries, no command start/end, no exit codes. Nothing surfaces this as broken.

---

## Proof 1 — reproducing it

I didn't take the report on trust. I generated the wrapper files **from this repo's own source** (`getShellReadyLaunchConfig`) into a throwaway directory, then drove real zsh and bash on a real PTY with disposable `HOME`s — no real dotfiles touched:

```
== zsh ==
  zsh control            -> marker: 0.02
  zsh exec               -> marker: NEVER (10s)
      probe: ZD=[/var/folders/.../tmporvpj1om] PF=[] PC=[]
== bash ==
  bash control           -> marker: 0.01
  bash exec              -> marker: NEVER (10s)
      probe: ZD=[] PF=[] PC=[]
```

`ZD=` is `$ZDOTDIR`, `PF=` is `precmd_functions`, `PC=` is `PROMPT_COMMAND`. Both hook lists are **empty** — that's the silent half of the bug, confirmed. Both mechanisms in the report reproduce exactly as described.

Source citations in the issue check out against `c8ee48701b`: the zsh swap at `src/main/shell-templates.ts:115-123`, `SHELL_READY_TIMEOUT_MS = 15_000` at `src/main/daemon/session.ts:38`.

**Two scope corrections** (both narrow the blast radius, worth stating precisely):
- Only the **daemon** path has the 15s barrier. `local-pty-shell-ready.ts:37` and `pty-handler.ts:247` already fall back at **1500ms**. So the 15s figure is daemon-path-only.
- As @manuaudio noted, Codex startup commands take the 300ms path, so the pain is agent-dependent.

---

## Proof 2 — what I tried first, and why I threw it away

Two obvious "fix it in the shell" approaches, both tested and both rejected on evidence:

**Shadowing `exec` with a function** (restore `ZDOTDIR`, then `builtin exec "$@"`). This silently breaks redirection-only `exec`:

```
=== zsh ===   SHIM called with 0 args:    fd3 BROKEN
=== bash ===  SHIM called with 0 args:    fd3 BROKEN
```

`exec 3>&1` in an rc file would stop working, in **both** shells, because the caller's redirection gets scoped to the function call and undone on return. That's a new silent regression in a file that has already regressed four times this way (#1739, #4667, #10051, #12507). Not worth it.

**Exit hooks** (`zshexit` / `TRAPEXIT` / `trap ... EXIT`) — do any fire before `exec`?

```
=== zsh exec ===          before exec / EXECED          (no hook)
=== zsh normal exit ===   done / ZSHEXIT-HOOK-RAN       (hook fires)
=== bash exec ===         before exec / EXECED          (no trap)
```

No. `exec` bypasses all of them. There is no passive hook to hang a restore on.

Once `ZDOTDIR` is pinned to `$HOME`, **no Orca code runs in the replacement shell at all** — so there is no in-shell repair available from where we stand. That's what pushed me to the transport layer.

---

## Proof 3 — the signal the fix uses, validated before I built on it

zsh's `zle` and bash's `readline` clear `ECHO` on the PTY slave exactly when the line editor takes the tty — i.e. at the first prompt. An `exec` can't strip that; it's kernel state on the pty, not shell state.

The thing I had to rule out: does `-echo` just fire immediately at startup (useless), or does it actually track the prompt? Measured:

| case | marker | `-echo` |
|---|---|---|
| zsh healthy | 0.02s | 0.02s |
| zsh healthy, `sleep 3` in rc | **3.05s** | **3.05s** |
| zsh **exec** | **NEVER** | 0.02s |
| zsh **exec + slow post-exec rc** | **NEVER** | **3.03s** |
| bash healthy | 0.01s | 0.01s |
| bash **exec** | **NEVER** | 0.01s |
| bash **exec + slow post-exec rc** | **NEVER** | **3.02s** |

The two bolded 3-second rows are the ones that matter. The probe does **not** fire early during startup, and it still waits for the *real* prompt after an `exec`. It agrees with the marker whenever the marker works.

---

## Proof 4 — end to end, real modules against real shells

Running the **actual shipped modules** (`startPtyPromptReadinessProbe` + `createPtySlaveEchoProbe`, bundled from source) against real shells using wrappers generated from source:

```
zsh exec (BUG CASE)             marker=None   probe: READY via line discipline at 0.79s
zsh exec + slow post-exec rc    marker=None   probe: READY via line discipline at 3.10s
zsh healthy (marker works)      marker=0.02   probe: READY via line discipline at 0.79s
bash exec (BUG CASE)            marker=None   probe: READY via line discipline at 0.75s
bash exec + slow post-exec rc   marker=None   probe: READY via line discipline at 3.07s
```

**15s → 0.79s.** And 3.10s when the post-`exec` shell is genuinely slow — it waits for the real prompt rather than guessing.

On the healthy row: the marker lands at 0.02s, which clears the probe long before its 750ms grace expires. **The normal path never spawns a single `stty`.** The fallback costs nothing when nothing is wrong.

---

## Cross-reference: PR #13869 (@zfaustk)

There's a community PR on this issue taking a completely different and rather elegant approach: a zsh `DEBUG` trap that spots an upcoming `exec` via `ZSH_DEBUG_CMD` and flips `ZDOTDIR` back to the wrapper *just before* process replacement — reverting on the next command so redirection-only `exec` still works. It avoids exactly the hazard that killed my shim idea.

I checked it out and ran it through the same harness rather than guessing. Generated their wrappers from their branch's source:

| scenario | #13869 marker | line discipline (this PR) |
|---|---|---|
| `exec` in `.zprofile` (their target case) | **0.02s** ✅ | 0.02s ✅ |
| `eval 'exec zsh -l -i'` in `.zprofile` | **0.05s** ✅ | 0.05s ✅ |
| `exec` via a function in `.zprofile` | **0.03s** ✅ | 0.03s ✅ |
| `exec` in `.zshenv` | **NEVER** ❌ | 0.02s ✅ |
| bash `exec` | **NEVER** ❌ | 0.01s ✅ |

Their fix genuinely works, and it's better than mine in the way that matters most: **it restores OSC 133**, which mine does not. It also held up against `eval` and function-indirected `exec`, which I expected it to miss.

Two residual gaps their harness doesn't cover. Bash they scope out explicitly and flag in their own PR body. The `.zshenv` one looks unflagged: their change lives in `getZshStartupFileSourceBlock`, but the user's `.zshenv` is sourced from `getZshEnvTemplate` instead, so that path never gets the trap.

**These two PRs are complementary, not competing:**
- **#13869 is the repair** — it puts zsh's instrumentation back.
- **This PR is the backstop** — it guarantees the barrier can't stall, for any shell and any mechanism, including the two rows their patch doesn't reach.

With both merged, zsh users get their OSC 133 back *and* no spawn can ever burn 15s again. I'd suggest taking both. If only one lands, this one is the wider net; theirs is the deeper fix.

---

## What this PR does **not** fix

Stating it plainly because it's the half that stays silent: **this does not restore OSC 133 in an `exec`ed shell.** Doing that requires either shadowing `exec` (shown above to break `exec 3>&1`) or writing into the user's `$HOME` — neither is acceptable here. #13869 is the right fix for that on zsh.

What this PR does instead is make that failure **loud**, once per session:

```
[Session] <id>: shell-ready marker never arrived; fell back to line-discipline
prompt detection. Shell integration (OSC 133) is likely inactive — an `exec` in
a shell startup file strips Orca's wrapper.
```

That covers direction #3 from the issue: the ~15s silent wait was indistinguishable from a hang, and now it's neither silent nor 15s.

---

## The change

- **`src/shared/pty-prompt-readiness-probe.ts`** (new, 68 lines) — polls the echo probe after a 750ms grace. Only `quiet` counts as ready; `unknown` (probe couldn't read the slave) is never read as ready, so a broken probe degrades to today's timeout rather than flushing into a shell that can't take input.
- **`src/main/daemon/session.ts`** (+38) — starts the probe only while shell-ready is `pending`; the marker still wins whenever it arrives. Cleared on ready, timeout, exit, and teardown.

Design points worth a reviewer's eye:

- **Grace of 750ms** — a healthy wrapper marks ready ~0.02s in, so the normal path never consults the fallback. It also puts the window past any rc file that reads input during startup, which is the only false-positive shape I could construct.
- **`transitionToReady(true)`** — the line editor already owns the tty (that's literally what was just measured), so the flush gate's wait-for-raw-mode fallback would only add latency.
- **`releaseHeldShellReadyBytes()` before the transition** — `transitionToReady` drops the scan state, and a held partial-marker prefix must still reach the client.

## Testing

- [x] `pnpm lint` — clean; the only warnings are pre-existing in `WorktreeJumpPalette.tsx`, untouched here
- [x] `pnpm typecheck` (`tsconfig.node.json`) — clean
- [x] `pnpm test` on affected trees — `src/shared`, `src/main/daemon`, `src/main/providers`: **6373 passed**, 19 skipped, 0 failed
- [x] max-lines ratchet — no new bypasses (new module is 68 lines, well under the 300 cap; no disable added)
- [x] Added high-quality regression tests

**13 new tests:**
- `src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts` — 6 tests: ready-without-marker; queued startup command delivered instead of burning the timeout; warns exactly once; **stays pending through a slow rc** (the anti-false-positive case); **the real marker still wins**; **still times out when the slave can't be probed**.
- `src/shared/pty-prompt-readiness-probe.test.ts` — 7 tests: no probing during grace, `unknown` never reports ready, fires at most once, stop() mid-flight is safe.

I verified the repro test fails without the fix and passes with it.

## Platform notes

- **macOS/Linux:** the probe is POSIX `stty` on the pty slave, the same call `createPtySlaveEchoProbe` already makes; it handles the BSD `-f` vs GNU `-F` split. Measured on macOS 26.x arm64 with zsh 5.9 and bash 3.2.57. Linux not run locally.
- **Windows:** `createPtySlaveEchoProbe` returns `undefined` on win32, so the probe never starts and behavior is byte-identical to today.
- **SSH/remote:** unchanged. This touches only the daemon session barrier; the relay path has its own 1500ms fallback and is not modified.
- **Folder workspaces / worktrees:** no repo-shaped assumptions; this is pty state only.
- **Wire compatibility:** no RPC params, stream frames, or published content change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
