### PR TITLE
feat(agents): add Gajae Code as a supported TUI agent

### DIFF
--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -17,6 +17,7 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'pi',
   'omp',
   'prime-agent',
+  'gjc',
   'gemini',
   'antigravity',
   'aider',
@@ -78,7 +79,8 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   rovo: 'Rovo Dev',
   hermes: 'Hermes',
   devin: 'Devin',
-  openclaw: 'OpenClaw'
+  openclaw: 'OpenClaw',
+  gjc: 'Gajae Code'
 }
 
 export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>> = {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -453,6 +453,7 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
+          "c851f042e2": "Gajae Code",
           "mimo_code_label": "MiMo Code"
         },
         "skill": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -351,6 +351,7 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
+          "c851f042e2": "Gajae Code",
           "mimo_code_label": "MiMo Code"
         },
         "skill": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -351,6 +351,7 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
+          "c851f042e2": "Gajae Code",
           "mimo_code_label": "MiMo Code"
         },
         "skill": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -351,6 +351,7 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
+          "c851f042e2": "Gajae Code",
           "mimo_code_label": "MiMo Code"
         },
         "skill": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -351,6 +351,7 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
+          "c851f042e2": "Gajae Code",
           "mimo_code_label": "MiMo Code"
         },
         "skill": {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -135,6 +135,15 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://github.com/PrimeIntellect-ai/prime-agent'
   },
   {
+    id: 'gjc',
+    label: translate('auto.lib.agent.catalog.c851f042e2', 'Gajae Code'),
+    cmd: 'gjc',
+    // Why: no faviconDomain — gajae-code.com serves an inline data-URI favicon, so
+    // Google's favicon service 404s and would render its generic globe placeholder
+    // instead of the agent's mark; the letter glyph fallback is the honest icon.
+    homepageUrl: 'https://gajae-code.com'
+  },
+  {
     id: 'gemini',
     label: translate('auto.lib.agent.catalog.12e6baa4f7', 'Gemini'),
     cmd: 'gemini',

--- a/src/renderer/src/lib/agent-draft-readiness.ts
+++ b/src/renderer/src/lib/agent-draft-readiness.ts
@@ -1,4 +1,4 @@
-import type { DraftPasteReadySignal } from '../../../shared/tui-agent-config'
+import type { DraftPasteReadySignal } from '../../../shared/tui-agent-config-types'
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { replayPreHandlerPtyData } from '@/components/terminal-pane/pty-pre-handler-buffer'

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -133,7 +133,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   grok: true,
   devin: true,
   ante: true,
-  trae: true
+  trae: true,
+  gjc: true
 }
 
 // Why: return null (not a 'claude' fallback) for unknown so Codex panes don't flash the Claude icon before the hook fires.

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -173,6 +173,36 @@ describe('buildAgentStartupPlan', () => {
     ).toBe("prime-agent -- 'help me name this config'")
   })
 
+  it('passes the prompt to Gajae Code as a positional argv behind a `--` separator', () => {
+    expect(
+      buildAgentStartupPlan({
+        agent: 'gjc',
+        prompt: 'Summarize the failing tests',
+        cmdOverrides: {},
+        platform: 'linux'
+      })
+    ).toEqual({
+      agent: 'gjc',
+      launchCommand: "gjc -- 'Summarize the failing tests'",
+      expectedProcess: 'gjc',
+      followupPrompt: null,
+      launchConfig: emptyLaunchConfig('gjc')
+    })
+  })
+
+  // Why: `gjc resume` is its own launch alias and `stats`/`models` are subcommands, so an
+  // unseparated prompt of exactly those words would dispatch instead of seeding the composer.
+  it('keeps subcommand-shaped Gajae Code prompts as the positional prompt', () => {
+    expect(
+      buildAgentStartupPlan({
+        agent: 'gjc',
+        prompt: 'resume',
+        cmdOverrides: {},
+        platform: 'linux'
+      })?.launchCommand
+    ).toBe("gjc -- 'resume'")
+  })
+
   it('uses cursor-agent as the actual launch binary', () => {
     expect(
       buildAgentStartupPlan({

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -49,7 +49,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   grok: 'grok',
   devin: 'devin',
   ante: 'ante',
-  trae: 'trae'
+  trae: 'trae',
+  gjc: 'gjc'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/draft-paste-ready-scanner-grok-trace-replay.test.ts
+++ b/src/shared/draft-paste-ready-scanner-grok-trace-replay.test.ts
@@ -12,7 +12,7 @@
 // the inline mode that emits no alt-screen switch (quiet-window floor).
 import { describe, expect, it } from 'vitest'
 import { createDraftPasteReadyScanner } from './draft-paste-ready-scanner'
-import type { DraftPasteReadySignal } from './tui-agent-config'
+import type { DraftPasteReadySignal } from './tui-agent-config-types'
 import {
   GROK_STARTUP_PTY_TRACE,
   type GrokStartupTraceChunk

--- a/src/shared/draft-paste-ready-scanner.ts
+++ b/src/shared/draft-paste-ready-scanner.ts
@@ -1,4 +1,4 @@
-import type { DraftPasteReadySignal } from './tui-agent-config'
+import type { DraftPasteReadySignal } from './tui-agent-config-types'
 
 // Why: agents enable bracketed paste (DECSET 2004) before their composer is
 // actually mounted/focused. These markers let the scanner detect the real

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -49,7 +49,8 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   devin: 'devin',
   ante: null,
   // Why: Orca detects trae by `traecli`, an alias only TRAE CN ships.
-  trae: 'trae-cn'
+  trae: 'trae-cn',
+  gjc: null
 } satisfies Record<TuiAgent, string | null>
 
 /**

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -100,6 +100,7 @@ export const AGENT_KIND_VALUES = [
   'devin',
   'ante',
   'trae',
+  'gjc',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config-types.ts
+++ b/src/shared/tui-agent-config-types.ts
@@ -1,0 +1,51 @@
+/** Shape of a single agent's launch/detection entry in `TUI_AGENT_CONFIG`. Split out of
+ *  tui-agent-config.ts to keep that file's per-agent table under the shared max-lines ceiling. */
+
+export type AgentPromptInjectionMode =
+  | 'argv'
+  | 'flag-prompt'
+  | 'flag-prompt-interactive'
+  | 'flag-interactive'
+  | 'hermes-query'
+  | 'stdin-after-start'
+
+export type DraftPasteReadySignal =
+  | 'render-quiet-after-bracketed-paste'
+  | 'codex-composer-prompt'
+  | 'render-cursor-after-bracketed-paste'
+  | 'grok-composer-prompt'
+
+export type TuiAgentDetectionRuntime = NodeJS.Platform | 'wsl'
+
+export type TuiAgentConfig = {
+  detectCmd: string
+  /** Additional executable names that identify the same agent on PATH. */
+  detectCmdAliases?: readonly string[]
+  /** Other commands that must also be present before this agent counts as installed. */
+  detectRequiredCommands?: readonly string[]
+  /** Detection runtimes where this launch mode is not available as a detected agent. */
+  detectUnsupportedRuntimes?: readonly TuiAgentDetectionRuntime[]
+  launchCmd: string
+  /** Platform-specific launch command when the public binary name differs. */
+  launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
+  expectedProcess: string
+  promptInjectionMode: AgentPromptInjectionMode
+  /** Option terminator required before positional prompts that may look like CLI syntax. */
+  argvPromptSeparator?: '--'
+  /** Native CLI flag that seeds the input without submitting (e.g. Claude's `--prefill <text>`); preferred over the paste-after-ready path. */
+  draftPromptFlag?: string
+  /** Startup env var that seeds the input without submitting, for agents with no `--prefill`-style flag (e.g. pi); avoids the paste-after-ready race. */
+  draftPromptEnvVar?: string
+  /** Pre-write a trust artifact so the agent's first-launch "trust this folder?" menu doesn't consume the bracketed paste (see agent-trust-presets.ts). */
+  preflightTrust?: 'cursor' | 'copilot' | 'codex'
+  /** Agent-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
+  draftPasteReadySignal?: DraftPasteReadySignal
+  /** Hard deadline for the agent's composer readiness signal. */
+  draftPasteReadyTimeoutMs?: number
+  /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
+  windowsShiftEnterEncoding?: 'csi-u'
+  /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
+  windowsInputRecordPasteNewline?: 'alt-enter' | 'csi-u'
+  /** Ctrl+Enter encoding for agents that consume CSI-u without active kitty flags. */
+  ctrlEnterEncoding?: 'csi-u'
+}

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -1,54 +1,6 @@
 import type { TuiAgent } from './tui-agent'
 import { getOrcaCliCommandNameForPlatform } from './orca-cli-command-name'
-
-export type AgentPromptInjectionMode =
-  | 'argv'
-  | 'flag-prompt'
-  | 'flag-prompt-interactive'
-  | 'flag-interactive'
-  | 'hermes-query'
-  | 'stdin-after-start'
-
-export type DraftPasteReadySignal =
-  | 'render-quiet-after-bracketed-paste'
-  | 'codex-composer-prompt'
-  | 'render-cursor-after-bracketed-paste'
-  | 'grok-composer-prompt'
-
-export type TuiAgentDetectionRuntime = NodeJS.Platform | 'wsl'
-
-export type TuiAgentConfig = {
-  detectCmd: string
-  /** Additional executable names that identify the same agent on PATH. */
-  detectCmdAliases?: readonly string[]
-  /** Other commands that must also be present before this agent counts as installed. */
-  detectRequiredCommands?: readonly string[]
-  /** Detection runtimes where this launch mode is not available as a detected agent. */
-  detectUnsupportedRuntimes?: readonly TuiAgentDetectionRuntime[]
-  launchCmd: string
-  /** Platform-specific launch command when the public binary name differs. */
-  launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
-  expectedProcess: string
-  promptInjectionMode: AgentPromptInjectionMode
-  /** Option terminator required before positional prompts that may look like CLI syntax. */
-  argvPromptSeparator?: '--'
-  /** Native CLI flag that seeds the input without submitting (e.g. Claude's `--prefill <text>`); preferred over the paste-after-ready path. */
-  draftPromptFlag?: string
-  /** Startup env var that seeds the input without submitting, for agents with no `--prefill`-style flag (e.g. pi); avoids the paste-after-ready race. */
-  draftPromptEnvVar?: string
-  /** Pre-write a trust artifact so the agent's first-launch "trust this folder?" menu doesn't consume the bracketed paste (see agent-trust-presets.ts). */
-  preflightTrust?: 'cursor' | 'copilot' | 'codex'
-  /** Agent-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
-  draftPasteReadySignal?: DraftPasteReadySignal
-  /** Hard deadline for the agent's composer readiness signal. */
-  draftPasteReadyTimeoutMs?: number
-  /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
-  windowsShiftEnterEncoding?: 'csi-u'
-  /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
-  windowsInputRecordPasteNewline?: 'alt-enter' | 'csi-u'
-  /** Ctrl+Enter encoding for agents that consume CSI-u without active kitty flags. */
-  ctrlEnterEncoding?: 'csi-u'
-}
+import type { TuiAgentConfig } from './tui-agent-config-types'
 
 export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
   claude: {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -114,6 +114,23 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // Why: Prime Agent embeds Pi's TUI and decodes CSI-u the same way (see pi above).
     windowsShiftEnterEncoding: 'csi-u'
   },
+  gjc: {
+    detectCmd: 'gjc',
+    launchCmd: 'gjc',
+    // Why: `gjc` ships as a compiled single-file binary, so the foreground process
+    // carries its own name — no Node/Bun shim entrypoint to disambiguate.
+    expectedProcess: 'gjc',
+    // Why: `gjc [prompt]` takes the task as positional argv (`gjc "List all .ts files in src/"`).
+    promptInjectionMode: 'argv',
+    // Why: separator so a prompt that is exactly a subcommand word (`resume`, `stats`,
+    // `models`) or starts with `/` reaches the parser as message text instead of
+    // dispatching. Verified against its arg parser: a bare `--` is skipped and every
+    // following non-flag token lands in `messages`.
+    argvPromptSeparator: '--'
+    // Why no windowsShiftEnterEncoding: unlike the Pi TUI it forked, gjc binds newline to
+    // `alt+enter`/`ctrl+j` on win32 (interactive-mode.ts) rather than `shift+enter`, so the
+    // default Esc+CR path is already the encoding it expects.
+  },
   gemini: {
     detectCmd: 'gemini',
     launchCmd: 'gemini',

--- a/src/shared/tui-agent-detection-commands.ts
+++ b/src/shared/tui-agent-detection-commands.ts
@@ -1,10 +1,6 @@
 import type { TuiAgent } from './tui-agent'
-import {
-  getTuiAgentDetectCommands,
-  TUI_AGENT_CONFIG,
-  type TuiAgentConfig,
-  type TuiAgentDetectionRuntime
-} from './tui-agent-config'
+import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from './tui-agent-config'
+import type { TuiAgentConfig, TuiAgentDetectionRuntime } from './tui-agent-config-types'
 
 export type TuiAgentDetectionCommand = {
   id: TuiAgent

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -19,6 +19,7 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   pi: 'Pi',
   omp: 'OMP',
   'prime-agent': 'Prime Agent',
+  gjc: 'Gajae Code',
   gemini: 'Gemini',
   antigravity: 'Antigravity',
   aider: 'Aider',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -17,6 +17,7 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'pi',
   'omp',
   'prime-agent',
+  'gjc',
   'gemini',
   'antigravity',
   'aider',

--- a/src/shared/tui-agent.ts
+++ b/src/shared/tui-agent.ts
@@ -37,3 +37,4 @@ export type TuiAgent =
   | 'ante' // Ante (Antigma Labs)
   | 'trae' // Trae CLI
   | 'prime-agent' // Prime Agent (Prime Intellect)
+  | 'gjc' // Gajae Code


### PR DESCRIPTION
## What & Why

Registers the `gjc` CLI ([Gajae Code](https://gajae-code.com), npm [`gajae-code`](https://www.npmjs.com/package/gajae-code)) as a supported TUI agent, following the Trae/Prime Agent registration pattern.

**ELI5:** Orca can already run `gjc` in a terminal, but it doesn't *know* what it is — no entry in the agent picker, no process attribution, no prompt injection when you create a worktree. This adds the one catalog entry that makes it a first-class agent like the other 36.

Scope is registration only. Pi-style status hooks, prefill, and AI Vault session history are deliberately left out.

**Two commits, and the first one is a prerequisite, not scope creep.** On a rebase onto current `main` I found that `src/shared/tui-agent-config.ts` had reached **297 of the 300** counted lines oxlint allows for `src/**/*.ts`. A minimal agent entry is 7 code lines (5 fields plus braces), so `pnpm lint` now fails on *any* new agent registration, not just this one — and `AGENTS.md` forbids a `max-lines` disable. `bdc9b61` therefore moves the four type declarations (`TuiAgentConfig`, `AgentPromptInjectionMode`, `DraftPasteReadySignal`, `TuiAgentDetectionRuntime`) into `src/shared/tui-agent-config-types.ts`, leaving the per-agent table at **273/300**. It is a type-only move with no behavior change, four import sites repointed at the real module rather than a re-export (per #14447), and it lands *before* the registration so no commit on this branch is lint-red.

## Field-by-field rationale

Gajae Code is a Pi fork, so the tempting move is to copy Pi's config. Every field was instead verified against the installed CLI and its source — and two of them turn out to differ from Pi:

| Field | Value | Evidence |
| --- | --- | --- |
| `expectedProcess` | `gjc` | Ships as a compiled single-file binary (`file $(which gjc)` → `Mach-O 64-bit executable arm64`), so the foreground process carries its own name. Unlike Pi and Prime Agent there is no Node/Bun shim launching a generic `cli.js`, so no entry is needed in `agent-node-entrypoint-identities.ts`. |
| `promptInjectionMode` | `argv` | `gjc --help` documents `gjc [prompt]` with the example `gjc "List all .ts files in src/"`. |
| `argvPromptSeparator` | `--` | Its arg parser skips a bare `--` and pushes every following non-flag token into `messages`. Without the separator a prompt of exactly `resume` takes the `gjc resume` launch alias, and `stats`/`models` dispatch as subcommands. |
| `windowsShiftEnterEncoding` | *(omitted)* | **Diverges from Pi.** `interactive-mode.ts` binds newline to `alt+enter`/`ctrl+j` on win32 rather than `shift+enter`, so the default Esc+CR path is already what it expects; a `csi-u` override would be wrong here. |
| `faviconDomain` | *(omitted)* | gajae-code.com serves an inline `data:image/svg+xml` favicon, so `https://www.google.com/s2/favicons?domain=gajae-code.com&sz=64` returns **404** with the generic globe placeholder. The `AgentLetterIcon` fallback is the honest icon — same reasoning already recorded for OMP. |
| `skills-cli-agent-keys` | `null` | Following that file's stated rule: an unconfirmed key is dropped rather than guessed. |

I verified the separator behavior by running its parser directly rather than reading the help text:

```
["fix the bug"]              => messages: ["fix the bug"]
["--","fix the bug"]         => messages: ["fix the bug"]
["--","resume"]              => messages: ["resume"]     # without `--`: takes the resume alias
["--","/help me"]            => messages: ["/help me"]
```

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Added to `src/renderer/src/lib/tui-agent-startup.test.ts`, mirroring the existing Trae/Prime Agent cases:
- positional argv behind `--`
- subcommand-shaped prompt (`resume`) stays a prompt

Rebased onto `main` at `013eb53`. The only conflict was `src/shared/types.ts`, deleted by #14447 (drop the `shared/types` barrel); the `TuiAgent` union member moved to its new home in `src/shared/tui-agent.ts`. The other fifteen files merged cleanly.

Re-run on the rebased branch, macOS arm64:

| Check | Result |
| --- | --- |
| `pnpm typecheck` (node + web) | clean |
| `npx oxlint` | exit 0, no findings |
| `pnpm run audit:code-quality:native` | pass |
| `pnpm run audit:code-quality:type-aware` | pass |
| `pnpm run check:reliability-gates` | pass (87 gates) |
| `pnpm run check:max-lines-ratchet` | pass, no new bypasses |
| `pnpm run verify:localization-{catalog,extraction,coverage}` | pass |
| `pnpm run verify:bundled-skill-guides`, `verify:skill-bundle-manifest` | pass |
| `npx oxfmt --check` on the touched files | clean |
| `vitest run --config config/vitest.config.ts src/shared src/renderer` | **29,692 passed**, 44 skipped, 13 failed |

The 13 failures are all in four `terminal-ime-xterm-*` preedit-overlay suites. I ran those same four files on a clean `013eb53` checkout in the same environment and got an identical 13 failed / 9 passed, so they are environmental here and untouched by this PR. The `automation-schedules.test.ts` locale failure I reported in the original description is gone on current `main`, so it is no longer a caveat.

`pnpm test` as a whole still could not run locally: `ensure-native-runtime.mjs` cannot bind node-pty for Node 24.16.0 on this machine, so I invoked vitest directly against `config/vitest.config.ts`. CI covers the native path.

The i18n key `c851f042e2` was not hand-computed — I confirmed it by running `npx i18next-cli extract -c config/i18next.config.ts` and diffing the generated catalog. Added to all five locale files (en/es/ja/ko/zh) with the untranslated product name, as done for Prime Agent.

Mobile has no local `node_modules` here (separate Expo workspace), so in place of `tsc --noEmit` and `vitest run` I asserted the invariants those checks enforce:
- the `TuiAgent` union, `MOBILE_TUI_AGENT_LABELS` keys, and `MOBILE_TUI_AGENT_AUTO_PICK_ORDER` are all 37 with no missing or extra entries;
- `mobile-agent-catalog.test.ts` parses `tui-agent-config.ts` **by regex** for `TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {…^}`, which the type split could have broken — I ran that regex against the post-split file and it still yields all 37 keys, with mobile and desktop auto-pick order equal element-for-element and `gjc` at index 13 in both.

Not touched: README's Supported Agents badge list — the Prime Agent registration (#12935) did not touch it either, and doing so would pull in five translated READMEs.

## Review

- **Security:** no new I/O, network, or process-spawn surface; the entry is static data.
- **Cross-platform:** `gjc` is the binary name on all three platforms, so no `launchCmdByPlatform`. The win32 newline divergence from Pi is called out above and is the reason the `csi-u` override is intentionally absent.
- **Remote SSH / mobile:** detection rides the shared `detectCmd` path; mobile registry updated in the same commit.
- **Backwards compatibility:** additive union member; `agent-kind.ts` keeps its `'other'` runtime fallback for stale persisted settings.
- **Refactor risk:** `bdc9b61` moves types only — no value, function, or export shape changes, and `TUI_AGENT_CONFIG` itself stays in `tui-agent-config.ts` so the mobile test's source regex and `tui-agent-detection-commands.ts` still resolve it there. Reviewable as its own commit.
- **Performance:** none.

## Screenshots

N/A — no new UI. The agent picker renders the existing `AgentLetterIcon` ("G") through the unchanged catalog code path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## AI Disclosure

Authored with Claude (Sonnet 4.5) via Gajae Code. All CLI-contract claims above were verified against the installed binary and its source; none were inferred from the model's prior knowledge.

The rebase, the type split, and the re-verification above were done with Claude Opus 5 in Claude Code. Every result in the tables was run, not predicted; the IME baseline was measured on a clean `main` checkout rather than assumed.
