### PR TITLE
feat(tab-group): open Explorer-dragged files in a split pane

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -78,6 +78,7 @@ import {
 } from '../hooks/ipc-tab-switch'
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import AiVaultSessionDropLayer from './tab-group/AiVaultSessionDropLayer'
+import WorkspaceFileSplitDropLayer from './tab-group/WorkspaceFileSplitDropLayer'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
 import { useActiveTerminalRepair } from './terminal/use-active-terminal-repair'
 import { scheduleBackgroundTerminalWorktreeMeasure } from './terminal/background-terminal-worktree-visibility'
@@ -2794,6 +2795,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
       ) : null}
       <AiVaultSessionDropLayer worktreeId={worktreeId} enabled={isVisible} />
+      <WorkspaceFileSplitDropLayer worktreeId={worktreeId} enabled={isVisible} />
     </div>
   )
 })

--- a/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.test.tsx
+++ b/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+
+// Why: the split only happens if a native Explorer drag reaches the layer, so
+// these tests drive the real dragstart/dragover/drop gesture end to end.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
+import { resetWorkspaceFileDragActivityForTests } from '@/lib/workspace-file-drag-activity'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const { createEmptySplitGroupMock, openFileMock, setActiveTabTypeMock, statRuntimePathMock } =
+  vi.hoisted(() => ({
+    createEmptySplitGroupMock: vi.fn(() => 'new-group'),
+    openFileMock: vi.fn(),
+    setActiveTabTypeMock: vi.fn(),
+    statRuntimePathMock: vi.fn(async () => ({ isDirectory: false, mtime: 0, size: 1 }))
+  }))
+
+vi.mock('../../store', () => ({
+  useAppStore: {
+    getState: () => ({
+      createEmptySplitGroup: createEmptySplitGroupMock,
+      getKnownWorktreeById: () => ({ path: '/repo' }),
+      openFile: openFileMock,
+      setActiveTabType: setActiveTabTypeMock
+    })
+  }
+}))
+vi.mock('./tab-group-panel-split-target', () => ({
+  captureTabGroupPanelGeometrySnapshot: () => ({
+    byGroupId: new Map(),
+    entries: [{ bodyRect: { height: 200, left: 0, top: 0, width: 400 }, groupId: 'group-1' }]
+  })
+}))
+vi.mock('@/runtime/runtime-file-client', () => ({ statRuntimePath: statRuntimePathMock }))
+vi.mock('@/hooks/useGlobalFileDrop', () => ({
+  getEditorFileDropOperationContext: () => ({ settings: {}, worktreeId: 'worktree-1' })
+}))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => undefined }))
+vi.mock('@/lib/worktree-runtime-owner', () => ({ getRuntimeEnvironmentIdForWorktree: () => null }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+import WorkspaceFileSplitDropLayer from './WorkspaceFileSplitDropLayer'
+
+function dragEvent(type: string, types: string[], point = { x: 0, y: 0 }): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', {
+    value: { dropEffect: 'none', getData: () => '/repo/src/app.ts', types }
+  })
+  Object.defineProperty(event, 'clientX', { value: point.x })
+  Object.defineProperty(event, 'clientY', { value: point.y })
+  return event
+}
+
+function bands(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>('.pointer-events-auto')]
+}
+
+describe('WorkspaceFileSplitDropLayer', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetWorkspaceFileDragActivityForTests()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      root = createRoot(container)
+      root.render(<WorkspaceFileSplitDropLayer worktreeId="worktree-1" enabled={true} />)
+    })
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    container.remove()
+    resetWorkspaceFileDragActivityForTests()
+  })
+
+  it('arms one band per split direction once an Explorer drag starts', () => {
+    expect(bands(container)).toHaveLength(0)
+    act(() => {
+      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    expect(bands(container)).toHaveLength(4)
+  })
+
+  it('stays inert for drags that carry no workspace file path', () => {
+    act(() => {
+      window.dispatchEvent(dragEvent('dragstart', ['text/plain']))
+    })
+    expect(bands(container)).toHaveLength(0)
+  })
+
+  it('disarms when the drag ends without a drop', () => {
+    act(() => {
+      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    act(() => {
+      window.dispatchEvent(dragEvent('dragend', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    expect(bands(container)).toHaveLength(0)
+  })
+
+  it('previews the target half while a band is hovered', () => {
+    act(() => {
+      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    expect(container.querySelector('.tab-drop-overlay')).toBeNull()
+    act(() => {
+      bands(container)[0]?.dispatchEvent(dragEvent('dragover', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    expect(container.querySelector('.tab-drop-overlay')).not.toBeNull()
+  })
+
+  it('opens the dropped file in a split beside the hovered pane', async () => {
+    act(() => {
+      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    const rightBand = bands(container)[1]
+    await act(async () => {
+      rightBand?.dispatchEvent(dragEvent('drop', [WORKSPACE_FILE_PATH_MIME]))
+      await Promise.resolve()
+    })
+
+    expect(createEmptySplitGroupMock).toHaveBeenCalledWith('worktree-1', 'group-1', 'right')
+    expect(setActiveTabTypeMock).toHaveBeenCalledWith('editor')
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/repo/src/app.ts', relativePath: 'src/app.ts' }),
+      expect.objectContaining({ targetGroupId: 'new-group' })
+    )
+  })
+
+  it('leaves folder drops alone instead of opening an empty split', async () => {
+    statRuntimePathMock.mockResolvedValueOnce({ isDirectory: true, mtime: 0, size: 0 })
+    act(() => {
+      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+    })
+    await act(async () => {
+      bands(container)[0]?.dispatchEvent(dragEvent('drop', [WORKSPACE_FILE_PATH_MIME]))
+      await Promise.resolve()
+    })
+
+    expect(createEmptySplitGroupMock).not.toHaveBeenCalled()
+    expect(openFileMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.test.tsx
+++ b/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.test.tsx
@@ -59,6 +59,24 @@ function bands(container: HTMLElement): HTMLElement[] {
   return [...container.querySelectorAll<HTMLElement>('.pointer-events-auto')]
 }
 
+/**
+ * Mirrors how a real Explorer drag starts: React delegates `onDragStart` to the
+ * root, so `setData` lands on the way back up and the payload is still empty
+ * while capture-phase listeners run.
+ */
+function startExplorerDrag(): void {
+  const source = document.createElement('div')
+  document.body.appendChild(source)
+  const types: string[] = []
+  const populate = (): void => {
+    types.push(WORKSPACE_FILE_PATH_MIME)
+  }
+  document.body.addEventListener('dragstart', populate)
+  source.dispatchEvent(dragEvent('dragstart', types))
+  document.body.removeEventListener('dragstart', populate)
+  source.remove()
+}
+
 describe('WorkspaceFileSplitDropLayer', () => {
   let container: HTMLDivElement
   let root: Root | null = null
@@ -81,10 +99,10 @@ describe('WorkspaceFileSplitDropLayer', () => {
     resetWorkspaceFileDragActivityForTests()
   })
 
-  it('arms one band per split direction once an Explorer drag starts', () => {
+  it('arms one band per split direction from the payload the source sets while bubbling', () => {
     expect(bands(container)).toHaveLength(0)
     act(() => {
-      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+      startExplorerDrag()
     })
     expect(bands(container)).toHaveLength(4)
   })
@@ -98,7 +116,7 @@ describe('WorkspaceFileSplitDropLayer', () => {
 
   it('disarms when the drag ends without a drop', () => {
     act(() => {
-      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+      startExplorerDrag()
     })
     act(() => {
       window.dispatchEvent(dragEvent('dragend', [WORKSPACE_FILE_PATH_MIME]))
@@ -108,7 +126,7 @@ describe('WorkspaceFileSplitDropLayer', () => {
 
   it('previews the target half while a band is hovered', () => {
     act(() => {
-      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+      startExplorerDrag()
     })
     expect(container.querySelector('.tab-drop-overlay')).toBeNull()
     act(() => {
@@ -119,7 +137,7 @@ describe('WorkspaceFileSplitDropLayer', () => {
 
   it('opens the dropped file in a split beside the hovered pane', async () => {
     act(() => {
-      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+      startExplorerDrag()
     })
     const rightBand = bands(container)[1]
     await act(async () => {
@@ -138,7 +156,7 @@ describe('WorkspaceFileSplitDropLayer', () => {
   it('leaves folder drops alone instead of opening an empty split', async () => {
     statRuntimePathMock.mockResolvedValueOnce({ isDirectory: true, mtime: 0, size: 0 })
     act(() => {
-      window.dispatchEvent(dragEvent('dragstart', [WORKSPACE_FILE_PATH_MIME]))
+      startExplorerDrag()
     })
     await act(async () => {
       bands(container)[0]?.dispatchEvent(dragEvent('drop', [WORKSPACE_FILE_PATH_MIME]))

--- a/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { getConnectionId } from '@/lib/connection-context'
+import { useWorkspaceFileDragActive } from '@/lib/workspace-file-drag-activity'
+import {
+  getWorkspaceFileDragRejectionMessage,
+  hasWorkspaceFileDragTypes,
+  readWorkspaceFileDragPaths
+} from '@/lib/workspace-file-drag'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { getEditorFileDropOperationContext } from '@/hooks/useGlobalFileDrop'
+import { statRuntimePath } from '@/runtime/runtime-file-client'
+import { useAppStore } from '@/store'
+import { captureTabGroupPanelGeometrySnapshot } from './tab-group-panel-split-target'
+import {
+  buildWorkspaceFilePaneDropZones,
+  type DropZoneRect,
+  type WorkspaceFilePaneDropZone
+} from './workspace-file-pane-drop-zones'
+import { openWorkspaceFilePathsInSplit } from './workspace-file-pane-drop'
+
+function toOverlayStyle(rect: DropZoneRect): CSSProperties {
+  return { height: rect.height, left: rect.left, top: rect.top, width: rect.width }
+}
+
+function isSameZone(
+  a: WorkspaceFilePaneDropZone | null,
+  b: WorkspaceFilePaneDropZone | null
+): boolean {
+  return a?.groupId === b?.groupId && a?.splitDirection === b?.splitDirection
+}
+
+export default function WorkspaceFileSplitDropLayer({
+  worktreeId,
+  enabled
+}: {
+  worktreeId: string
+  enabled: boolean
+}): React.JSX.Element {
+  const layerRef = useRef<HTMLDivElement>(null)
+  const [zones, setZones] = useState<WorkspaceFilePaneDropZone[]>([])
+  const [hoveredZone, setHoveredZone] = useState<WorkspaceFilePaneDropZone | null>(null)
+  const isDragActive = useWorkspaceFileDragActive() && enabled
+
+  useLayoutEffect(() => {
+    if (!isDragActive) {
+      setZones([])
+      setHoveredZone(null)
+      return
+    }
+    const layerRect = layerRef.current?.getBoundingClientRect()
+    if (!layerRect) {
+      return
+    }
+    // Why: pane geometry cannot change mid-drag, so one snapshot beats measuring per dragover.
+    const geometry = captureTabGroupPanelGeometrySnapshot(worktreeId)
+    setZones(
+      buildWorkspaceFilePaneDropZones(
+        geometry.entries.map((entry) => ({ bodyRect: entry.bodyRect, groupId: entry.groupId })),
+        layerRect
+      )
+    )
+  }, [isDragActive, worktreeId])
+
+  const handleDrop = useCallback(
+    (zone: WorkspaceFilePaneDropZone, dataTransfer: DataTransfer) => {
+      setHoveredZone(null)
+      const pathsResult = readWorkspaceFileDragPaths(dataTransfer)
+      if (pathsResult.status === 'rejected') {
+        toast.error(getWorkspaceFileDragRejectionMessage(pathsResult.reason))
+        return
+      }
+      if (pathsResult.paths.length === 0) {
+        return
+      }
+
+      const store = useAppStore.getState()
+      const worktreePath = store.getKnownWorktreeById(worktreeId)?.path
+      const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(store, worktreeId)
+      let fileContext: ReturnType<typeof getEditorFileDropOperationContext>
+      try {
+        fileContext = getEditorFileDropOperationContext(
+          store,
+          worktreeId,
+          worktreePath,
+          getConnectionId(worktreeId) ?? undefined
+        )
+      } catch {
+        toast.error(
+          translate(
+            'auto.components.tab.group.WorkspaceFileSplitDropLayer.ownerUnresolved',
+            "Couldn't verify which host owns this workspace. Try again after it reconnects."
+          )
+        )
+        return
+      }
+
+      void openWorkspaceFilePathsInSplit(
+        {
+          createEmptySplitGroup: store.createEmptySplitGroup,
+          isDirectory: async (filePath) => {
+            try {
+              return (await statRuntimePath(fileContext, filePath)).isDirectory
+            } catch {
+              // Why: an unreadable path can't be proven openable; let the editor report the real error.
+              return false
+            }
+          },
+          openFile: store.openFile,
+          setActiveTabType: store.setActiveTabType
+        },
+        {
+          paths: pathsResult.paths,
+          runtimeEnvironmentId,
+          sourceGroupId: zone.groupId,
+          splitDirection: zone.splitDirection,
+          worktreeId,
+          worktreePath
+        }
+      ).catch(() => {
+        toast.error(
+          translate(
+            'auto.components.tab.group.WorkspaceFileSplitDropLayer.openFailed',
+            'Could not open the dropped files in a new pane.'
+          )
+        )
+      })
+    },
+    [worktreeId]
+  )
+
+  return (
+    <div
+      ref={layerRef}
+      aria-hidden="true"
+      data-workspace-file-split-drop-layer="true"
+      data-worktree-id={worktreeId}
+      className="absolute inset-0 z-[10000] pointer-events-none"
+    >
+      {zones.map((zone) => (
+        <div
+          key={`${zone.groupId}:${zone.splitDirection}`}
+          className="absolute pointer-events-auto"
+          style={toOverlayStyle(zone.hitRect)}
+          onDragOver={(event) => {
+            if (!hasWorkspaceFileDragTypes(event.dataTransfer)) {
+              return
+            }
+            event.preventDefault()
+            event.stopPropagation()
+            event.dataTransfer.dropEffect = 'copy'
+            setHoveredZone((current) => (isSameZone(current, zone) ? current : zone))
+          }}
+          onDragLeave={() => {
+            setHoveredZone((current) => (isSameZone(current, zone) ? null : current))
+          }}
+          onDrop={(event) => {
+            if (!hasWorkspaceFileDragTypes(event.dataTransfer)) {
+              return
+            }
+            event.preventDefault()
+            event.stopPropagation()
+            handleDrop(zone, event.dataTransfer)
+          }}
+        />
+      ))}
+      {hoveredZone ? (
+        <div
+          className="tab-drop-overlay absolute"
+          style={toOverlayStyle(hoveredZone.previewRect)}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/WorkspaceFileSplitDropLayer.tsx
@@ -2,7 +2,10 @@ import { useCallback, useLayoutEffect, useRef, useState, type CSSProperties } fr
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { getConnectionId } from '@/lib/connection-context'
-import { useWorkspaceFileDragActive } from '@/lib/workspace-file-drag-activity'
+import {
+  disarmWorkspaceFileDrag,
+  useWorkspaceFileDragActive
+} from '@/lib/workspace-file-drag-activity'
 import {
   getWorkspaceFileDragRejectionMessage,
   hasWorkspaceFileDragTypes,
@@ -65,8 +68,13 @@ export default function WorkspaceFileSplitDropLayer({
 
   const handleDrop = useCallback(
     (zone: WorkspaceFilePaneDropZone, dataTransfer: DataTransfer) => {
-      setHoveredZone(null)
+      // Why: read the payload before anything can re-render this handler's own
+      // drop target out from under the gesture.
       const pathsResult = readWorkspaceFileDragPaths(dataTransfer)
+      // Why: this handler stops propagation, so the window-level drop cleanup
+      // never runs — disarm here instead of leaving live bands over the panes.
+      disarmWorkspaceFileDrag()
+      setHoveredZone(null)
       if (pathsResult.status === 'rejected') {
         toast.error(getWorkspaceFileDragRejectionMessage(pathsResult.reason))
         return

--- a/src/renderer/src/components/tab-group/tab-drop-zone.ts
+++ b/src/renderer/src/components/tab-group/tab-drop-zone.ts
@@ -3,6 +3,9 @@ import type { TabDropZone } from './tab-drag-data'
 /** Matches TabGroupPanel tab row height (`h-[32px]`). */
 export const TAB_GROUP_TAB_STRIP_HEIGHT_PX = 32
 
+/** Share of a pane taken by each split-opening edge band. */
+export const PANE_COLUMN_EDGE_RATIO = 0.2
+
 type PaneRect = { left: number; top: number; width: number; height: number }
 
 export function resolveDropZone(
@@ -46,7 +49,7 @@ export function resolvePaneColumnEdgeZone(
   }
 ): Exclude<TabDropZone, 'center'> | null {
   const localX = point.x - panelRect.left
-  const horizontalEdge = panelRect.width * 0.2
+  const horizontalEdge = panelRect.width * PANE_COLUMN_EDGE_RATIO
 
   if (localX < horizontalEdge) {
     return 'left'
@@ -77,7 +80,7 @@ export function resolvePaneColumnEdgeZone(
   }
 
   const bodyLocalY = point.y - bodyRect.top
-  const verticalEdge = bodyRect.height * 0.2
+  const verticalEdge = bodyRect.height * PANE_COLUMN_EDGE_RATIO
 
   if (bodyLocalY < verticalEdge) {
     return 'up'

--- a/src/renderer/src/components/tab-group/workspace-file-pane-drop-zones.test.ts
+++ b/src/renderer/src/components/tab-group/workspace-file-pane-drop-zones.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWorkspaceFilePaneDropZones,
+  type WorkspaceFilePaneDropZone
+} from './workspace-file-pane-drop-zones'
+import type { TabSplitDirection } from '../../store/slices/tabs'
+
+const PANE = { bodyRect: { height: 200, left: 100, top: 50, width: 400 }, groupId: 'a' }
+const ORIGIN = { left: 100, top: 50 }
+
+function zoneFor(direction: TabSplitDirection): WorkspaceFilePaneDropZone {
+  const zone = buildWorkspaceFilePaneDropZones([PANE], ORIGIN).find(
+    (candidate) => candidate.splitDirection === direction
+  )
+  if (!zone) {
+    throw new Error(`missing ${direction} zone`)
+  }
+  return zone
+}
+
+describe('buildWorkspaceFilePaneDropZones', () => {
+  it('emits one band per split direction', () => {
+    expect(buildWorkspaceFilePaneDropZones([PANE], ORIGIN).map((z) => z.splitDirection)).toEqual([
+      'left',
+      'right',
+      'up',
+      'down'
+    ])
+  })
+
+  it('translates pane geometry into layer-local coordinates', () => {
+    expect(zoneFor('left').hitRect).toEqual({ height: 200, left: 0, top: 0, width: 80 })
+  })
+
+  it('leaves the middle of the pane uncovered so terminal drops still land', () => {
+    const centerX = 200
+    const centerY = 100
+    for (const direction of ['left', 'right', 'up', 'down'] as const) {
+      const rect = zoneFor(direction).hitRect
+      const insideX = centerX >= rect.left && centerX <= rect.left + rect.width
+      const insideY = centerY >= rect.top && centerY <= rect.top + rect.height
+      expect(insideX && insideY).toBe(false)
+    }
+  })
+
+  it('anchors the down band to the bottom edge', () => {
+    expect(zoneFor('down').hitRect).toEqual({ height: 40, left: 80, top: 160, width: 240 })
+  })
+
+  it('previews the half the dropped file would take', () => {
+    expect(zoneFor('right').previewRect).toEqual({ height: 200, left: 200, top: 0, width: 200 })
+    expect(zoneFor('up').previewRect).toEqual({ height: 100, left: 0, top: 0, width: 400 })
+  })
+
+  it('drops panes with no area', () => {
+    const collapsed = { bodyRect: { height: 0, left: 0, top: 0, width: 400 }, groupId: 'a' }
+    expect(buildWorkspaceFilePaneDropZones([collapsed], { left: 0, top: 0 })).toEqual([])
+  })
+})

--- a/src/renderer/src/components/tab-group/workspace-file-pane-drop-zones.ts
+++ b/src/renderer/src/components/tab-group/workspace-file-pane-drop-zones.ts
@@ -1,0 +1,74 @@
+import { PANE_COLUMN_EDGE_RATIO } from './tab-drop-zone'
+import type { TabSplitDirection } from '../../store/slices/tabs'
+
+export type DropZoneRect = { height: number; left: number; top: number; width: number }
+
+export type PaneBodyGeometry = { bodyRect: DropZoneRect; groupId: string }
+
+export type WorkspaceFilePaneDropZone = {
+  groupId: string
+  /** Hit area that arms the split. */
+  hitRect: DropZoneRect
+  /** Half of the pane the dropped file would take. */
+  previewRect: DropZoneRect
+  splitDirection: TabSplitDirection
+}
+
+/**
+ * Edge bands for every visible pane, in coordinates local to the drop layer.
+ * The middle of each pane stays uncovered so terminal panes keep receiving the
+ * path-into-PTY drop they already handle.
+ */
+export function buildWorkspaceFilePaneDropZones(
+  panes: readonly PaneBodyGeometry[],
+  layerOrigin: { left: number; top: number }
+): WorkspaceFilePaneDropZone[] {
+  const zones: WorkspaceFilePaneDropZone[] = []
+  for (const { bodyRect, groupId } of panes) {
+    const left = bodyRect.left - layerOrigin.left
+    const top = bodyRect.top - layerOrigin.top
+    const { height, width } = bodyRect
+    if (width <= 0 || height <= 0) {
+      continue
+    }
+    const edgeWidth = width * PANE_COLUMN_EDGE_RATIO
+    const edgeHeight = height * PANE_COLUMN_EDGE_RATIO
+
+    zones.push(
+      {
+        groupId,
+        hitRect: { height, left, top, width: edgeWidth },
+        previewRect: { height, left, top, width: width / 2 },
+        splitDirection: 'left'
+      },
+      {
+        groupId,
+        hitRect: { height, left: left + width - edgeWidth, top, width: edgeWidth },
+        previewRect: { height, left: left + width / 2, top, width: width / 2 },
+        splitDirection: 'right'
+      }
+    )
+
+    const verticalBandWidth = width - edgeWidth * 2
+    zones.push(
+      {
+        groupId,
+        hitRect: { height: edgeHeight, left: left + edgeWidth, top, width: verticalBandWidth },
+        previewRect: { height: height / 2, left, top, width },
+        splitDirection: 'up'
+      },
+      {
+        groupId,
+        hitRect: {
+          height: edgeHeight,
+          left: left + edgeWidth,
+          top: top + height - edgeHeight,
+          width: verticalBandWidth
+        },
+        previewRect: { height: height / 2, left, top: top + height / 2, width },
+        splitDirection: 'down'
+      }
+    )
+  }
+  return zones
+}

--- a/src/renderer/src/components/tab-group/workspace-file-pane-drop.test.ts
+++ b/src/renderer/src/components/tab-group/workspace-file-pane-drop.test.ts
@@ -92,6 +92,46 @@ describe('openWorkspaceFilePathsInSplit', () => {
     expect(deps.openFile.mock.calls.map((call) => call[1].focusEditor)).toEqual([false, true])
   })
 
+  it('checks the dropped paths concurrently, not one runtime round-trip at a time', async () => {
+    let inFlight = 0
+    let peakInFlight = 0
+    const deps = makeDeps({
+      isDirectory: vi.fn(async () => {
+        inFlight += 1
+        peakInFlight = Math.max(peakInFlight, inFlight)
+        await Promise.resolve()
+        inFlight -= 1
+        return false
+      })
+    })
+    await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/a.ts', '/repo/b.ts', '/repo/c.ts']
+    })
+
+    expect(peakInFlight).toBeGreaterThan(1)
+  })
+
+  it('keeps drop order when the directory checks settle out of order', async () => {
+    const delays: Record<string, number> = { '/repo/a.ts': 30, '/repo/b.ts': 1, '/repo/c.ts': 15 }
+    const deps = makeDeps({
+      isDirectory: vi.fn(
+        (path: string) =>
+          new Promise<boolean>((resolve) => setTimeout(() => resolve(false), delays[path] ?? 0))
+      )
+    })
+    await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/a.ts', '/repo/b.ts', '/repo/c.ts']
+    })
+
+    expect(deps.openFile.mock.calls.map((call) => call[0].relativePath)).toEqual([
+      'a.ts',
+      'b.ts',
+      'c.ts'
+    ])
+  })
+
   it('does not split when every dropped path is a directory', async () => {
     const deps = makeDeps({ isDirectory: vi.fn(async () => true) })
     const groupId = await openWorkspaceFilePathsInSplit(deps, {

--- a/src/renderer/src/components/tab-group/workspace-file-pane-drop.test.ts
+++ b/src/renderer/src/components/tab-group/workspace-file-pane-drop.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  openWorkspaceFilePathsInSplit,
+  resolveWorkspaceFileOpenTarget,
+  type WorkspaceFilePaneDropDeps
+} from './workspace-file-pane-drop'
+
+const WORKTREE_PATH = '/repo'
+
+function makeDeps(
+  overrides: Partial<WorkspaceFilePaneDropDeps> = {}
+): WorkspaceFilePaneDropDeps & { openFile: ReturnType<typeof vi.fn> } {
+  return {
+    createEmptySplitGroup: vi.fn(() => 'new-group'),
+    isDirectory: vi.fn(async () => false),
+    openFile: vi.fn(),
+    setActiveTabType: vi.fn(),
+    ...overrides
+  } as WorkspaceFilePaneDropDeps & { openFile: ReturnType<typeof vi.fn> }
+}
+
+const BASE_ARGS = {
+  runtimeEnvironmentId: null,
+  sourceGroupId: 'source-group',
+  splitDirection: 'right' as const,
+  worktreeId: 'worktree-1',
+  worktreePath: WORKTREE_PATH
+}
+
+describe('resolveWorkspaceFileOpenTarget', () => {
+  it('relativizes paths inside the worktree', () => {
+    expect(resolveWorkspaceFileOpenTarget('/repo/src/app.ts', WORKTREE_PATH)).toMatchObject({
+      filePath: '/repo/src/app.ts',
+      relativePath: 'src/app.ts'
+    })
+  })
+
+  it('keeps the absolute path for files outside the worktree', () => {
+    expect(resolveWorkspaceFileOpenTarget('/elsewhere/notes.md', WORKTREE_PATH)).toMatchObject({
+      relativePath: '/elsewhere/notes.md'
+    })
+  })
+
+  it('keeps the absolute path when the worktree path is unknown', () => {
+    expect(resolveWorkspaceFileOpenTarget('/repo/src/app.ts', null)).toMatchObject({
+      relativePath: '/repo/src/app.ts'
+    })
+  })
+})
+
+describe('openWorkspaceFilePathsInSplit', () => {
+  it('splits beside the drop target and opens the file in the new group', async () => {
+    const deps = makeDeps()
+    const groupId = await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/src/app.ts']
+    })
+
+    expect(groupId).toBe('new-group')
+    expect(deps.createEmptySplitGroup).toHaveBeenCalledWith('worktree-1', 'source-group', 'right')
+    expect(deps.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'edit',
+        relativePath: 'src/app.ts',
+        worktreeId: 'worktree-1'
+      }),
+      expect.objectContaining({ preview: false, targetGroupId: 'new-group' })
+    )
+  })
+
+  it('opens every dropped file into the one new group', async () => {
+    const deps = makeDeps()
+    await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/a.ts', '/repo/b.ts']
+    })
+
+    expect(deps.createEmptySplitGroup).toHaveBeenCalledTimes(1)
+    expect(deps.openFile).toHaveBeenCalledTimes(2)
+    for (const call of deps.openFile.mock.calls) {
+      expect(call[1]).toMatchObject({ targetGroupId: 'new-group' })
+    }
+  })
+
+  it('focuses only the tab left on top of a multi-file drop', async () => {
+    const deps = makeDeps()
+    await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/a.ts', '/repo/b.ts']
+    })
+
+    expect(deps.openFile.mock.calls.map((call) => call[1].focusEditor)).toEqual([false, true])
+  })
+
+  it('does not split when every dropped path is a directory', async () => {
+    const deps = makeDeps({ isDirectory: vi.fn(async () => true) })
+    const groupId = await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/src']
+    })
+
+    expect(groupId).toBeNull()
+    expect(deps.createEmptySplitGroup).not.toHaveBeenCalled()
+    expect(deps.openFile).not.toHaveBeenCalled()
+  })
+
+  it('opens only the files from a mixed file/folder selection', async () => {
+    const deps = makeDeps({ isDirectory: vi.fn(async (path: string) => path === '/repo/src') })
+    await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/src', '/repo/a.ts']
+    })
+
+    expect(deps.openFile).toHaveBeenCalledTimes(1)
+    expect(deps.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({ relativePath: 'a.ts' }),
+      expect.anything()
+    )
+  })
+
+  it('suppresses the active-runtime fallback only for local drops', async () => {
+    const local = makeDeps()
+    await openWorkspaceFilePathsInSplit(local, { ...BASE_ARGS, paths: ['/repo/a.ts'] })
+    expect(local.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeEnvironmentId: undefined }),
+      expect.objectContaining({ suppressActiveRuntimeFallback: true })
+    )
+
+    const remote = makeDeps()
+    await openWorkspaceFilePathsInSplit(remote, {
+      ...BASE_ARGS,
+      paths: ['/repo/a.ts'],
+      runtimeEnvironmentId: 'ssh-host'
+    })
+    expect(remote.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeEnvironmentId: 'ssh-host' }),
+      expect.objectContaining({ suppressActiveRuntimeFallback: false })
+    )
+  })
+
+  it('opens nothing when the split cannot be created', async () => {
+    const deps = makeDeps({ createEmptySplitGroup: vi.fn(() => null) })
+    const groupId = await openWorkspaceFilePathsInSplit(deps, {
+      ...BASE_ARGS,
+      paths: ['/repo/a.ts']
+    })
+
+    expect(groupId).toBeNull()
+    expect(deps.openFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-group/workspace-file-pane-drop.ts
+++ b/src/renderer/src/components/tab-group/workspace-file-pane-drop.ts
@@ -1,0 +1,106 @@
+import { detectLanguage } from '@/lib/language-detect'
+import { isPathInsideWorktree, toWorktreeRelativePath } from '@/lib/terminal-links'
+import type { TabSplitDirection } from '../../store/slices/tabs'
+
+export type WorkspaceFileOpenTarget = {
+  filePath: string
+  language: string
+  relativePath: string
+}
+
+export type WorkspaceFilePaneDropDeps = {
+  createEmptySplitGroup: (
+    worktreeId: string,
+    sourceGroupId: string,
+    direction: TabSplitDirection
+  ) => string | null
+  isDirectory: (filePath: string) => Promise<boolean>
+  openFile: (
+    target: WorkspaceFileOpenTarget & {
+      mode: 'edit'
+      runtimeEnvironmentId?: string | undefined
+      worktreeId: string
+    },
+    options: {
+      focusEditor: boolean
+      preview: boolean
+      suppressActiveRuntimeFallback: boolean
+      targetGroupId: string
+    }
+  ) => void
+  setActiveTabType: (type: 'editor') => void
+}
+
+export function resolveWorkspaceFileOpenTarget(
+  filePath: string,
+  worktreePath: string | null | undefined
+): WorkspaceFileOpenTarget {
+  const relativePath =
+    worktreePath && isPathInsideWorktree(filePath, worktreePath)
+      ? (toWorktreeRelativePath(filePath, worktreePath) ?? filePath)
+      : filePath
+  return {
+    filePath,
+    language: detectLanguage(filePath),
+    relativePath: relativePath.length > 0 ? relativePath : filePath
+  }
+}
+
+/**
+ * Opens Explorer-dragged paths in a new split beside `sourceGroupId`. Resolves to
+ * the new group id, or null when the drop carried nothing openable.
+ */
+export async function openWorkspaceFilePathsInSplit(
+  deps: WorkspaceFilePaneDropDeps,
+  args: {
+    paths: readonly string[]
+    runtimeEnvironmentId: string | null
+    sourceGroupId: string
+    splitDirection: TabSplitDirection
+    worktreeId: string
+    worktreePath: string | null | undefined
+  }
+): Promise<string | null> {
+  const openable: string[] = []
+  for (const filePath of args.paths) {
+    // Why: a folder drop must not leave an empty split behind, so filter before splitting.
+    if (!(await deps.isDirectory(filePath))) {
+      openable.push(filePath)
+    }
+  }
+  if (openable.length === 0) {
+    return null
+  }
+
+  const targetGroupId = deps.createEmptySplitGroup(
+    args.worktreeId,
+    args.sourceGroupId,
+    args.splitDirection
+  )
+  if (!targetGroupId) {
+    return null
+  }
+
+  deps.setActiveTabType('editor')
+  openable.forEach((filePath, index) => {
+    deps.openFile(
+      {
+        ...resolveWorkspaceFileOpenTarget(filePath, args.worktreePath),
+        mode: 'edit',
+        runtimeEnvironmentId: args.runtimeEnvironmentId ?? undefined,
+        worktreeId: args.worktreeId
+      },
+      {
+        // Why: only the tab left on top earns focus; focusing each open in turn
+        // would thrash the editor for a multi-file drop.
+        focusEditor: index === openable.length - 1,
+        // Why: a deliberate drop is a permanent open — preview tabs would let the
+        // next Explorer click replace the pane the user just created.
+        preview: false,
+        suppressActiveRuntimeFallback: args.runtimeEnvironmentId === null,
+        targetGroupId
+      }
+    )
+  })
+  return targetGroupId
+}

--- a/src/renderer/src/components/tab-group/workspace-file-pane-drop.ts
+++ b/src/renderer/src/components/tab-group/workspace-file-pane-drop.ts
@@ -61,13 +61,11 @@ export async function openWorkspaceFilePathsInSplit(
     worktreePath: string | null | undefined
   }
 ): Promise<string | null> {
-  const openable: string[] = []
-  for (const filePath of args.paths) {
-    // Why: a folder drop must not leave an empty split behind, so filter before splitting.
-    if (!(await deps.isDirectory(filePath))) {
-      openable.push(filePath)
-    }
-  }
+  // Why: a folder drop must not leave an empty split behind, so filter before
+  // splitting. Concurrent because isDirectory is a runtime round-trip on SSH
+  // workspaces, and map keeps drop order regardless of settle order.
+  const directoryFlags = await Promise.all(args.paths.map((path) => deps.isDirectory(path)))
+  const openable = args.paths.filter((_, index) => !directoryFlags[index])
   if (openable.length === 0) {
     return null
   }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3032,6 +3032,10 @@
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "New split"
+          },
+          "WorkspaceFileSplitDropLayer": {
+            "ownerUnresolved": "Couldn't verify which host owns this workspace. Try again after it reconnects.",
+            "openFailed": "Could not open the dropped files in a new pane."
           }
         },
         "bar": {

--- a/src/renderer/src/lib/workspace-file-drag-activity.test.ts
+++ b/src/renderer/src/lib/workspace-file-drag-activity.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WORKSPACE_FILE_PATH_MIME } from './workspace-file-drag'
+import {
+  disarmWorkspaceFileDrag,
+  getWorkspaceFileDragActiveSnapshot,
+  resetWorkspaceFileDragActivityForTests,
+  subscribeToWorkspaceFileDragActivity
+} from './workspace-file-drag-activity'
+
+type Registration = { capture: boolean; type: string }
+
+let registrations: Registration[] = []
+let addSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  registrations = []
+  addSpy = vi
+    .spyOn(window, 'addEventListener')
+    .mockImplementation((type: string, _listener: unknown, options?: unknown) => {
+      registrations.push({ capture: options === true, type })
+    })
+})
+
+afterEach(() => {
+  addSpy.mockRestore()
+  resetWorkspaceFileDragActivityForTests()
+})
+
+function phaseOf(type: string): boolean | undefined {
+  return registrations.find((entry) => entry.type === type)?.capture
+}
+
+describe('workspace file drag activity listeners', () => {
+  it('reads dragstart on the bubble phase, after React delegation has run setData', () => {
+    subscribeToWorkspaceFileDragActivity(() => {})
+    expect(phaseOf('dragstart')).toBe(false)
+  })
+
+  it('keeps a capture-phase dragenter backstop for sources that stop dragstart short', () => {
+    subscribeToWorkspaceFileDragActivity(() => {})
+    expect(phaseOf('dragenter')).toBe(true)
+  })
+
+  it('does not tear the drop zones down on a capture-phase drop', () => {
+    // Why: disarming during capture unmounts the drop target before React's
+    // delegated onDrop runs at the root, and the drop is silently lost.
+    subscribeToWorkspaceFileDragActivity(() => {})
+    expect(phaseOf('drop')).toBe(false)
+  })
+})
+
+describe('disarmWorkspaceFileDrag', () => {
+  it('clears the armed snapshot and notifies subscribers', () => {
+    addSpy.mockRestore()
+    const onChange = vi.fn()
+    subscribeToWorkspaceFileDragActivity(onChange)
+
+    const dragStart = new Event('dragstart', { bubbles: true })
+    Object.defineProperty(dragStart, 'dataTransfer', {
+      value: { types: [WORKSPACE_FILE_PATH_MIME] }
+    })
+    window.dispatchEvent(dragStart)
+    expect(getWorkspaceFileDragActiveSnapshot()).toBe(true)
+
+    onChange.mockClear()
+    disarmWorkspaceFileDrag()
+    expect(getWorkspaceFileDragActiveSnapshot()).toBe(false)
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/lib/workspace-file-drag-activity.ts
+++ b/src/renderer/src/lib/workspace-file-drag-activity.ts
@@ -17,8 +17,10 @@ function setSnapshot(next: boolean): void {
   }
 }
 
-function handleDragStart(event: DragEvent): void {
-  setSnapshot(Boolean(event.dataTransfer && hasWorkspaceFileDragTypes(event.dataTransfer)))
+function armIfWorkspaceFileDrag(event: DragEvent): void {
+  if (event.dataTransfer && hasWorkspaceFileDragTypes(event.dataTransfer)) {
+    setSnapshot(true)
+  }
 }
 
 function handleDragFinish(): void {
@@ -32,13 +34,17 @@ export function getWorkspaceFileDragActiveSnapshot(): boolean {
 export function subscribeToWorkspaceFileDragActivity(onChange: () => void): () => void {
   subscribers.add(onChange)
   if (!detachWindowListeners && typeof window !== 'undefined') {
-    // Why: capture so a stopPropagation inside the explorer row can't hide the
-    // gesture from panes that need to arm their drop zones.
-    window.addEventListener('dragstart', handleDragStart, true)
+    // Why: React delegates onDragStart to the root, so setData has not run yet
+    // during capture — read the payload on the way back up instead.
+    window.addEventListener('dragstart', armIfWorkspaceFileDrag)
+    // Why: backstop for a source that stops dragstart short of window; by the
+    // first dragenter the payload is always readable.
+    window.addEventListener('dragenter', armIfWorkspaceFileDrag, true)
     window.addEventListener('dragend', handleDragFinish, true)
     window.addEventListener('drop', handleDragFinish, true)
     detachWindowListeners = () => {
-      window.removeEventListener('dragstart', handleDragStart, true)
+      window.removeEventListener('dragstart', armIfWorkspaceFileDrag)
+      window.removeEventListener('dragenter', armIfWorkspaceFileDrag, true)
       window.removeEventListener('dragend', handleDragFinish, true)
       window.removeEventListener('drop', handleDragFinish, true)
     }

--- a/src/renderer/src/lib/workspace-file-drag-activity.ts
+++ b/src/renderer/src/lib/workspace-file-drag-activity.ts
@@ -31,6 +31,11 @@ export function getWorkspaceFileDragActiveSnapshot(): boolean {
   return snapshot
 }
 
+/** Tears the drop zones down without waiting for an event that may never arrive. */
+export function disarmWorkspaceFileDrag(): void {
+  setSnapshot(false)
+}
+
 export function subscribeToWorkspaceFileDragActivity(onChange: () => void): () => void {
   subscribers.add(onChange)
   if (!detachWindowListeners && typeof window !== 'undefined') {
@@ -41,12 +46,14 @@ export function subscribeToWorkspaceFileDragActivity(onChange: () => void): () =
     // first dragenter the payload is always readable.
     window.addEventListener('dragenter', armIfWorkspaceFileDrag, true)
     window.addEventListener('dragend', handleDragFinish, true)
-    window.addEventListener('drop', handleDragFinish, true)
+    // Why: NOT capture — tearing the zones down there unmounts the drop target
+    // before React's delegated onDrop runs at the root, and the drop is lost.
+    window.addEventListener('drop', handleDragFinish)
     detachWindowListeners = () => {
       window.removeEventListener('dragstart', armIfWorkspaceFileDrag)
       window.removeEventListener('dragenter', armIfWorkspaceFileDrag, true)
       window.removeEventListener('dragend', handleDragFinish, true)
-      window.removeEventListener('drop', handleDragFinish, true)
+      window.removeEventListener('drop', handleDragFinish)
     }
   }
   return () => {

--- a/src/renderer/src/lib/workspace-file-drag-activity.ts
+++ b/src/renderer/src/lib/workspace-file-drag-activity.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from 'react'
+import { hasWorkspaceFileDragTypes } from './workspace-file-drag'
+
+// Why: every visible tab group asks the same question during one drag. Share a
+// single pair of window listeners instead of registering them per pane.
+const subscribers = new Set<() => void>()
+let detachWindowListeners: (() => void) | null = null
+let snapshot = false
+
+function setSnapshot(next: boolean): void {
+  if (snapshot === next) {
+    return
+  }
+  snapshot = next
+  for (const subscriber of subscribers) {
+    subscriber()
+  }
+}
+
+function handleDragStart(event: DragEvent): void {
+  setSnapshot(Boolean(event.dataTransfer && hasWorkspaceFileDragTypes(event.dataTransfer)))
+}
+
+function handleDragFinish(): void {
+  setSnapshot(false)
+}
+
+export function getWorkspaceFileDragActiveSnapshot(): boolean {
+  return snapshot
+}
+
+export function subscribeToWorkspaceFileDragActivity(onChange: () => void): () => void {
+  subscribers.add(onChange)
+  if (!detachWindowListeners && typeof window !== 'undefined') {
+    // Why: capture so a stopPropagation inside the explorer row can't hide the
+    // gesture from panes that need to arm their drop zones.
+    window.addEventListener('dragstart', handleDragStart, true)
+    window.addEventListener('dragend', handleDragFinish, true)
+    window.addEventListener('drop', handleDragFinish, true)
+    detachWindowListeners = () => {
+      window.removeEventListener('dragstart', handleDragStart, true)
+      window.removeEventListener('dragend', handleDragFinish, true)
+      window.removeEventListener('drop', handleDragFinish, true)
+    }
+  }
+  return () => {
+    subscribers.delete(onChange)
+    if (subscribers.size > 0) {
+      return
+    }
+    detachWindowListeners?.()
+    detachWindowListeners = null
+    snapshot = false
+  }
+}
+
+export function useWorkspaceFileDragActive(): boolean {
+  return useSyncExternalStore(
+    subscribeToWorkspaceFileDragActivity,
+    getWorkspaceFileDragActiveSnapshot,
+    () => false
+  )
+}
+
+export function resetWorkspaceFileDragActivityForTests(): void {
+  detachWindowListeners?.()
+  subscribers.clear()
+  detachWindowListeners = null
+  snapshot = false
+}

--- a/src/renderer/src/lib/workspace-file-drag.ts
+++ b/src/renderer/src/lib/workspace-file-drag.ts
@@ -9,6 +9,13 @@ import { measureClipboardTextByteLength } from '../../../shared/clipboard-text'
 export const WORKSPACE_FILE_PATH_MIME = 'text/x-orca-file-path'
 export const WORKSPACE_FILE_PATHS_MIME = 'text/x-orca-file-paths'
 
+export function hasWorkspaceFileDragTypes(dataTransfer: Pick<DataTransfer, 'types'>): boolean {
+  return (
+    dataTransfer.types.includes(WORKSPACE_FILE_PATH_MIME) ||
+    dataTransfer.types.includes(WORKSPACE_FILE_PATHS_MIME)
+  )
+}
+
 export type WorkspaceFileDragRejectionReason = 'paths-too-large' | 'too-many-paths'
 
 export type WorkspaceFileDragPathsReadResult =


### PR DESCRIPTION
## ELI5

Drag a file out of the File Explorer, drop it on the edge of a pane, and that pane splits with your file opened in the new half. Drop it in the middle of a terminal and nothing changes — the path still goes into the CLI like it does today.

## What Changed

A new worktree-level `WorkspaceFileSplitDropLayer` arms four edge bands over every visible pane while an Explorer file drag is in flight. Dropping on a band calls `createEmptySplitGroup` in that direction and opens the dropped files into the new group.

- `lib/workspace-file-drag-activity.ts` — one shared set of window listeners behind `useSyncExternalStore`, so N panes don't each register their own. Worth knowing if you touch this: `dragstart` must be read on the **bubble** phase, because React delegates `onDragStart` to the root and `setData` has not run yet during capture — `dataTransfer.types` is empty there. A capture-phase `dragenter` is kept as a backstop. This is the same ordering problem `AiVaultSessionRow` sidesteps by dispatching its own drag-start event.
- `tab-group/workspace-file-pane-drop-zones.ts` — pure geometry: pane body rects → edge band hit areas + the half the file would take.
- `tab-group/workspace-file-pane-drop.ts` — the drop action: filter out folders, split once, open each file into the new group.
- `tab-group/WorkspaceFileSplitDropLayer.tsx` — the layer, mounted next to `AiVaultSessionDropLayer` in `Terminal.tsx`.
- `tab-drop-zone.ts` — extracted the twice-inlined `0.2` edge share into `PANE_COLUMN_EDGE_RATIO` so the new bands and `resolvePaneColumnEdgeZone` can't drift.

Behavior details:

- **Bands cover the outer 20% of each pane only.** The middle stays uncovered, so terminal panes keep receiving the path-into-PTY drop they already handle (`TerminalPane.tsx`) and editor panes are unaffected in the center.
- **The layer arms only on a `dragstart` carrying `text/x-orca-file-path(s)`.** OS drops from Finder never fire an in-app `dragstart`, so `zones` is empty during one and no band div exists to intercept it — Finder drops still route through the preload's `data-native-file-drop-target` markers exactly as #289 left them.
- **Folder drops don't leave an empty split** — paths are stat'd first, and a drop with no openable file never creates a group.
- **Multi-select opens every file into the one new group**, and only the tab left on top takes focus.
- Any drag carrying the workspace-file MIME works, so Source Control rows and the combined-diff file tree get this for free alongside the Explorer.

## Why

Fixes the gap described in #13970: the Explorer drag had no drop target on the pane area at all, so opening a file beside an existing pane took two gestures (open into the active group, then drag the tab to a split). Orca already had both halves of this — tabs drag into splits, and AI Vault sessions drop onto a pane to open in one — so this reuses that machinery rather than adding a parallel one.

The edge-band shape (rather than a full-pane overlay like `AiVaultSessionDropLayer` uses) is the load-bearing choice: a full `inset-0` catcher would swallow center drops on terminal panes and silently break path-into-PTY.

## Linked Issue

Fixes #13970

## Visual Proof

Screen recording: https://github.com/stablyai/orca/pull/13982#issuecomment-5263245730

Shows the starting 2-pane layout, then three Explorer drags in a row — the blue overlay previewing the half each file would take, and each drop splitting the pane and opening the file (LICENSE, CLAUDE.md, AGENTS.md).

## Testing

Automated, all new:

- `workspace-file-pane-drop-zones.test.ts` — band geometry, layer-local translation, and an explicit assertion that the pane center is left uncovered.
- `workspace-file-pane-drop.test.ts` — split direction/target group, multi-file into one group, folder-only drop creates nothing, mixed file/folder selection, runtime-fallback suppression, focus on the last tab only.
- `WorkspaceFileSplitDropLayer.test.tsx` — the gesture in happy-dom, started the way the app starts it (from a source element whose payload is filled in on the way back up): `dragstart` arms the bands, a non-workspace drag leaves them inert, `dragend` disarms, hover renders the preview, and `drop` produces the split + open.
- `workspace-file-drag-activity.test.ts` — pins the listener phases, including that `drop` is **not** read on capture. happy-dom cannot reproduce React's discrete-event flush timing, so this pins the invariant directly rather than the symptom.

Verified in a running dev build on macOS with **genuine Chromium drags** driven through CDP drag interception (`Input.setInterceptDrags` + `Input.dispatchDragEvent`), so real hit testing and the real drag pipeline are exercised:

- Drag `package.json` out of the Explorer → 4 bands per pane arm, `dragover` renders the preview overlay, drop takes the layout from 3 panes to 4 with the file open in the new one.
- Drop in the **middle** of a terminal pane → `elementFromPoint` there is the xterm layer, not a band; the shell-escaped path is inserted into the PTY and no split is created.
- Bands disarm after every drop.

Synthesized `dispatchEvent` calls are not sufficient here and were what let two real bugs through — they bypass hit testing and do not reproduce React's event-delegation ordering.

Local gates on macOS: `pnpm lint`, `pnpm typecheck`, and `pnpm build:desktop` all pass, as do the CI-only static checks (`check:zustand-selector-fanout`, `check:code-quality:changed` and React Doctor — 0 new findings across the changed files). Renderer suites (`components/tab-group`, `hooks`, `lib`) pass: 3,969 tests. The full `pnpm test` run has 15 failing files, all in `src/main`/`src/relay` integration tests (real git, SSH, daemon, file locks) that pass in isolation — timeouts under load on my machine, untouched by this change.

Steps for a reviewer:

1. Open a workspace with a terminal pane and the File Explorer visible.
2. Drag a file from the Explorer over the left/right/top/bottom fifth of a pane — a blue overlay should preview the half it would take.
3. Drop → the pane splits and the file opens in the new half.
4. Drag the same file to the middle of a terminal pane and drop → the shell-escaped path is inserted into the CLI, unchanged from today.
5. Drag a file from Finder onto the tab strip → still opens in the editor, unchanged from today.
6. Drag a folder onto a pane edge → nothing happens, no empty split is left behind.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform**: no platform-dependent code — geometry is measured, not assumed, and no path separators or modifier keys are involved.
- **Remote SSH / folder workspaces**: the open path resolves the runtime environment via `getRuntimeEnvironmentIdForWorktree` and stats through `statRuntimePath`, so remote worktrees resolve on their own host. Unlike OS drops, Explorer paths already live on the workspace's host, so no upload step is needed. Folder workspaces go through the same worktree-id lookup as git worktrees.
- **Remote wire**: no wire change. Like `launchAiVaultSessionInNewTab`, the split is created through the local store; cross-client mirroring of drop-created splits is out of scope here.
- **Performance**: one shared set of window listeners for the whole window; pane geometry is snapshotted once per drag rather than measured per `dragover`; hover state bails out when the resolved zone is unchanged.
- **Backwards compatibility**: no existing drop target changed. Center drops, OS drops, tab drag-splitting, and Explorer file moves all take the same paths they did before.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see the caveat on `pnpm test` under Testing

## Follow-ups deliberately left out

- Dropping on a pane's **tab strip** to add the file to that group without splitting.
- Center drops on an **editor** pane opening into that group (today the center is left entirely to the existing handlers).

## AI Disclosure

Implemented with Claude Code (Claude Opus 5), reviewed by me before submitting.


