### PR TITLE
fix(pr): route remaining PR page avatars through GitHubUserAvatar

### DIFF
--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -882,13 +882,12 @@ function PRReviewersPanel({
         <span className="flex size-4 shrink-0 items-center justify-center text-foreground">
           {selected ? <Check className="size-3.5" /> : null}
         </span>
-        {reviewer.avatarUrl ? (
-          <img src={reviewer.avatarUrl} alt="" className="size-5 shrink-0 rounded-full" />
-        ) : (
-          <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
-            {reviewer.login.slice(0, 1).toUpperCase()}
-          </span>
-        )}
+        <GitHubUserAvatar
+          login={reviewer.login}
+          name={reviewer.name}
+          avatarUrl={reviewer.avatarUrl}
+          className="size-5"
+        />
         <span className="min-w-0 flex-1">
           <span className="block truncate">
             <span className="font-semibold text-foreground">{reviewer.login}</span>
@@ -2391,15 +2390,12 @@ function ConversationTab({
       )}
     >
       <div className="flex min-w-0 items-center gap-2 border-b border-border/40 px-3 py-2">
-        {comment.authorAvatarUrl ? (
-          <img
-            src={comment.authorAvatarUrl}
-            alt={comment.author}
-            className="size-5 shrink-0 rounded-full"
-          />
-        ) : (
-          <div className="size-5 shrink-0 rounded-full bg-muted" />
-        )}
+        <GitHubUserAvatar
+          login={comment.author}
+          avatarUrl={comment.authorAvatarUrl}
+          title={comment.author}
+          className="size-5"
+        />
         <span
           className={cn(
             'min-w-0 truncate text-[13px] font-semibold',
@@ -4294,13 +4290,12 @@ function MentionTextarea({
                 index === activeIndex && 'bg-accent text-accent-foreground'
               )}
             >
-              {option.avatarUrl ? (
-                <img src={option.avatarUrl} alt="" className="size-5 shrink-0 rounded-full" />
-              ) : (
-                <div className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
-                  {option.login.slice(0, 1).toUpperCase()}
-                </div>
-              )}
+              <GitHubUserAvatar
+                login={option.login}
+                name={option.name}
+                avatarUrl={option.avatarUrl}
+                className="size-5"
+              />
               <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
                 <span className="shrink-0 font-medium">@{option.login}</span>
                 {option.name && (

--- a/src/renderer/src/components/github/repro-8784-ghe-avatar-fallback.test.ts
+++ b/src/renderer/src/components/github/repro-8784-ghe-avatar-fallback.test.ts
@@ -51,4 +51,16 @@ describe('issue #8784 GHE avatar fallback (regression)', () => {
     // Why: list chip must not hardcode github.com/{login}.png.
     expect(taskPage).not.toMatch(/github\.com\/\$\{reviewer\.login\}\.png/)
   })
+
+  it('source does not leave bare avatar imgs on the PR page GHE fallback path (#13976)', () => {
+    // Why: private-mode GHE avatar URLs 302 to /login in the renderer session;
+    // only GitHubUserAvatar degrades to initials via onError. Bare <img> stays broken.
+    const prPage = readFileSync(join(__dirname, '../PullRequestPage.tsx'), 'utf8')
+    expect(prPage).not.toMatch(/src=\{comment\.authorAvatarUrl\}/)
+    expect(prPage).not.toMatch(/src=\{reviewer\.avatarUrl\}/)
+    expect(prPage).not.toMatch(/src=\{option\.avatarUrl\}/)
+    expect(prPage).toMatch(/GitHubUserAvatar[\s\S]*login=\{comment\.author\}/)
+    expect(prPage).toMatch(/GitHubUserAvatar[\s\S]*login=\{reviewer\.login\}/)
+    expect(prPage).toMatch(/GitHubUserAvatar[\s\S]*login=\{option\.login\}/)
+  })
 })


### PR DESCRIPTION
## Summary
- On private-mode GHE, avatar URLs 302 to `/login` in the renderer session
- Three `PullRequestPage` call sites still used bare `<img>` (reviewer picker, comment author, `@` mentions) so a present URL showed a broken image instead of initials (#13976)
- Route them through `GitHubUserAvatar` (already used for the PR author / reviewer badge after #8784)
- Extend the #8784 source contract test so bare avatar `src={…AvatarUrl}` cannot regress

## Test plan
- [x] `vitest` `github-user-avatar.test.tsx` + `repro-8784-ghe-avatar-fallback.test.ts`
- [ ] On private-mode GHE: open a PR with comments → author avatars show initials (not broken)
- [ ] Reviewer picker and `@` mention list degrade the same way
- [ ] github.com avatars still load normally

Closes #13976