### PR TITLE
fix(agents): detect a live OpenCode pane from its native OC | session title

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11432,6 +11432,57 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('keeps blocked prompt text authoritative over an OpenCode marker', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-1' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'opencode'
+    })
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'OC | Native session',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-1',
+          paneTitle: 'OC | Native session'
+        }
+      ]
+    })
+    runtime.onPtyData(
+      'pty-1',
+      'Permission required\nThis command requires permission\nAllow once\nAllow always\nReject\n',
+      123
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.getTerminalAgentStatus(terminal.handle)).resolves.toEqual({
+      handle: terminal.handle,
+      isRunningAgent: true,
+      status: 'permission'
+    })
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      satisfied: false,
+      blockedReason: 'codex-interactive-prompt'
+    })
+  })
+
   it('reports permission from blocked wait text over title-only working state', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
@@ -15609,6 +15660,28 @@ describe('OrcaRuntimeService', () => {
       runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
     ).resolves.toMatchObject({
       handle,
+      condition: 'tui-idle',
+      status: 'running'
+    })
+  })
+
+  it('resolves live-leaf tui-idle from an OpenCode native title', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime, 'remote:pty-1', {
+      tabTitle: 'repo terminal',
+      paneTitle: 'ssh build-host | OC | Native session'
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle: terminal.handle,
       condition: 'tui-idle',
       status: 'running'
     })
@@ -22794,6 +22867,65 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.isTerminalRunningAgent(terminal.handle)).resolves.toBe(false)
     await expect(runtime.getTerminalAgentStatus(terminal.handle)).resolves.toEqual({
       handle: terminal.handle,
+      isRunningAgent: false,
+      status: null
+    })
+  })
+
+  it('does not authorize an OpenCode marker left on a shell pane', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'zsh'
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'OC | zsh' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningAgent(terminal.handle)).resolves.toBe(false)
+    await expect(runtime.getTerminalAgentStatus(terminal.handle)).resolves.toEqual({
+      handle: terminal.handle,
+      isRunningAgent: false,
+      status: null
+    })
+  })
+
+  it('authorizes a hookless OpenCode marker with an OpenCode foreground process', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'opencode'
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'OC | Native session' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningAgent(terminal.handle)).resolves.toBe(true)
+    await expect(runtime.getTerminalAgentStatus(terminal.handle)).resolves.toEqual({
+      handle: terminal.handle,
+      isRunningAgent: true,
+      status: 'idle'
+    })
+  })
+
+  it('does not authorize an OpenCode marker left on a runtime PTY shell', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'zsh'
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'OC | zsh'
+    })
+
+    await expect(runtime.isTerminalRunningAgent(handle)).resolves.toBe(false)
+    await expect(runtime.getTerminalAgentStatus(handle)).resolves.toEqual({
+      handle,
       isRunningAgent: false,
       status: null
     })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6,6 +6,7 @@ import {
   isClaudeManagementTitle,
   isCursorAgentTitle,
   isCursorNativeAgentTitle,
+  isOpenCodeNativeTitle,
   isShellProcess,
   normalizeTerminalTitle
 } from '../../shared/agent-detection'
@@ -16766,7 +16767,8 @@ export class OrcaRuntimeService {
     const liveTitleClearsBlockedText =
       terminal.titleStatusIsLive &&
       terminal.titleStatus !== null &&
-      terminal.titleStatus !== 'permission'
+      terminal.titleStatus !== 'permission' &&
+      !isOpenCodeNativeTitle(terminal.title)
     if (terminal.titleStatus === 'permission' && terminal.titleStatusIsLive) {
       return { handle, isRunningAgent: true, status: 'permission' }
     }
@@ -16793,6 +16795,15 @@ export class OrcaRuntimeService {
       }
     }
     if (terminal.titleStatus) {
+      if (isOpenCodeNativeTitle(terminal.title)) {
+        const isRunningAgent = await this.isTerminalRunningAgent(handle)
+        this.assertTerminalAgentStatusPtyBinding(handle, ptyId)
+        return {
+          handle,
+          isRunningAgent,
+          status: isRunningAgent ? terminal.titleStatus : null
+        }
+      }
       return { handle, isRunningAgent: true, status: terminal.titleStatus }
     }
 
@@ -31532,16 +31543,17 @@ export class OrcaRuntimeService {
       // Why: check the leaf pane title and the tab title, which already carries OSC-enriched agent indicators (e.g. ✳ prefix).
       const paneTitle = getLatestLeafTitle(leaf, null)
       const paneTitleClassification = classifyAgentTitle(paneTitle)
-      if (paneTitleClassification === 'agent') {
+      if (paneTitleClassification === 'agent' && !isOpenCodeNativeTitle(paneTitle)) {
         return true
       }
       const tabTitle = this.tabs.get(leaf.tabId)?.title?.trim() || null
       const tabTitleClassification = paneTitle === null ? classifyAgentTitle(tabTitle) : 'neutral'
-      if (tabTitleClassification === 'agent') {
+      if (tabTitleClassification === 'agent' && !isOpenCodeNativeTitle(tabTitle)) {
         return true
       }
+      const openCodeMarkerTitle = paneTitle ?? tabTitle
       const waitText = buildTerminalWaitText(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
-      if (isKnownReadyPromptPreview(waitText)) {
+      if (!isOpenCodeNativeTitle(openCodeMarkerTitle) && isKnownReadyPromptPreview(waitText)) {
         return true
       }
       const hasCurrentTitleEvidence = paneTitle !== null || tabTitle !== null
@@ -31585,7 +31597,7 @@ export class OrcaRuntimeService {
         )
       : null
     const leafTitleClassification = classifyAgentTitle(leafTitle)
-    if (leafTitleClassification === 'agent') {
+    if (leafTitleClassification === 'agent' && !isOpenCodeNativeTitle(leafTitle)) {
       return true
     }
     const ptyTitle = getLatestAgentCandidateTitle(
@@ -31593,15 +31605,23 @@ export class OrcaRuntimeService {
       { title: pty.lastOscTitle, updatedAt: pty.lastOscTitleAt }
     )
     const ptyTitleClassification = classifyAgentTitle(ptyTitle)
-    if (leafTitle === null && ptyTitleClassification === 'agent') {
+    if (
+      leafTitle === null &&
+      ptyTitleClassification === 'agent' &&
+      !isOpenCodeNativeTitle(ptyTitle)
+    ) {
       return true
     }
     const managementTitleClassification = classifyLatestAgentTitle({
       title: pty.managementTitle,
       updatedAt: pty.managementTitleAt
     })
+    const openCodeMarkerTitle = leafTitle ?? ptyTitle
+    if (isOpenCodeNativeTitle(openCodeMarkerTitle) && pty.launchAgent === 'opencode') {
+      return true
+    }
     const waitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
-    if (isKnownReadyPromptPreview(waitText)) {
+    if (!isOpenCodeNativeTitle(openCodeMarkerTitle) && isKnownReadyPromptPreview(waitText)) {
       return true
     }
     // Why: stale status is a fallback only when no current title evidence exists; neutral titles (shells) clear it.
@@ -36845,6 +36865,8 @@ function detectExplicitIdleStatusFromTitle(title: string): AgentStatus | null {
   // Why: launch titles like "Codex YOLO" contain an agent name but aren't readiness signals; terminal.wait needs explicit idle evidence.
   if (
     EXPLICIT_IDLE_TITLE_RE.test(title) ||
+    // Why: unblock hookless remote waits; guarded writes corroborate this marker.
+    isOpenCodeNativeTitle(title) ||
     title.startsWith(CLAUDE_IDLE_PREFIX) ||
     title.startsWith('* ') ||
     title.includes(GEMINI_IDLE_PREFIX) ||
@@ -36982,7 +37004,7 @@ function isTerminalWaitWhitespace(value: string, index: number): boolean {
 }
 
 const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
-  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust/i
+  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always/i
 
 function findTerminalWaitBlockedSignal(
   normalized: string
@@ -37050,6 +37072,20 @@ function findTerminalWaitBlockedSignal(
     )
     if (!hasSpecificPromptInContext) {
       candidates.push({ reason: 'codex-interactive-prompt', index: interactivePromptIndex })
+    }
+  }
+  const permissionPromptIndex = Math.max(
+    normalized.lastIndexOf('permission required'),
+    normalized.lastIndexOf('requires permission')
+  )
+  if (permissionPromptIndex !== -1) {
+    const permissionSegment = normalized.slice(permissionPromptIndex, permissionPromptIndex + 1_500)
+    const decisionCount = ['allow once', 'allow always', 'reject', 'deny'].filter((choice) =>
+      permissionSegment.includes(choice)
+    ).length
+    if (decisionCount >= 2) {
+      // Why: preserve the existing remote receipt value for mixed-version clients.
+      candidates.push({ reason: 'codex-interactive-prompt', index: permissionPromptIndex })
     }
   }
   return candidates.length > 0

--- a/src/main/runtime/rpc/terminal-opencode-send-guard.integration.test.ts
+++ b/src/main/runtime/rpc/terminal-opencode-send-guard.integration.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../orca-runtime'
+import { RpcDispatcher } from './dispatcher'
+import type { RpcRequest } from './core'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+function request(method: string, params: unknown): RpcRequest {
+  return { id: 'request-1', authToken: 'test-token', method, params }
+}
+
+describe('OpenCode guarded terminal send', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('refuses a marker title left on a shell without writing notes', async () => {
+    vi.useFakeTimers()
+    const write = vi.fn(() => true)
+    const runtime = new OrcaRuntimeService()
+    runtime.setPtyController({
+      write,
+      kill: () => true,
+      getForegroundProcess: async () => 'zsh'
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree',
+          title: 'OC | zsh',
+          activeLeafId: 'pane-1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree',
+          leafId: 'pane-1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1',
+          paneTitle: 'OC | zsh'
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    await expect(
+      dispatcher.dispatch(request('terminal.agentStatus', { terminal: terminal.handle }))
+    ).resolves.toMatchObject({
+      ok: true,
+      result: { agentStatus: { isRunningAgent: false, status: null } }
+    })
+
+    const send = dispatcher.dispatch(
+      request('terminal.send', {
+        terminal: terminal.handle,
+        text: '$(touch should-not-run)',
+        requireAgentStatus: 'sendable',
+        client: { id: 'desktop-1', type: 'desktop' }
+      })
+    )
+    await vi.advanceTimersByTimeAsync(1_500)
+
+    await expect(send).resolves.toMatchObject({
+      ok: true,
+      result: { send: { accepted: false, bytesWritten: 0, refusedReason: 'no-agent' } }
+    })
+    expect(write).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -331,6 +331,22 @@ describe('buildTitleDerivedAgentRows', () => {
     }
   })
 
+  // Why: the native marker is the only signal a hookless OpenCode pane emits, so
+  // without it the sidebar showed no row for a running session.
+  it('rows an OpenCode pane from its undecorated native session title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'OC | Ad hoc build' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-opencode'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['opencode', 'idle']])
+  })
+
   it('still resolves Claude from a title that presents Claude, owner or not', () => {
     const rowsFor = (title: string, launchAgent?: TuiAgent) =>
       buildWorktreeAgentRows({

--- a/src/renderer/src/lib/agent-send-title-status.test.ts
+++ b/src/renderer/src/lib/agent-send-title-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { detectAgentSendTitleStatus } from './agent-send-title-status'
+
+describe('detectAgentSendTitleStatus', () => {
+  it.each([
+    'OC | Native session',
+    'OC | ✦ Gemini CLI',
+    'OC | ✋ review Gemini permission handling',
+    'ssh build-host | OC | Native session',
+    'user@host: ~/code | OC | Native session',
+    '▣ OC | Native session',
+    'OC |   Native session',
+    'OC |\tNative session'
+  ])('accepts OpenCode native idle title %j', (title) => {
+    expect(detectAgentSendTitleStatus(title)).toBe('idle')
+  })
+
+  it('preserves spinner working state for OpenCode', () => {
+    expect(detectAgentSendTitleStatus('⠋ OC | Native session')).toBe('working')
+    expect(detectAgentSendTitleStatus('ssh build-host | ⠋ OC | Native session')).toBe('working')
+  })
+
+  it.each(['OC |', 'OC |Native session', 'oc | Native session', 'OCTOPUS | Native session'])(
+    'rejects incomplete or lookalike OpenCode title %j',
+    (title) => {
+      expect(detectAgentSendTitleStatus(title)).toBeNull()
+    }
+  )
+
+  it('preserves non-OpenCode title behavior', () => {
+    expect(detectAgentSendTitleStatus('✦ Gemini CLI')).toBe('working')
+    expect(detectAgentSendTitleStatus('Codex ready')).toBe('idle')
+    expect(detectAgentSendTitleStatus('zsh')).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/agent-send-title-status.ts
+++ b/src/renderer/src/lib/agent-send-title-status.ts
@@ -1,4 +1,5 @@
 import type { AgentStatus } from './agent-status'
+import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 
 const EXPLICIT_IDLE_SEND_TITLE_RE = /(^|\s)(ready|idle|done)(\s|$|[.!?])/i
@@ -24,6 +25,10 @@ export function detectAgentSendTitleStatus(title: string | null | undefined): Ag
 function isExplicitIdleSendTitle(title: string): boolean {
   return (
     EXPLICIT_IDLE_SEND_TITLE_RE.test(title) ||
+    // Why: OpenCode only publishes `OC | <session>` from inside a running TUI session,
+    // so the marker is readiness proof the way `✳` is for Claude — it is the only
+    // pre-hook signal a hookless OpenCode pane ever emits.
+    isOpenCodeNativeTitle(title) ||
     title.startsWith(CLAUDE_IDLE_PREFIX) ||
     title.startsWith('* ') ||
     title.includes(GEMINI_IDLE_PREFIX) ||

--- a/src/renderer/src/lib/agent-send-title-status.ts
+++ b/src/renderer/src/lib/agent-send-title-status.ts
@@ -25,9 +25,8 @@ export function detectAgentSendTitleStatus(title: string | null | undefined): Ag
 function isExplicitIdleSendTitle(title: string): boolean {
   return (
     EXPLICIT_IDLE_SEND_TITLE_RE.test(title) ||
-    // Why: OpenCode only publishes `OC | <session>` from inside a running TUI session,
-    // so the marker is readiness proof the way `✳` is for Claude — it is the only
-    // pre-hook signal a hookless OpenCode pane ever emits.
+    // Why: this title-level filter exposes hookless OpenCode targets; the runtime
+    // still requires launch or foreground-process evidence before writing.
     isOpenCodeNativeTitle(title) ||
     title.startsWith(CLAUDE_IDLE_PREFIX) ||
     title.startsWith('* ') ||

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -679,7 +679,7 @@ describe('notes send agent targets', () => {
     ])
   })
 
-  it('promotes a stale OpenCode status row when the native title proves the pane is live', () => {
+  it('promotes a stale OpenCode status row from the native title hint', () => {
     const paneKey = makePaneKey(LAUNCH_TAB_ID, LEAF_A)
     const targets = deriveNotesSendAgentTargets(
       state({

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -653,4 +653,51 @@ describe('notes send agent targets', () => {
       })
     ])
   })
+
+  // Why: OpenCode publishes `OC | <session>` and no status word, so a hookless
+  // OpenCode pane used to be invisible in the send menu no matter how live it was.
+  it('lists a manual OpenCode pane by its native session title', () => {
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        tabsByWorktree: { [WORKTREE_ID]: [tab(MANUAL_TAB_ID, { title: 'Terminal 2' })] },
+        terminalLayoutsByTabId: { [MANUAL_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
+        runtimePaneTitlesByTabId: { [MANUAL_TAB_ID]: { 1: 'OC | Ad hoc build' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([
+      {
+        paneKey: makePaneKey(MANUAL_TAB_ID, LEAF_B),
+        tabId: MANUAL_TAB_ID,
+        leafId: LEAF_B,
+        agentType: 'opencode',
+        tabTitle: 'Terminal 2',
+        status: 'eligible'
+      }
+    ])
+  })
+
+  it('promotes a stale OpenCode status row when the native title proves the pane is live', () => {
+    const paneKey = makePaneKey(LAUNCH_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: {
+          [paneKey]: entry(paneKey, 'done', OLD_STATUS_UPDATED_AT, { agentType: 'opencode' })
+        },
+        tabsByWorktree: {
+          [WORKTREE_ID]: [tab(LAUNCH_TAB_ID, { title: 'Terminal 1', launchAgent: 'opencode' })]
+        },
+        terminalLayoutsByTabId: { [LAUNCH_TAB_ID]: leafLayout(LEAF_A, 'pty-a') },
+        runtimePaneTitlesByTabId: { [LAUNCH_TAB_ID]: { 1: 'OC | Ad hoc build' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([
+      expect.objectContaining({ paneKey, agentType: 'opencode', status: 'eligible' })
+    ])
+  })
 })

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -59,10 +59,8 @@ function detectTitleHintPaneEvidence(
  * CLIs do not have that owner bit, so their runtime title is the only pre-hook
  * signal available.
  *
- * The title hint is gated on a recognized agent title (pane or tab) — the same
- * signal isTerminalRunningAgent checks — so a freshly spawned tab is only listed
- * once the runtime would actually accept the send. Without that gate, clicking a
- * still-booting pane fails with "not a recognized agent session".
+ * The title hint gates discoverability only. The runtime independently checks
+ * current hook/process evidence before any guarded write.
  */
 export function deriveNotesSendAgentTargets(
   state: NotesSendAgentTargetState,
@@ -129,9 +127,8 @@ function deriveTitleHintAgentTarget(
   const paneTitleResolution = resolveRuntimePaneTitleLeafResolution(layout, paneTitles, leafId)
   const titleEvidence = detectTitleHintPaneEvidence(paneTitleResolution, tab.title)
   if (!titleEvidence) {
-    // Why: launchAgent is set the instant Orca spawns the tab, but the runtime
-    // only accepts a send once the pane reads as an agent; manually started
-    // CLIs need the same title proof before appearing in the send menu.
+    // Why: launch metadata predates TUI identity; require a matching current title
+    // before listing either launched or manually started panes.
     return null
   }
   const disabledReason =

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -23,7 +23,8 @@ const identityScenarios: [
 ][] = [
   ['live local', { isRemote: false }],
   ['inactive local split', { isRemote: false, siblingHookAgent: 'claude' }],
-  ['inactive SSH/tmux', { isRemote: true, title: 'tmux | OC | Greeting' }]
+  ['inactive SSH/tmux', { isRemote: true, title: 'tmux | OC | Greeting' }],
+  ['multi-token SSH wrapper', { isRemote: true, title: 'ssh build-host | OC | Greeting' }]
 ]
 
 function HookProbe({ tab }: { tab: TerminalTab }): null {
@@ -255,7 +256,6 @@ describe('OpenCode native title tab identity', () => {
     for (const title of [
       'OpenCode ready',
       'oc | Greeting',
-      'my session | OC | Greeting',
       '⠋ Fix foo | OC | Greeting',
       '✦ Gemini CLI',
       '⠋ Codex',

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -101,6 +101,37 @@ describe('MiMo title detection', () => {
   )
 })
 
+describe('OpenCode native title detection', () => {
+  // Why: `OC | …` names no agent token, so before this the status detector read it as a
+  // plain shell title and every status-derived surface (send targets, sidebar rows,
+  // runtime agent-presence) dropped a live OpenCode pane.
+  it.each([
+    'OC | Implement the Kitty IME preview',
+    'tmux | OC | Implement the Kitty IME preview',
+    'OC|Build'
+  ])('classifies the native session title %j as a live idle agent', (title) => {
+    expect(getAgentLabel(title)).toBe('OpenCode')
+    expect(detectAgentStatusFromTitle(title)).toBe('idle')
+  })
+
+  // Why: the marker states presence, not status, so a decorated frame keeps reading
+  // through the usual status decoration (#8940) — only undecorated frames go idle.
+  it.each([
+    ['OC | ⠋ ask claude about this', 'working'],
+    ['OC | ready to review', 'idle']
+  ] as const)('classifies the decorated frame %j as %s', (title, expectedStatus) => {
+    expect(getAgentLabel(title)).toBe('OpenCode')
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
+  it.each(['OC |', 'oc | lowercase lookalike', 'OCTOPUS | build'])(
+    'does not treat the lookalike title %j as an agent',
+    (title) => {
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  )
+})
+
 describe('Pi-compatible title detection', () => {
   it.each([
     ['\u280b OMP', 'OMP', 'working'],

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -105,26 +105,37 @@ describe('OpenCode native title detection', () => {
   // Why: `OC | …` names no agent token, so before this the status detector read it as a
   // plain shell title and every status-derived surface (send targets, sidebar rows,
   // runtime agent-presence) dropped a live OpenCode pane.
+  it.each(['OC | Implement the Kitty IME preview', 'tmux | OC | Implement the Kitty IME preview'])(
+    'classifies the native session title %j as a live idle agent',
+    (title) => {
+      expect(getAgentLabel(title)).toBe('OpenCode')
+      expect(detectAgentStatusFromTitle(title)).toBe('idle')
+    }
+  )
+
+  // Why: a spinner glyph is the one status decoration OpenCode adds to the marker, and
+  // its gate runs before the marker's, so an animating frame still reads working (#8940).
+  it('reads a spinner-decorated native frame as working', () => {
+    const title = 'OC | ⠋ ask claude about this'
+    expect(getAgentLabel(title)).toBe('OpenCode')
+    expect(detectAgentStatusFromTitle(title)).toBe('working')
+  })
+
+  // Why: the text after the marker is OpenCode's generated session summary — subject
+  // matter, not status. Routing it through the keyword gates would let an ordinary task
+  // name ("stop the flaky test") park a live pane in working/permission forever, so the
+  // marker asserts presence only. Do not "fix" these into keyword-derived statuses.
   it.each([
-    'OC | Implement the Kitty IME preview',
-    'tmux | OC | Implement the Kitty IME preview',
-    'OC|Build'
-  ])('classifies the native session title %j as a live idle agent', (title) => {
+    'OC | ready to review',
+    'OC | permission prompt keeps reappearing',
+    'OC | waiting on the flaky test',
+    'OC | stop the suite from running'
+  ])('keeps the status word inside the session summary %j inert', (title) => {
     expect(getAgentLabel(title)).toBe('OpenCode')
     expect(detectAgentStatusFromTitle(title)).toBe('idle')
   })
 
-  // Why: the marker states presence, not status, so a decorated frame keeps reading
-  // through the usual status decoration (#8940) — only undecorated frames go idle.
-  it.each([
-    ['OC | ⠋ ask claude about this', 'working'],
-    ['OC | ready to review', 'idle']
-  ] as const)('classifies the decorated frame %j as %s', (title, expectedStatus) => {
-    expect(getAgentLabel(title)).toBe('OpenCode')
-    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
-  })
-
-  it.each(['OC |', 'oc | lowercase lookalike', 'OCTOPUS | build'])(
+  it.each(['OC |', 'OC|Build', 'oc | lowercase lookalike', 'OCTOPUS | build'])(
     'does not treat the lookalike title %j as an agent',
     (title) => {
       expect(detectAgentStatusFromTitle(title)).toBeNull()

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -102,11 +102,10 @@ describe('MiMo title detection', () => {
 })
 
 describe('OpenCode native title detection', () => {
-  // Why: `OC | …` names no agent token, so before this the status detector read it as a
-  // plain shell title and every status-derived surface (send targets, sidebar rows,
-  // runtime agent-presence) dropped a live OpenCode pane.
+  // Why: `OC | …` names no agent token, so title-derived display and target surfaces
+  // previously dropped OpenCode panes. Runtime sends corroborate the title separately.
   it.each(['OC | Implement the Kitty IME preview', 'tmux | OC | Implement the Kitty IME preview'])(
-    'classifies the native session title %j as a live idle agent',
+    'classifies the native session title %j as title-derived idle OpenCode',
     (title) => {
       expect(getAgentLabel(title)).toBe('OpenCode')
       expect(detectAgentStatusFromTitle(title)).toBe('idle')
@@ -120,6 +119,14 @@ describe('OpenCode native title detection', () => {
     expect(getAgentLabel(title)).toBe('OpenCode')
     expect(detectAgentStatusFromTitle(title)).toBe('working')
   })
+
+  it.each(['OC | ✦ Gemini CLI', 'OC | ✋ review Gemini permission handling'])(
+    'does not let a Gemini glyph in OpenCode session text override identity for %j',
+    (title) => {
+      expect(getAgentLabel(title)).toBe('OpenCode')
+      expect(detectAgentStatusFromTitle(title)).toBe('idle')
+    }
+  )
 
   // Why: the text after the marker is OpenCode's generated session summary — subject
   // matter, not status. Routing it through the keyword gates would let an ordinary task

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -189,7 +189,9 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   // Why: only a live OpenCode TUI emits the native `OC | …` marker, and it names no
   // agent token, so the name gate below would drop it as a plain shell title. The
-  // marker states presence, never status, so an undecorated frame reads idle.
+  // marker states presence, never status, and the text after it is a generated session
+  // summary — so whatever the spinner gate above did not claim reads idle rather than
+  // falling through to the keyword gates, where a task name would decide the status.
   if (isOpenCodeNativeTitle(title)) {
     return 'idle'
   }

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -23,6 +23,7 @@ import {
   isPiTerminalTitle
 } from './agent-title-core'
 import type { AgentStatus } from './agent-title-core'
+import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentStatus } from './pi-compatible-synthetic-title'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
 
@@ -185,6 +186,12 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   }
   if (containsAgentSpinnerGlyph(title)) {
     return 'working'
+  }
+  // Why: only a live OpenCode TUI emits the native `OC | …` marker, and it names no
+  // agent token, so the name gate below would drop it as a plain shell title. The
+  // marker states presence, never status, so an undecorated frame reads idle.
+  if (isOpenCodeNativeTitle(title)) {
+    return 'idle'
   }
 
   const hasDroidAgentName = DROID_AGENT_NAME_RE.test(title)

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -161,6 +161,10 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
     return null
   }
 
+  if (isOpenCodeNativeTitle(title)) {
+    return containsAgentSpinnerGlyph(title) ? 'working' : 'idle'
+  }
+
   if (title.includes(GEMINI_PERMISSION)) {
     return 'permission'
   }
@@ -187,15 +191,6 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   if (containsAgentSpinnerGlyph(title)) {
     return 'working'
   }
-  // Why: only a live OpenCode TUI emits the native `OC | …` marker, and it names no
-  // agent token, so the name gate below would drop it as a plain shell title. The
-  // marker states presence, never status, and the text after it is a generated session
-  // summary — so whatever the spinner gate above did not claim reads idle rather than
-  // falling through to the keyword gates, where a task name would decide the status.
-  if (isOpenCodeNativeTitle(title)) {
-    return 'idle'
-  }
-
   const hasDroidAgentName = DROID_AGENT_NAME_RE.test(title)
   const hasHermesAgentName = HERMES_AGENT_NAME_RE.test(title)
   const hasAgyAgentName = AGY_AGENT_NAME_RE.test(title)

--- a/src/shared/opencode-terminal-title.test.ts
+++ b/src/shared/opencode-terminal-title.test.ts
@@ -4,7 +4,7 @@ import { isMeaningfulOpenCodeTerminalTitle, isOpenCodeNativeTitle } from './open
 describe('OpenCode terminal titles', () => {
   it('recognizes native session titles', () => {
     expect(isMeaningfulOpenCodeTerminalTitle('OC | Native Stable Session')).toBe(true)
-    expect(isMeaningfulOpenCodeTerminalTitle('  OC|Session  ')).toBe(true)
+    expect(isMeaningfulOpenCodeTerminalTitle('  OC | Session  ')).toBe(true)
     expect(isOpenCodeNativeTitle('OC | Understand about the plugin')).toBe(true)
     expect(isOpenCodeNativeTitle('tmux | OC | ses_123')).toBe(true)
   })
@@ -13,6 +13,9 @@ describe('OpenCode terminal titles', () => {
     expect(isMeaningfulOpenCodeTerminalTitle('OpenCode')).toBe(false)
     expect(isMeaningfulOpenCodeTerminalTitle('OpenCode ready')).toBe(false)
     expect(isMeaningfulOpenCodeTerminalTitle('OC |')).toBe(false)
+    // Why: the native marker always spaces its separator; `OC|x` is another tool's
+    // pipe-delimited title, so accepting it would make a non-OpenCode pane a send target.
+    expect(isMeaningfulOpenCodeTerminalTitle('OC|Session')).toBe(false)
     expect(isMeaningfulOpenCodeTerminalTitle(undefined)).toBe(false)
     // Why: lowercase is not OpenCode's native marker; avoid "oc |" cwd/task noise.
     expect(isOpenCodeNativeTitle('oc | Understand about the plugin')).toBe(false)

--- a/src/shared/opencode-terminal-title.test.ts
+++ b/src/shared/opencode-terminal-title.test.ts
@@ -7,6 +7,13 @@ describe('OpenCode terminal titles', () => {
     expect(isMeaningfulOpenCodeTerminalTitle('  OC | Session  ')).toBe(true)
     expect(isOpenCodeNativeTitle('OC | Understand about the plugin')).toBe(true)
     expect(isOpenCodeNativeTitle('tmux | OC | ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('ssh build-host | OC | ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('user@host: ~/code | OC | ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('▣ OC | ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('⠋ OC | ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('ssh build-host | ⠋ OC | ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('OC |   ses_123')).toBe(true)
+    expect(isOpenCodeNativeTitle('OC |\tses_123')).toBe(true)
   })
 
   it('rejects generic, incomplete, embedded, and lookalike titles', () => {
@@ -16,11 +23,11 @@ describe('OpenCode terminal titles', () => {
     // Why: the native marker always spaces its separator; `OC|x` is another tool's
     // pipe-delimited title, so accepting it would make a non-OpenCode pane a send target.
     expect(isMeaningfulOpenCodeTerminalTitle('OC|Session')).toBe(false)
+    expect(isMeaningfulOpenCodeTerminalTitle('OC |Session')).toBe(false)
     expect(isMeaningfulOpenCodeTerminalTitle(undefined)).toBe(false)
     // Why: lowercase is not OpenCode's native marker; avoid "oc |" cwd/task noise.
     expect(isOpenCodeNativeTitle('oc | Understand about the plugin')).toBe(false)
     // Why: mid-title OC must not steal another agent's braille/task frame.
     expect(isOpenCodeNativeTitle('⠋ Fix foo | OC | bar')).toBe(false)
-    expect(isOpenCodeNativeTitle('my session | OC | task')).toBe(false)
   })
 })

--- a/src/shared/opencode-terminal-title.ts
+++ b/src/shared/opencode-terminal-title.ts
@@ -1,14 +1,7 @@
-// Why: OpenCode abbreviates native OSC session titles as `OC | <task>` (no
-// agent-name token). Optional single-token multiplexer prefix covers SSH/tmux
-// frames like `tmux | OC | …`. Case-sensitive `OC` avoids ordinary lowercase
-// "oc" lookalikes; require non-whitespace after the marker so bare `OC |` is not
-// identity. The separator is the literal ` | ` OpenCode emits — an unspaced `OC|x`
-// is some other tool's pipe-delimited title, not a send target. Used for both
-// display-title preservation and tab-agent identity.
-// Leading `\s*` stands in for a trim(): one OSC frame fans this predicate out
-// across status, identity, agent-type and tab-title resolution, so the trimmed
-// copy was pure allocation. Trailing space never mattered — nothing anchors $.
-const OPENCODE_NATIVE_TITLE_RE = /^\s*(?:[^|\s]+ \| )?OC \| \S/u
+// Why: wrappers may prepend an SSH/tmux label, and OpenCode may prepend one
+// status glyph. A spinner-led task from another agent must not become a wrapper.
+const OPENCODE_NATIVE_TITLE_RE =
+  /^\s*(?:(?![▣\u2800-\u28ff])[^|]+? \| )?(?:[▣\u2800-\u28ff] )?OC \|[ \t]+\S/u
 
 export function isOpenCodeNativeTitle(title: string | null | undefined): boolean {
   return title ? OPENCODE_NATIVE_TITLE_RE.test(title) : false

--- a/src/shared/opencode-terminal-title.ts
+++ b/src/shared/opencode-terminal-title.ts
@@ -2,11 +2,16 @@
 // agent-name token). Optional single-token multiplexer prefix covers SSH/tmux
 // frames like `tmux | OC | …`. Case-sensitive `OC` avoids ordinary lowercase
 // "oc" lookalikes; require non-whitespace after the marker so bare `OC |` is not
-// identity. Used for both display-title preservation and tab-agent identity.
-const OPENCODE_NATIVE_TITLE_RE = /^(?:[^|\s]+ \| )?OC\s*\|\s*\S/u
+// identity. The separator is the literal ` | ` OpenCode emits — an unspaced `OC|x`
+// is some other tool's pipe-delimited title, not a send target. Used for both
+// display-title preservation and tab-agent identity.
+// Leading `\s*` stands in for a trim(): one OSC frame fans this predicate out
+// across status, identity, agent-type and tab-title resolution, so the trimmed
+// copy was pure allocation. Trailing space never mattered — nothing anchors $.
+const OPENCODE_NATIVE_TITLE_RE = /^\s*(?:[^|\s]+ \| )?OC \| \S/u
 
 export function isOpenCodeNativeTitle(title: string | null | undefined): boolean {
-  return OPENCODE_NATIVE_TITLE_RE.test(title?.trim() ?? '')
+  return title ? OPENCODE_NATIVE_TITLE_RE.test(title) : false
 }
 
 export function isMeaningfulOpenCodeTerminalTitle(title: string | null | undefined): boolean {

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -64,7 +64,7 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(getSharedAgentLabel('OC | Compare Codex and Claude')).toBe('OpenCode')
     expect(getSharedAgentLabel('OC | ✦ Gemini CLI')).toBe('OpenCode')
     expect(resolveExplicitTerminalTitleAgentType('tmux | OC | ses_123')).toBe('opencode')
-    expect(resolveExplicitTerminalTitleAgentType('OC|compact-session')).toBe('opencode')
+    expect(resolveExplicitTerminalTitleAgentType('OC|compact-session')).toBeNull()
     expect(resolveExplicitTerminalTitleAgentType('oc | Understand about the plugin')).toBeNull()
   })
 


### PR DESCRIPTION
## ELI5

Orca figures out "is an agent running in this pane?" partly by reading the terminal's title. OpenCode names its tab `OC | <session>`, which never contains the word "opencode" — so the check that looks for an agent's name found nothing and decided the pane was just a shell. The agent was right there, running, and Orca couldn't see it. Now Orca recognizes that `OC |` marker.

## What Changed

Two lines of behavior in the shared title layer:

- `src/shared/agent-title-status.ts` — `detectAgentStatusFromTitle()` returns `idle` for OpenCode's native `OC | <session>` marker. Placed after the spinner/glyph checks, so the decorated frames pinned by #8940 (`OC | ⠋ ask claude about this` → working) keep their status; only undecorated frames go idle.
- `src/renderer/src/lib/agent-send-title-status.ts` — `isExplicitIdleSendTitle()` accepts the same marker as readiness proof, the way Claude's `✳` prefix is accepted. Only a running OpenCode TUI ever publishes it.

Plus tests at all three seams: shared detection (including `oc | …` / `OCTOPUS | build` lookalike rejection), notes send targets, and sidebar rows.

## Why

`detectAgentStatusFromTitle` gates everything after the glyph checks behind a **whole-token agent-name match**. `OC | Ad hoc build` has no such token, so it returned `null` — "not an agent pane" — even though `getAgentLabel()` already resolved the very same title to **OpenCode**. Identity was known; activity was not. Every status-derived surface then dropped a live pane:

- **"Send notes to"** — `deriveNotesSendAgentTargets` only lists panes whose title passes `detectAgentSendTitleStatus`; `null` meant never listed.
- **Sidebar / dashboard rows** — `buildTitleDerivedAgentRows` bails on `!status`.
- **Runtime agent-presence** — `classifyAgentTitle` scored the pane neutral, falling through to the slower foreground-process probe.

A second gate compounded it: even with a status, the send path requires an explicit readiness marker (`ready`/`idle`/`done`, `✳`, `◇`). OpenCode publishes no readiness word at all, so the native marker had to be accepted as its equivalent.

Scoped deliberately to the native marker rather than loosening the name-token rule, which exists to stop cwd titles like `opencode-blinker` from minting a false agent identity.

## Linked Issue

No filed issue — reported directly with the screenshot now used as the "before" below.

## Visual Proof

Validated in a dev build launched from this branch, driven over CDP with playwright-cli.

**Before** — a live OpenCode session is absent from the menu:

![before-send-notes-menu.png](https://github.com/user-attachments/assets/d5d3dbc7-aa37-436e-b8a2-f252ca62480b)

**After** — the OpenCode pane is listed and enabled (`OpenCode · Idle · just now · OC | Ad hoc build`), and the sidebar shows it as an Idle OpenCode row. A plain `zsh` pane appears in neither (negative control — visible as the untouched `zsh` tab):

![orca-proof-3-send-notes-menu-final.png](https://github.com/user-attachments/assets/0c4cc4fc-e8dc-40ba-ac35-ca31ff40c346)

**Sidebar** — "2 agents" for the worktree, with a real OpenCode 1.18.16 TUI live in the pane behind it:

![orca-proof-2-sidebar-both-opencode-rows.png](https://github.com/user-attachments/assets/d8be2a52-3563-43f9-a7de-f6163f3b02bf)

## Testing

Platform tested: **macOS**. The change is pure string classification in `src/shared`, with no platform-dependent behavior, so Linux/Windows/SSH behave identically — the same title arrives over the same pipeline on every host.

Manual, in a dev build from this branch:

1. Open a terminal pane in a worktree and run `opencode`; send it a prompt so the session earns a title (it then publishes `OC | <session>`).
2. Confirm the pane renders as an Idle **OpenCode** row in the worktree sidebar.
3. Open the diff view → **AI notes** → **Send**; confirm OpenCode is listed under "Send notes to" and is enabled.
4. Negative control: a plain shell pane titled `zsh` gets neither a row nor a menu entry.

Automated: `src/shared`, `src/renderer/src/lib`, and `src/renderer/src/components/sidebar` — 10426 passing on the rebased branch.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new input surface; classification of a string Orca already parsed.
- **Cross-platform** — no platform branches touched; `src/shared` logic identical on macOS/Linux/Windows.
- **Remote SSH** — the marker's optional multiplexer prefix (`tmux | OC | …`) is covered by the existing regex and by test. No wire change: this reads a title both sides already exchange, and it changes only local classification, so a new client against an old host and vice versa behave the same.
- **Backwards compatibility** — additive. Titles that previously classified continue to classify identically; only the previously-`null` native marker changes.
- **Performance** — one extra regex test, reached only after the existing glyph/spinner checks fall through.

### Known remaining case

A *fresh* OpenCode session that hasn't been prompted yet publishes the bare title `OpenCode`, not `OC | …`. That already gets a sidebar row, but stays out of the send menu, because the send gate treats a bare agent name as identity rather than readiness. Left alone on purpose: a shell sitting in a directory named `opencode` produces the identical title, and promoting it would surface a menu entry that the runtime then refuses on click. Both states are visible in the sidebar screenshot above — two OpenCode rows, one send target.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

<sub>Lint (oxlint + oxfmt) and `typecheck:node` run clean locally. Two pre-existing failures in `src/main/ssh/ssh-relay-upload-stage-commands.test.ts` reproduce on a clean `main` checkout and are unrelated to this change.</sub>

## AI Disclosure

Written with Claude Code (Opus 5). The rendered validation above was run by an OpenCode agent driving the dev build over CDP.
