### PR TITLE
fix(dashboard): close terminal preview with pane shortcut

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -76,6 +76,7 @@ function AgentTerminalFrame({
         <AgentTerminalPreview
           ptyId={card.ptyId}
           terminalInput={card.terminalInput ?? null}
+          onClose={() => onOpenChange(false)}
           className={previewClassName}
         />
       ) : (

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -480,6 +480,29 @@ describe('AgentTerminalPreview', () => {
     expect(input).not.toHaveBeenCalled()
   })
 
+  it('closes the preview on the configured pane-close shortcut', async () => {
+    platformState.value = 'darwin'
+    const onClose = vi.fn()
+    render(<AgentTerminalPreview ptyId="pty-1" onClose={onClose} />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+
+    const keydown = new KeyboardEvent('keydown', {
+      key: 'w',
+      code: 'KeyW',
+      metaKey: true,
+      cancelable: true
+    })
+    const handled = terminal.customKeyHandler!(keydown)
+
+    expect(handled).toBe(false)
+    expect(keydown.defaultPrevented).toBe(true)
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(terminal.input).not.toHaveBeenCalled()
+    expect(input).not.toHaveBeenCalled()
+  })
+
   it('keeps a native input-source chord from inserting text into the preview', async () => {
     storeState.keybindings = { 'terminal.switchInputSource': ['Shift+Space'] }
     const view = render(<AgentTerminalPreview ptyId="pty-1" />)

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
@@ -48,16 +48,16 @@ function clamp(value: number, min: number, max: number): number {
  * anchored so the cursor stays visible. Keystrokes pass through to the PTY;
  * DOM renderer so it never grabs a WebGL context.
  */
-export function AgentTerminalPreview({
-  ptyId,
-  terminalInput = null,
-  className
-}: {
+type AgentTerminalPreviewProps = {
   ptyId: string
   /** Host-input facts relayed with the card; null routes bytes by client OS. */
   terminalInput?: DashboardCardTerminalInput | null
+  onClose?: () => void
   className?: string
-}): React.JSX.Element {
+}
+
+export function AgentTerminalPreview(props: AgentTerminalPreviewProps): React.JSX.Element {
+  const { ptyId, terminalInput = null, onClose, className } = props
   const containerRef = useRef<HTMLDivElement>(null)
   const terminalRef = useRef<Terminal | null>(null)
   const settings = useAppStore((state) => state.settings)
@@ -68,6 +68,7 @@ export function AgentTerminalPreview({
   const settingsRef = useRef(settings)
   const macOptionAsAltRef = useRef(macOptionAsAlt)
   const terminalInputRef = useRef(terminalInput)
+  const closePreview = useEffectEvent(() => onClose?.())
   const { terminalTheme, terminalMode } = useMemo(() => {
     if (!settings) {
       return { terminalTheme: null, terminalMode: 'dark' as const }
@@ -221,6 +222,7 @@ export function AgentTerminalPreview({
       disposeKeyHandler = installPreviewTerminalKeyHandler({
         terminal,
         claimImeKeyEvent: (event) => imeBridge?.claimKeyEvent(event) ?? false,
+        closePreview,
         pasteClipboardText: (activeElement, source) =>
           void pasteClipboardText(activeElement, source),
         // Why: route through terminal.input so the chord's bytes carry core's user-input signal, like typed keys.

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -22,6 +22,7 @@ import {
 export function installPreviewTerminalKeyHandler(args: {
   terminal: Terminal
   claimImeKeyEvent: (event: KeyboardEvent) => boolean
+  closePreview: () => void
   pasteClipboardText: (activeElement: Element | null, source: 'keyboard') => void
   sendInput: (data: string) => void
   /** Everything but optionKeyLocation, which this installer tracks itself. */
@@ -168,14 +169,18 @@ export function installPreviewTerminalKeyHandler(args: {
         nativeOnlyShortcutTracker.armKeyDown(event)
         event.stopImmediatePropagation()
         return false
-      // Why: pane-scoped chords have no target in a preview dialog. Swallow them
+      case 'closeActivePane':
+        if (!event.repeat) {
+          args.closePreview()
+        }
+        return consumeEvent(event)
+      // Why: the remaining pane-scoped chords have no target in a preview. Swallow them
       // — a pane never sends these bytes to the shell, and xterm would encode
       // e.g. Ctrl+Shift+D as a bare Ctrl+D. Listed one by one rather than under a
       // `default` so a newly added action has to be classified here, not
       // silently swallowed.
       case 'clearActivePane':
       case 'clearPaneTitle':
-      case 'closeActivePane':
       case 'copySelection':
       case 'equalizePaneSizes':
       case 'focusPane':


### PR DESCRIPTION
## ELI5

Pressing the configured close-pane shortcut while a dashboard terminal preview is focused now closes the preview instead of doing nothing. The dashboard window and the underlying agent session stay open.

## What Changed

- Route the dashboard preview close action through the existing `closeActivePane` keybinding.
- Share the same close callback between dialog and adjacent-panel presentation modes.
- Add a regression test covering the macOS `Command+W` binding and confirming that no bytes reach the PTY.

## Why

The preview already consumed pane-scoped shortcuts, but `closeActivePane` was swallowed without closing anything. Handling the resolved action keeps custom keybindings and cross-platform shortcut resolution intact while limiting the change to preview UI state.

## Linked Issue

Fixes #13958

## Visual Proof

N/A — the UI has no visual change. This is a keyboard interaction fix: before, `Command+W` was consumed with the preview left open; after, it closes only the preview.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Tested on macOS in the built Electron app: opened an Agent Dashboard card, focused its terminal preview, and pressed `Command+W`. The preview closed while the dashboard and agent session remained open.

Automated/local checks:
- `pnpm exec vitest run --config config/vitest.config.ts AgentTerminalPreview.test.tsx AgentTerminalDialog.test.tsx preview-terminal-shortcuts.test.ts` (46 tests passed)
- `pnpm run typecheck:web`
- focused `oxlint` and `oxfmt --check` for the four changed files
- `pnpm run check:max-lines-ratchet`
- `pnpm build`

Linux, Windows, and SSH were not manually exercised. The implementation uses Orca’s existing platform-aware keybinding resolver and does not change PTY, filesystem, host, or wire behavior.

## AI Disclosure

Codex (GPT-5) was used to inspect the shortcut path, implement the change test-first, run verification, and draft this PR. I reviewed the diff and manually verified the resulting behavior.

## Review

No security, performance, mobile, SSH/remote, or backward-compatibility impact is expected. The change only closes local preview UI in response to the already-resolved pane-close action.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Full `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally. Full `pnpm test` was also run: 50,462 tests passed and 16 unrelated existing tests failed across terminal snapshot/IME, filesystem timing, SSH GC, and cross-version suites. The dashboard-focused suite remains green (46/46). CI will provide the clean-run comparison.

## Author

N/A

