### PR TITLE
feat(terminal): support split left and split up

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1899,6 +1899,7 @@ type RuntimeNotifier = {
     paneRuntimeId: number,
     opts: {
       direction: 'horizontal' | 'vertical'
+      position?: 'before' | 'after'
       command?: string
       telemetrySource?: TerminalPaneSplitSource
     }
@@ -27169,6 +27170,7 @@ export class OrcaRuntimeService {
     handle: string,
     opts: {
       direction?: 'horizontal' | 'vertical'
+      position?: 'before' | 'after'
       command?: string
       env?: Record<string, string>
       envToDelete?: string[]
@@ -27197,6 +27199,7 @@ export class OrcaRuntimeService {
 
     this.notifier?.splitTerminal(leaf.tabId, leaf.paneRuntimeId, {
       direction,
+      ...(opts.position ? { position: opts.position } : {}),
       command: opts.command,
       telemetrySource: opts.telemetrySource
     })

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -973,6 +973,7 @@ const TerminalSplit = TerminalHandle.extend({
     .optional(),
   command: OptionalString,
   env: z.record(z.string(), z.string()).optional(),
+  position: z.enum(['before', 'after']).optional(),
   telemetrySource: z.enum(TERMINAL_PANE_SPLIT_SOURCES).optional()
 })
 
@@ -1458,6 +1459,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
     handler: async (params, { runtime }) => ({
       split: await runtime.splitTerminal(params.terminal, {
         direction: params.direction,
+        position: params.position,
         command: params.command,
         env: params.env,
         telemetrySource: params.telemetrySource

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -439,6 +439,7 @@ function registerRuntimeWindowLifecycle(
         tabId,
         paneRuntimeId,
         direction: opts.direction,
+        ...(opts.position ? { position: opts.position } : {}),
         command: opts.command,
         telemetrySource: opts.telemetrySource
       })

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3217,6 +3217,7 @@ export type PreloadApi = {
         tabId: string
         paneRuntimeId: number
         direction: 'horizontal' | 'vertical'
+        position?: 'before' | 'after'
         command?: string
         telemetrySource?: TerminalPaneSplitSource
       }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3905,6 +3905,7 @@ const api = {
         tabId: string
         paneRuntimeId: number
         direction: 'horizontal' | 'vertical'
+        position?: 'before' | 'after'
         command?: string
         telemetrySource?: TerminalPaneSplitSource
       }) => void
@@ -3915,6 +3916,7 @@ const api = {
           tabId: string
           paneRuntimeId: number
           direction: 'horizontal' | 'vertical'
+          position?: 'before' | 'after'
           command?: string
           telemetrySource?: TerminalPaneSplitSource
         }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-shortcuts.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-shortcuts.test.ts
@@ -149,7 +149,7 @@ describe('resolvePreviewShortcutAction', () => {
   it('reports pane-scoped chords so the caller can swallow them', () => {
     expect(
       resolvePreviewShortcutAction(keydown({ key: 'd', code: 'KeyD', metaKey: true }), contextFor())
-    ).toEqual({ type: 'splitActivePane', direction: 'vertical' })
+    ).toEqual({ type: 'splitActivePane', direction: 'vertical', position: 'after' })
   })
 
   // Why: a terminal-first user remapped terminal.closePane away, so only the

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
@@ -69,6 +69,8 @@ function renderMenu(overrides: Record<string, unknown> = {}): string {
     onPaste: vi.fn(),
     onSplitRight: vi.fn(),
     onSplitDown: vi.fn(),
+    onSplitLeft: vi.fn(),
+    onSplitUp: vi.fn(),
     keybindings: {},
     canEqualizePaneSizes: false,
     onEqualizePaneSizes: vi.fn(),
@@ -125,6 +127,28 @@ describe('TerminalContextMenu', () => {
     expect(onCopyAgentSessionContext).toHaveBeenCalledTimes(1)
     // Why: copying context must not go through the fork dialog path.
     expect(onForkAgentSession).not.toHaveBeenCalled()
+  })
+
+  it('offers all four split directions', () => {
+    const onSplitLeft = vi.fn()
+    const onSplitUp = vi.fn()
+    renderMenu({ onSplitLeft, onSplitUp })
+
+    const findSplitItem = (label: string): (typeof items.list)[number] | undefined =>
+      items.list.find((item) => childrenText(item.children).startsWith(label))
+
+    for (const label of ['Right', 'Down', 'Left', 'Up']) {
+      expect(findSplitItem(`Split Terminal ${label}`)).toBeDefined()
+    }
+
+    // Why: unbound actions must not render the 'Unassigned' sentinel as a chip.
+    expect(childrenText(findSplitItem('Split Terminal Left')!.children)).toBe('Split Terminal Left')
+    expect(childrenText(findSplitItem('Split Terminal Up')!.children)).toBe('Split Terminal Up')
+
+    findSplitItem('Split Terminal Left')?.onSelect?.()
+    findSplitItem('Split Terminal Up')?.onSelect?.()
+    expect(onSplitLeft).toHaveBeenCalledTimes(1)
+    expect(onSplitUp).toHaveBeenCalledTimes(1)
   })
 
   it('shows new-session continuation only for eligible agent panes', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -9,8 +9,10 @@ import {
   MessageSquare,
   Minimize2,
   PanelBottomClose,
+  PanelLeftClose,
   PanelsTopLeft,
   PanelRightClose,
+  PanelTopClose,
   Pencil,
   SquareTerminal,
   TextSelect,
@@ -27,7 +29,7 @@ import {
 import { shouldIgnoreTerminalMenuPointerDownOutside } from './terminal-context-menu-dismiss'
 import type { TerminalQuickCommand } from '../../../../shared/types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
-import { formatPrimaryShortcutLabel } from '@/hooks/useShortcutLabel'
+import { formatOptionalShortcutLabel, formatPrimaryShortcutLabel } from '@/hooks/useShortcutLabel'
 import type { KeybindingOverrides } from '../../../../shared/keybindings'
 import { translate } from '@/i18n/i18n'
 import { isMacPlatform, nativeChatToggleShortcutLabel } from '../native-chat/native-chat-shortcut'
@@ -48,6 +50,8 @@ type TerminalContextMenuProps = {
   onPaste: () => void
   onSplitRight: () => void
   onSplitDown: () => void
+  onSplitLeft: () => void
+  onSplitUp: () => void
   keybindings: KeybindingOverrides
   canEqualizePaneSizes: boolean
   onEqualizePaneSizes: () => void
@@ -87,6 +91,8 @@ export default function TerminalContextMenu({
   onPaste,
   onSplitRight,
   onSplitDown,
+  onSplitLeft,
+  onSplitUp,
   keybindings,
   canEqualizePaneSizes,
   onEqualizePaneSizes,
@@ -120,6 +126,8 @@ export default function TerminalContextMenu({
       paste: formatPrimaryShortcutLabel('terminal.paste', keybindings),
       splitRight: formatPrimaryShortcutLabel('terminal.splitRight', keybindings),
       splitDown: formatPrimaryShortcutLabel('terminal.splitDown', keybindings),
+      splitLeft: formatOptionalShortcutLabel('terminal.splitLeft', keybindings),
+      splitUp: formatOptionalShortcutLabel('terminal.splitUp', keybindings),
       equalize: formatPrimaryShortcutLabel('terminal.equalizePaneSizes', keybindings),
       expand: formatPrimaryShortcutLabel('terminal.expandPane', keybindings),
       setTitle: formatPrimaryShortcutLabel('terminal.setTitle', keybindings),
@@ -246,6 +254,26 @@ export default function TerminalContextMenu({
             'Split Terminal Down'
           )}
           <DropdownMenuShortcut>{shortcuts.splitDown}</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitLeft}>
+          <PanelLeftClose />
+          {translate(
+            'auto.components.terminal.pane.TerminalContextMenu.e179938889',
+            'Split Terminal Left'
+          )}
+          {shortcuts.splitLeft ? (
+            <DropdownMenuShortcut>{shortcuts.splitLeft}</DropdownMenuShortcut>
+          ) : null}
+        </DropdownMenuItem>
+        <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitUp}>
+          <PanelTopClose />
+          {translate(
+            'auto.components.terminal.pane.TerminalContextMenu.81f1f200c7',
+            'Split Terminal Up'
+          )}
+          {shortcuts.splitUp ? (
+            <DropdownMenuShortcut>{shortcuts.splitUp}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         {canEqualizePaneSizes && (
           <DropdownMenuItem onSelect={onEqualizePaneSizes}>

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -3089,6 +3089,8 @@ function TerminalPane(
         onPaste={() => void contextMenu.onPaste()}
         onSplitRight={contextMenu.onSplitRight}
         onSplitDown={contextMenu.onSplitDown}
+        onSplitLeft={contextMenu.onSplitLeft}
+        onSplitUp={contextMenu.onSplitUp}
         keybindings={keybindings}
         onEqualizePaneSizes={contextMenu.onEqualizePaneSizes}
         onClosePane={contextMenu.onClosePane}

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -830,6 +830,7 @@ export function useTerminalKeyboardShortcuts({
           fallbackCwd,
           pane,
           direction: action.direction,
+          position: action.position,
           source: getKeyboardSplitTelemetrySource()
         })
       }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
@@ -57,11 +57,80 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     await flushAsyncSplit()
 
     expect(staleSplitPane).not.toHaveBeenCalled()
-    expect(liveSplitPane).toHaveBeenCalledWith(1, 'vertical', { cwd: '/resolved' })
+    expect(liveSplitPane).toHaveBeenCalledWith(1, 'vertical', {
+      cwd: '/resolved',
+      position: 'after'
+    })
     expect(mocks.recordCreatedTerminalPaneSplit).toHaveBeenCalledWith(
       { id: 2 },
       { source: 'context_menu', direction: 'vertical' }
     )
+  })
+
+  it('forwards a leading position through the cached-cwd path', () => {
+    const splitPane = vi.fn(() => ({ id: 2 }))
+
+    splitTerminalPaneWithInheritedCwd({
+      manager: makeManager(splitPane),
+      paneTransports: new Map<number, PtyTransport>(),
+      paneCwdMap: new Map([[1, { cwd: '/cached', confirmed: true }]]),
+      fallbackCwd: '/fallback',
+      pane: { id: 1 } as ManagedPane,
+      direction: 'vertical',
+      position: 'before',
+      source: 'context_menu'
+    })
+
+    expect(splitPane).toHaveBeenCalledWith(1, 'vertical', { cwd: '/cached', position: 'before' })
+  })
+
+  it('forwards a leading position through the async cwd path', async () => {
+    const splitPane = vi.fn(() => ({ id: 2 }))
+    mocks.resolveSplitCwd.mockResolvedValue('/resolved')
+
+    splitTerminalPaneWithInheritedCwd({
+      manager: makeManager(splitPane),
+      paneTransports: new Map<number, PtyTransport>(),
+      paneCwdMap: new Map(),
+      fallbackCwd: '/fallback',
+      pane: { id: 1 } as ManagedPane,
+      direction: 'horizontal',
+      position: 'before',
+      source: 'context_menu'
+    })
+
+    await flushAsyncSplit()
+
+    expect(splitPane).toHaveBeenCalledWith(1, 'horizontal', {
+      cwd: '/resolved',
+      position: 'before'
+    })
+  })
+
+  it('hands the position to the remote runtime so SSH panes split the same way', () => {
+    const splitPane = vi.fn()
+    const transport = { getPtyId: () => 'remote-pty' } as unknown as PtyTransport
+    mocks.splitWebRuntimeTerminal.mockReturnValue(true)
+
+    splitTerminalPaneWithInheritedCwd({
+      manager: makeManager(splitPane),
+      paneTransports: new Map([[1, transport]]),
+      paneCwdMap: new Map(),
+      fallbackCwd: '/fallback',
+      pane: { id: 1 } as ManagedPane,
+      direction: 'vertical',
+      position: 'before',
+      source: 'context_menu'
+    })
+
+    expect(mocks.splitWebRuntimeTerminal).toHaveBeenCalledWith(
+      'remote-pty',
+      'vertical',
+      'context_menu',
+      'before'
+    )
+    // Why: the host owns the remote split; a local one would mint a mirrored tab instead.
+    expect(splitPane).not.toHaveBeenCalled()
   })
 
   it('does not split a stale manager when the live manager is gone', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
@@ -1,5 +1,6 @@
 import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PaneSplitPosition } from '@/lib/pane-manager/pane-manager-types'
 import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import type { PtyTransport } from './pty-transport'
 import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
@@ -13,15 +14,20 @@ export function splitTerminalPaneWithInheritedCwd(args: {
   fallbackCwd: string
   pane: ManagedPane
   direction: 'vertical' | 'horizontal'
+  position?: PaneSplitPosition
   source: TerminalPaneSplitSource
 }): void {
+  const position = args.position ?? 'after'
   const ptyId = args.paneTransports.get(args.pane.id)?.getPtyId() ?? null
-  if (splitWebRuntimeTerminal(ptyId, args.direction, args.source)) {
+  if (splitWebRuntimeTerminal(ptyId, args.direction, args.source, position)) {
     return
   }
   const cached = args.paneCwdMap.get(args.pane.id)
   if (cached?.confirmed && cached.cwd) {
-    const createdPane = args.manager.splitPane(args.pane.id, args.direction, { cwd: cached.cwd })
+    const createdPane = args.manager.splitPane(args.pane.id, args.direction, {
+      cwd: cached.cwd,
+      position
+    })
     recordCreatedTerminalPaneSplit(createdPane, {
       source: args.source,
       direction: args.direction
@@ -38,7 +44,7 @@ export function splitTerminalPaneWithInheritedCwd(args: {
       sourcePtyId: ptyId,
       fallbackCwd: args.fallbackCwd
     })
-    const createdPane = resolveManager()?.splitPane(paneId, args.direction, { cwd })
+    const createdPane = resolveManager()?.splitPane(paneId, args.direction, { cwd, position })
     recordCreatedTerminalPaneSplit(createdPane, {
       source: args.source,
       direction: args.direction

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -52,13 +52,13 @@ describe('resolveTerminalShortcutAction', () => {
     })
     expect(
       resolveTerminalShortcutAction(event({ key: 'd', code: 'KeyD', metaKey: true }), true)
-    ).toEqual({ type: 'splitActivePane', direction: 'vertical' })
+    ).toEqual({ type: 'splitActivePane', direction: 'vertical', position: 'after' })
     expect(
       resolveTerminalShortcutAction(
         event({ key: 'd', code: 'KeyD', metaKey: true, shiftKey: true }),
         true
       )
-    ).toEqual({ type: 'splitActivePane', direction: 'horizontal' })
+    ).toEqual({ type: 'splitActivePane', direction: 'horizontal', position: 'after' })
     expect(
       resolveTerminalShortcutAction(event({ key: '[', code: 'BracketLeft', metaKey: true }), true)
     ).toEqual({ type: 'focusPane', direction: 'previous' })
@@ -496,7 +496,7 @@ describe('resolveTerminalShortcutAction', () => {
         event({ key: 'd', code: 'KeyD', ctrlKey: true, shiftKey: true }),
         false
       )
-    ).toEqual({ type: 'splitActivePane', direction: 'vertical' })
+    ).toEqual({ type: 'splitActivePane', direction: 'vertical', position: 'after' })
 
     // Alt+Shift+D on Windows/Linux splits the pane down (horizontal)
     expect(
@@ -504,7 +504,7 @@ describe('resolveTerminalShortcutAction', () => {
         event({ key: 'd', code: 'KeyD', altKey: true, shiftKey: true }),
         false
       )
-    ).toEqual({ type: 'splitActivePane', direction: 'horizontal' })
+    ).toEqual({ type: 'splitActivePane', direction: 'horizontal', position: 'after' })
 
     // Alt+Shift+D should NOT trigger split-down on Mac (Mac uses Cmd+Shift+D)
     expect(
@@ -684,19 +684,6 @@ describe('resolveTerminalShortcutAction', () => {
     expect(
       resolveTerminalShortcutAction(event({ key: 'b', code: 'KeyB', altKey: true }), true, 'true')
     ).toBeNull()
-  })
-
-  it('keeps Cmd+D and Cmd+Shift+D for split on macOS', () => {
-    expect(
-      resolveTerminalShortcutAction(event({ key: 'd', code: 'KeyD', metaKey: true }), true)
-    ).toEqual({ type: 'splitActivePane', direction: 'vertical' })
-
-    expect(
-      resolveTerminalShortcutAction(
-        event({ key: 'd', code: 'KeyD', metaKey: true, shiftKey: true }),
-        true
-      )
-    ).toEqual({ type: 'splitActivePane', direction: 'horizontal' })
   })
 
   it('resolves terminal.switchInputSource via explicit override (for OS input-source chords)', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -62,7 +62,11 @@ export type TerminalShortcutAction =
   | { type: 'setTitle' }
   | { type: 'clearPaneTitle' }
   | { type: 'closeActivePane' }
-  | { type: 'splitActivePane'; direction: 'vertical' | 'horizontal' }
+  | {
+      type: 'splitActivePane'
+      direction: 'vertical' | 'horizontal'
+      position: 'before' | 'after'
+    }
   | { type: 'scrollViewport'; position: 'top' | 'bottom' }
   | { type: 'sendInput'; data: string }
   | { type: 'switchInputSource' }
@@ -174,11 +178,19 @@ export function resolveTerminalShortcutAction(
     }
 
     if (keybindingMatchesAction('terminal.splitRight', event, platform, keybindings)) {
-      return { type: 'splitActivePane', direction: 'vertical' }
+      return { type: 'splitActivePane', direction: 'vertical', position: 'after' }
     }
 
     if (keybindingMatchesAction('terminal.splitDown', event, platform, keybindings)) {
-      return { type: 'splitActivePane', direction: 'horizontal' }
+      return { type: 'splitActivePane', direction: 'horizontal', position: 'after' }
+    }
+
+    if (keybindingMatchesAction('terminal.splitLeft', event, platform, keybindings)) {
+      return { type: 'splitActivePane', direction: 'vertical', position: 'before' }
+    }
+
+    if (keybindingMatchesAction('terminal.splitUp', event, platform, keybindings)) {
+      return { type: 'splitActivePane', direction: 'horizontal', position: 'before' }
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/terminal-split-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-split-shortcut-policy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+describe('terminal split shortcuts', () => {
+  it('keeps Cmd+D and Cmd+Shift+D for split on macOS', () => {
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'd', code: 'KeyD', metaKey: true }), true)
+    ).toEqual({ type: 'splitActivePane', direction: 'vertical', position: 'after' })
+
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'd', code: 'KeyD', metaKey: true, shiftKey: true }),
+        true
+      )
+    ).toEqual({ type: 'splitActivePane', direction: 'horizontal', position: 'after' })
+  })
+
+  it('resolves split left/up to a leading split once the user binds a chord', () => {
+    // Why: both actions ship unbound, so only an override can reach them.
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'd', code: 'KeyD', metaKey: true, altKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        { 'terminal.splitLeft': ['Mod+Alt+D'] }
+      )
+    ).toEqual({ type: 'splitActivePane', direction: 'vertical', position: 'before' })
+
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'd', code: 'KeyD', metaKey: true, altKey: true, shiftKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        { 'terminal.splitUp': ['Mod+Alt+Shift+D'] }
+      )
+    ).toEqual({ type: 'splitActivePane', direction: 'horizontal', position: 'before' })
+  })
+
+  it('leaves split left/up unbound by default so no chord is stolen from the shell', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'd', code: 'KeyD', metaKey: true, altKey: true }),
+        true
+      )
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -95,6 +95,8 @@ type TerminalMenuState = {
   onPaste: () => Promise<void>
   onSplitRight: () => void
   onSplitDown: () => void
+  onSplitLeft: () => void
+  onSplitUp: () => void
   onEqualizePaneSizes: () => void
   onClosePane: () => void
   onClearScreen: () => void
@@ -354,7 +356,8 @@ export function useTerminalPaneContextMenu({
   const splitWithInheritedCwd = useCallback(
     (
       direction: 'vertical' | 'horizontal',
-      source: 'contextual_tour' | 'context_menu' = 'context_menu'
+      source: 'contextual_tour' | 'context_menu' = 'context_menu',
+      position: 'before' | 'after' = 'after'
     ): void => {
       const pane = resolveMenuPane()
       const manager = managerRef.current
@@ -369,6 +372,7 @@ export function useTerminalPaneContextMenu({
         fallbackCwd,
         pane,
         direction,
+        position,
         source
       })
     },
@@ -377,6 +381,8 @@ export function useTerminalPaneContextMenu({
 
   const onSplitRight = (): void => splitWithInheritedCwd('vertical')
   const onSplitDown = (): void => splitWithInheritedCwd('horizontal')
+  const onSplitLeft = (): void => splitWithInheritedCwd('vertical', 'context_menu', 'before')
+  const onSplitUp = (): void => splitWithInheritedCwd('horizontal', 'context_menu', 'before')
 
   useEffect(() => {
     const onRequestSplit = (event: Event): void => {
@@ -603,6 +609,8 @@ export function useTerminalPaneContextMenu({
     onPaste,
     onSplitRight,
     onSplitDown,
+    onSplitLeft,
+    onSplitUp,
     onEqualizePaneSizes,
     onClosePane,
     onClearScreen,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1684,7 +1684,8 @@ export function useTerminalPaneLifecycle({
       }
       const splitOptions = {
         ...(detail.newLeafId ? { leafId: detail.newLeafId } : {}),
-        ...(detail.ptyId ? { ptyId: detail.ptyId } : {})
+        ...(detail.ptyId ? { ptyId: detail.ptyId } : {}),
+        ...(detail.position ? { position: detail.position } : {})
       }
       if (detail.command) {
         const createdPane = splitPaneWithOneShotStartup(ptyDeps, { command: detail.command }, () =>

--- a/src/renderer/src/constants/terminal.ts
+++ b/src/renderer/src/constants/terminal.ts
@@ -50,6 +50,7 @@ export type SplitTerminalPaneDetail = {
   tabId: string
   paneRuntimeId: number
   direction: 'horizontal' | 'vertical'
+  position?: 'before' | 'after'
   command?: string
   sourceLeafId?: string
   sourcePtyId?: string

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1812,11 +1812,12 @@ export function useIpcEvents(): void {
 
     unsubs.push(
       window.api.ui.onSplitTerminal(
-        ({ tabId, paneRuntimeId, direction, command, telemetrySource }) => {
+        ({ tabId, paneRuntimeId, direction, position, command, telemetrySource }) => {
           const detail: SplitTerminalPaneDetail = {
             tabId,
             paneRuntimeId,
             direction,
+            ...(position ? { position } : {}),
             command,
             telemetrySource
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2830,7 +2830,9 @@
             "925f49f210": "Expand Pane",
             "df766809e0": "Collapse Pane",
             "cff67afad1": "Copy Context",
-            "15dd899676": "Add to {{value0}}…"
+            "15dd899676": "Add to {{value0}}…",
+            "e179938889": "Split Terminal Left",
+            "81f1f200c7": "Split Terminal Up"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Restart daemon",

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -14,6 +14,10 @@ import type { TerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
 // Public interfaces
 // ---------------------------------------------------------------------------
 
+/** Where the new pane lands relative to the pane being split: 'after' is
+ *  split right/down, 'before' is split left/up. */
+export type PaneSplitPosition = 'before' | 'after'
+
 /** Hints forwarded from splitPane() into onPaneCreated for a single split.
  *  Carries one-shot PTY spawn/adoption data for the new pane.
  *  Kept as a separate parameter (rather than extending ManagedPane) so the

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -8,7 +8,8 @@ import type {
   DropZone,
   PaneExternalDropHandler,
   PaneExternalDropResolver,
-  PaneExternalDropTarget
+  PaneExternalDropTarget,
+  PaneSplitPosition
 } from './pane-manager-types'
 import type { SplitPaneAroundLeafIdsOptions } from './pane-subtree-split'
 import {
@@ -113,7 +114,13 @@ export class PaneManager {
   splitPane(
     paneId: number,
     direction: 'vertical' | 'horizontal',
-    opts?: { ratio?: number; cwd?: string; leafId?: string; ptyId?: string }
+    opts?: {
+      ratio?: number
+      cwd?: string
+      leafId?: string
+      ptyId?: string
+      position?: PaneSplitPosition
+    }
   ): ManagedPane | null {
     return splitManagedPane({
       paneId,

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -2,6 +2,7 @@ import type {
   ManagedPane,
   ManagedPaneInternal,
   PaneManagerOptions,
+  PaneSplitPosition,
   PaneStyleOptions
 } from './pane-manager-types'
 import type { DragReorderCallbacks } from './pane-drag-reorder'
@@ -30,7 +31,13 @@ type MovedPaneSplitState = {
 type SplitManagedPaneArgs = {
   paneId: number
   direction: 'vertical' | 'horizontal'
-  opts?: { ratio?: number; cwd?: string; leafId?: string; ptyId?: string }
+  opts?: {
+    ratio?: number
+    cwd?: string
+    leafId?: string
+    ptyId?: string
+    position?: PaneSplitPosition
+  }
   sourceContainer?: HTMLElement
   panes: Map<number, ManagedPaneInternal>
   root: HTMLElement

--- a/src/renderer/src/lib/pane-manager/pane-split-position.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-position.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { serializePaneTree } from '@/components/terminal-pane/layout-serialization'
+import { wrapInSplit } from './pane-tree-ops'
+
+const LEAF_IDS = {
+  '1': '11111111-1111-4111-8111-111111111111',
+  '2': '22222222-2222-4222-8222-222222222222'
+} as const
+
+function makePane(id: '1' | '2'): HTMLElement {
+  const el = document.createElement('div')
+  el.className = 'pane'
+  el.dataset.paneId = id
+  el.dataset.leafId = LEAF_IDS[id]
+  return el
+}
+
+function setup(): { root: HTMLElement; existing: HTMLElement; created: HTMLElement } {
+  const root = document.createElement('div')
+  const existing = makePane('1')
+  root.appendChild(existing)
+  return { root, existing, created: makePane('2') }
+}
+
+function paneOrder(root: HTMLElement): string[] {
+  const split = root.firstElementChild as HTMLElement
+  return [...split.children].map((child) =>
+    child.classList.contains('pane') ? (child as HTMLElement).dataset.paneId! : 'divider'
+  )
+}
+
+describe('wrapInSplit position', () => {
+  it('appends the new pane after the source pane by default', () => {
+    const { root, existing, created } = setup()
+
+    wrapInSplit(existing, created, true, document.createElement('div'))
+
+    expect(paneOrder(root)).toEqual(['1', 'divider', '2'])
+  })
+
+  it('places the new pane before the source pane for split left/up', () => {
+    const { root, existing, created } = setup()
+
+    wrapInSplit(existing, created, true, document.createElement('div'), { position: 'before' })
+
+    expect(paneOrder(root)).toEqual(['2', 'divider', '1'])
+  })
+
+  it('keeps the divider between the panes in both orders', () => {
+    const { root, existing, created } = setup()
+
+    wrapInSplit(existing, created, false, document.createElement('div'), { position: 'before' })
+
+    expect(paneOrder(root)[1]).toBe('divider')
+    expect((root.firstElementChild as HTMLElement).className).toContain('is-horizontal')
+  })
+
+  it('serializes a leading split so a restored layout keeps the new pane on the left', () => {
+    // Why: replay only ever splits 'after' and rebuilds from tree order, so the
+    // serialized `first` must be the pane the user actually sees on the left.
+    const { root, existing, created } = setup()
+
+    wrapInSplit(existing, created, true, document.createElement('div'), {
+      ratio: 0.3,
+      position: 'before'
+    })
+
+    expect(serializePaneTree(root.firstElementChild as HTMLElement)).toEqual({
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: LEAF_IDS['2'] },
+      second: { type: 'leaf', leafId: LEAF_IDS['1'] },
+      ratio: 0.3
+    })
+  })
+
+  it('applies the ratio to whichever pane leads, so a replayed layout keeps its sizes', () => {
+    const after = setup()
+    wrapInSplit(after.existing, after.created, true, document.createElement('div'), { ratio: 0.25 })
+    expect(after.existing.style.flex).toBe('0.25 1 0%')
+    expect(after.created.style.flex).toBe('0.75 1 0%')
+
+    const before = setup()
+    wrapInSplit(before.existing, before.created, true, document.createElement('div'), {
+      ratio: 0.25,
+      position: 'before'
+    })
+    expect(before.created.style.flex).toBe('0.25 1 0%')
+    expect(before.existing.style.flex).toBe('0.75 1 0%')
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -3,6 +3,7 @@ import type {
   DropZone,
   ManagedPane,
   ManagedPaneInternal,
+  PaneSplitPosition,
   PaneStyleOptions
 } from './pane-manager-types'
 import { createDivider, disposeDivider } from './pane-divider'
@@ -304,14 +305,15 @@ export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
 
 /**
  * Create a flex split wrapper that replaces `existingContainer` in the DOM,
- * then places [existing] [divider] [new] inside it.
+ * then places [existing] [divider] [new] inside it — or the reverse when
+ * `position` is 'before' (split left / split up).
  */
 export function wrapInSplit(
   existingContainer: HTMLElement,
   newContainer: HTMLElement,
   isVertical: boolean,
   divider: HTMLElement,
-  opts?: { ratio?: number }
+  opts?: { ratio?: number; position?: PaneSplitPosition }
 ): void {
   const parent = existingContainer.parentElement
   if (!parent) {
@@ -342,16 +344,21 @@ export function wrapInSplit(
   applyPaneFlexStyle(existingContainer)
   applyPaneFlexStyle(newContainer)
 
-  // Apply custom ratio if provided
+  const [leading, trailing] =
+    opts?.position === 'before'
+      ? [newContainer, existingContainer]
+      : [existingContainer, newContainer]
+
+  // Ratio is the leading child's fraction, matching the serialized `first`/`second` order.
   const ratio = opts?.ratio
   if (ratio !== undefined && ratio > 0 && ratio < 1) {
-    existingContainer.style.flex = `${ratio} 1 0%`
-    newContainer.style.flex = `${1 - ratio} 1 0%`
+    leading.style.flex = `${ratio} 1 0%`
+    trailing.style.flex = `${1 - ratio} 1 0%`
   }
 
   // Replace existing with split in the DOM, then build children
   parent.replaceChild(split, existingContainer)
-  split.appendChild(existingContainer)
+  split.appendChild(leading)
   split.appendChild(divider)
-  split.appendChild(newContainer)
+  split.appendChild(trailing)
 }

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -13,6 +13,7 @@ import type {
   RuntimeTerminalSplit
 } from '../../../shared/runtime-types'
 import type { TerminalPaneSplitSource } from '../../../shared/feature-education-telemetry'
+import type { PaneSplitPosition } from '../lib/pane-manager/pane-manager-types'
 import type { StartupCommandDelivery } from '../../../shared/codex-startup-delivery'
 import type {
   SleepingAgentLaunchConfig,
@@ -966,7 +967,10 @@ async function callWebRuntimeSessionTabMethod(
 export function splitWebRuntimeTerminal(
   ptyId: string | null | undefined,
   direction: 'horizontal' | 'vertical',
-  telemetrySource: TerminalPaneSplitSource
+  telemetrySource: TerminalPaneSplitSource,
+  // Why: optional on the wire — a host too old to know `position` still splits
+  // after the source pane rather than failing the call.
+  position: PaneSplitPosition = 'after'
 ): boolean {
   if (!ptyId) {
     return false
@@ -991,6 +995,7 @@ export function splitWebRuntimeTerminal(
       params: {
         terminal: remote.handle,
         direction,
+        ...(position === 'before' ? { position } : {}),
         telemetrySource
       },
       timeoutMs: 15_000

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -114,6 +114,8 @@ export type KeybindingActionId =
   | 'terminal.closePane'
   | 'terminal.splitRight'
   | 'terminal.splitDown'
+  | 'terminal.splitLeft'
+  | 'terminal.splitUp'
   | 'terminal.switchInputSource'
   | PluginKeybindingActionId
 
@@ -1065,6 +1067,24 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       linux: ['Alt+Shift+D'],
       win32: ['Alt+Shift+D']
     }
+  },
+  // Why: no default chord — every Mod/Alt+D combination is already taken by the
+  // right/down splits on some platform, so users opt in from shortcut settings.
+  {
+    id: 'terminal.splitLeft',
+    title: 'Split terminal left',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: ['shortcut', 'pane', 'split', 'left'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'terminal.splitUp',
+    title: 'Split terminal up',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: ['shortcut', 'pane', 'split', 'up'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'terminal.switchInputSource',


### PR DESCRIPTION
## Summary

Terminal panes could only split right or down, so there was no way to place a new pane *before* the source pane in its split. This adds **Split Terminal Left** and **Split Terminal Up**.

Both are available from the terminal right-click menu and as bindable actions (`terminal.splitLeft`, `terminal.splitUp`) in keyboard shortcut settings.

Partially addresses #8263 — this is the **directional split** half only. Spatial pane focus (the Windows Terminal `NavigateDirection` semantics discussed in that issue) is deliberately left for a follow-up PR so this one stays reviewable on a single topic.

### Approach

Splits keep the existing `'vertical' | 'horizontal'` axis and gain a `position: 'before' | 'after'` option (defaulting to `'after'`). Split Left is `vertical + before`; Split Up is `horizontal + before`.

This was chosen over replacing `direction` with a four-way `'left' | 'right' | 'up' | 'down'` type because it leaves the serialized layout format (`TerminalPaneSplitDirection`) and every existing binding untouched, which is also what #8263 asks for ("Keep the existing `splitRight` and `splitDown` actions working for backward compatibility").

`wrapInSplit` now picks which container leads the flex row/column; everything downstream reads DOM order, so layout persistence needed no format change. A round-trip test covers this (see below).

### No default keybindings

`terminal.splitLeft` and `terminal.splitUp` ship **unbound**. Every `Mod`/`Alt` + `D` combination is already taken by split right/down on at least one platform, and I did not want to claim a new chord from the shell on the user's behalf. Users bind them from shortcut settings. Unbound actions render no shortcut chip in the menu (via the existing `formatOptionalShortcutLabel`) rather than showing the `Unassigned` sentinel.

## Screenshots

**I was not able to capture a screenshot** — I developed this in a headless environment with no display, so I could not launch the Electron app to photograph the menu. I did not want to claim a visual check I did not perform.

The visual change is limited to the terminal right-click menu, which gains two items directly below the existing split entries:

```
Split Terminal Right   Ctrl+Shift+D
Split Terminal Down    Alt+Shift+D
Split Terminal Left                  ← new (no chip until bound)
Split Terminal Up                    ← new (no chip until bound)
```

Icons are `PanelLeftClose` and `PanelTopClose`, mirroring the `PanelRightClose` / `PanelBottomClose` already used by the two existing items. No token, spacing, or layout values were introduced. Happy to add a screenshot if a maintainer wants one before merge.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 4639 files / 49576 tests passing
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New and updated tests:

- `pane-split-position.test.ts` (new) — DOM child order for both positions, divider placement, ratio applied to the leading pane, and a **serialization round-trip**: a leading split must serialize with the new pane as `first`, because replay only ever splits `'after'` and rebuilds from tree order. Without this the restored layout would silently mirror itself.
- `terminal-split-shortcut-policy.test.ts` (new) — split actions resolve to the right axis *and* position; left/up resolve only once the user binds a chord, and are null by default.
- `terminal-pane-split-with-inherited-cwd.test.ts` — position forwarded through the cached-cwd path, the async-cwd path, and the remote runtime path.
- `TerminalContextMenu.test.tsx` — all four directions render; unbound actions render no shortcut chip.

Note on file layout: my additions pushed `terminal-shortcut-policy.test.ts` past the 800-line `max-lines` cap, so I extracted the split-shortcut cases into their own focused file rather than adding a lint disable.

## AI Review Report

Reviewed with Claude Code across the dimensions below.

**Cross-platform (macOS / Windows / Linux).** No new default chords on any platform, so there is nothing to conflict with existing bindings or to steal from the shell — a test asserts the default-unbound behavior explicitly. No new `e.metaKey` checks were introduced; the new actions route through the same `keybindingMatchesAction` path as split right/down, which already resolves per-platform. Menu labels use the existing platform-aware shortcut formatter. No path handling was touched.

**SSH / remote / local.** This was the main risk the review surfaced. A remote pane's split is executed by the host, not locally, so an early version that only changed the renderer would have silently degraded every SSH and web-runtime split back to right/down. `position` is now threaded through the full host path: `terminal.split` RPC → `OrcaRuntime.splitTerminal` → notifier → `ui:splitTerminal` IPC → `SplitTerminalPaneDetail` → `PaneManager.splitPane`.

Per `docs/reference/remote-wire-compatibility.md`, `position` is a **new optional field**, which is the safe category — a host that predates it ignores the field and splits after the source pane, exactly as it does today. It is also only sent when it is `'before'`, so the request to an old host is byte-identical to the current one for right/down splits. `tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` passes against the baseline release. No new stream opcode is involved, so no capability negotiation is needed.

**Folder workspaces / worktrees.** Nothing in this change reads worktree or git state; it operates on the pane tree only.

**Agent / integration / git-provider compatibility.** No agent-specific, integration-specific, or provider-specific code paths are touched. The change is provider-neutral by construction.

**Performance.** No new work in a hot path. `wrapInSplit` gains one ternary and is called once per split. The scroll-state capture, WebGL dispose/reattach, and fit scheduling around a split are untouched, so panes moved by a leading split get the same treatment as today.

**UI quality.** Menu items reuse existing primitives and icon conventions; no new color, spacing, or shadow values. The unbound-shortcut case renders no chip rather than an `Unassigned` string, matching how other optionally-bound actions behave.

**Correctness risk it caught.** Ratio semantics. `wrapInSplit` previously assigned `ratio` to the existing pane and `1 - ratio` to the new one. With the panes swapped that would invert a restored layout's proportions. It now assigns `ratio` to whichever container *leads*, matching the serializer's definition of `first`. Both the ratio behavior and the full round-trip are covered by tests.

## Security Audit

Low risk; no security-relevant surface is added.

- **Input handling / IPC.** One new field on an existing RPC. It is validated as `z.enum(['before', 'after'])`, so any other value is rejected by the schema rather than reaching the runtime. The same value crosses the `ui:splitTerminal` IPC as a closed union.
- **Command execution.** None. No new process is spawned and no command string is constructed; a split reuses the existing pane-creation path.
- **Path handling.** None. The inherited-cwd logic is unchanged — `position` rides alongside the existing `cwd` and does not influence how it is resolved.
- **Auth / secrets / dependencies.** No credential, token, or auth path touched. No dependency added or upgraded.
- **Privilege / trust boundary.** `position` is a layout hint. It cannot select a different pane, worktree, or host, so a malformed or hostile value can at worst place a pane on the wrong side of a split the user already requested.

No follow-up security work identified.

## Notes

- **Remote/SSH testing note.** The cross-version wire test and the unit test for the remote path both pass, but I could not exercise a real SSH host or a live paired client/host from my environment. A maintainer with a remote workspace may want to confirm Split Left on an SSH pane end to end.
- **Follow-up.** Spatial pane focus (focus left/right/up/down) is the other half of #8263 and is not in this PR. The commenter there makes a good case for adopting Windows Terminal's adjacency semantics rather than a center-distance heuristic; that deserves its own PR and its own test matrix.
- No release version changes are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
