### PR TITLE
fix(sidebar): give draft reviews their own glyph instead of a red PR icon

### DIFF
--- a/src/renderer/src/components/right-sidebar/hosted-review-header-chrome.tsx
+++ b/src/renderer/src/components/right-sidebar/hosted-review-header-chrome.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { GitMerge } from 'lucide-react'
+import { GitMerge, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon } from './checks-panel-content'
@@ -17,6 +17,23 @@ function hostedReviewStateClass(review: HostedReviewInfo): string {
   return 'text-muted-foreground/50'
 }
 
+// Why: draft and closed only differed by a near-identical muted tone on the same
+// glyph, so a draft review read as closed.
+function hostedReviewStateIcon(
+  review: HostedReviewInfo
+): React.ComponentType<{ className?: string }> | null {
+  if (review.state === 'merged') {
+    return GitMerge
+  }
+  if (review.state === 'closed') {
+    return GitPullRequestClosed
+  }
+  if (review.state === 'draft') {
+    return GitPullRequestDraft
+  }
+  return null
+}
+
 export function HostedReviewIcon({
   review,
   className
@@ -24,7 +41,8 @@ export function HostedReviewIcon({
   review: HostedReviewInfo
   className?: string
 }): React.JSX.Element {
-  const Icon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
+  const providerIcon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
+  const Icon = hostedReviewStateIcon(review) ?? providerIcon
   return <Icon className={cn(className, hostedReviewStateClass(review))} />
 }
 

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -98,4 +98,31 @@ describe('ReviewIcon', () => {
 
     expect(merged).toContain('lucide-git-merge')
   })
+
+  // Why: a closed MR used to render the merge glyph, which read as "already merged".
+  it('overrides the GitLab provider glyph for closed merge requests', () => {
+    const closed = renderToStaticMarkup(
+      <ReviewIcon review={{ ...gitlabReview, state: 'closed' }} className="size-3" />
+    )
+
+    expect(closed).toContain('lucide-git-pull-request-closed')
+    expect(closed).not.toContain('lucide-git-merge')
+  })
+
+  // Why: folder cards render a stateless row while a linked review loads or its
+  // details fail. There is no state glyph to contradict, so problems must still be
+  // visible — but a tone-less row must not be promoted to a passing green.
+  it('flags problems on a stateless row without ever claiming success', () => {
+    const stateless = (status: 'failure' | 'pending' | 'success') =>
+      renderToStaticMarkup(
+        <ReviewIcon
+          review={{ provider: 'github', number: 1, title: 'Loading PR...', status }}
+          className="size-3"
+        />
+      )
+
+    expect(stateless('failure')).toContain('text-rose-500/85')
+    expect(stateless('pending')).toContain('text-amber-500/85')
+    expect(stateless('success')).not.toContain('text-emerald-500/80')
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -44,4 +44,58 @@ describe('ReviewIcon', () => {
     expect(blocked).not.toContain('text-emerald-500/80')
     expect(blocked).not.toBe(passing)
   })
+
+  // Why: #13088 — a draft with failing checks used the same glyph as every other
+  // review and was painted red, so it was indistinguishable from a closed PR.
+  it('gives a draft its own glyph and never paints it with a check tone', () => {
+    const draft = renderToStaticMarkup(
+      <ReviewIcon
+        review={{
+          provider: 'github',
+          number: 1,
+          title: 'Draft',
+          state: 'draft',
+          status: 'failure'
+        }}
+        className="size-3"
+        variant="generic"
+      />
+    )
+    const closed = renderToStaticMarkup(
+      <ReviewIcon
+        review={{ provider: 'github', number: 1, title: 'Closed', state: 'closed' }}
+        className="size-3"
+        variant="generic"
+      />
+    )
+
+    expect(draft).toContain('lucide-git-pull-request-draft')
+    expect(draft).not.toContain('text-rose-500/85')
+    expect(closed).toContain('lucide-git-pull-request-closed')
+    expect(draft).not.toBe(closed)
+  })
+
+  it('keeps check tones on open reviews so failing checks still stand out', () => {
+    const failing = renderToStaticMarkup(
+      <ReviewIcon
+        review={{ provider: 'github', number: 1, title: 'Open', state: 'open', status: 'failure' }}
+        className="size-3"
+        variant="generic"
+      />
+    )
+
+    expect(failing).toContain('text-rose-500/85')
+  })
+
+  it('renders merged reviews with the merge glyph', () => {
+    const merged = renderToStaticMarkup(
+      <ReviewIcon
+        review={{ provider: 'github', number: 1, title: 'Merged', state: 'merged' }}
+        className="size-3"
+        variant="generic"
+      />
+    )
+
+    expect(merged).toContain('lucide-git-merge')
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -1,4 +1,4 @@
-import { GitMerge } from 'lucide-react'
+import { GitMerge, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
@@ -23,6 +23,57 @@ export function getProviderName(review: WorktreeCardPrDisplay): string {
   return 'GitHub'
 }
 
+// Why: the glyph must carry review state — tone alone made a draft with failing
+// checks render as a red PR icon, which reads as closed.
+function getStateIcon(
+  state: WorktreeCardPrDisplay['state']
+): React.ComponentType<{ className?: string }> | null {
+  if (state === 'merged') {
+    return GitMerge
+  }
+  if (state === 'closed') {
+    return GitPullRequestClosed
+  }
+  if (state === 'draft') {
+    return GitPullRequestDraft
+  }
+  return null
+}
+
+// Why: checks only gate a review that is actually open; draft/closed/merged keep
+// their state tone so the glyph agrees with its tooltip.
+function getCheckTone(review: WorktreeCardPrDisplay): string | null {
+  if (review.state && review.state !== 'open') {
+    return null
+  }
+  if (review.status === 'failure') {
+    return 'text-rose-500/85'
+  }
+  if (review.status === 'pending') {
+    return 'text-amber-500/85'
+  }
+  if (review.state === 'open' && review.status === 'success') {
+    return 'text-emerald-500/80'
+  }
+  return null
+}
+
+function getStateTone(state: WorktreeCardPrDisplay['state']): string {
+  if (state === 'merged') {
+    return 'text-purple-600/70 dark:text-purple-400/70'
+  }
+  if (state === 'open') {
+    return 'text-emerald-500/80'
+  }
+  if (state === 'closed') {
+    return 'text-muted-foreground/60'
+  }
+  if (state === 'draft') {
+    return 'text-muted-foreground/50'
+  }
+  return 'text-muted-foreground opacity-70'
+}
+
 export function ReviewIcon({
   review,
   className,
@@ -32,28 +83,8 @@ export function ReviewIcon({
   className?: string
   variant?: 'provider' | 'generic'
 }): React.JSX.Element {
-  const Icon = variant === 'provider' && review.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const checkTone =
-    review.state !== 'merged' && review.status === 'failure'
-      ? 'text-rose-500/85'
-      : review.state !== 'merged' && review.status === 'pending'
-        ? 'text-amber-500/85'
-        : review.state === 'open' && review.status === 'success'
-          ? 'text-emerald-500/80'
-          : null
-  return (
-    <Icon
-      className={cn(
-        className,
-        checkTone,
-        review.state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
-        !checkTone && review.state === 'open' && 'text-emerald-500/80',
-        !checkTone && review.state === 'closed' && 'text-muted-foreground/60',
-        !checkTone && review.state === 'draft' && 'text-muted-foreground/50',
-        !checkTone &&
-          (!review.state || !['merged', 'open', 'closed', 'draft'].includes(review.state)) &&
-          'text-muted-foreground opacity-70'
-      )}
-    />
-  )
+  const providerIcon =
+    variant === 'provider' && review.provider === 'gitlab' ? GitMerge : PullRequestIcon
+  const Icon = getStateIcon(review.state) ?? providerIcon
+  return <Icon className={cn(className, getCheckTone(review) ?? getStateTone(review.state))} />
 }

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -41,7 +41,10 @@ function getStateIcon(
 }
 
 // Why: checks only gate a review that is actually open; draft/closed/merged keep
-// their state tone so the glyph agrees with its tooltip.
+// their state tone so the glyph agrees with its tooltip. A stateless row (folder
+// cards render one while a linked review is loading or its details failed) has no
+// state glyph to contradict, so it still flags problems — but never claims success,
+// since emerald would assert an open review we have not confirmed.
 function getCheckTone(review: WorktreeCardPrDisplay): string | null {
   if (review.state && review.state !== 'open') {
     return null


### PR DESCRIPTION
## ELI5

The little pull-request icon on a worktree card was the *same drawing* no matter what state the PR was in — open, draft, closed, merged. The only thing that changed was its colour, and the colour was picked from CI checks, not from the PR. So a draft PR with a failing build got painted red, and a red PR icon is universally "this PR is closed". That's what the reporter hit.

Now the *shape* of the icon says what the PR is (draft / closed / merged / open), and colour is only used for CI checks on PRs that are actually open. The icon finally agrees with its own tooltip.

## What Changed

`ReviewIcon` (`worktree-review-helpers.tsx`) — used by the worktree card status lane, the card meta badges, and the card hover detail:

- Glyph is now chosen by review state: `draft` → `GitPullRequestDraft`, `closed` → `GitPullRequestClosed`, `merged` → `GitMerge`. Open/unknown keeps the existing provider glyph (GitLab MR icon or the GitHub PR octicon).
- Check tone (rose / amber / emerald) now applies **only** to open reviews. Draft, closed and merged keep their state tone.

`HostedReviewIcon` (`hosted-review-header-chrome.tsx`, source-control panel header) had the same collision — draft and closed were the same glyph separated only by `text-muted-foreground/50` vs `/60`. Same state→glyph mapping applied there.

This matches what the codebase already does elsewhere (`AgentKanbanCard`, `PullRequestPage`), so the sidebar no longer disagrees with the dashboard and the PR page.

## Why

The reported symptom is "draft PRs use the closed PR icon", and the reporter's follow-up nailed the cause: the PR glyph was being coloured by *check* status. Two different facts (review state, CI state) were fighting over one visual channel, and state lost. Giving state the shape channel and checks the colour channel resolves it without dropping either signal — and check status is still spelled out on the card's hover detail via `ReviewChecksBadge`.

Note this also fixes a smaller mismatch: `getReviewStatusTooltip` already prioritises state over checks, so a draft's tooltip said "PR: Draft" while its icon was painted "checks failing" red.

## Linked Issue

- Fixes #13088

## Screenshots

Captured from a dev build of this branch over CDP, on the real sidebar, with the same store state for both shots.

### Before

Draft (LSP), closed (GH-Link-bug) and open (multi-repo-selection) are indistinguishable — one red glyph:

![before](https://github.com/user-attachments/assets/06445e32-15d9-4101-a475-da098a60de3f)

### After

![after](https://github.com/user-attachments/assets/196186c7-f0d7-4aeb-9ec5-d769b400c965)

### Side by side, real sidebar

![sidebar](https://github.com/user-attachments/assets/83dac58d-f1ca-4651-bcbd-67922e4db282)

The icon matrix above is rendered by the real `ReviewIcon` component, imported live from the running dev server, so the glyphs and Tailwind tones are the shipped ones:

![matrix](https://github.com/user-attachments/assets/5a886dd5-9e8b-4376-8afb-71aece427738)

## How to test

Open the worktree sidebar with a repo that has a draft PR with failing checks on one branch and a closed PR on another. Before: both branches show the same red PR icon. After: the draft shows the draft glyph, the closed one shows the closed glyph. Hover either — the tooltip now matches the icon.

Verified on macOS. Renderer-only change; no main-process, IPC, git, or provider-API surface touched, so SSH, folder workspaces, remote hosts and Windows/Linux are unaffected by construction. GitLab MRs go through the same component and were checked in the existing `ReviewIcon` tests.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm lint` ✅ · `pnpm typecheck:web` ✅ · `vitest run src/renderer/src/components/sidebar/` → 229 files / 2086 tests ✅

Three new cases in `worktree-review-helpers.test.tsx`:
- a draft with failing checks gets the draft glyph and no check tone, and does not render identically to a closed review (the #13088 regression)
- an open review with failing checks still gets the rose tone (guards against over-correcting)
- a merged review gets the merge glyph

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck` pass locally; CI covers the rest

## AI assistance

- [x] This PR was created or substantially assisted by an AI coding agent
- [x] I reviewed the full diff, understand every change, and can explain it in review

## AI Review Report

Reviewed the tone-selection rewrite against the original nested ternary case by case, since that's where a silent regression would hide:

- **Stateless rows**: old code applied rose on failure, amber on pending, no tone on success. New code preserves all three — the `review.state && review.state !== 'open'` guard is falsy for `undefined`, and the emerald branch still requires `state === 'open'`. I originally reasoned this combination was unreachable (the `makeLinkedReviewFallback` placeholder sets neither `state` nor `status`); CodeRabbit correctly pushed back. It *is* reachable, via `parentPrChecksRowToCardDisplay` in `folder-workspace-card-pr-display.ts`, which spreads `state` conditionally but always sets `status`. That makes preserving the tone the right call rather than an incidental one: those rows are folder-workspace cards whose linked review is loading (`pending`) or whose details failed to fetch (`failure`), and that icon is the card's only review affordance. Now covered by a test.
- **Merged**: previously unreachable for check tone (failure/pending excluded merged, success required open), so restricting tone to open changes nothing there.
- **Closed**: this *is* a deliberate behaviour change — a closed PR with failing checks was rose, now muted. Correct, because it now carries the closed glyph and its tooltip says "PR: Closed"; the red was reporting a stale CI run on a dead PR.
- **Dead-branch check**: confirmed the new state branches are reachable — `WorktreeCardPrDisplay['state']` is `'open' | 'closed' | 'merged' | 'draft' | undefined`.
- **GitLab**: the state glyphs override the provider glyph for closed/draft MRs. This is a fix, not a regression — a closed MR previously rendered `GitMerge`, i.e. the *merged* glyph. Open MRs keep GitLab branding; both are now tested.
- **Remote/mixed versions**: `HostedReviewState` is unchanged, and an unrecognised state string degrades to the neutral provider glyph rather than throwing.
- **Scope check**: swept every other PR-icon call site (`AgentKanbanCard`, `PullRequestPage`, `TaskPage`, `GitHubItemDialog`) — the first three already map state→glyph, the dialog uses a text state badge, so no other surface has this bug.

## Notes

Supersedes #13131, which targeted `GitHubItemDialog` rather than the sidebar surface in the report, and whose state-button branch was unreachable (`nextState` is `'closed'` whenever `localState === 'draft'`, so the added `localState === 'draft'` arm never evaluates). Thanks @LavyaTandel for digging into it.

Made with [Orca](https://github.com/stablyai/orca) 🐋

