### PR TITLE
feat(sidebar): show primary badge and server glyph only on exceptions

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
@@ -259,8 +259,13 @@ describe('WorktreeCard SSH reconnect prompt', () => {
     )
 
     expect(disconnectedOwnerMarkup).toContain('Remote Mac disconnected')
+    // Why: the glyph presence/absence is the contract, not just the tooltip
+    // copy — and the disconnected row must name the owner, never the repo host.
+    expect(disconnectedOwnerMarkup).toContain('lucide-server-off')
+    expect(disconnectedOwnerMarkup).not.toContain('Build Linux')
     expect(connectedMarkup).not.toContain('Project on Build Linux')
     expect(connectedMarkup).not.toContain('disconnected')
+    expect(connectedMarkup).not.toContain('lucide-server-off')
   })
 
   it('reads nested SSH readiness from the owning HUB instead of client-local SSH state', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
@@ -232,22 +232,25 @@ describe('WorktreeCard SSH reconnect prompt', () => {
     expect(markup).toContain('Remote Mac disconnected')
   })
 
-  it('distinguishes connected worktrees on different Orca servers', () => {
+  // Why: connected rows drop the per-row server glyph (mixed-host chips and host
+  // sections carry identity); the disconnected exception must still name the
+  // per-row owner, not the repo's host.
+  it('names the owning Orca server only on the disconnected exception', () => {
     runtimeEnvironments = [
       { id: 'env-1', name: 'Remote Mac' },
       { id: 'env-2', name: 'Build Linux' }
     ]
-    runtimeStatusByEnvironmentId.set('env-1', { status: { runtimeId: 'r1' } })
     runtimeStatusByEnvironmentId.set('env-2', { status: { runtimeId: 'r2' } })
+    // No status entry for env-1 → the worktree's owner is disconnected.
 
-    const remoteMacMarkup = renderToStaticMarkup(
+    const disconnectedOwnerMarkup = renderToStaticMarkup(
       <WorktreeCard
         worktree={{ ...makeWorktree(), runtimeOwnerEnvironmentId: 'env-1' }}
         repo={{ ...makeRepo(), connectionId: undefined, executionHostId: 'runtime:env-2' }}
         isActive={false}
       />
     )
-    const buildLinuxMarkup = renderToStaticMarkup(
+    const connectedMarkup = renderToStaticMarkup(
       <WorktreeCard
         worktree={makeWorktree()}
         repo={{ ...makeRepo(), connectionId: undefined, executionHostId: 'runtime:env-2' }}
@@ -255,8 +258,9 @@ describe('WorktreeCard SSH reconnect prompt', () => {
       />
     )
 
-    expect(remoteMacMarkup).toContain('Project on Remote Mac')
-    expect(buildLinuxMarkup).toContain('Project on Build Linux')
+    expect(disconnectedOwnerMarkup).toContain('Remote Mac disconnected')
+    expect(connectedMarkup).not.toContain('Project on Build Linux')
+    expect(connectedMarkup).not.toContain('disconnected')
   })
 
   it('reads nested SSH readiness from the owning HUB instead of client-local SSH state', () => {

--- a/src/renderer/src/components/sidebar/worktree-card-header.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AlertCircle, Server, ServerOff, Star, Trash2 } from 'lucide-react'
+import { AlertCircle, ServerOff, Star, Trash2 } from 'lucide-react'
 
 import { RepoIconGlyph } from '@/components/repo/repo-icon'
 import { Badge } from '@/components/ui/badge'
@@ -9,7 +9,11 @@ import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import type { Repo } from '../../../../shared/repo-types'
 import { resolveRepoHeaderColor } from './project-header-color'
-import { formatSparseDirectoryPreview, shouldBeginWorktreeRename } from './worktree-card-model'
+import {
+  formatSparseDirectoryPreview,
+  shouldBeginWorktreeRename,
+  shouldMarkPrimaryWorkspaceTitle
+} from './worktree-card-model'
 import type { WorktreeCardPresentation } from './worktree-card-presentation'
 import { WorktreeCardSshHostControl } from './WorktreeCardSshHostControl'
 import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
@@ -115,42 +119,29 @@ export function WorktreeCardHeader({
           />
         )}
 
-        {!repo?.connectionId && parsedRepoHost?.kind === 'runtime' && (
+        {/* Why: connected runtime rows drop the glyph — repeating the server on
+            every row is noise; only the disconnected exception earns a mark. */}
+        {!repo?.connectionId && parsedRepoHost?.kind === 'runtime' && isRuntimeDisconnected && (
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="shrink-0 inline-flex items-center">
-                {isRuntimeDisconnected ? (
-                  // Passive by design: runtime ("Orca server") hosts have no
-                  // renderer-reachable connect API, unlike the SSH glyph above which is
-                  // now a control. Don't "fix" the inconsistency by wiring one up.
-                  <ServerOff className="size-3 text-destructive" />
-                ) : (
-                  <Server className="size-3 text-muted-foreground" />
-                )}
+                {/* Passive by design: runtime ("Orca server") hosts have no
+                    renderer-reachable connect API, unlike the SSH glyph above which is
+                    now a control. Don't "fix" the inconsistency by wiring one up. */}
+                <ServerOff className="size-3 text-destructive" />
               </span>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={8}>
-              {isRuntimeDisconnected
-                ? runtimeHostLabel
-                  ? translate(
-                      'auto.components.sidebar.WorktreeCard.runtimeHostDisconnectedNamed',
-                      '{{hostName}} disconnected',
-                      { hostName: runtimeHostLabel }
-                    )
-                  : translate(
-                      'auto.components.sidebar.WorktreeCard.runtimeHostDisconnected',
-                      'Server disconnected'
-                    )
-                : runtimeHostLabel
-                  ? translate(
-                      'auto.components.sidebar.WorktreeCard.runtimeHostProjectNamed',
-                      'Project on {{hostName}}',
-                      { hostName: runtimeHostLabel }
-                    )
-                  : translate(
-                      'auto.components.sidebar.WorktreeCard.runtimeHostProject',
-                      'Project on Orca server'
-                    )}
+              {runtimeHostLabel
+                ? translate(
+                    'auto.components.sidebar.WorktreeCard.runtimeHostDisconnectedNamed',
+                    '{{hostName}} disconnected',
+                    { hostName: runtimeHostLabel }
+                  )
+                : translate(
+                    'auto.components.sidebar.WorktreeCard.runtimeHostDisconnected',
+                    'Server disconnected'
+                  )}
             </TooltipContent>
           </Tooltip>
         )}
@@ -214,24 +205,27 @@ export function WorktreeCardHeader({
             </TooltipContent>
           </Tooltip>
         ) : null}
-        {!compactCards && worktree.isMainWorktree && !isFolder && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Badge
-                variant="outline"
-                className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
-              >
-                {translate('auto.components.sidebar.WorktreeCard.7d517f82e2', 'primary')}
-              </Badge>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8}>
-              {translate(
-                'auto.components.sidebar.WorktreeCard.0777de5970',
-                'Primary worktree (original clone directory)'
-              )}
-            </TooltipContent>
-          </Tooltip>
-        )}
+        {!compactCards &&
+          worktree.isMainWorktree &&
+          !isFolder &&
+          shouldMarkPrimaryWorkspaceTitle(visibleCardTitle) && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant="outline"
+                  className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
+                >
+                  {translate('auto.components.sidebar.WorktreeCard.7d517f82e2', 'primary')}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={8}>
+                {translate(
+                  'auto.components.sidebar.WorktreeCard.0777de5970',
+                  'Primary worktree (original clone directory)'
+                )}
+              </TooltipContent>
+            </Tooltip>
+          )}
 
         {worktree.isSparse && (
           <Tooltip>

--- a/src/renderer/src/components/sidebar/worktree-card-model.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-model.ts
@@ -101,6 +101,13 @@ export function shouldBeginWorktreeRename(
   )
 }
 
+// Why: a title of "main"/"master" already reads as the primary workspace; the
+// badge only earns its keep when a rename hides that convention.
+export function shouldMarkPrimaryWorkspaceTitle(title: string): boolean {
+  const normalized = title.trim().toLowerCase()
+  return normalized !== 'main' && normalized !== 'master'
+}
+
 export function formatSparseDirectoryPreview(directories: string[]): string {
   const preview = directories.slice(0, 4).join(', ')
   return directories.length <= 4 ? preview : `${preview}, +${directories.length - 4} more`

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -4,6 +4,7 @@ import {
   getFlushWorktreeCardPaddingLeft,
   getNewCardStyleParentContentMarginLeft
 } from './worktree-list/rows/indentation'
+import { shouldMarkPrimaryWorkspaceTitle } from './worktree-card-model'
 import {
   hasWorktreeCardDetails,
   WorktreeCardDetailsHover,
@@ -89,7 +90,11 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
   const showUnreadQuickAction = !affiliateListMode && showStatus && !newCardStyle
   // Why: the slot owns the unread/status lane; legacy keeps the bell toggle, the new card keeps the glyph passive.
   const showCombinedStatusSlot = showStatus
-  const showTitleRowPrimary = compactCards && worktree.isMainWorktree && !isFolder
+  const showTitleRowPrimary =
+    compactCards &&
+    worktree.isMainWorktree &&
+    !isFolder &&
+    shouldMarkPrimaryWorkspaceTitle(visibleCardTitle)
   const showMetaRowDetails = !newCardStyle && !compactCards && (hasDetails || hasPorts)
   const showTitleRowIndicators = (newCardStyle || compactCards) && (hasDetails || hasPorts)
   // Why: grouped views can hide the repo badge; don't reserve a blank metadata lane unless there's real content.

--- a/src/renderer/src/components/sidebar/worktree-card-primary-badge.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-primary-badge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { shouldMarkPrimaryWorkspaceTitle } from './worktree-card-model'
+
+// Why: the primary badge is exception-only — a title of "main"/"master"
+// already reads as the primary workspace.
+describe('shouldMarkPrimaryWorkspaceTitle', () => {
+  it('hides the badge for conventional primary titles', () => {
+    expect(shouldMarkPrimaryWorkspaceTitle('main')).toBe(false)
+    expect(shouldMarkPrimaryWorkspaceTitle('master')).toBe(false)
+    expect(shouldMarkPrimaryWorkspaceTitle(' Main ')).toBe(false)
+    expect(shouldMarkPrimaryWorkspaceTitle('MASTER')).toBe(false)
+  })
+
+  it('marks renamed primaries whose title no longer says main', () => {
+    expect(shouldMarkPrimaryWorkspaceTitle('release prep')).toBe(true)
+    expect(shouldMarkPrimaryWorkspaceTitle('main-backup')).toBe(true)
+    expect(shouldMarkPrimaryWorkspaceTitle('')).toBe(true)
+  })
+})


### PR DESCRIPTION
## ELI5

The sidebar stamped a `primary` badge on every primary workspace and a server glyph on every runtime-owned row. After this change those marks only appear when they say something you don't already know: the badge when a renamed primary no longer says "main", the glyph when the server is disconnected.

## What Changed

- The `primary` badge (and its compact-mode star variant) renders only when the visible workspace title is not `main`/`master` — the states where the convention itself no longer marks the primary. Shared predicate `shouldMarkPrimaryWorkspaceTitle` in `worktree-card-model.ts`.
- The per-row runtime server glyph renders only in the disconnected state (destructive `ServerOff` + named tooltip). Connected rows drop it; host identity stays visible through mixed-host chips and host sections.
- Updated the reconnect-prompt spec to the new contract (the disconnected exception still names the per-row owner) and added unit tests for the predicate.

## Why

A badge that appears on every row carries no information after the first one. Exception-only metadata keeps every remaining mark meaningful and removes most of the repeated chrome from a typical multi-project sidebar without touching any interaction.

## Linked Issue

Fixes #13953

## Visual Proof

Synthetic demo data (two paired servers, six projects), captured via the repo's Playwright electron-headless harness.

Before — `primary` on every main row:

![before](https://raw.githubusercontent.com/powtick/orca/refs/heads/assets-sidebar-screenshots/sidebar-redesign-before.png)

After — badges only where they inform (none here; all primaries are literally "main"):

![after](https://raw.githubusercontent.com/powtick/orca/refs/heads/assets-sidebar-screenshots/sidebar-redesign-after-quiet-badges.png)

A renamed primary (title ≠ main) still gets the badge; a disconnected server still gets the glyph.

## Testing

- New `worktree-card-primary-badge.test.ts` covers the predicate (main/master/case/whitespace/renamed).
- `WorktreeCard.ssh-reconnect-prompt.test.tsx` updated: the disconnected exception names the per-row owner; connected rows render no server glyph.
- Full `src/renderer/src/components/sidebar` vitest suite passes; `tsc --noEmit -p config/tsconfig.tc.web.json` passes.
- Rendered UI verified via the Playwright electron-headless harness (screenshots above).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Designed and implemented with Claude Code (Claude Fable 5), reviewed by the author.

## Review

- Security: none — presentation-only.
- Cross-platform: no platform APIs; identical on macOS/Linux/Windows.
- Remote SSH: SSH host control untouched (it is a functional control, not a passive glyph).
- Mobile: not used by the mobile surface.
- Backwards compatibility: no wire/RPC change.
- Performance: one string comparison per row render; no new allocations.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint (pre-commit), web typecheck, and the sidebar suite ran locally; CI covers the rest

## Author

- X / Twitter: @powtick
