### PR TITLE
fix(worktrees): release preserved cleanup routes with reviews

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -280,7 +280,9 @@ import {
   LINEAGE_HYDRATION_TIMEOUT_MS,
   __getDetectedWorktreeScanCacheStatsForTests,
   __resetDetectedWorktreeScanCacheForTests,
-  registerWorktreeHandlers
+  getPreservedBranchCleanupTargetCountForTests,
+  registerWorktreeHandlers,
+  resetPreservedBranchCleanupTargetsForTests
 } from './worktrees'
 import { clearConfiguredWorktreeSharedDirectoriesCacheForTests } from '../git/worktree-shared-directories'
 import {
@@ -342,6 +344,7 @@ describe('registerWorktreeHandlers', () => {
     clearConfiguredWorktreeSharedDirectoriesCacheForTests()
     __resetSshWorktreeCreateFetchCacheForTests()
     __resetDetectedWorktreeScanCacheForTests()
+    resetPreservedBranchCleanupTargetsForTests()
     resetSshProviderAuthorities()
     invalidateAuthorizedRootsCache()
     for (const m of [
@@ -9552,6 +9555,58 @@ describe('registerWorktreeHandlers', () => {
       'feature/test',
       'def456'
     )
+  })
+
+  it('releases dismissed preserved-branch cleanup routes', async () => {
+    const cleanups = Array.from({ length: 8 }, (_, index) => ({
+      worktreeId: `repo-1::/workspace/feature-${index}`,
+      branchName: `feature/${index}`,
+      expectedHead: `head-${index}`,
+      hostId: LOCAL_EXECUTION_HOST_ID
+    }))
+
+    for (const cleanup of cleanups) {
+      mockKnownFeatureWorktree(cleanup.worktreeId.split('::')[1])
+      removeWorktreeMock.mockResolvedValueOnce({
+        preservedBranch: { branchName: cleanup.branchName, head: cleanup.expectedHead }
+      })
+      await handlers['worktrees:remove'](null, { worktreeId: cleanup.worktreeId })
+    }
+
+    expect(getPreservedBranchCleanupTargetCountForTests()).toBe(8)
+    await handlers['worktrees:releasePreservedBranchCleanups'](null, {
+      cleanups: cleanups.slice(0, -1)
+    })
+    expect(getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+    await handlers['worktrees:releasePreservedBranchCleanups'](null, {
+      cleanups: cleanups.slice(-1)
+    })
+    expect(getPreservedBranchCleanupTargetCountForTests()).toBe(0)
+  })
+
+  it('does not release a newer cleanup route from a stale dismissal', async () => {
+    const worktreeId = 'repo-1::/workspace/recreated'
+    for (const [branchName, head] of [
+      ['feature/old', 'old-head'],
+      ['feature/new', 'new-head']
+    ] as const) {
+      mockKnownFeatureWorktree('/workspace/recreated')
+      removeWorktreeMock.mockResolvedValueOnce({ preservedBranch: { branchName, head } })
+      await handlers['worktrees:remove'](null, { worktreeId })
+    }
+
+    await handlers['worktrees:releasePreservedBranchCleanups'](null, {
+      cleanups: [
+        {
+          worktreeId,
+          branchName: 'feature/old',
+          expectedHead: 'old-head',
+          hostId: LOCAL_EXECUTION_HOST_ID
+        }
+      ]
+    })
+
+    expect(getPreservedBranchCleanupTargetCountForTests()).toBe(1)
   })
 
   it('force-deletes an SSH branch that was preserved by safe worktree removal', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -4,7 +4,13 @@ import type * as GitUsernameModule from '../git/git-username'
 import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import type { CreateWorktreeResult, GitWorktreeInfo, Repo, Worktree } from '../../shared/types'
+import type {
+  CreateWorktreeResult,
+  GitWorktreeInfo,
+  RemoveWorktreeResult,
+  Repo,
+  Worktree
+} from '../../shared/types'
 import type { ProviderRequestId } from '../../shared/detected-worktree-provider-contract'
 import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
 import * as localWorktreeFilesystem from '../local-worktree-filesystem'
@@ -8413,7 +8419,11 @@ describe('registerWorktreeHandlers', () => {
       })
 
       expect(result).toEqual({
-        preservedBranch: { branchName: 'feature', head: 'feature' }
+        preservedBranch: {
+          branchName: 'feature',
+          head: 'feature',
+          cleanupId: expect.any(String)
+        }
       })
       if (ORIGINAL_PLATFORM === 'win32') {
         await expect(lstat(worktreePath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -8527,7 +8537,11 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(result).toEqual({
-      preservedBranch: { branchName: 'feature', head: 'feature' }
+      preservedBranch: {
+        branchName: 'feature',
+        head: 'feature',
+        cleanupId: expect.any(String)
+      }
     })
     expect(runHookMock).not.toHaveBeenCalled()
     expect(killAllProcessesForWorktreeMock).not.toHaveBeenCalled()
@@ -9609,6 +9623,71 @@ describe('registerWorktreeHandlers', () => {
     expect(getPreservedBranchCleanupTargetCountForTests()).toBe(1)
   })
 
+  it('does not release a recreated same-value cleanup with an older cleanup id', async () => {
+    const worktreeId = 'repo-1::/workspace/recreated-same-value'
+    const cleanupIds: string[] = []
+    for (let index = 0; index < 2; index += 1) {
+      mockKnownFeatureWorktree('/workspace/recreated-same-value')
+      removeWorktreeMock.mockResolvedValueOnce({
+        preservedBranch: { branchName: 'feature/same', head: 'same-head' }
+      })
+      const result = (await handlers['worktrees:remove'](null, {
+        worktreeId
+      })) as RemoveWorktreeResult
+      const cleanupId = result.preservedBranch?.cleanupId
+      expect(cleanupId).toEqual(expect.any(String))
+      if (!cleanupId) {
+        throw new Error('missing cleanup id')
+      }
+      cleanupIds.push(cleanupId)
+    }
+
+    await handlers['worktrees:releasePreservedBranchCleanups'](null, {
+      cleanups: [
+        {
+          cleanupId: cleanupIds[0],
+          worktreeId,
+          branchName: 'feature/same',
+          expectedHead: 'same-head',
+          hostId: LOCAL_EXECUTION_HOST_ID
+        }
+      ]
+    })
+
+    expect(getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+  })
+
+  it('does not force-delete a recreated same-value cleanup with an older cleanup id', async () => {
+    const worktreeId = 'repo-1::/workspace/recreated-force-delete'
+    const cleanupIds: string[] = []
+    for (let index = 0; index < 2; index += 1) {
+      mockKnownFeatureWorktree('/workspace/recreated-force-delete')
+      removeWorktreeMock.mockResolvedValueOnce({
+        preservedBranch: { branchName: 'feature/same', head: 'same-head' }
+      })
+      const result = (await handlers['worktrees:remove'](null, {
+        worktreeId
+      })) as RemoveWorktreeResult
+      const cleanupId = result.preservedBranch?.cleanupId
+      expect(cleanupId).toEqual(expect.any(String))
+      if (!cleanupId) {
+        throw new Error('missing cleanup id')
+      }
+      cleanupIds.push(cleanupId)
+    }
+
+    await expect(
+      handlers['worktrees:forceDeletePreservedBranch'](null, {
+        cleanupId: cleanupIds[0],
+        worktreeId,
+        branchName: 'feature/same',
+        expectedHead: 'same-head'
+      })
+    ).rejects.toThrow('No preserved branch cleanup is pending')
+    expect(forceDeleteLocalBranchMock).not.toHaveBeenCalled()
+    expect(getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+  })
+
   it('force-deletes an SSH branch that was preserved by safe worktree removal', async () => {
     const repo = {
       id: 'repo-ssh',
@@ -10183,6 +10262,41 @@ describe('registerWorktreeHandlers', () => {
     expect(store.removeWorktreeMeta).toHaveBeenCalledTimes(1)
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledTimes(1)
     expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the authoritative cleanup id to coalesced preserved-branch removals', async () => {
+    mockKnownFeatureWorktree()
+    let removalStarted!: () => void
+    let finishRemoval!: () => void
+    const started = new Promise<void>((resolve) => {
+      removalStarted = resolve
+    })
+    removeWorktreeMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          removalStarted()
+          finishRemoval = () =>
+            resolve({ preservedBranch: { branchName: 'feature/test', head: 'same-head' } })
+        })
+    )
+
+    const first = handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt'
+    }) as Promise<RemoveWorktreeResult>
+    const second = handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt'
+    }) as Promise<RemoveWorktreeResult>
+
+    await started
+    finishRemoval()
+    const [firstResult, secondResult] = await Promise.all([first, second])
+    expect(firstResult).toEqual(secondResult)
+    expect(firstResult.preservedBranch).toEqual({
+      branchName: 'feature/test',
+      head: 'same-head',
+      cleanupId: expect.any(String)
+    })
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1)
   })
 
   it('rejects concurrent deletes for the same worktree id with different options', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -526,6 +526,7 @@ type WorktreeRemovalInFlight = {
 }
 
 type PreservedBranchCleanupTarget = {
+  cleanupId?: string
   worktreeId: string
   hostId: ExecutionHostId
   branchName: string
@@ -551,6 +552,8 @@ function rememberPreservedBranchCleanupTarget(
   pushTarget: GitPushTarget | undefined
 ): void {
   if (result?.preservedBranch) {
+    const cleanupId = randomUUID()
+    result.preservedBranch.cleanupId = cleanupId
     const head = result.preservedBranch.head ?? fallbackHead
     if (!head) {
       throw new Error(
@@ -558,6 +561,7 @@ function rememberPreservedBranchCleanupTarget(
       )
     }
     preservedBranchCleanupByScope.set(preservedBranchCleanupScopeKey({ worktreeId, hostId }), {
+      ...(cleanupId ? { cleanupId } : {}),
       worktreeId,
       hostId,
       branchName: result.preservedBranch.branchName,
@@ -589,7 +593,8 @@ function getPreservedBranchCleanupTarget(
   worktreeId: string,
   branchName: string,
   expectedHead: string,
-  hostId?: ExecutionHostId
+  hostId?: ExecutionHostId,
+  cleanupId?: string
 ): PreservedBranchCleanupTarget {
   const exactTarget = hostId
     ? preservedBranchCleanupByScope.get(preservedBranchCleanupScopeKey({ worktreeId, hostId }))
@@ -603,7 +608,12 @@ function getPreservedBranchCleanupTarget(
           target.head === expectedHead
       )
   const target = exactTarget ?? (legacyMatches.length === 1 ? legacyMatches[0] : undefined)
-  if (!target || target.branchName !== branchName || target.head !== expectedHead) {
+  if (
+    !target ||
+    target.branchName !== branchName ||
+    target.head !== expectedHead ||
+    (cleanupId && target.cleanupId !== cleanupId)
+  ) {
     throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
   }
   return target
@@ -620,7 +630,8 @@ function releasePreservedBranchCleanupTargets(cleanups: readonly PreservedBranch
         cleanup.worktreeId,
         cleanup.branchName,
         cleanup.expectedHead,
-        cleanup.hostId
+        cleanup.hostId,
+        cleanup.cleanupId
       )
       preservedBranchCleanupByScope.delete(
         preservedBranchCleanupScopeKey({ worktreeId: target.worktreeId, hostId: target.hostId })
@@ -3121,6 +3132,7 @@ export function registerWorktreeHandlers(
     async (
       _event,
       args: {
+        cleanupId?: string
         worktreeId: string
         branchName: string
         expectedHead: string
@@ -3132,7 +3144,8 @@ export function registerWorktreeHandlers(
         args.worktreeId,
         args.branchName,
         args.expectedHead,
-        args.hostId
+        args.hostId,
+        args.cleanupId
       )
       const repo = getRepoForWorktreeRemoval(store, repoId, cleanupTarget.hostId)
       if (!repo) {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -142,7 +142,10 @@ import {
   registerSshProviderRequestAbort
 } from '../ssh/ssh-provider-authority'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
-import { preservedBranchCleanupScopeKey } from '../../shared/preserved-branch-cleanup'
+import {
+  preservedBranchCleanupScopeKey,
+  type PreservedBranchCleanup
+} from '../../shared/preserved-branch-cleanup'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -532,6 +535,14 @@ type PreservedBranchCleanupTarget = {
 
 const preservedBranchCleanupByScope = new Map<string, PreservedBranchCleanupTarget>()
 
+export function getPreservedBranchCleanupTargetCountForTests(): number {
+  return preservedBranchCleanupByScope.size
+}
+
+export function resetPreservedBranchCleanupTargetsForTests(): void {
+  preservedBranchCleanupByScope.clear()
+}
+
 function rememberPreservedBranchCleanupTarget(
   worktreeId: string,
   hostId: ExecutionHostId,
@@ -596,6 +607,30 @@ function getPreservedBranchCleanupTarget(
     throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
   }
   return target
+}
+
+function releasePreservedBranchCleanupTargets(cleanups: readonly PreservedBranchCleanup[]): number {
+  let released = 0
+  for (const cleanup of cleanups) {
+    if (!cleanup.expectedHead) {
+      continue
+    }
+    try {
+      const target = getPreservedBranchCleanupTarget(
+        cleanup.worktreeId,
+        cleanup.branchName,
+        cleanup.expectedHead,
+        cleanup.hostId
+      )
+      preservedBranchCleanupByScope.delete(
+        preservedBranchCleanupScopeKey({ worktreeId: target.worktreeId, hostId: target.hostId })
+      )
+      released += 1
+    } catch {
+      // Stale dismissal must not release newer cleanup authority.
+    }
+  }
+  return released
 }
 
 const loggedUnavailableSshGitProviders = new Set<string>()
@@ -1822,6 +1857,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:remove')
   ipcMain.removeHandler('worktrees:forgetLocal')
   ipcMain.removeHandler('worktrees:forceDeletePreservedBranch')
+  ipcMain.removeHandler('worktrees:releasePreservedBranchCleanups')
   ipcMain.removeHandler('worktrees:updateMeta')
   ipcMain.removeHandler('worktrees:listLineage')
   ipcMain.removeHandler('worktrees:listLineageForHost')
@@ -3149,6 +3185,15 @@ export function registerWorktreeHandlers(
       )
       return { deleted: true }
     }
+  )
+
+  ipcMain.handle(
+    'worktrees:releasePreservedBranchCleanups',
+    (_event, args: { cleanups?: readonly PreservedBranchCleanup[] }) => ({
+      released: releasePreservedBranchCleanupTargets(
+        Array.isArray(args?.cleanups) ? args.cleanups : []
+      )
+    })
   )
 
   ipcMain.handle(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -46585,7 +46585,11 @@ describe('OrcaRuntimeService', () => {
       const result = await runtime.removeManagedWorktree(TEST_WORKTREE_ID, true)
 
       expect(result).toEqual({
-        preservedBranch: { branchName: 'feature/foo', head: 'abc' },
+        preservedBranch: {
+          branchName: 'feature/foo',
+          head: 'abc',
+          cleanupId: expect.any(String)
+        },
         warning: `orca.yaml archive hook skipped for ${TEST_WORKTREE_PATH}; pass --run-hooks to run it.`
       })
       expect(gitSpy).toHaveBeenCalledWith(['worktree', 'prune'], {
@@ -46674,7 +46678,11 @@ describe('OrcaRuntimeService', () => {
       const result = await runtime.removeManagedWorktree(worktreeId, true)
 
       expect(result).toEqual({
-        preservedBranch: { branchName: 'feature/foo', head: 'abc' }
+        preservedBranch: {
+          branchName: 'feature/foo',
+          head: 'abc',
+          cleanupId: expect.any(String)
+        }
       })
       expect(runHook).not.toHaveBeenCalled()
       expect(removeWorktree).not.toHaveBeenCalled()
@@ -46957,6 +46965,92 @@ describe('OrcaRuntimeService', () => {
     expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(1)
   })
 
+  it('does not release a recreated same-value runtime cleanup with an older cleanup id', () => {
+    const runtime = createWorktreeRemovalRuntime()
+    const lifecycle = runtime as unknown as {
+      rememberPreservedBranchCleanupTarget: (
+        worktreeId: string,
+        hostId: undefined,
+        result: {
+          preservedBranch: { branchName: string; head: string; cleanupId?: string }
+        },
+        fallbackHead: undefined,
+        pushTarget: undefined
+      ) => void
+    }
+    const results: {
+      preservedBranch: { branchName: string; head: string; cleanupId?: string }
+    }[] = Array.from({ length: 2 }, () => ({
+      preservedBranch: { branchName: 'feature/same', head: 'same-head' }
+    }))
+    for (const result of results) {
+      lifecycle.rememberPreservedBranchCleanupTarget(
+        TEST_WORKTREE_ID,
+        undefined,
+        result,
+        undefined,
+        undefined
+      )
+    }
+    expect(results[0].preservedBranch.cleanupId).toEqual(expect.any(String))
+    expect(results[1].preservedBranch.cleanupId).not.toBe(results[0].preservedBranch.cleanupId)
+
+    expect(
+      runtime.releasePreservedBranchCleanups([
+        {
+          cleanupId: results[0].preservedBranch.cleanupId,
+          worktreeSelector: `id:${TEST_WORKTREE_ID}`,
+          branchName: 'feature/same',
+          expectedHead: 'same-head'
+        }
+      ])
+    ).toEqual({ released: 0 })
+    expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+  })
+
+  it('does not force-delete a recreated same-value runtime cleanup with an older cleanup id', async () => {
+    const runtime = createWorktreeRemovalRuntime()
+    const lifecycle = runtime as unknown as {
+      rememberPreservedBranchCleanupTarget: (
+        worktreeId: string,
+        hostId: undefined,
+        result: {
+          preservedBranch: { branchName: string; head: string; cleanupId?: string }
+        },
+        fallbackHead: undefined,
+        pushTarget: undefined
+      ) => void
+    }
+    const results: {
+      preservedBranch: { branchName: string; head: string; cleanupId?: string }
+    }[] = Array.from({ length: 2 }, () => ({
+      preservedBranch: { branchName: 'feature/same', head: 'same-head' }
+    }))
+    for (const result of results) {
+      lifecycle.rememberPreservedBranchCleanupTarget(
+        TEST_WORKTREE_ID,
+        undefined,
+        result,
+        undefined,
+        undefined
+      )
+    }
+    expect(results[0].preservedBranch.cleanupId).toEqual(expect.any(String))
+    expect(results[1].preservedBranch.cleanupId).not.toBe(results[0].preservedBranch.cleanupId)
+
+    await expect(
+      runtime.forceDeletePreservedBranch(
+        TEST_WORKTREE_ID,
+        'feature/same',
+        'same-head',
+        undefined,
+        results[0].preservedBranch.cleanupId
+      )
+    ).rejects.toThrow('No preserved branch cleanup is pending')
+    expect(forceDeleteLocalBranchMock).not.toHaveBeenCalled()
+    expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+  })
+
   it('force-deletes an SSH branch that was preserved by runtime worktree removal', async () => {
     const remoteRepo = {
       ...store.getRepo(TEST_REPO_ID)!,
@@ -47102,6 +47196,31 @@ describe('OrcaRuntimeService', () => {
 
     finishRemoval.resolve()
     await expect(Promise.all([first, second])).resolves.toEqual([{}, {}])
+  })
+
+  it('returns the authoritative cleanup id to coalesced runtime removals', async () => {
+    const runtime = createWorktreeRemovalRuntime()
+    const removeStarted = deferred<void>()
+    const finishRemoval = deferred<void>()
+    vi.mocked(removeWorktree).mockImplementation(async () => {
+      removeStarted.resolve()
+      await finishRemoval.promise
+      return { preservedBranch: { branchName: 'feature/test', head: 'same-head' } }
+    })
+
+    const first = runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+    const second = runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+
+    await removeStarted.promise
+    finishRemoval.resolve()
+    const [firstResult, secondResult] = await Promise.all([first, second])
+    expect(firstResult).toEqual(secondResult)
+    expect(firstResult.preservedBranch).toEqual({
+      branchName: 'feature/test',
+      head: 'same-head',
+      cleanupId: expect.any(String)
+    })
+    expect(removeWorktree).toHaveBeenCalledTimes(1)
   })
 
   it('rejects concurrent runtime worktree removals for the same id with different options', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -46884,6 +46884,79 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('releases dismissed runtime preserved-branch cleanup routes', () => {
+    const runtime = createWorktreeRemovalRuntime()
+    const cleanups = Array.from({ length: 8 }, (_, index) => ({
+      worktreeSelector: `id:${TEST_REPO_ID}::/workspace/feature-${index}`,
+      branchName: `feature/${index}`,
+      expectedHead: `head-${index}`
+    }))
+    const lifecycle = runtime as unknown as {
+      rememberPreservedBranchCleanupTarget: (
+        worktreeId: string,
+        hostId: undefined,
+        result: { preservedBranch: { branchName: string; head: string } },
+        fallbackHead: undefined,
+        pushTarget: undefined
+      ) => void
+      releasePreservedBranchCleanups: (items: typeof cleanups) => { released: number }
+    }
+
+    for (const cleanup of cleanups) {
+      lifecycle.rememberPreservedBranchCleanupTarget(
+        cleanup.worktreeSelector.slice(3),
+        undefined,
+        { preservedBranch: { branchName: cleanup.branchName, head: cleanup.expectedHead } },
+        undefined,
+        undefined
+      )
+    }
+
+    expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(8)
+    expect(lifecycle.releasePreservedBranchCleanups(cleanups.slice(0, -1))).toEqual({ released: 7 })
+    expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+    expect(lifecycle.releasePreservedBranchCleanups(cleanups.slice(-1))).toEqual({ released: 1 })
+    expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(0)
+  })
+
+  it('does not release a newer runtime cleanup route from a stale dismissal', () => {
+    const runtime = createWorktreeRemovalRuntime()
+    const lifecycle = runtime as unknown as {
+      rememberPreservedBranchCleanupTarget: (
+        worktreeId: string,
+        hostId: undefined,
+        result: { preservedBranch: { branchName: string; head: string } },
+        fallbackHead: undefined,
+        pushTarget: undefined
+      ) => void
+    }
+    lifecycle.rememberPreservedBranchCleanupTarget(
+      TEST_WORKTREE_ID,
+      undefined,
+      { preservedBranch: { branchName: 'feature/old', head: 'old-head' } },
+      undefined,
+      undefined
+    )
+    lifecycle.rememberPreservedBranchCleanupTarget(
+      TEST_WORKTREE_ID,
+      undefined,
+      { preservedBranch: { branchName: 'feature/new', head: 'new-head' } },
+      undefined,
+      undefined
+    )
+
+    expect(
+      runtime.releasePreservedBranchCleanups([
+        {
+          worktreeSelector: `id:${TEST_WORKTREE_ID}`,
+          branchName: 'feature/old',
+          expectedHead: 'old-head'
+        }
+      ])
+    ).toEqual({ released: 0 })
+    expect(runtime.getPreservedBranchCleanupTargetCountForTests()).toBe(1)
+  })
+
   it('force-deletes an SSH branch that was preserved by runtime worktree removal', async () => {
     const remoteRepo = {
       ...store.getRepo(TEST_REPO_ID)!,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2147,6 +2147,7 @@ type RuntimeWorktreeRemovalInFlight = {
 }
 
 type PreservedBranchCleanupTarget = {
+  cleanupId?: string
   worktreeId: string
   hostId?: ExecutionHostId
   branchName: string
@@ -24236,6 +24237,8 @@ export class OrcaRuntimeService {
     pushTarget: GitPushTarget | undefined
   ): void {
     if (result?.preservedBranch) {
+      const cleanupId = randomUUID()
+      result.preservedBranch.cleanupId = cleanupId
       const head = result.preservedBranch.head ?? fallbackHead
       if (!head) {
         throw new Error(
@@ -24245,6 +24248,7 @@ export class OrcaRuntimeService {
       this.preservedBranchCleanupByScope.set(
         preservedBranchCleanupScopeKey({ worktreeId, hostId }),
         {
+          ...(cleanupId ? { cleanupId } : {}),
           worktreeId,
           ...(hostId ? { hostId } : {}),
           branchName: result.preservedBranch.branchName,
@@ -24279,7 +24283,8 @@ export class OrcaRuntimeService {
     worktreeSelector: string,
     branchName: string,
     expectedHead: string,
-    hostId?: string
+    hostId?: string,
+    cleanupId?: string
   ): Promise<ForceDeleteWorktreeBranchResult> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
@@ -24305,7 +24310,8 @@ export class OrcaRuntimeService {
       !removalTarget ||
       !cleanupTarget ||
       cleanupTarget.branchName !== branchName ||
-      cleanupTarget.head !== expectedHead
+      cleanupTarget.head !== expectedHead ||
+      (cleanupId && cleanupTarget.cleanupId !== cleanupId)
     ) {
       throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
     }
@@ -24365,6 +24371,7 @@ export class OrcaRuntimeService {
 
   releasePreservedBranchCleanups(
     cleanups: readonly {
+      cleanupId?: string
       worktreeSelector: string
       branchName: string
       expectedHead?: string
@@ -24386,7 +24393,8 @@ export class OrcaRuntimeService {
         !worktree ||
         !cleanup.expectedHead ||
         target?.branchName !== cleanup.branchName ||
-        target.head !== cleanup.expectedHead
+        target.head !== cleanup.expectedHead ||
+        (cleanup.cleanupId && target.cleanupId !== cleanup.cleanupId)
       ) {
         continue
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3216,6 +3216,10 @@ export class OrcaRuntimeService {
   private optimisticReconcileTokens = new Map<string, string>()
   private removeManagedWorktreeInFlight = new Map<string, RuntimeWorktreeRemovalInFlight>()
   private preservedBranchCleanupByScope = new Map<string, PreservedBranchCleanupTarget>()
+
+  getPreservedBranchCleanupTargetCountForTests(): number {
+    return this.preservedBranchCleanupByScope.size
+  }
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private readonly getSshProviderFn: ((connectionId: string) => IPtyProvider | undefined) | null
   private readonly onPtyStopped: ((ptyId: string) => void) | null
@@ -24357,6 +24361,41 @@ export class OrcaRuntimeService {
       })
     )
     return { deleted: true }
+  }
+
+  releasePreservedBranchCleanups(
+    cleanups: readonly {
+      worktreeSelector: string
+      branchName: string
+      expectedHead?: string
+      hostId?: string
+    }[]
+  ): { released: number } {
+    let released = 0
+    for (const cleanup of cleanups) {
+      const worktree = parseExactWorktreeIdSelector(cleanup.worktreeSelector)
+      const normalizedHostId = parseExecutionHostId(cleanup.hostId)?.id
+      const target = worktree
+        ? cleanup.hostId && !normalizedHostId
+          ? undefined
+          : this.preservedBranchCleanupByScope.get(
+              preservedBranchCleanupScopeKey({ worktreeId: worktree.id, hostId: normalizedHostId })
+            )
+        : undefined
+      if (
+        !worktree ||
+        !cleanup.expectedHead ||
+        target?.branchName !== cleanup.branchName ||
+        target.head !== cleanup.expectedHead
+      ) {
+        continue
+      }
+      this.preservedBranchCleanupByScope.delete(
+        preservedBranchCleanupScopeKey({ worktreeId: worktree.id, hostId: normalizedHostId })
+      )
+      released += 1
+    }
+    return { released }
   }
 
   async removeManagedWorktree(

--- a/src/main/runtime/rpc/methods/worktree-preserved-cleanup-release.ts
+++ b/src/main/runtime/rpc/methods/worktree-preserved-cleanup-release.ts
@@ -1,0 +1,16 @@
+import { defineMethod } from '../core'
+import { WorktreeReleasePreservedBranchCleanups } from './worktree-schemas'
+
+export const WORKTREE_PRESERVED_CLEANUP_RELEASE_METHOD = defineMethod({
+  name: 'worktree.releasePreservedBranchCleanups',
+  params: WorktreeReleasePreservedBranchCleanups,
+  handler: async (params, { runtime }) =>
+    runtime.releasePreservedBranchCleanups(
+      params.cleanups.map((cleanup) => ({
+        worktreeSelector: cleanup.worktree,
+        branchName: cleanup.branchName,
+        expectedHead: cleanup.expectedHead,
+        hostId: cleanup.hostId
+      }))
+    )
+})

--- a/src/main/runtime/rpc/methods/worktree-preserved-cleanup-release.ts
+++ b/src/main/runtime/rpc/methods/worktree-preserved-cleanup-release.ts
@@ -7,6 +7,7 @@ export const WORKTREE_PRESERVED_CLEANUP_RELEASE_METHOD = defineMethod({
   handler: async (params, { runtime }) =>
     runtime.releasePreservedBranchCleanups(
       params.cleanups.map((cleanup) => ({
+        ...(cleanup.cleanupId ? { cleanupId: cleanup.cleanupId } : {}),
         worktreeSelector: cleanup.worktree,
         branchName: cleanup.branchName,
         expectedHead: cleanup.expectedHead,

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -296,6 +296,19 @@ export const WorktreeForceDeleteBranch = WorktreeSelector.extend({
     .pipe(z.string().min(1, 'Missing expected branch head'))
 })
 
+export const WorktreeReleasePreservedBranchCleanups = z.object({
+  cleanups: z
+    .array(
+      z.object({
+        worktree: z.string().min(1),
+        branchName: z.string().min(1),
+        expectedHead: z.string().min(1).optional(),
+        hostId: OptionalString
+      })
+    )
+    .max(10_000)
+})
+
 export const WorktreeResolvePrBase = z.object({
   repo: z
     .unknown()

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -285,6 +285,7 @@ export const WorktreeRemove = WorktreeSelector.extend({
 })
 
 export const WorktreeForceDeleteBranch = WorktreeSelector.extend({
+  cleanupId: OptionalString,
   hostId: OptionalString,
   branchName: z
     .unknown()
@@ -300,6 +301,7 @@ export const WorktreeReleasePreservedBranchCleanups = z.object({
   cleanups: z
     .array(
       z.object({
+        cleanupId: OptionalString,
         worktree: z.string().min(1),
         branchName: z.string().min(1),
         expectedHead: z.string().min(1).optional(),

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -291,18 +291,13 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.forceDeleteBranch',
     params: WorktreeForceDeleteBranch,
     handler: async (params, { runtime }) =>
-      params.hostId
-        ? runtime.forceDeletePreservedBranch(
-            params.worktree,
-            params.branchName,
-            params.expectedHead,
-            params.hostId
-          )
-        : runtime.forceDeletePreservedBranch(
-            params.worktree,
-            params.branchName,
-            params.expectedHead
-          )
+      runtime.forceDeletePreservedBranch(
+        params.worktree,
+        params.branchName,
+        params.expectedHead,
+        params.hostId,
+        params.cleanupId
+      )
   }),
   WORKTREE_PRESERVED_CLEANUP_RELEASE_METHOD
 ]

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -24,6 +24,7 @@ import {
   WorktreeSortOrder,
   WorktreeTeardownMissingTerminalsParams
 } from './worktree-schemas'
+import { WORKTREE_PRESERVED_CLEANUP_RELEASE_METHOD } from './worktree-preserved-cleanup-release'
 
 export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
@@ -302,5 +303,6 @@ export const WORKTREE_METHODS: RpcMethod[] = [
             params.branchName,
             params.expectedHead
           )
-  })
+  }),
+  WORKTREE_PRESERVED_CLEANUP_RELEASE_METHOD
 ]

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1409,6 +1409,7 @@ export type PreloadApi = {
       hostId?: ExecutionHostId
     }) => Promise<RemoveWorktreeResult>
     forceDeletePreservedBranch: (args: {
+      cleanupId?: string
       worktreeId: string
       branchName: string
       expectedHead: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -124,6 +124,7 @@ import type { PluginLanguagePackRegistration } from '../shared/plugins/plugin-la
 import type { PluginChangeEvent } from '../shared/plugins/plugin-change-event'
 import type { PluginManifest } from '../shared/plugins/plugin-manifest'
 import type { PluginMarketplaceGitSource } from '../shared/plugins/plugin-marketplace'
+import type { PreservedBranchCleanup } from '../shared/preserved-branch-cleanup'
 import type {
   LocalhostWorktreeLabelResult,
   LocalhostWorktreeLabelRoute
@@ -1413,6 +1414,9 @@ export type PreloadApi = {
       expectedHead: string
       hostId?: ExecutionHostId
     }) => Promise<ForceDeleteWorktreeBranchResult>
+    releasePreservedBranchCleanups: (args: {
+      cleanups: readonly PreservedBranchCleanup[]
+    }) => Promise<{ released: number }>
     updateMeta: (args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => Promise<Worktree>
     listLineage: () => Promise<{
       lineage: Record<string, WorktreeLineage>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -821,6 +821,9 @@ const api = {
     forceDeletePreservedBranch: (args) =>
       ipcRenderer.invoke('worktrees:forceDeletePreservedBranch', args),
 
+    releasePreservedBranchCleanups: (args) =>
+      ipcRenderer.invoke('worktrees:releasePreservedBranchCleanups', args),
+
     updateMeta: (args) => ipcRenderer.invoke('worktrees:updateMeta', args),
 
     listLineage: () => ipcRenderer.invoke('worktrees:listLineage'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2699,16 +2699,14 @@ function App(): React.JSX.Element {
                   <DeleteWorktreeDialog />
                 </RecoverableRenderErrorBoundary>
               ) : null}
-              {activeModal === 'preserved-branch-review' ? (
-                <RecoverableRenderErrorBoundary
-                  boundaryId="modal.preserved-branch-review"
-                  surface="modal"
-                  resetKey
-                  compact
-                >
-                  <PreservedBranchBatchReviewModal />
-                </RecoverableRenderErrorBoundary>
-              ) : null}
+              <RecoverableRenderErrorBoundary
+                boundaryId="modal.preserved-branch-review"
+                surface="modal"
+                resetKey
+                compact
+              >
+                <PreservedBranchBatchReviewModal />
+              </RecoverableRenderErrorBoundary>
             </Suspense>
             {hasSshCredentialRequest ? (
               <Suspense fallback={null}>

--- a/src/renderer/src/components/sidebar/PreservedBranchBatchReviewModal.tsx
+++ b/src/renderer/src/components/sidebar/PreservedBranchBatchReviewModal.tsx
@@ -1,5 +1,8 @@
-import { useMemo } from 'react'
-import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+import { useEffect, useMemo, useRef } from 'react'
+import {
+  preservedBranchCleanupKey,
+  type PreservedBranchCleanup
+} from '@/lib/preserved-branch-cleanup'
 import { useAppStore } from '@/store'
 import { PreservedBranchBatchReviewDialog } from './PreservedBranchBatchReviewDialog'
 import {
@@ -13,6 +16,7 @@ function isPreservedBranchCleanup(value: unknown): value is PreservedBranchClean
   }
   const branch = value as Partial<PreservedBranchCleanup>
   return (
+    (branch.cleanupId === undefined || typeof branch.cleanupId === 'string') &&
     typeof branch.worktreeId === 'string' &&
     typeof branch.branchName === 'string' &&
     (branch.expectedHead === undefined || typeof branch.expectedHead === 'string') &&
@@ -29,21 +33,42 @@ export default function PreservedBranchBatchReviewModal(): React.JSX.Element {
   const activeModal = useAppStore((state) => state.activeModal)
   const modalData = useAppStore((state) => state.modalData)
   const closeModal = useAppStore((state) => state.closeModal)
+  const releasePreservedBranchCleanups = useAppStore(
+    (state) => state.releasePreservedBranchCleanups
+  )
   const branches = useMemo(() => getModalBranches(modalData.branches), [modalData.branches])
   const open = activeModal === 'preserved-branch-review' && branches.length > 0
+  const reviewKey = branches.map(preservedBranchCleanupKey).join('\0')
+  const ownedBranches = useRef<readonly PreservedBranchCleanup[]>([])
+  useEffect(() => {
+    const previous = ownedBranches.current
+    if (previous.length > 0 && previous !== branches) {
+      void releasePreservedBranchCleanups(previous)
+    }
+    ownedBranches.current = open ? branches : []
+  }, [branches, open, releasePreservedBranchCleanups])
 
   const handleForceDelete = (selectedBranches: readonly ActionablePreservedBranch[]): void => {
+    const selectedKeys = new Set(selectedBranches.map(preservedBranchCleanupKey))
+    const unselectedBranches = branches.filter(
+      (branch) => !selectedKeys.has(preservedBranchCleanupKey(branch))
+    )
+    ownedBranches.current = []
     closeModal()
+    void releasePreservedBranchCleanups(unselectedBranches)
     void forceDeletePreservedBranchBatch(selectedBranches)
   }
 
   return (
     <PreservedBranchBatchReviewDialog
+      key={reviewKey}
       branches={branches}
       open={open}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) {
+          ownedBranches.current = []
           closeModal()
+          void releasePreservedBranchCleanups(branches)
         }
       }}
       onForceDelete={handleForceDelete}

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.test.tsx
@@ -57,6 +57,17 @@ function renderToastBody(): HTMLElement {
   return container
 }
 
+function renderErrorToastBody(): HTMLElement {
+  const description = vi.mocked(toast.error).mock.calls.at(-1)?.[1]
+    ?.description as React.ReactElement
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  act(() => root.render(description))
+  return container
+}
+
 function renderReviewModal(branches: readonly PreservedBranchCleanup[]): Root {
   mocks.state.activeModal = 'preserved-branch-review'
   mocks.state.modalData = { branches }
@@ -342,6 +353,30 @@ describe('showPreservedBranchBatchToast', () => {
 
     expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledOnce()
     expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith([failedBranch])
+  })
+
+  it('starts only one retry when its button is clicked twice', async () => {
+    const failedBranch = {
+      worktreeId: 'repo-a::one',
+      branchName: 'feature/one',
+      expectedHead: 'head-one'
+    }
+    mocks.state.forceDeletePreservedBranch
+      .mockResolvedValueOnce({ ok: false, error: 'busy' })
+      .mockImplementation(() => new Promise(() => {}))
+
+    await forceDeletePreservedBranchBatch([failedBranch])
+    const body = renderErrorToastBody()
+    const button = body.querySelector('button')
+    if (!button) {
+      throw new Error('retry button not found')
+    }
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.state.forceDeletePreservedBranch).toHaveBeenCalledTimes(2)
   })
 
   it('keeps concurrent failed batches on distinct retry toasts', async () => {

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.test.tsx
@@ -20,7 +20,8 @@ const mocks = vi.hoisted(() => {
     repos: [],
     closeModal: vi.fn(),
     openModal: vi.fn(),
-    forceDeletePreservedBranch: vi.fn()
+    forceDeletePreservedBranch: vi.fn(),
+    releasePreservedBranchCleanups: vi.fn()
   }
   return { state }
 })
@@ -56,7 +57,7 @@ function renderToastBody(): HTMLElement {
   return container
 }
 
-function renderReviewModal(branches: readonly PreservedBranchCleanup[]): void {
+function renderReviewModal(branches: readonly PreservedBranchCleanup[]): Root {
   mocks.state.activeModal = 'preserved-branch-review'
   mocks.state.modalData = { branches }
   const container = document.createElement('div')
@@ -64,6 +65,7 @@ function renderReviewModal(branches: readonly PreservedBranchCleanup[]): void {
   const root = createRoot(container)
   mountedRoots.push(root)
   act(() => root.render(<PreservedBranchBatchReviewModal />))
+  return root
 }
 
 async function clickButton(container: HTMLElement, label: string): Promise<void> {
@@ -96,6 +98,7 @@ beforeEach(() => {
   mocks.state.closeModal.mockReset()
   mocks.state.openModal.mockReset()
   mocks.state.forceDeletePreservedBranch.mockReset().mockResolvedValue({ ok: true, deleted: true })
+  mocks.state.releasePreservedBranchCleanups.mockReset().mockResolvedValue(undefined)
 })
 
 afterEach(() => {
@@ -107,7 +110,12 @@ afterEach(() => {
 describe('showPreservedBranchBatchToast', () => {
   it('explains disk cleanup and opens one review dialog for the batch', async () => {
     const branches = [
-      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' },
+      {
+        cleanupId: 'batch-one',
+        worktreeId: 'repo-a::one',
+        branchName: 'feature/one',
+        expectedHead: 'head-one'
+      },
       { worktreeId: 'repo-b::two', branchName: 'feature/two', expectedHead: 'head-two' }
     ]
     showPreservedBranchBatchToast(12, branches)
@@ -123,14 +131,46 @@ describe('showPreservedBranchBatchToast', () => {
     await clickButton(body, 'Review 2 Branches')
 
     expect(mocks.state.openModal).toHaveBeenCalledWith('preserved-branch-review', { branches })
-    expect(toast.dismiss).toHaveBeenCalledWith('preserved-branch-batch:repo-a::one:2')
+    expect(toast.dismiss).toHaveBeenCalledWith('preserved-branch-batch:batch-one')
     expect(mocks.state.forceDeletePreservedBranch).not.toHaveBeenCalled()
+    const options = vi.mocked(toast.warning).mock.calls.at(-1)?.[1]
+    options?.onDismiss?.({ id: 'preserved-branch-batch:repo-a::one:2' } as never)
+    expect(mocks.state.releasePreservedBranchCleanups).not.toHaveBeenCalled()
+  })
+
+  it('releases the batch when its toast is dismissed', () => {
+    const branches = [
+      {
+        cleanupId: 'batch-dismiss',
+        worktreeId: 'repo-a::one',
+        branchName: 'feature/one',
+        expectedHead: 'head-one'
+      }
+    ]
+    showPreservedBranchBatchToast(1, branches)
+
+    const options = vi.mocked(toast.warning).mock.calls.at(-1)?.[1]
+    options?.onDismiss?.({ id: 'preserved-branch-batch:repo-a::one:1' } as never)
+    options?.onAutoClose?.({ id: 'preserved-branch-batch:repo-a::one:1' } as never)
+
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledOnce()
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith(branches)
   })
 
   it('force-deletes only the branches selected in review', async () => {
     renderReviewModal([
-      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' },
-      { worktreeId: 'repo-b::two', branchName: 'feature/two', expectedHead: 'head-two' }
+      {
+        cleanupId: 'batch-one',
+        worktreeId: 'repo-a::one',
+        branchName: 'feature/one',
+        expectedHead: 'head-one'
+      },
+      {
+        cleanupId: 'batch-two',
+        worktreeId: 'repo-b::two',
+        branchName: 'feature/two',
+        expectedHead: 'head-two'
+      }
     ])
 
     expect(document.body.textContent).toContain('Review kept branches')
@@ -148,11 +188,92 @@ describe('showPreservedBranchBatchToast', () => {
       'repo-a::one',
       'feature/one',
       'head-one',
-      { suppressToast: true }
+      { cleanupId: 'batch-one', suppressToast: true }
     )
     expect(toast.success).toHaveBeenCalledWith('Local branches deleted: 1', {
-      id: 'force-delete-branch-batch:repo-a::one:1'
+      id: 'force-delete-branch-batch:batch-one'
     })
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith([
+      {
+        cleanupId: 'batch-two',
+        worktreeId: 'repo-b::two',
+        branchName: 'feature/two',
+        expectedHead: 'head-two'
+      }
+    ])
+  })
+
+  it('releases the batch when review is cancelled', async () => {
+    const branches = [
+      { worktreeId: 'repo-a::one', branchName: 'feature/one', expectedHead: 'head-one' }
+    ]
+    renderReviewModal(branches)
+
+    await clickButton(document.body, 'Cancel')
+
+    expect(mocks.state.closeModal).toHaveBeenCalledOnce()
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith(branches)
+  })
+
+  it('releases the batch when another modal replaces its review', async () => {
+    const branches = [
+      { cleanupId: 'replaced', worktreeId: 'repo-a::one', branchName: 'feature/one' }
+    ]
+    const root = renderReviewModal(branches)
+    mocks.state.activeModal = 'none'
+    mocks.state.modalData = {}
+
+    await act(async () => {
+      root.render(<PreservedBranchBatchReviewModal />)
+      await Promise.resolve()
+    })
+
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith(branches)
+  })
+
+  it('releases the prior batch when another review replaces it', async () => {
+    const previous = [
+      { cleanupId: 'previous', worktreeId: 'repo-a::one', branchName: 'feature/one' }
+    ]
+    const replacement = [
+      { cleanupId: 'replacement', worktreeId: 'repo-b::two', branchName: 'feature/two' }
+    ]
+    const root = renderReviewModal(previous)
+    mocks.state.modalData = { branches: replacement }
+
+    await act(async () => {
+      root.render(<PreservedBranchBatchReviewModal />)
+      await Promise.resolve()
+    })
+
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith(previous)
+  })
+
+  it('selects a batch that opens after the controller mounts closed', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    mountedRoots.push(root)
+    act(() => root.render(<PreservedBranchBatchReviewModal />))
+    mocks.state.activeModal = 'preserved-branch-review'
+    mocks.state.modalData = {
+      branches: [
+        {
+          cleanupId: 'opened-later',
+          worktreeId: 'repo-a::one',
+          branchName: 'feature/one',
+          expectedHead: 'head-one'
+        }
+      ]
+    }
+
+    await act(async () => {
+      root.render(<PreservedBranchBatchReviewModal />)
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('1 of 1 selected')
+    expect(document.body.textContent).toContain('Force Delete 1 Branch')
   })
 
   it('keeps older-server branches visible without offering an unsafe delete', () => {
@@ -204,5 +325,49 @@ describe('showPreservedBranchBatchToast', () => {
       'head-one',
       { suppressToast: true }
     )
+  })
+
+  it('releases failed branches when the retry toast is dismissed', async () => {
+    const failedBranch = {
+      worktreeId: 'repo-a::one',
+      branchName: 'feature/one',
+      expectedHead: 'head-one'
+    }
+    mocks.state.forceDeletePreservedBranch.mockResolvedValueOnce({ ok: false, error: 'busy' })
+
+    await forceDeletePreservedBranchBatch([failedBranch])
+    const options = vi.mocked(toast.error).mock.calls.at(-1)?.[1]
+    options?.onDismiss?.({ id: 'force-delete-branch-batch:repo-a::one:1' } as never)
+    options?.onAutoClose?.({ id: 'force-delete-branch-batch:repo-a::one:1' } as never)
+
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledOnce()
+    expect(mocks.state.releasePreservedBranchCleanups).toHaveBeenCalledWith([failedBranch])
+  })
+
+  it('keeps concurrent failed batches on distinct retry toasts', async () => {
+    mocks.state.forceDeletePreservedBranch.mockResolvedValue({ ok: false, error: 'busy' })
+    await forceDeletePreservedBranchBatch([
+      {
+        cleanupId: 'failed-one',
+        worktreeId: 'repo-a::one',
+        branchName: 'feature/one',
+        expectedHead: 'head-one'
+      }
+    ])
+    await forceDeletePreservedBranchBatch([
+      {
+        cleanupId: 'failed-two',
+        worktreeId: 'repo-a::one',
+        branchName: 'feature/one',
+        expectedHead: 'head-one'
+      }
+    ])
+
+    expect(
+      vi
+        .mocked(toast.error)
+        .mock.calls.slice(-2)
+        .map(([, options]) => options?.id)
+    ).toEqual(['force-delete-branch-batch:failed-one', 'force-delete-branch-batch:failed-two'])
   })
 })

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
@@ -6,6 +6,7 @@ import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { Button } from '../ui/button'
 import type { PreservedBranchCleanup } from '@/lib/preserved-branch-cleanup'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 
 const BRANCH_REPO_DELETE_CONCURRENCY = 4
 
@@ -55,7 +56,7 @@ export function showPreservedBranchBatchToast(
     return
   }
   const actionableCount = branches.filter((branch) => branch.expectedHead).length
-  const toastId = `preserved-branch-batch:${branches[0].worktreeId}:${branches.length}`
+  const toastId = `preserved-branch-batch:${branches[0].cleanupId ?? createBrowserUuid()}`
   const removedWorkspaces = translate(
     'auto.components.sidebar.preserved.branch.batch.toast.cea24c2b7d',
     '{{count}} workspaces removed',
@@ -66,7 +67,16 @@ export function showPreservedBranchBatchToast(
     '{{count}} branches kept',
     { count: branches.length }
   )
+  let reviewStarted = false
+  let reviewCompleted = false
+  const release = (): void => {
+    if (!reviewStarted && !reviewCompleted) {
+      reviewCompleted = true
+      void useAppStore.getState().releasePreservedBranchCleanups(branches)
+    }
+  }
   const onReview = (): void => {
+    reviewStarted = true
     useAppStore.getState().openModal('preserved-branch-review', { branches })
     toast.dismiss(toastId)
   }
@@ -81,6 +91,8 @@ export function showPreservedBranchBatchToast(
       id: toastId,
       description: <PreservedBranchBatchToastBody branches={branches} onReview={onReview} />,
       dismissible: true,
+      onDismiss: release,
+      onAutoClose: release,
       ...(actionableCount > 0 ? { duration: Infinity } : {})
     }
   )
@@ -92,7 +104,7 @@ export async function forceDeletePreservedBranchBatch(
   if (branches.length === 0) {
     return
   }
-  const progressToastId = `force-delete-branch-batch:${branches[0].worktreeId}:${branches.length}`
+  const progressToastId = `force-delete-branch-batch:${branches[0].cleanupId ?? createBrowserUuid()}`
   toast.loading(
     translate(
       'auto.components.sidebar.preserved.branch.batch.toast.e61d78054f',
@@ -123,6 +135,7 @@ export async function forceDeletePreservedBranchBatch(
             .getState()
             .forceDeletePreservedBranch(branch.worktreeId, branch.branchName, branch.expectedHead, {
               suppressToast: true,
+              ...(branch.cleanupId ? { cleanupId: branch.cleanupId } : {}),
               ...(branch.hostId ? { hostId: branch.hostId } : {}),
               ...(branch.runtimeEnvironmentId
                 ? { runtimeEnvironmentId: branch.runtimeEnvironmentId }
@@ -152,6 +165,14 @@ export async function forceDeletePreservedBranchBatch(
     .filter(Boolean)
     .join('; ')
   const failedBranches = failures.map(({ branch }) => branch)
+  let retryStarted = false
+  let retryReviewCompleted = false
+  const releaseFailures = (): void => {
+    if (!retryStarted && !retryReviewCompleted) {
+      retryReviewCompleted = true
+      void useAppStore.getState().releasePreservedBranchCleanups(failedBranches)
+    }
+  }
   toast.error(
     translate(
       'auto.components.sidebar.preserved.branch.batch.toast.43d9395605',
@@ -171,6 +192,7 @@ export async function forceDeletePreservedBranchBatch(
             size="sm"
             className="w-full"
             onClick={() => {
+              retryStarted = true
               void forceDeletePreservedBranchBatch(failedBranches)
             }}
           >
@@ -184,7 +206,9 @@ export async function forceDeletePreservedBranchBatch(
         </div>
       ),
       duration: Infinity,
-      dismissible: true
+      dismissible: true,
+      onDismiss: releaseFailures,
+      onAutoClose: releaseFailures
     }
   )
 }

--- a/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-batch-toast.tsx
@@ -192,6 +192,9 @@ export async function forceDeletePreservedBranchBatch(
             size="sm"
             className="w-full"
             onClick={() => {
+              if (retryStarted) {
+                return
+              }
               retryStarted = true
               void forceDeletePreservedBranchBatch(failedBranches)
             }}

--- a/src/renderer/src/components/sidebar/preserved-branch-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-toast.test.tsx
@@ -48,8 +48,8 @@ afterEach(() => {
 })
 
 describe('showPreservedBranchToast', () => {
-  it('renders the branch recovery action below the long description', () => {
-    const onForceDelete = vi.fn()
+  it('renders the branch recovery action below the long description', async () => {
+    const onForceDelete = vi.fn().mockResolvedValue(true)
     const result: RemoveWorktreeResult = {
       preservedBranch: {
         branchName: 'feat/notes-send-any-running-agent',
@@ -63,14 +63,16 @@ describe('showPreservedBranchToast', () => {
         displayName: 'Send review notes to any running agent of a worktree',
         isMainWorktree: false
       },
-      onForceDelete
+      onForceDelete,
+      vi.fn(),
+      'cleanup-one'
     )
     const body = renderToastBody()
 
     expect(toast.warning).toHaveBeenCalledWith(
       'Worktree deleted, branch kept',
       expect.objectContaining({
-        id: 'preserved-branch:feat/notes-send-any-running-agent:abc123',
+        id: 'preserved-branch:cleanup-one',
         dismissible: true,
         duration: Infinity
       })
@@ -81,8 +83,8 @@ describe('showPreservedBranchToast', () => {
     clickButton(body, 'Force Delete Branch')
 
     expect(onForceDelete).toHaveBeenCalledWith('feat/notes-send-any-running-agent', 'abc123')
-    expect(toast.dismiss).toHaveBeenCalledWith(
-      'preserved-branch:feat/notes-send-any-running-agent:abc123'
+    await vi.waitFor(() =>
+      expect(toast.dismiss).toHaveBeenCalledWith('preserved-branch:cleanup-one')
     )
   })
 
@@ -93,7 +95,7 @@ describe('showPreservedBranchToast', () => {
       }
     }
 
-    showPreservedBranchToast(result, undefined, vi.fn())
+    showPreservedBranchToast(result, undefined, vi.fn().mockResolvedValue(true))
     const body = renderToastBody()
 
     expect(body.textContent).not.toContain('Force Delete Branch')
@@ -101,5 +103,77 @@ describe('showPreservedBranchToast', () => {
       'Worktree deleted, branch kept',
       expect.not.objectContaining({ duration: Infinity })
     )
+  })
+
+  it.each(['onDismiss', 'onAutoClose'] as const)(
+    '%s releases the retained cleanup route',
+    (event) => {
+      const onRelease = vi.fn()
+      showPreservedBranchToast(
+        { preservedBranch: { branchName: 'feature/test', head: 'abc123' } },
+        undefined,
+        vi.fn().mockResolvedValue(true),
+        onRelease,
+        'cleanup-release'
+      )
+
+      const options = vi.mocked(toast.warning).mock.calls.at(-1)?.[1]
+      options?.[event]?.({ id: 'preserved-branch:cleanup-release' } as never)
+      options?.onDismiss?.({ id: 'preserved-branch:cleanup-release' } as never)
+      options?.onAutoClose?.({ id: 'preserved-branch:cleanup-release' } as never)
+
+      expect(onRelease).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('releases a pending force-delete route when the toast is dismissed', () => {
+    const onRelease = vi.fn()
+    showPreservedBranchToast(
+      { preservedBranch: { branchName: 'feature/test', head: 'abc123' } },
+      undefined,
+      vi.fn().mockResolvedValue(true),
+      onRelease,
+      'cleanup-delete'
+    )
+    const body = renderToastBody()
+    const options = vi.mocked(toast.warning).mock.calls.at(-1)?.[1]
+
+    clickButton(body, 'Force Delete Branch')
+    options?.onDismiss?.({ id: 'preserved-branch:cleanup-delete' } as never)
+
+    expect(onRelease).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the force-delete surface when deletion fails', async () => {
+    const onRelease = vi.fn()
+    const onForceDelete = vi.fn().mockResolvedValue(false)
+    showPreservedBranchToast(
+      { preservedBranch: { branchName: 'feature/test', head: 'abc123' } },
+      undefined,
+      onForceDelete,
+      onRelease,
+      'cleanup-failed-delete'
+    )
+    const body = renderToastBody()
+    const options = vi.mocked(toast.warning).mock.calls.at(-1)?.[1]
+
+    clickButton(body, 'Force Delete Branch')
+    await vi.waitFor(() => expect(onForceDelete).toHaveBeenCalledOnce())
+
+    expect(toast.dismiss).not.toHaveBeenCalled()
+    options?.onDismiss?.({ id: 'preserved-branch:cleanup-failed-delete' } as never)
+    expect(onRelease).toHaveBeenCalledOnce()
+  })
+
+  it('uses distinct toast identities for identical branch heads', () => {
+    const result = { preservedBranch: { branchName: 'feature/test', head: 'abc123' } }
+
+    showPreservedBranchToast(result, undefined, vi.fn().mockResolvedValue(true), vi.fn(), 'first')
+    showPreservedBranchToast(result, undefined, vi.fn().mockResolvedValue(true), vi.fn(), 'second')
+
+    expect(vi.mocked(toast.warning).mock.calls.map(([, options]) => options?.id)).toEqual([
+      'preserved-branch:first',
+      'preserved-branch:second'
+    ])
   })
 })

--- a/src/renderer/src/components/sidebar/preserved-branch-toast.tsx
+++ b/src/renderer/src/components/sidebar/preserved-branch-toast.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import type { RemoveWorktreeResult, Worktree } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import { Button } from '../ui/button'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 
 type PreservedBranchWorktree = Pick<Worktree, 'displayName' | 'isMainWorktree'>
 
@@ -10,10 +11,6 @@ type PreservedBranchToastBodyProps = {
   description: string
   forceDeleteLabel: string | undefined
   onForceDelete: (() => void) | undefined
-}
-
-function preservedBranchToastId(branchName: string, expectedHead: string | undefined): string {
-  return `preserved-branch:${branchName}:${expectedHead ?? 'unknown'}`
 }
 
 function getPreservedBranchTitle(isWorkspace: boolean): string {
@@ -80,7 +77,9 @@ function PreservedBranchToastBody({
 export function showPreservedBranchToast(
   result: RemoveWorktreeResult | undefined,
   worktree: PreservedBranchWorktree | undefined,
-  onForceDelete: (branchName: string, expectedHead: string) => void
+  onForceDelete: (branchName: string, expectedHead: string) => Promise<boolean>,
+  onRelease: () => void = () => {},
+  cleanupId = createBrowserUuid()
 ): void {
   const preservedBranch = result?.preservedBranch
   const branch = preservedBranch?.branchName
@@ -91,17 +90,39 @@ export function showPreservedBranchToast(
   const isWorkspace = worktree?.isMainWorktree === true
   const targetName = worktree?.displayName?.trim()
   const expectedHead = preservedBranch.head
-  const toastId = preservedBranchToastId(branch, expectedHead)
+  const toastId = `preserved-branch:${cleanupId}`
   const forceDeleteLabel = expectedHead
     ? translate('auto.store.slices.worktrees.e50495aae6', 'Force Delete Branch')
     : undefined
   const description = getPreservedBranchDescription(branch, targetName, isWorkspace)
+  let reviewCompleted = false
+  let forceDeleteStarted = false
   const forceDelete = expectedHead
     ? (): void => {
-        onForceDelete(branch, expectedHead)
-        toast.dismiss(toastId)
+        if (forceDeleteStarted) {
+          return
+        }
+        forceDeleteStarted = true
+        void onForceDelete(branch, expectedHead).then(
+          (deleted) => {
+            forceDeleteStarted = false
+            if (deleted) {
+              reviewCompleted = true
+              toast.dismiss(toastId)
+            }
+          },
+          () => {
+            forceDeleteStarted = false
+          }
+        )
       }
     : undefined
+  const release = (): void => {
+    if (!reviewCompleted) {
+      reviewCompleted = true
+      onRelease()
+    }
+  }
 
   toast.warning(getPreservedBranchTitle(isWorkspace), {
     id: toastId,
@@ -113,6 +134,8 @@ export function showPreservedBranchToast(
       />
     ),
     dismissible: true,
+    onDismiss: release,
+    onAutoClose: release,
     ...(expectedHead ? { duration: Infinity } : {})
   })
 }

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -218,13 +218,19 @@ describe('removeWorktree cascade', () => {
 
     expect(result).toEqual({
       ok: true,
-      preservedBranch: { branchName: 'feature/test', head: 'def456', hostId: 'local' }
+      preservedBranch: expect.objectContaining({
+        branchName: 'feature/test',
+        head: 'def456',
+        hostId: 'local'
+      })
     })
     expect(toast.warning).toHaveBeenCalledWith('Worktree deleted, branch kept', {
-      id: 'preserved-branch:feature/test:def456',
+      id: expect.stringMatching(/^preserved-branch:/),
       description: expect.anything(),
       dismissible: true,
-      duration: Infinity
+      duration: Infinity,
+      onDismiss: expect.any(Function),
+      onAutoClose: expect.any(Function)
     })
   })
 
@@ -254,7 +260,11 @@ describe('removeWorktree cascade', () => {
 
     expect(result).toEqual({
       ok: true,
-      preservedBranch: { branchName: 'feature/test', head: 'def456', hostId: 'local' }
+      preservedBranch: expect.objectContaining({
+        branchName: 'feature/test',
+        head: 'def456',
+        hostId: 'local'
+      })
     })
     expect(toast.warning).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/store/slices/workspace-cleanup-removal-preflight.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-removal-preflight.test.ts
@@ -96,7 +96,12 @@ describe('workspace cleanup removal and protection', () => {
     )
     const removeWorktree = vi.fn().mockResolvedValue({
       ok: true,
-      preservedBranch: { branchName: 'feature/cleanup', head: 'saved-head' }
+      preservedBranch: {
+        branchName: 'feature/cleanup',
+        head: 'saved-head',
+        hostId: 'ssh:cleanup-target',
+        runtimeEnvironmentId: 'cleanup-hub'
+      }
     })
     const store = createCleanupTestStore(removeWorktree)
     store.setState({
@@ -112,7 +117,9 @@ describe('workspace cleanup removal and protection', () => {
         {
           worktreeId: candidate.worktreeId,
           branchName: 'feature/cleanup',
-          expectedHead: 'saved-head'
+          expectedHead: 'saved-head',
+          hostId: 'ssh:cleanup-target',
+          runtimeEnvironmentId: 'cleanup-hub'
         }
       ]
     })

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -341,9 +341,16 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
         removedIds.push(candidate.worktreeId)
         if (result.preservedBranch) {
           preservedBranches.push({
+            ...(result.preservedBranch.cleanupId
+              ? { cleanupId: result.preservedBranch.cleanupId }
+              : {}),
             worktreeId: candidate.worktreeId,
             branchName: result.preservedBranch.branchName,
-            expectedHead: result.preservedBranch.head
+            expectedHead: result.preservedBranch.head,
+            ...(result.preservedBranch.hostId ? { hostId: result.preservedBranch.hostId } : {}),
+            ...(result.preservedBranch.runtimeEnvironmentId
+              ? { runtimeEnvironmentId: result.preservedBranch.runtimeEnvironmentId }
+              : {})
           })
         }
       } else {

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -30,6 +30,7 @@ import type {
   SshExecutionHostId
 } from '../../../../shared/detected-worktree-provider-contract'
 import type { DirectSshAuthority } from '../../../../shared/ssh-types'
+import type { PreservedBranchCleanup } from '../../../../shared/preserved-branch-cleanup'
 import type {
   PendingWorktreeCreation,
   WorktreeCreationPhase
@@ -49,6 +50,7 @@ export type WorktreeDeleteState = {
 
 type RendererRemoveWorktreeResult = Omit<RemoveWorktreeResult, 'preservedBranch'> & {
   preservedBranch?: NonNullable<RemoveWorktreeResult['preservedBranch']> & {
+    cleanupId?: string
     hostId?: ExecutionHostId
     runtimeEnvironmentId?: string
   }
@@ -256,8 +258,10 @@ export type WorktreeSlice = {
       suppressToast?: boolean
       hostId?: ExecutionHostId
       runtimeEnvironmentId?: string
+      cleanupId?: string
     }
   ) => Promise<({ ok: true } & ForceDeleteWorktreeBranchResult) | { ok: false; error: string }>
+  releasePreservedBranchCleanups: (cleanups: readonly PreservedBranchCleanup[]) => Promise<void>
   clearWorktreeDeleteState: (worktreeId: string) => void
   /** Never rejects — most callers fire-and-forget. Callers that own a surface
    *  the user is waiting on should read the result and say what went wrong. */

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -28,6 +28,7 @@ import type {
   ListDetectedWorktreesArgs
 } from '../../../../shared/detected-worktree-provider-contract'
 import type { DirectSshAuthority, SshProviderEpoch } from '../../../../shared/ssh-types'
+import type { PreservedBranchCleanup } from '../../../../shared/preserved-branch-cleanup'
 import {
   beginHugeRepoWarningProbe,
   clearHugeRepoWarningDismissalsForTests,
@@ -132,6 +133,7 @@ const mockApi = {
     remove: vi.fn().mockResolvedValue(undefined),
     forgetLocal: vi.fn().mockResolvedValue({}),
     forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
+    releasePreservedBranchCleanups: vi.fn().mockResolvedValue({ released: 0 }),
     resolvePrBase: vi.fn(),
     resolveMrBase: vi.fn(),
     updateMeta: vi.fn().mockResolvedValue(undefined),
@@ -167,9 +169,11 @@ import {
   WORKTREE_REFRESH_CONCURRENCY,
   acquireDirectSshDetectedWorktreeRefresh,
   createWorktreeSlice,
+  getPreservedBranchRuntimeTargetCountForTests,
   getHostedReviewLinkMutationGenerationForTests,
   getHostedReviewLinkWorktreeAliasCountForTests,
   resetAuthoritativelyRemovedWorktreeMemoryForTests,
+  resetPreservedBranchRuntimeTargetsForTests,
   resetHostedReviewLinkMutationGenerationForTests
 } from './worktrees'
 import type { PendingWorktreeCreation } from '@/lib/pending-worktree-creation'
@@ -197,6 +201,8 @@ function resetRemoteRuntimeMocks() {
 // earlier describe would silently suppress a row here. Reset for every case, not just the fetch suites.
 beforeEach(() => {
   resetAuthoritativelyRemovedWorktreeMemoryForTests()
+  resetPreservedBranchRuntimeTargetsForTests()
+  mockApi.worktrees.releasePreservedBranchCleanups.mockReset().mockResolvedValue({ released: 0 })
 })
 
 function createTestStore() {
@@ -6291,12 +6297,12 @@ describe('worktree remote runtime mutations', () => {
 
     expect(result).toEqual({
       ok: true,
-      preservedBranch: {
+      preservedBranch: expect.objectContaining({
         branchName: 'feature/nested',
         head: 'saved-head',
         hostId: 'ssh:hub-private-target',
         runtimeEnvironmentId: 'owner-hub'
-      }
+      })
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'owner-hub',
@@ -6401,6 +6407,179 @@ describe('worktree remote runtime mutations', () => {
         }
       })
     )
+  })
+
+  it('releases renderer routes when preserved-branch reviews are dismissed', async () => {
+    const store = createTestStore()
+    const cleanups: PreservedBranchCleanup[] = Array.from({ length: 8 }, (_, index) => ({
+      worktreeId: `repo-cleanup::/path/wt-${index}`,
+      branchName: `feature/${index}`,
+      expectedHead: `head-${index}`,
+      hostId: LOCAL_EXECUTION_HOST_ID
+    }))
+
+    for (const cleanup of cleanups) {
+      const worktree = makeWorktree({
+        id: cleanup.worktreeId,
+        repoId: 'repo-cleanup',
+        path: cleanup.worktreeId.split('::')[1]
+      })
+      mockApi.worktrees.remove.mockResolvedValueOnce({
+        preservedBranch: { branchName: cleanup.branchName, head: cleanup.expectedHead }
+      })
+      store.setState({ worktreesByRepo: { 'repo-cleanup': [worktree] } } as Partial<AppState>)
+      await store.getState().removeWorktree(worktree.id)
+    }
+
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(8)
+    await store.getState().releasePreservedBranchCleanups(cleanups.slice(0, -1))
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(1)
+    await store.getState().releasePreservedBranchCleanups(cleanups.slice(-1))
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(0)
+    const releasedCleanups = mockApi.worktrees.releasePreservedBranchCleanups.mock.calls.map(
+      ([args]) => args.cleanups.map(({ cleanupId: _cleanupId, ...cleanup }) => cleanup)
+    )
+    expect(releasedCleanups).toEqual([cleanups.slice(0, -1), cleanups.slice(-1)])
+  })
+
+  it('drops renderer routing after a best-effort cleanup release', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo-cleanup::/path/offline',
+      repoId: 'repo-cleanup',
+      path: '/path/offline'
+    })
+    mockApi.worktrees.remove.mockResolvedValueOnce({
+      preservedBranch: { branchName: 'feature/offline', head: 'offline-head' }
+    })
+    mockApi.worktrees.releasePreservedBranchCleanups.mockRejectedValue(
+      new Error('transport unavailable')
+    )
+    store.setState({ worktreesByRepo: { 'repo-cleanup': [wt] } } as Partial<AppState>)
+    const result = await store.getState().removeWorktree(wt.id)
+
+    await store.getState().releasePreservedBranchCleanups([
+      {
+        cleanupId: result.ok ? result.preservedBranch?.cleanupId : undefined,
+        worktreeId: wt.id,
+        branchName: 'feature/offline',
+        expectedHead: 'offline-head',
+        hostId: LOCAL_EXECUTION_HOST_ID
+      }
+    ])
+
+    expect(mockApi.worktrees.releasePreservedBranchCleanups).toHaveBeenCalledOnce()
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(0)
+  })
+
+  it('does not let an old same-value review release a recreated cleanup', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-cleanup::/path/recreated'
+    const cleanups: PreservedBranchCleanup[] = []
+    for (let index = 0; index < 2; index += 1) {
+      const wt = makeWorktree({ id: worktreeId, repoId: 'repo-cleanup', path: '/path/recreated' })
+      mockApi.worktrees.remove.mockResolvedValueOnce({
+        preservedBranch: { branchName: 'feature/same', head: 'same-head' }
+      })
+      store.setState({ worktreesByRepo: { 'repo-cleanup': [wt] } } as Partial<AppState>)
+      const result = await store.getState().removeWorktree(worktreeId)
+      if (result.ok && result.preservedBranch) {
+        cleanups.push({
+          cleanupId: result.preservedBranch.cleanupId,
+          worktreeId,
+          branchName: result.preservedBranch.branchName,
+          expectedHead: result.preservedBranch.head,
+          hostId: result.preservedBranch.hostId,
+          runtimeEnvironmentId: result.preservedBranch.runtimeEnvironmentId
+        })
+      }
+    }
+
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(1)
+    await store.getState().releasePreservedBranchCleanups([cleanups[0]!])
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(1)
+    expect(mockApi.worktrees.releasePreservedBranchCleanups).not.toHaveBeenCalled()
+    await expect(
+      store.getState().forceDeletePreservedBranch(worktreeId, 'feature/same', 'same-head', {
+        cleanupId: cleanups[0]!.cleanupId,
+        hostId: LOCAL_EXECUTION_HOST_ID
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'No preserved branch cleanup is pending for "feature/same".'
+    })
+    expect(mockApi.worktrees.forceDeletePreservedBranch).not.toHaveBeenCalled()
+    await store.getState().releasePreservedBranchCleanups([cleanups[1]!])
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(0)
+    expect(mockApi.worktrees.releasePreservedBranchCleanups).toHaveBeenCalledOnce()
+  })
+
+  it('releases renderer authority when an older paired runtime lacks the release method', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo-remote::/srv/old-runtime-wt',
+      repoId: 'repo-remote',
+      path: '/srv/old-runtime-wt',
+      hostId: 'ssh:old-runtime-target',
+      runtimeOwnerEnvironmentId: 'old-runtime'
+    })
+    runtimeEnvironmentCall
+      .mockResolvedValueOnce({
+        id: 'rpc-rm-old-runtime',
+        ok: true,
+        result: {
+          preservedBranch: { branchName: 'feature/old-runtime', head: 'saved-head' }
+        },
+        _meta: { runtimeId: 'runtime-old' }
+      })
+      .mockResolvedValueOnce({
+        id: 'rpc-release-old-runtime',
+        ok: false,
+        error: {
+          code: 'method_not_found',
+          message: 'Unknown method: worktree.releasePreservedBranchCleanups'
+        },
+        _meta: { runtimeId: 'runtime-old' }
+      })
+    store.setState({ worktreesByRepo: { 'repo-remote': [wt] } } as Partial<AppState>)
+
+    const result = await store.getState().removeWorktree(wt.id)
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(1)
+    await store.getState().releasePreservedBranchCleanups([
+      {
+        worktreeId: wt.id,
+        branchName: 'feature/old-runtime',
+        expectedHead: 'saved-head',
+        hostId: 'ssh:old-runtime-target',
+        runtimeEnvironmentId: 'old-runtime'
+      }
+    ])
+
+    expect(result).toEqual({
+      ok: true,
+      preservedBranch: expect.objectContaining({
+        branchName: 'feature/old-runtime',
+        head: 'saved-head',
+        hostId: 'ssh:old-runtime-target',
+        runtimeEnvironmentId: 'old-runtime'
+      })
+    })
+    expect(getPreservedBranchRuntimeTargetCountForTests()).toBe(0)
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
+      selector: 'old-runtime',
+      method: 'worktree.releasePreservedBranchCleanups',
+      params: {
+        cleanups: [
+          {
+            worktree: `id:${wt.id}`,
+            branchName: 'feature/old-runtime',
+            expectedHead: 'saved-head',
+            hostId: 'ssh:old-runtime-target'
+          }
+        ]
+      },
+      timeoutMs: 15_000
+    })
   })
 
   it('fails HUB-owned SSH removal closed when the exact id has two HUB owners', async () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6314,7 +6314,8 @@ describe('worktree remote runtime mutations', () => {
         allowUnverifiedPtyStop: false,
         runHooks: true
       },
-      timeoutMs: 60_000
+      timeoutMs: 60_000,
+      expectedEnvironmentPairingRevision: undefined
     })
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
     expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([])
@@ -6572,13 +6573,15 @@ describe('worktree remote runtime mutations', () => {
         cleanups: [
           {
             worktree: `id:${wt.id}`,
+            cleanupId: expect.any(String),
             branchName: 'feature/old-runtime',
             expectedHead: 'saved-head',
             hostId: 'ssh:old-runtime-target'
           }
         ]
       },
-      timeoutMs: 15_000
+      timeoutMs: 15_000,
+      expectedEnvironmentPairingRevision: undefined
     })
   })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4611,7 +4611,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const preservedBranch = removalResult?.preservedBranch
       const cleanup = preservedBranch
         ? {
-            cleanupId: createBrowserUuid(),
+            cleanupId: preservedBranch.cleanupId ?? createBrowserUuid(),
             worktreeId,
             branchName: preservedBranch.branchName,
             expectedHead: preservedBranch.head,
@@ -4790,6 +4790,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         getActiveRuntimeTarget(settingsForWorktreeOwner(get(), worktreeId))
       const result = await (target.kind === 'local'
         ? window.api.worktrees.forceDeletePreservedBranch({
+            ...(requestedCleanup.cleanupId ? { cleanupId: requestedCleanup.cleanupId } : {}),
             worktreeId,
             branchName,
             expectedHead,
@@ -4799,6 +4800,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             target,
             'worktree.forceDeleteBranch',
             {
+              ...(requestedCleanup.cleanupId ? { cleanupId: requestedCleanup.cleanupId } : {}),
               worktree: toRuntimeWorktreeSelector(worktreeId),
               branchName,
               expectedHead,
@@ -4887,6 +4889,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 'worktree.releasePreservedBranchCleanups',
                 {
                   cleanups: targetCleanups.map((cleanup) => ({
+                    ...(cleanup.cleanupId ? { cleanupId: cleanup.cleanupId } : {}),
                     worktree: toRuntimeWorktreeSelector(cleanup.worktreeId),
                     branchName: cleanup.branchName,
                     expectedHead: cleanup.expectedHead,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -121,6 +121,7 @@ import {
 import { getTerminalActivationSpawnSuppression } from './terminal-activation-spawn-suppression'
 import {
   preservedBranchCleanupKey,
+  preservedBranchCleanupScopeKey,
   type PreservedBranchCleanup
 } from '../../../../shared/preserved-branch-cleanup'
 import type {
@@ -133,6 +134,7 @@ import type {
 import type { DirectSshAuthority } from '../../../../shared/ssh-types'
 import { findIndexedWorktreeOwnerForHost } from '@/lib/worktree-runtime-owner-index'
 import { catalogRowsEqual, reuseEqualCatalogRows } from './worktree-catalog-reconciliation'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 export type { WorktreeSlice, WorktreeDeleteState } from './worktree-helpers'
 
 // Why: old runtime servers only have `worktree.list`; preserve the large-list UI hydration parity used before `worktree.detectedList` existed.
@@ -151,6 +153,14 @@ const preservedBranchRuntimeTargetByCleanupKey = new Map<
   string,
   { cleanup: PreservedBranchCleanup; target: ReturnType<typeof getActiveRuntimeTarget> }
 >()
+
+export function getPreservedBranchRuntimeTargetCountForTests(): number {
+  return preservedBranchRuntimeTargetByCleanupKey.size
+}
+
+export function resetPreservedBranchRuntimeTargetsForTests(): void {
+  preservedBranchRuntimeTargetByCleanupKey.clear()
+}
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 const hostedReviewPushTargetLookupsInFlight = new Set<string>()
 const runtimeDetectedWorktreeRefreshesInFlight = new Map<
@@ -4601,6 +4611,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const preservedBranch = removalResult?.preservedBranch
       const cleanup = preservedBranch
         ? {
+            cleanupId: createBrowserUuid(),
             worktreeId,
             branchName: preservedBranch.branchName,
             expectedHead: preservedBranch.head,
@@ -4611,20 +4622,41 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           }
         : null
       if (preservedBranch) {
+        for (const [key, retained] of preservedBranchRuntimeTargetByCleanupKey) {
+          if (
+            preservedBranchCleanupScopeKey(retained.cleanup) ===
+            preservedBranchCleanupScopeKey(cleanup!)
+          ) {
+            preservedBranchRuntimeTargetByCleanupKey.delete(key)
+          }
+        }
         preservedBranchRuntimeTargetByCleanupKey.set(preservedBranchCleanupKey(cleanup!), {
           cleanup: cleanup!,
           target
         })
       }
-      if (preservedBranch && options?.suppressPreservedBranchToast !== true) {
-        showPreservedBranchToast(removalResult, worktreeBeforeRemoval, (branch, expectedHead) => {
-          void get().forceDeletePreservedBranch(worktreeId, branch, expectedHead, {
-            ...(hostId ? { hostId } : {}),
-            ...(removalRoute?.runtimeEnvironmentId
-              ? { runtimeEnvironmentId: removalRoute.runtimeEnvironmentId }
-              : {})
-          })
-        })
+      if (preservedBranch && cleanup && options?.suppressPreservedBranchToast !== true) {
+        showPreservedBranchToast(
+          removalResult,
+          worktreeBeforeRemoval,
+          async (branch, expectedHead) => {
+            const result = await get().forceDeletePreservedBranch(
+              worktreeId,
+              branch,
+              expectedHead,
+              {
+                ...(hostId ? { hostId } : {}),
+                ...(removalRoute?.runtimeEnvironmentId
+                  ? { runtimeEnvironmentId: removalRoute.runtimeEnvironmentId }
+                  : {}),
+                cleanupId: cleanup.cleanupId
+              }
+            )
+            return result.ok
+          },
+          () => void get().releasePreservedBranchCleanups([cleanup]),
+          cleanup.cleanupId
+        )
       }
       pruneHostedReviewLinkMutationGenerations([worktreeId])
       return preservedBranch && cleanup
@@ -4632,6 +4664,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ok: true as const,
             preservedBranch: {
               ...preservedBranch,
+              cleanupId: cleanup.cleanupId,
               ...(cleanup.hostId ? { hostId: cleanup.hostId } : {}),
               ...(cleanup.runtimeEnvironmentId
                 ? { runtimeEnvironmentId: cleanup.runtimeEnvironmentId }
@@ -4718,6 +4751,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   forceDeletePreservedBranch: async (worktreeId, branchName, expectedHead, options) => {
     try {
       const requestedCleanup: PreservedBranchCleanup = {
+        ...(options?.cleanupId ? { cleanupId: options.cleanupId } : {}),
         worktreeId,
         branchName,
         expectedHead,
@@ -4728,20 +4762,25 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
       const requestedCleanupKey = preservedBranchCleanupKey(requestedCleanup)
       const exactRetainedTarget = preservedBranchRuntimeTargetByCleanupKey.get(requestedCleanupKey)
-      const matchingRetainedTargets = exactRetainedTarget
-        ? [exactRetainedTarget]
-        : [...preservedBranchRuntimeTargetByCleanupKey.values()].filter(
-            ({ cleanup }) =>
-              cleanup.worktreeId === worktreeId &&
-              cleanup.branchName === branchName &&
-              cleanup.expectedHead === expectedHead
-          )
+      const matchingRetainedTargets =
+        exactRetainedTarget || options?.cleanupId
+          ? [exactRetainedTarget]
+          : [...preservedBranchRuntimeTargetByCleanupKey.values()].filter(
+              ({ cleanup }) =>
+                cleanup.worktreeId === worktreeId &&
+                cleanup.branchName === branchName &&
+                cleanup.expectedHead === expectedHead &&
+                (!options?.hostId || cleanup.hostId === options.hostId) &&
+                (!options?.runtimeEnvironmentId ||
+                  cleanup.runtimeEnvironmentId === options.runtimeEnvironmentId)
+            )
       const retainedTarget =
         exactRetainedTarget ??
-        (options?.hostId || options?.runtimeEnvironmentId || matchingRetainedTargets.length !== 1
-          ? undefined
-          : matchingRetainedTargets[0])
-      if ((options?.hostId || options?.runtimeEnvironmentId) && !retainedTarget) {
+        (matchingRetainedTargets.length === 1 ? matchingRetainedTargets[0] : undefined)
+      if (
+        (options?.cleanupId || options?.hostId || options?.runtimeEnvironmentId) &&
+        !retainedTarget
+      ) {
         throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
       }
       const cleanupHostId = options?.hostId ?? retainedTarget?.cleanup.hostId
@@ -4792,6 +4831,81 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
       return { ok: false as const, error }
     }
+  },
+
+  releasePreservedBranchCleanups: async (cleanups) => {
+    const releasesByTarget = new Map<
+      string,
+      {
+        target: ReturnType<typeof getActiveRuntimeTarget>
+        cleanups: PreservedBranchCleanup[]
+      }
+    >()
+    for (const cleanup of cleanups) {
+      const exactKey = preservedBranchCleanupKey(cleanup)
+      const exactRetained = preservedBranchRuntimeTargetByCleanupKey.get(exactKey)
+      const legacyMatches = cleanup.cleanupId
+        ? []
+        : [...preservedBranchRuntimeTargetByCleanupKey.entries()].filter(
+            ([, candidate]) =>
+              candidate.cleanup.worktreeId === cleanup.worktreeId &&
+              candidate.cleanup.branchName === cleanup.branchName &&
+              candidate.cleanup.expectedHead === cleanup.expectedHead &&
+              (!cleanup.hostId || candidate.cleanup.hostId === cleanup.hostId) &&
+              (!cleanup.runtimeEnvironmentId ||
+                candidate.cleanup.runtimeEnvironmentId === cleanup.runtimeEnvironmentId)
+          )
+      const key = exactRetained
+        ? exactKey
+        : legacyMatches.length === 1
+          ? legacyMatches[0]?.[0]
+          : undefined
+      const retained =
+        exactRetained ?? (legacyMatches.length === 1 ? legacyMatches[0]?.[1] : undefined)
+      if (!key || !retained) {
+        continue
+      }
+      const targetKey =
+        retained.target.kind === 'local' ? 'local' : `runtime:${retained.target.environmentId}`
+      const release = releasesByTarget.get(targetKey)
+      if (release) {
+        release.cleanups.push(retained.cleanup)
+      } else {
+        releasesByTarget.set(targetKey, {
+          target: retained.target,
+          cleanups: [retained.cleanup]
+        })
+      }
+    }
+    await Promise.all(
+      [...releasesByTarget.values()].map(async ({ target, cleanups: targetCleanups }) => {
+        try {
+          await (target.kind === 'local'
+            ? window.api.worktrees.releasePreservedBranchCleanups({ cleanups: targetCleanups })
+            : callRuntimeRpc(
+                target,
+                'worktree.releasePreservedBranchCleanups',
+                {
+                  cleanups: targetCleanups.map((cleanup) => ({
+                    worktree: toRuntimeWorktreeSelector(cleanup.worktreeId),
+                    branchName: cleanup.branchName,
+                    expectedHead: cleanup.expectedHead,
+                    hostId: cleanup.hostId
+                  }))
+                },
+                { timeoutMs: 15_000 }
+              ))
+        } catch (error) {
+          if (!isRuntimeMethodNotFoundError(error)) {
+            console.warn('Failed to release preserved branch cleanup:', error)
+          }
+        } finally {
+          for (const cleanup of targetCleanups) {
+            preservedBranchRuntimeTargetByCleanupKey.delete(preservedBranchCleanupKey(cleanup))
+          }
+        }
+      })
+    )
   },
 
   clearWorktreeDeleteState: (worktreeId) => {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -3019,6 +3019,57 @@ describe('web worktree preload API', () => {
     ])
   })
 
+  it('treats preserved-cleanup release as optional on an older paired runtime', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: 'release-cleanup',
+            ok: false,
+            error: { code: 'method_not_found', message: 'Unknown method' },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      globals.window.api.worktrees.releasePreservedBranchCleanups({
+        cleanups: [
+          {
+            worktreeId: 'repo-1::/workspace/kept',
+            branchName: 'feature/kept',
+            expectedHead: 'abc123',
+            hostId: 'local'
+          }
+        ]
+      })
+    ).resolves.toEqual({ released: 0 })
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'worktree.releasePreservedBranchCleanups',
+        params: {
+          cleanups: [
+            {
+              worktree: 'id:repo-1::/workspace/kept',
+              branchName: 'feature/kept',
+              expectedHead: 'abc123',
+              hostId: 'local'
+            }
+          ]
+        }
+      }
+    ])
+  })
+
   it.each(['web-server-a', 'web-server-b'])(
     'attributes server-local worktrees to their own paired runtime %s',
     async (environmentId) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1868,6 +1868,27 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         expectedHead,
         ...(hostId ? { hostId } : {})
       }),
+    releasePreservedBranchCleanups: async ({ cleanups }) => {
+      const response = await callRuntimeEnvelope(
+        'worktree.releasePreservedBranchCleanups',
+        {
+          cleanups: cleanups.map((cleanup) => ({
+            worktree: toRuntimeWorktreeSelector(cleanup.worktreeId),
+            branchName: cleanup.branchName,
+            expectedHead: cleanup.expectedHead,
+            hostId: cleanup.hostId
+          }))
+        },
+        15_000
+      )
+      if (!response.ok) {
+        if (response.error.code === 'method_not_found') {
+          return { released: 0 }
+        }
+        throw new Error(response.error.message)
+      }
+      return response.result as { released: number }
+    },
     updateMeta: async ({ worktreeId, updates }) => {
       const rpcUpdates =
         Object.hasOwn(updates, 'pushTarget') && updates.pushTarget === undefined

--- a/src/shared/preserved-branch-cleanup.ts
+++ b/src/shared/preserved-branch-cleanup.ts
@@ -1,6 +1,7 @@
 import type { ExecutionHostId } from './execution-host'
 
 export type PreservedBranchCleanup = {
+  cleanupId?: string
   worktreeId: string
   branchName: string
   expectedHead?: string
@@ -17,6 +18,7 @@ export function preservedBranchCleanupScopeKey(
 export function preservedBranchCleanupKey(cleanup: PreservedBranchCleanup): string {
   return [
     preservedBranchCleanupScopeKey(cleanup),
+    cleanup.cleanupId ?? '',
     cleanup.branchName,
     cleanup.expectedHead ?? ''
   ].join('\0')

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2380,6 +2380,7 @@ export type WorktreeCreateBaseFallback = {
 }
 
 export type PreservedWorktreeBranch = {
+  cleanupId?: string
   branchName: string
   head?: string
 }


### PR DESCRIPTION
## Summary

Preserved-branch force-delete routing now lives only as long as its toast or batch review UI. Dismissal, cancellation, replacement, unselected branches, completed deletion, and dismissed retry surfaces release the renderer/main/runtime entries; an app restart naturally clears all process-local state.

## Design

- no Git-config provenance, restart reconstruction, persistence, timers, or durable recovery
- one additive optional release RPC for paired runtimes; older hosts returning `method_not_found` remain compatible
- per-review in-memory IDs prevent stale or overlapping UI from acting on a recreated cleanup
- exact local, direct SSH, paired-runtime, and nested SSH routing is retained only while force-delete remains actionable
- folder workspace cleanup continues without inventing Git branch authority

## Validation

- focused lifecycle/topology gate: 1,921 passed, 1 unrelated skip
- `pnpm typecheck`
- changed-code quality
- max-lines ratchet
- reliability manifest
- `git diff --check`
- fresh internal functional, remote/adversarial, and performance reviews: clean

## Compatibility

The wire change is additive and optional. No Git command changed, so the Git 2.25 baseline is unaffected; no provider-specific behavior was added.

## Visual proof

Not applicable: existing toast and modal presentation is unchanged; this fixes their cleanup lifecycle.

## Linked issue

[STA-3926](https://linear.app/stably/issue/STA-3926/p2daily-14181-preserved-branch-cleanup-maps-retain-dismissed-entries)

## AI disclosure

OpenAI Codex assisted with implementation and internal review.
