### PR TITLE
Fix stale retained worker release reconciliation

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -7878,15 +7878,22 @@
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Deterministic service tests cover release-versus-reuse ordering, transactional retain and takeover cancellation, exact host/pane/process identity, conservative schema-v23 backfill, immutable transcript and bounded terminal archives, mutation restart, reset cleanup, replay idempotency, and 50-resource accounting. Live SSH, WSL, Windows, paired-runtime, and provider-close lost-ack journeys remain explicit gaps.",
-      "motivatingLinks": ["https://github.com/stablyai/orca/pull/12355", "STA-905"],
-      "invariant": "A settled Dispatch may close only its one coordinator-created terminal lease. Explicit reuse, real user input, retain, identity or host change, ambiguity, and another resource for the same exact host/pane/process must fence closure. Output preservation and the requested-to-releasing transition are atomic, archives remain readable without the provider file, retries resume idempotently, and orchestration reset removes archive and authority state.",
-      "oracle": "Record release intent for a settled owner, attempt exact reuse before close, and require worker-start to fail with terminal_release_in_progress while the terminal stays open; then release the original owner exactly once. Race retain and real user input against a controlled archive promise and require no committed archive or close. Change host or process identity and inject duplicate resource evidence to require retention. Freeze a structured transcript, delete its source file, and require archived worker-read to return the same bounded redacted messages. Restart a pending mutation, reset orchestration state, and create 50 resources while asserting replay convergence, zero orphan rows, two-query worker listing, and no unrelated close.",
+      "coverageNotes": "Deterministic service tests cover release-versus-reuse ordering, transactional retain and takeover cancellation, exact host/pane/process identity, dead external/user-owned/transferred/stopped/abandoned reconciliation, conservative unknown provider and legacy metadata handling, immutable transcript and bounded terminal archives, mutation restart, reset cleanup, replay idempotency, and 50-resource accounting. Injected inventories cover local and SSH provider routing; live SSH, WSL, Windows, paired-runtime, and provider-close lost-ack journeys remain explicit gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/12355",
+        "https://github.com/stablyai/orca/issues/13860",
+        "STA-905",
+        "STA-3932"
+      ],
+      "invariant": "A settled Dispatch may close only its one coordinator-created terminal lease. Explicit reuse, real user input, retain, identity or host change, ambiguity, and another resource for the same exact host/pane/process must fence closure. Once the authoritative owning provider positively excludes the resource's exact immutable process incarnation, even an external, user-owned, or transferred dead resource must converge to released without any process close. Unknown host scope, missing incarnation metadata, or unavailable inventory must remain retained. Output preservation and the requested-to-releasing transition are atomic, archives remain readable without the provider file, retries resume idempotently, and orchestration reset removes archive and authority state.",
+      "oracle": "Record release intent for a settled owner, attempt exact reuse before close, and require worker-start to fail with terminal_release_in_progress while the terminal stays open; then release the original owner exactly once. Race retain and real user input against a controlled archive promise and require no committed archive or close. For retained external, user-owned, transferred, stopped, and abandoned resources, run one fresh inventory against the exact local/WSL or SSH provider: an exact live incarnation and every unknown inventory shape stay retained, while positive absence atomically sets ownership_state and release_state to released with processAction none and zero closeTerminal calls. Change host or process identity and inject duplicate resource evidence to require retention. Freeze a structured transcript, delete its source file, and require archived worker-read to return the same bounded redacted messages. Restart a pending mutation, reset orchestration state, and create 50 resources while asserting replay convergence, zero orphan rows, two-query worker listing, and no unrelated close.",
       "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts src/main/runtime/rpc/methods/orchestration-worker-release.test.ts src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts src/main/runtime/rpc/orchestration-mutation-ledger.test.ts src/main/runtime/orchestration/worker-transcript-read.test.ts src/renderer/src/lib/worker-terminal-takeover-report.test.ts --reporter=dot",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-worker-release.test.ts src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts src/main/runtime/rpc/orchestration-mutation-ledger.test.ts src/main/runtime/orchestration/worker-transcript-read.test.ts src/renderer/src/lib/worker-terminal-takeover-report.test.ts --reporter=dot",
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/completed-worker-retirement-resume.unit.test.ts --reporter=verbose"
       ],
       "testFiles": [
+        "src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts",
         "src/main/runtime/rpc/methods/orchestration-worker-release.test.ts",
         "src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts",
         "src/main/runtime/rpc/orchestration-mutation-ledger.test.ts",
@@ -7896,6 +7903,15 @@
       ],
       "assertionRefs": [
         {
+          "file": "src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts",
+          "assertions": [
+            "classifies only an exact incarnation as live on its owning provider",
+            "keeps missing or malformed identity and unavailable inventory unknown",
+            "does not inspect an unproven host scope",
+            "uses the local provider inventory for local and WSL scopes"
+          ]
+        },
+        {
           "file": "tests/e2e/completed-worker-retirement-resume.unit.test.ts",
           "assertions": [
             "an already-exited succeeded Dispatch reaches released while its late exact close revokes the missing tab's stale resume record"
@@ -7904,6 +7920,10 @@
         {
           "file": "src/main/runtime/rpc/methods/orchestration-worker-release.test.ts",
           "assertions": [
+            "reconciles a dead external terminal without closing a process",
+            "reconciles a dead user-taken-over terminal without closing a process",
+            "reconciles a dead stopped or abandoned worker without closing a process",
+            "reconciles dead transferred ownership after the current owner settles",
             "rejects exact reuse after release intent instead of closing the new worker",
             "lets an explicit retain cancel a release while output capture is pending",
             "retains when the terminal host scope changed instead of closing",
@@ -7927,6 +7947,15 @@
       ],
       "evidenceRuns": [
         {
+          "date": "2026-08-11",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts src/main/runtime/rpc/methods/orchestration-worker-release.test.ts src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts src/main/runtime/rpc/orchestration-mutation-ledger.test.ts src/main/runtime/orchestration/worker-transcript-read.test.ts src/renderer/src/lib/worker-terminal-takeover-report.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 4.98,
+          "summary": "Six focused files passed 67 tests on the rebased candidate, covering dead external, user-owned, stopped, abandoned, and transferred reconciliation; exact local/WSL/SSH provider routing; malformed, missing, and unavailable inventory retention; zero process closes; existing lease, archive, recovery, mutation, and renderer-input contracts."
+        },
+        {
           "date": "2026-08-03",
           "runner": "local",
           "platform": "macos",
@@ -7937,20 +7966,20 @@
         }
       ],
       "runtimeBudget": {
-        "p95Seconds": 8,
+        "p95Seconds": 15,
         "scope": "deterministic runtime, SQLite, transcript, renderer-input, and mutation contracts"
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "First local deterministic run only; focused CI and soak history are not yet available."
+        "evidence": "Repeated local deterministic runs pass; focused CI and soak history are not yet available."
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical 56-test oracle produced 12 deterministic failures and 44 passes with production restored to exact PR head 4aa66b62e3, including ready reuse during release, unsafe migration, stale archives, mutable transcript output, host/identity close gaps, and mutation replay loss. Candidate 457bc4edd1 passed all 56; restoring the same five production files to 4aa66b62e3 reproduced the same red state."
+        "evidence": "The original byte-identical 56-test oracle produced 12 deterministic failures and 44 passes with production restored to exact PR head 4aa66b62e3; candidate 457bc4edd1 passed all 56 and restoring the same production files reproduced red. For issue #13860, the unchanged three-case dead external/user-owned/transferred oracle failed 3/3 on actual latest main 444638d96b because every resource remained retained, passed 3/3 on the rebased candidate, failed 3/3 after restoring production exactly to 444638d96b, and passed 3/3 after restoring the candidate. Every run asserted both durable ownership/release state and zero terminal close calls."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Release performs constant-count indexed resource and identity queries plus one bounded archive capture. Worker-list uses two set queries rather than one resource lookup per worker. Reconciliation remains serial and adds no polling, timers, subprocesses, renderer subscriptions, or provider-wide listing."
+        "evidence": "Normal owned release performs constant-count indexed resource and identity queries plus one bounded archive capture. A retained release performs exactly one bounded inventory against its authoritative local/WSL or specific SSH provider, with no retry, polling, timer, subprocess, renderer subscription, or per-session follow-up fanout. Worker-list uses two set queries rather than one resource lookup per worker."
       },
       "promotionCriteria": [
         "Collect 100 consecutive focused CI passes or 14 days of soak history.",
@@ -7961,7 +7990,7 @@
       "knownGaps": [
         "Provider close has no durable cross-process operation receipt, so a crash after host mutation but before SQLite settlement remains release_pending until exact inventory returns.",
         "Federated release remains explicitly unsupported and retained.",
-        "Mobile/direct remote input takeover and live Linux, Windows, WSL, SSH, headed, and headless paired-runtime release are not exercised."
+        "Mobile/direct remote input takeover and live Linux, Windows, WSL, SSH, headed, and headless paired-runtime release are not exercised; the current fix changes provider inventory classification and SQLite state only, not ConPTY, filesystem, update, sleep, firewall, or window lifecycle semantics."
       ],
       "demotionRule": "Keep experimental or demote if release can overlap exact reuse, close a conflicting lease, lose immutable output, retain reset archives, fan out per worker, or any focused ordering test flakes without a product or harness defect."
     },

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -7877,7 +7877,7 @@
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
       "coveredPlatforms": ["macos"],
-      "coveredProviders": ["local"],
+      "coveredProviders": ["local", "ssh"],
       "coverageNotes": "Deterministic service tests cover release-versus-reuse ordering, transactional retain and takeover cancellation, exact host/pane/process identity, dead external/user-owned/transferred/stopped/abandoned reconciliation, conservative unknown provider and legacy metadata handling, immutable transcript and bounded terminal archives, mutation restart, reset cleanup, replay idempotency, and 50-resource accounting. Injected inventories cover local and SSH provider routing; live SSH, WSL, Windows, paired-runtime, and provider-close lost-ack journeys remain explicit gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/12355",

--- a/src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts
+++ b/src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const SSH_SCOPE = JSON.stringify({ kind: 'ssh', targetId: 'ssh-1' })
+const PROCESS_INCARNATION = 'remote:ssh-1:pty-1:inc-1'
+
+function runtimeWithInventory(
+  listProcesses: (connectionId?: string | null) => Promise<PtyProcessInfo[]>
+): OrcaRuntimeService {
+  const runtime = new OrcaRuntimeService()
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    listProcesses
+  })
+  return runtime
+}
+
+describe('terminal process incarnation liveness', () => {
+  it('classifies only an exact incarnation as live on its owning provider', async () => {
+    const listProcesses = vi.fn().mockResolvedValue([
+      {
+        id: 'remote:ssh-1:pty-1',
+        incarnationId: 'inc-1',
+        cwd: '',
+        title: 'worker'
+      }
+    ])
+    const runtime = runtimeWithInventory(listProcesses)
+
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, SSH_SCOPE)
+    ).resolves.toBe('live')
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness('remote:ssh-1:pty-1:inc-old', SSH_SCOPE)
+    ).resolves.toBe('dead')
+    expect(listProcesses).toHaveBeenNthCalledWith(1, 'ssh-1')
+    expect(listProcesses).toHaveBeenNthCalledWith(2, 'ssh-1')
+  })
+
+  it('keeps missing or malformed identity and unavailable inventory unknown', async () => {
+    const listProcesses = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'remote:ssh-1:pty-1', cwd: '', title: 'worker' }])
+      .mockResolvedValueOnce([
+        { id: 'remote:ssh-1:pty-1', incarnationId: ' inc-1 ', cwd: '', title: 'worker' }
+      ])
+      .mockRejectedValueOnce(new Error('provider unavailable'))
+    const runtime = runtimeWithInventory(listProcesses)
+
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, SSH_SCOPE)
+    ).resolves.toBe('unknown')
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, SSH_SCOPE)
+    ).resolves.toBe('unknown')
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, SSH_SCOPE)
+    ).resolves.toBe('unknown')
+  })
+
+  it('does not inspect an unproven host scope', async () => {
+    const listProcesses = vi.fn().mockResolvedValue([])
+    const runtime = runtimeWithInventory(listProcesses)
+
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, null)
+    ).resolves.toBe('unknown')
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness(PROCESS_INCARNATION, '{"kind":"ssh"}')
+    ).resolves.toBe('unknown')
+    expect(listProcesses).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [{ kind: 'local', hostId: 'local' }, null],
+    [{ kind: 'wsl', hostId: 'local', distro: 'Ubuntu' }, null]
+  ] as const)('uses the local provider inventory for %s scope', async (scope, connectionId) => {
+    const listProcesses = vi.fn().mockResolvedValue([])
+    const runtime = runtimeWithInventory(listProcesses)
+
+    await expect(
+      runtime.inspectTerminalProcessIncarnationLiveness('local-pty:inc-1', JSON.stringify(scope))
+    ).resolves.toBe('dead')
+    expect(listProcesses).toHaveBeenCalledWith(connectionId)
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -117,6 +117,11 @@ import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { OrchestrationDb } from './orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
+import {
+  classifyWorkerTerminalProcessIncarnation,
+  parseWorkerTerminalHostScope,
+  type WorkerTerminalHostScope
+} from './orchestration/worker-terminal-process-liveness'
 import { rollbackWorkspaceSessionAfterFailedAsyncWrite } from './workspace-session-failed-write-rollback'
 import { OrchestrationError } from './orchestration/orchestration-error'
 import {
@@ -1983,10 +1988,7 @@ export type OrchestrationCompatibilityTerminalAuthority = {
   processIncarnation: string | null
   paneKey: string | null
   launchTokenHash: string | null
-  hostScope:
-    | { kind: 'local'; hostId: 'local' }
-    | { kind: 'wsl'; hostId: 'local'; distro: string }
-    | { kind: 'ssh'; targetId: string }
+  hostScope: WorkerTerminalHostScope
 }
 
 export type LegacyWorkerTerminalRecoveryResult = {
@@ -15510,6 +15512,24 @@ export class OrcaRuntimeService {
       totalCount: matchingTerminals.length,
       truncated: matchingTerminals.length > limit
     }
+  }
+
+  async inspectTerminalProcessIncarnationLiveness(
+    processIncarnation: string,
+    serializedHostScope: string | null
+  ): Promise<'live' | 'dead' | 'unknown'> {
+    const hostScope = parseWorkerTerminalHostScope(serializedHostScope)
+    if (!hostScope || !this.ptyController?.listProcesses) {
+      return 'unknown'
+    }
+    const listed = await withTimeoutResult(
+      this.ptyController.listProcesses(hostScope.kind === 'ssh' ? hostScope.targetId : null),
+      PTY_CONTROLLER_LIST_TIMEOUT_MS
+    )
+    if (!listed.ok) {
+      return 'unknown'
+    }
+    return classifyWorkerTerminalProcessIncarnation(processIncarnation, listed.value)
   }
 
   private getTerminalTopologyRevision(worktreeId: string): number {

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -44,6 +44,7 @@ import { OrchestrationError } from './orchestration-error'
 import { resolveOrchestrationMigrationStartVersion } from './orchestration-schema-version-skew'
 import {
   deriveWorkerTerminalListState,
+  WORKER_SETTLED_STATES,
   type WorkerTerminalResourceRow,
   type WorkerTerminalArchiveRow,
   type WorkerTerminalArchiveStatus,
@@ -70,6 +71,17 @@ function isEquivalentPaneKey(a: string, b: string): boolean {
   const aLeaf = parsePaneKey(a)?.leafId
   const bLeaf = parsePaneKey(b)?.leafId
   return Boolean(aLeaf && bLeaf && aLeaf === bLeaf)
+}
+
+function parseWorkerTerminalPriorOwnerIds(value: string): string[] | null {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed) && parsed.every((entry) => typeof entry === 'string')
+      ? parsed
+      : null
+  } catch {
+    return null
+  }
 }
 
 // Why: indexable pre-filter for isEquivalentPaneKey — equal strings and equal leaves both share the
@@ -5818,12 +5830,12 @@ export class OrchestrationDb {
       if (!worker) {
         throw new OrchestrationError('dispatch_not_found', `Dispatch ${dispatchId} was not found.`)
       }
-      if (!['succeeded', 'failed'].includes(worker.state)) {
+      if (!WORKER_SETTLED_STATES.includes(worker.state)) {
         // Why: release is post-completion cleanup only; recording intent for an unsettled or
         // uncertain worker would let recovery close a terminal the coordinator never reviewed.
         throw new OrchestrationError(
           'dispatch_inactive',
-          `Dispatch ${dispatchId} is ${worker.state}; only a succeeded or failed worker can release. Use worker-stop to cancel an active worker.`
+          `Dispatch ${dispatchId} is ${worker.state}; only a settled worker can release. Use worker-stop to cancel an active worker.`
         )
       }
       const resource = this.getWorkerTerminalResourceByOwner(dispatchId)
@@ -5837,6 +5849,10 @@ export class OrchestrationDb {
       if (resource.release_state === 'released' || resource.ownership_state === 'released') {
         this.db.exec('COMMIT')
         return { disposition: 'already_released', resource }
+      }
+      if (worker.state === 'stopped' || worker.state === 'abandoned') {
+        this.db.exec('COMMIT')
+        return { disposition: 'retained', resource, reason: 'identity_unproven' }
       }
       if (resource.ownership_state === 'external') {
         this.db.exec('COMMIT')
@@ -5880,6 +5896,66 @@ export class OrchestrationDb {
         disposition: 'requested',
         resource: this.getWorkerTerminalResource(resource.id) as WorkerTerminalResourceRow
       }
+    } catch (error) {
+      this.db.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  settleDeadWorkerTerminalRelease(params: {
+    requestingDispatchId: string
+    resourceId: string
+    processIncarnation: string
+  }):
+    | { disposition: 'released'; resource: WorkerTerminalResourceRow }
+    | { disposition: 'retained'; resource: WorkerTerminalResourceRow } {
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      const resource = this.getWorkerTerminalResource(params.resourceId)
+      if (!resource) {
+        throw new OrchestrationError(
+          'dispatch_not_found',
+          `Worker terminal resource ${params.resourceId} was not found.`
+        )
+      }
+      const priorOwners = parseWorkerTerminalPriorOwnerIds(resource.prior_owner_dispatch_ids)
+      const requesterRelated =
+        resource.owner_dispatch_id === params.requestingDispatchId ||
+        priorOwners?.includes(params.requestingDispatchId) === true
+      const requester = this.getWorkerDispatch(params.requestingDispatchId)
+      const owner = this.getWorkerDispatch(resource.owner_dispatch_id)
+      const requesterSettled = Boolean(requester && WORKER_SETTLED_STATES.includes(requester.state))
+      const ownerSettled = Boolean(owner && WORKER_SETTLED_STATES.includes(owner.state))
+      if (
+        !priorOwners ||
+        !requesterRelated ||
+        !requesterSettled ||
+        !ownerSettled ||
+        resource.process_incarnation !== params.processIncarnation ||
+        resource.ownership_state === 'released' ||
+        !['not_requested', 'retained', 'unknown'].includes(resource.release_state)
+      ) {
+        this.db.exec('COMMIT')
+        return { disposition: 'retained', resource }
+      }
+      this.db
+        .prepare(
+          `UPDATE worker_terminal_resources
+           SET release_state = 'released', ownership_state = 'released', retained_reason = NULL,
+               release_requested_at = COALESCE(release_requested_at, datetime('now')),
+               release_completed_at = datetime('now'), release_error = NULL,
+               updated_at = datetime('now')
+           WHERE id = ? AND process_incarnation = ? AND ownership_state != 'released'
+             AND release_state IN ('not_requested', 'retained', 'unknown')`
+        )
+        .run(params.resourceId, params.processIncarnation)
+      const released = this.getWorkerTerminalResource(
+        params.resourceId
+      ) as WorkerTerminalResourceRow
+      this.db.exec('COMMIT')
+      return released.release_state === 'released'
+        ? { disposition: 'released', resource: released }
+        : { disposition: 'retained', resource: released }
     } catch (error) {
       this.db.exec('ROLLBACK')
       throw error

--- a/src/main/runtime/orchestration/worker-terminal-process-liveness.ts
+++ b/src/main/runtime/orchestration/worker-terminal-process-liveness.ts
@@ -1,0 +1,62 @@
+import type { PtyProcessInfo } from '../../providers/pty-process-info'
+
+export type WorkerTerminalHostScope =
+  | { kind: 'local'; hostId: 'local' }
+  | { kind: 'wsl'; hostId: 'local'; distro: string }
+  | { kind: 'ssh'; targetId: string }
+
+export function parseWorkerTerminalHostScope(value: string | null): WorkerTerminalHostScope | null {
+  if (!value) {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return null
+  }
+  const scope = parsed as Record<string, unknown>
+  if (scope.kind === 'local' && scope.hostId === 'local') {
+    return { kind: 'local', hostId: 'local' }
+  }
+  if (
+    scope.kind === 'wsl' &&
+    scope.hostId === 'local' &&
+    typeof scope.distro === 'string' &&
+    scope.distro.length > 0
+  ) {
+    return { kind: 'wsl', hostId: 'local', distro: scope.distro }
+  }
+  if (scope.kind === 'ssh' && typeof scope.targetId === 'string' && scope.targetId.length > 0) {
+    return { kind: 'ssh', targetId: scope.targetId }
+  }
+  return null
+}
+
+export function classifyWorkerTerminalProcessIncarnation(
+  processIncarnation: string,
+  sessions: readonly PtyProcessInfo[]
+): 'live' | 'dead' | 'unknown' {
+  const possibleMatches = sessions.filter((session) =>
+    processIncarnation.startsWith(`${session.id}:`)
+  )
+  if (
+    possibleMatches.some((session) => {
+      const incarnationId = session.incarnationId
+      if (!incarnationId || incarnationId !== incarnationId.trim()) {
+        return false
+      }
+      return `${session.id}:${incarnationId}` === processIncarnation
+    })
+  ) {
+    return 'live'
+  }
+  return possibleMatches.some(
+    (session) => !session.incarnationId || session.incarnationId !== session.incarnationId.trim()
+  )
+    ? 'unknown'
+    : 'dead'
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -21,6 +21,7 @@ describe('orchestration worker release', () => {
   let runtime: OrcaRuntimeService
   let ctx: RpcContext
   let activeRunId: string
+  let inspectProcessLiveness: ReturnType<typeof vi.fn>
 
   const coordinatorPaneKey = 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
   const workerPaneKey = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
@@ -30,6 +31,12 @@ describe('orchestration worker release', () => {
     dbOpen = true
     runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
+    inspectProcessLiveness = vi.fn().mockResolvedValue('live')
+    ;(
+      runtime as unknown as {
+        inspectTerminalProcessIncarnationLiveness: typeof inspectProcessLiveness
+      }
+    ).inspectTerminalProcessIncarnationLiveness = inspectProcessLiveness
     vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
       handle === 'term_coord'
         ? coordinatorPaneKey
@@ -215,7 +222,7 @@ describe('orchestration worker release', () => {
     setup()
     const { dispatchId } = await startWorker()
     await expect(call('orchestration.workerRelease', { dispatch: dispatchId })).rejects.toThrow(
-      /only a succeeded or failed worker can release/
+      /only a settled worker can release/
     )
     expect(runtime.closeTerminal).not.toHaveBeenCalled()
     expect(db.getWorkerTerminalResourceByOwner(dispatchId)?.release_state).toBe('not_requested')
@@ -230,6 +237,44 @@ describe('orchestration worker release', () => {
     }
     expect(receipt).toMatchObject({ state: 'retained', reason: 'external_terminal' })
     expect(runtime.closeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('reconciles a dead external terminal without closing a process', async () => {
+    setup()
+    const { dispatchId } = await startSettledWorker('succeeded', { terminal: 'term_worker' })
+    inspectProcessLiveness.mockResolvedValue('dead')
+
+    await expect(
+      call('orchestration.workerRelease', { dispatch: dispatchId })
+    ).resolves.toMatchObject({ state: 'released', processAction: 'none' })
+    expect(inspectProcessLiveness).toHaveBeenCalledWith(
+      'runtime_test:term_worker:1',
+      JSON.stringify({ kind: 'local', hostId: 'local' })
+    )
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(db.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+      ownership_state: 'released',
+      release_state: 'released'
+    })
+  })
+
+  it('retains dead inventory evidence when persisted ownership history is invalid', async () => {
+    setup()
+    const { dispatchId } = await startSettledWorker('succeeded', { terminal: 'term_worker' })
+    const resource = db.getWorkerTerminalResourceByOwner(dispatchId)
+    const raw = (
+      db as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }
+    ).db
+    raw
+      .prepare('UPDATE worker_terminal_resources SET prior_owner_dispatch_ids = ? WHERE id = ?')
+      .run('{invalid', resource?.id)
+    inspectProcessLiveness.mockResolvedValue('dead')
+
+    await expect(
+      call('orchestration.workerRelease', { dispatch: dispatchId })
+    ).resolves.toMatchObject({ state: 'retained', processAction: 'none' })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(db.getWorkerTerminalResourceByOwner(dispatchId)?.release_state).not.toBe('released')
   })
 
   it('retains a user-taken-over terminal durably', async () => {
@@ -247,6 +292,50 @@ describe('orchestration worker release', () => {
     expect(runtime.closeTerminal).not.toHaveBeenCalled()
     expect(db.getWorkerTerminalResourceByOwner(dispatchId)?.ownership_state).toBe('user_owned')
   })
+
+  it('reconciles a dead user-taken-over terminal without closing a process', async () => {
+    setup()
+    const { dispatchId } = await startSettledWorker()
+    await call('orchestration.workerTerminalUserInput', { paneKey: workerPaneKey })
+    inspectProcessLiveness.mockResolvedValue('dead')
+
+    await expect(
+      call('orchestration.workerRelease', { dispatch: dispatchId })
+    ).resolves.toMatchObject({ state: 'released', processAction: 'none' })
+    expect(inspectProcessLiveness).toHaveBeenCalledWith(
+      'runtime_test:term_worker:1',
+      JSON.stringify({ kind: 'local', hostId: 'local' })
+    )
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(db.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+      ownership_state: 'released',
+      release_state: 'released'
+    })
+  })
+
+  it.each(['stopped', 'abandoned'] as const)(
+    'reconciles a dead %s worker without closing a process',
+    async (state) => {
+      setup()
+      const { dispatchId } = await startWorker()
+      if (state === 'stopped') {
+        db.beginWorkerStop(dispatchId)
+        db.settleWorkerStop(dispatchId)
+      } else {
+        db.abandonWorkerDispatch(dispatchId)
+      }
+      inspectProcessLiveness.mockResolvedValue('dead')
+
+      await expect(
+        call('orchestration.workerRelease', { dispatch: dispatchId })
+      ).resolves.toMatchObject({ state: 'released', processAction: 'none' })
+      expect(runtime.closeTerminal).not.toHaveBeenCalled()
+      expect(db.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+        ownership_state: 'released',
+        release_state: 'released'
+      })
+    }
+  )
 
   it('lets user takeover cancel a release while output capture is pending', async () => {
     setup()
@@ -617,6 +706,7 @@ describe('orchestration worker release', () => {
     expect(transferred?.terminal_handle).toBe('term_reminted')
     expect(db.getWorkerTerminalResourceByOwner(first.dispatchId)).toBeUndefined()
 
+    inspectProcessLiveness.mockResolvedValueOnce('dead')
     const oldRelease = (await call('orchestration.workerRelease', {
       dispatch: first.dispatchId
     })) as { state: string; reason?: string }
@@ -630,6 +720,27 @@ describe('orchestration worker release', () => {
     expect(newRelease.state).toBe('released')
     expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
     expect(runtime.closeTerminal).toHaveBeenCalledWith('term_reminted')
+  })
+
+  it('reconciles dead transferred ownership after the current owner settles', async () => {
+    setup()
+    const first = await startSettledWorker('succeeded')
+    const second = await startWorker({ terminal: 'term_reminted' })
+    settle(second.taskId, second.dispatchId, 'succeeded')
+    inspectProcessLiveness.mockResolvedValue('dead')
+
+    await expect(
+      call('orchestration.workerRelease', { dispatch: first.dispatchId })
+    ).resolves.toMatchObject({ state: 'released', processAction: 'none' })
+    expect(inspectProcessLiveness).toHaveBeenCalledWith(
+      'runtime_test:term_worker:1',
+      JSON.stringify({ kind: 'local', hostId: 'local' })
+    )
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+    expect(db.getWorkerTerminalResourceByOwner(second.dispatchId)).toMatchObject({
+      ownership_state: 'released',
+      release_state: 'released'
+    })
   })
 
   it('rejects exact reuse after release intent instead of closing the new worker', async () => {
@@ -744,9 +855,14 @@ describe('orchestration worker release', () => {
     expect(listed.workers).toContainEqual(
       expect.objectContaining({ dispatchId, terminalState: 'retained' })
     )
-    await expect(call('orchestration.workerRelease', { dispatch: dispatchId })).rejects.toThrow(
-      /only a succeeded or failed worker can release/
-    )
+    await expect(
+      call('orchestration.workerRelease', { dispatch: dispatchId })
+    ).resolves.toMatchObject({
+      state: 'retained',
+      reason: 'identity_unproven',
+      processAction: 'none'
+    })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
   })
 
   it('worker-show exposes the terminal resource', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.ts
@@ -54,12 +54,36 @@ export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = [
         }
       }
       if (requested.disposition === 'retained') {
+        const resource = requested.resource
+        const processIncarnation = resource?.process_incarnation
+        if (
+          processIncarnation &&
+          (await runtime.inspectTerminalProcessIncarnationLiveness(
+            processIncarnation,
+            resource.host_scope
+          )) === 'dead'
+        ) {
+          const reconciled = db.settleDeadWorkerTerminalRelease({
+            requestingDispatchId: params.dispatch,
+            resourceId: resource.id,
+            processIncarnation
+          })
+          if (reconciled.disposition === 'released') {
+            runtime.notifyMessageArrived(`dispatch:${params.dispatch}`, 'status')
+            return {
+              dispatchId: params.dispatch,
+              state: 'released',
+              processAction: 'none',
+              archive: archiveSummary(reconciled.resource)
+            }
+          }
+        }
         return {
           dispatchId: params.dispatch,
           state: 'retained',
           reason: requested.reason,
           processAction: 'none',
-          archive: archiveSummary(requested.resource)
+          archive: archiveSummary(resource)
         }
       }
       return completeWorkerTerminalRelease({


### PR DESCRIPTION
Fixes https://github.com/stablyai/orca/issues/13860
Linear: STA-3932

## Problem

Settled supervised workers with external, user-owned, or transferred terminal ownership stayed permanently `retained` after their runtime terminal handle went stale. Release returned before consulting the provider that authoritatively owns process liveness, so there was no safe path from retained ownership to released accounting.

## Root cause and invariant

SQLite is authoritative for orchestration ownership/release state, while the owning local/WSL/SSH provider inventory is authoritative for the immutable PTY process incarnation. Handle staleness is not death: a daemon, SSH, or restored PTY may survive a runtime handle generation.

Invariant: a settled resource may reconcile to `released` only when one fresh inventory from its exact owning provider positively excludes its exact immutable process incarnation. Live, missing/malformed identity, invalid host scope, unavailable inventory, active transferred owner, or corrupted ownership history all remain retained.

The two-signal oracle requires:

1. persisted `ownership_state` and `release_state` both become `released`;
2. `closeTerminal` remains uncalled and the receipt reports `processAction: none`.

## Design

- Perform one bounded provider-scoped inventory only on the retained release path.
- Classify an exact incarnation as `live`, positive absence as `dead`, and every unavailable or ambiguous shape as `unknown`.
- Re-check requester/current-owner settlement, ownership history, resource identity, and release state inside one `BEGIN IMMEDIATE` transaction before committing release.
- Extend dead reconciliation to all domain-settled states, including stopped and abandoned, without enabling their normal process-close path.
- Register the invariant and executable evidence in the settled-worker reliability gate.

Alternatives rejected:

- Treating `terminal_handle_stale` as death could discard a surviving daemon/SSH/paired PTY.
- Widening the retained-reason allowlist could release a live user-owned terminal.
- A force flag would move unsafe liveness classification to callers instead of fixing authoritative truth.

## Deterministic red / red / green evidence

Byte-identical command:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/rpc/methods/orchestration-worker-release.test.ts \
  -t 'reconciles a dead external|reconciles a dead user|reconciles dead transferred' \
  --reporter=verbose
```

- Actual latest `origin/main` `444638d96b`: **3/3 red**; all three resources remained `retained`.
- Candidate `d44d46178b`: **3/3 green**.
- Candidate with production restored exactly to `444638d96b`: **3/3 red**.
- Restored candidate: **3/3 green**.

The same test bytes asserted durable state and zero terminal-close calls in every run.

## Validation

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime-process-incarnation-liveness.test.ts \
  src/main/runtime/rpc/methods/orchestration-worker-release.test.ts \
  src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts \
  src/main/runtime/rpc/orchestration-mutation-ledger.test.ts \
  src/main/runtime/orchestration/worker-transcript-read.test.ts \
  src/renderer/src/lib/worker-terminal-takeover-report.test.ts --reporter=dot
# 6 files, 67 tests passed

pnpm exec vitest run --config config/vitest.config.ts \
  tests/e2e/completed-worker-retirement-resume.unit.test.ts \
  src/cli/handlers/orchestration-worker-cli.test.ts --reporter=dot
# 2 files, 9 tests passed

pnpm typecheck:node
pnpm check:reliability-gates
pnpm check:max-lines-ratchet
pnpm exec oxlint <six touched TypeScript files>
git diff --check origin/main...HEAD
```

Two internal-review-until-clean rounds completed. Round 1 fixed malformed provider-incarnation metadata being usable as evidence; round 2 was clean across adversarial, architecture, performance/resource, platform, security, UX, mobile/backcompat, and readiness lenses.

## Risks and gaps

- A retained release adds one explicit, timeout-bounded provider inventory. It adds no polling, retries, timers, subprocesses, renderer work, or per-session follow-up fanout.
- Output cannot be archived after the terminal surface/process record is already gone; the receipt may correctly keep `archive: null`.
- Live Windows/WSL/SSH/paired-runtime journeys remain reliability-gate gaps. Physical Windows was not required for this fix because no ConPTY, OS process termination, filesystem, updater, sleep, firewall, or window lifecycle semantics changed; the causal boundary is provider inventory classification plus SQLite settlement.
- Federated worker release remains explicitly unsupported and retained; no RPC/wire field or mixed-version contract changed.
