### PR TITLE
fix(agent-title): treat Claude Code quarter-circle spinners as working (#13889)

### DIFF
--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -2,7 +2,7 @@ import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
-import { containsBrailleSpinner } from '../../../shared/agent-title-core'
+import { containsAgentSpinnerGlyph } from '../../../shared/agent-title-core'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -106,7 +106,7 @@ function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | 
   // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
   // token, #9040); the tab's launch identity supplies it, mirroring the row builder's spinner
   // fallback (#9647) so the dot and the sidebar row agree.
-  return containsBrailleSpinner(title) && Boolean(launchAgent)
+  return containsAgentSpinnerGlyph(title) && Boolean(launchAgent)
 }
 
 export function getWorktreeStatusLabel(status: WorktreeStatus): string {

--- a/src/shared/agent-decorative-title-signature.ts
+++ b/src/shared/agent-decorative-title-signature.ts
@@ -27,7 +27,10 @@ function normalizeDecorativeAgentTitleText(title: string): string {
   let pendingWhitespace = false
   for (let index = 0; index < title.length; index += 1) {
     const code = title.charCodeAt(index)
-    if (normalized.length === 0 && (isDecorativeTitleWhitespace(code) || isBrailleSpinner(code))) {
+    if (
+      normalized.length === 0 &&
+      (isDecorativeTitleWhitespace(code) || isSpinnerFrameGlyph(code))
+    ) {
       continue
     }
     if (isDecorativeTitleWhitespace(code)) {
@@ -43,8 +46,9 @@ function normalizeDecorativeAgentTitleText(title: string): string {
   return normalized
 }
 
-function isBrailleSpinner(code: number): boolean {
-  return code >= 0x2800 && code <= 0x28ff
+// Why: braille (most agents) plus quarter circles (Claude Code 2.1.228+, #13889).
+function isSpinnerFrameGlyph(code: number): boolean {
+  return (code >= 0x2800 && code <= 0x28ff) || (code >= 0x25d0 && code <= 0x25d3)
 }
 
 function isDecorativeTitleWhitespace(code: number): boolean {

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -50,7 +50,6 @@ export const BRAILLE_SPINNER_RE = /[\u2800-\u28ff]/g
 // Why: Claude Code 2.1.228 swapped its busy title spinner from braille to
 // quarter circles (#13889), which read as "no agent" and looked like an exit.
 // Reserve the whole quarter-circle block so a later frame addition cannot regress this.
-// eslint-disable-next-line no-control-regex -- intentional unicode range
 export const QUARTER_CIRCLE_SPINNER_RE = /[\u25d0-\u25d3]/g
 
 export function isGeminiTerminalTitle(title: string): boolean {

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -47,6 +47,12 @@ export const CURSOR_NATIVE_TITLE_LOWER = 'cursor agent'
 // eslint-disable-next-line no-control-regex -- intentional unicode range
 export const BRAILLE_SPINNER_RE = /[\u2800-\u28ff]/g
 
+// Why: Claude Code 2.1.228 swapped its busy title spinner from braille to
+// quarter circles (#13889), which read as "no agent" and looked like an exit.
+// Reserve the whole quarter-circle block so a later frame addition cannot regress this.
+// eslint-disable-next-line no-control-regex -- intentional unicode range
+export const QUARTER_CIRCLE_SPINNER_RE = /[\u25d0-\u25d3]/g
+
 export function isGeminiTerminalTitle(title: string): boolean {
   // Why: Gemini OSC glyphs are stronger evidence than any cwd/session text.
   if (
@@ -81,6 +87,25 @@ export function containsBrailleSpinner(title: string): boolean {
     }
   }
   return false
+}
+
+export function containsQuarterCircleSpinner(title: string): boolean {
+  for (const char of title) {
+    const codePoint = char.codePointAt(0)
+    if (codePoint !== undefined && codePoint >= 0x25d0 && codePoint <= 0x25d3) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Any spinner frame glyph an agent animates its OSC title with. Use this for
+ * generic "something is running" checks; agent-specific frame shapes (Grok,
+ * Pi, synthetic Cursor) stay pinned to their own glyph set.
+ */
+export function containsAgentSpinnerGlyph(title: string): boolean {
+  return containsBrailleSpinner(title) || containsQuarterCircleSpinner(title)
 }
 
 export function containsLegacyAgentName(title: string): boolean {

--- a/src/shared/agent-title-decoration.ts
+++ b/src/shared/agent-title-decoration.ts
@@ -1,11 +1,11 @@
 // Leading status decorations that coding agents prepend to their OSC title —
-// Claude's '✳', Gemini's glyphs (✦ ⏲ ◇ ✋), braille spinners, and Claude's
-// '. '/'* ' working/idle prefixes. Once the tab bar shows the provider icon,
-// this leading glyph reads as a redundant second icon, so strip it from the
-// displayed title. Scoped to titles we already know belong to an agent.
+// Claude's '✳', Gemini's glyphs (✦ ⏲ ◇ ✋), braille and quarter-circle spinners,
+// and Claude's '. '/'* ' working/idle prefixes. Once the tab bar shows the
+// provider icon, this leading glyph reads as a redundant second icon, so strip
+// it from the displayed title. Scoped to titles we already know belong to an agent.
 const LEADING_AGENT_TITLE_DECORATION_RE =
   // eslint-disable-next-line no-control-regex -- intentional unicode status-glyph ranges
-  /^(?:[✳✦⏲◇✋⠀-⣿]+|[.*]\s)\s*/
+  /^(?:[✳✦⏲◇✋⠀-⣿◐-◓]+|[.*]\s)\s*/
 
 export function stripLeadingAgentTitleDecorationOrEmpty(title: string): string {
   return title.replace(LEADING_AGENT_TITLE_DECORATION_RE, '').trimStart()

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -3,7 +3,7 @@ import {
   CLAUDE_IDLE,
   DROID_AGENT_NAME_RE,
   HERMES_AGENT_NAME_RE,
-  containsBrailleSpinner,
+  containsAgentSpinnerGlyph,
   isClaudeManagementTitle,
   isCursorAgentTitle,
   isGeminiTerminalTitle,
@@ -31,7 +31,7 @@ export function isClaudeAgent(title: string): boolean {
   if (title.startsWith('. ') || title.startsWith('* ')) {
     return true
   }
-  if (containsBrailleSpinner(title)) {
+  if (containsAgentSpinnerGlyph(title)) {
     // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
     // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
     return !isCursorAgentTitle(title) && !lower.includes('openclaude')

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -9,12 +9,13 @@ import {
   GEMINI_SILENT_WORKING,
   GEMINI_WORKING,
   HERMES_AGENT_NAME_RE,
+  QUARTER_CIRCLE_SPINNER_RE,
   STRONG_IDLE_KEYWORDS_RE,
   STRONG_WORKING_KEYWORDS_RE,
   STRONG_WORKING_KEYWORDS_RE_GLOBAL,
   containsAgentName,
+  containsAgentSpinnerGlyph,
   containsAny,
-  containsBrailleSpinner,
   containsLegacyAgentName,
   isClaudeManagementTitle,
   isGeminiTerminalTitle,
@@ -34,6 +35,7 @@ export function clearWorkingIndicators(title: string): string {
   cleaned = cleaned.replace(GEMINI_WORKING, '')
   cleaned = cleaned.replace(GEMINI_SILENT_WORKING, '')
   cleaned = cleaned.replace(BRAILLE_SPINNER_RE, '')
+  cleaned = cleaned.replace(QUARTER_CIRCLE_SPINNER_RE, '')
   if (cleaned.startsWith('. ')) {
     cleaned = cleaned.slice(2)
   }
@@ -181,7 +183,7 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   if (isPiTerminalTitle(title)) {
     return 'idle'
   }
-  if (containsBrailleSpinner(title)) {
+  if (containsAgentSpinnerGlyph(title)) {
     return 'working'
   }
 

--- a/src/shared/repro-13889-claude-quarter-circle-busy-title.test.ts
+++ b/src/shared/repro-13889-claude-quarter-circle-busy-title.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clearWorkingIndicators,
+  createAgentStatusTracker,
+  detectAgentStatusFromTitle,
+  getAgentLabel,
+  isClaudeAgent
+} from './agent-detection'
+import { isDecorativeAgentTitleFrameChange } from './agent-decorative-title-signature'
+import { stripLeadingAgentTitleDecoration } from './agent-title-decoration'
+import { resolveExplicitTerminalTitleAgentType } from './terminal-title-agent-type'
+
+// Titles captured from real `claude` binaries running the same one-line prompt.
+// 2.1.228 swapped the busy spinner from braille to quarter circles, which read as
+// "no agent" and made the tracker report a confirmed exit mid-turn (#13889).
+const BUSY_2_1_227 = ['⠂ Claude Code', '⠐ Claude Code', '⠂ Say hi in one word'] as const
+const BUSY_2_1_228 = ['◐ Claude Code', '◑ Claude Code', '◑ Say hi in one word'] as const
+
+const CAPTURED_2_1_228_TURN = [
+  '✳ Claude Code',
+  '◐ Claude Code',
+  '◑ Claude Code',
+  '◑ Say hi in one word',
+  '◐ Say hi in one word',
+  '✳ Say hi in one word'
+] as const
+
+function trackTurn(titles: readonly string[]): string[] {
+  const events: string[] = []
+  const tracker = createAgentStatusTracker(
+    () => events.push('idle'),
+    () => events.push('working'),
+    () => events.push('exited')
+  )
+  for (const title of titles) {
+    tracker.handleTitle(title)
+  }
+  return events
+}
+
+describe('Claude Code quarter-circle busy titles (#13889)', () => {
+  it('reports working for every quarter-circle spinner frame', () => {
+    for (const title of ['◐ Claude Code', '◑ Claude Code', '◒ Claude Code', '◓ Claude Code']) {
+      expect(detectAgentStatusFromTitle(title)).toBe('working')
+    }
+  })
+
+  it('reports working when the busy title carries task text instead of the agent name', () => {
+    // Why: the summary-bearing frame has no "claude" token, so it previously fell
+    // through to null — the value the tracker reads as an exit.
+    expect(detectAgentStatusFromTitle('◐ Say hi in one word')).toBe('working')
+  })
+
+  it('keeps Claude identity while busy', () => {
+    for (const title of BUSY_2_1_228) {
+      expect(isClaudeAgent(title)).toBe(true)
+      expect(getAgentLabel(title)).toBe('Claude Code')
+    }
+  })
+
+  it('matches 2.1.227 status and identity frame for frame', () => {
+    BUSY_2_1_228.forEach((title, index) => {
+      const braille = BUSY_2_1_227[index]
+      expect(detectAgentStatusFromTitle(title)).toBe(detectAgentStatusFromTitle(braille))
+      expect(getAgentLabel(title)).toBe(getAgentLabel(braille))
+      expect(resolveExplicitTerminalTitleAgentType(title)).toBe(
+        resolveExplicitTerminalTitleAgentType(braille)
+      )
+    })
+  })
+
+  it('never confirms an agent exit across a real 2.1.228 turn', () => {
+    const events = trackTurn(CAPTURED_2_1_228_TURN)
+    expect(events).not.toContain('exited')
+    expect(events).toEqual(['working', 'idle'])
+  })
+
+  it('tracks the 2.1.228 turn exactly like the 2.1.227 turn', () => {
+    const brailleTurn = CAPTURED_2_1_228_TURN.map((title) =>
+      title.replace('◐', '⠂').replace('◑', '⠐')
+    )
+    expect(trackTurn(CAPTURED_2_1_228_TURN)).toEqual(trackTurn(brailleTurn))
+  })
+
+  it('strips the spinner from stale exit titles and displayed labels', () => {
+    expect(clearWorkingIndicators('◐ Say hi in one word')).toBe('Say hi in one word')
+    expect(stripLeadingAgentTitleDecoration('◐ Claude Code')).toBe('Claude Code')
+  })
+
+  it('treats a spinner tick as decoration, not a title change', () => {
+    expect(isDecorativeAgentTitleFrameChange('◐ Say hi', '◑ Say hi')).toBe(true)
+  })
+
+  it('does not claim Gemini’s ◇ idle glyph, which neighbors the spinner block', () => {
+    expect(detectAgentStatusFromTitle('◇ Gemini CLI')).toBe('idle')
+    expect(getAgentLabel('◇ Gemini CLI')).toBe('Gemini CLI')
+  })
+})

--- a/src/shared/terminal-output-side-effects.ts
+++ b/src/shared/terminal-output-side-effects.ts
@@ -28,16 +28,16 @@ import { createOsc133CommandFinishedScanner } from './terminal-osc133-command-fi
 /** Ms of title-less output after a working title before it is cleared. */
 export const STALE_WORKING_TITLE_TIMEOUT_MS = 3000
 
-// Braille spinner glyphs (U+2800–U+28FF); mirrors the range clearWorkingIndicators strips in agent-detection.ts.
-// eslint-disable-next-line no-control-regex -- intentional unicode range
-const BRAILLE_SPINNER_RE = /[\u2800-\u28FF]/g
+// Braille and quarter-circle spinner glyphs; mirrors the ranges clearWorkingIndicators strips in agent-detection.ts.
+// eslint-disable-next-line no-control-regex -- intentional unicode ranges
+const SPINNER_FRAME_GLYPH_RE = /[\u2800-\u28FF\u25D0-\u25D3]/g
 
 /**
- * Strip decorative braille spinner frame glyphs so titles differing only by the animation frame
+ * Strip decorative spinner frame glyphs so titles differing only by the animation frame
  * compare equal — the gate consumers use to avoid fan-out churn on spinner ticks.
  */
-export function stripBrailleSpinnerGlyphs(title: string): string {
-  return title.replace(BRAILLE_SPINNER_RE, '').trim()
+export function stripSpinnerFrameGlyphs(title: string): string {
+  return title.replace(SPINNER_FRAME_GLYPH_RE, '').trim()
 }
 
 /** Provenance for title/idle facts; `staleWorkingTitleClear` marks facts synthesized by the 3s stale timer — not genuine task completions. */

--- a/src/shared/terminal-output-side-effects.ts
+++ b/src/shared/terminal-output-side-effects.ts
@@ -28,16 +28,16 @@ import { createOsc133CommandFinishedScanner } from './terminal-osc133-command-fi
 /** Ms of title-less output after a working title before it is cleared. */
 export const STALE_WORKING_TITLE_TIMEOUT_MS = 3000
 
-// Braille and quarter-circle spinner glyphs; mirrors the ranges clearWorkingIndicators strips in agent-detection.ts.
-// eslint-disable-next-line no-control-regex -- intentional unicode ranges
-const SPINNER_FRAME_GLYPH_RE = /[\u2800-\u28FF\u25D0-\u25D3]/g
+// Braille spinner glyphs (U+2800–U+28FF); mirrors the range clearWorkingIndicators strips in agent-detection.ts.
+// eslint-disable-next-line no-control-regex -- intentional unicode range
+const BRAILLE_SPINNER_RE = /[\u2800-\u28FF]/g
 
 /**
- * Strip decorative spinner frame glyphs so titles differing only by the animation frame
+ * Strip decorative braille spinner frame glyphs so titles differing only by the animation frame
  * compare equal — the gate consumers use to avoid fan-out churn on spinner ticks.
  */
-export function stripSpinnerFrameGlyphs(title: string): string {
-  return title.replace(SPINNER_FRAME_GLYPH_RE, '').trim()
+export function stripBrailleSpinnerGlyphs(title: string): string {
+  return title.replace(BRAILLE_SPINNER_RE, '').trim()
 }
 
 /** Provenance for title/idle facts; `staleWorkingTitleClear` marks facts synthesized by the 3s stale timer — not genuine task completions. */

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -4,7 +4,7 @@ import {
   HERMES_AGENT_NAME_RE,
   titleHasAgentName
 } from './agent-name-token-match'
-import { isCursorAgentTitle } from './agent-title-core'
+import { containsAgentSpinnerGlyph, isCursorAgentTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
@@ -96,7 +96,7 @@ export function isClaudeAgent(title: string): boolean {
   if (title.startsWith('. ') || title.startsWith('* ')) {
     return true
   }
-  if (containsBrailleSpinner(title)) {
+  if (containsAgentSpinnerGlyph(title)) {
     // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
     // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
     return !isCursorAgentTitle(title) && !lower.includes('openclaude')
@@ -231,7 +231,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
 
 function hasGenericClaudeStatusPrefix(title: string): boolean {
   return (
-    containsBrailleSpinner(title) ||
+    containsAgentSpinnerGlyph(title) ||
     title.startsWith('✳ ') ||
     title === '✳' ||
     title.startsWith('. ') ||


### PR DESCRIPTION
## ELI5

Claude Code shows a little spinner in the terminal's title while it's thinking. In 2.1.228 it changed that spinner from braille dots (`⠂`) to quarter circles (`◐`). Orca only knew about the braille dots, so the moment Claude started working, Orca thought "there's no agent here anymore — it must have quit" and dumped you out of the Chat UI back to the raw terminal. This teaches Orca the new spinner shapes.

## What Changed

`detectAgentStatusFromTitle` and the Claude identity checks now accept quarter-circle spinner glyphs (U+25D0–U+25D3) alongside braille, via a new shared `containsAgentSpinnerGlyph` helper in `agent-title-core.ts`.

Applied at every site that treats "title has a spinner" as *generic* agent activity — 7 in total, not the 3 the issue suggested:

| File | Why it mattered |
|---|---|
| `agent-title-status.ts` | `detectAgentStatusFromTitle` → `working`; `clearWorkingIndicators` strips the new glyph |
| `agent-title-identity.ts` | `isClaudeAgent` — busy pane keeps its "Claude Code" identity |
| `terminal-title-agent-type.ts` | **second, independent copy** of `isClaudeAgent` + `hasGenericClaudeStatusPrefix` (6 importers) |
| `agent-decorative-title-signature.ts` | otherwise every `◐`→`◑` tick reads as a real title change and churns tab/sort state |
| `agent-title-decoration.ts` | strips the leading glyph so the tab label isn't a redundant second icon |
| `worktree-status.ts` | worktree status dot attribution while working |

Agent-specific braille frame shapes (Grok rotating frames, Pi, synthetic Cursor titles) are deliberately left braille-only — those are other agents' or Orca's own formats.

## Why

Claude Code 2.1.228 (2026-08-11) changed its busy title spinner. I captured OSC titles from both real binaries running the same one-line prompt:

| Version | idle | busy |
|---|---|---|
| 2.1.227 | `✳ Claude Code` | `⠂` / `⠐ Claude Code` (U+2802 / U+2810) |
| 2.1.228 | `✳ Claude Code` | `◐` / `◑ Claude Code` (U+25D0 / U+25D1) |

**Note: the issue's stated mechanism is slightly off, and it matters for the fix.** #13889 says `◐ Claude Code` returns `null`. It doesn't — that title still contains `claude` as a whole token, so it falls through to the name-based tail and returns `'idle'` (wrong status, but no exit). The exit actually fires on the *summary-bearing* frame, which has no agent-name token:

```
✳ Claude Code  →  ◐ Claude Code  →  ◑ Say hi in one word
   idle              (was 'idle')       null  → "idle → no-status = exited"
```

→ `confirmPtyAgentExit` → `resolveNativeChatLeafRoute` returns `exitChat` → `setTabViewMode(tabId, 'terminal')`.

Claude switches to the task-summary title *within the first turn*, which is why the symptom hits every message including the first, exactly as reported. The one-line test the issue suggests (`detectAgentStatusFromTitle('◐ Claude Code')`) would have passed against `'idle'` and missed the actual exit path.

I also placed the identity check inside `isClaudeAgent` rather than the top-level prefix block the issue suggested — that block runs *before* the Codex/Grok/Cursor name checks, so `◐ Grok` would have been mislabeled "Claude Code".

This will hit every Orca + Claude Code user as the 2.1.228 autoupdate rolls out.

## Linked Issue

Fixes #13889

## Visual Proof

**No before/after recording — flagging honestly rather than writing N/A, since there is a real interaction change.** Capturing it requires installing 2.1.228 as the machine's global `claude`, which I didn't want to do unprompted. Happy to record one if a reviewer wants it before merge.

The behavior change is pinned deterministically instead. Replaying the *captured* 2.1.228 title sequence through `createAgentStatusTracker`:

```
titles: ✳ Claude Code → ◐ Claude Code → ◑ Claude Code
      → ◑ Say hi in one word → ◐ Say hi in one word → ✳ Say hi in one word

before:  ['exited']              ← chat surface routes exitChat, tab flips to terminal
after:   ['working', 'idle']     ← identical to the 2.1.227 braille sequence
```

Per-title, before → after:

| title | status | label | isClaude |
|---|---|---|---|
| `◐ Claude Code` | `idle` → **`working`** | `null` → **`Claude Code`** | `false` → **`true`** |
| `◐ Say hi in one word` | `null` → **`working`** | `null` → **`Claude Code`** | `false` → **`true`** |
| `⠂ Say hi in one word` (2.1.227) | `working` (unchanged) | `Claude Code` (unchanged) | `true` (unchanged) |

## How to test

Repro without installing anything globally — download the binary to a temp dir and PTY-capture its titles:

```bash
cd $(mktemp -d)
npm pack @anthropic-ai/claude-code-darwin-arm64@2.1.228   # or your platform
tar xzf *.tgz
# spawn package/claude under node-pty, scrape /\x1b\]([012]);([^\x07\x1b]*)(?:\x07|\x1b\\)/g
```

Note that grepping the binary for a spinner array does **not** work — the npm package is a 24KB thin installer and the real 290MB binary has a compressed JS payload. A null grep result is meaningless (2.1.227 shows no braille array either), and random machine-code bytes decode as `◐`, giving convincing false hits. PTY capture is the only reliable oracle.

In-app: install Claude Code 2.1.228, enable the experimental Chat UI, open a Claude session in chat view, send any message. Before this change the tab flips to terminal view as Claude starts working; after, it stays in chat.

Automated:
```bash
npx vitest run --config config/vitest.config.ts src/shared/repro-13889-claude-quarter-circle-busy-title.test.ts
```

Platforms: logic is pure string/codepoint matching over OSC titles with no platform branches, so it behaves identically on macOS/Linux/Windows and over SSH. Verified on macOS.

- [ ] I manually tested these changes locally — **not checked:** no live in-app run; see Visual Proof
- [x] Automated tests added/updated, or explained why not below

`src/shared/repro-13889-claude-quarter-circle-busy-title.test.ts` replays the captured turn and asserts parity with 2.1.227 frame-for-frame. **Verified non-vacuous:** with the source fix stashed, 8 of 9 assertions fail, including `expected [ 'exited' ] to not include 'exited'`. (The 9th is a boundary guard that Gemini's `◇` U+25C7 idle glyph — which neighbors the spinner block — is not swallowed; it correctly passes both ways.)

## AI Disclosure

Internal contribution. Investigated and implemented with Claude Opus 5.

## Review

- **Security:** none — no new input surface; matching is over OSC titles Orca already parses, against two fixed codepoint ranges.
- **Cross-platform:** no platform branches; pure codepoint matching. The glyph change ships in Claude Code itself, so Linux/Windows are affected identically and fixed identically.
- **Remote SSH:** OSC titles arrive over the same PTY path regardless of transport; no wire format, RPC param, or stream opcode changed.
- **Mobile / remote wire compatibility:** no wire change. Mobile has no copy of this logic — it consumes shared detection through the daemon. Old clients paired to a new host see the same title strings they see today; the host publishes no new content.
- **Backwards compatibility:** purely additive — braille and `✳` / `. ` / `* ` handling is untouched, so 2.1.227 and earlier behave exactly as before (asserted frame-for-frame in the tests).
- **Performance:** the added scan is a bounded codepoint check that only runs when the braille scan already missed.
- **Forward-looking:** reserves the full U+25D0–U+25D3 quarter-circle block, so adding `◒`/`◓` frames later won't regress this. The deeper fragility the issue calls out — *any* unrecognized glyph after an idle title reads as an exit — is not addressed here and is worth a separate issue.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — **see Visual Proof; deliberately not claimed**
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck` pass locally; targeted `vitest` suites pass — see below

Ran locally: `pnpm lint` (clean), `pnpm typecheck:tsc` (clean), `oxfmt --check` (clean), and vitest over `src/shared`, `src/renderer`, `src/main`, `src/renderer/src/store` — 8310 passed in the changed surface, no regressions. `pnpm build` not run locally; leaving that to CI.

**Local-only red, not caused by this PR:** `src/main/ipc/pty.test.ts` fails 10 tests locally (MiMo/Pi/OMP overlay env). It fails identically on a clean tree at `origin/main` (444638d) with this change stashed, so it is not from this branch. Most likely a local-environment artifact — my node is v26.5.0 while the repo pins node 24 — rather than a real break on main; CI's node 24 / node 26 shards are the authority. Nothing in this change touches PTY spawn env.