### PR TITLE
fix(ai-vault): attribute Cursor legacy transcripts to their project cwd

### DIFF
--- a/src/main/ai-vault/session-scanner-cursor-parser.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { parseCursorSessionFile } from './session-scanner-cursor-parser'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+describe('parseCursorSessionFile cwd attribution', () => {
+  it('sets cwd from the Cursor project slug when JSONL has no cwd field', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-cursor-parse-'))
+    tempDirs.push(root)
+    const projectDir = join(root, 'projects', 'Users-ada-code-orca')
+    const transcripts = join(projectDir, 'agent-transcripts')
+    mkdirSync(transcripts, { recursive: true })
+    const filePath = join(transcripts, 'cursor-session.jsonl')
+    writeFileSync(
+      filePath,
+      [
+        JSON.stringify({
+          role: 'user',
+          message: { content: [{ type: 'text', text: 'Hello' }] },
+          timestamp: '2026-08-12T00:00:00.000Z'
+        }),
+        JSON.stringify({
+          role: 'assistant',
+          message: { content: [{ type: 'text', text: 'Hi' }] },
+          timestamp: '2026-08-12T00:00:01.000Z'
+        })
+      ].join('\n')
+    )
+
+    const session = await parseCursorSessionFile({ path: filePath, mtimeMs: 1, modifiedAt: '' })
+    expect(session?.cwd).toBe('/Users/ada/code/orca')
+    expect(session?.sessionId).toBe('cursor-session')
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-parser.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.ts
@@ -15,6 +15,7 @@ import {
   sessionIdFromFileName,
   updateTimeline
 } from './session-scanner-accumulator'
+import { resolveCursorTranscriptCwd } from './session-scanner-cursor-project-cwd'
 import {
   asRecord,
   extractContentText,
@@ -76,10 +77,16 @@ function consumeCursorRecordLine(accumulator: SessionAccumulator, line: string):
 }
 
 export function createCursorSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
-  return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'cursor', file, sessionId: sessionIdFromFileName(file.path) }),
-    consumeCursorRecordLine
-  )
+  const accumulator = createAccumulator({
+    agent: 'cursor',
+    file,
+    sessionId: sessionIdFromFileName(file.path)
+  })
+  // Why: Cursor JSONL has no cwd field; legacy paths encode the workspace only
+  // as ~/.cursor/projects/<slug>/…, so without this sessions group under
+  // "Unknown location" and drop out of Workspace scope (#13931).
+  accumulator.cwd = resolveCursorTranscriptCwd(file.path)
+  return accumulatorFoldResumeState(accumulator, consumeCursorRecordLine)
 }
 
 async function parseCursorSessionLines(args: {

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  cursorProjectDirFromTranscriptPath,
+  decodeCursorProjectSlug,
+  resolveCursorTranscriptCwd
+} from './session-scanner-cursor-project-cwd'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-cursor-cwd-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe('cursorProjectDirFromTranscriptPath', () => {
+  it('returns the projects/<slug> dir for nested session transcripts', () => {
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        '/home/u/.cursor/projects/Users-u-repo/agent-transcripts/sid/sid.jsonl'
+      )
+    ).toBe('/home/u/.cursor/projects/Users-u-repo')
+  })
+
+  it('returns the projects/<slug> dir for flat agent-transcripts files', () => {
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe('C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc')
+  })
+
+  it('returns null when agent-transcripts is missing', () => {
+    expect(cursorProjectDirFromTranscriptPath('/home/u/.cursor/projects/slug/sid.jsonl')).toBeNull()
+  })
+})
+
+describe('decodeCursorProjectSlug', () => {
+  it('reconstructs Windows drive paths used by Cursor on Windows', () => {
+    expect(decodeCursorProjectSlug('c-Dev-simulations-opc')).toBe('C:\\Dev\\simulations\\opc')
+  })
+
+  it('reconstructs POSIX paths with the leading slash restored', () => {
+    expect(decodeCursorProjectSlug('Users-ada-code-orca')).toBe('/Users/ada/code/orca')
+  })
+
+  it('rejects empty or relative junk slugs', () => {
+    expect(decodeCursorProjectSlug('')).toBeNull()
+    expect(decodeCursorProjectSlug('..')).toBeNull()
+  })
+})
+
+describe('resolveCursorTranscriptCwd', () => {
+  it('prefers .workspace-trusted workspacePath over slug decode', () => {
+    const root = tempDir()
+    const projectDir = join(root, 'projects', 'c-Dev-simulations-opc')
+    const transcripts = join(projectDir, 'agent-transcripts', 'sid')
+    mkdirSync(transcripts, { recursive: true })
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({
+        trustedAt: '2026-08-12T00:00:00.000Z',
+        workspacePath: 'C:\\Dev\\simulations\\opc'
+      })
+    )
+    const filePath = join(transcripts, 'sid.jsonl')
+    writeFileSync(filePath, '')
+    expect(resolveCursorTranscriptCwd(filePath)).toBe('C:\\Dev\\simulations\\opc')
+  })
+
+  it('falls back to slug decode when the trust marker is absent', () => {
+    const root = tempDir()
+    const projectDir = join(root, 'projects', 'Users-ada-code-orca')
+    const transcripts = join(projectDir, 'agent-transcripts')
+    mkdirSync(transcripts, { recursive: true })
+    const filePath = join(transcripts, 'session.jsonl')
+    writeFileSync(filePath, '')
+    expect(resolveCursorTranscriptCwd(filePath)).toBe('/Users/ada/code/orca')
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { extractString, parseJsonObject } from './session-scanner-values'
+
+/**
+ * Cursor legacy transcripts live under:
+ *   ~/.cursor/projects/<slug>/agent-transcripts/...
+ * JSONL rows do not carry cwd. Resolve the workspace from the project bucket:
+ * prefer `.workspace-trusted` (Cursor + Orca trust marker), else decode the slug.
+ */
+export function resolveCursorTranscriptCwd(filePath: string): string | null {
+  const projectDir = cursorProjectDirFromTranscriptPath(filePath)
+  if (!projectDir) {
+    return null
+  }
+  const slug = pathLeaf(projectDir)
+  return readCursorWorkspaceTrustedPath(projectDir) ?? decodeCursorProjectSlug(slug)
+}
+
+/** Walk parents with both `/` and `\` so Windows transcript paths parse on any host. */
+export function cursorProjectDirFromTranscriptPath(filePath: string): string | null {
+  const segments = splitPathSegments(filePath)
+  const marker = segments.lastIndexOf('agent-transcripts')
+  if (marker < 1) {
+    return null
+  }
+  return joinPathSegments(segments.slice(0, marker), filePath)
+}
+
+function splitPathSegments(filePath: string): string[] {
+  return filePath.split(/[\\/]+/).filter(Boolean)
+}
+
+function pathLeaf(filePath: string): string {
+  const segments = splitPathSegments(filePath)
+  return segments[segments.length - 1] ?? ''
+}
+
+function joinPathSegments(segments: string[], originalPath: string): string {
+  if (segments.length === 0) {
+    return originalPath.startsWith('/') ? '/' : ''
+  }
+  const useBackslash = originalPath.includes('\\') && !originalPath.includes('/')
+  const joined = segments.join(useBackslash ? '\\' : '/')
+  // Preserve absolute POSIX prefix; Windows drive is already the first segment.
+  if (originalPath.startsWith('/') && !/^[A-Za-z]:/.test(segments[0] ?? '')) {
+    return `/${joined}`
+  }
+  return joined
+}
+
+export function readCursorWorkspaceTrustedPath(projectDir: string): string | null {
+  const trustFile = join(projectDir, '.workspace-trusted')
+  if (!existsSync(trustFile)) {
+    return null
+  }
+  try {
+    const record = parseJsonObject(readFileSync(trustFile, 'utf-8'))
+    const workspacePath = extractString(record?.workspacePath)?.trim()
+    return workspacePath || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Inverse of Cursor/Orca project slugging (`/` `\` `:` and other reserved
+ * path chars → `-`). Lossy when a path segment itself contains `-`; prefer
+ * `.workspace-trusted` when present.
+ */
+export function decodeCursorProjectSlug(slug: string): string | null {
+  const trimmed = slug.trim()
+  if (!trimmed || trimmed === '.' || trimmed === '..') {
+    return null
+  }
+  const windowsDrive = trimmed.match(/^([A-Za-z])-(.+)$/)
+  if (windowsDrive) {
+    const drive = windowsDrive[1].toUpperCase()
+    const rest = windowsDrive[2].replace(/-/g, '\\')
+    return `${drive}:\\${rest}`
+  }
+  // POSIX absolute path with leading `/` stripped by Cursor's slugger.
+  return `/${trimmed.replace(/-/g, '/')}`
+}


### PR DESCRIPTION
## Summary
- Cursor `agent-transcripts` JSONL has no `cwd`; sessions scanned as `cwd: null` → **Unknown location** and missing from Workspace scope (#13931)
- Resolve workspace from the project bucket: prefer `.workspace-trusted` `workspacePath`, else decode the Cursor project slug (e.g. `c-Dev-simulations-opc` → `C:\Dev\simulations\opc`)
- Unit coverage for path walk, slug decode, trust-file preference, and parser attribution

## Test plan
- [x] `vitest` `session-scanner-cursor-project-cwd.test.ts` + `session-scanner-cursor-parser.test.ts`
- [ ] Open a Windows workspace whose Cursor slug is under `~/.cursor/projects/<slug>/agent-transcripts`
- [ ] Agent Session History → **All**: Cursor rows group under the project folder, not Unknown location
- [ ] **Workspace** scope: Cursor sessions for the active worktree appear
- [ ] When `.workspace-trusted` exists, its `workspacePath` wins over slug decode

Closes #13931