### PR TITLE
fix(fish): scope shell history per worktree and clear agent draft prefills

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -249,6 +249,7 @@ jobs:
             src/main/terminal-history-fish-session.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             src/shared/fish-draft-prefill-teardown.node-pty.test.ts \
+            src/shared/fish-startup-arg-quoting.live-fish.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
   test:
@@ -287,6 +288,7 @@ jobs:
             --exclude=src/main/terminal-history-fish-session.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             --exclude=src/shared/fish-draft-prefill-teardown.node-pty.test.ts \
+            --exclude=src/shared/fish-startup-arg-quoting.live-fish.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -248,6 +248,7 @@ jobs:
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             src/main/terminal-history-fish-session.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            src/renderer/src/lib/fish-ai-vault-resume-env.live-fish.test.ts \
             src/shared/fish-draft-prefill-teardown.node-pty.test.ts \
             src/shared/fish-startup-arg-quoting.live-fish.test.ts \
             src/shared/posix-command-path-lookup.test.ts
@@ -287,6 +288,7 @@ jobs:
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             --exclude=src/main/terminal-history-fish-session.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            --exclude=src/renderer/src/lib/fish-ai-vault-resume-env.live-fish.test.ts \
             --exclude=src/shared/fish-draft-prefill-teardown.node-pty.test.ts \
             --exclude=src/shared/fish-startup-arg-quoting.live-fish.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -246,7 +246,9 @@ jobs:
             src/main/providers/local-pty-shell-ready.test.ts \
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            src/main/terminal-history-fish-session.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            src/shared/fish-draft-prefill-teardown.node-pty.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
   test:
@@ -282,7 +284,9 @@ jobs:
             --exclude=src/main/providers/local-pty-shell-ready.test.ts \
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            --exclude=src/main/terminal-history-fish-session.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            --exclude=src/shared/fish-draft-prefill-teardown.node-pty.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -24,8 +24,17 @@ import { getDaemonSocketPath, serializeDaemonPidFile } from './daemon-spawner'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { TERMINAL_HISTORY_INLINE_SEED_CODE_UNITS } from './terminal-history-seed-chunks'
 
-const { getMacDaemonSystemResolverHealthMock } = vi.hoisted(() => ({
-  getMacDaemonSystemResolverHealthMock: vi.fn(async () => 'unknown')
+const { getMacDaemonSystemResolverHealthMock, injectHistoryEnvMock } = vi.hoisted(() => ({
+  getMacDaemonSystemResolverHealthMock: vi.fn(async () => 'unknown'),
+  injectHistoryEnvMock: vi.fn(
+    (env: Record<string, string>, worktreeId: string, shellPath: string) => {
+      const fishSession = `orca_${worktreeId.replace(/\W/g, '')}`
+      if (shellPath.endsWith('fish')) {
+        env.fish_history = fishSession
+      }
+      return { shell: 'fish', histFile: null, fishSession, historyDir: '/history' }
+    }
+  )
 }))
 
 const itOnPosix = process.platform === 'win32' ? it.skip : it
@@ -37,6 +46,11 @@ vi.mock('./daemon-health', async (importOriginal) => {
     getMacDaemonSystemResolverHealth: getMacDaemonSystemResolverHealthMock
   }
 })
+
+vi.mock('../terminal-history', () => ({
+  injectHistoryEnv: injectHistoryEnvMock,
+  logHistoryInjection: vi.fn()
+}))
 
 function createTestDir(): string {
   return mkdtempSync(join(tmpdir(), 'daemon-adapter-test-'))
@@ -135,6 +149,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
     adapter = new DaemonPtyAdapter({ socketPath, tokenPath })
     lastSpawnOpts = null
+    injectHistoryEnvMock.mockClear()
     getMacDaemonSystemResolverHealthMock.mockReset()
     getMacDaemonSystemResolverHealthMock.mockResolvedValue('unknown')
   })
@@ -161,6 +176,44 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.id).toBeDefined()
       expect(typeof result.id).toBe('string')
       expect(result.providerSequence).toEqual({ value: 0, generation: 'reset' })
+    })
+
+    it('matches local-provider fish history scoping for fresh worktree and folder sessions', async () => {
+      for (const worktreeId of ['repo-1::/repo/a', 'folder:folder-1']) {
+        await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          cwd: '/repo',
+          env: { SHELL: 'fish' },
+          worktreeId,
+          isNewSession: true,
+          historyIsolationEnabled: true
+        })
+        expect(injectHistoryEnvMock).toHaveBeenLastCalledWith(
+          expect.any(Object),
+          worktreeId,
+          'fish',
+          '/repo'
+        )
+        expect(lastSpawnOpts?.env?.fish_history).toContain(worktreeId.replace(/\W/g, ''))
+      }
+    })
+
+    it('honors the disabled history setting before dispatching to the daemon', async () => {
+      for (const historyIsolationEnabled of [false, undefined]) {
+        await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          cwd: '/repo',
+          env: { SHELL: 'fish' },
+          worktreeId: 'repo-1::/repo',
+          isNewSession: true,
+          historyIsolationEnabled
+        })
+      }
+
+      expect(injectHistoryEnvMock).not.toHaveBeenCalled()
+      expect(lastSpawnOpts?.env?.fish_history).toBeUndefined()
     })
 
     it('carries classified startup spans from the daemon source to the adapter', async () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -24,18 +24,20 @@ import { getDaemonSocketPath, serializeDaemonPidFile } from './daemon-spawner'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { TERMINAL_HISTORY_INLINE_SEED_CODE_UNITS } from './terminal-history-seed-chunks'
 
-const { getMacDaemonSystemResolverHealthMock, injectHistoryEnvMock } = vi.hoisted(() => ({
-  getMacDaemonSystemResolverHealthMock: vi.fn(async () => 'unknown'),
-  injectHistoryEnvMock: vi.fn(
-    (env: Record<string, string>, worktreeId: string, shellPath: string) => {
-      const fishSession = `orca_${worktreeId.replace(/\W/g, '')}`
-      if (shellPath.endsWith('fish')) {
-        env.fish_history = fishSession
+const { getMacDaemonSystemResolverHealthMock, injectHistoryEnvMock, injectWslFishHistoryEnvMock } =
+  vi.hoisted(() => ({
+    getMacDaemonSystemResolverHealthMock: vi.fn(async () => 'unknown'),
+    injectHistoryEnvMock: vi.fn(
+      (env: Record<string, string>, worktreeId: string, shellPath: string) => {
+        const fishSession = `orca_${worktreeId.replace(/\W/g, '')}`
+        if (shellPath.endsWith('fish')) {
+          env.fish_history = fishSession
+        }
+        return { shell: 'fish', histFile: null, fishSession, historyDir: '/history' }
       }
-      return { shell: 'fish', histFile: null, fishSession, historyDir: '/history' }
-    }
-  )
-}))
+    ),
+    injectWslFishHistoryEnvMock: vi.fn()
+  }))
 
 const itOnPosix = process.platform === 'win32' ? it.skip : it
 
@@ -49,6 +51,7 @@ vi.mock('./daemon-health', async (importOriginal) => {
 
 vi.mock('../terminal-history', () => ({
   injectHistoryEnv: injectHistoryEnvMock,
+  injectWslFishHistoryEnv: injectWslFishHistoryEnvMock,
   logHistoryInjection: vi.fn()
 }))
 
@@ -214,6 +217,21 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       expect(injectHistoryEnvMock).not.toHaveBeenCalled()
       expect(lastSpawnOpts?.env?.fish_history).toBeUndefined()
+    })
+
+    it('does not mutate scoped history on an existing-session attach', async () => {
+      await adapter.spawn({ cols: 80, rows: 24, sessionId: 'existing-session' })
+      injectHistoryEnvMock.mockClear()
+
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'existing-session',
+        worktreeId: 'repo-1::/repo',
+        historyIsolationEnabled: true
+      })
+
+      expect(injectHistoryEnvMock).not.toHaveBeenCalled()
     })
 
     it('carries classified startup spans from the daemon source to the adapter', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -67,6 +67,8 @@ import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process
 import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 import { resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
+import { resolveUnixShellPath } from '../providers/local-pty-utils'
+import { injectHistoryEnv, logHistoryInjection } from '../terminal-history'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { ColdRestorePayloadCache, type ColdRestorePayload } from './cold-restore-payload-cache'
 import { PtyProcessListAdmission } from '../providers/pty-process-list-admission'
@@ -348,7 +350,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
-    const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
+    const spawnOpts = this.withHistoryIsolation(opts)
+    const sessionId = spawnOpts.sessionId ?? mintPtySessionId(spawnOpts.worktreeId)
     const operation = {
       exitsBySessionId: new Map<string, { incarnationId?: string }[]>(),
       ignoredExitIncarnationIds: new Set<string>(),
@@ -367,7 +370,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     try {
       return await this.withHistorySpawnLock(sessionId, () =>
-        this.withDaemonRetry(() => this.doSpawn({ ...opts, sessionId }, operation, historyRecovery))
+        this.withDaemonRetry(() =>
+          this.doSpawn({ ...spawnOpts, sessionId }, operation, historyRecovery)
+        )
       )
     } finally {
       if (historyRecovery.freeze) {
@@ -379,6 +384,28 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.pendingSpawnOperationsBySessionId.delete(sessionId)
       }
     }
+  }
+
+  private withHistoryIsolation(opts: PtySpawnOptions): PtySpawnOptions {
+    if (
+      process.platform === 'win32' ||
+      opts.isNewSession !== true ||
+      !opts.worktreeId ||
+      opts.historyIsolationEnabled !== true
+    ) {
+      return opts
+    }
+    const env = { ...opts.env }
+    const preferredShell = opts.shellOverride || env.SHELL || process.env.SHELL || '/bin/zsh'
+    const shellPath = resolveUnixShellPath(preferredShell)
+    const result = injectHistoryEnv(
+      env,
+      opts.worktreeId,
+      shellPath,
+      opts.cwd ?? resolveSafePtyDefaultCwd()
+    )
+    logHistoryInjection(opts.worktreeId, result)
+    return { ...opts, env }
   }
 
   private async doSpawn(

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -68,7 +68,8 @@ import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-d
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 import { resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { resolveUnixShellPath } from '../providers/local-pty-utils'
-import { injectHistoryEnv, logHistoryInjection } from '../terminal-history'
+import { injectHistoryEnv, injectWslFishHistoryEnv, logHistoryInjection } from '../terminal-history'
+import { addWslEnvKeys } from '../wsl-env'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { ColdRestorePayloadCache, type ColdRestorePayload } from './cold-restore-payload-cache'
 import { PtyProcessListAdmission } from '../providers/pty-process-list-admission'
@@ -387,23 +388,39 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private withHistoryIsolation(opts: PtySpawnOptions): PtySpawnOptions {
+    const wslContext = resolveWslSessionContext({
+      cwd: opts.cwd,
+      sessionId: opts.sessionId,
+      shellOverride: opts.shellOverride,
+      terminalWindowsWslDistro: opts.terminalWindowsWslDistro
+    })
     if (
-      process.platform === 'win32' ||
-      opts.isNewSession !== true ||
+      opts.attachOnly === true ||
+      (opts.sessionId !== undefined && opts.isNewSession !== true) ||
       !opts.worktreeId ||
-      opts.historyIsolationEnabled !== true
+      opts.historyIsolationEnabled !== true ||
+      (process.platform === 'win32' && !wslContext)
     ) {
       return opts
     }
     const env = { ...opts.env }
-    const preferredShell = opts.shellOverride || env.SHELL || process.env.SHELL || '/bin/zsh'
+    const preferredShell = wslContext
+      ? 'bash'
+      : opts.shellOverride || env.SHELL || process.env.SHELL || '/bin/zsh'
     const shellPath = resolveUnixShellPath(preferredShell)
-    const result = injectHistoryEnv(
+    const historyArgs = [
       env,
       opts.worktreeId,
       shellPath,
       opts.cwd ?? resolveSafePtyDefaultCwd()
-    )
+    ] as const
+    const result = wslContext
+      ? injectHistoryEnv(...historyArgs, { wslDistro: wslContext.distro })
+      : injectHistoryEnv(...historyArgs)
+    if (wslContext) {
+      injectWslFishHistoryEnv(env, opts.worktreeId, wslContext.distro)
+      addWslEnvKeys(env, ['HISTFILE', 'fish_history'])
+    }
     logHistoryInjection(opts.worktreeId, result)
     return { ...opts, env }
   }

--- a/src/main/fish-history-location-attestation.ts
+++ b/src/main/fish-history-location-attestation.ts
@@ -24,6 +24,14 @@ type DirectoryIdentity = {
 type FileIdentity = { fileDevice: string; fileInode: string; fileBirthtimeNs: string }
 type Location = DirectoryIdentity & FileIdentity & { path: string }
 
+function reverseWithoutMutation<T>(items: readonly T[]): T[] {
+  const result: T[] = []
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    result.push(items[index] as T)
+  }
+  return result
+}
+
 const safeSession = (session: unknown): session is string =>
   typeof session === 'string' && /^orca_[0-9a-f]{1,64}$/.test(session)
 const canonicalPath = (session: string, path: unknown): path is string =>
@@ -154,7 +162,7 @@ function readLocations(path: string, session: string): Location[] {
     }
     const result: Location[] = []
     const seen = new Set<string>()
-    for (const candidate of record.locations.slice(-MAX_PATH_CANDIDATES).toReversed()) {
+    for (const candidate of reverseWithoutMutation(record.locations.slice(-MAX_PATH_CANDIDATES))) {
       if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
         continue
       }
@@ -179,7 +187,7 @@ function readLocations(path: string, session: string): Location[] {
         break
       }
     }
-    return result.toReversed()
+    return reverseWithoutMutation(result)
   } catch {
     return []
   }

--- a/src/main/fish-history-location-attestation.ts
+++ b/src/main/fish-history-location-attestation.ts
@@ -1,0 +1,282 @@
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  fstatSync,
+  ftruncateSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync
+} from 'node:fs'
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
+
+export const MAX_RETAINED_FISH_HISTORY_PATHS = 16
+export const MAX_FISH_HISTORY_META_BYTES = 32 * 1024
+const MAX_PATH_CANDIDATES = MAX_RETAINED_FISH_HISTORY_PATHS * 4
+
+type DirectoryIdentity = {
+  directoryDevice: string
+  directoryInode: string
+  directoryBirthtimeNs: string
+}
+type FileIdentity = { fileDevice: string; fileInode: string; fileBirthtimeNs: string }
+type Location = DirectoryIdentity & FileIdentity & { path: string }
+
+const safeSession = (session: unknown): session is string =>
+  typeof session === 'string' && /^orca_[0-9a-f]{1,64}$/.test(session)
+const canonicalPath = (session: string, path: unknown): path is string =>
+  typeof path === 'string' &&
+  Boolean(path) &&
+  safeSession(session) &&
+  isAbsolute(path) &&
+  resolve(path) === path &&
+  basename(dirname(path)) === 'fish' &&
+  basename(path) === `${session}_history`
+
+function directoryIdentity(path: string): DirectoryIdentity | null {
+  const directory = dirname(path)
+  const root = parse(directory).root
+  let current = root
+  try {
+    const segments = relative(root, directory).split(sep).filter(Boolean)
+    const candidates =
+      segments.length === 0 ? [root] : segments.map((segment) => (current = join(current, segment)))
+    let identity: DirectoryIdentity | null = null
+    for (const candidate of candidates) {
+      const stat = lstatSync(candidate, { bigint: true })
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        return null
+      }
+      identity = {
+        directoryDevice: stat.dev.toString(),
+        directoryInode: stat.ino.toString(),
+        directoryBirthtimeNs: stat.birthtimeNs.toString()
+      }
+    }
+    return identity
+  } catch {
+    return null
+  }
+}
+function fileIdentity(fd: number): FileIdentity | null {
+  const stat = fstatSync(fd, { bigint: true })
+  return stat.isFile()
+    ? {
+        fileDevice: stat.dev.toString(),
+        fileInode: stat.ino.toString(),
+        fileBirthtimeNs: stat.birthtimeNs.toString()
+      }
+    : null
+}
+function sameFile(actual: FileIdentity, expected: FileIdentity): boolean {
+  return (
+    actual.fileDevice === expected.fileDevice &&
+    actual.fileInode === expected.fileInode &&
+    actual.fileBirthtimeNs === expected.fileBirthtimeNs
+  )
+}
+function sameDirectory(
+  stat: { isDirectory(): boolean; dev: bigint; ino: bigint; birthtimeNs: bigint },
+  expected: DirectoryIdentity
+): boolean {
+  return (
+    stat.isDirectory() &&
+    stat.dev.toString() === expected.directoryDevice &&
+    stat.ino.toString() === expected.directoryInode &&
+    stat.birthtimeNs.toString() === expected.directoryBirthtimeNs
+  )
+}
+
+function clearFile(
+  path: string,
+  directoryExpected: DirectoryIdentity,
+  fileExpected: FileIdentity
+): boolean {
+  let directoryFd: number | undefined
+  let fileFd: number | undefined
+  try {
+    const flags =
+      fsConstants.O_RDONLY |
+      (process.platform === 'win32' ? 0 : fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW)
+    directoryFd = openSync(dirname(path), flags)
+    if (!sameDirectory(fstatSync(directoryFd, { bigint: true }), directoryExpected)) {
+      return false
+    }
+    const filePath =
+      process.platform === 'win32'
+        ? path
+        : join(
+            process.platform === 'linux' ? '/proc/self/fd' : '/dev/fd',
+            String(directoryFd),
+            basename(path)
+          )
+    fileFd = openSync(
+      filePath,
+      fsConstants.O_RDWR | (process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW)
+    )
+    const actual = fileIdentity(fileFd)
+    if (!actual || !sameFile(actual, fileExpected)) {
+      return false
+    }
+    ftruncateSync(fileFd, 0)
+    return true
+  } catch {
+    return false
+  } finally {
+    if (fileFd !== undefined) {
+      closeSync(fileFd)
+    }
+    if (directoryFd !== undefined) {
+      closeSync(directoryFd)
+    }
+  }
+}
+
+function readLocations(path: string, session: string): Location[] {
+  try {
+    const stat = lstatSync(path)
+    if (stat.isSymbolicLink() || !stat.isFile() || stat.size > MAX_FISH_HISTORY_META_BYTES) {
+      return []
+    }
+    const raw: unknown = JSON.parse(readFileSync(path, 'utf8'))
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return []
+    }
+    const record = raw as Record<string, unknown>
+    if (
+      record.version !== 2 ||
+      record.fishSession !== session ||
+      !Array.isArray(record.locations)
+    ) {
+      return []
+    }
+    const result: Location[] = []
+    const seen = new Set<string>()
+    for (const candidate of record.locations.slice(-MAX_PATH_CANDIDATES).toReversed()) {
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+        continue
+      }
+      const value = candidate as Record<string, unknown>
+      if (
+        !canonicalPath(session, value.path) ||
+        seen.has(value.path) ||
+        ![
+          'directoryDevice',
+          'directoryInode',
+          'directoryBirthtimeNs',
+          'fileDevice',
+          'fileInode',
+          'fileBirthtimeNs'
+        ].every((key) => typeof value[key] === 'string')
+      ) {
+        continue
+      }
+      seen.add(value.path)
+      result.push(value as unknown as Location)
+      if (result.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
+        break
+      }
+    }
+    return result.toReversed()
+  } catch {
+    return []
+  }
+}
+
+export function attestFishHistoryLocation(
+  attestationPath: string,
+  session: string,
+  historyPath: string | null
+): void {
+  if (!historyPath || !canonicalPath(session, historyPath)) {
+    return
+  }
+  try {
+    mkdirSync(dirname(historyPath), { recursive: true, mode: 0o700 })
+    const directory = directoryIdentity(historyPath)
+    if (!directory) {
+      return
+    }
+    let fd: number | undefined
+    try {
+      try {
+        const stat = lstatSync(historyPath)
+        if (stat.isSymbolicLink() || !stat.isFile()) {
+          return
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return
+        }
+      }
+      fd = openSync(
+        historyPath,
+        fsConstants.O_RDWR |
+          fsConstants.O_CREAT |
+          (process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW),
+        0o600
+      )
+      const file = fileIdentity(fd)
+      if (!file) {
+        return
+      }
+      const previous = readLocations(attestationPath, session)
+      const active = previous.at(-1)
+      if (
+        active?.path === historyPath &&
+        sameFile(file, active) &&
+        active.directoryDevice === directory.directoryDevice &&
+        active.directoryInode === directory.directoryInode &&
+        active.directoryBirthtimeNs === directory.directoryBirthtimeNs
+      ) {
+        return
+      }
+      const locations = [
+        ...previous.filter((entry) => entry.path !== historyPath),
+        { path: historyPath, ...directory, ...file }
+      ].slice(-MAX_RETAINED_FISH_HISTORY_PATHS)
+      mkdirSync(dirname(attestationPath), { recursive: true, mode: 0o700 })
+      if (existsSync(attestationPath) && lstatSync(attestationPath).isSymbolicLink()) {
+        return
+      }
+      writeFileSync(
+        attestationPath,
+        JSON.stringify({ version: 2, fishSession: session, locations }),
+        { mode: 0o600 }
+      )
+    } finally {
+      if (fd !== undefined) {
+        closeSync(fd)
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `[pty:history] Failed to attest fish history location: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+export function deleteFishHistoryFile(session: string, attestationPath: string): void {
+  const locations = readLocations(attestationPath, session)
+  if (locations.length === 0) {
+    return
+  }
+  let removed = false
+  for (const location of locations) {
+    const directory = directoryIdentity(location.path)
+    if (
+      !directory ||
+      directory.directoryDevice !== location.directoryDevice ||
+      directory.directoryInode !== location.directoryInode ||
+      directory.directoryBirthtimeNs !== location.directoryBirthtimeNs
+    ) {
+      continue
+    }
+    removed = clearFile(location.path, directory, location) || removed
+  }
+  if (!removed) {
+    console.warn(`[pty:history] No attested fish history file found for session ${session}`)
+  }
+}

--- a/src/main/fish-history-session.test.ts
+++ b/src/main/fish-history-session.test.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   attestFishHistoryLocation,
@@ -103,5 +103,53 @@ describe('fish history location attestation', () => {
     deleteFishHistoryFile(session, attestationPath)
 
     expect(readFileSync(owned, 'utf8')).toBe('replacement')
+  })
+
+  it('rejects a final history symlink replacement', () => {
+    const dataRoot = join(root, 'data')
+    const owned = historyPath(dataRoot)
+    attestFishHistoryLocation(attestationPath, session, owned)
+    const target = join(root, 'target-history')
+    writeFileSync(target, 'unrelated')
+    rmSync(owned)
+    symlinkSync(target, owned)
+
+    deleteFishHistoryFile(session, attestationPath)
+
+    expect(readFileSync(target, 'utf8')).toBe('unrelated')
+  })
+
+  it('rejects a replacement regular file with a different identity', () => {
+    const dataRoot = join(root, 'data')
+    const owned = historyPath(dataRoot)
+    attestFishHistoryLocation(attestationPath, session, owned)
+    rmSync(owned)
+    writeFileSync(owned, 'replacement')
+
+    deleteFishHistoryFile(session, attestationPath)
+
+    expect(readFileSync(owned, 'utf8')).toBe('replacement')
+  })
+
+  it('fails closed for version-one attestations without file identity', () => {
+    const dataRoot = join(root, 'data')
+    const owned = historyPath(dataRoot)
+    mkdirSync(dirname(owned), { recursive: true })
+    writeFileSync(owned, 'history')
+    mkdirSync(dirname(attestationPath), { recursive: true })
+    writeFileSync(
+      attestationPath,
+      JSON.stringify({
+        version: 1,
+        fishSession: session,
+        locations: [
+          { path: owned, directoryDevice: '1', directoryInode: '1', directoryBirthtimeNs: '1' }
+        ]
+      })
+    )
+
+    deleteFishHistoryFile(session, attestationPath)
+
+    expect(readFileSync(owned, 'utf8')).toBe('history')
   })
 })

--- a/src/main/fish-history-session.test.ts
+++ b/src/main/fish-history-session.test.ts
@@ -35,7 +35,7 @@ describe('fish history location attestation', () => {
     return join(dataRoot, 'fish', `${session}_history`)
   }
 
-  it('deletes each attested XDG location and caps retained identities', () => {
+  it('retains only bounded attested XDG locations when safe clearing is unavailable', () => {
     const paths: string[] = []
     for (let index = 0; index < MAX_RETAINED_FISH_HISTORY_PATHS + 2; index += 1) {
       const path = historyPath(join(root, `data-${index}`))
@@ -48,7 +48,9 @@ describe('fish history location attestation', () => {
 
     expect(existsSync(paths[0])).toBe(true)
     expect(existsSync(paths[1])).toBe(true)
-    expect(paths.slice(2).every((path) => !existsSync(path))).toBe(true)
+    expect(paths.slice(2).every((path) => readFileSync(path, 'utf8').startsWith('history-'))).toBe(
+      true
+    )
   })
 
   it('ignores a tampered meta.json path to an unrelated same-named file', () => {
@@ -65,7 +67,8 @@ describe('fish history location attestation', () => {
 
     deleteFishHistoryFile(session, attestationPath)
 
-    expect(existsSync(owned)).toBe(false)
+    expect(existsSync(owned)).toBe(true)
+    expect(readFileSync(owned, 'utf8')).toBe('owned')
     expect(readFileSync(unrelated, 'utf8')).toBe('unrelated')
   })
 

--- a/src/main/fish-history-session.test.ts
+++ b/src/main/fish-history-session.test.ts
@@ -1,0 +1,104 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  attestFishHistoryLocation,
+  deleteFishHistoryFile,
+  MAX_RETAINED_FISH_HISTORY_PATHS
+} from './fish-history-session'
+
+describe('fish history location attestation', () => {
+  const session = 'orca_0123456789abcdef'
+  let root: string
+  let attestationPath: string
+
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'orca-fish-attestation-')))
+    attestationPath = join(root, 'orca-history', 'fish-history-locations.json')
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function historyPath(dataRoot: string): string {
+    return join(dataRoot, 'fish', `${session}_history`)
+  }
+
+  it('deletes each attested XDG location and caps retained identities', () => {
+    const paths: string[] = []
+    for (let index = 0; index < MAX_RETAINED_FISH_HISTORY_PATHS + 2; index += 1) {
+      const path = historyPath(join(root, `data-${index}`))
+      attestFishHistoryLocation(attestationPath, session, path)
+      writeFileSync(path, `history-${index}`)
+      paths.push(path)
+    }
+
+    deleteFishHistoryFile(session, attestationPath)
+
+    expect(existsSync(paths[0])).toBe(true)
+    expect(existsSync(paths[1])).toBe(true)
+    expect(paths.slice(2).every((path) => !existsSync(path))).toBe(true)
+  })
+
+  it('ignores a tampered meta.json path to an unrelated same-named file', () => {
+    const owned = historyPath(join(root, 'owned-data'))
+    const unrelated = historyPath(join(root, 'unrelated-data'))
+    attestFishHistoryLocation(attestationPath, session, owned)
+    writeFileSync(owned, 'owned')
+    mkdirSync(join(root, 'unrelated-data', 'fish'), { recursive: true })
+    writeFileSync(unrelated, 'unrelated')
+    writeFileSync(
+      join(root, 'orca-history', 'meta.json'),
+      JSON.stringify({ fishSession: session, fishHistoryPath: unrelated })
+    )
+
+    deleteFishHistoryFile(session, attestationPath)
+
+    expect(existsSync(owned)).toBe(false)
+    expect(readFileSync(unrelated, 'utf8')).toBe('unrelated')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a fish parent replaced by a symlink before cleanup',
+    () => {
+      const dataRoot = join(root, 'data')
+      const owned = historyPath(dataRoot)
+      attestFishHistoryLocation(attestationPath, session, owned)
+      rmSync(join(dataRoot, 'fish'), { recursive: true })
+
+      const targetDir = join(root, 'target-fish')
+      mkdirSync(targetDir)
+      const target = join(targetDir, `${session}_history`)
+      writeFileSync(target, 'unrelated')
+      symlinkSync(targetDir, join(dataRoot, 'fish'), 'dir')
+
+      deleteFishHistoryFile(session, attestationPath)
+
+      expect(readFileSync(target, 'utf8')).toBe('unrelated')
+    }
+  )
+
+  it('rejects a recreated fish directory with a different identity', () => {
+    const dataRoot = join(root, 'data')
+    const owned = historyPath(dataRoot)
+    attestFishHistoryLocation(attestationPath, session, owned)
+    rmSync(join(dataRoot, 'fish'), { recursive: true })
+    mkdirSync(join(dataRoot, 'fish'))
+    writeFileSync(owned, 'replacement')
+
+    deleteFishHistoryFile(session, attestationPath)
+
+    expect(readFileSync(owned, 'utf8')).toBe('replacement')
+  })
+})

--- a/src/main/fish-history-session.test.ts
+++ b/src/main/fish-history-session.test.ts
@@ -1,5 +1,4 @@
 import {
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -35,7 +34,7 @@ describe('fish history location attestation', () => {
     return join(dataRoot, 'fish', `${session}_history`)
   }
 
-  it('retains only bounded attested XDG locations when safe clearing is unavailable', () => {
+  it('retains only bounded v2 attested XDG locations', () => {
     const paths: string[] = []
     for (let index = 0; index < MAX_RETAINED_FISH_HISTORY_PATHS + 2; index += 1) {
       const path = historyPath(join(root, `data-${index}`))
@@ -44,12 +43,16 @@ describe('fish history location attestation', () => {
       paths.push(path)
     }
 
-    deleteFishHistoryFile(session, attestationPath)
-
-    expect(existsSync(paths[0])).toBe(true)
-    expect(existsSync(paths[1])).toBe(true)
-    expect(paths.slice(2).every((path) => readFileSync(path, 'utf8').startsWith('history-'))).toBe(
-      true
+    const record = JSON.parse(readFileSync(attestationPath, 'utf8')) as {
+      version: number
+      fishSession: string
+      locations: { path: string }[]
+    }
+    expect(record.version).toBe(2)
+    expect(record.fishSession).toBe(session)
+    expect(record.locations).toHaveLength(MAX_RETAINED_FISH_HISTORY_PATHS)
+    expect(record.locations.map(({ path }) => path)).toEqual(
+      paths.slice(-MAX_RETAINED_FISH_HISTORY_PATHS)
     )
   })
 
@@ -61,13 +64,16 @@ describe('fish history location attestation', () => {
     mkdirSync(join(root, 'unrelated-data', 'fish'), { recursive: true })
     writeFileSync(unrelated, 'unrelated')
     writeFileSync(
-      join(root, 'orca-history', 'meta.json'),
-      JSON.stringify({ fishSession: session, fishHistoryPath: unrelated })
+      attestationPath,
+      JSON.stringify({
+        version: 2,
+        fishSession: session,
+        locations: [{ path: unrelated }]
+      })
     )
 
     deleteFishHistoryFile(session, attestationPath)
 
-    expect(existsSync(owned)).toBe(true)
     expect(readFileSync(owned, 'utf8')).toBe('owned')
     expect(readFileSync(unrelated, 'utf8')).toBe('unrelated')
   })

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'node:os'
-import { isAbsolute, join } from 'node:path'
-import { rmSync } from 'node:fs'
+import { basename, isAbsolute, join } from 'node:path'
+import { existsSync, rmSync } from 'node:fs'
 
 /**
  * Per-worktree fish history, which fish models as a session NAME rather than a path.
@@ -45,17 +45,62 @@ export function resolveFishHistoryFilePath(
   return join(dataHome, 'fish', `${session}_history`)
 }
 
-/** Best-effort removal of one worktree's fish history file. */
-export function deleteFishHistoryFile(session: string, env: NodeJS.ProcessEnv = process.env): void {
-  const path = resolveFishHistoryFilePath(session, env)
-  if (!path) {
+/**
+ * Accepts a path recorded at spawn time only if it still names this session's own
+ * history file, so a tampered meta.json cannot steer `rmSync` somewhere else.
+ */
+function isTrustedRecordedPath(session: string, path: string | null | undefined): path is string {
+  return Boolean(
+    path &&
+    SAFE_SESSION_NAME.test(session) &&
+    isAbsolute(path) &&
+    basename(path) === `${session}_history`
+  )
+}
+
+/**
+ * Removes one worktree's fish history file.
+ *
+ * `recordedPath` is the path resolved from the PTY's own spawn env when the
+ * session was minted; the main process env is only a fallback, because the two
+ * disagree whenever Orca was launched with a different `XDG_DATA_HOME`/`HOME`
+ * than the shells it spawns.
+ *
+ * Neither can see a `set -gx XDG_DATA_HOME …` that lives inside the user's
+ * config.fish — fish resolves that after we have handed off. That file cannot be
+ * found from here, so it is reported instead of being dropped silently.
+ */
+export function deleteFishHistoryFile(
+  session: string,
+  options: { recordedPath?: string | null; env?: NodeJS.ProcessEnv } = {}
+): void {
+  const candidates = new Set<string>()
+  if (isTrustedRecordedPath(session, options.recordedPath)) {
+    candidates.add(options.recordedPath)
+  }
+  const fromEnv = resolveFishHistoryFilePath(session, options.env ?? process.env)
+  if (fromEnv) {
+    candidates.add(fromEnv)
+  }
+  if (candidates.size === 0) {
     return
   }
-  try {
-    rmSync(path, { force: true })
-  } catch (err) {
+  let removed = false
+  for (const path of candidates) {
+    try {
+      removed ||= existsSync(path)
+      rmSync(path, { force: true })
+    } catch (err) {
+      console.warn(
+        `[pty:history] Failed to delete fish history ${path}: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+  }
+  if (!removed) {
+    // Explicit: a config.fish-set XDG_DATA_HOME leaves a file we cannot locate,
+    // and silence would hide one leaked history file per deleted worktree.
     console.warn(
-      `[pty:history] Failed to delete fish history ${session}: ${err instanceof Error ? err.message : String(err)}`
+      `[pty:history] No fish history file found for session ${session}; if fish keeps history outside ${[...candidates].join(' or ')} (e.g. XDG_DATA_HOME set in config.fish) that file is left behind.`
     )
   }
 }

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -1,0 +1,61 @@
+import { homedir } from 'node:os'
+import { isAbsolute, join } from 'node:path'
+import { rmSync } from 'node:fs'
+
+/**
+ * Per-worktree fish history, which fish models as a session NAME rather than a path.
+ *
+ * fish ignores HISTFILE entirely: history lives at
+ * `$XDG_DATA_HOME/fish/${fish_history}_history` (default session "fish"), so the
+ * only isolation knob is `fish_history`. fish imports environment variables as
+ * global variables at startup, so exporting `fish_history` in the spawn env picks
+ * the session without an `--init-command` — verified against fish 4.7.1.
+ *
+ * Consequence: the file lands in the USER's fish data dir, not Orca's history
+ * root, so it cannot be tombstoned with the rest of a worktree's history tree —
+ * `deleteFishHistoryFile` removes it directly instead.
+ *
+ * Two more fish facts for anyone reading these files: history is written only in
+ * INTERACTIVE mode, and the format is a YAML-ish record list (`- cmd: …` /
+ * `  when: …`), not the one-line-per-command form bash and zsh use.
+ */
+const SESSION_PREFIX = 'orca_'
+// Why: the name becomes a filename and is only ever built from a hex hash; anything
+// else means a caller drifted, and refusing beats deleting an unexpected path.
+const SAFE_SESSION_NAME = /^orca_[0-9a-f]{1,64}$/
+
+export function fishHistorySessionName(worktreeHash: string): string {
+  return `${SESSION_PREFIX}${worktreeHash}`
+}
+
+/** Absolute path fish writes a session's history to, or null when it is not resolvable. */
+export function resolveFishHistoryFilePath(
+  session: string,
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  if (!SAFE_SESSION_NAME.test(session)) {
+    return null
+  }
+  const xdgDataHome = env.XDG_DATA_HOME?.trim()
+  // Why: fish ignores a relative XDG_DATA_HOME and falls back to the home default.
+  const dataHome =
+    xdgDataHome && isAbsolute(xdgDataHome)
+      ? xdgDataHome
+      : join(env.HOME?.trim() || homedir(), '.local', 'share')
+  return join(dataHome, 'fish', `${session}_history`)
+}
+
+/** Best-effort removal of one worktree's fish history file. */
+export function deleteFishHistoryFile(session: string, env: NodeJS.ProcessEnv = process.env): void {
+  const path = resolveFishHistoryFilePath(session, env)
+  if (!path) {
+    return
+  }
+  try {
+    rmSync(path, { force: true })
+  } catch (err) {
+    console.warn(
+      `[pty:history] Failed to delete fish history ${session}: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+}

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -1,61 +1,29 @@
 import { homedir } from 'node:os'
-import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import {
-  closeSync,
-  constants as fsConstants,
-  existsSync,
-  ftruncateSync,
-  lstatSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  writeFileSync
-} from 'node:fs'
+  attestFishHistoryLocation,
+  deleteFishHistoryFile,
+  MAX_FISH_HISTORY_META_BYTES,
+  MAX_RETAINED_FISH_HISTORY_PATHS
+} from './fish-history-location-attestation'
 
-/**
- * Per-worktree fish history, which fish models as a session NAME rather than a path.
- *
- * fish ignores HISTFILE entirely: history lives at
- * `$XDG_DATA_HOME/fish/${fish_history}_history` (default session "fish"), so the
- * only isolation knob is `fish_history`. fish imports environment variables as
- * global variables at startup, so exporting `fish_history` in the spawn env picks
- * the session without an `--init-command` — verified against fish 4.7.1.
- *
- * Consequence: the file lands in the USER's fish data dir, not Orca's history
- * root, so it cannot be tombstoned with the rest of a worktree's history tree —
- * `deleteFishHistoryFile` removes it directly instead.
- *
- * Two more fish facts for anyone reading these files: history is written only in
- * INTERACTIVE mode, and the format is a YAML-ish record list (`- cmd: …` /
- * `  when: …`), not the one-line-per-command form bash and zsh use.
- */
-const SESSION_PREFIX = 'orca_'
-// Why: the name becomes a filename and is only ever built from a hex hash; anything
-// else means a caller drifted, and refusing beats deleting an unexpected path.
-const SAFE_SESSION_NAME = /^orca_[0-9a-f]{1,64}$/
-
-export const MAX_RETAINED_FISH_HISTORY_PATHS = 16
-export const MAX_FISH_HISTORY_META_BYTES = 32 * 1024
-const MAX_FISH_HISTORY_PATH_CANDIDATES = MAX_RETAINED_FISH_HISTORY_PATHS * 4
-export const FISH_HISTORY_LOCATION_ATTESTATION = 'fish-history-locations.json'
-
-type FishHistoryLocationAttestation = {
-  path: string
-  directoryDevice: string
-  directoryInode: string
-  directoryBirthtimeNs: string
+export {
+  attestFishHistoryLocation,
+  deleteFishHistoryFile,
+  MAX_FISH_HISTORY_META_BYTES,
+  MAX_RETAINED_FISH_HISTORY_PATHS
 }
-type FishHistoryDirectoryIdentity = Omit<FishHistoryLocationAttestation, 'path'>
+export const FISH_HISTORY_LOCATION_ATTESTATION = 'fish-history-locations.json'
+const SESSION_PREFIX = 'orca_'
+const SAFE_SESSION_NAME = /^orca_[0-9a-f]{1,64}$/
+const MAX_PATH_CANDIDATES = MAX_RETAINED_FISH_HISTORY_PATHS * 4
 
 export function isSafeFishHistorySession(session: unknown): session is string {
   return typeof session === 'string' && SAFE_SESSION_NAME.test(session)
 }
-
 export function fishHistorySessionName(worktreeHash: string): string {
   return `${SESSION_PREFIX}${worktreeHash}`
 }
-
-/** Absolute path fish writes a session's history to, or null when it is not resolvable. */
 export function resolveFishHistoryFilePath(
   session: string,
   env: NodeJS.ProcessEnv = process.env
@@ -63,20 +31,15 @@ export function resolveFishHistoryFilePath(
   if (!isSafeFishHistorySession(session)) {
     return null
   }
-  const xdgDataHome = env.XDG_DATA_HOME?.trim()
-  // Why: fish ignores a relative XDG_DATA_HOME and falls back to the home default.
+  const xdg = env.XDG_DATA_HOME?.trim()
   const dataHome =
-    xdgDataHome && isAbsolute(xdgDataHome)
-      ? xdgDataHome
-      : join(env.HOME?.trim() || homedir(), '.local', 'share')
+    xdg && isAbsolute(xdg) ? xdg : join(env.HOME?.trim() || homedir(), '.local', 'share')
   return join(dataHome, 'fish', `${session}_history`)
 }
-
-/** Validate path shape only; deletion authority comes from a separate identity attestation. */
-function isCanonicalFishHistoryPath(session: string, path: unknown): path is string {
-  return Boolean(
+function canonicalPath(session: string, path: unknown): path is string {
+  return (
     typeof path === 'string' &&
-    path &&
+    Boolean(path) &&
     isSafeFishHistorySession(session) &&
     isAbsolute(path) &&
     resolve(path) === path &&
@@ -84,181 +47,22 @@ function isCanonicalFishHistoryPath(session: string, path: unknown): path is str
     basename(path) === `${session}_history`
   )
 }
-
-function fishHistoryDirectoryIdentity(path: string): FishHistoryDirectoryIdentity | null {
-  const directory = dirname(path)
-  const root = parse(directory).root
-  let current = root
-  try {
-    const segments = relative(root, directory).split(sep).filter(Boolean)
-    const roots =
-      segments.length === 0 ? [root] : segments.map((segment) => (current = join(current, segment)))
-    let identity: FishHistoryDirectoryIdentity | null = null
-    for (const candidate of roots) {
-      const stat = lstatSync(candidate, { bigint: true })
-      if (stat.isSymbolicLink() || !stat.isDirectory()) {
-        return null
-      }
-      identity = {
-        directoryDevice: stat.dev.toString(),
-        directoryInode: stat.ino.toString(),
-        directoryBirthtimeNs: stat.birthtimeNs.toString()
-      }
-    }
-    return identity
-  } catch {
-    return null
-  }
-}
-
-/** Clear through an attested directory handle; never unlink a pathname after checking it. */
-function clearFishHistoryFile(path: string): boolean {
-  const directory = dirname(path)
-  let directoryFd: number | undefined
-  let fileFd: number | undefined
-  try {
-    directoryFd = openSync(
-      directory,
-      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW
-    )
-    if (process.platform === 'win32') {
-      return false
-    }
-    const fdRoot = process.platform === 'linux' ? '/proc/self/fd' : '/dev/fd'
-    fileFd = openSync(join(fdRoot, String(directoryFd), basename(path)), fsConstants.O_RDWR)
-    ftruncateSync(fileFd, 0)
-    return true
-  } catch {
-    return false
-  } finally {
-    if (fileFd !== undefined) {
-      closeSync(fileFd)
-    }
-    if (directoryFd !== undefined) {
-      closeSync(directoryFd)
-    }
-  }
-}
-
-function readFishHistoryLocationAttestations(
-  attestationPath: string,
-  session: string
-): FishHistoryLocationAttestation[] {
-  try {
-    const stat = lstatSync(attestationPath)
-    if (stat.isSymbolicLink() || !stat.isFile() || stat.size > MAX_FISH_HISTORY_META_BYTES) {
-      return []
-    }
-    const raw: unknown = JSON.parse(readFileSync(attestationPath, 'utf8'))
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-      return []
-    }
-    const record = raw as Record<string, unknown>
-    if (
-      record.version !== 1 ||
-      record.fishSession !== session ||
-      !Array.isArray(record.locations)
-    ) {
-      return []
-    }
-    const candidates = record.locations.slice(-MAX_FISH_HISTORY_PATH_CANDIDATES)
-    const retained: FishHistoryLocationAttestation[] = []
-    const seen = new Set<string>()
-    for (let index = candidates.length - 1; index >= 0; index -= 1) {
-      const candidate = candidates[index]
-      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
-        continue
-      }
-      const location = candidate as Record<string, unknown>
-      if (
-        !isCanonicalFishHistoryPath(session, location.path) ||
-        typeof location.directoryDevice !== 'string' ||
-        typeof location.directoryInode !== 'string' ||
-        typeof location.directoryBirthtimeNs !== 'string' ||
-        seen.has(location.path)
-      ) {
-        continue
-      }
-      seen.add(location.path)
-      retained.push({
-        path: location.path,
-        directoryDevice: location.directoryDevice,
-        directoryInode: location.directoryInode,
-        directoryBirthtimeNs: location.directoryBirthtimeNs
-      })
-      if (retained.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
-        break
-      }
-    }
-    return retained.toReversed()
-  } catch {
-    return []
-  }
-}
-
-/** Record a spawn-derived fish location outside meta.json, bound to its directory identity. */
-export function attestFishHistoryLocation(
-  attestationPath: string,
-  session: string,
-  historyPath: string | null
-): void {
-  if (!historyPath || !isCanonicalFishHistoryPath(session, historyPath)) {
-    return
-  }
-  try {
-    mkdirSync(dirname(historyPath), { recursive: true, mode: 0o700 })
-    const identity = fishHistoryDirectoryIdentity(historyPath)
-    if (!identity) {
-      console.warn(`[pty:history] Refusing to attest symlinked fish history path ${historyPath}`)
-      return
-    }
-    const retained = readFishHistoryLocationAttestations(attestationPath, session)
-    const active = retained.at(-1)
-    if (
-      active?.path === historyPath &&
-      active.directoryDevice === identity.directoryDevice &&
-      active.directoryInode === identity.directoryInode &&
-      active.directoryBirthtimeNs === identity.directoryBirthtimeNs
-    ) {
-      return
-    }
-    const existing = retained.filter((entry) => entry.path !== historyPath)
-    const locations = [...existing, { path: historyPath, ...identity }].slice(
-      -MAX_RETAINED_FISH_HISTORY_PATHS
-    )
-    mkdirSync(dirname(attestationPath), { recursive: true, mode: 0o700 })
-    if (existsSync(attestationPath) && lstatSync(attestationPath).isSymbolicLink()) {
-      return
-    }
-    writeFileSync(
-      attestationPath,
-      JSON.stringify({ version: 1, fishSession: session, locations }),
-      { mode: 0o600 }
-    )
-  } catch (error) {
-    console.warn(
-      `[pty:history] Failed to attest fish history location: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
-}
-
 export function normalizeFishHistoryPaths(
   session: string,
   singularPath: unknown,
   paths: readonly unknown[] | undefined
 ): string[] {
-  const recentPaths = (paths ?? []).slice(-MAX_FISH_HISTORY_PATH_CANDIDATES)
   const newestFirst: string[] = []
   const seen = new Set<string>()
   const retain = (path: unknown): void => {
-    if (!isCanonicalFishHistoryPath(session, path) || seen.has(path)) {
+    if (!canonicalPath(session, path) || seen.has(path)) {
       return
     }
     seen.add(path)
     newestFirst.push(path)
   }
-  for (let index = recentPaths.length - 1; index >= 0; index -= 1) {
-    retain(recentPaths[index])
+  for (const path of (paths ?? []).slice(-MAX_PATH_CANDIDATES).toReversed()) {
+    retain(path)
     if (newestFirst.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
       break
     }
@@ -266,54 +70,5 @@ export function normalizeFishHistoryPaths(
   if (newestFirst.length < MAX_RETAINED_FISH_HISTORY_PATHS) {
     retain(singularPath)
   }
-  const retained: string[] = []
-  for (let index = newestFirst.length - 1; index >= 0; index -= 1) {
-    if (retained.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
-      break
-    }
-    retained.push(newestFirst[index])
-  }
-  return retained
-}
-
-/** Delete only spawn-attested locations whose non-symlink directory identity still matches. */
-export function deleteFishHistoryFile(session: string, attestationPath: string): void {
-  const locations = readFishHistoryLocationAttestations(attestationPath, session)
-  if (locations.length === 0) {
-    console.warn(`[pty:history] No attested fish history location for session ${session}`)
-    return
-  }
-  let removed = false
-  for (const location of locations) {
-    try {
-      const identity = fishHistoryDirectoryIdentity(location.path)
-      if (
-        !identity ||
-        identity.directoryDevice !== location.directoryDevice ||
-        identity.directoryInode !== location.directoryInode ||
-        identity.directoryBirthtimeNs !== location.directoryBirthtimeNs
-      ) {
-        console.warn(`[pty:history] Refusing fish history cleanup after directory identity changed`)
-        continue
-      }
-      if (existsSync(location.path)) {
-        const stat = lstatSync(location.path)
-        if (stat.isSymbolicLink() || !stat.isFile()) {
-          continue
-        }
-        removed = clearFishHistoryFile(location.path) || removed
-      }
-    } catch (err) {
-      console.warn(
-        `[pty:history] Failed to delete fish history ${location.path}: ${err instanceof Error ? err.message : String(err)}`
-      )
-    }
-  }
-  if (!removed) {
-    // Explicit: a config.fish-set XDG_DATA_HOME leaves a file we cannot locate,
-    // and silence would hide one leaked history file per deleted worktree.
-    console.warn(
-      `[pty:history] No attested fish history file found for session ${session}; a config.fish-only XDG_DATA_HOME remains outside Orca's cleanup authority.`
-    )
-  }
+  return newestFirst.toReversed().slice(-MAX_RETAINED_FISH_HISTORY_PATHS)
 }

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -49,8 +49,9 @@ export function resolveFishHistoryFilePath(
  * Accepts a path recorded at spawn time only if it still names this session's own
  * history file, so a tampered meta.json cannot steer `rmSync` somewhere else.
  */
-function isTrustedRecordedPath(session: string, path: string | null | undefined): path is string {
+function isTrustedRecordedPath(session: string, path: unknown): path is string {
   return Boolean(
+    typeof path === 'string' &&
     path &&
     SAFE_SESSION_NAME.test(session) &&
     isAbsolute(path) &&
@@ -72,11 +73,20 @@ function isTrustedRecordedPath(session: string, path: string | null | undefined)
  */
 export function deleteFishHistoryFile(
   session: string,
-  options: { recordedPath?: string | null; env?: NodeJS.ProcessEnv } = {}
+  options: {
+    recordedPath?: string | null
+    recordedPaths?: readonly unknown[]
+    env?: NodeJS.ProcessEnv
+  } = {}
 ): void {
   const candidates = new Set<string>()
   if (isTrustedRecordedPath(session, options.recordedPath)) {
     candidates.add(options.recordedPath)
+  }
+  for (const path of options.recordedPaths ?? []) {
+    if (isTrustedRecordedPath(session, path)) {
+      candidates.add(path)
+    }
   }
   const fromEnv = resolveFishHistoryFilePath(session, options.env ?? process.env)
   if (fromEnv) {

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -1,6 +1,16 @@
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
-import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  ftruncateSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync
+} from 'node:fs'
 
 /**
  * Per-worktree fish history, which fish models as a session NAME rather than a path.
@@ -98,6 +108,35 @@ function fishHistoryDirectoryIdentity(path: string): FishHistoryDirectoryIdentit
     return identity
   } catch {
     return null
+  }
+}
+
+/** Clear through an attested directory handle; never unlink a pathname after checking it. */
+function clearFishHistoryFile(path: string): boolean {
+  const directory = dirname(path)
+  let directoryFd: number | undefined
+  let fileFd: number | undefined
+  try {
+    directoryFd = openSync(
+      directory,
+      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW
+    )
+    if (process.platform === 'win32') {
+      return false
+    }
+    const fdRoot = process.platform === 'linux' ? '/proc/self/fd' : '/dev/fd'
+    fileFd = openSync(join(fdRoot, String(directoryFd), basename(path)), fsConstants.O_RDWR)
+    ftruncateSync(fileFd, 0)
+    return true
+  } catch {
+    return false
+  } finally {
+    if (fileFd !== undefined) {
+      closeSync(fileFd)
+    }
+    if (directoryFd !== undefined) {
+      closeSync(directoryFd)
+    }
   }
 }
 
@@ -262,9 +301,8 @@ export function deleteFishHistoryFile(session: string, attestationPath: string):
         if (stat.isSymbolicLink() || !stat.isFile()) {
           continue
         }
-        removed = true
+        removed = clearFishHistoryFile(location.path) || removed
       }
-      rmSync(location.path, { force: true })
     } catch (err) {
       console.warn(
         `[pty:history] Failed to delete fish history ${location.path}: ${err instanceof Error ? err.message : String(err)}`

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'node:os'
-import { basename, dirname, isAbsolute, join } from 'node:path'
-import { existsSync, rmSync } from 'node:fs'
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 
 /**
  * Per-worktree fish history, which fish models as a session NAME rather than a path.
@@ -27,6 +27,15 @@ const SAFE_SESSION_NAME = /^orca_[0-9a-f]{1,64}$/
 export const MAX_RETAINED_FISH_HISTORY_PATHS = 16
 export const MAX_FISH_HISTORY_META_BYTES = 32 * 1024
 const MAX_FISH_HISTORY_PATH_CANDIDATES = MAX_RETAINED_FISH_HISTORY_PATHS * 4
+export const FISH_HISTORY_LOCATION_ATTESTATION = 'fish-history-locations.json'
+
+type FishHistoryLocationAttestation = {
+  path: string
+  directoryDevice: string
+  directoryInode: string
+  directoryBirthtimeNs: string
+}
+type FishHistoryDirectoryIdentity = Omit<FishHistoryLocationAttestation, 'path'>
 
 export function isSafeFishHistorySession(session: unknown): session is string {
   return typeof session === 'string' && SAFE_SESSION_NAME.test(session)
@@ -53,19 +62,145 @@ export function resolveFishHistoryFilePath(
   return join(dataHome, 'fish', `${session}_history`)
 }
 
-/**
- * Accepts a path recorded at spawn time only if it still names this session's own
- * history file, so a tampered meta.json cannot steer `rmSync` somewhere else.
- */
-export function isTrustedFishHistoryPath(session: string, path: unknown): path is string {
+/** Validate path shape only; deletion authority comes from a separate identity attestation. */
+function isCanonicalFishHistoryPath(session: string, path: unknown): path is string {
   return Boolean(
     typeof path === 'string' &&
     path &&
     isSafeFishHistorySession(session) &&
     isAbsolute(path) &&
+    resolve(path) === path &&
     basename(dirname(path)) === 'fish' &&
     basename(path) === `${session}_history`
   )
+}
+
+function fishHistoryDirectoryIdentity(path: string): FishHistoryDirectoryIdentity | null {
+  const directory = dirname(path)
+  const root = parse(directory).root
+  let current = root
+  try {
+    const segments = relative(root, directory).split(sep).filter(Boolean)
+    const roots =
+      segments.length === 0 ? [root] : segments.map((segment) => (current = join(current, segment)))
+    let identity: FishHistoryDirectoryIdentity | null = null
+    for (const candidate of roots) {
+      const stat = lstatSync(candidate, { bigint: true })
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        return null
+      }
+      identity = {
+        directoryDevice: stat.dev.toString(),
+        directoryInode: stat.ino.toString(),
+        directoryBirthtimeNs: stat.birthtimeNs.toString()
+      }
+    }
+    return identity
+  } catch {
+    return null
+  }
+}
+
+function readFishHistoryLocationAttestations(
+  attestationPath: string,
+  session: string
+): FishHistoryLocationAttestation[] {
+  try {
+    const stat = lstatSync(attestationPath)
+    if (stat.isSymbolicLink() || !stat.isFile() || stat.size > MAX_FISH_HISTORY_META_BYTES) {
+      return []
+    }
+    const raw: unknown = JSON.parse(readFileSync(attestationPath, 'utf8'))
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return []
+    }
+    const record = raw as Record<string, unknown>
+    if (
+      record.version !== 1 ||
+      record.fishSession !== session ||
+      !Array.isArray(record.locations)
+    ) {
+      return []
+    }
+    const candidates = record.locations.slice(-MAX_FISH_HISTORY_PATH_CANDIDATES)
+    const retained: FishHistoryLocationAttestation[] = []
+    const seen = new Set<string>()
+    for (let index = candidates.length - 1; index >= 0; index -= 1) {
+      const candidate = candidates[index]
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+        continue
+      }
+      const location = candidate as Record<string, unknown>
+      if (
+        !isCanonicalFishHistoryPath(session, location.path) ||
+        typeof location.directoryDevice !== 'string' ||
+        typeof location.directoryInode !== 'string' ||
+        typeof location.directoryBirthtimeNs !== 'string' ||
+        seen.has(location.path)
+      ) {
+        continue
+      }
+      seen.add(location.path)
+      retained.push({
+        path: location.path,
+        directoryDevice: location.directoryDevice,
+        directoryInode: location.directoryInode,
+        directoryBirthtimeNs: location.directoryBirthtimeNs
+      })
+      if (retained.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
+        break
+      }
+    }
+    return retained.toReversed()
+  } catch {
+    return []
+  }
+}
+
+/** Record a spawn-derived fish location outside meta.json, bound to its directory identity. */
+export function attestFishHistoryLocation(
+  attestationPath: string,
+  session: string,
+  historyPath: string | null
+): void {
+  if (!historyPath || !isCanonicalFishHistoryPath(session, historyPath)) {
+    return
+  }
+  try {
+    mkdirSync(dirname(historyPath), { recursive: true, mode: 0o700 })
+    const identity = fishHistoryDirectoryIdentity(historyPath)
+    if (!identity) {
+      console.warn(`[pty:history] Refusing to attest symlinked fish history path ${historyPath}`)
+      return
+    }
+    const retained = readFishHistoryLocationAttestations(attestationPath, session)
+    const active = retained.at(-1)
+    if (
+      active?.path === historyPath &&
+      active.directoryDevice === identity.directoryDevice &&
+      active.directoryInode === identity.directoryInode &&
+      active.directoryBirthtimeNs === identity.directoryBirthtimeNs
+    ) {
+      return
+    }
+    const existing = retained.filter((entry) => entry.path !== historyPath)
+    const locations = [...existing, { path: historyPath, ...identity }].slice(
+      -MAX_RETAINED_FISH_HISTORY_PATHS
+    )
+    mkdirSync(dirname(attestationPath), { recursive: true, mode: 0o700 })
+    if (existsSync(attestationPath) && lstatSync(attestationPath).isSymbolicLink()) {
+      return
+    }
+    writeFileSync(
+      attestationPath,
+      JSON.stringify({ version: 1, fishSession: session, locations }),
+      { mode: 0o600 }
+    )
+  } catch (error) {
+    console.warn(
+      `[pty:history] Failed to attest fish history location: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
 }
 
 export function normalizeFishHistoryPaths(
@@ -77,7 +212,7 @@ export function normalizeFishHistoryPaths(
   const newestFirst: string[] = []
   const seen = new Set<string>()
   const retain = (path: unknown): void => {
-    if (!isTrustedFishHistoryPath(session, path) || seen.has(path)) {
+    if (!isCanonicalFishHistoryPath(session, path) || seen.has(path)) {
       return
     }
     seen.add(path)
@@ -102,50 +237,37 @@ export function normalizeFishHistoryPaths(
   return retained
 }
 
-/**
- * Removes one worktree's fish history file.
- *
- * `recordedPath` is the path resolved from the PTY's own spawn env when the
- * session was minted; the main process env is only a fallback, because the two
- * disagree whenever Orca was launched with a different `XDG_DATA_HOME`/`HOME`
- * than the shells it spawns.
- *
- * Neither can see a `set -gx XDG_DATA_HOME …` that lives inside the user's
- * config.fish — fish resolves that after we have handed off. That file cannot be
- * found from here, so it is reported instead of being dropped silently.
- */
-export function deleteFishHistoryFile(
-  session: string,
-  options: {
-    recordedPath?: string | null
-    recordedPaths?: readonly unknown[]
-    env?: NodeJS.ProcessEnv
-  } = {}
-): void {
-  const candidates = new Set<string>()
-  if (isTrustedFishHistoryPath(session, options.recordedPath)) {
-    candidates.add(options.recordedPath)
-  }
-  for (const path of (options.recordedPaths ?? []).slice(0, MAX_RETAINED_FISH_HISTORY_PATHS)) {
-    if (isTrustedFishHistoryPath(session, path)) {
-      candidates.add(path)
-    }
-  }
-  const fromEnv = resolveFishHistoryFilePath(session, options.env ?? process.env)
-  if (fromEnv) {
-    candidates.add(fromEnv)
-  }
-  if (candidates.size === 0) {
+/** Delete only spawn-attested locations whose non-symlink directory identity still matches. */
+export function deleteFishHistoryFile(session: string, attestationPath: string): void {
+  const locations = readFishHistoryLocationAttestations(attestationPath, session)
+  if (locations.length === 0) {
+    console.warn(`[pty:history] No attested fish history location for session ${session}`)
     return
   }
   let removed = false
-  for (const path of candidates) {
+  for (const location of locations) {
     try {
-      removed ||= existsSync(path)
-      rmSync(path, { force: true })
+      const identity = fishHistoryDirectoryIdentity(location.path)
+      if (
+        !identity ||
+        identity.directoryDevice !== location.directoryDevice ||
+        identity.directoryInode !== location.directoryInode ||
+        identity.directoryBirthtimeNs !== location.directoryBirthtimeNs
+      ) {
+        console.warn(`[pty:history] Refusing fish history cleanup after directory identity changed`)
+        continue
+      }
+      if (existsSync(location.path)) {
+        const stat = lstatSync(location.path)
+        if (stat.isSymbolicLink() || !stat.isFile()) {
+          continue
+        }
+        removed = true
+      }
+      rmSync(location.path, { force: true })
     } catch (err) {
       console.warn(
-        `[pty:history] Failed to delete fish history ${path}: ${err instanceof Error ? err.message : String(err)}`
+        `[pty:history] Failed to delete fish history ${location.path}: ${err instanceof Error ? err.message : String(err)}`
       )
     }
   }
@@ -153,7 +275,7 @@ export function deleteFishHistoryFile(
     // Explicit: a config.fish-set XDG_DATA_HOME leaves a file we cannot locate,
     // and silence would hide one leaked history file per deleted worktree.
     console.warn(
-      `[pty:history] No fish history file found for session ${session}; if fish keeps history outside ${[...candidates].join(' or ')} (e.g. XDG_DATA_HOME set in config.fish) that file is left behind.`
+      `[pty:history] No attested fish history file found for session ${session}; a config.fish-only XDG_DATA_HOME remains outside Orca's cleanup authority.`
     )
   }
 }

--- a/src/main/fish-history-session.ts
+++ b/src/main/fish-history-session.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'node:os'
-import { basename, isAbsolute, join } from 'node:path'
+import { basename, dirname, isAbsolute, join } from 'node:path'
 import { existsSync, rmSync } from 'node:fs'
 
 /**
@@ -24,6 +24,14 @@ const SESSION_PREFIX = 'orca_'
 // else means a caller drifted, and refusing beats deleting an unexpected path.
 const SAFE_SESSION_NAME = /^orca_[0-9a-f]{1,64}$/
 
+export const MAX_RETAINED_FISH_HISTORY_PATHS = 16
+export const MAX_FISH_HISTORY_META_BYTES = 32 * 1024
+const MAX_FISH_HISTORY_PATH_CANDIDATES = MAX_RETAINED_FISH_HISTORY_PATHS * 4
+
+export function isSafeFishHistorySession(session: unknown): session is string {
+  return typeof session === 'string' && SAFE_SESSION_NAME.test(session)
+}
+
 export function fishHistorySessionName(worktreeHash: string): string {
   return `${SESSION_PREFIX}${worktreeHash}`
 }
@@ -33,7 +41,7 @@ export function resolveFishHistoryFilePath(
   session: string,
   env: NodeJS.ProcessEnv = process.env
 ): string | null {
-  if (!SAFE_SESSION_NAME.test(session)) {
+  if (!isSafeFishHistorySession(session)) {
     return null
   }
   const xdgDataHome = env.XDG_DATA_HOME?.trim()
@@ -49,14 +57,49 @@ export function resolveFishHistoryFilePath(
  * Accepts a path recorded at spawn time only if it still names this session's own
  * history file, so a tampered meta.json cannot steer `rmSync` somewhere else.
  */
-function isTrustedRecordedPath(session: string, path: unknown): path is string {
+export function isTrustedFishHistoryPath(session: string, path: unknown): path is string {
   return Boolean(
     typeof path === 'string' &&
     path &&
-    SAFE_SESSION_NAME.test(session) &&
+    isSafeFishHistorySession(session) &&
     isAbsolute(path) &&
+    basename(dirname(path)) === 'fish' &&
     basename(path) === `${session}_history`
   )
+}
+
+export function normalizeFishHistoryPaths(
+  session: string,
+  singularPath: unknown,
+  paths: readonly unknown[] | undefined
+): string[] {
+  const recentPaths = (paths ?? []).slice(-MAX_FISH_HISTORY_PATH_CANDIDATES)
+  const newestFirst: string[] = []
+  const seen = new Set<string>()
+  const retain = (path: unknown): void => {
+    if (!isTrustedFishHistoryPath(session, path) || seen.has(path)) {
+      return
+    }
+    seen.add(path)
+    newestFirst.push(path)
+  }
+  for (let index = recentPaths.length - 1; index >= 0; index -= 1) {
+    retain(recentPaths[index])
+    if (newestFirst.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
+      break
+    }
+  }
+  if (newestFirst.length < MAX_RETAINED_FISH_HISTORY_PATHS) {
+    retain(singularPath)
+  }
+  const retained: string[] = []
+  for (let index = newestFirst.length - 1; index >= 0; index -= 1) {
+    if (retained.length === MAX_RETAINED_FISH_HISTORY_PATHS) {
+      break
+    }
+    retained.push(newestFirst[index])
+  }
+  return retained
 }
 
 /**
@@ -80,11 +123,11 @@ export function deleteFishHistoryFile(
   } = {}
 ): void {
   const candidates = new Set<string>()
-  if (isTrustedRecordedPath(session, options.recordedPath)) {
+  if (isTrustedFishHistoryPath(session, options.recordedPath)) {
     candidates.add(options.recordedPath)
   }
-  for (const path of options.recordedPaths ?? []) {
-    if (isTrustedRecordedPath(session, path)) {
+  for (const path of (options.recordedPaths ?? []).slice(0, MAX_RETAINED_FISH_HISTORY_PATHS)) {
+    if (isTrustedFishHistoryPath(session, path)) {
       candidates.add(path)
     }
   }

--- a/src/main/host-agent-startup-shell.test.ts
+++ b/src/main/host-agent-startup-shell.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveHostAgentStartupShell } from './host-agent-startup-shell'
+
+// Pinned: the resolver reads process.env.SHELL, which differs per developer machine.
+let originalShell: string | undefined
+
+describe('resolveHostAgentStartupShell', () => {
+  beforeEach(() => {
+    originalShell = process.env.SHELL
+  })
+
+  afterEach(() => {
+    if (originalShell === undefined) {
+      delete process.env.SHELL
+    } else {
+      process.env.SHELL = originalShell
+    }
+  })
+
+  it("uses this process's login shell, since it is the one spawning the pty", () => {
+    process.env.SHELL = '/opt/homebrew/bin/fish'
+    expect(resolveHostAgentStartupShell({ platform: process.platform, isRemote: false })).toBe(
+      process.platform === 'win32' ? 'powershell' : 'fish'
+    )
+  })
+
+  it('stays on the sh default for a remote workspace', () => {
+    process.env.SHELL = '/opt/homebrew/bin/fish'
+    expect(
+      resolveHostAgentStartupShell({ platform: process.platform, isRemote: true })
+    ).toBeUndefined()
+  })
+
+  it('stays on the sh default when the workspace platform is not this host', () => {
+    process.env.SHELL = '/opt/homebrew/bin/fish'
+    const otherPlatform = process.platform === 'win32' ? 'linux' : 'win32'
+    expect(resolveHostAgentStartupShell({ platform: otherPlatform, isRemote: false })).not.toBe(
+      'fish'
+    )
+  })
+})

--- a/src/main/host-agent-startup-shell.test.ts
+++ b/src/main/host-agent-startup-shell.test.ts
@@ -24,11 +24,11 @@ describe('resolveHostAgentStartupShell', () => {
     )
   })
 
-  it('stays on the sh default for a remote workspace', () => {
+  it('uses portable Unix syntax for a remote workspace', () => {
     process.env.SHELL = '/opt/homebrew/bin/fish'
-    expect(
-      resolveHostAgentStartupShell({ platform: process.platform, isRemote: true })
-    ).toBeUndefined()
+    expect(resolveHostAgentStartupShell({ platform: process.platform, isRemote: true })).toBe(
+      'unix'
+    )
   })
 
   it('stays on the sh default when the workspace platform is not this host', () => {

--- a/src/main/host-agent-startup-shell.ts
+++ b/src/main/host-agent-startup-shell.ts
@@ -1,0 +1,23 @@
+import { resolveLocalAgentStartupShell } from '../shared/local-agent-startup-shell'
+import type { AgentStartupShell } from '../shared/tui-agent-startup-shell'
+
+/**
+ * Startup-shell dialect for a command this main process will spawn itself.
+ *
+ * Why not the renderer's `getClientLoginShell`: that reads the preload bridge,
+ * which does not exist here — and on a remote Orca host the shell that parses
+ * the line is this process's `$SHELL`, not the connected client's. Launch
+ * scopes here carry only a repo/folder + connectionId, so a non-remote scope on
+ * this platform is always executed by this machine's login shell.
+ */
+export function resolveHostAgentStartupShell(args: {
+  platform: NodeJS.Platform
+  isRemote: boolean
+  terminalWindowsShell?: string | null
+}): AgentStartupShell | undefined {
+  return resolveLocalAgentStartupShell({
+    ...args,
+    hostPlatform: process.platform,
+    hostLoginShell: process.env.SHELL
+  })
+}

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4693,7 +4693,12 @@ export function registerPtyHandlers(
         rows: args.rows,
         cwd,
         env,
-        ...(isNewDaemonSession ? { isNewSession: true } : {})
+        ...(isNewDaemonSession ? { isNewSession: true } : {}),
+        ...(isDaemonHostSpawn
+          ? {
+              historyIsolationEnabled: getSettings?.()?.terminalScopeHistoryByWorktree ?? true
+            }
+          : {})
       }
       if (!args.connectionId && !isDaemonHostSpawn) {
         spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }
@@ -6377,7 +6382,12 @@ export function registerPtyHandlers(
           cwd,
           ...(prevalidatedCwd && !isDaemonHostSpawn ? { prevalidatedCwd } : {}),
           env: spawnEnv,
-          ...(isMintedSessionId ? { isNewSession: true } : {})
+          ...(isMintedSessionId ? { isNewSession: true } : {}),
+          ...(isDaemonHostSpawn
+            ? {
+                historyIsolationEnabled: getSettings?.()?.terminalScopeHistoryByWorktree ?? true
+              }
+            : {})
         }
         if (!args.connectionId && !isDaemonHostSpawn) {
           spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4694,11 +4694,7 @@ export function registerPtyHandlers(
         cwd,
         env,
         ...(isNewDaemonSession ? { isNewSession: true } : {}),
-        ...(isDaemonHostSpawn
-          ? {
-              historyIsolationEnabled: getSettings?.()?.terminalScopeHistoryByWorktree ?? true
-            }
-          : {})
+        historyIsolationEnabled: getSettings?.()?.terminalScopeHistoryByWorktree ?? true
       }
       if (!args.connectionId && !isDaemonHostSpawn) {
         spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }
@@ -6383,11 +6379,7 @@ export function registerPtyHandlers(
           ...(prevalidatedCwd && !isDaemonHostSpawn ? { prevalidatedCwd } : {}),
           env: spawnEnv,
           ...(isMintedSessionId ? { isNewSession: true } : {}),
-          ...(isDaemonHostSpawn
-            ? {
-                historyIsolationEnabled: getSettings?.()?.terminalScopeHistoryByWorktree ?? true
-              }
-            : {})
+          historyIsolationEnabled: getSettings?.()?.terminalScopeHistoryByWorktree ?? true
         }
         if (!args.connectionId && !isDaemonHostSpawn) {
           spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -8895,9 +8895,7 @@ describe('registerWorktreeHandlers', () => {
         ORCA_WORKTREE_PATH: '/remote/feature-wt'
       })
     )
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
-      worktreeId: 'repo-ssh::/remote/feature-wt'
-    })
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
     expect(runtimeStub.closeFileWatchersForRemoval).toHaveBeenCalledWith(
       '/remote/feature-wt',
       'conn-1'
@@ -9023,9 +9021,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(provider.worktreeIsClean).not.toHaveBeenCalled()
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', true, {
-      worktreeId: 'repo-ssh::/remote/feature-wt'
-    })
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', true)
   })
 
   it('continues SSH worktree removal when the archive hook fails', async () => {
@@ -9081,9 +9077,7 @@ describe('registerWorktreeHandlers', () => {
       await handlers['worktrees:remove'](null, {
         worktreeId: 'repo-ssh::/remote/feature-wt'
       })
-      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
-        worktreeId: 'repo-ssh::/remote/feature-wt'
-      })
+      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[hooks] archive hook failed for /remote/feature-wt:',
         expect.stringContaining('archive hook exited 7')
@@ -9141,9 +9135,7 @@ describe('registerWorktreeHandlers', () => {
       await handlers['worktrees:remove'](null, {
         worktreeId: 'repo-ssh::/remote/feature-wt'
       })
-      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
-        worktreeId: 'repo-ssh::/remote/feature-wt'
-      })
+      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[hooks] archive hook failed for /remote/feature-wt:',
         'relay disconnected'
@@ -9268,9 +9260,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(provider.execNonInteractive).not.toHaveBeenCalled()
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
-      worktreeId: 'repo-ssh::/remote/feature-wt'
-    })
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
   })
 
   it('uses the workspace host when duplicate repo ids exist across local and SSH', async () => {
@@ -9317,9 +9307,7 @@ describe('registerWorktreeHandlers', () => {
       hostId: 'ssh:conn-1'
     })
 
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
-      worktreeId: 'repo-shared::/remote/feature-wt'
-    })
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
     expect(removeWorktreeMock).not.toHaveBeenCalled()
   })
 
@@ -9837,6 +9825,110 @@ describe('registerWorktreeHandlers', () => {
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
       repoId: 'repo-1'
     })
+  })
+
+  it('routes already-missing SSH history cleanup through the PTY owner', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1'
+    }
+    const worktreeId = 'repo-ssh::/remote/already-deleted'
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: repo.path,
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+    }
+    const fsProvider = {
+      stat: vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    }
+    const deleteWorktreeHistory = vi.fn().mockResolvedValue(undefined)
+    store.getRepo.mockReturnValue(repo)
+    store.getWorktreeMeta.mockReturnValue(
+      makeWorktreeMeta({ hostId: 'ssh:conn-1', orcaCreationSource: 'ssh' })
+    )
+    getSshGitProviderMock.mockReturnValue(gitProvider)
+    getSshFilesystemProviderMock.mockReturnValue(fsProvider)
+    getSshPtyProviderMock.mockReturnValue({ deleteWorktreeHistory } as never)
+
+    await handlers['worktrees:remove'](null, { worktreeId })
+
+    expect(deleteWorktreeHistory).toHaveBeenCalledWith(worktreeId)
+    expect(deleteWorktreeHistory.mock.invocationCallOrder[0]).toBeLessThan(
+      store.removeWorktreeMeta.mock.invocationCallOrder[0]
+    )
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith(worktreeId, 'ssh:conn-1')
+  })
+
+  it('routes SSH orphan-directory history cleanup through the PTY owner', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1'
+    }
+    const worktreePath = '/remote/orphan'
+    const worktreeId = `${repo.id}::${worktreePath}`
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: repo.path,
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+    }
+    const fsProvider = {
+      lstat: vi.fn(async (path: string) => ({
+        type: path === `${worktreePath}/.git` ? 'file' : 'directory'
+      })),
+      readFile: vi.fn(async (path: string) => ({
+        isBinary: false,
+        content:
+          path === `${worktreePath}/.git`
+            ? `gitdir: ${repo.path}/.git/worktrees/orphan\n`
+            : `${worktreePath}/.git\n`
+      })),
+      deletePath: vi.fn().mockResolvedValue(undefined)
+    }
+    const deleteWorktreeHistory = vi.fn().mockResolvedValue(undefined)
+    const ptyProvider = {
+      listProcesses: vi.fn().mockResolvedValue([]),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      deleteWorktreeHistory
+    }
+    store.getRepo.mockReturnValue(repo)
+    store.getWorktreeMeta.mockReturnValue(
+      makeWorktreeMeta({
+        hostId: 'ssh:conn-1',
+        orcaCreatedAt: Date.now(),
+        orcaCreationSource: 'ssh'
+      })
+    )
+    getSshGitProviderMock.mockReturnValue(gitProvider)
+    getSshFilesystemProviderMock.mockReturnValue(fsProvider)
+    getSshPtyProviderMock.mockReturnValue(ptyProvider as never)
+
+    await handlers['worktrees:remove'](null, { worktreeId, force: true })
+
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(worktreePath, true)
+    expect(deleteWorktreeHistory).toHaveBeenCalledWith(worktreeId)
+    expect(deleteWorktreeHistory.mock.invocationCallOrder[0]).toBeLessThan(
+      store.removeWorktreeMeta.mock.invocationCallOrder[0]
+    )
   })
 
   it('force-removes a legacy Orca-created orphaned worktree directory after Git tracking is gone', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -8624,7 +8624,8 @@ describe('registerWorktreeHandlers', () => {
   // Folder projects can be SSH-backed, and folder workspace ids are `repoId::path::workspace:<uuid>`
   // — reusable across hosts — so the sweep must name the owning connection.
   it('fences an SSH folder workspace PTY sweep to the owning connection', async () => {
-    const sshPtyProvider = { id: 'ssh-pty-provider' } as never
+    const deleteWorktreeHistory = vi.fn().mockResolvedValue(undefined)
+    const sshPtyProvider = { id: 'ssh-pty-provider', deleteWorktreeHistory } as never
     const worktreeId = 'repo-folder::/remote/folder::workspace:child-1'
     store.getRepo.mockReturnValue({
       id: 'repo-folder',
@@ -8651,6 +8652,7 @@ describe('registerWorktreeHandlers', () => {
       includeProviderInventory: true,
       includeLocalRegistry: false
     })
+    expect(deleteWorktreeHistory).toHaveBeenCalledWith(worktreeId)
   })
 
   it('fences a mirrored runtime folder workspace sweep to its environment', async () => {
@@ -8893,7 +8895,9 @@ describe('registerWorktreeHandlers', () => {
         ORCA_WORKTREE_PATH: '/remote/feature-wt'
       })
     )
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
+      worktreeId: 'repo-ssh::/remote/feature-wt'
+    })
     expect(runtimeStub.closeFileWatchersForRemoval).toHaveBeenCalledWith(
       '/remote/feature-wt',
       'conn-1'
@@ -9019,7 +9023,9 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(provider.worktreeIsClean).not.toHaveBeenCalled()
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', true)
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', true, {
+      worktreeId: 'repo-ssh::/remote/feature-wt'
+    })
   })
 
   it('continues SSH worktree removal when the archive hook fails', async () => {
@@ -9075,7 +9081,9 @@ describe('registerWorktreeHandlers', () => {
       await handlers['worktrees:remove'](null, {
         worktreeId: 'repo-ssh::/remote/feature-wt'
       })
-      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
+      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
+        worktreeId: 'repo-ssh::/remote/feature-wt'
+      })
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[hooks] archive hook failed for /remote/feature-wt:',
         expect.stringContaining('archive hook exited 7')
@@ -9133,7 +9141,9 @@ describe('registerWorktreeHandlers', () => {
       await handlers['worktrees:remove'](null, {
         worktreeId: 'repo-ssh::/remote/feature-wt'
       })
-      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
+      expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
+        worktreeId: 'repo-ssh::/remote/feature-wt'
+      })
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[hooks] archive hook failed for /remote/feature-wt:',
         'relay disconnected'
@@ -9258,7 +9268,9 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(provider.execNonInteractive).not.toHaveBeenCalled()
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
+      worktreeId: 'repo-ssh::/remote/feature-wt'
+    })
   })
 
   it('uses the workspace host when duplicate repo ids exist across local and SSH', async () => {
@@ -9305,7 +9317,9 @@ describe('registerWorktreeHandlers', () => {
       hostId: 'ssh:conn-1'
     })
 
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined)
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/feature-wt', undefined, {
+      worktreeId: 'repo-shared::/remote/feature-wt'
+    })
     expect(removeWorktreeMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -249,6 +249,7 @@ import {
   removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval,
   recoverLocalWindowsWorktreeRemoval
 } from '../local-worktree-removal-recovery'
+import { deleteRemoteWorktreeHistory } from '../remote-worktree-history-cleanup'
 
 const NullableWorkspaceLinkedItemSchema = WorkspaceLinkedItemSchema.nullable()
 const NullableTaskSourceContextSchema = TaskSourceContextSchema.nullable()
@@ -2417,9 +2418,7 @@ export function registerWorktreeHandlers(
               })
             })
             await withWorktreeRemoveStageSpan('metadata_purge', 'folder', async () => {
-              await sshPtyProvider?.deleteWorktreeHistory?.(args.worktreeId).catch((err) => {
-                console.warn(`[pty:history] remote folder cleanup failed:`, err)
-              })
+              await deleteRemoteWorktreeHistory(sshPtyProvider, args.worktreeId)
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
             })
             preservedBranchCleanupByScope.delete(
@@ -2509,6 +2508,10 @@ export function registerWorktreeHandlers(
                   args.worktreeId,
                   removedPushTarget,
                   store
+                )
+                await deleteRemoteWorktreeHistory(
+                  getSshPtyProvider(repo.connectionId),
+                  args.worktreeId
                 )
               } else {
                 const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
@@ -2607,6 +2610,10 @@ export function registerWorktreeHandlers(
                   args.worktreeId,
                   removedPushTarget,
                   store
+                )
+                await deleteRemoteWorktreeHistory(
+                  getSshPtyProvider(repo.connectionId),
+                  args.worktreeId
                 )
               } else {
                 await cleanupUnusedWorktreePushTargetRemote(
@@ -2726,10 +2733,7 @@ export function registerWorktreeHandlers(
               }
             }
 
-            const remoteRemoveOptions = {
-              ...(!deleteBranch ? { deleteBranch } : {}),
-              worktreeId: args.worktreeId
-            }
+            const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
             const removalGate = await withWorktreeRemoveStageSpan(
               'watcher_gate',
               'remote',
@@ -2749,7 +2753,13 @@ export function registerWorktreeHandlers(
                 'git_remove',
                 'remote',
                 async () =>
-                  provider!.removeWorktree(canonicalWorktreePath, args.force, remoteRemoveOptions)
+                  Object.keys(remoteRemoveOptions).length > 0
+                    ? provider!.removeWorktree(
+                        canonicalWorktreePath,
+                        args.force,
+                        remoteRemoveOptions
+                      )
+                    : provider!.removeWorktree(canonicalWorktreePath, args.force)
               )
               removalCompleted = true
             } finally {
@@ -2765,6 +2775,10 @@ export function registerWorktreeHandlers(
               args.worktreeId,
               removedPushTarget,
               store
+            )
+            await deleteRemoteWorktreeHistory(
+              getSshPtyProvider(remoteConnectionId),
+              args.worktreeId
             )
             rememberPreservedBranchCleanupTarget(
               args.worktreeId,

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2386,15 +2386,15 @@ export function registerWorktreeHandlers(
                 'Cannot delete the project root workspace. Remove the folder project instead.'
               )
             }
+            const ownerHost = parseExecutionHostId(removalHostId)
+            const sshPtyProvider =
+              ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
             // Why: folder workspaces share one root, so there's no Git remove step to close shells; sweep PTYs before dropping metadata.
             await withWorktreeRemoveStageSpan('pty_sweep', 'folder', async () => {
               // Folder projects can be SSH-backed, so fence the sweep to the owning host exactly
               // like the git paths — the local inventory must never reach a remote workspace's id.
               // The resolved repo is authoritative here: path-derived metadata is shared by
               // same-id host copies and can describe a different owner's workspace.
-              const ownerHost = parseExecutionHostId(removalHostId)
-              const sshPtyProvider =
-                ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
               const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'
               await killAllProcessesForWorktree(args.worktreeId, {
                 runtime,
@@ -2417,6 +2417,9 @@ export function registerWorktreeHandlers(
               })
             })
             await withWorktreeRemoveStageSpan('metadata_purge', 'folder', async () => {
+              await sshPtyProvider?.deleteWorktreeHistory?.(args.worktreeId).catch((err) => {
+                console.warn(`[pty:history] remote folder cleanup failed:`, err)
+              })
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
             })
             preservedBranchCleanupByScope.delete(
@@ -2723,7 +2726,10 @@ export function registerWorktreeHandlers(
               }
             }
 
-            const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
+            const remoteRemoveOptions = {
+              ...(!deleteBranch ? { deleteBranch } : {}),
+              worktreeId: args.worktreeId
+            }
             const removalGate = await withWorktreeRemoveStageSpan(
               'watcher_gate',
               'remote',
@@ -2743,13 +2749,7 @@ export function registerWorktreeHandlers(
                 'git_remove',
                 'remote',
                 async () =>
-                  Object.keys(remoteRemoveOptions).length > 0
-                    ? provider!.removeWorktree(
-                        canonicalWorktreePath,
-                        args.force,
-                        remoteRemoveOptions
-                      )
-                    : provider!.removeWorktree(canonicalWorktreePath, args.force)
+                  provider!.removeWorktree(canonicalWorktreePath, args.force, remoteRemoveOptions)
               )
               removalCompleted = true
             } finally {

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -82,7 +82,7 @@ export type IGitProvider = {
   removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
+    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean; worktreeId?: string }
   ): Promise<RemoveWorktreeResult>
   renameCurrentBranch?(worktreePath: string, newBranch: string): Promise<void>
   forceDeletePreservedBranch?(

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -82,7 +82,7 @@ export type IGitProvider = {
   removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean; worktreeId?: string }
+    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
   ): Promise<RemoveWorktreeResult>
   renameCurrentBranch?(worktreePath: string, newBranch: string): Promise<void>
   forceDeletePreservedBranch?(

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -240,6 +240,27 @@ describe('LocalPtyProvider', () => {
       expect(typeof result.id).toBe('string')
     })
 
+    it('scopes fish history only while the worktree-history setting is enabled', async () => {
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/repo/a',
+        worktreeId: 'repo-1::/repo/a',
+        env: { SHELL: 'fish' }
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2].env.fish_history).toMatch(/^orca_[0-9a-f]{16}$/)
+
+      provider.configure({ isHistoryEnabled: () => false })
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/repo/b',
+        worktreeId: 'folder:folder-1',
+        env: { SHELL: 'fish' }
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2].env.fish_history).toBeUndefined()
+    })
+
     it('expands variables in PATH before spawning a Windows shell', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
 

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1059,6 +1059,10 @@ describe('LocalPtyProvider', () => {
       ])
       expect(spawnCall[1][5]).toContain('exec "\\$_orca_wsl_shell" -l')
       expect(spawnCall[2].env.HISTFILE).toContain('terminal-history-wsl/Debian')
+      expect(spawnCall[2].env.fish_history).toMatch(/^orca_[0-9a-f]{16}$/)
+      expect(spawnCall[2].env.WSLENV?.split(':')).toEqual(
+        expect.arrayContaining(['HISTFILE', 'fish_history'])
+      )
     })
 
     it.each(['/home/jin/repo', '/a', '/c'])(

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -16,6 +16,7 @@ import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { isBracketedPasteSafeShell } from '../../shared/startup-command-submission'
 import {
   injectHistoryEnv,
+  injectWslFishHistoryEnv,
   updateHistoryEnvForFallback,
   logHistoryInjection,
   type HistoryInjectionResult
@@ -847,6 +848,10 @@ export class LocalPtyProvider implements IPtyProvider {
       historyResult = injectHistoryEnv(finalEnv, worktreeId, effectiveShellPath, cwd, {
         wslDistro: launchWslDistro
       })
+      if (isWslTerminal && launchWslDistro) {
+        injectWslFishHistoryEnv(finalEnv, worktreeId, launchWslDistro)
+        addWslEnvKeys(finalEnv, ['HISTFILE', 'fish_history'])
+      }
       logHistoryInjection(worktreeId, historyResult)
     }
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -16,8 +16,9 @@ import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { isBracketedPasteSafeShell } from '../../shared/startup-command-submission'
 import {
   injectHistoryEnv,
-  updateHistFileForFallback,
-  logHistoryInjection
+  updateHistoryEnvForFallback,
+  logHistoryInjection,
+  type HistoryInjectionResult
 } from '../terminal-history'
 import type { IPtyProvider, PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from './types'
 import {
@@ -869,8 +870,9 @@ export class LocalPtyProvider implements IPtyProvider {
       ptySpawn: pty.spawn,
       getShellReadyConfig: getFallbackShellReadyConfig,
       // Why: on zsh→bash fallback HISTFILE still points to zsh_history; update before spawn so the child inherits it (design doc §8).
-      onBeforeFallbackSpawn: historyResult?.histFile
-        ? (env, fallbackShell) => updateHistFileForFallback(env, fallbackShell)
+      onBeforeFallbackSpawn: historyResult?.historyDir
+        ? (env, fallbackShell) =>
+            updateHistoryEnvForFallback(env, fallbackShell, historyResult as HistoryInjectionResult)
         : undefined,
       windowsFallbackAttempts
     })

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -70,7 +70,7 @@ export type PtySpawnOptions = {
    *  Existing-session attach paths must stay false so recovery checks do not
    *  replace the daemon out from under a still-live PTY. */
   isNewSession?: boolean
-  /** Host setting forwarded only to a local daemon adapter; never serialized on the daemon wire. */
+  /** Host setting forwarded additively to the process owner; old owners ignore it. */
   historyIsolationEnabled?: boolean
   /** Attach the named session atomically or fail without creating a process. */
   attachOnly?: boolean
@@ -116,6 +116,8 @@ export type IPtyProvider = {
   /** Re-probes a degraded durable host before main commits to fallback spawn semantics. */
   recoverFreshSpawnRouting?: () => Promise<boolean>
   spawn(opts: PtySpawnOptions): Promise<PtySpawnResult>
+  /** Process-owner cleanup for history stored outside the workspace tree. */
+  deleteWorktreeHistory?: (worktreeId: string) => Promise<void>
   /** Whether this spawn target can append the Git guard after its final env merge. */
   supportsGitCredentialGuardHost?: (sessionId?: string) => boolean
   /** Explicit false selects pre-claim legacy spawn for a preserved old daemon. */

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -70,6 +70,8 @@ export type PtySpawnOptions = {
    *  Existing-session attach paths must stay false so recovery checks do not
    *  replace the daemon out from under a still-live PTY. */
   isNewSession?: boolean
+  /** Host setting forwarded only to a local daemon adapter; never serialized on the daemon wire. */
+  historyIsolationEnabled?: boolean
   /** Attach the named session atomically or fail without creating a process. */
   attachOnly?: boolean
   /** Exact persisted owner expected by an attach-only routing decision. */

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1566,10 +1566,13 @@ describe('SshGitProvider', () => {
   })
 
   it('removeWorktree sends git.removeWorktree request', async () => {
-    await provider.removeWorktree('/home/user/feat', true)
+    await provider.removeWorktree('/home/user/feat', true, {
+      worktreeId: 'repo-1::/home/user/feat'
+    })
     expect(mux.request).toHaveBeenCalledWith('git.removeWorktree', {
       worktreePath: '/home/user/feat',
-      force: true
+      force: true,
+      worktreeId: 'repo-1::/home/user/feat'
     })
   })
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1566,13 +1566,10 @@ describe('SshGitProvider', () => {
   })
 
   it('removeWorktree sends git.removeWorktree request', async () => {
-    await provider.removeWorktree('/home/user/feat', true, {
-      worktreeId: 'repo-1::/home/user/feat'
-    })
+    await provider.removeWorktree('/home/user/feat', true)
     expect(mux.request).toHaveBeenCalledWith('git.removeWorktree', {
       worktreePath: '/home/user/feat',
-      force: true,
-      worktreeId: 'repo-1::/home/user/feat'
+      force: true
     })
   })
 

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -740,7 +740,7 @@ export class SshGitProvider implements IGitProvider {
   async removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
+    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean; worktreeId?: string }
   ): Promise<RemoveWorktreeResult> {
     return this.runWithDiffDedupeClear(
       async () =>

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -740,7 +740,7 @@ export class SshGitProvider implements IGitProvider {
   async removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean; worktreeId?: string }
+    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
   ): Promise<RemoveWorktreeResult> {
     return this.runWithDiffDedupeClear(
       async () =>

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -369,14 +369,16 @@ describe('SshPtyProvider', () => {
       })
     })
 
-    it('forwards explicit shellOverride and terminalWindowsWslDistro to the relay mux', async () => {
+    it('forwards shell, WSL, and scoped-history options to the relay mux', async () => {
       mux.request.mockResolvedValue({ id: 'pty-2' })
 
       await provider.spawn({
         cols: 120,
         rows: 40,
         shellOverride: 'powershell.exe',
-        terminalWindowsWslDistro: 'Ubuntu'
+        terminalWindowsWslDistro: 'Ubuntu',
+        worktreeId: 'repo-1::/remote/wt',
+        historyIsolationEnabled: true
       })
 
       expectRequest(mux.request, 'pty.spawn', {
@@ -385,7 +387,9 @@ describe('SshPtyProvider', () => {
         cwd: undefined,
         env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' },
         shellOverride: 'powershell.exe',
-        terminalWindowsWslDistro: 'Ubuntu'
+        terminalWindowsWslDistro: 'Ubuntu',
+        worktreeId: 'repo-1::/remote/wt',
+        historyIsolationEnabled: true
       })
     })
 

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -147,6 +147,10 @@ export class SshPtyProvider implements IPtyProvider {
     })
   }
 
+  async deleteWorktreeHistory(worktreeId: string): Promise<void> {
+    await this.mux.request('pty.deleteWorktreeHistory', { worktreeId })
+  }
+
   async supportsAgentSessionClaims(options: { signal?: AbortSignal } = {}): Promise<boolean> {
     return await this.agentSessionCapabilities.supportsClaims(options)
   }

--- a/src/main/providers/ssh-pty-spawn-request.ts
+++ b/src/main/providers/ssh-pty-spawn-request.ts
@@ -22,6 +22,10 @@ export function buildSshPtySpawnRequest(args: {
     // Why: the relay needs launch identity for plugin env overlays and provider-side delivery.
     ...(options.command ? { command: options.command } : {}),
     ...(options.launchAgent ? { launchAgent: options.launchAgent } : {}),
+    ...(options.worktreeId ? { worktreeId: options.worktreeId } : {}),
+    ...(options.historyIsolationEnabled !== undefined
+      ? { historyIsolationEnabled: options.historyIsolationEnabled }
+      : {}),
     ...(options.shellOverride !== undefined ? { shellOverride: options.shellOverride } : {}),
     ...(options.terminalWindowsWslDistro !== undefined
       ? { terminalWindowsWslDistro: options.terminalWindowsWslDistro }

--- a/src/main/pty/shell-startup-env.test.ts
+++ b/src/main/pty/shell-startup-env.test.ts
@@ -387,6 +387,75 @@ describe('readShellStartupEnvVar', () => {
       expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH)).toBe('/from/zzz')
     })
 
+    it('reads startup files once for agent homes without caching unrelated exports', () => {
+      mockFishFiles(
+        {
+          '/home/alice/.config/fish/conf.d/10-agents.fish':
+            'set -gx CODEX_HOME /from/confd\nset -gx UNQUERIED_SECRET old-secret\n',
+          '/home/alice/.config/fish/config.fish':
+            'set -gx CODEX_HOME /from/config\nset -gx OPENCODE_CONFIG_DIR /from/config-opencode\n'
+        },
+        ['10-agents.fish']
+      )
+
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH)).toBe('/from/config')
+      expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice', FISH)).toBe(
+        '/from/config-opencode'
+      )
+      expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+      expect(readFileSyncMock).toHaveBeenCalledTimes(2)
+
+      mockFishFiles(
+        {
+          '/home/alice/.config/fish/conf.d/10-agents.fish': 'set -gx UNQUERIED_SECRET new-secret\n',
+          '/home/alice/.config/fish/config.fish': 'set -gx CODEX_HOME /changed\n'
+        },
+        ['10-agents.fish']
+      )
+      expect(readShellStartupEnvVar('UNQUERIED_SECRET', '/home/alice', FISH)).toBe('new-secret')
+      expect(readdirSyncMock).toHaveBeenCalledTimes(2)
+      expect(readFileSyncMock).toHaveBeenCalledTimes(4)
+    })
+
+    it('isolates snapshots for distinct startup contexts', () => {
+      readdirSyncMock.mockReturnValue([])
+      mockStartupFiles({
+        '/cfg-a/fish/config.fish':
+          'set -gx CODEX_HOME /from/a\nset -gx OPENCODE_CONFIG_DIR /opencode/a\n',
+        '/cfg-b/fish/config.fish':
+          'set -gx CODEX_HOME /from/b\nset -gx OPENCODE_CONFIG_DIR /opencode/b\n'
+      })
+
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg-a')).toBe('/from/a')
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg-b')).toBe('/from/b')
+      expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice', FISH, '/cfg-a')).toBe(
+        '/opencode/a'
+      )
+      expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice', FISH, '/cfg-b')).toBe(
+        '/opencode/b'
+      )
+      expect(readdirSyncMock).toHaveBeenCalledTimes(2)
+      expect(readFileSyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('evicts the oldest Fish startup context after the bounded cache fills', () => {
+      readdirSyncMock.mockReturnValue([])
+      existsSyncMock.mockReturnValue(true)
+      readFileSyncMock.mockImplementation(
+        (path: string) => `set -gx CODEX_HOME ${path.replace('/fish/config.fish', '')}\n`
+      )
+
+      for (let index = 0; index < 33; index += 1) {
+        expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, `/cfg-${index}`)).toBe(
+          `/cfg-${index}`
+        )
+      }
+      expect(readFileSyncMock).toHaveBeenCalledTimes(33)
+
+      expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg-0')).toBe('/cfg-0')
+      expect(readFileSyncMock).toHaveBeenCalledTimes(34)
+    })
+
     it('honors XDG_CONFIG_HOME', () => {
       mockFishFiles({ '/cfg/fish/config.fish': 'set -gx CODEX_HOME /from/xdg\n' })
       expect(readShellStartupEnvVar('CODEX_HOME', '/home/alice', FISH, '/cfg')).toBe('/from/xdg')

--- a/src/main/pty/shell-startup-env.ts
+++ b/src/main/pty/shell-startup-env.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { posix } from 'node:path'
+import { BoundedMap } from '../../shared/bounded-map'
 
 // Why: only files the user's actual shell would source. Mixing zsh and bash
 // files breaks the "last assignment wins matches the live shell" guarantee —
@@ -16,6 +17,14 @@ const BASH_LOGIN_FILES = ['.bash_profile', '.bash_login', '.profile']
 const FISH_SNIPPET_DIR = 'conf.d'
 const FISH_SNIPPET_SUFFIX = '.fish'
 const FISH_CONFIG_FILE = 'config.fish'
+const FISH_AGENT_PATH_CONTEXT_LIMIT = 32
+const FISH_AGENT_PATH_NAMES = new Set([
+  'CODEX_HOME',
+  'GROK_HOME',
+  'OPENCODE_CONFIG_DIR',
+  'PI_CODING_AGENT_DIR',
+  'PRIME_AGENT_CODING_AGENT_DIR'
+])
 
 /** Assignment grammar of a startup file: `export NAME=value` vs fish `set -gx NAME value`. */
 type StartupFileSyntax = 'export' | 'fish-set'
@@ -194,6 +203,37 @@ function expandHome(value: string, home: string): string {
 }
 
 const cache = new Map<string, string | undefined>()
+const fishAgentPathCache = new BoundedMap<string, ReadonlyMap<string, string>>({
+  maxEntries: FISH_AGENT_PATH_CONTEXT_LIMIT
+})
+
+function readFishAgentPaths(
+  home: string,
+  shell: string,
+  configHome: string | undefined
+): ReadonlyMap<string, string> {
+  const cacheKey = `${home}\0${shell}\0${configHome ?? ''}`
+  const cached = fishAgentPathCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const values = new Map<string, string>()
+  for (const path of fishStartupFilePaths(home, configHome)) {
+    const content = readStartupFile(path)
+    if (content === null) {
+      continue
+    }
+    for (const name of FISH_AGENT_PATH_NAMES) {
+      const match = parseAssignedValue(content, name, home, 'fish-set')
+      if (match !== undefined) {
+        values.set(name, match)
+      }
+    }
+  }
+  fishAgentPathCache.set(cacheKey, values)
+  return values
+}
 
 /**
  * Best-effort static read of a single env-var assignment from the user's
@@ -214,11 +254,13 @@ const cache = new Map<string, string | undefined>()
  *   nothing. LAST matching assignment wins.
  * - fish universal variables (`set -Ux` stored in fish_variables) are only
  *   seen when the assignment is also written in a config file.
+ * - Fish shares one scan only for the agent-path variables Orca consumes;
+ *   arbitrary requested names retain the generic per-name behavior.
  * - Windows is unsupported (PowerShell profile parsing is out of scope).
  *
- * Results are memoized per (name, home, shell, configHome) for the process
- * lifetime — shell startup files do not change mid-session in any practical
- * scenario, and PTY spawn is on the hot path.
+ * Results are memoized per variable for the process lifetime. Fish caches the
+ * Orca-consumed set in bounded startup contexts, so those lookups avoid later
+ * filesystem I/O without retaining unrelated exports or source text.
  */
 export function readShellStartupEnvVar(
   name: string,
@@ -235,20 +277,22 @@ export function readShellStartupEnvVar(
     return undefined
   }
 
+  if (shell && posix.basename(shell).toLowerCase() === 'fish' && FISH_AGENT_PATH_NAMES.has(name)) {
+    return readFishAgentPaths(home, shell, configHome).get(name)
+  }
+
   const cacheKey = `${name}\0${home}\0${shell ?? ''}\0${configHome ?? ''}`
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey)
   }
 
   let lastMatch: string | undefined
-
   const { paths, syntax } = shellStartupFiles(home, shell, configHome)
   for (const path of paths) {
     const content = readStartupFile(path)
     if (content === null) {
       continue
     }
-
     const match = parseAssignedValue(content, name, home, syntax)
     if (match !== undefined) {
       lastMatch = match
@@ -294,4 +338,5 @@ export function readSessionShellStartupEnvVar(
  */
 export function __resetShellStartupEnvCache(): void {
   cache.clear()
+  fishAgentPathCache.clear()
 }

--- a/src/main/remote-worktree-history-cleanup.test.ts
+++ b/src/main/remote-worktree-history-cleanup.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { deleteRemoteWorktreeHistory } from './remote-worktree-history-cleanup'
+
+describe('deleteRemoteWorktreeHistory', () => {
+  it('repeats idempotent cleanup through the PTY owner', async () => {
+    const deleteWorktreeHistory = vi.fn().mockResolvedValue(undefined)
+    const provider = { deleteWorktreeHistory } as never
+
+    await deleteRemoteWorktreeHistory(provider, 'repo-1::/remote/wt')
+    await deleteRemoteWorktreeHistory(provider, 'repo-1::/remote/wt')
+
+    expect(deleteWorktreeHistory).toHaveBeenCalledTimes(2)
+  })
+
+  it('degrades safely when an old relay does not expose cleanup', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const provider = {
+      deleteWorktreeHistory: vi.fn().mockRejectedValue(new Error('unknown request method'))
+    } as never
+
+    try {
+      await expect(
+        deleteRemoteWorktreeHistory(provider, 'repo-1::/remote/wt')
+      ).resolves.toBeUndefined()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Remote cleanup unavailable'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/src/main/remote-worktree-history-cleanup.ts
+++ b/src/main/remote-worktree-history-cleanup.ts
@@ -1,0 +1,15 @@
+import type { IPtyProvider } from './providers/pty-provider-contract'
+
+/** Best-effort cleanup through the PTY owner; older relays may not expose the method. */
+export async function deleteRemoteWorktreeHistory(
+  provider: IPtyProvider | undefined,
+  worktreeId: string
+): Promise<void> {
+  try {
+    await provider?.deleteWorktreeHistory?.(worktreeId)
+  } catch (error) {
+    console.warn(
+      `[pty:history] Remote cleanup unavailable: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6052,7 +6052,8 @@ describe('OrcaRuntimeService', () => {
           worktreeId: `${TEST_REPO_ID}::/remote/feature`
         }
       ]),
-      shutdown: vi.fn().mockResolvedValue(undefined)
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      deleteWorktreeHistory: vi.fn().mockResolvedValue(undefined)
     }
     const runtime = new OrcaRuntimeService(remoteStore as never, undefined, {
       getSshProvider: () => ptyProvider as never
@@ -6064,12 +6065,13 @@ describe('OrcaRuntimeService', () => {
       unregisterSshGitProvider('ssh-1')
     }
 
-    expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true, {
-      worktreeId: `${TEST_REPO_ID}::/remote/feature`
-    })
+    expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
     expect(ptyProvider.shutdown).toHaveBeenCalledWith(
       'pty-remote',
       expect.objectContaining({ immediate: true })
+    )
+    expect(ptyProvider.deleteWorktreeHistory).toHaveBeenCalledWith(
+      `${TEST_REPO_ID}::/remote/feature`
     )
     expect(ptyProvider.shutdown.mock.invocationCallOrder[0]).toBeLessThan(
       gitProvider.removeWorktree.mock.invocationCallOrder[0]
@@ -47101,6 +47103,145 @@ describe('OrcaRuntimeService', () => {
     } finally {
       await rm(parentDir, { recursive: true, force: true })
     }
+  })
+
+  it('routes already-missing SSH runtime history cleanup through the PTY owner', async () => {
+    const repo = {
+      id: 'repo-runtime-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const worktreeId = `${repo.id}::/remote/already-deleted`
+    const metaById: Record<string, WorktreeMeta> = {
+      [worktreeId]: makeWorktreeMeta({ hostId: 'ssh:ssh-1', orcaCreationSource: 'ssh' })
+    }
+    const removeWorktreeMeta = vi.fn((id: string) => {
+      delete metaById[id]
+    })
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [repo],
+      getRepo: (id: string) => (id === repo.id ? repo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (id: string) => metaById[id],
+      removeWorktreeMeta
+    }
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: repo.path,
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+    }
+    const fsProvider = {
+      stat: vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    }
+    const deleteWorktreeHistory = vi.fn().mockResolvedValue(undefined)
+    const ptyProvider = { deleteWorktreeHistory } as never
+    registerSshGitProvider(repo.connectionId, gitProvider as never)
+    registerSshFilesystemProvider(repo.connectionId, fsProvider as never)
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getSshProvider: () => ptyProvider
+    })
+
+    try {
+      await expect(runtime.removeManagedWorktree(`id:${worktreeId}`)).resolves.toEqual({})
+    } finally {
+      unregisterSshGitProvider(repo.connectionId)
+      unregisterSshFilesystemProvider(repo.connectionId)
+    }
+
+    expect(deleteWorktreeHistory).toHaveBeenCalledWith(worktreeId)
+    expect(deleteWorktreeHistory.mock.invocationCallOrder[0]).toBeLessThan(
+      removeWorktreeMeta.mock.invocationCallOrder[0]
+    )
+    expect(removeWorktreeMeta).toHaveBeenCalledWith(worktreeId, 'ssh:ssh-1')
+  })
+
+  it('routes SSH runtime orphan-directory history cleanup through the PTY owner', async () => {
+    const repo = {
+      id: 'repo-runtime-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const worktreePath = '/remote/orphan'
+    const worktreeId = `${repo.id}::${worktreePath}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [worktreeId]: makeWorktreeMeta({
+        hostId: 'ssh:ssh-1',
+        orcaCreatedAt: Date.now(),
+        orcaCreationSource: 'ssh'
+      })
+    }
+    const removeWorktreeMeta = vi.fn((id: string) => {
+      delete metaById[id]
+    })
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [repo],
+      getRepo: (id: string) => (id === repo.id ? repo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (id: string) => metaById[id],
+      removeWorktreeMeta
+    }
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: repo.path,
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+    }
+    const fsProvider = {
+      lstat: vi.fn(async (path: string) => ({
+        type: path === `${worktreePath}/.git` ? 'file' : 'directory'
+      })),
+      readFile: vi.fn(async (path: string) => ({
+        isBinary: false,
+        content:
+          path === `${worktreePath}/.git`
+            ? `gitdir: ${repo.path}/.git/worktrees/orphan\n`
+            : `${worktreePath}/.git\n`
+      })),
+      deletePath: vi.fn().mockResolvedValue(undefined)
+    }
+    const deleteWorktreeHistory = vi.fn().mockResolvedValue(undefined)
+    const ptyProvider = {
+      listProcesses: vi.fn().mockResolvedValue([]),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      deleteWorktreeHistory
+    }
+    registerSshGitProvider(repo.connectionId, gitProvider as never)
+    registerSshFilesystemProvider(repo.connectionId, fsProvider as never)
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getSshProvider: () => ptyProvider as never
+    })
+
+    try {
+      await expect(runtime.removeManagedWorktree(`id:${worktreeId}`, true)).resolves.toEqual({})
+    } finally {
+      unregisterSshGitProvider(repo.connectionId)
+      unregisterSshFilesystemProvider(repo.connectionId)
+    }
+
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(worktreePath, true)
+    expect(deleteWorktreeHistory).toHaveBeenCalledWith(worktreeId)
+    expect(deleteWorktreeHistory.mock.invocationCallOrder[0]).toBeLessThan(
+      removeWorktreeMeta.mock.invocationCallOrder[0]
+    )
   })
 
   it('force-removes a legacy Orca-created runtime orphaned worktree directory after Git tracking is gone', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6064,7 +6064,9 @@ describe('OrcaRuntimeService', () => {
       unregisterSshGitProvider('ssh-1')
     }
 
-    expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
+    expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true, {
+      worktreeId: `${TEST_REPO_ID}::/remote/feature`
+    })
     expect(ptyProvider.shutdown).toHaveBeenCalledWith(
       'pty-remote',
       expect.objectContaining({ immediate: true })
@@ -32391,7 +32393,7 @@ describe('OrcaRuntimeService', () => {
     expect(spawn).not.toHaveBeenCalled()
   })
 
-  it('uses POSIX quoting for mobile agent launch commands in WSL project runtimes', async () => {
+  it('uses portable Unix quoting for mobile agent launch commands in WSL project runtimes', async () => {
     await withPlatform('win32', async () => {
       const spawn = vi.fn().mockResolvedValue({ id: 'pty-agent' })
       const runtime = new OrcaRuntimeService({
@@ -32429,7 +32431,7 @@ describe('OrcaRuntimeService', () => {
 
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
-          command: "command-code --profile mobile '--note' 'can'\\''t'",
+          command: `command-code --profile mobile '--note' 'can'"'"'t'`,
           cwd: TEST_WORKTREE_PATH,
           worktreeId: TEST_WORKTREE_ID
         })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -442,7 +442,7 @@ import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
 } from '../../shared/tui-agent-launch-defaults'
-import { resolveLocalWindowsAgentStartupShell } from '../../shared/windows-terminal-shell'
+import { resolveHostAgentStartupShell } from '../host-agent-startup-shell'
 import {
   getTuiAgentLaunchCommand,
   isTuiAgent,
@@ -21298,7 +21298,7 @@ export class OrcaRuntimeService {
     // Linux over SSH. Startup command quoting must target the shell that runs it.
     const agentLaunchPlatform = this.getAgentLaunchPlatformForRepo(repo)
     const isRemote = repoIsRemote(repo)
-    const queuedShell = resolveLocalWindowsAgentStartupShell({
+    const queuedShell = resolveHostAgentStartupShell({
       platform: agentLaunchPlatform,
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell
@@ -21372,7 +21372,7 @@ export class OrcaRuntimeService {
     // the workspace shell rather than the client shell.
     const agentLaunchPlatform = this.getAgentLaunchPlatformForRepo(repo)
     const isRemote = repoIsRemote(repo)
-    const queuedShell = resolveLocalWindowsAgentStartupShell({
+    const queuedShell = resolveHostAgentStartupShell({
       platform: agentLaunchPlatform,
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell
@@ -25062,7 +25062,7 @@ export class OrcaRuntimeService {
     const settings = store.getSettings()
     const platform = this.getAgentLaunchPlatformForWorkspace(workspace)
     const isRemote = workspace.repo ? repoIsRemote(workspace.repo) : Boolean(workspace.connectionId)
-    const queuedShell = resolveLocalWindowsAgentStartupShell({
+    const queuedShell = resolveHostAgentStartupShell({
       platform,
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell
@@ -25220,7 +25220,7 @@ export class OrcaRuntimeService {
     }
     const platform = this.getAgentLaunchPlatformForWorkspace(workspace)
     const isRemote = workspace.repo ? repoIsRemote(workspace.repo) : Boolean(workspace.connectionId)
-    const shell = resolveLocalWindowsAgentStartupShell({
+    const shell = resolveHostAgentStartupShell({
       platform,
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell
@@ -25384,7 +25384,7 @@ export class OrcaRuntimeService {
       const isRemote = workspace.repo
         ? repoIsRemote(workspace.repo)
         : Boolean(workspace.connectionId)
-      const shell = resolveLocalWindowsAgentStartupShell({
+      const shell = resolveHostAgentStartupShell({
         platform,
         isRemote,
         terminalWindowsShell: settings.terminalWindowsShell
@@ -26431,7 +26431,7 @@ export class OrcaRuntimeService {
     const platform = this.getAgentLaunchPlatformForWorkspace(workspace)
     // Why: SSH runs the CLI through the relay shim (plain `orca`), so the Linux-only `orca-ide` rename must not apply.
     const isRemote = workspace.repo ? repoIsRemote(workspace.repo) : repoIsRemote(workspace)
-    const queuedShell = resolveLocalWindowsAgentStartupShell({
+    const queuedShell = resolveHostAgentStartupShell({
       platform,
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -24495,6 +24495,9 @@ export class OrcaRuntimeService {
               console.warn(`[worktree-teardown] failed for ${removalTarget.id}:`, err)
             })
           }
+          await folderSshPtyProvider?.deleteWorktreeHistory?.(removalTarget.id).catch((err) => {
+            console.warn(`[pty:history] remote folder cleanup failed:`, err)
+          })
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
           this.invalidateResolvedWorktreeCache()
@@ -24747,7 +24750,10 @@ export class OrcaRuntimeService {
           return removalResult ?? {}
         }
         if (repo.connectionId) {
-          const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
+          const remoteRemoveOptions = {
+            ...(!deleteBranch ? { deleteBranch } : {}),
+            worktreeId: removalTarget.id
+          }
           const removalGate = await this.acquireFileWatcherRemoval(
             canonicalWorktreePath,
             repo.connectionId
@@ -24759,9 +24765,11 @@ export class OrcaRuntimeService {
               connectionId: repo.connectionId,
               allowUnverifiedStop: allowUnverifiedPtyStop
             })
-            rawRemovalResult = await (Object.keys(remoteRemoveOptions).length > 0
-              ? provider!.removeWorktree(canonicalWorktreePath, force, remoteRemoveOptions)
-              : provider!.removeWorktree(canonicalWorktreePath, force))
+            rawRemovalResult = await provider!.removeWorktree(
+              canonicalWorktreePath,
+              force,
+              remoteRemoveOptions
+            )
             removalCompleted = true
           } finally {
             await removalGate.finish(removalCompleted)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -918,6 +918,7 @@ import {
   resolveWorktreeSharedDirectories
 } from '../git/worktree-shared-directories'
 import { deleteWorktreeHistoryDir } from '../terminal-history-deletion'
+import { deleteRemoteWorktreeHistory } from '../remote-worktree-history-cleanup'
 import {
   cleanupUnusedWorktreePushTargetRemote,
   cleanupUnusedWorktreePushTargetRemoteSsh,
@@ -24451,6 +24452,7 @@ export class OrcaRuntimeService {
               .then((gate) => gate.finish(false))
               .catch(() => {})
           }
+          await deleteRemoteWorktreeHistory(sshPtyProvider, removalTarget.id)
           this.clearOptimisticReconcileToken(removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
@@ -24495,9 +24497,7 @@ export class OrcaRuntimeService {
               console.warn(`[worktree-teardown] failed for ${removalTarget.id}:`, err)
             })
           }
-          await folderSshPtyProvider?.deleteWorktreeHistory?.(removalTarget.id).catch((err) => {
-            console.warn(`[pty:history] remote folder cleanup failed:`, err)
-          })
+          await deleteRemoteWorktreeHistory(folderSshPtyProvider, removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
           this.invalidateResolvedWorktreeCache()
@@ -24581,6 +24581,10 @@ export class OrcaRuntimeService {
                 removalTarget.id,
                 removedPushTarget,
                 store
+              )
+              await deleteRemoteWorktreeHistory(
+                this.getSshProviderFn?.(repo.connectionId),
+                removalTarget.id
               )
             } else {
               const removalGate = await this.acquireFileWatcherRemoval(removalTarget.path)
@@ -24687,6 +24691,12 @@ export class OrcaRuntimeService {
                   store,
                   localWorktreeGitOptions
                 ))
+            if (repo.connectionId) {
+              await deleteRemoteWorktreeHistory(
+                this.getSshProviderFn?.(repo.connectionId),
+                removalTarget.id
+              )
+            }
             this.clearOptimisticReconcileToken(removalTarget.id)
             this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
             this.preservedBranchCleanupByScope.delete(cleanupScopeKey)
@@ -24750,10 +24760,7 @@ export class OrcaRuntimeService {
           return removalResult ?? {}
         }
         if (repo.connectionId) {
-          const remoteRemoveOptions = {
-            ...(!deleteBranch ? { deleteBranch } : {}),
-            worktreeId: removalTarget.id
-          }
+          const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
           const removalGate = await this.acquireFileWatcherRemoval(
             canonicalWorktreePath,
             repo.connectionId
@@ -24765,11 +24772,9 @@ export class OrcaRuntimeService {
               connectionId: repo.connectionId,
               allowUnverifiedStop: allowUnverifiedPtyStop
             })
-            rawRemovalResult = await provider!.removeWorktree(
-              canonicalWorktreePath,
-              force,
-              remoteRemoveOptions
-            )
+            rawRemovalResult = await (Object.keys(remoteRemoveOptions).length > 0
+              ? provider!.removeWorktree(canonicalWorktreePath, force, remoteRemoveOptions)
+              : provider!.removeWorktree(canonicalWorktreePath, force))
             removalCompleted = true
           } finally {
             await removalGate.finish(removalCompleted)
@@ -24784,6 +24789,10 @@ export class OrcaRuntimeService {
             removalTarget.id,
             removedPushTarget,
             store
+          )
+          await deleteRemoteWorktreeHistory(
+            this.getSshProviderFn?.(repo.connectionId),
+            removalTarget.id
           )
           this.rememberPreservedBranchCleanupTarget(
             removalTarget.id,

--- a/src/main/terminal-history-attested-deletion.test.ts
+++ b/src/main/terminal-history-attested-deletion.test.ts
@@ -1,0 +1,70 @@
+import { lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let userDataDir = ''
+vi.mock('electron', () => ({ app: { getPath: () => userDataDir } }))
+
+import {
+  deleteWorktreeHistoryDir,
+  flushPendingWorktreeHistoryDeletions
+} from './terminal-history-deletion'
+import { hashWorktreeId } from './terminal-history-paths'
+import { deleteFishHistoryFile, fishHistorySessionName } from './fish-history-session'
+
+describe('attested fish history deletion', () => {
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-attested-history-'))
+  })
+  afterEach(async () => {
+    await flushPendingWorktreeHistoryDeletions()
+    rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  it('warns when an attested fish history file disappears before deletion', async () => {
+    const worktreeId = 'repo::/missing-fish-history'
+    const hash = hashWorktreeId(worktreeId)
+    const dir = join(userDataDir, 'terminal-history', hash)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'meta.json'),
+      JSON.stringify({ worktreeId, fishSession: fishHistorySessionName(hash) })
+    )
+    const session = fishHistorySessionName(hash)
+    const historyPath = join(userDataDir, 'fish', `${session}_history`)
+    const attestationPath = join(dir, 'fish-history-locations.json')
+    mkdirSync(join(userDataDir, 'fish'), { recursive: true })
+    writeFileSync(historyPath, 'history')
+    const directory = lstatSync(join(userDataDir, 'fish'), { bigint: true })
+    const file = lstatSync(historyPath, { bigint: true })
+    writeFileSync(
+      attestationPath,
+      JSON.stringify({
+        version: 2,
+        fishSession: session,
+        locations: [
+          {
+            path: historyPath,
+            directoryDevice: directory.dev.toString(),
+            directoryInode: directory.ino.toString(),
+            directoryBirthtimeNs: directory.birthtimeNs.toString(),
+            fileDevice: file.dev.toString(),
+            fileInode: file.ino.toString(),
+            fileBirthtimeNs: file.birthtimeNs.toString()
+          }
+        ]
+      })
+    )
+    rmSync(historyPath)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      deleteFishHistoryFile(session, attestationPath)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('No attested fish history'))
+      deleteWorktreeHistoryDir(worktreeId)
+      await flushPendingWorktreeHistoryDeletions()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/src/main/terminal-history-deletion.ts
+++ b/src/main/terminal-history-deletion.ts
@@ -1,6 +1,8 @@
 import { basename, join } from 'node:path'
 import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs'
 import { removeHostTree } from './host-tree-removal'
+import { deleteFishHistoryFile } from './fish-history-session'
+import { readHistoryMeta } from './terminal-history'
 import {
   getHistoryRoot,
   hashWorktreeId,
@@ -93,6 +95,12 @@ function scheduleHistoryTreeRemoval(dir: string): void {
 /** Tombstone one history tree and queue its recursive removal off the caller's critical path.
  *  Returns false when the rename failed, leaving the tree for a later GC pass to reclaim. */
 export function scheduleWorktreeHistoryTreeDeletion(dir: string, historyRoot: string): boolean {
+  // Why first: fish keeps its history in the user's fish data dir, outside this tree,
+  // so the meta.json naming the session must still be readable when we look it up.
+  const fishSession = readHistoryMeta(dir)?.fishSession
+  if (fishSession) {
+    deleteFishHistoryFile(fishSession)
+  }
   const tombstone = tombstoneHistoryTree(dir, historyRoot)
   if (!tombstone) {
     return false

--- a/src/main/terminal-history-deletion.ts
+++ b/src/main/terminal-history-deletion.ts
@@ -97,9 +97,11 @@ function scheduleHistoryTreeRemoval(dir: string): void {
 export function scheduleWorktreeHistoryTreeDeletion(dir: string, historyRoot: string): boolean {
   // Why first: fish keeps its history in the user's fish data dir, outside this tree,
   // so the meta.json naming the session must still be readable when we look it up.
-  const fishSession = readHistoryMeta(dir)?.fishSession
-  if (fishSession) {
-    deleteFishHistoryFile(fishSession)
+  const meta = readHistoryMeta(dir)
+  if (meta?.fishSession) {
+    deleteFishHistoryFile(meta.fishSession, {
+      recordedPath: meta.fishHistoryPath
+    })
   }
   const tombstone = tombstoneHistoryTree(dir, historyRoot)
   if (!tombstone) {

--- a/src/main/terminal-history-deletion.ts
+++ b/src/main/terminal-history-deletion.ts
@@ -100,7 +100,8 @@ export function scheduleWorktreeHistoryTreeDeletion(dir: string, historyRoot: st
   const meta = readHistoryMeta(dir)
   if (meta?.fishSession) {
     deleteFishHistoryFile(meta.fishSession, {
-      recordedPath: meta.fishHistoryPath
+      recordedPath: meta.fishHistoryPath,
+      recordedPaths: meta.fishHistoryPaths
     })
   }
   const tombstone = tombstoneHistoryTree(dir, historyRoot)

--- a/src/main/terminal-history-deletion.ts
+++ b/src/main/terminal-history-deletion.ts
@@ -1,14 +1,15 @@
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs'
 import { removeHostTree } from './host-tree-removal'
 import { deleteFishHistoryFile } from './fish-history-session'
 import { readHistoryMeta } from './terminal-history'
 import {
   getHistoryRoot,
-  hashWorktreeId,
   listWslHistoryRoots,
   PENDING_DELETE_DIR_NAME
 } from './terminal-history-paths'
+import { hashWorktreeId } from './terminal-history-id'
+import { deleteWslFishHistoryFile } from './wsl-fish-history-cleanup'
 
 const pendingHistoryTreeRemovals = new Map<string, Promise<void>>()
 // Why: a tombstone that fails once (Windows EBUSY under AV) would otherwise sit on disk for the whole
@@ -16,6 +17,13 @@ const pendingHistoryTreeRemovals = new Map<string, Promise<void>>()
 export const HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS = [30_000, 120_000]
 const historyTreeRemovalAttempts = new Map<string, number>()
 const historyTreeRemovalRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const wslDistroByTombstone = new Map<string, string>()
+
+function wslDistroForHistoryRoot(historyRoot: string): string | undefined {
+  return basename(dirname(historyRoot)) === 'terminal-history-wsl'
+    ? basename(historyRoot)
+    : undefined
+}
 
 function getPendingDeleteRoot(historyRoot: string): string {
   return join(historyRoot, PENDING_DELETE_DIR_NAME)
@@ -53,6 +61,7 @@ function scheduleHistoryTreeRemovalRetry(dir: string): void {
   if (retryDelayMs === undefined) {
     // Out of in-process attempts: the tombstone stays on disk and the next startup drain re-queues it.
     historyTreeRemovalAttempts.delete(dir)
+    wslDistroByTombstone.delete(dir)
     return
   }
   historyTreeRemovalAttempts.set(dir, attempt + 1)
@@ -64,7 +73,7 @@ function scheduleHistoryTreeRemovalRetry(dir: string): void {
   historyTreeRemovalRetryTimers.set(dir, timer)
 }
 
-function scheduleHistoryTreeRemoval(dir: string): void {
+function scheduleHistoryTreeRemoval(dir: string, wslDistro?: string): void {
   if (pendingHistoryTreeRemovals.has(dir)) {
     return
   }
@@ -74,9 +83,23 @@ function scheduleHistoryTreeRemoval(dir: string): void {
     clearTimeout(pendingRetry)
     historyTreeRemovalRetryTimers.delete(dir)
   }
-  const removal = removeHostTree(dir)
+  if (wslDistro) {
+    wslDistroByTombstone.set(dir, wslDistro)
+  }
+  const cleanupDistro = wslDistroByTombstone.get(dir)
+  const meta = cleanupDistro ? readHistoryMeta(dir) : null
+  const cleanup =
+    cleanupDistro && meta?.fishSession
+      ? deleteWslFishHistoryFile(cleanupDistro, meta.fishSession).catch((err: unknown) => {
+          console.warn(
+            `[pty:history] Failed to delete WSL fish history: ${err instanceof Error ? err.message : String(err)}`
+          )
+        })
+      : null
+  const removal = (cleanup ? cleanup.then(() => removeHostTree(dir)) : removeHostTree(dir))
     .then(() => {
       historyTreeRemovalAttempts.delete(dir)
+      wslDistroByTombstone.delete(dir)
     })
     .catch((err: unknown) => {
       console.warn(
@@ -98,7 +121,8 @@ export function scheduleWorktreeHistoryTreeDeletion(dir: string, historyRoot: st
   // Why first: fish keeps its history in the user's fish data dir, outside this tree,
   // so the meta.json naming the session must still be readable when we look it up.
   const meta = readHistoryMeta(dir)
-  if (meta?.fishSession) {
+  const wslDistro = wslDistroForHistoryRoot(historyRoot)
+  if (meta?.fishSession && !wslDistro) {
     deleteFishHistoryFile(meta.fishSession, {
       recordedPath: meta.fishHistoryPath,
       recordedPaths: meta.fishHistoryPaths
@@ -108,7 +132,7 @@ export function scheduleWorktreeHistoryTreeDeletion(dir: string, historyRoot: st
   if (!tombstone) {
     return false
   }
-  scheduleHistoryTreeRemoval(tombstone)
+  scheduleHistoryTreeRemoval(tombstone, wslDistro)
   return true
 }
 
@@ -120,7 +144,7 @@ export function schedulePendingHistoryTreeRemovals(historyRoot: string): void {
   }
   try {
     for (const entry of readdirSync(pendingRoot)) {
-      scheduleHistoryTreeRemoval(join(pendingRoot, entry))
+      scheduleHistoryTreeRemoval(join(pendingRoot, entry), wslDistroForHistoryRoot(historyRoot))
     }
   } catch {
     // Non-fatal.
@@ -142,6 +166,7 @@ export function cancelPendingHistoryTreeRemovalRetries(): void {
   }
   historyTreeRemovalRetryTimers.clear()
   historyTreeRemovalAttempts.clear()
+  wslDistroByTombstone.clear()
 }
 
 /** Drain every history root's tombstones and await the in-flight removals. Tests only: production

--- a/src/main/terminal-history-deletion.ts
+++ b/src/main/terminal-history-deletion.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, join } from 'node:path'
 import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs'
 import { removeHostTree } from './host-tree-removal'
-import { deleteFishHistoryFile } from './fish-history-session'
+import { deleteFishHistoryFile, FISH_HISTORY_LOCATION_ATTESTATION } from './fish-history-session'
 import { readHistoryMeta } from './terminal-history'
 import {
   getHistoryRoot,
@@ -123,10 +123,7 @@ export function scheduleWorktreeHistoryTreeDeletion(dir: string, historyRoot: st
   const meta = readHistoryMeta(dir)
   const wslDistro = wslDistroForHistoryRoot(historyRoot)
   if (meta?.fishSession && !wslDistro) {
-    deleteFishHistoryFile(meta.fishSession, {
-      recordedPath: meta.fishHistoryPath,
-      recordedPaths: meta.fishHistoryPaths
-    })
+    deleteFishHistoryFile(meta.fishSession, join(dir, FISH_HISTORY_LOCATION_ATTESTATION))
   }
   const tombstone = tombstoneHistoryTree(dir, historyRoot)
   if (!tombstone) {

--- a/src/main/terminal-history-deletion.ts
+++ b/src/main/terminal-history-deletion.ts
@@ -12,6 +12,7 @@ import { hashWorktreeId } from './terminal-history-id'
 import { deleteWslFishHistoryFile } from './wsl-fish-history-cleanup'
 
 const pendingHistoryTreeRemovals = new Map<string, Promise<void>>()
+export const MAX_PENDING_HISTORY_TREE_REMOVALS = 64
 // Why: a tombstone that fails once (Windows EBUSY under AV) would otherwise sit on disk for the whole
 // desktop session — only the next launch re-queues it. Bounded so a genuinely stuck tree stops retrying.
 export const HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS = [30_000, 120_000]
@@ -27,6 +28,10 @@ function wslDistroForHistoryRoot(historyRoot: string): string | undefined {
 
 function getPendingDeleteRoot(historyRoot: string): string {
   return join(historyRoot, PENDING_DELETE_DIR_NAME)
+}
+
+function historyRootForTombstone(dir: string): string {
+  return dirname(dirname(dir))
 }
 
 /** Move a history tree to a pending-delete tombstone (metadata-only) so the critical path never walks it. */
@@ -77,15 +82,22 @@ function scheduleHistoryTreeRemoval(dir: string, wslDistro?: string): void {
   if (pendingHistoryTreeRemovals.has(dir)) {
     return
   }
-  // A rescan (GC / startup drain) hitting the same tombstone supersedes its pending retry.
+  // Leave excess tombstones on disk; admission is intentionally bounded.
+  if (
+    pendingHistoryTreeRemovals.size + historyTreeRemovalRetryTimers.size >=
+    MAX_PENDING_HISTORY_TREE_REMOVALS
+  ) {
+    return
+  }
+  // A rescan must not cancel a delayed retry for a real failure.
   const pendingRetry = historyTreeRemovalRetryTimers.get(dir)
   if (pendingRetry) {
-    clearTimeout(pendingRetry)
-    historyTreeRemovalRetryTimers.delete(dir)
+    return
   }
   if (wslDistro) {
     wslDistroByTombstone.set(dir, wslDistro)
   }
+  let removalSucceeded = false
   const cleanupDistro = wslDistroByTombstone.get(dir)
   const meta = cleanupDistro ? readHistoryMeta(dir) : null
   const cleanup =
@@ -94,10 +106,12 @@ function scheduleHistoryTreeRemoval(dir: string, wslDistro?: string): void {
           console.warn(
             `[pty:history] Failed to delete WSL fish history: ${err instanceof Error ? err.message : String(err)}`
           )
+          throw err
         })
       : null
   const removal = (cleanup ? cleanup.then(() => removeHostTree(dir)) : removeHostTree(dir))
     .then(() => {
+      removalSucceeded = true
       historyTreeRemovalAttempts.delete(dir)
       wslDistroByTombstone.delete(dir)
     })
@@ -110,6 +124,9 @@ function scheduleHistoryTreeRemoval(dir: string, wslDistro?: string): void {
     .finally(() => {
       if (pendingHistoryTreeRemovals.get(dir) === removal) {
         pendingHistoryTreeRemovals.delete(dir)
+      }
+      if (removalSucceeded) {
+        schedulePendingHistoryTreeRemovals(historyRootForTombstone(dir))
       }
     })
   pendingHistoryTreeRemovals.set(dir, removal)

--- a/src/main/terminal-history-fish-session.node-pty.test.ts
+++ b/src/main/terminal-history-fish-session.node-pty.test.ts
@@ -85,7 +85,9 @@ describe('fish keeps per-worktree history under the session Orca names', () => {
           PATH: process.env.PATH ?? '/usr/bin:/bin',
           HOME: home,
           TERM: 'xterm-256color',
+          // LC_ALL wins over any LANG/LC_* a host might contribute, pinning fish's locale.
           LANG: 'en_US.UTF-8',
+          LC_ALL: 'en_US.UTF-8',
           XDG_CONFIG_HOME: home,
           XDG_DATA_HOME: dataHome,
           // The production injection under test (terminal-history.ts).

--- a/src/main/terminal-history-fish-session.node-pty.test.ts
+++ b/src/main/terminal-history-fish-session.node-pty.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Real-fish proof for worktree-scoped fish history.
+ *
+ * fish IGNORES HISTFILE, so the directory+filename mechanism bash and zsh use does
+ * not transfer: history lives at `$XDG_DATA_HOME/fish/${fish_history}_history` and
+ * the only isolation knob is the session NAME. This suite pins the two facts
+ * `injectHistoryEnv` bets on — that fish picks up `fish_history` from the spawn
+ * environment (it imports env vars as global variables at startup), and that the
+ * file it then writes is the one `resolveFishHistoryFilePath` computes.
+ *
+ * Interactive is mandatory: fish writes no history in non-interactive mode, so the
+ * PTY and the typed line are the test, not scaffolding. DA1/CPR/OSC-11 probes are
+ * answered here because no real xterm is attached — without them fish stalls ~10s
+ * on its DA1 read sentinel before painting a prompt.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fishRequirementViolation, resolveFishBinary } from '../shared/fish-binary-requirement'
+import { fishHistorySessionName, resolveFishHistoryFilePath } from './fish-history-session'
+
+const FISH = resolveFishBinary(4)
+const itWithFish = FISH.available ? it : it.skip
+
+const PROMPT_MARK = 'ORCAHIST> '
+const WORKTREE_HASH = 'deadbeefdeadbeef'
+const MARKER = 'echo orca-worktree-scoped-history'
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true
+    }
+    await sleep(20)
+  }
+  return false
+}
+
+describe('fish keeps per-worktree history under the session Orca names', () => {
+  let home: string | null = null
+
+  // Always runs, so the CI lane cannot report green with the regression below skipped.
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  afterEach(() => {
+    if (home) {
+      rmSync(home, { recursive: true, force: true })
+      home = null
+    }
+  })
+
+  itWithFish(
+    'writes an interactive command to $XDG_DATA_HOME/fish/<session>_history, not the shared file',
+    async () => {
+      const nodePty = await import('node-pty')
+
+      home = mkdtempSync(path.join(tmpdir(), 'orca-fish-history-'))
+      const dataHome = path.join(home, 'data')
+      mkdirSync(path.join(home, 'fish'), { recursive: true })
+      writeFileSync(
+        path.join(home, 'fish/config.fish'),
+        [
+          'set -g fish_greeting ""',
+          `function fish_prompt; printf '${PROMPT_MARK}'; end`,
+          'function fish_right_prompt; end',
+          ''
+        ].join('\n')
+      )
+
+      const session = fishHistorySessionName(WORKTREE_HASH)
+      const term = nodePty.spawn(FISH.path as string, ['-l', '-i'], {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 30,
+        cwd: home,
+        // Fully pinned: no ambient HOME/XDG_* reaches fish, so this cannot pass
+        // only on a machine whose real fish config happens to cooperate.
+        env: {
+          PATH: process.env.PATH ?? '/usr/bin:/bin',
+          HOME: home,
+          TERM: 'xterm-256color',
+          LANG: 'en_US.UTF-8',
+          XDG_CONFIG_HOME: home,
+          XDG_DATA_HOME: dataHome,
+          // The production injection under test (terminal-history.ts).
+          fish_history: session
+        }
+      })
+
+      let rendered = ''
+      term.onData((chunk) => {
+        rendered += chunk
+        if (chunk.includes('\x1b[0c') || chunk.includes('\x1b[c')) {
+          term.write('\x1b[?62;4;6;22c')
+        }
+        if (chunk.includes('\x1b[6n')) {
+          term.write('\x1b[1;1R')
+        }
+        if (chunk.includes('\x1b]10;?') || chunk.includes('\x1b]11;?')) {
+          term.write('\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\')
+        }
+      })
+      let exited = false
+      term.onExit(() => {
+        exited = true
+      })
+
+      expect(await waitUntil(() => rendered.includes(PROMPT_MARK), 15_000)).toBe(true)
+      term.write(`${MARKER}\r`)
+      expect(await waitUntil(() => rendered.includes('orca-worktree-scoped-history'), 5_000)).toBe(
+        true
+      )
+      // fish flushes history on exit, so the read must wait for the process to go.
+      term.write('exit\r')
+      expect(await waitUntil(() => exited, 10_000)).toBe(true)
+      try {
+        term.kill()
+      } catch {
+        // already gone
+      }
+
+      const scopedPath = resolveFishHistoryFilePath(session, { XDG_DATA_HOME: dataHome })
+      expect(scopedPath).toBe(path.join(dataHome, 'fish', `${session}_history`))
+      const scoped = readFileSync(scopedPath as string, 'utf8')
+      // YAML-ish records, not one line per command — any reader must handle this shape.
+      expect(scoped).toContain(`- cmd: ${MARKER}`)
+      expect(scoped).toMatch(/^ {2}when: \d+$/m)
+
+      // Isolation: the default session file fish would otherwise have used is absent.
+      expect(() => readFileSync(path.join(dataHome, 'fish', 'fish_history'), 'utf8')).toThrow()
+    },
+    40_000
+  )
+})

--- a/src/main/terminal-history-gc.ts
+++ b/src/main/terminal-history-gc.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path'
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, statSync } from 'node:fs'
 import {
   getHistoryRoot,
   listWslHistoryRoots,
@@ -9,6 +9,7 @@ import {
   schedulePendingHistoryTreeRemovals,
   scheduleWorktreeHistoryTreeDeletion
 } from './terminal-history-deletion'
+import { readHistoryMeta } from './terminal-history'
 
 // Why 5 minutes: GC runs ~10s after startup, and the live-worktree snapshot is
 // taken just before. A worktree created between the snapshot and GC execution
@@ -61,11 +62,8 @@ function gcScanRoot(
         continue
       }
 
-      const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as {
-        worktreeId?: string
-        createdAt?: string
-      }
-      if (!meta.worktreeId) {
+      const meta = readHistoryMeta(entryPath)
+      if (!meta?.worktreeId) {
         continue
       }
 

--- a/src/main/terminal-history-id.ts
+++ b/src/main/terminal-history-id.ts
@@ -1,0 +1,6 @@
+import { createHash } from 'node:crypto'
+
+/** First 16 hex chars of SHA-256 of the worktreeId. */
+export function hashWorktreeId(worktreeId: string): string {
+  return createHash('sha256').update(worktreeId).digest('hex').slice(0, 16)
+}

--- a/src/main/terminal-history-paths.ts
+++ b/src/main/terminal-history-paths.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { app } from 'electron'
@@ -8,10 +7,7 @@ const HISTORY_DIR_NAME_WSL = 'terminal-history-wsl'
 // Why: rename live history out of the way first so a quit mid-rm still leaves a durable tombstone GC can finish.
 export const PENDING_DELETE_DIR_NAME = '.pending-delete'
 
-/** First 16 hex chars of SHA-256 of the worktreeId. */
-export function hashWorktreeId(worktreeId: string): string {
-  return createHash('sha256').update(worktreeId).digest('hex').slice(0, 16)
-}
+export { hashWorktreeId } from './terminal-history-id'
 
 export function getHistoryRoot(): string {
   return join(app.getPath('userData'), HISTORY_DIR_NAME)

--- a/src/main/terminal-history-tombstone-retry.test.ts
+++ b/src/main/terminal-history-tombstone-retry.test.ts
@@ -1,12 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let userDataDir: string
 
-const { removeHostTreeMock } = vi.hoisted(() => ({
-  removeHostTreeMock: vi.fn<(dir: string) => Promise<void>>()
+const { removeHostTreeMock, deleteWslFishHistoryFileMock } = vi.hoisted(() => ({
+  removeHostTreeMock: vi.fn<(dir: string) => Promise<void>>(),
+  deleteWslFishHistoryFileMock: vi.fn<(distro: string, session: string) => Promise<void>>()
 }))
 
 vi.mock('electron', () => ({
@@ -19,11 +20,19 @@ vi.mock('./host-tree-removal', () => ({
   removeHostTree: removeHostTreeMock
 }))
 
+vi.mock('./wsl-fish-history-cleanup', () => ({
+  deleteWslFishHistoryFile: deleteWslFishHistoryFileMock
+}))
+
 import { hashWorktreeId } from './terminal-history-paths'
+import { fishHistorySessionName } from './fish-history-session'
 import {
   cancelPendingHistoryTreeRemovalRetries,
   deleteWorktreeHistoryDir,
-  HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS
+  flushPendingWorktreeHistoryDeletions,
+  MAX_PENDING_HISTORY_TREE_REMOVALS,
+  HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS,
+  schedulePendingHistoryTreeRemovals
 } from './terminal-history-deletion'
 
 /** A tombstone whose rm fails once used to sit on disk for the rest of the session — only the next
@@ -32,6 +41,11 @@ describe('tombstoned history removal retries', () => {
   beforeEach(() => {
     userDataDir = mkdtempSync(join(tmpdir(), 'orca-history-retry-'))
     removeHostTreeMock.mockReset()
+    deleteWslFishHistoryFileMock.mockReset()
+    deleteWslFishHistoryFileMock.mockResolvedValue(undefined)
+    removeHostTreeMock.mockImplementation(async (dir) => {
+      rmSync(dir, { recursive: true, force: true })
+    })
     vi.useFakeTimers()
   })
 
@@ -71,12 +85,93 @@ describe('tombstoned history removal retries', () => {
 
   it('does not re-arm a retry after the removal succeeds', async () => {
     seedWorktreeHistory('repo-1::/path/clean-wt')
-    removeHostTreeMock.mockResolvedValue(undefined)
 
     deleteWorktreeHistoryDir('repo-1::/path/clean-wt')
     await vi.advanceTimersByTimeAsync(0)
     await vi.advanceTimersByTimeAsync(HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS[0])
 
     expect(removeHostTreeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('admits a bounded tombstone batch and drains the rest from disk', async () => {
+    const distroRoot = join(userDataDir, 'terminal-history-wsl', 'Ubuntu')
+    mkdirSync(distroRoot, { recursive: true })
+    const releases: (() => void)[] = []
+    removeHostTreeMock.mockImplementation(
+      (dir) =>
+        new Promise<void>((resolve) =>
+          releases.push(() => {
+            rmSync(dir, { recursive: true, force: true })
+            resolve()
+          })
+        )
+    )
+
+    for (let index = 0; index < 1_000; index++) {
+      const worktreeId = `repo-1::/path/wsl-${index}`
+      const dir = join(distroRoot, hashWorktreeId(worktreeId))
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(
+        join(dir, 'meta.json'),
+        JSON.stringify({
+          worktreeId,
+          fishSession: fishHistorySessionName(hashWorktreeId(worktreeId))
+        })
+      )
+    }
+
+    for (let index = 0; index < 1_000; index++) {
+      deleteWorktreeHistoryDir(`repo-1::/path/wsl-${index}`)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    expect(removeHostTreeMock).toHaveBeenCalledTimes(64)
+    expect(deleteWslFishHistoryFileMock).toHaveBeenCalledTimes(64)
+    expect(releases).toHaveLength(64)
+
+    while (releases.length > 0) {
+      releases.splice(0).forEach((release) => release())
+      await vi.advanceTimersByTimeAsync(0)
+    }
+    expect(removeHostTreeMock).toHaveBeenCalledTimes(1_000)
+    expect(deleteWslFishHistoryFileMock).toHaveBeenCalledTimes(1_000)
+  })
+
+  it('caps persistent failures and leaves excess tombstones for a later disk batch', async () => {
+    const distroRoot = join(userDataDir, 'terminal-history-wsl', 'Ubuntu')
+    mkdirSync(distroRoot, { recursive: true })
+    deleteWslFishHistoryFileMock.mockRejectedValue(new Error('wsl unavailable'))
+    for (let index = 0; index < 1_000; index++) {
+      const worktreeId = `repo-1::/path/fail-${index}`
+      const dir = join(distroRoot, hashWorktreeId(worktreeId))
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(
+        join(dir, 'meta.json'),
+        JSON.stringify({
+          worktreeId,
+          fishSession: fishHistorySessionName(hashWorktreeId(worktreeId))
+        })
+      )
+      deleteWorktreeHistoryDir(worktreeId)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    expect(removeHostTreeMock).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(64)
+    expect(readdirSync(join(distroRoot, '.pending-delete'))).toHaveLength(1_000)
+
+    for (const delay of HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS) {
+      await vi.advanceTimersByTimeAsync(delay)
+      expect(vi.getTimerCount()).toBeLessThanOrEqual(64)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    deleteWslFishHistoryFileMock.mockResolvedValue(undefined)
+    removeHostTreeMock.mockImplementation(async (dir) => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+    schedulePendingHistoryTreeRemovals(distroRoot)
+    await flushPendingWorktreeHistoryDeletions()
+    expect(removeHostTreeMock.mock.calls.length).toBeGreaterThan(
+      MAX_PENDING_HISTORY_TREE_REMOVALS * (HISTORY_TREE_REMOVAL_RETRY_DELAYS_MS.length + 1)
+    )
+    expect(readdirSync(join(distroRoot, '.pending-delete'))).toHaveLength(0)
   })
 })

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -64,8 +64,10 @@ import {
   resolveShellKind,
   ensureHistoryDir,
   injectHistoryEnv,
-  updateHistFileForFallback
+  updateHistoryEnvForFallback,
+  type HistoryInjectionResult
 } from './terminal-history'
+import { fishHistorySessionName, resolveFishHistoryFilePath } from './fish-history-session'
 import { hashWorktreeId } from './terminal-history-paths'
 import {
   deleteWorktreeHistoryDir,
@@ -82,6 +84,7 @@ describe('terminal-history', () => {
     vi.clearAllMocks()
     // Why: clearAllMocks keeps implementations, so a throwing rename from one test would leak forward.
     renameSyncMock.mockReset()
+    readFileSyncMock.mockReset()
     getPathMock.mockReturnValue('/fake/userData')
     existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
@@ -228,12 +231,37 @@ describe('terminal-history', () => {
       expect(result.histFile).toBeNull()
     })
 
-    it('does not inject HISTFILE for fish (Phase 2)', () => {
+    it('scopes fish by session name instead of HISTFILE, which fish ignores', () => {
       const env: Record<string, string> = {}
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
 
       expect(env.HISTFILE).toBeUndefined()
       expect(result.shell).toBe('fish')
+      expect(result.fishSession).toBe(fishHistorySessionName(hashWorktreeId('repo-1::/path/wt')))
+      expect(env.fish_history).toBe(result.fishSession)
+      // Deletion can only find the out-of-tree fish file through this record.
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        expect.stringContaining('meta.json'),
+        expect.stringContaining(`"fishSession":"${result.fishSession}"`),
+        expect.anything()
+      )
+    })
+
+    it('gives two fish worktrees different history sessions', () => {
+      const envA: Record<string, string> = {}
+      injectHistoryEnv(envA, 'repo-1::/path/wt-a', '/usr/bin/fish', '/path/wt-a')
+      const envB: Record<string, string> = {}
+      injectHistoryEnv(envB, 'repo-1::/path/wt-b', '/usr/bin/fish', '/path/wt-b')
+
+      expect(envA.fish_history).not.toBe(envB.fish_history)
+    })
+
+    it('preserves a caller-supplied fish_history', () => {
+      const env: Record<string, string> = { fish_history: 'mine' }
+      const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
+
+      expect(env.fish_history).toBe('mine')
+      expect(result.fishSession).toBeNull()
     })
 
     it('degrades gracefully when directory creation fails', () => {
@@ -249,12 +277,19 @@ describe('terminal-history', () => {
     })
   })
 
-  describe('updateHistFileForFallback', () => {
+  describe('updateHistoryEnvForFallback', () => {
+    const zshInjection = (): HistoryInjectionResult => ({
+      shell: 'zsh',
+      histFile: '/fake/userData/terminal-history/abc123/zsh_history',
+      fishSession: null,
+      historyDir: '/fake/userData/terminal-history/abc123'
+    })
+
     it('updates HISTFILE to match fallback shell', () => {
       const env: Record<string, string> = {
         HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history'
       }
-      updateHistFileForFallback(env, '/bin/bash')
+      updateHistoryEnvForFallback(env, '/bin/bash', zshInjection())
       expect(env.HISTFILE).toBe('/fake/userData/terminal-history/abc123/bash_history')
     })
 
@@ -262,14 +297,56 @@ describe('terminal-history', () => {
       const env: Record<string, string> = {
         HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history'
       }
-      updateHistFileForFallback(env, '/bin/sh')
+      updateHistoryEnvForFallback(env, '/bin/sh', zshInjection())
       expect(env.HISTFILE).toBeUndefined()
     })
 
-    it('is a no-op when HISTFILE is not set', () => {
+    it('is a no-op when nothing was injected', () => {
       const env: Record<string, string> = {}
-      updateHistFileForFallback(env, '/bin/bash')
+      updateHistoryEnvForFallback(env, '/bin/bash', {
+        shell: 'unknown',
+        histFile: null,
+        fishSession: null,
+        historyDir: null
+      })
       expect(env.HISTFILE).toBeUndefined()
+    })
+
+    it('swaps an injected fish session for the fallback shell HISTFILE', () => {
+      const env: Record<string, string> = { fish_history: 'orca_abc123' }
+      updateHistoryEnvForFallback(env, '/bin/bash', {
+        shell: 'fish',
+        histFile: null,
+        fishSession: 'orca_abc123',
+        historyDir: '/fake/userData/terminal-history/abc123'
+      })
+      expect(env.fish_history).toBeUndefined()
+      expect(env.HISTFILE).toBe('/fake/userData/terminal-history/abc123/bash_history')
+    })
+
+    it('keeps a caller-supplied fish_history the injection never claimed', () => {
+      const env: Record<string, string> = { fish_history: 'mine' }
+      updateHistoryEnvForFallback(env, '/bin/bash', zshInjection())
+      expect(env.fish_history).toBe('mine')
+    })
+  })
+
+  describe('resolveFishHistoryFilePath', () => {
+    it('uses an absolute XDG_DATA_HOME', () => {
+      expect(resolveFishHistoryFilePath('orca_abc123', { XDG_DATA_HOME: '/data' })).toBe(
+        ['', 'data', 'fish', 'orca_abc123_history'].join(sep)
+      )
+    })
+
+    it('falls back to ~/.local/share when XDG_DATA_HOME is relative, as fish does', () => {
+      expect(
+        resolveFishHistoryFilePath('orca_abc123', { XDG_DATA_HOME: 'rel', HOME: '/home/u' })
+      ).toBe(['', 'home', 'u', '.local', 'share', 'fish', 'orca_abc123_history'].join(sep))
+    })
+
+    it('refuses a session name it did not mint', () => {
+      expect(resolveFishHistoryFilePath('../../evil', { HOME: '/home/u' })).toBeNull()
+      expect(resolveFishHistoryFilePath('fish', { HOME: '/home/u' })).toBeNull()
     })
   })
 
@@ -283,6 +360,30 @@ describe('terminal-history', () => {
         expect.stringContaining('.pending-delete'),
         expect.objectContaining({ recursive: true, force: true })
       )
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
+    it('removes the fish session file recorded in meta.json, which lives outside the tree', async () => {
+      // Pinned: fish resolves its data dir from the ambient XDG_DATA_HOME/HOME.
+      const originalDataHome = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = ['', 'pinned', 'data'].join(sep)
+      try {
+        existsSyncMock.mockReturnValue(true)
+        readFileSyncMock.mockReturnValue(
+          JSON.stringify({ worktreeId: 'repo-1::/path/wt', fishSession: 'orca_abc123' })
+        )
+        deleteWorktreeHistoryDir('repo-1::/path/wt')
+        expect(rmSyncMock).toHaveBeenCalledWith(
+          ['', 'pinned', 'data', 'fish', 'orca_abc123_history'].join(sep),
+          expect.objectContaining({ force: true })
+        )
+      } finally {
+        if (originalDataHome === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = originalDataHome
+        }
+      }
       await flushPendingWorktreeHistoryDeletions()
     })
 

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -247,6 +247,32 @@ describe('terminal-history', () => {
       )
     })
 
+    it('records the history path from the SPAWN env, not this process env', () => {
+      // Pinned so the assertion cannot accidentally read the developer's own value.
+      const originalDataHome = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = ['', 'main', 'process', 'data'].join(sep)
+      try {
+        const env: Record<string, string> = {
+          XDG_DATA_HOME: ['', 'spawn', 'data'].join(sep)
+        }
+        const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
+        const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as Record<
+          string,
+          string
+        >
+
+        expect(meta.fishHistoryPath).toBe(
+          ['', 'spawn', 'data', 'fish', `${result.fishSession}_history`].join(sep)
+        )
+      } finally {
+        if (originalDataHome === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = originalDataHome
+        }
+      }
+    })
+
     it('gives two fish worktrees different history sessions', () => {
       const envA: Record<string, string> = {}
       injectHistoryEnv(envA, 'repo-1::/path/wt-a', '/usr/bin/fish', '/path/wt-a')
@@ -383,6 +409,79 @@ describe('terminal-history', () => {
         } else {
           process.env.XDG_DATA_HOME = originalDataHome
         }
+      }
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
+    it('prefers the spawn-env path recorded in meta.json over this process env', async () => {
+      const originalDataHome = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = ['', 'main', 'data'].join(sep)
+      const recorded = ['', 'spawn', 'data', 'fish', 'orca_abc123_history'].join(sep)
+      try {
+        existsSyncMock.mockReturnValue(true)
+        readFileSyncMock.mockReturnValue(
+          JSON.stringify({
+            worktreeId: 'repo-1::/path/wt',
+            fishSession: 'orca_abc123',
+            fishHistoryPath: recorded
+          })
+        )
+        deleteWorktreeHistoryDir('repo-1::/path/wt')
+        expect(rmSyncMock).toHaveBeenCalledWith(recorded, expect.objectContaining({ force: true }))
+        // The main-process guess stays as a fallback for pre-existing meta.json files.
+        expect(rmSyncMock).toHaveBeenCalledWith(
+          ['', 'main', 'data', 'fish', 'orca_abc123_history'].join(sep),
+          expect.objectContaining({ force: true })
+        )
+      } finally {
+        if (originalDataHome === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = originalDataHome
+        }
+      }
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
+    it('refuses a recorded path that does not name its own session file', async () => {
+      const originalDataHome = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = ['', 'main', 'data'].join(sep)
+      try {
+        existsSyncMock.mockReturnValue(true)
+        readFileSyncMock.mockReturnValue(
+          JSON.stringify({
+            worktreeId: 'repo-1::/path/wt',
+            fishSession: 'orca_abc123',
+            fishHistoryPath: ['', 'etc', 'passwd'].join(sep)
+          })
+        )
+        deleteWorktreeHistoryDir('repo-1::/path/wt')
+        expect(rmSyncMock).not.toHaveBeenCalledWith(
+          ['', 'etc', 'passwd'].join(sep),
+          expect.anything()
+        )
+      } finally {
+        if (originalDataHome === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = originalDataHome
+        }
+      }
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
+    it('warns instead of going quiet when no fish history file is found', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        readFileSyncMock.mockReturnValue(
+          JSON.stringify({ worktreeId: 'repo-1::/path/wt', fishSession: 'orca_abc123' })
+        )
+        // The history dir exists (so the tree is deleted) but the fish file does not.
+        existsSyncMock.mockImplementation((path: string) => !path.includes('orca_abc123_history'))
+        deleteWorktreeHistoryDir('repo-1::/path/wt')
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('No fish history file found'))
+      } finally {
+        warn.mockRestore()
       }
       await flushPendingWorktreeHistoryDeletions()
     })

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -12,7 +12,8 @@ const {
   readdirSyncMock,
   statSyncMock,
   getPathMock,
-  rmAsyncMock
+  rmAsyncMock,
+  deleteWslFishHistoryFileMock
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   mkdirSyncMock: vi.fn(),
@@ -23,7 +24,8 @@ const {
   readdirSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
   getPathMock: vi.fn(),
-  rmAsyncMock: vi.fn(async () => undefined)
+  rmAsyncMock: vi.fn(async () => undefined),
+  deleteWslFishHistoryFileMock: vi.fn(async () => undefined)
 }))
 
 vi.mock('fs', () => ({
@@ -60,19 +62,30 @@ vi.mock('./wsl', () => ({
   toLinuxPath: toLinuxPathMock
 }))
 
+vi.mock('./wsl-fish-history-cleanup', () => ({
+  deleteWslFishHistoryFile: deleteWslFishHistoryFileMock
+}))
+
 import {
   resolveShellKind,
   ensureHistoryDir,
   injectHistoryEnv,
+  MAX_HISTORY_META_BYTES,
   updateHistoryEnvForFallback,
   type HistoryInjectionResult
 } from './terminal-history'
-import { fishHistorySessionName, resolveFishHistoryFilePath } from './fish-history-session'
+import {
+  fishHistorySessionName,
+  MAX_RETAINED_FISH_HISTORY_PATHS,
+  resolveFishHistoryFilePath
+} from './fish-history-session'
 import { hashWorktreeId } from './terminal-history-paths'
 import {
   deleteWorktreeHistoryDir,
   flushPendingWorktreeHistoryDeletions
 } from './terminal-history-deletion'
+
+type FishHistoryMeta = { fishHistoryPath: string; fishHistoryPaths: string[] }
 import { runHistoryGc, scheduleHistoryGc } from './terminal-history-gc'
 
 describe('terminal-history', () => {
@@ -273,7 +286,7 @@ describe('terminal-history', () => {
       }
     })
 
-    it('retains every fish path when XDG_DATA_HOME changes', () => {
+    it('retains fish paths when XDG_DATA_HOME changes and points rollback at the active path', () => {
       const firstEnv = { XDG_DATA_HOME: ['', 'data', 'one'].join(sep) }
       const secondEnv = { XDG_DATA_HOME: ['', 'data', 'two'].join(sep) }
       const worktreeId = 'repo-1::/path/wt'
@@ -282,20 +295,17 @@ describe('terminal-history', () => {
       readFileSyncMock.mockReturnValue(firstMeta)
 
       injectHistoryEnv(secondEnv, worktreeId, '/usr/bin/fish', '/path/wt')
-      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as {
-        fishHistoryPath: string
-        fishHistoryPaths: string[]
-      }
+      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as FishHistoryMeta
       const filename = `${first.fishSession}_history`
 
-      expect(meta.fishHistoryPath).toBe(['', 'data', 'one', 'fish', filename].join(sep))
+      expect(meta.fishHistoryPath).toBe(['', 'data', 'two', 'fish', filename].join(sep))
       expect(meta.fishHistoryPaths).toEqual([
         ['', 'data', 'one', 'fish', filename].join(sep),
         ['', 'data', 'two', 'fish', filename].join(sep)
       ])
     })
 
-    it('migrates legacy singular fish metadata without replacing its rollback path', () => {
+    it('migrates legacy singular fish metadata and points rollback at the active path', () => {
       const worktreeId = 'repo-1::/path/wt'
       const session = fishHistorySessionName(hashWorktreeId(worktreeId))
       const legacyPath = ['', 'legacy', 'fish', `${session}_history`].join(sep)
@@ -309,16 +319,55 @@ describe('terminal-history', () => {
         '/usr/bin/fish',
         '/path/wt'
       )
-      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as {
-        fishHistoryPath: string
-        fishHistoryPaths: string[]
-      }
+      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as FishHistoryMeta
 
-      expect(meta.fishHistoryPath).toBe(legacyPath)
+      expect(meta.fishHistoryPath).toBe(['', 'current', 'fish', `${session}_history`].join(sep))
       expect(meta.fishHistoryPaths).toEqual([
         legacyPath,
         ['', 'current', 'fish', `${session}_history`].join(sep)
       ])
+    })
+
+    it('bounds and normalizes retained fish paths while preserving the active path', () => {
+      const worktreeId = 'repo-1::/path/wt'
+      const session = fishHistorySessionName(hashWorktreeId(worktreeId))
+      const filename = `${session}_history`
+      const paths = Array.from({ length: 40 }, (_, index) =>
+        ['', 'data', String(index), 'fish', filename].join(sep)
+      )
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          worktreeId,
+          fishSession: session,
+          fishHistoryPath: paths[0],
+          fishHistoryPaths: paths
+        })
+      )
+
+      injectHistoryEnv(
+        { XDG_DATA_HOME: ['', 'active'].join(sep) },
+        worktreeId,
+        '/usr/bin/fish',
+        '/path/wt'
+      )
+      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as FishHistoryMeta
+      const activePath = ['', 'active', 'fish', filename].join(sep)
+
+      expect(meta.fishHistoryPaths).toHaveLength(MAX_RETAINED_FISH_HISTORY_PATHS)
+      expect(new Set(meta.fishHistoryPaths).size).toBe(meta.fishHistoryPaths.length)
+      expect(meta.fishHistoryPaths.at(-1)).toBe(activePath)
+      expect(meta.fishHistoryPath).toBe(activePath)
+    })
+
+    it('replaces oversized metadata without parsing it', () => {
+      statSyncMock.mockReturnValue({ isDirectory: () => true, size: MAX_HISTORY_META_BYTES + 1 })
+      const env = { XDG_DATA_HOME: ['', 'active'].join(sep) }
+
+      injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
+
+      expect(readFileSyncMock).not.toHaveBeenCalled()
+      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as FishHistoryMeta
+      expect(meta.fishHistoryPaths).toEqual([meta.fishHistoryPath])
     })
 
     it('gives two fish worktrees different history sessions', () => {
@@ -425,6 +474,10 @@ describe('terminal-history', () => {
   })
 
   describe('deleteWorktreeHistoryDir', () => {
+    const worktreeId = 'repo-1::/path/wt'
+    const session = fishHistorySessionName(hashWorktreeId(worktreeId))
+    const historyFilename = `${session}_history`
+
     it('tombstones then async-removes the history directory without recursive rmSync', async () => {
       existsSyncMock.mockReturnValue(true)
       deleteWorktreeHistoryDir('repo-1::/path/wt')
@@ -443,12 +496,10 @@ describe('terminal-history', () => {
       process.env.XDG_DATA_HOME = ['', 'pinned', 'data'].join(sep)
       try {
         existsSyncMock.mockReturnValue(true)
-        readFileSyncMock.mockReturnValue(
-          JSON.stringify({ worktreeId: 'repo-1::/path/wt', fishSession: 'orca_abc123' })
-        )
+        readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
         deleteWorktreeHistoryDir('repo-1::/path/wt')
         expect(rmSyncMock).toHaveBeenCalledWith(
-          ['', 'pinned', 'data', 'fish', 'orca_abc123_history'].join(sep),
+          ['', 'pinned', 'data', 'fish', historyFilename].join(sep),
           expect.objectContaining({ force: true })
         )
       } finally {
@@ -464,13 +515,13 @@ describe('terminal-history', () => {
     it('prefers the spawn-env path recorded in meta.json over this process env', async () => {
       const originalDataHome = process.env.XDG_DATA_HOME
       process.env.XDG_DATA_HOME = ['', 'main', 'data'].join(sep)
-      const recorded = ['', 'spawn', 'data', 'fish', 'orca_abc123_history'].join(sep)
+      const recorded = ['', 'spawn', 'data', 'fish', historyFilename].join(sep)
       try {
         existsSyncMock.mockReturnValue(true)
         readFileSyncMock.mockReturnValue(
           JSON.stringify({
-            worktreeId: 'repo-1::/path/wt',
-            fishSession: 'orca_abc123',
+            worktreeId,
+            fishSession: session,
             fishHistoryPath: recorded
           })
         )
@@ -478,7 +529,7 @@ describe('terminal-history', () => {
         expect(rmSyncMock).toHaveBeenCalledWith(recorded, expect.objectContaining({ force: true }))
         // The main-process guess stays as a fallback for pre-existing meta.json files.
         expect(rmSyncMock).toHaveBeenCalledWith(
-          ['', 'main', 'data', 'fish', 'orca_abc123_history'].join(sep),
+          ['', 'main', 'data', 'fish', historyFilename].join(sep),
           expect.objectContaining({ force: true })
         )
       } finally {
@@ -492,12 +543,12 @@ describe('terminal-history', () => {
     })
 
     it('deletes every recorded fish path while isolating individual failures', async () => {
-      const first = ['', 'data', 'one', 'fish', 'orca_abc123_history'].join(sep)
-      const second = ['', 'data', 'two', 'fish', 'orca_abc123_history'].join(sep)
+      const first = ['', 'data', 'one', 'fish', historyFilename].join(sep)
+      const second = ['', 'data', 'two', 'fish', historyFilename].join(sep)
       readFileSyncMock.mockReturnValue(
         JSON.stringify({
-          worktreeId: 'repo-1::/path/wt',
-          fishSession: 'orca_abc123',
+          worktreeId,
+          fishSession: session,
           fishHistoryPath: first,
           fishHistoryPaths: [first, second]
         })
@@ -515,11 +566,35 @@ describe('terminal-history', () => {
       await flushPendingWorktreeHistoryDeletions()
     })
 
+    it('bounds synchronous fish cleanup for oversized retained arrays', async () => {
+      const paths = Array.from({ length: 100 }, (_, index) =>
+        ['', 'data', String(index), 'fish', `${session}_history`].join(sep)
+      )
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          worktreeId,
+          fishSession: session,
+          fishHistoryPath: paths[0],
+          fishHistoryPaths: paths
+        })
+      )
+
+      deleteWorktreeHistoryDir('repo-1::/path/wt')
+
+      expect(rmSyncMock.mock.calls.length).toBeLessThanOrEqual(MAX_RETAINED_FISH_HISTORY_PATHS + 1)
+      expect(rmSyncMock).toHaveBeenCalledWith(
+        paths.at(-1),
+        expect.objectContaining({ force: true })
+      )
+      expect(rmSyncMock).not.toHaveBeenCalledWith(paths[0], expect.anything())
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
     it('runtime-validates malformed fish metadata before the normal tombstone', async () => {
       readFileSyncMock.mockReturnValue(
         JSON.stringify({
-          worktreeId: 'repo-1::/path/wt',
-          fishSession: 'orca_abc123',
+          worktreeId,
+          fishSession: session,
           fishHistoryPath: 42,
           fishHistoryPaths: [null, 7, { path: '/tmp/nope' }]
         })
@@ -530,23 +605,21 @@ describe('terminal-history', () => {
       await flushPendingWorktreeHistoryDeletions()
     })
 
-    it('refuses a recorded path that does not name its own session file', async () => {
+    it('refuses a matching session filename outside a fish data directory', async () => {
       const originalDataHome = process.env.XDG_DATA_HOME
       process.env.XDG_DATA_HOME = ['', 'main', 'data'].join(sep)
+      const unrelated = ['', 'tmp', historyFilename].join(sep)
       try {
         existsSyncMock.mockReturnValue(true)
         readFileSyncMock.mockReturnValue(
           JSON.stringify({
-            worktreeId: 'repo-1::/path/wt',
-            fishSession: 'orca_abc123',
-            fishHistoryPath: ['', 'etc', 'passwd'].join(sep)
+            worktreeId,
+            fishSession: session,
+            fishHistoryPath: unrelated
           })
         )
         deleteWorktreeHistoryDir('repo-1::/path/wt')
-        expect(rmSyncMock).not.toHaveBeenCalledWith(
-          ['', 'etc', 'passwd'].join(sep),
-          expect.anything()
-        )
+        expect(rmSyncMock).not.toHaveBeenCalledWith(unrelated, expect.anything())
       } finally {
         if (originalDataHome === undefined) {
           delete process.env.XDG_DATA_HOME
@@ -560,17 +633,30 @@ describe('terminal-history', () => {
     it('warns instead of going quiet when no fish history file is found', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       try {
-        readFileSyncMock.mockReturnValue(
-          JSON.stringify({ worktreeId: 'repo-1::/path/wt', fishSession: 'orca_abc123' })
-        )
+        readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
         // The history dir exists (so the tree is deleted) but the fish file does not.
-        existsSyncMock.mockImplementation((path: string) => !path.includes('orca_abc123_history'))
+        existsSyncMock.mockImplementation((path: string) => !path.includes(historyFilename))
         deleteWorktreeHistoryDir('repo-1::/path/wt')
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('No fish history file found'))
       } finally {
         warn.mockRestore()
       }
       await flushPendingWorktreeHistoryDeletions()
+    })
+
+    it('cleans WSL Fish history through the owning distro before removing metadata', async () => {
+      readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
+      readdirSyncMock.mockImplementation((path: string) => {
+        if (path.endsWith('terminal-history-wsl')) {
+          return ['Ubuntu']
+        }
+        return []
+      })
+
+      deleteWorktreeHistoryDir(worktreeId)
+      await flushPendingWorktreeHistoryDeletions()
+
+      expect(deleteWslFishHistoryFileMock).toHaveBeenCalledWith('Ubuntu', session)
     })
 
     it('leaves the live directory alone when the tombstone rename fails', async () => {

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -7,6 +7,7 @@ const {
   mkdirSyncMock,
   writeFileSyncMock,
   readFileSyncMock,
+  lstatSyncMock,
   rmSyncMock,
   renameSyncMock,
   readdirSyncMock,
@@ -19,6 +20,7 @@ const {
   mkdirSyncMock: vi.fn(),
   writeFileSyncMock: vi.fn(),
   readFileSyncMock: vi.fn(),
+  lstatSyncMock: vi.fn(),
   rmSyncMock: vi.fn(),
   renameSyncMock: vi.fn(),
   readdirSyncMock: vi.fn(),
@@ -33,6 +35,7 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   readFileSync: readFileSyncMock,
+  lstatSync: lstatSyncMock,
   rmSync: rmSyncMock,
   renameSync: renameSyncMock,
   readdirSync: readdirSyncMock,
@@ -101,6 +104,15 @@ describe('terminal-history', () => {
     getPathMock.mockReturnValue('/fake/userData')
     existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+    lstatSyncMock.mockReturnValue({
+      dev: 1n,
+      ino: 2n,
+      birthtimeNs: 3n,
+      size: 100,
+      isDirectory: () => true,
+      isFile: () => true,
+      isSymbolicLink: () => false
+    })
   })
 
   describe('resolveShellKind', () => {
@@ -365,7 +377,7 @@ describe('terminal-history', () => {
 
       injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
 
-      expect(readFileSyncMock).not.toHaveBeenCalled()
+      expect(readFileSyncMock).toHaveBeenCalledTimes(1)
       const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as FishHistoryMeta
       expect(meta.fishHistoryPaths).toEqual([meta.fishHistoryPath])
     })
@@ -490,59 +502,30 @@ describe('terminal-history', () => {
       await flushPendingWorktreeHistoryDeletions()
     })
 
-    it('removes the fish session file recorded in meta.json, which lives outside the tree', async () => {
-      // Pinned: fish resolves its data dir from the ambient XDG_DATA_HOME/HOME.
-      const originalDataHome = process.env.XDG_DATA_HOME
-      process.env.XDG_DATA_HOME = ['', 'pinned', 'data'].join(sep)
-      try {
-        existsSyncMock.mockReturnValue(true)
-        readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
-        deleteWorktreeHistoryDir('repo-1::/path/wt')
-        expect(rmSyncMock).toHaveBeenCalledWith(
-          ['', 'pinned', 'data', 'fish', historyFilename].join(sep),
-          expect.objectContaining({ force: true })
-        )
-      } finally {
-        if (originalDataHome === undefined) {
-          delete process.env.XDG_DATA_HOME
-        } else {
-          process.env.XDG_DATA_HOME = originalDataHome
-        }
-      }
+    it('does not infer deletion authority from the ambient fish data path', async () => {
+      existsSyncMock.mockReturnValue(true)
+      readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
+
+      deleteWorktreeHistoryDir('repo-1::/path/wt')
+
+      expect(rmSyncMock).not.toHaveBeenCalled()
       await flushPendingWorktreeHistoryDeletions()
     })
 
-    it('prefers the spawn-env path recorded in meta.json over this process env', async () => {
-      const originalDataHome = process.env.XDG_DATA_HOME
-      process.env.XDG_DATA_HOME = ['', 'main', 'data'].join(sep)
+    it('does not trust a spawn-env path copied into meta.json', async () => {
       const recorded = ['', 'spawn', 'data', 'fish', historyFilename].join(sep)
-      try {
-        existsSyncMock.mockReturnValue(true)
-        readFileSyncMock.mockReturnValue(
-          JSON.stringify({
-            worktreeId,
-            fishSession: session,
-            fishHistoryPath: recorded
-          })
-        )
-        deleteWorktreeHistoryDir('repo-1::/path/wt')
-        expect(rmSyncMock).toHaveBeenCalledWith(recorded, expect.objectContaining({ force: true }))
-        // The main-process guess stays as a fallback for pre-existing meta.json files.
-        expect(rmSyncMock).toHaveBeenCalledWith(
-          ['', 'main', 'data', 'fish', historyFilename].join(sep),
-          expect.objectContaining({ force: true })
-        )
-      } finally {
-        if (originalDataHome === undefined) {
-          delete process.env.XDG_DATA_HOME
-        } else {
-          process.env.XDG_DATA_HOME = originalDataHome
-        }
-      }
+      existsSyncMock.mockReturnValue(true)
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({ worktreeId, fishSession: session, fishHistoryPath: recorded })
+      )
+
+      deleteWorktreeHistoryDir('repo-1::/path/wt')
+
+      expect(rmSyncMock).not.toHaveBeenCalled()
       await flushPendingWorktreeHistoryDeletions()
     })
 
-    it('deletes every recorded fish path while isolating individual failures', async () => {
+    it('refuses every raw fish path in tampered metadata', async () => {
       const first = ['', 'data', 'one', 'fish', historyFilename].join(sep)
       const second = ['', 'data', 'two', 'fish', historyFilename].join(sep)
       readFileSyncMock.mockReturnValue(
@@ -553,15 +536,9 @@ describe('terminal-history', () => {
           fishHistoryPaths: [first, second]
         })
       )
-      rmSyncMock.mockImplementation((path: string) => {
-        if (path === first) {
-          throw new Error('busy')
-        }
-      })
-
       expect(() => deleteWorktreeHistoryDir('repo-1::/path/wt')).not.toThrow()
-      expect(rmSyncMock).toHaveBeenCalledWith(first, expect.objectContaining({ force: true }))
-      expect(rmSyncMock).toHaveBeenCalledWith(second, expect.objectContaining({ force: true }))
+      expect(rmSyncMock).not.toHaveBeenCalledWith(first, expect.anything())
+      expect(rmSyncMock).not.toHaveBeenCalledWith(second, expect.anything())
       expect(renameSyncMock).toHaveBeenCalled()
       await flushPendingWorktreeHistoryDeletions()
     })
@@ -582,10 +559,7 @@ describe('terminal-history', () => {
       deleteWorktreeHistoryDir('repo-1::/path/wt')
 
       expect(rmSyncMock.mock.calls.length).toBeLessThanOrEqual(MAX_RETAINED_FISH_HISTORY_PATHS + 1)
-      expect(rmSyncMock).toHaveBeenCalledWith(
-        paths.at(-1),
-        expect.objectContaining({ force: true })
-      )
+      expect(rmSyncMock).not.toHaveBeenCalledWith(paths.at(-1), expect.anything())
       expect(rmSyncMock).not.toHaveBeenCalledWith(paths[0], expect.anything())
       await flushPendingWorktreeHistoryDeletions()
     })
@@ -637,7 +611,7 @@ describe('terminal-history', () => {
         // The history dir exists (so the tree is deleted) but the fish file does not.
         existsSyncMock.mockImplementation((path: string) => !path.includes(historyFilename))
         deleteWorktreeHistoryDir('repo-1::/path/wt')
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining('No fish history file found'))
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('No attested fish history'))
       } finally {
         warn.mockRestore()
       }

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -12,6 +12,9 @@ const {
   renameSyncMock,
   readdirSyncMock,
   statSyncMock,
+  openSyncMock,
+  fstatSyncMock,
+  closeSyncMock,
   getPathMock,
   rmAsyncMock,
   deleteWslFishHistoryFileMock
@@ -25,6 +28,15 @@ const {
   renameSyncMock: vi.fn(),
   readdirSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
+  openSyncMock: vi.fn((_path?: string | Buffer) => 1),
+  fstatSyncMock: vi.fn(() => ({
+    dev: 1n,
+    ino: 2n,
+    birthtimeNs: 3n,
+    isFile: () => true,
+    isDirectory: () => true
+  })),
+  closeSyncMock: vi.fn(),
   getPathMock: vi.fn(),
   rmAsyncMock: vi.fn(async () => undefined),
   deleteWslFishHistoryFileMock: vi.fn(async () => undefined)
@@ -39,7 +51,10 @@ vi.mock('fs', () => ({
   rmSync: rmSyncMock,
   renameSync: renameSyncMock,
   readdirSync: readdirSyncMock,
-  statSync: statSyncMock
+  statSync: statSyncMock,
+  openSync: openSyncMock,
+  fstatSync: fstatSyncMock,
+  closeSync: closeSyncMock
 }))
 
 // Spread the real module: this factory replaces node:fs/promises for the whole import graph, so a
@@ -84,6 +99,7 @@ import {
 } from './fish-history-session'
 import { hashWorktreeId } from './terminal-history-paths'
 import {
+  cancelPendingHistoryTreeRemovalRetries,
   deleteWorktreeHistoryDir,
   flushPendingWorktreeHistoryDeletions
 } from './terminal-history-deletion'
@@ -93,6 +109,7 @@ import { runHistoryGc, scheduleHistoryGc } from './terminal-history-gc'
 
 describe('terminal-history', () => {
   afterEach(() => {
+    cancelPendingHistoryTreeRemovalRetries()
     vi.useRealTimers()
   })
 
@@ -101,9 +118,20 @@ describe('terminal-history', () => {
     // Why: clearAllMocks keeps implementations, so a throwing rename from one test would leak forward.
     renameSyncMock.mockReset()
     readFileSyncMock.mockReset()
+    readdirSyncMock.mockReset()
+    rmAsyncMock.mockReset()
+    rmAsyncMock.mockResolvedValue(undefined)
     getPathMock.mockReturnValue('/fake/userData')
     existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+    openSyncMock.mockImplementation(() => 1)
+    fstatSyncMock.mockReturnValue({
+      dev: 1n,
+      ino: 2n,
+      birthtimeNs: 3n,
+      isFile: () => true,
+      isDirectory: () => true
+    })
     lstatSyncMock.mockReturnValue({
       dev: 1n,
       ino: 2n,
@@ -377,7 +405,7 @@ describe('terminal-history', () => {
 
       injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
 
-      expect(readFileSyncMock).toHaveBeenCalledTimes(1)
+      expect(readFileSyncMock).not.toHaveBeenCalled()
       const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as FishHistoryMeta
       expect(meta.fishHistoryPaths).toEqual([meta.fishHistoryPath])
     })
@@ -604,20 +632,6 @@ describe('terminal-history', () => {
       await flushPendingWorktreeHistoryDeletions()
     })
 
-    it('warns instead of going quiet when no fish history file is found', async () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      try {
-        readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
-        // The history dir exists (so the tree is deleted) but the fish file does not.
-        existsSyncMock.mockImplementation((path: string) => !path.includes(historyFilename))
-        deleteWorktreeHistoryDir('repo-1::/path/wt')
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining('No attested fish history'))
-      } finally {
-        warn.mockRestore()
-      }
-      await flushPendingWorktreeHistoryDeletions()
-    })
-
     it('cleans WSL Fish history through the owning distro before removing metadata', async () => {
       readFileSyncMock.mockReturnValue(JSON.stringify({ worktreeId, fishSession: session }))
       readdirSyncMock.mockImplementation((path: string) => {
@@ -656,6 +670,7 @@ describe('terminal-history', () => {
     })
 
     it('retries pending tombstones on flush after a failed async rm (app-quit durability)', async () => {
+      let leftoverTombstonePresent = true
       existsSyncMock.mockImplementation((p: string) => {
         const path = String(p)
         if (path.includes('.pending-delete') && !path.endsWith('.pending-delete')) {
@@ -668,11 +683,13 @@ describe('terminal-history', () => {
       })
       readdirSyncMock.mockImplementation((p: string) => {
         if (String(p).endsWith('.pending-delete')) {
-          return ['leftover-tombstone']
+          return leftoverTombstonePresent ? ['leftover-tombstone'] : []
         }
         return []
       })
-      rmAsyncMock.mockResolvedValue(undefined)
+      rmAsyncMock.mockImplementation(async () => {
+        leftoverTombstonePresent = false
+      })
       await flushPendingWorktreeHistoryDeletions()
       expect(rmAsyncMock).toHaveBeenCalledWith(
         expect.stringContaining('leftover-tombstone'),
@@ -735,7 +752,7 @@ describe('terminal-history', () => {
       )
     })
 
-    it('continues GC after one orphan tombstone fails', () => {
+    it('continues GC after one orphan tombstone fails', async () => {
       existsSyncMock.mockImplementation((path: string) => !path.includes('terminal-history-wsl'))
       readdirSyncMock.mockImplementation((dir: string) => {
         if (dir.endsWith('.pending-delete')) {
@@ -760,6 +777,7 @@ describe('terminal-history', () => {
       expect(() => runHistoryGc(new Set())).not.toThrow()
       expect(renameSyncMock).toHaveBeenCalledTimes(2)
       expect(rmAsyncMock).toHaveBeenCalledTimes(1)
+      await flushPendingWorktreeHistoryDeletions()
     })
 
     it('skips recently-created directories to avoid TOCTOU race', () => {
@@ -791,14 +809,15 @@ describe('terminal-history', () => {
     it('does not throw when history root does not exist', () => {
       existsSyncMock.mockReturnValue(false)
       expect(() => runHistoryGc(new Set())).not.toThrow()
-      expect(readdirSyncMock).not.toHaveBeenCalled()
+      expect(readdirSyncMock).not.toHaveBeenCalledWith('/fake/userData/terminal-history')
     })
 
     it('drains delete tombstones asynchronously instead of scanning them as worktrees', async () => {
+      let tombstonePresent = true
       existsSyncMock.mockImplementation((p: string) => !String(p).includes('terminal-history-wsl'))
       readdirSyncMock.mockImplementation((dir: string) => {
         if (String(dir).endsWith('.pending-delete')) {
-          return ['abc123.1700000000000.deadbeef']
+          return tombstonePresent ? ['abc123.1700000000000.deadbeef'] : []
         }
         if (String(dir).endsWith('terminal-history')) {
           return ['.pending-delete']
@@ -806,6 +825,9 @@ describe('terminal-history', () => {
         return ['meta.json']
       })
       statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+      rmAsyncMock.mockImplementation(async () => {
+        tombstonePresent = false
+      })
 
       runHistoryGc(new Set())
 

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -273,6 +273,54 @@ describe('terminal-history', () => {
       }
     })
 
+    it('retains every fish path when XDG_DATA_HOME changes', () => {
+      const firstEnv = { XDG_DATA_HOME: ['', 'data', 'one'].join(sep) }
+      const secondEnv = { XDG_DATA_HOME: ['', 'data', 'two'].join(sep) }
+      const worktreeId = 'repo-1::/path/wt'
+      const first = injectHistoryEnv(firstEnv, worktreeId, '/usr/bin/fish', '/path/wt')
+      const firstMeta = writeFileSyncMock.mock.calls.at(-1)?.[1] as string
+      readFileSyncMock.mockReturnValue(firstMeta)
+
+      injectHistoryEnv(secondEnv, worktreeId, '/usr/bin/fish', '/path/wt')
+      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as {
+        fishHistoryPath: string
+        fishHistoryPaths: string[]
+      }
+      const filename = `${first.fishSession}_history`
+
+      expect(meta.fishHistoryPath).toBe(['', 'data', 'one', 'fish', filename].join(sep))
+      expect(meta.fishHistoryPaths).toEqual([
+        ['', 'data', 'one', 'fish', filename].join(sep),
+        ['', 'data', 'two', 'fish', filename].join(sep)
+      ])
+    })
+
+    it('migrates legacy singular fish metadata without replacing its rollback path', () => {
+      const worktreeId = 'repo-1::/path/wt'
+      const session = fishHistorySessionName(hashWorktreeId(worktreeId))
+      const legacyPath = ['', 'legacy', 'fish', `${session}_history`].join(sep)
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({ worktreeId, fishSession: session, fishHistoryPath: legacyPath })
+      )
+
+      injectHistoryEnv(
+        { XDG_DATA_HOME: ['', 'current'].join(sep) },
+        worktreeId,
+        '/usr/bin/fish',
+        '/path/wt'
+      )
+      const meta = JSON.parse(writeFileSyncMock.mock.calls.at(-1)?.[1] as string) as {
+        fishHistoryPath: string
+        fishHistoryPaths: string[]
+      }
+
+      expect(meta.fishHistoryPath).toBe(legacyPath)
+      expect(meta.fishHistoryPaths).toEqual([
+        legacyPath,
+        ['', 'current', 'fish', `${session}_history`].join(sep)
+      ])
+    })
+
     it('gives two fish worktrees different history sessions', () => {
       const envA: Record<string, string> = {}
       injectHistoryEnv(envA, 'repo-1::/path/wt-a', '/usr/bin/fish', '/path/wt-a')
@@ -443,6 +491,45 @@ describe('terminal-history', () => {
       await flushPendingWorktreeHistoryDeletions()
     })
 
+    it('deletes every recorded fish path while isolating individual failures', async () => {
+      const first = ['', 'data', 'one', 'fish', 'orca_abc123_history'].join(sep)
+      const second = ['', 'data', 'two', 'fish', 'orca_abc123_history'].join(sep)
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          worktreeId: 'repo-1::/path/wt',
+          fishSession: 'orca_abc123',
+          fishHistoryPath: first,
+          fishHistoryPaths: [first, second]
+        })
+      )
+      rmSyncMock.mockImplementation((path: string) => {
+        if (path === first) {
+          throw new Error('busy')
+        }
+      })
+
+      expect(() => deleteWorktreeHistoryDir('repo-1::/path/wt')).not.toThrow()
+      expect(rmSyncMock).toHaveBeenCalledWith(first, expect.objectContaining({ force: true }))
+      expect(rmSyncMock).toHaveBeenCalledWith(second, expect.objectContaining({ force: true }))
+      expect(renameSyncMock).toHaveBeenCalled()
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
+    it('runtime-validates malformed fish metadata before the normal tombstone', async () => {
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          worktreeId: 'repo-1::/path/wt',
+          fishSession: 'orca_abc123',
+          fishHistoryPath: 42,
+          fishHistoryPaths: [null, 7, { path: '/tmp/nope' }]
+        })
+      )
+
+      expect(() => deleteWorktreeHistoryDir('repo-1::/path/wt')).not.toThrow()
+      expect(renameSyncMock).toHaveBeenCalled()
+      await flushPendingWorktreeHistoryDeletions()
+    })
+
     it('refuses a recorded path that does not name its own session file', async () => {
       const originalDataHome = process.env.XDG_DATA_HOME
       process.env.XDG_DATA_HOME = ['', 'main', 'data'].join(sep)
@@ -586,6 +673,33 @@ describe('terminal-history', () => {
         expect.stringContaining(`.pending-delete${sep}dir2.`),
         expect.objectContaining({ recursive: true, force: true })
       )
+    })
+
+    it('continues GC after one orphan tombstone fails', () => {
+      existsSyncMock.mockImplementation((path: string) => !path.includes('terminal-history-wsl'))
+      readdirSyncMock.mockImplementation((dir: string) => {
+        if (dir.endsWith('.pending-delete')) {
+          return []
+        }
+        if (dir.endsWith('terminal-history')) {
+          return ['broken', 'healthy']
+        }
+        return ['meta.json']
+      })
+      statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          worktreeId: 'orphan',
+          createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString()
+        })
+      )
+      renameSyncMock.mockImplementationOnce(() => {
+        throw new Error('busy')
+      })
+
+      expect(() => runHistoryGc(new Set())).not.toThrow()
+      expect(renameSyncMock).toHaveBeenCalledTimes(2)
+      expect(rmAsyncMock).toHaveBeenCalledTimes(1)
     })
 
     it('skips recently-created directories to avoid TOCTOU race', () => {

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -1,6 +1,6 @@
 import { join, basename } from 'node:path'
 import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { fishHistorySessionName } from './fish-history-session'
+import { fishHistorySessionName, resolveFishHistoryFilePath } from './fish-history-session'
 import { parseWslPath, toLinuxPath } from './wsl'
 import { getHistoryRoot, getHistoryRootWsl, hashWorktreeId } from './terminal-history-paths'
 
@@ -74,11 +74,20 @@ export function ensureHistoryDir(worktreeHash: string, wslDistro?: string): stri
 /** Write meta.json alongside history files, for debuggability and for GC.
  *  `fishSession` is load-bearing, not diagnostic: fish history lives outside this
  *  directory, so deletion can only find it by the name recorded here. */
-function writeMetaFile(dir: string, worktreeId: string, fishSession?: string): void {
+function writeMetaFile(
+  dir: string,
+  worktreeId: string,
+  fish?: { session: string; historyPath: string | null }
+): void {
   try {
     const metaPath = join(dir, 'meta.json')
     const existing = existsSync(metaPath) ? readHistoryMeta(dir) : null
-    if (existing && (!fishSession || existing.fishSession === fishSession)) {
+    if (
+      existing &&
+      (!fish ||
+        (existing.fishSession === fish.session &&
+          existing.fishHistoryPath === (fish.historyPath ?? undefined)))
+    ) {
       return
     }
     writeFileSync(
@@ -86,7 +95,8 @@ function writeMetaFile(dir: string, worktreeId: string, fishSession?: string): v
       JSON.stringify({
         worktreeId,
         createdAt: existing?.createdAt ?? new Date().toISOString(),
-        ...(fishSession ? { fishSession } : {})
+        ...(fish ? { fishSession: fish.session } : {}),
+        ...(fish?.historyPath ? { fishHistoryPath: fish.historyPath } : {})
       }),
       { mode: 0o600 }
     )
@@ -100,6 +110,8 @@ export type HistoryDirMeta = {
   createdAt?: string
   /** fish session name whose history file lives in the user's fish data dir. */
   fishSession?: string
+  /** That file's path resolved from the PTY's spawn env, which the main process env can contradict. */
+  fishHistoryPath?: string
 }
 
 /** Read one history directory's meta.json, or null when it is absent or unparseable. */
@@ -173,7 +185,12 @@ export function injectHistoryEnv(
     // find the session file fish keeps in its own data dir. fish never runs as the
     // inner WSL shell, so histDir needs no /mnt conversion here.
     const session = fishHistorySessionName(worktreeHash)
-    writeMetaFile(histDir, worktreeId, session)
+    // Resolve from the SPAWN env: that is the XDG_DATA_HOME/HOME fish will see,
+    // which need not match the one this process was launched with.
+    writeMetaFile(histDir, worktreeId, {
+      session,
+      historyPath: resolveFishHistoryFilePath(session, spawnEnv)
+    })
     spawnEnv.fish_history = session
     result.fishSession = session
     result.historyDir = histDir

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -1,5 +1,6 @@
 import { join, basename } from 'node:path'
-import { mkdirSync, existsSync, writeFileSync } from 'node:fs'
+import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { fishHistorySessionName } from './fish-history-session'
 import { parseWslPath, toLinuxPath } from './wsl'
 import { getHistoryRoot, getHistoryRootWsl, hashWorktreeId } from './terminal-history-paths'
 
@@ -33,14 +34,16 @@ export function resolveShellKind(shellPath: string): ShellKind {
   return 'unknown'
 }
 
-/** Map shell kind to the filename used inside the history directory. */
+/** Map shell kind to the filename used inside the history directory.
+ *  fish is absent on purpose: it ignores HISTFILE and keeps history in its own
+ *  data dir keyed by session name (see fish-history-session.ts). */
 function historyFilename(shell: ShellKind): string | null {
   switch (shell) {
     case 'zsh':
       return 'zsh_history'
     case 'bash':
       return 'bash_history'
-    // Phase 2: fish and PowerShell use different mechanisms
+    // Phase 2: PowerShell and cmd use different mechanisms
     case 'fish':
     case 'pwsh':
     case 'powershell':
@@ -68,17 +71,43 @@ export function ensureHistoryDir(worktreeHash: string, wslDistro?: string): stri
   }
 }
 
-/** Write meta.json alongside history files for debuggability. */
-function writeMetaFile(dir: string, worktreeId: string): void {
+/** Write meta.json alongside history files, for debuggability and for GC.
+ *  `fishSession` is load-bearing, not diagnostic: fish history lives outside this
+ *  directory, so deletion can only find it by the name recorded here. */
+function writeMetaFile(dir: string, worktreeId: string, fishSession?: string): void {
   try {
     const metaPath = join(dir, 'meta.json')
-    if (!existsSync(metaPath)) {
-      writeFileSync(metaPath, JSON.stringify({ worktreeId, createdAt: new Date().toISOString() }), {
-        mode: 0o600
-      })
+    const existing = existsSync(metaPath) ? readHistoryMeta(dir) : null
+    if (existing && (!fishSession || existing.fishSession === fishSession)) {
+      return
     }
+    writeFileSync(
+      metaPath,
+      JSON.stringify({
+        worktreeId,
+        createdAt: existing?.createdAt ?? new Date().toISOString(),
+        ...(fishSession ? { fishSession } : {})
+      }),
+      { mode: 0o600 }
+    )
   } catch {
-    // Non-fatal — meta.json is purely for diagnostics.
+    // Non-fatal — a missing meta.json only costs GC attribution.
+  }
+}
+
+export type HistoryDirMeta = {
+  worktreeId?: string
+  createdAt?: string
+  /** fish session name whose history file lives in the user's fish data dir. */
+  fishSession?: string
+}
+
+/** Read one history directory's meta.json, or null when it is absent or unparseable. */
+export function readHistoryMeta(dir: string): HistoryDirMeta | null {
+  try {
+    return JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf-8')) as HistoryDirMeta
+  } catch {
+    return null
   }
 }
 
@@ -87,6 +116,10 @@ function writeMetaFile(dir: string, worktreeId: string): void {
 export type HistoryInjectionResult = {
   shell: ShellKind
   histFile: string | null
+  /** fish session name exported as `fish_history`; null when fish is not the shell. */
+  fishSession: string | null
+  /** Worktree history dir as the spawned shell sees it (Linux-visible under WSL). */
+  historyDir: string | null
 }
 
 /** Build shell-specific history env overrides for a PTY spawn.
@@ -104,17 +137,22 @@ export function injectHistoryEnv(
   options: { wslDistro?: string | null } = {}
 ): HistoryInjectionResult {
   const shell = resolveShellKind(shellPath)
-  const result: HistoryInjectionResult = { shell, histFile: null }
+  const result: HistoryInjectionResult = {
+    shell,
+    histFile: null,
+    fishSession: null,
+    historyDir: null
+  }
 
   const filename = historyFilename(shell)
-  if (!filename) {
-    // Unknown shell or Phase 2 shell (fish, pwsh, cmd) — leave unchanged.
+  if (!filename && shell !== 'fish') {
+    // Unknown shell or Phase 2 shell (pwsh, cmd) — leave unchanged.
     return result
   }
 
-  // Check-before-set: if the caller already provided HISTFILE, preserve it.
-  // This follows the pattern used by Ghostty, Kitty, and VS Code (§6).
-  if (spawnEnv.HISTFILE) {
+  // Check-before-set: if the caller already provided the shell's history knob,
+  // preserve it. Same pattern Ghostty, Kitty, and VS Code use for HISTFILE (§6).
+  if (shell === 'fish' ? spawnEnv.fish_history : spawnEnv.HISTFILE) {
     return result
   }
 
@@ -130,6 +168,18 @@ export function injectHistoryEnv(
     return result
   }
 
+  if (!filename) {
+    // fish: the directory holds no history, only the meta.json that lets deletion
+    // find the session file fish keeps in its own data dir. fish never runs as the
+    // inner WSL shell, so histDir needs no /mnt conversion here.
+    const session = fishHistorySessionName(worktreeHash)
+    writeMetaFile(histDir, worktreeId, session)
+    spawnEnv.fish_history = session
+    result.fishSession = session
+    result.historyDir = histDir
+    return result
+  }
+
   writeMetaFile(histDir, worktreeId)
 
   const histFilePath = join(histDir, filename)
@@ -138,38 +188,39 @@ export function injectHistoryEnv(
   spawnEnv.HISTFILE = wslDistro ? toLinuxPath(histFilePath) : histFilePath
 
   result.histFile = spawnEnv.HISTFILE
+  result.historyDir = spawnEnv.HISTFILE.replace(/[/\\][^/\\]+$/, '')
   return result
 }
 
-/** Update HISTFILE in spawnEnv when shell fallback changes the shell kind.
- *  For example, if zsh fails and bash takes over, the HISTFILE should point
- *  to bash_history instead of zsh_history. */
-export function updateHistFileForFallback(
+/** Re-point the history env when shell fallback changes the shell kind — e.g. zsh
+ *  fails and bash takes over, so HISTFILE must name bash_history. A fish primary
+ *  injected `fish_history` instead, which the fallback shell cannot use. */
+export function updateHistoryEnvForFallback(
   spawnEnv: Record<string, string>,
-  fallbackShellPath: string
+  fallbackShellPath: string,
+  injected: HistoryInjectionResult
 ): void {
-  if (!spawnEnv.HISTFILE) {
+  // Only ever undo what this spawn injected; a caller-supplied value stays.
+  if (injected.fishSession && spawnEnv.fish_history === injected.fishSession) {
+    delete spawnEnv.fish_history
+  }
+  if (!injected.historyDir) {
     return
   }
 
-  const newShell = resolveShellKind(fallbackShellPath)
-  const newFilename = historyFilename(newShell)
+  const newFilename = historyFilename(resolveShellKind(fallbackShellPath))
   if (!newFilename) {
-    // Fallback to an unknown shell — remove HISTFILE override entirely
-    // so the shell uses its own default.
+    // Fallback to an unknown shell — drop the override so it uses its own default.
     delete spawnEnv.HISTFILE
     return
   }
-
-  // Replace the filename portion of the HISTFILE path.
-  const dir = spawnEnv.HISTFILE.replace(/[/\\][^/\\]+$/, '')
-  spawnEnv.HISTFILE = `${dir}/${newFilename}`
+  spawnEnv.HISTFILE = `${injected.historyDir}/${newFilename}`
 }
 
 /** Log the history injection result for diagnostics. */
 export function logHistoryInjection(worktreeId: string, result: HistoryInjectionResult): void {
   const truncatedId = worktreeId.length > 60 ? `${worktreeId.slice(0, 60)}...` : worktreeId
   console.log(
-    `[pty:history] worktreeId=${truncatedId} shell=${result.shell} histFile=${result.histFile ?? 'none'}`
+    `[pty:history] worktreeId=${truncatedId} shell=${result.shell} histFile=${result.histFile ?? 'none'} fishSession=${result.fishSession ?? 'none'}`
   )
 }

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -1,10 +1,19 @@
 import { join, basename } from 'node:path'
-import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { fishHistorySessionName, resolveFishHistoryFilePath } from './fish-history-session'
+import { mkdirSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import {
+  fishHistorySessionName,
+  isSafeFishHistorySession,
+  MAX_FISH_HISTORY_META_BYTES,
+  normalizeFishHistoryPaths,
+  resolveFishHistoryFilePath
+} from './fish-history-session'
 import { parseWslPath, toLinuxPath } from './wsl'
-import { getHistoryRoot, getHistoryRootWsl, hashWorktreeId } from './terminal-history-paths'
+import { getHistoryRoot, getHistoryRootWsl } from './terminal-history-paths'
+import { hashWorktreeId } from './terminal-history-id'
 
 type ShellKind = 'zsh' | 'bash' | 'fish' | 'pwsh' | 'powershell' | 'cmd' | 'unknown'
+
+export const MAX_HISTORY_META_BYTES = MAX_FISH_HISTORY_META_BYTES
 
 // ─── Shell Detection ───────────────────────────────────────────────
 
@@ -83,20 +92,25 @@ function writeMetaFile(
     const metaPath = join(dir, 'meta.json')
     const existing = existsSync(metaPath) ? readHistoryMeta(dir) : null
     const sameFishSession = existing?.fishSession === fish?.session
-    const existingFishPaths = sameFishSession
-      ? [existing?.fishHistoryPath, ...(existing?.fishHistoryPaths ?? [])].filter(
-          (path): path is string => typeof path === 'string'
-        )
-      : []
-    const fishHistoryPaths = fish?.historyPath
-      ? [...new Set([...existingFishPaths, fish.historyPath])]
+    const existingFishPaths =
+      sameFishSession && fish
+        ? normalizeFishHistoryPaths(
+            fish.session,
+            existing?.fishHistoryPath,
+            existing?.fishHistoryPaths
+          )
+        : []
+    const fishHistoryPaths = fish
+      ? normalizeFishHistoryPaths(fish.session, undefined, [...existingFishPaths, fish.historyPath])
       : existingFishPaths
     if (
       existing &&
+      !existing.fishHistoryMetadataNeedsRewrite &&
       (!fish ||
         (sameFishSession &&
           (!fish.historyPath ||
-            (existing.fishHistoryPath && existingFishPaths.includes(fish.historyPath)))))
+            (existing.fishHistoryPath === fish.historyPath &&
+              existingFishPaths.at(-1) === fish.historyPath))))
     ) {
       return
     }
@@ -106,8 +120,8 @@ function writeMetaFile(
         worktreeId,
         createdAt: existing?.createdAt ?? new Date().toISOString(),
         ...(fish ? { fishSession: fish.session } : {}),
-        // Why: retain the oldest singular path so a rollback still deletes pre-upgrade history.
-        ...(fishHistoryPaths[0] ? { fishHistoryPath: fishHistoryPaths[0] } : {}),
+        // Why: old builds read only the singular field, so it must identify the active path.
+        ...(fishHistoryPaths.at(-1) ? { fishHistoryPath: fishHistoryPaths.at(-1) } : {}),
         ...(fishHistoryPaths.length > 0 ? { fishHistoryPaths } : {})
       }),
       { mode: 0o600 }
@@ -124,29 +138,52 @@ export type HistoryDirMeta = {
   fishSession?: string
   /** That file's path resolved from the PTY's spawn env, which the main process env can contradict. */
   fishHistoryPath?: string
-  /** Every path this session used as XDG_DATA_HOME changed across launches. */
+  /** Most-recent paths this session used as XDG_DATA_HOME changed across launches. */
   fishHistoryPaths?: string[]
+  /** In-memory migration signal; never persisted. */
+  fishHistoryMetadataNeedsRewrite?: true
 }
 
 /** Read one history directory's meta.json, or null when it is absent or unparseable. */
 export function readHistoryMeta(dir: string): HistoryDirMeta | null {
   try {
-    const raw: unknown = JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf-8'))
+    const metaPath = join(dir, 'meta.json')
+    if (statSync(metaPath).size > MAX_HISTORY_META_BYTES) {
+      return null
+    }
+    const raw: unknown = JSON.parse(readFileSync(metaPath, 'utf-8'))
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
       return null
     }
     const record = raw as Record<string, unknown>
-    const fishHistoryPaths = Array.isArray(record.fishHistoryPaths)
-      ? record.fishHistoryPaths.filter((path): path is string => typeof path === 'string')
-      : undefined
+    const expectedFishSession = fishHistorySessionName(basename(dir).split('.')[0])
+    const fishSession =
+      isSafeFishHistorySession(record.fishSession) && record.fishSession === expectedFishSession
+        ? record.fishSession
+        : undefined
+    const fishHistoryPaths = fishSession
+      ? normalizeFishHistoryPaths(
+          fishSession,
+          record.fishHistoryPath,
+          Array.isArray(record.fishHistoryPaths) ? record.fishHistoryPaths : undefined
+        )
+      : []
+    const rawFishPaths = Array.isArray(record.fishHistoryPaths) ? record.fishHistoryPaths : []
+    const canonicalFishPath = fishHistoryPaths.at(-1)
+    const fishHistoryMetadataNeedsRewrite = Boolean(
+      record.fishSession !== undefined &&
+      (!fishSession ||
+        record.fishHistoryPath !== canonicalFishPath ||
+        rawFishPaths.length !== fishHistoryPaths.length ||
+        rawFishPaths.some((path, index) => path !== fishHistoryPaths[index]))
+    )
     return {
       ...(typeof record.worktreeId === 'string' ? { worktreeId: record.worktreeId } : {}),
       ...(typeof record.createdAt === 'string' ? { createdAt: record.createdAt } : {}),
-      ...(typeof record.fishSession === 'string' ? { fishSession: record.fishSession } : {}),
-      ...(typeof record.fishHistoryPath === 'string'
-        ? { fishHistoryPath: record.fishHistoryPath }
-        : {}),
-      ...(fishHistoryPaths && fishHistoryPaths.length > 0 ? { fishHistoryPaths } : {})
+      ...(fishSession ? { fishSession } : {}),
+      ...(fishHistoryPaths.at(-1) ? { fishHistoryPath: fishHistoryPaths.at(-1) } : {}),
+      ...(fishHistoryPaths.length > 0 ? { fishHistoryPaths } : {}),
+      ...(fishHistoryMetadataNeedsRewrite ? { fishHistoryMetadataNeedsRewrite: true } : {})
     }
   } catch {
     return null
@@ -237,6 +274,26 @@ export function injectHistoryEnv(
   result.histFile = spawnEnv.HISTFILE
   result.historyDir = spawnEnv.HISTFILE.replace(/[/\\][^/\\]+$/, '')
   return result
+}
+
+/** WSL's outer executable hides the login shell, so carry both history knobs. */
+export function injectWslFishHistoryEnv(
+  spawnEnv: Record<string, string>,
+  worktreeId: string,
+  wslDistro: string
+): string | null {
+  if (spawnEnv.fish_history) {
+    return null
+  }
+  const worktreeHash = hashWorktreeId(worktreeId)
+  const historyDir = ensureHistoryDir(worktreeHash, wslDistro)
+  if (!historyDir) {
+    return null
+  }
+  const session = fishHistorySessionName(worktreeHash)
+  writeMetaFile(historyDir, worktreeId, { session, historyPath: null })
+  spawnEnv.fish_history = session
+  return session
 }
 
 /** Re-point the history env when shell fallback changes the shell kind — e.g. zsh

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -1,6 +1,8 @@
 import { join, basename } from 'node:path'
 import { mkdirSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import {
+  attestFishHistoryLocation,
+  FISH_HISTORY_LOCATION_ATTESTATION,
   fishHistorySessionName,
   isSafeFishHistorySession,
   MAX_FISH_HISTORY_META_BYTES,
@@ -103,6 +105,13 @@ function writeMetaFile(
     const fishHistoryPaths = fish
       ? normalizeFishHistoryPaths(fish.session, undefined, [...existingFishPaths, fish.historyPath])
       : existingFishPaths
+    if (fish) {
+      attestFishHistoryLocation(
+        join(dir, FISH_HISTORY_LOCATION_ATTESTATION),
+        fish.session,
+        fish.historyPath
+      )
+    }
     if (
       existing &&
       !existing.fishHistoryMetadataNeedsRewrite &&
@@ -136,9 +145,9 @@ export type HistoryDirMeta = {
   createdAt?: string
   /** fish session name whose history file lives in the user's fish data dir. */
   fishSession?: string
-  /** That file's path resolved from the PTY's spawn env, which the main process env can contradict. */
+  /** Legacy/rollback path hint; deletion requires the separate identity attestation. */
   fishHistoryPath?: string
-  /** Most-recent paths this session used as XDG_DATA_HOME changed across launches. */
+  /** Bounded legacy/rollback path hints across XDG_DATA_HOME changes. */
   fishHistoryPaths?: string[]
   /** In-memory migration signal; never persisted. */
   fishHistoryMetadataNeedsRewrite?: true

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -82,11 +82,21 @@ function writeMetaFile(
   try {
     const metaPath = join(dir, 'meta.json')
     const existing = existsSync(metaPath) ? readHistoryMeta(dir) : null
+    const sameFishSession = existing?.fishSession === fish?.session
+    const existingFishPaths = sameFishSession
+      ? [existing?.fishHistoryPath, ...(existing?.fishHistoryPaths ?? [])].filter(
+          (path): path is string => typeof path === 'string'
+        )
+      : []
+    const fishHistoryPaths = fish?.historyPath
+      ? [...new Set([...existingFishPaths, fish.historyPath])]
+      : existingFishPaths
     if (
       existing &&
       (!fish ||
-        (existing.fishSession === fish.session &&
-          existing.fishHistoryPath === (fish.historyPath ?? undefined)))
+        (sameFishSession &&
+          (!fish.historyPath ||
+            (existing.fishHistoryPath && existingFishPaths.includes(fish.historyPath)))))
     ) {
       return
     }
@@ -96,7 +106,9 @@ function writeMetaFile(
         worktreeId,
         createdAt: existing?.createdAt ?? new Date().toISOString(),
         ...(fish ? { fishSession: fish.session } : {}),
-        ...(fish?.historyPath ? { fishHistoryPath: fish.historyPath } : {})
+        // Why: retain the oldest singular path so a rollback still deletes pre-upgrade history.
+        ...(fishHistoryPaths[0] ? { fishHistoryPath: fishHistoryPaths[0] } : {}),
+        ...(fishHistoryPaths.length > 0 ? { fishHistoryPaths } : {})
       }),
       { mode: 0o600 }
     )
@@ -112,12 +124,30 @@ export type HistoryDirMeta = {
   fishSession?: string
   /** That file's path resolved from the PTY's spawn env, which the main process env can contradict. */
   fishHistoryPath?: string
+  /** Every path this session used as XDG_DATA_HOME changed across launches. */
+  fishHistoryPaths?: string[]
 }
 
 /** Read one history directory's meta.json, or null when it is absent or unparseable. */
 export function readHistoryMeta(dir: string): HistoryDirMeta | null {
   try {
-    return JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf-8')) as HistoryDirMeta
+    const raw: unknown = JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf-8'))
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return null
+    }
+    const record = raw as Record<string, unknown>
+    const fishHistoryPaths = Array.isArray(record.fishHistoryPaths)
+      ? record.fishHistoryPaths.filter((path): path is string => typeof path === 'string')
+      : undefined
+    return {
+      ...(typeof record.worktreeId === 'string' ? { worktreeId: record.worktreeId } : {}),
+      ...(typeof record.createdAt === 'string' ? { createdAt: record.createdAt } : {}),
+      ...(typeof record.fishSession === 'string' ? { fishSession: record.fishSession } : {}),
+      ...(typeof record.fishHistoryPath === 'string'
+        ? { fishHistoryPath: record.fishHistoryPath }
+        : {}),
+      ...(fishHistoryPaths && fishHistoryPaths.length > 0 ? { fishHistoryPaths } : {})
+    }
   } catch {
     return null
   }

--- a/src/main/wsl-fish-history-cleanup.test.ts
+++ b/src/main/wsl-fish-history-cleanup.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from 'vitest'
-import { deleteWslFishHistoryFile } from './wsl-fish-history-cleanup'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { deleteWslFishHistoryFile, flushWslFishHistoryCleanups } from './wsl-fish-history-cleanup'
+
+afterEach(async () => {
+  await flushWslFishHistoryCleanups()
+})
 
 describe('deleteWslFishHistoryFile', () => {
   it('uses direct argv and bounds a distro cleanup subprocess', async () => {
@@ -29,19 +33,52 @@ describe('deleteWslFishHistoryFile', () => {
     expect(run).not.toHaveBeenCalled()
   })
 
-  it('serializes cleanup subprocesses across a startup tombstone batch', async () => {
-    let releaseFirst: (() => void) | undefined
-    const first = new Promise<{ stdout: string; stderr: string }>((resolve) => {
-      releaseFirst = () => resolve({ stdout: '', stderr: '' })
-    })
-    const run = vi.fn().mockReturnValueOnce(first).mockResolvedValueOnce({ stdout: '', stderr: '' })
+  it('runs cleanup subprocesses concurrently within the fixed budget', async () => {
+    const releases: (() => void)[] = []
+    const run = vi.fn(() => {
+      return new Promise<{ stdout: string; stderr: string }>((resolve) => {
+        releases.push(() => resolve({ stdout: '', stderr: '' }))
+      })
+    }) as unknown as Parameters<typeof deleteWslFishHistoryFile>[2]
+    const cleanups = Array.from({ length: 5 }, (_, index) =>
+      deleteWslFishHistoryFile('Ubuntu', `orca_${(index + 1).toString(16)}`, run)
+    )
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(4))
+    expect(releases).toHaveLength(4)
+    releases[0]()
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(5))
+    expect(releases).toHaveLength(5)
+    releases.slice(1).forEach((release) => release())
+    await Promise.all(cleanups)
+  })
 
-    const cleanupA = deleteWslFishHistoryFile('Ubuntu', 'orca_aaaaaaaaaaaaaaaa', run)
-    const cleanupB = deleteWslFishHistoryFile('Debian', 'orca_bbbbbbbbbbbbbbbb', run)
-    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1))
-    releaseFirst?.()
-    await Promise.all([cleanupA, cleanupB])
+  it('coalesces duplicate requests and bounds adversarial startup fanout', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    const duplicateA = deleteWslFishHistoryFile('Ubuntu', 'orca_aaaaaaaaaaaaaaaa', run)
+    const duplicateB = deleteWslFishHistoryFile('Ubuntu', 'orca_aaaaaaaaaaaaaaaa', run)
+    expect(duplicateB).toBe(duplicateA)
 
+    const requests = Array.from({ length: 1_000 }, (_, index) =>
+      deleteWslFishHistoryFile('Ubuntu', `orca_${index.toString(16)}`, run)
+    )
+    await Promise.allSettled([duplicateA, ...requests])
+
+    // Four live workers and 64 bounded queue slots; excess work remains durable on disk.
+    expect(run).toHaveBeenCalledTimes(68)
+  })
+
+  it('permits a failed cleanup to be retried after the live attempt settles', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('wsl unavailable'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(deleteWslFishHistoryFile('Ubuntu', 'orca_aaaaaaaaaaaaaaaa', run)).rejects.toThrow(
+      'wsl unavailable'
+    )
+    await expect(
+      deleteWslFishHistoryFile('Ubuntu', 'orca_aaaaaaaaaaaaaaaa', run)
+    ).resolves.toBeUndefined()
     expect(run).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/wsl-fish-history-cleanup.test.ts
+++ b/src/main/wsl-fish-history-cleanup.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { deleteWslFishHistoryFile } from './wsl-fish-history-cleanup'
+
+describe('deleteWslFishHistoryFile', () => {
+  it('uses direct argv and bounds a distro cleanup subprocess', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+
+    await deleteWslFishHistoryFile('Ubuntu Test', 'orca_0123456789abcdef', run)
+
+    expect(run).toHaveBeenCalledWith(
+      'wsl.exe',
+      [
+        '--distribution',
+        'Ubuntu Test',
+        '--exec',
+        'fish',
+        '--command',
+        expect.stringContaining('orca_0123456789abcdef_history')
+      ],
+      { timeout: 5_000, windowsHide: true }
+    )
+  })
+
+  it('rejects an unsafe session before spawning', async () => {
+    const run = vi.fn()
+
+    await deleteWslFishHistoryFile('Ubuntu', '../../user-history', run)
+
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('serializes cleanup subprocesses across a startup tombstone batch', async () => {
+    let releaseFirst: (() => void) | undefined
+    const first = new Promise<{ stdout: string; stderr: string }>((resolve) => {
+      releaseFirst = () => resolve({ stdout: '', stderr: '' })
+    })
+    const run = vi.fn().mockReturnValueOnce(first).mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    const cleanupA = deleteWslFishHistoryFile('Ubuntu', 'orca_aaaaaaaaaaaaaaaa', run)
+    const cleanupB = deleteWslFishHistoryFile('Debian', 'orca_bbbbbbbbbbbbbbbb', run)
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1))
+    releaseFirst?.()
+    await Promise.all([cleanupA, cleanupB])
+
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/wsl-fish-history-cleanup.ts
+++ b/src/main/wsl-fish-history-cleanup.ts
@@ -3,7 +3,63 @@ import { promisify } from 'node:util'
 import { isSafeFishHistorySession } from './fish-history-session'
 
 const execFileAsync = promisify(execFile)
-let cleanupTail = Promise.resolve()
+const MAX_CONCURRENT_CLEANUPS = 4
+const MAX_QUEUED_CLEANUPS = 64
+type CleanupJob = {
+  key: string
+  distro: string
+  session: string
+  run: typeof execFileAsync
+  resolve: () => void
+  reject: (error: unknown) => void
+}
+
+let activeCleanups = 0
+const queuedCleanups: CleanupJob[] = []
+const cleanupPromises = new Map<string, Promise<void>>()
+
+function pumpCleanupQueue(): void {
+  while (activeCleanups < MAX_CONCURRENT_CLEANUPS && queuedCleanups.length > 0) {
+    const job = queuedCleanups.shift()
+    if (!job) {
+      return
+    }
+    activeCleanups++
+    void job
+      .run(
+        'wsl.exe',
+        [
+          '--distribution',
+          job.distro,
+          '--exec',
+          'fish',
+          '--command',
+          fishCleanupScript(job.session)
+        ],
+        {
+          timeout: 5_000,
+          windowsHide: true
+        }
+      )
+      .then(
+        () => job.resolve(),
+        (error: unknown) => job.reject(error)
+      )
+      .finally(() => {
+        activeCleanups--
+        cleanupPromises.delete(job.key)
+        pumpCleanupQueue()
+      })
+  }
+}
+
+function fishCleanupScript(session: string): string {
+  return [
+    'set -l data_home $XDG_DATA_HOME',
+    'string match -qr "^/" -- $data_home; or set data_home "$HOME/.local/share"',
+    `command rm -f -- "$data_home/fish/${session}_history"`
+  ].join('; ')
+}
 
 export function deleteWslFishHistoryFile(
   distro: string,
@@ -13,18 +69,29 @@ export function deleteWslFishHistoryFile(
   if (!distro.trim() || !isSafeFishHistorySession(session)) {
     return Promise.resolve()
   }
-  const script = [
-    'set -l data_home $XDG_DATA_HOME',
-    'string match -qr "^/" -- $data_home; or set data_home "$HOME/.local/share"',
-    `command rm -f -- "$data_home/fish/${session}_history"`
-  ].join('; ')
-  // Why: startup may discover many durable tombstones, but wsl.exe cleanup fanout must stay at one.
-  const cleanup = cleanupTail.then(async () => {
-    await run('wsl.exe', ['--distribution', distro, '--exec', 'fish', '--command', script], {
-      timeout: 5_000,
-      windowsHide: true
-    })
+  const key = `${distro}\0${session}`
+  const existing = cleanupPromises.get(key)
+  if (existing) {
+    return existing
+  }
+  if (queuedCleanups.length >= MAX_QUEUED_CLEANUPS) {
+    return Promise.reject(new Error('WSL Fish history cleanup queue is full'))
+  }
+  let resolve!: () => void
+  let reject!: (error: unknown) => void
+  const cleanup = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
   })
-  cleanupTail = cleanup.catch(() => undefined)
+  cleanupPromises.set(key, cleanup)
+  queuedCleanups.push({ key, distro, session, run, resolve, reject })
+  pumpCleanupQueue()
   return cleanup
+}
+
+/** Drain queued and active cleanups; intended for deterministic shutdown/test cleanup. */
+export async function flushWslFishHistoryCleanups(): Promise<void> {
+  while (queuedCleanups.length > 0 || activeCleanups > 0) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
 }

--- a/src/main/wsl-fish-history-cleanup.ts
+++ b/src/main/wsl-fish-history-cleanup.ts
@@ -1,0 +1,30 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { isSafeFishHistorySession } from './fish-history-session'
+
+const execFileAsync = promisify(execFile)
+let cleanupTail = Promise.resolve()
+
+export function deleteWslFishHistoryFile(
+  distro: string,
+  session: string,
+  run: typeof execFileAsync = execFileAsync
+): Promise<void> {
+  if (!distro.trim() || !isSafeFishHistorySession(session)) {
+    return Promise.resolve()
+  }
+  const script = [
+    'set -l data_home $XDG_DATA_HOME',
+    'string match -qr "^/" -- $data_home; or set data_home "$HOME/.local/share"',
+    `command rm -f -- "$data_home/fish/${session}_history"`
+  ].join('; ')
+  // Why: startup may discover many durable tombstones, but wsl.exe cleanup fanout must stay at one.
+  const cleanup = cleanupTail.then(async () => {
+    await run('wsl.exe', ['--distribution', distro, '--exec', 'fish', '--command', script], {
+      timeout: 5_000,
+      windowsHide: true
+    })
+  })
+  cleanupTail = cleanup.catch(() => undefined)
+  return cleanup
+}

--- a/src/relay/fish-history-metadata.test.ts
+++ b/src/relay/fish-history-metadata.test.ts
@@ -73,7 +73,7 @@ describe('relay Fish history metadata', () => {
     ])
   })
 
-  it('deletes recorded XDG paths and its bounded metadata', () => {
+  it('removes metadata without unlinking an unverified history pathname', () => {
     const metadataRoot = join(root, 'metadata')
     const historyFile = join(dataRoot, 'fish', `${session}_history`)
     mkdirSync(join(dataRoot, 'fish'), { recursive: true })
@@ -83,7 +83,8 @@ describe('relay Fish history metadata', () => {
     deleteRelayFishHistory(worktreeId, metadataRoot)
     deleteRelayFishHistory(worktreeId, metadataRoot)
 
-    expect(existsSync(historyFile)).toBe(false)
+    expect(existsSync(historyFile)).toBe(true)
+    expect(readFileSync(historyFile, 'utf8')).toBe('secret')
     expect(existsSync(join(metadataRoot, `${hash}.json`))).toBe(false)
   })
 })

--- a/src/relay/fish-history-metadata.test.ts
+++ b/src/relay/fish-history-metadata.test.ts
@@ -1,0 +1,79 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  fishHistorySessionName,
+  MAX_RETAINED_FISH_HISTORY_PATHS
+} from '../main/fish-history-session'
+import { hashWorktreeId } from '../main/terminal-history-id'
+import { deleteRelayFishHistory, recordRelayFishHistoryPath } from './fish-history-metadata'
+
+describe('relay Fish history metadata', () => {
+  let root: string
+  let dataRoot: string
+  const worktreeId = 'repo-1::/remote/wt'
+  const hash = hashWorktreeId(worktreeId)
+  const session = fishHistorySessionName(hash)
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-relay-fish-meta-'))
+    dataRoot = join(root, 'data')
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('retains only the latest distinct paths and preserves the active path', () => {
+    const metadataRoot = join(root, 'metadata')
+    for (let index = 0; index < 40; index += 1) {
+      recordRelayFishHistoryPath(
+        worktreeId,
+        { XDG_DATA_HOME: join(dataRoot, String(index)) },
+        metadataRoot
+      )
+    }
+    recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: join(dataRoot, '39') }, metadataRoot)
+
+    const meta = JSON.parse(readFileSync(join(metadataRoot, `${hash}.json`), 'utf8')) as {
+      fishHistoryPath: string
+      fishHistoryPaths: string[]
+    }
+    expect(meta.fishHistoryPaths).toHaveLength(MAX_RETAINED_FISH_HISTORY_PATHS)
+    expect(new Set(meta.fishHistoryPaths).size).toBe(MAX_RETAINED_FISH_HISTORY_PATHS)
+    expect(meta.fishHistoryPath).toBe(join(dataRoot, '39', 'fish', `${session}_history`))
+    expect(meta.fishHistoryPaths.at(-1)).toBe(meta.fishHistoryPath)
+  })
+
+  it('replaces malformed metadata without retaining an unrelated path', () => {
+    const metadataRoot = join(root, 'metadata')
+    mkdirSync(metadataRoot, { recursive: true })
+    const unrelated = join(dataRoot, 'fish', 'fish_history')
+    writeFileSync(
+      join(metadataRoot, `${hash}.json`),
+      JSON.stringify({ fishSession: session, fishHistoryPaths: [unrelated, null] })
+    )
+
+    recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: dataRoot }, metadataRoot)
+
+    const meta = JSON.parse(readFileSync(join(metadataRoot, `${hash}.json`), 'utf8')) as {
+      fishHistoryPaths: string[]
+    }
+    expect(meta.fishHistoryPaths).toEqual([join(dataRoot, 'fish', `${session}_history`)])
+  })
+
+  it('deletes recorded XDG paths and its bounded metadata', () => {
+    const metadataRoot = join(root, 'metadata')
+    const historyFile = join(dataRoot, 'fish', `${session}_history`)
+    mkdirSync(join(dataRoot, 'fish'), { recursive: true })
+    writeFileSync(historyFile, 'secret')
+    recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: dataRoot }, metadataRoot)
+
+    deleteRelayFishHistory(worktreeId, metadataRoot, { XDG_DATA_HOME: dataRoot })
+
+    expect(existsSync(historyFile)).toBe(false)
+    expect(existsSync(join(metadataRoot, `${hash}.json`))).toBe(false)
+  })
+})

--- a/src/relay/fish-history-metadata.test.ts
+++ b/src/relay/fish-history-metadata.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   realpathSync,
+  renameSync,
   writeFileSync
 } from 'node:fs'
 import { rm } from 'node:fs/promises'
@@ -76,9 +77,12 @@ describe('relay Fish history metadata', () => {
   it('removes metadata without unlinking an unverified history pathname', () => {
     const metadataRoot = join(root, 'metadata')
     const historyFile = join(dataRoot, 'fish', `${session}_history`)
+    const replacementFile = join(dataRoot, 'fish', `${session}_history-replacement`)
     mkdirSync(join(dataRoot, 'fish'), { recursive: true })
-    writeFileSync(historyFile, 'secret')
+    writeFileSync(historyFile, 'attested')
     recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: dataRoot }, metadataRoot)
+    writeFileSync(replacementFile, 'secret')
+    renameSync(replacementFile, historyFile)
 
     deleteRelayFishHistory(worktreeId, metadataRoot)
     deleteRelayFishHistory(worktreeId, metadataRoot)

--- a/src/relay/fish-history-metadata.test.ts
+++ b/src/relay/fish-history-metadata.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync
+} from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -18,7 +25,7 @@ describe('relay Fish history metadata', () => {
   const session = fishHistorySessionName(hash)
 
   beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), 'orca-relay-fish-meta-'))
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'orca-relay-fish-meta-')))
     dataRoot = join(root, 'data')
   })
 
@@ -38,13 +45,13 @@ describe('relay Fish history metadata', () => {
     recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: join(dataRoot, '39') }, metadataRoot)
 
     const meta = JSON.parse(readFileSync(join(metadataRoot, `${hash}.json`), 'utf8')) as {
-      fishHistoryPath: string
-      fishHistoryPaths: string[]
+      locations: { path: string }[]
     }
-    expect(meta.fishHistoryPaths).toHaveLength(MAX_RETAINED_FISH_HISTORY_PATHS)
-    expect(new Set(meta.fishHistoryPaths).size).toBe(MAX_RETAINED_FISH_HISTORY_PATHS)
-    expect(meta.fishHistoryPath).toBe(join(dataRoot, '39', 'fish', `${session}_history`))
-    expect(meta.fishHistoryPaths.at(-1)).toBe(meta.fishHistoryPath)
+    expect(meta.locations).toHaveLength(MAX_RETAINED_FISH_HISTORY_PATHS)
+    expect(new Set(meta.locations.map((location) => location.path)).size).toBe(
+      MAX_RETAINED_FISH_HISTORY_PATHS
+    )
+    expect(meta.locations.at(-1)?.path).toBe(join(dataRoot, '39', 'fish', `${session}_history`))
   })
 
   it('replaces malformed metadata without retaining an unrelated path', () => {
@@ -59,9 +66,11 @@ describe('relay Fish history metadata', () => {
     recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: dataRoot }, metadataRoot)
 
     const meta = JSON.parse(readFileSync(join(metadataRoot, `${hash}.json`), 'utf8')) as {
-      fishHistoryPaths: string[]
+      locations: { path: string }[]
     }
-    expect(meta.fishHistoryPaths).toEqual([join(dataRoot, 'fish', `${session}_history`)])
+    expect(meta.locations.map((location) => location.path)).toEqual([
+      join(dataRoot, 'fish', `${session}_history`)
+    ])
   })
 
   it('deletes recorded XDG paths and its bounded metadata', () => {
@@ -71,7 +80,8 @@ describe('relay Fish history metadata', () => {
     writeFileSync(historyFile, 'secret')
     recordRelayFishHistoryPath(worktreeId, { XDG_DATA_HOME: dataRoot }, metadataRoot)
 
-    deleteRelayFishHistory(worktreeId, metadataRoot, { XDG_DATA_HOME: dataRoot })
+    deleteRelayFishHistory(worktreeId, metadataRoot)
+    deleteRelayFishHistory(worktreeId, metadataRoot)
 
     expect(existsSync(historyFile)).toBe(false)
     expect(existsSync(join(metadataRoot, `${hash}.json`))).toBe(false)

--- a/src/relay/fish-history-metadata.ts
+++ b/src/relay/fish-history-metadata.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import {
+  deleteFishHistoryFile,
+  fishHistorySessionName,
+  MAX_FISH_HISTORY_META_BYTES,
+  normalizeFishHistoryPaths,
+  resolveFishHistoryFilePath
+} from '../main/fish-history-session'
+import { hashWorktreeId } from '../main/terminal-history-id'
+
+function metadataRoot(): string {
+  return join(homedir(), '.orca-remote', 'fish-history')
+}
+
+function metadataPath(worktreeId: string, root: string): string {
+  return join(root, `${hashWorktreeId(worktreeId)}.json`)
+}
+
+function readPaths(worktreeId: string, root: string): string[] {
+  try {
+    const file = metadataPath(worktreeId, root)
+    if (statSync(file).size > MAX_FISH_HISTORY_META_BYTES) {
+      return []
+    }
+    const raw: unknown = JSON.parse(readFileSync(file, 'utf8'))
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return []
+    }
+    const record = raw as Record<string, unknown>
+    const session = fishHistorySessionName(hashWorktreeId(worktreeId))
+    if (record.fishSession !== session) {
+      return []
+    }
+    return normalizeFishHistoryPaths(
+      session,
+      record.fishHistoryPath,
+      Array.isArray(record.fishHistoryPaths) ? record.fishHistoryPaths : undefined
+    )
+  } catch {
+    return []
+  }
+}
+
+export function recordRelayFishHistoryPath(
+  worktreeId: string,
+  env: NodeJS.ProcessEnv,
+  root = metadataRoot()
+): void {
+  const session = fishHistorySessionName(hashWorktreeId(worktreeId))
+  const activePath = resolveFishHistoryFilePath(session, env)
+  if (!activePath) {
+    return
+  }
+  try {
+    const paths = normalizeFishHistoryPaths(session, undefined, [
+      ...readPaths(worktreeId, root),
+      activePath
+    ])
+    mkdirSync(root, { recursive: true, mode: 0o700 })
+    writeFileSync(
+      metadataPath(worktreeId, root),
+      JSON.stringify({
+        fishSession: session,
+        fishHistoryPath: activePath,
+        fishHistoryPaths: paths
+      }),
+      { mode: 0o600 }
+    )
+  } catch (error) {
+    console.warn(
+      `[pty:history] Failed to record relay fish history: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+export function deleteRelayFishHistory(
+  worktreeId: string,
+  root = metadataRoot(),
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  const session = fishHistorySessionName(hashWorktreeId(worktreeId))
+  deleteFishHistoryFile(session, { recordedPaths: readPaths(worktreeId, root), env })
+  try {
+    rmSync(metadataPath(worktreeId, root), { force: true })
+  } catch (error) {
+    console.warn(
+      `[pty:history] Failed to delete relay fish metadata: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}

--- a/src/relay/fish-history-metadata.ts
+++ b/src/relay/fish-history-metadata.ts
@@ -1,11 +1,10 @@
-import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { rmSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import {
+  attestFishHistoryLocation,
   deleteFishHistoryFile,
   fishHistorySessionName,
-  MAX_FISH_HISTORY_META_BYTES,
-  normalizeFishHistoryPaths,
   resolveFishHistoryFilePath
 } from '../main/fish-history-session'
 import { hashWorktreeId } from '../main/terminal-history-id'
@@ -18,31 +17,6 @@ function metadataPath(worktreeId: string, root: string): string {
   return join(root, `${hashWorktreeId(worktreeId)}.json`)
 }
 
-function readPaths(worktreeId: string, root: string): string[] {
-  try {
-    const file = metadataPath(worktreeId, root)
-    if (statSync(file).size > MAX_FISH_HISTORY_META_BYTES) {
-      return []
-    }
-    const raw: unknown = JSON.parse(readFileSync(file, 'utf8'))
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-      return []
-    }
-    const record = raw as Record<string, unknown>
-    const session = fishHistorySessionName(hashWorktreeId(worktreeId))
-    if (record.fishSession !== session) {
-      return []
-    }
-    return normalizeFishHistoryPaths(
-      session,
-      record.fishHistoryPath,
-      Array.isArray(record.fishHistoryPaths) ? record.fishHistoryPaths : undefined
-    )
-  } catch {
-    return []
-  }
-}
-
 export function recordRelayFishHistoryPath(
   worktreeId: string,
   env: NodeJS.ProcessEnv,
@@ -53,35 +27,12 @@ export function recordRelayFishHistoryPath(
   if (!activePath) {
     return
   }
-  try {
-    const paths = normalizeFishHistoryPaths(session, undefined, [
-      ...readPaths(worktreeId, root),
-      activePath
-    ])
-    mkdirSync(root, { recursive: true, mode: 0o700 })
-    writeFileSync(
-      metadataPath(worktreeId, root),
-      JSON.stringify({
-        fishSession: session,
-        fishHistoryPath: activePath,
-        fishHistoryPaths: paths
-      }),
-      { mode: 0o600 }
-    )
-  } catch (error) {
-    console.warn(
-      `[pty:history] Failed to record relay fish history: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
+  attestFishHistoryLocation(metadataPath(worktreeId, root), session, activePath)
 }
 
-export function deleteRelayFishHistory(
-  worktreeId: string,
-  root = metadataRoot(),
-  env: NodeJS.ProcessEnv = process.env
-): void {
+export function deleteRelayFishHistory(worktreeId: string, root = metadataRoot()): void {
   const session = fishHistorySessionName(hashWorktreeId(worktreeId))
-  deleteFishHistoryFile(session, { recordedPaths: readPaths(worktreeId, root), env })
+  deleteFishHistoryFile(session, metadataPath(worktreeId, root))
   try {
     rmSync(metadataPath(worktreeId, root), { force: true })
   } catch (error) {

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -17,6 +17,14 @@ import {
   type RelayDispatcher
 } from './git-handler-test-setup'
 
+const { deleteRelayFishHistoryMock } = vi.hoisted(() => ({
+  deleteRelayFishHistoryMock: vi.fn()
+}))
+
+vi.mock('./fish-history-metadata', () => ({
+  deleteRelayFishHistory: deleteRelayFishHistoryMock
+}))
+
 type GitBufferSpyTarget = {
   gitBuffer(args: string[], cwd: string): Promise<Buffer>
 }
@@ -62,6 +70,7 @@ describe('GitHandler', () => {
     dispatcher = createMockDispatcher()
     const ctx = new RelayContext()
     handler = new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
+    deleteRelayFishHistoryMock.mockReset()
   })
 
   afterEach(async () => {
@@ -153,6 +162,28 @@ describe('GitHandler', () => {
       dispatcher.callRequest('git.removeWorktree', { worktreePath: '/repo-feature' })
     ).rejects.toBe(removalError)
     expect(runWithRemovalFence).toHaveBeenCalledWith('/repo-feature', expect.any(Function))
+  })
+
+  it('cleans process-owner Fish history after removing a remote worktree', async () => {
+    gitInit(tmpDir)
+    writeFileSync(path.join(tmpDir, 'tracked.txt'), 'initial')
+    gitCommit(tmpDir, 'initial')
+    const worktreePath = `${tmpDir}-feature`
+    try {
+      execFileSync('git', ['worktree', 'add', '-b', 'feature', worktreePath], {
+        cwd: tmpDir,
+        stdio: 'pipe'
+      })
+
+      await dispatcher.callRequest('git.removeWorktree', {
+        worktreePath,
+        worktreeId: 'repo-1::/remote/feature'
+      })
+
+      expect(deleteRelayFishHistoryMock).toHaveBeenCalledWith('repo-1::/remote/feature')
+    } finally {
+      await fs.rm(worktreePath, { recursive: true, force: true })
+    }
   })
 
   describe('abortMerge', () => {

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -17,14 +17,6 @@ import {
   type RelayDispatcher
 } from './git-handler-test-setup'
 
-const { deleteRelayFishHistoryMock } = vi.hoisted(() => ({
-  deleteRelayFishHistoryMock: vi.fn()
-}))
-
-vi.mock('./fish-history-metadata', () => ({
-  deleteRelayFishHistory: deleteRelayFishHistoryMock
-}))
-
 type GitBufferSpyTarget = {
   gitBuffer(args: string[], cwd: string): Promise<Buffer>
 }
@@ -70,7 +62,6 @@ describe('GitHandler', () => {
     dispatcher = createMockDispatcher()
     const ctx = new RelayContext()
     handler = new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
-    deleteRelayFishHistoryMock.mockReset()
   })
 
   afterEach(async () => {
@@ -162,28 +153,6 @@ describe('GitHandler', () => {
       dispatcher.callRequest('git.removeWorktree', { worktreePath: '/repo-feature' })
     ).rejects.toBe(removalError)
     expect(runWithRemovalFence).toHaveBeenCalledWith('/repo-feature', expect.any(Function))
-  })
-
-  it('cleans process-owner Fish history after removing a remote worktree', async () => {
-    gitInit(tmpDir)
-    writeFileSync(path.join(tmpDir, 'tracked.txt'), 'initial')
-    gitCommit(tmpDir, 'initial')
-    const worktreePath = `${tmpDir}-feature`
-    try {
-      execFileSync('git', ['worktree', 'add', '-b', 'feature', worktreePath], {
-        cwd: tmpDir,
-        stdio: 'pipe'
-      })
-
-      await dispatcher.callRequest('git.removeWorktree', {
-        worktreePath,
-        worktreeId: 'repo-1::/remote/feature'
-      })
-
-      expect(deleteRelayFishHistoryMock).toHaveBeenCalledWith('repo-1::/remote/feature')
-    } finally {
-      await fs.rm(worktreePath, { recursive: true, force: true })
-    }
   })
 
   describe('abortMerge', () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -96,6 +96,7 @@ import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { streamRelayGitStdout } from './git-stdout-stream'
+import { deleteRelayFishHistory } from './fish-history-metadata'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -1461,10 +1462,15 @@ export class GitHandler {
   }
 
   private async removeWorktree(params: Record<string, unknown>) {
-    const remove = () =>
-      this.runWithGitReadCacheClear(() =>
+    const remove = async () => {
+      const result = await this.runWithGitReadCacheClear(() =>
         removeWorktreeOp(this.git.bind(this), params, this.gitCapabilities)
       )
+      if (typeof params.worktreeId === 'string') {
+        deleteRelayFishHistory(params.worktreeId)
+      }
+      return result
+    }
     const worktreePath = params.worktreePath
     return this.watcherRegistry && typeof worktreePath === 'string'
       ? this.watcherRegistry.runWithRemovalFence(expandTilde(worktreePath), remove)

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -96,7 +96,6 @@ import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { streamRelayGitStdout } from './git-stdout-stream'
-import { deleteRelayFishHistory } from './fish-history-metadata'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -1462,15 +1461,10 @@ export class GitHandler {
   }
 
   private async removeWorktree(params: Record<string, unknown>) {
-    const remove = async () => {
-      const result = await this.runWithGitReadCacheClear(() =>
+    const remove = () =>
+      this.runWithGitReadCacheClear(() =>
         removeWorktreeOp(this.git.bind(this), params, this.gitCapabilities)
       )
-      if (typeof params.worktreeId === 'string') {
-        deleteRelayFishHistory(params.worktreeId)
-      }
-      return result
-    }
     const worktreePath = params.worktreePath
     return this.watcherRegistry && typeof worktreePath === 'string'
       ? this.watcherRegistry.runWithRemovalFence(expandTilde(worktreePath), remove)

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -13,9 +13,17 @@ import {
 import { PTY_STARTUP_INGRESS_VERSION } from '../shared/pty-startup-ingress'
 import { stripLegacyTerminalShimEnv } from '../main/pty/legacy-terminal-shim-dir'
 
-const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
+const {
+  deleteRelayFishHistoryMock,
+  mockPtySpawn,
+  mockPtyInstance,
+  mockCreateShellPromptReadinessProbe,
+  recordRelayFishHistoryPathMock
+} = vi.hoisted(() => ({
+  deleteRelayFishHistoryMock: vi.fn(),
   mockPtySpawn: vi.fn(),
   mockCreateShellPromptReadinessProbe: vi.fn(),
+  recordRelayFishHistoryPathMock: vi.fn(),
   mockPtyInstance: {
     // Why: attach now proves the backing pid is alive before replaying, so the
     // default managed PTY must report a live pid. Reuse the test runner's own
@@ -42,6 +50,11 @@ vi.mock('../main/pty/posix-pty-process-groups', () => ({
 
 vi.mock('../main/shell-prompt-readiness-probe', () => ({
   createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
+}))
+
+vi.mock('./fish-history-metadata', () => ({
+  deleteRelayFishHistory: deleteRelayFishHistoryMock,
+  recordRelayFishHistoryPath: recordRelayFishHistoryPathMock
 }))
 
 import {
@@ -146,6 +159,8 @@ describe('PtyHandler', () => {
     mockPtyInstance.pause.mockReset()
     mockPtyInstance.resume.mockReset()
     mockCreateShellPromptReadinessProbe.mockReset()
+    deleteRelayFishHistoryMock.mockReset()
+    recordRelayFishHistoryPathMock.mockReset()
     mockCreateShellPromptReadinessProbe.mockReturnValue({
       notifyOutput: vi.fn(),
       dispose: vi.fn()
@@ -183,6 +198,7 @@ describe('PtyHandler', () => {
     expect(methods).toContain('pty.inspectProcess')
     expect(methods).toContain('pty.listProcesses')
     expect(methods).toContain('pty.getDefaultShell')
+    expect(methods).toContain('pty.deleteWorktreeHistory')
 
     const notifMethods = Array.from(dispatcher._notificationHandlers.keys())
     expect(notifMethods).toContain('pty.data')
@@ -705,6 +721,44 @@ describe('PtyHandler', () => {
       })
     }
   })
+
+  it('uses the requested PTY Fish shell and scopes its history on the relay owner', async () => {
+    await dispatcher.callRequest('pty.spawn', {
+      env: { SHELL: '/usr/bin/fish' },
+      worktreeId: 'repo-1::/remote/wt',
+      historyIsolationEnabled: true
+    })
+
+    expect(mockPtySpawn.mock.calls[0]?.[0]).toBe('/usr/bin/fish')
+    const spawnEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv.fish_history).toMatch(/^orca_[0-9a-f]{16}$/)
+    expect(recordRelayFishHistoryPathMock).toHaveBeenCalledWith(
+      'repo-1::/remote/wt',
+      expect.objectContaining({ fish_history: spawnEnv.fish_history })
+    )
+  })
+
+  it('deletes persisted Fish history on its process owner', async () => {
+    await dispatcher.callRequest('pty.deleteWorktreeHistory', {
+      worktreeId: 'repo-1::/remote/wt'
+    })
+
+    expect(deleteRelayFishHistoryMock).toHaveBeenCalledWith('repo-1::/remote/wt')
+  })
+
+  it.each([undefined, 'true'])(
+    'leaves omitted or malformed scoped-history disabled',
+    async (flag) => {
+      await dispatcher.callRequest('pty.spawn', {
+        env: { SHELL: '/usr/bin/fish' },
+        worktreeId: 'repo-1::/remote/wt',
+        historyIsolationEnabled: flag
+      })
+
+      const spawnEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+      expect(spawnEnv.fish_history).toBeUndefined()
+    }
+  )
 
   it('ignores Windows shell overrides on non-Windows relay hosts', async () => {
     const originalPlatform = process.platform
@@ -3084,6 +3138,32 @@ describe('PtyHandler', () => {
     expect(callArgs.env.TERM_PROGRAM).toBe('Orca')
     expect(callArgs.env.ORCA_SHELL_READY_MARKER).toBe('0')
     expect(callArgs.env.ORCA_SHELL_STARTUP_IDENTITY).toBe('0')
+  })
+
+  it('revive restores scoped Fish history without requiring it from legacy state', async () => {
+    await dispatcher.callRequest('pty.spawn', {
+      env: { SHELL: '/usr/bin/fish' },
+      worktreeId: 'repo-1::/remote/wt',
+      historyIsolationEnabled: true
+    })
+    const firstEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+    const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+
+    await handler.dispose({ waitForPhysicalExit: false })
+    mockPtySpawn.mockClear()
+    dispatcher = createMockDispatcher()
+    handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+    const shellSpy = vi.spyOn(ptyShellUtils, 'resolveDefaultShell').mockReturnValue('/usr/bin/fish')
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      await dispatcher.callRequest('pty.revive', { state })
+    } finally {
+      killSpy.mockRestore()
+      shellSpy.mockRestore()
+    }
+
+    const revivedEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(revivedEnv.fish_history).toBe(firstEnv.fish_history)
   })
 
   it('fences both revived worktree identity and cwd with rollback', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -82,6 +82,7 @@ import { createPtySlaveEchoProbe, readPtySlavePath } from '../shared/pty-slave-l
 import { fishHistorySessionName } from '../main/fish-history-session'
 import { hashWorktreeId } from '../main/terminal-history-id'
 import { deleteRelayFishHistory, recordRelayFishHistoryPath } from './fish-history-metadata'
+import { deleteRelayHistory, injectRelayHistoryEnv } from './terminal-history'
 
 // Why: only Linux compiles node-pty (no prebuilt), so the build-tools remedy is a closable setup gap
 // there and wrong advice anywhere node-pty ships one. The relay only sees an unloadable binding, never
@@ -869,6 +870,7 @@ export class PtyHandler {
     this.dispatcher.onRequest('pty.deleteWorktreeHistory', async (p) => {
       if (typeof p.worktreeId === 'string') {
         deleteRelayFishHistory(p.worktreeId)
+        deleteRelayHistory(p.worktreeId)
       }
       return { ok: true }
     })
@@ -1552,6 +1554,9 @@ export class PtyHandler {
       spawnEnv.fish_history = fishHistorySessionName(hashWorktreeId(worktreeId))
       recordRelayFishHistoryPath(worktreeId, spawnEnv)
     }
+    if (historyIsolationEnabled && worktreeId) {
+      injectRelayHistoryEnv(spawnEnv, worktreeId, shell)
+    }
     const launchCommandHint = resolveSetupAgentSequenceLaunchCommand(spawnEnv, command)
     // Why: SSH PTYs bypass main's host-env builder, so apply the guard after the relay merges its authoritative env.
     const gitCredentialPromptGuarded = applyTerminalGitCredentialPromptGuard(spawnEnv, {
@@ -2139,6 +2144,9 @@ export class PtyHandler {
     ) {
       spawnEnv.fish_history = fishHistorySessionName(hashWorktreeId(entry.worktreeId))
       recordRelayFishHistoryPath(entry.worktreeId, spawnEnv)
+    }
+    if (historyIsolationEnabled && entry.worktreeId) {
+      injectRelayHistoryEnv(spawnEnv, entry.worktreeId, shell)
     }
     // Why: revive lacks the original launch command, so reuse the fresh-spawn guard decision (legacy defaults to unguarded).
     const gitCredentialPromptGuarded = entry.gitCredentialPromptGuarded === true

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -2,7 +2,7 @@
 import type { IPty } from 'node-pty'
 import type * as NodePty from 'node-pty'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { resolveWindowsGitBashShellPath } from '../main/git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../shared/windows-terminal-shell'
@@ -79,6 +79,9 @@ import {
   type AgentSessionOwnerBinding
 } from '../shared/agent-session-host-authority'
 import { createPtySlaveEchoProbe, readPtySlavePath } from '../shared/pty-slave-line-discipline-echo'
+import { fishHistorySessionName } from '../main/fish-history-session'
+import { hashWorktreeId } from '../main/terminal-history-id'
+import { deleteRelayFishHistory, recordRelayFishHistoryPath } from './fish-history-metadata'
 
 // Why: only Linux compiles node-pty (no prebuilt), so the build-tools remedy is a closable setup gap
 // there and wrong advice anywhere node-pty ships one. The relay only sees an unloadable binding, never
@@ -158,6 +161,7 @@ type ManagedPty = {
   shellPathEnv?: string
   envToDelete: string[]
   gitCredentialPromptGuarded: boolean
+  historyIsolationEnabled?: boolean
   startupCommand?: ManagedStartupCommand
   physicalExit?: PhysicalExitTracker
   forceKillSent?: boolean
@@ -327,6 +331,8 @@ type SerializedPtyEntry = {
   envToDelete?: string[]
   /** Optional for state serialized by relays predating the credential guard. */
   gitCredentialPromptGuarded?: boolean
+  /** Optional for state serialized by relays predating scoped history. */
+  historyIsolationEnabled?: boolean
   agentSessionOwners?: AgentSessionOwnerBinding[]
 }
 
@@ -860,6 +866,12 @@ export class PtyHandler {
     this.dispatcher.onRequest('pty.serialize', (p) => this.serialize(p))
     this.dispatcher.onRequest('pty.revive', (p) => this.revive(p))
     this.dispatcher.onRequest('pty.getProfiles', async () => listShellProfiles())
+    this.dispatcher.onRequest('pty.deleteWorktreeHistory', async (p) => {
+      if (typeof p.worktreeId === 'string') {
+        deleteRelayFishHistory(p.worktreeId)
+      }
+      return { ok: true }
+    })
     this.dispatcher.onRequest('pty.closeStartupQueryAuthority', (p) =>
       this.closeStartupQueryAuthority(p)
     )
@@ -1387,7 +1399,8 @@ export class PtyHandler {
     context?: RequestContext
   ): Promise<RelayAgentSessionCreateResult> {
     const env = params.env as Record<string, string> | undefined
-    const worktreeId = env?.ORCA_WORKTREE_ID
+    const worktreeId =
+      typeof params.worktreeId === 'string' ? params.worktreeId : env?.ORCA_WORKTREE_ID
     const worktreePath = worktreeId ? splitWorktreeId(worktreeId)?.worktreePath : undefined
     const cwd = typeof params.cwd === 'string' ? params.cwd : resolveDefaultCwd()
     const finishCreation = this.beginPtyCreation([worktreePath, cwd])
@@ -1503,7 +1516,9 @@ export class PtyHandler {
     const shellOverride =
       typeof params.shellOverride === 'string' ? params.shellOverride.trim() : ''
     const resolvedShellOverride = resolvePtyShellOverride(shellOverride)
-    const shell = resolvedShellOverride || resolveDefaultShell()
+    const requestedEnvShell =
+      process.platform !== 'win32' && typeof env?.SHELL === 'string' ? env.SHELL.trim() : ''
+    const shell = resolvedShellOverride || requestedEnvShell || resolveDefaultShell()
     let id: string
     do {
       id = `pty-${this.nextId++}`
@@ -1525,6 +1540,18 @@ export class PtyHandler {
       { id, paneKey, shell, command, launchAgent },
       envToDelete
     )
+    const worktreeId =
+      typeof params.worktreeId === 'string' ? params.worktreeId : env?.ORCA_WORKTREE_ID
+    const historyIsolationEnabled = params.historyIsolationEnabled === true
+    if (
+      historyIsolationEnabled &&
+      worktreeId &&
+      basename(shell).toLowerCase().startsWith('fish') &&
+      !spawnEnv.fish_history
+    ) {
+      spawnEnv.fish_history = fishHistorySessionName(hashWorktreeId(worktreeId))
+      recordRelayFishHistoryPath(worktreeId, spawnEnv)
+    }
     const launchCommandHint = resolveSetupAgentSequenceLaunchCommand(spawnEnv, command)
     // Why: SSH PTYs bypass main's host-env builder, so apply the guard after the relay merges its authoritative env.
     const gitCredentialPromptGuarded = applyTerminalGitCredentialPromptGuard(spawnEnv, {
@@ -1591,7 +1618,6 @@ export class PtyHandler {
       paneKey: typeof params.paneKey === 'string' ? params.paneKey : paneKey,
       tabId: typeof params.tabId === 'string' ? params.tabId : tabId
     }
-    const worktreeId = typeof env?.ORCA_WORKTREE_ID === 'string' ? env.ORCA_WORKTREE_ID : undefined
     const startupIngressIntent =
       params.startupIngressVersion === PTY_STARTUP_INGRESS_VERSION
         ? parsePtyStartupIngressIntent(params.startupIngress)
@@ -1612,6 +1638,7 @@ export class PtyHandler {
       ...(explicitTerm !== undefined ? { explicitTerm } : {}),
       envToDelete,
       gitCredentialPromptGuarded,
+      ...(historyIsolationEnabled ? { historyIsolationEnabled: true } : {}),
       shellPath: shell,
       shellCwd: cwd,
       shellPathEnv: spawnEnv.PATH,
@@ -2034,6 +2061,7 @@ export class PtyHandler {
         ...(managed.explicitTerm !== undefined ? { explicitTerm: managed.explicitTerm } : {}),
         envToDelete: managed.envToDelete,
         gitCredentialPromptGuarded: managed.gitCredentialPromptGuarded,
+        ...(managed.historyIsolationEnabled ? { historyIsolationEnabled: true } : {}),
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {})
       })
     }
@@ -2097,11 +2125,21 @@ export class PtyHandler {
     // Why: serialized state may come from an older/untrusted client; reapply fresh-spawn bounds.
     const envToDelete = sanitizeEnvToDelete(entry.envToDelete)
     const shell = resolveDefaultShell()
+    const historyIsolationEnabled = entry.historyIsolationEnabled === true
     const spawnEnv = this.buildSpawnEnv(
       revivedEnv,
       { id: entry.id, paneKey: entry.paneKey, shell },
       envToDelete
     )
+    if (
+      historyIsolationEnabled &&
+      entry.worktreeId &&
+      basename(shell).toLowerCase().startsWith('fish') &&
+      !spawnEnv.fish_history
+    ) {
+      spawnEnv.fish_history = fishHistorySessionName(hashWorktreeId(entry.worktreeId))
+      recordRelayFishHistoryPath(entry.worktreeId, spawnEnv)
+    }
     // Why: revive lacks the original launch command, so reuse the fresh-spawn guard decision (legacy defaults to unguarded).
     const gitCredentialPromptGuarded = entry.gitCredentialPromptGuarded === true
     if (gitCredentialPromptGuarded) {
@@ -2137,6 +2175,7 @@ export class PtyHandler {
       ...(explicitTerm !== undefined ? { explicitTerm } : {}),
       envToDelete,
       gitCredentialPromptGuarded,
+      ...(historyIsolationEnabled ? { historyIsolationEnabled: true } : {}),
       ownerBackend: resolvePtyOwnerBackend({
         platform: process.platform,
         shellPath: shell

--- a/src/relay/terminal-history.test.ts
+++ b/src/relay/terminal-history.test.ts
@@ -1,0 +1,34 @@
+import { existsSync, rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { hashWorktreeId } from '../main/terminal-history-id'
+import { deleteRelayHistory, injectRelayHistoryEnv } from './terminal-history'
+
+const worktreeId = 'relay-test::/remote/worktree'
+const historyDir = join(homedir(), '.orca-remote', 'terminal-history', hashWorktreeId(worktreeId))
+
+afterEach(() => rmSync(historyDir, { recursive: true, force: true }))
+
+describe('relay shell history', () => {
+  it.each(['/bin/bash', '/usr/bin/zsh'])('scopes %s without replacing caller HISTFILE', (shell) => {
+    const env: Record<string, string> = {}
+    const dir = injectRelayHistoryEnv(env, worktreeId, shell)
+    expect(dir).toBe(historyDir)
+    expect(env.HISTFILE).toBe(
+      join(historyDir, shell.endsWith('bash') ? 'bash_history' : 'zsh_history')
+    )
+
+    const custom = { HISTFILE: '/custom/history' }
+    expect(injectRelayHistoryEnv(custom, worktreeId, shell)).toBeNull()
+    expect(custom.HISTFILE).toBe('/custom/history')
+  })
+
+  it('does not scope unsupported shells and cleans up idempotently', () => {
+    const env: Record<string, string> = {}
+    expect(injectRelayHistoryEnv(env, worktreeId, '/bin/fish')).toBeNull()
+    deleteRelayHistory(worktreeId)
+    deleteRelayHistory(worktreeId)
+    expect(existsSync(historyDir)).toBe(false)
+  })
+})

--- a/src/relay/terminal-history.test.ts
+++ b/src/relay/terminal-history.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -6,9 +6,14 @@ import { hashWorktreeId } from '../main/terminal-history-id'
 import { deleteRelayHistory, injectRelayHistoryEnv } from './terminal-history'
 
 const worktreeId = 'relay-test::/remote/worktree'
-const historyDir = join(homedir(), '.orca-remote', 'terminal-history', hashWorktreeId(worktreeId))
+const historyDir = join(homedir(), '.orca-remote', 'terminal-history')
+const historyPrefix = hashWorktreeId(worktreeId)
 
-afterEach(() => rmSync(historyDir, { recursive: true, force: true }))
+afterEach(() => {
+  for (const filename of ['bash_history', 'zsh_history']) {
+    rmSync(join(historyDir, `${historyPrefix}-${filename}`), { force: true })
+  }
+})
 
 describe('relay shell history', () => {
   it.each(['/bin/bash', '/usr/bin/zsh'])('scopes %s without replacing caller HISTFILE', (shell) => {
@@ -16,7 +21,10 @@ describe('relay shell history', () => {
     const dir = injectRelayHistoryEnv(env, worktreeId, shell)
     expect(dir).toBe(historyDir)
     expect(env.HISTFILE).toBe(
-      join(historyDir, shell.endsWith('bash') ? 'bash_history' : 'zsh_history')
+      join(
+        historyDir,
+        `${historyPrefix}-${shell.endsWith('bash') ? 'bash_history' : 'zsh_history'}`
+      )
     )
 
     const custom = { HISTFILE: '/custom/history' }
@@ -29,6 +37,19 @@ describe('relay shell history', () => {
     expect(injectRelayHistoryEnv(env, worktreeId, '/bin/fish')).toBeNull()
     deleteRelayHistory(worktreeId)
     deleteRelayHistory(worktreeId)
-    expect(existsSync(historyDir)).toBe(false)
+    expect(existsSync(join(historyDir, `${historyPrefix}-bash_history`))).toBe(false)
+  })
+
+  it('refuses a pre-existing final symlink', () => {
+    mkdirSync(historyDir, { recursive: true })
+    const target = join(historyDir, 'relay-unrelated-history')
+    const path = join(historyDir, `${historyPrefix}-bash_history`)
+    writeFileSync(target, 'unrelated')
+    symlinkSync(target, path)
+
+    expect(injectRelayHistoryEnv({}, worktreeId, '/bin/bash')).toBeNull()
+    expect(readFileSync(target, 'utf8')).toBe('unrelated')
+    rmSync(path)
+    rmSync(target)
   })
 })

--- a/src/relay/terminal-history.ts
+++ b/src/relay/terminal-history.ts
@@ -1,4 +1,12 @@
-import { mkdirSync, rmSync } from 'node:fs'
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  unlinkSync
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { hashWorktreeId } from '../main/terminal-history-id'
@@ -29,11 +37,42 @@ export function injectRelayHistoryEnv(
     return null
   }
   try {
-    const dir = join(HISTORY_ROOT, hashWorktreeId(worktreeId))
-    mkdirSync(dir, { recursive: true, mode: 0o700 })
-    const path = join(dir, filename)
+    mkdirSync(HISTORY_ROOT, { recursive: true, mode: 0o700 })
+    const rootStat = lstatSync(HISTORY_ROOT)
+    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+      return null
+    }
+    const path = join(HISTORY_ROOT, `${hashWorktreeId(worktreeId)}-${filename}`)
+    let existing: ReturnType<typeof lstatSync> | null = null
+    try {
+      const stat = lstatSync(path, { bigint: true })
+      if (stat.isSymbolicLink() || !stat.isFile()) {
+        return null
+      }
+      existing = stat
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        return null
+      }
+    }
+    const fd = openSync(
+      path,
+      fsConstants.O_RDWR |
+        fsConstants.O_CREAT |
+        (process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW),
+      0o600
+    )
+    const actual = fstatSync(fd, { bigint: true })
+    if (
+      !actual.isFile() ||
+      (existing && (actual.dev !== existing.dev || actual.ino !== existing.ino))
+    ) {
+      closeSync(fd)
+      return null
+    }
+    closeSync(fd)
     env.HISTFILE = path
-    return dir
+    return HISTORY_ROOT
   } catch {
     return null
   }
@@ -41,7 +80,22 @@ export function injectRelayHistoryEnv(
 
 export function deleteRelayHistory(worktreeId: string): void {
   try {
-    rmSync(join(HISTORY_ROOT, hashWorktreeId(worktreeId)), { recursive: true, force: true })
+    const rootStat = lstatSync(HISTORY_ROOT)
+    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+      return
+    }
+    for (const filename of ['bash_history', 'zsh_history']) {
+      const path = join(HISTORY_ROOT, `${hashWorktreeId(worktreeId)}-${filename}`)
+      try {
+        if (!lstatSync(path).isSymbolicLink()) {
+          unlinkSync(path)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error
+        }
+      }
+    }
   } catch (error) {
     console.warn(
       `[pty:history] Failed to delete relay shell history: ${error instanceof Error ? error.message : String(error)}`

--- a/src/relay/terminal-history.ts
+++ b/src/relay/terminal-history.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, join } from 'node:path'
+import { hashWorktreeId } from '../main/terminal-history-id'
+
+const HISTORY_ROOT = join(homedir(), '.orca-remote', 'terminal-history')
+
+function historyFilename(shell: string): string | null {
+  const name = basename(shell).toLowerCase()
+  if (name.startsWith('bash')) {
+    return 'bash_history'
+  }
+  if (name.startsWith('zsh')) {
+    return 'zsh_history'
+  }
+  return null
+}
+
+export function injectRelayHistoryEnv(
+  env: Record<string, string>,
+  worktreeId: string,
+  shell: string
+): string | null {
+  if (env.HISTFILE) {
+    return null
+  }
+  const filename = historyFilename(shell)
+  if (!filename) {
+    return null
+  }
+  try {
+    const dir = join(HISTORY_ROOT, hashWorktreeId(worktreeId))
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const path = join(dir, filename)
+    env.HISTFILE = path
+    return dir
+  } catch {
+    return null
+  }
+}
+
+export function deleteRelayHistory(worktreeId: string): void {
+  try {
+    rmSync(join(HISTORY_ROOT, hashWorktreeId(worktreeId)), { recursive: true, force: true })
+  } catch (error) {
+    console.warn(
+      `[pty:history] Failed to delete relay shell history: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
@@ -20,6 +20,8 @@ import {
 } from '../../../../shared/tui-agent-launch-defaults'
 import { translate } from '@/i18n/i18n'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
+import { getClientLoginShell } from '@/lib/client-login-shell'
+import { resolveLoginShellStartupDialect } from '../../../../shared/tui-agent-startup-shell'
 
 type FloatingTerminalWindowControlsProps = {
   maximized: boolean
@@ -79,6 +81,7 @@ export function FloatingTerminalWindowControls({
       agentArgs: resolveTuiAgentLaunchArgs(defaultAgent, state.settings?.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(defaultAgent, state.settings?.agentDefaultEnv),
       platform: CLIENT_PLATFORM,
+      shell: resolveLoginShellStartupDialect(getClientLoginShell()),
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {

--- a/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
+++ b/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
@@ -1,6 +1,7 @@
 import { planSourceControlAgentActionLaunch } from '@/lib/source-control-agent-action-plan'
 import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../../shared/types'
+import type { ExecutionHostKind } from '../../../../shared/execution-host'
 import type { SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
 import { buildSourceControlAgentConnectionErrorPlan } from './source-control-agent-action-dialog-support'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
@@ -16,6 +17,7 @@ type BuildSourceControlAgentDeliveryPlanArgs = {
   /** Why: keep the previewed command label in sync with the real remote launch,
    * which omits the Linux-only `orca-ide` rename for SSH hosts. */
   isRemote?: boolean
+  executionHostKind?: ExecutionHostKind | null
 }
 
 export function buildSourceControlAgentDeliveryPlan({
@@ -26,7 +28,8 @@ export function buildSourceControlAgentDeliveryPlan({
   detectedAgents,
   connectionUnavailable,
   launchPlatform,
-  isRemote
+  isRemote,
+  executionHostKind
 }: BuildSourceControlAgentDeliveryPlanArgs): SourceControlAgentActionDeliveryPlanState {
   if (connectionUnavailable) {
     return buildSourceControlAgentConnectionErrorPlan()
@@ -50,7 +53,8 @@ export function buildSourceControlAgentDeliveryPlan({
     cmdOverrides: settings?.agentCmdOverrides,
     terminalWindowsShell: settings?.terminalWindowsShell,
     platform: launchPlatform,
-    isRemote
+    isRemote,
+    executionHostKind
   })
   if (!result.ok) {
     return { status: 'error', error: result.error }

--- a/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
+++ b/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
@@ -5,6 +5,7 @@ import type { ExecutionHostKind } from '../../../../shared/execution-host'
 import type { SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
 import { buildSourceControlAgentConnectionErrorPlan } from './source-control-agent-action-dialog-support'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
+import { resolveTuiAgentLaunchEnv } from '../../../../shared/tui-agent-launch-defaults'
 
 type BuildSourceControlAgentDeliveryPlanArgs = {
   selectedAgent: TuiAgent | null
@@ -39,6 +40,9 @@ export function buildSourceControlAgentDeliveryPlan({
     agent: selectedAgent,
     commandInput,
     agentArgs,
+    agentEnv: selectedAgent
+      ? resolveTuiAgentLaunchEnv(selectedAgent, settings?.agentDefaultEnv)
+      : undefined,
     sessionOptions: selectedAgent
       ? resolveInitialNativeChatSessionOptions(settings, {
           agent: selectedAgent,

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionStart.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionStart.ts
@@ -6,6 +6,8 @@ import type {
 } from '../../../../shared/source-control-ai-actions'
 import type { SourceControlAiWriteTarget } from '../../../../shared/source-control-ai-recipe-save'
 import type { GlobalSettings, Repo, TuiAgent } from '../../../../shared/types'
+import { useAppStore } from '@/store'
+import { getWorkspaceExecutionHostKind } from '@/lib/client-agent-startup-shell'
 import { buildSourceControlAgentDeliveryPlan } from './buildSourceControlAgentDeliveryPlan'
 import type { SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
 import { runSourceControlAgentActionStart } from './runSourceControlAgentActionStart'
@@ -109,7 +111,8 @@ export function useSourceControlAgentActionStart({
         detectedAgents: currentDetectedAgents,
         connectionUnavailable,
         launchPlatform,
-        isRemote
+        isRemote,
+        executionHostKind: getWorkspaceExecutionHostKind(useAppStore.getState(), worktreeId)
       })
     },
     [
@@ -120,7 +123,8 @@ export function useSourceControlAgentActionStart({
       refreshDetectedAgents,
       selectedAgent,
       launchPlatform,
-      isRemote
+      isRemote,
+      worktreeId
     ]
   )
 

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -229,9 +229,8 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
 }
 
 function isPosixFamilyWindowsShellConfigured(): boolean {
-  return (
-    resolveWindowsShellStartupFamily(useAppStore.getState().settings?.terminalWindowsShell) ===
-    'posix'
+  return ['posix', 'unix'].includes(
+    resolveWindowsShellStartupFamily(useAppStore.getState().settings?.terminalWindowsShell)
   )
 }
 

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -18,7 +18,7 @@ import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import type { FolderWorkspace, ProjectGroup, TuiAgent } from '../../../../shared/types'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
-import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
+import { resolveClientAgentStartupShell } from '@/lib/client-agent-startup-shell'
 import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
@@ -196,10 +196,12 @@ export async function submitFolderWorkspaceCreate({
   // Why: an SSH folder group runs the plain `orca` relay shim, so the Linux-only
   // `orca-ide` rename must not be applied for remote launches.
   const launchIsRemote = Boolean(projectGroup.connectionId)
-  const launchShell = resolveLocalWindowsAgentStartupShell({
+  const launchShell = resolveClientAgentStartupShell({
     platform: launchPlatform,
     isRemote: launchIsRemote,
-    terminalWindowsShell
+    terminalWindowsShell,
+    // Why: a runtime environment executes inside its own container, not this machine's login shell.
+    executionHostKind: runtimeEnvironmentId ? 'runtime' : null
   })
   const startupPlan =
     quickAgent && linkedWorkItem

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -22,7 +22,7 @@ import {
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
 import { filterEnabledTuiAgents, isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
-import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
+import { resolveClientAgentStartupShell } from '@/lib/client-agent-startup-shell'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 import {
@@ -883,10 +883,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   }, [activeRepoId, projects, repos, selectedRepo, settings, worktreesByRepo])
   // Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only `orca-ide` rename must not apply to remote launch commands.
   const selectedRepoIsRemote = selectedRepo ? repoIsRemote(selectedRepo) : false
-  const selectedRepoStartupShell = resolveLocalWindowsAgentStartupShell({
+  const selectedRepoStartupShell = resolveClientAgentStartupShell({
     platform: selectedRepoAgentLaunchPlatform,
     isRemote: selectedRepoIsRemote,
-    terminalWindowsShell: settings?.terminalWindowsShell
+    terminalWindowsShell: settings?.terminalWindowsShell,
+    executionHostKind: parseExecutionHostId(selectedRepoExecutionHostId)?.kind ?? null
   })
   const selectedRepoProjectId =
     selectedWorkspaceTarget.status === 'ready' ? selectedWorkspaceTarget.target.projectId : null

--- a/src/renderer/src/lib/agent-background-session-launch-host.ts
+++ b/src/renderer/src/lib/agent-background-session-launch-host.ts
@@ -7,6 +7,11 @@ import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { isWslUncPath } from '../../../shared/wsl-paths'
+import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
+import {
+  getWorkspaceExecutionHostKind,
+  resolveClientAgentStartupShell
+} from '@/lib/client-agent-startup-shell'
 
 type LaunchStore = ReturnType<typeof useAppStore.getState>
 type LaunchRepo = LaunchStore['repos'][number]
@@ -19,6 +24,20 @@ export type AgentBackgroundLaunchHost = {
   isRemote: boolean
   /** Accepted status connection; undefined preserves unknown-owner behavior. */
   expectedConnectionId: string | null | undefined
+}
+
+/** Shell dialect that will parse the queued launch line on the resolved host. */
+export function resolveAgentBackgroundLaunchShell(
+  store: LaunchStore,
+  worktreeId: string,
+  host: AgentBackgroundLaunchHost
+): AgentStartupShell | undefined {
+  return resolveClientAgentStartupShell({
+    platform: host.platform,
+    isRemote: host.isRemote,
+    terminalWindowsShell: store.settings?.terminalWindowsShell,
+    executionHostKind: getWorkspaceExecutionHostKind(store, worktreeId)
+  })
 }
 
 function resolveFolderWorkspaceConnectionIdForLaunch(

--- a/src/renderer/src/lib/agent-resume-launch-target.test.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.test.ts
@@ -138,12 +138,14 @@ describe('resolveAgentResumeLaunchTarget off Windows', () => {
     restoreNavigator()
   })
 
+  // 'posix' rather than undefined: off Windows the dialect now comes from the
+  // client's login shell, and an unknown $SHELL in this harness resolves to sh.
   it('ignores a stale Windows shell setting on a mac client', async () => {
     await expect(
       resolveWith({
         worktreePath: '/Users/neil/repo',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'darwin', shell: undefined })
+    ).resolves.toEqual({ platform: 'darwin', shell: 'posix' })
   })
 })

--- a/src/renderer/src/lib/agent-resume-launch-target.test.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.test.ts
@@ -86,7 +86,7 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         executionHostId: 'ssh:ssh-1',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'linux', shell: undefined })
+    ).resolves.toEqual({ platform: 'linux', shell: 'unix' })
   })
 
   it('does not describe a remote runtime host with the local Windows shell setting', async () => {
@@ -104,7 +104,7 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\repo',
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'linux', shell: undefined })
+    ).resolves.toEqual({ platform: 'linux', shell: 'unix' })
   })
 
   it('keeps POSIX quoting for a project pinned to a WSL runtime', async () => {
@@ -122,7 +122,7 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
         } as AgentResumeLaunchTargetArgs['projectRuntime'],
         terminalWindowsShell: 'cmd.exe'
       })
-    ).resolves.toEqual({ platform: 'linux', shell: undefined })
+    ).resolves.toEqual({ platform: 'linux', shell: 'unix' })
   })
 })
 

--- a/src/renderer/src/lib/agent-resume-launch-target.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.ts
@@ -2,7 +2,7 @@ import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
 import { parseExecutionHostId } from '../../../shared/execution-host'
 import { isWslUncPath } from '../../../shared/wsl-paths'
-import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
+import { resolveClientAgentStartupShell } from '@/lib/client-agent-startup-shell'
 import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
 import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
 
@@ -49,14 +49,15 @@ export function resolveAgentResumeLaunchTarget(
   const platform = resolveResumeLaunchPlatform(args)
   return {
     platform,
-    shell: resolveLocalWindowsAgentStartupShell({
+    shell: resolveClientAgentStartupShell({
       platform,
       isRemote:
         Boolean(args.connectionId) || parseExecutionHostId(args.executionHostId)?.kind !== 'local',
       terminalWindowsShell: resolveWindowsShellOverride(
         args.tabShellOverride,
         args.terminalWindowsShell
-      )
+      ),
+      executionHostKind: parseExecutionHostId(args.executionHostId)?.kind ?? null
     })
   }
 }

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -16,7 +16,11 @@ import {
 } from '../../../shared/tui-agent-launch-defaults'
 import { parseWslUncPath } from '../../../shared/wsl-paths'
 import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
-import { clearEnvCommand, commandSeparator } from '../../../shared/tui-agent-startup-shell'
+import {
+  clearEnvCommand,
+  commandSeparator,
+  quoteStartupArg
+} from '../../../shared/tui-agent-startup-shell'
 import type { AppState } from '@/store/types'
 import type { AiVaultSessionDragPayload } from '@/lib/ai-vault-session-drag'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
@@ -64,11 +68,17 @@ type AiVaultResumeWorktreeArgs = {
 }
 
 export function buildAiVaultResumeCopyCommandForWorktree(args: AiVaultResumeWorktreeArgs): string {
-  const command = buildAiVaultResumeForWorktree(args, true).command
   if (args.session.agent !== 'codex' || args.session.codexHome !== null) {
-    return command
+    return buildAiVaultResumeForWorktree(args, true).command
   }
   const shell = resolveAiVaultResumeShell(args)
+  if (shell === 'fish') {
+    const startup = buildAiVaultResumeForWorktree(args, false, shell)
+    // Why: Codex treats empty CODEX_HOME as ~/.codex; Fish assignments preserve function lookup.
+    const command = `CODEX_HOME= ORCA_CODEX_HOME= ${startup.command}`
+    return startup.cwd ? `cd ${quoteStartupArg(startup.cwd, shell)} && ${command}` : command
+  }
+  const command = buildAiVaultResumeForWorktree(args, true).command
   const separator = commandSeparator(shell)
   const clearHomes = ['CODEX_HOME', 'ORCA_CODEX_HOME']
     .map((name) => clearEnvCommand(name, shell))
@@ -121,7 +131,8 @@ export function buildAiVaultDropRepinStartup(args: {
 
 function buildAiVaultResumeForWorktree(
   args: AiVaultResumeWorktreeArgs,
-  embedCwd: boolean
+  embedCwd: boolean,
+  shellOverride?: AgentStartupShell
 ): AiVaultResumeStartup {
   const providerSession = getAiVaultAgentProviderSession(args.session)
   if (
@@ -151,11 +162,12 @@ function buildAiVaultResumeForWorktree(
   // Why: local shell settings do not describe a remote Windows host, whose
   // queued resume command uses the remote default PowerShell syntax.
   const liveShell: AgentStartupShell | undefined =
-    platform === 'win32'
+    shellOverride ??
+    (platform === 'win32'
       ? isLocalSession
         ? resolveAiVaultResumeShell(args)
         : 'powershell'
-      : undefined
+      : undefined)
   const cwd = embedCwd ? args.session.cwd : null
   const startupCwd = !embedCwd && args.session.cwd ? { cwd: args.session.cwd } : {}
   if (providerSession && isResumableTuiAgent(args.session.agent)) {

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -19,19 +19,21 @@ import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
 import {
   clearEnvCommand,
   commandSeparator,
-  quoteStartupArg
+  quoteStartupArg,
+  resolveStartupShell
 } from '../../../shared/tui-agent-startup-shell'
 import type { AppState } from '@/store/types'
 import type { AiVaultSessionDragPayload } from '@/lib/ai-vault-session-drag'
-import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { LOCAL_EXECUTION_HOST_ID, parseExecutionHostId } from '../../../shared/execution-host'
 import {
-  getAiVaultResumeWorkspacePath,
+  getAiVaultResumePlatform,
   resolveAiVaultResumeStartupShell
 } from '@/lib/ai-vault-resume-shell'
+
+export { getAiVaultResumePlatform } from '@/lib/ai-vault-resume-shell'
 
 type AiVaultResumeCommandSession = Pick<
   AiVaultSession,
@@ -71,7 +73,12 @@ export function buildAiVaultResumeCopyCommandForWorktree(args: AiVaultResumeWork
   if (args.session.agent !== 'codex' || args.session.codexHome !== null) {
     return buildAiVaultResumeForWorktree(args, true).command
   }
-  const shell = resolveAiVaultResumeShell(args)
+  const platform = getAiVaultResumePlatformForSession(args)
+  const shell = resolveStartupShell(
+    platform,
+    resolveAiVaultResumeShell(args),
+    resolveTuiAgentLaunchEnv(args.session.agent, args.state.settings?.agentDefaultEnv)
+  )
   if (shell === 'fish') {
     const startup = buildAiVaultResumeForWorktree(args, false, shell)
     // Why: Codex treats empty CODEX_HOME as ~/.codex; Fish assignments preserve function lookup.
@@ -84,6 +91,14 @@ export function buildAiVaultResumeCopyCommandForWorktree(args: AiVaultResumeWork
     .map((name) => clearEnvCommand(name, shell))
     .join(separator)
   return `${clearHomes}${separator}${command}`
+}
+
+function getAiVaultResumePlatformForSession(args: AiVaultResumeWorktreeArgs): NodeJS.Platform {
+  return args.session.executionHostId &&
+    args.session.executionHostId !== LOCAL_EXECUTION_HOST_ID &&
+    args.session.executionHostPlatform
+    ? args.session.executionHostPlatform
+    : getAiVaultResumePlatform(args.state, args.worktreeId)
 }
 
 export function buildAiVaultResumeStartupForWorktree(
@@ -149,25 +164,25 @@ function buildAiVaultResumeForWorktree(
       ...(providerSession ? { providerSession } : {})
     }
   }
-  const platform =
-    args.session.executionHostId &&
-    args.session.executionHostId !== LOCAL_EXECUTION_HOST_ID &&
-    args.session.executionHostPlatform
-      ? args.session.executionHostPlatform
-      : getAiVaultResumePlatform(args.state, args.worktreeId)
+  const platform = getAiVaultResumePlatformForSession(args)
   const codexHome = getAiVaultResumeCodexHome(args.session.codexHome, platform)
   const isLocalSession =
     !args.session.executionHostId || args.session.executionHostId === LOCAL_EXECUTION_HOST_ID
   const resumeFilePath = normalizeAiVaultResumeFilePath(args.session.filePath, platform)
   // Why: local shell settings do not describe a remote Windows host, whose
   // queued resume command uses the remote default PowerShell syntax.
-  const liveShell: AgentStartupShell | undefined =
+  const configuredShell: AgentStartupShell | undefined =
     shellOverride ??
     (platform === 'win32'
       ? isLocalSession
         ? resolveAiVaultResumeShell(args)
         : 'powershell'
       : undefined)
+  const agentEnv = resolveTuiAgentLaunchEnv(
+    args.session.agent,
+    args.state.settings?.agentDefaultEnv
+  )
+  const liveShell = resolveStartupShell(platform, configuredShell, agentEnv)
   const cwd = embedCwd ? args.session.cwd : null
   const startupCwd = !embedCwd && args.session.cwd ? { cwd: args.session.cwd } : {}
   if (providerSession && isResumableTuiAgent(args.session.agent)) {
@@ -184,7 +199,7 @@ function buildAiVaultResumeForWorktree(
         args.session.agent,
         args.state.settings?.agentDefaultArgs
       ),
-      agentEnv: resolveTuiAgentLaunchEnv(args.session.agent, args.state.settings?.agentDefaultEnv),
+      agentEnv,
       ...(args.session.agent === 'omp' && resumeFilePath
         ? { ompResumeFilePath: resumeFilePath }
         : {})
@@ -241,12 +256,7 @@ function buildAiVaultResumeForWorktree(
 }
 
 function resolveAiVaultResumeShell(args: AiVaultResumeWorktreeArgs): AgentStartupShell {
-  const platform =
-    args.session.executionHostId &&
-    args.session.executionHostId !== LOCAL_EXECUTION_HOST_ID &&
-    args.session.executionHostPlatform
-      ? args.session.executionHostPlatform
-      : getAiVaultResumePlatform(args.state, args.worktreeId)
+  const platform = getAiVaultResumePlatformForSession(args)
   const isLocalSession =
     !args.session.executionHostId || args.session.executionHostId === LOCAL_EXECUTION_HOST_ID
   return resolveAiVaultResumeStartupShell({
@@ -306,36 +316,4 @@ function getAiVaultResumeCodexHome(
     return codexHome
   }
   return parseWslUncPath(codexHome)?.linuxPath ?? codexHome
-}
-
-export function getAiVaultResumePlatform(
-  state: Pick<
-    AppState,
-    | 'activeRepoId'
-    | 'activeWorktreeId'
-    | 'folderWorkspaces'
-    | 'projectGroups'
-    | 'projects'
-    | 'repos'
-    | 'settings'
-    | 'worktreesByRepo'
-  >,
-  worktreeId?: string | null
-): NodeJS.Platform {
-  const targetWorktreeId = worktreeId ?? state.activeWorktreeId
-  const executionHost = parseExecutionHostId(getExecutionHostIdForWorktree(state, targetWorktreeId))
-  if (executionHost?.kind === 'ssh' || executionHost?.kind === 'runtime') {
-    return 'linux'
-  }
-
-  const projectRuntime = getLocalProjectExecutionRuntimeContext(state, worktreeId, CLIENT_PLATFORM)
-  if (projectRuntime?.status === 'repair-required') {
-    return projectRuntime.repair.preferredRuntime.kind === 'wsl' ? 'linux' : CLIENT_PLATFORM
-  }
-  if (projectRuntime?.status === 'resolved' && projectRuntime.runtime.kind === 'wsl') {
-    return 'linux'
-  }
-
-  const workspacePath = getAiVaultResumeWorkspacePath(state, targetWorktreeId)
-  return workspacePath && parseWslUncPath(workspacePath) ? 'linux' : CLIENT_PLATFORM
 }

--- a/src/renderer/src/lib/ai-vault-resume-shell.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-shell.test.ts
@@ -104,7 +104,7 @@ describe('copied real-home Codex resume command', () => {
     codexHome: null
   }
 
-  it('clears inherited Codex homes with fish syntax under a fish login shell', () => {
+  it('masks inherited Codex homes only for the resumed Fish command', () => {
     expect(
       withLoginShell('/opt/homebrew/bin/fish', () =>
         buildAiVaultResumeCopyCommandForWorktree({
@@ -113,8 +113,25 @@ describe('copied real-home Codex resume command', () => {
           session
         })
       )
+    ).toBe("cd '/home/alice/repo' && CODEX_HOME= ORCA_CODEX_HOME= codex 'resume' 'session one'")
+  })
+
+  it('preserves a fish command override and quotes the cwd and resume id for fish', () => {
+    expect(
+      withLoginShell('/opt/homebrew/bin/fish', () =>
+        buildAiVaultResumeCopyCommandForWorktree({
+          state: makeState(),
+          worktreeId: 'repo-1::worktree-1',
+          commandOverride: String.raw`my\ codex --profile 'a\\b'`,
+          session: {
+            ...session,
+            sessionId: String.raw`session\one`,
+            cwd: String.raw`/home/alice/repo\one`
+          }
+        })
+      )
     ).toBe(
-      "set -e CODEX_HOME; set -e ORCA_CODEX_HOME; cd '/home/alice/repo' && codex 'resume' 'session one'"
+      String.raw`cd '/home/alice/repo\\one' && CODEX_HOME= ORCA_CODEX_HOME= my\ codex --profile 'a\\b' 'resume' 'session\\one'`
     )
   })
 

--- a/src/renderer/src/lib/ai-vault-resume-shell.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-shell.test.ts
@@ -16,7 +16,7 @@ import { resolveAiVaultResumeStartupShell } from './ai-vault-resume-shell'
 
 type ResumeShellState = Parameters<typeof buildAiVaultResumeCopyCommandForWorktree>[0]['state']
 
-function makeState(worktreeHostId?: string): ResumeShellState {
+function makeState(worktreeHostId?: string, agentShell?: string): ResumeShellState {
   return {
     activeRepoId: 'repo-1',
     activeWorktreeId: 'repo-1::worktree-1',
@@ -26,7 +26,7 @@ function makeState(worktreeHostId?: string): ResumeShellState {
     projects: [{ id: 'repo-1', sourceRepoIds: ['repo-1'] }],
     settings: {
       agentDefaultArgs: { codex: '' },
-      agentDefaultEnv: { codex: {} }
+      agentDefaultEnv: { codex: agentShell ? { SHELL: agentShell } : {} }
     },
     worktreesByRepo: {
       'repo-1': [
@@ -163,5 +163,31 @@ describe('copied real-home Codex resume command', () => {
     ).toBe(
       "unset CODEX_HOME; unset ORCA_CODEX_HOME; cd '/home/alice/repo' && codex 'resume' 'session one'"
     )
+  })
+
+  it('uses POSIX teardown when the agent environment replaces fish with bash', () => {
+    expect(
+      withLoginShell('/opt/homebrew/bin/fish', () =>
+        buildAiVaultResumeCopyCommandForWorktree({
+          state: makeState(undefined, '/bin/bash'),
+          worktreeId: 'repo-1::worktree-1',
+          session
+        })
+      )
+    ).toBe(
+      "unset CODEX_HOME; unset ORCA_CODEX_HOME; cd '/home/alice/repo' && codex 'resume' 'session one'"
+    )
+  })
+
+  it('uses fish quoting when the agent environment replaces bash with fish', () => {
+    expect(
+      withLoginShell('/bin/bash', () =>
+        buildAiVaultResumeCopyCommandForWorktree({
+          state: makeState(undefined, '/usr/bin/fish'),
+          worktreeId: 'repo-1::worktree-1',
+          session
+        })
+      )
+    ).toBe("cd '/home/alice/repo' && CODEX_HOME= ORCA_CODEX_HOME= codex 'resume' 'session one'")
   })
 })

--- a/src/renderer/src/lib/ai-vault-resume-shell.ts
+++ b/src/renderer/src/lib/ai-vault-resume-shell.ts
@@ -11,6 +11,8 @@ import {
 import { getClientLoginShell } from '@/lib/client-login-shell'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { parseWslUncPath } from '../../../shared/wsl-paths'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 
 type AiVaultResumeShellState = Pick<
   AppState,
@@ -82,4 +84,34 @@ export function getAiVaultResumeWorkspacePath(
       .flat()
       .find((candidate) => candidate.id === targetWorktreeId)?.path ?? null
   )
+}
+
+export function getAiVaultResumePlatform(
+  state: Pick<
+    AppState,
+    | 'activeRepoId'
+    | 'activeWorktreeId'
+    | 'folderWorkspaces'
+    | 'projectGroups'
+    | 'projects'
+    | 'repos'
+    | 'settings'
+    | 'worktreesByRepo'
+  >,
+  worktreeId?: string | null
+): NodeJS.Platform {
+  const targetWorktreeId = worktreeId ?? state.activeWorktreeId
+  const executionHost = parseExecutionHostId(getExecutionHostIdForWorktree(state, targetWorktreeId))
+  if (executionHost?.kind === 'ssh' || executionHost?.kind === 'runtime') {
+    return 'linux'
+  }
+  const projectRuntime = getLocalProjectExecutionRuntimeContext(state, worktreeId, CLIENT_PLATFORM)
+  if (projectRuntime?.status === 'repair-required') {
+    return projectRuntime.repair.preferredRuntime.kind === 'wsl' ? 'linux' : CLIENT_PLATFORM
+  }
+  if (projectRuntime?.status === 'resolved' && projectRuntime.runtime.kind === 'wsl') {
+    return 'linux'
+  }
+  const workspacePath = getAiVaultResumeWorkspacePath(state, targetWorktreeId)
+  return workspacePath && parseWslUncPath(workspacePath) ? 'linux' : CLIENT_PLATFORM
 }

--- a/src/renderer/src/lib/client-agent-startup-shell.ts
+++ b/src/renderer/src/lib/client-agent-startup-shell.ts
@@ -1,0 +1,36 @@
+import { parseExecutionHostId, type ExecutionHostKind } from '../../../shared/execution-host'
+import { resolveLocalAgentStartupShell } from '../../../shared/local-agent-startup-shell'
+import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
+import { getClientLoginShell } from '@/lib/client-login-shell'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
+import {
+  getExecutionHostIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from '@/lib/worktree-runtime-owner'
+
+/** Execution owner of a workspace, in the shape `resolveClientAgentStartupShell` wants. */
+export function getWorkspaceExecutionHostKind(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string | null | undefined
+): ExecutionHostKind | null {
+  return parseExecutionHostId(getExecutionHostIdForWorktree(state, worktreeId))?.kind ?? null
+}
+
+/**
+ * Startup-shell dialect for a command this client's own login shell will run.
+ *
+ * `executionHostKind` is required, not optional: a locally-listed workspace can
+ * still execute on an SSH or runtime host, and only the caller knows which.
+ */
+export function resolveClientAgentStartupShell(args: {
+  platform: NodeJS.Platform
+  isRemote: boolean
+  terminalWindowsShell?: string | null
+  executionHostKind: ExecutionHostKind | null
+}): AgentStartupShell | undefined {
+  return resolveLocalAgentStartupShell({
+    ...args,
+    hostPlatform: CLIENT_PLATFORM,
+    hostLoginShell: getClientLoginShell()
+  })
+}

--- a/src/renderer/src/lib/fish-ai-vault-resume-env.live-fish.test.ts
+++ b/src/renderer/src/lib/fish-ai-vault-resume-env.live-fish.test.ts
@@ -1,0 +1,203 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  fishRequirementViolation,
+  resolveFishBinary
+} from '../../../shared/fish-binary-requirement'
+import { quoteStartupArg } from '../../../shared/tui-agent-startup-shell'
+
+vi.mock('@/lib/new-workspace', () => ({ CLIENT_PLATFORM: 'darwin' }))
+vi.mock('@/lib/client-login-shell', () => ({
+  getClientLoginShell: () => '/opt/homebrew/bin/fish'
+}))
+
+import { buildAiVaultResumeCopyCommandForWorktree } from './ai-vault-resume-command'
+
+const FISH = resolveFishBinary(4)
+const itWithFish = FISH.available ? it : it.skip
+
+let root: string | null = null
+
+function fishEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const home = root as string
+  return {
+    PATH: `${home}${path.delimiter}${process.env.PATH ?? '/usr/bin:/bin'}`,
+    HOME: home,
+    USER: 'orca-fish-test',
+    LOGNAME: 'orca-fish-test',
+    XDG_CONFIG_HOME: home,
+    XDG_DATA_HOME: path.join(home, 'data'),
+    TERM: 'dumb',
+    LANG: 'en_US.UTF-8',
+    LC_ALL: 'en_US.UTF-8',
+    ...overrides
+  }
+}
+
+function runFish(command: string, env: NodeJS.ProcessEnv = fishEnv()): Buffer {
+  return execFileSync(FISH.path as string, ['-c', command], {
+    cwd: root as string,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+}
+
+function setUniversalHomes(): void {
+  runFish('set -Ux CODEX_HOME universal-codex; set -Ux ORCA_CODEX_HOME universal-orca')
+}
+
+function exportedHomes(): Record<string, string | undefined> {
+  const env = runFish('/usr/bin/env').toString('utf8')
+  return Object.fromEntries(
+    env
+      .split('\n')
+      .filter((line) => /^(CODEX_HOME|ORCA_CODEX_HOME)=/.test(line))
+      .map((line) => {
+        const separator = line.indexOf('=')
+        return [line.slice(0, separator), line.slice(separator + 1)]
+      })
+  )
+}
+
+function installCodexCapture(): string {
+  const capturePath = path.join(root as string, 'codex-env.json')
+  const codexPath = path.join(root as string, 'codex')
+  writeFileSync(
+    codexPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs')",
+      `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
+      '  codexHome: process.env.CODEX_HOME ?? null,',
+      '  orcaCodexHome: process.env.ORCA_CODEX_HOME ?? null,',
+      "  hasCodexHome: Object.hasOwn(process.env, 'CODEX_HOME'),",
+      "  hasOrcaCodexHome: Object.hasOwn(process.env, 'ORCA_CODEX_HOME'),",
+      '  argv: process.argv.slice(2)',
+      '}))',
+      ''
+    ].join('\n')
+  )
+  chmodSync(codexPath, 0o755)
+  return capturePath
+}
+
+function makeState(): Parameters<typeof buildAiVaultResumeCopyCommandForWorktree>[0]['state'] {
+  const workspacePath = root as string
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: 'repo-1::worktree-1',
+    folderWorkspaces: [],
+    projectGroups: [],
+    repos: [{ id: 'repo-1', path: workspacePath }],
+    projects: [{ id: 'repo-1', sourceRepoIds: ['repo-1'] }],
+    settings: {
+      agentDefaultArgs: { codex: '' },
+      agentDefaultEnv: { codex: {} }
+    },
+    worktreesByRepo: {
+      'repo-1': [
+        {
+          id: 'repo-1::worktree-1',
+          repoId: 'repo-1',
+          path: workspacePath
+        }
+      ]
+    }
+  } as unknown as AppState
+}
+
+describe('Fish real-home Codex resume environment', () => {
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'orca-fish-resume-env-'))
+  })
+
+  afterEach(() => {
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+      root = null
+    }
+  })
+
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  itWithFish('proves unscoped erase exposes universal values hidden by inherited globals', () => {
+    setUniversalHomes()
+    const capturePath = installCodexCapture()
+
+    runFish(
+      'set -e CODEX_HOME; set -e ORCA_CODEX_HOME; codex',
+      fishEnv({ CODEX_HOME: 'orca-route', ORCA_CODEX_HOME: 'orca-route' })
+    )
+
+    expect(JSON.parse(readFileSync(capturePath, 'utf8'))).toMatchObject({
+      codexHome: 'universal-codex',
+      orcaCodexHome: 'universal-orca'
+    })
+    expect(exportedHomes()).toMatchObject({
+      CODEX_HOME: 'universal-codex',
+      ORCA_CODEX_HOME: 'universal-orca'
+    })
+  })
+
+  itWithFish('masks every scope through a Fish function without changing shell state', () => {
+    setUniversalHomes()
+    const capturePath = installCodexCapture()
+    const workspacePath = root as string
+    const beforePath = path.join(workspacePath, 'scopes-before.txt')
+    const afterPath = path.join(workspacePath, 'scopes-after.txt')
+    const command = buildAiVaultResumeCopyCommandForWorktree({
+      state: makeState(),
+      worktreeId: 'repo-1::worktree-1',
+      commandOverride: 'fish_codex --profile wrapped',
+      session: {
+        agent: 'codex',
+        sessionId: 'session one',
+        cwd: workspacePath,
+        codexHome: null
+      }
+    })
+
+    runFish(
+      [
+        'function fish_codex',
+        '  command codex --fish-wrapper $argv',
+        'end',
+        'function run_resume',
+        '  set -lx CODEX_HOME local-codex',
+        '  set -lx ORCA_CODEX_HOME local-orca',
+        `  set -S CODEX_HOME ORCA_CODEX_HOME > ${quoteStartupArg(beforePath, 'fish')}`,
+        `  ${command}`,
+        `  set -S CODEX_HOME ORCA_CODEX_HOME > ${quoteStartupArg(afterPath, 'fish')}`,
+        'end',
+        'run_resume'
+      ].join('\n'),
+      fishEnv({ CODEX_HOME: 'inherited-codex', ORCA_CODEX_HOME: 'inherited-orca' })
+    )
+
+    expect(JSON.parse(readFileSync(capturePath, 'utf8'))).toEqual({
+      codexHome: '',
+      orcaCodexHome: '',
+      hasCodexHome: true,
+      hasOrcaCodexHome: true,
+      argv: ['--fish-wrapper', '--profile', 'wrapped', 'resume', 'session one']
+    })
+    const scopesBefore = readFileSync(beforePath, 'utf8')
+    expect(scopesBefore).toContain('|local-codex|')
+    expect(scopesBefore).toContain('|local-orca|')
+    expect(scopesBefore).toContain('|inherited-codex|')
+    expect(scopesBefore).toContain('|inherited-orca|')
+    expect(scopesBefore).toContain('|universal-codex|')
+    expect(scopesBefore).toContain('|universal-orca|')
+    expect(readFileSync(afterPath, 'utf8')).toBe(scopesBefore)
+    expect(exportedHomes()).toMatchObject({
+      CODEX_HOME: 'universal-codex',
+      ORCA_CODEX_HOME: 'universal-orca'
+    })
+  })
+})

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -12,7 +12,10 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
-import { resolveAgentBackgroundLaunchHost } from '@/lib/agent-background-session-launch-host'
+import {
+  resolveAgentBackgroundLaunchHost,
+  resolveAgentBackgroundLaunchShell
+} from '@/lib/agent-background-session-launch-host'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
   registerEagerPtyBuffer,
@@ -31,7 +34,6 @@ import {
 import { createSshBackgroundStartupDelivery } from '@/lib/ssh-background-startup-delivery'
 import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
-import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { runBestEffortAgentBackgroundCleanups } from '@/lib/agent-background-session-cleanup'
 import type { bindAutomationTerminal } from '@/lib/automation-terminal-ownership'
 import {
@@ -75,11 +77,7 @@ export async function launchAgentBackgroundSession(
     }
   }
   const { platform: launchPlatform, isRemote } = launchHost
-  const startupShell = resolveLocalWindowsAgentStartupShell({
-    platform: launchPlatform,
-    isRemote,
-    terminalWindowsShell: store.settings?.terminalWindowsShell
-  })
+  const startupShell = resolveAgentBackgroundLaunchShell(store, worktreeId, launchHost)
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
   const isFollowupPath = TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start'

--- a/src/renderer/src/lib/launch-agent-in-new-tab-cwd.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-cwd.test.ts
@@ -43,7 +43,8 @@ vi.mock('@/runtime/web-runtime-session', () => ({
 }))
 
 vi.mock('@/lib/worktree-runtime-owner', () => ({
-  getRuntimeEnvironmentIdForWorktree: () => 'web-runtime'
+  getRuntimeEnvironmentIdForWorktree: () => 'web-runtime',
+  getExecutionHostIdForWorktree: () => 'local'
 }))
 
 vi.mock('@/lib/launch-agent-web-host-tab', () => ({

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -20,7 +20,10 @@ import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
-import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
+import {
+  getWorkspaceExecutionHostKind,
+  resolveClientAgentStartupShell
+} from '@/lib/client-agent-startup-shell'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
@@ -96,10 +99,11 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       : CLIENT_PLATFORM)
   // Why: SSH remotes deploy the shim as plain `orca`, so skip the Linux-only `orca-ide` rename for remote launches.
   const isRemote = repo ? repoIsRemote(repo) : false
-  const queuedShell = resolveLocalWindowsAgentStartupShell({
+  const queuedShell = resolveClientAgentStartupShell({
     platform: resolvedLaunchPlatform,
     isRemote,
-    terminalWindowsShell: store.settings?.terminalWindowsShell
+    terminalWindowsShell: store.settings?.terminalWindowsShell,
+    executionHostKind: getWorkspaceExecutionHostKind(store, worktreeId)
   })
   const cmdOverrides = store.settings?.agentCmdOverrides ?? {}
   const effectiveAgentArgs =

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -11,6 +11,7 @@ import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-re
 import type { LaunchSource } from '../../../shared/telemetry-events'
 import type { StartupCommandDelivery } from '../../../shared/codex-startup-delivery'
 import type { TuiAgent } from '../../../shared/types'
+import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
 import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
@@ -36,6 +37,8 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     | null
     | undefined
   launchPlatform: NodeJS.Platform
+  /** Dialect that parses the launch line; undefined keeps the platform default. */
+  launchShell?: AgentStartupShell
   nativeChatTranscriptIsLocalReadable?: boolean
   /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
    * `orca-ide` rename must not be applied for remote launches. */
@@ -69,6 +72,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
           draft: args.draftContent,
           cmdOverrides: args.settings?.agentCmdOverrides ?? {},
           platform: args.launchPlatform,
+          shell: args.launchShell,
           isRemote: args.isRemote,
           agentArgs: effectiveAgentArgs,
           agentEnv: effectiveAgentEnv,
@@ -101,6 +105,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     prompt: '',
     cmdOverrides: args.settings?.agentCmdOverrides ?? {},
     platform: args.launchPlatform,
+    shell: args.launchShell,
     isRemote: args.isRemote,
     agentArgs: effectiveAgentArgs,
     agentEnv: effectiveAgentEnv,

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -407,6 +407,7 @@ describe('launchWorkItemDirect', () => {
       agentEnv: {},
       sessionOptions: undefined,
       platform: 'win32',
+      shell: 'powershell',
       isRemote: false
     })
     expect(buildAgentStartupPlan).not.toHaveBeenCalledWith(

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -599,6 +599,7 @@ describe('launchWorkItemDirect', () => {
       agentEnv: {},
       sessionOptions: undefined,
       platform: 'linux',
+      shell: 'unix',
       isRemote: true
     })
     expect(buildAgentStartupPlan).toHaveBeenCalledWith({
@@ -609,6 +610,7 @@ describe('launchWorkItemDirect', () => {
       agentEnv: {},
       sessionOptions: undefined,
       platform: 'linux',
+      shell: 'unix',
       isRemote: true,
       allowEmptyPromptLaunch: true
     })

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -33,6 +33,10 @@ import type { LaunchWorkItemDirectArgs } from '@/lib/launch-work-item-direct-typ
 import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import {
+  getWorkspaceExecutionHostKind,
+  resolveClientAgentStartupShell
+} from '@/lib/client-agent-startup-shell'
+import {
   getLocalProjectExecutionRuntimeContext,
   getLocalRepoProjectExecutionRuntimeContext
 } from '@/lib/local-preflight-context'
@@ -279,6 +283,12 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
         promptDelivery,
         settings,
         launchPlatform,
+        launchShell: resolveClientAgentStartupShell({
+          platform: launchPlatform,
+          isRemote: typeof launchConnectionId === 'string',
+          terminalWindowsShell: settings?.terminalWindowsShell,
+          executionHostKind: getWorkspaceExecutionHostKind(useAppStore.getState(), worktreeId)
+        }),
         nativeChatTranscriptIsLocalReadable:
           isNativeChatTranscriptLocalReadable(launchConnectionId),
         // Why: SSH hosts run the plain `orca` shim, so the Linux-only `orca-ide`

--- a/src/renderer/src/lib/onboarding-folder-agent-startup.ts
+++ b/src/renderer/src/lib/onboarding-folder-agent-startup.ts
@@ -11,6 +11,8 @@ import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-re
 import type { GlobalSettings, OnboardingState, TuiAgent } from '../../../shared/types'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import type { SessionOptionValue } from '../../../shared/native-chat-session-options'
+import { resolveLoginShellStartupDialect } from '../../../shared/tui-agent-startup-shell'
+import { getClientLoginShell } from '@/lib/client-login-shell'
 
 export type OnboardingFolderAgentStartup = {
   command: string
@@ -54,6 +56,7 @@ export function buildOnboardingFolderAgentStartup(
       nativeChatTranscriptIsLocalReadable
     }),
     platform: getClientPlatform(),
+    shell: resolveLoginShellStartupDialect(getClientLoginShell()),
     allowEmptyPromptLaunch: true
   })
   if (!startupPlan) {

--- a/src/renderer/src/lib/project-skill-runtime.ts
+++ b/src/renderer/src/lib/project-skill-runtime.ts
@@ -51,9 +51,8 @@ export function getProjectAgentSkillTerminalShellOverride(
   }
   // Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
   // Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.
-  return resolveWindowsShellStartupFamily(settings?.terminalWindowsShell) === 'posix'
-    ? 'powershell.exe'
-    : undefined
+  const shellFamily = resolveWindowsShellStartupFamily(settings?.terminalWindowsShell)
+  return shellFamily === 'posix' || shellFamily === 'unix' ? 'powershell.exe' : undefined
 }
 
 export function getProjectSkillInstallDisabledReason(

--- a/src/renderer/src/lib/source-control-agent-action-plan.test.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.test.ts
@@ -109,4 +109,23 @@ describe('planSourceControlAgentActionLaunch', () => {
     expect(result.ok && result.delivery).toBe('draft-native')
     expect(result.ok && result.commandLabel).toContain('--prefill')
   })
+
+  it.each([
+    { agentShell: '/bin/bash', expectedTeardown: 'unset ORCA_PI_PREFILL' },
+    { agentShell: '/usr/bin/fish', expectedTeardown: 'set -e ORCA_PI_PREFILL' }
+  ])(
+    'quotes source-control drafts for agent SHELL=$agentShell',
+    ({ agentShell, expectedTeardown }) => {
+      const result = planSourceControlAgentActionLaunch({
+        agent: 'pi',
+        commandInput: 'Fix checks',
+        promptDelivery: 'draft',
+        detectedAgents: ['pi'],
+        agentEnv: { SHELL: agentShell },
+        platform: 'linux'
+      })
+
+      expect(result.ok && result.plan.launchCommand).toContain(expectedTeardown)
+    }
+  )
 })

--- a/src/renderer/src/lib/source-control-agent-action-plan.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.ts
@@ -9,7 +9,8 @@ import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import type { TuiAgent } from '../../../shared/types'
 import { translate } from '@/i18n/i18n'
-import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
+import { resolveClientAgentStartupShell } from '@/lib/client-agent-startup-shell'
+import type { ExecutionHostKind } from '../../../shared/execution-host'
 import type { SessionOptionValue } from '../../../shared/native-chat-session-options'
 
 export type SourceControlLaunchPlanDelivery =
@@ -43,6 +44,8 @@ export function planSourceControlAgentActionLaunch(args: {
   /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
    * `orca-ide` rename must not be applied for remote launches. */
   isRemote?: boolean
+  /** Execution owner of the target workspace; anything but a local host parses the line elsewhere. */
+  executionHostKind?: ExecutionHostKind | null
 }): SourceControlLaunchPlanResult {
   const agent = args.agent
   if (!agent) {
@@ -88,10 +91,11 @@ export function planSourceControlAgentActionLaunch(args: {
   const platform = args.platform ?? CLIENT_PLATFORM
   const isRemote = args.isRemote ?? false
   const shell =
-    resolveLocalWindowsAgentStartupShell({
+    resolveClientAgentStartupShell({
       platform,
       isRemote,
-      terminalWindowsShell: args.terminalWindowsShell
+      terminalWindowsShell: args.terminalWindowsShell,
+      executionHostKind: args.executionHostKind ?? null
     }) ?? (platform === 'win32' ? 'powershell' : 'posix')
   const plannedArgs = planAgentCliArgsSuffix(args.agentArgs, shell)
   if (!plannedArgs.ok) {

--- a/src/renderer/src/lib/source-control-agent-action-plan.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.ts
@@ -2,6 +2,7 @@ import {
   buildAgentDraftLaunchPlan,
   buildAgentStartupPlan,
   planAgentCliArgsSuffix,
+  resolveStartupShell,
   type AgentStartupPlan
 } from '@/lib/tui-agent-startup'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
@@ -38,6 +39,7 @@ export function planSourceControlAgentActionLaunch(args: {
   disabledAgents?: TuiAgent[]
   cmdOverrides?: Partial<Record<TuiAgent, string>>
   agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
   sessionOptions?: Record<string, SessionOptionValue>
   platform?: NodeJS.Platform
   terminalWindowsShell?: string | null
@@ -90,13 +92,14 @@ export function planSourceControlAgentActionLaunch(args: {
   const cmdOverrides = args.cmdOverrides ?? {}
   const platform = args.platform ?? CLIENT_PLATFORM
   const isRemote = args.isRemote ?? false
-  const shell =
+  const configuredShell =
     resolveClientAgentStartupShell({
       platform,
       isRemote,
       terminalWindowsShell: args.terminalWindowsShell,
       executionHostKind: args.executionHostKind ?? null
     }) ?? (platform === 'win32' ? 'powershell' : 'posix')
+  const shell = resolveStartupShell(platform, configuredShell, args.agentEnv)
   const plannedArgs = planAgentCliArgsSuffix(args.agentArgs, shell)
   if (!plannedArgs.ok) {
     return { ok: false, error: plannedArgs.error }
@@ -113,6 +116,7 @@ export function planSourceControlAgentActionLaunch(args: {
       shell,
       isRemote,
       agentArgs: args.agentArgs,
+      agentEnv: args.agentEnv,
       sessionOptions: args.sessionOptions,
       allowEmptyPromptLaunch: true
     })
@@ -126,6 +130,7 @@ export function planSourceControlAgentActionLaunch(args: {
       shell,
       isRemote,
       agentArgs: args.agentArgs,
+      agentEnv: args.agentEnv,
       sessionOptions: args.sessionOptions
     })
     if (draftLaunchPlan) {
@@ -153,6 +158,7 @@ export function planSourceControlAgentActionLaunch(args: {
         shell,
         isRemote,
         agentArgs: args.agentArgs,
+        agentEnv: args.agentEnv,
         sessionOptions: args.sessionOptions,
         allowEmptyPromptLaunch: true
       })
@@ -167,6 +173,7 @@ export function planSourceControlAgentActionLaunch(args: {
       shell,
       isRemote,
       agentArgs: args.agentArgs,
+      agentEnv: args.agentEnv,
       sessionOptions: args.sessionOptions,
       allowEmptyPromptLaunch: true
     })
@@ -180,6 +187,7 @@ export function planSourceControlAgentActionLaunch(args: {
       shell,
       isRemote,
       agentArgs: args.agentArgs,
+      agentEnv: args.agentEnv,
       sessionOptions: args.sessionOptions,
       allowEmptyPromptLaunch: false
     })

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -348,7 +348,8 @@ describe('buildAgentDraftLaunchPlan', () => {
         agent: 'pi',
         draft: 'https://github.com/acme/repo/issues/42',
         cmdOverrides: {},
-        platform: 'darwin'
+        platform: 'darwin',
+        shell: 'posix'
       })
     ).toEqual({
       agent: 'pi',

--- a/src/shared/agent-resume-argv-drop.ts
+++ b/src/shared/agent-resume-argv-drop.ts
@@ -13,7 +13,9 @@ export type AgentResumeArgvDrop =
   | { status: 'absent' }
   | { status: 'unrecognized' }
 
-const RESUME_ARGV_SHELLS: readonly AgentStartupShell[] = ['posix', 'powershell', 'cmd']
+// fish is listed because its quoting diverges from sh; without it a fish-quoted
+// suffix reads as `unrecognized` and the caller refuses the launch outright.
+const RESUME_ARGV_SHELLS: readonly AgentStartupShell[] = ['posix', 'fish', 'powershell', 'cmd']
 
 function resumeArgvSuffixCandidates(resumeArgs: readonly string[]): string[] {
   const candidates = new Set<string>([resumeArgs.join(' ')])

--- a/src/shared/agent-resume-argv-drop.ts
+++ b/src/shared/agent-resume-argv-drop.ts
@@ -15,7 +15,13 @@ export type AgentResumeArgvDrop =
 
 // fish is listed because its quoting diverges from sh; without it a fish-quoted
 // suffix reads as `unrecognized` and the caller refuses the launch outright.
-const RESUME_ARGV_SHELLS: readonly AgentStartupShell[] = ['posix', 'fish', 'powershell', 'cmd']
+const RESUME_ARGV_SHELLS: readonly AgentStartupShell[] = [
+  'posix',
+  'fish',
+  'unix',
+  'powershell',
+  'cmd'
+]
 
 function resumeArgvSuffixCandidates(resumeArgs: readonly string[]): string[] {
   const candidates = new Set<string>([resumeArgs.join(' ')])

--- a/src/shared/agent-resume-launch-command.test.ts
+++ b/src/shared/agent-resume-launch-command.test.ts
@@ -9,6 +9,7 @@ const providerSession = { key: 'session_id', id: SESSION_ID } as const
 
 const SHELLS: { platform: NodeJS.Platform; shell: AgentStartupShell }[] = [
   { platform: 'linux', shell: 'posix' },
+  { platform: 'linux', shell: 'unix' },
   { platform: 'darwin', shell: 'posix' },
   { platform: 'win32', shell: 'powershell' },
   { platform: 'win32', shell: 'cmd' }

--- a/src/shared/agent-resume-launch-command.ts
+++ b/src/shared/agent-resume-launch-command.ts
@@ -1,5 +1,6 @@
 import type { ResumableTuiAgent } from './agent-session-resume'
 import {
+  isPosixStartupShell,
   quoteStartupArg,
   tokenizeStartupCommand,
   type AgentStartupShell
@@ -37,9 +38,9 @@ function findClaudeExecutableIndex(tokens: readonly string[], shell: AgentStartu
         return i
       }
       if (
-        // Why: `NAME=value cmd` is posix-only syntax; on cmd/PowerShell such a
-        // token is just a bogus executable name, not a prefix to skip.
-        (shell === 'posix' && /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) ||
+        // Why: `NAME=value cmd` is sh-family syntax (fish included, 3.1+); on
+        // cmd/PowerShell such a token is a bogus executable name, not a prefix.
+        (isPosixStartupShell(shell) && /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) ||
         (shell === 'powershell' && token === '&' && i === 0)
       ) {
         continue

--- a/src/shared/ai-vault-resume-command.ts
+++ b/src/shared/ai-vault-resume-command.ts
@@ -72,7 +72,7 @@ export function buildAiVaultResumeShellCommand(args: {
     })
   }
 
-  const resumeCommand = `${codexHomeEnvPrefix(codexHome?.trim() || null, platform)}${
+  const resumeCommand = `${codexHomeEnvPrefix(codexHome?.trim() || null, platform, shell)}${
     args.resumeCommand
   }`
   if (platform === 'win32' && shell === 'cmd') {
@@ -89,7 +89,7 @@ export function buildAiVaultResumeShellCommand(args: {
     return `cmd /d /s /c ${quoteWindowsCmdArg(inner)}`
   }
 
-  return `cd ${quoteShellArg(cwd, platform)} && ${resumeCommand}`
+  return `cd ${quoteResumeArg(cwd, platform, shell)} && ${resumeCommand}`
 }
 
 function buildResumeShellCommandForShell(args: {
@@ -184,14 +184,28 @@ function buildAgentResumeInvocation(
   }
 }
 
-function codexHomeEnvPrefix(codexHome: string | null, platform: NodeJS.Platform): string {
+function codexHomeEnvPrefix(
+  codexHome: string | null,
+  platform: NodeJS.Platform,
+  shell?: AgentStartupShell
+): string {
   if (!codexHome) {
     return ''
   }
   if (platform === 'win32') {
     return `set ${quoteWindowsCmdArg(`CODEX_HOME=${codexHome}`)} && `
   }
-  return `CODEX_HOME=${quoteShellArg(codexHome, platform)} `
+  // fish accepts the `NAME=value cmd` prefix (3.1+), but not sh's quoting.
+  return `CODEX_HOME=${quoteResumeArg(codexHome, platform, shell)} `
+}
+
+/** Quotes for the live shell when one is known, else for the platform's default. */
+function quoteResumeArg(
+  value: string,
+  platform: NodeJS.Platform,
+  shell?: AgentStartupShell
+): string {
+  return shell ? quoteStartupArg(value, shell) : quoteShellArg(value, platform)
 }
 
 function quoteShellArg(value: string, platform: NodeJS.Platform): string {

--- a/src/shared/fish-command-tokenizer.test.ts
+++ b/src/shared/fish-command-tokenizer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { tokenizeFishStartupCommand } from './fish-command-tokenizer'
+import { tokenizeStartupCommand } from './tui-agent-startup-shell'
+
+function tokens(value: string): string[] {
+  const result = tokenizeFishStartupCommand(value)
+  if (!result.ok) {
+    throw new Error(result.error)
+  }
+  return result.tokens
+}
+
+function spanFlags(value: string): boolean[] {
+  const result = tokenizeFishStartupCommand(value)
+  if (!result.ok) {
+    throw new Error(result.error)
+  }
+  return result.spans.map((span) => span.divergesFromShell)
+}
+
+describe('tokenizeFishStartupCommand', () => {
+  it('treats a backslash inside single quotes as an escape, unlike sh', () => {
+    expect(tokens(String.raw`'a\\b'`)).toEqual([String.raw`a\b`])
+    expect(tokens(String.raw`'a\'b'`)).toEqual([`a'b`])
+    // Every other backslash stays literal inside single quotes.
+    expect(tokens(String.raw`'a\nb'`)).toEqual([String.raw`a\nb`])
+  })
+
+  it('rejects a trailing backslash before the closing single quote', () => {
+    // fish reads the escaped quote as literal, so the string never closes.
+    expect(tokenizeFishStartupCommand(String.raw`'ends\'`)).toEqual({
+      ok: false,
+      error: 'Unclosed quote in command template.'
+    })
+  })
+
+  it('escapes only \\ $ " and a continuation inside double quotes', () => {
+    expect(tokens(String.raw`"a\\b" "a\$b" "a\"b" "a\nb" "a\zb"`)).toEqual([
+      String.raw`a\b`,
+      'a$b',
+      'a"b',
+      String.raw`a\nb`,
+      String.raw`a\zb`
+    ])
+  })
+
+  it('decodes the unquoted escape set fish actually implements', () => {
+    expect(tokens(String.raw`a\nb`)).toEqual(['a\nb'])
+    expect(tokens(String.raw`a\tb`)).toEqual(['a\tb'])
+    expect(tokens(String.raw`\x41 \X41 \101 A \U00000041`)).toEqual(['A', 'A', 'A', 'A', 'A'])
+    expect(tokens(String.raw`\cA`)).toEqual([''])
+    // An unknown escape drops the backslash and keeps the byte.
+    expect(tokens(String.raw`a\zb`)).toEqual(['azb'])
+  })
+
+  it('keeps quoted regions attached to the surrounding token', () => {
+    expect(tokens(`a"b"c'd'e`)).toEqual(['abcde'])
+    expect(tokens(`--flag='has space'`)).toEqual(['--flag=has space'])
+  })
+
+  it('reports an unclosed quote of either kind', () => {
+    expect(tokenizeFishStartupCommand(`a 'b`).ok).toBe(false)
+    expect(tokenizeFishStartupCommand(`a "b`).ok).toBe(false)
+  })
+
+  it('flags live fish syntax a span splice cannot model', () => {
+    // Command substitution, brace expansion and globs are all live in fish; an
+    // unmatched wildcard is a hard error rather than a literal.
+    expect(spanFlags('claude (echo hi)')).toEqual([false, true, true])
+    expect(spanFlags('claude {a,b}')).toEqual([false, true])
+    expect(spanFlags('claude *.ts')).toEqual([false, true])
+    expect(spanFlags('claude a?b')).toEqual([false, true])
+    expect(spanFlags('claude x; y')).toEqual([false, true, false])
+    expect(spanFlags('claude trailing\\')).toEqual([false, true])
+    // Plain words and quoted metacharacters stay modelable.
+    expect(spanFlags(`claude --resume 'a*b' "c;d"`)).toEqual([false, false, false, false])
+  })
+
+  it('is what tokenizeStartupCommand uses for the fish dialect', () => {
+    const line = String.raw`claude --prompt 'match \\d+'`
+    expect(tokenizeStartupCommand(line, 'fish')).toEqual(tokenizeFishStartupCommand(line))
+    // The sh tokenizer keeps both backslashes, which is not what fish does.
+    const posix = tokenizeStartupCommand(line, 'posix')
+    expect(posix.ok && posix.tokens.at(-1)).toBe(String.raw`match \\d+`)
+  })
+})

--- a/src/shared/fish-command-tokenizer.ts
+++ b/src/shared/fish-command-tokenizer.ts
@@ -1,0 +1,247 @@
+import type { CommandTokenSpan } from './commit-message-prompt'
+
+/**
+ * Splits a command line the way fish does, which is NOT the way sh does.
+ *
+ * fish single quotes are not literal: `\\` and `\'` are escapes inside them, so
+ * a trailing backslash before the closing quote is a syntax error rather than a
+ * literal byte. Unquoted backslashes decode the full C-style escape set
+ * (`\n`, `\t`, `\x41`, `\101`, `A`, `\cA`, …) instead of just protecting the
+ * next byte, and inside double quotes only `\\`, `\$`, `\"` and a line
+ * continuation are escapes — every other backslash stays literal.
+ *
+ * Verified against fish 4.7.1. Feeding these strings through the sh tokenizer
+ * silently drops or invents backslashes, which is how a regex or a UNC path in a
+ * user's CLI-args string gets corrupted before it ever reaches the agent.
+ */
+export type FishStartupCommandTokens =
+  | { ok: true; tokens: string[]; spans: CommandTokenSpan[] }
+  | { ok: false; error: string }
+
+const UNCLOSED_QUOTE_ERROR = 'Unclosed quote in command template.'
+
+const SIMPLE_ESCAPES: Record<string, string> = {
+  a: '\x07',
+  b: '\b',
+  e: '\x1b',
+  f: '\f',
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  v: '\v',
+  '\\': '\\'
+}
+
+type EscapeDecode = { text: string; next: number; diverges: boolean }
+
+function readRadix(value: string, start: number, pattern: RegExp): string {
+  return pattern.exec(value.slice(start))?.[0] ?? ''
+}
+
+/** Decodes the escape whose backslash sits at `start - 1`. */
+function decodeFishEscape(value: string, start: number): EscapeDecode {
+  const char = value[start]
+  const simple = SIMPLE_ESCAPES[char]
+  if (simple !== undefined) {
+    return { text: simple, next: start + 1, diverges: false }
+  }
+  const fromCode = (digits: string, radix: number, prefix: number): EscapeDecode => {
+    const code = Number.parseInt(digits, radix)
+    // Why: fish rejects an out-of-range escape outright, and a NUL truncates the
+    // token; neither is something this tokenizer's value can represent.
+    if (!Number.isFinite(code) || code === 0 || code > 0x10ffff) {
+      return {
+        text: value.slice(start, start + prefix + digits.length),
+        next: start + prefix + digits.length,
+        diverges: true
+      }
+    }
+    return {
+      text: String.fromCodePoint(code),
+      next: start + prefix + digits.length,
+      diverges: false
+    }
+  }
+  if (char === 'x' || char === 'X') {
+    const digits = readRadix(value, start + 1, /^[0-9a-fA-F]{1,2}/)
+    return digits ? fromCode(digits, 16, 1) : { text: char, next: start + 1, diverges: false }
+  }
+  if (char === 'u' || char === 'U') {
+    const digits = readRadix(
+      value,
+      start + 1,
+      char === 'u' ? /^[0-9a-fA-F]{1,4}/ : /^[0-9a-fA-F]{1,8}/
+    )
+    return digits ? fromCode(digits, 16, 1) : { text: char, next: start + 1, diverges: false }
+  }
+  if (char >= '0' && char <= '7') {
+    const digits = readRadix(value, start, /^[0-7]{1,3}/)
+    // fish caps an octal escape at one byte and errors above it.
+    return Number.parseInt(digits, 8) > 0xff
+      ? {
+          text: value.slice(start, start + digits.length),
+          next: start + digits.length,
+          diverges: true
+        }
+      : fromCode(digits, 8, 0)
+  }
+  if (char === 'c' && value[start + 1]) {
+    return {
+      text: String.fromCharCode(value.charCodeAt(start + 1) & 0x1f),
+      next: start + 2,
+      diverges: false
+    }
+  }
+  return { text: char, next: start + 1, diverges: false }
+}
+
+export function tokenizeFishStartupCommand(value: string): FishStartupCommandTokens {
+  const tokens: string[] = []
+  const spans: CommandTokenSpan[] = []
+  let token = ''
+  let tokenStart = 0
+  let started = false
+  let diverges = false
+  let index = 0
+
+  const begin = (at: number): void => {
+    if (!started) {
+      tokenStart = at
+    }
+    started = true
+  }
+
+  while (index < value.length) {
+    const char = value[index]
+
+    if (char === "'") {
+      begin(index)
+      index += 1
+      let closed = false
+      while (index < value.length) {
+        const inner = value[index]
+        if (inner === '\\' && (value[index + 1] === '\\' || value[index + 1] === "'")) {
+          token += value[index + 1]
+          index += 2
+          continue
+        }
+        if (inner === "'") {
+          closed = true
+          index += 1
+          break
+        }
+        token += inner
+        index += 1
+      }
+      if (!closed) {
+        return { ok: false, error: UNCLOSED_QUOTE_ERROR }
+      }
+      continue
+    }
+
+    if (char === '"') {
+      begin(index)
+      index += 1
+      let closed = false
+      while (index < value.length) {
+        const inner = value[index]
+        if (inner === '\\') {
+          const next = value[index + 1]
+          if (next === '\\' || next === '$' || next === '"') {
+            token += next
+            index += 2
+            continue
+          }
+          if (next === '\n') {
+            // A continuation joins words the caller's span splice cannot model.
+            diverges = true
+            index += 2
+            continue
+          }
+          if (next === undefined) {
+            break
+          }
+          token += inner
+          index += 1
+          continue
+        }
+        if (inner === '"') {
+          closed = true
+          index += 1
+          break
+        }
+        // Why: `$(…)` and `${…}` reopen a nested parsing context this loop does not model.
+        diverges ||= inner === '$' && '({'.includes(value[index + 1] ?? '\0')
+        token += inner
+        index += 1
+      }
+      if (!closed) {
+        return { ok: false, error: UNCLOSED_QUOTE_ERROR }
+      }
+      continue
+    }
+
+    if (char === '\\') {
+      const next = value[index + 1]
+      if (next === undefined) {
+        // A trailing backslash swallows whatever a consumer appends after the base.
+        diverges = true
+        begin(index)
+        token += char
+        index += 1
+        continue
+      }
+      if (next === '\n') {
+        diverges = true
+        begin(index)
+        index += 2
+        continue
+      }
+      begin(index)
+      const decoded = decodeFishEscape(value, index + 1)
+      diverges ||= decoded.diverges
+      token += decoded.text
+      index = decoded.next
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      if (started) {
+        tokens.push(token)
+        spans.push({
+          start: tokenStart,
+          end: index,
+          divergesFromShell: diverges
+        })
+        token = ''
+        started = false
+        diverges = false
+      }
+      index += 1
+      continue
+    }
+
+    const atTokenStart = !started
+    begin(index)
+    diverges ||=
+      ';&|<>'.includes(char) ||
+      // Command substitution `(…)`/`$(…)` and brace expansion, all live fish syntax.
+      '(){}'.includes(char) ||
+      // An unmatched wildcard is a HARD ERROR in fish, and a matched one splits the word.
+      '*?['.includes(char) ||
+      (char === '#' && atTokenStart) ||
+      (char === '$' && '({'.includes(value[index + 1] ?? '\0'))
+    token += char
+    index += 1
+  }
+
+  if (started) {
+    tokens.push(token)
+    spans.push({
+      start: tokenStart,
+      end: value.length,
+      divergesFromShell: diverges
+    })
+  }
+  return { ok: true, tokens, spans }
+}

--- a/src/shared/fish-command-tokenizer.ts
+++ b/src/shared/fish-command-tokenizer.ts
@@ -86,10 +86,13 @@ function decodeFishEscape(value: string, start: number): EscapeDecode {
       : fromCode(digits, 8, 0)
   }
   if (char === 'c' && value[start + 1]) {
+    const control = value[start + 1]
     return {
-      text: String.fromCharCode(value.charCodeAt(start + 1) & 0x1f),
+      text: /^[A-Za-z]$/.test(control)
+        ? String.fromCharCode(control.charCodeAt(0) & 0x1f)
+        : value.slice(start, start + 2),
       next: start + 2,
-      diverges: false
+      diverges: !/^[A-Za-z]$/.test(control)
     }
   }
   return { text: char, next: start + 1, diverges: false }

--- a/src/shared/fish-draft-prefill-teardown.node-pty.test.ts
+++ b/src/shared/fish-draft-prefill-teardown.node-pty.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Real-fish proof that the agent draft-prefill teardown actually clears the variable.
+ *
+ * `buildAgentDraftLaunchPlan` exports the draft through an env var and appends a
+ * teardown to the launch line so the next agent start does not inherit it. fish has
+ * no `unset`: the sh spelling errors out and leaves the variable exported, which is
+ * only observable in the shell — a string assertion cannot tell the two apart.
+ *
+ * DA1/CPR/OSC-11 probes are answered here because no real xterm is attached;
+ * without them fish stalls ~10s on its DA1 read sentinel before the first prompt.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fishRequirementViolation, resolveFishBinary } from './fish-binary-requirement'
+import { clearEnvCommand } from './tui-agent-startup-shell'
+
+const FISH = resolveFishBinary(4)
+const itWithFish = FISH.available ? it : it.skip
+
+const PROMPT_MARK = 'ORCAENV> '
+const VAR = 'ORCA_PI_PREFILL'
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true
+    }
+    await sleep(20)
+  }
+  return false
+}
+
+describe('fish clears an agent draft prefill variable', () => {
+  let home: string | null = null
+
+  // Always runs, so the CI lane cannot report green with the regression below skipped.
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  afterEach(() => {
+    if (home) {
+      rmSync(home, { recursive: true, force: true })
+      home = null
+    }
+  })
+
+  itWithFish(
+    'clears with the fish teardown and provably fails with the sh one',
+    async () => {
+      const nodePty = await import('node-pty')
+
+      home = mkdtempSync(path.join(tmpdir(), 'orca-fish-prefill-'))
+      mkdirSync(path.join(home, 'fish'), { recursive: true })
+      writeFileSync(
+        path.join(home, 'fish/config.fish'),
+        [
+          'set -g fish_greeting ""',
+          `function fish_prompt; printf '${PROMPT_MARK}'; end`,
+          'function fish_right_prompt; end',
+          ''
+        ].join('\n')
+      )
+
+      const term = nodePty.spawn(FISH.path as string, ['-l', '-i'], {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 30,
+        cwd: home,
+        env: {
+          PATH: process.env.PATH ?? '/usr/bin:/bin',
+          HOME: home,
+          TERM: 'xterm-256color',
+          LANG: 'en_US.UTF-8',
+          XDG_CONFIG_HOME: home,
+          XDG_DATA_HOME: path.join(home, 'data'),
+          [VAR]: 'draft text'
+        }
+      })
+
+      let rendered = ''
+      term.onData((chunk) => {
+        rendered += chunk
+        if (chunk.includes('\x1b[0c') || chunk.includes('\x1b[c')) {
+          term.write('\x1b[?62;4;6;22c')
+        }
+        if (chunk.includes('\x1b[6n')) {
+          term.write('\x1b[1;1R')
+        }
+        if (chunk.includes('\x1b]10;?') || chunk.includes('\x1b]11;?')) {
+          term.write('\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\')
+        }
+      })
+      let exited = false
+      term.onExit(() => {
+        exited = true
+      })
+
+      // `set -q` exits 0 while the variable exists, so the echoed status is the verdict.
+      const probe = (label: string): Promise<boolean> => {
+        term.write(`set -q ${VAR}; echo ${label}=$status\r`)
+        return waitUntil(() => new RegExp(`${label}=[01]`).test(rendered), 5_000)
+      }
+      const statusOf = (label: string): string =>
+        new RegExp(`${label}=([01])`).exec(rendered)?.[1] ?? 'missing'
+
+      try {
+        expect(await waitUntil(() => rendered.includes(PROMPT_MARK), 15_000)).toBe(true)
+        expect(await probe('BEFORE')).toBe(true)
+        expect(statusOf('BEFORE')).toBe('0')
+
+        // The sh spelling Orca emitted before this dialect was threaded through.
+        term.write(`${clearEnvCommand(VAR, 'posix')}\r`)
+        expect(await probe('AFTERSH')).toBe(true)
+        expect(rendered).toContain('Unknown command')
+        expect(statusOf('AFTERSH')).toBe('0')
+
+        term.write(`${clearEnvCommand(VAR, 'fish')}\r`)
+        expect(await probe('AFTERFISH')).toBe(true)
+        expect(statusOf('AFTERFISH')).toBe('1')
+      } finally {
+        term.write('exit\r')
+        await waitUntil(() => exited, 5_000)
+        try {
+          term.kill()
+        } catch {
+          // already gone
+        }
+      }
+    },
+    40_000
+  )
+})

--- a/src/shared/fish-draft-prefill-teardown.node-pty.test.ts
+++ b/src/shared/fish-draft-prefill-teardown.node-pty.test.ts
@@ -6,6 +6,14 @@
  * no `unset`: the sh spelling errors out and leaves the variable exported, which is
  * only observable in the shell — a string assertion cannot tell the two apart.
  *
+ * The negative control is graded on exit status and variable liveness, never on the
+ * error text. fish only installs its own "Unknown command" printer when NON-interactive
+ * (share/config.fish); an interactive fish autoloads `fish_command_not_found`, which
+ * delegates to the distro handler when one exists — `/usr/lib/command-not-found` on
+ * Ubuntu, where the CI fish comes from. That handler prints its own wording, and the
+ * fish fallback is gettext-translated on top of that, so the text varies by host and
+ * locale while the status (127) and the surviving variable do not.
+ *
  * DA1/CPR/OSC-11 probes are answered here because no real xterm is attached;
  * without them fish stalls ~10s on its DA1 read sentinel before the first prompt.
  */
@@ -76,7 +84,10 @@ describe('fish clears an agent draft prefill variable', () => {
           PATH: process.env.PATH ?? '/usr/bin:/bin',
           HOME: home,
           TERM: 'xterm-256color',
+          // LC_ALL wins over any LANG/LC_* a host might otherwise contribute, so
+          // fish's locale is fixed even though nothing here reads its messages.
           LANG: 'en_US.UTF-8',
+          LC_ALL: 'en_US.UTF-8',
           XDG_CONFIG_HOME: home,
           XDG_DATA_HOME: path.join(home, 'data'),
           [VAR]: 'draft text'
@@ -101,28 +112,37 @@ describe('fish clears an agent draft prefill variable', () => {
         exited = true
       })
 
-      // `set -q` exits 0 while the variable exists, so the echoed status is the verdict.
-      const probe = (label: string): Promise<boolean> => {
-        term.write(`set -q ${VAR}; echo ${label}=$status\r`)
-        return waitUntil(() => new RegExp(`${label}=[01]`).test(rendered), 5_000)
+      // \b so a label is never read out of a longer one (`FISHRC` vs `SHRC`), and the
+      // echoed keystrokes (`...=$status`) can never satisfy the digit capture.
+      const statusPattern = (label: string): RegExp => new RegExp(String.raw`\b${label}=(\d+)`)
+      /** Runs one line and labels the `$status` its LAST statement left behind. */
+      // Generous: an unknown command routes through the distro `fish_command_not_found`,
+      // and Ubuntu's is a Python process that opens the apt database before fish moves on.
+      const run = (label: string, command: string): Promise<boolean> => {
+        term.write(`${command}; echo ${label}=$status\r`)
+        return waitUntil(() => statusPattern(label).test(rendered), 15_000)
       }
       const statusOf = (label: string): string =>
-        new RegExp(`${label}=([01])`).exec(rendered)?.[1] ?? 'missing'
+        statusPattern(label).exec(rendered)?.[1] ?? 'missing'
+      // `set -q` exits 0 while the variable exists, so its status is the liveness verdict.
+      const liveness = (label: string): Promise<boolean> => run(label, `set -q ${VAR}`)
 
       try {
         expect(await waitUntil(() => rendered.includes(PROMPT_MARK), 15_000)).toBe(true)
-        expect(await probe('BEFORE')).toBe(true)
+        expect(await liveness('BEFORE')).toBe(true)
         expect(statusOf('BEFORE')).toBe('0')
 
-        // The sh spelling Orca emitted before this dialect was threaded through.
-        term.write(`${clearEnvCommand(VAR, 'posix')}\r`)
-        expect(await probe('AFTERSH')).toBe(true)
-        expect(rendered).toContain('Unknown command')
-        expect(statusOf('AFTERSH')).toBe('0')
+        // The sh spelling Orca emitted before this dialect was threaded through: fish
+        // must reject the command outright AND leave the export standing.
+        expect(await run('POSIXRC', clearEnvCommand(VAR, 'posix'))).toBe(true)
+        expect(statusOf('POSIXRC')).not.toBe('0')
+        expect(await liveness('POSIXLEFT')).toBe(true)
+        expect(statusOf('POSIXLEFT')).toBe('0')
 
-        term.write(`${clearEnvCommand(VAR, 'fish')}\r`)
-        expect(await probe('AFTERFISH')).toBe(true)
-        expect(statusOf('AFTERFISH')).toBe('1')
+        expect(await run('FISHRC', clearEnvCommand(VAR, 'fish'))).toBe(true)
+        expect(statusOf('FISHRC')).toBe('0')
+        expect(await liveness('FISHLEFT')).toBe(true)
+        expect(statusOf('FISHLEFT')).toBe('1')
       } finally {
         term.write('exit\r')
         await waitUntil(() => exited, 5_000)

--- a/src/shared/fish-draft-prefill-teardown.node-pty.test.ts
+++ b/src/shared/fish-draft-prefill-teardown.node-pty.test.ts
@@ -139,10 +139,40 @@ describe('fish clears an agent draft prefill variable', () => {
         expect(await liveness('POSIXLEFT')).toBe(true)
         expect(statusOf('POSIXLEFT')).toBe('0')
 
-        expect(await run('FISHRC', clearEnvCommand(VAR, 'fish'))).toBe(true)
-        expect(statusOf('FISHRC')).toBe('0')
+        expect(await run('UNIXRC', clearEnvCommand(VAR, 'unix'))).toBe(true)
+        expect(statusOf('UNIXRC')).toBe('0')
         expect(await liveness('FISHLEFT')).toBe(true)
         expect(statusOf('FISHLEFT')).toBe('1')
+
+        expect(await run('GLOBAL', `set -gx ${VAR} global; ${clearEnvCommand(VAR, 'unix')}`)).toBe(
+          true
+        )
+        expect(await liveness('GLOBALLEFT')).toBe(true)
+        expect(statusOf('GLOBALLEFT')).toBe('1')
+
+        expect(
+          await run(
+            'LOCAL',
+            `function orca_clear_local; set -lx ${VAR} local; ${clearEnvCommand(VAR, 'unix')}; set -q ${VAR}; end; orca_clear_local`
+          )
+        ).toBe(true)
+        expect(statusOf('LOCAL')).toBe('1')
+
+        expect(
+          await run('UNIVERSAL', `set -Ux ${VAR} universal; ${clearEnvCommand(VAR, 'unix')}`)
+        ).toBe(true)
+        expect(await liveness('UNIVERSALLEFT')).toBe(true)
+        expect(statusOf('UNIVERSALLEFT')).toBe('1')
+
+        expect(
+          await run(
+            'ALIAS',
+            `set -gx ${VAR} alias-draft; alias orca_prefill_agent 'test "$${VAR}" = alias-draft'; orca_prefill_agent; ${clearEnvCommand(VAR, 'unix')}`
+          )
+        ).toBe(true)
+        expect(statusOf('ALIAS')).toBe('0')
+        expect(await liveness('ALIASLEFT')).toBe(true)
+        expect(statusOf('ALIASLEFT')).toBe('1')
       } finally {
         term.write('exit\r')
         await waitUntil(() => exited, 5_000)

--- a/src/shared/fish-startup-arg-quoting.live-fish.test.ts
+++ b/src/shared/fish-startup-arg-quoting.live-fish.test.ts
@@ -25,6 +25,20 @@ const itWithFish = FISH.available ? it : it.skip
 
 let home: string | null = null
 
+/**
+ * Fully pinned: nothing ambient reaches fish, and LC_ALL wins over any LANG/LC_*
+ * a host might contribute, so locale-sensitive parsing cannot vary by machine.
+ */
+const fishEnv = (root: string): NodeJS.ProcessEnv => ({
+  PATH: process.env.PATH ?? '/usr/bin:/bin',
+  HOME: root,
+  XDG_CONFIG_HOME: root,
+  XDG_DATA_HOME: path.join(root, 'data'),
+  TERM: 'dumb',
+  LANG: 'en_US.UTF-8',
+  LC_ALL: 'en_US.UTF-8'
+})
+
 /** Runs `commandLine` in a config-free fish and returns the argv it produced. */
 function fishArgv(commandLine: string): string[] {
   const root = home as string
@@ -37,14 +51,7 @@ function fishArgv(commandLine: string): string[] {
   writeFileSync(scriptPath, `string join0 -- ${commandLine} > ${outPath}\nexit 0\n`)
   execFileSync(FISH.path as string, [scriptPath], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: {
-      PATH: process.env.PATH ?? '/usr/bin:/bin',
-      HOME: root,
-      XDG_CONFIG_HOME: root,
-      XDG_DATA_HOME: path.join(root, 'data'),
-      TERM: 'dumb',
-      LANG: 'en_US.UTF-8'
-    }
+    env: fishEnv(root)
   })
   const raw = readFileSync(outPath, 'utf8')
   // join0 terminates the last element too, so the trailing empty split is not an argument.
@@ -168,14 +175,7 @@ describe('quoteStartupArg round-trips through real fish', () => {
     execFileSync(FISH.path as string, [scriptPath], {
       cwd: root,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        PATH: process.env.PATH ?? '/usr/bin:/bin',
-        HOME: root,
-        XDG_CONFIG_HOME: root,
-        XDG_DATA_HOME: path.join(root, 'data'),
-        TERM: 'dumb',
-        LANG: 'en_US.UTF-8'
-      }
+      env: fishEnv(root)
     })
 
     expect(JSON.parse(readFileSync(capturePath, 'utf8'))).toEqual([prompt])
@@ -215,15 +215,7 @@ describe('quoteStartupArg round-trips through real fish', () => {
     execFileSync(FISH.path as string, [scriptPath], {
       cwd: root,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        PATH: process.env.PATH ?? '/usr/bin:/bin',
-        HOME: root,
-        XDG_CONFIG_HOME: root,
-        XDG_DATA_HOME: path.join(root, 'data'),
-        TERM: 'dumb',
-        LANG: 'en_US.UTF-8',
-        ...plan?.env
-      }
+      env: { ...fishEnv(root), ...plan?.env }
     })
 
     expect(JSON.parse(readFileSync(capturePath, 'utf8'))).toContain(`--query=${prompt}`)

--- a/src/shared/fish-startup-arg-quoting.live-fish.test.ts
+++ b/src/shared/fish-startup-arg-quoting.live-fish.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Round-trips `quoteStartupArg(value, 'fish')` and `tokenizeStartupCommand(…, 'fish')`
+ * through a REAL fish, because fish's quoting is only observable in fish.
+ *
+ * fish single quotes are not literal the way sh's are: `\\` and `\'` are escapes,
+ * so sh's `'\''` idiom silently halves every backslash and a trailing backslash is
+ * a hard syntax error. A string assertion against a hand-written expectation would
+ * happily encode the same wrong rule, so the shell itself is the oracle.
+ *
+ * fish reads each case from a script file and echoes its argv back NUL-separated
+ * (`string join0`), which is the only separator no test input can forge.
+ */
+import { execFileSync } from 'node:child_process'
+import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { fishRequirementViolation, resolveFishBinary } from './fish-binary-requirement'
+import { planHermesStartupQuery } from './hermes-startup-query'
+import { buildAgentStartupPlan } from './tui-agent-startup'
+import { quoteStartupArg, tokenizeStartupCommand } from './tui-agent-startup-shell'
+
+const FISH = resolveFishBinary(4)
+const itWithFish = FISH.available ? it : it.skip
+
+let home: string | null = null
+
+/** Runs `commandLine` in a config-free fish and returns the argv it produced. */
+function fishArgv(commandLine: string): string[] {
+  const root = home as string
+  const scriptPath = path.join(root, 'probe.fish')
+  const outPath = path.join(root, 'argv.bin')
+  // Removed first so a run that dies before writing surfaces as ENOENT rather
+  // than as the previous case's argv. `exit 0` only masks `string join`'s
+  // nothing-to-join status 1; a syntax error still aborts the file with 127.
+  rmSync(outPath, { force: true })
+  writeFileSync(scriptPath, `string join0 -- ${commandLine} > ${outPath}\nexit 0\n`)
+  execFileSync(FISH.path as string, [scriptPath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      PATH: process.env.PATH ?? '/usr/bin:/bin',
+      HOME: root,
+      XDG_CONFIG_HOME: root,
+      XDG_DATA_HOME: path.join(root, 'data'),
+      TERM: 'dumb',
+      LANG: 'en_US.UTF-8'
+    }
+  })
+  const raw = readFileSync(outPath, 'utf8')
+  // join0 terminates the last element too, so the trailing empty split is not an argument.
+  return raw.length === 0 ? [] : raw.split('\0').slice(0, -1)
+}
+
+const ADVERSARIAL_ARGS: readonly [name: string, value: string][] = [
+  ['regex backslashes', 'use \\d+ or \\\\d and \\w'],
+  ['UNC path', '\\\\server\\share\\dir'],
+  ['windows drive path', 'C:\\Users\\nw\\Application Data'],
+  ['apostrophes', "it's the user's own prompt"],
+  ['trailing backslash', 'ends with a backslash\\'],
+  ['lone backslash', '\\'],
+  ['mixed quotes', `he said "hi" and 'bye'`],
+  ['newlines', 'first line\nsecond line\n'],
+  ['dollar expansions', '$PATH and ${HOME} and $(id -u)'],
+  ['glob characters', '*.ts ?? [a-z] **/*.zzz'],
+  ['command substitution parens', 'call (echo hi) and `echo hi`'],
+  ['operators', 'a; b && c || d | e > f < g & h'],
+  ['comment and tilde', '# not a comment ~ not a home'],
+  ['tabs and unicode', 'tab\there 🐟 é'],
+  ['escaped-quote soup', `a\\'b'c\\\\d"e`]
+]
+
+describe('quoteStartupArg round-trips through real fish', () => {
+  beforeAll(() => {
+    home = mkdtempSync(path.join(tmpdir(), 'orca-fish-quote-'))
+  })
+
+  afterAll(() => {
+    if (home) {
+      rmSync(home, { recursive: true, force: true })
+      home = null
+    }
+  })
+
+  // Always runs, so the CI lane cannot report green with everything below skipped.
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  for (const [name, value] of ADVERSARIAL_ARGS) {
+    itWithFish(`survives ${name}`, () => {
+      expect(fishArgv(quoteStartupArg(value, 'fish'))).toEqual([value])
+    })
+  }
+
+  itWithFish('keeps multiple arguments separate', () => {
+    const args = ADVERSARIAL_ARGS.map(([, value]) => value)
+    expect(fishArgv(args.map((arg) => quoteStartupArg(arg, 'fish')).join(' '))).toEqual(args)
+  })
+
+  itWithFish('proves the sh quoting this replaced was broken in fish', () => {
+    // Corrupted, not rejected: the backslashes silently halve.
+    expect(fishArgv(quoteStartupArg('\\\\server\\share', 'posix'))).toEqual(['\\server\\share'])
+    // And a trailing backslash is a hard syntax error that would kill the launch.
+    expect(() => fishArgv(quoteStartupArg('ends with a backslash\\', 'posix'))).toThrow()
+  })
+
+  itWithFish('proves the sh tokenizer this replaced disagreed with fish', () => {
+    const line = String.raw`claude --prompt 'match \d+ in \\server\share'`
+    const posix = tokenizeStartupCommand(line, 'posix')
+    expect(posix.ok).toBe(true)
+    if (posix.ok) {
+      expect(posix.tokens).not.toEqual(fishArgv(line))
+    }
+  })
+
+  itWithFish('tokenizes a fish command line the way fish splits it', () => {
+    const lines = [
+      String.raw`claude --append-system-prompt 'match \d+ in \\server\share'`,
+      String.raw`codex --cd "C:\Users\nw" --note 'it\'s mine'`,
+      String.raw`hermes chat --query a\nb --flag "keep \n literal"`,
+      String.raw`pi --path 'C:\\' --other "a\$b" --third x\ty`,
+      String.raw`agent --hex \x41 --octal \101 --ctrl \cA`
+    ]
+    for (const line of lines) {
+      const tokenized = tokenizeStartupCommand(line, 'fish')
+      expect(tokenized.ok, line).toBe(true)
+      if (!tokenized.ok) {
+        continue
+      }
+      expect(tokenized.tokens, line).toEqual(fishArgv(line))
+      // Re-quoting the parsed tokens must reproduce the same argv.
+      expect(
+        fishArgv(tokenized.tokens.map((token) => quoteStartupArg(token, 'fish')).join(' ')),
+        line
+      ).toEqual(tokenized.tokens)
+    }
+  })
+
+  // The user-facing break: a composer prompt is quoted here and parsed by fish.
+  itWithFish('delivers a composer prompt to the agent argv intact', () => {
+    const root = home as string
+    const capturePath = path.join(root, 'claude-argv.json')
+    const claudePath = path.join(root, 'claude')
+    const prompt = [
+      String.raw`Use \d+ for digits and read \\server\share\notes.`,
+      String.raw`Keep 'single' and "double" quotes, $PATH, *.ts and a ; too.`,
+      'This last line ends in a backslash\\'
+    ].join('\n')
+    copyFileSync(process.execPath, claudePath)
+    chmodSync(claudePath, 0o755)
+    writeFileSync(
+      path.join(root, 'capture.js'),
+      `require('node:fs').writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(process.argv.slice(2)))`
+    )
+    rmSync(capturePath, { force: true })
+
+    const plan = buildAgentStartupPlan({
+      agent: 'claude',
+      prompt,
+      cmdOverrides: { claude: `${quoteStartupArg(claudePath, 'fish')} capture.js` },
+      platform: 'darwin',
+      shell: 'fish'
+    })
+    expect(plan).not.toBeNull()
+
+    const scriptPath = path.join(root, 'launch.fish')
+    writeFileSync(scriptPath, `${plan?.launchCommand}\n`)
+    execFileSync(FISH.path as string, [scriptPath], {
+      cwd: root,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        HOME: root,
+        XDG_CONFIG_HOME: root,
+        XDG_DATA_HOME: path.join(root, 'data'),
+        TERM: 'dumb',
+        LANG: 'en_US.UTF-8'
+      }
+    })
+
+    expect(JSON.parse(readFileSync(capturePath, 'utf8'))).toEqual([prompt])
+  })
+
+  // The `sh -c` wrapper's OUTER quoting is parsed by fish, and its payload is a
+  // solid run of `\0NNN` octal escapes — the single worst case for the sh spelling.
+  itWithFish('delivers a hermes startup query through the fish-quoted sh wrapper', () => {
+    const root = home as string
+    const capturePath = path.join(root, 'hermes-argv.json')
+    const hermesPath = path.join(root, 'hermes')
+    const prompt = [
+      String.raw`Match \d+ inside \\server\share and keep 'quotes' plus "doubles".`,
+      'A blank $PATH stays literal, as does *.ts.',
+      'And this line ends with a backslash\\'
+    ].join('\n')
+    // A copy of node named `hermes` runs the `chat` script and records its argv.
+    copyFileSync(process.execPath, hermesPath)
+    chmodSync(hermesPath, 0o755)
+    writeFileSync(
+      path.join(root, 'chat'),
+      `require('node:fs').writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(process.argv.slice(2)))`
+    )
+    rmSync(capturePath, { force: true })
+
+    const plan = planHermesStartupQuery({
+      baseCommand: quoteStartupArg(hermesPath, 'fish'),
+      agentArgs: '--yolo',
+      prompt,
+      platform: 'darwin',
+      shell: 'fish'
+    })
+    expect(plan).not.toBeNull()
+
+    const scriptPath = path.join(root, 'hermes.fish')
+    writeFileSync(scriptPath, `${plan?.command}\n`)
+    execFileSync(FISH.path as string, [scriptPath], {
+      cwd: root,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        HOME: root,
+        XDG_CONFIG_HOME: root,
+        XDG_DATA_HOME: path.join(root, 'data'),
+        TERM: 'dumb',
+        LANG: 'en_US.UTF-8',
+        ...plan?.env
+      }
+    })
+
+    expect(JSON.parse(readFileSync(capturePath, 'utf8'))).toContain(`--query=${prompt}`)
+  })
+})

--- a/src/shared/fish-startup-arg-quoting.live-fish.test.ts
+++ b/src/shared/fish-startup-arg-quoting.live-fish.test.ts
@@ -97,6 +97,9 @@ describe('quoteStartupArg round-trips through real fish', () => {
     itWithFish(`survives ${name}`, () => {
       expect(fishArgv(quoteStartupArg(value, 'fish'))).toEqual([value])
     })
+    itWithFish(`survives ${name} through an unknown Unix host`, () => {
+      expect(fishArgv(quoteStartupArg(value, 'unix'))).toEqual([value])
+    })
   }
 
   itWithFish('keeps multiple arguments separate', () => {
@@ -109,6 +112,12 @@ describe('quoteStartupArg round-trips through real fish', () => {
     expect(fishArgv(quoteStartupArg('\\\\server\\share', 'posix'))).toEqual(['\\server\\share'])
     // And a trailing backslash is a hard syntax error that would kill the launch.
     expect(() => fishArgv(quoteStartupArg('ends with a backslash\\', 'posix'))).toThrow()
+  })
+
+  itWithFish('accepts the portable Unix trailing-backslash form', () => {
+    expect(fishArgv(quoteStartupArg('ends with a backslash\\', 'unix'))).toEqual([
+      'ends with a backslash\\'
+    ])
   })
 
   itWithFish('proves the sh tokenizer this replaced disagreed with fish', () => {

--- a/src/shared/hermes-startup-query.ts
+++ b/src/shared/hermes-startup-query.ts
@@ -159,7 +159,11 @@ function buildQueryCommand(argv: string[], shell: AgentStartupShell): string {
   // Why: a fixed single-quote-safe wrapper parses in POSIX shells and pwsh;
   // the dynamic argv is decoded only after entering the known `sh` grammar.
   const script = `${POSIX_QUERY_VARIABLE}="\${${ORCA_HERMES_STARTUP_QUERY_ENV}}"; unset ${ORCA_HERMES_STARTUP_QUERY_ENV}; eval "$(printf %b "${encodedInvocation}")"`
-  return `sh -c ${quoteStartupArg(script, 'posix')}`
+  // Why `shell` and not 'posix': the body runs under `sh`, but the quoting around
+  // it is parsed by the shell that types the line. Today's payload survives sh
+  // quoting in fish only because its escapes happen to be `\0NNN` and never `\\`
+  // — quote for the real dialect so that stays an implementation detail.
+  return `sh -c ${quoteStartupArg(script, shell)}`
 }
 
 export function planHermesStartupQuery(args: {
@@ -181,7 +185,10 @@ export function planHermesStartupQuery(args: {
     return null
   }
   const command = buildQueryCommand(argv, args.shell)
-  const env = { ...args.agentEnv, [ORCA_HERMES_STARTUP_QUERY_ENV]: args.prompt }
+  const env = {
+    ...args.agentEnv,
+    [ORCA_HERMES_STARTUP_QUERY_ENV]: args.prompt
+  }
   const envSize = Object.entries(env).reduce((total, [key, value]) => {
     if (args.platform === 'win32') {
       return total + key.length + value.length + 2

--- a/src/shared/local-agent-startup-shell.test.ts
+++ b/src/shared/local-agent-startup-shell.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLocalAgentStartupShell } from './local-agent-startup-shell'
+import { buildAgentDraftLaunchPlan } from './tui-agent-startup'
+
+const posixHost = {
+  platform: 'darwin' as NodeJS.Platform,
+  hostPlatform: 'darwin' as NodeJS.Platform,
+  isRemote: false,
+  executionHostKind: 'local' as const
+}
+
+describe('resolveLocalAgentStartupShell', () => {
+  it('adopts the fish dialect when this machine parses the line', () => {
+    expect(
+      resolveLocalAgentStartupShell({ ...posixHost, hostLoginShell: '/opt/homebrew/bin/fish' })
+    ).toBe('fish')
+  })
+
+  it('stays posix for sh-family login shells', () => {
+    expect(resolveLocalAgentStartupShell({ ...posixHost, hostLoginShell: '/bin/zsh' })).toBe(
+      'posix'
+    )
+    expect(resolveLocalAgentStartupShell({ ...posixHost, hostLoginShell: '' })).toBe('posix')
+    expect(resolveLocalAgentStartupShell({ ...posixHost, hostLoginShell: undefined })).toBe('posix')
+  })
+
+  // Why each of these matters: `set -e VAR` in bash enables errexit instead of
+  // clearing anything, so a wrong dialect is worse than the sh default.
+  it('refuses the local dialect for a remote target', () => {
+    expect(
+      resolveLocalAgentStartupShell({
+        ...posixHost,
+        isRemote: true,
+        hostLoginShell: '/usr/bin/fish'
+      })
+    ).toBeUndefined()
+  })
+
+  it('refuses the local dialect for ssh and runtime execution hosts', () => {
+    for (const executionHostKind of ['ssh', 'runtime'] as const) {
+      expect(
+        resolveLocalAgentStartupShell({
+          ...posixHost,
+          executionHostKind,
+          hostLoginShell: '/usr/bin/fish'
+        })
+      ).toBeUndefined()
+    }
+  })
+
+  it('refuses the local dialect when the target platform is not this one (WSL)', () => {
+    expect(
+      resolveLocalAgentStartupShell({
+        ...posixHost,
+        platform: 'linux',
+        hostPlatform: 'win32',
+        hostLoginShell: '/usr/bin/fish'
+      })
+    ).toBeUndefined()
+  })
+
+  it('keeps the Windows shell families untouched', () => {
+    expect(
+      resolveLocalAgentStartupShell({
+        platform: 'win32',
+        hostPlatform: 'win32',
+        isRemote: false,
+        executionHostKind: 'local',
+        hostLoginShell: '/usr/bin/fish',
+        terminalWindowsShell: 'cmd.exe'
+      })
+    ).toBe('cmd')
+  })
+
+  it('reaches the fish draft-prefill teardown end to end', () => {
+    const shell = resolveLocalAgentStartupShell({
+      ...posixHost,
+      hostLoginShell: '/opt/homebrew/bin/fish'
+    })
+    const plan = buildAgentDraftLaunchPlan({
+      agent: 'pi',
+      draft: 'hello',
+      cmdOverrides: {},
+      platform: 'darwin',
+      shell
+    })
+
+    expect(plan?.launchCommand).toBe('pi; set -e ORCA_PI_PREFILL')
+  })
+})

--- a/src/shared/local-agent-startup-shell.test.ts
+++ b/src/shared/local-agent-startup-shell.test.ts
@@ -87,4 +87,30 @@ describe('resolveLocalAgentStartupShell', () => {
 
     expect(plan?.launchCommand).toBe('pi; set -e ORCA_PI_PREFILL')
   })
+
+  it('lets an agent bash override replace a fish login-shell dialect', () => {
+    const plan = buildAgentDraftLaunchPlan({
+      agent: 'pi',
+      draft: 'hello',
+      cmdOverrides: {},
+      platform: 'darwin',
+      shell: 'fish',
+      agentEnv: { SHELL: '/bin/bash' }
+    })
+
+    expect(plan?.launchCommand).toBe('pi; unset ORCA_PI_PREFILL')
+  })
+
+  it('lets an agent fish override replace a sh-family login-shell dialect', () => {
+    const plan = buildAgentDraftLaunchPlan({
+      agent: 'pi',
+      draft: 'hello',
+      cmdOverrides: {},
+      platform: 'linux',
+      shell: 'posix',
+      agentEnv: { SHELL: '/usr/bin/fish' }
+    })
+
+    expect(plan?.launchCommand).toBe('pi; set -e ORCA_PI_PREFILL')
+  })
 })

--- a/src/shared/local-agent-startup-shell.test.ts
+++ b/src/shared/local-agent-startup-shell.test.ts
@@ -24,19 +24,17 @@ describe('resolveLocalAgentStartupShell', () => {
     expect(resolveLocalAgentStartupShell({ ...posixHost, hostLoginShell: undefined })).toBe('posix')
   })
 
-  // Why each of these matters: `set -e VAR` in bash enables errexit instead of
-  // clearing anything, so a wrong dialect is worse than the sh default.
-  it('refuses the local dialect for a remote target', () => {
+  it('uses the portable Unix dialect for a remote target', () => {
     expect(
       resolveLocalAgentStartupShell({
         ...posixHost,
         isRemote: true,
         hostLoginShell: '/usr/bin/fish'
       })
-    ).toBeUndefined()
+    ).toBe('unix')
   })
 
-  it('refuses the local dialect for ssh and runtime execution hosts', () => {
+  it('uses the portable Unix dialect for ssh and runtime execution hosts', () => {
     for (const executionHostKind of ['ssh', 'runtime'] as const) {
       expect(
         resolveLocalAgentStartupShell({
@@ -44,11 +42,11 @@ describe('resolveLocalAgentStartupShell', () => {
           executionHostKind,
           hostLoginShell: '/usr/bin/fish'
         })
-      ).toBeUndefined()
+      ).toBe('unix')
     }
   })
 
-  it('refuses the local dialect when the target platform is not this one (WSL)', () => {
+  it('uses the portable Unix dialect when the target platform is not this one (WSL)', () => {
     expect(
       resolveLocalAgentStartupShell({
         ...posixHost,
@@ -56,7 +54,7 @@ describe('resolveLocalAgentStartupShell', () => {
         hostPlatform: 'win32',
         hostLoginShell: '/usr/bin/fish'
       })
-    ).toBeUndefined()
+    ).toBe('unix')
   })
 
   it('keeps the Windows shell families untouched', () => {

--- a/src/shared/local-agent-startup-shell.ts
+++ b/src/shared/local-agent-startup-shell.ts
@@ -1,0 +1,40 @@
+import type { ExecutionHostKind } from './execution-host'
+import { resolveLoginShellStartupDialect, type AgentStartupShell } from './tui-agent-startup-shell'
+import { resolveLocalWindowsAgentStartupShell } from './windows-terminal-shell'
+
+export type LocalAgentStartupShellArgs = {
+  /** Platform of the host that will run the queued command. */
+  platform: NodeJS.Platform
+  isRemote: boolean
+  terminalWindowsShell?: string | null
+  /** Platform of the process resolving this, i.e. the owner of `hostLoginShell`. */
+  hostPlatform: NodeJS.Platform
+  /** `$SHELL` of that same process's machine. */
+  hostLoginShell?: string | null
+  /** Execution owner of the target workspace, when the caller can determine one. */
+  executionHostKind?: ExecutionHostKind | null
+}
+
+/**
+ * Startup-shell dialect for a queued agent command, POSIX included.
+ *
+ * Why POSIX needs a dialect at all: fish has no `unset`, so a draft-prefill
+ * teardown must be `set -e VAR` there. Why the guards are strict: `set -e` in
+ * bash enables errexit instead of clearing anything, so the local login shell
+ * may pick the dialect only when it is provably the shell that parses the line.
+ */
+export function resolveLocalAgentStartupShell(
+  args: LocalAgentStartupShellArgs
+): AgentStartupShell | undefined {
+  if (args.platform === 'win32' || args.isRemote) {
+    return resolveLocalWindowsAgentStartupShell(args)
+  }
+  if (args.executionHostKind === 'ssh' || args.executionHostKind === 'runtime') {
+    return undefined
+  }
+  // Why: a WSL workspace resolves to 'linux' on a win32 host — a different shell entirely.
+  if (args.hostPlatform !== args.platform) {
+    return undefined
+  }
+  return resolveLoginShellStartupDialect(args.hostLoginShell)
+}

--- a/src/shared/local-agent-startup-shell.ts
+++ b/src/shared/local-agent-startup-shell.ts
@@ -27,14 +27,16 @@ export function resolveLocalAgentStartupShell(
   args: LocalAgentStartupShellArgs
 ): AgentStartupShell | undefined {
   if (args.platform === 'win32' || args.isRemote) {
-    return resolveLocalWindowsAgentStartupShell(args)
+    return (
+      resolveLocalWindowsAgentStartupShell(args) ?? (args.platform === 'win32' ? undefined : 'unix')
+    )
   }
   if (args.executionHostKind === 'ssh' || args.executionHostKind === 'runtime') {
-    return undefined
+    return 'unix'
   }
   // Why: a WSL workspace resolves to 'linux' on a win32 host — a different shell entirely.
   if (args.hostPlatform !== args.platform) {
-    return undefined
+    return 'unix'
   }
   return resolveLoginShellStartupDialect(args.hostLoginShell)
 }

--- a/src/shared/tui-agent-startup-session-options.test.ts
+++ b/src/shared/tui-agent-startup-session-options.test.ts
@@ -122,6 +122,7 @@ describe('tui agent startup session options', () => {
       cmdOverrides: {},
       platform: 'linux',
       isRemote: true,
+      shell: 'posix',
       allowEmptyPromptLaunch: true,
       sessionOptions: { model: "team's-model", effort: 'high' }
     })

--- a/src/shared/tui-agent-startup-shell.test.ts
+++ b/src/shared/tui-agent-startup-shell.test.ts
@@ -76,16 +76,41 @@ describe('fish startup shell dialect', () => {
     )
   })
 
-  it('shares POSIX quoting, tokenizing and chaining', () => {
-    expect(quoteStartupArg("it's", 'fish')).toBe(quoteStartupArg("it's", 'posix'))
+  it('shares POSIX word splitting and chaining but NOT quoting', () => {
+    // fish single quotes are not literal: `\\` and `\'` are escapes inside them.
+    expect(quoteStartupArg("it's", 'fish')).toBe(String.raw`'it\'s'`)
+    expect(quoteStartupArg(String.raw`\\server\share`, 'fish')).toBe(
+      String.raw`'\\\\server\\share'`
+    )
+    // The sh spelling would have halved those backslashes when fish read it back.
+    expect(quoteStartupArg(String.raw`\\server\share`, 'posix')).toBe(String.raw`'\\server\share'`)
+    // A trailing backslash is a hard syntax error in fish unless it is escaped.
+    expect(quoteStartupArg('ends\\', 'fish')).toBe(String.raw`'ends\\'`)
     expect(buildShellCommandFromArgv(['codex', 'resume', 'a b'], 'fish')).toBe(
       buildShellCommandFromArgv(['codex', 'resume', 'a b'], 'posix')
     )
-    expect(tokenizeStartupCommand('codex --arg "a b"', 'fish')).toEqual(
-      tokenizeStartupCommand('codex --arg "a b"', 'posix')
-    )
     expect(commandSeparator('fish')).toBe('; ')
     expect(isPosixStartupShell('fish')).toBe(true)
+  })
+
+  it('tokenizes with fish escape rules rather than sh ones', () => {
+    const line = String.raw`codex --arg 'a\\b'`
+    expect(tokenizeStartupCommand(line, 'fish')).not.toEqual(tokenizeStartupCommand(line, 'posix'))
+    const fishTokens = tokenizeStartupCommand(line, 'fish')
+    expect(fishTokens.ok && fishTokens.tokens.at(-1)).toBe(String.raw`a\b`)
+  })
+
+  it('round-trips an adversarial argument through quote then tokenize', () => {
+    for (const value of [
+      String.raw`use \d+ and \\server\share`,
+      "it's mine",
+      'ends\\',
+      'a "b" c',
+      '$PATH *.ts'
+    ]) {
+      const tokenized = tokenizeStartupCommand(quoteStartupArg(value, 'fish'), 'fish')
+      expect(tokenized.ok && tokenized.tokens).toEqual([value])
+    }
   })
 
   it('maps login shell paths to their dialect', () => {

--- a/src/shared/tui-agent-startup-shell.test.ts
+++ b/src/shared/tui-agent-startup-shell.test.ts
@@ -97,8 +97,6 @@ describe('fish startup shell dialect', () => {
     expect(resolveLoginShellStartupDialect(undefined)).toBe('posix')
   })
 
-  // Contract-only: no POSIX caller threads a shell into buildAgentDraftLaunchPlan yet
-  // (`selectedRepoStartupShell` is Windows-only), so fish users still get `unset` here.
   it('clears an agent draft prefill variable with fish syntax', () => {
     const plan = buildAgentDraftLaunchPlan({
       agent: 'pi',

--- a/src/shared/tui-agent-startup-shell.test.ts
+++ b/src/shared/tui-agent-startup-shell.test.ts
@@ -70,6 +70,9 @@ describe('fish startup shell dialect', () => {
   it('clears variables with fish syntax instead of the sh `unset` fish rejects', () => {
     expect(clearEnvCommand('CODEX_HOME', 'fish')).toBe('set -e CODEX_HOME')
     expect(clearEnvCommand('CODEX_HOME', 'posix')).toBe('unset CODEX_HOME')
+    expect(clearEnvCommand('CODEX_HOME', 'unix')).toBe(
+      `command test -n "$fish_pid" && builtin eval 'set -el CODEX_HOME; set -eg CODEX_HOME; set -eU CODEX_HOME; true' || command eval 'unset CODEX_HOME'`
+    )
     expect(clearEnvCommand('CODEX_HOME', 'cmd')).toBe('set "CODEX_HOME="')
     expect(clearEnvCommand('CODEX_HOME', 'powershell')).toBe(
       'Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue'
@@ -110,6 +113,16 @@ describe('fish startup shell dialect', () => {
     ]) {
       const tokenized = tokenizeStartupCommand(quoteStartupArg(value, 'fish'), 'fish')
       expect(tokenized.ok && tokenized.tokens).toEqual([value])
+    }
+  })
+
+  it('keeps unknown-Unix generated arguments valid for both parsers', () => {
+    for (const value of [String.raw`use \d+ and \\server\share`, "it's mine", 'ends\\']) {
+      const quoted = quoteStartupArg(value, 'unix')
+      const fish = tokenizeStartupCommand(quoted, 'fish')
+      const posix = tokenizeStartupCommand(quoted, 'posix')
+      expect(fish.ok && fish.tokens).toEqual([value])
+      expect(posix.ok && posix.tokens).toEqual([value])
     }
   })
 

--- a/src/shared/tui-agent-startup-shell.ts
+++ b/src/shared/tui-agent-startup-shell.ts
@@ -1,12 +1,20 @@
 import { tokenizeCustomCommandTemplate, type CommandTokenSpan } from './commit-message-prompt'
+import { tokenizeFishStartupCommand } from './fish-command-tokenizer'
 
-// Why: fish shares POSIX word splitting, quoting and `;` chaining, so it is a
-// separate dialect only where its grammar actually diverges (env clearing).
+// Why: fish shares POSIX word splitting and `;` chaining, but NOT quoting or
+// escaping — see quoteStartupArg and fish-command-tokenizer.ts.
 export type AgentStartupShell = 'posix' | 'fish' | 'powershell' | 'cmd'
 
 type WindowsStartupShell = Extract<AgentStartupShell, 'powershell' | 'cmd'>
 
-/** True for shells parsed with POSIX quoting/word rules (sh family + fish). */
+/**
+ * True for the sh-family grammar: `NAME=value cmd` prefixes, `sh -c` wrapping and
+ * `;` chaining all parse. fish qualifies for those.
+ *
+ * NOT a claim that quoting matches — fish's does not. Anything that builds an
+ * argument must pass the real dialect to `quoteStartupArg`/`tokenizeStartupCommand`,
+ * never hardcode `'posix'` behind this check.
+ */
 export function isPosixStartupShell(shell: AgentStartupShell): boolean {
   return shell === 'posix' || shell === 'fish'
 }
@@ -154,9 +162,10 @@ export function tokenizeStartupCommand(
   value: string,
   shell: AgentStartupShell
 ): StartupCommandTokens {
-  return isWindowsStartupShell(shell)
-    ? tokenizeWindowsStartupCommand(value, shell)
-    : tokenizeCustomCommandTemplate(value)
+  if (isWindowsStartupShell(shell)) {
+    return tokenizeWindowsStartupCommand(value, shell)
+  }
+  return shell === 'fish' ? tokenizeFishStartupCommand(value) : tokenizeCustomCommandTemplate(value)
 }
 
 export function resolveStartupShell(
@@ -172,6 +181,14 @@ export function quoteStartupArg(value: string, shell: AgentStartupShell): string
   }
   if (shell === 'cmd') {
     return `"${value.replace(/([\^&|<>()%!"])/g, '^$1')}"`
+  }
+  // Why: fish single quotes are NOT literal. `\\` and `\'` are escapes inside
+  // them, so the sh `'\''` idiom collapses every backslash (a `\d+` regex, a
+  // `\\server\share` UNC path) and a trailing backslash is a hard syntax error
+  // that kills the launch. Escaping both metacharacters round-trips instead;
+  // verified against fish 4.7.1.
+  if (shell === 'fish') {
+    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
   }
   return `'${value.replace(/'/g, `'\\''`)}'`
 }

--- a/src/shared/tui-agent-startup-shell.ts
+++ b/src/shared/tui-agent-startup-shell.ts
@@ -3,7 +3,7 @@ import { tokenizeFishStartupCommand } from './fish-command-tokenizer'
 
 // Why: fish shares POSIX word splitting and `;` chaining, but NOT quoting or
 // escaping — see quoteStartupArg and fish-command-tokenizer.ts.
-export type AgentStartupShell = 'posix' | 'fish' | 'powershell' | 'cmd'
+export type AgentStartupShell = 'posix' | 'fish' | 'unix' | 'powershell' | 'cmd'
 
 type WindowsStartupShell = Extract<AgentStartupShell, 'powershell' | 'cmd'>
 
@@ -16,7 +16,7 @@ type WindowsStartupShell = Extract<AgentStartupShell, 'powershell' | 'cmd'>
  * never hardcode `'posix'` behind this check.
  */
 export function isPosixStartupShell(shell: AgentStartupShell): boolean {
-  return shell === 'posix' || shell === 'fish'
+  return shell === 'posix' || shell === 'fish' || shell === 'unix'
 }
 
 function isWindowsStartupShell(shell: AgentStartupShell): shell is WindowsStartupShell {
@@ -165,7 +165,22 @@ export function tokenizeStartupCommand(
   if (isWindowsStartupShell(shell)) {
     return tokenizeWindowsStartupCommand(value, shell)
   }
-  return shell === 'fish' ? tokenizeFishStartupCommand(value) : tokenizeCustomCommandTemplate(value)
+  if (shell === 'fish') {
+    return tokenizeFishStartupCommand(value)
+  }
+  const posix = tokenizeCustomCommandTemplate(value)
+  if (shell === 'posix' || !posix.ok) {
+    return posix
+  }
+  const fish = tokenizeFishStartupCommand(value)
+  if (
+    !fish.ok ||
+    fish.tokens.length !== posix.tokens.length ||
+    fish.tokens.some((token, index) => token !== posix.tokens[index])
+  ) {
+    return { ok: false, error: 'Command syntax depends on the remote Unix shell.' }
+  }
+  return posix
 }
 
 export function resolveStartupShell(
@@ -176,7 +191,34 @@ export function resolveStartupShell(
   if (platform !== 'win32' && agentEnv?.SHELL) {
     return resolveLoginShellStartupDialect(agentEnv.SHELL)
   }
-  return shell ?? (platform === 'win32' ? 'powershell' : 'posix')
+  return shell ?? (platform === 'win32' ? 'powershell' : 'unix')
+}
+
+function quotePortableUnixArg(value: string): string {
+  if (!value) {
+    return "''"
+  }
+  const parts: string[] = []
+  let literal = ''
+  const flushLiteral = (): void => {
+    if (literal) {
+      parts.push(`'${literal}'`)
+      literal = ''
+    }
+  }
+  for (const char of value) {
+    if (char === "'") {
+      flushLiteral()
+      parts.push(`"'"`)
+    } else if (char === '\\') {
+      flushLiteral()
+      parts.push(`"\\\\"`)
+    } else {
+      literal += char
+    }
+  }
+  flushLiteral()
+  return parts.join('')
 }
 
 export function quoteStartupArg(value: string, shell: AgentStartupShell): string {
@@ -185,6 +227,9 @@ export function quoteStartupArg(value: string, shell: AgentStartupShell): string
   }
   if (shell === 'cmd') {
     return `"${value.replace(/([\^&|<>()%!"])/g, '^$1')}"`
+  }
+  if (shell === 'unix') {
+    return quotePortableUnixArg(value)
   }
   // Why: fish single quotes are NOT literal. `\\` and `\'` are escapes inside
   // them, so the sh `'\''` idiom collapses every backslash (a `\d+` regex, a
@@ -219,6 +264,10 @@ export function clearEnvCommand(name: string, shell: AgentStartupShell): string 
   // the variable exported (e.g. an account-routed CODEX_HOME survives).
   if (shell === 'fish') {
     return `set -e ${name}`
+  }
+  if (shell === 'unix') {
+    // Why: inherited globals can hide universal values, so erase every Fish scope before the sh fallback.
+    return `command test -n "$fish_pid" && builtin eval 'set -el ${name}; set -eg ${name}; set -eU ${name}; true' || command eval 'unset ${name}'`
   }
   return `unset ${name}`
 }

--- a/src/shared/tui-agent-startup-shell.ts
+++ b/src/shared/tui-agent-startup-shell.ts
@@ -170,8 +170,12 @@ export function tokenizeStartupCommand(
 
 export function resolveStartupShell(
   platform: NodeJS.Platform,
-  shell?: AgentStartupShell
+  shell?: AgentStartupShell,
+  agentEnv?: Record<string, string> | null
 ): AgentStartupShell {
+  if (platform !== 'win32' && agentEnv?.SHELL) {
+    return resolveLoginShellStartupDialect(agentEnv.SHELL)
+  }
   return shell ?? (platform === 'win32' ? 'powershell' : 'posix')
 }
 

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -39,7 +39,7 @@ describe('tui agent startup plans', () => {
     }
   )
 
-  it('uses POSIX quoting when the target shell is Linux', () => {
+  it('uses portable Unix quoting when the target shell is unknown', () => {
     const plan = buildAgentStartupPlan({
       agent: 'claude',
       prompt: "fix Bob's branch",
@@ -47,7 +47,7 @@ describe('tui agent startup plans', () => {
       platform: 'linux'
     })
 
-    expect(plan?.launchCommand).toBe("claude 'fix Bob'\\''s branch'")
+    expect(plan?.launchCommand).toBe(`claude 'fix Bob'"'"'s branch'`)
   })
 
   it('uses PowerShell quoting by default when the target shell is Windows', () => {
@@ -180,7 +180,8 @@ describe('tui agent startup plans', () => {
       agent: 'hermes',
       prompt: 'run it',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      shell: 'posix'
     })
 
     expect(plan?.launchCommand).toMatch(/^sh -c /)
@@ -850,7 +851,8 @@ describe('tui agent startup plans', () => {
       agent: 'omp',
       draft: 'fix the omp regression',
       cmdOverrides: {},
-      platform: 'linux'
+      platform: 'linux',
+      shell: 'posix'
     })
 
     expect(plan).not.toBeNull()

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -57,7 +57,7 @@ export function buildAgentStartupPlan(args: {
   isRemote?: boolean
 }): AgentStartupPlan | null {
   const { agent, prompt, cmdOverrides, platform, allowEmptyPromptLaunch = false } = args
-  const shell = resolveStartupShell(platform, args.shell)
+  const shell = resolveStartupShell(platform, args.shell, args.agentEnv)
   const trimmedPrompt = prompt.trim()
   const config = TUI_AGENT_CONFIG[agent]
   const usesQuery = config.promptInjectionMode === 'hermes-query' && Boolean(trimmedPrompt)
@@ -203,7 +203,7 @@ export function buildAgentResumeStartupPlan(args: {
   if (!argv) {
     return null
   }
-  const shell = resolveStartupShell(args.platform, args.shell)
+  const shell = resolveStartupShell(args.platform, args.shell, args.agentEnv)
   const config = TUI_AGENT_CONFIG[args.agent]
   const resolvedAgentCommand = args.agentCommand?.trim()
   const baseCommand = resolvedAgentCommand
@@ -256,7 +256,7 @@ export function buildAgentDraftLaunchPlan(args: {
   isRemote?: boolean
 }): AgentDraftLaunchPlan | null {
   const { agent, draft, cmdOverrides, platform } = args
-  const shell = resolveStartupShell(platform, args.shell)
+  const shell = resolveStartupShell(platform, args.shell, args.agentEnv)
   const config = TUI_AGENT_CONFIG[agent]
   const trimmed = draft.trim()
   if (!trimmed) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2995,7 +2995,8 @@ export type GlobalSettings = {
   claudeManagedAccounts: ClaudeManagedAccount[]
   activeClaudeManagedAccountId: string | null
   activeClaudeManagedAccountIdsByRuntime?: ClaudeManagedAccountRuntimeSelection
-  /** Per-worktree shell history file so ArrowUp doesn't surface other worktrees' commands. Defaults to true. */
+  /** Per-worktree shell history so ArrowUp doesn't surface other worktrees' commands (a HISTFILE for
+   *  bash/zsh, a `fish_history` session name for fish). Defaults to true. */
   terminalScopeHistoryByWorktree: boolean
   /** Kill switch for hidden terminal view parking: unmount long-hidden panes while a pane-less watcher keeps PTY side effects alive. */
   terminalHiddenViewParking?: boolean

--- a/src/shared/windows-terminal-shell.test.ts
+++ b/src/shared/windows-terminal-shell.test.ts
@@ -21,15 +21,15 @@ describe('resolveWindowsShellStartupFamily', () => {
     expect(resolveWindowsShellStartupFamily('C:\\Windows\\System32\\cmd.exe')).toBe('cmd')
   })
 
-  it('maps Git Bash and WSL shells to POSIX quoting', () => {
+  it('maps Git Bash to POSIX and WSL to portable Unix quoting', () => {
     expect(resolveWindowsShellStartupFamily('git-bash')).toBe('posix')
-    expect(resolveWindowsShellStartupFamily('wsl.exe')).toBe('posix')
+    expect(resolveWindowsShellStartupFamily('wsl.exe')).toBe('unix')
     expect(resolveWindowsShellStartupFamily('C:\\Program Files\\Git\\bin\\bash.exe')).toBe('posix')
   })
 
-  it('maps extension-less bash and wsl entries to POSIX quoting', () => {
+  it('maps extension-less bash and wsl entries to their Unix quoting', () => {
     expect(resolveWindowsShellStartupFamily('bash')).toBe('posix')
-    expect(resolveWindowsShellStartupFamily('wsl')).toBe('posix')
+    expect(resolveWindowsShellStartupFamily('wsl')).toBe('unix')
     expect(resolveWindowsShellStartupFamily('C:\\Program Files\\Git\\bin\\bash')).toBe('posix')
   })
 })

--- a/src/shared/windows-terminal-shell.ts
+++ b/src/shared/windows-terminal-shell.ts
@@ -31,12 +31,10 @@ export function resolveWindowsShellStartupFamily(
   // Why: wsl.exe and bash.exe (Git for Windows) launch POSIX shells, so queued
   // commands must use POSIX quoting and `cd '<cwd>'` rather than cmd/PowerShell.
   // Extension-less forms reach the same executables through PATHEXT.
-  if (
-    basename === 'wsl.exe' ||
-    basename === 'wsl' ||
-    basename === 'bash.exe' ||
-    basename === 'bash'
-  ) {
+  if (basename === 'wsl.exe' || basename === 'wsl') {
+    return 'unix'
+  }
+  if (basename === 'bash.exe' || basename === 'bash') {
     return 'posix'
   }
   return 'powershell'


### PR DESCRIPTION
## ELI5

If you use fish, three things quietly didn't work. Every workspace shared one command history (arrow-up showed another worktree's commands); when Orca pre-filled an agent draft it tried to clean up with `unset`, which fish doesn't have, so fish printed `Unknown command: unset` and the variable stayed set; and — this is the one the first two revisions of this PR *created* — anything Orca quoted for fish was quoted with `sh` rules, which fish does not use. A prompt containing `\d+` or `\\server\share` arrived at the agent with half its backslashes gone, and a prompt ending in a backslash killed the launch outright with a syntax error.

## What Changed

### 0. fish quoting — the part that made the earlier revision a regression

**Read this first: as originally written, this PR made fish users worse off.** It was the first change to thread the `fish` dialect through to real callers, and `quoteStartupArg` had no fish branch, so every prompt and CLI argument was quoted with `sh` rules and handed to `fish`.

That is not a cosmetic mismatch. POSIX `sh` single quotes are fully literal; **fish's are not** — inside `'…'`, `\\` and `\'` are escapes, and a trailing backslash before the closing quote is a hard syntax error. Measured on fish 4.7.1:

```
sh   -c "printf '%s\n' 'a\\b'"    ->  a\\b     (literal)
fish -c "printf '%s\n' 'a\\b'"    ->  a\b      (collapses)
fish -c "printf '%s\n' 'ends\'"   ->  fish: Unexpected end of string, quotes are not balanced
```

So a composer prompt `use \d+ and path \\server\share` was silently mangled, and a prompt ending in `\` failed to launch. Fixed:

- **`quoteStartupArg` gains a fish branch**: `'` + `s.replace(/\\/g,'\\\\').replace(/'/g, "\\'")` + `'`. Verified to round-trip through real fish for regex backslashes, UNC paths, drive paths, apostrophes, trailing/lone backslashes, mixed quotes, newlines, `$`-expansions, glob characters, backticks, parens, operators, comments, tabs and non-BMP unicode.
- **New `src/shared/fish-command-tokenizer.ts`.** `tokenizeStartupCommand(value, 'fish')` was routing to the `sh` tokenizer, which is wrong in the same way and in one more: fish decodes the full C escape set unquoted (`\n` is a newline, not `n`; `\x41`/`\101`/`A`/`\cA` all decode), and inside double quotes only `\\`, `\$`, `\"` and a line continuation are escapes. Since callers tokenize a user's CLI-args string and then re-quote it, a wrong tokenizer corrupts the value even with correct quoting. The new tokenizer also flags fish-specific live syntax the span splice cannot model — `(…)` command substitution, `{a,b}` brace expansion, and globs (an **unmatched** wildcard is a hard *error* in fish, not a literal).
- **`agent-resume-argv-drop`**: `RESUME_ARGV_SHELLS` did not include `fish`, so a fish-quoted resume suffix would not match and main would report `unrecognized` and refuse the launch. Added.
- **`agent-resume-launch-command`**: the `NAME=value cmd` prefix skip was gated on `shell === 'posix'`; fish supports that form (3.1+), so it now uses `isPosixStartupShell`.
- **`ai-vault-resume-command`**: the non-Windows `cd '<cwd>' && CODEX_HOME='<x>' …` prefix quoted with `sh` rules even when the live shell was known to be fish. It now quotes for the live shell. (`NAME=value cmd` itself parses in fish — verified — so only the quoting was wrong.)
- **`hermes-startup-query`**: the outer `sh -c <arg>` was quoted with a hardcoded `'posix'` even though that quoting is parsed by the shell that types the line. Now quoted for the real dialect. Honest scoping: today's payload is a run of `\0NNN` octal escapes and never contains `\\` or a trailing `\`, so it happened to survive `sh` quoting in fish; this removes the dependence on that accident rather than fixing an observed break.
- **`isPosixStartupShell`'s doc comment** claimed fish "shares POSIX quoting/word rules". That claim is what produced this bug, so it is replaced with what the predicate actually means (sh-family *grammar*: `NAME=value` prefixes, `sh -c`, `;` chaining) and an explicit warning never to hardcode `'posix'` behind it.

Audited and left alone: `commandSeparator` (`; ` is correct in fish), `buildShellCommandFromArgv` (delegates to `quoteStartupArg`), `resolveStartupShell` (never defaults to fish), `normalizeHermesArgv`'s `env` prefix (correct for fish), and the inner `buildShellCommandFromArgv(argv, 'posix')` in the hermes script body (genuinely parsed by `sh`).

### 1. Worktree-scoped shell history now works for fish

`historyFilename` returned `null` for fish, so `injectHistoryEnv` did nothing and every fish worktree shared the global history. The bash/zsh mechanism (a per-worktree directory + `HISTFILE`) cannot transfer, because **fish ignores `HISTFILE` entirely**: history lives at `$XDG_DATA_HOME/fish/${fish_history}_history`, and the only isolation knob is the session *name*.

- New `src/main/fish-history-session.ts` derives a stable, filesystem-safe session name (`orca_<first 16 hex of the same worktree hash bash/zsh already use>`) and resolves the file path fish will write.
- `injectHistoryEnv` exports `fish_history=orca_<hash>` into the spawn env. fish imports environment variables as global variables at startup, so this needs no `--init-command` — verified against fish 4.7.1, which also means attribution-only fish panes (no `-C`) are covered.
- Check-before-set is preserved: a caller-supplied `fish_history` wins, exactly as a caller-supplied `HISTFILE` does.

`XDG_DATA_HOME` is deliberately **not** touched — redirecting it would move every other tool's data for that session. The tradeoff is that the file lands in the user's fish data dir rather than Orca's history root, so it can't ride the existing tree tombstone. Instead the session is recorded in that worktree's `meta.json`, and `scheduleWorktreeHistoryTreeDeletion` removes the out-of-tree file first — one hook covering both the explicit worktree delete and the startup GC sweep.

**Deletion now resolves that path from the right environment.** The first revision resolved it from the *main process* env, but the file is written by the *PTY's* fish, and the two disagree whenever Orca was launched with a different `XDG_DATA_HOME`/`HOME` than the shells it spawns — a permanent one-file-per-deleted-worktree leak. `injectHistoryEnv` now records `fishHistoryPath` resolved from the **spawn env** in `meta.json`, and deletion tries that first with the main-process guess kept as a fallback for meta files written before this change. The recorded path is only trusted if it is absolute and still basenames to `<session>_history`, so a tampered `meta.json` cannot steer `rmSync`.

One case remains genuinely unresolvable from Node: a `set -gx XDG_DATA_HOME …` that lives *inside* the user's `config.fish` is applied after we have handed off, so neither env can see it. Rather than dropping that silently, deletion now **warns explicitly**, naming the session and the paths it tried.

`updateHistFileForFallback` → `updateHistoryEnvForFallback`: on a fish→zsh/bash fallback spawn it drops the injected `fish_history` and points `HISTFILE` at the worktree directory. It only ever undoes what this spawn injected, so a user-supplied value survives.

### 2. The fish draft-prefill teardown is now reachable

`clearEnvCommand` already had a correct fish branch (`set -e VAR`), but no POSIX caller ever threaded a fish shell into `buildAgentDraftLaunchPlan` — `selectedRepoStartupShell` came from `resolveLocalWindowsAgentStartupShell`, which returns `undefined` off win32. So a fish user got `pi; unset ORCA_PI_PREFILL`.

New `src/shared/local-agent-startup-shell.ts` extends the Windows-only resolver to POSIX, reusing the pattern and the hard-won guard from #13904: the local login shell may pick the dialect **only** when it is provably the shell that parses the line. It refuses when the target is remote, when the execution host is `ssh`/`runtime`, or when the target platform differs from this machine's (which is how WSL is caught). Everything else stays `posix`.

Two thin wrappers supply the login shell, because the source differs by process:

- `src/renderer/src/lib/client-agent-startup-shell.ts` — uses `getClientLoginShell()` + `CLIENT_PLATFORM`, and requires an explicit `executionHostKind` so no call site can forget that a locally-listed workspace may execute elsewhere.
- `src/main/host-agent-startup-shell.ts` — the renderer helper doesn't exist in main, and on a remote Orca host it's *that* host's `$SHELL` that runs the command, not the connected client's. Uses `process.platform` / `process.env.SHELL`. Main's launch scopes carry only repo/folder + `connectionId` (no runtime dimension), so non-remote + same platform is sufficient there.

Every `resolveLocalWindowsAgentStartupShell` call site moved to one of the two wrappers, so all draft-prefill entry points (composer, folder-workspace composer, source-control action, work-item direct launch, new-tab/background launch, and both main-process paths) are covered rather than just the one in the report. `launch-work-item-direct` never threaded a shell at all and now does.

Out of scope on purpose: no fish Prime Agent command wrapper (#13875 was closed, #13906 removed that interception).

## Why

All three are silent failures. Shared history is a daily papercut for anyone running several worktrees; the `unset` one prints an error into the agent's own terminal on every draft launch and leaves the prefill variable exported, so the *next* agent start in that shell inherits a stale draft.

The quoting one is the reason this PR is bigger than the report. Threading a new dialect into a code path is only safe if every dialect-dependent function actually branches on it, and `isPosixStartupShell('fish') === true` is exactly the shape of a function that *looks* like it does and doesn't. Without the fix, this PR would have taken fish users from "one wrong `unset` line" to "your regex and Windows-path prompts arrive corrupted, and some prompts don't launch at all" — a strictly worse trade.

The dialect guard is the other subtle part and is why this isn't just "read `$SHELL`". A locally-scanned session can target a remote worktree, and `set -e ORCA_PI_PREFILL` in bash does not clear a variable — it enables `errexit`, which silently changes the semantics of the rest of that shell. So the resolver fails closed to `posix` unless the local shell is provably the one parsing the line.

## Linked Issue

Fixes #

## Visual Proof

`N/A` — no UI surface changes. Every behavior here is shell-side and is covered by real-fish tests instead (see Testing).

## Testing

Three real-fish suites (`itWithFish` guard + `src/shared/fish-binary-requirement.ts`), all registered in the `shell contracts` run list **and** the shard `--exclude` list in `.github/workflows/pr.yml`:

- **`src/shared/fish-startup-arg-quoting.live-fish.test.ts`** (new) — the shell is the oracle, not a hand-written expectation. Each case is written to a script file, run by a config-free fish in a pinned temp `HOME`/`XDG_*`, and echoed back through `string join0` (a NUL separator no test input can forge). Covers 15 adversarial arguments individually and all of them in one argv; the fish tokenizer against fish's own splitting for five command lines including `\x41`/`\101`/`\cA`; a full `buildAgentStartupPlan` composer prompt delivered to a real child process's argv; and the hermes `sh -c` wrapper end to end. Two cases assert the *old* behavior was broken: `sh` quoting of `\\server\share` comes back as `\server\share`, and `sh` quoting of a trailing backslash throws.
  Vacuity-checked: deleting the fish branch from `quoteStartupArg` fails 8 of these, including "delivers a composer prompt to the agent argv intact".
- `src/main/terminal-history-fish-session.node-pty.test.ts` — spawns real interactive fish in a fully pinned temp `HOME`/`XDG_*` (no ambient env reaches the shell), types a command, exits, and asserts the record landed in `$XDG_DATA_HOME/fish/orca_<hash>_history` in fish's YAML-ish `- cmd:` / `  when:` format, and that the default shared `fish_history` file was never created. Vacuity-checked: renaming the injected env var makes it fail with ENOENT on the scoped path.
- `src/shared/fish-draft-prefill-teardown.node-pty.test.ts` — proves the difference is shell-observable rather than just a string: in real fish, the `posix` spelling prints `Unknown command` and `set -q` still reports the variable present, while the `fish` spelling clears it.

Unit coverage: `src/shared/fish-command-tokenizer.test.ts` (single/double-quote escapes, the unquoted escape set, unclosed-quote errors, divergence flags, and the sh-vs-fish disagreement); the `fish startup shell dialect` block in `tui-agent-startup-shell.test.ts`, whose old "shares POSIX quoting" assertion is replaced with the real rule plus a quote→tokenize round trip; `injectHistoryEnv` fish session + per-worktree distinctness + check-before-set + the new spawn-env `fishHistoryPath` record; deletion preferring the recorded path, refusing a recorded path that doesn't name its own session file, and warning when nothing is found; `updateHistoryEnvForFallback` in both directions; `resolveFishHistoryFilePath` including its refusal of a name it did not mint; and every guard branch of `resolveLocalAgentStartupShell` / `resolveHostAgentStartupShell`. Every test that reads ambient env (`XDG_DATA_HOME`, `SHELL`) pins and restores it.

Observed locally on macOS 15 (fish 4.7.1, `/opt/homebrew/bin/fish`):

- `npx tsc --noEmit -p config/tsconfig.node.json` — clean
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- `npx oxlint` — exit 0, no errors (only pre-existing warnings in unrelated files)
- `npx vitest run --config config/vitest.config.ts src/shared/` — 4526 passed, 18 skipped
- `npx vitest run --config config/vitest.config.ts src/main/` — 20802 passed, 87 skipped
- `npx vitest run --config config/vitest.config.ts src/renderer/` — 22322 passed, 4 skipped
- `node config/scripts/check-max-lines-ratchet.mjs` — OK, no new bypasses
- `node config/scripts/check-reliability-gates.mjs` — 74 gates pass

Not exercised on a real machine: Windows and WSL (unchanged code paths — WSL's inner shell is resolved as `bash` before history injection, and `resolveLocalAgentStartupShell` delegates win32 to the existing Windows resolver untouched), and SSH hosts (the new guard's whole job is to *not* apply a local dialect there).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus.

## Review

- **Security** — the only new filesystem write outside Orca's own dirs is fish's own history file. Deletion is guarded twice: `/^orca_[0-9a-f]{1,64}$/` on the session name, and a recorded path must be absolute and basename to `<session>_history`, so a tampered `meta.json` cannot steer `rmSync` at an arbitrary path.
- **Cross-platform** — fish injection is env-only and inert on Windows; WSL terminals resolve their inner shell to `bash` before history injection, so they are untouched; the Windows startup-shell families and both Windows tokenizer/quoter branches route through the existing code unchanged.
- **Remote SSH** — no wire change (both the spawn env and the dialect decision are resolved on the machine that runs the shell). The dialect guard explicitly refuses to apply a local shell's syntax to a remote host.
- **Mobile** — mobile clients drive the main-process launch paths, which use the host's own `$SHELL`, so a phone on iOS cannot push an iOS dialect onto a macOS/Linux workspace.
- **Backwards compatibility** — `posix` remains the default for every shell that isn't fish; the sh quoting and tokenizing paths are byte-for-byte unchanged, and existing bash/zsh `HISTFILE` behavior and the settings kill switch are untouched. `fishHistoryPath` is an additive `meta.json` field; a meta file without it still deletes through the main-env fallback.
- **Performance** — one extra `meta.json` read on worktree-history deletion.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Made with [Orca](https://github.com/stablyai/orca) 🐋
