### PR TITLE
fix(orchestration): close federated-read benchmark socket

### DIFF
--- a/src/main/ipc/runtime-environment-federated-read-transport.bench.test.ts
+++ b/src/main/ipc/runtime-environment-federated-read-transport.bench.test.ts
@@ -1,14 +1,54 @@
 import { readFileSync } from 'node:fs'
 import { performance } from 'node:perf_hooks'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { sendRemoteRuntimeRequest } from '../../shared/remote-runtime-client'
 import { RemoteRuntimeSharedControlConnection } from '../../shared/remote-runtime-shared-control-connection'
 import { RuntimeEnvironmentStoreSchema } from '../../shared/runtime-environments'
 
-const runLiveBenchmark = process.env.ORCA_FEDERATED_READ_BENCH === '1'
+const runLiveBenchmark = isFederatedReadBenchmarkEnabled(process.env.ORCA_FEDERATED_READ_BENCH)
 
 it('interpolates even-sized benchmark samples', () => expect(percentile([1, 3], 0.5)).toBe(2))
+
+it.each([
+  ['1', true],
+  ['true', false],
+  [undefined, false]
+])('enables the live benchmark only for %s', (value, enabled) => {
+  expect(isFederatedReadBenchmarkEnabled(value)).toBe(enabled)
+})
+
+it('closes the retained connection after a measured request rejects', async () => {
+  let requestCount = 0
+  const fixture = createSharedControlFixture(async () => {
+    requestCount += 1
+    if (requestCount === 4) {
+      throw new Error('injected measured request failure')
+    }
+    return { ok: true }
+  })
+
+  await expect(measureSharedControlRequests(fixture.connection, {}, 1)).rejects.toThrow(
+    'injected measured request failure'
+  )
+
+  expect.soft(fixture.close).toHaveBeenCalledOnce()
+  expect.soft(fixture.socketClose).toHaveBeenCalledOnce()
+  expect(fixture.retainedHandles).toHaveLength(0)
+})
+
+it('closes the retained connection after successful measurements', async () => {
+  const fixture = createSharedControlFixture(async () => ({ ok: true }))
+
+  await expect(measureSharedControlRequests(fixture.connection, {}, 1)).resolves.toMatchObject({
+    sharedControl: { count: 1 },
+    diagnostics: { state: 'ready', pendingRequestCount: 0 }
+  })
+
+  expect(fixture.close).toHaveBeenCalledOnce()
+  expect(fixture.socketClose).toHaveBeenCalledOnce()
+  expect(fixture.retainedHandles).toHaveLength(0)
+})
 
 describe.runIf(runLiveBenchmark)('federated read RPC transport benchmark', () => {
   it('compares one-shot and shared-control latency on one saved runtime', async () => {
@@ -49,18 +89,35 @@ describe.runIf(runLiveBenchmark)('federated read RPC transport benchmark', () =>
     const shared = new RemoteRuntimeSharedControlConnection(pairing, {
       environmentId: environment.id
     })
-    const sharedControl = await measureRequests(() =>
-      shared.request('orchestration.federationPull', params, 15_000, {
-        orchestrationContractVersion: 1
-      })
-    )
-    const diagnostics = shared.getDiagnostics()
-    shared.close()
+    const { sharedControl, diagnostics } = await measureSharedControlRequests(shared, params)
 
     expect(diagnostics).toMatchObject({ state: 'ready', pendingRequestCount: 0 })
     process.stdout.write(`${JSON.stringify({ oneShot, sharedControl }, null, 2)}\n`)
   }, 120_000)
 })
+
+async function measureSharedControlRequests(
+  shared: RemoteRuntimeSharedControlConnection,
+  params: unknown,
+  count = 30
+): Promise<{
+  sharedControl: Awaited<ReturnType<typeof measureRequests>>
+  diagnostics: ReturnType<RemoteRuntimeSharedControlConnection['getDiagnostics']>
+}> {
+  try {
+    const sharedControl = await measureRequests(
+      () =>
+        shared.request('orchestration.federationPull', params, 15_000, {
+          orchestrationContractVersion: 1
+        }),
+      count
+    )
+    const diagnostics = shared.getDiagnostics()
+    return { sharedControl, diagnostics }
+  } finally {
+    shared.close()
+  }
+}
 
 async function measureRequests(
   request: () => Promise<{ ok: boolean; error?: { code: string } }>,
@@ -113,4 +170,38 @@ function percentile(sorted: number[], fraction: number): number {
 
 function round(value: number): number {
   return Math.round(value * 100) / 100
+}
+
+function isFederatedReadBenchmarkEnabled(value: string | undefined): boolean {
+  return value === '1'
+}
+
+function createSharedControlFixture(
+  request: () => Promise<{ ok: boolean; error?: { code: string } }>
+): {
+  connection: RemoteRuntimeSharedControlConnection
+  close: ReturnType<typeof vi.fn>
+  socketClose: ReturnType<typeof vi.fn>
+  retainedHandles: string[]
+} {
+  const connection = new RemoteRuntimeSharedControlConnection({
+    v: 2,
+    endpoint: 'ws://127.0.0.1:1',
+    deviceToken: 'token',
+    publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64')
+  })
+  const retainedHandles = ['shared-control WebSocket']
+  const socketClose = vi.fn(() => retainedHandles.splice(0))
+  const unsafe = connection as unknown as {
+    state: string
+    ws: { readyState: number; close: () => void } | null
+    sharedKey: Uint8Array | null
+    request: typeof request
+  }
+  unsafe.state = 'ready'
+  unsafe.ws = { readyState: 1, close: socketClose }
+  unsafe.sharedKey = new Uint8Array(32).fill(2)
+  unsafe.request = vi.fn(request)
+  const close = vi.spyOn(connection, 'close')
+  return { connection, close, socketClose, retainedHandles }
 }

--- a/src/main/ipc/runtime-environment-federated-read-transport.bench.test.ts
+++ b/src/main/ipc/runtime-environment-federated-read-transport.bench.test.ts
@@ -32,9 +32,10 @@ it('closes the retained connection after a measured request rejects', async () =
     'injected measured request failure'
   )
 
+  expect(requestCount).toBe(4)
   expect.soft(fixture.close).toHaveBeenCalledOnce()
   expect.soft(fixture.socketClose).toHaveBeenCalledOnce()
-  expect(fixture.retainedHandles).toHaveLength(0)
+  expect(fixture.retainedHandleCount()).toBe(0)
 })
 
 it('closes the retained connection after successful measurements', async () => {
@@ -47,7 +48,7 @@ it('closes the retained connection after successful measurements', async () => {
 
   expect(fixture.close).toHaveBeenCalledOnce()
   expect(fixture.socketClose).toHaveBeenCalledOnce()
-  expect(fixture.retainedHandles).toHaveLength(0)
+  expect(fixture.retainedHandleCount()).toBe(0)
 })
 
 describe.runIf(runLiveBenchmark)('federated read RPC transport benchmark', () => {
@@ -182,7 +183,7 @@ function createSharedControlFixture(
   connection: RemoteRuntimeSharedControlConnection
   close: ReturnType<typeof vi.fn>
   socketClose: ReturnType<typeof vi.fn>
-  retainedHandles: string[]
+  retainedHandleCount: () => number
 } {
   const connection = new RemoteRuntimeSharedControlConnection({
     v: 2,
@@ -190,8 +191,7 @@ function createSharedControlFixture(
     deviceToken: 'token',
     publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64')
   })
-  const retainedHandles = ['shared-control WebSocket']
-  const socketClose = vi.fn(() => retainedHandles.splice(0))
+  const socketClose = vi.fn()
   const unsafe = connection as unknown as {
     state: string
     ws: { readyState: number; close: () => void } | null
@@ -203,5 +203,5 @@ function createSharedControlFixture(
   unsafe.sharedKey = new Uint8Array(32).fill(2)
   unsafe.request = vi.fn(request)
   const close = vi.spyOn(connection, 'close')
-  return { connection, close, socketClose, retainedHandles }
+  return { connection, close, socketClose, retainedHandleCount: () => (unsafe.ws ? 1 : 0) }
 }


### PR DESCRIPTION
## ELI5

The optional federated-read speed test kept one WebSocket open for reuse. If a measured request failed, the test jumped past cleanup and left that socket alive. The benchmark now closes its socket whether measurements pass or fail.

## What Changed

- wrap the retained shared-control benchmark lifetime in `try/finally`
- deterministically reject the first measured request after three successful warmups
- assert connection close, underlying socket close, zero retained handles, normal-success cleanup, and the exact opt-in gate

## Why

The benchmark creates and owns the retained connection, so lexical `try/finally` is the smallest reliable ownership model. This changes benchmark/test code only; production transport behavior is unchanged.

## Linked Issue

[STA-3961](https://linear.app/stably/issue/STA-3961/p2-federated-read-bench-leaks-websocket-without-finally-close-pr-13814)

Follow-up to merged PR [#13814](https://github.com/stablyai/orca/pull/13814).

## Visual Proof

N/A — benchmark/test-only resource cleanup with no UI or interaction change.

## Testing

- [x] Focused Vitest suite on macOS: 6 passed, 1 live benchmark skipped by default
- [x] Baseline oracle: measured rejection produced 0 closes and 1 retained handle
- [x] Candidate oracle: rejection and success each produced exactly 1 close and 0 retained handles
- [x] Reverted candidate oracle: returned to 0 closes and 1 retained handle
- [x] `pnpm typecheck`
- [x] `pnpm lint` (passes; existing warning-level React dependency notices remain outside this diff)
- [x] CI: 44 checks passed; E2E intentionally skipped because no E2E specs changed

## AI Disclosure

Implemented and tested with OpenAI Codex under human-authorized ownership.

## Review

Focused self-review and a fresh resource-lifecycle/adversarial review are clean with no actionable in-scope findings. The review strengthened the oracle to inspect the connection's retained socket directly, then repeated the candidate/revert control. Scope is test-only and does not alter production behavior, wire formats, SSH, folder workspace, platform, path, shortcut, mobile, or provider behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A: benchmark-only)
- [x] `pnpm lint`, `pnpm typecheck`, tests, and packaging pass locally or in CI

## Author

- X / Twitter: N/A
