### PR TITLE
fix(terminal): ignore a fit hold with no dimensions

### DIFF
--- a/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
@@ -51,7 +51,11 @@ function notifyChange(event: OverrideChangeEvent): void {
 
 export function setFitOverride(ptyId: string, mode: FitHoldMode, cols: number, rows: number): void {
   const prior = overridesByPtyId.get(ptyId) ?? null
-  if (mode === 'mobile-fit' || mode === 'remote-desktop-fit') {
+  // Why: a host that cannot read the pty size holds at 0x0, and xterm clamps
+  // resize(0, 0) up to its 2x1 floor, so the size guard never matches the hold
+  // again and the pane stays pinned there. Fall back to container fitting.
+  const holdsGrid = (mode === 'mobile-fit' || mode === 'remote-desktop-fit') && cols > 0 && rows > 0
+  if (holdsGrid) {
     overridesByPtyId.set(ptyId, { mode, cols, rows })
   } else {
     overridesByPtyId.delete(ptyId)

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -550,6 +550,30 @@ describe('deferred metric flush inside safeFit', () => {
     }
   })
 
+  it('ignores a hold with no dimensions instead of pinning xterm at its floor', () => {
+    const resize = vi.fn()
+    const fit = vi.fn()
+    const pane = {
+      terminal: { cols: 80, rows: 24, options: {}, resize },
+      container: {
+        dataset: { ptyId: 'pty-sizeless-hold' },
+        getBoundingClientRect: () => ({ width: 500, height: 300 })
+      },
+      fitAddon: { fit, proposeDimensions: vi.fn(() => ({ cols: 160, rows: 50 })) }
+    } as unknown as ManagedPane
+    // Why: a host that cannot read the pty size emits the hold at 0x0, and xterm
+    // clamps resize(0, 0) up to its 2x1 floor, so the size guard never matches again.
+    setFitOverride('pty-sizeless-hold', 'remote-desktop-fit', 0, 0)
+
+    try {
+      expect(readProposedPaneFitDimensions(pane)).toEqual({ cols: 160, rows: 50 })
+      expect(safeFit(pane)).toBe(true)
+      expect(resize).not.toHaveBeenCalled()
+    } finally {
+      setFitOverride('pty-sizeless-hold', 'desktop-fit', 0, 0)
+    }
+  })
+
   it('flushes deferred metrics before reporting a measurable owner override', () => {
     const pane = createMetricPane()
     pane.container.dataset.ptyId = 'pty-metric-override'


### PR DESCRIPTION
## Problem

`getRemoteDesktopFitHold` falls back to `{ cols: 0, rows: 0 }` when the host cannot read a pty's size:

```ts
// src/main/runtime/orca-runtime.ts
const size = this.getTerminalSize(ptyId) ?? { cols: 0, rows: 0 }
```

`getTerminalSize` is `ptySizes.get(ptyId) ?? null`, and that map is deleted on close and re-keyed on several attach paths, so a sizeless hold is reachable.

The renderer stores it verbatim — `setFitOverride` has no positivity guard — and then `performSafeFit` takes the override branch:

```ts
if (pane.terminal.cols !== override.cols || pane.terminal.rows !== override.rows) {
  pane.terminal.resize(override.cols, override.rows)   // resize(0, 0)
}
return true
```

xterm clamps that to `MINIMUM_COLS = 2` / `MINIMUM_ROWS = 1`. From then on the guard compares `2 !== 0`, which is **permanently true**, so every later fit re-runs a full `terminal.resize` — a synchronous `_writeBuffer.flushSync()` plus a `buffers.resize()` — on every ResizeObserver tick, `fitAllPanes`, and reveal, for the life of the pane.

Two things make it invisible: the pin returns `true`, so it is scored as a *successful* fit (no retry armed, no exhaustion breadcrumb), and `readProposedPaneFitDimensions` reports `0x0` as the pane's proposed grid.

## Change

Treat a hold without a positive grid as no hold. The pane falls back to normal container fitting, which is the correct behavior when the host cannot report a size.

Guarding on the receiving side rather than only at the emitter keeps it effective across mixed client/host versions, which `docs/reference/remote-wire-compatibility.md` treats as the normal state.

## Test plan

- [x] `npx vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-fit.test.ts` — one new case, written first and confirmed red on `main` (`readProposedPaneFitDimensions` returned `{ cols: 0, rows: 0 }` instead of the container's `{ cols: 160, rows: 50 }`)
- [x] Regression across every `setFitOverride` / `mobile-fit-overrides` consumer — `pane-manager/`, `pty-connection`, `remote-runtime-pty-transport`, `use-mobile-overlay-ticks.perf`, `useIpcEvents`: 64 files / 1508 tests pass
- [x] `pnpm run typecheck:web`
- [x] `npx oxlint` on both changed files

## Compatibility

Renderer-only. No wire format, no RPC params, no protocol version. A host that reports a real grid is unaffected — the guard only rejects a hold that carries no grid at all, which could never have been applied correctly. Mobile-fit holds are gated identically. No paths, accelerators, or `metaKey`; nothing provider-specific; the SSH relay is untouched.

## Note on scope

Found while investigating a separate report of remote panes opening at their spawn grid and staying there. **This is not that bug** — those panes sit at 120x40 and 80x24, not at the 2x1 this defect produces. It is filed on its own because it is an unambiguous defect on that code path, independent of the original report.