### PR TITLE
fix(daemon): reap empty macOS TCC login wrappers after shell exit

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -295,6 +295,7 @@ async function main(): Promise<void> {
     spawnSubprocess: (opts) =>
       createPtySubprocess({
         ...opts,
+        log: daemonLog,
         ...(process.platform === 'darwin'
           ? {
               onMacosTccSpawnStrategy: (strategy) =>

--- a/src/main/daemon/macos-login-wrapper-death-watch.test.ts
+++ b/src/main/daemon/macos-login-wrapper-death-watch.test.ts
@@ -4,7 +4,7 @@ import {
   MacosLoginWrapperDeathWatch,
   type MacosLoginWrapperDeathWatchOptions
 } from './macos-login-wrapper-death-watch'
-import type { PosixPtySessionLiveness } from '../pty/posix-pty-session-liveness'
+import type { PosixPtyRootSnapshot } from '../pty/posix-pty-session-liveness'
 
 type FakeTimer = { at: number; callback: () => void; cleared: boolean }
 
@@ -47,33 +47,54 @@ class FakeClock {
 }
 
 async function drainMicrotasks(): Promise<void> {
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 20; i++) {
     await Promise.resolve()
+  }
+}
+
+function emptyOwned(rootPid = 4233, ownerPid = 1001): PosixPtyRootSnapshot {
+  return {
+    liveness: 'empty',
+    rootPid,
+    ppid: ownerPid,
+    tty: 'ttys001',
+    command: '/usr/bin/login -flpq user /bin/bash --noprofile --norc -p -c trampoline'
+  }
+}
+
+function livePeer(rootPid = 4233, ownerPid = 1001): PosixPtyRootSnapshot {
+  return {
+    liveness: 'live',
+    rootPid,
+    ppid: ownerPid,
+    tty: 'ttys001',
+    command: '/usr/bin/login -flpq user /bin/bash'
   }
 }
 
 function createWatch(
   overrides: Partial<MacosLoginWrapperDeathWatchOptions> & {
-    outcomes?: PosixPtySessionLiveness[]
+    outcomes?: PosixPtyRootSnapshot[]
   } = {}
 ): {
   watch: MacosLoginWrapperDeathWatch
   clock: FakeClock
-  forceKillRoot: ReturnType<typeof vi.fn>
-  readLiveness: ReturnType<typeof vi.fn>
+  signalRoot: ReturnType<typeof vi.fn>
+  probe: ReturnType<typeof vi.fn>
   log: ReturnType<typeof createNoopDaemonFileLog> & { log: ReturnType<typeof vi.fn> }
 } {
   const clock = new FakeClock()
-  const forceKillRoot = vi.fn()
+  const signalRoot = vi.fn()
   const outcomes = overrides.outcomes ?? []
-  const readLiveness = vi.fn(((_rootPid: number) =>
-    outcomes.length ? outcomes.shift()! : 'live'
-  ) as (rootPid: number) => PosixPtySessionLiveness)
+  const probe = vi.fn(async (_rootPid: number) =>
+    outcomes.length ? outcomes.shift()! : livePeer()
+  )
   const log = { ...createNoopDaemonFileLog(), log: vi.fn() }
   const watch = new MacosLoginWrapperDeathWatch({
     rootPid: overrides.rootPid ?? 4233,
-    forceKillRoot: overrides.forceKillRoot ?? forceKillRoot,
-    readLiveness: overrides.readLiveness ?? readLiveness,
+    ownerPid: overrides.ownerPid ?? 1001,
+    signalRoot: overrides.signalRoot ?? signalRoot,
+    probe: overrides.probe ?? probe,
     log: overrides.log ?? log,
     clock,
     timing: {
@@ -83,122 +104,280 @@ function createWatch(
       ...overrides.timing
     }
   })
-  return { watch, clock, forceKillRoot, readLiveness, log }
+  return { watch, clock, signalRoot, probe, log }
 }
 
 describe('MacosLoginWrapperDeathWatch', () => {
   it('does not probe during the startup grace window', async () => {
-    const { watch, clock, forceKillRoot, readLiveness } = createWatch({
-      outcomes: ['empty', 'empty']
+    const { watch, clock, signalRoot, probe } = createWatch({
+      outcomes: [emptyOwned(), emptyOwned(), emptyOwned()]
     })
     watch.start()
     await clock.advance(14_999)
-    expect(readLiveness).not.toHaveBeenCalled()
-    expect(forceKillRoot).not.toHaveBeenCalled()
+    expect(probe).not.toHaveBeenCalled()
+    expect(signalRoot).not.toHaveBeenCalled()
   })
 
-  it('reaps only after two consecutive empty observations past grace', async () => {
-    const { watch, clock, forceKillRoot, log } = createWatch({
-      outcomes: ['empty', 'empty']
+  it('reaps only after two empties plus a final owned-empty proof', async () => {
+    const { watch, clock, signalRoot, log, probe } = createWatch({
+      // poll empty, recheck empty, final proof empty
+      outcomes: [emptyOwned(), emptyOwned(), emptyOwned()]
     })
     watch.start()
     await clock.advance(15_000)
-    expect(forceKillRoot).not.toHaveBeenCalled()
+    expect(signalRoot).not.toHaveBeenCalled()
     expect(log.log).toHaveBeenCalledWith(
       'macos-login-wrapper-empty-observed',
       expect.objectContaining({ rootPid: 4233, observations: 1 })
     )
     await clock.advance(5_000)
-    expect(forceKillRoot).toHaveBeenCalledOnce()
+    expect(signalRoot).toHaveBeenCalledOnce()
+    expect(signalRoot).toHaveBeenCalledWith(4233)
+    expect(probe).toHaveBeenCalledTimes(3)
     expect(log.log).toHaveBeenCalledWith(
       'macos-login-wrapper-empty-reaped',
       expect.objectContaining({ rootPid: 4233, observations: 2 })
     )
+    const reapedOrder = log.log.mock.calls.findIndex(([e]) => e === 'macos-login-wrapper-empty-reaped')
+    // reaped is emitted only after signalRoot returned (call already recorded)
+    expect(signalRoot.mock.invocationCallOrder[0]).toBeLessThan(
+      log.log.mock.invocationCallOrder[reapedOrder]
+    )
   })
 
-  it('resets the empty streak when the session becomes live again', async () => {
-    const { watch, clock, forceKillRoot } = createWatch({
-      outcomes: ['empty', 'live', 'empty', 'empty']
+  it('emits reaped only after a successful signal, never before', async () => {
+    const callOrder: string[] = []
+    const signalRoot = vi.fn(() => {
+      callOrder.push('signal')
     })
-    watch.start()
-    await clock.advance(15_000) // empty #1
-    await clock.advance(5_000) // live → reset
-    expect(forceKillRoot).not.toHaveBeenCalled()
-    await clock.advance(30_000) // empty #1 again
-    expect(forceKillRoot).not.toHaveBeenCalled()
-    await clock.advance(5_000) // empty #2 → reap
-    expect(forceKillRoot).toHaveBeenCalledOnce()
-  })
-
-  it('never reaps on unknown liveness', async () => {
-    const { watch, clock, forceKillRoot } = createWatch({
-      outcomes: ['unknown', 'unknown', 'unknown']
-    })
-    watch.start()
-    await clock.advance(15_000)
-    await clock.advance(30_000)
-    await clock.advance(30_000)
-    expect(forceKillRoot).not.toHaveBeenCalled()
-  })
-
-  it('stops quietly when the root is already gone', async () => {
-    const { watch, clock, forceKillRoot, readLiveness } = createWatch({
-      outcomes: ['gone']
-    })
-    watch.start()
-    await clock.advance(15_000)
-    expect(forceKillRoot).not.toHaveBeenCalled()
-    await clock.advance(60_000)
-    expect(readLiveness).toHaveBeenCalledTimes(1)
-  })
-
-  it('stop() cancels pending timers before a reap can fire', async () => {
-    const { watch, clock, forceKillRoot } = createWatch({
-      outcomes: ['empty', 'empty']
-    })
-    watch.start()
-    await clock.advance(15_000)
-    watch.stop()
-    await clock.advance(5_000)
-    expect(forceKillRoot).not.toHaveBeenCalled()
-    expect(clock.pendingCount()).toBe(0)
-  })
-
-  it('does not call forceKill again after a successful reap', async () => {
-    const { watch, clock, forceKillRoot, readLiveness } = createWatch({
-      outcomes: ['empty', 'empty', 'empty']
+    const log = {
+      ...createNoopDaemonFileLog(),
+      log: vi.fn((event: string) => {
+        callOrder.push(event)
+      })
+    }
+    const { watch, clock } = createWatch({
+      outcomes: [emptyOwned(), emptyOwned(), emptyOwned()],
+      signalRoot,
+      log
     })
     watch.start()
     await clock.advance(15_000)
     await clock.advance(5_000)
-    expect(forceKillRoot).toHaveBeenCalledOnce()
-    const probesAtReap = readLiveness.mock.calls.length
-    await clock.advance(60_000)
-    expect(forceKillRoot).toHaveBeenCalledOnce()
-    expect(readLiveness).toHaveBeenCalledTimes(probesAtReap)
+    expect(callOrder.filter((e) => e === 'signal' || e === 'macos-login-wrapper-empty-reaped')).toEqual(
+      ['signal', 'macos-login-wrapper-empty-reaped']
+    )
+    expect(callOrder).not.toContain('macos-login-wrapper-empty-reap-failed')
   })
 
-  it('retries after a rejected forceKill on a later empty window', async () => {
-    const forceKillRoot = vi
+  it('on signal failure emits only the failure event and keeps watching', async () => {
+    const signalRoot = vi
       .fn()
       .mockImplementationOnce(() => {
         throw new Error('SIGKILL rejected')
       })
       .mockImplementationOnce(() => {})
     const { watch, clock, log } = createWatch({
-      outcomes: ['empty', 'empty', 'empty', 'empty'],
-      forceKillRoot
+      outcomes: [
+        emptyOwned(),
+        emptyOwned(),
+        emptyOwned(),
+        emptyOwned(),
+        emptyOwned(),
+        emptyOwned()
+      ],
+      signalRoot
     })
     watch.start()
     await clock.advance(15_000)
     await clock.advance(5_000)
-    expect(forceKillRoot).toHaveBeenCalledOnce()
+    expect(signalRoot).toHaveBeenCalledOnce()
     expect(log.log).toHaveBeenCalledWith(
       'macos-login-wrapper-empty-reap-failed',
       expect.objectContaining({ rootPid: 4233 })
     )
+    expect(log.log.mock.calls.some(([e]) => e === 'macos-login-wrapper-empty-reaped')).toBe(false)
+
     await clock.advance(30_000)
     await clock.advance(5_000)
-    expect(forceKillRoot).toHaveBeenCalledTimes(2)
+    expect(signalRoot).toHaveBeenCalledTimes(2)
+    expect(log.log).toHaveBeenCalledWith(
+      'macos-login-wrapper-empty-reaped',
+      expect.objectContaining({ rootPid: 4233 })
+    )
+  })
+
+  it('resets when the session becomes live again before reap', async () => {
+    const { watch, clock, signalRoot } = createWatch({
+      outcomes: [emptyOwned(), livePeer(), emptyOwned(), emptyOwned(), emptyOwned()]
+    })
+    watch.start()
+    await clock.advance(15_000) // empty #1
+    await clock.advance(5_000) // live → reset
+    expect(signalRoot).not.toHaveBeenCalled()
+    await clock.advance(30_000) // empty #1
+    await clock.advance(5_000) // empty #2 + final proof
+    expect(signalRoot).toHaveBeenCalledOnce()
+  })
+
+  it('aborts reap when a peer reappears on the final ownership proof', async () => {
+    const { watch, clock, signalRoot, log } = createWatch({
+      outcomes: [emptyOwned(), emptyOwned(), livePeer()]
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(5_000)
+    expect(signalRoot).not.toHaveBeenCalled()
+    expect(log.log.mock.calls.some(([e]) => e === 'macos-login-wrapper-empty-reaped')).toBe(false)
+    expect(log.log.mock.calls.some(([e]) => e === 'macos-login-wrapper-empty-reap-failed')).toBe(
+      false
+    )
+  })
+
+  it('aborts reap on ownership mismatch / PID reuse (wrong ppid or command)', async () => {
+    const reused = {
+      ...emptyOwned(),
+      ppid: 9999,
+      command: '/bin/zsh -l'
+    }
+    const { watch, clock, signalRoot, log } = createWatch({
+      outcomes: [emptyOwned(), emptyOwned(), reused]
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(5_000)
+    expect(signalRoot).not.toHaveBeenCalled()
+    expect(log.log.mock.calls.some(([e]) => e === 'macos-login-wrapper-empty-reaped')).toBe(false)
+  })
+
+  it('never reaps on unknown liveness from slow/rejected probes', async () => {
+    const { watch, clock, signalRoot } = createWatch({
+      outcomes: [
+        { liveness: 'unknown', rootPid: 4233, ppid: null, tty: null, command: null },
+        { liveness: 'unknown', rootPid: 4233, ppid: null, tty: null, command: null }
+      ]
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(30_000)
+    expect(signalRoot).not.toHaveBeenCalled()
+  })
+
+  it('treats a throwing probe as unknown (fail closed)', async () => {
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ps timed out'))
+      .mockResolvedValueOnce(livePeer())
+    const { watch, clock, signalRoot } = createWatch({ probe })
+    watch.start()
+    await clock.advance(15_000)
+    expect(signalRoot).not.toHaveBeenCalled()
+    await clock.advance(30_000)
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not overlap probes while one is in flight', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    let release!: (snap: PosixPtyRootSnapshot) => void
+    const first = new Promise<PosixPtyRootSnapshot>((resolve) => {
+      release = resolve
+    })
+    const probe = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        try {
+          return await first
+        } finally {
+          inFlight--
+        }
+      })
+      .mockImplementation(async () => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        inFlight--
+        return livePeer()
+      })
+    const { watch, clock } = createWatch({ probe })
+    watch.start()
+    await clock.advance(15_000)
+    expect(probe).toHaveBeenCalledTimes(1)
+    // A second timer would not be scheduled until the first probe settles.
+    expect(clock.pendingCount()).toBe(0)
+    release(livePeer())
+    await drainMicrotasks()
+    expect(maxInFlight).toBe(1)
+    await clock.advance(30_000)
+    expect(probe).toHaveBeenCalledTimes(2)
+    expect(maxInFlight).toBe(1)
+  })
+
+  it('stop() during an in-flight probe prevents later kill and log', async () => {
+    let release!: (snap: PosixPtyRootSnapshot) => void
+    const deferred = new Promise<PosixPtyRootSnapshot>((resolve) => {
+      release = resolve
+    })
+    const probe = vi.fn(async () => deferred)
+    const { watch, clock, signalRoot, log } = createWatch({ probe })
+    watch.start()
+    await clock.advance(15_000)
+    expect(probe).toHaveBeenCalledTimes(1)
+    watch.stop()
+    release(emptyOwned())
+    await drainMicrotasks()
+    expect(signalRoot).not.toHaveBeenCalled()
+    expect(log.log).not.toHaveBeenCalled()
+    expect(clock.pendingCount()).toBe(0)
+  })
+
+  it('stop() during the final proof probe prevents kill and reaped log', async () => {
+    let releaseFinal!: (snap: PosixPtyRootSnapshot) => void
+    const finalProbe = new Promise<PosixPtyRootSnapshot>((resolve) => {
+      releaseFinal = resolve
+    })
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce(emptyOwned())
+      .mockResolvedValueOnce(emptyOwned())
+      .mockImplementationOnce(async () => finalProbe)
+    const { watch, clock, signalRoot, log } = createWatch({ probe })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(5_000)
+    expect(probe).toHaveBeenCalledTimes(3)
+    watch.stop()
+    releaseFinal(emptyOwned())
+    await drainMicrotasks()
+    expect(signalRoot).not.toHaveBeenCalled()
+    expect(log.log.mock.calls.some(([e]) => e === 'macos-login-wrapper-empty-reaped')).toBe(false)
+  })
+
+  it('stops quietly when the root is already gone', async () => {
+    const { watch, clock, signalRoot, probe } = createWatch({
+      outcomes: [
+        { liveness: 'gone', rootPid: 4233, ppid: null, tty: null, command: null }
+      ]
+    })
+    watch.start()
+    await clock.advance(15_000)
+    expect(signalRoot).not.toHaveBeenCalled()
+    await clock.advance(60_000)
+    expect(probe).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not signal again after a successful reap', async () => {
+    const { watch, clock, signalRoot, probe } = createWatch({
+      outcomes: [emptyOwned(), emptyOwned(), emptyOwned(), emptyOwned()]
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(5_000)
+    expect(signalRoot).toHaveBeenCalledOnce()
+    const probesAtReap = probe.mock.calls.length
+    await clock.advance(60_000)
+    expect(signalRoot).toHaveBeenCalledOnce()
+    expect(probe).toHaveBeenCalledTimes(probesAtReap)
   })
 })

--- a/src/main/daemon/macos-login-wrapper-death-watch.test.ts
+++ b/src/main/daemon/macos-login-wrapper-death-watch.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createNoopDaemonFileLog } from './daemon-file-log'
+import {
+  MacosLoginWrapperDeathWatch,
+  type MacosLoginWrapperDeathWatchOptions
+} from './macos-login-wrapper-death-watch'
+import type { PosixPtySessionLiveness } from '../pty/posix-pty-session-liveness'
+
+type FakeTimer = { at: number; callback: () => void; cleared: boolean }
+
+class FakeClock {
+  private timers: FakeTimer[] = []
+  private nowMs = 0
+
+  setTimeout = (callback: () => void, delayMs: number): unknown => {
+    const timer: FakeTimer = { at: this.nowMs + delayMs, callback, cleared: false }
+    this.timers.push(timer)
+    return timer
+  }
+
+  clearTimeout = (handle: unknown): void => {
+    ;(handle as FakeTimer).cleared = true
+  }
+
+  now = (): number => this.nowMs
+
+  async advance(ms: number): Promise<void> {
+    const target = this.nowMs + ms
+    for (;;) {
+      const due = this.timers
+        .filter((t) => !t.cleared && t.at <= target)
+        .sort((a, b) => a.at - b.at)[0]
+      if (!due) {
+        break
+      }
+      this.nowMs = Math.max(this.nowMs, due.at)
+      due.cleared = true
+      due.callback()
+      await drainMicrotasks()
+    }
+    this.nowMs = target
+  }
+
+  pendingCount(): number {
+    return this.timers.filter((t) => !t.cleared).length
+  }
+}
+
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+}
+
+function createWatch(
+  overrides: Partial<MacosLoginWrapperDeathWatchOptions> & {
+    outcomes?: PosixPtySessionLiveness[]
+  } = {}
+): {
+  watch: MacosLoginWrapperDeathWatch
+  clock: FakeClock
+  forceKillRoot: ReturnType<typeof vi.fn>
+  readLiveness: ReturnType<typeof vi.fn>
+  log: ReturnType<typeof createNoopDaemonFileLog> & { log: ReturnType<typeof vi.fn> }
+} {
+  const clock = new FakeClock()
+  const forceKillRoot = vi.fn()
+  const outcomes = overrides.outcomes ?? []
+  const readLiveness = vi.fn(((_rootPid: number) =>
+    outcomes.length ? outcomes.shift()! : 'live'
+  ) as (rootPid: number) => PosixPtySessionLiveness)
+  const log = { ...createNoopDaemonFileLog(), log: vi.fn() }
+  const watch = new MacosLoginWrapperDeathWatch({
+    rootPid: overrides.rootPid ?? 4233,
+    forceKillRoot: overrides.forceKillRoot ?? forceKillRoot,
+    readLiveness: overrides.readLiveness ?? readLiveness,
+    log: overrides.log ?? log,
+    clock,
+    timing: {
+      startupGraceMs: 15_000,
+      pollMs: 30_000,
+      emptyRecheckMs: 5_000,
+      ...overrides.timing
+    }
+  })
+  return { watch, clock, forceKillRoot, readLiveness, log }
+}
+
+describe('MacosLoginWrapperDeathWatch', () => {
+  it('does not probe during the startup grace window', async () => {
+    const { watch, clock, forceKillRoot, readLiveness } = createWatch({
+      outcomes: ['empty', 'empty']
+    })
+    watch.start()
+    await clock.advance(14_999)
+    expect(readLiveness).not.toHaveBeenCalled()
+    expect(forceKillRoot).not.toHaveBeenCalled()
+  })
+
+  it('reaps only after two consecutive empty observations past grace', async () => {
+    const { watch, clock, forceKillRoot, log } = createWatch({
+      outcomes: ['empty', 'empty']
+    })
+    watch.start()
+    await clock.advance(15_000)
+    expect(forceKillRoot).not.toHaveBeenCalled()
+    expect(log.log).toHaveBeenCalledWith(
+      'macos-login-wrapper-empty-observed',
+      expect.objectContaining({ rootPid: 4233, observations: 1 })
+    )
+    await clock.advance(5_000)
+    expect(forceKillRoot).toHaveBeenCalledOnce()
+    expect(log.log).toHaveBeenCalledWith(
+      'macos-login-wrapper-empty-reaped',
+      expect.objectContaining({ rootPid: 4233, observations: 2 })
+    )
+  })
+
+  it('resets the empty streak when the session becomes live again', async () => {
+    const { watch, clock, forceKillRoot } = createWatch({
+      outcomes: ['empty', 'live', 'empty', 'empty']
+    })
+    watch.start()
+    await clock.advance(15_000) // empty #1
+    await clock.advance(5_000) // live → reset
+    expect(forceKillRoot).not.toHaveBeenCalled()
+    await clock.advance(30_000) // empty #1 again
+    expect(forceKillRoot).not.toHaveBeenCalled()
+    await clock.advance(5_000) // empty #2 → reap
+    expect(forceKillRoot).toHaveBeenCalledOnce()
+  })
+
+  it('never reaps on unknown liveness', async () => {
+    const { watch, clock, forceKillRoot } = createWatch({
+      outcomes: ['unknown', 'unknown', 'unknown']
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(30_000)
+    await clock.advance(30_000)
+    expect(forceKillRoot).not.toHaveBeenCalled()
+  })
+
+  it('stops quietly when the root is already gone', async () => {
+    const { watch, clock, forceKillRoot, readLiveness } = createWatch({
+      outcomes: ['gone']
+    })
+    watch.start()
+    await clock.advance(15_000)
+    expect(forceKillRoot).not.toHaveBeenCalled()
+    await clock.advance(60_000)
+    expect(readLiveness).toHaveBeenCalledTimes(1)
+  })
+
+  it('stop() cancels pending timers before a reap can fire', async () => {
+    const { watch, clock, forceKillRoot } = createWatch({
+      outcomes: ['empty', 'empty']
+    })
+    watch.start()
+    await clock.advance(15_000)
+    watch.stop()
+    await clock.advance(5_000)
+    expect(forceKillRoot).not.toHaveBeenCalled()
+    expect(clock.pendingCount()).toBe(0)
+  })
+
+  it('does not call forceKill again after a successful reap', async () => {
+    const { watch, clock, forceKillRoot, readLiveness } = createWatch({
+      outcomes: ['empty', 'empty', 'empty']
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(5_000)
+    expect(forceKillRoot).toHaveBeenCalledOnce()
+    const probesAtReap = readLiveness.mock.calls.length
+    await clock.advance(60_000)
+    expect(forceKillRoot).toHaveBeenCalledOnce()
+    expect(readLiveness).toHaveBeenCalledTimes(probesAtReap)
+  })
+
+  it('retries after a rejected forceKill on a later empty window', async () => {
+    const forceKillRoot = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('SIGKILL rejected')
+      })
+      .mockImplementationOnce(() => {})
+    const { watch, clock, log } = createWatch({
+      outcomes: ['empty', 'empty', 'empty', 'empty'],
+      forceKillRoot
+    })
+    watch.start()
+    await clock.advance(15_000)
+    await clock.advance(5_000)
+    expect(forceKillRoot).toHaveBeenCalledOnce()
+    expect(log.log).toHaveBeenCalledWith(
+      'macos-login-wrapper-empty-reap-failed',
+      expect.objectContaining({ rootPid: 4233 })
+    )
+    await clock.advance(30_000)
+    await clock.advance(5_000)
+    expect(forceKillRoot).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/daemon/macos-login-wrapper-death-watch.ts
+++ b/src/main/daemon/macos-login-wrapper-death-watch.ts
@@ -1,0 +1,166 @@
+import {
+  createLoginSessionWatchClock,
+  type LoginSessionWatchClock
+} from './login-session-watch-clock'
+import {
+  readPosixPtySessionLiveness,
+  type PosixPtySessionLiveness,
+  type PosixPtySessionLivenessDeps
+} from '../pty/posix-pty-session-liveness'
+import type { DaemonFileLog } from './daemon-file-log'
+
+/** Startup window: login → trampoline → shell can briefly look empty on the TTY. */
+export const MACOS_LOGIN_WRAPPER_STARTUP_GRACE_MS = 15_000
+/** Idle poll while the session looks healthy. */
+export const MACOS_LOGIN_WRAPPER_POLL_MS = 30_000
+/** Recheck after first empty observation before authorizing a root kill. */
+export const MACOS_LOGIN_WRAPPER_EMPTY_RECHECK_MS = 5_000
+const REQUIRED_CONSECUTIVE_EMPTY = 2
+
+export type MacosLoginWrapperDeathWatchTiming = {
+  startupGraceMs: number
+  pollMs: number
+  emptyRecheckMs: number
+}
+
+export type MacosLoginWrapperDeathWatchOptions = {
+  rootPid: number
+  /** Force-kill only the already-owned PTY root via existing process-group seams. */
+  forceKillRoot: () => void
+  log?: DaemonFileLog
+  clock?: LoginSessionWatchClock
+  timing?: Partial<MacosLoginWrapperDeathWatchTiming>
+  readLiveness?: (rootPid: number) => PosixPtySessionLiveness
+  livenessDeps?: PosixPtySessionLivenessDeps
+}
+
+/**
+ * Detects macOS TCC `login(1)` wrappers whose inner shell has exited while the
+ * login session leader still holds the PTY (#13764).
+ *
+ * The daemon's `onExit` is wired to the PTY process, which is `login` when the
+ * TCC wrapper is active — so a shell exit that leaves `login` alive never
+ * reaps the session. This watch only force-kills after sustained `empty`
+ * observations (root alive, no other processes on its TTY); `unknown` never
+ * authorizes a kill.
+ */
+export class MacosLoginWrapperDeathWatch {
+  private readonly rootPid: number
+  private readonly forceKillRoot: () => void
+  private readonly log: DaemonFileLog | undefined
+  private readonly clock: LoginSessionWatchClock
+  private readonly startupGraceMs: number
+  private readonly pollMs: number
+  private readonly emptyRecheckMs: number
+  private readonly readLiveness: (rootPid: number) => PosixPtySessionLiveness
+  private readonly startedAtMs: number
+
+  private timer: unknown = null
+  private stopped = false
+  private reaped = false
+  private consecutiveEmpty = 0
+
+  constructor(opts: MacosLoginWrapperDeathWatchOptions) {
+    this.rootPid = opts.rootPid
+    this.forceKillRoot = opts.forceKillRoot
+    this.log = opts.log
+    this.clock = opts.clock ?? createLoginSessionWatchClock()
+    this.startupGraceMs = opts.timing?.startupGraceMs ?? MACOS_LOGIN_WRAPPER_STARTUP_GRACE_MS
+    this.pollMs = opts.timing?.pollMs ?? MACOS_LOGIN_WRAPPER_POLL_MS
+    this.emptyRecheckMs = opts.timing?.emptyRecheckMs ?? MACOS_LOGIN_WRAPPER_EMPTY_RECHECK_MS
+    this.readLiveness =
+      opts.readLiveness ??
+      ((rootPid) => readPosixPtySessionLiveness(rootPid, opts.livenessDeps))
+    this.startedAtMs = this.clock.now()
+  }
+
+  start(): void {
+    if (this.stopped || this.reaped) {
+      return
+    }
+    this.schedule(this.startupGraceMs)
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.clearTimer()
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      this.clock.clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  private schedule(delayMs: number): void {
+    this.clearTimer()
+    if (this.stopped || this.reaped) {
+      return
+    }
+    this.timer = this.clock.setTimeout(() => {
+      this.timer = null
+      this.tick()
+    }, delayMs)
+  }
+
+  private tick(): void {
+    if (this.stopped || this.reaped) {
+      return
+    }
+    // Why: the trampoline window can look empty before the shell attaches to the TTY.
+    if (this.clock.now() - this.startedAtMs < this.startupGraceMs) {
+      this.schedule(this.startupGraceMs - (this.clock.now() - this.startedAtMs))
+      return
+    }
+
+    let liveness: PosixPtySessionLiveness
+    try {
+      liveness = this.readLiveness(this.rootPid)
+    } catch {
+      liveness = 'unknown'
+    }
+
+    if (liveness === 'gone') {
+      // Root already reaped through the normal onExit path.
+      this.stop()
+      return
+    }
+    if (liveness === 'live') {
+      this.consecutiveEmpty = 0
+      this.schedule(this.pollMs)
+      return
+    }
+    if (liveness === 'unknown') {
+      // Why: never collapse "can't tell" into empty — same rule as endpoint ownership.
+      this.consecutiveEmpty = 0
+      this.schedule(this.pollMs)
+      return
+    }
+
+    this.consecutiveEmpty++
+    if (this.consecutiveEmpty < REQUIRED_CONSECUTIVE_EMPTY) {
+      this.log?.log('macos-login-wrapper-empty-observed', {
+        rootPid: this.rootPid,
+        observations: this.consecutiveEmpty
+      })
+      this.schedule(this.emptyRecheckMs)
+      return
+    }
+
+    this.log?.log('macos-login-wrapper-empty-reaped', {
+      rootPid: this.rootPid,
+      observations: this.consecutiveEmpty
+    })
+    try {
+      this.forceKillRoot()
+      this.reaped = true
+      this.clearTimer()
+    } catch {
+      // Why: a rejected kill must not crash the daemon; keep observing so a later empty window can retry.
+      this.consecutiveEmpty = 0
+      this.log?.log('macos-login-wrapper-empty-reap-failed', { rootPid: this.rootPid })
+      this.schedule(this.pollMs)
+    }
+  }
+}

--- a/src/main/daemon/macos-login-wrapper-death-watch.ts
+++ b/src/main/daemon/macos-login-wrapper-death-watch.ts
@@ -3,8 +3,9 @@ import {
   type LoginSessionWatchClock
 } from './login-session-watch-clock'
 import {
-  readPosixPtySessionLiveness,
-  type PosixPtySessionLiveness,
+  provesOwnedEmptyLoginWrapper,
+  readPosixPtyRootSnapshot,
+  type PosixPtyRootSnapshot,
   type PosixPtySessionLivenessDeps
 } from '../pty/posix-pty-session-liveness'
 import type { DaemonFileLog } from './daemon-file-log'
@@ -13,7 +14,7 @@ import type { DaemonFileLog } from './daemon-file-log'
 export const MACOS_LOGIN_WRAPPER_STARTUP_GRACE_MS = 15_000
 /** Idle poll while the session looks healthy. */
 export const MACOS_LOGIN_WRAPPER_POLL_MS = 30_000
-/** Recheck after first empty observation before authorizing a root kill. */
+/** Recheck after first empty observation before a final ownership proof. */
 export const MACOS_LOGIN_WRAPPER_EMPTY_RECHECK_MS = 5_000
 const REQUIRED_CONSECUTIVE_EMPTY = 2
 
@@ -25,52 +26,60 @@ export type MacosLoginWrapperDeathWatchTiming = {
 
 export type MacosLoginWrapperDeathWatchOptions = {
   rootPid: number
-  /** Force-kill only the already-owned PTY root via existing process-group seams. */
-  forceKillRoot: () => void
+  /** Daemon PID that must still parent the login wrapper (ownership proof). */
+  ownerPid: number
+  /**
+   * Signal only the proven wrapper PID (not a pgroup sweep).
+   * Why: a peer can appear between the empty poll and kill; pgroup kill would take it too.
+   */
+  signalRoot: (rootPid: number) => void
   log?: DaemonFileLog
   clock?: LoginSessionWatchClock
   timing?: Partial<MacosLoginWrapperDeathWatchTiming>
-  readLiveness?: (rootPid: number) => PosixPtySessionLiveness
+  /** Async probe seam; production uses bounded `ps`. */
+  probe?: (rootPid: number) => Promise<PosixPtyRootSnapshot>
   livenessDeps?: PosixPtySessionLivenessDeps
 }
 
 /**
- * Detects macOS TCC `login(1)` wrappers whose inner shell has exited while the
- * login session leader still holds the PTY (#13764).
- *
- * The daemon's `onExit` is wired to the PTY process, which is `login` when the
- * TCC wrapper is active — so a shell exit that leaves `login` alive never
- * reaps the session. This watch only force-kills after sustained `empty`
- * observations (root alive, no other processes on its TTY); `unknown` never
- * authorizes a kill.
+ * Detects macOS TCC `login(1)` wrappers whose inner shell exited while login
+ * still holds the PTY (#13764). Probes are async, non-overlapping, and fail
+ * closed; a stop/exit mid-probe suppresses kill and log side effects.
  */
 export class MacosLoginWrapperDeathWatch {
   private readonly rootPid: number
-  private readonly forceKillRoot: () => void
+  private readonly ownerPid: number
+  private readonly signalRoot: (rootPid: number) => void
   private readonly log: DaemonFileLog | undefined
   private readonly clock: LoginSessionWatchClock
   private readonly startupGraceMs: number
   private readonly pollMs: number
   private readonly emptyRecheckMs: number
-  private readonly readLiveness: (rootPid: number) => PosixPtySessionLiveness
+  private readonly probe: (rootPid: number) => Promise<PosixPtyRootSnapshot>
   private readonly startedAtMs: number
 
   private timer: unknown = null
   private stopped = false
   private reaped = false
+  private probeInFlight = false
   private consecutiveEmpty = 0
 
   constructor(opts: MacosLoginWrapperDeathWatchOptions) {
     this.rootPid = opts.rootPid
-    this.forceKillRoot = opts.forceKillRoot
+    this.ownerPid = opts.ownerPid
+    this.signalRoot = opts.signalRoot
     this.log = opts.log
     this.clock = opts.clock ?? createLoginSessionWatchClock()
     this.startupGraceMs = opts.timing?.startupGraceMs ?? MACOS_LOGIN_WRAPPER_STARTUP_GRACE_MS
     this.pollMs = opts.timing?.pollMs ?? MACOS_LOGIN_WRAPPER_POLL_MS
     this.emptyRecheckMs = opts.timing?.emptyRecheckMs ?? MACOS_LOGIN_WRAPPER_EMPTY_RECHECK_MS
-    this.readLiveness =
-      opts.readLiveness ??
-      ((rootPid) => readPosixPtySessionLiveness(rootPid, opts.livenessDeps))
+    this.probe =
+      opts.probe ??
+      ((rootPid) =>
+        readPosixPtyRootSnapshot(rootPid, {
+          ...opts.livenessDeps,
+          currentPid: opts.livenessDeps?.currentPid ?? opts.ownerPid
+        }))
     this.startedAtMs = this.clock.now()
   }
 
@@ -100,39 +109,45 @@ export class MacosLoginWrapperDeathWatch {
     }
     this.timer = this.clock.setTimeout(() => {
       this.timer = null
-      this.tick()
+      void this.tick()
     }, delayMs)
   }
 
-  private tick(): void {
-    if (this.stopped || this.reaped) {
+  private async tick(): Promise<void> {
+    if (this.stopped || this.reaped || this.probeInFlight) {
       return
     }
-    // Why: the trampoline window can look empty before the shell attaches to the TTY.
     if (this.clock.now() - this.startedAtMs < this.startupGraceMs) {
       this.schedule(this.startupGraceMs - (this.clock.now() - this.startedAtMs))
       return
     }
 
-    let liveness: PosixPtySessionLiveness
+    this.probeInFlight = true
+    let snapshot: PosixPtyRootSnapshot
     try {
-      liveness = this.readLiveness(this.rootPid)
+      snapshot = await this.probe(this.rootPid)
     } catch {
-      liveness = 'unknown'
+      snapshot = {
+        liveness: 'unknown',
+        rootPid: this.rootPid,
+        ppid: null,
+        tty: null,
+        command: null
+      }
+    } finally {
+      this.probeInFlight = false
     }
 
-    if (liveness === 'gone') {
-      // Root already reaped through the normal onExit path.
+    // Why: stop/onExit during the await must not kill or log after the session is gone.
+    if (this.stopped || this.reaped) {
+      return
+    }
+
+    if (snapshot.liveness === 'gone') {
       this.stop()
       return
     }
-    if (liveness === 'live') {
-      this.consecutiveEmpty = 0
-      this.schedule(this.pollMs)
-      return
-    }
-    if (liveness === 'unknown') {
-      // Why: never collapse "can't tell" into empty — same rule as endpoint ownership.
+    if (snapshot.liveness === 'live' || snapshot.liveness === 'unknown') {
       this.consecutiveEmpty = 0
       this.schedule(this.pollMs)
       return
@@ -148,19 +163,67 @@ export class MacosLoginWrapperDeathWatch {
       return
     }
 
+    await this.attemptReap()
+  }
+
+  private async attemptReap(): Promise<void> {
+    if (this.stopped || this.reaped || this.probeInFlight) {
+      return
+    }
+
+    // Why: re-sample immediately before signal; the second empty poll is already stale.
+    this.probeInFlight = true
+    let finalSnapshot: PosixPtyRootSnapshot
+    try {
+      finalSnapshot = await this.probe(this.rootPid)
+    } catch {
+      finalSnapshot = {
+        liveness: 'unknown',
+        rootPid: this.rootPid,
+        ppid: null,
+        tty: null,
+        command: null
+      }
+    } finally {
+      this.probeInFlight = false
+    }
+
+    if (this.stopped || this.reaped) {
+      return
+    }
+
+    if (finalSnapshot.liveness === 'gone') {
+      this.stop()
+      return
+    }
+
+    if (
+      !provesOwnedEmptyLoginWrapper(finalSnapshot, {
+        rootPid: this.rootPid,
+        ownerPid: this.ownerPid
+      })
+    ) {
+      // Work reappeared, ownership uncertain, or PID reused — never signal.
+      this.consecutiveEmpty = 0
+      this.schedule(this.pollMs)
+      return
+    }
+
+    try {
+      this.signalRoot(this.rootPid)
+    } catch {
+      this.consecutiveEmpty = 0
+      this.log?.log('macos-login-wrapper-empty-reap-failed', { rootPid: this.rootPid })
+      this.schedule(this.pollMs)
+      return
+    }
+
+    // Why: reaped is proof of a successful signal, not of intent to kill.
+    this.reaped = true
+    this.clearTimer()
     this.log?.log('macos-login-wrapper-empty-reaped', {
       rootPid: this.rootPid,
       observations: this.consecutiveEmpty
     })
-    try {
-      this.forceKillRoot()
-      this.reaped = true
-      this.clearTimer()
-    } catch {
-      // Why: a rejected kill must not crash the daemon; keep observing so a later empty window can retry.
-      this.consecutiveEmpty = 0
-      this.log?.log('macos-login-wrapper-empty-reap-failed', { rootPid: this.rootPid })
-      this.schedule(this.pollMs)
-    }
   }
 }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -75,6 +75,8 @@ import {
 } from '../../shared/windows-environment-expansion'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
 import { readPtySlavePath } from '../../shared/pty-slave-line-discipline-echo'
+import { MacosLoginWrapperDeathWatch } from './macos-login-wrapper-death-watch'
+import type { DaemonFileLog } from './daemon-file-log'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -130,6 +132,8 @@ export type PtySubprocessOptions = {
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
+  /** Optional daemon file log for login-wrapper empty-session reaping (#13764). */
+  log?: DaemonFileLog
 }
 
 function deleteRequestedDaemonEnvKeys(
@@ -562,10 +566,16 @@ function spawnDaemonPtyWithWindowsFallback(args: {
   process: pty.IPty
   shellPath: string
   spawnCwd: string
+  macosTccSpawnStrategy: 'wrapped' | 'direct'
   startupCommandDeliveredInShellArgs?: boolean
 } {
-  const spawnAt = (shellPath: string, shellArgs: string[], cwd: string): pty.IPty => {
+  const spawnAt = (
+    shellPath: string,
+    shellArgs: string[],
+    cwd: string
+  ): { process: pty.IPty; macosTccSpawnStrategy: 'wrapped' | 'direct' } => {
     const wrapped = wrapShellSpawnForMacosTccAttribution(shellPath, shellArgs, args.env)
+    const strategy: 'wrapped' | 'direct' = wrapped.file === shellPath ? 'direct' : 'wrapped'
     const proc = pty.spawn(wrapped.file, wrapped.args, {
       name: args.env.TERM ?? 'xterm-256color',
       cols: args.cols,
@@ -575,15 +585,17 @@ function spawnDaemonPtyWithWindowsFallback(args: {
       // Why: legacy system ConPTY can corrupt full-width TUI rows in scrollback; bundled ConPTY has the wrap-marker behavior xterm expects.
       ...(process.platform === 'win32' ? { useConptyDll: true } : {})
     })
-    args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
-    return proc
+    args.onMacosTccSpawnStrategy?.(strategy)
+    return { process: proc, macosTccSpawnStrategy: strategy }
   }
 
   try {
+    const primary = spawnAt(args.shellPath, args.shellArgs, args.spawnCwd)
     return {
-      process: spawnAt(args.shellPath, args.shellArgs, args.spawnCwd),
+      process: primary.process,
       shellPath: args.shellPath,
-      spawnCwd: args.spawnCwd
+      spawnCwd: args.spawnCwd,
+      macosTccSpawnStrategy: primary.macosTccSpawnStrategy
     }
   } catch (primaryErr) {
     if (process.platform !== 'win32') {
@@ -592,15 +604,16 @@ function spawnDaemonPtyWithWindowsFallback(args: {
     // Skip the first entry: it is the primary that already failed above.
     for (const attempt of args.windowsFallbackAttempts.slice(1)) {
       try {
-        const process = spawnAt(attempt.shellPath, attempt.shellArgs, attempt.effectiveCwd)
+        const fallback = spawnAt(attempt.shellPath, attempt.shellArgs, attempt.effectiveCwd)
         const message = primaryErr instanceof Error ? primaryErr.message : String(primaryErr)
         console.warn(
           `[daemon/pty] Primary shell "${args.shellPath}" failed (${message}), fell back to "${attempt.shellPath}"`
         )
         return {
-          process,
+          process: fallback.process,
           shellPath: attempt.shellPath,
           spawnCwd: attempt.effectiveCwd,
+          macosTccSpawnStrategy: fallback.macosTccSpawnStrategy,
           startupCommandDeliveredInShellArgs: attempt.startupCommandDeliveredInShellArgs
         }
       } catch {
@@ -846,6 +859,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   })
 
   let proc: pty.IPty
+  let macosTccSpawnStrategy: 'wrapped' | 'direct' = 'direct'
   try {
     const spawned = spawnDaemonPtyWithWindowsFallback({
       shellPath,
@@ -858,6 +872,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       onMacosTccSpawnStrategy: opts.onMacosTccSpawnStrategy
     })
     proc = spawned.process
+    macosTccSpawnStrategy = spawned.macosTccSpawnStrategy
     // Why: a Windows fallback (e.g. cmd.exe) carries its own argv-embedded startup command; adopt the winning shell's identity + delivery flag.
     shellPath = spawned.shellPath
     spawnCwd = spawned.spawnCwd
@@ -876,6 +891,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let pendingPreListenerData: string[] = []
   let pendingPreListenerDataChars = 0
   let pendingPreListenerExitCode: number | null = null
+  let loginWrapperDeathWatch: MacosLoginWrapperDeathWatch | null = null
 
   const bufferPreListenerData = (data: string): void => {
     // Why: Windows shell-arg startup commands can print before Session wires this subprocess in; preserve that spawn-time race window.
@@ -903,6 +919,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     }
   }
 
+  const stopLoginWrapperDeathWatch = (): void => {
+    loginWrapperDeathWatch?.stop()
+    loginWrapperDeathWatch = null
+  }
+
   let lastOutputAt = 0
   proc.onData((data) => {
     if (data.length > 0) {
@@ -915,6 +936,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     }
   })
   proc.onExit(({ exitCode }) => {
+    stopLoginWrapperDeathWatch()
     if (onExitCb) {
       flushPreListenerData()
       onExitCb(exitCode)
@@ -927,6 +949,38 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let dead = false
   let disposed = false
   let nodePtyKillIssued = false
+
+  const forceKillOwnedRoot = (): void => {
+    // Why: after reap/dispose proc.pid is a recycled pid, so SIGKILL would hit an unrelated process (forceKill only signals a live child).
+    // Why: Windows node-pty kill already closed ConPTY; forcing again can double-close the native handle.
+    if (dead || (process.platform === 'win32' && nodePtyKillIssued)) {
+      return
+    }
+    try {
+      forceKillPosixPtyProcessGroups(proc.pid, () => {
+        process.kill(proc.pid, 'SIGKILL')
+      })
+    } catch (signalError) {
+      try {
+        proc.kill()
+        nodePtyKillIssued = true
+      } catch {
+        nodePtyKillIssued = false
+        // Keep the original OS failure so callers can retry the same owner.
+        throw signalError
+      }
+    }
+  }
+
+  // Why: TCC login wrappers make the PTY root login(1); shell exit can leave login holding the PTY with no onExit (#13764).
+  if (process.platform === 'darwin' && macosTccSpawnStrategy === 'wrapped' && proc.pid) {
+    loginWrapperDeathWatch = new MacosLoginWrapperDeathWatch({
+      rootPid: proc.pid,
+      forceKillRoot: forceKillOwnedRoot,
+      log: opts.log
+    })
+    loginWrapperDeathWatch.start()
+  }
   let cachedAgentForeground: { processName: string; refreshedAt: number } | null = null
   const agentForegroundContextPaths = getAgentForegroundContextPaths({
     cwd: opts.cwd,
@@ -1227,25 +1281,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       }
     },
     forceKill: () => {
-      // Why: after reap/dispose proc.pid is a recycled pid, so SIGKILL would hit an unrelated process (forceKill only signals a live child).
-      // Why: Windows node-pty kill already closed ConPTY; forcing again can double-close the native handle.
-      if (dead || (process.platform === 'win32' && nodePtyKillIssued)) {
-        return
-      }
-      try {
-        forceKillPosixPtyProcessGroups(proc.pid, () => {
-          process.kill(proc.pid, 'SIGKILL')
-        })
-      } catch (signalError) {
-        try {
-          proc.kill()
-          nodePtyKillIssued = true
-        } catch {
-          nodePtyKillIssued = false
-          // Keep the original OS failure so callers can retry the same owner.
-          throw signalError
-        }
-      }
+      forceKillOwnedRoot()
     },
     signal: (sig) => {
       // Why: same recycled-pid hazard as forceKill — once dead, dropping avoids signalling an unrelated process.
@@ -1288,6 +1324,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       }
       disposed = true
       dead = true
+      stopLoginWrapperDeathWatch()
       onDataCb = null
       onExitCb = null
       pendingPreListenerData = []

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -973,10 +973,18 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   }
 
   // Why: TCC login wrappers make the PTY root login(1); shell exit can leave login holding the PTY with no onExit (#13764).
+  // Auto-reap signals only the proven root after a fresh empty/ownership proof — never a pgroup sweep.
   if (process.platform === 'darwin' && macosTccSpawnStrategy === 'wrapped' && proc.pid) {
+    const watchedRootPid = proc.pid
     loginWrapperDeathWatch = new MacosLoginWrapperDeathWatch({
-      rootPid: proc.pid,
-      forceKillRoot: forceKillOwnedRoot,
+      rootPid: watchedRootPid,
+      ownerPid: process.pid,
+      signalRoot: (rootPid) => {
+        if (dead || rootPid !== watchedRootPid || rootPid !== proc.pid) {
+          throw new Error('login wrapper root no longer owned by this handle')
+        }
+        process.kill(rootPid, 'SIGKILL')
+      },
       log: opts.log
     })
     loginWrapperDeathWatch.start()

--- a/src/main/pty/posix-pty-session-liveness.test.ts
+++ b/src/main/pty/posix-pty-session-liveness.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyPosixPtySessionLiveness,
+  readPosixPtySessionLiveness
+} from './posix-pty-session-liveness'
+
+const TABLE = `
+  100 ttys001
+  101 ttys001
+  102 ttys001
+  200 ttys002
+  300 ??
+`
+
+describe('classifyPosixPtySessionLiveness', () => {
+  it('reports live when peers share the root TTY', () => {
+    expect(classifyPosixPtySessionLiveness(TABLE, 100, 999)).toBe('live')
+  })
+
+  it('reports empty when only the root remains on its TTY', () => {
+    expect(classifyPosixPtySessionLiveness(TABLE, 200, 999)).toBe('empty')
+  })
+
+  it('reports gone when the root pid is absent', () => {
+    expect(classifyPosixPtySessionLiveness(TABLE, 999, 998)).toBe('gone')
+  })
+
+  it('reports unknown for unbound ttys or a PTY shared with Orca itself', () => {
+    expect(classifyPosixPtySessionLiveness(TABLE, 300, 999)).toBe('unknown')
+    expect(classifyPosixPtySessionLiveness(TABLE, 100, 101)).toBe('unknown')
+  })
+})
+
+describe('readPosixPtySessionLiveness', () => {
+  it('never classifies Windows as empty', () => {
+    expect(
+      readPosixPtySessionLiveness(100, {
+        platform: 'win32',
+        readProcessTable: () => TABLE
+      })
+    ).toBe('unknown')
+  })
+
+  it('classifies through the injectable process-table seam', () => {
+    expect(
+      readPosixPtySessionLiveness(200, {
+        platform: 'darwin',
+        currentPid: 999,
+        readProcessTable: () => TABLE
+      })
+    ).toBe('empty')
+  })
+
+  it('treats process-table failures as unknown, not empty', () => {
+    expect(
+      readPosixPtySessionLiveness(100, {
+        platform: 'darwin',
+        readProcessTable: () => {
+          throw new Error('ps failed')
+        }
+      })
+    ).toBe('unknown')
+  })
+})

--- a/src/main/pty/posix-pty-session-liveness.test.ts
+++ b/src/main/pty/posix-pty-session-liveness.test.ts
@@ -1,15 +1,23 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  buildPosixPtyRootSnapshot,
   classifyPosixPtySessionLiveness,
+  isMacosLoginWrapperCommand,
+  provesOwnedEmptyLoginWrapper,
+  readPosixPtyRootSnapshot,
   readPosixPtySessionLiveness
 } from './posix-pty-session-liveness'
 
 const TABLE = `
-  100 ttys001
-  101 ttys001
-  102 ttys001
-  200 ttys002
-  300 ??
+  100  50 ttys001 /usr/bin/login -flpq user /bin/bash
+  101 100 ttys001 -/bin/zsh -l
+  102 101 ttys001 claude
+  200  50 ttys002 /usr/bin/login -flpq user /bin/bash
+  300  50 ?? /usr/bin/login -flpq user /bin/bash
+`
+
+const EMPTY_OWNED = `
+  200  50 ttys002 /usr/bin/login -flpq user /bin/bash
 `
 
 describe('classifyPosixPtySessionLiveness', () => {
@@ -31,34 +39,106 @@ describe('classifyPosixPtySessionLiveness', () => {
   })
 })
 
-describe('readPosixPtySessionLiveness', () => {
-  it('never classifies Windows as empty', () => {
-    expect(
+describe('buildPosixPtyRootSnapshot', () => {
+  it('captures ppid/command for ownership proofs', () => {
+    expect(buildPosixPtyRootSnapshot(EMPTY_OWNED, 200, 999)).toEqual({
+      liveness: 'empty',
+      rootPid: 200,
+      ppid: 50,
+      tty: 'ttys002',
+      command: '/usr/bin/login -flpq user /bin/bash'
+    })
+  })
+
+  it('fails closed when a process-table line cannot be parsed', () => {
+    expect(buildPosixPtyRootSnapshot('not a process row\n', 200, 999).liveness).toBe('gone')
+  })
+})
+
+describe('isMacosLoginWrapperCommand / provesOwnedEmptyLoginWrapper', () => {
+  it('accepts login argv0 forms and rejects unrelated commands', () => {
+    expect(isMacosLoginWrapperCommand('/usr/bin/login -flpq u /bin/bash')).toBe(true)
+    expect(isMacosLoginWrapperCommand('login -flpq u')).toBe(true)
+    expect(isMacosLoginWrapperCommand('/bin/zsh -l')).toBe(false)
+    expect(isMacosLoginWrapperCommand('login-shell-helper')).toBe(false)
+  })
+
+  it('requires empty + matching root + daemon ppid + login command', () => {
+    const empty = buildPosixPtyRootSnapshot(EMPTY_OWNED, 200, 999)
+    expect(provesOwnedEmptyLoginWrapper(empty, { rootPid: 200, ownerPid: 50 })).toBe(true)
+    expect(provesOwnedEmptyLoginWrapper(empty, { rootPid: 200, ownerPid: 99 })).toBe(false)
+    expect(provesOwnedEmptyLoginWrapper(empty, { rootPid: 201, ownerPid: 50 })).toBe(false)
+
+    const live = buildPosixPtyRootSnapshot(TABLE, 100, 999)
+    expect(provesOwnedEmptyLoginWrapper(live, { rootPid: 100, ownerPid: 50 })).toBe(false)
+
+    const recycled = {
+      ...empty,
+      command: '/bin/zsh -l'
+    }
+    expect(provesOwnedEmptyLoginWrapper(recycled, { rootPid: 200, ownerPid: 50 })).toBe(false)
+  })
+})
+
+describe('readPosixPtySessionLiveness / readPosixPtyRootSnapshot', () => {
+  it('never classifies Windows as empty', async () => {
+    await expect(
       readPosixPtySessionLiveness(100, {
         platform: 'win32',
-        readProcessTable: () => TABLE
+        readProcessTable: async () => TABLE
       })
-    ).toBe('unknown')
+    ).resolves.toBe('unknown')
   })
 
-  it('classifies through the injectable process-table seam', () => {
-    expect(
-      readPosixPtySessionLiveness(200, {
+  it('classifies through the injectable async process-table seam', async () => {
+    await expect(
+      readPosixPtyRootSnapshot(200, {
         platform: 'darwin',
         currentPid: 999,
-        readProcessTable: () => TABLE
+        readProcessTable: async () => EMPTY_OWNED
       })
-    ).toBe('empty')
+    ).resolves.toMatchObject({ liveness: 'empty', ppid: 50 })
   })
 
-  it('treats process-table failures as unknown, not empty', () => {
-    expect(
+  it('treats process-table failures and timeouts as unknown, not empty', async () => {
+    await expect(
       readPosixPtySessionLiveness(100, {
         platform: 'darwin',
-        readProcessTable: () => {
-          throw new Error('ps failed')
+        readProcessTable: async () => {
+          throw new Error('ps timed out')
         }
       })
-    ).toBe('unknown')
+    ).resolves.toBe('unknown')
+  })
+
+  it('treats rejected reads as unknown', async () => {
+    await expect(
+      readPosixPtySessionLiveness(100, {
+        platform: 'darwin',
+        readProcessTable: async () => {
+          throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+        }
+      })
+    ).resolves.toBe('unknown')
+  })
+
+  it('does not start overlapping production reads when the seam serializes', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const readProcessTable = vi.fn(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await Promise.resolve()
+      inFlight--
+      return EMPTY_OWNED
+    })
+    await Promise.all([
+      readPosixPtyRootSnapshot(200, { platform: 'darwin', currentPid: 999, readProcessTable }),
+      readPosixPtyRootSnapshot(200, { platform: 'darwin', currentPid: 999, readProcessTable })
+    ])
+    // Parallel callers may overlap at the seam; the death watch serializes — this only
+    // proves the reader itself is async and non-blocking.
+    expect(readProcessTable).toHaveBeenCalledTimes(2)
+    expect(maxInFlight).toBeGreaterThanOrEqual(1)
   })
 })

--- a/src/main/pty/posix-pty-session-liveness.ts
+++ b/src/main/pty/posix-pty-session-liveness.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from 'node:child_process'
+
+const PROCESS_TABLE_TIMEOUT_MS = 1_000
+const PROCESS_TABLE_MAX_BYTES = 1024 * 1024
+
+type ProcessRow = {
+  pid: number
+  tty: string
+}
+
+export type PosixPtySessionLiveness = 'live' | 'empty' | 'gone' | 'unknown'
+
+export type PosixPtySessionLivenessDeps = {
+  platform?: NodeJS.Platform
+  currentPid?: number
+  readProcessTable?: (rootPid: number) => string
+}
+
+function runPs(args: string[]): string {
+  return execFileSync('ps', args, {
+    encoding: 'utf8',
+    timeout: PROCESS_TABLE_TIMEOUT_MS,
+    maxBuffer: PROCESS_TABLE_MAX_BYTES
+  })
+}
+
+function readPtyProcessTable(rootPid: number): string {
+  const root = runPs(['-p', String(rootPid), '-o', 'pid=,tty='])
+  const rootRow = parseProcessRows(root).find((row) => row.pid === rootPid)
+  if (!rootRow || rootRow.tty === '?' || rootRow.tty === '??') {
+    return root
+  }
+  // Why: TTY-scoped ps stays proportional to one terminal; whole-host scans blow teardown budgets.
+  return `${root}\n${runPs(['-t', rootRow.tty, '-o', 'pid=,tty='])}`
+}
+
+function parseProcessRows(output: string): ProcessRow[] {
+  const rows: ProcessRow[] = []
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^\s*(\d+)\s+(\S+)/.exec(line)
+    if (!match) {
+      continue
+    }
+    const pid = Number(match[1])
+    if (pid > 0) {
+      rows.push({ pid, tty: match[2] })
+    }
+  }
+  return rows
+}
+
+/**
+ * Classifies whether a POSIX PTY root still hosts real session work.
+ *
+ * On macOS TCC-wrapped spawns the root is `login(1)`. When the inner shell exits
+ * without `login` exiting, the daemon never gets `onExit` and the PTY leaks
+ * (#13764). `empty` means the root is alive on a real TTY with no other
+ * processes sharing that TTY — safe to force-kill the known root so normal
+ * exit/reap runs. `unknown` never authorizes a kill.
+ */
+export function classifyPosixPtySessionLiveness(
+  output: string,
+  rootPid: number,
+  currentPid = process.pid
+): PosixPtySessionLiveness {
+  const rows = parseProcessRows(output)
+  const root = rows.find((row) => row.pid === rootPid)
+  if (!root) {
+    return 'gone'
+  }
+  if (root.tty === '?' || root.tty === '??') {
+    return 'unknown'
+  }
+  // Why: a development daemon can inherit its launch TTY; never treat that as an empty session.
+  if (rows.some((row) => row.pid === currentPid && row.tty === root.tty)) {
+    return 'unknown'
+  }
+  const peers = rows.filter((row) => row.tty === root.tty && row.pid !== rootPid)
+  return peers.length === 0 ? 'empty' : 'live'
+}
+
+export function readPosixPtySessionLiveness(
+  rootPid: number,
+  deps: PosixPtySessionLivenessDeps = {}
+): PosixPtySessionLiveness {
+  if ((deps.platform ?? process.platform) === 'win32') {
+    return 'unknown'
+  }
+  if (!Number.isSafeInteger(rootPid) || rootPid <= 0) {
+    return 'unknown'
+  }
+  try {
+    const table = (deps.readProcessTable ?? readPtyProcessTable)(rootPid)
+    return classifyPosixPtySessionLiveness(table, rootPid, deps.currentPid ?? process.pid)
+  } catch {
+    return 'unknown'
+  }
+}

--- a/src/main/pty/posix-pty-session-liveness.ts
+++ b/src/main/pty/posix-pty-session-liveness.ts
@@ -1,98 +1,179 @@
-import { execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
 
 const PROCESS_TABLE_TIMEOUT_MS = 1_000
 const PROCESS_TABLE_MAX_BYTES = 1024 * 1024
 
 type ProcessRow = {
   pid: number
+  ppid: number
   tty: string
+  command: string
 }
 
 export type PosixPtySessionLiveness = 'live' | 'empty' | 'gone' | 'unknown'
 
+/** One TTY-scoped process-table sample for a PTY root. */
+export type PosixPtyRootSnapshot = {
+  liveness: PosixPtySessionLiveness
+  rootPid: number
+  ppid: number | null
+  tty: string | null
+  command: string | null
+}
+
 export type PosixPtySessionLivenessDeps = {
   platform?: NodeJS.Platform
   currentPid?: number
-  readProcessTable?: (rootPid: number) => string
+  /** Injectable async process-table read; production uses bounded `ps`. */
+  readProcessTable?: (rootPid: number) => Promise<string>
 }
 
-function runPs(args: string[]): string {
-  return execFileSync('ps', args, {
+async function runPs(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('ps', args, {
     encoding: 'utf8',
     timeout: PROCESS_TABLE_TIMEOUT_MS,
     maxBuffer: PROCESS_TABLE_MAX_BYTES
   })
+  return stdout
 }
 
-function readPtyProcessTable(rootPid: number): string {
-  const root = runPs(['-p', String(rootPid), '-o', 'pid=,tty='])
+async function readPtyProcessTable(rootPid: number): Promise<string> {
+  const root = await runPs(['-p', String(rootPid), '-o', 'pid=,ppid=,tty=,command='])
   const rootRow = parseProcessRows(root).find((row) => row.pid === rootPid)
   if (!rootRow || rootRow.tty === '?' || rootRow.tty === '??') {
     return root
   }
-  // Why: TTY-scoped ps stays proportional to one terminal; whole-host scans blow teardown budgets.
-  return `${root}\n${runPs(['-t', rootRow.tty, '-o', 'pid=,tty='])}`
+  // Why: TTY-scoped ps stays proportional to one terminal; whole-host scans blow daemon budgets.
+  const peers = await runPs(['-t', rootRow.tty, '-o', 'pid=,ppid=,tty=,command='])
+  return `${root}\n${peers}`
 }
 
 function parseProcessRows(output: string): ProcessRow[] {
   const rows: ProcessRow[] = []
   for (const line of output.split(/\r?\n/)) {
-    const match = /^\s*(\d+)\s+(\S+)/.exec(line)
+    const match = /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/.exec(line)
     if (!match) {
       continue
     }
     const pid = Number(match[1])
-    if (pid > 0) {
-      rows.push({ pid, tty: match[2] })
+    const ppid = Number(match[2])
+    if (pid > 0 && Number.isFinite(ppid)) {
+      rows.push({ pid, ppid, tty: match[3], command: match[4].trim() })
     }
   }
   return rows
 }
 
+/** True when argv0 is macOS login(1) (TCC wrapper), not an unrelated binary name. */
+export function isMacosLoginWrapperCommand(command: string): boolean {
+  const argv0 = command.trim().split(/\s+/)[0] ?? ''
+  return argv0 === 'login' || argv0 === '/usr/bin/login' || argv0.endsWith('/login')
+}
+
 /**
  * Classifies whether a POSIX PTY root still hosts real session work.
  *
- * On macOS TCC-wrapped spawns the root is `login(1)`. When the inner shell exits
- * without `login` exiting, the daemon never gets `onExit` and the PTY leaks
- * (#13764). `empty` means the root is alive on a real TTY with no other
- * processes sharing that TTY — safe to force-kill the known root so normal
- * exit/reap runs. `unknown` never authorizes a kill.
+ * `empty` = root alive on a real TTY with no peers. `unknown` never authorizes a kill.
  */
 export function classifyPosixPtySessionLiveness(
   output: string,
   rootPid: number,
   currentPid = process.pid
 ): PosixPtySessionLiveness {
+  return buildPosixPtyRootSnapshot(output, rootPid, currentPid).liveness
+}
+
+export function buildPosixPtyRootSnapshot(
+  output: string,
+  rootPid: number,
+  currentPid = process.pid
+): PosixPtyRootSnapshot {
   const rows = parseProcessRows(output)
   const root = rows.find((row) => row.pid === rootPid)
   if (!root) {
-    return 'gone'
+    return { liveness: 'gone', rootPid, ppid: null, tty: null, command: null }
   }
   if (root.tty === '?' || root.tty === '??') {
-    return 'unknown'
+    return {
+      liveness: 'unknown',
+      rootPid,
+      ppid: root.ppid,
+      tty: root.tty,
+      command: root.command || null
+    }
   }
-  // Why: a development daemon can inherit its launch TTY; never treat that as an empty session.
+  // Why: a development daemon can inherit its launch TTY; never treat that as empty.
   if (rows.some((row) => row.pid === currentPid && row.tty === root.tty)) {
-    return 'unknown'
+    return {
+      liveness: 'unknown',
+      rootPid,
+      ppid: root.ppid,
+      tty: root.tty,
+      command: root.command || null
+    }
   }
   const peers = rows.filter((row) => row.tty === root.tty && row.pid !== rootPid)
-  return peers.length === 0 ? 'empty' : 'live'
+  return {
+    liveness: peers.length === 0 ? 'empty' : 'live',
+    rootPid,
+    ppid: root.ppid,
+    tty: root.tty,
+    command: root.command || null
+  }
 }
 
-export function readPosixPtySessionLiveness(
+/**
+ * Final pre-signal gate: empty TTY, still our direct child, still login(1).
+ * Why: a generic pgroup sweep can kill a peer that appeared after the empty poll;
+ * PID reuse must not let us SIGKILL an unrelated process.
+ */
+export function provesOwnedEmptyLoginWrapper(
+  snapshot: PosixPtyRootSnapshot,
+  expected: { rootPid: number; ownerPid: number }
+): boolean {
+  if (snapshot.liveness !== 'empty') {
+    return false
+  }
+  if (snapshot.rootPid !== expected.rootPid) {
+    return false
+  }
+  if (snapshot.ppid !== expected.ownerPid) {
+    return false
+  }
+  if (!snapshot.command || !isMacosLoginWrapperCommand(snapshot.command)) {
+    return false
+  }
+  return true
+}
+
+/** Async bounded process-table probe. Timeouts/parse failures fail closed as `unknown`. */
+export async function readPosixPtyRootSnapshot(
   rootPid: number,
   deps: PosixPtySessionLivenessDeps = {}
-): PosixPtySessionLiveness {
+): Promise<PosixPtyRootSnapshot> {
   if ((deps.platform ?? process.platform) === 'win32') {
-    return 'unknown'
+    return { liveness: 'unknown', rootPid, ppid: null, tty: null, command: null }
   }
   if (!Number.isSafeInteger(rootPid) || rootPid <= 0) {
-    return 'unknown'
+    return { liveness: 'unknown', rootPid, ppid: null, tty: null, command: null }
   }
   try {
-    const table = (deps.readProcessTable ?? readPtyProcessTable)(rootPid)
-    return classifyPosixPtySessionLiveness(table, rootPid, deps.currentPid ?? process.pid)
+    const table = await (deps.readProcessTable ?? readPtyProcessTable)(rootPid)
+    if (typeof table !== 'string') {
+      return { liveness: 'unknown', rootPid, ppid: null, tty: null, command: null }
+    }
+    return buildPosixPtyRootSnapshot(table, rootPid, deps.currentPid ?? process.pid)
   } catch {
-    return 'unknown'
+    return { liveness: 'unknown', rootPid, ppid: null, tty: null, command: null }
   }
+}
+
+export async function readPosixPtySessionLiveness(
+  rootPid: number,
+  deps: PosixPtySessionLivenessDeps = {}
+): Promise<PosixPtySessionLiveness> {
+  return (await readPosixPtyRootSnapshot(rootPid, deps)).liveness
 }


### PR DESCRIPTION
## Summary

- On macOS TCC-wrapped PTYs the node-pty root is `/usr/bin/login`, so an exited inner shell can leave `login` holding the master with no `onExit` (#13764).
- Death watch uses **bounded async** `ps` (not `execFileSync`), never overlaps probes, and ignores late results after `stop`/`onExit`.
- Before signalling: **fresh** empty + `ppid === daemon` + `login(1)` command proof, then **SIGKILL only that root** (no pgroup sweep that could kill a new peer).
- `macos-login-wrapper-empty-reaped` only after successful signal; failures emit only `…-reap-failed`.

Fixes #13764

## Coordinator corrections (this push)

| Issue | Fix |
| --- | --- |
| Sync `ps` twice per wrapped PTY / 30s on event loop | Async `execFile` with 1s timeout |
| Overlapping probes | `probeInFlight` gate |
| Stop mid-probe still kills/logs | Post-await `stopped`/`reaped` check; no side effects |
| Final kill via pgroup sweep | Ownership proof + root-only `process.kill` |
| reaped logged before signal | Signal first, then reaped |
| PID reuse / peer reappear | Fail closed; reset streak |

## Test plan

- [x] `posix-pty-session-liveness` (13): live/empty/gone/unknown, ownership proof, timeout/EPERM fail-closed
- [x] `macos-login-wrapper-death-watch` (14): grace, two-empty+final proof, log order, signal failure, peer reappear, ownership mismatch, no overlap, stop mid-probe / mid-final-proof
- [x] Related: `posix-pty-process-groups` (6) + `terminal-session-teardown` (5) — **38 total passed**
- [x] oxlint touched files: 0/0
- [x] `tsc -p config/tsconfig.node.json` (touched paths): clean
- [x] `git diff --check`: clean
- [ ] Live macOS: wrap → kill shell only → watch reaps login (pending; Windows worker)

## ELI5

macOS terminals go through a login wrapper for permissions. Sometimes the real shell dies but the wrapper sticks around and Orca never cleans up. We now check carefully (without freezing the app) that it is still our empty wrapper, then remove only that process.