### PR TITLE
Fix reveal active workspace needing multiple clicks

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -111,6 +111,11 @@ import {
   WORKTREE_SIDEBAR_REVEAL_TOP_INSET
 } from './worktree-sidebar-reveal'
 import {
+  createPendingRevealScroll,
+  isRevealScrollSettling,
+  type PendingRevealScroll
+} from './worktree-sidebar-reveal-scroll-settle'
+import {
   getWorkspaceStatus,
   getWorkspaceStatusFromGroupKey,
   getWorkspaceStatusGroupKey,
@@ -493,7 +498,8 @@ function revealMountedWorktreeElement(
   container: HTMLElement,
   worktreeId: string,
   behavior: ScrollBehavior,
-  optionId?: string
+  optionId?: string,
+  onScrollIssued?: (targetTop: number) => void
 ): HTMLElement | null {
   const element = optionId
     ? document.getElementById(optionId)
@@ -501,19 +507,24 @@ function revealMountedWorktreeElement(
   if (!element || !container.contains(element)) {
     return null
   }
-  return revealElementInScrollContainer(container, element, behavior) ? element : null
+  return revealElementInScrollContainer(container, element, behavior, onScrollIssued)
+    ? element
+    : null
 }
 
 function revealMountedSidebarRowElement(
   container: HTMLElement,
   rowKey: string,
-  behavior: ScrollBehavior
+  behavior: ScrollBehavior,
+  onScrollIssued?: (targetTop: number) => void
 ): HTMLElement | null {
   const element = document.getElementById(getWorktreeOptionId(rowKey))
   if (!element || !container.contains(element)) {
     return null
   }
-  return revealElementInScrollContainer(container, element, behavior) ? element : null
+  return revealElementInScrollContainer(container, element, behavior, onScrollIssued)
+    ? element
+    : null
 }
 
 function getRenderRowSidebarKey(row: RenderRow): string | null {
@@ -1410,6 +1421,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const pendingRevealRetryRef = useRef<{ worktreeId: string; count: number } | null>(null)
   const pendingRowRevealRetryRef = useRef<{ rowKey: string; count: number } | null>(null)
   const pendingRevealFrameIdsRef = useRef<Set<number>>(new Set())
+  const pendingRevealScrollRef = useRef<PendingRevealScroll | null>(null)
   const revealHighlightFrameIdRef = useRef<number | null>(null)
   const revealHighlightTimeoutRef = useRef<number | null>(null)
   const cancelPendingRevealFrames = useCallback(() => {
@@ -2050,10 +2062,26 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     () => window.performance.now() < directScrollInputUntilRef.current,
     []
   )
+  const markRevealScroll = useCallback((targetTop: number) => {
+    pendingRevealScrollRef.current = createPendingRevealScroll(targetTop, window.performance.now())
+  }, [])
+  const isRevealScrollSettlingNow = useCallback(() => {
+    const settling = isRevealScrollSettling({
+      now: window.performance.now(),
+      pending: pendingRevealScrollRef.current,
+      scrollTop: scrollRef.current?.scrollTop ?? 0
+    })
+    if (!settling) {
+      pendingRevealScrollRef.current = null
+    }
+    return settling
+  }, [])
   // Why: programmatic scrolls keep measurement correction quiet, but only direct input blocks anchor-restore retries.
+  // A reveal's smooth scroll is the exception: restoring the anchor mid-animation cancels it a few pixels in.
   const shouldSkipScrollAnchorRestore = useCallback(
-    () => window.performance.now() < directScrollInputUntilRef.current,
-    []
+    () =>
+      window.performance.now() < directScrollInputUntilRef.current || isRevealScrollSettlingNow(),
+    [isRevealScrollSettlingNow]
   )
 
   const virtualizer = useVirtualizer({
@@ -2219,7 +2247,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               container,
               pendingRevealWorktree.worktreeId,
               pendingRevealWorktree.behavior,
-              getRenderRowOptionId(targetRow, pendingRevealWorktree.worktreeId)
+              getRenderRowOptionId(targetRow, pendingRevealWorktree.worktreeId),
+              markRevealScroll
             )
           : null
         if (revealedOption) {
@@ -2291,6 +2320,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     projectGroups,
     pendingRevealRetryTick,
     flashRevealedRow,
+    markRevealScroll,
     setRenamingWorktreeId,
     schedulePendingRevealFrame,
     cancelPendingRevealFrames
@@ -2379,7 +2409,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         ? revealMountedSidebarRowElement(
             container,
             pendingRevealSidebarRow.rowKey,
-            pendingRevealSidebarRow.behavior
+            pendingRevealSidebarRow.behavior,
+            markRevealScroll
           )
         : null
       if (revealedElement) {
@@ -2414,6 +2445,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     virtualizer,
     pendingRevealRetryTick,
     flashRevealedRow,
+    markRevealScroll,
     clearPendingRevealSidebarRow,
     schedulePendingRevealFrame,
     cancelPendingRevealFrames

--- a/src/renderer/src/components/sidebar/worktree-sidebar-reveal-scroll-settle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-reveal-scroll-settle.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createPendingRevealScroll,
+  isRevealScrollSettling,
+  REVEAL_SCROLL_SETTLE_TIMEOUT_MS
+} from './worktree-sidebar-reveal-scroll-settle'
+
+describe('isRevealScrollSettling', () => {
+  it('is not settling without a reveal scroll in flight', () => {
+    expect(isRevealScrollSettling({ now: 0, pending: null, scrollTop: 120 })).toBe(false)
+  })
+
+  it('stays settling while a smooth reveal scroll is still animating', () => {
+    // Regression: the anchor restore wrote scrollTop two frames into the animation and
+    // cancelled it after a couple of pixels, so revealing took several button clicks.
+    const pending = createPendingRevealScroll(387, 0)
+    expect(isRevealScrollSettling({ now: 16, pending, scrollTop: 2 })).toBe(true)
+    expect(isRevealScrollSettling({ now: 200, pending, scrollTop: 260 })).toBe(true)
+  })
+
+  it('stops settling once the scroll reaches its target', () => {
+    const pending = createPendingRevealScroll(387, 0)
+    expect(isRevealScrollSettling({ now: 300, pending, scrollTop: 387 })).toBe(false)
+    // Sub-pixel landings still count as arrived.
+    expect(isRevealScrollSettling({ now: 300, pending, scrollTop: 386.5 })).toBe(false)
+  })
+
+  it('stops settling after the timeout so an unreachable target cannot pin the guard open', () => {
+    const pending = createPendingRevealScroll(387, 0)
+    expect(
+      isRevealScrollSettling({ now: REVEAL_SCROLL_SETTLE_TIMEOUT_MS, pending, scrollTop: 40 })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-sidebar-reveal-scroll-settle.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-reveal-scroll-settle.ts
@@ -1,0 +1,36 @@
+/**
+ * Tracks a smooth reveal scroll the sidebar issued itself.
+ *
+ * A smooth scroll animates across many frames, and any other scrollTop write
+ * during that window silently cancels it. The sidebar's scroll-anchor restore
+ * writes exactly that, so without this the reveal stops a couple of pixels in
+ * and the user has to click the reveal button repeatedly.
+ */
+export type PendingRevealScroll = {
+  targetTop: number
+  expiresAt: number
+}
+
+/** Ceiling for a browser smooth-scroll animation; also the escape hatch when the target turns out to be unreachable. */
+export const REVEAL_SCROLL_SETTLE_TIMEOUT_MS = 1000
+
+const SETTLED_TOLERANCE_PX = 1
+
+export function createPendingRevealScroll(targetTop: number, now: number): PendingRevealScroll {
+  return { targetTop, expiresAt: now + REVEAL_SCROLL_SETTLE_TIMEOUT_MS }
+}
+
+export function isRevealScrollSettling({
+  now,
+  pending,
+  scrollTop
+}: {
+  now: number
+  pending: PendingRevealScroll | null
+  scrollTop: number
+}): boolean {
+  if (!pending || now >= pending.expiresAt) {
+    return false
+  }
+  return Math.abs(scrollTop - pending.targetTop) > SETTLED_TOLERANCE_PX
+}

--- a/src/renderer/src/components/sidebar/worktree-sidebar-reveal.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-reveal.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
+
+function makeContainer(scrollTop: number, clientHeight: number) {
+  const scrollTo = vi.fn()
+  const container = {
+    clientHeight,
+    scrollTop,
+    contains: () => true,
+    getBoundingClientRect: () => ({ top: 0, bottom: clientHeight }) as DOMRect,
+    scrollTo
+  }
+  return { container: container as unknown as HTMLElement, scrollTo }
+}
+
+function makeElement(top: number, bottom: number): Element {
+  return {
+    getBoundingClientRect: () => ({ top, bottom }) as DOMRect
+  } as unknown as Element
+}
+
+describe('revealElementInScrollContainer', () => {
+  it('reports the scroll target it issues so callers can guard the animation', () => {
+    const { container, scrollTo } = makeContainer(0, 673)
+    const onScrollIssued = vi.fn()
+
+    // A card mounted below the fold: reveal scrolls until its bottom is in view.
+    const revealed = revealElementInScrollContainer(
+      container,
+      makeElement(1005, 1060),
+      'smooth',
+      onScrollIssued
+    )
+
+    expect(revealed).toBe(true)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 387, behavior: 'smooth' })
+    expect(onScrollIssued).toHaveBeenCalledWith(387)
+  })
+
+  it('does not report a scroll when the element is already in view', () => {
+    const { container, scrollTo } = makeContainer(0, 673)
+    const onScrollIssued = vi.fn()
+
+    const revealed = revealElementInScrollContainer(
+      container,
+      makeElement(200, 260),
+      'smooth',
+      onScrollIssued
+    )
+
+    expect(revealed).toBe(true)
+    expect(scrollTo).not.toHaveBeenCalled()
+    expect(onScrollIssued).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-sidebar-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-reveal.ts
@@ -38,7 +38,10 @@ export function getScrollTopToRevealBounds(
 export function revealElementInScrollContainer(
   container: HTMLElement,
   element: Element,
-  behavior: ScrollBehavior
+  behavior: ScrollBehavior,
+  // Why: any other scrollTop write cancels the scroll issued here mid-animation;
+  // callers use this to stand their scroll-position guards down until it lands.
+  onScrollIssued?: (targetTop: number) => void
 ): boolean {
   if (!container.contains(element)) {
     return false
@@ -59,6 +62,8 @@ export function revealElementInScrollContainer(
     window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
   const resolvedBehavior: ScrollBehavior =
     behavior === 'smooth' && prefersReducedMotion ? 'auto' : behavior
-  container.scrollTo({ top: Math.max(0, nextScrollTop), behavior: resolvedBehavior })
+  const targetTop = Math.max(0, nextScrollTop)
+  onScrollIssued?.(targetTop)
+  container.scrollTo({ top: targetTop, behavior: resolvedBehavior })
   return true
 }


### PR DESCRIPTION
## ELI5

The "Reveal active workspace" button (the crosshair at the bottom of the sidebar) starts a smooth scroll toward your active workspace. Another piece of sidebar code writes the scroll position a couple of frames later, and in a browser that instantly **cancels** an in-flight smooth scroll. So the list nudged a few pixels and stopped — you had to click the button 3-5 times to actually get there.

## What Changed

- `revealElementInScrollContainer` now reports the scroll target it issues (`onScrollIssued`).
- `WorktreeList` arms a short "reveal scroll in flight" guard from that callback, and `shouldSkipScrollAnchorRestore` honours it — so the virtualized scroll-anchor restore stands down until the reveal lands (or 1s passes, or the target is reached).
- New pure module `worktree-sidebar-reveal-scroll-settle.ts` holds the settle predicate, with unit tests.

This is the same idiom the jump-to-top button already uses (`onUserScrollIntent` → `markDirectScrollInput`): a programmatic sidebar scroll must announce itself so the scroll-position guards don't fight it. The reveal path never did.

## Why

Reproduced in a dev build against real data (312 workspaces), with the active workspace mounted just below the fold — the reported case (`nwparker/orca-lost-new-moon`).

Sidebar `scrollTop` after each click of the button, starting from the top of the list:

| | click 1 | click 2 | click 3 | click 4 | click 5 |
|---|---|---|---|---|---|
| before | 13 | 38 | 90 | 322 | 387 ✅ |
| after | **387 ✅** | 387 | 387 | 387 | 387 |

Instrumenting writes to the container's `scrollTop` during one click showed the exact collision:

```
scrollTo {top: 387, behavior: "smooth"}   at revealElementInScrollContainer  (from 0)
set 4                                     at restoreFromDomElement <- runVirtualizedScrollAnchorRestore  (from 2)
```

The restore fires two frames in, at `scrollTop: 2`, pins the anchored row back, and the animation dies at 13px. After the fix the same trace shows **zero** competing writes and the scroll completes.

The far-offscreen path (target outside the virtual window → `scrollToIndex` + retry frames) was never affected because it retries; only the "already mounted, just scroll to it" path clears the pending reveal immediately after issuing the scroll, so it had no second chance.

## Linked Issue

No issue filed — reported directly by @nwparker against the prod release.

## Visual Proof

After the fix, one click from the top of the sidebar reveals and highlights `nwparker/orca-lost-new-moon` (screenshot captured from the running Electron app via CDP). Before the fix the identical action moved the list 13px and the card stayed offscreen — see the scroll-position table above, which is the same evidence in a form that survives a screenshot diff.

## How to test

1. Open a workspace whose sidebar card sits a few hundred pixels below the fold (a long list makes this easy).
2. Scroll the left sidebar to the very top.
3. Click "Reveal active workspace" (crosshair, bottom-right of the sidebar) **once**.
4. The active card scrolls into view and flashes on the first click. Repeat clicks are a no-op instead of creeping down a few pixels at a time.

Also worth exercising: reveal a workspace that is far offscreen (thousands of px away) and reveal a sidebar row via cmd-palette/"reveal in sidebar" — both still land in one action.

Tested on macOS (Electron dev build, real profile with 312 workspaces). The change is renderer-only DOM scroll bookkeeping — no platform, path, shortcut, SSH, or remote-wire surface is touched, so behavior is identical on Linux/Windows and for remote/folder workspaces.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`worktree-sidebar-reveal-scroll-settle.test.ts` (settle predicate: in-flight, arrived, sub-pixel landing, timeout escape hatch) and `worktree-sidebar-reveal.test.ts` (the reveal reports the target it scrolls to, and reports nothing when the element is already in view). The frame-level race itself can't be unit-tested — jsdom has no smooth scrolling — so the browser-level proof is the trace above.

`pnpm vitest` over `components/sidebar` + `hooks`: 303 files / 2771 tests pass. `tsc -p config/tsconfig.tc.web.json` and `oxlint` clean.

## AI Disclosure

N/A (internal).

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Security: none — no IPC, no data flow.
- Cross-platform: renderer-only scroll math, no platform branches.
- Remote SSH / folder workspaces: the reveal path is workspace-kind agnostic; unchanged.
- Performance: one ref write per reveal scroll and a comparison inside an existing guard callback.
- Backwards compatibility: `onScrollIssued` is optional; the third caller (`WorktreeCardAgents`, instant scroll) is untouched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after evidence attached for the behavior change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Lint, typecheck, and the affected test suites pass locally

Made with [Orca](https://github.com/stablyai/orca) 🐋
