### PR TITLE
fix(gitlab): resolve project refs from non-origin remotes

### DIFF
--- a/src/main/git/remote-url-probe.test.ts
+++ b/src/main/git/remote-url-probe.test.ts
@@ -15,6 +15,8 @@ vi.mock('./runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
 import {
   assertRemoteUrlReadable,
   isTransientGitProbeError,
+  listRemoteNames,
+  parseRemoteNames,
   readRemoteUrl,
   REMOTE_URL_PROBE_TIMEOUT_MS
 } from './remote-url-probe'
@@ -23,6 +25,58 @@ describe('remote URL probe', () => {
   beforeEach(() => {
     getSshGitProviderMock.mockReset()
     gitExecFileAsyncMock.mockReset()
+  })
+
+  it('parses remote names from git remote stdout', () => {
+    expect(parseRemoteNames('origin\nupstream\nmyremote\n')).toEqual([
+      'origin',
+      'upstream',
+      'myremote'
+    ])
+    expect(parseRemoteNames('')).toEqual([])
+  })
+
+  it('lists remote names locally with the shared timeout', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'myremote\norigin\n', stderr: '' })
+
+    await expect(listRemoteNames({ repoPath: '/repo' })).resolves.toEqual(['myremote', 'origin'])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote'], {
+      cwd: '/repo',
+      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+    })
+  })
+
+  it('lists remote names through WSL with the shared timeout', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'myremote\n', stderr: '' })
+
+    await expect(listRemoteNames({ repoPath: '/home/repo', wslDistro: 'Ubuntu' })).resolves.toEqual(
+      ['myremote']
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote'], {
+      cwd: '/home/repo',
+      timeout: REMOTE_URL_PROBE_TIMEOUT_MS,
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('lists remote names through the SSH provider', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'myremote\n', stderr: '' })
+    getSshGitProviderMock.mockReturnValue({ exec })
+
+    await expect(listRemoteNames({ repoPath: '/repo', connectionId: 'conn-1' })).resolves.toEqual([
+      'myremote'
+    ])
+    expect(exec).toHaveBeenCalledWith(['remote'], '/repo', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty list when the SSH provider is unavailable', async () => {
+    getSshGitProviderMock.mockReturnValue(null)
+    await expect(listRemoteNames({ repoPath: '/repo', connectionId: 'conn-1' })).resolves.toEqual(
+      []
+    )
   })
 
   it('bounds local and WSL remote reads with the shared timeout', async () => {

--- a/src/main/git/remote-url-probe.ts
+++ b/src/main/git/remote-url-probe.ts
@@ -47,6 +47,43 @@ export async function readRemoteUrl(
   return stdout
 }
 
+export function parseRemoteNames(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Lists configured remote names (`git remote`), or [] when the SSH runtime is
+ * down / the probe fails. Callers that only care about named remotes use this
+ * after preferred names miss so custom remote labels still resolve.
+ */
+export async function listRemoteNames(context: RemoteUrlProbeContext): Promise<string[]> {
+  try {
+    if (context.connectionId) {
+      const provider = getSshGitProvider(context.connectionId)
+      if (!provider) {
+        return []
+      }
+      const { stdout } = await provider.exec(['remote'], context.repoPath, {
+        signal: AbortSignal.timeout(REMOTE_URL_PROBE_TIMEOUT_MS)
+      })
+      return parseRemoteNames(stdout)
+    }
+    const { stdout } = await gitExecFileAsync(['remote'], {
+      cwd: context.repoPath,
+      timeout: REMOTE_URL_PROBE_TIMEOUT_MS,
+      ...(context.wslDistro ? { wslDistro: context.wslDistro } : {})
+    })
+    return parseRemoteNames(stdout)
+  } catch {
+    // Why: a list failure is not "no remotes" evidence worth caching at this
+    // layer — callers treat [] as "no fallback candidates" and re-ask later.
+    return []
+  }
+}
+
 const TRANSIENT_PROBE_PATTERNS = [
   /\btimed out\b/i,
   /\bETIMEDOUT\b/,

--- a/src/main/gitlab/gitlab-nonstandard-remote.test.ts
+++ b/src/main/gitlab/gitlab-nonstandard-remote.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, sshExecMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  sshExecMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  glabExecFileAsync: vi.fn()
+}))
+
+import {
+  _resetProjectRefCache,
+  getIssueProjectRef,
+  getProjectRef,
+  orderRemoteNamesForProjectRefProbe,
+  resolveIssueSource
+} from './gl-utils'
+import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
+
+function mockGitRemotes(remotes: Record<string, string | null>): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote' && args.length === 1) {
+      return { stdout: `${Object.keys(remotes).join('\n')}\n`, stderr: '' }
+    }
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      const name = args[2] ?? ''
+      if (!(name in remotes) || remotes[name] === null) {
+        throw new Error(`error: No such remote '${name}'`)
+      }
+      return { stdout: `${remotes[name]}\n`, stderr: '' }
+    }
+    throw new Error(`unexpected git args: ${args.join(' ')}`)
+  })
+}
+
+describe('gitlab nonstandard remote project ref resolution', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    sshExecMock.mockReset()
+    unregisterSshGitProvider('conn-1')
+    _resetProjectRefCache()
+  })
+
+  afterEach(() => {
+    unregisterSshGitProvider('conn-1')
+  })
+
+  it('resolves a custom-named remote when origin and upstream are absent', async () => {
+    mockGitRemotes({
+      myremote: 'ssh://git@gitlab.example.com:2222/group/project.git'
+    })
+
+    await expect(getIssueProjectRef('/repo', ['gitlab.example.com'])).resolves.toEqual({
+      host: 'gitlab.example.com',
+      path: 'group/project'
+    })
+    await expect(getProjectRef('/repo', ['gitlab.example.com'])).resolves.toEqual({
+      host: 'gitlab.example.com',
+      path: 'group/project'
+    })
+  })
+
+  it('skips a non-GitLab origin and still finds a custom GitLab remote', async () => {
+    mockGitRemotes({
+      origin: 'git@github.com:user/fork.git',
+      myremote: 'git@gitlab.com:group/project.git'
+    })
+
+    await expect(getIssueProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+  })
+
+  it('keeps upstream-then-origin preference over alphabetically earlier custom remotes', async () => {
+    mockGitRemotes({
+      aaa: 'git@gitlab.com:custom/aaa.git',
+      origin: 'git@gitlab.com:fork/orca.git',
+      upstream: 'git@gitlab.com:parent/orca.git'
+    })
+
+    await expect(getIssueProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'parent/orca'
+    })
+  })
+
+  it('breaks ties among custom remotes deterministically by remote name', async () => {
+    mockGitRemotes({
+      zebra: 'git@gitlab.com:team/zebra.git',
+      alpha: 'git@gitlab.com:team/alpha.git'
+    })
+
+    await expect(getIssueProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'team/alpha'
+    })
+    expect(orderRemoteNamesForProjectRefProbe(['zebra', 'alpha'])).toEqual(['alpha', 'zebra'])
+  })
+
+  it('resolves a custom remote through the SSH git provider', async () => {
+    sshExecMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: 'myremote\n', stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'myremote') {
+        return { stdout: 'git@gitlab.com:remote/custom.git\n', stderr: '' }
+      }
+      throw new Error(`error: No such remote '${args[2] ?? ''}'`)
+    })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(getIssueProjectRef('/repo', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'remote/custom'
+    })
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps preferred-name negatives and custom-remote positives cached across polls', async () => {
+    mockGitRemotes({
+      myremote: 'git@gitlab.com:group/project.git'
+    })
+
+    await expect(getIssueProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+    const callsAfterFirst = gitExecFileAsyncMock.mock.calls.length
+
+    await expect(getIssueProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'group/project'
+    })
+    // Preferred-name misses stay negatively cached; the custom remote stays positively cached.
+    // Only a fresh `git remote` list is needed to know which custom names to try.
+    expect(gitExecFileAsyncMock.mock.calls.length).toBe(callsAfterFirst + 1)
+    expect(gitExecFileAsyncMock.mock.calls.at(-1)?.[0]).toEqual(['remote'])
+  })
+
+  it("'auto' resolves a custom remote name when origin/upstream are absent", async () => {
+    mockGitRemotes({
+      myremote: 'ssh://git@gitlab.example.com:2222/group/project.git'
+    })
+
+    await expect(resolveIssueSource('/repo', 'auto', ['gitlab.example.com'])).resolves.toEqual({
+      source: { host: 'gitlab.example.com', path: 'group/project' },
+      fellBack: false
+    })
+  })
+
+  it("'origin' preference does not fall back to a custom remote name", async () => {
+    mockGitRemotes({
+      myremote: 'git@gitlab.com:group/project.git'
+    })
+
+    await expect(resolveIssueSource('/repo', 'origin')).resolves.toEqual({
+      source: null,
+      fellBack: false
+    })
+  })
+
+  it("'upstream' + no upstream/origin falls back to a custom remote, fellBack=true", async () => {
+    mockGitRemotes({
+      myremote: 'git@gitlab.com:group/project.git'
+    })
+
+    await expect(resolveIssueSource('/repo', 'upstream')).resolves.toEqual({
+      source: { host: 'gitlab.com', path: 'group/project' },
+      fellBack: true
+    })
+  })
+})

--- a/src/main/gitlab/gitlab-project-ref-remote-preference.ts
+++ b/src/main/gitlab/gitlab-project-ref-remote-preference.ts
@@ -1,0 +1,165 @@
+import { listRemoteNames, type RemoteUrlProbeContext } from '../git/remote-url-probe'
+import type { IssueSourcePreference } from '../../shared/types'
+import type { LocalGitExecOptions } from './gitlab-known-host-probe'
+import { getProjectRefForRemote, type ProjectRef } from './gitlab-project-ref-resolution'
+
+/** Prefer upstream, then origin, then a stable name order for custom remotes. */
+export function orderRemoteNamesForProjectRefProbe(remoteNames: readonly string[]): string[] {
+  return [...remoteNames].sort((left, right) => {
+    const rank = (name: string): number => {
+      if (name === 'upstream') {
+        return 0
+      }
+      if (name === 'origin') {
+        return 1
+      }
+      return 2
+    }
+    const byRank = rank(left) - rank(right)
+    return byRank !== 0 ? byRank : left.localeCompare(right)
+  })
+}
+
+function remoteUrlProbeContext(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): RemoteUrlProbeContext {
+  return {
+    repoPath,
+    connectionId,
+    ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+  }
+}
+
+/**
+ * Probe preferred remote names first, then any remaining configured remotes.
+ * Why: repos often use a custom remote label (not origin/upstream); Issues and
+ * hosted-review still need a GitLab project ref when that label's host matches.
+ */
+export async function getProjectRefPreferringRemotes(
+  repoPath: string,
+  preferredRemoteNames: readonly string[],
+  knownHosts?: readonly string[],
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<ProjectRef | null> {
+  const tried = new Set<string>()
+  for (const remoteName of preferredRemoteNames) {
+    tried.add(remoteName)
+    const ref = await getProjectRefForRemote(
+      repoPath,
+      remoteName,
+      knownHosts,
+      connectionId,
+      localGitOptions
+    )
+    if (ref) {
+      return ref
+    }
+  }
+
+  const configured = await listRemoteNames(
+    remoteUrlProbeContext(repoPath, connectionId, localGitOptions)
+  )
+  for (const remoteName of orderRemoteNamesForProjectRefProbe(configured)) {
+    if (tried.has(remoteName)) {
+      continue
+    }
+    tried.add(remoteName)
+    const ref = await getProjectRefForRemote(
+      repoPath,
+      remoteName,
+      knownHosts,
+      connectionId,
+      localGitOptions
+    )
+    if (ref) {
+      return ref
+    }
+  }
+  return null
+}
+
+export async function getProjectRef(
+  repoPath: string,
+  knownHosts?: readonly string[],
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<ProjectRef | null> {
+  return getProjectRefPreferringRemotes(
+    repoPath,
+    ['origin'],
+    knownHosts,
+    connectionId,
+    localGitOptions
+  )
+}
+
+export async function getIssueProjectRef(
+  repoPath: string,
+  knownHosts?: readonly string[],
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<ProjectRef | null> {
+  return getProjectRefPreferringRemotes(
+    repoPath,
+    ['upstream', 'origin'],
+    knownHosts,
+    connectionId,
+    localGitOptions
+  )
+}
+
+export type ResolvedIssueSource = {
+  source: ProjectRef | null
+  /** True when explicit upstream is gone and resolver fell back to another remote. */
+  fellBack: boolean
+}
+
+export async function resolveIssueSource(
+  repoPath: string,
+  preference: IssueSourcePreference | undefined,
+  knownHosts?: readonly string[],
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<ResolvedIssueSource> {
+  if (preference === 'upstream') {
+    const upstream = await getProjectRefForRemote(
+      repoPath,
+      'upstream',
+      knownHosts,
+      connectionId,
+      localGitOptions
+    )
+    if (upstream) {
+      return { source: upstream, fellBack: false }
+    }
+    // Origin (then any other configured remote) when upstream is absent.
+    const fallback = await getProjectRefPreferringRemotes(
+      repoPath,
+      ['origin'],
+      knownHosts,
+      connectionId,
+      localGitOptions
+    )
+    return { source: fallback, fellBack: fallback !== null }
+  }
+  if (preference === 'origin') {
+    // Explicit origin preference keeps that remote name only — no custom fallback.
+    return {
+      source: await getProjectRefForRemote(
+        repoPath,
+        'origin',
+        knownHosts,
+        connectionId,
+        localGitOptions
+      ),
+      fellBack: false
+    }
+  }
+  return {
+    source: await getIssueProjectRef(repoPath, knownHosts, connectionId, localGitOptions),
+    fellBack: false
+  }
+}

--- a/src/main/gitlab/gitlab-project-ref-resolution.live-git.test.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.live-git.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  _resetProjectRefCache,
+  getIssueProjectRef,
+  getProjectRef,
+  resolveIssueSource
+} from './gitlab-project-ref-resolution'
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' })
+}
+
+describe('gitlab project ref resolution (live git)', () => {
+  let repoPath = ''
+
+  beforeEach(async () => {
+    _resetProjectRefCache()
+    repoPath = await mkdtemp(join(tmpdir(), 'orca-gitlab-ref-'))
+    git(repoPath, ['init'])
+  })
+
+  afterEach(async () => {
+    _resetProjectRefCache()
+    if (repoPath) {
+      await rm(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves Issues project ref when the only remote is not named origin/upstream', async () => {
+    git(repoPath, [
+      'remote',
+      'add',
+      'myremote',
+      'ssh://git@gitlab.example.com:2222/group/project.git'
+    ])
+
+    await expect(getIssueProjectRef(repoPath, ['gitlab.example.com'])).resolves.toEqual({
+      host: 'gitlab.example.com',
+      path: 'group/project'
+    })
+    await expect(getProjectRef(repoPath, ['gitlab.example.com'])).resolves.toEqual({
+      host: 'gitlab.example.com',
+      path: 'group/project'
+    })
+    await expect(resolveIssueSource(repoPath, 'auto', ['gitlab.example.com'])).resolves.toEqual({
+      source: { host: 'gitlab.example.com', path: 'group/project' },
+      fellBack: false
+    })
+  })
+
+  it('prefers upstream over origin and over custom remotes in a fork layout', async () => {
+    git(repoPath, ['remote', 'add', 'origin', 'git@gitlab.com:fork/orca.git'])
+    git(repoPath, ['remote', 'add', 'upstream', 'git@gitlab.com:parent/orca.git'])
+    git(repoPath, ['remote', 'add', 'aaa', 'git@gitlab.com:custom/aaa.git'])
+
+    await expect(getIssueProjectRef(repoPath)).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'parent/orca'
+    })
+  })
+
+  it('breaks ties among custom GitLab remotes by remote name', async () => {
+    git(repoPath, ['remote', 'add', 'zebra', 'git@gitlab.com:team/zebra.git'])
+    git(repoPath, ['remote', 'add', 'alpha', 'git@gitlab.com:team/alpha.git'])
+
+    await expect(getIssueProjectRef(repoPath)).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'team/alpha'
+    })
+  })
+
+  it('ignores non-GitLab remotes while matching a known self-hosted host', async () => {
+    git(repoPath, ['remote', 'add', 'origin', 'git@github.com:user/fork.git'])
+    git(repoPath, [
+      'remote',
+      'add',
+      'gitlab-work',
+      'https://gitlab.example.com:8443/group/project.git'
+    ])
+
+    await expect(getIssueProjectRef(repoPath, ['gitlab.example.com:8443'])).resolves.toEqual({
+      host: 'gitlab.example.com:8443',
+      path: 'group/project'
+    })
+  })
+
+  it('returns null before fix-equivalent path when remotes only have non-matching hosts', async () => {
+    git(repoPath, ['remote', 'add', 'myremote', 'git@github.com:user/fork.git'])
+
+    await expect(getIssueProjectRef(repoPath, ['gitlab.example.com'])).resolves.toBeNull()
+  })
+})

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -2,7 +2,6 @@ import { glabExecFileAsync } from '../git/runner'
 import { isTransientGitProbeError, readRemoteUrl } from '../git/remote-url-probe'
 import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
-import type { IssueSourcePreference } from '../../shared/types'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 import {
   _resetGlabUnauthenticatedHosts,
@@ -163,84 +162,13 @@ async function resolveProjectRefForRemote(
   return null
 }
 
-export async function getProjectRef(
-  repoPath: string,
-  knownHosts?: readonly string[],
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<ProjectRef | null> {
-  return getProjectRefForRemote(repoPath, 'origin', knownHosts, connectionId, localGitOptions)
-}
-
-export async function getIssueProjectRef(
-  repoPath: string,
-  knownHosts?: readonly string[],
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<ProjectRef | null> {
-  const upstream = await getProjectRefForRemote(
-    repoPath,
-    'upstream',
-    knownHosts,
-    connectionId,
-    localGitOptions
-  )
-  return (
-    upstream ??
-    getProjectRefForRemote(repoPath, 'origin', knownHosts, connectionId, localGitOptions)
-  )
-}
-
-export type ResolvedIssueSource = {
-  source: ProjectRef | null
-  /** True when explicit upstream is gone and resolver fell back to origin. */
-  fellBack: boolean
-}
-
-export async function resolveIssueSource(
-  repoPath: string,
-  preference: IssueSourcePreference | undefined,
-  knownHosts?: readonly string[],
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<ResolvedIssueSource> {
-  if (preference === 'upstream') {
-    const upstream = await getProjectRefForRemote(
-      repoPath,
-      'upstream',
-      knownHosts,
-      connectionId,
-      localGitOptions
-    )
-    if (upstream) {
-      return { source: upstream, fellBack: false }
-    }
-    const origin = await getProjectRefForRemote(
-      repoPath,
-      'origin',
-      knownHosts,
-      connectionId,
-      localGitOptions
-    )
-    return { source: origin, fellBack: origin !== null }
-  }
-  if (preference === 'origin') {
-    return {
-      source: await getProjectRefForRemote(
-        repoPath,
-        'origin',
-        knownHosts,
-        connectionId,
-        localGitOptions
-      ),
-      fellBack: false
-    }
-  }
-  return {
-    source: await getIssueProjectRef(repoPath, knownHosts, connectionId, localGitOptions),
-    fellBack: false
-  }
-}
+export {
+  getIssueProjectRef,
+  getProjectRef,
+  orderRemoteNamesForProjectRefProbe,
+  resolveIssueSource
+} from './gitlab-project-ref-remote-preference'
+export type { ResolvedIssueSource } from './gitlab-project-ref-remote-preference'
 
 export function glabRepoExecOptions(
   repoPath: string,

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -32,6 +32,22 @@ import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/s
 import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
 import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 
+function mockGitRemotes(remotes: Record<string, string | null>): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote' && args.length === 1) {
+      return { stdout: `${Object.keys(remotes).join('\n')}\n`, stderr: '' }
+    }
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      const name = args[2] ?? ''
+      if (!(name in remotes) || remotes[name] === null) {
+        throw new Error(`error: No such remote '${name}'`)
+      }
+      return { stdout: `${remotes[name]}\n`, stderr: '' }
+    }
+    throw new Error(`unexpected git args: ${args.join(' ')}`)
+  })
+}
+
 describe('gitlab project ref resolution', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
@@ -220,6 +236,8 @@ describe('gitlab project ref resolution', () => {
   it('does not cache a local probe killed on its deadline as a definitive miss', async () => {
     gitExecFileAsyncMock
       .mockRejectedValueOnce(new Error('git timed out.'))
+      // After the preferred-name miss, list remotes (empty) then succeed on re-probe.
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'git@gitlab.com:fork/orca.git\n' })
 
     await expect(getProjectRef('/repo')).resolves.toBeNull()
@@ -227,28 +245,41 @@ describe('gitlab project ref resolution', () => {
       host: 'gitlab.com',
       path: 'fork/orca'
     })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(3)
   })
 
   it('re-probes a repo whose GitLab remote could have been added since the miss', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
-    gitExecFileAsyncMock.mockRejectedValueOnce(new Error("error: No such remote 'origin'"))
+    // Miss path: no origin, and listing remotes finds nothing (list is not negatively cached).
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: '', stderr: '' }
+      }
+      throw new Error("error: No such remote 'origin'")
+    })
 
     await expect(getProjectRef('/repo')).resolves.toBeNull()
     await expect(getProjectRef('/repo')).resolves.toBeNull()
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    // origin get-url once (negative cached) + `git remote` list on each resolve attempt.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(3)
 
     // Nothing watches `.git/config`, and SSH/WSL repos have no file to watch, so
     // a remote configured after the miss is only visible once the negative ages out.
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:fork/orca.git\n' })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+        return { stdout: 'git@gitlab.com:fork/orca.git\n', stderr: '' }
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
     vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
 
     await expect(getProjectRef('/repo')).resolves.toEqual({
       host: 'gitlab.com',
       path: 'fork/orca'
     })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    // Re-probe origin after negative TTL; no list needed when origin hits.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
   })
 
   it('keeps a resolved project ref past the negative interval', async () => {
@@ -351,9 +382,9 @@ describe('resolveIssueSource', () => {
   })
 
   it("'upstream' + no upstream remote → origin, fellBack=true", async () => {
-    gitExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('fatal: No such remote'))
-      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:solo/orca.git\n' })
+    mockGitRemotes({
+      origin: 'git@gitlab.com:solo/orca.git'
+    })
 
     await expect(resolveIssueSource('/repo', 'upstream')).resolves.toEqual({
       source: { host: 'gitlab.com', path: 'solo/orca' },

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -19,6 +19,7 @@ export {
   getProjectRefForRemote,
   glabHostnameArgs,
   glabRepoExecOptions,
+  orderRemoteNamesForProjectRefProbe,
   parseGlabAuthStatusHosts,
   parseGitLabProjectRef,
   resolveIssueSource


### PR DESCRIPTION
## ELI5

GitLab Tasks only looked for remotes named `upstream` or `origin`. If your only remote is named something like `myremote`, Issues stayed empty even when `glab` and Orca already knew the project. We now keep the old preference order, then fall back to any configured remote whose URL matches a known GitLab host.

## What Changed

- Prefer `upstream` then `origin` as before for automatic issue sources.
- After preferred names miss, run `git remote` (Git 2.25-compatible) and probe remaining names in a deterministic order (`upstream` > `origin` > localeCompare).
- Explicit `origin` preference stays strict (no custom fallback). Explicit `upstream` falls back to origin, then other configured remotes, with `fellBack: true`.
- Shared `listRemoteNames` supports native, WSL, and SSH git providers with the same 30s probe timeout as `get-url`.
- Negative cache still applies per remote name; listing remotes is not negatively cached so a newly added remote can appear without waiting for TTL once preferred negatives age out.

## Why

#13816: a repo with only `myremote → ssh://git@gitlab…/group/project.git` never resolved a project ref, short-circuited before `glab`, and showed an empty Issues list.

## Related open PRs

- #13936 uses a sole-remote-only fallback (does not pick a custom GitLab remote when a non-GitLab `origin` exists).
- #13886 takes a similar enumerate-remotes approach.

This PR keeps fork-safe precedence and also covers non-GitLab `origin` + custom GitLab remote.

## Linked Issue

Fixes #13816

## Testing

```bash
node ./node_modules/vitest/vitest.mjs run --config config/vitest.config.ts \
  src/main/gitlab/gl-utils.test.ts \
  src/main/git/remote-url-probe.test.ts \
  src/main/gitlab/gitlab-nonstandard-remote.test.ts \
  src/main/gitlab/gitlab-project-ref-resolution.live-git.test.ts
```

Result: **4 files / 82 tests passed**, including live temporary repos that only have `myremote`.

Also: `tsc -p config/tsconfig.node.json --noEmit` (exit 0), oxlint on changed files (exit 0).

### Reproduction evidence (pre-fix baseline on main)

In a real temp git repo with only:

```
myremote  ssh://git@gitlab.example.com:2222/group/project.git
```

main-code path only runs:

```
git remote get-url upstream  → No such remote 'upstream'
git remote get-url origin    → No such remote 'origin'
```

and never reads `myremote`. After the fix, live-git tests resolve `{ host: 'gitlab.example.com', path: 'group/project' }`.

### Coverage

- Sole custom remote resolves for Issues / hosted-review / `auto`
- Non-GitLab origin + custom GitLab remote still resolves
- Upstream-then-origin still beats alphabetically earlier custom remotes
- Multi-custom tie-break is deterministic by remote name
- Cache: preferred negatives + custom positive; warm poll only re-lists remotes
- SSH provider path for list + get-url (unit)
- WSL listRemoteNames timeout/options (unit)
- Explicit origin preference does not custom-fall-back

### SSH Docker

Full Electron + Docker SSH validation was **not** run: `docker` is not available on this Windows host. SSH execution is covered by the existing SSH git provider unit path (`listRemoteNames` + `getIssueProjectRef` with `connectionId`).

## Checklist

- [x] Focused and linked to #13816
- [x] Automated regression with real temporary repos
- [x] Cross-platform git argv only (`git remote`, `git remote get-url`)
- [x] No max-lines disables; preference logic extracted to keep file budgets
- [x] No Linear mutation