### PR TITLE
fix(omp): preserve native WSL status and clear stale spinners

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2003,6 +2003,19 @@ describe('AgentHookServer listener replay', () => {
       },
       'conn-1'
     )
+    server.clearStatusEntriesForConnection('conn-1')
+    server.clearPaneState(PANE)
+    expect(listener).not.toHaveBeenCalled()
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', agentType: 'claude' }
+      },
+      'conn-1'
+    )
     server.dropStatusEntry(PANE)
 
     expect(listener).toHaveBeenCalledExactlyOnceWith(PANE)

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1988,6 +1988,26 @@ describe('AgentHookServer listener replay', () => {
     expect(listener).toHaveBeenNthCalledWith(4, [])
   })
 
+  it('notifies status-drop subscribers only when a live row is dropped', () => {
+    const server = new AgentHookServer()
+    const listener = vi.fn()
+    server.subscribeStatusDrop(listener)
+
+    server.dropStatusEntry(PANE)
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+    server.dropStatusEntry(PANE)
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(PANE)
+  })
+
   it('notifies pane-status-clear listener when pane teardown evicts a cached status', () => {
     const server = new AgentHookServer()
     const listener = vi.fn()

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1920,6 +1920,26 @@ describe('AgentHookServer listener replay', () => {
     expect(listener).toHaveBeenNthCalledWith(4, [])
   })
 
+  it('notifies status-drop subscribers only when a live row is dropped', () => {
+    const server = new AgentHookServer()
+    const listener = vi.fn()
+    server.subscribeStatusDrop(listener)
+
+    server.dropStatusEntry(PANE)
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+    server.dropStatusEntry(PANE)
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(PANE)
+  })
+
   it('notifies pane-status-clear listener when pane teardown evicts a cached status', () => {
     const server = new AgentHookServer()
     const listener = vi.fn()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -147,6 +147,7 @@ export type AgentHookAuthorityAttestation = Readonly<{
 type StatusChangeListener = (statuses: AgentHookStatusChangeEntry[]) => void
 type ProviderSessionChangeListener = (providerSessions: AgentHookProviderSessionIdentity[]) => void
 type PaneStatusClearListener = (clear: AgentStatusClearIpcPayload) => void
+type StatusDropListener = (paneKey: string) => void
 type PaneKeyAliasPersistenceListener = (entries: LegacyPaneKeyAliasEntry[]) => void
 type PaneKeyAliasEntry = {
   stablePaneKey: string
@@ -602,6 +603,7 @@ export class AgentHookServer {
   private onClaudeStatusLine: ((event: ClaudeStatusLineRateLimits) => void) | null = null
   private onPaneStatusCleared: PaneStatusClearListener | null = null
   private paneStatusClearListeners = new Set<PaneStatusClearListener>()
+  private statusDropListeners = new Set<StatusDropListener>()
   private statusChangeListeners = new Set<StatusChangeListener>()
   private providerSessionChangeListeners = new Set<ProviderSessionChangeListener>()
   // Why: setListener is a single slot owned by the main-window fanout; the
@@ -693,6 +695,23 @@ export class AgentHookServer {
     this.paneStatusClearListeners.add(listener)
     return () => {
       this.paneStatusClearListeners.delete(listener)
+    }
+  }
+
+  subscribeStatusDrop(listener: StatusDropListener): () => void {
+    this.statusDropListeners.add(listener)
+    return () => {
+      this.statusDropListeners.delete(listener)
+    }
+  }
+
+  private emitStatusDropped(paneKey: string): void {
+    for (const listener of this.statusDropListeners) {
+      try {
+        listener(paneKey)
+      } catch (err) {
+        console.error('[agent-hooks] status-drop listener threw', err)
+      }
     }
   }
 
@@ -2266,6 +2285,7 @@ export class AgentHookServer {
     }
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
+    this.emitStatusDropped(deleted.paneKey)
   }
 
   /** Clear statuses proven to belong to one lost SSH transport. */

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -698,6 +698,7 @@ export class AgentHookServer {
     }
   }
 
+  /** Subscribes to definitive live-row deletions, excluding transient connection clears. */
   subscribeStatusDrop(listener: StatusDropListener): () => void {
     this.statusDropListeners.add(listener)
     return () => {
@@ -705,6 +706,7 @@ export class AgentHookServer {
     }
   }
 
+  /** Notifies pane-owned cleanup only after its status row was deleted. */
   private emitStatusDropped(paneKey: string): void {
     for (const listener of this.statusDropListeners) {
       try {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -147,6 +147,7 @@ export type AgentHookAuthorityAttestation = Readonly<{
 type StatusChangeListener = (statuses: AgentHookStatusChangeEntry[]) => void
 type ProviderSessionChangeListener = (providerSessions: AgentHookProviderSessionIdentity[]) => void
 type PaneStatusClearListener = (clear: AgentStatusClearIpcPayload) => void
+type StatusDropListener = (paneKey: string) => void
 type PaneKeyAliasPersistenceListener = (entries: LegacyPaneKeyAliasEntry[]) => void
 type PaneKeyAliasEntry = {
   stablePaneKey: string
@@ -602,6 +603,7 @@ export class AgentHookServer {
   private onClaudeStatusLine: ((event: ClaudeStatusLineRateLimits) => void) | null = null
   private onPaneStatusCleared: PaneStatusClearListener | null = null
   private paneStatusClearListeners = new Set<PaneStatusClearListener>()
+  private statusDropListeners = new Set<StatusDropListener>()
   private statusChangeListeners = new Set<StatusChangeListener>()
   private providerSessionChangeListeners = new Set<ProviderSessionChangeListener>()
   // Why: setListener is a single slot owned by the main-window fanout; the
@@ -693,6 +695,23 @@ export class AgentHookServer {
     this.paneStatusClearListeners.add(listener)
     return () => {
       this.paneStatusClearListeners.delete(listener)
+    }
+  }
+
+  subscribeStatusDrop(listener: StatusDropListener): () => void {
+    this.statusDropListeners.add(listener)
+    return () => {
+      this.statusDropListeners.delete(listener)
+    }
+  }
+
+  private emitStatusDropped(paneKey: string): void {
+    for (const listener of this.statusDropListeners) {
+      try {
+        listener(paneKey)
+      } catch (err) {
+        console.error('[agent-hooks] status-drop listener threw', err)
+      }
     }
   }
 
@@ -2258,6 +2277,7 @@ export class AgentHookServer {
     }
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
+    this.emitStatusDropped(deleted.paneKey)
   }
 
   /** Clear statuses proven to belong to one lost SSH transport. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1950,6 +1950,8 @@ registerPaneKeyTeardownListener((paneKey) => {
   stopSyntheticTitleSpinner(paneKey)
 })
 
+agentHookServer.subscribeStatusDrop(stopSyntheticTitleSpinner)
+
 function sendSyntheticTitle(ptyId: string, data: string, options: { force?: boolean } = {}): void {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1947,6 +1947,8 @@ registerPaneKeyTeardownListener((paneKey) => {
   stopSyntheticTitleSpinner(paneKey)
 })
 
+agentHookServer.subscribeStatusDrop(stopSyntheticTitleSpinner)
+
 function sendSyntheticTitle(ptyId: string, data: string, options: { force?: boolean } = {}): void {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return

--- a/src/main/startup/agent-hook-spinner-wiring.test.ts
+++ b/src/main/startup/agent-hook-spinner-wiring.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('agent hook spinner wiring', () => {
   it('stops the pane spinner when its live hook status is dropped', () => {
-    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const source = readFileSync(join(process.cwd(), 'src', 'main', 'index.ts'), 'utf8')
 
     expect(source).toContain('agentHookServer.subscribeStatusDrop(stopSyntheticTitleSpinner)')
   })

--- a/src/main/startup/agent-hook-spinner-wiring.test.ts
+++ b/src/main/startup/agent-hook-spinner-wiring.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('agent hook spinner wiring', () => {
+  it('stops the pane spinner when its live hook status is dropped', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+
+    expect(source).toContain('agentHookServer.subscribeStatusDrop(stopSyntheticTitleSpinner)')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
@@ -137,19 +137,19 @@ describe('main title tracker parity with the renderer transport processor', () =
   })
 
   it('clears a stale wrapped native OMP working title in both paths', () => {
-    feedBoth(paths, `${ESC}]0;zsh | π : release | π > note | π ! note${BEL}`)
+    feedBoth(paths, `${ESC}]0;zsh | π : release | π > note | π ! note ✦ ⏲ ◇ ✋ ⠋${BEL}`)
     feedBoth(paths, 'title-free output')
     vi.advanceTimersByTime(3_000)
 
     expect(paths.main.events).toEqual(paths.renderer.events)
     expect(paths.main.events).toContainEqual({
       kind: 'title',
-      normalized: 'zsh | π > release | π > note | π ! note',
-      raw: 'zsh | π > release | π > note | π ! note'
+      normalized: 'zsh | π > release | π > note | π ! note ✦ ⏲ ◇ ✋ ⠋',
+      raw: 'zsh | π > release | π > note | π ! note ✦ ⏲ ◇ ✋ ⠋'
     })
     expect(paths.main.events).toContainEqual({
       kind: 'became-idle',
-      title: 'zsh | π > release | π > note | π ! note'
+      title: 'zsh | π > release | π > note | π ! note ✦ ⏲ ◇ ✋ ⠋'
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
@@ -119,6 +119,40 @@ describe('main title tracker parity with the renderer transport processor', () =
     expect(kinds.indexOf('became-working')).toBeLessThan(kinds.indexOf('became-idle'))
   })
 
+  it('derives working and idle facts from static OMP WSL titles', () => {
+    const chunk = `${ESC}]0;zsh | π : cwd${BEL}response text\r\n` + `${ESC}]0;zsh | π > cwd${BEL}`
+    feedBoth(paths, chunk)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    const kinds = paths.main.events.map((event) => event.kind)
+    expect(kinds).toContain('became-working')
+    expect(kinds.indexOf('became-working')).toBeLessThan(kinds.indexOf('became-idle'))
+  })
+
+  it('treats marker-shaped text in the OMP label as opaque', () => {
+    feedBoth(paths, `${ESC}]0;zsh | π > session | π : note | π ! note${BEL}`)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    expect(paths.main.events.map((event) => event.kind)).not.toContain('became-working')
+  })
+
+  it('clears a stale wrapped native OMP working title in both paths', () => {
+    feedBoth(paths, `${ESC}]0;zsh | π : release | π > note | π ! note${BEL}`)
+    feedBoth(paths, 'title-free output')
+    vi.advanceTimersByTime(3_000)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    expect(paths.main.events).toContainEqual({
+      kind: 'title',
+      normalized: 'zsh | π > release | π > note | π ! note',
+      raw: 'zsh | π > release | π > note | π ! note'
+    })
+    expect(paths.main.events).toContainEqual({
+      kind: 'became-idle',
+      title: 'zsh | π > release | π > note | π ! note'
+    })
+  })
+
   it('derives identical facts from BEL- and ST-terminated titles', () => {
     feedBoth(paths, `${ESC}]2;Codex working${ST}body bytes`)
     feedBoth(paths, `${ESC}]0;Codex done${BEL}`)

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -167,6 +167,35 @@ describe('Pi-compatible title detection', () => {
     expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
   })
 
+  it.each([
+    ['π : my-project', 'working'],
+    ['π > my-project', 'idle'],
+    ['π ! my-project', 'permission'],
+    ['π: my-project', 'idle'],
+    ['zsh | π : wrapped-project', 'working'],
+    ['zsh | tmux | π > wrapped-project', 'idle'],
+    ['zsh | π ! wrapped-project', 'permission'],
+    ['π : release | windows', 'working'],
+    ['π > release | windows', 'idle'],
+    ['π ! release | windows', 'permission'],
+    ['zsh | π : release | windows', 'working'],
+    ['zsh | π > release | windows', 'idle'],
+    ['zsh | π ! release | windows', 'permission']
+  ] as const)('classifies native OMP title %s', (title, expectedStatus) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
+  it.each([
+    ['π : session | π > note | π ! note', 'working'],
+    ['π > session | π : note | π ! note', 'idle'],
+    ['π ! session | π : note | π > note', 'permission'],
+    ['zsh | π : session | π > note | π ! note', 'working'],
+    ['zsh | π > session | π : note | π ! note', 'idle'],
+    ['zsh | π ! session | π : note | π > note', 'permission']
+  ] as const)('treats the native OMP label as opaque: %s', (title, expectedStatus) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
   it('re-detects status after display-title normalization for Pi idle frames', () => {
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
     expect(detectAgentStatusFromTitle(normalizeTerminalTitle('π - my-project'))).toBe('idle')

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -196,6 +196,22 @@ describe('Pi-compatible title detection', () => {
     expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
   })
 
+  it.each([
+    ['π : session ✦ ⏲ ◇ ✋', 'working'],
+    ['π > session ✦ ⏲ ◇ ✋', 'idle'],
+    ['π ! session ✦ ⏲ ◇ ✋', 'permission'],
+    ['zsh | π : session ✦ ⏲ ◇ ✋', 'working'],
+    ['zsh | π > session ✦ ⏲ ◇ ✋', 'idle'],
+    ['zsh | π ! session ✦ ⏲ ◇ ✋', 'permission']
+  ] as const)('prioritizes native OMP state over glyphs in its label: %s', (title, status) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(status)
+  })
+
+  it('does not normalize a wrapped OMP title as Gemini from label glyphs', () => {
+    const title = 'zsh | π > session ✦ ⏲ ◇ ✋'
+    expect(normalizeTerminalTitle(title)).toBe(title)
+  })
+
   it('re-detects status after display-title normalization for Pi idle frames', () => {
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
     expect(detectAgentStatusFromTitle(normalizeTerminalTitle('π - my-project'))).toBe('idle')

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -147,6 +147,22 @@ describe('Pi-compatible title detection', () => {
     expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
   })
 
+  it.each([
+    ['π : session ✦ ⏲ ◇ ✋', 'working'],
+    ['π > session ✦ ⏲ ◇ ✋', 'idle'],
+    ['π ! session ✦ ⏲ ◇ ✋', 'permission'],
+    ['zsh | π : session ✦ ⏲ ◇ ✋', 'working'],
+    ['zsh | π > session ✦ ⏲ ◇ ✋', 'idle'],
+    ['zsh | π ! session ✦ ⏲ ◇ ✋', 'permission']
+  ] as const)('prioritizes native OMP state over glyphs in its label: %s', (title, status) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(status)
+  })
+
+  it('does not normalize a wrapped OMP title as Gemini from label glyphs', () => {
+    const title = 'zsh | π > session ✦ ⏲ ◇ ✋'
+    expect(normalizeTerminalTitle(title)).toBe(title)
+  })
+
   it('re-detects status after display-title normalization for Pi idle frames', () => {
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
     expect(detectAgentStatusFromTitle(normalizeTerminalTitle('π - my-project'))).toBe('idle')

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -118,6 +118,35 @@ describe('Pi-compatible title detection', () => {
     expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
   })
 
+  it.each([
+    ['π : my-project', 'working'],
+    ['π > my-project', 'idle'],
+    ['π ! my-project', 'permission'],
+    ['π: my-project', 'idle'],
+    ['zsh | π : wrapped-project', 'working'],
+    ['zsh | tmux | π > wrapped-project', 'idle'],
+    ['zsh | π ! wrapped-project', 'permission'],
+    ['π : release | windows', 'working'],
+    ['π > release | windows', 'idle'],
+    ['π ! release | windows', 'permission'],
+    ['zsh | π : release | windows', 'working'],
+    ['zsh | π > release | windows', 'idle'],
+    ['zsh | π ! release | windows', 'permission']
+  ] as const)('classifies native OMP title %s', (title, expectedStatus) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
+  it.each([
+    ['π : session | π > note | π ! note', 'working'],
+    ['π > session | π : note | π ! note', 'idle'],
+    ['π ! session | π : note | π > note', 'permission'],
+    ['zsh | π : session | π > note | π ! note', 'working'],
+    ['zsh | π > session | π : note | π ! note', 'idle'],
+    ['zsh | π ! session | π : note | π > note', 'permission']
+  ] as const)('treats the native OMP label as opaque: %s', (title, expectedStatus) => {
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
   it('re-detects status after display-title normalization for Pi idle frames', () => {
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
     expect(detectAgentStatusFromTitle(normalizeTerminalTitle('π - my-project'))).toBe('idle')

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -24,6 +24,7 @@ import {
   isPiTerminalTitle
 } from './agent-title-core'
 import type { AgentStatus } from './agent-title-core'
+import { clearOmpNativeWorkingStatus, getOmpNativeTitleStatus } from './omp-native-title-status'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentStatus } from './pi-compatible-synthetic-title'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
@@ -32,7 +33,7 @@ import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
  * Strip working-status indicators so stale exit titles stop reporting working.
  */
 export function clearWorkingIndicators(title: string): string {
-  let cleaned = title
+  let cleaned = clearOmpNativeWorkingStatus(title) ?? title
 
   cleaned = cleaned.replace(GEMINI_WORKING, '')
   cleaned = cleaned.replace(GEMINI_SILENT_WORKING, '')
@@ -174,6 +175,11 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   if (title.includes(GEMINI_IDLE)) {
     return 'idle'
+  }
+
+  const ompNativeStatus = getOmpNativeTitleStatus(title)
+  if (ompNativeStatus) {
+    return ompNativeStatus
   }
 
   // Why: resolve synthetic Pi/OMP permission/idle labels before the broader

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -33,7 +33,11 @@ import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
  * Strip working-status indicators so stale exit titles stop reporting working.
  */
 export function clearWorkingIndicators(title: string): string {
-  let cleaned = clearOmpNativeWorkingStatus(title) ?? title
+  const clearedOmpNativeWorkingStatus = clearOmpNativeWorkingStatus(title)
+  if (clearedOmpNativeWorkingStatus) {
+    return clearedOmpNativeWorkingStatus
+  }
+  let cleaned = title
 
   cleaned = cleaned.replace(GEMINI_WORKING, '')
   cleaned = cleaned.replace(GEMINI_SILENT_WORKING, '')
@@ -120,7 +124,7 @@ export function normalizeTerminalTitle(title: string): string {
     return title
   }
 
-  if (isGeminiTerminalTitle(title)) {
+  if (!getOmpNativeTitleStatus(title) && isGeminiTerminalTitle(title)) {
     const status = detectAgentStatusFromTitle(title)
     if (status === 'permission') {
       return `${GEMINI_PERMISSION} Gemini CLI`
@@ -167,6 +171,11 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
     return containsAgentSpinnerGlyph(title) ? 'working' : 'idle'
   }
 
+  const ompNativeStatus = getOmpNativeTitleStatus(title)
+  if (ompNativeStatus) {
+    return ompNativeStatus
+  }
+
   if (title.includes(GEMINI_PERMISSION)) {
     return 'permission'
   }
@@ -175,11 +184,6 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   if (title.includes(GEMINI_IDLE)) {
     return 'idle'
-  }
-
-  const ompNativeStatus = getOmpNativeTitleStatus(title)
-  if (ompNativeStatus) {
-    return ompNativeStatus
   }
 
   // Why: resolve synthetic Pi/OMP permission/idle labels before the broader

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -22,6 +22,7 @@ import {
   isPiTerminalTitle
 } from './agent-title-core'
 import type { AgentStatus } from './agent-title-core'
+import { clearOmpNativeWorkingStatus, getOmpNativeTitleStatus } from './omp-native-title-status'
 import { getPiCompatibleSyntheticAgentStatus } from './pi-compatible-synthetic-title'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
 
@@ -29,7 +30,7 @@ import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
  * Strip working-status indicators so stale exit titles stop reporting working.
  */
 export function clearWorkingIndicators(title: string): string {
-  let cleaned = title
+  let cleaned = clearOmpNativeWorkingStatus(title) ?? title
 
   cleaned = cleaned.replace(GEMINI_WORKING, '')
   cleaned = cleaned.replace(GEMINI_SILENT_WORKING, '')
@@ -166,6 +167,11 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   if (title.includes(GEMINI_IDLE)) {
     return 'idle'
+  }
+
+  const ompNativeStatus = getOmpNativeTitleStatus(title)
+  if (ompNativeStatus) {
+    return ompNativeStatus
   }
 
   // Why: resolve synthetic Pi/OMP permission/idle labels before the broader

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -30,7 +30,11 @@ import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
  * Strip working-status indicators so stale exit titles stop reporting working.
  */
 export function clearWorkingIndicators(title: string): string {
-  let cleaned = clearOmpNativeWorkingStatus(title) ?? title
+  const clearedOmpNativeWorkingStatus = clearOmpNativeWorkingStatus(title)
+  if (clearedOmpNativeWorkingStatus) {
+    return clearedOmpNativeWorkingStatus
+  }
+  let cleaned = title
 
   cleaned = cleaned.replace(GEMINI_WORKING, '')
   cleaned = cleaned.replace(GEMINI_SILENT_WORKING, '')
@@ -116,7 +120,7 @@ export function normalizeTerminalTitle(title: string): string {
     return title
   }
 
-  if (isGeminiTerminalTitle(title)) {
+  if (!getOmpNativeTitleStatus(title) && isGeminiTerminalTitle(title)) {
     const status = detectAgentStatusFromTitle(title)
     if (status === 'permission') {
       return `${GEMINI_PERMISSION} Gemini CLI`
@@ -159,6 +163,11 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
     return null
   }
 
+  const ompNativeStatus = getOmpNativeTitleStatus(title)
+  if (ompNativeStatus) {
+    return ompNativeStatus
+  }
+
   if (title.includes(GEMINI_PERMISSION)) {
     return 'permission'
   }
@@ -167,11 +176,6 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   if (title.includes(GEMINI_IDLE)) {
     return 'idle'
-  }
-
-  const ompNativeStatus = getOmpNativeTitleStatus(title)
-  if (ompNativeStatus) {
-    return ompNativeStatus
   }
 
   // Why: resolve synthetic Pi/OMP permission/idle labels before the broader

--- a/src/shared/omp-native-title-status.ts
+++ b/src/shared/omp-native-title-status.ts
@@ -1,0 +1,44 @@
+import type { AgentStatus } from './agent-title-core'
+
+const OMP_NATIVE_STATE_RE = /(?:^| \| )\s*π\s+([:>!])(?=\s|$)/u
+
+type OmpNativeStateMatch = {
+  delimiter: string
+  delimiterIndex: number
+}
+
+function getOmpNativeStateMatch(title: string): OmpNativeStateMatch | null {
+  const match = OMP_NATIVE_STATE_RE.exec(title)
+  const delimiter = match?.[1]
+  if (delimiter === undefined || match?.index === undefined) {
+    return null
+  }
+  return {
+    delimiter,
+    delimiterIndex: match.index + match[0].lastIndexOf(delimiter)
+  }
+}
+
+/** Resolves the native OMP marker while treating its remaining label as opaque. */
+export function getOmpNativeTitleStatus(title: string): AgentStatus | null {
+  const delimiter = getOmpNativeStateMatch(title)?.delimiter
+  if (delimiter === ':') {
+    return 'working'
+  }
+  if (delimiter === '!') {
+    return 'permission'
+  }
+  if (delimiter === '>') {
+    return 'idle'
+  }
+  return null
+}
+
+/** Converts an authoritative native OMP working marker into an idle marker. */
+export function clearOmpNativeWorkingStatus(title: string): string | null {
+  const match = getOmpNativeStateMatch(title)
+  if (match?.delimiter !== ':') {
+    return null
+  }
+  return `${title.slice(0, match.delimiterIndex)}>${title.slice(match.delimiterIndex + 1)}`
+}


### PR DESCRIPTION
## ELI5

OMP changed the terminal-title punctuation it uses on Windows/WSL. Orca read every new title as idle and could leave its fallback spinner running after the live hook row disappeared. This teaches the shared title authority the new states and stops that spinner at the authoritative row-deletion boundary.

## What Changed

- Parse OMP 17.2.12+ native titles: `π :` is working, `π >` is idle, and `π !` needs input.
- Preserve legacy no-space `π:` as idle.
- Support wrapper prefixes and legal ` | ` / marker-shaped text inside OMP labels by treating the label as opaque after the first native marker.
- Neutralize a stale native working marker through the existing 3-second main/renderer fallback.
- Publish successful live hook-row drops and stop that pane's synthetic spinner; transient connection clears remain isolated.
- Add parser, main/renderer parity, stale fallback, status-drop, and main wiring contracts.

## Why

Fixes https://github.com/stablyai/orca/issues/13890.

Authoritative ownership is split deliberately:

- The shared title classifier owns title-derived OMP status for main, renderer, local, SSH, and mixed-version remote consumers.
- `AgentHookServer.dropStatusEntry` owns definitive removal of a live hook row, so spinner cleanup occurs only after a real deletion. Connection-scoped transient clears do not falsely idle a possibly-working remote PTY.

Alternatives considered:

- Patch only renderer title handling: rejected because main-side status, mobile titles, and worktree state would still drift.
- Stop spinners on every clear: rejected because transient SSH clears do not prove the remote PTY stopped working.
- Reuse wrapper-segment splitting alone: rejected because OMP labels may legally contain the same ` | ` delimiter.

## Linked Issue

Fixes #13890

Related upstream evidence: can1357/oh-my-pi#8014. Existing PR #13891 was reviewed as reference only; this PR adds authoritative live-row ownership, opaque-label parsing, stale-title neutralization, and a main wiring contract.

## Visual Proof

N/A — no layout or styling changed. Rendered Electron validation on physical Windows 11 + Ubuntu 24.04 WSL/ConPTY observed:

- `π : physical-wsl` → `Pi - Running` / `⠋ Pi`
- `π > physical-wsl` → `Pi - Idle` / `Pi`
- `π ! physical-wsl` → `Needs input`
- A real authenticated hook row followed by renderer `agentStatus.drop(paneKey)` removed the row and the 80 ms synthetic spinner did not repaint the later idle title.

## How to test

Falsifiable invariant:

- `π :` → working
- `π >` → idle
- `π !` → permission
- legacy `π:` → idle
- wrapper prefixes do not hide the native marker, and everything after it is opaque label text
- a successful live hook-row drop retires only that pane's synthetic spinner
- transient connection clears retain possibly-working remote authority

Deterministic baseline/candidate/disabled evidence, using the same oracle command:

```powershell
pnpm vitest run src/shared/agent-detection.test.ts src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts src/main/synthetic-title-spinner.test.ts src/main/agent-hooks/server.test.ts src/main/startup/agent-hook-spinner-wiring.test.ts --config config/vitest.config.ts
```

- Affected latest-main at `991a3fe963`: red, 8 failures / 95 tests in the original focused contract.
- Final rebased candidate at `adbcd4f64d` over `64aec94cb2`: green, 384/384.
- Same final oracle with native parsing and live-drop notification disabled: red, 23 failures / 361 passing.
- Restored final candidate: green, 384/384.

Additional validation:

- `pnpm typecheck` — passed all node, CLI, and web projects.
- Touched-file oxlint — passed.
- Touched-file `oxfmt --check` — passed.
- `git diff --check` — passed.
- Fresh architecture/security/correctness, performance/resource/UX, and platform/readiness reviews — clean.
- Full `pnpm lint` passed code-quality, type-aware, reliability, max-lines, and bundled-skill guide gates, then stopped only on unrelated stale generated skill artifacts already present on current main: `resources/skills/current-manifest.json`, `snapshot-registry.json`, and `release-mapping.json`. They were not regenerated or included.

Risk is limited to title classification and hook-row lifecycle. There is no RPC, stream opcode, persistence, or wire-shape change. macOS/Linux, folder workspaces, git worktrees, Git providers, Git 2.25, SSH, WSL, and remote version skew were considered; all consumers use the shared classifier and old peers continue exchanging the same title bytes.

- [x] I manually tested these changes locally on physical Windows + WSL/ConPTY/Electron
- [x] Automated tests added/updated

## AI Disclosure

Implemented with OpenAI Codex. Independent review passes covered architecture/security/correctness, performance/resources/UX, and cross-platform/readiness concerns.

## Review

Clean for security, Windows/Linux/macOS compatibility, WSL/ConPTY, SSH and remote skew, folder workspaces/worktrees, mobile/shared consumers, backwards compatibility, and performance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is N/A for layout/styling; rendered behavior evidence is documented above
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Focused tests, typecheck, and code-quality gates pass; CI covers the broader matrix and the unrelated generated-manifest lint limitation is documented

## Author

- X / Twitter: N/A
