### PR TITLE
fix(sidebar): stop collapsed host cards overlapping after viewport remount

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2433,6 +2433,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     rows: renderRows,
     rangeStartIndex: stickyRangeStartIndexRef.current,
     scrollOffset: virtualizer.scrollOffset ?? scrollOffsetRef.current,
+    // Why: after a viewport remount the virtualizer holds the previous view's
+    // offset until a scroll event fires; short (all-collapsed) content never
+    // fires one, so an unclamped stale offset pins the wrong host card.
+    maxScrollOffset: Math.max(0, totalSize - (virtualizer.scrollRect?.height ?? 0)),
     stickyHeaderIndexes,
     virtualItems
   })

--- a/src/renderer/src/components/sidebar/host-section-rows.pending-header-keys.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.pending-header-keys.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo, Worktree } from '../../../../shared/types'
+import type { Row } from './worktree-list-groups'
+import { addHostSectionRows } from './host-section-rows'
+import { getRenderRowKey } from './worktree-list-virtual-rows'
+
+function repo(id: string, connectionId: string): Repo {
+  return {
+    id,
+    path: `/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 0,
+    connectionId
+  }
+}
+
+function item(id: string, project: Repo): Extract<Row, { type: 'item' }> {
+  const worktree: Worktree = {
+    id,
+    repoId: project.id,
+    path: `/${project.id}/${id}`,
+    branch: `refs/heads/${id}`,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    comment: '',
+    isUnread: false,
+    isPinned: false,
+    displayName: id,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+  return {
+    type: 'item',
+    rowKey: `all:${id}`,
+    sectionKey: 'all',
+    worktree,
+    repo: project,
+    depth: 0,
+    groupDepth: 0,
+    lineageTrail: [],
+    isLastLineageChild: true,
+    lineageChildCount: 0
+  }
+}
+
+// Why: a status/"All" header repeats above every host-owned run. Its copies
+// must carry the section's hostId or their render keys collide, corrupting
+// React reconciliation and the scroll anchor's row index.
+describe('addHostSectionRows pass-through pending header keys', () => {
+  it('stamps each duplicated pass-through header with its section host', () => {
+    const repoA = repo('project-a', 'ssh-1')
+    const repoB = repo('project-b', 'ssh-2')
+    const allHeader: Extract<Row, { type: 'header' }> = {
+      type: 'header',
+      key: 'all',
+      label: 'All',
+      count: 2,
+      tone: 'text-foreground'
+    }
+    const rows: Row[] = [allHeader, item('wt-a', repoA), item('wt-b', repoB)]
+
+    const sectioned = addHostSectionRows({
+      rows,
+      hostOptions: [
+        { id: 'ssh:ssh-1', kind: 'ssh', label: 'Builder', detail: 'SSH', health: 'available' },
+        { id: 'ssh:ssh-2', kind: 'ssh', label: 'Runner', detail: 'SSH', health: 'available' }
+      ],
+      workspaceHostScope: 'all',
+      defaultHostId: 'local'
+    })
+
+    const renderKeys = sectioned.map((row) => getRenderRowKey(row))
+    expect(renderKeys).toContain('hdr:ssh:ssh-1:all')
+    expect(renderKeys).toContain('hdr:ssh:ssh-2:all')
+    expect(new Set(renderKeys).size).toBe(renderKeys.length)
+  })
+})

--- a/src/renderer/src/components/sidebar/host-section-rows.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.ts
@@ -142,7 +142,9 @@ function localizePendingRowsForHost(
   const localized: Extract<Row, { type: 'header' }>[] = []
   for (const row of rows) {
     if (!row.hostWorktreeCounts) {
-      localized.push(row)
+      // Why: pass-through headers repeat in every host section; without the
+      // host stamp their render keys collide across sections.
+      localized.push(row.hostId === hostId ? row : { ...row, hostId })
       continue
     }
     const count = row.hostWorktreeCounts.get(hostId)

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
@@ -135,6 +135,39 @@ describe('getActiveStickyIndexesForScroll', () => {
     expect(after).toEqual({ hostIndex: 4, groupIndex: 5 })
   })
 
+  it('clamps a stale scroll offset so the first host card pins when content fits the viewport', () => {
+    // Why: after a viewport remount the virtualizer reports the previous
+    // view's offset until a scroll event fires; all-collapsed content fits the
+    // viewport so no event ever fires. Unclamped, the LAST host card pins
+    // in-flow at the top and paints over the first one.
+    const collapsedRows: RenderRow[] = [hostRow('ssh:a'), hostRow('ssh:b')]
+    const collapsedSticky = getStickyHeaderIndexes(collapsedRows)
+    const collapsedItems = [virtualItem(0, 0), virtualItem(1, 38)]
+    expect(
+      getActiveStickyIndexesForScroll({
+        rows: collapsedRows,
+        rangeStartIndex: 1,
+        scrollOffset: 500,
+        maxScrollOffset: 0,
+        stickyHeaderIndexes: collapsedSticky,
+        virtualItems: collapsedItems
+      })
+    ).toEqual({ hostIndex: 0, groupIndex: null })
+  })
+
+  it('leaves in-range offsets untouched when a max offset is provided', () => {
+    expect(
+      getActiveStickyIndexesForScroll({
+        rows,
+        rangeStartIndex: 2,
+        scrollOffset: 250,
+        maxScrollOffset: 600,
+        stickyHeaderIndexes,
+        virtualItems
+      })
+    ).toEqual({ hostIndex: 0, groupIndex: 1 })
+  })
+
   it('degrades to single-tier rules when no host sections exist', () => {
     const flatRows: RenderRow[] = [
       groupRow('g1'),

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
@@ -189,6 +189,10 @@ function getHostStickyIndexes(rows: readonly RenderRow[], sticky: readonly numbe
   return sticky.filter((index) => rows[index]?.type === 'host-header')
 }
 
+function getVirtualRowIndexAtOffset(items: readonly VirtualItem[], offset: number): number | null {
+  return (items.findLast((item) => item.start <= offset) ?? items[0])?.index ?? null
+}
+
 /** Two-tier sticky resolution: the host card is the outer hierarchy level so
  *  it stays pinned for the whole section while group headers hand off beneath
  *  it. Without host sections this degrades to the original single-tier rules. */
@@ -198,7 +202,19 @@ export function getActiveStickyIndexesForScroll(args: {
   scrollOffset: number
   stickyHeaderIndexes: readonly number[]
   virtualItems: readonly VirtualItem[]
+  /** Largest offset the scroll element can actually reach (totalSize - viewport). */
+  maxScrollOffset?: number
 }): ActiveStickyIndexes {
+  // Why: a remounted viewport keeps reporting the previous view's offset until
+  // a scroll event fires, and content that fits the viewport never fires one.
+  // Unclamped, the stale offset pins the last host card in-flow over the first
+  // one whenever every host section is collapsed.
+  let scrollOffset = args.scrollOffset
+  let rangeStartIndex = args.rangeStartIndex
+  if (args.maxScrollOffset !== undefined && scrollOffset > args.maxScrollOffset) {
+    scrollOffset = Math.max(0, args.maxScrollOffset)
+    rangeStartIndex = getVirtualRowIndexAtOffset(args.virtualItems, scrollOffset) ?? 0
+  }
   const hostIndexes = getHostStickyIndexes(args.rows, args.stickyHeaderIndexes)
 
   const resolveWithHandoff = (
@@ -206,7 +222,7 @@ export function getActiveStickyIndexesForScroll(args: {
     pinnedOffset: number,
     fallbackToCandidate: boolean
   ): number | null => {
-    const candidateIndex = getActiveStickyHeaderIndex(candidates, args.rangeStartIndex)
+    const candidateIndex = getActiveStickyHeaderIndex(candidates, rangeStartIndex)
     if (candidateIndex === null) {
       return null
     }
@@ -227,7 +243,7 @@ export function getActiveStickyIndexesForScroll(args: {
     }
     // Why: hand off the moment the incoming header reaches its pinned slot
     // (top of the viewport, or the bottom edge of the pinned host card).
-    if (args.scrollOffset + pinnedOffset >= candidate.start) {
+    if (scrollOffset + pinnedOffset >= candidate.start) {
       return candidateIndex
     }
     const previous = getPreviousStickyHeaderIndex(candidates, candidateIndex)


### PR DESCRIPTION
## ELI5

With several Orca servers paired, collapsing all host sections could leave the server cards painted on top of each other (one card half-hidden behind another, plus a blank gap above). The sidebar was pinning the wrong host card using a scroll position that no longer existed.

## What Changed

- `getActiveStickyIndexesForScroll` accepts an optional `maxScrollOffset` and clamps the offset it uses for sticky-host resolution to the reachable scroll range, re-deriving the effective range start from mounted geometry when clamping. `WorktreeList` passes `totalSize - viewport height`.
- `localizePendingRowsForHost` now stamps pass-through pending headers (status/"All" headers without per-host counts) with the host section they are copied into, so their render keys (`hdr:<hostId>:<key>`) no longer collide across sections.

## Why

After a viewport remount (grouping change, host-filter change, sidebar reopen) the virtualizer keeps reporting the previous view's scroll offset until a scroll event fires. All-collapsed content fits the viewport, so no scroll event ever fires and the stale offset never heals. Sticky resolution then picks the *last* host header, which renders in-flow (`position: sticky`, no translate) at the top of the list — painting over the first host card while its own slot renders blank. Clamping at the consumption site fixes both the persistent all-collapsed case and the one-frame flash when collapsing while scrolled.

The key collision is an adjacent defect in the same pipeline: duplicated pass-through headers rendered with identical React/virtualizer keys, corrupting list reconciliation and scroll-anchor row lookup. #13429 fixed this for count-carrying headers only.

## Linked Issue

Fixes #13945

## Visual Proof

Before (names redacted): with two Orca servers and both host sections collapsed, the second host card renders clipped behind the first with a blank band above.

![before: collapsed host cards overlapping](https://raw.githubusercontent.com/powtick/orca/refs/heads/assets-sidebar-screenshots/before-collapsed-host-overlap.png)

After: collapsed sections stack as two clean host cards at the top.

## Testing

- New regression tests (fail without the fix, verified by stashing the source changes):
  - `worktree-list-virtual-rows.test.ts`: stale-offset clamp pins the first host card when content fits the viewport; in-range offsets are untouched.
  - `host-section-rows.pending-header-keys.test.ts`: duplicated pass-through headers get distinct per-host render keys.
- Full `src/renderer/src/components/sidebar` vitest suite: 2083 tests pass.
- `tsc --noEmit -p config/tsconfig.tc.web.json` passes.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and implemented with Claude Code (Claude Fable 5), reviewed by the author.

## Review

- Security: none — pure renderer layout logic.
- Cross-platform: no platform APIs; identical on macOS/Linux/Windows.
- Remote SSH: no wire change; multi-host sidebar behavior only.
- Mobile: not used by the mobile surface.
- Backwards compatibility: `maxScrollOffset` is optional, so the other caller (`AiVaultSessionVirtualList`, single-tier path) is unaffected.
- Performance: clamp is O(mounted rows) via `findLast` on the mounted window only, once per render; header stamping allocates one object per duplicated header per row build.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint (pre-commit), web typecheck, and the sidebar suite ran locally; CI covers the rest

## Author

- X / Twitter: @powtick
