### PR TITLE
fix(cli): actionable error when file open path is outside worktree

### DIFF
--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -123,24 +123,65 @@ describe('absolute file CLI paths', () => {
     })
   })
 
-  it('leaves outside-worktree absolute paths for the runtime guard', async () => {
+  it('rejects outside-worktree absolute paths with an actionable error', async () => {
     const absolutePath = '/tmp/elsewhere/App.tsx'
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
+    )
+
+    await main(['file', 'open', '--path', absolutePath, '--worktree', 'id:wt-1'], '/tmp')
+
+    expect(process.exitCode).toBe(1)
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('only opens files inside a worktree')
+    )
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'id:wt-1' })
+  })
+
+  it('rejects parent-segment relative paths that escape the worktree', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
+    )
+
+    await main(
+      ['file', 'open', '--path', '../shared/config.yaml', '--worktree', 'id:wt-1'],
+      '/tmp/repo'
+    )
+
+    expect(process.exitCode).toBe(1)
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
+    )
+    expect(callMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('relativizes parent-segment paths that stay inside the worktree', async () => {
     queueFixtures(
       callMock,
       okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') }),
       okFixture('req_open', {
         worktree: 'wt-1',
-        relativePath: absolutePath,
+        relativePath: 'src/App.tsx',
         kind: 'text',
         opened: true
       })
     )
 
-    await main(['file', 'open', '--path', absolutePath, '--worktree', 'id:wt-1'], '/tmp')
+    await main(
+      ['file', 'open', '--path', 'src/lib/../App.tsx', '--worktree', 'id:wt-1'],
+      '/tmp/repo'
+    )
 
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.show', { worktree: 'id:wt-1' })
     expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
       worktree: 'id:wt-1',
-      relativePath: absolutePath
+      relativePath: 'src/App.tsx'
     })
   })
 

--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -291,24 +291,65 @@ describe('absolute file CLI paths', () => {
     })
   })
 
-  it('leaves outside-worktree absolute paths for the runtime guard', async () => {
+  it('rejects outside-worktree absolute paths with an actionable error', async () => {
     const absolutePath = '/tmp/elsewhere/App.tsx'
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
+    )
+
+    await main(['file', 'open', '--path', absolutePath, '--worktree', 'id:wt-1'], '/tmp')
+
+    expect(process.exitCode).toBe(1)
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('only opens files inside a worktree')
+    )
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'id:wt-1' })
+  })
+
+  it('rejects parent-segment relative paths that escape the worktree', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
+    )
+
+    await main(
+      ['file', 'open', '--path', '../shared/config.yaml', '--worktree', 'id:wt-1'],
+      '/tmp/repo'
+    )
+
+    expect(process.exitCode).toBe(1)
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
+    )
+    expect(callMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('relativizes parent-segment paths that stay inside the worktree', async () => {
     queueFixtures(
       callMock,
       okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') }),
       okFixture('req_open', {
         worktree: 'wt-1',
-        relativePath: absolutePath,
+        relativePath: 'src/App.tsx',
         kind: 'text',
         opened: true
       })
     )
 
-    await main(['file', 'open', '--path', absolutePath, '--worktree', 'id:wt-1'], '/tmp')
+    await main(
+      ['file', 'open', '--path', 'src/lib/../App.tsx', '--worktree', 'id:wt-1'],
+      '/tmp/repo'
+    )
 
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.show', { worktree: 'id:wt-1' })
     expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
       worktree: 'id:wt-1',
-      relativePath: absolutePath
+      relativePath: 'src/App.tsx'
     })
   })
 

--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -361,16 +361,64 @@ describe('absolute file CLI paths', () => {
       okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
     )
 
-    await main(
-      ['file', 'open', '--path', '../shared/config.yaml', '--worktree', 'id:wt-1'],
-      '/tmp/repo'
-    )
+    // Why: escape is vs the selected worktree root, not client cwd. The
+    // previous candidate resolved `../` against cwd, so this used to require
+    // cwd === worktree to fail for the right reason.
+    await main(['file', 'open', '--path', '../shared/config.yaml', '--worktree', 'id:wt-1'], '/tmp')
 
     expect(process.exitCode).toBe(1)
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
     )
     expect(callMock).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['POSIX client cwd', '/home/deploy/repo', '/tmp'],
+    ['Windows client cwd', '/home/deploy/repo', 'C:\\users\\ada']
+  ])('resolves dotted relatives against the worktree root with a %s', async (_label, root, cwd) => {
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree(root, 'feature') }),
+      okFixture('req_open', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(['file', 'open', '--path', 'src/lib/../App.tsx', '--worktree', 'id:wt-1'], cwd)
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.show', { worktree: 'id:wt-1' })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx'
+    })
+  })
+
+  it('does not give a POSIX absolute path Windows separator semantics from a Windows cwd', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree('/home/deploy/repo', 'feature') }),
+      okFixture('req_open', {
+        worktree: 'wt-1',
+        relativePath: 'src/a\\b.ts',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(
+      ['file', 'open', '--path', '/home/deploy/repo/src/a\\b.ts', '--worktree', 'id:wt-1'],
+      'C:\\users\\ada'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/a\\b.ts'
+    })
+    expect(callMock.mock.calls.some((call) => call[1]?.relativePath === 'src/a/b.ts')).toBe(false)
   })
 
   it('relativizes parent-segment paths that stay inside the worktree', async () => {

--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -315,25 +315,28 @@ describe('absolute file CLI paths', () => {
     })
   })
 
-  it('rejects outside-worktree absolute paths with an actionable error', async () => {
-    const absolutePath = '/tmp/elsewhere/App.tsx'
-    queueFixtures(
-      callMock,
-      okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
-    )
+  it.each(['open', 'diff'])(
+    'rejects outside-worktree file %s paths with a command-neutral error',
+    async (command) => {
+      const absolutePath = '/tmp/elsewhere/App.tsx'
+      queueFixtures(
+        callMock,
+        okFixture('req_show', { worktree: buildWorktree('/tmp/repo', 'feature') })
+      )
 
-    await main(['file', 'open', '--path', absolutePath, '--worktree', 'id:wt-1'], '/tmp')
+      await main(['file', command, '--path', absolutePath, '--worktree', 'id:wt-1'], '/tmp')
 
-    expect(process.exitCode).toBe(1)
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
-    )
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('only opens files inside a worktree')
-    )
-    expect(callMock).toHaveBeenCalledTimes(1)
-    expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'id:wt-1' })
-  })
+      expect(process.exitCode).toBe(1)
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Path is outside the selected worktree (/tmp/repo).')
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('This command only supports files inside a worktree')
+      )
+      expect(callMock).toHaveBeenCalledTimes(1)
+      expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'id:wt-1' })
+    }
+  )
 
   it.each([
     ['Windows', 'C:\\repo', 'C:\\elsewhere\\App.tsx', 'C:\\users\\ada'],

--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -421,6 +421,29 @@ describe('absolute file CLI paths', () => {
     expect(callMock.mock.calls.some((call) => call[1]?.relativePath === 'src/a/b.ts')).toBe(false)
   })
 
+  it.each(['src/lib/../a\\b.ts', '/home/deploy/repo/src/lib/../a\\b.ts'])(
+    'normalizes POSIX dot segments while preserving a literal backslash: %s',
+    async (path) => {
+      queueFixtures(
+        callMock,
+        okFixture('req_show', { worktree: buildWorktree('/home/deploy/repo', 'feature') }),
+        okFixture('req_open', {
+          worktree: 'wt-1',
+          relativePath: 'src/a\\b.ts',
+          kind: 'text',
+          opened: true
+        })
+      )
+
+      await main(['file', 'open', '--path', path, '--worktree', 'id:wt-1'], 'C:\\users\\ada')
+
+      expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+        worktree: 'id:wt-1',
+        relativePath: 'src/a\\b.ts'
+      })
+    }
+  )
+
   it('relativizes parent-segment paths that stay inside the worktree', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -335,6 +335,26 @@ describe('absolute file CLI paths', () => {
     expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'id:wt-1' })
   })
 
+  it.each([
+    ['Windows', 'C:\\repo', 'C:\\elsewhere\\App.tsx', 'C:\\users\\ada'],
+    ['SSH POSIX', '/home/deploy/repo', '/var/elsewhere/App.tsx', '/tmp'],
+    ['folder workspace', '/Users/ada/notes', '/Users/ada/Downloads/App.tsx', '/Users/ada/notes']
+  ])(
+    'rejects an outside %s path with the worktree root in the error',
+    async (_flavor, root, absolutePath, cwd) => {
+      queueFixtures(callMock, okFixture('req_show', { worktree: buildWorktree(root, 'feature') }))
+
+      await main(['file', 'open', '--path', absolutePath, '--worktree', 'id:wt-1'], cwd)
+
+      expect(process.exitCode).toBe(1)
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Path is outside the selected worktree (${root}).`)
+      )
+      expect(callMock).toHaveBeenCalledTimes(1)
+      expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'id:wt-1' })
+    }
+  )
+
   it('rejects parent-segment relative paths that escape the worktree', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/handlers/file-absolute-paths.test.ts
+++ b/src/cli/handlers/file-absolute-paths.test.ts
@@ -271,6 +271,30 @@ describe('absolute file CLI paths', () => {
     })
   })
 
+  it.each([
+    ['POSIX', '/tmp/repo', '/tmp/repo/src/lib/../App.tsx', '/tmp'],
+    ['Windows', 'C:\\repo', 'C:\\repo\\src\\lib\\..\\App.tsx', 'C:\\users\\ada']
+  ])('normalizes dot segments in %s absolute paths', async (_flavor, root, path, cwd) => {
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree(root, 'feature') }),
+      okFixture('req_open', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(['file', 'open', '--path', path, '--worktree', 'id:wt-1'], cwd)
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.show', { worktree: 'id:wt-1' })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx'
+    })
+  })
+
   it('keeps relative paths on the single-rpc path', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/handlers/file-open-path.ts
+++ b/src/cli/handlers/file-open-path.ts
@@ -1,0 +1,114 @@
+import type { RuntimeWorktreeRecord } from '../../shared/runtime-types'
+import {
+  isRuntimePathAbsolute,
+  isWindowsAbsolutePathLike,
+  relativePathInsideRoot,
+  resolveRuntimePath
+} from '../../shared/cross-platform-path'
+import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
+import type { HandlerContext } from '../dispatch'
+import { RuntimeClientError } from '../runtime-client'
+
+/**
+ * Why: a WSL workspace stores its worktree root as a Windows UNC path while the
+ * user types the Linux path they see inside the distro, so the two never match
+ * (#11393). Only the distro the caller is sitting in can name that Linux path, and
+ * only a UNC root wants the rewrite — a POSIX root already matches, so rewriting
+ * it would strand every absolute path.
+ *
+ * Backslash is a legal Linux filename character but a separator once the path
+ * reads as UNC, so `a\b.ts` would relativize to a different file, `a/b.ts`.
+ * Such a path has no Windows spelling; leave it to fail the match instead.
+ */
+function toWorktreeRootPathFlavor(rootPath: string, cwd: string, path: string): string {
+  // Why: WSL_DISTRO_NAME reaches this process only if interop forwards it, but the
+  // WSL launcher always sets ORCA_CLI_CWD, and its UNC form names the distro itself.
+  const distro = process.env.WSL_DISTRO_NAME || parseWslUncPath(cwd)?.distro
+  if (
+    !distro ||
+    !path.startsWith('/') ||
+    path.startsWith('//') ||
+    path.includes('\\') ||
+    !isWslUncPath(rootPath)
+  ) {
+    return path
+  }
+  return toWindowsWslPath(path, distro)
+}
+
+function pathHasParentSegment(path: string): boolean {
+  return path.split(/[\\/]/).includes('..')
+}
+
+function fileOpenPathsAreComparable(rootPath: string, candidatePath: string): boolean {
+  const rootWindows = isWindowsAbsolutePathLike(rootPath) || isWslUncPath(rootPath)
+  const candidateWindows = isWindowsAbsolutePathLike(candidatePath) || isWslUncPath(candidatePath)
+  return rootWindows === candidateWindows
+}
+
+function fileOpenPathFlavor(rootPath: string, path: string): 'posix' | 'windows' {
+  if (isWindowsAbsolutePathLike(path) || isWslUncPath(path)) {
+    return 'windows'
+  }
+  // POSIX-absolute user paths keep POSIX separators even when the client cwd is Windows.
+  if (path.startsWith('/') && !path.startsWith('//')) {
+    return 'posix'
+  }
+  if (isWindowsAbsolutePathLike(rootPath) || isWslUncPath(rootPath)) {
+    return 'windows'
+  }
+  return 'posix'
+}
+
+function resolveFileOpenCandidate(rootPath: string, path: string): string {
+  const flavor = fileOpenPathFlavor(rootPath, path)
+  // Why: resolveRuntimePath infers Windows from any `\`, which would rewrite a
+  // legal POSIX filename. Skip join/normalize and keep the bytes.
+  if (flavor === 'posix' && path.includes('\\')) {
+    return path
+  }
+  if (isRuntimePathAbsolute(path, flavor)) {
+    return resolveRuntimePath(flavor === 'windows' ? 'C:\\' : '/', path)
+  }
+  // Spec: relatives (including dotted) are vs the selected worktree, not client cwd.
+  return resolveRuntimePath(rootPath, path)
+}
+
+export async function resolveFilePath(
+  ctx: HandlerContext,
+  worktree: string,
+  path: string
+): Promise<string> {
+  // Why: plain relative paths stay on the single-RPC path. Absolute paths and
+  // parent-segment relatives need the worktree root so we can relativize or
+  // reject outside-worktree targets with an actionable message (#13949).
+  if (!isRuntimePathAbsolute(path) && !pathHasParentSegment(path)) {
+    return path
+  }
+  const result = await ctx.client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.show', {
+    worktree
+  })
+  const worktreePath = result.result.worktree.path
+  const flavored = toWorktreeRootPathFlavor(worktreePath, ctx.cwd, path)
+  const candidate = resolveFileOpenCandidate(worktreePath, flavored)
+  const relativePath = relativePathInsideRoot(worktreePath, candidate)
+  if (relativePath === '') {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'The selected worktree root is a directory, not a file-open target.'
+    )
+  }
+  if (relativePath !== null) {
+    return relativePath
+  }
+  // Same-flavor outside paths get a CLI error. Compare the user path, not a
+  // cwd-joined candidate: cross-flavor WSL/SSH misses still reach the runtime.
+  if (pathHasParentSegment(path) || fileOpenPathsAreComparable(worktreePath, path)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Path is outside the selected worktree (${worktreePath}). ` +
+        '`orca file open` only opens files inside a worktree; pass a path under that root or choose a different --worktree.'
+    )
+  }
+  return path
+}

--- a/src/cli/handlers/file-open-path.ts
+++ b/src/cli/handlers/file-open-path.ts
@@ -1,3 +1,4 @@
+import { posix } from 'node:path'
 import type { RuntimeWorktreeRecord } from '../../shared/runtime-types'
 import {
   isRuntimePathAbsolute,
@@ -62,13 +63,9 @@ function fileOpenPathFlavor(rootPath: string, path: string): 'posix' | 'windows'
 
 function resolveFileOpenCandidate(rootPath: string, path: string): string {
   const flavor = fileOpenPathFlavor(rootPath, path)
-  // Why: resolveRuntimePath infers Windows from any `\`, which would rewrite a
-  // legal POSIX filename. Skip join/normalize and keep the bytes.
-  if (flavor === 'posix' && path.includes('\\')) {
-    return path
-  }
-  if (isRuntimePathAbsolute(path, flavor)) {
-    return resolveRuntimePath(flavor === 'windows' ? 'C:\\' : '/', path)
+  // POSIX normalization preserves literal backslashes while resolving dot segments.
+  if (flavor === 'posix') {
+    return posix.resolve(rootPath, path)
   }
   // Spec: relatives (including dotted) are vs the selected worktree, not client cwd.
   return resolveRuntimePath(rootPath, path)

--- a/src/cli/handlers/file-open-path.ts
+++ b/src/cli/handlers/file-open-path.ts
@@ -104,7 +104,7 @@ export async function resolveFilePath(
     throw new RuntimeClientError(
       'invalid_argument',
       `Path is outside the selected worktree (${worktreePath}). ` +
-        '`orca file open` only opens files inside a worktree; pass a path under that root or choose a different --worktree.'
+        'This command only supports files inside a worktree; pass a path under that root or choose a different --worktree.'
     )
   }
   return path

--- a/src/cli/handlers/file.test.ts
+++ b/src/cli/handlers/file.test.ts
@@ -339,6 +339,39 @@ describe('orca file CLI handlers', () => {
     expect(output).toContain('docs/old.md: deleted file has no edit target')
   })
 
+  it('resolves remote dotted relatives against the explicit worktree, not client cwd', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { worktree: buildWorktree('/home/deploy/repo', 'feature') }),
+      okFixture('req_open', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(
+      [
+        'file',
+        'open',
+        '--path',
+        'src/lib/../App.tsx',
+        '--worktree',
+        'id:wt-1',
+        '--pairing-code',
+        'remote-runtime'
+      ],
+      '/tmp'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.show', { worktree: 'id:wt-1' })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx'
+    })
+  })
+
   it('requires an explicit worktree for remote file commands', async () => {
     const priorExitCode = process.exitCode
 

--- a/src/cli/handlers/file.ts
+++ b/src/cli/handlers/file.ts
@@ -1,6 +1,10 @@
 import type { GitStatusEntry, GitStatusResult } from '../../shared/git-status-types'
 import type { RuntimeFileOpenResult, RuntimeWorktreeRecord } from '../../shared/runtime-types'
-import { isRuntimePathAbsolute, relativePathInsideRoot } from '../../shared/cross-platform-path'
+import {
+  isRuntimePathAbsolute,
+  relativePathInsideRoot,
+  resolveRuntimePath
+} from '../../shared/cross-platform-path'
 import type { CommandHandler, HandlerContext } from '../dispatch'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { printResult } from '../format'
@@ -51,21 +55,36 @@ async function resolveFilePath(
   worktree: string,
   path: string
 ): Promise<string> {
-  if (!isRuntimePathAbsolute(path)) {
+  // Why: plain relative paths stay on the single-RPC path. Absolute paths and
+  // parent-segment relatives need the worktree root so we can relativize or
+  // reject outside-worktree targets with an actionable message (#13949).
+  if (!isRuntimePathAbsolute(path) && !pathHasParentSegment(path)) {
     return path
   }
-  // Why: only in-worktree absolute paths should be relativized here; outside paths must reach the runtime guard unchanged.
   const result = await ctx.client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.show', {
     worktree
   })
-  const relativePath = relativePathInsideRoot(result.result.worktree.path, path)
+  const worktreePath = result.result.worktree.path
+  const candidate = isRuntimePathAbsolute(path) ? path : resolveRuntimePath(ctx.cwd, path)
+  const relativePath = relativePathInsideRoot(worktreePath, candidate)
   if (relativePath === '') {
     throw new RuntimeClientError(
       'invalid_argument',
       'The selected worktree root is a directory, not a file-open target.'
     )
   }
-  return relativePath ?? path
+  if (relativePath === null) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Path is outside the selected worktree (${worktreePath}). ` +
+        '`orca file open` only opens files inside a worktree; pass a path under that root or choose a different --worktree.'
+    )
+  }
+  return relativePath
+}
+
+function pathHasParentSegment(path: string): boolean {
+  return path.split(/[\\/]/).includes('..')
 }
 
 function getOpenChangedMode(flags: Map<string, string | boolean>): OpenChangedMode {

--- a/src/cli/handlers/file.ts
+++ b/src/cli/handlers/file.ts
@@ -1,17 +1,11 @@
 import type { GitStatusEntry, GitStatusResult } from '../../shared/git-status-types'
-import type { RuntimeFileOpenResult, RuntimeWorktreeRecord } from '../../shared/runtime-types'
-import {
-  isRuntimePathAbsolute,
-  isWindowsAbsolutePathLike,
-  relativePathInsideRoot,
-  resolveRuntimePath
-} from '../../shared/cross-platform-path'
-import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
+import type { RuntimeFileOpenResult } from '../../shared/runtime-types'
 import type { CommandHandler, HandlerContext } from '../dispatch'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { printResult } from '../format'
 import { RuntimeClientError } from '../runtime-client'
 import { getOptionalWorktreeSelector, resolveCurrentWorktreeSelector } from '../selectors'
+import { resolveFilePath } from './file-open-path'
 
 type FileOpenMode = 'edit' | 'diff'
 type OpenChangedMode = FileOpenMode | 'both'
@@ -50,85 +44,6 @@ async function getFileWorktreeSelector({ flags, cwd, client }: HandlerContext): 
     )
   }
   return await resolveCurrentWorktreeSelector(cwd, client)
-}
-
-/**
- * Why: a WSL workspace stores its worktree root as a Windows UNC path while the
- * user types the Linux path they see inside the distro, so the two never match
- * (#11393). Only the distro the caller is sitting in can name that Linux path, and
- * only a UNC root wants the rewrite — a POSIX root already matches, so rewriting
- * it would strand every absolute path.
- *
- * Backslash is a legal Linux filename character but a separator once the path
- * reads as UNC, so `a\b.ts` would relativize to a different file, `a/b.ts`.
- * Such a path has no Windows spelling; leave it to fail the match instead.
- */
-function toWorktreeRootPathFlavor(rootPath: string, cwd: string, path: string): string {
-  // Why: WSL_DISTRO_NAME reaches this process only if interop forwards it, but the
-  // WSL launcher always sets ORCA_CLI_CWD, and its UNC form names the distro itself.
-  const distro = process.env.WSL_DISTRO_NAME || parseWslUncPath(cwd)?.distro
-  if (
-    !distro ||
-    !path.startsWith('/') ||
-    path.startsWith('//') ||
-    path.includes('\\') ||
-    !isWslUncPath(rootPath)
-  ) {
-    return path
-  }
-  return toWindowsWslPath(path, distro)
-}
-
-async function resolveFilePath(
-  ctx: HandlerContext,
-  worktree: string,
-  path: string
-): Promise<string> {
-  // Why: plain relative paths stay on the single-RPC path. Absolute paths and
-  // parent-segment relatives need the worktree root so we can relativize or
-  // reject outside-worktree targets with an actionable message (#13949).
-  if (!isRuntimePathAbsolute(path) && !pathHasParentSegment(path)) {
-    return path
-  }
-  const result = await ctx.client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.show', {
-    worktree
-  })
-  const worktreePath = result.result.worktree.path
-  const candidate = resolveRuntimePath(
-    ctx.cwd,
-    toWorktreeRootPathFlavor(worktreePath, ctx.cwd, path)
-  )
-  const relativePath = relativePathInsideRoot(worktreePath, candidate)
-  if (relativePath === '') {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      'The selected worktree root is a directory, not a file-open target.'
-    )
-  }
-  if (relativePath !== null) {
-    return relativePath
-  }
-  // Same-flavor outside paths get a CLI error. Cross-flavor misses (WSL UNC vs
-  // Linux spelling, SSH flavor mismatch) still reach the runtime guard.
-  const originalCandidate = resolveRuntimePath(ctx.cwd, path)
-  if (pathHasParentSegment(path) || fileOpenPathsAreComparable(worktreePath, originalCandidate)) {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      `Path is outside the selected worktree (${worktreePath}). ` +
-        '`orca file open` only opens files inside a worktree; pass a path under that root or choose a different --worktree.'
-    )
-  }
-  return path
-}
-
-function fileOpenPathsAreComparable(rootPath: string, candidatePath: string): boolean {
-  const rootWindows = isWindowsAbsolutePathLike(rootPath) || isWslUncPath(rootPath)
-  const candidateWindows = isWindowsAbsolutePathLike(candidatePath) || isWslUncPath(candidatePath)
-  return rootWindows === candidateWindows
-}
-
-function pathHasParentSegment(path: string): boolean {
-  return path.split(/[\\/]/).includes('..')
 }
 
 function getOpenChangedMode(flags: Map<string, string | boolean>): OpenChangedMode {

--- a/src/cli/handlers/file.ts
+++ b/src/cli/handlers/file.ts
@@ -1,6 +1,11 @@
 import type { GitStatusEntry, GitStatusResult } from '../../shared/git-status-types'
 import type { RuntimeFileOpenResult, RuntimeWorktreeRecord } from '../../shared/runtime-types'
-import { isRuntimePathAbsolute, relativePathInsideRoot } from '../../shared/cross-platform-path'
+import {
+  isRuntimePathAbsolute,
+  isWindowsAbsolutePathLike,
+  relativePathInsideRoot,
+  resolveRuntimePath
+} from '../../shared/cross-platform-path'
 import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
 import type { CommandHandler, HandlerContext } from '../dispatch'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
@@ -79,26 +84,52 @@ async function resolveFilePath(
   worktree: string,
   path: string
 ): Promise<string> {
-  if (!isRuntimePathAbsolute(path)) {
+  // Why: plain relative paths stay on the single-RPC path. Absolute paths and
+  // parent-segment relatives need the worktree root so we can relativize or
+  // reject outside-worktree targets with an actionable message (#13949).
+  if (!isRuntimePathAbsolute(path) && !pathHasParentSegment(path)) {
     return path
   }
-  // Why: only in-worktree absolute paths should be relativized here; outside paths must reach the runtime guard unchanged.
   const result = await ctx.client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.show', {
     worktree
   })
-
-  const rootPath = result.result.worktree.path
-  const relativePath = relativePathInsideRoot(
-    rootPath,
-    toWorktreeRootPathFlavor(rootPath, ctx.cwd, path)
+  const worktreePath = result.result.worktree.path
+  const candidate = resolveRuntimePath(
+    ctx.cwd,
+    toWorktreeRootPathFlavor(worktreePath, ctx.cwd, path)
   )
+  const relativePath = relativePathInsideRoot(worktreePath, candidate)
   if (relativePath === '') {
     throw new RuntimeClientError(
       'invalid_argument',
       'The selected worktree root is a directory, not a file-open target.'
     )
   }
-  return relativePath ?? path
+  if (relativePath !== null) {
+    return relativePath
+  }
+  // Same-flavor outside paths get a CLI error. Cross-flavor misses (WSL UNC vs
+  // Linux spelling, SSH flavor mismatch) still reach the runtime guard.
+  const originalCandidate = resolveRuntimePath(ctx.cwd, path)
+  if (pathHasParentSegment(path) || fileOpenPathsAreComparable(worktreePath, originalCandidate)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Path is outside the selected worktree (${worktreePath}). ` +
+        '`orca file open` only opens files inside a worktree; pass a path under that root or choose a different --worktree.'
+    )
+  }
+  return path
+}
+
+function fileOpenPathsAreComparable(rootPath: string, candidatePath: string): boolean {
+  const rootWindows = isWindowsAbsolutePathLike(rootPath) || isWslUncPath(rootPath)
+  const candidateWindows =
+    isWindowsAbsolutePathLike(candidatePath) || isWslUncPath(candidatePath)
+  return rootWindows === candidateWindows
+}
+
+function pathHasParentSegment(path: string): boolean {
+  return path.split(/[\\/]/).includes('..')
 }
 
 function getOpenChangedMode(flags: Map<string, string | boolean>): OpenChangedMode {

--- a/src/cli/handlers/file.ts
+++ b/src/cli/handlers/file.ts
@@ -123,8 +123,7 @@ async function resolveFilePath(
 
 function fileOpenPathsAreComparable(rootPath: string, candidatePath: string): boolean {
   const rootWindows = isWindowsAbsolutePathLike(rootPath) || isWslUncPath(rootPath)
-  const candidateWindows =
-    isWindowsAbsolutePathLike(candidatePath) || isWslUncPath(candidatePath)
+  const candidateWindows = isWindowsAbsolutePathLike(candidatePath) || isWslUncPath(candidatePath)
   return rootWindows === candidateWindows
 }
 


### PR DESCRIPTION
## Review follow-up (26dbd86e)

Use command-neutral outside-worktree error text for both `file open` and `file diff`. The previous message assertion is intentionally updated and expanded to both commands; path handling and error codes are unchanged. At this head, 44 focused tests, CLI non-composite TypeScript and changed-file lint/format passed. Full suite/build and live cross-platform/SSH smoke were not repeated. Independent Cursor review passed for this exact commit.

## Previously verified rebase

## Summary

Normalize file paths inside the selected workspace before calling `files.open` / `files.openDiff`, and give an actionable error for comparable paths outside that root. Plain relative paths keep the single-RPC path; cross-flavor WSL/SSH misses still reach the runtime guard.

Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`, preserving current WSL UNC conversion. Independent review found and corrected two path-resolution problems: dotted relatives must resolve against the selected workspace rather than client cwd, and POSIX normalization must preserve literal backslashes even from a Windows client. The final resolver uses POSIX path semantics for POSIX targets and the existing runtime resolver for Windows targets.

Fixes #13949

## Existing test changes

The outside-workspace test now expects an early CLI error instead of forwarding the invalid target to the runtime; that is the intended behavior change. The parent-escape case uses a client cwd outside the selected root to verify that containment depends on the workspace. Existing WSL and plain-relative coverage remains intact.

## Validation

- Final focused file CLI suites: 43 passed, including explicit remote selection and Windows/POSIX path fixtures.
- Two additional dotted-path/literal-backslash cases failed before the final correction and passed afterward.
- Changed-file lint/format, CLI non-composite typecheck and diff checks passed with lock-matched dependencies.
- Cursor implemented the rebase and first corrective pass. Codex independently reviewed it and made the final two-file correction; Cursor then explicitly approved final HEAD `744f7911b582afcca294492136e48e25f7f5eb33` / tree `6b6792da1d32c62ace9a97dec511b24cac637ae0`.
- Full suite/build, default composite typecheck and live Windows/SSH smoke were not run for this scoped CLI change. Default composite has the previously reproduced baseline TS2883 limitation.
