### PR TITLE
fix(sidebar): place stamped folder workspaces under their own host section

### DIFF
--- a/src/renderer/src/components/sidebar/host-section-row-fixtures.ts
+++ b/src/renderer/src/components/sidebar/host-section-row-fixtures.ts
@@ -1,5 +1,10 @@
-import type { FolderWorkspace, ProjectGroup, Repo, Worktree } from '../../../../shared/types'
-import { PINNED_GROUP_KEY, type Row } from './worktree-list-groups'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { PINNED_GROUP_KEY } from './worktree-list/grouping/group-keys'
+import type { Row } from './worktree-list/grouping/row-types'
 import type { HostSectionRow } from './host-section-rows'
 
 export function repo(id: string, connectionId?: string | null): Repo {
@@ -46,8 +51,8 @@ export function header(key: string, label = key): Extract<Row, { type: 'header' 
 }
 
 export function pinnedHeader(
-  counts: ReadonlyMap<'local' | 'ssh:ssh-1', number>,
-  idsByHost?: ReadonlyMap<'local' | 'ssh:ssh-1', readonly string[]>
+  counts: ReadonlyMap<ExecutionHostId, number>,
+  idsByHost?: ReadonlyMap<ExecutionHostId, readonly string[]>
 ): Extract<Row, { type: 'header' }> {
   return {
     ...header(PINNED_GROUP_KEY, 'Pinned'),
@@ -95,7 +100,8 @@ export function pinnedItem(
 
 export function folderWorkspaceRow(
   connectionId: string | null,
-  groupExecutionHostId?: string
+  groupExecutionHostId?: ExecutionHostId,
+  folderExecutionHostId?: ExecutionHostId
 ): Extract<Row, { type: 'folder-workspace' }> {
   const projectGroup: ProjectGroup = {
     id: 'group-1',
@@ -117,6 +123,7 @@ export function folderWorkspaceRow(
     name: 'Folder workspace',
     folderPath: '/srv/project',
     connectionId,
+    ...(folderExecutionHostId ? { executionHostId: folderExecutionHostId } : {}),
     linkedTask: null,
     comment: '',
     isArchived: false,

--- a/src/renderer/src/components/sidebar/host-section-row-fixtures.ts
+++ b/src/renderer/src/components/sidebar/host-section-row-fixtures.ts
@@ -1,0 +1,142 @@
+import type { FolderWorkspace, ProjectGroup, Repo, Worktree } from '../../../../shared/types'
+import { PINNED_GROUP_KEY, type Row } from './worktree-list-groups'
+import type { HostSectionRow } from './host-section-rows'
+
+export function repo(id: string, connectionId?: string | null): Repo {
+  return {
+    id,
+    path: `/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 0,
+    connectionId
+  }
+}
+
+export function worktree(id: string, repoId: string): Worktree {
+  return {
+    id,
+    repoId,
+    path: `/${repoId}/${id}`,
+    branch: `refs/heads/${id}`,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    comment: '',
+    isUnread: false,
+    isPinned: false,
+    displayName: id,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+export function header(key: string, label = key): Extract<Row, { type: 'header' }> {
+  return {
+    type: 'header',
+    key,
+    label,
+    count: 1,
+    tone: 'text-foreground'
+  }
+}
+
+export function pinnedHeader(
+  counts: ReadonlyMap<'local' | 'ssh:ssh-1', number>,
+  idsByHost?: ReadonlyMap<'local' | 'ssh:ssh-1', readonly string[]>
+): Extract<Row, { type: 'header' }> {
+  return {
+    ...header(PINNED_GROUP_KEY, 'Pinned'),
+    count: Array.from(counts.values()).reduce((sum, count) => sum + count, 0),
+    hostWorktreeCounts: counts,
+    hostWorktreeIds: idsByHost,
+    worktreeIds: idsByHost ? Array.from(idsByHost.values()).flat() : undefined
+  }
+}
+
+export function repoHeader(project: Repo): Extract<Row, { type: 'header' }> {
+  return {
+    ...header(`repo:${project.id}`, project.displayName),
+    repo: project
+  }
+}
+
+export function item(id: string, project: Repo): Extract<Row, { type: 'item' }> {
+  const sectionKey = `repo:${project.id}`
+  return {
+    type: 'item',
+    rowKey: `${sectionKey}:${id}`,
+    sectionKey,
+    worktree: worktree(id, project.id),
+    repo: project,
+    depth: 0,
+    groupDepth: 0,
+    lineageTrail: [],
+    isLastLineageChild: true,
+    lineageChildCount: 0
+  }
+}
+
+export function pinnedItem(
+  id: string,
+  project: Repo,
+  sectionKey: string
+): Extract<Row, { type: 'item' }> {
+  const row = item(id, project)
+  row.worktree.isPinned = true
+  row.rowKey = `${sectionKey}:${id}`
+  row.sectionKey = sectionKey
+  return row
+}
+
+export function folderWorkspaceRow(
+  connectionId: string | null,
+  groupExecutionHostId?: string
+): Extract<Row, { type: 'folder-workspace' }> {
+  const projectGroup: ProjectGroup = {
+    id: 'group-1',
+    name: 'Remote folder',
+    parentPath: '/srv/project',
+    connectionId,
+    ...(groupExecutionHostId ? { executionHostId: groupExecutionHostId } : {}),
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const folderWorkspace: FolderWorkspace = {
+    id: 'folder-1',
+    projectGroupId: projectGroup.id,
+    name: 'Folder workspace',
+    folderPath: '/srv/project',
+    connectionId,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  return {
+    type: 'folder-workspace',
+    key: 'folder-workspace:folder-1',
+    folderWorkspace,
+    projectGroup,
+    depth: 0,
+    groupDepth: 0
+  }
+}
+
+export function rowKey(row: HostSectionRow): string {
+  return row.type === 'item' ? row.worktree.id : row.key
+}

--- a/src/renderer/src/components/sidebar/host-section-rows.stamped-host-attribution.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.stamped-host-attribution.test.ts
@@ -56,6 +56,30 @@ describe('addHostSectionRows stamped host attribution', () => {
     ])
   })
 
+  it('lets a folder workspace stamp override a conflicting project-group host', () => {
+    const macOwned: Repo = { ...repo('mac-project'), executionHostId: 'runtime:mac-mini' }
+    const rows: Row[] = [
+      repoHeader(macOwned),
+      item('mac-wt', macOwned),
+      folderWorkspaceRow(null, 'runtime:mac-mini', 'runtime:devbox')
+    ]
+
+    const sectioned = addHostSectionRows({
+      rows,
+      hostOptions: TWO_RUNTIME_HOSTS,
+      workspaceHostScope: 'all',
+      defaultHostId: 'runtime:mac-mini'
+    })
+
+    expect(sectioned.map(rowKey)).toEqual([
+      'host:runtime:devbox',
+      'folder-workspace:folder-1',
+      'host:runtime:mac-mini',
+      'repo:mac-project',
+      'mac-wt'
+    ])
+  })
+
   it('attributes a repo-less project-group header to its stamped host instead of buffering it', () => {
     const macOwned: Repo = { ...repo('mac-project'), executionHostId: 'runtime:mac-mini' }
     const folderRow = folderWorkspaceRow(null, 'runtime:devbox')

--- a/src/renderer/src/components/sidebar/host-section-rows.stamped-host-attribution.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.stamped-host-attribution.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Row } from './worktree-list/grouping/row-types'
+import { addHostSectionRows, type HostSectionOption } from './host-section-rows'
+import {
+  folderWorkspaceRow,
+  header,
+  item,
+  repo,
+  repoHeader,
+  rowKey
+} from './host-section-row-fixtures'
+
+const TWO_RUNTIME_HOSTS: readonly HostSectionOption[] = [
+  {
+    id: 'runtime:devbox',
+    kind: 'runtime',
+    label: 'devbox',
+    detail: 'Orca server',
+    health: 'available'
+  },
+  {
+    id: 'runtime:mac-mini',
+    kind: 'runtime',
+    label: 'Mac mini',
+    detail: 'Orca server',
+    health: 'available'
+  }
+]
+
+// Why: placement must agree with the visibility filter's executionHostId
+// resolution, or a stamped remote project group renders under whichever
+// Orca server happens to be focused.
+describe('addHostSectionRows stamped host attribution', () => {
+  it('places a runtime-stamped folder workspace under its stamped host, not the focused host', () => {
+    const macOwned: Repo = { ...repo('mac-project'), executionHostId: 'runtime:mac-mini' }
+    const rows: Row[] = [
+      repoHeader(macOwned),
+      item('mac-wt', macOwned),
+      folderWorkspaceRow(null, 'runtime:devbox')
+    ]
+
+    const sectioned = addHostSectionRows({
+      rows,
+      hostOptions: TWO_RUNTIME_HOSTS,
+      workspaceHostScope: 'all',
+      defaultHostId: 'runtime:mac-mini'
+    })
+
+    expect(sectioned.map(rowKey)).toEqual([
+      'host:runtime:devbox',
+      'folder-workspace:folder-1',
+      'host:runtime:mac-mini',
+      'repo:mac-project',
+      'mac-wt'
+    ])
+  })
+
+  it('attributes a repo-less project-group header to its stamped host instead of buffering it', () => {
+    const macOwned: Repo = { ...repo('mac-project'), executionHostId: 'runtime:mac-mini' }
+    const folderRow = folderWorkspaceRow(null, 'runtime:devbox')
+    const groupHeader: Extract<Row, { type: 'header' }> = {
+      ...header('project-group:group-1', 'Remote folder'),
+      projectGroup: folderRow.projectGroup
+    }
+    const rows: Row[] = [groupHeader, folderRow, repoHeader(macOwned), item('mac-wt', macOwned)]
+
+    const sectioned = addHostSectionRows({
+      rows,
+      hostOptions: TWO_RUNTIME_HOSTS,
+      workspaceHostScope: 'all',
+      defaultHostId: 'runtime:mac-mini'
+    })
+
+    expect(sectioned.map(rowKey)).toEqual([
+      'host:runtime:devbox',
+      'project-group:group-1',
+      'folder-workspace:folder-1',
+      'host:runtime:mac-mini',
+      'repo:mac-project',
+      'mac-wt'
+    ])
+  })
+})

--- a/src/renderer/src/components/sidebar/host-section-rows.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.ts
@@ -4,6 +4,7 @@ import {
   getLocalExecutionHostLabel,
   getRepoExecutionHostId,
   getWorktreeExecutionHostId,
+  normalizeExecutionHostId,
   type ExecutionHostId,
   type ExecutionHostKind,
   type ExecutionHostScope
@@ -11,9 +12,11 @@ import {
 import type { ExecutionHostHealth } from '../../../../shared/execution-host-registry'
 import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
-import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
-import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
+import {
+  getFolderWorkspaceExecutionHostIdForRows,
+  getProjectGroupExecutionHostIdForRows
+} from './worktree-list/listing/host-filtering'
 import type { Row } from './worktree-list/grouping/row-types'
 
 export type HostHeaderRow = {
@@ -56,19 +59,6 @@ function getRepoHostId(
   return defaultHostId
 }
 
-function getSshHostId(connectionId: string): ExecutionHostId {
-  return `ssh:${encodeURIComponent(connectionId)}` as ExecutionHostId
-}
-
-function getFolderWorkspaceHostId(
-  folderWorkspace: Pick<FolderWorkspace, 'connectionId'>,
-  projectGroup: Pick<ProjectGroup, 'connectionId'>,
-  defaultHostId: ExecutionHostId
-): ExecutionHostId {
-  const connectionId = folderWorkspace.connectionId ?? projectGroup.connectionId
-  return connectionId ? getSshHostId(connectionId) : defaultHostId
-}
-
 function getRowHostId(row: Row, defaultHostId: ExecutionHostId): ExecutionHostId | null {
   switch (row.type) {
     case 'item':
@@ -78,9 +68,29 @@ function getRowHostId(row: Row, defaultHostId: ExecutionHostId): ExecutionHostId
     case 'new-external-worktrees-inbox':
       return getRepoHostId(row.repo, defaultHostId)
     case 'folder-workspace':
-      return getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, defaultHostId)
-    case 'header':
-      return row.repo ? getRepoHostId(row.repo, defaultHostId) : null
+      // Why: placement must match the visibility filter's resolver, or a
+      // stamped remote group renders under whichever host happens to be focused.
+      return getFolderWorkspaceExecutionHostIdForRows({
+        folderWorkspace: row.folderWorkspace,
+        projectGroup: row.projectGroup,
+        defaultHostId
+      })
+    case 'header': {
+      if (row.repo) {
+        return getRepoHostId(row.repo, defaultHostId)
+      }
+      // Why: a stamped project group already names its host; pending-buffering
+      // it instead would attach it to whichever host section follows.
+      const projectGroup = row.projectGroup
+      if (
+        projectGroup &&
+        typeof projectGroup.id === 'string' &&
+        (normalizeExecutionHostId(projectGroup.executionHostId) || projectGroup.connectionId)
+      ) {
+        return getProjectGroupExecutionHostIdForRows(projectGroup, defaultHostId)
+      }
+      return null
+    }
   }
 }
 


### PR DESCRIPTION
## ELI5

With more than one Orca server paired, a project belonging to server A could render under server B's section in the Projects sidebar — it followed whichever server happened to be *focused*, not the server that owns it.

## What Changed

- `host-section-rows.ts`: folder-workspace rows are now placed using `getFolderWorkspaceExecutionHostIdForRows` — the same resolver the sidebar's visibility filter already uses — instead of a local helper that only looked at `connectionId` and fell back to the focused host.
- Repo-less project-group headers that carry an explicit `executionHostId`/`connectionId` stamp are now attributed to that host directly instead of being pending-buffered into whichever host-owned run happens to follow.
- Extracted the shared row fixtures from `host-section-rows.test.ts` into `host-section-row-fixtures.ts` (the test file was over the `max-lines` limit once new tests were added) and added two regression tests in `host-section-rows.stamped-host-attribution.test.ts`.

## Why

Placement and visibility disagreed: `filterProjectGroupsForVisibleHosts` / `getFolderWorkspaceExecutionHostIdForRows` honor `executionHostId` stamps, but section *placement* read only `connectionId`. A runtime-owned project group (stamped `runtime:<env>`, `connectionId: null`) passed the filter as belonging to server A, then rendered under server B's host card whenever B was focused. Routing placement through the filter path's resolvers makes the two agree by construction.

## Linked Issue

Fixes #13944

## Visual Proof

Before (names redacted): a project group owned by server A rendered under server B's host section while B was the focused server.

![before: project group under the wrong host section](https://raw.githubusercontent.com/powtick/orca/refs/heads/assets-sidebar-screenshots/before-host-attribution.png)

After: the same group renders under its own host's section regardless of which server is focused.

## Testing

- `host-section-rows.stamped-host-attribution.test.ts`: both new tests fail without the fix (verified by stashing the source change) and pass with it.
- Full `src/renderer/src/components/sidebar` vitest suite: 2082 tests pass.
- `tsc --noEmit -p config/tsconfig.tc.web.json` passes.
- Manually reproduced against a real two-server pairing where the misplacement occurred.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and implemented with Claude Code (Claude Fable 5), reviewed by the author.

## Review

- Security: none — pure renderer grouping logic, no I/O.
- Cross-platform: no platform APIs touched; behavior identical on macOS/Linux/Windows.
- Remote SSH: SSH-stamped rows keep their existing `ssh:` attribution (covered by existing tests); this only fixes runtime-stamped and stamped-group cases.
- Mobile: not used by the mobile surface.
- Backwards compatibility: no wire/RPC change; renderer-only.
- Performance: same row pass, one extra field read per row; no added allocations on the hot path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint (pre-commit), web typecheck, and the sidebar suite ran locally; CI covers the rest

## Author

- X / Twitter: @powtick
