### PR TITLE
perf(renderer): publish agent status bursts once

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -23154,6 +23154,159 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('resets stale keyboard state when a batched done→working→done burst lands as one publication', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const firstDoneAt = Date.now()
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'first turn',
+        updatedAt: firstDoneAt,
+        stateStartedAt: firstDoneAt,
+        agentType: 'codex',
+        paneKey,
+        stateHistory: [{ state: 'working', prompt: 'first turn', startedAt: firstDoneAt - 5_000 }]
+      }
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+
+      // The burst's intermediate `working` never publishes, so the entry stays `done` end-to-end;
+      // only the stateHistory row proves a second turn ran and re-armed the kitty protocol.
+      const secondDoneAt = firstDoneAt + 10_000
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'second turn',
+        updatedAt: secondDoneAt,
+        stateStartedAt: secondDoneAt,
+        agentType: 'codex',
+        paneKey,
+        stateHistory: [
+          { state: 'working', prompt: 'first turn', startedAt: firstDoneAt - 5_000 },
+          { state: 'done', prompt: 'first turn', startedAt: firstDoneAt },
+          { state: 'working', prompt: 'second turn', startedAt: secondDoneAt - 2_000 }
+        ]
+      }
+      notifyStoreSubscribers()
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        expect.any(Function)
+      )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('resets stale keyboard state when a batched burst ends on working after a completed turn', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const startedAt = Date.now()
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'working',
+        prompt: 'ship it',
+        updatedAt: startedAt,
+        stateStartedAt: startedAt,
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      notifyStoreSubscribers()
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'working',
+        prompt: 'follow-up',
+        updatedAt: startedAt + 8_000,
+        stateStartedAt: startedAt + 8_000,
+        agentType: 'codex',
+        paneKey,
+        stateHistory: [
+          { state: 'working', prompt: 'ship it', startedAt },
+          { state: 'done', prompt: 'ship it', startedAt: startedAt + 4_000 }
+        ]
+      }
+      notifyStoreSubscribers()
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        expect.any(Function)
+      )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('keeps native Windows same-turn done repaints from re-resetting keyboard state', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const doneAt = Date.now()
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'ship it',
+        updatedAt: doneAt,
+        stateStartedAt: doneAt,
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+      const writesAfterDone = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.length
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'ship it',
+        updatedAt: doneAt + 1_000,
+        stateStartedAt: doneAt,
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+
+      expect((pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+        writesAfterDone
+      )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
   it('drops native Windows Codex focus reports while a history resume is idle', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1081,6 +1081,25 @@ function isSetupSplitGeometryReady(
   )
 }
 
+/** Start time of the newest completed turn, counting turns already folded into history.
+ *  Why: batched publications coalesce done→working→done into a single store notification,
+ *  so the done EDGE survives only in stateHistory; comparing `state` alone misses it. */
+function resolveLatestAgentDoneStartedAt(entry: AgentStatusEntry | undefined): number | undefined {
+  if (!entry) {
+    return undefined
+  }
+  if (entry.state === 'done') {
+    return entry.stateStartedAt
+  }
+  const history = entry.stateHistory ?? []
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    if (history[index].state === 'done') {
+      return history[index].startedAt
+    }
+  }
+  return undefined
+}
+
 /**
  * Establishes a binding between a terminal pane and its corresponding PTY stream,
  * managing input, output, title synchronization, and agent status tracking.
@@ -3595,10 +3614,10 @@ export function connectPanePty(
   const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
   const shouldApplyWindowsRendererUnicodeRefresh = CLIENT_PLATFORM === 'win32'
   const shouldProtectNativeWindowsSynchronizedOutput = isNativeWindowsConpty
-  let lastAgentStatusState = state.agentStatusByPaneKey[cacheKey]?.state
   let unsubscribeWindowsDoneTerminalModeReset: (() => void) | null = null
   if (isNativeWindowsConpty) {
     const initialAgentStatus = state.agentStatusByPaneKey[cacheKey]
+    let lastAgentDoneStartedAt = resolveLatestAgentDoneStartedAt(initialAgentStatus)
     if (
       !initialAgentStatus &&
       paneStartup?.telemetry?.launch_source === 'sidebar' &&
@@ -3617,13 +3636,18 @@ export function connectPanePty(
       const nextAgentStatusState = nextAgentStatus?.state
       if (nextAgentStatusState === 'done') {
         setFocusReportSuppressionForAgentCompletion(undefined, nextAgentStatus.agentType)
-        if (lastAgentStatusState !== 'done') {
-          queueAgentIdleTerminalModeReset()
-        }
       } else if (nextAgentStatusState) {
         suppressNativeWindowsIdleCodexFocusReports = false
       }
-      lastAgentStatusState = nextAgentStatusState
+      const nextAgentDoneStartedAt = resolveLatestAgentDoneStartedAt(nextAgentStatus)
+      // Why: a NEW completed turn — same-state `done` pings keep stateStartedAt, so they no-op.
+      if (
+        nextAgentDoneStartedAt !== undefined &&
+        nextAgentDoneStartedAt !== lastAgentDoneStartedAt
+      ) {
+        queueAgentIdleTerminalModeReset()
+      }
+      lastAgentDoneStartedAt = nextAgentDoneStartedAt
     })
   }
 

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -5,6 +5,7 @@ const mockLaunchAgentBackgroundSession = vi.fn()
 const mockLaunchWorktreeBackgroundTerminals = vi.fn()
 const mockFindReusableAutomationSession = vi.fn()
 const mockObserveExistingAutomationSession = vi.fn()
+const mockSubmitPromptToAgentPty = vi.fn()
 const mockCreateWorktree = vi.fn()
 const mockMarkDispatchResult = vi.fn()
 const mockOnDispatchRequested = vi.fn()
@@ -14,6 +15,11 @@ const mockReleaseTerminalOwnership = vi.fn()
 const mockSshNeedsPassphrasePrompt = vi.fn()
 const mockSshGetState = vi.fn()
 const mockSshConnect = vi.fn()
+let latestStoreSubscriber: (() => void) | null = null
+const mockStoreSubscribe = vi.fn((listener: () => void) => {
+  latestStoreSubscriber = listener
+  return () => {}
+})
 
 const setupLaunch = {
   runnerScriptPath: '/tmp/setup.sh',
@@ -124,7 +130,9 @@ vi.mock('@/lib/launch-worktree-background-terminals', () => ({
   launchWorktreeBackgroundTerminals: mockLaunchWorktreeBackgroundTerminals
 }))
 
-vi.mock('@/lib/agent-paste-draft', () => ({}))
+vi.mock('@/lib/agent-paste-draft', () => ({
+  submitPromptToAgentPty: mockSubmitPromptToAgentPty
+}))
 
 vi.mock('@/lib/automation-session-reuse', () => ({
   findReusableAutomationSession: mockFindReusableAutomationSession
@@ -137,9 +145,20 @@ vi.mock('@/lib/automation-session-observer', () => ({
 vi.mock('@/components/automations/automation-run-output-snapshot', () => ({
   createAutomationRunOutputSnapshotBuffer: () => ({
     append: vi.fn(),
-    snapshot: () => ''
+    snapshot: () => null
   }),
-  selectAutomationRunOutputSnapshot: () => null
+  selectAutomationRunOutputSnapshot: (
+    assistantMessage: string | null | undefined,
+    terminalSnapshot: unknown
+  ) =>
+    assistantMessage
+      ? {
+          format: 'plain_text',
+          content: assistantMessage,
+          capturedAt: 1,
+          truncated: false
+        }
+      : terminalSnapshot
 }))
 
 vi.mock('@/i18n/i18n', () => ({
@@ -153,7 +172,7 @@ vi.mock('@/lib/browser-uuid', () => ({
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => state,
-    subscribe: vi.fn(() => () => {})
+    subscribe: mockStoreSubscribe
   }
 }))
 
@@ -171,6 +190,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     state.projectGroups = []
     state.worktreesByRepo = {}
     state.agentStatusByPaneKey = {}
+    latestStoreSubscriber = null
     state.allWorktrees.mockReturnValue([])
     state.getKnownWorktreeById.mockReturnValue(undefined)
     mockCreateWorktree.mockResolvedValue({ worktree: createdWorktree, setup: setupLaunch })
@@ -189,6 +209,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     mockSshNeedsPassphrasePrompt.mockResolvedValue(false)
     mockSshGetState.mockResolvedValue({ status: 'connected' })
     mockSshConnect.mockResolvedValue({ status: 'connected' })
+    mockSubmitPromptToAgentPty.mockResolvedValue(true)
     vi.stubGlobal('window', {
       api: {
         automations: {
@@ -579,6 +600,132 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
     launchArgs.onAgentStatus?.({ state: 'done' })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
+  })
+
+  it('persists assistant output from a batched working→done→working transition', async () => {
+    const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+
+    await registerAndDispatch()
+    const transitionStartedAt = Date.now() + 1
+    state.agentStatusByPaneKey = {
+      [paneKey]: {
+        paneKey,
+        state: 'working',
+        prompt: 'second turn',
+        agentType: 'claude',
+        updatedAt: transitionStartedAt + 2,
+        stateStartedAt: transitionStartedAt + 2,
+        lastCompletedAssistantMessage: 'Summary.\n\nDetails.',
+        stateHistory: [
+          { state: 'working', prompt: 'first turn', startedAt: transitionStartedAt },
+          { state: 'done', prompt: 'first turn', startedAt: transitionStartedAt + 1 }
+        ]
+      }
+    }
+    if (!latestStoreSubscriber) {
+      throw new Error('agent status observer was not registered')
+    }
+    latestStoreSubscriber()
+
+    await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
+    expect(mockMarkDispatchResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-1',
+        status: 'completed',
+        outputSnapshot: {
+          format: 'plain_text',
+          content: 'Summary.\n\nDetails.',
+          capturedAt: 1,
+          truncated: false
+        }
+      })
+    )
+  })
+
+  it('does not let later working authorize an earlier historical done on rescan', async () => {
+    const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+    mockFindReusableAutomationSession.mockReturnValue({
+      tabId: 'agent-tab',
+      paneKey,
+      ptyId: 'agent-pty'
+    })
+    mockObserveExistingAutomationSession.mockResolvedValue(() => {})
+
+    await registerAndDispatch(makeAutomation({ reuseSession: true }))
+    const transitionStartedAt = Date.now() + 1
+    state.agentStatusByPaneKey = {
+      [paneKey]: {
+        paneKey,
+        state: 'working',
+        prompt: 'new turn',
+        agentType: 'claude',
+        updatedAt: transitionStartedAt + 1,
+        stateStartedAt: transitionStartedAt + 1,
+        stateHistory: [{ state: 'done', prompt: 'old turn', startedAt: transitionStartedAt }]
+      }
+    }
+    if (!latestStoreSubscriber) {
+      throw new Error('agent status observer was not registered')
+    }
+
+    latestStoreSubscriber()
+    latestStoreSubscriber()
+    await Promise.resolve()
+
+    expect(mockMarkDispatchResult).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed' })
+    )
+  })
+
+  // Why: transport loss, PTY exit and cap eviction all drop and recreate the live
+  // entry with an empty stateHistory. The working edge is only in the observer's
+  // own bookkeeping by then, so it must survive a zero-overlap rescan.
+  it('completes a reuse-session run when the entry is recreated with no history', async () => {
+    const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+    mockFindReusableAutomationSession.mockReturnValue({
+      tabId: 'agent-tab',
+      paneKey,
+      ptyId: 'agent-pty'
+    })
+    mockObserveExistingAutomationSession.mockResolvedValue(() => {})
+
+    await registerAndDispatch(makeAutomation({ reuseSession: true }))
+    const workingStartedAt = Date.now() + 1
+    state.agentStatusByPaneKey = {
+      [paneKey]: {
+        paneKey,
+        state: 'working',
+        prompt: 'turn',
+        agentType: 'claude',
+        updatedAt: workingStartedAt,
+        stateStartedAt: workingStartedAt,
+        stateHistory: [{ state: 'working', prompt: 'turn', startedAt: workingStartedAt }]
+      }
+    }
+    if (!latestStoreSubscriber) {
+      throw new Error('agent status observer was not registered')
+    }
+    latestStoreSubscriber()
+    await Promise.resolve()
+
+    // The entry is dropped and recreated: same pane, now done, history gone.
+    state.agentStatusByPaneKey = {
+      [paneKey]: {
+        paneKey,
+        state: 'done',
+        prompt: 'turn',
+        agentType: 'claude',
+        updatedAt: workingStartedAt + 2,
+        stateStartedAt: workingStartedAt + 2,
+        stateHistory: []
+      }
+    }
+    latestStoreSubscriber()
+    await Promise.resolve()
+
+    expect(mockMarkDispatchResult).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed' })
+    )
   })
 
   it('consumes duplicate done and zero-exit completion through one finalizer', async () => {

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
+import type { AgentStateHistoryEntry } from '../../../shared/agent-status-types'
 
 const AUTOMATIONS_CHANGED_EVENT = 'orca:automations-changed'
 const activeReuseDispatchTabIds = new Set<string>()
@@ -52,6 +53,37 @@ function buildAutomationWorkspaceName(runTitle: string, scheduledFor: number): s
     .slice(0, 40)
   const stamp = new Date(scheduledFor).toISOString().replace(/[-:]/g, '').slice(0, 13)
   return `auto-${slug || 'run'}-${stamp}`
+}
+
+function agentStateHistoryEntriesEqual(
+  left: AgentStateHistoryEntry,
+  right: AgentStateHistoryEntry
+): boolean {
+  return (
+    left.state === right.state &&
+    left.prompt === right.prompt &&
+    left.startedAt === right.startedAt &&
+    left.interrupted === right.interrupted
+  )
+}
+
+function getAgentStateHistoryOverlap(
+  previous: AgentStateHistoryEntry[],
+  current: AgentStateHistoryEntry[]
+): number {
+  for (let overlap = Math.min(previous.length, current.length); overlap > 0; overlap -= 1) {
+    const previousOffset = previous.length - overlap
+    if (
+      current
+        .slice(0, overlap)
+        .every((entry, index) =>
+          agentStateHistoryEntriesEqual(entry, previous[previousOffset + index])
+        )
+    ) {
+      return overlap
+    }
+  }
+  return 0
 }
 
 export function useAutomationDispatchEvents(): void {
@@ -405,12 +437,41 @@ export function useAutomationDispatchEvents(): void {
             options?: { requireWorkingAfterStart?: boolean }
           ): void => {
             let sawWorkingAfterStart = false
+            let observedStateHistory: AgentStateHistoryEntry[] = []
             const checkCurrentStatus = (): void => {
               const { agentStatusByPaneKey } = useAppStore.getState()
               for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
                 if (paneKey !== targetPaneKey || entry.updatedAt < startedAfter) {
                   continue
                 }
+                const historyOverlap = getAgentStateHistoryOverlap(
+                  observedStateHistory,
+                  entry.stateHistory
+                )
+                // Why: sawWorkingAfterStart stays monotonic — a recreated entry
+                // (transport loss, PTY exit, cap eviction) arrives with an empty
+                // stateHistory, so clearing it here would strand reuseSession runs
+                // with nothing left to re-derive the working edge from.
+                for (const historicalState of entry.stateHistory.slice(historyOverlap)) {
+                  if (historicalState.startedAt < startedAfter) {
+                    continue
+                  }
+                  if (historicalState.state === 'working') {
+                    sawWorkingAfterStart = true
+                  }
+                  if (
+                    historicalState.state === 'done' &&
+                    (!options?.requireWorkingAfterStart || sawWorkingAfterStart)
+                  ) {
+                    // Why: this `done` already rolled out of the live entry, so its output
+                    // survives only in the entry-level completed slot.
+                    latestAssistantMessage =
+                      entry.lastCompletedAssistantMessage?.trim() || latestAssistantMessage
+                    handleAgentDone()
+                    return
+                  }
+                }
+                observedStateHistory = [...entry.stateHistory]
                 if (entry.state === 'working') {
                   sawWorkingAfterStart = true
                 }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -22,11 +22,21 @@ import {
   makeWorktree,
   TEST_REPO
 } from '../store/slices/store-test-helpers'
+import type {
+  AgentStatusBatchTransaction,
+  AgentStatusBatchUpdate,
+  AgentStatusUpdate
+} from '../store/slices/agent-status'
+import type { AppState } from '../store/types'
 import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-resume'
-import type { AgentStatusClearIpcPayload } from '../../../shared/agent-status-types'
-import type { TuiAgent } from '../../../shared/types'
+import type {
+  AgentStatusClearIpcPayload,
+  MigrationUnsupportedPtyEntry
+} from '../../../shared/agent-status-types'
+import type { TerminalPaneLayoutNode, TuiAgent } from '../../../shared/types'
 import type * as CmdJRowIndexJump from '@/lib/cmd-j-row-index-jump'
 import { makePaneKey } from '../../../shared/stable-pane-id'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { YOLO_TUI_AGENT_ARGS } from '../../../shared/tui-agent-permissions'
 import {
   FLOATING_WORKSPACE_GUEST_CLOSE_EVENT,
@@ -5000,6 +5010,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     terminalHandle?: string
     launchToken?: string
     providerSession?: { key: 'session_id'; id: string }
+    providerSessionOnly?: boolean
     orchestration?: {
       taskId?: string
       dispatchId?: string
@@ -5030,11 +5041,72 @@ describe('useIpcEvents agent status snapshot integration', () => {
     driver: { kind: 'mobile'; clientId: string }
   }) => void
 
+  function applyMockAgentStatusUpdate(state: StoreLike, update: AgentStatusBatchUpdate): boolean {
+    const statuses = state.agentStatusByPaneKey as Record<
+      string,
+      | ({ agentType?: string; state?: string; updatedAt?: number } & Record<string, unknown>)
+      | undefined
+    >
+    const existing = statuses[update.paneKey]
+    const updatedAt = update.timing?.updatedAt
+    if (
+      existing?.updatedAt !== undefined &&
+      updatedAt !== undefined &&
+      updatedAt < existing.updatedAt
+    ) {
+      return false
+    }
+    const next = { ...statuses }
+    if (update.kind === 'providerSession') {
+      delete next[update.paneKey]
+    } else {
+      next[update.paneKey] = {
+        ...existing,
+        ...update.payload,
+        updatedAt,
+        providerSession: update.metadata?.providerSession
+      }
+    }
+    state.agentStatusByPaneKey = next
+    return true
+  }
+
+  function installMockAgentStatusTransaction(state: StoreLike): void {
+    state.transactAgentStatuses = <Result>(
+      operation: (transaction: AgentStatusBatchTransaction) => Result
+    ): Result => {
+      const stagedState = {
+        ...state,
+        agentStatusByPaneKey: {
+          ...(state.agentStatusByPaneKey as Record<string, unknown>)
+        }
+      }
+      const attemptedUpdates: AgentStatusBatchUpdate[] = []
+      const effects: (() => void)[] = []
+      const result = operation({
+        getState: () => stagedState as AppState,
+        apply: (update) => {
+          attemptedUpdates.push(update)
+          return applyMockAgentStatusUpdate(stagedState, update)
+        },
+        afterCommit: (effect) => effects.push(effect)
+      })
+      const setStatuses = state.setAgentStatuses as (
+        updates: readonly AgentStatusBatchUpdate[]
+      ) => readonly boolean[]
+      setStatuses(attemptedUpdates)
+      for (const effect of effects) {
+        effect()
+      }
+      return result
+    }
+  }
+
   function buildStoreState(overrides: StoreLike): StoreLike {
     // Why: copy the defensive set of getState() fields the hook touches during
     // mount so individual tests only need to override workspaceSessionReady,
     // tabsByWorktree, and setAgentStatus.
-    return {
+    const state: StoreLike = {
       setUpdateStatus: vi.fn(),
       fetchRepos: vi.fn(),
       fetchWorktrees: vi.fn(),
@@ -5064,9 +5136,12 @@ describe('useIpcEvents agent status snapshot integration', () => {
       removeSshCredentialRequest: vi.fn(),
       clearTabPtyId: vi.fn(),
       updateTabTitle: vi.fn(),
+      updateTabTitles: vi.fn(),
       runtimePaneTitlesByTabId: {},
       terminalLayoutsByTabId: {},
       agentStatusByPaneKey: {},
+      setAgentStatuses: vi.fn(() => []),
+      recordAgentProviderSession: vi.fn(),
       clearTransientAgentStatuses: vi.fn(),
       getAgentLaunchConfigForStatusMetadata: vi.fn(() => undefined),
       recentlyClosedAgentStatusTabIds: {},
@@ -5078,6 +5153,45 @@ describe('useIpcEvents agent status snapshot integration', () => {
       settings: { terminalFontSize: 13 },
       ...overrides
     }
+    if (!('updateTabTitles' in overrides)) {
+      state.updateTabTitles = vi.fn((updates: readonly { tabId: string; title: string }[]) => {
+        const updateTitle = state.updateTabTitle as AppState['updateTabTitle']
+        for (const { tabId, title } of updates) {
+          updateTitle(tabId, title)
+        }
+      })
+    }
+    if (!('setAgentStatuses' in overrides)) {
+      state.setAgentStatuses = vi.fn((updates: readonly AgentStatusBatchUpdate[]) =>
+        updates.map((update) => {
+          if (update.kind === 'providerSession') {
+            const recordProviderSession =
+              state.recordAgentProviderSession as AppState['recordAgentProviderSession']
+            recordProviderSession(
+              update.paneKey,
+              update.agent,
+              update.providerSession,
+              update.timing,
+              update.routing,
+              update.metadata
+            )
+          } else {
+            const setStatus = state.setAgentStatus as AppState['setAgentStatus']
+            setStatus(
+              update.paneKey,
+              update.payload,
+              update.terminalTitle,
+              update.timing,
+              update.routing,
+              update.metadata
+            )
+          }
+          return true
+        })
+      )
+    }
+    installMockAgentStatusTransaction(state)
+    return state
   }
 
   function buildWindowApi(args: {
@@ -5087,6 +5201,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
       cb: (data: { paneKey: string; resolution: 'adopted' | 'exited' }) => void
     ) => () => void
     getSnapshot?: () => Promise<AgentStatusSetData[]>
+    getMigrationUnsupportedSnapshot?: () => Promise<MigrationUnsupportedPtyEntry[]>
     drop?: (paneKey: string) => void
     remoteWorkspace?: Record<string, unknown>
     runtime?: Record<string, unknown>
@@ -5200,6 +5315,9 @@ describe('useIpcEvents agent status snapshot integration', () => {
           onLegacyWorkerTerminalRecovery:
             args.onLegacyWorkerTerminalRecovery ?? vi.fn(() => () => {}),
           getSnapshot: args.getSnapshot ?? vi.fn(() => Promise.resolve([])),
+          ...(args.getMigrationUnsupportedSnapshot
+            ? { getMigrationUnsupportedSnapshot: args.getMigrationUnsupportedSnapshot }
+            : {}),
           drop: args.drop ?? vi.fn()
         },
         remoteWorkspace: args.remoteWorkspace
@@ -6136,6 +6254,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
       tabsByWorktree: {},
       workspaceSessionReady: false
     })
+    const setAgentStatuses = vi.mocked(storeState.setAgentStatuses as AppState['setAgentStatuses'])
 
     stubReactSyncEffect()
     vi.doMock('../store', () => ({
@@ -6201,6 +6320,8 @@ describe('useIpcEvents agent status snapshot integration', () => {
     await Promise.resolve()
 
     expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatuses).toHaveBeenCalledTimes(1)
+    expect(setAgentStatuses.mock.calls[0]?.[0]).toHaveLength(1)
     expect(setAgentStatus).toHaveBeenCalledWith(
       FUTURE_PANE_KEY,
       expect.objectContaining({ state: 'working', prompt: 'p', agentType: 'claude' }),
@@ -6211,18 +6332,582 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
+  it('applies a large snapshot with one status and two bounded title publications', async () => {
+    const paneCount = 100
+    const snapshot: AgentStatusSetData[] = []
+    const worktrees: AppState['worktreesByRepo'][string] = []
+    const tabsByWorktree: AppState['tabsByWorktree'] = {}
+    const terminalLayoutsByTabId: AppState['terminalLayoutsByTabId'] = {}
+    for (let index = 0; index < paneCount; index += 1) {
+      const worktreeId = `wt-snapshot-${index}`
+      const tabId = `tab-snapshot-${index}`
+      const leafId = `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+      const paneKey = makePaneKey(tabId, leafId)
+      worktrees.push(makeWorktree({ id: worktreeId, repoId: TEST_REPO.id }))
+      tabsByWorktree[worktreeId] = [
+        makeTab({ id: tabId, worktreeId, title: 'Pi', ptyId: `pty-${index}` })
+      ]
+      terminalLayoutsByTabId[tabId] = {
+        root: { type: 'leaf', leafId },
+        activeLeafId: leafId,
+        expandedLeafId: null
+      }
+      snapshot.push({
+        paneKey,
+        worktreeId,
+        state: 'waiting',
+        prompt: `remote prompt ${index}`,
+        agentType: 'pi',
+        receivedAt: 1_700_000_000_000 + index,
+        stateStartedAt: 1_700_000_000_000 + index
+      })
+    }
+    let resolveSnapshot: ((entries: AgentStatusSetData[]) => void) | undefined
+    const getSnapshot = vi.fn(
+      () =>
+        new Promise<AgentStatusSetData[]>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const store = createTestStore()
+    store.setState({
+      workspaceSessionReady: true,
+      repos: [TEST_REPO],
+      worktreesByRepo: { [TEST_REPO.id]: worktrees },
+      tabsByWorktree,
+      terminalLayoutsByTabId,
+      activeWorktreeId: worktrees[0]?.id ?? null,
+      settings: {
+        ...store.getState().settings,
+        tabAutoGenerateTitle: true,
+        terminalFontSize: 13
+      }
+    } as Partial<AppState>)
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: store.subscribe,
+        getState: store.getState,
+        setState: store.setState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        getSnapshot,
+        onSet: () => () => {}
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+    let relevantPublications = 0
+    const unsubscribe = store.subscribe((state, previousState) => {
+      if (
+        state.agentStatusByPaneKey !== previousState.agentStatusByPaneKey ||
+        state.tabsByWorktree !== previousState.tabsByWorktree
+      ) {
+        relevantPublications += 1
+      }
+    })
+    resolveSnapshot?.(snapshot)
+
+    await vi.waitFor(() => {
+      expect(Object.keys(store.getState().agentStatusByPaneKey)).toHaveLength(paneCount)
+      expect(store.getState().tabsByWorktree['wt-snapshot-99']?.[0]?.title).toBe(
+        'Pi - action required'
+      )
+      expect(store.getState().tabsByWorktree['wt-snapshot-99']?.[0]?.generatedTitle).toBeTruthy()
+    })
+
+    expect(relevantPublications).toBe(3)
+    unsubscribe()
+  })
+
+  it('indexes one 100-pane tab and its split tree once per snapshot', async () => {
+    const paneCount = 100
+    const tabId = 'tab-indexed-snapshot'
+    const worktreeId = 'wt-indexed-snapshot'
+    const leafIds = Array.from(
+      { length: paneCount },
+      (_, index) => `00000000-0000-4000-8001-${String(index).padStart(12, '0')}`
+    )
+    let leafIdLookupCount = 0
+    const leaves = leafIds.map((leafId) => {
+      const leaf = { type: 'leaf' } as TerminalPaneLayoutNode
+      Object.defineProperty(leaf, 'leafId', {
+        enumerable: true,
+        get: () => {
+          leafIdLookupCount += 1
+          return leafId
+        }
+      })
+      return leaf
+    })
+    const root = leaves
+      .slice(1)
+      .reduce<TerminalPaneLayoutNode>(
+        (tree, leaf) => ({ type: 'split', direction: 'vertical', first: tree, second: leaf }),
+        leaves[0]!
+      )
+    let tabIdLookupCount = 0
+    const tab = makeTab({ id: tabId, worktreeId, title: 'Workspace', ptyId: 'pty-indexed' })
+    Object.defineProperty(tab, 'id', {
+      enumerable: true,
+      get: () => {
+        tabIdLookupCount += 1
+        return tabId
+      }
+    })
+    const snapshot = leafIds.map(
+      (leafId, index): AgentStatusSetData => ({
+        paneKey: makePaneKey(tabId, leafId),
+        worktreeId,
+        state: 'working',
+        prompt: `indexed prompt ${index}`,
+        agentType: 'claude',
+        receivedAt: 1_700_000_000_000 + index,
+        stateStartedAt: 1_700_000_000_000 + index
+      })
+    )
+    let resolveSnapshot!: (entries: AgentStatusSetData[]) => void
+    const getSnapshot = vi.fn(
+      () =>
+        new Promise<AgentStatusSetData[]>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const store = createTestStore()
+    store.setState({
+      workspaceSessionReady: true,
+      repos: [TEST_REPO],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: worktreeId, repoId: TEST_REPO.id })]
+      },
+      tabsByWorktree: { [worktreeId]: [tab] },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root,
+          activeLeafId: leafIds[0]!,
+          expandedLeafId: null
+        }
+      },
+      setGeneratedTabTitlesFromAgentPrompts: vi.fn(),
+      settings: { ...store.getState().settings, terminalFontSize: 13 }
+    } as Partial<AppState>)
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: store.subscribe,
+        getState: store.getState,
+        setState: store.setState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal('window', buildWindowApi({ getSnapshot, onSet: () => () => {} }))
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+    tabIdLookupCount = 0
+    leafIdLookupCount = 0
+    resolveSnapshot(snapshot)
+
+    await vi.waitFor(() => {
+      expect(Object.keys(store.getState().agentStatusByPaneKey)).toHaveLength(paneCount)
+    })
+    expect(tabIdLookupCount).toBe(1)
+    expect(leafIdLookupCount).toBe(paneCount)
+  })
+
+  it('indexes 100 distinct tab owners once per snapshot', async () => {
+    const paneCount = 100
+    const worktreeId = 'wt-indexed-tabs'
+    const tabs: AppState['tabsByWorktree'][string] = []
+    const snapshot: AgentStatusSetData[] = []
+    const unsupportedSnapshot: MigrationUnsupportedPtyEntry[] = []
+    let tabIdLookupCount = 0
+    for (let index = 0; index < paneCount; index += 1) {
+      const tabId = `tab-indexed-${index}`
+      const leafId = `00000000-0000-4000-8003-${String(index).padStart(12, '0')}`
+      const tab = makeTab({
+        id: tabId,
+        worktreeId,
+        title: 'Workspace',
+        ptyId: `pty-indexed-${index}`
+      })
+      Object.defineProperty(tab, 'id', {
+        enumerable: true,
+        get: () => {
+          tabIdLookupCount += 1
+          return tabId
+        }
+      })
+      tabs.push(tab)
+      snapshot.push({
+        paneKey: makePaneKey(tabId, leafId),
+        worktreeId,
+        state: 'working',
+        prompt: `indexed tab prompt ${index}`,
+        agentType: 'claude',
+        receivedAt: 1_700_000_000_500 + index,
+        stateStartedAt: 1_700_000_000_500 + index
+      })
+      unsupportedSnapshot.push({
+        ptyId: `pty-indexed-${index}`,
+        worktreeId,
+        tabId,
+        leafId,
+        paneKey: makePaneKey(tabId, leafId),
+        reason: 'legacy-numeric-pane-key',
+        source: 'local',
+        updatedAt: 1_700_000_000_500 + index
+      })
+    }
+    let resolveSnapshot!: (entries: AgentStatusSetData[]) => void
+    const getSnapshot = vi.fn(
+      () =>
+        new Promise<AgentStatusSetData[]>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    let resolveUnsupportedSnapshot!: (entries: MigrationUnsupportedPtyEntry[]) => void
+    const getMigrationUnsupportedSnapshot = vi.fn(
+      () =>
+        new Promise<MigrationUnsupportedPtyEntry[]>((resolve) => {
+          resolveUnsupportedSnapshot = resolve
+        })
+    )
+    const store = createTestStore()
+    store.setState({
+      workspaceSessionReady: true,
+      repos: [TEST_REPO],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: worktreeId, repoId: TEST_REPO.id })]
+      },
+      tabsByWorktree: { [worktreeId]: tabs },
+      terminalLayoutsByTabId: {},
+      setGeneratedTabTitlesFromAgentPrompts: vi.fn(),
+      settings: {
+        ...store.getState().settings,
+        terminalFontSize: 13,
+        tabAutoGenerateTitle: false
+      }
+    } as Partial<AppState>)
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: store.subscribe,
+        getState: store.getState,
+        setState: store.setState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        getSnapshot,
+        getMigrationUnsupportedSnapshot,
+        onSet: () => () => {}
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+    tabIdLookupCount = 0
+    resolveSnapshot(snapshot)
+
+    await vi.waitFor(() => {
+      expect(Object.keys(store.getState().agentStatusByPaneKey)).toHaveLength(paneCount)
+    })
+    expect(tabIdLookupCount).toBe(paneCount)
+    expect(getMigrationUnsupportedSnapshot).toHaveBeenCalledTimes(1)
+
+    tabIdLookupCount = 0
+    resolveUnsupportedSnapshot(unsupportedSnapshot)
+    await vi.waitFor(() => {
+      expect(Object.keys(store.getState().migrationUnsupportedByPtyId)).toHaveLength(paneCount)
+    })
+    expect(tabIdLookupCount).toBe(paneCount)
+  })
+
+  it('preserves inactive, SSH, and folder routing parity in one batch', async () => {
+    type RoutingCase = {
+      tabId: string
+      leafId: string
+      ownerId: string
+      payloadWorktreeId: string
+      connectionId?: string
+      rootless?: boolean
+      expected: boolean
+    }
+    const folderId = 'folder-routing'
+    const folderKey = folderWorkspaceKey(folderId)
+    const cases: RoutingCase[] = [
+      {
+        tabId: 'tab-routing-inactive',
+        leafId: '00000000-0000-4000-8002-000000000001',
+        ownerId: 'wt-routing-local',
+        payloadWorktreeId: 'wt-routing-local',
+        rootless: true,
+        expected: true
+      },
+      {
+        tabId: 'tab-routing-ssh-match',
+        leafId: '00000000-0000-4000-8002-000000000002',
+        ownerId: 'wt-routing-ssh',
+        payloadWorktreeId: 'wt-routing-ssh',
+        connectionId: 'ssh-live',
+        expected: true
+      },
+      {
+        tabId: 'tab-routing-ssh-mismatch',
+        leafId: '00000000-0000-4000-8002-000000000003',
+        ownerId: 'wt-routing-ssh',
+        payloadWorktreeId: 'wt-routing-ssh',
+        connectionId: 'ssh-stale',
+        expected: false
+      },
+      {
+        tabId: 'tab-routing-hydrating',
+        leafId: '00000000-0000-4000-8002-000000000004',
+        ownerId: 'wt-routing-hydrating',
+        payloadWorktreeId: 'wt-routing-hydrating',
+        connectionId: 'ssh-hydrating',
+        expected: true
+      },
+      {
+        tabId: 'tab-routing-hydrating-mismatch',
+        leafId: '00000000-0000-4000-8002-000000000005',
+        ownerId: 'wt-routing-hydrating',
+        payloadWorktreeId: 'wt-routing-other',
+        connectionId: 'ssh-hydrating',
+        expected: false
+      },
+      {
+        tabId: 'tab-routing-folder',
+        leafId: '00000000-0000-4000-8002-000000000006',
+        ownerId: folderKey,
+        payloadWorktreeId: folderKey,
+        connectionId: 'ssh-folder-stale',
+        expected: true
+      }
+    ]
+    const tabsByWorktree: AppState['tabsByWorktree'] = {}
+    const terminalLayoutsByTabId: AppState['terminalLayoutsByTabId'] = {}
+    for (const entry of cases) {
+      ;(tabsByWorktree[entry.ownerId] ??= []).push(
+        makeTab({
+          id: entry.tabId,
+          worktreeId: entry.ownerId,
+          title: 'Workspace',
+          ptyId: `pty-${entry.tabId}`
+        })
+      )
+      terminalLayoutsByTabId[entry.tabId] = {
+        root: entry.rootless ? null : { type: 'leaf', leafId: entry.leafId },
+        activeLeafId: entry.rootless ? null : entry.leafId,
+        expandedLeafId: null
+      }
+    }
+    const snapshot = cases.map(
+      (entry, index): AgentStatusSetData => ({
+        paneKey: makePaneKey(entry.tabId, entry.leafId),
+        worktreeId: entry.payloadWorktreeId,
+        ...(entry.connectionId ? { connectionId: entry.connectionId } : {}),
+        state: 'working',
+        prompt: `routing case ${index}`,
+        agentType: 'claude',
+        receivedAt: 1_700_000_001_000 + index,
+        stateStartedAt: 1_700_000_001_000 + index
+      })
+    )
+    const localRepo = { ...TEST_REPO, id: 'repo-routing-local', connectionId: null }
+    const sshRepo = { ...TEST_REPO, id: 'repo-routing-ssh', connectionId: 'ssh-live' }
+    const store = createTestStore()
+    store.setState({
+      workspaceSessionReady: true,
+      repos: [localRepo, sshRepo],
+      worktreesByRepo: {
+        [localRepo.id]: [makeWorktree({ id: 'wt-routing-local', repoId: localRepo.id })],
+        [sshRepo.id]: [makeWorktree({ id: 'wt-routing-ssh', repoId: sshRepo.id })]
+      },
+      folderWorkspaces: [
+        {
+          id: folderId,
+          projectGroupId: 'group-routing',
+          name: 'Folder routing',
+          folderPath: '/folder-routing',
+          connectionId: 'ssh-folder-live',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 0,
+          lastActivityAt: 0,
+          createdAt: 0,
+          updatedAt: 0
+        }
+      ],
+      tabsByWorktree,
+      terminalLayoutsByTabId,
+      activeWorktreeId: null,
+      settings: { ...store.getState().settings, terminalFontSize: 13 }
+    } as Partial<AppState>)
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: store.subscribe,
+        getState: store.getState,
+        setState: store.setState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({ getSnapshot: vi.fn().mockResolvedValue(snapshot), onSet: () => () => {} })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+
+    await vi.waitFor(() => {
+      expect(
+        cases
+          .filter((entry) => entry.expected)
+          .every(
+            (entry) => store.getState().agentStatusByPaneKey[makePaneKey(entry.tabId, entry.leafId)]
+          )
+      ).toBe(true)
+    })
+    for (const entry of cases) {
+      expect(
+        store.getState().agentStatusByPaneKey[makePaneKey(entry.tabId, entry.leafId)] !== undefined
+      ).toBe(entry.expected)
+    }
+  })
+
+  it('projects ordered tab titles across panes in an inactive split snapshot', async () => {
+    const tabId = 'tab-inactive-split'
+    const worktreeId = 'wt-inactive-split'
+    const waitingPaneKey = makePaneKey(tabId, '00000000-0000-4000-8000-000000000001')
+    const donePaneKey = makePaneKey(tabId, '00000000-0000-4000-8000-000000000002')
+    const getSnapshot = vi.fn().mockResolvedValue([
+      {
+        paneKey: waitingPaneKey,
+        worktreeId,
+        state: 'waiting',
+        prompt: 'waiting turn',
+        agentType: 'pi',
+        receivedAt: 1_700_000_000_000,
+        stateStartedAt: 1_700_000_000_000
+      },
+      {
+        paneKey: donePaneKey,
+        worktreeId,
+        state: 'done',
+        prompt: 'completed turn',
+        agentType: 'pi',
+        receivedAt: 1_700_000_000_001,
+        stateStartedAt: 1_700_000_000_001
+      }
+    ] satisfies AgentStatusSetData[])
+    const store = createTestStore()
+    store.setState({
+      workspaceSessionReady: true,
+      repos: [TEST_REPO],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: worktreeId, repoId: TEST_REPO.id })]
+      },
+      tabsByWorktree: {
+        [worktreeId]: [makeTab({ id: tabId, worktreeId, title: 'My Project' })]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      },
+      activeWorktreeId: null,
+      settings: { ...store.getState().settings, terminalFontSize: 13 }
+    } as Partial<AppState>)
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: store.subscribe,
+        getState: store.getState,
+        setState: store.setState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        getSnapshot,
+        onSet: () => () => {}
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+
+    await vi.waitFor(() => {
+      expect(store.getState().agentStatusByPaneKey[waitingPaneKey]?.state).toBe('waiting')
+      expect(store.getState().agentStatusByPaneKey[donePaneKey]?.state).toBe('done')
+      expect(store.getState().tabsByWorktree[worktreeId]?.[0]?.title).toBe('Pi ready')
+    })
+  })
+
   it('applies a burst leading-edge first, then coalesces the rest into one deferred batch', async () => {
     // Why: each live status event is its own IPC task, so N events used to pay
     // N full render passes (STA-3328 mechanism 2). The leading event must stay
     // synchronous (zero added latency); followers within the burst window must
     // apply together on one later task, in arrival order.
     vi.useFakeTimers()
-    const setAgentStatus = vi.fn()
+    let storeState: StoreLike
+    let publicationCount = 0
+    const applyStatus = (paneKey: string, payload: unknown): void => {
+      storeState.agentStatusByPaneKey = {
+        ...(storeState.agentStatusByPaneKey as Record<string, unknown>),
+        [paneKey]: payload
+      }
+    }
+    const setAgentStatus = vi.fn((paneKey: string, payload: unknown) => {
+      applyStatus(paneKey, payload)
+      publicationCount += 1
+    })
+    const setAgentStatuses = vi.fn((updates: readonly AgentStatusBatchUpdate[]) => {
+      for (const update of updates) {
+        if (update.kind === 'providerSession') {
+          const next = { ...(storeState.agentStatusByPaneKey as Record<string, unknown>) }
+          delete next[update.paneKey]
+          storeState.agentStatusByPaneKey = next
+        } else {
+          applyStatus(update.paneKey, update.payload)
+        }
+      }
+      publicationCount += 1
+      return updates.map(() => true)
+    })
+    const recordAgentProviderSession = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
       current: null
     }
-    const storeState: StoreLike = buildStoreState({
+    storeState = buildStoreState({
       setAgentStatus,
+      setAgentStatuses,
+      recordAgentProviderSession,
       workspaceSessionReady: true,
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
@@ -6235,7 +6920,6 @@ describe('useIpcEvents agent status snapshot integration', () => {
         }
       }
     })
-
     stubReactSyncEffect()
     vi.doMock('../store', () => ({
       useAppStore: {
@@ -6273,15 +6957,275 @@ describe('useIpcEvents agent status snapshot integration', () => {
 
       emit(1_700_000_000_000, 'first')
       expect(setAgentStatus).toHaveBeenCalledTimes(1)
+      expect(publicationCount).toBe(1)
 
       emit(1_700_000_000_001, 'second')
       emit(1_700_000_000_002, 'third')
+      onSetListenerRef.current({
+        paneKey: FUTURE_PANE_KEY,
+        state: 'working',
+        prompt: 'provider identity',
+        agentType: 'pi',
+        providerSession: { key: 'session_id', id: 'pi-session' },
+        providerSessionOnly: true,
+        receivedAt: 1_700_000_000_003,
+        stateStartedAt: 1_700_000_000_003
+      })
       expect(setAgentStatus).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses).not.toHaveBeenCalled()
 
       vi.advanceTimersByTime(40)
-      expect(setAgentStatus).toHaveBeenCalledTimes(3)
-      expect(setAgentStatus.mock.calls[1][1]).toEqual(expect.objectContaining({ prompt: 'second' }))
-      expect(setAgentStatus.mock.calls[2][1]).toEqual(expect.objectContaining({ prompt: 'third' }))
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses.mock.calls[0][0]).toEqual([
+        expect.objectContaining({
+          paneKey: FUTURE_PANE_KEY,
+          payload: expect.objectContaining({ prompt: 'second' })
+        }),
+        expect.objectContaining({
+          paneKey: FUTURE_PANE_KEY,
+          payload: expect.objectContaining({ prompt: 'third' })
+        }),
+        expect.objectContaining({
+          kind: 'providerSession',
+          paneKey: FUTURE_PANE_KEY,
+          agent: 'pi',
+          providerSession: { key: 'session_id', id: 'pi-session' }
+        })
+      ])
+      expect(recordAgentProviderSession).not.toHaveBeenCalled()
+      expect(publicationCount).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a live event enqueued by a synchronous batch subscriber for the next flush', async () => {
+    vi.useFakeTimers()
+    const setAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    let reentered = false
+    const setAgentStatuses = vi.fn((updates: readonly AgentStatusUpdate[]) => {
+      if (!reentered) {
+        reentered = true
+        onSetListenerRef.current?.({
+          paneKey: FUTURE_PANE_KEY,
+          state: 'working',
+          prompt: 'reentered',
+          agentType: 'claude',
+          receivedAt: 1_700_000_000_002,
+          stateStartedAt: 1_700_000_000_002
+        })
+      }
+      return updates.map(() => true)
+    })
+    const storeState = buildStoreState({
+      setAgentStatus,
+      setAgentStatuses,
+      workspaceSessionReady: true,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (callback) => {
+          onSetListenerRef.current = callback
+          return () => {}
+        }
+      })
+    )
+
+    try {
+      const { useIpcEvents } = await import('./useIpcEvents')
+      useIpcEvents()
+      if (!onSetListenerRef.current) {
+        throw new Error('Expected agentStatus.onSet listener to be registered')
+      }
+
+      onSetListenerRef.current({
+        paneKey: FUTURE_PANE_KEY,
+        state: 'working',
+        prompt: 'leading',
+        agentType: 'claude',
+        receivedAt: 1_700_000_000_000,
+        stateStartedAt: 1_700_000_000_000
+      })
+      onSetListenerRef.current({
+        paneKey: FUTURE_PANE_KEY,
+        state: 'working',
+        prompt: 'queued',
+        agentType: 'claude',
+        receivedAt: 1_700_000_000_001,
+        stateStartedAt: 1_700_000_000_001
+      })
+
+      vi.advanceTimersByTime(40)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses.mock.calls[0][0][0].payload.prompt).toBe('queued')
+
+      vi.advanceTimersByTime(40)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(2)
+      expect(setAgentStatuses.mock.calls[1][0][0].payload.prompt).toBe('reentered')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('projects synthetic pane titles across ordered same-pane batch updates', async () => {
+    vi.useFakeTimers()
+    let storeState: StoreLike
+    const applyStatusUpdate = (update: AgentStatusUpdate): void => {
+      storeState.agentStatusByPaneKey = {
+        ...(storeState.agentStatusByPaneKey as Record<string, unknown>),
+        [update.paneKey]: {
+          ...update.payload,
+          updatedAt: update.timing?.updatedAt,
+          providerSession: update.metadata?.providerSession
+        }
+      }
+    }
+    const setAgentStatus = vi.fn(
+      (
+        paneKey: string,
+        payload: AgentStatusUpdate['payload'],
+        terminalTitle?: string,
+        timing?: AgentStatusUpdate['timing'],
+        routing?: AgentStatusUpdate['routing'],
+        metadata?: AgentStatusUpdate['metadata']
+      ) => applyStatusUpdate({ paneKey, payload, terminalTitle, timing, routing, metadata })
+    )
+    const setAgentStatuses = vi.fn((updates: readonly AgentStatusUpdate[]) => {
+      return updates.map((update) => {
+        const existing = (
+          storeState.agentStatusByPaneKey as Record<string, { updatedAt?: number } | undefined>
+        )[update.paneKey]
+        if (
+          existing?.updatedAt !== undefined &&
+          update.timing?.updatedAt !== undefined &&
+          update.timing.updatedAt < existing.updatedAt
+        ) {
+          return false
+        }
+        applyStatusUpdate(update)
+        return true
+      })
+    })
+    const updateTabTitle = vi.fn()
+    const observeAgentHookCompletionForNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    storeState = buildStoreState({
+      setAgentStatus,
+      setAgentStatuses,
+      updateTabTitle,
+      workspaceSessionReady: true,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+    const updateTabTitles = vi.mocked(storeState.updateTabTitles as AppState['updateTabTitles'])
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    vi.doMock('./agent-hook-completion-notifications', () => ({
+      observeAgentHookCompletionForNotification,
+      resetAgentHookCompletionNotificationCoordinators: vi.fn(),
+      syncAgentHookCompletionNotificationsForStoreUpdate: vi.fn()
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (callback) => {
+          onSetListenerRef.current = callback
+          return () => {}
+        }
+      })
+    )
+
+    try {
+      const { useIpcEvents } = await import('./useIpcEvents')
+      useIpcEvents()
+      const onSet = onSetListenerRef.current
+      if (!onSet) {
+        throw new Error('Expected agentStatus.onSet listener to be registered')
+      }
+      const emit = (
+        receivedAt: number,
+        state: AgentStatusSetData['state'],
+        agentType?: string
+      ): void => {
+        onSet({
+          paneKey: FUTURE_PANE_KEY,
+          state,
+          prompt: state,
+          agentType,
+          receivedAt,
+          stateStartedAt: receivedAt
+        })
+      }
+
+      emit(1_700_000_000_000, 'working', 'pi')
+      emit(1_700_000_000_001, 'waiting', 'pi')
+      emit(1_700_000_000_002, 'waiting', 'pi')
+      emit(1_700_000_000_003, 'done', 'pi')
+      emit(1_700_000_000_002, 'waiting', 'pi')
+      vi.advanceTimersByTime(40)
+
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses.mock.calls[0][0]).toEqual([
+        expect.objectContaining({
+          payload: expect.objectContaining({ agentType: 'pi', state: 'waiting' }),
+          terminalTitle: 'Pi - action required'
+        }),
+        expect.objectContaining({
+          payload: expect.objectContaining({ agentType: 'pi', state: 'waiting' }),
+          terminalTitle: 'Pi - action required'
+        }),
+        expect.objectContaining({
+          payload: expect.objectContaining({ agentType: 'pi', state: 'done' }),
+          terminalTitle: 'Pi ready'
+        })
+      ])
+      expect(setAgentStatuses.mock.results[0].value).toEqual([true, true, true])
+      expect(updateTabTitle).toHaveBeenCalledOnce()
+      expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Pi ready')
+      expect(updateTabTitles).toHaveBeenCalledTimes(1)
+      expect(observeAgentHookCompletionForNotification).toHaveBeenCalledTimes(4)
     } finally {
       vi.useRealTimers()
     }
@@ -6290,19 +7234,32 @@ describe('useIpcEvents agent status snapshot integration', () => {
   it('preserves queued set-clear order for working removal and done retention', async () => {
     vi.useFakeTimers()
     let storeState: StoreLike
+    const applyStatusUpdate = (
+      paneKey: string,
+      payload: { state: string },
+      timing: { updatedAt?: number } | undefined
+    ): void => {
+      storeState.agentStatusByPaneKey = {
+        ...(storeState.agentStatusByPaneKey as Record<string, unknown>),
+        [paneKey]: { ...payload, updatedAt: timing?.updatedAt }
+      }
+    }
     const setAgentStatus = vi.fn(
       (
         paneKey: string,
         payload: { state: string },
         _title: unknown,
-        timing: { updatedAt: number }
+        timing: { updatedAt?: number } | undefined
       ) => {
-        storeState.agentStatusByPaneKey = {
-          ...(storeState.agentStatusByPaneKey as Record<string, unknown>),
-          [paneKey]: { ...payload, updatedAt: timing.updatedAt }
-        }
+        applyStatusUpdate(paneKey, payload, timing)
       }
     )
+    const setAgentStatuses = vi.fn((updates: readonly AgentStatusUpdate[]) => {
+      for (const update of updates) {
+        applyStatusUpdate(update.paneKey, update.payload, update.timing)
+      }
+      return updates.map(() => true)
+    })
     const removeAgentStatus = vi.fn((paneKey: string) => {
       const next = { ...(storeState.agentStatusByPaneKey as Record<string, unknown>) }
       delete next[paneKey]
@@ -6316,6 +7273,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     }
     storeState = buildStoreState({
       setAgentStatus,
+      setAgentStatuses,
       removeAgentStatus,
       workspaceSessionReady: true,
       tabsByWorktree: {
@@ -6385,23 +7343,28 @@ describe('useIpcEvents agent status snapshot integration', () => {
       expect(storeState.agentStatusByPaneKey).toEqual({})
 
       vi.advanceTimersByTime(40)
-      expect(setAgentStatus).toHaveBeenCalledTimes(2)
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(1)
       expect(storeState.agentStatusByPaneKey).toEqual({})
 
       emit(1_700_000_000_002, 'task')
       emit(1_700_000_000_003, 'task', 'done')
-      expect(setAgentStatus).toHaveBeenCalledTimes(3)
+      expect(setAgentStatus).toHaveBeenCalledTimes(2)
 
       onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY })
 
-      expect(setAgentStatus).toHaveBeenCalledTimes(4)
-      expect(setAgentStatus.mock.calls[3][1]).toEqual(expect.objectContaining({ state: 'done' }))
+      expect(setAgentStatus).toHaveBeenCalledTimes(2)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(2)
+      expect(setAgentStatuses.mock.calls[1][0][0]).toEqual(
+        expect.objectContaining({ payload: expect.objectContaining({ state: 'done' }) })
+      )
       expect(removeAgentStatus).toHaveBeenCalledTimes(1)
       expect(storeState.agentStatusByPaneKey).toEqual({
         [FUTURE_PANE_KEY]: expect.objectContaining({ state: 'done' })
       })
       vi.advanceTimersByTime(40)
-      expect(setAgentStatus).toHaveBeenCalledTimes(4)
+      expect(setAgentStatus).toHaveBeenCalledTimes(2)
+      expect(setAgentStatuses).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -6503,6 +7466,93 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(() => notify()).not.toThrow()
     // Applied exactly once — the re-entrant flush is a no-op, not a loop.
     expect(setAgentStatusCalls).toBe(1)
+  })
+
+  // Why: the pending queue is spliced before the fold, so a throwing fold would drop every
+  // buffered event permanently. Before batching the queue was only replaced after the loop,
+  // so a throw left it intact — keep that.
+  it('keeps pending statuses queued when the retry fold throws', async () => {
+    const subscribeListenerRef: { current: StoreSubscribeListener | null } = { current: null }
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    let shouldThrow = true
+    const setAgentStatuses = vi.fn((updates: readonly AgentStatusUpdate[]) => {
+      if (shouldThrow) {
+        shouldThrow = false
+        throw new Error('fold blew up')
+      }
+      return updates.map(() => true)
+    })
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus: vi.fn(),
+      setAgentStatuses,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      // Pane does not exist yet -> the incoming event is buffered as pending.
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    })
+    const notify = (): void => subscribeListenerRef.current?.(storeState, storeState)
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          subscribeListenerRef.current = listener
+          return () => {
+            subscribeListenerRef.current = null
+          }
+        }),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'working',
+      prompt: 'buffered',
+      agentType: 'claude',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_700_000_000_100
+    })
+
+    // Tab hydrates, so the next store update flushes the pending event — and throws.
+    storeState.tabsByWorktree = {
+      'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+    }
+    storeState.terminalLayoutsByTabId = {
+      'tab-future': {
+        root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+        activeLeafId: FUTURE_LEAF_ID,
+        expandedLeafId: null
+      }
+    }
+    expect(() => notify()).toThrow('fold blew up')
+
+    // The event must still be queued, so the next flush replays it.
+    notify()
+    const replayedAfterThrow = setAgentStatuses.mock.calls
+      .slice(1)
+      .flatMap((call) => call[0].map((update) => update.payload.prompt))
+    expect(replayedAfterThrow).toContain('buffered')
   })
 
   it('applies ready push events for an unmounted inactive terminal tab', async () => {
@@ -7728,6 +8778,9 @@ describe('useIpcEvents agent status snapshot integration', () => {
         }
       }
     })
+    const setAgentStatusBatch = vi.mocked(
+      storeState.setAgentStatuses as AppState['setAgentStatuses']
+    )
 
     stubReactSyncEffect()
     vi.doMock('../store', () => ({
@@ -7799,6 +8852,8 @@ describe('useIpcEvents agent status snapshot integration', () => {
     subscribeListenerRef.current(storeState, previousStoreState)
 
     expect(setAgentStatus).toHaveBeenCalledTimes(2)
+    expect(setAgentStatusBatch).toHaveBeenCalledTimes(1)
+    expect(setAgentStatusBatch.mock.calls[0]?.[0]).toHaveLength(2)
     expect(setAgentStatus).toHaveBeenNthCalledWith(
       1,
       FUTURE_PANE_KEY,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -153,9 +153,15 @@ import { shouldSuppressCodexAutoApprovalStatus } from '@/components/terminal-pan
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
 import { titleHasAgentName } from '../../../shared/agent-detection'
+import { isDecorativeAgentTitleFrameChange } from '../../../shared/agent-decorative-title-signature'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import { resolveAgentPaneAuthorityKey } from '@/store/slices/agent-pane-authority'
+import type {
+  AgentStatusBatchTransaction,
+  AgentStatusBatchUpdate,
+  AgentStatusUpdate
+} from '@/store/slices/agent-status'
 import { translate } from '@/i18n/i18n'
 import { redactKagiSessionToken } from '../../../shared/browser-url'
 import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
@@ -761,6 +767,27 @@ export function useIpcEvents(): void {
       replay: boolean
     }
     type AgentStatusApplyResult = 'applied' | 'pending' | 'dropped'
+    type ProjectedAgentTabTitles = {
+      title: string | undefined
+      identityTitle: string | undefined
+    }
+    type AgentStatusBatchContext = {
+      transaction: AgentStatusBatchTransaction
+      routingIndex: AgentStatusPaneRoutingIndex
+      projectedTitlesByTabId: Map<string, ProjectedAgentTabTitles>
+      tabTitlesByTabId: Map<string, string>
+      notificationEffects: (() => void)[]
+    }
+    type AgentStatusBatchEvent = {
+      data: AgentStatusIpcPayload
+      replay?: boolean
+      retry?: boolean
+    }
+    type AgentStatusApplyOptions = {
+      replay?: boolean
+      retry?: boolean
+      batch?: AgentStatusBatchContext
+    }
     const pendingAgentStatusEvents: PendingAgentStatusEvent[] = []
     const transientClearWatermarkByConnectionId = new Map<string, number>()
     let agentStatusEffectDisposed = false
@@ -3061,18 +3088,25 @@ export function useIpcEvents(): void {
       isFlushingAgentStatuses = true
       try {
         const now = Date.now()
-        const remaining: PendingAgentStatusEvent[] = []
-        for (const event of pendingAgentStatusEvents) {
-          if (now - event.firstSeenAt > PENDING_AGENT_STATUS_TTL_MS) {
-            continue
-          }
-          const result = applyAgentStatus(event.data, { retry: true, replay: event.replay })
-          if (result === 'pending') {
-            remaining.push(event)
+        const candidates = pendingAgentStatusEvents
+          .splice(0)
+          .filter((event) => now - event.firstSeenAt <= PENDING_AGENT_STATUS_TTL_MS)
+        let results: AgentStatusApplyResult[]
+        try {
+          results = applyAgentStatusBatch(
+            candidates.map((event) => ({ data: event.data, replay: event.replay, retry: true }))
+          )
+        } catch (err) {
+          // Why: the queue was already spliced, so a throwing fold would drop the whole
+          // burst and strand every pane in it. Requeue ahead of newer arrivals and retry.
+          pendingAgentStatusEvents.unshift(...candidates)
+          throw err
+        }
+        for (let index = 0; index < candidates.length; index += 1) {
+          if (results[index] === 'pending') {
+            pendingAgentStatusEvents.push(candidates[index])
           }
         }
-        pendingAgentStatusEvents.length = 0
-        pendingAgentStatusEvents.push(...remaining)
         if (pendingAgentStatusEvents.length === 0 && pendingAgentStatusRetryTimer !== null) {
           globalThis.clearTimeout(pendingAgentStatusRetryTimer)
           pendingAgentStatusRetryTimer = null
@@ -3085,9 +3119,9 @@ export function useIpcEvents(): void {
 
     const applyAgentStatus = (
       data: AgentStatusIpcPayload,
-      options?: { replay?: boolean; retry?: boolean }
+      options?: AgentStatusApplyOptions
     ): AgentStatusApplyResult => {
-      const store = useAppStore.getState()
+      const store = options?.batch?.transaction.getState() ?? useAppStore.getState()
       if (!store.workspaceSessionReady) {
         return 'dropped'
       }
@@ -3120,12 +3154,25 @@ export function useIpcEvents(): void {
         identityTitle,
         repoConnectionId,
         repoConnectionResolved,
-        owningWorktreeId
-      } = resolvePaneKey(store, paneKey)
+        owningWorktreeId,
+        titleUsesTabTitle
+      } = options?.batch
+        ? resolvePaneKeyFromRoutingIndex(options.batch.routingIndex, paneKey)
+        : resolvePaneKey(store, paneKey)
+      const projectedTitles =
+        titleUsesTabTitle && ownerTabId
+          ? options?.batch?.projectedTitlesByTabId.get(ownerTabId)
+          : undefined
+      if (projectedTitles) {
+        title = projectedTitles.title
+        identityTitle = projectedTitles.identityTitle
+      }
       if (!exists && data.worktreeId && hasRuntimeBackedWorktreeAttribution(data)) {
         // Why: orchestration worker hooks may carry worktree attribution before this renderer has a tab for the pane.
         // Require runtime identity too — worktreeId-only snapshots can be stale rows from closed/remounted panes.
-        const fallbackOwnership = resolveWorktreeConnection(store, data.worktreeId)
+        const fallbackOwnership = options?.batch
+          ? resolveWorktreeConnectionFromRoutingIndex(options.batch.routingIndex, data.worktreeId)
+          : resolveWorktreeConnection(store, data.worktreeId)
         if (fallbackOwnership.worktreeExists) {
           owningWorktreeId = data.worktreeId
           repoConnectionId = fallbackOwnership.repoConnectionId
@@ -3163,7 +3210,7 @@ export function useIpcEvents(): void {
           }
         }
       }
-      // Why: drop in-flight events stamped with a dead connection's id after SSH disconnect/reconnect — see docs/design/agent-status-over-ssh.md §5.
+      // Why: drop in-flight events stamped with a dead connection's id after SSH disconnect/reconnect.
       // Why: startup snapshot replay can beat SSH repo hydration; accept when worktreeId matches the tab until repo ownership resolves.
       // Why: WSL relay stamps a `wsl:<distro>` connectionId but the pane is a local repo (ownership null); normalize so the strict check below doesn't drop it.
       const ownershipConnectionId = isWslHookRelayConnectionId(data.connectionId)
@@ -3199,18 +3246,30 @@ export function useIpcEvents(): void {
         if (!data.providerSession || data.agentType !== 'pi') {
           return 'dropped'
         }
-        store.recordAgentProviderSession(
+        const providerSessionUpdate: AgentStatusBatchUpdate = {
+          kind: 'providerSession',
           paneKey,
-          'pi',
-          data.providerSession,
-          { updatedAt: data.receivedAt },
-          {
+          agent: 'pi',
+          providerSession: data.providerSession,
+          timing: { updatedAt: data.receivedAt },
+          routing: {
             tabId: ownerTabId,
             worktreeId: data.worktreeId ?? owningWorktreeId,
             // Why: persist the WSL-normalized ownership id, not raw relay provenance; a `wsl:*` connectionId would misroute later resumes.
             ...(ownershipConnectionId !== undefined ? { connectionId: ownershipConnectionId } : {})
           },
-          data.launchToken ? { launchToken: data.launchToken } : undefined
+          metadata: data.launchToken ? { launchToken: data.launchToken } : undefined
+        }
+        if (options?.batch) {
+          return options.batch.transaction.apply(providerSessionUpdate) ? 'applied' : 'dropped'
+        }
+        store.recordAgentProviderSession(
+          providerSessionUpdate.paneKey,
+          providerSessionUpdate.agent,
+          providerSessionUpdate.providerSession,
+          providerSessionUpdate.timing,
+          providerSessionUpdate.routing,
+          providerSessionUpdate.metadata
         )
         return 'applied'
       }
@@ -3263,39 +3322,75 @@ export function useIpcEvents(): void {
       }
       const terminalTitle = resolveAgentStatusTerminalTitle(statusPayload, title)
       const statusWorktreeId = data.worktreeId ?? owningWorktreeId
-      store.setAgentStatus(
+      const update: AgentStatusUpdate = {
         paneKey,
-        statusPayloadWithProvenance,
+        payload: statusPayloadWithProvenance,
         terminalTitle,
-        {
+        timing: {
           updatedAt: data.receivedAt,
           stateStartedAt: data.stateStartedAt
         },
-        {
+        routing: {
           tabId: ownerTabId,
           worktreeId: statusWorktreeId,
           terminalHandle: data.terminalHandle,
           ...(ownershipConnectionId !== undefined ? { connectionId: ownershipConnectionId } : {})
         },
-        data.providerSession || data.launchToken
-          ? {
-              ...(data.providerSession ? { providerSession: data.providerSession } : {}),
-              ...(data.launchToken ? { launchToken: data.launchToken } : {})
+        metadata:
+          data.providerSession || data.launchToken
+            ? {
+                ...(data.providerSession ? { providerSession: data.providerSession } : {}),
+                ...(data.launchToken ? { launchToken: data.launchToken } : {})
+              }
+            : undefined
+      }
+      const applyPostCommitNotification = (): void => {
+        if (options?.replay !== true && statusWorktreeId) {
+          // Why: local Codex/Claude hooks arrive via this main-process IPC path, not the PTY OSC fallback, so task-complete notifications must observe accepted hook state here too.
+          const notificationPayload =
+            typeof data.stateStartedAt === 'number'
+              ? { ...resolvedPayload, stateStartedAt: data.stateStartedAt }
+              : resolvedPayload
+          observeAgentHookCompletionForNotification({
+            paneKey,
+            worktreeId: statusWorktreeId,
+            payload: notificationPayload
+          })
+        }
+      }
+      if (options?.batch) {
+        if (!options.batch.transaction.apply(update)) {
+          return 'dropped'
+        }
+        options.batch.notificationEffects.push(applyPostCommitNotification)
+        if (
+          terminalTitle &&
+          shouldApplyResolvedAgentTerminalTitleToTab(store, paneKey, title, terminalTitle)
+        ) {
+          const tabId = parsePaneKey(paneKey)?.tabId
+          if (tabId) {
+            options.batch.tabTitlesByTabId.set(tabId, terminalTitle)
+            if (titleUsesTabTitle) {
+              const titleChanges =
+                !title || !isDecorativeAgentTitleFrameChange(title, terminalTitle)
+              options.batch.projectedTitlesByTabId.set(tabId, {
+                title: titleChanges ? terminalTitle : title,
+                identityTitle: titleChanges ? terminalTitle : identityTitle
+              })
             }
-          : undefined
-      )
-      applyResolvedAgentTerminalTitleToTab(store, paneKey, title, terminalTitle)
-      if (options?.replay !== true && statusWorktreeId) {
-        // Why: local Codex/Claude hooks arrive via this main-process IPC path, not the PTY OSC fallback, so task-complete notifications must observe accepted hook state here too.
-        const notificationPayload =
-          typeof data.stateStartedAt === 'number'
-            ? { ...resolvedPayload, stateStartedAt: data.stateStartedAt }
-            : resolvedPayload
-        observeAgentHookCompletionForNotification({
-          paneKey,
-          worktreeId: statusWorktreeId,
-          payload: notificationPayload
-        })
+          }
+        }
+      } else {
+        store.setAgentStatus(
+          update.paneKey,
+          update.payload,
+          update.terminalTitle,
+          update.timing,
+          update.routing,
+          update.metadata
+        )
+        applyResolvedAgentTerminalTitleToTab(useAppStore.getState(), paneKey, title, terminalTitle)
+        applyPostCommitNotification()
       }
       return 'applied'
     }
@@ -3326,9 +3421,7 @@ export function useIpcEvents(): void {
           if (!current.workspaceSessionReady) {
             return
           }
-          for (const entry of entries) {
-            applyAgentStatus(entry, { replay: true })
-          }
+          applyAgentStatusBatch(entries.map((data) => ({ data, replay: true })))
           const getMigrationUnsupportedSnapshot =
             window.api.agentStatus.getMigrationUnsupportedSnapshot
           if (typeof getMigrationUnsupportedSnapshot !== 'function') {
@@ -3342,8 +3435,12 @@ export function useIpcEvents(): void {
             if (!unsupportedStore.workspaceSessionReady) {
               return
             }
+            const unsupportedRoutingIndex = createAgentStatusPaneRoutingIndex(unsupportedStore)
             for (const entry of unsupportedEntries) {
-              if (entry.paneKey && resolvePaneKey(unsupportedStore, entry.paneKey).exists) {
+              if (
+                entry.paneKey &&
+                resolvePaneKeyFromRoutingIndex(unsupportedRoutingIndex, entry.paneKey).exists
+              ) {
                 unsupportedStore.setMigrationUnsupportedPty(entry)
               }
             }
@@ -3355,19 +3452,51 @@ export function useIpcEvents(): void {
         })
     }
 
+    function applyAgentStatusBatch(
+      events: readonly AgentStatusBatchEvent[]
+    ): AgentStatusApplyResult[] {
+      if (events.length === 0) {
+        return []
+      }
+      return useAppStore.getState().transactAgentStatuses((transaction) => {
+        const batch: AgentStatusBatchContext = {
+          transaction,
+          routingIndex: createAgentStatusPaneRoutingIndex(transaction.getState()),
+          projectedTitlesByTabId: new Map(),
+          tabTitlesByTabId: new Map(),
+          notificationEffects: []
+        }
+        const results = events.map(({ data, replay, retry }) =>
+          applyAgentStatus(data, { batch, replay, retry })
+        )
+        if (batch.tabTitlesByTabId.size > 0) {
+          transaction.afterCommit(() => {
+            useAppStore
+              .getState()
+              .updateTabTitles(
+                [...batch.tabTitlesByTabId].map(([tabId, title]) => ({ tabId, title }))
+              )
+          })
+        }
+        for (const effect of batch.notificationEffects) {
+          transaction.afterCommit(effect)
+        }
+        return results
+      })
+    }
+
+    function applyLiveAgentStatusBatch(batch: readonly AgentStatusIpcPayload[]): boolean {
+      return applyAgentStatusBatch(batch.map((data) => ({ data }))).some(
+        (result) => result === 'applied'
+      )
+    }
+
     function flushLiveAgentStatusBurst(): void {
       liveAgentStatusBurstTimer = null
       lastLiveAgentStatusApplyAt = Date.now()
-      // Why: splice before applying — applyAgentStatus can synchronously
-      // re-enter the queue via subscribers, and it must not see this batch.
+      // Why: splice before publishing — synchronous Zustand subscribers can enqueue the next burst.
       const batch = liveAgentStatusBurstQueue.splice(0)
-      let anyApplied = false
-      for (const data of batch) {
-        if (applyAgentStatus(data) === 'applied') {
-          anyApplied = true
-        }
-      }
-      if (!anyApplied) {
+      if (!applyLiveAgentStatusBatch(batch)) {
         lastLiveAgentStatusApplyAt = 0
       }
     }
@@ -3384,9 +3513,7 @@ export function useIpcEvents(): void {
       }
       liveAgentStatusBurstQueue.length = 0
       liveAgentStatusBurstQueue.push(...remaining)
-      for (const queued of queuedForPane) {
-        applyAgentStatus(queued)
-      }
+      applyLiveAgentStatusBatch(queuedForPane)
     }
 
     function enqueueLiveAgentStatus(data: AgentStatusIpcPayload): void {
@@ -3705,25 +3832,194 @@ function applyResolvedAgentTerminalTitleToTab(
   previousTitle: string | undefined,
   nextTitle: string | undefined
 ): void {
-  if (!nextTitle || nextTitle === previousTitle) {
+  if (
+    !nextTitle ||
+    !shouldApplyResolvedAgentTerminalTitleToTab(store, paneKey, previousTitle, nextTitle)
+  ) {
     return
   }
   const parsed = parsePaneKey(paneKey)
   if (!parsed) {
     return
   }
-  const layout = store.terminalLayoutsByTabId?.[parsed.tabId]
-  if (layout?.root && layout.activeLeafId && layout.activeLeafId !== parsed.leafId) {
-    return
-  }
   // Why: hook completion can arrive while the pane transport is unmounted; keep the tab label synced to the resolved state title.
   store.updateTabTitle(parsed.tabId, nextTitle)
 }
 
+function shouldApplyResolvedAgentTerminalTitleToTab(
+  store: ReturnType<typeof useAppStore.getState>,
+  paneKey: string,
+  previousTitle: string | undefined,
+  nextTitle: string | undefined
+): boolean {
+  if (!nextTitle || nextTitle === previousTitle) {
+    return false
+  }
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return false
+  }
+  const layout = store.terminalLayoutsByTabId?.[parsed.tabId]
+  if (layout?.root && layout.activeLeafId && layout.activeLeafId !== parsed.leafId) {
+    return false
+  }
+  return true
+}
+
+type AgentStatusPaneResolution = {
+  exists: boolean
+  title: string | undefined
+  identityTitle: string | undefined
+  repoConnectionId: string | null
+  repoConnectionResolved: boolean
+  owningWorktreeId: string | undefined
+  titleUsesTabTitle: boolean
+}
+
+type AgentStatusWorktreeConnectionResolution = {
+  worktreeExists: boolean
+  repoConnectionId: string | null
+  repoConnectionResolved: boolean
+}
+
+type IndexedAgentStatusTab = {
+  title: string | undefined
+  unifiedLabel: string | undefined
+  owningWorktreeId: string
+}
+
+type AgentStatusPaneRoutingIndex = {
+  tabsById: Map<string, IndexedAgentStatusTab>
+  layoutsByTabId: AppState['terminalLayoutsByTabId']
+  leafIdsByRoot: WeakMap<TerminalPaneLayoutNode, Set<string>>
+  worktreesById: ReturnType<typeof getWorktreeMapFromState>
+  reposById: ReturnType<typeof getRepoMapFromState>
+}
+
+function createUnifiedTerminalLabelIndex(
+  entries: AppState['unifiedTabsByWorktree'][string] | undefined
+): Map<string, string | undefined> {
+  const labelsByTabId = new Map<string, string | undefined>()
+  for (const entry of entries ?? []) {
+    if (entry.contentType !== 'terminal' || labelsByTabId.has(entry.entityId)) {
+      continue
+    }
+    const rawLabel = entry.label?.trim()
+    labelsByTabId.set(entry.entityId, rawLabel && rawLabel.length > 0 ? rawLabel : undefined)
+  }
+  return labelsByTabId
+}
+
+function createAgentStatusPaneRoutingIndex(
+  store: ReturnType<typeof useAppStore.getState>
+): AgentStatusPaneRoutingIndex {
+  const tabsById = new Map<string, IndexedAgentStatusTab>()
+  for (const [worktreeId, tabs] of Object.entries(store.tabsByWorktree)) {
+    const unifiedLabelsByTabId = createUnifiedTerminalLabelIndex(
+      store.unifiedTabsByWorktree?.[worktreeId]
+    )
+    for (const tab of tabs) {
+      const tabId = tab.id
+      if (!tabsById.has(tabId)) {
+        tabsById.set(tabId, {
+          title: tab.title,
+          unifiedLabel: unifiedLabelsByTabId.get(tabId),
+          owningWorktreeId: worktreeId
+        })
+      }
+    }
+  }
+  return {
+    tabsById,
+    layoutsByTabId: store.terminalLayoutsByTabId,
+    leafIdsByRoot: new WeakMap(),
+    worktreesById: getWorktreeMapFromState(store),
+    reposById: getRepoMapFromState(store)
+  }
+}
+
+function resolveWorktreeConnectionFromRoutingIndex(
+  index: AgentStatusPaneRoutingIndex,
+  worktreeId: string
+): AgentStatusWorktreeConnectionResolution {
+  const worktree = index.worktreesById.get(worktreeId)
+  if (!worktree) {
+    return { worktreeExists: false, repoConnectionId: null, repoConnectionResolved: false }
+  }
+  const repo = index.reposById.get(worktree.repoId)
+  return {
+    worktreeExists: true,
+    repoConnectionId: repo?.connectionId ?? null,
+    repoConnectionResolved: repo !== undefined
+  }
+}
+
+function resolvePaneKeyFromRoutingIndex(
+  index: AgentStatusPaneRoutingIndex,
+  paneKey: string
+): AgentStatusPaneResolution {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return {
+      exists: false,
+      title: undefined,
+      identityTitle: undefined,
+      repoConnectionId: null,
+      repoConnectionResolved: false,
+      owningWorktreeId: undefined,
+      titleUsesTabTitle: false
+    }
+  }
+  const { tabId, leafId } = parsed
+  const tab = index.tabsById.get(tabId)
+  if (!tab) {
+    return {
+      exists: false,
+      title: undefined,
+      identityTitle: undefined,
+      repoConnectionId: null,
+      repoConnectionResolved: false,
+      owningWorktreeId: undefined,
+      titleUsesTabTitle: false
+    }
+  }
+  const connection = resolveWorktreeConnectionFromRoutingIndex(index, tab.owningWorktreeId)
+  const layout = index.layoutsByTabId?.[tabId]
+  if (layout?.root) {
+    let leafIds = index.leafIdsByRoot.get(layout.root)
+    if (!leafIds) {
+      leafIds = new Set(collectLeafIdsInOrder(layout.root))
+      index.leafIdsByRoot.set(layout.root, leafIds)
+    }
+    if (!leafIds.has(leafId)) {
+      return {
+        exists: false,
+        title: undefined,
+        identityTitle: undefined,
+        repoConnectionId: connection.repoConnectionId,
+        repoConnectionResolved: connection.repoConnectionResolved,
+        owningWorktreeId: tab.owningWorktreeId,
+        titleUsesTabTitle: false
+      }
+    }
+  }
+  const rawPaneTitle = layout?.titlesByLeafId?.[leafId]
+  const paneTitle = rawPaneTitle && rawPaneTitle.length > 0 ? rawPaneTitle : undefined
+  return {
+    exists: true,
+    title: paneTitle ?? tab.title,
+    identityTitle: paneTitle ?? tab.unifiedLabel ?? tab.title,
+    repoConnectionId: connection.repoConnectionId,
+    repoConnectionResolved: connection.repoConnectionResolved,
+    owningWorktreeId: tab.owningWorktreeId,
+    titleUsesTabTitle: paneTitle === undefined
+  }
+}
+
 /** Resolve a paneKey (tabId:leafId) to liveness, current title, owning worktree,
  *  and the owning repo's connectionId. Used for agent-type inference and to drop
- *  status updates for torn-down tabs or dead connections
- *  (see docs/design/agent-status-over-ssh.md §5). */
+ *  status updates for torn-down tabs or dead connections (an SSH reconnect retires the
+ *  old connectionId, so events still in flight under it must not land). */
 function resolvePaneKey(
   store: ReturnType<typeof useAppStore.getState>,
   paneKey: string
@@ -3734,6 +4030,7 @@ function resolvePaneKey(
   repoConnectionId: string | null
   repoConnectionResolved: boolean
   owningWorktreeId: string | undefined
+  titleUsesTabTitle: boolean
 } {
   const parsed = parsePaneKey(paneKey)
   if (!parsed) {
@@ -3743,7 +4040,8 @@ function resolvePaneKey(
       identityTitle: undefined,
       repoConnectionId: null,
       repoConnectionResolved: false,
-      owningWorktreeId: undefined
+      owningWorktreeId: undefined,
+      titleUsesTabTitle: false
     }
   }
   const { tabId, leafId } = parsed
@@ -3789,7 +4087,8 @@ function resolvePaneKey(
       identityTitle: undefined,
       repoConnectionId,
       repoConnectionResolved,
-      owningWorktreeId
+      owningWorktreeId,
+      titleUsesTabTitle: false
     }
   }
   // Why: an empty layout snapshot from a worktree switch (tab/PTY still live) counts as missing metadata; a non-empty layout lacking the leaf still means closed.
@@ -3801,7 +4100,8 @@ function resolvePaneKey(
       identityTitle: undefined,
       repoConnectionId,
       repoConnectionResolved,
-      owningWorktreeId
+      owningWorktreeId,
+      titleUsesTabTitle: false
     }
   }
   // Why: inactive worktrees can have a durable tab and live PTY while the layout is unmounted; hook state must still land there.
@@ -3815,7 +4115,8 @@ function resolvePaneKey(
     identityTitle: paneTitle ?? unifiedTabLabel ?? tabTitle,
     repoConnectionId,
     repoConnectionResolved,
-    owningWorktreeId
+    owningWorktreeId,
+    titleUsesTabTitle: paneTitle === undefined
   }
 }
 

--- a/src/renderer/src/store/slices/agent-status-batch.test.ts
+++ b/src/renderer/src/store/slices/agent-status-batch.test.ts
@@ -1,0 +1,506 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import type { AppState } from '../types'
+import {
+  MAX_LIVE_AGENT_STATUSES,
+  type AgentStatusBatchUpdate,
+  type RetainedAgentEntry
+} from './agent-status'
+import type { GeneratedTabTitleUpdate } from './terminal-tab-title-batch'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+const BASE_TIME = 2_000_000
+const FIRST_PANE = 'tab-1:11111111-1111-4111-8111-111111111111'
+const SECOND_PANE = 'tab-1:22222222-2222-4222-8222-222222222222'
+const PROVIDER_SESSION = {
+  key: 'session_id' as const,
+  id: 'pi-session-1',
+  transcriptPath: '/tmp/pi-session-1.jsonl'
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve))
+}
+
+function seedBatchStore() {
+  const store = createTestStore()
+  const tab = makeTab({ id: 'tab-1', worktreeId: 'wt-1', title: 'pi' })
+  const retainedEntry: AgentStatusEntry = {
+    paneKey: FIRST_PANE,
+    state: 'done',
+    prompt: 'old turn',
+    agentType: 'pi',
+    updatedAt: BASE_TIME - 100,
+    stateStartedAt: BASE_TIME - 200,
+    stateHistory: []
+  }
+  const retained: RetainedAgentEntry = {
+    entry: retainedEntry,
+    worktreeId: 'wt-1',
+    tab,
+    agentType: 'pi',
+    startedAt: BASE_TIME - 200
+  }
+  store.setState({
+    tabsByWorktree: { 'wt-1': [tab] },
+    retainedAgentsByPaneKey: { [FIRST_PANE]: retained },
+    retentionSuppressedPaneKeys: { [FIRST_PANE]: true },
+    refreshGitHubForWorktreeIfStale: vi.fn().mockResolvedValue(undefined)
+  } as Partial<AppState>)
+  return store
+}
+
+function makeUpdates(): AgentStatusBatchUpdate[] {
+  return [
+    {
+      paneKey: FIRST_PANE,
+      payload: { state: 'working', prompt: 'first turn', agentType: 'pi' },
+      terminalTitle: 'Pi',
+      timing: { updatedAt: BASE_TIME, stateStartedAt: BASE_TIME },
+      routing: { tabId: 'tab-1', worktreeId: 'wt-1', terminalHandle: 'pty-1' },
+      metadata: { providerSession: PROVIDER_SESSION }
+    },
+    {
+      paneKey: FIRST_PANE,
+      payload: {
+        state: 'waiting',
+        prompt: 'first turn',
+        agentType: 'pi',
+        toolName: 'AskUserQuestion'
+      },
+      timing: { updatedAt: BASE_TIME + 1, stateStartedAt: BASE_TIME + 1 }
+    },
+    {
+      paneKey: FIRST_PANE,
+      payload: {
+        state: 'done',
+        prompt: 'first turn',
+        agentType: 'pi',
+        lastAssistantMessage: 'Finished.'
+      },
+      timing: { updatedAt: BASE_TIME + 2, stateStartedAt: BASE_TIME + 2 }
+    },
+    {
+      paneKey: FIRST_PANE,
+      payload: { state: 'working', prompt: 'second turn', agentType: 'pi' },
+      timing: { updatedAt: BASE_TIME + 3, stateStartedAt: BASE_TIME + 3 }
+    },
+    {
+      paneKey: FIRST_PANE,
+      payload: { state: 'done', prompt: 'late first turn', agentType: 'pi' },
+      timing: { updatedAt: BASE_TIME + 2, stateStartedAt: BASE_TIME + 2 }
+    },
+    {
+      kind: 'providerSession',
+      paneKey: SECOND_PANE,
+      agent: 'pi',
+      providerSession: PROVIDER_SESSION,
+      timing: { updatedAt: BASE_TIME + 4 },
+      routing: { tabId: 'tab-1', worktreeId: 'wt-1' }
+    },
+    {
+      paneKey: SECOND_PANE,
+      payload: { state: 'working', prompt: 'provider turn', agentType: 'pi' },
+      timing: { updatedAt: BASE_TIME + 5, stateStartedAt: BASE_TIME + 5 },
+      routing: { tabId: 'tab-1', worktreeId: 'wt-1' },
+      metadata: { providerSession: PROVIDER_SESSION }
+    }
+  ]
+}
+
+function selectBatchState(state: AppState) {
+  return {
+    agentStatusByPaneKey: state.agentStatusByPaneKey,
+    retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
+    sleepingAgentSessionsByPaneKey: state.sleepingAgentSessionsByPaneKey,
+    agentLaunchConfigByPaneKey: state.agentLaunchConfigByPaneKey,
+    migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
+    retentionSuppressedPaneKeys: state.retentionSuppressedPaneKeys,
+    agentStatusEpoch: state.agentStatusEpoch,
+    sortEpoch: state.sortEpoch
+  }
+}
+
+describe('setAgentStatuses', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('matches sequential updates across repeated panes and provider-session records', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BASE_TIME + 10)
+    const sequentialStore = seedBatchStore()
+    const batchStore = seedBatchStore()
+    const sequentialTitleGeneration = vi.fn()
+    const batchTitleGeneration = vi.fn()
+    const batchTitleGenerationBulk = vi.fn((updates: readonly GeneratedTabTitleUpdate[]) => {
+      for (const update of updates) {
+        if (update.options) {
+          batchTitleGeneration(update.paneKey, update.prompt, update.options)
+        } else {
+          batchTitleGeneration(update.paneKey, update.prompt)
+        }
+      }
+    })
+    sequentialStore.setState({
+      setGeneratedTabTitleFromAgentPrompt: sequentialTitleGeneration
+    } as Partial<AppState>)
+    batchStore.setState({
+      setGeneratedTabTitlesFromAgentPrompts: batchTitleGenerationBulk
+    } as Partial<AppState>)
+    const updates = makeUpdates()
+
+    for (const update of updates) {
+      if (update.kind === 'providerSession') {
+        sequentialStore
+          .getState()
+          .recordAgentProviderSession(
+            update.paneKey,
+            update.agent,
+            update.providerSession,
+            update.timing,
+            update.routing,
+            update.metadata
+          )
+      } else {
+        sequentialStore
+          .getState()
+          .setAgentStatus(
+            update.paneKey,
+            update.payload,
+            update.terminalTitle,
+            update.timing,
+            update.routing,
+            update.metadata
+          )
+      }
+    }
+    const outcomes = batchStore.getState().setAgentStatuses(updates)
+
+    expect(outcomes).toEqual([true, true, true, true, false, true, true])
+    expect(selectBatchState(batchStore.getState())).toEqual(
+      selectBatchState(sequentialStore.getState())
+    )
+    expect(
+      batchStore.getState().agentStatusByPaneKey[FIRST_PANE].stateHistory.at(-1)
+    ).toMatchObject({ state: 'done' })
+    // The swallowed `done`'s output survives on the entry, not on the history row.
+    expect(
+      batchStore.getState().agentStatusByPaneKey[FIRST_PANE].lastCompletedAssistantMessage
+    ).toBe('Finished.')
+    expect(batchTitleGeneration.mock.calls).toEqual(sequentialTitleGeneration.mock.calls)
+    expect(batchTitleGeneration).toHaveBeenCalledTimes(5)
+    expect(batchTitleGenerationBulk).toHaveBeenCalledOnce()
+    await flushMicrotasks()
+    expect(batchStore.getState().refreshGitHubForWorktreeIfStale).toHaveBeenCalledTimes(1)
+    expect(sequentialStore.getState().refreshGitHubForWorktreeIfStale).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
+    expect(selectBatchState(batchStore.getState())).toEqual(
+      selectBatchState(sequentialStore.getState())
+    )
+  })
+
+  it('publishes once and reports skipped ordered updates', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BASE_TIME + 10)
+    const store = seedBatchStore()
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    const outcomes = store.getState().setAgentStatuses(makeUpdates())
+
+    expect(outcomes).toEqual([true, true, true, true, false, true, true])
+    expect(publications).toBe(1)
+    expect(store.getState().setAgentStatuses([])).toEqual([])
+    expect(publications).toBe(1)
+    unsubscribe()
+  })
+
+  it('coalesces 100 generated tab titles into one post-status publication', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BASE_TIME + 10)
+    const store = createTestStore()
+    const paneCount = 100
+    const tabsByWorktree = Object.fromEntries(
+      Array.from({ length: paneCount }, (_, index) => {
+        const worktreeId = `wt-${index}`
+        return [worktreeId, [makeTab({ id: `tab-${index}`, worktreeId })]]
+      })
+    )
+    store.setState({
+      settings: { ...store.getState().settings, tabAutoGenerateTitle: true },
+      tabsByWorktree
+    } as Partial<AppState>)
+    const updates: AgentStatusBatchUpdate[] = Array.from({ length: paneCount }, (_, index) => ({
+      paneKey: `tab-${index}:11111111-1111-4111-8111-111111111111`,
+      payload: {
+        state: 'working',
+        prompt: `Refactor remote startup module ${index}`,
+        agentType: 'pi'
+      },
+      timing: { updatedAt: BASE_TIME + index, stateStartedAt: BASE_TIME + index },
+      routing: { tabId: `tab-${index}`, worktreeId: `wt-${index}` }
+    }))
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    const outcomes = store.getState().setAgentStatuses(updates)
+
+    unsubscribe()
+    expect(outcomes).toEqual(Array(paneCount).fill(true))
+    expect(publications).toBe(2)
+    expect(store.getState().tabsByWorktree['wt-99']?.[0]?.generatedTitle).toBe(
+      'Refactor remote startup module 99'
+    )
+  })
+
+  it('coalesces batch freshness requests while preserving standalone scheduling', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BASE_TIME + 10)
+    const store = seedBatchStore()
+    const queueMicrotaskSpy = vi.spyOn(globalThis, 'queueMicrotask')
+    const workingUpdate = (updatedAt: number, prompt: string): AgentStatusBatchUpdate => ({
+      paneKey: FIRST_PANE,
+      payload: { state: 'working', prompt, agentType: 'pi' },
+      timing: { updatedAt, stateStartedAt: updatedAt },
+      routing: { tabId: 'tab-1', worktreeId: 'wt-1' }
+    })
+
+    const outcomes = store
+      .getState()
+      .setAgentStatuses([
+        workingUpdate(BASE_TIME, 'first'),
+        workingUpdate(BASE_TIME + 1, 'second'),
+        workingUpdate(BASE_TIME + 2, 'third'),
+        workingUpdate(BASE_TIME + 1, 'stale')
+      ])
+
+    expect(outcomes).toEqual([true, true, true, false])
+    expect(queueMicrotaskSpy).toHaveBeenCalledTimes(1)
+
+    queueMicrotaskSpy.mockClear()
+    store
+      .getState()
+      .setAgentStatus(
+        FIRST_PANE,
+        { state: 'working', prompt: 'standalone', agentType: 'pi' },
+        undefined,
+        { updatedAt: BASE_TIME + 3, stateStartedAt: BASE_TIME + 3 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        FIRST_PANE,
+        { state: 'working', prompt: 'standalone stale', agentType: 'pi' },
+        undefined,
+        { updatedAt: BASE_TIME + 2, stateStartedAt: BASE_TIME + 2 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' }
+      )
+
+    expect(queueMicrotaskSpy).toHaveBeenCalledTimes(2)
+    await flushMicrotasks()
+  })
+
+  it('shares freshness across nested folds but isolates synchronous reentrant transactions', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BASE_TIME + 10)
+    const store = seedBatchStore()
+    const queueMicrotaskSpy = vi.spyOn(globalThis, 'queueMicrotask')
+    const update = (paneKey: string, updatedAt: number): AgentStatusBatchUpdate => ({
+      paneKey,
+      payload: { state: 'working', prompt: paneKey, agentType: 'pi' },
+      timing: { updatedAt, stateStartedAt: updatedAt },
+      routing: { tabId: 'tab-1', worktreeId: 'wt-1' }
+    })
+    let publications = 0
+    const unsubscribeNested = store.subscribe(() => {
+      publications += 1
+    })
+
+    const nestedOutcomes = store
+      .getState()
+      .transactAgentStatuses((transaction) => [
+        transaction.apply(update(FIRST_PANE, BASE_TIME)),
+        store
+          .getState()
+          .transactAgentStatuses((nestedTransaction) =>
+            nestedTransaction.apply(update(SECOND_PANE, BASE_TIME + 1))
+          )
+      ])
+
+    expect(nestedOutcomes).toEqual([true, true])
+    expect(publications).toBe(1)
+    expect(queueMicrotaskSpy).toHaveBeenCalledTimes(1)
+    unsubscribeNested()
+
+    queueMicrotaskSpy.mockClear()
+    let reentered = false
+    const unsubscribeReentrant = store.subscribe(() => {
+      publications += 1
+      if (!reentered) {
+        reentered = true
+        store.getState().setAgentStatuses([update(SECOND_PANE, BASE_TIME + 3)])
+      }
+    })
+
+    store.getState().setAgentStatuses([update(FIRST_PANE, BASE_TIME + 2)])
+
+    expect(publications).toBe(3)
+    expect(queueMicrotaskSpy).toHaveBeenCalledTimes(2)
+    expect(store.getState().agentStatusByPaneKey[FIRST_PANE]?.updatedAt).toBe(BASE_TIME + 2)
+    expect(store.getState().agentStatusByPaneKey[SECOND_PANE]?.updatedAt).toBe(BASE_TIME + 3)
+    unsubscribeReentrant()
+    await flushMicrotasks()
+  })
+
+  it('exposes cap evictions to later updates in the same transaction', () => {
+    const store = seedBatchStore()
+    const firstPane = 'orphan-tab:orphan-0'
+    const entries = Object.fromEntries(
+      Array.from({ length: MAX_LIVE_AGENT_STATUSES }, (_, index) => {
+        const paneKey = `orphan-tab:orphan-${index}`
+        return [
+          paneKey,
+          {
+            paneKey,
+            state: 'working',
+            prompt: 'old turn',
+            agentType: 'pi',
+            updatedAt: BASE_TIME,
+            stateStartedAt: BASE_TIME,
+            stateHistory: []
+          } satisfies AgentStatusEntry
+        ]
+      })
+    )
+    store.setState({ agentStatusByPaneKey: entries } as Partial<AppState>)
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    const outcomes = store.getState().transactAgentStatuses((transaction) => {
+      const added = transaction.apply({
+        paneKey: 'orphan-tab:new-pane',
+        payload: { state: 'working', prompt: 'new turn', agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME + 1, stateStartedAt: BASE_TIME + 1 }
+      })
+      expect(transaction.getState().agentStatusByPaneKey[firstPane]).toBeUndefined()
+      const completed = transaction.apply({
+        paneKey: firstPane,
+        payload: { state: 'done', prompt: 'different agent', agentType: 'claude' },
+        timing: { updatedAt: BASE_TIME + 2, stateStartedAt: BASE_TIME + 2 }
+      })
+      return [added, completed]
+    })
+
+    expect(outcomes).toEqual([true, true])
+    expect(store.getState().agentStatusByPaneKey[firstPane]).toMatchObject({
+      agentType: 'claude',
+      state: 'done'
+    })
+    expect(publications).toBe(1)
+    unsubscribe()
+  })
+
+  it('preserves a store write that bypassed the transaction instead of reverting it', () => {
+    const store = seedBatchStore()
+
+    const outcome = store.getState().transactAgentStatuses((transaction) => {
+      const applied = transaction.apply({
+        paneKey: FIRST_PANE,
+        payload: { state: 'working', prompt: 'first turn', agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME, stateStartedAt: BASE_TIME }
+      })
+      // Any slice action reached through get() writes straight to the real store — a
+      // REPLACE commit of the fold's snapshot would silently revert it.
+      store.setState({ worktreesByRepo: { 'repo-late': [] } } as Partial<AppState>)
+      return applied
+    })
+
+    expect(outcome).toBe(true)
+    expect(store.getState().worktreesByRepo).toEqual({ 'repo-late': [] })
+    expect(store.getState().agentStatusByPaneKey[FIRST_PANE]).toMatchObject({ state: 'working' })
+  })
+
+  it('keeps one completed-turn message per entry instead of one per history row', () => {
+    const store = seedBatchStore()
+    const turns: AgentStatusBatchUpdate[] = []
+    for (let turn = 0; turn < 5; turn += 1) {
+      turns.push({
+        paneKey: FIRST_PANE,
+        payload: { state: 'working', prompt: `turn ${turn}`, agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME + turn * 2, stateStartedAt: BASE_TIME + turn * 2 }
+      })
+      turns.push({
+        paneKey: FIRST_PANE,
+        payload: {
+          state: 'done',
+          prompt: `turn ${turn}`,
+          agentType: 'pi',
+          lastAssistantMessage: `output ${turn}`
+        },
+        timing: { updatedAt: BASE_TIME + turn * 2 + 1, stateStartedAt: BASE_TIME + turn * 2 + 1 }
+      })
+    }
+    store.getState().setAgentStatuses(turns)
+
+    const entry = store.getState().agentStatusByPaneKey[FIRST_PANE]
+    expect(entry.stateHistory.length).toBeGreaterThan(1)
+    expect(entry.stateHistory.some((row) => 'lastAssistantMessage' in row)).toBe(false)
+    // Only the newest done that rolled into history is retained, so memory is O(1) per pane.
+    expect(entry.lastCompletedAssistantMessage).toBe('output 3')
+    expect(entry.lastAssistantMessage).toBe('output 4')
+  })
+
+  it('clears the completed-turn message when a done carried no assistant output', () => {
+    const store = seedBatchStore()
+    store.getState().setAgentStatuses([
+      {
+        paneKey: FIRST_PANE,
+        payload: { state: 'working', prompt: 'first turn', agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME, stateStartedAt: BASE_TIME }
+      },
+      {
+        paneKey: FIRST_PANE,
+        payload: {
+          state: 'done',
+          prompt: 'first turn',
+          agentType: 'pi',
+          lastAssistantMessage: 'Finished.'
+        },
+        timing: { updatedAt: BASE_TIME + 1, stateStartedAt: BASE_TIME + 1 }
+      },
+      {
+        paneKey: FIRST_PANE,
+        payload: { state: 'working', prompt: 'second turn', agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME + 2, stateStartedAt: BASE_TIME + 2 }
+      },
+      {
+        paneKey: FIRST_PANE,
+        payload: { state: 'done', prompt: 'second turn', agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME + 3, stateStartedAt: BASE_TIME + 3 }
+      },
+      {
+        paneKey: FIRST_PANE,
+        payload: { state: 'working', prompt: 'third turn', agentType: 'pi' },
+        timing: { updatedAt: BASE_TIME + 4, stateStartedAt: BASE_TIME + 4 }
+      }
+    ])
+
+    // The second turn finished silently; leaking turn one's output would misreport the run.
+    expect(
+      store.getState().agentStatusByPaneKey[FIRST_PANE].lastCompletedAssistantMessage
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -47,6 +47,7 @@ import {
   transferAgentPaneAuthorityAlias
 } from './agent-pane-authority'
 import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
+import type { GeneratedTabTitleUpdate } from './terminal-tab-title-batch'
 
 /** Snapshot of a finished/vanished agent status entry, kept so the dashboard and sidebar hover
  *  keep showing the completion until the user clicks the worktree. `worktreeId` is stamped at
@@ -107,6 +108,65 @@ type AgentLaunchConfigRegistryEntry = {
   identity: AgentLaunchConfigRegistrationMetadata
 }
 
+export type AgentStatusPayload = ParsedAgentStatusPayload & {
+  orchestration?: AgentStatusOrchestrationContext
+  promptInteractionKey?: string
+  restoredUnconfirmed?: boolean
+}
+
+export type AgentStatusTiming = { updatedAt?: number; stateStartedAt?: number }
+
+export type AgentStatusRouting = {
+  tabId?: string
+  worktreeId?: string
+  terminalHandle?: string
+  connectionId?: string | null
+}
+
+export type AgentStatusMetadata = {
+  providerSession?: AgentProviderSessionMetadata
+  launchConfig?: SleepingAgentLaunchConfig
+  launchToken?: string
+}
+
+export type AgentStatusUpdate = {
+  kind?: 'status'
+  paneKey: string
+  payload: AgentStatusPayload
+  terminalTitle?: string
+  timing?: AgentStatusTiming
+  routing?: AgentStatusRouting
+  metadata?: AgentStatusMetadata
+}
+
+export type AgentProviderSessionTiming = { updatedAt?: number }
+
+export type AgentProviderSessionRouting = {
+  tabId?: string
+  worktreeId?: string
+  connectionId?: string | null
+}
+
+export type AgentProviderSessionRecordMetadata = { launchToken?: string }
+
+export type AgentProviderSessionUpdate = {
+  kind: 'providerSession'
+  paneKey: string
+  agent: ResumableTuiAgent
+  providerSession: AgentProviderSessionMetadata
+  timing?: AgentProviderSessionTiming
+  routing?: AgentProviderSessionRouting
+  metadata?: AgentProviderSessionRecordMetadata
+}
+
+export type AgentStatusBatchUpdate = AgentStatusUpdate | AgentProviderSessionUpdate
+
+export type AgentStatusBatchTransaction = {
+  getState: () => AppState
+  apply: (update: AgentStatusBatchUpdate) => boolean
+  afterCommit: (effect: () => void) => void
+}
+
 export type AgentStatusSlice = {
   /** Explicit agent status entries keyed by `${tabId}:${leafId}`; real-time only, not persisted. */
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
@@ -153,34 +213,30 @@ export type AgentStatusSlice = {
   /** Update or insert an agent status entry from a status payload. */
   setAgentStatus: (
     paneKey: string,
-    payload: ParsedAgentStatusPayload & {
-      orchestration?: AgentStatusOrchestrationContext
-      promptInteractionKey?: string
-      restoredUnconfirmed?: boolean
-    },
+    payload: AgentStatusPayload,
     terminalTitle?: string,
-    timing?: { updatedAt?: number; stateStartedAt?: number },
-    routing?: {
-      tabId?: string
-      worktreeId?: string
-      terminalHandle?: string
-      connectionId?: string | null
-    },
-    metadata?: {
-      providerSession?: AgentProviderSessionMetadata
-      launchConfig?: SleepingAgentLaunchConfig
-      launchToken?: string
-    }
+    timing?: AgentStatusTiming,
+    routing?: AgentStatusRouting,
+    metadata?: AgentStatusMetadata
   ) => void
+
+  /** Apply ordered status updates as one status publication (generated titles and tab
+   *  titles still publish after it — three total, not 2N). */
+  setAgentStatuses: (updates: readonly AgentStatusBatchUpdate[]) => boolean[]
+
+  /** Fold caller-derived updates against exact staged state, committing one status publication. */
+  transactAgentStatuses: <Result>(
+    operation: (transaction: AgentStatusBatchTransaction) => Result
+  ) => Result
 
   /** Record resume identity without creating a visible turn-status row. */
   recordAgentProviderSession: (
     paneKey: string,
     agent: ResumableTuiAgent,
     providerSession: AgentProviderSessionMetadata,
-    timing?: { updatedAt?: number },
-    routing?: { tabId?: string; worktreeId?: string; connectionId?: string | null },
-    metadata?: { launchToken?: string }
+    timing?: AgentProviderSessionTiming,
+    routing?: AgentProviderSessionRouting,
+    metadata?: AgentProviderSessionRecordMetadata
   ) => void
 
   registerAgentLaunchConfig: (
@@ -1212,10 +1268,143 @@ function collectWorktreeIdsForConnection(state: AppState, connectionId: string):
   return onConnection
 }
 
+/** Slices that only the fold touched, so the batch commits as a MERGE.
+ *  Why: the fold runs against a snapshot taken at transaction start. Committing that
+ *  snapshot wholesale (zustand REPLACE) would silently revert any write that landed on
+ *  the real store meanwhile — and it can, because a batched action reaching another
+ *  slice's setter through `get()` bypasses the shadowed `set` entirely
+ *  (setRuntimeAgentOrchestrationByPaneKey → setGeneratedTabTitleFromAgentPrompt does this).
+ *  A merge keeps the single publication while confining conflicts to keys this fold wrote. */
+function buildAgentStatusBatchPatch(
+  initialState: AppState,
+  nextState: AppState
+): Partial<AppState> {
+  const patch: Record<string, unknown> = {}
+  for (const key of Object.keys(nextState) as (keyof AppState)[]) {
+    if (!Object.is(nextState[key], initialState[key])) {
+      patch[key as string] = nextState[key]
+    }
+  }
+  return patch as Partial<AppState>
+}
+
 export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusSlice> = (
-  set,
-  get
+  storeSet,
+  storeGet
 ) => {
+  type AgentStatusStateUpdate =
+    | AppState
+    | Partial<AppState>
+    | ((state: AppState) => AppState | Partial<AppState>)
+
+  let batchedAgentStatusState: AppState | null = null
+  let batchedAgentStatusEffects: (() => void)[] | null = null
+  let batchedGeneratedTabTitleUpdates: GeneratedTabTitleUpdate[] | null = null
+  let batchedAgentStatusFreshnessRequested = false
+  const get = (): AppState => batchedAgentStatusState ?? storeGet()
+  // Deliberately narrower than zustand's `set`: no `replace` parameter, so no call site in
+  // this slice can compile into a REPLACE the batch commit is unable to express.
+  const set = (update: AgentStatusStateUpdate): void => {
+    if (batchedAgentStatusState === null) {
+      storeSet(update, false)
+      return
+    }
+    const nextState = typeof update === 'function' ? update(batchedAgentStatusState) : update
+    if (Object.is(nextState, batchedAgentStatusState)) {
+      return
+    }
+    batchedAgentStatusState = Object.assign({}, batchedAgentStatusState, nextState)
+  }
+  const runAfterAgentStatusCommit = (effect: () => void): void => {
+    if (batchedAgentStatusEffects) {
+      batchedAgentStatusEffects.push(effect)
+      return
+    }
+    effect()
+  }
+  const applyGeneratedTabTitleUpdate = (update: GeneratedTabTitleUpdate): void => {
+    if (batchedGeneratedTabTitleUpdates) {
+      batchedGeneratedTabTitleUpdates.push(update)
+      return
+    }
+    if (update.options) {
+      get().setGeneratedTabTitleFromAgentPrompt(update.paneKey, update.prompt, update.options)
+    } else {
+      get().setGeneratedTabTitleFromAgentPrompt(update.paneKey, update.prompt)
+    }
+  }
+  const applyBatchedAgentStatusUpdate = (update: AgentStatusBatchUpdate): boolean => {
+    const stateBeforeUpdate = batchedAgentStatusState
+    if (!stateBeforeUpdate) {
+      return false
+    }
+    if (update.kind === 'providerSession') {
+      get().recordAgentProviderSession(
+        update.paneKey,
+        update.agent,
+        update.providerSession,
+        update.timing,
+        update.routing,
+        update.metadata
+      )
+    } else {
+      get().setAgentStatus(
+        update.paneKey,
+        update.payload,
+        update.terminalTitle,
+        update.timing,
+        update.routing,
+        update.metadata
+      )
+    }
+    return batchedAgentStatusState !== stateBeforeUpdate
+  }
+  const batchTransaction: AgentStatusBatchTransaction = {
+    getState: get,
+    apply: applyBatchedAgentStatusUpdate,
+    afterCommit: runAfterAgentStatusCommit
+  }
+  const transactAgentStatuses = <Result>(
+    operation: (transaction: AgentStatusBatchTransaction) => Result
+  ): Result => {
+    if (batchedAgentStatusState) {
+      return operation(batchTransaction)
+    }
+    const initialState = storeGet()
+    batchedAgentStatusState = initialState
+    batchedAgentStatusEffects = []
+    batchedGeneratedTabTitleUpdates = []
+    try {
+      const result = operation(batchTransaction)
+      const nextState = batchedAgentStatusState
+      const effects = batchedAgentStatusEffects
+      const generatedTabTitleUpdates = batchedGeneratedTabTitleUpdates
+      const freshnessRequested = batchedAgentStatusFreshnessRequested
+      batchedAgentStatusState = null
+      batchedAgentStatusEffects = null
+      batchedGeneratedTabTitleUpdates = null
+      batchedAgentStatusFreshnessRequested = false
+      if (nextState !== initialState) {
+        storeSet(buildAgentStatusBatchPatch(initialState, nextState), false)
+      }
+      if (generatedTabTitleUpdates.length > 0) {
+        storeGet().setGeneratedTabTitlesFromAgentPrompts(generatedTabTitleUpdates)
+      }
+      if (freshnessRequested) {
+        queueMicrotask(() => freshness.schedule())
+      }
+      for (const effect of effects) {
+        effect()
+      }
+      return result
+    } finally {
+      batchedAgentStatusState = null
+      batchedAgentStatusEffects = null
+      batchedGeneratedTabTitleUpdates = null
+      batchedAgentStatusFreshnessRequested = false
+    }
+  }
+
   // Why: scheduler is process-lifetime-scoped (no dispose) because the store is a
   // module-level singleton with no teardown lifecycle anywhere in the codebase.
   const freshness = createFreshnessScheduler({
@@ -1229,6 +1418,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }))
     }
   })
+  const requestAgentStatusFreshness = (acceptedInBatch: boolean): void => {
+    if (batchedAgentStatusState !== null) {
+      batchedAgentStatusFreshnessRequested ||= acceptedInBatch
+      return
+    }
+    queueMicrotask(() => freshness.schedule())
+  }
 
   const clearSleepingAgentSessionsByPaneKey = (paneKeys: readonly string[]): void => {
     if (paneKeys.length === 0) {
@@ -1707,7 +1903,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
       })
       if (removedLiveStatus) {
-        queueMicrotask(() => freshness.schedule())
+        requestAgentStatusFreshness(true)
       }
     },
 
@@ -1746,6 +1942,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         // must push that completion into history, or the finished timestamp and unread badge
         // lose the turn the moment the flag overwrites the live entry.
         let history: AgentStateHistoryEntry[] = existing?.stateHistory ?? []
+        // Why: a batched burst can fold a whole done→working turn into one publication, so a
+        // completion-reactive subscriber never sees `lastAssistantMessage` while state is `done`.
+        // One slot per entry, not one per history row — 20 transcripts per live status OOMs (#9872).
+        let lastCompletedAssistantMessage = existing?.lastCompletedAssistantMessage
         const boundaryLandsOnRealDone =
           existing?.state === 'done' &&
           existing.sessionBoundary !== true &&
@@ -1769,6 +1969,11 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           ]
           if (history.length > AGENT_STATE_HISTORY_MAX) {
             history = history.slice(history.length - AGENT_STATE_HISTORY_MAX)
+          }
+          if (existing.state === 'done') {
+            // The push above just moved this completion out of the live entry; a done that
+            // carried no message must clear the slot, or a stale prior turn leaks forward.
+            lastCompletedAssistantMessage = existing.lastAssistantMessage
           }
         }
 
@@ -1934,6 +2139,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           // card; parseAgentStatusPayload clears it on tool/state change.
           interactivePrompt: payload.interactivePrompt,
           lastAssistantMessage: payload.lastAssistantMessage,
+          ...(lastCompletedAssistantMessage ? { lastCompletedAssistantMessage } : {}),
           // Why: reused panes can start non-orchestrated work; only final done rows keep the
           // previous lineage fallback so completed children stay grouped.
           orchestration,
@@ -2163,21 +2369,32 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             ? getAgentRowGeneratedTitleText(entryForGeneratedTitle)
             : entryForGeneratedTitle.prompt
         if (shouldReplaceGeneratedTitle) {
-          get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt, {
-            replaceExistingGeneratedTitle: true
+          applyGeneratedTabTitleUpdate({
+            paneKey,
+            prompt: generatedTitlePrompt,
+            options: {
+              replaceExistingGeneratedTitle: true
+            }
           })
         } else {
-          get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt)
+          applyGeneratedTabTitleUpdate({ paneKey, prompt: generatedTitlePrompt })
         }
       }
-      // Why: schedule via queueMicrotask after set so the timer reads the updated map without re-entering the store during set.
-      queueMicrotask(() => freshness.schedule())
+      // Why: batches coalesce accepted updates; standalone calls keep their existing deferred scheduling.
+      requestAgentStatusFreshness(generatedTitleEntry.current !== null)
       if (completionRefreshWorktreeId) {
         const worktreeId = completionRefreshWorktreeId
         // Why: agents can create a PR via `gh pr create`, bypassing Orca's flow and leaving a stale "no PR" cache entry in place.
         queueMicrotask(() => get().refreshGitHubForWorktreeIfStale(worktreeId))
       }
     },
+
+    setAgentStatuses: (updates) =>
+      updates.length === 0
+        ? []
+        : transactAgentStatuses((transaction) => updates.map(transaction.apply)),
+
+    transactAgentStatuses,
 
     setMigrationUnsupportedPty: (entry) => {
       set((s) => {

--- a/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
+++ b/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
@@ -226,6 +226,42 @@ describe('runtimePaneTitle → sortEpoch', () => {
     expect(publications).toBe(tabCount * 2)
   })
 
+  it('publishes a bulk tab-title update once across worktrees', () => {
+    const store = createTestStore()
+    const tabCount = 20
+    const worktrees = Array.from({ length: tabCount }, (_, index) =>
+      makeWorktree({ id: `wt-${index}`, repoId: 'repo1', path: `/path/wt-${index}` })
+    )
+    seedStore(store, {
+      worktreesByRepo: { repo1: worktrees },
+      tabsByWorktree: Object.fromEntries(
+        worktrees.map((worktree, index) => [
+          worktree.id,
+          [makeTab({ id: `tab-${index}`, worktreeId: worktree.id })]
+        ])
+      )
+    })
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    store.getState().updateTabTitles(
+      worktrees.map((_, index) => ({
+        tabId: `tab-${index}`,
+        title: `Codex ready ${index}`
+      }))
+    )
+
+    unsubscribe()
+    expect(publications).toBe(1)
+    for (let index = 0; index < tabCount; index += 1) {
+      expect(store.getState().tabsByWorktree[`wt-${index}`]?.[0]?.title).toBe(
+        `Codex ready ${index}`
+      )
+    }
+  })
+
   it('does not enumerate terminal tabs when only the spinner frame changes', () => {
     const store = createTestStore()
     seedStore(store, {

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync: vi.fn() }))
+vi.mock('@/components/terminal-pane/pty-transport', () => ({
+  registerEagerPtyBuffer: vi.fn(),
+  ensurePtyDispatcher: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/shutdown-buffer-captures', () => ({
+  shutdownBufferCaptures: vi.fn()
+}))
+
+// @ts-expect-error -- minimal preload API stub for the slice's IPC writes
+globalThis.window = { api: {} }
+
+import {
+  createTestStore,
+  makeTab,
+  makeUnifiedTab,
+  makeWorktree,
+  seedStore
+} from './store-test-helpers'
+import type { GeneratedTabTitleUpdate } from './terminal-tab-title-batch'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function makeScaleState(count: number) {
+  let idReads = 0
+  const worktrees = Array.from({ length: count }, (_, index) =>
+    makeWorktree({ id: `wt-${index}`, repoId: 'repo1' })
+  )
+  const tabsByWorktree = Object.fromEntries(
+    worktrees.map((worktree, index) => {
+      const tab = makeTab({ id: `tab-${index}`, worktreeId: worktree.id })
+      const id = tab.id
+      Object.defineProperty(tab, 'id', {
+        configurable: true,
+        enumerable: true,
+        get() {
+          idReads += 1
+          return id
+        }
+      })
+      return [worktree.id, [tab]]
+    })
+  )
+  const unifiedTabsByWorktree = Object.fromEntries(
+    worktrees.map((worktree, index) => [
+      worktree.id,
+      [makeUnifiedTab({ id: `tab-${index}`, worktreeId: worktree.id, groupId: 'group-1' })]
+    ])
+  )
+  return {
+    getIdReads: () => idReads,
+    resetIdReads: () => {
+      idReads = 0
+    },
+    tabsByWorktree,
+    unifiedTabsByWorktree,
+    worktrees
+  }
+}
+
+describe('terminal tab title batches', () => {
+  it('updates 100 owners with one publication and a linear owner-index pass', () => {
+    const store = createTestStore()
+    const fixture = makeScaleState(101)
+    seedStore(store, {
+      worktreesByRepo: { repo1: fixture.worktrees },
+      tabsByWorktree: fixture.tabsByWorktree,
+      unifiedTabsByWorktree: fixture.unifiedTabsByWorktree
+    })
+    const untouchedTabs = fixture.tabsByWorktree['wt-100']
+    const baselineSortEpoch = store.getState().sortEpoch
+    fixture.resetIdReads()
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    store.getState().updateTabTitles(
+      Array.from({ length: 100 }, (_, index) => ({
+        tabId: `tab-${index}`,
+        title: `Remote agent ${index}`
+      }))
+    )
+
+    unsubscribe()
+    expect(publications).toBe(1)
+    expect(fixture.getIdReads()).toBeLessThanOrEqual(305)
+    expect(store.getState().tabsByWorktree['wt-100']).toBe(untouchedTabs)
+    expect(store.getState().sortEpoch).toBe(baselineSortEpoch + 100)
+    for (let index = 0; index < 100; index += 1) {
+      expect(store.getState().tabsByWorktree[`wt-${index}`]?.[0]?.title).toBe(
+        `Remote agent ${index}`
+      )
+    }
+  })
+
+  it('preserves ordered duplicate updates and last-owner duplicate-id routing', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      tabsByWorktree: {
+        first: [makeTab({ id: 'duplicate-tab', worktreeId: 'first', title: 'First owner' })],
+        second: [makeTab({ id: 'duplicate-tab', worktreeId: 'second', title: 'Second owner' })]
+      }
+    })
+
+    store.getState().updateTabTitles([
+      { tabId: 'duplicate-tab', title: 'Intermediate' },
+      { tabId: 'duplicate-tab', title: 'Final' }
+    ])
+
+    expect(store.getState().tabsByWorktree.first?.[0]?.title).toBe('First owner')
+    expect(store.getState().tabsByWorktree.second?.[0]?.title).toBe('Final')
+  })
+
+  it('updates every same-owner backing duplicate but only the first unified row', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      settings: { ...getDefaultSettings('/tmp'), tabAutoGenerateTitle: true },
+      tabsByWorktree: {
+        owner: [
+          makeTab({ id: 'duplicate-tab', worktreeId: 'owner', title: 'First backing' }),
+          makeTab({ id: 'duplicate-tab', worktreeId: 'owner', title: 'Second backing' })
+        ]
+      },
+      unifiedTabsByWorktree: {
+        owner: [
+          makeUnifiedTab({
+            id: 'duplicate-tab',
+            worktreeId: 'owner',
+            groupId: 'group-1',
+            label: 'First visible'
+          }),
+          makeUnifiedTab({
+            id: 'duplicate-tab',
+            worktreeId: 'owner',
+            groupId: 'group-2',
+            label: 'Second visible'
+          })
+        ]
+      }
+    })
+
+    store.getState().updateTabTitles([{ tabId: 'duplicate-tab', title: 'Final live title' }])
+    store.getState().setGeneratedTabTitlesFromAgentPrompts([
+      {
+        paneKey: makePaneKey('duplicate-tab', LEAF_ID),
+        prompt: 'Generated duplicate title for remote startup'
+      }
+    ])
+
+    expect(store.getState().tabsByWorktree.owner?.map((tab) => tab.title)).toEqual([
+      'Final live title',
+      'Final live title'
+    ])
+    expect(store.getState().tabsByWorktree.owner?.map((tab) => tab.generatedTitle)).toEqual([
+      'Generated duplicate title for remote',
+      'Generated duplicate title for remote'
+    ])
+    expect(store.getState().unifiedTabsByWorktree.owner?.map((tab) => tab.label)).toEqual([
+      'Final live title',
+      'Second visible'
+    ])
+    expect(store.getState().unifiedTabsByWorktree.owner?.map((tab) => tab.generatedLabel)).toEqual([
+      'Generated duplicate title for remote',
+      undefined
+    ])
+  })
+
+  it('matches sequential live and generated title semantics in event order', () => {
+    const sequentialStore = createTestStore()
+    const batchStore = createTestStore()
+    const fixture = {
+      settings: { ...getDefaultSettings('/tmp'), tabAutoGenerateTitle: true },
+      tabsByWorktree: {
+        owner: [makeTab({ id: 'tab-1', worktreeId: 'owner', title: 'Terminal 1' })]
+      },
+      unifiedTabsByWorktree: {
+        owner: [makeUnifiedTab({ id: 'tab-1', worktreeId: 'owner', groupId: 'group-1' })]
+      }
+    }
+    seedStore(sequentialStore, structuredClone(fixture))
+    seedStore(batchStore, structuredClone(fixture))
+    const liveUpdates = [
+      { tabId: 'tab-1', title: 'Codex' },
+      { tabId: 'tab-1', title: '⠋ Codex is thinking' },
+      { tabId: 'tab-1', title: '⠙ Codex is thinking' },
+      { tabId: 'tab-1', title: '' },
+      { tabId: 'tab-1', title: 'Final stable title' }
+    ]
+    const generatedUpdates = [
+      { paneKey: makePaneKey('tab-1', LEAF_ID), prompt: 'First generated title wins here' },
+      { paneKey: makePaneKey('tab-1', LEAF_ID), prompt: 'Ignored later generated title' },
+      {
+        paneKey: makePaneKey('tab-1', LEAF_ID),
+        prompt: 'Forced replacement generated title',
+        options: { replaceExistingGeneratedTitle: true }
+      }
+    ]
+
+    for (const update of liveUpdates) {
+      sequentialStore.getState().updateTabTitle(update.tabId, update.title)
+    }
+    for (const update of generatedUpdates) {
+      sequentialStore
+        .getState()
+        .setGeneratedTabTitleFromAgentPrompt(update.paneKey, update.prompt, update.options)
+    }
+    batchStore.getState().updateTabTitles(liveUpdates)
+    batchStore.getState().setGeneratedTabTitlesFromAgentPrompts(generatedUpdates)
+
+    expect(batchStore.getState().tabsByWorktree).toEqual(sequentialStore.getState().tabsByWorktree)
+    expect(batchStore.getState().unifiedTabsByWorktree).toEqual(
+      sequentialStore.getState().unifiedTabsByWorktree
+    )
+    expect(batchStore.getState().sortEpoch).toBe(sequentialStore.getState().sortEpoch)
+  })
+
+  it('coalesces generated titles while preserving first-write and replacement semantics', () => {
+    const store = createTestStore()
+    const fixture = makeScaleState(100)
+    seedStore(store, {
+      settings: { ...getDefaultSettings('/tmp'), tabAutoGenerateTitle: true },
+      worktreesByRepo: { repo1: fixture.worktrees },
+      tabsByWorktree: fixture.tabsByWorktree,
+      unifiedTabsByWorktree: fixture.unifiedTabsByWorktree
+    })
+    fixture.resetIdReads()
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+    const updates: GeneratedTabTitleUpdate[] = Array.from({ length: 100 }, (_, index) => ({
+      paneKey: makePaneKey(`tab-${index}`, LEAF_ID),
+      prompt: `Refactor remote module ${index} for startup performance`
+    }))
+    updates.push(
+      {
+        paneKey: makePaneKey('tab-0', LEAF_ID),
+        prompt: 'This later prompt must not replace the first generated title'
+      },
+      {
+        paneKey: makePaneKey('tab-0', LEAF_ID),
+        prompt: 'Replacement title for a newer dispatch',
+        options: { replaceExistingGeneratedTitle: true }
+      }
+    )
+
+    store.getState().setGeneratedTabTitlesFromAgentPrompts(updates)
+
+    unsubscribe()
+    expect(publications).toBe(1)
+    expect(fixture.getIdReads()).toBeLessThanOrEqual(305)
+    expect(store.getState().tabsByWorktree['wt-0']?.[0]?.generatedTitle).toBe(
+      'Replacement title for a newer dispatch'
+    )
+    expect(store.getState().tabsByWorktree['wt-99']?.[0]?.generatedTitle).toBe(
+      'Refactor remote module 99 for startup'
+    )
+  })
+})

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.ts
@@ -1,0 +1,242 @@
+import { deriveGeneratedTabTitle } from '../../../../shared/agent-tab-title'
+import { isDecorativeAgentTitleFrameChange } from '../../../../shared/agent-decorative-title-signature'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { Tab, TerminalTab } from '../../../../shared/types'
+import type { AppState } from '../types'
+
+export type TerminalTabTitleUpdate = { tabId: string; title: string }
+
+export type GeneratedTabTitleUpdate = {
+  paneKey: string
+  prompt: string
+  options?: { replaceExistingGeneratedTitle?: boolean }
+}
+
+type TitleState = Pick<
+  AppState,
+  'activeWorktreeId' | 'settings' | 'sortEpoch' | 'tabsByWorktree' | 'unifiedTabsByWorktree'
+>
+
+type TitlePatch = Partial<Pick<AppState, 'sortEpoch' | 'tabsByWorktree' | 'unifiedTabsByWorktree'>>
+
+type TitleUpdateResult = {
+  patch: TitlePatch | null
+  runtimeGraphChanged: boolean
+}
+
+type OwnerStage = {
+  tabs: TerminalTab[]
+  tabsChanged: boolean
+  tabIndexesById: Map<string, number[]>
+  unifiedTabs: Tab[]
+  unifiedTabsChanged: boolean
+  unifiedIndexByTabId: Map<string, number>
+}
+
+function getFallbackTabTitle(tab: TerminalTab): string {
+  return (
+    tab.customTitle?.trim() ||
+    tab.quickCommandLabel?.trim() ||
+    tab.defaultTitle?.trim() ||
+    tab.title ||
+    'Terminal 1'
+  )
+}
+
+function getTabIdFromPaneKey(paneKey: string): string | null {
+  return parsePaneKey(paneKey)?.tabId ?? parseLegacyNumericPaneKey(paneKey)?.tabId ?? null
+}
+
+function buildOwnerIndex(tabsByWorktree: TitleState['tabsByWorktree']): Map<string, string> {
+  const ownerByTabId = new Map<string, string>()
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs) {
+      ownerByTabId.set(tab.id, worktreeId)
+    }
+  }
+  return ownerByTabId
+}
+
+function getOwnerStage(
+  state: TitleState,
+  stages: Map<string, OwnerStage>,
+  worktreeId: string
+): OwnerStage {
+  const existing = stages.get(worktreeId)
+  if (existing) {
+    return existing
+  }
+  const tabs = state.tabsByWorktree[worktreeId] ?? []
+  const unifiedTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
+  const tabIndexesById = new Map<string, number[]>()
+  for (let index = 0; index < tabs.length; index += 1) {
+    const tabId = tabs[index].id
+    const indexes = tabIndexesById.get(tabId)
+    if (indexes) {
+      indexes.push(index)
+    } else {
+      tabIndexesById.set(tabId, [index])
+    }
+  }
+  const unifiedIndexByTabId = new Map<string, number>()
+  for (let index = 0; index < unifiedTabs.length; index += 1) {
+    const tab = unifiedTabs[index]
+    if (tab.contentType === 'terminal' && !unifiedIndexByTabId.has(tab.entityId)) {
+      unifiedIndexByTabId.set(tab.entityId, index)
+    }
+  }
+  const stage: OwnerStage = {
+    tabs,
+    tabsChanged: false,
+    tabIndexesById,
+    unifiedTabs,
+    unifiedTabsChanged: false,
+    unifiedIndexByTabId
+  }
+  stages.set(worktreeId, stage)
+  return stage
+}
+
+function updateStageTabs(
+  stage: OwnerStage,
+  indexes: readonly number[],
+  update: (tab: TerminalTab) => TerminalTab
+): void {
+  if (!stage.tabsChanged) {
+    stage.tabs = [...stage.tabs]
+    stage.tabsChanged = true
+  }
+  for (const index of indexes) {
+    stage.tabs[index] = update(stage.tabs[index])
+  }
+}
+
+function updateStageUnifiedLabel(
+  stage: OwnerStage,
+  tabId: string,
+  key: 'generatedLabel' | 'label',
+  value: string
+): void {
+  const index = stage.unifiedIndexByTabId.get(tabId)
+  if (index === undefined || stage.unifiedTabs[index]?.[key] === value) {
+    return
+  }
+  if (!stage.unifiedTabsChanged) {
+    stage.unifiedTabs = [...stage.unifiedTabs]
+    stage.unifiedTabsChanged = true
+  }
+  stage.unifiedTabs[index] = { ...stage.unifiedTabs[index], [key]: value }
+}
+
+function finishTitleStages(
+  state: TitleState,
+  stages: Map<string, OwnerStage>,
+  sortEpochIncrement = 0
+): TitleUpdateResult {
+  const tabsChanged = [...stages.values()].some((stage) => stage.tabsChanged)
+  const unifiedTabsChanged = [...stages.values()].some((stage) => stage.unifiedTabsChanged)
+  if (!tabsChanged && !unifiedTabsChanged) {
+    return { patch: null, runtimeGraphChanged: false }
+  }
+  const patch: TitlePatch = {}
+  if (tabsChanged) {
+    patch.tabsByWorktree = { ...state.tabsByWorktree }
+  }
+  if (unifiedTabsChanged) {
+    patch.unifiedTabsByWorktree = { ...state.unifiedTabsByWorktree }
+  }
+  for (const [worktreeId, stage] of stages) {
+    if (stage.tabsChanged) {
+      patch.tabsByWorktree![worktreeId] = stage.tabs
+    }
+    if (stage.unifiedTabsChanged) {
+      patch.unifiedTabsByWorktree![worktreeId] = stage.unifiedTabs
+    }
+  }
+  if (sortEpochIncrement > 0) {
+    patch.sortEpoch = state.sortEpoch + sortEpochIncrement
+  }
+  return { patch, runtimeGraphChanged: tabsChanged }
+}
+
+export function applyTerminalTabTitleUpdates(
+  state: TitleState,
+  updates: readonly TerminalTabTitleUpdate[],
+  ownerByTabId = buildOwnerIndex(state.tabsByWorktree)
+): TitleUpdateResult {
+  const stages = new Map<string, OwnerStage>()
+  let sortEpochIncrement = 0
+  for (const { tabId, title } of updates) {
+    const ownerWorktreeId = ownerByTabId.get(tabId)
+    if (!ownerWorktreeId) {
+      continue
+    }
+    const stage = getOwnerStage(state, stages, ownerWorktreeId)
+    const tabIndexes = stage.tabIndexesById.get(tabId)
+    const currentTab = tabIndexes ? stage.tabs[tabIndexes[0]] : undefined
+    if (!currentTab || !tabIndexes) {
+      continue
+    }
+    const nextTitle = title.trim() || getFallbackTabTitle(currentTab)
+    if (isDecorativeAgentTitleFrameChange(currentTab.title, nextTitle)) {
+      updateStageUnifiedLabel(stage, tabId, 'label', currentTab.title)
+      continue
+    }
+    updateStageUnifiedLabel(stage, tabId, 'label', nextTitle)
+    if (currentTab.title === nextTitle) {
+      continue
+    }
+    updateStageTabs(stage, tabIndexes, (tab) => ({
+      ...tab,
+      title: nextTitle,
+      defaultTitle:
+        tab.defaultTitle ??
+        (/^Terminal \d+$/.test(tab.title) ? tab.title : undefined) ??
+        (/^Terminal \d+$/.test(nextTitle) ? nextTitle : undefined)
+    }))
+    if (ownerWorktreeId !== state.activeWorktreeId) {
+      sortEpochIncrement += 1
+    }
+  }
+  return finishTitleStages(state, stages, sortEpochIncrement)
+}
+
+export function applyGeneratedTabTitleUpdates(
+  state: TitleState,
+  updates: readonly GeneratedTabTitleUpdate[],
+  ownerByTabId = buildOwnerIndex(state.tabsByWorktree)
+): TitleUpdateResult {
+  if (state.settings?.tabAutoGenerateTitle !== true) {
+    return { patch: null, runtimeGraphChanged: false }
+  }
+  const stages = new Map<string, OwnerStage>()
+  for (const { paneKey, prompt, options } of updates) {
+    const tabId = getTabIdFromPaneKey(paneKey)
+    const ownerWorktreeId = tabId ? ownerByTabId.get(tabId) : undefined
+    if (!tabId || !ownerWorktreeId || prompt.length === 0) {
+      continue
+    }
+    const stage = getOwnerStage(state, stages, ownerWorktreeId)
+    const tabIndexes = stage.tabIndexesById.get(tabId)
+    const currentTab = tabIndexes ? stage.tabs[tabIndexes[0]] : undefined
+    if (
+      !currentTab ||
+      !tabIndexes ||
+      currentTab.customTitle?.trim() ||
+      currentTab.quickCommandLabel?.trim()
+    ) {
+      continue
+    }
+    const existingGeneratedTitle = currentTab.generatedTitle?.trim()
+    if (existingGeneratedTitle && options?.replaceExistingGeneratedTitle !== true) {
+      continue
+    }
+    const generatedTitle = deriveGeneratedTabTitle(prompt)
+    if (!generatedTitle || existingGeneratedTitle === generatedTitle) {
+      continue
+    }
+    updateStageTabs(stage, tabIndexes, (tab) => ({ ...tab, generatedTitle }))
+    updateStageUnifiedLabel(stage, tabId, 'generatedLabel', generatedTitle)
+  }
+  return finishTitleStages(state, stages)
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -28,7 +28,6 @@ import {
   parseWorkspaceKey,
   worktreeWorkspaceKey
 } from '../../../../shared/workspace-scope'
-import { deriveGeneratedTabTitle } from '../../../../shared/agent-tab-title'
 import { isDecorativeAgentTitleFrameChange } from '../../../../shared/agent-decorative-title-signature'
 import {
   isTerminalLeafId,
@@ -72,6 +71,12 @@ import { isClaudeAgent } from '@/lib/agent-status'
 import { recordTerminalInputActivity } from '@/lib/terminal-input-activity-coalescing'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
+import {
+  applyGeneratedTabTitleUpdates,
+  applyTerminalTabTitleUpdates,
+  type GeneratedTabTitleUpdate,
+  type TerminalTabTitleUpdate
+} from './terminal-tab-title-batch'
 import {
   dedupeTabOrder,
   ensureGroup,
@@ -227,16 +232,6 @@ function consumePendingActivationSpawn(
   return count === 2 ? true : count - 1
 }
 
-function getFallbackTabTitle(tab: TerminalTab, index?: number): string {
-  return (
-    tab.customTitle?.trim() ||
-    tab.quickCommandLabel?.trim() ||
-    tab.defaultTitle?.trim() ||
-    tab.title ||
-    `Terminal ${(index ?? 0) + 1}`
-  )
-}
-
 function getPathDisplayName(path: string, fallback: string): string {
   const normalized = path.trim().replace(/[\\/]+$/g, '')
   const basename = normalized.split(/[\\/]/).findLast(Boolean)?.trim()
@@ -337,36 +332,6 @@ function getTerminalTabOwnerWorktreeId(
     terminalTabOwnerCache = nextCache
   }
   return terminalTabOwnerCache.get(tabId) ?? null
-}
-
-function updateUnifiedTerminalLabel(
-  unifiedTabs: Tab[],
-  terminalTabId: string,
-  label: string
-): Tab[] | null {
-  const unifiedIndex = unifiedTabs.findIndex(
-    (entry) => entry.contentType === 'terminal' && entry.entityId === terminalTabId
-  )
-  if (unifiedIndex === -1 || unifiedTabs[unifiedIndex]?.label === label) {
-    return null
-  }
-  return unifiedTabs.map((entry, index) => (index === unifiedIndex ? { ...entry, label } : entry))
-}
-
-function updateUnifiedTerminalGeneratedLabel(
-  unifiedTabs: Tab[],
-  terminalTabId: string,
-  generatedLabel: string
-): Tab[] | null {
-  const unifiedIndex = unifiedTabs.findIndex(
-    (entry) => entry.contentType === 'terminal' && entry.entityId === terminalTabId
-  )
-  if (unifiedIndex === -1 || unifiedTabs[unifiedIndex]?.generatedLabel === generatedLabel) {
-    return null
-  }
-  return unifiedTabs.map((entry, index) =>
-    index === unifiedIndex ? { ...entry, generatedLabel } : entry
-  )
 }
 
 function getTabIdFromPaneKey(paneKey: string): string | null {
@@ -690,12 +655,14 @@ export type TerminalSlice = {
   setActiveTab: (tabId: string) => void
   setActiveTabForWorktree: (worktreeId: string, tabId: string) => void
   updateTabTitle: (tabId: string, title: string) => void
+  updateTabTitles: (updates: readonly TerminalTabTitleUpdate[]) => void
   setAiVaultTabTitle: (tabId: string, aiVaultTitle: AiVaultSessionTitle | null) => void
   setGeneratedTabTitleFromAgentPrompt: (
     paneKey: string,
     prompt: string,
     options?: { replaceExistingGeneratedTitle?: boolean }
   ) => void
+  setGeneratedTabTitlesFromAgentPrompts: (updates: readonly GeneratedTabTitleUpdate[]) => void
   clearTabLaunchAgent: (tabId: string) => void
   setRuntimePaneTitle: (tabId: string, paneId: number, title: string) => void
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
@@ -2002,77 +1969,29 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   updateTabTitle: (tabId, title) => {
-    set((s) => {
-      // Why: update only the owner to preserve selector equality for background worktrees.
-      const ownerWorktreeId = getTerminalTabOwnerWorktreeId(s.tabsByWorktree, tabId)
-      if (!ownerWorktreeId) {
-        return s
+    set((state) => {
+      const ownerWorktreeId = getTerminalTabOwnerWorktreeId(state.tabsByWorktree, tabId)
+      const ownerByTabId = ownerWorktreeId
+        ? new Map([[tabId, ownerWorktreeId]])
+        : new Map<string, string>()
+      const result = applyTerminalTabTitleUpdates(state, [{ tabId, title }], ownerByTabId)
+      if (result.runtimeGraphChanged) {
+        scheduleRuntimeGraphSync()
       }
-      const tabs = s.tabsByWorktree[ownerWorktreeId] ?? []
-      const tabIndex = tabs.findIndex((t) => t.id === tabId)
-      const currentTab = tabs[tabIndex]
-      if (!currentTab) {
-        return s
+      return result.patch ?? state
+    })
+  },
+
+  updateTabTitles: (updates) => {
+    if (updates.length === 0) {
+      return
+    }
+    set((state) => {
+      const result = applyTerminalTabTitleUpdates(state, updates)
+      if (result.runtimeGraphChanged) {
+        scheduleRuntimeGraphSync()
       }
-      const nextTitle = title.trim() || getFallbackTabTitle(currentTab)
-      const currentUnifiedTabs = s.unifiedTabsByWorktree[ownerWorktreeId] ?? []
-      if (isDecorativeAgentTitleFrameChange(currentTab.title, nextTitle)) {
-        const unifiedTabsWithCurrentLabel = updateUnifiedTerminalLabel(
-          currentUnifiedTabs,
-          tabId,
-          currentTab.title
-        )
-        return unifiedTabsWithCurrentLabel
-          ? {
-              unifiedTabsByWorktree: {
-                ...s.unifiedTabsByWorktree,
-                [ownerWorktreeId]: unifiedTabsWithCurrentLabel
-              }
-            }
-          : s
-      }
-      const unifiedTabsWithUpdatedLabel = updateUnifiedTerminalLabel(
-        currentUnifiedTabs,
-        tabId,
-        nextTitle
-      )
-      if (currentTab.title === nextTitle) {
-        return unifiedTabsWithUpdatedLabel
-          ? {
-              unifiedTabsByWorktree: {
-                ...s.unifiedTabsByWorktree,
-                [ownerWorktreeId]: unifiedTabsWithUpdatedLabel
-              }
-            }
-          : s
-      }
-      const ownerTabs = tabs.map((tab) =>
-        tab.id === tabId
-          ? {
-              ...tab,
-              // Why: PTYs can briefly emit an empty title as an agent exits; keep the stable fallback instead of a blank tab.
-              title: nextTitle,
-              defaultTitle:
-                tab.defaultTitle ??
-                (/^Terminal \d+$/.test(tab.title) ? tab.title : undefined) ??
-                (/^Terminal \d+$/.test(nextTitle) ? nextTitle : undefined)
-            }
-          : tab
-      )
-      scheduleRuntimeGraphSync()
-      const nextTabsByWorktree = { ...s.tabsByWorktree, [ownerWorktreeId]: ownerTabs }
-      // Why: title changes affect sorting, except active-worktree remount side effects.
-      const isActive = ownerWorktreeId === s.activeWorktreeId
-      const nextState: Partial<AppState> = isActive
-        ? { tabsByWorktree: nextTabsByWorktree }
-        : { tabsByWorktree: nextTabsByWorktree, sortEpoch: s.sortEpoch + 1 }
-      if (unifiedTabsWithUpdatedLabel) {
-        nextState.unifiedTabsByWorktree = {
-          ...s.unifiedTabsByWorktree,
-          [ownerWorktreeId]: unifiedTabsWithUpdatedLabel
-        }
-      }
-      return nextState
+      return result.patch ?? state
     })
   },
 
@@ -2109,18 +2028,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   setGeneratedTabTitleFromAgentPrompt: (paneKey, prompt, options) => {
     // Why: setAgentStatus is high-frequency; skip derive/set unless the feature is on and this tab still needs a (re)generated title.
-    if (get().settings?.tabAutoGenerateTitle !== true) {
-      return
-    }
+    const state = get()
     const tabId = getTabIdFromPaneKey(paneKey)
-    if (!tabId || prompt.length === 0) {
+    if (!tabId || prompt.length === 0 || state.settings?.tabAutoGenerateTitle !== true) {
       return
     }
-    const ownerWorktreeId = getTerminalTabOwnerWorktreeId(get().tabsByWorktree, tabId)
+    const ownerWorktreeId = getTerminalTabOwnerWorktreeId(state.tabsByWorktree, tabId)
     if (!ownerWorktreeId) {
       return
     }
-    const tabs = get().tabsByWorktree[ownerWorktreeId] ?? []
+    const tabs = state.tabsByWorktree[ownerWorktreeId] ?? []
     const currentTab = tabs.find((tab) => tab.id === tabId)
     if (!currentTab || currentTab.customTitle?.trim() || currentTab.quickCommandLabel?.trim()) {
       return
@@ -2129,57 +2046,29 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     if (existingGeneratedTitle && options?.replaceExistingGeneratedTitle !== true) {
       return
     }
-    const generatedTitle = deriveGeneratedTabTitle(prompt)
-    if (!generatedTitle || existingGeneratedTitle === generatedTitle) {
+    set((latestState) => {
+      const result = applyGeneratedTabTitleUpdates(
+        latestState,
+        [{ paneKey, prompt, options }],
+        new Map([[tabId, ownerWorktreeId]])
+      )
+      if (result.runtimeGraphChanged) {
+        scheduleRuntimeGraphSync()
+      }
+      return result.patch ?? latestState
+    })
+  },
+
+  setGeneratedTabTitlesFromAgentPrompts: (updates) => {
+    if (updates.length === 0) {
       return
     }
-    set((s) => {
-      const ownerTabsForWrite = s.tabsByWorktree[ownerWorktreeId]
-      if (!ownerTabsForWrite) {
-        return s
+    set((state) => {
+      const result = applyGeneratedTabTitleUpdates(state, updates)
+      if (result.runtimeGraphChanged) {
+        scheduleRuntimeGraphSync()
       }
-      const tabIndex = ownerTabsForWrite.findIndex((tab) => tab.id === tabId)
-      const tabForWrite = ownerTabsForWrite[tabIndex]
-      // Why: re-check inside set so concurrent renames / setting flips win.
-      if (
-        !tabForWrite ||
-        s.settings?.tabAutoGenerateTitle !== true ||
-        tabForWrite.customTitle?.trim() ||
-        tabForWrite.quickCommandLabel?.trim()
-      ) {
-        return s
-      }
-      const latestGeneratedTitle = tabForWrite.generatedTitle?.trim()
-      if (
-        latestGeneratedTitle &&
-        (latestGeneratedTitle === generatedTitle || options?.replaceExistingGeneratedTitle !== true)
-      ) {
-        return s
-      }
-      const ownerTabs = ownerTabsForWrite.map((tab) =>
-        tab.id === tabId ? { ...tab, generatedTitle } : tab
-      )
-      const currentUnifiedTabs = s.unifiedTabsByWorktree[ownerWorktreeId] ?? []
-      const unifiedTabsWithGeneratedLabel = updateUnifiedTerminalGeneratedLabel(
-        currentUnifiedTabs,
-        tabId,
-        generatedTitle
-      )
-      scheduleRuntimeGraphSync()
-      return {
-        tabsByWorktree: {
-          ...s.tabsByWorktree,
-          [ownerWorktreeId]: ownerTabs
-        },
-        ...(unifiedTabsWithGeneratedLabel
-          ? {
-              unifiedTabsByWorktree: {
-                ...s.unifiedTabsByWorktree,
-                [ownerWorktreeId]: unifiedTabsWithGeneratedLabel
-              }
-            }
-          : {})
-      }
+      return result.patch ?? state
     })
   },
 

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -44,7 +44,9 @@ export type AgentType = WellKnownAgentType | (string & {})
 
 /** A snapshot of a previous agent state, used to render activity blocks.
  *  Why: intentionally narrower than AgentStatusEntry — tool/assistant context is
- *  per-turn, not meaningful on a historical snapshot, and would bloat memory. */
+ *  per-turn, not meaningful on a historical snapshot, and would bloat memory.
+ *  Coalesced-turn output lives in AgentStatusEntry.lastCompletedAssistantMessage,
+ *  one copy per pane, so it can't multiply by AGENT_STATE_HISTORY_MAX. */
 export type AgentStateHistoryEntry = {
   state: AgentStatusState
   prompt: string
@@ -124,6 +126,10 @@ export type AgentStatusEntry = {
   interactivePrompt?: string
   /** Most recent assistant message preview, when the hook carried one. */
   lastAssistantMessage?: string
+  /** Output of the newest completed (non-boundary) turn, kept across the next `working`.
+   *  Why: batched publications can fold a whole done→working turn into one notification,
+   *  so `lastAssistantMessage` is already cleared by the time a subscriber observes it. */
+  lastCompletedAssistantMessage?: string
   /** True when this `done` was reached via interrupt, not normal completion
    *  (agent-reported or Orca's guarded fallback). Undefined otherwise. */
   interrupted?: boolean
@@ -226,7 +232,7 @@ export type AgentStatusIpcPayload = ParsedAgentStatusPayload & {
   tabId?: string
   worktreeId?: string
   /** Identifies the SSH connection the event arrived on, or null for local.
-   *  Only the remote-ingest path (`ingestRemote`) can stamp it; the HTTP path always sets null. See docs/design/agent-status-over-ssh.md §5. */
+   *  Only the remote-ingest path (`ingestRemote`) can stamp it from mux identity; the HTTP path has no mux and always sets null. */
   connectionId: string | null
   /** Timestamp (ms) when the hook server received this latest status event. */
   receivedAt: number


### PR DESCRIPTION
## The problem, in one line

When lots of agent updates arrive at once, the app told the whole UI about **every single one, one at a time** — and each one made the sidebar do a full search to figure out which pane it belonged to.

## Why that hurts

There are about **9,300 things listening** for store changes in a big workspace. Every update wakes all of them.

Reconnect to a remote host with 256 panes and you get 256 separate updates → roughly **2.4 million** wake-ups for what is really one event: "here's the current state of everything."

Measured on `main`, 100 worktrees + 100 agent rows:

| | |
| --- | ---: |
| Listeners in the store | 9,279 |
| Renderer CPU, sitting idle | 6.63% |
| Renderer CPU, 2,000 updates | **18.25%** |
| How late timers ran (median) | **5,150 ms** |

That ~12-point CPU jump is the cost of announcing updates one at a time. The 5-second timer delay is why the app feels frozen.

## What this PR does

Collects the updates that arrive together, applies them in order, then announces the result **3 times instead of 2 per update**:

1. once for the statuses
2. once for auto-generated tab titles
3. once for terminal tab titles

Same end state, far fewer announcements. It also builds the "which pane owns this?" lookup table **once per batch** instead of once per update.

## The catch, and how it's handled

Announcing less often means some code could miss a step. If a pane goes `working → done → working` quickly, the UI now hears "working" once, not three separate things.

That's fine for anything that just reads the current state. It is **not** fine for code that watches for *changes*. Every listener was checked one by one; two needed fixing:

- **Windows terminals.** A coalesced `done → working → done` looked like "no change", so the terminal never reset its keyboard mode and typing got corrupted. Now it tracks when the last turn actually finished, so it can't be fooled. This would have been a real bug — it's fixed here.
- **Scheduled automations.** These watched for a `done` that could now be swallowed, and would have hung forever. They now read the history instead of just the current state.

A third was checked and left alone: it's driven by React renders, not this path, so it already behaved this way.

The full list of every listener and which category it falls into is in the first comment. Worth keeping, because **tests cannot catch this kind of bug** — the final state is identical either way, so nothing fails. Only reading the code finds it.

## Other fixes in here

- **Memory.** An earlier version kept the last assistant message on all 20 history entries per pane — about 80 MB worst case, in a renderer that already has a cap specifically to avoid running out of memory. Now it keeps one message per pane, ~4 MB.
- **Dropped updates on error.** If applying a batch threw, the whole queue was already emptied and those updates were gone for good, leaving panes stuck showing stale state. They're now put back and retried.
- **A footgun.** The batch used to overwrite the store wholesale, which would silently undo any unrelated write that happened at the same time. It now merges instead, and the type signature makes overwriting impossible to reintroduce.

## Known limits, not fixed here

- If two turns finish inside the same 33 ms window, an automation can record the wrong turn's output. Deliberate trade for bounded memory.
- Remote hosts still send one message per pane on reconnect. This PR makes handling that cheap; it doesn't make the host send less. Tracked in **STA-3983**.

## Checks

- 741 tests pass across the 6 changed files
- Typecheck clean
- Each fix has a test verified to **fail** without it — including the Windows terminal case, the store-overwrite guard, and the dropped-updates case
- Nothing sent between machines changed, so old and new versions still talk to each other
