### PR TITLE
Fix GitLab task resolution for sole nonstandard remotes

### DIFF
--- a/src/main/gitlab/gitlab-exec-options.ts
+++ b/src/main/gitlab/gitlab-exec-options.ts
@@ -1,0 +1,22 @@
+import type { LocalGitExecOptions } from './gitlab-known-host-probe'
+import type { ProjectRef } from './project-ref-parser'
+
+export function glabRepoExecOptions(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): { cwd?: string; wslDistro?: string } {
+  return connectionId
+    ? {}
+    : {
+        cwd: repoPath,
+        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+      }
+}
+
+export function glabHostnameArgs(
+  projectRef: Pick<ProjectRef, 'host'> | null | undefined,
+  connectionId?: string | null
+): string[] {
+  return connectionId && projectRef?.host ? ['--hostname', projectRef.host] : []
+}

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -2,16 +2,17 @@ import { runCoalescedProbe, type CoalescedProbes } from '../git/coalesced-probe'
 import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 import { glabExecFileAsync } from '../git/runner'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
-import { DEFAULT_GITLAB_HOSTS, normalizeGitLabHost } from './project-ref-parser'
+import { DEFAULT_GITLAB_HOSTS, normalizeGitLabHost, type ProjectRef } from './project-ref-parser'
 
 export type LocalGitExecOptions = {
   wslDistro?: string
 }
 
-const GLAB_KNOWN_HOSTS_TIMEOUT_MS = 10_000
+export const GLAB_KNOWN_HOSTS_TIMEOUT_MS = 10_000
 const UNAUTHENTICATED_HOSTS_MAX_ENTRIES = 128
 const knownHostsCacheByExecutionContext = new Map<string, readonly string[]>()
 const knownHostsInFlightByExecutionContext: CoalescedProbes<readonly string[]> = new Map()
+const hostAuthInFlight: CoalescedProbes<boolean> = new Map()
 const unauthenticatedHostExpiries = new Map<string, number>()
 
 function knownHostsExecutionKey(
@@ -29,11 +30,13 @@ function knownHostsExecutionKey(
 export function _resetKnownHostsCache(): void {
   knownHostsCacheByExecutionContext.clear()
   knownHostsInFlightByExecutionContext.clear()
+  hostAuthInFlight.clear()
   unauthenticatedHostExpiries.clear()
 }
 
 /** @internal - exposed for tests only */
 export function _resetGlabUnauthenticatedHosts(): void {
+  hostAuthInFlight.clear()
   unauthenticatedHostExpiries.clear()
 }
 
@@ -120,6 +123,70 @@ export function rememberGlabKnownHosts(
     return
   }
   knownHostsCacheByExecutionContext.set(key, [...cached, ...additions])
+}
+
+export class GlabHostProbeUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('GitLab host authentication probe is unavailable', { cause })
+    this.name = 'GlabHostProbeUnavailableError'
+  }
+}
+
+function isDefinitiveGlabUnauthenticatedError(output: string): boolean {
+  return /(?:not|has not been) (?:logged in|authenticated)|authentication required|glab auth login|http 401|invalid (?:token|credentials)|no (?:authentication )?token/i.test(
+    output
+  )
+}
+
+export async function isGlabConfiguredForRemoteHost(
+  projectRef: Pick<ProjectRef, 'host'>,
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): Promise<boolean> {
+  // Why: without the per-host memo, every non-GitLab repo respawns `glab` when
+  // its project-ref negative expires.
+  if (isGlabHostKnownUnauthenticated(projectRef.host, connectionId, localGitOptions)) {
+    return false
+  }
+  const key = unauthenticatedHostKey(projectRef.host, connectionId, localGitOptions)
+  return runCoalescedProbe(hostAuthInFlight, key, () =>
+    probeGlabConfiguredForRemoteHost(projectRef, connectionId, localGitOptions)
+  )
+}
+
+async function probeGlabConfiguredForRemoteHost(
+  projectRef: Pick<ProjectRef, 'host'>,
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): Promise<boolean> {
+  try {
+    const result = await glabExecFileAsync(['auth', 'status', '--hostname', projectRef.host], {
+      timeout: GLAB_KNOWN_HOSTS_TIMEOUT_MS,
+      ...(!connectionId && localGitOptions.wslDistro
+        ? { wslDistro: localGitOptions.wslDistro }
+        : {})
+    })
+    if (result === undefined) {
+      rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
+      return false
+    }
+    return true
+  } catch (error) {
+    const execLike = error as { stdout?: unknown; stderr?: unknown; message?: unknown }
+    const output =
+      [execLike.stdout, execLike.stderr, execLike.message]
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .join('\n') || String(error)
+    const hosts = parseGlabAuthStatusHosts(output).map(normalizeGitLabHost)
+    if (hosts.includes(normalizeGitLabHost(projectRef.host))) {
+      return true
+    }
+    if (!isDefinitiveGlabUnauthenticatedError(output)) {
+      throw new GlabHostProbeUnavailableError(error)
+    }
+    rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
+    return false
+  }
 }
 
 export async function getGlabKnownHosts(

--- a/src/main/gitlab/gitlab-nonstandard-remote-hosts.test.ts
+++ b/src/main/gitlab/gitlab-nonstandard-remote-hosts.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, glabExecFileAsyncMock, sshExecMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  glabExecFileAsyncMock: vi.fn(),
+  sshExecMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  glabExecFileAsync: glabExecFileAsyncMock
+}))
+
+import { _resetProjectRefCache, getIssueProjectRef } from './gitlab-project-ref-resolution'
+import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
+import { GLAB_KNOWN_HOSTS_TIMEOUT_MS } from './gitlab-known-host-probe'
+import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
+
+describe('GitLab nonstandard remote host contracts', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    glabExecFileAsyncMock.mockReset()
+    sshExecMock.mockReset()
+    unregisterSshGitProvider('conn-1')
+    _resetProjectRefCache()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    unregisterSshGitProvider('conn-1')
+  })
+
+  it('uses bounded SSH provider calls and does not repeat the added fallback probes', async () => {
+    sshExecMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'], 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+    expect(sshExecMock.mock.calls.map((call) => call.slice(0, 2))).toEqual([
+      [['remote', 'get-url', 'upstream'], '/repo'],
+      [['remote', 'get-url', 'origin'], '/repo'],
+      [['remote'], '/repo'],
+      [['remote', 'get-url', 'myremote'], '/repo']
+    ])
+
+    sshExecMock.mockClear()
+    await getIssueProjectRef('/repo', ['gitlab.com'], 'conn-1')
+    expect(sshExecMock.mock.calls.map((call) => call[0])).toEqual([
+      ['remote', 'get-url', 'upstream'],
+      ['remote', 'get-url', 'origin']
+    ])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('threads WSL execution through every fallback command and caches the result', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    const options = { wslDistro: 'Ubuntu' }
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'], null, options)).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
+    expect(
+      gitExecFileAsyncMock.mock.calls.every(
+        (call) =>
+          call[1]?.wslDistro === 'Ubuntu' && call[1]?.timeout === REMOTE_URL_PROBE_TIMEOUT_MS
+      )
+    ).toBe(true)
+
+    gitExecFileAsyncMock.mockClear()
+    await getIssueProjectRef('/repo', ['gitlab.com'], null, options)
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('does not re-probe a transient upstream through sole-remote fallback', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'upstream\n', stderr: '' }
+      }
+      if (args[2] === 'upstream') {
+        throw new Error('git timed out')
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+      ['remote', 'get-url', 'upstream'],
+      ['remote', 'get-url', 'origin']
+    ])
+  })
+
+  it('coalesces concurrent local resolution across the complete fallback', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      await Promise.resolve()
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+
+    await expect(
+      Promise.all(Array.from({ length: 8 }, () => getIssueProjectRef('/repo', ['gitlab.com'])))
+    ).resolves.toEqual(
+      Array.from({ length: 8 }, () => ({ host: 'gitlab.com', path: 'group/project' }))
+    )
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+      ['remote', 'get-url', 'upstream'],
+      ['remote', 'get-url', 'origin'],
+      ['remote'],
+      ['remote', 'get-url', 'myremote']
+    ])
+  })
+
+  it('coalesces concurrent WSL resolution across the complete fallback', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      await Promise.resolve()
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    const options = { wslDistro: 'Ubuntu' }
+
+    await expect(
+      Promise.all(
+        Array.from({ length: 8 }, () => getIssueProjectRef('/repo', ['gitlab.com'], null, options))
+      )
+    ).resolves.toEqual(
+      Array.from({ length: 8 }, () => ({ host: 'gitlab.com', path: 'group/project' }))
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
+    expect(gitExecFileAsyncMock.mock.calls.every((call) => call[1]?.wslDistro === 'Ubuntu')).toBe(
+      true
+    )
+  })
+
+  it('coalesces concurrent SSH resolution across the complete fallback', async () => {
+    sshExecMock.mockImplementation(async (args: string[]) => {
+      await Promise.resolve()
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(
+      Promise.all(
+        Array.from({ length: 8 }, () => getIssueProjectRef('/repo', ['gitlab.com'], 'conn-1'))
+      )
+    ).resolves.toEqual(
+      Array.from({ length: 8 }, () => ({ host: 'gitlab.com', path: 'group/project' }))
+    )
+    expect(sshExecMock.mock.calls.map((call) => call[0])).toEqual([
+      ['remote', 'get-url', 'upstream'],
+      ['remote', 'get-url', 'origin'],
+      ['remote'],
+      ['remote', 'get-url', 'myremote']
+    ])
+  })
+
+  it('coalesces a concurrent failed enumeration', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      await Promise.resolve()
+      if (args.length === 1) {
+        return { stdout: 'fork\nmirror\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+
+    await expect(
+      Promise.all(Array.from({ length: 8 }, () => getIssueProjectRef('/repo', ['gitlab.com'])))
+    ).resolves.toEqual(Array.from({ length: 8 }, () => null))
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+      ['remote', 'get-url', 'upstream'],
+      ['remote', 'get-url', 'origin'],
+      ['remote']
+    ])
+  })
+
+  it('recovers when the sole remote is replaced after the topology interval', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
+    let remoteName = 'oldremote'
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: `${remoteName}\n`, stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:group/project.git\n', stderr: '' }
+      }
+      if (args[2] === 'oldremote') {
+        return { stdout: 'git@example.com:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    remoteName = 'myremote'
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+  })
+
+  it('bounds glab host discovery for a sole nonstandard remote', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.internal:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'gitlab.internal'],
+      { timeout: GLAB_KNOWN_HOSTS_TIMEOUT_MS }
+    )
+  })
+
+  it('coalesces host discovery across concurrent repos', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      await Promise.resolve()
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.internal:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    glabExecFileAsyncMock.mockImplementation(async () => {
+      await Promise.resolve()
+      throw new Error('not authenticated')
+    })
+
+    await expect(
+      Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          getIssueProjectRef(`/repo-${index}`, ['gitlab.com'])
+        )
+      )
+    ).resolves.toEqual(Array.from({ length: 8 }, () => null))
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'gitlab.internal'],
+      { timeout: GLAB_KNOWN_HOSTS_TIMEOUT_MS }
+    )
+  })
+
+  it('memoizes a definitive unauthenticated host across repo paths', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.internal:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
+
+    await expect(getIssueProjectRef('/repo-a', ['gitlab.com'])).resolves.toBeNull()
+    await expect(getIssueProjectRef('/repo-b', ['gitlab.com'])).resolves.toBeNull()
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(8)
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'gitlab.internal'],
+      { timeout: GLAB_KNOWN_HOSTS_TIMEOUT_MS }
+    )
+  })
+
+  it.each([
+    'glab timed out',
+    'network is unreachable',
+    'could not resolve host: gitlab.internal',
+    'dial tcp 10.0.0.1:443: i/o timeout',
+    'context deadline exceeded',
+    'HTTP 503 Service Unavailable',
+    'HTTP 502 Bad Gateway',
+    'unexpected EOF',
+    'dial tcp: lookup gitlab.internal on 127.0.0.53:53: server misbehaving',
+    'Temporary failure in name resolution',
+    'connect: no route to host'
+  ])('retries host discovery after a transient failure: %s', async (message) => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.internal:group/project.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+    glabExecFileAsyncMock
+      .mockRejectedValueOnce(new Error(message))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toEqual({
+      host: 'gitlab.internal',
+      path: 'group/project'
+    })
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not guess among multiple nonstandard remotes', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'fork\nmirror\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    })
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    await expect(getIssueProjectRef('/repo', ['gitlab.com'])).resolves.toBeNull()
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+      ['remote', 'get-url', 'upstream'],
+      ['remote', 'get-url', 'origin'],
+      ['remote']
+    ])
+  })
+})

--- a/src/main/gitlab/gitlab-nonstandard-remote.contract.test.ts
+++ b/src/main/gitlab/gitlab-nonstandard-remote.contract.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GlUtils from './gl-utils'
+
+const { gitExecFileAsyncMock, glabExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  glabExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  glabExecFileAsync: glabExecFileAsyncMock
+}))
+
+vi.mock('./gl-utils', async () => {
+  const actual = await vi.importActual<typeof GlUtils>('./gl-utils')
+  return {
+    ...actual,
+    acquire: vi.fn(async () => undefined),
+    getGlabKnownHosts: vi.fn(async () => ['gitlab.com']),
+    release: vi.fn()
+  }
+})
+
+import { listIssues } from './issues'
+import { _resetProjectRefCache, resolveIssueSource } from './gitlab-project-ref-resolution'
+import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
+
+const GIT_OPTIONS = {
+  cwd: '/repo',
+  timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+}
+
+function remoteUrlCall(remoteName: string): [string[], typeof GIT_OPTIONS] {
+  return [['remote', 'get-url', remoteName], GIT_OPTIONS]
+}
+
+function mockSoleRemote(remoteName: string, remoteUrl: string): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote' && args.length === 1) {
+      return { stdout: `${remoteName}\n`, stderr: '' }
+    }
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      if (args[2] === remoteName) {
+        return { stdout: `${remoteUrl}\n`, stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2]}'`)
+    }
+    throw new Error(`unexpected git args: ${args.join(' ')}`)
+  })
+}
+
+describe('GitLab nonstandard remote contract (#13816)', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    glabExecFileAsyncMock.mockReset()
+    _resetProjectRefCache()
+  })
+
+  it('resolves and lists issues through a sole myremote without repeat Git fanout', async () => {
+    mockSoleRemote('myremote', 'git@gitlab.com:group/project.git')
+    glabExecFileAsyncMock.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          iid: 7,
+          title: 'Fixture issue',
+          state: 'opened',
+          web_url: 'https://gitlab.com/group/project/-/issues/7',
+          labels: []
+        }
+      ])
+    })
+
+    await expect(resolveIssueSource('/repo', 'auto', ['gitlab.com'])).resolves.toEqual({
+      source: { host: 'gitlab.com', path: 'group/project' },
+      fellBack: false
+    })
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      remoteUrlCall('upstream'),
+      remoteUrlCall('origin'),
+      [['remote'], GIT_OPTIONS],
+      remoteUrlCall('myremote')
+    ])
+
+    gitExecFileAsyncMock.mockClear()
+    await expect(listIssues('/repo', 20)).resolves.toMatchObject({
+      items: [{ number: 7, title: 'Fixture issue' }]
+    })
+    await expect(listIssues('/repo', 20)).resolves.toMatchObject({
+      items: [{ number: 7, title: 'Fixture issue' }]
+    })
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(glabExecFileAsyncMock.mock.calls).toEqual([
+      [
+        [
+          'api',
+          'projects/group%2Fproject/issues?per_page=20&order_by=updated_at&sort=desc&state=opened'
+        ],
+        { cwd: '/repo' }
+      ],
+      [
+        [
+          'api',
+          'projects/group%2Fproject/issues?per_page=20&order_by=updated_at&sort=desc&state=opened'
+        ],
+        { cwd: '/repo' }
+      ]
+    ])
+  })
+
+  it('keeps upstream then origin precedence without enumerating remotes', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[2] === 'upstream') {
+        return { stdout: 'git@gitlab.com:canonical/project.git\n', stderr: '' }
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    await expect(resolveIssueSource('/repo', 'auto', ['gitlab.com'])).resolves.toEqual({
+      source: { host: 'gitlab.com', path: 'canonical/project' },
+      fellBack: false
+    })
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([remoteUrlCall('upstream')])
+  })
+
+  it('does not reinterpret explicit origin as an arbitrary sole remote', async () => {
+    mockSoleRemote('myremote', 'git@gitlab.com:group/project.git')
+
+    await expect(resolveIssueSource('/repo', 'origin', ['gitlab.com'])).resolves.toEqual({
+      source: null,
+      fellBack: false
+    })
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([remoteUrlCall('origin')])
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/gitlab/gitlab-nonstandard-remote.real-git.test.ts
+++ b/src/main/gitlab/gitlab-nonstandard-remote.real-git.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { gitExecFileAsync } from '../git/runner'
+import { _resetProjectRefCache, getIssueProjectRef } from './gitlab-project-ref-resolution'
+
+const describeWithGit =
+  spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0 ? describe : describe.skip
+
+describeWithGit('GitLab nonstandard remote with the real Git binary', () => {
+  let repoPath = ''
+
+  beforeEach(async () => {
+    repoPath = await mkdtemp(join(tmpdir(), 'orca-gitlab-remote-'))
+    await gitExecFileAsync(['init'], { cwd: repoPath })
+    await gitExecFileAsync(['remote', 'add', 'myremote', 'git@gitlab.com:group/project.git'], {
+      cwd: repoPath
+    })
+    _resetProjectRefCache()
+  })
+
+  afterEach(async () => {
+    if (repoPath) {
+      await rm(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves the same project before and after naming the sole remote origin', async () => {
+    await expect(getIssueProjectRef(repoPath, ['gitlab.com'])).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+
+    await gitExecFileAsync(['remote', 'rename', 'myremote', 'origin'], { cwd: repoPath })
+    _resetProjectRefCache()
+
+    await expect(getIssueProjectRef(repoPath, ['gitlab.com'])).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+  })
+})

--- a/src/main/gitlab/gitlab-project-ref-cache.ts
+++ b/src/main/gitlab/gitlab-project-ref-cache.ts
@@ -1,0 +1,43 @@
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
+import type { ProjectRef } from './project-ref-parser'
+
+const CACHE_MAX_ENTRIES = 512
+
+type CachedProjectRef = { value: ProjectRef | null; expiresAt: number }
+
+const cache = new Map<string, CachedProjectRef>()
+
+export function getCachedProjectRef(cacheKey: string): ProjectRef | null | undefined {
+  const cached = cache.get(cacheKey)
+  if (!cached) {
+    return undefined
+  }
+  if (cached.expiresAt > Date.now()) {
+    return cached.value
+  }
+  cache.delete(cacheKey)
+  return undefined
+}
+
+export function rememberProjectRef(cacheKey: string, value: ProjectRef | null): void {
+  // A missing/unauthenticated remote can change without an observable mutation.
+  cache.set(cacheKey, {
+    value,
+    expiresAt: value === null ? Date.now() + NEGATIVE_ENTRY_TTL_MS : Number.POSITIVE_INFINITY
+  })
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    cache.delete(oldestKey)
+  }
+}
+
+export function clearProjectRefCache(): void {
+  cache.clear()
+}
+
+export function getProjectRefCacheSize(): number {
+  return cache.size
+}

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,20 +1,31 @@
-import { glabExecFileAsync } from '../git/runner'
 import { isTransientGitProbeError, readRemoteUrl } from '../git/remote-url-probe'
-import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
+import { isStableMissingGitRemoteError } from '../git/stable-missing-git-remote-error'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
 import type { IssueSourcePreference } from '../../shared/types'
-import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
+import {
+  clearProjectRefInFlight,
+  runProjectRefProbeOnce,
+  type ProjectRefProbeResult
+} from './project-ref-inflight'
+import {
+  clearSoleRemoteNameProbeCache,
+  resolveFromSoleRemote
+} from './gitlab-sole-remote-name-probe'
 import {
   _resetGlabUnauthenticatedHosts,
-  isGlabHostKnownUnauthenticated,
-  parseGlabAuthStatusHosts,
-  rememberGlabHostUnauthenticated,
+  GlabHostProbeUnavailableError,
+  isGlabConfiguredForRemoteHost,
   rememberGlabKnownHost,
   type LocalGitExecOptions
 } from './gitlab-known-host-probe'
 import {
+  clearProjectRefCache,
+  getCachedProjectRef,
+  getProjectRefCacheSize,
+  rememberProjectRef
+} from './gitlab-project-ref-cache'
+import {
   DEFAULT_GITLAB_HOSTS,
-  normalizeGitLabHost,
   parseGitLabProjectRef,
   parseRemoteProjectRefCandidate,
   type ProjectRef
@@ -28,41 +39,19 @@ export {
   parseGlabAuthStatusHosts
 } from './gitlab-known-host-probe'
 export type { LocalGitExecOptions } from './gitlab-known-host-probe'
-
-const PROJECT_REF_CACHE_MAX_ENTRIES = 512
-
-type CachedProjectRef = { value: ProjectRef | null; expiresAt: number }
-
-const projectRefCache = new Map<string, CachedProjectRef>()
+export { glabHostnameArgs, glabRepoExecOptions } from './gitlab-exec-options'
 
 /** @internal - exposed for tests only */
 export function _resetProjectRefCache(): void {
-  projectRefCache.clear()
+  clearProjectRefCache()
   clearProjectRefInFlight()
+  clearSoleRemoteNameProbeCache()
   _resetGlabUnauthenticatedHosts()
 }
 
 /** @internal - exposed for tests only */
 export function _getProjectRefCacheSize(): number {
-  return projectRefCache.size
-}
-
-function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
-  // Why: "not GitLab" only holds until someone configures `origin` or logs into
-  // `glab` — a repo probed before either kept hosted-review detection stale for
-  // the life of the process. Negatives expire the way every other forge's do;
-  // positives still stay (see `createRemoteRefProbeCache`).
-  projectRefCache.set(cacheKey, {
-    value,
-    expiresAt: value === null ? Date.now() + NEGATIVE_ENTRY_TTL_MS : Number.POSITIVE_INFINITY
-  })
-  while (projectRefCache.size > PROJECT_REF_CACHE_MAX_ENTRIES) {
-    const oldestKey = projectRefCache.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    projectRefCache.delete(oldestKey)
-  }
+  return getProjectRefCacheSize()
 }
 
 export async function getProjectRefForRemote(
@@ -72,6 +61,18 @@ export async function getProjectRefForRemote(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
+  return (
+    await probeProjectRefForRemote(repoPath, remoteName, knownHosts, connectionId, localGitOptions)
+  ).value
+}
+
+async function probeProjectRefForRemote(
+  repoPath: string,
+  remoteName: string,
+  knownHosts: readonly string[] = DEFAULT_GITLAB_HOSTS,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<ProjectRefProbeResult> {
   // Why: a reconnect replaces the host an answer came from under the same id, so
   // the generation is part of the signature; `knownHosts` carries the glab auth
   // state, so logging into a self-hosted instance re-asks rather than reusing a
@@ -80,12 +81,9 @@ export async function getProjectRefForRemote(
     ? `${connectionId}:${getSshGitProviderGeneration(connectionId)}`
     : `local:${localGitOptions.wslDistro ?? 'host'}`
   const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}\0${knownHosts.join(',')}`
-  const cached = projectRefCache.get(cacheKey)
-  if (cached) {
-    if (cached.expiresAt > Date.now()) {
-      return cached.value
-    }
-    projectRefCache.delete(cacheKey)
+  const cached = getCachedProjectRef(cacheKey)
+  if (cached !== undefined) {
+    return cached ? { status: 'found', value: cached } : { status: 'miss', value: null }
   }
 
   return runProjectRefProbeOnce(cacheKey, (ownsKey) =>
@@ -109,13 +107,13 @@ async function resolveProjectRefForRemote(
   cacheKey: string,
   ownsKey: () => boolean,
   localGitOptions: LocalGitExecOptions
-): Promise<ProjectRef | null> {
+): Promise<ProjectRefProbeResult> {
   // Why: a probe abandoned as stale still runs, and the repo state it read is
   // older than whatever its successor already published. It may answer its own
   // callers; it may not overwrite the cache.
   const publish = (value: ProjectRef | null): void => {
     if (ownsKey()) {
-      rememberProjectRefCacheEntry(cacheKey, value)
+      rememberProjectRef(cacheKey, value)
     }
   }
   try {
@@ -128,26 +126,21 @@ async function resolveProjectRefForRemote(
       remoteName
     )
     if (stdout === null) {
-      return null
+      return { status: 'unavailable', value: null }
     }
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
       publish(result)
-      return result
+      return { status: 'found', value: result }
     }
     const remoteCandidate = parseRemoteProjectRefCandidate(stdout)
     if (
       remoteCandidate &&
-      (await isGlabConfiguredForRemoteHost(
-        repoPath,
-        remoteCandidate,
-        connectionId,
-        localGitOptions
-      ))
+      (await isGlabConfiguredForRemoteHost(remoteCandidate, connectionId, localGitOptions))
     ) {
       rememberGlabKnownHost(remoteCandidate.host, connectionId, localGitOptions)
       publish(remoteCandidate)
-      return remoteCandidate
+      return { status: 'found', value: remoteCandidate }
     }
   } catch (error) {
     // Why: a wedged or killed probe is not evidence the remote is not GitLab —
@@ -155,12 +148,17 @@ async function resolveProjectRefForRemote(
     // SSH failures stay uncached outright rather than adopting the generic
     // cache's stable-missing-remote exception: keeping a connected host's
     // detection fresh is worth the extra probe.
-    if (connectionId || isTransientGitProbeError(error)) {
-      return null
+    if (isTransientGitProbeError(error) || error instanceof GlabHostProbeUnavailableError) {
+      return { status: 'unavailable', value: null }
+    }
+    if (connectionId) {
+      return isStableMissingGitRemoteError(error)
+        ? { status: 'miss', value: null }
+        : { status: 'unavailable', value: null }
     }
   }
   publish(null)
-  return null
+  return { status: 'miss', value: null }
 }
 
 export async function getProjectRef(
@@ -169,7 +167,19 @@ export async function getProjectRef(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
-  return getProjectRefForRemote(repoPath, 'origin', knownHosts, connectionId, localGitOptions)
+  const origin = await probeProjectRefForRemote(
+    repoPath,
+    'origin',
+    knownHosts,
+    connectionId,
+    localGitOptions
+  )
+  if (origin.status !== 'miss') {
+    return origin.value
+  }
+  return resolveFromSoleRemote(repoPath, ['origin'], connectionId, localGitOptions, (remoteName) =>
+    getProjectRefForRemote(repoPath, remoteName, knownHosts, connectionId, localGitOptions)
+  )
 }
 
 export async function getIssueProjectRef(
@@ -178,16 +188,36 @@ export async function getIssueProjectRef(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
-  const upstream = await getProjectRefForRemote(
+  const upstream = await probeProjectRefForRemote(
     repoPath,
     'upstream',
     knownHosts,
     connectionId,
     localGitOptions
   )
-  return (
-    upstream ??
-    getProjectRefForRemote(repoPath, 'origin', knownHosts, connectionId, localGitOptions)
+  if (upstream.status === 'found') {
+    return upstream.value
+  }
+  const origin = await probeProjectRefForRemote(
+    repoPath,
+    'origin',
+    knownHosts,
+    connectionId,
+    localGitOptions
+  )
+  if (origin.status === 'found') {
+    return origin.value
+  }
+  if (upstream.status === 'unavailable' || origin.status === 'unavailable') {
+    return null
+  }
+  return resolveFromSoleRemote(
+    repoPath,
+    ['upstream', 'origin'],
+    connectionId,
+    localGitOptions,
+    (remoteName) =>
+      getProjectRefForRemote(repoPath, remoteName, knownHosts, connectionId, localGitOptions)
   )
 }
 
@@ -205,15 +235,18 @@ export async function resolveIssueSource(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ResolvedIssueSource> {
   if (preference === 'upstream') {
-    const upstream = await getProjectRefForRemote(
+    const upstream = await probeProjectRefForRemote(
       repoPath,
       'upstream',
       knownHosts,
       connectionId,
       localGitOptions
     )
-    if (upstream) {
-      return { source: upstream, fellBack: false }
+    if (upstream.status === 'found') {
+      return { source: upstream.value, fellBack: false }
+    }
+    if (upstream.status === 'unavailable') {
+      return { source: null, fellBack: false }
     }
     const origin = await getProjectRefForRemote(
       repoPath,
@@ -239,62 +272,5 @@ export async function resolveIssueSource(
   return {
     source: await getIssueProjectRef(repoPath, knownHosts, connectionId, localGitOptions),
     fellBack: false
-  }
-}
-
-export function glabRepoExecOptions(
-  repoPath: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): { cwd?: string; wslDistro?: string } {
-  return connectionId
-    ? {}
-    : {
-        cwd: repoPath,
-        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
-      }
-}
-
-export function glabHostnameArgs(
-  projectRef: Pick<ProjectRef, 'host'> | null | undefined,
-  connectionId?: string | null
-): string[] {
-  return connectionId && projectRef?.host ? ['--hostname', projectRef.host] : []
-}
-
-async function isGlabConfiguredForRemoteHost(
-  repoPath: string,
-  projectRef: Pick<ProjectRef, 'host'>,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<boolean> {
-  // Why: this probe is per host, but the project-ref miss that reaches it is per
-  // repo — without the memo, every non-GitLab repo re-spawns `glab` each time
-  // its negative expires.
-  if (isGlabHostKnownUnauthenticated(projectRef.host, connectionId, localGitOptions)) {
-    return false
-  }
-  try {
-    const result = await glabExecFileAsync(
-      ['auth', 'status', '--hostname', projectRef.host],
-      glabRepoExecOptions(repoPath, connectionId, localGitOptions)
-    )
-    if (result === undefined) {
-      rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
-      return false
-    }
-    return true
-  } catch (error) {
-    const execLike = error as { stdout?: unknown; stderr?: unknown; message?: unknown }
-    const output =
-      [execLike.stdout, execLike.stderr, execLike.message]
-        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-        .join('\n') || String(error)
-    const hosts = parseGlabAuthStatusHosts(output).map(normalizeGitLabHost)
-    if (hosts.includes(normalizeGitLabHost(projectRef.host))) {
-      return true
-    }
-    rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
-    return false
   }
 }

--- a/src/main/gitlab/gitlab-sole-remote-name-probe.test.ts
+++ b/src/main/gitlab/gitlab-sole-remote-name-probe.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, sshExecMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  sshExecMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
+
+import {
+  _getSoleRemoteNameProbeCacheSize,
+  clearSoleRemoteNameProbeCache,
+  getSoleRemoteName
+} from './gitlab-sole-remote-name-probe'
+import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
+import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
+
+describe('sole Git remote name probe', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    gitExecFileAsyncMock.mockReset()
+    sshExecMock.mockReset()
+    unregisterSshGitProvider('conn-1')
+    clearSoleRemoteNameProbeCache()
+  })
+
+  it('lists a local WSL remote once and reuses the result', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'myremote\r\n', stderr: '' })
+
+    await expect(getSoleRemoteName('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      'myremote'
+    )
+    await expect(getSoleRemoteName('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      'myremote'
+    )
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['remote'], { cwd: '/repo', timeout: REMOTE_URL_PROBE_TIMEOUT_MS, wslDistro: 'Ubuntu' }]
+    ])
+  })
+
+  it('coalesces concurrent sole-remote name probes', async () => {
+    let releaseProbe!: () => void
+    const probeGate = new Promise<void>((resolve) => {
+      releaseProbe = resolve
+    })
+    gitExecFileAsyncMock.mockImplementationOnce(async () => {
+      await probeGate
+      return { stdout: 'myremote\n', stderr: '' }
+    })
+
+    const probes = Array.from({ length: 64 }, () => getSoleRemoteName('/repo'))
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    releaseProbe()
+
+    await expect(Promise.all(probes)).resolves.toEqual(Array.from({ length: 64 }, () => 'myremote'))
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the SSH provider and keeps its cache isolated from local Git', async () => {
+    sshExecMock.mockResolvedValue({ stdout: 'myremote\n', stderr: '' })
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'localremote\n', stderr: '' })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(getSoleRemoteName('/repo', 'conn-1')).resolves.toBe('myremote')
+    await expect(getSoleRemoteName('/repo')).resolves.toBe('localremote')
+
+    expect(sshExecMock).toHaveBeenCalledWith(['remote'], '/repo', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to guess among multiple remotes and caches the bounded miss', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'fork\nmirror\n', stderr: '' })
+
+    await expect(getSoleRemoteName('/repo')).resolves.toBeNull()
+    await expect(getSoleRemoteName('/repo')).resolves.toBeNull()
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache a failed list probe', async () => {
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('git timed out'))
+      .mockResolvedValueOnce({ stdout: 'myremote\n', stderr: '' })
+
+    await expect(getSoleRemoteName('/repo')).resolves.toBeNull()
+    await expect(getSoleRemoteName('/repo')).resolves.toBe('myremote')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes a cached sole remote after the topology interval', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'oldremote\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'myremote\n', stderr: '' })
+
+    await expect(getSoleRemoteName('/repo')).resolves.toBe('oldremote')
+    await expect(getSoleRemoteName('/repo')).resolves.toBe('oldremote')
+    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
+    await expect(getSoleRemoteName('/repo')).resolves.toBe('myremote')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds cached repo locations', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'myremote\n', stderr: '' })
+
+    for (let index = 0; index < 513; index += 1) {
+      await getSoleRemoteName(`/repo-${index}`)
+    }
+
+    expect(_getSoleRemoteNameProbeCacheSize()).toBe(512)
+  })
+})

--- a/src/main/gitlab/gitlab-sole-remote-name-probe.ts
+++ b/src/main/gitlab/gitlab-sole-remote-name-probe.ts
@@ -1,0 +1,118 @@
+import { runCoalescedProbe, type CoalescedProbes } from '../git/coalesced-probe'
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
+import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
+import { gitExecFileAsync } from '../git/runner'
+import { getSshGitProvider, getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
+import type { LocalGitExecOptions } from './gitlab-known-host-probe'
+
+const CACHE_MAX_ENTRIES = 512
+
+type CachedRemoteName = { value: string | null; expiresAt: number }
+
+const cache = new Map<string, CachedRemoteName>()
+const inFlight: CoalescedProbes<string | null> = new Map()
+
+function remember(cacheKey: string, value: string | null): void {
+  // Remote topology can change without an Orca-observable mutation on SSH/WSL.
+  cache.set(cacheKey, {
+    value,
+    expiresAt: Date.now() + NEGATIVE_ENTRY_TTL_MS
+  })
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    cache.delete(oldestKey)
+  }
+}
+
+function runtimeKey(
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): string {
+  return connectionId
+    ? `${connectionId}:${getSshGitProviderGeneration(connectionId)}`
+    : `local:${localGitOptions.wslDistro ?? 'host'}`
+}
+
+async function probeSoleRemoteName(
+  cacheKey: string,
+  ownsKey: () => boolean,
+  repoPath: string,
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): Promise<string | null> {
+  try {
+    const result = connectionId
+      ? await getSshGitProvider(connectionId)?.exec(['remote'], repoPath, {
+          signal: AbortSignal.timeout(REMOTE_URL_PROBE_TIMEOUT_MS)
+        })
+      : await gitExecFileAsync(['remote'], {
+          cwd: repoPath,
+          timeout: REMOTE_URL_PROBE_TIMEOUT_MS,
+          ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+        })
+    if (!result) {
+      return null
+    }
+    const remoteNames = [
+      ...new Set(
+        result.stdout
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+      )
+    ]
+    const remoteName = remoteNames.length === 1 ? remoteNames[0]! : null
+    if (ownsKey()) {
+      remember(cacheKey, remoteName)
+    }
+    return remoteName
+  } catch {
+    // Why: a failed list says nothing about topology and must self-heal immediately.
+    return null
+  }
+}
+
+export async function getSoleRemoteName(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<string | null> {
+  const cacheKey = `${runtimeKey(connectionId, localGitOptions)}\0${repoPath}`
+  const cached = cache.get(cacheKey)
+  if (cached) {
+    if (cached.expiresAt > Date.now()) {
+      return cached.value
+    }
+    cache.delete(cacheKey)
+  }
+  return runCoalescedProbe(inFlight, cacheKey, (ownsKey) =>
+    probeSoleRemoteName(cacheKey, ownsKey, repoPath, connectionId, localGitOptions)
+  )
+}
+
+export async function resolveFromSoleRemote<T>(
+  repoPath: string,
+  excludedRemoteNames: readonly string[],
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions,
+  resolveRemote: (remoteName: string) => Promise<T | null>
+): Promise<T | null> {
+  const remoteName = await getSoleRemoteName(repoPath, connectionId, localGitOptions)
+  if (!remoteName || excludedRemoteNames.includes(remoteName)) {
+    return null
+  }
+  return resolveRemote(remoteName)
+}
+
+export function clearSoleRemoteNameProbeCache(): void {
+  cache.clear()
+  inFlight.clear()
+}
+
+/** @internal - exposed for tests only */
+export function _getSoleRemoteNameProbeCacheSize(): number {
+  return cache.size
+}

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -221,9 +221,17 @@ describe('gitlab project ref resolution', () => {
   })
 
   it('does not cache a local probe killed on its deadline as a definitive miss', async () => {
-    gitExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('git timed out.'))
-      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:fork/orca.git\n' })
+    let originCalls = 0
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: 'origin\n' }
+      }
+      originCalls += 1
+      if (originCalls === 1) {
+        throw new Error('git timed out.')
+      }
+      return { stdout: 'git@gitlab.com:fork/orca.git\n' }
+    })
 
     await expect(getProjectRef('/repo')).resolves.toBeNull()
     await expect(getProjectRef('/repo')).resolves.toEqual({
@@ -236,22 +244,31 @@ describe('gitlab project ref resolution', () => {
   it('re-probes a repo whose GitLab remote could have been added since the miss', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
-    gitExecFileAsyncMock.mockRejectedValueOnce(new Error("error: No such remote 'origin'"))
+    let hasOrigin = false
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.length === 1) {
+        return { stdout: hasOrigin ? 'origin\n' : '' }
+      }
+      if (!hasOrigin) {
+        throw new Error("error: No such remote 'origin'")
+      }
+      return { stdout: 'git@gitlab.com:fork/orca.git\n' }
+    })
 
     await expect(getProjectRef('/repo')).resolves.toBeNull()
     await expect(getProjectRef('/repo')).resolves.toBeNull()
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
 
     // Nothing watches `.git/config`, and SSH/WSL repos have no file to watch, so
     // a remote configured after the miss is only visible once the negative ages out.
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:fork/orca.git\n' })
+    hasOrigin = true
     vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
 
     await expect(getProjectRef('/repo')).resolves.toEqual({
       host: 'gitlab.com',
       path: 'fork/orca'
     })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(3)
   })
 
   it('keeps a resolved project ref past the negative interval', async () => {
@@ -361,6 +378,20 @@ describe('resolveIssueSource', () => {
     await expect(resolveIssueSource('/repo', 'upstream')).resolves.toEqual({
       source: { host: 'gitlab.com', path: 'solo/orca' },
       fellBack: true
+    })
+  })
+
+  it("'upstream' + transient upstream failure does not probe origin", async () => {
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('git timed out'))
+
+    await expect(resolveIssueSource('/repo', 'upstream')).resolves.toEqual({
+      source: null,
+      fellBack: false
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'upstream'], {
+      cwd: '/repo',
+      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
     })
   })
 

--- a/src/main/gitlab/project-ref-inflight.ts
+++ b/src/main/gitlab/project-ref-inflight.ts
@@ -1,7 +1,11 @@
 import { runCoalescedProbe, type CoalescedProbes } from '../git/coalesced-probe'
-import type { ProjectRef } from './gl-utils'
+import type { ProjectRef } from './project-ref-parser'
 
-const projectRefInFlight: CoalescedProbes<ProjectRef | null> = new Map()
+export type ProjectRefProbeResult =
+  | { status: 'found'; value: ProjectRef }
+  | { status: 'miss' | 'unavailable'; value: null }
+
+const projectRefInFlight: CoalescedProbes<ProjectRefProbeResult> = new Map()
 
 export function clearProjectRefInFlight(): void {
   projectRefInFlight.clear()
@@ -9,8 +13,8 @@ export function clearProjectRefInFlight(): void {
 
 export async function runProjectRefProbeOnce(
   cacheKey: string,
-  createProbe: (ownsKey: () => boolean) => Promise<ProjectRef | null>
-): Promise<ProjectRef | null> {
+  createProbe: (ownsKey: () => boolean) => Promise<ProjectRefProbeResult>
+): Promise<ProjectRefProbeResult> {
   // Why: joining only a probe that is still young keeps a wedged host's dead
   // promise from pinning every later retry for the process lifetime (P1-D).
   return runCoalescedProbe(projectRefInFlight, cacheKey, createProbe)


### PR DESCRIPTION
## ELI5

GitLab Tasks used to look only for remotes literally named `upstream` or `origin`. A repository with one valid GitLab remote named `myremote` now resolves that project too, without changing which project wins when the conventional remotes exist.

## What Changed

- Preserve the existing `upstream` → `origin` lookup for automatic issue sources.
- After both conventional names are definitive misses, run one Git 2.25-compatible `git remote` query and accept the fallback only when exactly one remote exists.
- Keep explicit `origin` strict and explicit `upstream` limited to its existing origin fallback.
- Distinguish definitive misses from unavailable Git/glab probes, coalesce concurrent work, bound subprocesses, scope caches to the native/WSL/SSH execution context, and cap/expire negative topology state.
- Treat only proven glab authentication diagnostics as unauthenticated; DNS, timeout, 502/503, EOF, and unknown outages remain retryable.

## Why

Issue #13816 short-circuited before invoking `glab` whenever the only remote had a nonstandard name. The invariant is: a repository whose only valid GitLab remote is `myremote` resolves the same project as when it is `origin`, while upstream/origin precedence and explicit source preferences remain unchanged.

I compared three ownership options. Passing persisted `gitRemoteIdentity.remoteName` would broaden caller/persistence and potentially remote-wire ownership while depending on state that can be stale or unavailable at startup; enumerating and probing every remote (as proposed in #13886) guesses from list order and creates unbounded process fanout. The bounded sole-remote fallback is the smallest long-term resolver-owned rule that satisfies the invariant without guessing among multiple remotes.

The remote-enumeration hypothesis in #13886 materially informed this design comparison; credit to @bbingz. I did not change #13817 / STA-3902 or its stale-eligibility/error-aggregation path.

## Linked Issue

Fixes #13816

Linear: https://linear.app/stably/issue/STA-3901/bug-gitlab-task-source-only-resolves-projects-via-a-remote

## Visual Proof

Before: the deterministic latest-main run below returns `{ source: null }` before any `glab api` call (1 failed / 2 passed). No baseline UI screenshot was retained; the visible symptom is the empty GitLab Issues list described in #13816.

After (full Orca app, post-rebase):

![GitLab Issues lists issue 1 from a repository whose only remote is myremote](https://github.com/user-attachments/assets/090c2260-ba3d-4880-854e-206a5fd71bda)

The persisted repo identity in the isolated app was `gitlab.com/Jinwoo-H/orca-gitlab-task-fixture`, `remoteName: "myremote"`. A separate `window.api.gl.listIssues(...)` IPC call returned issue `#1`, and clicking Refresh kept the rendered row. Screenshot SHA-256: `fefab4563dd38813866f1a03795e0ec24a1be712169206fa682f6921bc228046`.

## Testing

Deterministic oracle SHA-256: `e054382076992afa9917d3d6939b3bb7b6a0011faf0da284a51e89abfdff2e61`.

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/gitlab/gitlab-nonstandard-remote.contract.test.ts
```

The same byte-identical oracle produced red/red/green:

- affected main production sources: **red**, `{ source: null }`, 1 failed / 2 passed;
- candidate with only `resolveFromSoleRemote` disabled: **red**, `{ source: null }`, 1 failed / 2 passed;
- candidate: **green**, 3/3 passed.

Latest-main relevant GitLab/Git probe sources are byte-identical between the baseline `b51ef400ec74b3dc761809b7cd4a8ef7489e96dd` run and actual merge-base `e5971365e4d165d0a5356eaf88a9d8d7e754fd07` (`git diff --quiet ... -- src/main/gitlab src/main/git/remote-url-probe.ts` exited 0). The cold candidate boundary is exactly four Git calls — `remote get-url upstream`, `remote get-url origin`, `remote`, `remote get-url myremote` — followed by `glab api`; warm native/WSL polling adds zero Git calls.

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/gitlab/gl-utils.test.ts \
  src/main/gitlab/issues.test.ts \
  src/main/gitlab/gitlab-sole-remote-name-probe.test.ts \
  src/main/gitlab/gitlab-nonstandard-remote-hosts.test.ts \
  src/main/gitlab/gitlab-nonstandard-remote.real-git.test.ts \
  src/main/gitlab/gitlab-nonstandard-remote.contract.test.ts
```

Final result: 6 files / 126 tests passed, including real Git 2.50.1 and recovery after timeout, DNS, no-route, 502/503, EOF, and unknown glab failures. Review regressions also prove that transient explicit-upstream failures never probe origin, 64 concurrent sole-remote callers share one enumeration, definitive unauthenticated host state is shared across repo paths, and the real-Git suite skips when Git is unavailable. `pnpm typecheck`, `pnpm lint`, `pnpm build`, and `git diff --check origin/main...HEAD` passed; lint emitted only pre-existing `WorktreeJumpPalette.tsx` hook warnings.

Live macOS golden path used the private reusable fixture `https://gitlab.com/Jinwoo-H/orca-gitlab-task-fixture`, open issue `#1`, cloned with only `myremote`. `git remote` returned only `myremote`; both `glab issue list -O json` and the Electron IPC/UI returned issue `#1`.

Compatibility contracts cover native, WSL, SSH generation isolation, folder repositories, and linked worktrees. The new Git command is available in Git 2.25; all Git/glab calls use argv execution with 30-second/10-second bounds. No UI implementation, preload/wire schema, persistence, mobile, dependency, GitHub provider, or generic error-UX surface changed.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Codex. Independent adversarial reviewers audited correctness, architecture/ownership, performance/resources, security, platform/SSH/WSL/folder/worktree compatibility, provider isolation, mobile/wire compatibility, UX/readiness, and the exclusion of #13817. Review-discovered transient negative-cache defects were fixed with recovery contracts; the final same-snapshot pair reported CLEAN.

## Review

- Correctness/architecture: bounded sole-remote fallback preserves all preference semantics and refuses ambiguous multiple-remotes.
- Performance/resources: cold native/WSL 4 Git calls and warm 0; SSH cold 4 and warm 2 pre-existing preferred misses; concurrent callers coalesce; caches are capped and TTL/generation scoped; no polling, startup scans, timers, or leaks.
- Security: no shell interpolation, token handling, credential output, or dependency change.
- Cross-platform/remote: Git 2.25-compatible argv; native/WSL/SSH/folder/worktree contracts pass.
- Backwards compatibility: no wire, renderer, preload, persistence, or mobile-facing surface changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after evidence attached; deterministic baseline substitutes for an unavailable baseline screenshot
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, focused tests, and `pnpm build` pass

## Author

- X / Twitter: N/A
