### PR TITLE
Gate paired web creation actions by provider

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1678,10 +1678,14 @@ function Terminal(): React.JSX.Element | null {
         }).catch(showClientCreationActionError)
         return
       }
-      createBrowserTab(activeWorktreeId, source.url, {
-        ...buildDuplicatedBrowserTabOptions(source),
-        ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
-      })
+      try {
+        createBrowserTab(activeWorktreeId, source.url, {
+          ...buildDuplicatedBrowserTabOptions(source),
+          ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
+        })
+      } catch (error) {
+        showClientCreationActionError(error)
+      }
     },
     [activeWorktreeId, createBrowserTab]
   )
@@ -2056,7 +2060,11 @@ function Terminal(): React.JSX.Element | null {
       if (!e.repeat && matchShortcut('tab.reopenClosed')) {
         e.preventDefault()
         notifyTerminalCapture('tab.reopenClosed')
-        useAppStore.getState().reopenClosedTab(activeWorktreeId)
+        try {
+          useAppStore.getState().reopenClosedTab(activeWorktreeId)
+        } catch (error) {
+          showClientCreationActionError(error)
+        }
         return
       }
 

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/constants/terminal'
 import { useAppStore } from '../store'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { useAllWorktrees } from '../store/selectors'
 import { getConnectionId } from '../lib/connection-context'
 import { basename } from '../lib/path'
@@ -181,12 +182,17 @@ import {
   useManualTerminalWorktreeParking
 } from './terminal-pane/use-manual-terminal-worktree-parking'
 import { EDITOR_TAB_CONTENT_TYPES, getEditorCmdSaveFileId } from './editor/editor-cmd-save-target'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
 // Why: gate handler runs after a dialog advances so a stray carry-over click can't act on the next dialog; ~200ms absorbs a physical double-click while staying responsive.
 const CLOSE_DIALOG_DEBOUNCE_MS = 200
 type TerminalStoreSnapshot = ReturnType<typeof useAppStore.getState>
+
+function showClientCreationActionError(error: unknown): void {
+  toast.error(error instanceof Error ? error.message : String(error))
+}
 
 function haveSameIdSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
   if (left.size !== right.size) {
@@ -1597,7 +1603,7 @@ function Terminal(): React.JSX.Element | null {
     void openMobileEmulatorTab(activeWorktreeId, {
       placement: 'rightSplit',
       targetGroupId: targetGroupId ?? undefined
-    })
+    }).catch(showClientCreationActionError)
   }, [activeWorktreeId])
 
   const handleNewBrowserTab = useCallback(() => {
@@ -1608,22 +1614,31 @@ function Terminal(): React.JSX.Element | null {
       useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
       useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
     if (targetGroupId) {
-      void openNewBrowserTabInActiveWorkspace(targetGroupId)
+      void openNewBrowserTabInActiveWorkspace(targetGroupId).catch(showClientCreationActionError)
       return
     }
-    const defaultUrl = useAppStore.getState().browserDefaultUrl ?? 'about:blank'
+    const state = useAppStore.getState()
+    const browserAvailability = getClientCreationActionPolicy(state, activeWorktreeId)[
+      'managed-browser'
+    ]
+    if (browserAvailability.state !== 'enabled') {
+      toast.error(browserAvailability.reason)
+      return
+    }
+    const defaultUrl = state.browserDefaultUrl ?? 'about:blank'
     const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
-    if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+    if (browserAvailability.provider === 'paired-runtime' && runtimeEnvironmentId) {
       void createWebRuntimeSessionBrowserTab({
         worktreeId: activeWorktreeId,
         environmentId: runtimeEnvironmentId,
         url: defaultUrl
-      })
+      }).catch(showClientCreationActionError)
       return
     }
     createBrowserTab(activeWorktreeId, defaultUrl, {
       title: translate('auto.components.Terminal.37da0d736f', 'New Browser Tab'),
-      focusAddressBar: true
+      focusAddressBar: true,
+      ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
     })
   }, [activeWorktreeId, createBrowserTab, openNewBrowserTabInActiveWorkspace])
 
@@ -1643,8 +1658,16 @@ function Terminal(): React.JSX.Element | null {
         return
       }
       const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
+      const browserAvailability = getClientCreationActionPolicy(state, activeWorktreeId)[
+        'managed-browser'
+      ]
+      if (browserAvailability.state !== 'enabled') {
+        toast.error(browserAvailability.reason)
+        return
+      }
       if (
-        isWebRuntimeSessionActive(runtimeEnvironmentId) &&
+        browserAvailability.provider === 'paired-runtime' &&
+        runtimeEnvironmentId &&
         browserWorkspaceHasRemoteOwner(state, source.id, runtimeEnvironmentId)
       ) {
         void createWebRuntimeSessionBrowserTab({
@@ -1652,11 +1675,12 @@ function Terminal(): React.JSX.Element | null {
           environmentId: runtimeEnvironmentId,
           url: source.url,
           profileId: source.sessionProfileId
-        })
+        }).catch(showClientCreationActionError)
         return
       }
       createBrowserTab(activeWorktreeId, source.url, {
-        ...buildDuplicatedBrowserTabOptions(source)
+        ...buildDuplicatedBrowserTabOptions(source),
+        ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
       })
     },
     [activeWorktreeId, createBrowserTab]
@@ -2040,8 +2064,18 @@ function Terminal(): React.JSX.Element | null {
       if (!e.repeat && matchShortcut('tab.newBrowser')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newBrowser')
+        const browserAvailability = getClientCreationActionPolicy(
+          useAppStore.getState(),
+          floatingWorkspaceFocused ? FLOATING_TERMINAL_WORKTREE_ID : activeWorktreeId
+        )['managed-browser']
+        if (browserAvailability.state !== 'enabled') {
+          toast.error(browserAvailability.reason)
+          return
+        }
         if (floatingWorkspaceFocused) {
-          void createFloatingWorkspaceBrowserTab(useAppStore.getState())
+          void createFloatingWorkspaceBrowserTab(useAppStore.getState()).catch(
+            showClientCreationActionError
+          )
           return
         }
         handleNewBrowserTab()
@@ -2052,6 +2086,14 @@ function Terminal(): React.JSX.Element | null {
       if (!e.repeat && mobileEmulatorEnabled && matchShortcut('tab.newSimulator')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newSimulator')
+        const simulatorAvailability = getClientCreationActionPolicy(
+          useAppStore.getState(),
+          activeWorktreeId
+        )['mobile-emulator']
+        if (simulatorAvailability.state !== 'enabled') {
+          toast.error(simulatorAvailability.reason)
+          return
+        }
         if (!floatingWorkspaceFocused) {
           handleNewSimulatorTab()
         }

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1480,23 +1480,37 @@ function WorktreeJumpPaletteContent({
   // Why: filtering via buildQuickActionContext() inside a memo with stable primitive deps
   // instead of calling it inline every render — a fresh context object as a useMemo dep
   // defeated the middleItems memo (new identity every keystroke).
+  const quickActionAvailabilityInputs = useMemo(
+    () => ({
+      activeView,
+      activeWorktreeId,
+      worktreesByRepo,
+      repos,
+      sshConnectionStates,
+      activeGroupIdByWorktree,
+      groupsByWorktree,
+      isLoading,
+      activeRuntimeEnvironmentId: settings?.activeRuntimeEnvironmentId,
+      runtimeStatusByEnvironmentId
+    }),
+    [
+      activeView,
+      activeWorktreeId,
+      worktreesByRepo,
+      repos,
+      sshConnectionStates,
+      activeGroupIdByWorktree,
+      groupsByWorktree,
+      isLoading,
+      settings?.activeRuntimeEnvironmentId,
+      runtimeStatusByEnvironmentId
+    ]
+  )
   const availableActionResults = useMemo(() => {
+    void quickActionAvailabilityInputs
     const ctx = buildQuickActionContext()
     return actionResults.filter((action) => action.isAvailable(ctx).available)
-  }, [
-    actionResults,
-    buildQuickActionContext,
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- these are the availability-determining primitives buildQuickActionContext reads from the store; listing them ensures the memo recomputes when availability actually changes, not on every render.
-    activeView,
-    activeWorktreeId,
-    worktreesByRepo,
-    repos,
-    sshConnectionStates,
-    activeGroupIdByWorktree,
-    groupsByWorktree,
-    isLoading,
-    settings?.activeRuntimeEnvironmentId
-  ])
+  }, [actionResults, buildQuickActionContext, quickActionAvailabilityInputs])
 
   const middleItems = useMemo<(SettingsPaletteItem | QuickActionPaletteItem)[]>(
     () =>

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -189,6 +189,7 @@ import { shouldPollChromiumErrorPage } from './chromium-error-page-polling'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
 import { translate } from '@/i18n/i18n'
 import { isBrowserPagePanePaintable } from './browser-page-paintability'
+import { openWorkspaceBrowserTab } from '@/lib/workspace-browser-tab-open'
 import { useMarkupMode, type MarkupCaptureContext } from './markup/useMarkupMode'
 import { MarkupOverlay } from './markup/MarkupOverlay'
 import { MarkupDrawButton } from './markup/MarkupDrawButton'
@@ -935,7 +936,6 @@ function RemoteBrowserPagePane({
   const remotePageHandle = useAppStore(
     (s) => s.remoteBrowserPageHandlesByPageId[browserTab.id] ?? null
   )
-  const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   const closeBrowserPage = useAppStore((s) => s.closeBrowserPage)
   const closeBrowserTab = useAppStore((s) => s.closeBrowserTab)
   const keybindings = useAppStore((state) => state.keybindings)
@@ -2037,10 +2037,18 @@ function RemoteBrowserPagePane({
                       role="menuitem"
                       className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
                       onClick={() => {
-                        createBrowserTab(worktreeId, contextMenu.linkUrl!, {
-                          title: contextMenu.linkUrl!
-                        })
+                        const linkUrl = contextMenu.linkUrl!
                         setContextMenu(null)
+                        void openWorkspaceBrowserTab({
+                          workspaceId: worktreeId,
+                          url: linkUrl,
+                          intent: { kind: 'url' }
+                        }).catch((error) => {
+                          setPaneNotice({
+                            kind: 'direct',
+                            text: error instanceof Error ? error.message : String(error)
+                          })
+                        })
                       }}
                     >
                       {translate(

--- a/src/renderer/src/components/cmd-j/quick-action-context.test.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.test.ts
@@ -278,6 +278,43 @@ describe('Cmd+J quick action context', () => {
     expect(calls).toEqual([])
   })
 
+  it('omits unsupported paired-web browser execution without affecting terminal or markdown', async () => {
+    const calls: string[] = []
+    const actions = new Map(getCmdJQuickActions().map((action) => [action.id, action]))
+    const context = {
+      ...ctx({}),
+      activeWorktree: null,
+      runtimeMode: 'paired-web' as const,
+      managedBrowserCreationEnabled: false,
+      openNewBrowserTab: async () => {
+        calls.push('browser')
+      },
+      openNewMarkdownFile: async () => {
+        calls.push('markdown')
+      },
+      openNewTerminalTab: async () => {
+        calls.push('terminal')
+      },
+      openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
+      openAddQuickCommand: () => {}
+    } satisfies CmdJQuickActionContext
+
+    expect(actions.get('new-browser-tab')?.isAvailable(context)).toEqual({
+      available: false,
+      reason: 'client-action-unsupported'
+    })
+    await expect(actions.get('new-browser-tab')?.run(context)).resolves.toEqual({
+      status: 'unavailable',
+      reason: 'client-action-unsupported'
+    })
+    expect(actions.get('new-markdown-file')?.isAvailable(context)).toEqual({ available: true })
+    expect(actions.get('new-terminal-tab')?.isAvailable(context)).toEqual({ available: true })
+    await actions.get('new-markdown-file')?.run(context)
+    await actions.get('new-terminal-tab')?.run(context)
+    expect(calls).toEqual(['markdown', 'terminal'])
+  })
+
   it('runtime re-check invokes the current workspace delete action when available', async () => {
     const calls: string[] = []
     const action = getCmdJQuickActions().find((entry) => entry.id === 'delete-workspace')

--- a/src/renderer/src/components/cmd-j/quick-action-context.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.ts
@@ -2,12 +2,14 @@ import type { AppState } from '@/store/types'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { Worktree } from '../../../../shared/types'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 export type CmdJUnavailableReason =
   | 'loading'
   | 'no-active-workspace'
   | 'ssh-disconnected'
   | 'no-active-group'
+  | 'client-action-unsupported'
 
 export type CmdJQuickActionAvailability =
   | { available: true }
@@ -25,6 +27,7 @@ export type CmdJQuickActionContext = {
   isLoading: boolean
   sshStatus: SshConnectionStatus | null
   runtimeMode: 'local-desktop' | 'paired-web'
+  managedBrowserCreationEnabled?: boolean
   activeGroupId: string | null
   openNewBrowserTab: (groupId: string) => Promise<void>
   openNewMarkdownFile: (groupId: string) => Promise<void>
@@ -110,6 +113,15 @@ export function getWorkspaceScopedActionAvailability(
   return { available: true }
 }
 
+export function getBrowserWorkspaceActionAvailability(
+  ctx: CmdJQuickActionContext
+): CmdJQuickActionAvailability {
+  if (ctx.managedBrowserCreationEnabled === false) {
+    return { available: false, reason: 'client-action-unsupported' }
+  }
+  return getWorkspaceScopedActionAvailability(ctx)
+}
+
 export function getCurrentWorkspaceActionAvailability(
   ctx: Pick<CmdJQuickActionContext, 'activeView' | 'activeWorktreeId' | 'isLoading' | 'sshStatus'>
 ): CmdJQuickActionAvailability {
@@ -151,6 +163,9 @@ export function buildCmdJQuickActionContext(args: {
     args.state.settings?.activeRuntimeEnvironmentId?.trim()
       ? 'paired-web'
       : 'local-desktop'
+  const managedBrowserCreationEnabled =
+    getClientCreationActionPolicy(args.state, activeWorktreeId)['managed-browser'].state ===
+    'enabled'
 
   return {
     activeView: args.state.activeView,
@@ -159,6 +174,7 @@ export function buildCmdJQuickActionContext(args: {
     isLoading,
     sshStatus: getActiveWorktreeSshStatus(args.state, activeWorktree),
     runtimeMode,
+    managedBrowserCreationEnabled,
     activeGroupId,
     openNewBrowserTab: args.openNewBrowserTab,
     openNewMarkdownFile: args.openNewMarkdownFile,
@@ -182,5 +198,7 @@ export function getUnavailableQuickActionMessage(
       return `Can't ${actionTitle.toLowerCase()} — workspace is disconnected.`
     case 'no-active-group':
       return `Can't ${actionTitle.toLowerCase()} — no tab group is available.`
+    case 'client-action-unsupported':
+      return `Can't ${actionTitle.toLowerCase()} — this client and runtime do not support it.`
   }
 }

--- a/src/renderer/src/components/cmd-j/quick-actions.ts
+++ b/src/renderer/src/components/cmd-j/quick-actions.ts
@@ -3,6 +3,7 @@ import type { LucideIcon } from 'lucide-react'
 import type { CmdJQuickActionAvailability, CmdJQuickActionContext } from './quick-action-context'
 import {
   getCurrentWorkspaceActionAvailability,
+  getBrowserWorkspaceActionAvailability,
   getWorkspaceScopedActionAvailability
 } from './quick-action-context'
 import { translate } from '@/i18n/i18n'
@@ -36,6 +37,12 @@ function currentWorkspaceActionAvailability(
   ctx: CmdJQuickActionContext
 ): CmdJQuickActionAvailability {
   return getCurrentWorkspaceActionAvailability(ctx)
+}
+
+function browserWorkspaceActionAvailability(
+  ctx: CmdJQuickActionContext
+): CmdJQuickActionAvailability {
+  return getBrowserWorkspaceActionAvailability(ctx)
 }
 
 async function runWorkspaceAction(
@@ -72,8 +79,14 @@ export const getCmdJQuickActions = createLocalizedCatalog((): CmdJQuickAction[] 
       translate('auto.components.cmd.j.quick.actions.verbs.openBrowser', 'open browser'),
       translate('auto.components.cmd.j.quick.actions.verbs.browserTab', 'browser tab')
     ],
-    isAvailable: workspaceActionAvailability,
-    run: (ctx) => runWorkspaceAction(ctx, ctx.openNewBrowserTab)
+    isAvailable: browserWorkspaceActionAvailability,
+    run: async (ctx) => {
+      const availability = browserWorkspaceActionAvailability(ctx)
+      if (!availability.available) {
+        return { status: 'unavailable', reason: availability.reason }
+      }
+      return runWorkspaceAction(ctx, ctx.openNewBrowserTab)
+    }
   },
   {
     id: 'new-markdown-file',

--- a/src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx
@@ -16,9 +16,15 @@ import {
   promptForSetupGuideProject,
   useSetupTargetWorktree
 } from './FeatureWallSetupWorkflowActions'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 export function BrowserAction(props: { done: boolean }): React.JSX.Element {
   const targetWorktree = useSetupTargetWorktree()
+  const browserCreationEnabled = useAppStore(
+    (state) =>
+      getClientCreationActionPolicy(state, targetWorktree?.id ?? null)['managed-browser'].state ===
+      'enabled'
+  )
   const openModal = useAppStore((s) => s.openModal)
   const closeModal = useAppStore((s) => s.closeModal)
   const openNewBrowserTabInActiveWorkspace = useAppStore(
@@ -39,7 +45,9 @@ export function BrowserAction(props: { done: boolean }): React.JSX.Element {
       state.activeGroupIdByWorktree[targetWorktree.id] ??
       state.groupsByWorktree[targetWorktree.id]?.[0]?.id
     if (groupId) {
-      void openNewBrowserTabInActiveWorkspace(groupId)
+      void openNewBrowserTabInActiveWorkspace(groupId).catch((error) => {
+        toast.error(error instanceof Error ? error.message : String(error))
+      })
     } else {
       toast.warning(
         translate(
@@ -58,7 +66,7 @@ export function BrowserAction(props: { done: boolean }): React.JSX.Element {
 
   return (
     <div className="flex flex-wrap items-center gap-2.5">
-      {props.done ? null : (
+      {props.done || !browserCreationEnabled ? null : (
         <Button type="button" size="sm" className="w-fit gap-2" onClick={handleTryIt}>
           <ArrowUpRight className="size-3.5" />
           {translate(

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -116,6 +116,7 @@ import { shouldRestoreMaximizedPanelBounds } from './floating-terminal-panel-res
 import { translate } from '@/i18n/i18n'
 import { consumeFloatingTerminalOpenMaximizedIntent } from '@/lib/floating-terminal'
 import { selectFloatingTerminalPanelInputs } from './floating-terminal-panel-inputs'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 const LOCAL_RUNTIME_SETTINGS = { activeRuntimeEnvironmentId: null } as const
 const NO_ACTIVITY_TERMINAL_PORTALS = []
 
@@ -271,6 +272,11 @@ export function FloatingTerminalPanel({
   const newMarkdownShortcut = useShortcutKeyDetails('tab.newMarkdown')
   const openMarkdownShortcut = useShortcutKeyDetails('tab.openMarkdown')
   const closeShortcut = useShortcutKeyDetails('tab.close')
+  const managedBrowserCreationEnabled = useAppStore(
+    (state) =>
+      getClientCreationActionPolicy(state, FLOATING_TERMINAL_WORKTREE_ID)['managed-browser']
+        .state === 'enabled'
+  )
 
   const [cwd, setCwd] = useState<string | null>(null)
   const [markdownCwd, setMarkdownCwd] = useState<string | null>(null)
@@ -795,6 +801,14 @@ export function FloatingTerminalPanel({
   )
 
   const createFloatingBrowserTab = useCallback(() => {
+    const availability = getClientCreationActionPolicy(
+      useAppStore.getState(),
+      FLOATING_TERMINAL_WORKTREE_ID
+    )['managed-browser']
+    if (availability.state !== 'enabled') {
+      toast.error(availability.reason)
+      return
+    }
     const url = browserDefaultUrl ?? 'about:blank'
     createBrowserTab(FLOATING_TERMINAL_WORKTREE_ID, url, {
       title: translate(
@@ -1285,6 +1299,14 @@ export function FloatingTerminalPanel({
         if (resolution.action === 'tab.newTerminal') {
           createFloatingTerminalTab()
         } else if (resolution.action === 'tab.newBrowser') {
+          const availability = getClientCreationActionPolicy(
+            useAppStore.getState(),
+            FLOATING_TERMINAL_WORKTREE_ID
+          )['managed-browser']
+          if (availability.state !== 'enabled') {
+            toast.error(availability.reason)
+            return 'handled'
+          }
           createFloatingBrowserTab()
         } else if (resolution.action === 'tab.newMarkdown') {
           createFloatingMarkdownTab()
@@ -1960,6 +1982,7 @@ export function FloatingTerminalPanel({
               onNewMarkdown={createFloatingMarkdownTab}
               onOpenMarkdown={openFloatingMarkdownTab}
               onNewBrowser={createFloatingBrowserTab}
+              showNewBrowser={managedBrowserCreationEnabled}
               onClose={() => onOpenChange(false)}
               onFocusPanel={focusPanelForShortcuts}
               newTerminalShortcut={newTerminalShortcut}
@@ -2102,6 +2125,7 @@ function FloatingTerminalEmptyState({
   onNewMarkdown,
   onOpenMarkdown,
   onNewBrowser,
+  showNewBrowser,
   onClose,
   onFocusPanel,
   newTerminalShortcut,
@@ -2114,6 +2138,7 @@ function FloatingTerminalEmptyState({
   onNewMarkdown: () => void
   onOpenMarkdown: () => void
   onNewBrowser: () => void
+  showNewBrowser: boolean
   onClose: () => void
   onFocusPanel: () => void
   newTerminalShortcut: ShortcutKeyComboDetails
@@ -2177,21 +2202,23 @@ function FloatingTerminalEmptyState({
           </span>
           <FloatingEmptyStateShortcut shortcut={openMarkdownShortcut} />
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
-          onClick={onNewBrowser}
-        >
-          <Globe className="size-3.5 opacity-90" />
-          <span className="truncate text-left leading-none">
-            {translate(
-              'auto.components.floating.terminal.FloatingTerminalPanel.8b07759314',
-              'New Browser'
-            )}
-          </span>
-          <FloatingEmptyStateShortcut shortcut={newBrowserShortcut} />
-        </Button>
+        {showNewBrowser ? (
+          <Button
+            type="button"
+            variant="ghost"
+            className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+            onClick={onNewBrowser}
+          >
+            <Globe className="size-3.5 opacity-90" />
+            <span className="truncate text-left leading-none">
+              {translate(
+                'auto.components.floating.terminal.FloatingTerminalPanel.8b07759314',
+                'New Browser'
+              )}
+            </span>
+            <FloatingEmptyStateShortcut shortcut={newBrowserShortcut} />
+          </Button>
+        ) : null}
         <Button
           type="button"
           variant="ghost"

--- a/src/renderer/src/components/right-sidebar/GitHistoryCommitContextMenu.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryCommitContextMenu.tsx
@@ -7,6 +7,8 @@ import {
 } from '@/components/ui/context-menu'
 import { translate } from '@/i18n/i18n'
 import type { GitHistoryItem } from '../../../../shared/git-history'
+import { useAppStore } from '@/store'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 export type GitHistoryCommitAction = 'open-remote' | 'copy-hash' | 'copy-message' | 'explain'
 
@@ -17,15 +19,22 @@ export function GitHistoryCommitContextMenu({
   item: GitHistoryItem
   onAction: (action: GitHistoryCommitAction, item: GitHistoryItem) => void
 }): React.JSX.Element {
+  const managedBrowserCreationEnabled = useAppStore(
+    (state) =>
+      getClientCreationActionPolicy(state, state.activeWorktreeId)['managed-browser'].state ===
+      'enabled'
+  )
   return (
     <ContextMenuContent className="w-56">
-      <ContextMenuItem onSelect={() => onAction('open-remote', item)}>
-        <Globe className="size-3.5" />
-        {translate(
-          'auto.components.right.sidebar.GitHistoryCommitContextMenu.7b1c4e9a02',
-          'Open commit in browser'
-        )}
-      </ContextMenuItem>
+      {managedBrowserCreationEnabled ? (
+        <ContextMenuItem onSelect={() => onAction('open-remote', item)}>
+          <Globe className="size-3.5" />
+          {translate(
+            'auto.components.right.sidebar.GitHistoryCommitContextMenu.7b1c4e9a02',
+            'Open commit in browser'
+          )}
+        </ContextMenuItem>
+      ) : null}
       <ContextMenuItem onSelect={() => onAction('copy-hash', item)}>
         <Hash className="size-3.5" />
         {translate(

--- a/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
@@ -353,7 +353,8 @@ describe('PortsPanel runtime routing', () => {
       'repo::/workspace/app',
       'http://127.0.0.1:63468',
       {
-        activate: true
+        activate: true,
+        browserRuntimeEnvironmentId: 'env-1'
       }
     )
     expect(setRemoteBrowserPageHandle).toHaveBeenCalledWith('local-page-1', {
@@ -579,7 +580,7 @@ describe('PortsPanel runtime routing', () => {
     expect(createBrowserTab).toHaveBeenCalledWith(
       'repo::/workspace/app',
       'http://127.0.0.1:63468',
-      { activate: true }
+      { activate: true, browserRuntimeEnvironmentId: 'env-1' }
     )
     expect(setRemoteBrowserPageHandle).toHaveBeenCalledWith('local-page-1', {
       environmentId: 'env-1',

--- a/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
@@ -61,7 +61,8 @@ const compatibleStatus = {
   runtimeId: 'runtime-1',
   graphStatus: 'ready',
   runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
-  minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+  minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+  capabilities: ['browser.screencast.v1']
 }
 
 const localScan = vi.fn()
@@ -361,6 +362,34 @@ describe('PortsPanel runtime routing', () => {
       environmentId: 'env-1',
       remotePageId: 'remote-browser-page-1'
     })
+  })
+
+  it('rejects remote port browser creation before RPC without the screencast provider', async () => {
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
+      Promise.resolve({
+        id: method,
+        ok: true,
+        result: { ...compatibleStatus, capabilities: [] },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    const createBrowserTab = vi.fn()
+
+    await expect(
+      openWorkspacePortInBrowser({
+        port: workspacePort,
+        runtimeTarget: { kind: 'environment', environmentId: 'env-1' },
+        createBrowserTab: createBrowserTab as never,
+        setRemoteBrowserPageHandle: vi.fn() as never
+      })
+    ).resolves.toEqual({
+      ok: false,
+      reason:
+        'Managed browser tabs are unavailable because the paired runtime does not support browser streaming.'
+    })
+
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual(['status.get'])
+    expect(createBrowserTab).not.toHaveBeenCalled()
   })
 
   it('opens workspace ports in the system browser when link routing is off', async () => {

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -58,6 +58,7 @@ import {
 import type { PortForwardEntry, EnrichedDetectedPort } from '../../../../shared/ssh-types'
 import type { WorkspacePort } from '../../../../shared/workspace-ports'
 import { translate } from '@/i18n/i18n'
+import { openWorkspaceBrowserTab } from '@/lib/workspace-browser-tab-open'
 
 export {
   killWorkspacePortForTarget,
@@ -804,7 +805,6 @@ function SshPortsPanel(): React.JSX.Element {
   const portForwardsByConnection = useAppStore((s) => s.portForwardsByConnection)
   const detectedPortsByConnection = useAppStore((s) => s.detectedPortsByConnection)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
-  const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   // Why: scope the panel to the active worktree's SSH connection so
   // actions target the correct machine and the disconnected state
   // reflects the active worktree, not some other SSH session.
@@ -884,11 +884,15 @@ function SshPortsPanel(): React.JSX.Element {
         )
         return
       }
-      createBrowserTab(activeWorktree.id, url, {
-        activate: true
+      void openWorkspaceBrowserTab({
+        workspaceId: activeWorktree.id,
+        url,
+        intent: { kind: 'url' }
+      }).catch((error) => {
+        toast.error(error instanceof Error ? error.message : String(error))
       })
     },
-    [activeWorktree?.id, createBrowserTab, settings]
+    [activeWorktree?.id, settings]
   )
 
   const handleDialogClose = useCallback(() => {

--- a/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
@@ -18,6 +18,7 @@ import {
   type SourceControlRowOpenEvent
 } from './source-control-split-open'
 import type { GitHistoryCommitAction } from './GitHistoryCommitContextMenu'
+import { openWorkspaceBrowserTab } from '@/lib/workspace-browser-tab-open'
 
 const EMPTY_BRANCH_CHANGE_ENTRIES: GitBranchChangeEntry[] = []
 
@@ -47,7 +48,6 @@ export function useGitHistoryCommitActions({
 }): GitHistoryCommitActions {
   const openCommitAllDiffs = useAppStore((s) => s.openCommitAllDiffs)
   const openCommitDiff = useAppStore((s) => s.openCommitDiff)
-  const createBrowserTab = useAppStore((s) => s.createBrowserTab)
 
   // Caches each commit's compare result so expanding a commit fetches its files
   // once, and opening a single file (or the combined diff) reuses that same
@@ -202,16 +202,20 @@ export function useGitHistoryCommitActions({
           { sha: item.id }
         )
           .then((url) => {
-            if (url) {
-              createBrowserTab(activeWorktreeId, url, { activate: true })
-            } else {
+            if (!url) {
               toast.error(
                 translate(
                   'auto.components.right.sidebar.SourceControl.04a5d7239b',
                   'This repository has no supported web remote'
                 )
               )
+              return
             }
+            return openWorkspaceBrowserTab({
+              workspaceId: activeWorktreeId,
+              url,
+              intent: { kind: 'url' }
+            })
           })
           .catch(() => {
             toast.error(
@@ -279,7 +283,7 @@ export function useGitHistoryCommitActions({
         promptDelivery: 'submit-after-ready'
       })
     },
-    [activeRepoSettings, activeWorktreeId, copyCommitText, createBrowserTab, worktreePath]
+    [activeRepoSettings, activeWorktreeId, copyCommitText, worktreePath]
   )
 
   return { loadCommitFiles, openHistoryCommitDiff, openCommitFile, handleCommitAction }

--- a/src/renderer/src/components/settings/FloatingWorkspacePane.tsx
+++ b/src/renderer/src/components/settings/FloatingWorkspacePane.tsx
@@ -10,6 +10,7 @@ import { getFloatingWorkspaceSearchEntries } from './floating-workspace-search'
 import { matchesSettingsSearch } from './settings-search'
 import { useAppStore } from '../../store'
 import { translate } from '@/i18n/i18n'
+import { isWebClientLocation } from '@/lib/web-client-location'
 
 type FloatingWorkspacePaneProps = {
   settings: GlobalSettings
@@ -35,6 +36,7 @@ export function FloatingWorkspacePane({
   updateSettings
 }: FloatingWorkspacePaneProps): React.JSX.Element | null {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
+  const includeBrowser = !isWebClientLocation()
   const [resolvedFloatingWorkspacePath, setResolvedFloatingWorkspacePath] = useState('')
 
   useEffect(() => {
@@ -72,7 +74,7 @@ export function FloatingWorkspacePane({
     resolvedFloatingWorkspacePath
   })
 
-  if (!matchesSettingsSearch(searchQuery, getFloatingWorkspaceSearchEntries())) {
+  if (!matchesSettingsSearch(searchQuery, getFloatingWorkspaceSearchEntries({ includeBrowser }))) {
     return null
   }
 
@@ -91,7 +93,7 @@ export function FloatingWorkspacePane({
           'floating workspace',
           'floating terminal',
           'terminal',
-          'browser',
+          ...(includeBrowser ? ['browser'] : []),
           'markdown',
           'note',
           'global',

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import {
   findKeybindingConflictsForDefinitions,
   formatKeybindingList,
@@ -60,14 +61,15 @@ export function ShortcutsPane(): React.JSX.Element {
   const resetKeybindingOverride = useAppStore((state) => state.resetKeybindingOverride)
   const disableKeybindingAction = useAppStore((state) => state.disableKeybindingAction)
   const pluginCommands = useEditablePluginCommands()
-  const managedBrowserCreationEnabled = useAppStore((state) => {
-    const policy = getClientCreationActionPolicy(state, state.activeWorktreeId)
-    return policy['managed-browser'].state === 'enabled'
-  })
-  const mobileEmulatorCreationEnabled = useAppStore((state) => {
-    const policy = getClientCreationActionPolicy(state, state.activeWorktreeId)
-    return policy['mobile-emulator'].state === 'enabled'
-  })
+  const [managedBrowserCreationEnabled, mobileEmulatorCreationEnabled] = useAppStore(
+    useShallow((state) => {
+      const policy = getClientCreationActionPolicy(state, state.activeWorktreeId)
+      return [
+        policy['managed-browser'].state === 'enabled',
+        policy['mobile-emulator'].state === 'enabled'
+      ] as const
+    })
+  )
   const mountedRef = useMountedRef()
   const [errors, setErrors] = useState<Partial<Record<KeybindingActionId, string>>>({})
   const [recordingActionId, setRecordingActionId] = useState<KeybindingActionId | null>(null)

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -14,22 +14,12 @@ import { EMPTY_DISABLED_TUI_AGENTS } from './shortcut-groups'
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
-import { getShortcutTerminalStatus } from './shortcut-terminal-status'
 import {
   hasCommonBindingOverride,
-  hasOwnBindingOverride,
   removeBindingOverride,
   sameBindings
 } from './keybinding-override-edits'
-import {
-  buildShortcutGlobalSearchMatcher,
-  matchesShortcutFilter,
-  matchesShortcutLocalSearch,
-  normalizeShortcutLocalSearchQuery,
-  ShortcutFilterRail,
-  type ShortcutFilter,
-  type ShortcutRowsByGroup
-} from './ShortcutFilterRail'
+import { ShortcutFilterRail, type ShortcutFilter } from './ShortcutFilterRail'
 import { ShortcutRowsList } from './ShortcutRowsList'
 import { ShortcutTerminalPolicyControl } from './ShortcutTerminalPolicyControl'
 import { getTerminalShortcutPolicySearchEntry } from './shortcuts-search'
@@ -45,6 +35,8 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 import { useEditablePluginCommands } from '@/store/plugin-panels'
 import { buildShortcutDefinitionCatalog } from './shortcut-definition-catalog'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
+import { buildShortcutRowVisibility } from './shortcut-row-visibility'
 
 const isMac = navigator.userAgent.includes('Mac')
 const platform: NodeJS.Platform = isMac
@@ -68,23 +60,27 @@ export function ShortcutsPane(): React.JSX.Element {
   const resetKeybindingOverride = useAppStore((state) => state.resetKeybindingOverride)
   const disableKeybindingAction = useAppStore((state) => state.disableKeybindingAction)
   const pluginCommands = useEditablePluginCommands()
+  const managedBrowserCreationEnabled = useAppStore((state) => {
+    const policy = getClientCreationActionPolicy(state, state.activeWorktreeId)
+    return policy['managed-browser'].state === 'enabled'
+  })
+  const mobileEmulatorCreationEnabled = useAppStore((state) => {
+    const policy = getClientCreationActionPolicy(state, state.activeWorktreeId)
+    return policy['mobile-emulator'].state === 'enabled'
+  })
   const mountedRef = useMountedRef()
   const [errors, setErrors] = useState<Partial<Record<KeybindingActionId, string>>>({})
   const [recordingActionId, setRecordingActionId] = useState<KeybindingActionId | null>(null)
-  // Which binding index of the recording action is being captured. Equals the
-  // effective length when capturing a brand-new (appended) binding.
+  // The effective length targets a new appended binding.
   const [recordingBindingIndex, setRecordingBindingIndex] = useState<number | null>(null)
-  // Bindings an action had right before it was disabled, so "Enable" can restore
-  // them in one click instead of forcing a reset-to-default.
+  // Preserve disabled bindings so Enable can restore them.
   const [disableMemory, setDisableMemory] = useState<Partial<Record<KeybindingActionId, string[]>>>(
     {}
   )
   const [shortcutQuery, setShortcutQuery] = useState('')
   const [shortcutFilter, setShortcutFilter] = useState<ShortcutFilter>('all')
 
-  // Why: tell the main process to suspend global shortcut dispatch while any row
-  // is recording, so the captured chord lands in the editor instead of firing.
-  // One source of truth here avoids races between per-row recorder effects.
+  // Why: suspend global dispatch so a captured chord reaches the editor.
   useEffect(() => {
     window.api.ui.setShortcutRecorderFocused(recordingActionId !== null)
     return () => window.api.ui.setShortcutRecorderFocused(false)
@@ -110,55 +106,31 @@ export function ShortcutsPane(): React.JSX.Element {
     const definition = definitionForAction(actionId)
     return definition ? getEffectiveKeybindingsForDefinition(definition, platform, overrides) : []
   }
-  const shortcutGroups = useMemo<ShortcutRowsByGroup[]>(
+  const { filterCounts, shortcutRows, visibleShortcutCount, visibleShortcutGroups } = useMemo(
     () =>
-      groups.map((group) => ({
-        title: group.title,
-        rows: group.items.map((item) => {
-          const effective = getEffectiveKeybindingsForDefinition(item, platform, keybindings)
-          const modified = hasOwnBindingOverride(keybindings, item.id)
-          const warnings = conflictByAction.get(item.id) ?? []
-          return {
-            item,
-            groupTitle: group.title,
-            effective,
-            modified,
-            warnings,
-            terminalStatus: getShortcutTerminalStatus(
-              item,
-              terminalShortcutPolicy,
-              effective.length > 0
-            )
-          }
-        })
-      })),
-    [conflictByAction, groups, keybindings, terminalShortcutPolicy]
-  )
-  const shortcutSearchQuery = normalizeShortcutLocalSearchQuery(shortcutQuery)
-  const shortcutRows = shortcutGroups.flatMap((group) => group.rows)
-  const matchesShortcutGlobalSearch = buildShortcutGlobalSearchMatcher(shortcutRows, searchQuery)
-  const matchesShortcutSearch = (row: ShortcutRowsByGroup['rows'][number]): boolean =>
-    shortcutSearchQuery !== null &&
-    matchesShortcutGlobalSearch(row) &&
-    matchesShortcutLocalSearch(row, shortcutSearchQuery, platform)
-  const baseVisibleRows = shortcutRows.filter((row) => matchesShortcutSearch(row))
-  const filterCounts: Record<ShortcutFilter, number> = {
-    all: baseVisibleRows.length,
-    modified: baseVisibleRows.filter((row) => row.modified).length,
-    unassigned: baseVisibleRows.filter((row) => row.effective.length === 0).length,
-    conflicts: baseVisibleRows.filter((row) => row.warnings.length > 0).length
-  }
-  const visibleShortcutGroups = shortcutGroups
-    .map((group) => ({
-      title: group.title,
-      rows: group.rows.filter(
-        (row) => matchesShortcutSearch(row) && matchesShortcutFilter(row, shortcutFilter)
-      )
-    }))
-    .filter((group) => group.rows.length > 0)
-  const visibleShortcutCount = visibleShortcutGroups.reduce(
-    (sum, group) => sum + group.rows.length,
-    0
+      buildShortcutRowVisibility({
+        groups,
+        keybindings,
+        conflictByAction,
+        terminalShortcutPolicy,
+        platform,
+        managedBrowserCreationEnabled,
+        mobileEmulatorCreationEnabled,
+        settingsSearchQuery: searchQuery,
+        shortcutQuery,
+        shortcutFilter
+      }),
+    [
+      conflictByAction,
+      groups,
+      keybindings,
+      managedBrowserCreationEnabled,
+      mobileEmulatorCreationEnabled,
+      searchQuery,
+      shortcutFilter,
+      shortcutQuery,
+      terminalShortcutPolicy
+    ]
   )
 
   const saveBindings = async (
@@ -236,8 +208,7 @@ export function ShortcutsPane(): React.JSX.Element {
       return
     }
 
-    // Edit just the targeted binding (or append a new one) instead of replacing
-    // the whole list, so an action's other bindings survive the capture.
+    // Preserve sibling bindings when editing or appending one chord.
     const current = effectiveBindingsForAction(actionId)
     const next =
       recordingBindingIndex === null || recordingBindingIndex >= current.length
@@ -290,8 +261,7 @@ export function ShortcutsPane(): React.JSX.Element {
   }
 
   const clearRecordingForAction = (actionId: KeybindingActionId): void => {
-    // Why: disable/reset are final shortcut edits; the next keypress must not
-    // be captured into the shortcut the user just removed or restored.
+    // Why: final edits must not leave the recorder armed.
     if (recordingActionId === actionId) {
       setRecordingBindingIndex(null)
     }
@@ -367,9 +337,7 @@ export function ShortcutsPane(): React.JSX.Element {
           />
 
           <ShortcutRowsList
-            // overflow-x-hidden is explicit: overflow-y-auto alone makes the
-            // browser compute overflow-x to auto, which produced the phantom
-            // horizontal scroll when long edit-time content popped in.
+            // Why: overflow-y-auto otherwise creates a phantom horizontal scrollbar.
             className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1 scrollbar-sleek"
             groups={visibleShortcutGroups}
             platform={platform}

--- a/src/renderer/src/components/settings/floating-workspace-search.ts
+++ b/src/renderer/src/components/settings/floating-workspace-search.ts
@@ -2,69 +2,86 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 
-export const getFloatingWorkspaceSearchEntries = createLocalizedCatalog(() => [
-  {
-    title: translate(
-      'auto.components.settings.floating.workspace.search.b2b60e7163',
-      'Floating Workspace'
-    ),
-    description: translate(
-      'auto.components.settings.floating.workspace.search.b96b5ee6cf',
-      'Enable the floating workspace, choose where new tabs start, and choose where the toggle button appears.'
-    ),
-    keywords: [
-      translate(
-        'auto.components.settings.floating.workspace.search.a08e482f6d',
-        'floating workspace'
+function buildFloatingWorkspaceSearchEntries(includeBrowser: boolean) {
+  return [
+    {
+      title: translate(
+        'auto.components.settings.floating.workspace.search.b2b60e7163',
+        'Floating Workspace'
       ),
-      translate(
-        'auto.components.settings.floating.workspace.search.6f183fa1b9',
-        'floating terminal'
+      description: translate(
+        'auto.components.settings.floating.workspace.search.b96b5ee6cf',
+        'Enable the floating workspace, choose where new tabs start, and choose where the toggle button appears.'
       ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.ebeedb2f6a',
-        'quick terminal'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.2b5efa55c9',
-        'global'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.6410fe83d8',
-        'terminal'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.49db74a92d',
-        'browser'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.884e5e6132',
-        'markdown'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.156ffeee08',
-        'note'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.52db6e3baf',
-        'notes'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.a38bfc3f77',
-        'quick panel'
-      ),
-      translate(
-        'auto.components.settings.floating.workspace.search.6765b85e48',
-        'launch directory'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.a452146574',
-        'toggle button'
-      ),
-      ...translateSearchKeyword(
-        'auto.components.settings.floating.workspace.search.94f4d013c8',
-        'status bar'
-      )
-    ]
-  }
-])
+      keywords: [
+        translate(
+          'auto.components.settings.floating.workspace.search.a08e482f6d',
+          'floating workspace'
+        ),
+        translate(
+          'auto.components.settings.floating.workspace.search.6f183fa1b9',
+          'floating terminal'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.ebeedb2f6a',
+          'quick terminal'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.2b5efa55c9',
+          'global'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.6410fe83d8',
+          'terminal'
+        ),
+        ...(includeBrowser
+          ? translateSearchKeyword(
+              'auto.components.settings.floating.workspace.search.49db74a92d',
+              'browser'
+            )
+          : []),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.884e5e6132',
+          'markdown'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.156ffeee08',
+          'note'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.52db6e3baf',
+          'notes'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.a38bfc3f77',
+          'quick panel'
+        ),
+        translate(
+          'auto.components.settings.floating.workspace.search.6765b85e48',
+          'launch directory'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.a452146574',
+          'toggle button'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.floating.workspace.search.94f4d013c8',
+          'status bar'
+        )
+      ]
+    }
+  ]
+}
+
+const getFloatingWorkspaceSearchEntriesWithBrowser = createLocalizedCatalog(() =>
+  buildFloatingWorkspaceSearchEntries(true)
+)
+const getFloatingWorkspaceSearchEntriesWithoutBrowser = createLocalizedCatalog(() =>
+  buildFloatingWorkspaceSearchEntries(false)
+)
+
+export function getFloatingWorkspaceSearchEntries(options?: { includeBrowser?: boolean }) {
+  return options?.includeBrowser === false
+    ? getFloatingWorkspaceSearchEntriesWithoutBrowser()
+    : getFloatingWorkspaceSearchEntriesWithBrowser()
+}

--- a/src/renderer/src/components/settings/shortcut-row-visibility.test.ts
+++ b/src/renderer/src/components/settings/shortcut-row-visibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { getKeybindingDefinition } from '../../../../shared/keybindings'
+import type { ShortcutGroup } from './shortcut-groups'
+import { buildShortcutRowVisibility } from './shortcut-row-visibility'
+
+function creationGroup(): ShortcutGroup {
+  const items = (
+    ['tab.newTerminal', 'tab.newBrowser', 'tab.newMarkdown', 'tab.newSimulator'] as const
+  ).map((actionId) => {
+    const definition = getKeybindingDefinition(actionId)
+    if (!definition) {
+      throw new Error(`Missing keybinding definition: ${actionId}`)
+    }
+    return definition
+  })
+  return { title: 'Tabs', items }
+}
+
+describe('buildShortcutRowVisibility', () => {
+  it('hides client-impossible creation shortcuts without hiding terminal or markdown', () => {
+    const result = buildShortcutRowVisibility({
+      groups: [creationGroup()],
+      keybindings: {},
+      conflictByAction: new Map(),
+      terminalShortcutPolicy: 'orca-first',
+      platform: 'darwin',
+      managedBrowserCreationEnabled: false,
+      mobileEmulatorCreationEnabled: false,
+      settingsSearchQuery: '',
+      shortcutQuery: '',
+      shortcutFilter: 'all'
+    })
+
+    expect(result.shortcutRows.map((row) => row.item.id)).toEqual([
+      'tab.newTerminal',
+      'tab.newMarkdown'
+    ])
+  })
+})

--- a/src/renderer/src/components/settings/shortcut-row-visibility.ts
+++ b/src/renderer/src/components/settings/shortcut-row-visibility.ts
@@ -1,0 +1,96 @@
+import {
+  getEffectiveKeybindingsForDefinition,
+  type KeybindingActionId,
+  type KeybindingOverrides,
+  type TerminalShortcutPolicy
+} from '../../../../shared/keybindings'
+import { hasOwnBindingOverride } from './keybinding-override-edits'
+import type { ShortcutGroup } from './shortcut-groups'
+import { getShortcutTerminalStatus } from './shortcut-terminal-status'
+import {
+  buildShortcutGlobalSearchMatcher,
+  matchesShortcutFilter,
+  matchesShortcutLocalSearch,
+  normalizeShortcutLocalSearchQuery,
+  type ShortcutFilter,
+  type ShortcutRowsByGroup
+} from './ShortcutFilterRail'
+
+export function buildShortcutRowVisibility(options: {
+  groups: ShortcutGroup[]
+  keybindings: KeybindingOverrides
+  conflictByAction: Map<KeybindingActionId, string[]>
+  terminalShortcutPolicy: TerminalShortcutPolicy
+  platform: NodeJS.Platform
+  managedBrowserCreationEnabled: boolean
+  mobileEmulatorCreationEnabled: boolean
+  settingsSearchQuery: string
+  shortcutQuery: string
+  shortcutFilter: ShortcutFilter
+}): {
+  filterCounts: Record<ShortcutFilter, number>
+  shortcutRows: ShortcutRowsByGroup['rows']
+  visibleShortcutCount: number
+  visibleShortcutGroups: ShortcutRowsByGroup[]
+} {
+  const shortcutGroups = options.groups.map((group) => ({
+    title: group.title,
+    rows: group.items
+      .filter(
+        (item) =>
+          (options.managedBrowserCreationEnabled || item.id !== 'tab.newBrowser') &&
+          (options.mobileEmulatorCreationEnabled || item.id !== 'tab.newSimulator')
+      )
+      .map((item) => {
+        const effective = getEffectiveKeybindingsForDefinition(
+          item,
+          options.platform,
+          options.keybindings
+        )
+        return {
+          item,
+          groupTitle: group.title,
+          effective,
+          modified: hasOwnBindingOverride(options.keybindings, item.id),
+          warnings: options.conflictByAction.get(item.id) ?? [],
+          terminalStatus: getShortcutTerminalStatus(
+            item,
+            options.terminalShortcutPolicy,
+            effective.length > 0
+          )
+        }
+      })
+  }))
+  const shortcutRows = shortcutGroups.flatMap((group) => group.rows)
+  const localQuery = normalizeShortcutLocalSearchQuery(options.shortcutQuery)
+  const matchesGlobalSearch = buildShortcutGlobalSearchMatcher(
+    shortcutRows,
+    options.settingsSearchQuery
+  )
+  const matchesSearch = (row: ShortcutRowsByGroup['rows'][number]): boolean =>
+    localQuery !== null &&
+    matchesGlobalSearch(row) &&
+    matchesShortcutLocalSearch(row, localQuery, options.platform)
+  const baseVisibleRows = shortcutRows.filter(matchesSearch)
+  const filterCounts: Record<ShortcutFilter, number> = {
+    all: baseVisibleRows.length,
+    modified: baseVisibleRows.filter((row) => row.modified).length,
+    unassigned: baseVisibleRows.filter((row) => row.effective.length === 0).length,
+    conflicts: baseVisibleRows.filter((row) => row.warnings.length > 0).length
+  }
+  const visibleShortcutGroups = shortcutGroups
+    .map((group) => ({
+      title: group.title,
+      rows: group.rows.filter(
+        (row) => matchesSearch(row) && matchesShortcutFilter(row, options.shortcutFilter)
+      )
+    }))
+    .filter((group) => group.rows.length > 0)
+
+  return {
+    filterCounts,
+    shortcutRows,
+    visibleShortcutCount: visibleShortcutGroups.reduce((sum, group) => sum + group.rows.length, 0),
+    visibleShortcutGroups
+  }
+}

--- a/src/renderer/src/components/settings/shortcuts-search.ts
+++ b/src/renderer/src/components/settings/shortcuts-search.ts
@@ -34,15 +34,35 @@ export const getTerminalShortcutPolicySearchEntry = createLocalizedCatalog(
   })
 )
 
-export const getShortcutsPaneSearchEntries = createLocalizedCatalog(() => [
-  ...KEYBINDING_DEFINITIONS.map((item) => ({
-    title: item.title,
-    description: translate(
-      'auto.components.settings.shortcuts.search.groupShortcut',
-      '{{value0}} shortcut',
-      { value0: item.group }
-    ),
-    keywords: [...item.searchKeywords]
-  })),
-  getTerminalShortcutPolicySearchEntry()
-])
+const getShortcutDefinitionSearchEntries = createLocalizedCatalog(() =>
+  KEYBINDING_DEFINITIONS.map((item) => ({
+    actionId: item.id,
+    searchEntry: {
+      title: item.title,
+      description: translate(
+        'auto.components.settings.shortcuts.search.groupShortcut',
+        '{{value0}} shortcut',
+        { value0: item.group }
+      ),
+      keywords: [...item.searchKeywords]
+    }
+  }))
+)
+
+export function getShortcutsPaneSearchEntries(options?: {
+  includeManagedBrowser?: boolean
+  includeMobileEmulator?: boolean
+}): SettingsSearchEntry[] {
+  const includeManagedBrowser = options?.includeManagedBrowser !== false
+  const includeMobileEmulator = options?.includeMobileEmulator !== false
+  return [
+    ...getShortcutDefinitionSearchEntries()
+      .filter(
+        ({ actionId }) =>
+          (includeManagedBrowser || actionId !== 'tab.newBrowser') &&
+          (includeMobileEmulator || actionId !== 'tab.newSimulator')
+      )
+      .map(({ searchEntry }) => searchEntry),
+    getTerminalShortcutPolicySearchEntry()
+  ]
+}

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -142,7 +142,7 @@ export default function BrowserTab({
   onCloseOthers: () => void
   onCloseToRight: () => void
   onCloseToLeft: () => void
-  onDuplicate: () => void
+  onDuplicate?: () => void
   onTogglePin: () => void
   dragData: TabDragItemData
   dropIndicator?: DropIndicator
@@ -307,11 +307,15 @@ export default function BrowserTab({
             groupId={dragData.groupId}
             trailingSeparator
           />
-          <DropdownMenuItem onSelect={onDuplicate}>
-            <Copy className="size-3.5" />
-            {translate('auto.components.tab.bar.BrowserTab.5d6e89891f', 'Duplicate Tab')}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
+          {onDuplicate ? (
+            <>
+              <DropdownMenuItem onSelect={onDuplicate}>
+                <Copy className="size-3.5" />
+                {translate('auto.components.tab.bar.BrowserTab.5d6e89891f', 'Duplicate Tab')}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          ) : null}
           <DropdownMenuItem onSelect={onTogglePin}>
             {isPinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
             {isPinned

--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -497,6 +497,26 @@ describe('TabBar context menu wiring', () => {
     expect(menuLabels[3]).toContain('New Browser Tab')
   })
 
+  it('omits impossible paired-web actions while keeping terminal and markdown', async () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const element = await renderTabBar({
+      tabs: [TERMINAL_TAB],
+      onNewFileTab: () => {},
+      onOpenFileTab: () => {},
+      onNewSimulatorTab: () => {}
+    })
+
+    const menuLabels = findChildrenByType(element, 'DropdownMenuItem').map((item) =>
+      extractText(item.props.children)
+    )
+
+    expect(menuLabels.some((label) => label.includes('New Terminal'))).toBe(true)
+    expect(menuLabels.some((label) => label.includes('New Markdown'))).toBe(true)
+    expect(menuLabels.some((label) => label.includes('Open Markdown...'))).toBe(true)
+    expect(menuLabels.some((label) => label.includes('Browser'))).toBe(false)
+    expect(menuLabels.some((label) => label.includes('Mobile Emulator'))).toBe(false)
+  })
+
   it('turns New Mobile Emulator into a go-to action when the workspace already has one', async () => {
     const onNewSimulatorTab = vi.fn()
     appStoreSnapshot.unifiedTabsByWorktree = {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -27,6 +27,8 @@ function TabBarInner(props: TabBarProps): React.JSX.Element {
     resolvedGroupId: runtime.resolvedGroupId,
     terminalOnly,
     mobileEmulatorEnabled: runtime.mobileEmulatorEnabled,
+    managedBrowserCreationEnabled: runtime.managedBrowserCreationEnabled,
+    mobileEmulatorCreationEnabled: runtime.mobileEmulatorCreationEnabled,
     workspaceHasSimulatorTab: runtime.workspaceHasSimulatorTab,
     showWindowsShellMenu: runtime.showWindowsShellMenu,
     projectRuntimeShellMenuMode: runtime.projectRuntimeShellMenuMode,

--- a/src/renderer/src/components/tab-bar/tab-bar-item-surface.tsx
+++ b/src/renderer/src/components/tab-bar/tab-bar-item-surface.tsx
@@ -149,7 +149,11 @@ export function renderTabBarItems({
           onCloseOthers={() => onCloseOthers(item.id)}
           onCloseToRight={() => onCloseToRight(item.id)}
           onCloseToLeft={() => onCloseToLeft(item.id)}
-          onDuplicate={() => onDuplicateBrowserTab?.(item.id)}
+          onDuplicate={
+            runtime.managedBrowserCreationEnabled
+              ? () => onDuplicateBrowserTab?.(item.id)
+              : undefined
+          }
           onTogglePin={() => togglePinned(item)}
           dragData={dragData}
           dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}

--- a/src/renderer/src/components/tab-bar/tab-bar-static-create-menu.tsx
+++ b/src/renderer/src/components/tab-bar/tab-bar-static-create-menu.tsx
@@ -16,6 +16,8 @@ import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
 export function renderTabBarStaticCreateMenu({
   terminalOnly,
   mobileEmulatorEnabled,
+  managedBrowserCreationEnabled,
+  mobileEmulatorCreationEnabled,
   workspaceHasSimulatorTab,
   showMobileEmulatorIntroCallout,
   props,
@@ -32,6 +34,8 @@ export function renderTabBarStaticCreateMenu({
   props: TabBarProps
   terminalOnly: boolean
   mobileEmulatorEnabled: boolean
+  managedBrowserCreationEnabled: boolean
+  mobileEmulatorCreationEnabled: boolean
   workspaceHasSimulatorTab: boolean
   showMobileEmulatorIntroCallout: boolean
   windowsShellEntries: WindowsShellMenuEntry[] | undefined
@@ -97,18 +101,19 @@ export function renderTabBarStaticCreateMenu({
         <DropdownMenuShortcut>{newTerminalShortcut}</DropdownMenuShortcut>
       </DropdownMenuItem>
     )
-  const newBrowserMenuItem = !terminalOnly ? (
-    <DropdownMenuItem
-      onSelect={onNewBrowserTab}
-      className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
-    >
-      <Globe className="size-4 text-muted-foreground" />
-      {translate('auto.components.tab.bar.TabBar.4833fb2cbe', 'New Browser Tab')}
-      <DropdownMenuShortcut>{newBrowserShortcut}</DropdownMenuShortcut>
-    </DropdownMenuItem>
-  ) : null
+  const newBrowserMenuItem =
+    !terminalOnly && managedBrowserCreationEnabled ? (
+      <DropdownMenuItem
+        onSelect={onNewBrowserTab}
+        className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
+      >
+        <Globe className="size-4 text-muted-foreground" />
+        {translate('auto.components.tab.bar.TabBar.4833fb2cbe', 'New Browser Tab')}
+        <DropdownMenuShortcut>{newBrowserShortcut}</DropdownMenuShortcut>
+      </DropdownMenuItem>
+    ) : null
   const newSimulatorMenuItem =
-    !terminalOnly && mobileEmulatorEnabled && onNewSimulatorTab ? (
+    !terminalOnly && mobileEmulatorEnabled && mobileEmulatorCreationEnabled && onNewSimulatorTab ? (
       workspaceHasSimulatorTab ? (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -168,6 +173,7 @@ export function renderTabBarStaticCreateMenu({
     !terminalOnly &&
     isMacOs &&
     mobileEmulatorEnabled &&
+    mobileEmulatorCreationEnabled &&
     onNewSimulatorTab ? (
       <MobileEmulatorTabIntroCallout />
     ) : null

--- a/src/renderer/src/components/tab-bar/tab-bar-surface.tsx
+++ b/src/renderer/src/components/tab-bar/tab-bar-surface.tsx
@@ -52,6 +52,8 @@ export function renderTabBarSurface({
   const {
     resolvedGroupId,
     mobileEmulatorEnabled,
+    managedBrowserCreationEnabled,
+    mobileEmulatorCreationEnabled,
     workspaceHasSimulatorTab,
     showMobileEmulatorIntroCallout,
     windowsTerminalCapabilities,
@@ -93,6 +95,8 @@ export function renderTabBarSurface({
     props,
     terminalOnly,
     mobileEmulatorEnabled,
+    managedBrowserCreationEnabled,
+    mobileEmulatorCreationEnabled,
     workspaceHasSimulatorTab,
     showMobileEmulatorIntroCallout,
     windowsShellEntries,

--- a/src/renderer/src/components/tab-bar/tab-create-menu-options.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-menu-options.test.ts
@@ -53,6 +53,25 @@ describe('tab create menu options', () => {
     ).toEqual(['new-browser'])
   })
 
+  it('keeps terminal and markdown results when client-impossible actions are omitted', () => {
+    const options = buildTabCreateMenuOptions({
+      terminalOnly: false,
+      hasNewBrowser: false,
+      hasNewMarkdown: true,
+      hasOpenMarkdown: true,
+      hasSimulator: false,
+      simulatorIsGoTo: false
+    })
+
+    expect(options.map((option) => option.kind)).toEqual([
+      'new-terminal',
+      'new-markdown',
+      'open-markdown'
+    ])
+    expect(findMatchingTabCreateMenuOptions('browser', options)).toEqual([])
+    expect(findMatchingTabCreateMenuOptions('mobile emulator', options)).toEqual([])
+  })
+
   it('preserves default Windows shell order for tied terminal matches', () => {
     const options = buildTabCreateMenuOptions({
       terminalOnly: false,

--- a/src/renderer/src/components/tab-bar/use-tab-bar-create-menu-controller.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-bar-create-menu-controller.ts
@@ -42,6 +42,8 @@ export function useTabBarCreateMenuController({
   resolvedGroupId,
   terminalOnly,
   mobileEmulatorEnabled,
+  managedBrowserCreationEnabled,
+  mobileEmulatorCreationEnabled,
   workspaceHasSimulatorTab,
   showWindowsShellMenu,
   projectRuntimeShellMenuMode,
@@ -60,6 +62,8 @@ export function useTabBarCreateMenuController({
   resolvedGroupId: string
   terminalOnly: boolean
   mobileEmulatorEnabled: boolean
+  managedBrowserCreationEnabled: boolean
+  mobileEmulatorCreationEnabled: boolean
   workspaceHasSimulatorTab: boolean
   showWindowsShellMenu: boolean
   projectRuntimeShellMenuMode: ReturnType<typeof getProjectRuntimeShellMenuMode>
@@ -155,14 +159,20 @@ export function useTabBarCreateMenuController({
       buildTabCreateMenuOptions({
         terminalOnly,
         windowsShellEntries,
-        hasNewBrowser: !terminalOnly,
+        hasNewBrowser: !terminalOnly && managedBrowserCreationEnabled,
         hasNewMarkdown: !terminalOnly && Boolean(onNewFileTab),
         hasOpenMarkdown: !terminalOnly && Boolean(onOpenFileTab),
-        hasSimulator: !terminalOnly && mobileEmulatorEnabled && Boolean(onNewSimulatorTab),
+        hasSimulator:
+          !terminalOnly &&
+          mobileEmulatorEnabled &&
+          mobileEmulatorCreationEnabled &&
+          Boolean(onNewSimulatorTab),
         simulatorIsGoTo: workspaceHasSimulatorTab
       }),
     [
       mobileEmulatorEnabled,
+      managedBrowserCreationEnabled,
+      mobileEmulatorCreationEnabled,
       onNewFileTab,
       onNewSimulatorTab,
       onOpenFileTab,

--- a/src/renderer/src/components/tab-bar/use-tab-bar-runtime-model.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-bar-runtime-model.ts
@@ -26,6 +26,7 @@ import { buildTabAgentLaunchOptions, orderTabLaunchAgents } from './tab-agent-la
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
 import { shouldShowWindowsShellMenu } from './windows-shell-menu-visibility'
 import { createUnifiedTabLookup } from './tab-bar-item-model'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 const isWindows = navigator.userAgent.includes('Windows')
 export const isMacOs = navigator.userAgent.includes('Mac')
@@ -77,6 +78,8 @@ export type TabBarRuntimeModel = {
   workspaceHasSimulatorTab: boolean
   toggleTabViewMode: (tabId: string) => void
   nativeChatTranscriptIsLocalReadable: boolean
+  managedBrowserCreationEnabled: boolean
+  mobileEmulatorCreationEnabled: boolean
 } & TabBarAgentProjections
 
 export function useTabBarRuntimeModel({
@@ -221,6 +224,15 @@ export function useTabBarRuntimeModel({
     () => unifiedTabs.some((tab) => tab.contentType === 'simulator'),
     [unifiedTabs]
   )
+  const [managedBrowserCreationEnabled, mobileEmulatorCreationEnabled] = useAppStore(
+    useShallow((state) => {
+      const policy = getClientCreationActionPolicy(state, worktreeId)
+      return [
+        policy['managed-browser'].state === 'enabled',
+        policy['mobile-emulator'].state === 'enabled'
+      ] as const
+    })
+  )
   // Why: tab-wide launch/title hints are safe only before split; gate the view-mode toggle to the active leaf's agent.
   const toggleTabViewMode = useAppStore((s) => s.toggleTabViewMode)
   // Why: every retained TabBar observes the same hot maps; one feature-gated selector shares their projections.
@@ -256,6 +268,8 @@ export function useTabBarRuntimeModel({
     nativeChatEnabled,
     tabAgentTypesByTabId,
     nativeChatTabWideFallbackUnsafeTabsById,
-    nativeChatTranscriptIsLocalReadable
+    nativeChatTranscriptIsLocalReadable,
+    managedBrowserCreationEnabled,
+    mobileEmulatorCreationEnabled
   }
 }

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: keeps group-scoped activation, close, split, and tab-order rules together with the TabGroupPanel surface. */
 import { useCallback, useMemo } from 'react'
+import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'
 import type { OpenFile } from '@/store/slices/editor'
 import type {
@@ -28,6 +29,7 @@ import { ensureSimulatorTab, getSimulatorTabForWorktree } from '@/lib/ensure-sim
 import { buildDuplicatedBrowserTabOptions } from '@/lib/duplicate-browser-tab-options'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 export function recordTerminalTabGroupSplit(createdTerminal: TerminalTab | null | undefined): void {
   if (!createdTerminal) {
@@ -585,7 +587,9 @@ export function useTabGroupWorkspaceModel({
       closeToLeft,
       createSplitGroup,
       newBrowserTab: () => {
-        void openNewBrowserTabInActiveWorkspace(groupId)
+        void openNewBrowserTabInActiveWorkspace(groupId).catch((error) => {
+          toast.error(error instanceof Error ? error.message : String(error))
+        })
       },
       newSimulatorTab: worktreeState.mobileEmulatorEnabled
         ? () => {
@@ -597,6 +601,8 @@ export function useTabGroupWorkspaceModel({
             void openMobileEmulatorTab(worktreeId, {
               placement: 'rightSplit',
               targetGroupId: groupId
+            }).catch((error) => {
+              toast.error(error instanceof Error ? error.message : String(error))
             })
           }
         : undefined,
@@ -612,23 +618,36 @@ export function useTabGroupWorkspaceModel({
             return
           }
           const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+          const browserAvailability = getClientCreationActionPolicy(state, worktreeId)[
+            'managed-browser'
+          ]
+          if (browserAvailability.state !== 'enabled') {
+            throw new Error(browserAvailability.reason)
+          }
           if (
-            browserWorkspaceHasRemoteOwner(state, source.id, runtimeEnvironmentId) &&
-            (await createWebRuntimeSessionBrowserTab({
+            browserAvailability.provider === 'paired-runtime' &&
+            browserWorkspaceHasRemoteOwner(state, source.id, runtimeEnvironmentId)
+          ) {
+            const created = await createWebRuntimeSessionBrowserTab({
               worktreeId,
               environmentId: runtimeEnvironmentId,
               url: source.url,
               profileId: source.sessionProfileId,
               targetGroupId: groupId
-            }))
-          ) {
-            return
+            })
+            if (created) {
+              return
+            }
+            throw new Error('The paired runtime could not duplicate the managed browser tab.')
           }
           createBrowserTab(worktreeId, source.url, {
             ...buildDuplicatedBrowserTabOptions(source),
+            ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {}),
             targetGroupId: groupId
           })
-        })()
+        })().catch((error) => {
+          toast.error(error instanceof Error ? error.message : String(error))
+        })
       },
       // Why: target the owning group explicitly; the "+" menu can fire from an unfocused panel without updating global group focus.
       newFileTab: async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -128,7 +128,6 @@ import type { AppState } from '../store/types'
 import { guardPinnedTabClose, resolvePinnedTabLabel } from '../store/pinned-tab-close-guard'
 import {
   closeWebRuntimeSessionTab,
-  createWebRuntimeSessionBrowserTab,
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
@@ -2147,35 +2146,23 @@ export function useIpcEvents(): void {
       window.api.ui.onNewBrowserTab(() => {
         const store = useAppStore.getState()
         if (isFloatingWorkspacePanelFocused()) {
-          void createFloatingWorkspaceBrowserTab(store)
+          void createFloatingWorkspaceBrowserTab(store).catch((error) => {
+            toast.error(error instanceof Error ? error.message : String(error))
+          })
           return
         }
         const worktreeId = store.activeWorktreeId
-        if (worktreeId) {
-          const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
-          if (environmentId) {
-            if (!isWebRuntimeSessionActive(environmentId)) {
-              store.createBrowserTab(worktreeId, store.browserDefaultUrl ?? 'about:blank', {
-                title: translate('auto.hooks.useIpcEvents.f6300deb8b', 'New Browser Tab'),
-                focusAddressBar: true
-              })
-              return
-            }
-            void (async () => {
-              // Why: paired web tabs are host-owned; on RPC failure leave local state so the next host snapshot stays authoritative.
-              await createWebRuntimeSessionBrowserTab({
-                worktreeId,
-                environmentId,
-                url: store.browserDefaultUrl ?? 'about:blank'
-              })
-            })()
-            return
-          }
-          store.createBrowserTab(worktreeId, store.browserDefaultUrl ?? 'about:blank', {
-            title: translate('auto.hooks.useIpcEvents.f6300deb8b', 'New Browser Tab'),
-            focusAddressBar: true
-          })
+        if (!worktreeId) {
+          return
         }
+        const targetGroupId =
+          store.activeGroupIdByWorktree[worktreeId] ?? store.groupsByWorktree[worktreeId]?.[0]?.id
+        if (!targetGroupId) {
+          return
+        }
+        void store.openNewBrowserTabInActiveWorkspace(targetGroupId).catch((error) => {
+          toast.error(error instanceof Error ? error.message : String(error))
+        })
       })
     )
 
@@ -2217,7 +2204,9 @@ export function useIpcEvents(): void {
       if (!worktreeId) {
         return
       }
-      void openMobileEmulatorTab(worktreeId, { placement: 'rightSplit' })
+      void openMobileEmulatorTab(worktreeId, { placement: 'rightSplit' }).catch((error) => {
+        toast.error(error instanceof Error ? error.message : String(error))
+      })
     })
     if (unsubscribeNewSimulatorTab) {
       unsubs.push(unsubscribeNewSimulatorTab)

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -149,6 +149,28 @@ describe('settings navigation metadata', () => {
     expect(floatingWorkspace?.searchEntries.flatMap((entry) => entry.keywords)).not.toContain(
       'browser'
     )
+    const shortcuts = webSections.find((section) => section.id === 'shortcuts')
+    expect(shortcuts?.searchEntries.map((entry) => entry.title)).not.toContain('New browser tab')
+    expect(shortcuts?.searchEntries.map((entry) => entry.title)).not.toContain(
+      'New mobile emulator tab'
+    )
+  })
+
+  it('keeps the Browser shortcut searchable for a capable web runtime', () => {
+    const sections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: true,
+      managedBrowserCreationEnabled: true,
+      mobileEmulatorCreationEnabled: false,
+      repos: [repo]
+    })
+    const shortcutTitles = sections
+      .find((section) => section.id === 'shortcuts')
+      ?.searchEntries.map((entry) => entry.title)
+
+    expect(shortcutTitles).toContain('New browser tab')
+    expect(shortcutTitles).not.toContain('New mobile emulator tab')
   })
 
   it('does not mark installable AI capabilities as beta in the sidebar metadata', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -128,7 +128,13 @@ describe('settings navigation metadata', () => {
   })
 
   it('keeps desktop-only Settings panes out of web metadata', () => {
-    const webIds = ids({ isWebClient: true })
+    const webSections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: true,
+      repos: [repo]
+    })
+    const webIds = webSections.map((section) => section.id)
 
     expect(webIds).not.toContain('browser')
     expect(webIds).not.toContain('ssh')
@@ -138,6 +144,11 @@ describe('settings navigation metadata', () => {
     expect(webIds).not.toContain('advanced')
     expect(webIds).toContain('servers')
     expect(webIds).toContain('repo-repo-1')
+    const floatingWorkspace = webSections.find((section) => section.id === 'floating-workspace')
+    expect(floatingWorkspace?.description).toBe('Global terminal and markdown tabs.')
+    expect(floatingWorkspace?.searchEntries.flatMap((entry) => entry.keywords)).not.toContain(
+      'browser'
+    )
   })
 
   it('does not mark installable AI capabilities as beta in the sidebar metadata', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines */
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useShallow } from 'zustand/react/shallow'
 // Why: this registry mirrors the Settings sidebar in one neutral module so
 // Cmd+J and Settings visibility cannot drift. Keep it free of Settings pane UI
 // imports; the boundary is enforced by a focused architecture test.
@@ -90,6 +91,7 @@ import { useWindowsTerminalCapabilityOwnerKey } from './useWindowsTerminalCapabi
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { useLinearProviderConnected } from '@/hooks/useLinearProviderConnected'
 import { translate } from '@/i18n/i18n'
+import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
 
 export { isWebClientLocation } from '@/lib/web-client-location'
 
@@ -124,6 +126,8 @@ export function buildSettingsNavigationMetadata({
   isLocalWindowsHost = isWindows,
   isWindowsTerminalHost = isWindows,
   isWebClient,
+  managedBrowserCreationEnabled = !isWebClient,
+  mobileEmulatorCreationEnabled = !isWebClient,
   isDev = import.meta.env.DEV,
   isLinearConnected = false,
   repos
@@ -133,6 +137,8 @@ export function buildSettingsNavigationMetadata({
   isLocalWindowsHost?: boolean
   isWindowsTerminalHost?: boolean
   isWebClient: boolean
+  managedBrowserCreationEnabled?: boolean
+  mobileEmulatorCreationEnabled?: boolean
   isDev?: boolean
   isLinearConnected?: boolean
   repos: readonly Repo[]
@@ -504,7 +510,10 @@ export function buildSettingsNavigationMetadata({
         'Keyboard shortcuts for common actions.'
       ),
       icon: Keyboard,
-      searchEntries: getShortcutsPaneSearchEntries(),
+      searchEntries: getShortcutsPaneSearchEntries({
+        includeManagedBrowser: managedBrowserCreationEnabled,
+        includeMobileEmulator: mobileEmulatorCreationEnabled
+      }),
       group: 'interface'
     },
     {
@@ -676,6 +685,15 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
   const activeLocale = i18n.language
   const repos = useAppStore((state) => state.repos)
   const settings = useAppStore((state) => state.settings)
+  const [managedBrowserCreationEnabled, mobileEmulatorCreationEnabled] = useAppStore(
+    useShallow((state) => {
+      const policy = getClientCreationActionPolicy(state, state.activeWorktreeId)
+      return [
+        policy['managed-browser'].state === 'enabled',
+        policy['mobile-emulator'].state === 'enabled'
+      ] as const
+    })
+  )
   const isMac = isMacUserAgent()
   const isWindows = isWindowsUserAgent()
   const isWebClient = isWebClientLocation()
@@ -718,6 +736,8 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
         isLocalWindowsHost,
         isWindowsTerminalHost,
         isWebClient,
+        managedBrowserCreationEnabled,
+        mobileEmulatorCreationEnabled,
         isDev: import.meta.env.DEV,
         isLinearConnected,
         repos
@@ -729,6 +749,8 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
       isLocalWindowsHost,
       isWindowsTerminalHost,
       isWebClient,
+      managedBrowserCreationEnabled,
+      mobileEmulatorCreationEnabled,
       isLinearConnected,
       repos,
       activeLocale

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -437,12 +437,19 @@ export function buildSettingsNavigationMetadata({
     {
       id: 'floating-workspace',
       title: translate('auto.hooks.useSettingsNavigationMetadata.65b19f5bde', 'Floating Workspace'),
-      description: translate(
-        'auto.hooks.useSettingsNavigationMetadata.2d0659f6f0',
-        'Global terminal, browser, and markdown tabs.'
-      ),
+      description: showDesktopOnlySettings
+        ? translate(
+            'auto.hooks.useSettingsNavigationMetadata.2d0659f6f0',
+            'Global terminal, browser, and markdown tabs.'
+          )
+        : translate(
+            'auto.hooks.useSettingsNavigationMetadata.floatingWorkspaceWebDescription',
+            'Global terminal and markdown tabs.'
+          ),
       icon: PanelsTopLeft,
-      searchEntries: getFloatingWorkspaceSearchEntries(),
+      searchEntries: getFloatingWorkspaceSearchEntries({
+        includeBrowser: showDesktopOnlySettings
+      }),
       group: 'workflows'
     },
     {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -912,7 +912,8 @@
         "artifactsTitle": "Artifacts",
         "artifactsDescription": "Share HTML and Markdown files with your team and manage their public links.",
         "automationsTitle": "Automations",
-        "automationsDescription": "Schedule agent work and choose whether Automations appears in the sidebar."
+        "automationsDescription": "Schedule agent work and choose whether Automations appears in the sidebar.",
+        "floatingWorkspaceWebDescription": "Global terminal and markdown tabs."
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "Paste is too large."

--- a/src/renderer/src/lib/client-creation-action-policy.test.ts
+++ b/src/renderer/src/lib/client-creation-action-policy.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { RuntimeStatus } from '../../../shared/runtime-types'
+import { toRuntimeExecutionHostId, toSshExecutionHostId } from '../../../shared/execution-host'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import {
   FLOATING_BROWSER_UNAVAILABLE_MESSAGE,
   LOCAL_BROWSER_UNAVAILABLE_MESSAGE,
@@ -164,5 +166,45 @@ describe('client creation action guards', () => {
         'managed-browser'
       ]
     ).toEqual({ state: 'hidden', reason: FLOATING_BROWSER_UNAVAILABLE_MESSAGE })
+  })
+
+  it('uses folder and SSH workspace ownership instead of the focused runtime', () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const capableStatus = runtimeStatus(['browser.screencast.v1'])
+    const state = {
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+      folderWorkspaces: [
+        {
+          id: 'remote-folder',
+          projectGroupId: 'remote-group',
+          executionHostId: toRuntimeExecutionHostId('folder-owner')
+        }
+      ],
+      projectGroups: [
+        { id: 'remote-group', executionHostId: toRuntimeExecutionHostId('folder-owner') }
+      ],
+      worktreesByRepo: {
+        repo: [
+          {
+            id: 'ssh-worktree',
+            repoId: 'repo',
+            hostId: toSshExecutionHostId('ssh-owner')
+          }
+        ]
+      },
+      runtimeStatusByEnvironmentId: new Map([
+        ['folder-owner', { status: capableStatus, checkedAt: 1 }],
+        ['focused-runtime', { status: capableStatus, checkedAt: 1 }]
+      ])
+    }
+
+    expect(
+      getClientCreationActionPolicy(state as never, folderWorkspaceKey('remote-folder'))[
+        'managed-browser'
+      ]
+    ).toEqual({ state: 'enabled', provider: 'paired-runtime' })
+    expect(
+      getClientCreationActionPolicy(state as never, 'ssh-worktree')['managed-browser']
+    ).toEqual({ state: 'hidden', reason: MANAGED_BROWSER_UNAVAILABLE_MESSAGE })
   })
 })

--- a/src/renderer/src/lib/client-creation-action-policy.test.ts
+++ b/src/renderer/src/lib/client-creation-action-policy.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { RuntimeStatus } from '../../../shared/runtime-types'
+import {
+  FLOATING_BROWSER_UNAVAILABLE_MESSAGE,
+  LOCAL_BROWSER_UNAVAILABLE_MESSAGE,
+  MANAGED_BROWSER_UNAVAILABLE_MESSAGE,
+  MOBILE_EMULATOR_UNAVAILABLE_MESSAGE,
+  assertClientCreationActionAvailable,
+  assertManagedBrowserMaterializationAllowed,
+  getClientCreationActionPolicy,
+  resolveClientCreationActionPolicy
+} from './client-creation-action-policy'
+
+function runtimeStatus(capabilities?: string[]): RuntimeStatus {
+  return {
+    runtimeId: 'runtime-1',
+    rendererGraphEpoch: 1,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    hostPlatform: 'darwin',
+    capabilities
+  }
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('resolveClientCreationActionPolicy', () => {
+  it('preserves Electron creation behavior without negotiated runtime signals', () => {
+    expect(resolveClientCreationActionPolicy({ surface: 'electron', runtimeStatus: null })).toEqual(
+      {
+        'managed-browser': { state: 'enabled', provider: 'local-client' },
+        'mobile-emulator': { state: 'enabled', provider: 'local-client' }
+      }
+    )
+  })
+
+  it('selects the provider that the browser action path can actually consume', () => {
+    const desktopHost = runtimeStatus(['browser.screencast.v1'])
+    const npmHostWithoutDisplay = { ...runtimeStatus(), hostPlatform: 'linux' as const }
+    const npmHostWithDisplay = {
+      ...runtimeStatus(['browser.screencast.v1', 'browser.headless.v1']),
+      hostPlatform: 'linux' as const
+    }
+
+    expect(
+      resolveClientCreationActionPolicy({ surface: 'electron', runtimeStatus: desktopHost })
+    ).toEqual({
+      'managed-browser': { state: 'enabled', provider: 'paired-runtime' },
+      'mobile-emulator': { state: 'enabled', provider: 'local-client' }
+    })
+    expect(
+      resolveClientCreationActionPolicy({
+        surface: 'electron',
+        runtimeStatus: npmHostWithoutDisplay
+      })
+    ).toEqual({
+      'managed-browser': { state: 'enabled', provider: 'local-client' },
+      'mobile-emulator': { state: 'enabled', provider: 'local-client' }
+    })
+    expect(
+      resolveClientCreationActionPolicy({ surface: 'paired-web', runtimeStatus: desktopHost })
+    ).toEqual({
+      'managed-browser': { state: 'enabled', provider: 'paired-runtime' },
+      'mobile-emulator': { state: 'hidden', reason: MOBILE_EMULATOR_UNAVAILABLE_MESSAGE }
+    })
+    expect(
+      resolveClientCreationActionPolicy({
+        surface: 'paired-web',
+        runtimeStatus: npmHostWithoutDisplay
+      })
+    ).toEqual({
+      'managed-browser': { state: 'hidden', reason: MANAGED_BROWSER_UNAVAILABLE_MESSAGE },
+      'mobile-emulator': { state: 'hidden', reason: MOBILE_EMULATOR_UNAVAILABLE_MESSAGE }
+    })
+    expect(
+      resolveClientCreationActionPolicy({
+        surface: 'paired-web',
+        runtimeStatus: npmHostWithDisplay
+      })['managed-browser']
+    ).toEqual({ state: 'enabled', provider: 'paired-runtime' })
+  })
+
+  it('enables paired-web browser creation only with negotiated streaming support', () => {
+    expect(
+      resolveClientCreationActionPolicy({
+        surface: 'paired-web',
+        runtimeStatus: runtimeStatus(['browser.screencast.v1'])
+      })['managed-browser']
+    ).toEqual({ state: 'enabled', provider: 'paired-runtime' })
+
+    expect(
+      resolveClientCreationActionPolicy({
+        surface: 'paired-web',
+        runtimeStatus: runtimeStatus()
+      })['managed-browser']
+    ).toEqual({ state: 'hidden', reason: MANAGED_BROWSER_UNAVAILABLE_MESSAGE })
+  })
+
+  it('hides web-client floating browsers and mobile emulators as impossible surfaces', () => {
+    const policy = resolveClientCreationActionPolicy({
+      surface: 'paired-web',
+      runtimeStatus: runtimeStatus(['browser.screencast.v1', 'mobile.tasks.v1']),
+      floatingWorkspace: true
+    })
+
+    expect(policy['managed-browser']).toEqual({
+      state: 'hidden',
+      reason: FLOATING_BROWSER_UNAVAILABLE_MESSAGE
+    })
+    expect(policy['mobile-emulator']).toEqual({
+      state: 'hidden',
+      reason: MOBILE_EMULATOR_UNAVAILABLE_MESSAGE
+    })
+  })
+})
+
+describe('client creation action guards', () => {
+  it('fails closed for an older paired runtime and rejects local browser materialization', () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const state = {
+      settings: { activeRuntimeEnvironmentId: 'runtime-1' },
+      runtimeStatusByEnvironmentId: new Map([
+        ['runtime-1', { status: runtimeStatus(), checkedAt: 1 }]
+      ])
+    }
+
+    expect(getClientCreationActionPolicy(state as never, null)['managed-browser'].state).toBe(
+      'hidden'
+    )
+    expect(() =>
+      assertClientCreationActionAvailable(state as never, null, 'managed-browser')
+    ).toThrow(MANAGED_BROWSER_UNAVAILABLE_MESSAGE)
+    expect(() => assertManagedBrowserMaterializationAllowed(state as never, null)).toThrow(
+      LOCAL_BROWSER_UNAVAILABLE_MESSAGE
+    )
+  })
+
+  it('permits host-confirmed remote browser materialization in paired web', () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const state = {
+      runtimeStatusByEnvironmentId: new Map([
+        ['runtime-1', { status: runtimeStatus(['browser.screencast.v1']), checkedAt: 1 }]
+      ])
+    }
+    expect(() =>
+      assertManagedBrowserMaterializationAllowed(state as never, 'runtime-1')
+    ).not.toThrow()
+  })
+
+  it('treats the floating workspace as local even with an active capable runtime', () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const state = {
+      settings: { activeRuntimeEnvironmentId: 'runtime-1' },
+      runtimeStatusByEnvironmentId: new Map([
+        ['runtime-1', { status: runtimeStatus(['browser.screencast.v1']), checkedAt: 1 }]
+      ])
+    }
+
+    expect(
+      getClientCreationActionPolicy(state as never, FLOATING_TERMINAL_WORKTREE_ID)[
+        'managed-browser'
+      ]
+    ).toEqual({ state: 'hidden', reason: FLOATING_BROWSER_UNAVAILABLE_MESSAGE })
+  })
+})

--- a/src/renderer/src/lib/client-creation-action-policy.ts
+++ b/src/renderer/src/lib/client-creation-action-policy.ts
@@ -22,7 +22,6 @@ export type ClientCreationActionProvider = 'local-client' | 'paired-runtime'
 export type ClientCreationActionAvailability =
   | { state: 'enabled'; provider: ClientCreationActionProvider }
   | { state: 'hidden'; reason: string }
-  | { state: 'disabled'; reason: string }
 
 export type ClientCreationActionPolicy = Record<
   ClientCreationAction,

--- a/src/renderer/src/lib/client-creation-action-policy.ts
+++ b/src/renderer/src/lib/client-creation-action-policy.ts
@@ -1,0 +1,117 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import type { RuntimeStatus } from '../../../shared/runtime-types'
+import type { AppState } from '@/store/types'
+import { isPairedWebClientWindow } from './desktop-window-chrome'
+import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
+
+export const MANAGED_BROWSER_UNAVAILABLE_MESSAGE =
+  "Managed browser tabs are unavailable because this web client's paired runtime does not support browser streaming."
+export const RUNTIME_BROWSER_UNAVAILABLE_MESSAGE =
+  'Managed browser tabs are unavailable because the paired runtime does not support browser streaming.'
+export const FLOATING_BROWSER_UNAVAILABLE_MESSAGE =
+  'Managed browser tabs are unavailable in the web client floating workspace.'
+export const LOCAL_BROWSER_UNAVAILABLE_MESSAGE =
+  'Managed browser tabs in the web client must be created by a capable paired runtime.'
+export const MOBILE_EMULATOR_UNAVAILABLE_MESSAGE =
+  'Mobile Emulator is unavailable in the web client.'
+
+export type ClientCreationAction = 'managed-browser' | 'mobile-emulator'
+export type ClientCreationActionProvider = 'local-client' | 'paired-runtime'
+
+export type ClientCreationActionAvailability =
+  | { state: 'enabled'; provider: ClientCreationActionProvider }
+  | { state: 'hidden'; reason: string }
+  | { state: 'disabled'; reason: string }
+
+export type ClientCreationActionPolicy = Record<
+  ClientCreationAction,
+  ClientCreationActionAvailability
+>
+
+export function resolveClientCreationActionPolicy(args: {
+  surface: 'electron' | 'paired-web'
+  runtimeStatus: Pick<RuntimeStatus, 'capabilities' | 'hostPlatform'> | null
+  floatingWorkspace?: boolean
+}): ClientCreationActionPolicy {
+  const browserStreamingAvailable = args.runtimeStatus?.capabilities?.includes(
+    BROWSER_SCREENCAST_RUNTIME_CAPABILITY
+  )
+
+  if (args.surface === 'electron') {
+    return {
+      'managed-browser': {
+        state: 'enabled',
+        provider: browserStreamingAvailable ? 'paired-runtime' : 'local-client'
+      },
+      'mobile-emulator': { state: 'enabled', provider: 'local-client' }
+    }
+  }
+
+  return {
+    'managed-browser': args.floatingWorkspace
+      ? { state: 'hidden', reason: FLOATING_BROWSER_UNAVAILABLE_MESSAGE }
+      : browserStreamingAvailable
+        ? { state: 'enabled', provider: 'paired-runtime' }
+        : { state: 'hidden', reason: MANAGED_BROWSER_UNAVAILABLE_MESSAGE },
+    // The web preload cannot stream emulator frames, even when the host can run emulator tasks.
+    'mobile-emulator': { state: 'hidden', reason: MOBILE_EMULATOR_UNAVAILABLE_MESSAGE }
+  }
+}
+
+export function getClientCreationActionPolicy(
+  state: AppState,
+  worktreeId: string | null
+): ClientCreationActionPolicy {
+  const floatingWorkspace = worktreeId === FLOATING_TERMINAL_WORKTREE_ID
+  const runtimeEnvironmentId = floatingWorkspace
+    ? null
+    : worktreeId
+      ? getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+      : (state.settings?.activeRuntimeEnvironmentId?.trim() ?? null)
+  const runtimeStatus = runtimeEnvironmentId
+    ? (state.runtimeStatusByEnvironmentId?.get(runtimeEnvironmentId)?.status ?? null)
+    : null
+
+  return resolveClientCreationActionPolicy({
+    surface: isPairedWebClientWindow() ? 'paired-web' : 'electron',
+    runtimeStatus,
+    floatingWorkspace
+  })
+}
+
+export function assertClientCreationActionAvailable(
+  state: AppState,
+  worktreeId: string | null,
+  action: ClientCreationAction
+): void {
+  const availability = getClientCreationActionPolicy(state, worktreeId)[action]
+  if (availability.state !== 'enabled') {
+    throw new Error(availability.reason)
+  }
+}
+
+export function assertRuntimeManagedBrowserCreationAvailable(
+  state: AppState,
+  runtimeEnvironmentId: string
+): void {
+  const capabilities =
+    state.runtimeStatusByEnvironmentId?.get(runtimeEnvironmentId)?.status?.capabilities
+  if (!capabilities?.includes(BROWSER_SCREENCAST_RUNTIME_CAPABILITY)) {
+    throw new Error(RUNTIME_BROWSER_UNAVAILABLE_MESSAGE)
+  }
+}
+
+export function assertManagedBrowserMaterializationAllowed(
+  state: AppState,
+  browserRuntimeEnvironmentId: string | null | undefined
+): void {
+  if (!isPairedWebClientWindow()) {
+    return
+  }
+  const runtimeEnvironmentId = browserRuntimeEnvironmentId?.trim()
+  if (!runtimeEnvironmentId) {
+    throw new Error(LOCAL_BROWSER_UNAVAILABLE_MESSAGE)
+  }
+  assertRuntimeManagedBrowserCreationAvailable(state, runtimeEnvironmentId)
+}

--- a/src/renderer/src/lib/floating-workspace-tab-creation.ts
+++ b/src/renderer/src/lib/floating-workspace-tab-creation.ts
@@ -6,6 +6,7 @@ import { detectLanguage } from './language-detect'
 import type { AppState } from '@/store/types'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 import { translate } from '@/i18n/i18n'
+import { assertClientCreationActionAvailable } from './client-creation-action-policy'
 
 type FloatingWorkspaceTerminalStore = Pick<
   AppState,
@@ -38,6 +39,11 @@ export async function createFloatingWorkspaceTerminalTab(
 export async function createFloatingWorkspaceBrowserTab(
   store: FloatingWorkspaceBrowserStore
 ): Promise<BrowserTab | null> {
+  assertClientCreationActionAvailable(
+    store as AppState,
+    FLOATING_TERMINAL_WORKTREE_ID,
+    'managed-browser'
+  )
   const targetGroupId = store.activeGroupIdByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
   const url = store.browserDefaultUrl ?? 'about:blank'
 

--- a/src/renderer/src/lib/open-mobile-emulator-tab.test.ts
+++ b/src/renderer/src/lib/open-mobile-emulator-tab.test.ts
@@ -14,7 +14,11 @@ const mockStoreState = vi.hoisted(() => ({
   activeGroupIdByWorktree: { 'wt-1': 'group-1' } as Record<string, string>,
   groupsByWorktree: { 'wt-1': [{ id: 'group-1' }] } as Record<string, { id: string }[]>,
   unifiedTabsByWorktree: {} as Record<string, { id: string; contentType: string }[]>,
-  settings: { mobileEmulatorEnabled: true } as { mobileEmulatorEnabled?: boolean }
+  settings: { mobileEmulatorEnabled: true } as {
+    mobileEmulatorEnabled?: boolean
+    activeRuntimeEnvironmentId?: string | null
+  },
+  runtimeStatusByEnvironmentId: new Map()
 }))
 
 vi.mock('@/store', () => ({
@@ -68,6 +72,22 @@ describe('openMobileEmulatorTab', () => {
   afterEach(() => {
     cancelPendingSimulatorPaneShutdown('wt-1')
     vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects web-client invocation before creating a tab or attaching', async () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    mockStoreState.settings = {
+      mobileEmulatorEnabled: true,
+      activeRuntimeEnvironmentId: 'runtime-1'
+    }
+
+    await expect(openMobileEmulatorTab('wt-1')).rejects.toThrow(
+      'Mobile Emulator is unavailable in the web client.'
+    )
+
+    expect(ensureSimulatorTab).not.toHaveBeenCalled()
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
   })
 
   it('surfaces the simulator tab before attaching the emulator stream', async () => {

--- a/src/renderer/src/lib/open-mobile-emulator-tab.ts
+++ b/src/renderer/src/lib/open-mobile-emulator-tab.ts
@@ -16,6 +16,7 @@ import {
   cancelPendingSimulatorPaneShutdown,
   shutdownManagedSimulatorIfNoPane
 } from './simulator-pane-shutdown-scheduler'
+import { assertClientCreationActionAvailable } from './client-creation-action-policy'
 
 type OpenMobileEmulatorTabOptions = {
   targetGroupId?: string
@@ -55,6 +56,7 @@ export async function openMobileEmulatorTab(
   options: OpenMobileEmulatorTabOptions = {}
 ): Promise<string | null> {
   const store = useAppStore.getState()
+  assertClientCreationActionAvailable(store, worktreeId, 'mobile-emulator')
   if (store.settings?.mobileEmulatorEnabled === false) {
     return null
   }

--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -37,6 +37,14 @@ function ownerState(hostId?: string, runtimeOwnerEnvironmentId?: string): Record
   }
 }
 
+function browserCapableRuntime(environmentId: string): Record<string, unknown> {
+  return {
+    runtimeStatusByEnvironmentId: new Map([
+      [environmentId, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+    ])
+  }
+}
+
 beforeEach(() => {
   mocks.createRemote.mockReset().mockResolvedValue(true)
   mocks.getState.mockReset().mockImplementation(() => mocks.state)
@@ -80,6 +88,7 @@ describe('openWorkspaceBrowserTab', () => {
     const createBrowserTab = vi.fn()
     mocks.state = {
       ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      ...browserCapableRuntime('hub-a'),
       createBrowserTab,
       defaultBrowserSessionProfileId: 'client-profile',
       defaultBrowserSessionProfileIdByHostId: {}
@@ -124,7 +133,7 @@ describe('openWorkspaceBrowserTab', () => {
     ])
   })
 
-  it('keeps the worktree session profile when a runtime open soft-fails', async () => {
+  it('uses the desktop provider when the runtime cannot stream browsers', async () => {
     const createBrowserTab = vi.fn()
     const sshHost = toSshExecutionHostId('ssh-target')
     mocks.state = {
@@ -141,7 +150,7 @@ describe('openWorkspaceBrowserTab', () => {
       intent: { kind: 'search', engine: 'google' }
     })
 
-    expect(mocks.createRemote).toHaveBeenCalledOnce()
+    expect(mocks.createRemote).not.toHaveBeenCalled()
     expect(createBrowserTab).toHaveBeenCalledWith(
       WORKSPACE_ID,
       'https://www.google.com/search?q=hooks',
@@ -184,19 +193,13 @@ describe('openWorkspaceBrowserTab', () => {
 
     mocks.state = {
       ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      ...browserCapableRuntime('hub-a'),
       createBrowserTab: vi.fn(),
       defaultBrowserSessionProfileId: 'focused-profile',
       defaultBrowserSessionProfileIdByHostId: { local: 'local-profile' }
     }
     mocks.createRemote.mockResolvedValue(false)
-    await openWorkspaceBrowserTab(request)
-    expect(mocks.state.createBrowserTab).toHaveBeenCalledWith(WORKSPACE_ID, secretUrl, {
-      activate: true,
-      browserRuntimeEnvironmentId: null,
-      focusAddressBar: false,
-      sessionProfileId: 'local-profile',
-      targetGroupId: undefined,
-      title: 'Search Kagi'
-    })
+    await expect(openWorkspaceBrowserTab(request)).rejects.toThrow('Unable to search with Kagi.')
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -8,6 +8,10 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { SEARCH_ENGINE_LABELS, type SearchEngine } from '../../../shared/browser-url'
+import {
+  getClientCreationActionPolicy,
+  type ClientCreationActionAvailability
+} from './client-creation-action-policy'
 import { resolveWorktreeOperationRoute } from './worktree-operation-route'
 
 export type WorkspaceBrowserTabIntent = { kind: 'url' } | { kind: 'search'; engine: SearchEngine }
@@ -105,6 +109,15 @@ function createClientBrowserTab(
   }
 }
 
+function assertManagedBrowserEnabled(
+  availability: ClientCreationActionAvailability,
+  presentation: { error: string }
+): asserts availability is Extract<ClientCreationActionAvailability, { state: 'enabled' }> {
+  if (availability.state !== 'enabled') {
+    throw openFailure(presentation.error, availability.reason)
+  }
+}
+
 export async function openWorkspaceBrowserTab(
   request: OpenWorkspaceBrowserTabRequest
 ): Promise<void> {
@@ -113,6 +126,8 @@ export async function openWorkspaceBrowserTab(
     throw openFailure(presentation.error, 'target is not an http(s) URL')
   }
   const state = useAppStore.getState()
+  const availability = getClientCreationActionPolicy(state, request.workspaceId)['managed-browser']
+  assertManagedBrowserEnabled(availability, presentation)
   const route = resolveWorktreeOperationRoute(state, request.workspaceId)
   if (!route) {
     throw openFailure(presentation.error, 'no active worktree route')
@@ -135,6 +150,11 @@ export async function openWorkspaceBrowserTab(
       `host ${route.executionHostId} does not own runtime ${environmentId}`
     )
   }
+  if (availability.provider === 'local-client') {
+    const localHostId = host && host.kind !== 'runtime' ? host.id : LOCAL_EXECUTION_HOST_ID
+    createClientBrowserTab(state, request, localHostId, presentation)
+    return
+  }
   let created = false
   try {
     created = await createWebRuntimeSessionBrowserTab({
@@ -153,10 +173,6 @@ export async function openWorkspaceBrowserTab(
     throw openFailure(presentation.error, 'runtime browser tab creation failed', error)
   }
   if (!created) {
-    // Why: a soft runtime failure still opens client-side, so keep the
-    // workspace's own session profile rather than collapsing every remote
-    // host onto the local cookie jar.
-    const fallbackHostId = host && host.kind !== 'runtime' ? host.id : LOCAL_EXECUTION_HOST_ID
-    createClientBrowserTab(state, request, fallbackHostId, presentation)
+    throw openFailure(presentation.error, 'runtime browser tab creation was unavailable')
   }
 }

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -130,7 +130,10 @@ export async function openWorkspacePortInBrowser(args: {
         { worktree: toRuntimeWorktreeSelector(worktreeId), url },
         { timeoutMs: 30_000 }
       )
-      const tab = args.createBrowserTab(worktreeId, url, { activate: true })
+      const tab = args.createBrowserTab(worktreeId, url, {
+        activate: true,
+        browserRuntimeEnvironmentId: args.runtimeTarget.environmentId
+      })
       if (!tab.activePageId) {
         return { ok: false, reason: 'Failed to create a browser page.' }
       }

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -1,6 +1,7 @@
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import type { useAppStore } from '@/store'
 import {
+  assertRuntimeEnvironmentCapability,
   callRuntimeRpc,
   RuntimeRpcCallError,
   type RuntimeClientTarget
@@ -15,6 +16,8 @@ import type {
 import type { LocalhostWorktreeLabelRoute } from '../../../shared/localhost-worktree-labels'
 import { runWorkspacePortScanForTarget } from './workspace-port-scan-client'
 import { browserUrlForPort } from './workspace-port-urls'
+import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import { RUNTIME_BROWSER_UNAVAILABLE_MESSAGE } from './client-creation-action-policy'
 
 export { addressForPort } from './workspace-port-urls'
 
@@ -124,6 +127,11 @@ export async function openWorkspacePortInBrowser(args: {
   activateAndRevealWorktree(worktreeId)
   if (args.runtimeTarget.kind === 'environment') {
     try {
+      await assertRuntimeEnvironmentCapability(
+        args.runtimeTarget.environmentId,
+        BROWSER_SCREENCAST_RUNTIME_CAPABILITY,
+        RUNTIME_BROWSER_UNAVAILABLE_MESSAGE
+      )
       const remotePage = await callRuntimeRpc<{ browserPageId: string }>(
         args.runtimeTarget,
         'browser.tabCreate',
@@ -147,8 +155,13 @@ export async function openWorkspacePortInBrowser(args: {
       return { ok: false, reason: message || 'Failed to open remote browser.' }
     }
   }
-  args.createBrowserTab(worktreeId, url, { activate: true })
-  return { ok: true }
+  try {
+    args.createBrowserTab(worktreeId, url, { activate: true })
+    return { ok: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, reason: message || 'Failed to open browser.' }
+  }
 }
 
 export async function refreshWorkspacePortScanAfterStop(args: {

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -306,6 +306,27 @@ describe('createWebRuntimeSessionBrowserTab', () => {
     vi.clearAllMocks()
   })
 
+  it('rejects before RPC when the selected runtime does not advertise screencast', async () => {
+    mocks.getState.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: ENVIRONMENT_ID },
+      runtimeStatusByEnvironmentId: new Map([
+        [ENVIRONMENT_ID, { status: { capabilities: [] }, checkedAt: 1 }]
+      ])
+    })
+    const runtimeCall = vi.fn()
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      createWebRuntimeSessionBrowserTab({
+        worktreeId: WORKTREE_ID,
+        environmentId: ENVIRONMENT_ID
+      })
+    ).rejects.toThrow('does not support browser streaming')
+
+    expect(runtimeCall).not.toHaveBeenCalled()
+    expect(mocks.createBrowserTab).not.toHaveBeenCalled()
+  })
+
   it('applies an empty host snapshot without retaining delayed browser focus', async () => {
     const snapshot = makeSnapshot()
     let resolveList!: (response: unknown) => void

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -257,6 +257,9 @@ describe('createWebRuntimeSessionBrowserTab', () => {
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
+      runtimeStatusByEnvironmentId: new Map([
+        [ENVIRONMENT_ID, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+      ]),
       activeWorktreeId: WORKTREE_ID,
       activeWorkspaceExecutionHostId: RUNTIME_EXECUTION_HOST_ID,
       activeTabType: 'editor',
@@ -626,6 +629,9 @@ describe('createWebRuntimeSessionBrowserTab', () => {
   it('creates an unfocused browser while preserving its requested split', async () => {
     mocks.getState.mockReturnValue({
       settings: { activeRuntimeEnvironmentId: ENVIRONMENT_ID },
+      runtimeStatusByEnvironmentId: new Map([
+        [ENVIRONMENT_ID, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+      ]),
       activeWorktreeId: WORKTREE_ID,
       browserPagesByWorkspace: {
         'host-browser-workspace': [
@@ -791,6 +797,9 @@ describe('createWebRuntimeSessionBrowserTab', () => {
   it('does not reselect an already active browser worktree on the same runtime', async () => {
     mocks.getState.mockReturnValue({
       settings: { activeRuntimeEnvironmentId: ENVIRONMENT_ID },
+      runtimeStatusByEnvironmentId: new Map([
+        [ENVIRONMENT_ID, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+      ]),
       activeWorktreeId: WORKTREE_ID,
       activeWorkspaceExecutionHostId: RUNTIME_EXECUTION_HOST_ID,
       browserPagesByWorkspace: {},
@@ -872,6 +881,9 @@ describe('createWebRuntimeSessionBrowserTab', () => {
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
+      runtimeStatusByEnvironmentId: new Map([
+        [ENVIRONMENT_ID, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+      ]),
       activeWorktreeId,
       browserPagesByWorkspace: {},
       remoteBrowserPageHandlesByPageId: {},

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -72,6 +72,7 @@ import {
   moveWebSessionBrowserPlacement,
   recordWebSessionBrowserPlacement
 } from './web-session-browser-placement'
+import { assertRuntimeManagedBrowserCreationAvailable } from '../lib/client-creation-action-policy'
 
 export {
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -449,6 +450,7 @@ export async function createWebRuntimeSessionBrowserTab(args: {
   if (!environmentId || !isWebRuntimeSessionActive(environmentId)) {
     return false
   }
+  assertRuntimeManagedBrowserCreationAvailable(useAppStore.getState(), environmentId)
   const intentOwner = captureWebSessionIntentOwner(environmentId)
   const callEnvironment = captureRuntimeEnvironmentCall(environmentId, intentOwner.pairingRevision)
   const shouldFocusOnCreate = args.focusOnCreate !== false

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: browser slice behavior shares one mocked store harness; splitting only the tests would duplicate more setup than it saves. */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import { createBrowserSlice, isLocalBrowserPageOwner } from './browser'
 import type { AppState } from '../types'
@@ -64,6 +64,18 @@ function createTestStore() {
 
 function settingsWithRuntime(id: string): AppState['settings'] {
   return { activeRuntimeEnvironmentId: id } as AppState['settings']
+}
+
+function runtimeStatuses(capabilities: string[]): AppState['runtimeStatusByEnvironmentId'] {
+  return new Map([
+    [
+      'env-1',
+      {
+        status: { capabilities },
+        checkedAt: 1
+      }
+    ]
+  ]) as AppState['runtimeStatusByEnvironmentId']
 }
 
 function seedUnifiedBrowserTab(
@@ -548,6 +560,35 @@ describe('createBrowserSlice runtime guard', () => {
     runtimeEnvironmentCall.mockResolvedValue({ id: 'rpc-1', ok: true, result: {} })
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects direct client-local materialization in the web client', () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const store = createTestStore()
+
+    expect(() => store.getState().createBrowserTab('wt-1', 'about:blank')).toThrow(
+      'must be created by a capable paired runtime'
+    )
+    expect(store.getState().browserTabsByWorktree['wt-1']).toBeUndefined()
+    expect(store.getState().createUnifiedTab).not.toHaveBeenCalled()
+  })
+
+  it('rejects direct remote materialization without the provider capability', () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const store = createTestStore()
+    store.setState({ runtimeStatusByEnvironmentId: runtimeStatuses([]) })
+
+    expect(() =>
+      store.getState().createBrowserTab('wt-1', 'about:blank', {
+        browserRuntimeEnvironmentId: 'env-1'
+      })
+    ).toThrow('paired runtime does not support browser streaming')
+    expect(store.getState().browserTabsByWorktree['wt-1']).toBeUndefined()
+    expect(store.getState().createUnifiedTab).not.toHaveBeenCalled()
+  })
+
   it('fetches browser profiles from the active runtime environment', async () => {
     const store = createTestStore()
     runtimeEnvironmentCall.mockResolvedValueOnce({
@@ -956,6 +997,7 @@ describe('createBrowserSlice runtime guard', () => {
     store.setState({
       activeWorktreeId: 'wt-remote',
       settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      runtimeStatusByEnvironmentId: runtimeStatuses(['browser.screencast.v1']),
       browserDefaultUrl: 'about:blank',
       repos: [
         {
@@ -1006,15 +1048,12 @@ describe('createBrowserSlice runtime guard', () => {
     expect(store.getState().recordFeatureInteraction).toHaveBeenCalledWith('browser-tab-created')
   })
 
-  it('does not create a local fallback tab when remote browser creation fails', async () => {
+  it('uses the desktop client browser when a remote npm host cannot stream', async () => {
     const store = createTestStore()
-    // Why: a remote-owned workspace must stay remote-owned. If the remote host
-    // cannot create the page, we must NOT silently open a local desktop tab —
-    // that produces confusing split ownership (issue #5321 UX requirement).
-    createWebRuntimeSessionBrowserTabMock.mockResolvedValueOnce(false)
     store.setState({
       activeWorktreeId: 'wt-remote',
-      settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings'],
+      settings: settingsWithRuntime('env-1'),
+      runtimeStatusByEnvironmentId: runtimeStatuses([]),
       worktreesByRepo: {
         'repo-1': [
           {
@@ -1028,6 +1067,39 @@ describe('createBrowserSlice runtime guard', () => {
     })
 
     await store.getState().openNewBrowserTabInActiveWorkspace('group-1')
+
+    expect(createWebRuntimeSessionBrowserTabMock).not.toHaveBeenCalled()
+    const tab = store.getState().browserTabsByWorktree['wt-remote']?.[0]
+    const page = tab ? store.getState().browserPagesByWorkspace[tab.id]?.[0] : undefined
+    expect(page?.browserRuntimeEnvironmentId).toBeNull()
+    expect(store.getState().createUnifiedTab).toHaveBeenCalled()
+  })
+
+  it('does not create a local fallback tab when remote browser creation fails', async () => {
+    const store = createTestStore()
+    // Why: a remote-owned workspace must stay remote-owned. If the remote host
+    // cannot create the page, we must NOT silently open a local desktop tab —
+    // that produces confusing split ownership (issue #5321 UX requirement).
+    createWebRuntimeSessionBrowserTabMock.mockResolvedValueOnce(false)
+    store.setState({
+      activeWorktreeId: 'wt-remote',
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings'],
+      runtimeStatusByEnvironmentId: runtimeStatuses(['browser.screencast.v1']),
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-remote',
+            repoId: 'repo-1',
+            hostId: 'local',
+            runtimeOwnerEnvironmentId: 'env-1'
+          } as never
+        ]
+      }
+    })
+
+    await expect(store.getState().openNewBrowserTabInActiveWorkspace('group-1')).rejects.toThrow(
+      'The paired runtime could not create a managed browser tab.'
+    )
 
     expect(createWebRuntimeSessionBrowserTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-remote',
@@ -1081,6 +1153,7 @@ describe('createBrowserSlice runtime guard', () => {
     store.setState({
       activeWorktreeId: 'wt-remote',
       settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings'],
+      runtimeStatusByEnvironmentId: runtimeStatuses(['browser.screencast.v1']),
       worktreesByRepo: {
         'repo-1': [
           {
@@ -1093,7 +1166,9 @@ describe('createBrowserSlice runtime guard', () => {
       }
     })
 
-    await store.getState().openNewBrowserTabInActiveWorkspace('group-1')
+    await expect(store.getState().openNewBrowserTabInActiveWorkspace('group-1')).rejects.toThrow(
+      'remote down'
+    )
 
     expect(store.getState().browserTabsByWorktree['wt-remote']).toBeUndefined()
     expect(store.getState().createUnifiedTab).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -1120,6 +1120,7 @@ describe('createBrowserSlice runtime guard', () => {
     store.setState({
       activeWorktreeId: 'wt-remote',
       settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings'],
+      runtimeStatusByEnvironmentId: runtimeStatuses(['browser.screencast.v1']),
       worktreesByRepo: {
         'repo-1': [
           {
@@ -1144,6 +1145,66 @@ describe('createBrowserSlice runtime guard', () => {
       url: 'https://accounts.google.com/',
       profileId: 'profile-1'
     })
+    expect(store.getState().browserTabsByWorktree['wt-remote']).toBeUndefined()
+  })
+
+  it('opens a local desktop sign-in tab when the remote host cannot stream browsers', async () => {
+    const store = createTestStore()
+    store.setState({
+      activeWorktreeId: 'wt-remote',
+      settings: settingsWithRuntime('env-1'),
+      runtimeStatusByEnvironmentId: runtimeStatuses([]),
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-remote',
+            repoId: 'repo-1',
+            hostId: 'local',
+            runtimeOwnerEnvironmentId: 'env-1'
+          } as never
+        ]
+      }
+    })
+
+    await expect(
+      store
+        .getState()
+        .openBrowserProfileTabInActiveWorkspace('https://accounts.google.com/', 'profile-1')
+    ).resolves.toBe(true)
+
+    expect(createWebRuntimeSessionBrowserTabMock).not.toHaveBeenCalled()
+    expect(store.getState().browserTabsByWorktree['wt-remote']?.[0]).toMatchObject({
+      url: 'https://accounts.google.com/',
+      sessionProfileId: 'profile-1'
+    })
+  })
+
+  it('rejects a paired-web sign-in tab when the remote host cannot stream browsers', async () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', true)
+    const store = createTestStore()
+    store.setState({
+      activeWorktreeId: 'wt-remote',
+      settings: settingsWithRuntime('env-1'),
+      runtimeStatusByEnvironmentId: runtimeStatuses([]),
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-remote',
+            repoId: 'repo-1',
+            hostId: 'local',
+            runtimeOwnerEnvironmentId: 'env-1'
+          } as never
+        ]
+      }
+    })
+
+    await expect(
+      store
+        .getState()
+        .openBrowserProfileTabInActiveWorkspace('https://accounts.google.com/', 'profile-1')
+    ).resolves.toBe(false)
+
+    expect(createWebRuntimeSessionBrowserTabMock).not.toHaveBeenCalled()
     expect(store.getState().browserTabsByWorktree['wt-remote']).toBeUndefined()
   })
 

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -728,8 +728,15 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     if (!worktreeId) {
       return false
     }
+    const browserAvailability = getClientCreationActionPolicy(state, worktreeId)['managed-browser']
+    if (browserAvailability.state !== 'enabled') {
+      return false
+    }
     const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
-    if (runtimeEnvironmentId) {
+    if (browserAvailability.provider === 'paired-runtime') {
+      if (!runtimeEnvironmentId) {
+        return false
+      }
       const { createWebRuntimeSessionBrowserTab } = await import('@/runtime/web-runtime-session')
       try {
         return await createWebRuntimeSessionBrowserTab({
@@ -746,7 +753,11 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         return false
       }
     }
-    get().createBrowserTab(worktreeId, url, { activate: true, sessionProfileId: profileId })
+    get().createBrowserTab(worktreeId, url, {
+      activate: true,
+      sessionProfileId: profileId,
+      ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {})
+    })
     return true
   },
   closeBrowserTab: (tabId) => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -59,6 +59,10 @@ import {
   type WorkspaceSessionHydrationOptions
 } from '@/lib/workspace-session-hydration-keys'
 import { buildValidWorktreeIdsForSessionHydration } from './degraded-repo-worktree-validity'
+import {
+  assertManagedBrowserMaterializationAllowed,
+  getClientCreationActionPolicy
+} from '@/lib/client-creation-action-policy'
 
 type CreateBrowserTabOptions = {
   activate?: boolean
@@ -561,6 +565,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
   },
 
   createBrowserTab: (worktreeId, url, options) => {
+    assertManagedBrowserMaterializationAllowed(get(), options?.browserRuntimeEnvironmentId)
     const workspaceId = createBrowserUuid()
     const page = buildBrowserPage(
       workspaceId,
@@ -676,9 +681,16 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     if (!worktreeId) {
       return
     }
+    const browserAvailability = getClientCreationActionPolicy(state, worktreeId)['managed-browser']
+    if (browserAvailability.state !== 'enabled') {
+      throw new Error(browserAvailability.reason)
+    }
     const defaultUrl = state.browserDefaultUrl ?? 'about:blank'
     const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
-    if (runtimeEnvironmentId) {
+    if (browserAvailability.provider === 'paired-runtime') {
+      if (!runtimeEnvironmentId) {
+        throw new Error('The paired runtime browser provider is unavailable.')
+      }
       const { createWebRuntimeSessionBrowserTab } = await import('@/runtime/web-runtime-session')
       try {
         const created = await createWebRuntimeSessionBrowserTab({
@@ -697,12 +709,14 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           '[browser] remote browser tab creation failed:',
           error instanceof Error ? error.message : String(error)
         )
+        throw error
       }
-      return
+      throw new Error('The paired runtime could not create a managed browser tab.')
     }
     get().createBrowserTab(worktreeId, defaultUrl, {
       title: translate('auto.store.slices.browser.d175274b6d', 'New Browser Tab'),
       focusAddressBar: true,
+      ...(runtimeEnvironmentId ? { browserRuntimeEnvironmentId: null } : {}),
       targetGroupId: groupId
     })
     get().recordFeatureInteraction('browser-tab-created')

--- a/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
+++ b/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
@@ -3,6 +3,10 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { AppState } from '../types'
 import { createTestStore, makeWorktree, seedStore, TEST_REPO } from './store-test-helpers'
+import {
+  FLOATING_BROWSER_UNAVAILABLE_MESSAGE,
+  MANAGED_BROWSER_UNAVAILABLE_MESSAGE
+} from '@/lib/client-creation-action-policy'
 
 const createWebRuntimeSessionBrowserTabMock = vi.hoisted(() => vi.fn())
 const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
@@ -23,10 +27,19 @@ vi.mock('@/lib/web-client-location', () => ({
 
 const pairedWebFlag = globalThis as { __ORCA_WEB_CLIENT__?: boolean }
 
+function browserCapableRuntimeStatus(
+  environmentId: string
+): AppState['runtimeStatusByEnvironmentId'] {
+  return new Map([
+    [environmentId, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+  ]) as AppState['runtimeStatusByEnvironmentId']
+}
+
 function seedActiveWorkspace(store: ReturnType<typeof createTestStore>): void {
   seedStore(store, {
     activeWorktreeId: 'wt-1',
     settings: { activeRuntimeEnvironmentId: 'runtime-1' } as AppState['settings'],
+    runtimeStatusByEnvironmentId: browserCapableRuntimeStatus('runtime-1'),
     worktreesByRepo: {
       [TEST_REPO.id]: [
         makeWorktree({
@@ -55,7 +68,7 @@ describe('Cmd+J lifted creation actions', () => {
     delete pairedWebFlag.__ORCA_WEB_CLIENT__
   })
 
-  it('does not fall back to a local browser tab when paired-web creation fails', async () => {
+  it('rejects without a local browser fallback when paired-web creation fails', async () => {
     // Why: a remote-owned workspace must stay remote-owned. If the remote host
     // cannot create the page, we must NOT silently open a local desktop tab —
     // that produces confusing split ownership (issue #5321). Mirrors the
@@ -64,7 +77,9 @@ describe('Cmd+J lifted creation actions', () => {
     const store = createTestStore()
     seedActiveWorkspace(store)
 
-    await store.getState().openNewBrowserTabInActiveWorkspace('group-1')
+    await expect(store.getState().openNewBrowserTabInActiveWorkspace('group-1')).rejects.toThrow(
+      'The paired runtime could not create a managed browser tab.'
+    )
 
     expect(createWebRuntimeSessionBrowserTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
@@ -75,7 +90,7 @@ describe('Cmd+J lifted creation actions', () => {
     expect(store.getState().browserTabsByWorktree['wt-1'] ?? []).toEqual([])
   })
 
-  it('routes browser tab creation to the explicit owner runtime when another runtime is focused', async () => {
+  it('routes browser creation to the owner runtime without a local fallback', async () => {
     createWebRuntimeSessionBrowserTabMock.mockResolvedValue(false)
     const store = createTestStore()
     seedActiveWorkspace(store)
@@ -91,10 +106,13 @@ describe('Cmd+J lifted creation actions', () => {
           })
         ]
       },
-      settings: { activeRuntimeEnvironmentId: 'focused-runtime' } as AppState['settings']
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' } as AppState['settings'],
+      runtimeStatusByEnvironmentId: browserCapableRuntimeStatus('owner-runtime')
     })
 
-    await store.getState().openNewBrowserTabInActiveWorkspace('group-1')
+    await expect(store.getState().openNewBrowserTabInActiveWorkspace('group-1')).rejects.toThrow(
+      'The paired runtime could not create a managed browser tab.'
+    )
 
     expect(createWebRuntimeSessionBrowserTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
@@ -106,7 +124,7 @@ describe('Cmd+J lifted creation actions', () => {
     expect(store.getState().browserTabsByWorktree['wt-1'] ?? []).toEqual([])
   })
 
-  it('creates a local browser tab for explicitly local workspaces while a runtime is focused', async () => {
+  it('rejects local browser tabs for explicitly local paired-web workspaces', async () => {
     createWebRuntimeSessionBrowserTabMock.mockResolvedValue(false)
     const store = createTestStore()
     seedActiveWorkspace(store)
@@ -118,13 +136,15 @@ describe('Cmd+J lifted creation actions', () => {
       settings: { activeRuntimeEnvironmentId: 'focused-runtime' } as AppState['settings']
     })
 
-    await store.getState().openNewBrowserTabInActiveWorkspace('group-1')
+    await expect(store.getState().openNewBrowserTabInActiveWorkspace('group-1')).rejects.toThrow(
+      MANAGED_BROWSER_UNAVAILABLE_MESSAGE
+    )
 
     expect(createWebRuntimeSessionBrowserTabMock).not.toHaveBeenCalled()
-    expect(store.getState().browserTabsByWorktree['wt-1'] ?? []).toHaveLength(1)
+    expect(store.getState().browserTabsByWorktree['wt-1'] ?? []).toEqual([])
   })
 
-  it('creates local browser and terminal tabs for the synthetic floating workspace while a runtime is focused', async () => {
+  it('rejects floating browsers while preserving floating terminal creation', async () => {
     createWebRuntimeSessionBrowserTabMock.mockResolvedValue(false)
     createWebRuntimeSessionTerminalMock.mockResolvedValue(false)
     const store = createTestStore()
@@ -144,14 +164,14 @@ describe('Cmd+J lifted creation actions', () => {
       activeGroupIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: 'group-1' }
     })
 
-    await store.getState().openNewBrowserTabInActiveWorkspace('group-1')
+    await expect(store.getState().openNewBrowserTabInActiveWorkspace('group-1')).rejects.toThrow(
+      FLOATING_BROWSER_UNAVAILABLE_MESSAGE
+    )
     await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
 
     expect(createWebRuntimeSessionBrowserTabMock).not.toHaveBeenCalled()
     expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
-    expect(
-      store.getState().browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
-    ).toHaveLength(1)
+    expect(store.getState().browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).toEqual([])
     expect(store.getState().tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).toHaveLength(1)
   })
 

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -54,6 +54,7 @@ export const AI_VAULT_SESSION_TITLES_RUNTIME_CAPABILITY = 'aiVault.session-title
 // offscreen backend). Advertised only when that backend is actually available, so
 // clients never fall back to a local desktop browser tab for a remote-owned page.
 export const BROWSER_HEADLESS_RUNTIME_CAPABILITY = 'browser.headless.v1' as const
+export const BROWSER_SCREENCAST_RUNTIME_CAPABILITY = 'browser.screencast.v1' as const
 export const BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY = 'browser.certificate-trust.v1' as const
 // Why: hosts without this strip terminal.send's inputKind (zod object drops
 // unknown keys), so a mobile xterm query reply would land as ordinary
@@ -97,7 +98,7 @@ export const RUNTIME_CAPABILITIES = [
   ORCHESTRATION_FEDERATION_LIFECYCLE_SETTLEMENT_RUNTIME_CAPABILITY,
   ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY,
   ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY,
-  'browser.screencast.v1',
+  BROWSER_SCREENCAST_RUNTIME_CAPABILITY,
   'terminal.binary-stream.v1',
   'terminal.multiplex.v1',
   'workspace-ports.v1',

--- a/tests/e2e/multi-client-navigation-isolation.spec.ts
+++ b/tests/e2e/multi-client-navigation-isolation.spec.ts
@@ -179,6 +179,55 @@ test('keeps two paired browser clients and the host on independent worktrees', a
   }
 })
 
+test('shows only provider-backed creation actions in paired web', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => {
+  const visibleWorktreeId = await orcaPage.evaluate(
+    () => window.__store?.getState().activeWorktreeId
+  )
+  if (!visibleWorktreeId) {
+    throw new Error('Host worktree was not active before paired web validation')
+  }
+
+  const offer = await createPairingOffer(orcaPage)
+  const client = await openPairedClient(electronApp, offer, visibleWorktreeId)
+  try {
+    await selectWorktree(client, visibleWorktreeId)
+    await expect
+      .poll(() =>
+        client.evaluate(() => {
+          const state = window.__store?.getState()
+          const worktree = state
+            ?.allWorktrees()
+            .find((candidate) => candidate.id === state.activeWorktreeId)
+          const environmentId = worktree?.runtimeOwnerEnvironmentId
+          return environmentId
+            ? state.runtimeStatusByEnvironmentId
+                .get(environmentId)
+                ?.status.capabilities?.includes('browser.screencast.v1') === true
+            : false
+        })
+      )
+      .toBe(true)
+
+    await client.getByRole('button', { name: 'New tab' }).first().click()
+    await expect(client.getByRole('menuitem', { name: /New Terminal/i })).toBeVisible()
+    await expect(client.getByRole('menuitem', { name: /New Browser Tab/i })).toBeVisible()
+    await expect(client.getByRole('menuitem', { name: /New Markdown/i })).toBeVisible()
+    await expect(client.getByRole('menuitem', { name: /Mobile Emulator/i })).toHaveCount(0)
+
+    const screenshotPath = testInfo.outputPath('paired-web-provider-backed-create-menu.png')
+    await client.screenshot({ path: screenshotPath })
+    await testInfo.attach('paired-web-provider-backed-create-menu', {
+      path: screenshotPath,
+      contentType: 'image/png'
+    })
+  } finally {
+    await client.close()
+  }
+})
+
 test('routes Add Project folder browsing through the paired host', async ({
   electronApp,
   orcaPage,


### PR DESCRIPTION
## Summary

- Centralize Browser and Mobile Emulator creation policy around the provider that can actually fulfill each action.
- Gate the `+` menu, searchable create results, tab context menus, Cmd/Ctrl+J, keyboard and Electron-menu creation, floating-workspace actions and empty states, onboarding, settings links, URL creation, Browser duplication, and workspace-port materialization.
- Preserve Terminal and supported Markdown creation, keep Electron Mobile Emulator local, and fail direct unsupported Browser/Emulator invocations clearly without `window.open`, normal-tab, or local managed-browser fallback.

Provider behavior:

- Desktop client + desktop host: Browser uses the negotiated paired runtime; Emulator remains local.
- Desktop client + npm/headless host without screencast: Browser and Emulator remain available through the desktop client locally.
- Web client + Electron host or headless host with a real offscreen/Xvfb provider: Browser is shown and uses the paired runtime existing end-to-end screencast path; Emulator is hidden.
- Web client + npm/headless host without a display/provider: Browser and Emulator are hidden.

## Screenshots

Paired web connected to a host advertising `browser.screencast.v1`: Terminal, managed Browser, and Markdown are available; Mobile Emulator is omitted.

![Paired web provider-backed create menu](https://github.com/user-attachments/assets/ae7f0675-0efd-43a6-9a14-d4939a7b79b2)

## Testing

- [x] Rebased onto `main` at `fc7c2a1cd5`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (native/type-aware quality, reliability, max-lines, skill manifests, and localization gates)
- [x] 12 focused unit/integration files: 208 passed
- [x] `pnpm test:e2e:multi-client-navigation`: 3 rendered Electron/CDP journeys passed
- [x] `git diff --check`
- [x] Focused coverage proves the four client/host provider combinations, conservative absent capabilities, folder and SSH ownership, hidden duplicate action families, unchanged Electron behavior, and guarded direct invocations

A mistakenly broad local Vitest invocation was stopped after an unrelated updater test failed; the intended 12-file invocation then passed all 208 tests. This does not affect the focused result above.

## Internal Review Report

Two review-until-clean rounds were completed against the full diff. Round one fixed remaining Shortcut Settings advertising, browser-profile provider selection, remote Browser link routing, commit and SSH/port Browser routing, exact screencast preflight, and clear error handling for direct duplication/reopen paths. Round two and the post-rebase audit found no P0, P1, or P2 issue in scope.

The review traced each advertised action to its exact provider and checked direct-call guards, host/workspace ownership, stale or absent runtime status, remote Browser materialization, failed remote creation, and duplicate UI entry points. It verified that `OrcaRuntime.getStatus()` advertises `browser.screencast.v1` only with an authoritative Electron renderer or `OffscreenBrowserBackend`; serve installs the latter only after a real display is confirmed. The Node 24 dogfood image has no Xvfb, while browser-enabled headless environments legitimately advertise both screencast and headless capabilities.

Cross-platform review covered macOS, Linux, and Windows. No new modifier behavior, shortcut labels, paths, shell commands, native modules, or Electron platform assumptions were introduced. SSH, folder workspaces, runtime-owned worktrees, and local desktop execution remain distinct in provider resolution.

## Security and Compatibility Audit

No dependency, lockfile, binary, install-hook, download, updater, auth, secret, command-execution, path-mutation, or new IPC surface changes. The policy only consumes an existing optional runtime-status capability and adds fail-closed renderer guards. No new stream opcode or unnegotiated wire payload was added. Unsupported web clients cannot escape to `window.open` or another unmanaged browser surface. No mobile handshake/schema surface or persisted state changed.

## Notes

- #13885 is merged; PR #13909 targets `main`.
- Missing `browser.screencast.v1` is intentionally conservative for mixed client/server versions.
- Capability presence is used only where Browser creation and streaming consume that exact provider; `browser.headless.v1` alone does not enable the action.
- Impossible web-client actions are hidden. No recoverable setup state was added that would warrant disabled-with-reason UI.

