### PR TITLE
fix(workspace-emoji): keep the ':' shortcode suggestions scrolled to the highlight

### DIFF
--- a/src/renderer/src/components/workspace-emoji/WorkspaceEmojiSuggestionPopover.test.tsx
+++ b/src/renderer/src/components/workspace-emoji/WorkspaceEmojiSuggestionPopover.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { useRef } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorkspaceEmojiSuggestionPopover } from './WorkspaceEmojiSuggestionPopover'
+import type { WorkspaceEmojiSuggestion } from '@/lib/workspace-emoji-shortcodes'
+
+Element.prototype.scrollIntoView ??= () => {}
+
+const SUGGESTIONS: WorkspaceEmojiSuggestion[] = [
+  { shortcode: 'smile', emoji: '😄' },
+  { shortcode: 'smiley', emoji: '😃' },
+  { shortcode: 'smirk', emoji: '😏' }
+]
+
+function PopoverHarness({ commandValue }: { commandValue: string }): React.JSX.Element {
+  const anchorRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div>
+      <input ref={anchorRef} aria-label="Workspace name" readOnly value=":smi" />
+      <WorkspaceEmojiSuggestionPopover
+        anchorRef={anchorRef}
+        commandValue={commandValue}
+        heading="Emoji"
+        onCommandValueChange={() => {}}
+        onOpenChange={() => {}}
+        onSelect={() => {}}
+        open
+        suggestions={SUGGESTIONS}
+      />
+    </div>
+  )
+}
+
+describe('WorkspaceEmojiSuggestionPopover', () => {
+  let scrollIntoView: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    scrollIntoView.mockRestore()
+    cleanup()
+  })
+
+  it('scrolls the externally selected suggestion into view', async () => {
+    const { rerender } = render(<PopoverHarness commandValue="emoji:smile" />)
+    await screen.findByText(':smirk:')
+    scrollIntoView.mockClear()
+
+    rerender(<PopoverHarness commandValue="emoji:smirk" />)
+
+    const scrolled = scrollIntoView.mock.instances as unknown as Element[]
+    expect(scrolled.some((node) => node.getAttribute('data-value') === 'emoji:smirk')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/workspace-emoji/WorkspaceEmojiSuggestionPopover.tsx
+++ b/src/renderer/src/components/workspace-emoji/WorkspaceEmojiSuggestionPopover.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, RefObject } from 'react'
+import { useEffect, useRef, type ComponentProps, type RefObject } from 'react'
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
@@ -31,6 +31,28 @@ export function WorkspaceEmojiSuggestionPopover({
   side = 'top',
   suggestions
 }: WorkspaceEmojiSuggestionPopoverProps): React.JSX.Element {
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // cmdk only auto-scrolls when it owns the arrow keys; here selection is driven from the input.
+  useEffect(() => {
+    if (!open || !commandValue) {
+      return
+    }
+    const item = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>('[cmdk-item=""]') ?? []
+    ).find((node) => node.getAttribute('data-value') === commandValue)
+    if (!item) {
+      return
+    }
+    if (item.parentElement?.firstElementChild === item) {
+      item
+        .closest('[cmdk-group=""]')
+        ?.querySelector('[cmdk-group-heading=""]')
+        ?.scrollIntoView({ block: 'nearest' })
+    }
+    item.scrollIntoView({ block: 'nearest' })
+  }, [commandValue, open, suggestions])
+
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverAnchor virtualRef={anchorRef as RefObject<HTMLInputElement>} />
@@ -64,7 +86,7 @@ export function WorkspaceEmojiSuggestionPopover({
           shouldFilter={false}
           className="bg-transparent"
         >
-          <CommandList className="!max-h-none min-h-0 flex-1 scrollbar-sleek">
+          <CommandList ref={listRef} className="!max-h-none min-h-0 flex-1 scrollbar-sleek">
             <CommandGroup heading={heading} className="p-1">
               {suggestions.map((suggestion) => (
                 <CommandItem


### PR DESCRIPTION
## ELI5

Type `:smi` in a workspace-name field and a little emoji list pops up. Holding ↓ moved the highlight down the list but the list never scrolled, so the highlight disappeared below the visible area. Now the list follows the highlight.

## What Changed

`WorkspaceEmojiSuggestionPopover` scrolls the selected suggestion into view whenever the selection changes, mirroring cmdk's own `scrollSelectedIntoView` (including revealing the group heading when the first item is selected).

## Why

Arrow keys are handled in `useWorkspaceEmojiShortcodeInput` because focus stays in the text input — it moves the highlight by setting cmdk's **controlled `value` prop**. cmdk only calls `scrollSelectedIntoView` from its internal `setState('value', …)` path; when the controlled prop changes externally it just writes state and re-renders (`cmdk@1.1.1`, the `useLayoutEffect` on `value`). So nothing ever scrolled the `max-h-56` list.

Matching the item by `data-value` rather than `data-selected` avoids depending on when cmdk's store emit lands relative to our effect.

Fixed in the shared popover, so it covers all four consumers: `WorktreeDisplayNameField`, `WorktreeTitleInlineRename`, `SmartWorkspaceNameField`, `WorktreeJumpPalette`.

## Linked Issue

Fixes #

## Visual Proof

Not captured — happy to record a before/after if wanted. The behavior is covered by an automated regression test instead (see Testing).

## Testing

Repro: focus any workspace-name field, type `:s`, hold ↓ — before this change the highlight leaves the visible list; after, the list scrolls with it.

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/workspace-emoji/` → 6 passed
- New `WorkspaceEmojiSuggestionPopover.test.tsx` asserts the externally-selected item is scrolled into view; verified it **fails** with the new effect disabled and passes with it
- `oxlint` + `typecheck:web` clean

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Renderer-only, no platform-specific APIs, no wire/IPC surface — same behavior on macOS/Linux/Windows and over SSH/remote. The effect is a single `querySelectorAll` over the ≤N suggestion items, only on selection change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Made with [Orca](https://github.com/stablyai/orca) 🐋
