### PR TITLE
fix(agents): recognize Cline OSC titles in worktree agent rows

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -201,6 +201,53 @@ describe('buildTitleDerivedAgentRows', () => {
     }
   })
 
+  // Why: live Windows `cline -i` emits bare "Cline"; without title-path identity the row is dropped.
+  it('adds an idle Cline row for the live Cline identity title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'Cline' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-cline'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['cline', 'idle', 'Idle']
+    ])
+  })
+
+  it('does not invent a Cline row from Claude task text that merely mentions cline', () => {
+    const unowned = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠋ use cline for the sidebar fix' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-task'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(unowned).toHaveLength(0)
+
+    const owned = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠋ use cline for the sidebar fix' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-task'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+    expect(owned.map((row) => row.agentType)).toEqual(['claude'])
+  })
+
   it('attributes a spinner-only title to the launched agent when the title has no identity', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -37,6 +37,7 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
   Aider: 'aider',
+  Cline: 'cline',
   Cursor: 'cursor',
   Droid: 'droid',
   Hermes: 'hermes',

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -512,6 +512,11 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('⠋ preserve cursor visibility across replays')).toBe('Claude Code')
     expect(getAgentLabel('⠋ Codex: fix cursor offsets')).toBe('Codex')
     expect(getAgentLabel('Terminal Cursor and Orca slows down')).toBeNull()
+    expect(getAgentLabel('Cline')).toBe('Cline')
+    expect(getAgentLabel('Cline ready')).toBe('Cline')
+    expect(getAgentLabel('⠋ Cline')).toBe('Cline')
+    expect(getAgentLabel('⠋ use cline for the sidebar fix')).toBe('Claude Code')
+    expect(getAgentLabel('~/cline-scratch')).toBeNull()
   })
 })
 

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -11,6 +11,7 @@
 export type { AgentStatus } from './agent-title-core'
 export {
   isClaudeManagementTitle,
+  isClineAgentTitle,
   isCursorAgentTitle,
   isCursorNativeAgentTitle,
   isGeminiTerminalTitle,

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,7 +26,9 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin'
+  'devin',
+  // Why: bare OSC title "Cline" needs the token so status detection treats the pane as an agent.
+  'cline'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,9 +26,7 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin',
-  // Why: bare OSC title "Cline" needs the token so status detection treats the pane as an agent.
-  'cline'
+  'devin'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -5,7 +5,9 @@ import {
   titleHasAgentName,
   titleHasAnyLegacyAgentName
 } from './agent-name-token-match'
+import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
+import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
 export { AGY_AGENT_NAME_RE, DROID_AGENT_NAME_RE, HERMES_AGENT_NAME_RE, titleHasAgentName }
 
@@ -160,4 +162,19 @@ export function isCursorAgentTitle(title: string | null | undefined): boolean {
 // owns the pane. A hookless Cursor pane still needs the literal once, for identity.
 export function shouldSuppressCursorNativeTitle(lastEmittedTitle: string | null): boolean {
   return lastEmittedTitle !== null && isCursorAgentTitle(lastEmittedTitle)
+}
+
+// Why: only identity frames (not free-form task text mentioning "cline") claim the pane.
+const CLINE_IDENTITY_FRAME_RE =
+  /^cline(?:\.(?:exe|cmd|bat|ps1))?(?:\s+(?:ready|idle|done|working|thinking|running))?(?:\s*-\s*action required)?$/
+
+export function isClineAgentTitle(title: string | null | undefined): boolean {
+  if (typeof title !== 'string') {
+    return false
+  }
+  return getWrapperTitleSegments(title).some((segment) =>
+    CLINE_IDENTITY_FRAME_RE.test(
+      stripLeadingAgentTitleDecorationOrEmpty(segment).trim().toLowerCase()
+    )
+  )
 }

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -5,6 +5,7 @@ import {
   HERMES_AGENT_NAME_RE,
   containsAgentSpinnerGlyph,
   isClaudeManagementTitle,
+  isClineAgentTitle,
   isCursorAgentTitle,
   isGeminiTerminalTitle,
   isPiAgentTitle,
@@ -32,9 +33,10 @@ export function isClaudeAgent(title: string): boolean {
     return true
   }
   if (containsAgentSpinnerGlyph(title)) {
-    // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
-    // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
-    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
+    // Why: gate Cursor/Cline by identity frames so Claude task text mentioning them stays Claude.
+    return (
+      !isCursorAgentTitle(title) && !isClineAgentTitle(title) && !lower.includes('openclaude')
+    )
   }
 
   const trimmedTitle = title.trimStart()
@@ -101,6 +103,10 @@ export function getAgentLabel(title: string): string | null {
   }
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
+  }
+  // Why: identity frames only — task text mentioning "cline" must not steal Claude panes.
+  if (isClineAgentTitle(title)) {
+    return 'Cline'
   }
   // Why: `cursor` is ordinary editor vocabulary, not identity. Match Cursor's closed
   // title set (mirrors @cursor routing), before `isClaudeAgent` claims the braille frame.

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -18,6 +18,7 @@ import {
   containsAny,
   containsLegacyAgentName,
   isClaudeManagementTitle,
+  isClineAgentTitle,
   isGeminiTerminalTitle,
   isPiAgentTitle,
   isPiTerminalTitle
@@ -191,7 +192,15 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   const hasHermesAgentName = HERMES_AGENT_NAME_RE.test(title)
   const hasAgyAgentName = AGY_AGENT_NAME_RE.test(title)
   const hasLegacyAgentName = containsLegacyAgentName(title)
-  if (!hasLegacyAgentName && !hasDroidAgentName && !hasHermesAgentName && !hasAgyAgentName) {
+  // Why: Cline uses a closed identity frame — bare "cline" in task text is not agent status.
+  const hasClineIdentity = isClineAgentTitle(title)
+  if (
+    !hasLegacyAgentName &&
+    !hasDroidAgentName &&
+    !hasHermesAgentName &&
+    !hasAgyAgentName &&
+    !hasClineIdentity
+  ) {
     return null
   }
   if (containsAny(title, ['action required', 'permission', 'waiting'])) {
@@ -213,7 +222,7 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
 
   // Why: Droid hook events are authoritative; native name-only titles should
   // not turn a still-sleeping execute tool into completion.
-  if (hasDroidAgentName && !hasLegacyAgentName) {
+  if (hasDroidAgentName && !hasLegacyAgentName && !hasClineIdentity) {
     return null
   }
 

--- a/src/shared/cline-title-detection.test.ts
+++ b/src/shared/cline-title-detection.test.ts
@@ -44,8 +44,29 @@ describe('Cline OSC title detection (STA-3906)', () => {
     }
   })
 
+  it('maps Cline identity frames to status without treating task-text mentions as activity', () => {
+    expect(detectAgentStatusFromTitle('Cline')).toBe('idle')
+    expect(detectAgentStatusFromTitle('cline.exe')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Cline ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Cline working')).toBe('working')
+    expect(detectAgentStatusFromTitle('Cline - action required')).toBe('permission')
+    expect(detectAgentStatusFromTitle('⠋ Cline')).toBe('working')
+    expect(detectAgentStatusFromTitle('zsh | Cline')).toBe('idle')
+
+    for (const title of [
+      'port the cline prompt',
+      'ask cline later',
+      '~/cline-scratch',
+      'cline-rules'
+    ]) {
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  })
+
   it('keeps Claude braille task text that mentions cline as Claude', () => {
     expect(resolveTerminalTitleAgentType('⠋ use cline for the sidebar fix')).toBe('claude')
     expect(getAgentLabel('⠋ use cline for the sidebar fix')).toBe('Claude Code')
+    // Why: spinner still proves activity; the mention must not rebrand identity or invent Cline idle.
+    expect(detectAgentStatusFromTitle('⠋ use cline for the sidebar fix')).toBe('working')
   })
 })

--- a/src/shared/cline-title-detection.test.ts
+++ b/src/shared/cline-title-detection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { isClineAgentTitle } from './agent-title-core'
+import { getAgentLabel } from './agent-title-identity'
+import { detectAgentStatusFromTitle } from './agent-title-status'
+import {
+  resolveExplicitTerminalTitleAgentType,
+  resolveTerminalTitleAgentType
+} from './terminal-title-agent-type'
+
+describe('Cline OSC title detection (STA-3906)', () => {
+  // Observed on Windows: real `cline -i` sets the OSC title to exactly "Cline".
+  it('classifies the live Cline identity title', () => {
+    expect(isClineAgentTitle('Cline')).toBe(true)
+    expect(getAgentLabel('Cline')).toBe('Cline')
+    expect(resolveTerminalTitleAgentType('Cline')).toBe('cline')
+    expect(resolveExplicitTerminalTitleAgentType('Cline')).toBe('cline')
+    expect(detectAgentStatusFromTitle('Cline')).toBe('idle')
+  })
+
+  it('accepts decorated Cline identity frames and rejects task-text mentions', () => {
+    for (const title of [
+      'cline',
+      'cline.exe',
+      'Cline ready',
+      'Cline working',
+      'Cline - action required',
+      '⠋ Cline',
+      'zsh | Cline'
+    ]) {
+      expect(isClineAgentTitle(title)).toBe(true)
+      expect(getAgentLabel(title)).toBe('Cline')
+      expect(resolveTerminalTitleAgentType(title)).toBe('cline')
+    }
+    for (const title of [
+      '⠋ use cline for the sidebar fix',
+      'port the cline prompt',
+      '~/cline-scratch',
+      'cline-rules',
+      'ask cline later'
+    ]) {
+      expect(isClineAgentTitle(title)).toBe(false)
+      expect(getAgentLabel(title)).not.toBe('Cline')
+      expect(resolveTerminalTitleAgentType(title)).not.toBe('cline')
+    }
+  })
+
+  it('keeps Claude braille task text that mentions cline as Claude', () => {
+    expect(resolveTerminalTitleAgentType('⠋ use cline for the sidebar fix')).toBe('claude')
+    expect(getAgentLabel('⠋ use cline for the sidebar fix')).toBe('Claude Code')
+  })
+})

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -155,6 +155,15 @@ describe('resolveTerminalTitleAgentType', () => {
     )
     expect(resolveTerminalTitleAgentType('⠋ Codex: fix cursor offsets')).toBe('codex')
   })
+
+  it('resolves Cline identity titles and rejects task-text cline mentions', () => {
+    expect(resolveTerminalTitleAgentType('Cline')).toBe('cline')
+    expect(resolveTerminalTitleAgentType('Cline ready')).toBe('cline')
+    expect(resolveTerminalTitleAgentType('⠋ Cline')).toBe('cline')
+    expect(resolveExplicitTerminalTitleAgentType('Cline')).toBe('cline')
+    expect(resolveTerminalTitleAgentType('⠋ use cline for the sidebar fix')).toBe('claude')
+    expect(resolveExplicitTerminalTitleAgentType('port the cline prompt')).toBeNull()
+  })
 })
 
 // Why: this module carries its own isClaudeAgent copy parallel to agent-title-identity.ts;
@@ -165,5 +174,11 @@ describe('isClaudeAgent', () => {
     expect(isClaudeAgent('Cursor ready')).toBe(false)
     expect(isClaudeAgent('⠋ preserve cursor visibility across replays')).toBe(true)
     expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
+  })
+
+  it('excludes Cline identity titles from Claude braille ownership', () => {
+    expect(isClaudeAgent('⠋ Cline')).toBe(false)
+    expect(isClaudeAgent('Cline ready')).toBe(false)
+    expect(isClaudeAgent('⠋ use cline for the sidebar fix')).toBe(true)
   })
 })

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -4,7 +4,11 @@ import {
   HERMES_AGENT_NAME_RE,
   titleHasAgentName
 } from './agent-name-token-match'
-import { containsAgentSpinnerGlyph, isCursorAgentTitle } from './agent-title-core'
+import {
+  containsAgentSpinnerGlyph,
+  isClineAgentTitle,
+  isCursorAgentTitle
+} from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
@@ -97,9 +101,10 @@ export function isClaudeAgent(title: string): boolean {
     return true
   }
   if (containsAgentSpinnerGlyph(title)) {
-    // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
-    // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
-    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
+    // Why: gate Cursor/Cline by identity frames so Claude task text mentioning them stays Claude.
+    return (
+      !isCursorAgentTitle(title) && !isClineAgentTitle(title) && !lower.includes('openclaude')
+    )
   }
   // Why: permission/action-required Claude titles can omit the usual prefixes.
   // Token-match so cwd/worktree titles like "claude-scratch" do not become
@@ -184,6 +189,10 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
+  // Why: identity frames only — task text mentioning "cline" must not steal Claude panes.
+  if (isClineAgentTitle(title)) {
+    return 'Cline'
+  }
   // Why: `cursor` is ordinary editor vocabulary, not identity. Match Cursor's closed
   // title set (mirrors @cursor routing), before `isClaudeAgent` claims the braille frame.
   if (isCursorAgentTitle(title)) {
@@ -222,6 +231,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   OpenCode: 'opencode',
   'MiMo Code': 'mimo-code',
   Aider: 'aider',
+  Cline: 'cline',
   Cursor: 'cursor',
   Droid: 'droid',
   Hermes: 'hermes',


### PR DESCRIPTION
## Summary

Cline terminals launched in Orca did not appear in worktree sidebar agent rows or the agent dashboard because the OSC title path never classified them.

Live Windows repro (`cline -i` via Orca terminal create) sets the pane title to exactly **`Cline`**. The npm wrapper launches through `node`, so `expectedProcess: 'cline'` process matching is not enough — title detection must fill the gap (same class of bug as Cursor in #12466).

## Changes

- Add `isClineAgentTitle` identity-frame gating (Cursor-style) so free-form task text mentioning "cline" does not steal Claude panes or invent idle activity
- Map `Cline` → `cline` in `TITLE_LABEL_TO_AGENT` and the worktree title-derived row label map
- Place Cline label resolution above `isClaudeAgent` / spinner ownership
- Teach `detectAgentStatusFromTitle` to use the closed Cline identity frame (not global `AGENT_NAMES`) so titles like `port the cline prompt` stay `null` while `Cline` / `Cline working` / `Cline - action required` keep correct statuses
- Focused regression tests: live identity title, decorated frames, task-text rejection, status null vs real frames, sidebar rows, Claude non-rebranding

Managed hooks intentionally out of scope (Cline uses SDK plugins). AI Vault remains #13840.

## Test plan

- [x] Live Windows: `orca terminal create --worktree active --command "cline -i"` → `orca terminal show` reports `title: "Cline"`
- [x] HEAD repro: `getAgentLabel('Cline')` returns `null` without the fix
- [x] Non-identity mentions (`port the cline prompt`, `ask cline later`) return `detectAgentStatusFromTitle(...) === null`
- [x] Real frames: idle / working / permission / spinner / wrapper keep correct statuses
- [x] Focused vitest suite (224 tests) pass
- [x] `oxlint` on changed files clean
- [x] `tsc --noEmit` web + node clean
- [x] `git diff --check` clean

Fixes #13823