### PR TITLE
fix(fish): restore agent homes and the attribution PATH shim after config.fish

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -246,6 +246,7 @@ jobs:
             src/main/providers/local-pty-shell-ready.test.ts \
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            src/main/fish-startup-environment.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
@@ -282,6 +283,7 @@ jobs:
             --exclude=src/main/providers/local-pty-shell-ready.test.ts \
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            --exclude=src/main/fish-startup-environment.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -16,7 +16,8 @@ const shellContractFiles = [
 ]
 const patchedNodePtyContractFiles = [
   'src/main/daemon/node-pty-fd-leak.test.ts',
-  'src/main/pty/omp-shell-wrapper.node-pty.test.ts'
+  'src/main/pty/omp-shell-wrapper.node-pty.test.ts',
+  'src/main/fish-startup-environment.node-pty.test.ts'
 ]
 const nativeShellContractFiles = [...shellContractFiles, ...patchedNodePtyContractFiles]
 const testFilePatterns = [

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -269,7 +269,7 @@ describePosix('daemon shell-ready launch config', () => {
     expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
     expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
     const init = config.args?.[2] ?? ''
-    expect(init).toContain('set -gx PATH "$__orca_shim_dir" $PATH')
+    expect(init).toContain('set -gx PATH "$__orca_shim_dir" $__orca_kept_path')
     expect(init).toContain('set -gx OPENCODE_CONFIG_DIR "$ORCA_OPENCODE_CONFIG_DIR"')
     expect(init).toContain('set -gx MIMOCODE_HOME "$ORCA_MIMOCODE_HOME"')
     expect(init).toContain('set -gx CODEX_HOME "$ORCA_CODEX_HOME"')

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -258,12 +258,22 @@ describePosix('daemon shell-ready launch config', () => {
     expect(init).toContain('functions -e __orca_shell_ready_marker')
   })
 
-  it('keeps attribution-only fish spawns unwrapped', async () => {
+  it('gives attribution-only fish the shim/agent-home init command without the marker', async () => {
+    // Why: the markerless pane is where the user types commits by hand, so it needs the
+    // PATH shim most; only the marker stays gated so nothing is emitted into the pane.
     const { getAttributionShellLaunchConfig } = await importFreshShellReady()
 
     const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
 
-    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+    expect(config.supportsReadyMarker).toBe(false)
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
+    expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
+    const init = config.args?.[2] ?? ''
+    expect(init).toContain('set -gx PATH "$__orca_shim_dir" $PATH')
+    expect(init).toContain('set -gx OPENCODE_CONFIG_DIR "$ORCA_OPENCODE_CONFIG_DIR"')
+    expect(init).toContain('set -gx MIMOCODE_HOME "$ORCA_MIMOCODE_HOME"')
+    expect(init).toContain('set -gx CODEX_HOME "$ORCA_CODEX_HOME"')
+    expect(init).toContain('if test "$ORCA_SHELL_READY_MARKER" = 1')
   })
 
   itWithFish(

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -12,7 +12,7 @@ import {
 } from '../powershell-osc133-bootstrap'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import {
-  getFishShellReadyInitCommand,
+  getFishInitCommand,
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
@@ -419,12 +419,14 @@ function getWrappedShellLaunchConfig(
     }
   }
 
-  // Why: mirrors local-pty-shell-ready.ts; attribution-only fish stays unwrapped.
-  if (shellName === 'fish' && options.emitReadyMarker) {
+  // Why: mirrors local-pty-shell-ready.ts. Markerless fish still needs the init command —
+  // that is the pane where the user types commits by hand, so the shim and agent homes
+  // must survive config.fish there too; only the marker itself stays gated.
+  if (shellName === 'fish') {
     return {
-      args: ['-l', '-C', getFishShellReadyInitCommand(SHELL_READY_MARKER)],
-      env: { ORCA_SHELL_READY_MARKER: '1' },
-      supportsReadyMarker: true
+      args: ['-l', '-C', getFishInitCommand(SHELL_READY_MARKER)],
+      env: { ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0' },
+      supportsReadyMarker: options.emitReadyMarker
     }
   }
 

--- a/src/main/fish-launch-config-parity.test.ts
+++ b/src/main/fish-launch-config-parity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * fish is launched from three independent places — the local PTY provider, the
+ * daemon/SSH transport, and the relay running on a remote host. Each one used to grow
+ * its own idea of how to start a shell, and the relay simply had no fish branch at all
+ * (it fell through to bare `-l`), so an SSH user on fish lost the routed agent homes and
+ * the shim PATH entry that the same code fixes locally.
+ *
+ * This file is the drift alarm: it fails if any one site starts fish differently from
+ * the others, or stops sourcing its init text from `getFishInitCommand`.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  getAttributionShellLaunchConfig as getDaemonAttributionShellLaunchConfig,
+  getShellReadyLaunchConfig as getDaemonShellReadyLaunchConfig
+} from './daemon/shell-ready'
+import {
+  getAttributionShellLaunchConfig as getLocalPtyAttributionShellLaunchConfig,
+  getShellReadyLaunchConfig as getLocalPtyShellReadyLaunchConfig
+} from './providers/local-pty-shell-ready'
+import { getRelayShellLaunchConfig } from '../relay/pty-shell-launch'
+import { getFishInitCommand } from './shell-templates'
+
+const FISH_PATH = '/opt/homebrew/bin/fish'
+const SHELL_READY_MARKER = '\\033]777;orca-shell-ready\\007'
+const RELAY_ENV = { HOME: '/home/tester' }
+
+type LaunchShape = { args: string[]; env: Record<string, string> }
+
+function shape(config: { args: string[] | null; env: Record<string, string> }): LaunchShape {
+  return { args: config.args ?? [], env: config.env }
+}
+
+function launchShapes(emitReadyMarker: boolean): Record<string, LaunchShape> {
+  return {
+    local: shape(
+      emitReadyMarker
+        ? getLocalPtyShellReadyLaunchConfig(FISH_PATH)
+        : getLocalPtyAttributionShellLaunchConfig(FISH_PATH)
+    ),
+    daemon: shape(
+      emitReadyMarker
+        ? getDaemonShellReadyLaunchConfig(FISH_PATH)
+        : getDaemonAttributionShellLaunchConfig(FISH_PATH)
+    ),
+    relay: shape(getRelayShellLaunchConfig(FISH_PATH, RELAY_ENV, 'linux', { emitReadyMarker }))
+  }
+}
+
+describe('fish launch config parity across the three launch sites', () => {
+  for (const emitReadyMarker of [true, false]) {
+    const label = emitReadyMarker ? 'shell-ready' : 'attribution-only'
+
+    it(`starts ${label} fish identically from the local, daemon, and relay sites`, () => {
+      const { local, daemon, relay } = launchShapes(emitReadyMarker)
+      expect(daemon).toEqual(local)
+      expect(relay).toEqual(local)
+    })
+
+    it(`hands ${label} fish the shared init text rather than a per-site copy`, () => {
+      const expected = ['-l', '-C', getFishInitCommand(SHELL_READY_MARKER)]
+      for (const [site, config] of Object.entries(launchShapes(emitReadyMarker))) {
+        expect(config.args, site).toEqual(expected)
+        // Why: the marker block is inert unless this is set, so a site that drops it
+        // would look correct in the args diff and never emit a ready marker.
+        expect(config.env, site).toEqual({
+          ORCA_SHELL_READY_MARKER: emitReadyMarker ? '1' : '0'
+        })
+      }
+    })
+  }
+
+  it('re-prepends every shim variable the three sites can plant', () => {
+    const init = getFishInitCommand(SHELL_READY_MARKER)
+    // ORCA_REMOTE_CLI_BIN_DIR is the relay's own name for the shim dir; the local sites
+    // never set it and fish expands the unset name to nothing, which is what lets one
+    // text serve all three.
+    for (const variable of [
+      'ORCA_ATTRIBUTION_SHIM_DIR',
+      'ORCA_AGENT_TEAMS_SHIM_DIR',
+      'ORCA_REMOTE_CLI_BIN_DIR'
+    ]) {
+      expect(init).toContain(`$${variable}`)
+    }
+    for (const variable of ['ORCA_OPENCODE_CONFIG_DIR', 'ORCA_MIMOCODE_HOME', 'ORCA_CODEX_HOME']) {
+      expect(init).toContain(`$${variable}`)
+    }
+  })
+
+  it('keeps non-fish relay shells on their existing launch shapes', () => {
+    // Why: the fish branch sits ahead of the bash/zsh wrapper work, so a basename
+    // mismatch there would silently disarm the overlay wrappers for everyone else.
+    expect(getRelayShellLaunchConfig('/usr/bin/dash', RELAY_ENV, 'linux')).toEqual({
+      args: ['-l'],
+      env: {}
+    })
+  })
+})

--- a/src/main/fish-startup-environment.node-pty.test.ts
+++ b/src/main/fish-startup-environment.node-pty.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Real-fish coverage for the `-C` init command Orca hands every fish PTY.
+ *
+ * fish has no ZDOTDIR-style wrapper dir, so the only hook that runs AFTER the user's
+ * config.fish is `--init-command`. Two things depend on it:
+ *   - Orca's routed agent home must beat a `set -gx CODEX_HOME ...` in config.fish,
+ *     or the account switcher silently launches the agent against the wrong account.
+ *   - the attribution shim must be FIRST in PATH, or commits from fish panes lose the
+ *     Orca trailer. macOS fish's bundled config.fish runs /usr/libexec/path_helper,
+ *     which rebuilds PATH and demotes the inherited shim to near-last.
+ *
+ * Both are asserted against a control spawn with the init command removed, so a
+ * regression that makes the init command a no-op cannot pass this file.
+ */
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getAttributionShellLaunchConfig } from './daemon/shell-ready'
+import { getAttributionShellLaunchConfig as getLocalPtyAttributionShellLaunchConfig } from './providers/local-pty-shell-ready'
+import { fishRequirementViolation, resolveFishBinary } from '../shared/fish-binary-requirement'
+
+const FISH = resolveFishBinary()
+const itWithFish = FISH.available ? it : it.skip
+
+/** Minimal xterm-shaped answers to the probes fish blocks its first prompt on
+ *  (~10s on the DA1 wait alone), so this suite settles in milliseconds. */
+const TERMINAL_QUERY_REPLIES: readonly (readonly [string, string])[] = [
+  ['\x1b[0c', '\x1b[?6c'],
+  ['\x1b[?u', '\x1b[?0u'],
+  ['\x1b[6n', '\x1b[1;1R'],
+  ['\x1b]11;?', '\x1b]11;rgb:0000/0000/0000\x1b\\']
+]
+const QUERY_CARRY_LEN = Math.max(...TERMINAL_QUERY_REPLIES.map(([query]) => query.length))
+
+const SHIM_DIR = '/orca-test/attribution-shim'
+const USER_BIN_DIR = '/orca-test/user-bin'
+const ORCA_CODEX_HOME = '/orca-test/routed-codex-home'
+const USER_CODEX_HOME = '/orca-test/user-codex-home'
+
+/**
+ * Spawns fish on a real PTY with the given args and returns what the session looks
+ * like at its first prompt. Nothing is typed: a fish_prompt handler in config.fish
+ * writes the answer to disk, so the result never races the line editor.
+ */
+async function readFirstPromptEnvironment(args: string[]): Promise<{
+  pathFirstEntry: string
+  codexHome: string
+}> {
+  const pty = await import('node-pty')
+  const home = mkdtempSync(join(tmpdir(), 'orca-fish-startup-'))
+  const resultPath = join(home, 'probe-result')
+  const donePath = join(home, 'probe-done')
+  try {
+    mkdirSync(join(home, '.config', 'fish'), { recursive: true })
+    writeFileSync(
+      join(home, '.config', 'fish', 'config.fish'),
+      [
+        'set -g fish_greeting ""',
+        'function fish_prompt; printf "> "; end',
+        'function fish_right_prompt; end',
+        '# A user who routes their own agent home: Orca must still win.',
+        `set -gx CODEX_HOME ${USER_CODEX_HOME}`,
+        '# Stands in for macOS path_helper (which really does run here on macOS):',
+        '# whatever Orca prepended at spawn is no longer first once config.fish ran.',
+        `set -gx PATH ${USER_BIN_DIR} $PATH`,
+        'function __orca_probe --on-event fish_prompt',
+        `  echo "PATH1=$PATH[1]" >"${resultPath}"`,
+        `  echo "CODEX_HOME=$CODEX_HOME" >>"${resultPath}"`,
+        `  echo done >"${donePath}"`,
+        'end',
+        ''
+      ].join('\n')
+    )
+
+    const proc = pty.spawn(FISH.path as string, args, {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: home,
+      // Why fully specified and never spread from process.env: an inherited
+      // ORCA_* or XDG_* from the developer's own shell would change the outcome.
+      env: {
+        // The inherited PATH only follows so the child can still resolve the fish
+        // binary; both assertions read position 1, which is pinned here and then
+        // displaced by config.fish, so no ambient entry can decide them.
+        PATH: `${SHIM_DIR}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+        HOME: home,
+        TERM: 'xterm-256color',
+        XDG_CONFIG_HOME: join(home, '.config'),
+        XDG_DATA_HOME: join(home, '.local', 'share'),
+        ORCA_ATTRIBUTION_SHIM_DIR: SHIM_DIR,
+        ORCA_CODEX_HOME
+      }
+    })
+
+    let queryCarry = ''
+    let settle = (): void => {}
+    const done = new Promise<void>((resolve) => {
+      settle = resolve
+    })
+    const deadline = setTimeout(settle, 15_000)
+    const poll = setInterval(() => {
+      if (existsSync(donePath)) {
+        settle()
+      }
+    }, 25)
+    proc.onData((chunk) => {
+      // Why the carry: a query split across two chunks would otherwise go unanswered
+      // and re-stall the prompt, while re-answering one already handled would land in
+      // fish's stdin as typed input.
+      const carriedLength = queryCarry.length
+      const scan = queryCarry + chunk
+      queryCarry = scan.slice(-QUERY_CARRY_LEN)
+      for (const [query, reply] of TERMINAL_QUERY_REPLIES) {
+        for (let at = scan.indexOf(query); at !== -1; at = scan.indexOf(query, at + query.length)) {
+          if (at + query.length > carriedLength) {
+            proc.write(reply)
+          }
+        }
+      }
+    })
+    await done
+    clearTimeout(deadline)
+    clearInterval(poll)
+    proc.kill()
+
+    const result = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : ''
+    return {
+      pathFirstEntry: /^PATH1=(.*)$/m.exec(result)?.[1] ?? '',
+      codexHome: /^CODEX_HOME=(.*)$/m.exec(result)?.[1] ?? ''
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+}
+
+describe('fish startup environment', () => {
+  // Always runs, so the CI lane cannot report green with the live tests skipped.
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  it('hands both PTY transports the same fish attribution launch config', () => {
+    // Why: the daemon and local-PTY copies drifted before; a fix landing in one
+    // transport only is invisible until a user on the other one reports it.
+    expect(getAttributionShellLaunchConfig('fish')).toEqual(
+      getLocalPtyAttributionShellLaunchConfig('fish')
+    )
+  })
+
+  itWithFish(
+    'overrides a config.fish agent home and re-prepends the attribution shim',
+    async () => {
+      // Why the attribution config and not the shell-ready one: the markerless pane is
+      // where a user types `git commit` by hand, and it got none of this before.
+      const config = getAttributionShellLaunchConfig(FISH.path as string)
+      expect(config.env.ORCA_SHELL_READY_MARKER).toBe('0')
+
+      const withOrcaInit = await readFirstPromptEnvironment(config.args ?? [])
+      // Control: same fish, same config.fish, no init command. Proves the two
+      // assertions below are actually produced by the init command.
+      const withoutOrcaInit = await readFirstPromptEnvironment(['-l'])
+
+      expect(withOrcaInit.codexHome).toBe(ORCA_CODEX_HOME)
+      expect(withoutOrcaInit.codexHome).toBe(USER_CODEX_HOME)
+
+      expect(withOrcaInit.pathFirstEntry).toBe(SHIM_DIR)
+      // Why the exact value and not `not.toBe(SHIM_DIR)`: a probe that never ran reads
+      // as an empty string, which would satisfy a negative assertion for free.
+      expect(withoutOrcaInit.pathFirstEntry).toBe(USER_BIN_DIR)
+    },
+    45_000
+  )
+})

--- a/src/main/fish-startup-environment.node-pty.test.ts
+++ b/src/main/fish-startup-environment.node-pty.test.ts
@@ -245,4 +245,42 @@ describe('fish startup environment', () => {
       rmSync(home, { recursive: true, force: true })
     }
   })
+
+  itWithFish('drops a repeated shim even when a copy is already first in PATH', () => {
+    // Why: guarding on `$PATH[1]` alone would take the shim's front position as proof
+    // there is nothing to do and leave the later copy in place.
+    const home = mkdtempSync(join(tmpdir(), 'orca fish dedupe '))
+    try {
+      const initPath = join(home, 'init.fish')
+      writeFileSync(initPath, getFishInitCommand(SHELL_READY_MARKER))
+      const result = spawnSync(
+        FISH.path as string,
+        [
+          '--no-config',
+          '-c',
+          [
+            `set -gx PATH ${fishQuote(SHIM_DIR)} /usr/bin /bin ${fishQuote(SHIM_DIR)}`,
+            `source ${fishQuote(initPath)}`,
+            'for __probe_entry in $PATH; echo "PATH=$__probe_entry"; end'
+          ].join('\n')
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            PATH: process.env.PATH ?? '/usr/bin:/bin',
+            HOME: home,
+            ORCA_ATTRIBUTION_SHIM_DIR: SHIM_DIR,
+            ORCA_SHELL_READY_MARKER: '0'
+          }
+        }
+      )
+
+      expect(result.stderr).toBe('')
+      expect(result.status).toBe(0)
+      const pathEntries = [...result.stdout.matchAll(/^PATH=(.*)$/gm)].map((match) => match[1])
+      expect(pathEntries).toEqual([SHIM_DIR, '/usr/bin', '/bin'])
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/main/fish-startup-environment.node-pty.test.ts
+++ b/src/main/fish-startup-environment.node-pty.test.ts
@@ -11,13 +11,18 @@
  *
  * Both are asserted against a control spawn with the init command removed, so a
  * regression that makes the init command a no-op cannot pass this file.
+ *
+ * Every path here is deliberately spacey (and one carries glob characters), because the
+ * dirs this text moves around are really "~/Library/Application Support/...".
  */
+import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getAttributionShellLaunchConfig } from './daemon/shell-ready'
 import { getAttributionShellLaunchConfig as getLocalPtyAttributionShellLaunchConfig } from './providers/local-pty-shell-ready'
+import { getFishInitCommand } from './shell-templates'
 import { fishRequirementViolation, resolveFishBinary } from '../shared/fish-binary-requirement'
 
 const FISH = resolveFishBinary()
@@ -33,10 +38,25 @@ const TERMINAL_QUERY_REPLIES: readonly (readonly [string, string])[] = [
 ]
 const QUERY_CARRY_LEN = Math.max(...TERMINAL_QUERY_REPLIES.map(([query]) => query.length))
 
-const SHIM_DIR = '/orca-test/attribution-shim'
-const USER_BIN_DIR = '/orca-test/user-bin'
-const ORCA_CODEX_HOME = '/orca-test/routed-codex-home'
-const USER_CODEX_HOME = '/orca-test/user-codex-home'
+// Spaces on purpose: "~/Library/Application Support/..." is the real shape of an Orca
+// shim dir on macOS, and an unquoted fish `set` would silently split it into two entries.
+const SHIM_DIR = '/orca test/attribution shim'
+const TEAMS_SHIM_DIR = '/orca test/agent teams shim'
+// Glob characters on purpose: fish treats an unmatched glob as a hard error, so a filter
+// written with `string match` instead of a plain compare would take the whole init down.
+const RELAY_SHIM_DIR = '/orca test/relay [cli] bin'
+const USER_BIN_DIR = '/orca test/user bin'
+const ORCA_CODEX_HOME = '/orca test/routed codex home'
+const USER_CODEX_HOME = '/orca test/user codex home'
+const SHELL_READY_MARKER = '\\033]777;orca-shell-ready\\007'
+
+/**
+ * fish single quotes are NOT POSIX single quotes: `\\` and `\'` still escape inside them,
+ * and a trailing backslash before the closing quote is a syntax error. Verified on 4.7.1.
+ */
+function fishQuote(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
 
 /**
  * Spawns fish on a real PTY with the given args and returns what the session looks
@@ -48,7 +68,7 @@ async function readFirstPromptEnvironment(args: string[]): Promise<{
   codexHome: string
 }> {
   const pty = await import('node-pty')
-  const home = mkdtempSync(join(tmpdir(), 'orca-fish-startup-'))
+  const home = mkdtempSync(join(tmpdir(), 'orca fish startup '))
   const resultPath = join(home, 'probe-result')
   const donePath = join(home, 'probe-done')
   try {
@@ -60,14 +80,14 @@ async function readFirstPromptEnvironment(args: string[]): Promise<{
         'function fish_prompt; printf "> "; end',
         'function fish_right_prompt; end',
         '# A user who routes their own agent home: Orca must still win.',
-        `set -gx CODEX_HOME ${USER_CODEX_HOME}`,
+        `set -gx CODEX_HOME ${fishQuote(USER_CODEX_HOME)}`,
         '# Stands in for macOS path_helper (which really does run here on macOS):',
         '# whatever Orca prepended at spawn is no longer first once config.fish ran.',
-        `set -gx PATH ${USER_BIN_DIR} $PATH`,
+        `set -gx PATH ${fishQuote(USER_BIN_DIR)} $PATH`,
         'function __orca_probe --on-event fish_prompt',
-        `  echo "PATH1=$PATH[1]" >"${resultPath}"`,
-        `  echo "CODEX_HOME=$CODEX_HOME" >>"${resultPath}"`,
-        `  echo done >"${donePath}"`,
+        `  echo "PATH1=$PATH[1]" >${fishQuote(resultPath)}`,
+        `  echo "CODEX_HOME=$CODEX_HOME" >>${fishQuote(resultPath)}`,
+        `  echo done >${fishQuote(donePath)}`,
         'end',
         ''
       ].join('\n')
@@ -172,4 +192,57 @@ describe('fish startup environment', () => {
     },
     45_000
   )
+
+  itWithFish('runs clean and unchanged when a pane re-runs it', () => {
+    // Why: a re-initialized pane can evaluate this text a second time in the same
+    // session. A plain prepend would grow PATH by one duplicate per shim per run.
+    const home = mkdtempSync(join(tmpdir(), 'orca fish idempotent '))
+    try {
+      const initPath = join(home, 'init.fish')
+      writeFileSync(initPath, getFishInitCommand(SHELL_READY_MARKER))
+      const result = spawnSync(
+        FISH.path as string,
+        [
+          // --no-config so the outcome is the init text alone, not a developer's config.fish.
+          '--no-config',
+          '-c',
+          [
+            'set -gx PATH /usr/bin /bin',
+            `source ${fishQuote(initPath)}`,
+            `source ${fishQuote(initPath)}`,
+            'for __probe_entry in $PATH; echo "PATH=$__probe_entry"; end',
+            'echo "CODEX_HOME=$CODEX_HOME"',
+            // Nothing the init text declares may survive into the user's session.
+            'echo "LEAKED=$__orca_shim_dir$__orca_kept_path$__orca_path_entry"'
+          ].join('\n')
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            PATH: process.env.PATH ?? '/usr/bin:/bin',
+            HOME: home,
+            // All three shim variables, because the duplication only shows up once a
+            // later shim displaces an earlier one from PATH[1]. ORCA_REMOTE_CLI_BIN_DIR
+            // is the relay's name for it and is only ever set on an SSH host.
+            ORCA_ATTRIBUTION_SHIM_DIR: SHIM_DIR,
+            ORCA_AGENT_TEAMS_SHIM_DIR: TEAMS_SHIM_DIR,
+            ORCA_REMOTE_CLI_BIN_DIR: RELAY_SHIM_DIR,
+            ORCA_CODEX_HOME,
+            ORCA_SHELL_READY_MARKER: '0'
+          }
+        }
+      )
+
+      expect(result.stderr).toBe('')
+      expect(result.status).toBe(0)
+      const pathEntries = [...result.stdout.matchAll(/^PATH=(.*)$/gm)].map((match) => match[1])
+      // Two `source`s, one entry each — and the relay shim ends up first, matching where
+      // the relay's own bash/zsh wrappers put it.
+      expect(pathEntries).toEqual([RELAY_SHIM_DIR, TEAMS_SHIM_DIR, SHIM_DIR, '/usr/bin', '/bin'])
+      expect(result.stdout).toContain(`CODEX_HOME=${ORCA_CODEX_HOME}`)
+      expect(result.stdout).toContain('LEAKED=\n')
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -391,7 +391,7 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
     expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
     const init = config.args?.[2] ?? ''
-    expect(init).toContain('set -gx PATH "$__orca_shim_dir" $PATH')
+    expect(init).toContain('set -gx PATH "$__orca_shim_dir" $__orca_kept_path')
     expect(init).toContain('set -gx CODEX_HOME "$ORCA_CODEX_HOME"')
     expect(init).toContain('if test "$ORCA_SHELL_READY_MARKER" = 1')
   })

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -380,12 +380,20 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(init).toContain('functions -e __orca_shell_ready_marker')
   })
 
-  it('keeps attribution-only fish spawns unwrapped', async () => {
+  it('gives attribution-only fish the shim/agent-home init command without the marker', async () => {
+    // Why: the markerless pane is where the user types commits by hand, so it needs the
+    // PATH shim most; only the marker stays gated so nothing is emitted into the pane.
     const { getAttributionShellLaunchConfig } = await importFreshLocalPtyShellReady()
 
     const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
 
-    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+    expect(config.supportsReadyMarker).toBe(false)
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
+    expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
+    const init = config.args?.[2] ?? ''
+    expect(init).toContain('set -gx PATH "$__orca_shim_dir" $PATH')
+    expect(init).toContain('set -gx CODEX_HOME "$ORCA_CODEX_HOME"')
+    expect(init).toContain('if test "$ORCA_SHELL_READY_MARKER" = 1')
   })
 
   it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -17,7 +17,7 @@ import {
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
 import {
-  getFishShellReadyInitCommand,
+  getFishInitCommand,
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
@@ -402,12 +402,14 @@ function getWrappedShellLaunchConfig(
     }
   }
 
-  // Why: mirrors daemon/shell-ready.ts; attribution-only fish stays unwrapped.
-  if (shellName === 'fish' && options.emitReadyMarker) {
+  // Why: mirrors daemon/shell-ready.ts. Markerless fish still needs the init command —
+  // that is the pane where the user types commits by hand, so the shim and agent homes
+  // must survive config.fish there too; only the marker itself stays gated.
+  if (shellName === 'fish') {
     return {
-      args: ['-l', '-C', getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)],
-      env: { ORCA_SHELL_READY_MARKER: '1' },
-      supportsReadyMarker: true
+      args: ['-l', '-C', getFishInitCommand(SHELL_READY_MARKER_ESCAPED)],
+      env: { ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0' },
+      supportsReadyMarker: options.emitReadyMarker
     }
   }
 

--- a/src/main/pty/shell-startup-env.test.ts
+++ b/src/main/pty/shell-startup-env.test.ts
@@ -387,6 +387,75 @@ describe('readShellStartupEnvVar', () => {
       expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH)).toBe('/from/zzz')
     })
 
+    it('reads startup files once for agent homes without caching unrelated exports', () => {
+      mockFishFiles(
+        {
+          '/home/alice/.config/fish/conf.d/10-agents.fish':
+            'set -gx CODEX_HOME /from/confd\nset -gx UNQUERIED_SECRET old-secret\n',
+          '/home/alice/.config/fish/config.fish':
+            'set -gx CODEX_HOME /from/config\nset -gx OPENCODE_CONFIG_DIR /from/config-opencode\n'
+        },
+        ['10-agents.fish']
+      )
+
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH)).toBe('/from/config')
+      expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice', FISH)).toBe(
+        '/from/config-opencode'
+      )
+      expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+      expect(readFileSyncMock).toHaveBeenCalledTimes(2)
+
+      mockFishFiles(
+        {
+          '/home/alice/.config/fish/conf.d/10-agents.fish': 'set -gx UNQUERIED_SECRET new-secret\n',
+          '/home/alice/.config/fish/config.fish': 'set -gx CODEX_HOME /changed\n'
+        },
+        ['10-agents.fish']
+      )
+      expect(readShellStartupEnvVar('UNQUERIED_SECRET', '/home/alice', FISH)).toBe('new-secret')
+      expect(readdirSyncMock).toHaveBeenCalledTimes(2)
+      expect(readFileSyncMock).toHaveBeenCalledTimes(4)
+    })
+
+    it('isolates snapshots for distinct startup contexts', () => {
+      readdirSyncMock.mockReturnValue([])
+      mockStartupFiles({
+        '/cfg-a/fish/config.fish':
+          'set -gx CODEX_HOME /from/a\nset -gx OPENCODE_CONFIG_DIR /opencode/a\n',
+        '/cfg-b/fish/config.fish':
+          'set -gx CODEX_HOME /from/b\nset -gx OPENCODE_CONFIG_DIR /opencode/b\n'
+      })
+
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg-a')).toBe('/from/a')
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg-b')).toBe('/from/b')
+      expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice', FISH, '/cfg-a')).toBe(
+        '/opencode/a'
+      )
+      expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice', FISH, '/cfg-b')).toBe(
+        '/opencode/b'
+      )
+      expect(readdirSyncMock).toHaveBeenCalledTimes(2)
+      expect(readFileSyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('evicts the oldest Fish startup context after the bounded cache fills', () => {
+      readdirSyncMock.mockReturnValue([])
+      existsSyncMock.mockReturnValue(true)
+      readFileSyncMock.mockImplementation(
+        (path: string) => `set -gx CODEX_HOME ${path.replace('/fish/config.fish', '')}\n`
+      )
+
+      for (let index = 0; index < 33; index += 1) {
+        expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, `/cfg-${index}`)).toBe(
+          `/cfg-${index}`
+        )
+      }
+      expect(readFileSyncMock).toHaveBeenCalledTimes(33)
+
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg-0')).toBe('/cfg-0')
+      expect(readFileSyncMock).toHaveBeenCalledTimes(34)
+    })
+
     it('honors XDG_CONFIG_HOME', () => {
       mockFishFiles({ '/cfg/fish/config.fish': 'set -gx CODEX_HOME /from/xdg\n' })
       expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg')).toBe('/from/xdg')

--- a/src/main/pty/shell-startup-env.ts
+++ b/src/main/pty/shell-startup-env.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { posix } from 'node:path'
+import { BoundedMap } from '../../shared/bounded-map'
 
 // Why: only files the user's actual shell would source. Mixing zsh and bash
 // files breaks the "last assignment wins matches the live shell" guarantee —
@@ -16,6 +17,14 @@ const BASH_LOGIN_FILES = ['.bash_profile', '.bash_login', '.profile']
 const FISH_SNIPPET_DIR = 'conf.d'
 const FISH_SNIPPET_SUFFIX = '.fish'
 const FISH_CONFIG_FILE = 'config.fish'
+const FISH_AGENT_PATH_CONTEXT_LIMIT = 32
+const FISH_AGENT_PATH_NAMES = new Set([
+  'CODEX_HOME',
+  'GROK_HOME',
+  'OPENCODE_CONFIG_DIR',
+  'PI_CODING_AGENT_DIR',
+  'PRIME_AGENT_CODING_AGENT_DIR'
+])
 
 /** Assignment grammar of a startup file: `export NAME=value` vs fish `set -gx NAME value`. */
 type StartupFileSyntax = 'export' | 'fish-set'
@@ -194,6 +203,37 @@ function expandHome(value: string, home: string): string {
 }
 
 const cache = new Map<string, string | undefined>()
+const fishAgentPathCache = new BoundedMap<string, ReadonlyMap<string, string>>({
+  maxEntries: FISH_AGENT_PATH_CONTEXT_LIMIT
+})
+
+function readFishAgentPaths(
+  home: string,
+  shell: string,
+  configHome: string | undefined
+): ReadonlyMap<string, string> {
+  const cacheKey = `${home}\0${shell}\0${configHome ?? ''}`
+  const cached = fishAgentPathCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const values = new Map<string, string>()
+  for (const path of fishStartupFilePaths(home, configHome)) {
+    const content = readStartupFile(path)
+    if (content === null) {
+      continue
+    }
+    for (const name of FISH_AGENT_PATH_NAMES) {
+      const match = parseAssignedValue(content, name, home, 'fish-set')
+      if (match !== undefined) {
+        values.set(name, match)
+      }
+    }
+  }
+  fishAgentPathCache.set(cacheKey, values)
+  return values
+}
 
 /**
  * Best-effort static read of a single env-var assignment from the user's
@@ -214,11 +254,13 @@ const cache = new Map<string, string | undefined>()
  *   nothing. LAST matching assignment wins.
  * - fish universal variables (`set -Ux` stored in fish_variables) are only
  *   seen when the assignment is also written in a config file.
+ * - Fish shares one scan only for the agent-path variables Orca consumes;
+ *   arbitrary requested names retain the generic per-name behavior.
  * - Windows is unsupported (PowerShell profile parsing is out of scope).
  *
- * Results are memoized per (name, home, shell, configHome) for the process
- * lifetime — shell startup files do not change mid-session in any practical
- * scenario, and PTY spawn is on the hot path.
+ * Results are memoized per variable for the process lifetime. Fish caches the
+ * Orca-consumed set in bounded startup contexts, so those lookups avoid later
+ * filesystem I/O without retaining unrelated exports or source text.
  */
 export function readShellStartupEnvVar(
   name: string,
@@ -235,20 +277,22 @@ export function readShellStartupEnvVar(
     return undefined
   }
 
+  if (shell && posix.basename(shell).toLowerCase() === 'fish' && FISH_AGENT_PATH_NAMES.has(name)) {
+    return readFishAgentPaths(home, shell, configHome).get(name)
+  }
+
   const cacheKey = `${name}\0${home}\0${shell ?? ''}\0${configHome ?? ''}`
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey)
   }
 
   let lastMatch: string | undefined
-
   const { paths, syntax } = shellStartupFiles(home, shell, configHome)
   for (const path of paths) {
     const content = readStartupFile(path)
     if (content === null) {
       continue
     }
-
     const match = parseAssignedValue(content, name, home, syntax)
     if (match !== undefined) {
       lastMatch = match
@@ -294,4 +338,5 @@ export function readSessionShellStartupEnvVar(
  */
 export function __resetShellStartupEnvCache(): void {
   cache.clear()
+  fishAgentPathCache.clear()
 }

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -183,7 +183,7 @@ end`
 /**
  * Everything Orca must apply to a fish session *after* the user's own startup
  * files, delivered as one `--init-command` (fish evaluates -C after config.fish
- * and conf.d, and multi-`-C` support varies by version).
+ * and conf.d).
  *
  * The POSIX wrappers do this from their rc files; fish has no such hook, so
  * without this a fish pane silently loses both halves of the contract.
@@ -200,10 +200,11 @@ export function getFishInitCommand(escapedMarker: string): string {
   # of the user's session. Order matches the POSIX wrappers: attribution, then teams,
   # and the relay's own shim (ORCA_REMOTE_CLI_BIN_DIR) last so it ends up first.
   for __orca_shim_dir in $ORCA_ATTRIBUTION_SHIM_DIR $ORCA_AGENT_TEAMS_SHIM_DIR $ORCA_REMOTE_CLI_BIN_DIR
-    if test -n "$__orca_shim_dir"; and test "$PATH[1]" != "$__orca_shim_dir"
-      # Why drop existing copies instead of a plain prepend: this text can run twice in
-      # one session (a re-initialized pane), and a plain prepend grows PATH by one
-      # duplicate per shim per run. Filtered by string compare, not \`string match\`,
+    if test -n "$__orca_shim_dir"
+      # Why filter unconditionally instead of skipping when the shim is already $PATH[1]:
+      # the shim can be first *and* repeated later, and that skip would keep the copy.
+      # Filter-then-prepend also makes a re-run a no-op, where a plain prepend would grow
+      # PATH by one duplicate per shim. Compared as strings, not with \`string match\`,
       # because a shim path may contain glob characters.
       set -l __orca_kept_path
       for __orca_path_entry in $PATH

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -187,16 +187,29 @@ end`
  *
  * The POSIX wrappers do this from their rc files; fish has no such hook, so
  * without this a fish pane silently loses both halves of the contract.
+ *
+ * One text serves all three launch sites (local PTY, daemon/SSH, relay): fish expands
+ * an unset variable to nothing, so each site's unused shim variables drop out of the
+ * loop. Forking a per-site copy is how the POSIX call sites drifted apart before.
  */
 export function getFishInitCommand(escapedMarker: string): string {
   return `begin
   # Why: macOS fish's bundled config.fish runs path_helper, which rebuilds PATH and
   # appends inherited entries last — the attribution shim lands near-last and commits
   # from fish panes lose the Orca trailer. The begin block keeps the loop variable out
-  # of the user's session. Order matches the POSIX wrappers: attribution, then teams.
-  for __orca_shim_dir in $ORCA_ATTRIBUTION_SHIM_DIR $ORCA_AGENT_TEAMS_SHIM_DIR
+  # of the user's session. Order matches the POSIX wrappers: attribution, then teams,
+  # and the relay's own shim (ORCA_REMOTE_CLI_BIN_DIR) last so it ends up first.
+  for __orca_shim_dir in $ORCA_ATTRIBUTION_SHIM_DIR $ORCA_AGENT_TEAMS_SHIM_DIR $ORCA_REMOTE_CLI_BIN_DIR
     if test -n "$__orca_shim_dir"; and test "$PATH[1]" != "$__orca_shim_dir"
-      set -gx PATH "$__orca_shim_dir" $PATH
+      # Why drop existing copies instead of a plain prepend: this text can run twice in
+      # one session (a re-initialized pane), and a plain prepend grows PATH by one
+      # duplicate per shim per run. Filtered by string compare, not \`string match\`,
+      # because a shim path may contain glob characters.
+      set -l __orca_kept_path
+      for __orca_path_entry in $PATH
+        test "$__orca_path_entry" = "$__orca_shim_dir"; or set -a __orca_kept_path "$__orca_path_entry"
+      end
+      set -gx PATH "$__orca_shim_dir" $__orca_kept_path
     end
   end
 end

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -171,13 +171,48 @@ fi
 // zle-line-init this lands just *before* fish arms `?2004h`, which PostReadyFlushGate
 // absorbs. `builtin printf` so a user-defined printf can't silently swallow the marker
 // and send every launch to the ready timeout.
-export function getFishShellReadyInitCommand(escapedMarker: string): string {
+function getFishShellReadyMarkerBlock(escapedMarker: string): string {
   return `if test "$ORCA_SHELL_READY_MARKER" = 1
   function __orca_shell_ready_marker --on-event fish_prompt
     builtin printf "${escapedMarker}"
     functions -e __orca_shell_ready_marker
   end
 end`
+}
+
+/**
+ * Everything Orca must apply to a fish session *after* the user's own startup
+ * files, delivered as one `--init-command` (fish evaluates -C after config.fish
+ * and conf.d, and multi-`-C` support varies by version).
+ *
+ * The POSIX wrappers do this from their rc files; fish has no such hook, so
+ * without this a fish pane silently loses both halves of the contract.
+ */
+export function getFishInitCommand(escapedMarker: string): string {
+  return `begin
+  # Why: macOS fish's bundled config.fish runs path_helper, which rebuilds PATH and
+  # appends inherited entries last — the attribution shim lands near-last and commits
+  # from fish panes lose the Orca trailer. The begin block keeps the loop variable out
+  # of the user's session. Order matches the POSIX wrappers: attribution, then teams.
+  for __orca_shim_dir in $ORCA_ATTRIBUTION_SHIM_DIR $ORCA_AGENT_TEAMS_SHIM_DIR
+    if test -n "$__orca_shim_dir"; and test "$PATH[1]" != "$__orca_shim_dir"
+      set -gx PATH "$__orca_shim_dir" $PATH
+    end
+  end
+end
+# Why: a config.fish that sets its own agent home (\`set -gx CODEX_HOME ...\`) would
+# otherwise beat Orca's routed home and launch the agent against the wrong account,
+# which reads in the UI as the account switcher doing nothing.
+if test -n "$ORCA_OPENCODE_CONFIG_DIR"
+  set -gx OPENCODE_CONFIG_DIR "$ORCA_OPENCODE_CONFIG_DIR"
+end
+if test -n "$ORCA_MIMOCODE_HOME"
+  set -gx MIMOCODE_HOME "$ORCA_MIMOCODE_HOME"
+end
+if test -n "$ORCA_CODEX_HOME"
+  set -gx CODEX_HOME "$ORCA_CODEX_HOME"
+end
+${getFishShellReadyMarkerBlock(escapedMarker)}`
 }
 
 export function getZshFinalZdotdirRestoreBlock(homeExpression = '"${ORCA_ORIG_ZDOTDIR:-$HOME}"') {

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -1,9 +1,12 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getFishInitCommand } from '../main/shell-templates'
 import { getRelayShellLaunchConfig } from './pty-shell-launch'
+
+const SHELL_READY_MARKER_ESCAPED = '\\033]777;orca-shell-ready\\007'
 
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
@@ -120,6 +123,42 @@ describe('getRelayShellLaunchConfig', () => {
       args: ['-l'],
       env: {}
     })
+  })
+
+  it('restores agent homes and the shim PATH entry on a remote whose shell is fish', () => {
+    // Why: fish fell through to a bare `-l` here, so an SSH host on fish kept none of the
+    // overlay env the relay planted — the account switcher looked like a no-op remotely
+    // and remote commits lost the Orca trailer.
+    const config = getRelayShellLaunchConfig(
+      '/usr/bin/fish',
+      { HOME: homeDir, ORCA_REMOTE_CLI_BIN_DIR: '/tmp/orca-relay-bin' },
+      'linux'
+    )
+
+    expect(config.args.slice(0, 2)).toEqual(['-l', '-C'])
+    expect(config.args[2]).toBe(getFishInitCommand(SHELL_READY_MARKER_ESCAPED))
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '0' })
+  })
+
+  it('arms the fish ready marker only when the caller asks for it', () => {
+    const args = ['/usr/bin/fish', { HOME: homeDir }, 'linux'] as const
+    expect(
+      getRelayShellLaunchConfig(...args, { emitReadyMarker: true }).env.ORCA_SHELL_READY_MARKER
+    ).toBe('1')
+    // Markerless is still wrapped: that is the pane where a user types `git commit`.
+    const markerless = getRelayShellLaunchConfig(...args, { emitReadyMarker: false })
+    expect(markerless.env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(markerless.args).toHaveLength(3)
+  })
+
+  it('writes no persistent wrapper files for fish', () => {
+    // Why: fish carries everything on `-C`, so it must not create ~/.orca-relay on a
+    // remote or leave stale rc files behind for a shell that never reads them.
+    getRelayShellLaunchConfig('/usr/bin/fish', { HOME: homeDir }, 'linux', {
+      emitReadyMarker: true
+    })
+
+    expect(existsSync(join(homeDir, '.orca-relay'))).toBe(false)
   })
 
   it.skipIf(process.platform === 'win32')('rewrites stale persistent wrapper files', () => {

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { getPosixOmpShellWrapper } from '../main/pty/omp-shell-wrapper'
 import {
+  getFishInitCommand,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
   SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
@@ -285,6 +286,18 @@ export function getRelayShellLaunchConfig(
           terminalWindowsWslDistro: options.terminalWindowsWslDistro
         }) ?? [],
       env: {}
+    }
+  }
+
+  // Why: mirrors src/main/daemon/shell-ready.ts and providers/local-pty-shell-ready.ts.
+  // A remote whose login shell is fish gets no wrapper rc file, so `-C` is the only hook
+  // that runs after the remote's config.fish — without it the routed agent homes and the
+  // shim PATH entry the relay planted are silently lost on this host. Ungated like the
+  // local sites: the markerless pane is where the user types `git commit` by hand.
+  if (shellName === 'fish') {
+    return {
+      args: [...POSIX_LOGIN_ARGS, '-C', getFishInitCommand(SHELL_READY_MARKER_ESCAPED)],
+      env: { ORCA_SHELL_READY_MARKER: emitReadyMarker ? '1' : '0' }
     }
   }
 


### PR DESCRIPTION
## ELI5

If you use fish as your shell, Orca was quietly losing two things every time it opened a terminal: the agent account it routed you to, and the little wrapper that stamps commits as coming from Orca. Your own `config.fish` ran *after* Orca set those up and stomped on them. This adds one line of fish that re-applies them at the very end of startup, which is the only place fish lets you hook — and it does it on **all three** places Orca starts a shell, including SSH/remote hosts.

## What Changed

`src/main/shell-templates.ts` now generates a single fish `--init-command` (`getFishInitCommand`) that carries three things instead of one:

1. re-prepends the shim dirs (`ORCA_ATTRIBUTION_SHIM_DIR`, `ORCA_AGENT_TEAMS_SHIM_DIR`, and the relay's own `ORCA_REMOTE_CLI_BIN_DIR`) to `PATH`
2. restores `OPENCODE_CONFIG_DIR`, `MIMOCODE_HOME`, and `CODEX_HOME` from their `ORCA_*` counterparts
3. the existing shell-ready marker block, unchanged and still gated on `ORCA_SHELL_READY_MARKER`

All **three** fish call sites are wired to it: `src/main/providers/local-pty-shell-ready.ts` (local PTY), `src/main/daemon/shell-ready.ts` (daemon/SSH transport), and `src/relay/pty-shell-launch.ts` (the relay running on the remote host). Attribution-only (markerless) fish spawns get the init command too — previously they were spawned completely unwrapped — with `ORCA_SHELL_READY_MARKER=0` so a markerless pane still emits nothing.

Everything is folded into **one** `-C` string on purpose: it keeps all three launch sites sharing a single text, which is the property the parity test below locks down. (fish does accept repeated `-C` flags — verified on 4.7.1 — so this is about keeping one source of truth, not a version constraint.)

### The relay gap (SSH / remote hosts)

`getRelayShellLaunchConfig` returned early with `{ args: ['-l'], env: {} }` for anything that was not zsh or bash. So on a remote whose login shell is fish, **none** of the above applied: switching OpenCode/Codex accounts planted `ORCA_OPENCODE_CONFIG_DIR` / `ORCA_CODEX_HOME` / `ORCA_MIMOCODE_HOME` that were never restored after the remote's `config.fish`, and the shim the relay prepends to `PATH` was never re-prepended, so remote commits lost the Orca trailer.

The relay branch **reuses `getFishInitCommand`** rather than forking a second copy — a divergent duplicate is exactly how the two local sites drifted apart before. One text can serve all three sites because fish expands an unset variable to nothing, so each site's unused shim variables simply drop out of the loop (`ORCA_REMOTE_CLI_BIN_DIR` is only ever set on an SSH host; the local shim vars are only ever set locally). fish needs no wrapper rc files, so the relay writes nothing to `~/.orca-relay` for it — asserted.

### Idempotency fix found by running the text through real fish

The `PATH` block was **not** idempotent. Measured on fish 4.7.1: with more than one shim variable set, a second evaluation re-prepended every entry (`count $PATH` 5 → 8 → 11), because the guard only compared against `$PATH[1]` and each prepend displaced the previous shim from position 1. A pane can be re-initialized, so this is now a filter-then-prepend: existing copies are dropped first, by plain string compare rather than `string match`, since a shim path may contain glob characters and fish treats an unmatched glob as a hard error.

## Why

fish has no ZDOTDIR-style wrapper directory, so the POSIX (bash/zsh) wrappers' "run this after the user's startup files" hook has no equivalent. The only thing fish evaluates after `config.fish` and `conf.d/*.fish` is `--init-command`. Orca already rode it for the shell-ready marker; nothing else was riding it, and the relay was not riding it at all.

Two user-visible consequences, both fixed here, now on local **and** remote hosts:

- **Wrong agent account.** A fish user with `set -gx CODEX_HOME ...` in `config.fish` had that value win over Orca's routed home, so the agent launched against the wrong account and the account switcher appeared to do nothing. The POSIX wrappers already restore these; fish did not.
- **Lost commit attribution.** macOS fish's bundled `config.fish` runs `/usr/libexec/path_helper`, which rebuilds `PATH` and appends inherited entries last. Verified locally on fish 4.7.1: a shim dir prepended in the spawn env is demoted to near-last under `fish -l`. Commits made in Orca fish terminals therefore lost the Orca trailer / PR footer. Anything that must win in `PATH` has to be re-applied in the init command, not in the spawn env.

The markerless path matters most for the second one: that is the pane where a user types `git commit` by hand.

STA-3937 / #13875 left this unowned. **This does not reintroduce Prime Agent command rewriting** — #13875 tried to rebuild a fish command wrapper and its author closed it ("Orca must not redefine or rewrite typed Prime Agent commands"), and #13906 removed that interception across all shells. Nothing here inspects, redefines, or rewrites a typed command; it only sets environment variables and `PATH` before the first prompt. (For the same reason the relay's `omp` POSIX shell wrapper is deliberately **not** ported to fish: it is a command wrapper.)

## Linked Issue

Fixes #

STA-3937 (follow-up to the fish gap left by #13875 / #13906)

## Visual Proof

`N/A` — there is no UI surface. The change is shell startup state (`PATH` ordering and three environment variables) inside the PTY; its observable effect is asserted directly against a real fish process in the tests below.

## Testing

**Real fish** (`src/main/fish-startup-environment.node-pty.test.ts`, fish 4.7.1):

- Spawns real fish on a real PTY with a `config.fish` that both exports its own `CODEX_HOME` and displaces the inherited shim from the front of `PATH` (standing in for `path_helper`, which really does run here on macOS), then reads the session state from a `fish_prompt` handler — nothing is typed, so the result cannot race the line editor. Asserts Orca's routed `CODEX_HOME` beats the one `config.fish` exported, and that the shim dir is **first** in `PATH` at the first prompt. Both are checked against a **control spawn of the same fish with the init command removed**, which yields the user's `CODEX_HOME` and the user's dir at `PATH[1]`, so a regression that turns the init command into a no-op cannot pass. Confirmed by mutation: stubbing the `set -gx PATH` line fails with `expected '/orca test/user bin' to be '/orca test/attribution shim'`.
- New case: seeds `PATH` with the shim in **both** first and last position and asserts it survives exactly once. Guarding on `$PATH[1]` alone read the shim's front position as proof there was nothing to do and kept the later copy; the filter now runs unconditionally. Confirmed by mutation: restoring the `$PATH[1]` guard fails it with the duplicate still present.
- New case: sources the generated init text **twice** in one fish session with all three shim variables set and asserts `PATH` is exactly `[relay, teams, attribution, /usr/bin, /bin]`, stderr is empty, status is 0, and none of the init text's own variables leak into the session. Confirmed by mutation: restoring the plain prepend fails it with 8 entries instead of 5.
- Every path in this file now contains **spaces**, and the relay shim path also contains **glob characters** (`/orca test/relay [cli] bin`), because the real dirs are `~/Library/Application Support/...`. The generated `config.fish` is quoted with a fish-correct quoter (fish single quotes are not POSIX single quotes: `\\` and `\'` still escape inside them, and a trailing backslash before the closing quote is a syntax error).

**Drift alarm** (`src/main/fish-launch-config-parity.test.ts`, new): asserts the local, daemon, and relay sites produce byte-identical fish `args` and `env` for both the shell-ready and attribution-only shapes, and that all three take their `-C` payload from `getFishInitCommand`. Confirmed by mutation: reverting the relay branch to a bare `-l` fails 4 of its 6 tests.

**Relay unit tests** (`src/relay/pty-shell-launch.test.ts`): fish on a remote gets `-l -C <shared init>`; the marker env is armed only when the caller asks; markerless fish is still wrapped; no `~/.orca-relay` wrapper files are written for fish; non-fish shells keep their existing shapes.

Verified locally on macOS (fish 4.7.1) — real output, all clean:

```
npx tsc --noEmit -p config/tsconfig.node.json            # clean
npx tsc --noEmit -p config/tsconfig.tc.web.json          # clean
npx oxlint                                               # exit 0, only pre-existing warnings
node config/scripts/check-max-lines-ratchet.mjs          # OK, no new bypasses
node config/scripts/check-reliability-gates.mjs          # OK, 74 gates
npx vitest run daemon/shell-ready.test.ts local-pty-shell-ready.test.ts \
    fish-launch-config-parity.test.ts fish-startup-environment.node-pty.test.ts \
    relay/pty-shell-launch.test.ts relay/pty-handler.test.ts \
    pr-workflow-parallelism.test.mjs local-pty-provider.test.ts \
    pty-subprocess.test.ts                               # 9 files, 491 passed
```

The real-fish file stays registered in **both** CI lists per the repo contract: the `shell_contracts` run list and the shard `--exclude` list in `.github/workflows/pr.yml`, plus `patchedNodePtyContractFiles` in `config/scripts/pr-workflow-parallelism.test.mjs` so the registration itself is enforced. The new parity test needs no fish binary and runs in the normal shards.

Edge cases exercised against real fish 4.7.1 while developing the template: all `ORCA_*` unset (no-op, exit 0, no stderr), shim var set to the empty string (no-op), shim dirs containing spaces and glob characters, an empty inherited `PATH`, and three consecutive re-runs (`count $PATH` stays 5). The loops are wrapped in `begin`/`end` so no loop variable leaks into the user's session (verified: `LEAKED=` is empty).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform:** fish is POSIX-only. All three sites gate on `shellName === 'fish'`, and the relay's fish branch sits after its `win32` early return. bash/zsh/PowerShell paths are untouched. The `path_helper` demotion is macOS-specific but the fix is unconditional and harmless elsewhere (Linux fish simply finds the shim already first and skips the prepend).
- **SSH / remote:** this is the point of the change. The relay is the side that spawns the PTY on the remote host, and it now applies the same init command as local. A parity test keeps all three sites from drifting.
- **Remote wire compatibility:** no wire change — no new RPC params, stream frames, or opcodes. What the relay *publishes* does change in one way: a fish pane now emits the OSC 777 ready marker when the client asked for `startupCommandDelivery: 'shell-ready'`. That is safe for old clients because the client-side scanner that strips this marker is shell-agnostic and is armed by exactly the same condition that makes the relay emit it — a client that requests shell-ready delivery is by definition a client that scans and strips. Clients that do not request it get `ORCA_SHELL_READY_MARKER=0` and no marker at all. The previous behaviour for fish over SSH was to fall back to a timer; now the marker actually arrives.
- **Folder workspaces / worktrees:** nothing here reads git state.
- **Backwards compatibility:** markerless fish spawns gain `-l -C <init>` where they previously used the caller's default args — which on POSIX was already `['-l']`, so the only new argument is the init command itself.
- **Performance:** a handful of builtin `test`/`set` calls once per shell start; the PATH filter is O(len(PATH)) per shim.
- **Security:** no user-supplied text is interpolated into the generated fish source — the init command only references `$ORCA_*` variable names, so there is nothing to quote or inject through.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## AI Disclosure

Authored with Claude (Opus 5).

Made with [Orca](https://github.com/stablyai/orca) 🐋

