### PR TITLE
feat(sidebar): add collapse and expand all actions

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -10,10 +10,12 @@ import { translate } from '@/i18n/i18n'
 
 type SidebarHeaderProps = {
   onWorkspaceBoardMenuOpenChange: (open: boolean) => void
+  collapsibleSectionKeys?: readonly string[]
 }
 
 const SidebarHeader = React.memo(function SidebarHeader({
-  onWorkspaceBoardMenuOpenChange
+  onWorkspaceBoardMenuOpenChange,
+  collapsibleSectionKeys
 }: SidebarHeaderProps) {
   const openModal = useAppStore((s) => s.openModal)
   const newWorktreeShortcutLabel = useShortcutLabel('workspace.create')
@@ -35,6 +37,7 @@ const SidebarHeader = React.memo(function SidebarHeader({
         <SidebarWorkspaceOptionsMenu
           preserveWorkspaceBoardOpen
           onMenuOpenChange={onWorkspaceBoardMenuOpenChange}
+          collapsibleSectionKeys={collapsibleSectionKeys}
         />
 
         <Tooltip>

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { SlidersHorizontal } from 'lucide-react'
+import { ChevronsDownUp, ChevronsUpDown, SlidersHorizontal } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -30,11 +31,15 @@ import { SidebarGroupByToggle } from './SidebarGroupByToggle'
 type SidebarWorkspaceOptionsMenuProps = {
   preserveWorkspaceBoardOpen?: boolean
   onMenuOpenChange?: (open: boolean) => void
+  collapsibleSectionKeys?: readonly string[]
 }
+
+const EMPTY_SECTION_KEYS: readonly string[] = []
 
 const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsMenu({
   preserveWorkspaceBoardOpen = false,
-  onMenuOpenChange
+  onMenuOpenChange,
+  collapsibleSectionKeys = EMPTY_SECTION_KEYS
 }: SidebarWorkspaceOptionsMenuProps) {
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -54,6 +59,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const setGroupBy = useAppStore((s) => s.setGroupBy)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const setProjectOrderBy = useAppStore((s) => s.setProjectOrderBy)
+  const collapsedGroups = useAppStore((s) => s.collapsedGroups)
+  const setCollapsedGroups = useAppStore((s) => s.setCollapsedGroups)
 
   const [open, setOpen] = useState(false)
   const { hostOptions } = useSidebarHostScopeOptions()
@@ -112,6 +119,16 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const projectOrderLabel =
     PROJECT_ORDER_OPTIONS.find((opt) => opt.id === projectOrderBy)?.label ?? 'Manual'
   const hostVisibilityLabel = getSidebarHostVisibilityLabel(visibleWorkspaceHostIds, hostOptions)
+  const canCollapseAll = collapsibleSectionKeys.some((key) => !collapsedGroups.has(key))
+  const canExpandAll = collapsedGroups.size > 0
+
+  const collapseAllSections = useCallback(() => {
+    setCollapsedGroups(new Set([...collapsedGroups, ...collapsibleSectionKeys]))
+  }, [collapsedGroups, collapsibleSectionKeys, setCollapsedGroups])
+
+  const expandAllSections = useCallback(() => {
+    setCollapsedGroups([])
+  }, [setCollapsedGroups])
 
   return (
     <DropdownMenu modal={false} open={open} onOpenChange={handleOpenChange}>
@@ -171,6 +188,22 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
         className="w-72 pb-2"
         data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
       >
+        <DropdownMenuItem disabled={!canCollapseAll} onSelect={collapseAllSections}>
+          <ChevronsDownUp className="size-3.5" />
+          {translate(
+            'auto.components.sidebar.SidebarWorkspaceOptionsMenu.collapseAllSections',
+            'Collapse all sections'
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={!canExpandAll} onSelect={expandAllSections}>
+          <ChevronsUpDown className="size-3.5" />
+          {translate(
+            'auto.components.sidebar.SidebarWorkspaceOptionsMenu.expandAllSections',
+            'Expand all sections'
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+
         {/* Why: host + project filters share one section and the same single-row
             shell as Sort by (label left, value right) so the menu stays flat. */}
         {(showHostScopeControls || repos.length > 1) && (

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5192,6 +5192,7 @@ type WorktreeListProps = {
   onWorkspaceBoardDragPreviewStart?: () => void
   onWorkspaceBoardDragPreviewCommit?: () => void
   onWorkspaceBoardDragPreviewCancel?: () => void
+  onCollapsibleSectionKeysChange?: (keys: readonly string[]) => void
 }
 
 export function installWorktreeVisibleRefreshVisibilityListener(onChange: () => void): () => void {
@@ -5205,7 +5206,8 @@ const WorktreeList = React.memo(function WorktreeList({
   workspaceBoardOpen = false,
   onWorkspaceBoardDragPreviewStart = NOOP_WORKSPACE_BOARD_DRAG_PREVIEW_CALLBACK,
   onWorkspaceBoardDragPreviewCommit = NOOP_WORKSPACE_BOARD_DRAG_PREVIEW_CALLBACK,
-  onWorkspaceBoardDragPreviewCancel = NOOP_WORKSPACE_BOARD_DRAG_PREVIEW_CALLBACK
+  onWorkspaceBoardDragPreviewCancel = NOOP_WORKSPACE_BOARD_DRAG_PREVIEW_CALLBACK,
+  onCollapsibleSectionKeysChange
 }: WorktreeListProps) {
   // ── Granular selectors (each is a primitive or shallow-stable ref) ──
   const allWorktrees = useAllWorktrees()
@@ -5865,6 +5867,27 @@ const WorktreeList = React.memo(function WorktreeList({
       workspaceHostScope
     ]
   )
+  const collapsibleSectionKeys = useMemo(
+    () =>
+      sectionRows.flatMap((row) => {
+        if (row.type === 'host-header') {
+          return [row.key]
+        }
+        if (row.type !== 'header' || row.count === 0) {
+          return []
+        }
+        const isCollapsibleHeader =
+          (groupBy === 'repo' && Boolean(row.repo || row.projectGroup)) ||
+          (groupBy === 'workspace-status' &&
+            getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses) !== null) ||
+          row.key === PINNED_GROUP_KEY
+        return isCollapsibleHeader ? [row.key] : []
+      }),
+    [groupBy, sectionRows, workspaceStatuses]
+  )
+  useEffect(() => {
+    onCollapsibleSectionKeysChange?.(collapsibleSectionKeys)
+  }, [collapsibleSectionKeys, onCollapsibleSectionKeysChange])
   const renderedSidebarRowKeys = useMemo(() => {
     const keys = new Set<string>()
     for (const row of sectionRows) {

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -70,6 +70,15 @@ function Sidebar({
     solidifyWorkspaceBoardFromDrag,
     cancelWorkspaceBoardDragPreview
   } = useWorkspaceBoardPanel()
+  const [collapsibleSectionKeys, setCollapsibleSectionKeys] = React.useState<readonly string[]>([])
+  const handleCollapsibleSectionKeysChange = React.useCallback((keys: readonly string[]) => {
+    setCollapsibleSectionKeys((current) => {
+      if (current.length === keys.length && current.every((key, index) => key === keys[index])) {
+        return current
+      }
+      return [...keys]
+    })
+  }, [])
 
   const setLiveSidebarWidth = React.useCallback((width: number) => {
     document.documentElement.style.setProperty('--workspace-sidebar-live-width', `${width}px`)
@@ -115,7 +124,10 @@ function Sidebar({
           <>
             {/* Fixed controls */}
             <SidebarNav />
-            <SidebarHeader onWorkspaceBoardMenuOpenChange={setWorkspaceBoardMenuOpen} />
+            <SidebarHeader
+              onWorkspaceBoardMenuOpenChange={setWorkspaceBoardMenuOpen}
+              collapsibleSectionKeys={collapsibleSectionKeys}
+            />
 
             <WorktreeList
               scrollOffsetRef={worktreeScrollOffsetRef}
@@ -124,6 +136,7 @@ function Sidebar({
               onWorkspaceBoardDragPreviewStart={previewWorkspaceBoardFromDrag}
               onWorkspaceBoardDragPreviewCommit={solidifyWorkspaceBoardFromDrag}
               onWorkspaceBoardDragPreviewCancel={cancelWorkspaceBoardDragPreview}
+              onCollapsibleSectionKeysChange={handleCollapsibleSectionKeysChange}
             />
 
             <div className="relative shrink-0">

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4625,7 +4625,9 @@
           "65a9820bd1": "Agent statuses",
           "219ebf1961": "Branch name",
           "folderPathIdentity": "Branch / folder path",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "collapseAllSections": "Collapse all sections",
+          "expandAllSections": "Expand all sections"
         },
         "SshTargetRow": {
           "4677394048": "Connecting…",

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1138,6 +1138,18 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(setUI).toHaveBeenCalledWith({ groupBy: 'none', collapsedGroups: [] })
   })
 
+  it('replaces and persists collapsed groups in bulk', () => {
+    const setUI = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.setState({ collapsedGroups: new Set(['repo:old']) })
+    store.getState().setCollapsedGroups(['repo:one', 'host:local'])
+
+    expect([...store.getState().collapsedGroups]).toEqual(['repo:one', 'host:local'])
+    expect(setUI).toHaveBeenCalledWith({ collapsedGroups: ['repo:one', 'host:local'] })
+  })
+
   it('hydrates persisted per-worktree dotfile visibility', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -907,6 +907,7 @@ export type UISlice = {
   filterRepoIds: string[]
   setFilterRepoIds: (ids: string[]) => void
   collapsedGroups: Set<string>
+  setCollapsedGroups: (keys: Iterable<string>) => void
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]
   _worktreeCardModeDefaulted: boolean
@@ -2135,6 +2136,12 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setFilterRepoIds: (ids) => set({ filterRepoIds: ids }),
 
   collapsedGroups: new Set<string>(),
+  setCollapsedGroups: (keys) =>
+    set(() => {
+      const next = new Set(keys)
+      window.api.ui.set({ collapsedGroups: [...next] }).catch(console.error)
+      return { collapsedGroups: next }
+    }),
   toggleCollapsedGroup: (key) =>
     set((s) => {
       const next = new Set(s.collapsedGroups)


### PR DESCRIPTION
## ELI5

The sidebar previously required users to collapse or expand each section one at a time. This adds two actions that collapse or expand all sidebar sections at once.

## What Changed

- Added `Collapse all sections` and `Expand all sections` to the Workspace Options menu.
- Applied bulk collapse to the currently available project, project group, workspace status, host, and pinned sections.
- Added a store action that updates and persists collapsed group state in one operation.
- Disabled each action when there is nothing for it to change.
- Added a regression test for bulk collapsed-group persistence.

## Why

As more projects and remote hosts are added, navigating the sidebar requires repeatedly collapsing unrelated sections and expanding them again later.

The sidebar already stores collapsed sections in a single `collapsedGroups` set. Updating that set in one operation provides bulk collapse and expand without introducing a separate state model or loading additional data.

## Linked Issue

 Fixes #13585


## Visual Proof
### Before — Collapsing sidebar sections one by one

<img width="276" height="426" alt="image" src="https://github.com/user-attachments/assets/0ac31c7a-c748-4606-9c66-8750ab3d28f6" />


### After — Collapse and expand all sidebar sections

<img width="279" height="490" alt="image" src="https://github.com/user-attachments/assets/b0780d42-95bf-4947-a5e4-5d7d24512cd2" />

https://github.com/user-attachments/assets/7f58cc1a-6cd4-4feb-9136-ac4ec8bdd8ff

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Tested on macOS with Node 24.19.0 and pnpm 10.24.0.

Manual verification:

1. Opened the Workspace Options menu with multiple sidebar sections visible.
2. Selected `Collapse all sections` and verified that the available sections collapsed.
3. Selected `Expand all sections` and verified that the sections expanded again.
4. Verified that actions are disabled when they have no effect.
5. Verified the rendered behavior in the Electron app through CDP.

Automated verification:

- UI store regression tests: 169/169 passed
- `pnpm typecheck`
- Localization catalog, extraction, and coverage checks\
- Changed-code quality and max-lines checks

## AI Disclosure

OpenAI Codex (GPT-5) was used to research the issue, inspect the sidebar architecture, assist with implementation, run tests, and review the final changes.

## Review

- **Security:** No new IPC, command execution, path handling, authentication, network access, or dependency changes.
- **Cross-platform:** The implementation uses platform-neutral React and state logic. It does not introduce shortcuts, paths, shell behavior, or platform-specific APIs. Manually tested on macOS; Linux and Windows will be covered by CI.
- **Remote SSH:** Host sections use the existing collapsed-group state and are included when rendered. No remote protocol or SSH behavior was changed.
- **Mobile:** No mobile code or behavior was changed.
- **Backwards compatibility:** Existing per-section collapse behavior and persisted state remain compatible.
- **Performance:** Bulk updates are performed through a single set update and persistence call. No additional network or filesystem work is introduced.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

