### PR TITLE
fix(mobile): detect new-tab agents on runtime execution owner

### DIFF
--- a/mobile/scripts/mock-server-rpc-handlers.ts
+++ b/mobile/scripts/mock-server-rpc-handlers.ts
@@ -223,6 +223,7 @@ export function handleRequest(
 
     case 'preflight.detectAgents':
     case 'preflight.detectRemoteAgents':
+    case 'preflight.detectRuntimeAgents':
       respond(success(request.id, ['claude', 'codex', 'gemini']))
       break
 

--- a/mobile/src/session/mobile-new-tab-agent-loader.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.test.ts
@@ -69,4 +69,151 @@ describe('mobile new-tab agent loading', () => {
       'preflight.detectRemoteAgents'
     ])
   })
+
+  it('detects agents on the runtime execution owner, not the paired host', async () => {
+    const client = createClient(async (method, params) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'repo.list') {
+        return {
+          ok: true,
+          result: {
+            repos: [
+              {
+                id: 'repo-runtime',
+                connectionId: null,
+                executionHostId: 'runtime:env-headless'
+              }
+            ]
+          }
+        }
+      }
+      if (method === 'preflight.detectRuntimeAgents') {
+        expect(params).toEqual({ environmentId: 'env-headless' })
+        return { ok: true, result: ['pi'] }
+      }
+      if (method === 'preflight.detectAgents') {
+        throw new Error('must not probe the paired host for a runtime-owned repo')
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({
+        client,
+        worktreeId: 'repo-runtime::/runtime/worktree'
+      })
+    ).resolves.toEqual([{ agent: 'pi', label: 'Pi' }])
+    expect(client.sendRequest.mock.calls.map(([method]) => method)).toEqual([
+      'repo.list',
+      'settings.get',
+      'preflight.detectRuntimeAgents'
+    ])
+  })
+
+  it('prefers executionHostId over connectionId for SSH-stamped repos', async () => {
+    const client = createClient(async (method, params) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'repo.list') {
+        return {
+          ok: true,
+          result: {
+            repos: [
+              {
+                id: 'repo-ssh',
+                connectionId: 'stale-conn',
+                executionHostId: 'ssh:ssh-target-1'
+              }
+            ]
+          }
+        }
+      }
+      if (method === 'preflight.detectRemoteAgents') {
+        expect(params).toEqual({ connectionId: 'ssh-target-1' })
+        return { ok: true, result: ['codex'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({
+        client,
+        worktreeId: 'repo-ssh::/ssh/worktree'
+      })
+    ).resolves.toEqual([{ agent: 'codex', label: 'Codex' }])
+  })
+
+  it('falls back to paired-host detection when the host predates detectRuntimeAgents', async () => {
+    const client = createClient(async (method) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'repo.list') {
+        return {
+          ok: true,
+          result: {
+            repos: [
+              {
+                id: 'repo-runtime',
+                connectionId: null,
+                executionHostId: 'runtime:env-headless'
+              }
+            ]
+          }
+        }
+      }
+      if (method === 'preflight.detectRuntimeAgents') {
+        return {
+          ok: false,
+          error: { code: 'method_not_found', message: 'Unknown method' },
+          _meta: { runtimeId: 'host' }
+        }
+      }
+      if (method === 'preflight.detectAgents') {
+        return { ok: true, result: ['claude'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({
+        client,
+        worktreeId: 'repo-runtime::/runtime/worktree'
+      })
+    ).resolves.toEqual([{ agent: 'claude', label: 'Claude' }])
+    expect(client.sendRequest.mock.calls.map(([method]) => method)).toEqual([
+      'repo.list',
+      'settings.get',
+      'preflight.detectRuntimeAgents',
+      'preflight.detectAgents'
+    ])
+  })
+
+  it('detects agents on the paired host for local repos', async () => {
+    const client = createClient(async (method) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'repo.list') {
+        return {
+          ok: true,
+          result: { repos: [{ id: 'repo-local', connectionId: null, executionHostId: 'local' }] }
+        }
+      }
+      if (method === 'preflight.detectAgents') {
+        return { ok: true, result: ['codex'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({
+        client,
+        worktreeId: 'repo-local::/local/worktree'
+      })
+    ).resolves.toEqual([{ agent: 'codex', label: 'Codex' }])
+  })
 })

--- a/mobile/src/session/mobile-new-tab-agent-loader.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.ts
@@ -1,5 +1,6 @@
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcFailure, RpcSuccess } from '../transport/types'
+import { parseExecutionHostId } from '../../../src/shared/execution-host'
 import { isFloatingWorkspaceWorktreeId } from './floating-workspace'
 import { getRepoIdFromMobileWorktreeId } from './mobile-session-route-helpers'
 import {
@@ -11,6 +12,7 @@ import {
 type RuntimeRepoSummary = {
   id: string
   connectionId?: string | null
+  executionHostId?: string | null
 }
 
 export async function loadMobileNewTabAgentOptions(args: {
@@ -55,8 +57,49 @@ async function loadWorkspaceDetectedAgents(client: RpcClient, worktreeId: string
   if (!repo) {
     throw new Error('worktree_repo_not_found')
   }
+  return requestDetectedAgentsForRepo(client, repo)
+}
+
+async function requestDetectedAgentsForRepo(
+  client: RpcClient,
+  repo: RuntimeRepoSummary
+): Promise<RpcSuccess | RpcFailure> {
+  const executionHost = parseExecutionHostId(repo.executionHostId)
+  if (executionHost?.kind === 'runtime') {
+    return requestRuntimeDetectedAgents(client, executionHost.environmentId)
+  }
+  if (executionHost?.kind === 'ssh') {
+    return client.sendRequest('preflight.detectRemoteAgents', {
+      connectionId: executionHost.targetId
+    })
+  }
   const connectionId = repo.connectionId?.trim() || null
   return connectionId
     ? client.sendRequest('preflight.detectRemoteAgents', { connectionId })
     : client.sendRequest('preflight.detectAgents')
+}
+
+async function requestRuntimeDetectedAgents(
+  client: RpcClient,
+  environmentId: string
+): Promise<RpcSuccess | RpcFailure> {
+  const response = await client.sendRequest('preflight.detectRuntimeAgents', {
+    environmentId
+  })
+  // Why: hosts that predate the runtime-delegation RPC fall back to the paired
+  // host's local detection (previous behavior) instead of blanking the menu.
+  if (!response.ok && isMethodUnavailable(response as RpcFailure)) {
+    return client.sendRequest('preflight.detectAgents')
+  }
+  return response
+}
+
+function isMethodUnavailable(response: RpcFailure): boolean {
+  const code = response.error.code
+  const message = response.error.message
+  return (
+    code === 'method_not_found' ||
+    message.includes('not available to mobile clients') ||
+    message.includes('Unknown method')
+  )
 }

--- a/mobile/src/source-control/mobile-create-pr-action.test.ts
+++ b/mobile/src/source-control/mobile-create-pr-action.test.ts
@@ -145,8 +145,10 @@ describe('buildMobileCreatePrAction', () => {
   })
 
   it('keeps a disabled status row for providers without review creation', () => {
+    // Why: bitbucket/azure-devops/gitea are creation-capable after #5832; only
+    // the sentinel `unsupported` provider must stay non-creatable here.
     const { descriptor } = action({
-      eligibility: eligibility({ provider: 'bitbucket' as HostedReviewProvider })
+      eligibility: eligibility({ provider: 'unsupported' as HostedReviewProvider })
     })
 
     expect(descriptor).toMatchObject({
@@ -154,6 +156,20 @@ describe('buildMobileCreatePrAction', () => {
       disabled: true,
       label: 'Review creation unavailable for this provider'
     })
+  })
+
+  it('enables create for bitbucket once review creation is supported', () => {
+    const { descriptor, onCreatePr } = action({
+      eligibility: eligibility({ provider: 'bitbucket' as HostedReviewProvider })
+    })
+
+    expect(descriptor).toMatchObject({
+      visible: true,
+      disabled: false,
+      label: 'Create Pull Request'
+    })
+    descriptor.onPress()
+    expect(onCreatePr).toHaveBeenCalledWith(false)
   })
 
   it('keeps a creatable button visible but disabled while a newer eligibility loads', () => {
@@ -211,7 +227,7 @@ describe('cold-mount layout stability (issue #8411)', () => {
       'unsupported provider',
       {
         kind: 'ready',
-        eligibility: eligibility({ provider: 'bitbucket' as HostedReviewProvider })
+        eligibility: eligibility({ provider: 'unsupported' as HostedReviewProvider })
       } satisfies MobileCreatePrEligibilityState
     ],
     ['eligibility error', { kind: 'error' } satisfies MobileCreatePrEligibilityState]

--- a/src/main/ipc/preflight-runtime-agent-detection.test.ts
+++ b/src/main/ipc/preflight-runtime-agent-detection.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getCanonicalUserDataPathMock, resolveEnvironmentMock, callRuntimeEnvironmentMock } =
+  vi.hoisted(() => ({
+    getCanonicalUserDataPathMock: vi.fn(),
+    resolveEnvironmentMock: vi.fn(),
+    callRuntimeEnvironmentMock: vi.fn()
+  }))
+
+vi.mock('../persistence', () => ({
+  getCanonicalUserDataPath: getCanonicalUserDataPathMock
+}))
+
+vi.mock('../../shared/runtime-environment-store', () => ({
+  resolveEnvironment: resolveEnvironmentMock
+}))
+
+vi.mock('./runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+
+import { detectRuntimeAgents } from './preflight-runtime-agent-detection'
+
+describe('detectRuntimeAgents', () => {
+  beforeEach(() => {
+    getCanonicalUserDataPathMock.mockReset()
+    resolveEnvironmentMock.mockReset()
+    callRuntimeEnvironmentMock.mockReset()
+    getCanonicalUserDataPathMock.mockReturnValue('/user-data')
+    resolveEnvironmentMock.mockReturnValue({ id: 'env-1' })
+  })
+
+  it('proxies preflight.detectAgents to a known runtime environment', async () => {
+    callRuntimeEnvironmentMock.mockResolvedValueOnce({
+      ok: true,
+      result: ['pi', 'claude', 'pi']
+    })
+
+    await expect(detectRuntimeAgents({ environmentId: 'env-1' })).resolves.toEqual(['pi', 'claude'])
+    expect(resolveEnvironmentMock).toHaveBeenCalledWith('/user-data', 'env-1')
+    expect(callRuntimeEnvironmentMock).toHaveBeenCalledWith(
+      '/user-data',
+      'env-1',
+      'preflight.detectAgents',
+      undefined
+    )
+  })
+
+  it('returns no agents for an unknown or unpaired environment', async () => {
+    resolveEnvironmentMock.mockImplementationOnce(() => {
+      throw new Error('Unknown environment: env-missing')
+    })
+
+    await expect(detectRuntimeAgents({ environmentId: 'env-missing' })).resolves.toEqual([])
+    expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('returns no agents when the runtime is unreachable', async () => {
+    callRuntimeEnvironmentMock.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'runtime_unavailable', message: 'offline' }
+    })
+
+    await expect(detectRuntimeAgents({ environmentId: 'env-1' })).resolves.toEqual([])
+  })
+
+  it('returns no agents when the transport throws', async () => {
+    callRuntimeEnvironmentMock.mockRejectedValueOnce(new Error('timeout'))
+
+    await expect(detectRuntimeAgents({ environmentId: 'env-1' })).resolves.toEqual([])
+  })
+
+  it('never re-delegates via detectRuntimeAgents (loop prevention)', async () => {
+    callRuntimeEnvironmentMock.mockResolvedValueOnce({ ok: true, result: ['codex'] })
+
+    await detectRuntimeAgents({ environmentId: 'env-1' })
+
+    const [, , method] = callRuntimeEnvironmentMock.mock.calls[0]!
+    expect(method).toBe('preflight.detectAgents')
+    expect(method).not.toBe('preflight.detectRuntimeAgents')
+  })
+
+  it('ignores blank environment ids without contacting the store', async () => {
+    await expect(detectRuntimeAgents({ environmentId: '   ' })).resolves.toEqual([])
+    expect(resolveEnvironmentMock).not.toHaveBeenCalled()
+    expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/preflight-runtime-agent-detection.ts
+++ b/src/main/ipc/preflight-runtime-agent-detection.ts
@@ -1,0 +1,45 @@
+import { getCanonicalUserDataPath } from '../persistence'
+import { resolveEnvironment } from '../../shared/runtime-environment-store'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
+
+/**
+ * Probe agents installed on a paired runtime environment (host-side proxy for
+ * mobile). Always invokes plain `preflight.detectAgents` on the target so a
+ * remote host cannot re-delegate and form a loop.
+ */
+export async function detectRuntimeAgents(args: { environmentId: string }): Promise<string[]> {
+  const environmentId = args.environmentId.trim()
+  if (!environmentId) {
+    return []
+  }
+  try {
+    const userDataPath = getCanonicalUserDataPath()
+    // Why: only environments registered on this host are addressable — unknown
+    // ids fail closed before any network hop.
+    resolveEnvironment(userDataPath, environmentId)
+    const response = await callRuntimeEnvironment(
+      userDataPath,
+      environmentId,
+      'preflight.detectAgents',
+      undefined
+    )
+    if (response.ok !== true) {
+      // Why: passive UI polling — a disconnected runtime has no detectable
+      // agents until reconnect, but should not spam RPC errors.
+      return []
+    }
+    return uniqueAgentIds(response.result)
+  } catch {
+    return []
+  }
+}
+
+function uniqueAgentIds(result: unknown): string[] {
+  if (!Array.isArray(result)) {
+    return []
+  }
+  const ids = result.filter(
+    (entry): entry is string => typeof entry === 'string' && entry.length > 0
+  )
+  return [...new Set(ids)]
+}

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -22,6 +22,7 @@ import {
   detectRemoteWindowsTerminalCapabilities,
   type RemoteWindowsTerminalCapabilities
 } from './preflight-remote-windows-terminal-capabilities'
+import { detectRuntimeAgents } from './preflight-runtime-agent-detection'
 import {
   getTuiAgentDetectionProbeCommands,
   KNOWN_TUI_AGENT_DETECTION_COMMANDS,
@@ -306,6 +307,13 @@ export function registerPreflightHandlers(): void {
     'preflight:detectRemoteAgents',
     async (_event, args: { connectionId: string }): Promise<string[]> => {
       return detectRemoteAgents(args)
+    }
+  )
+
+  ipcMain.handle(
+    'preflight:detectRuntimeAgents',
+    async (_event, args: { environmentId: string }): Promise<string[]> => {
+      return detectRuntimeAgents(args)
     }
   )
 

--- a/src/main/runtime/rpc/methods/preflight.test.ts
+++ b/src/main/runtime/rpc/methods/preflight.test.ts
@@ -7,12 +7,14 @@ import { PREFLIGHT_METHODS } from './preflight'
 const {
   detectInstalledAgentsWithShellPathHydrationMock,
   detectRemoteAgentsMock,
+  detectRuntimeAgentsMock,
   detectRemoteWindowsTerminalCapabilitiesMock,
   refreshShellPathAndDetectAgentsMock,
   runPreflightCheckMock
 } = vi.hoisted(() => ({
   detectInstalledAgentsWithShellPathHydrationMock: vi.fn(),
   detectRemoteAgentsMock: vi.fn(),
+  detectRuntimeAgentsMock: vi.fn(),
   detectRemoteWindowsTerminalCapabilitiesMock: vi.fn(),
   refreshShellPathAndDetectAgentsMock: vi.fn(),
   runPreflightCheckMock: vi.fn()
@@ -24,6 +26,10 @@ vi.mock('../../../ipc/preflight', () => ({
   detectRemoteWindowsTerminalCapabilities: detectRemoteWindowsTerminalCapabilitiesMock,
   refreshShellPathAndDetectAgents: refreshShellPathAndDetectAgentsMock,
   runPreflightCheck: runPreflightCheckMock
+}))
+
+vi.mock('../../../ipc/preflight-runtime-agent-detection', () => ({
+  detectRuntimeAgents: detectRuntimeAgentsMock
 }))
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
@@ -83,6 +89,19 @@ describe('preflight RPC methods', () => {
 
     expect(detectRemoteAgentsMock).toHaveBeenCalledWith({ connectionId: 'ssh-1' })
     expect(response).toMatchObject({ ok: true, result: ['claude'] })
+  })
+
+  it('detects agents on paired runtime environments through runtime RPC', async () => {
+    detectRuntimeAgentsMock.mockResolvedValueOnce(['pi'])
+    const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: PREFLIGHT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('preflight.detectRuntimeAgents', { environmentId: 'env-1' })
+    )
+
+    expect(detectRuntimeAgentsMock).toHaveBeenCalledWith({ environmentId: 'env-1' })
+    expect(response).toMatchObject({ ok: true, result: ['pi'] })
   })
 
   it('detects remote Windows terminal capabilities through runtime RPC', async () => {

--- a/src/main/runtime/rpc/methods/preflight.ts
+++ b/src/main/runtime/rpc/methods/preflight.ts
@@ -7,12 +7,16 @@ import {
   refreshShellPathAndDetectAgents,
   runPreflightCheck
 } from '../../../ipc/preflight'
+import { detectRuntimeAgents } from '../../../ipc/preflight-runtime-agent-detection'
 
 const PreflightCheck = z.object({
   force: z.boolean().optional()
 })
 const PreflightDetectRemoteAgents = z.object({
   connectionId: z.string().min(1)
+})
+const PreflightDetectRuntimeAgents = z.object({
+  environmentId: z.string().min(1)
 })
 const PreflightDetectRemoteWindowsTerminalCapabilities = z.object({
   connectionId: z.string().min(1)
@@ -33,6 +37,11 @@ export const PREFLIGHT_METHODS: RpcMethod[] = [
     name: 'preflight.detectRemoteAgents',
     params: PreflightDetectRemoteAgents,
     handler: async (params) => detectRemoteAgents(params)
+  }),
+  defineMethod({
+    name: 'preflight.detectRuntimeAgents',
+    params: PreflightDetectRuntimeAgents,
+    handler: async (params) => detectRuntimeAgents(params)
   }),
   defineMethod({
     name: 'preflight.detectRemoteWindowsTerminalCapabilities',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -355,6 +355,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'preflight.check',
   'preflight.detectAgents',
   'preflight.detectRemoteAgents',
+  'preflight.detectRuntimeAgents',
   'projectGroup.list',
   'repo.baseRefDefault',
   'repo.gitAvailable',


### PR DESCRIPTION
## Summary

- Mobile new-tab agent menu previously resolved detection from `repo.connectionId` only, so runtime-hosted repos (`connectionId: null`) probed the **paired host** instead of the runtime execution owner.
- Adds host-side `preflight.detectRuntimeAgents` that proxies `preflight.detectAgents` to a registered paired runtime environment (authorization: environment must exist in the host store; loop prevention: remote hop never re-delegates).
- Mobile loader prefers `executionHostId` (runtime → SSH → local/connectionId) and falls back to paired-host detection when the host predates the new RPC.

Fixes #13752

## Wire compatibility

- New RPC method only; no protocol version bump required for optional new methods.
- **Old mobile / new host:** unused method; behavior unchanged.
- **New mobile / old host:** `method_not_found` falls back to `preflight.detectAgents` (previous behavior, not a hard failure).
- Remote hop always calls plain `preflight.detectAgents` so a runtime host cannot re-proxy.

## Testing

- [x] `pnpm exec vitest run` — `preflight-runtime-agent-detection.test.ts`, `preflight.test.ts` (RPC), `mobile-rpc-allowlist.test.ts`
- [x] `cd mobile && pnpm exec vitest run src/session/mobile-new-tab-agent-loader.test.ts` (6 tests)
- [x] `pnpm run typecheck:node`
- [x] mobile `tsc --noEmit`
- [x] oxlint on changed files
- [ ] Live paired-runtime + mobile emulator QA (not available in this environment; Electron binary install failed)

## Remaining gaps

- `NewWorktreeModal` and tasks workspace-create agent detection still use connectionId-only resolution (same class of bug, out of new-tab menu scope).
- No live multi-host pairing verification in this run.