### PR TITLE
fix(native-chat): show Codex goal-mode digests (mobile empty transcript)

### DIFF
--- a/src/main/native-chat/transcript-line-decoders-codex.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex.ts
@@ -11,8 +11,16 @@ import {
   parseJsonObject,
   timestampMs
 } from '../ai-vault/session-scanner-values'
-import { claudeContentBlocks, toolResultOutput } from './transcript-record-blocks'
+import { toolResultOutput } from './transcript-record-blocks'
 import { CODEX_EVENT_TURN_ABORTED } from './transcript-turn-markers'
+
+// Why: Codex dual-writes mid-turn `commentary` to event_msg/agent_message, but
+// goal-mode digests (`## Active goal`, handoff summaries) often land only as
+// response_item messages with phase `final_answer` and Response-API
+// output_text blocks. claudeContentBlocks ignores those block types, so the
+// chat view kept the working indicator while the goal transcript looked empty.
+const CODEX_RESPONSE_MESSAGE_PHASE_FINAL = 'final_answer'
+const CODEX_RESPONSE_MESSAGE_PHASE_COMMENTARY = 'commentary'
 
 export function decodeCodexTranscriptLine(
   line: string,
@@ -58,16 +66,7 @@ function codexResponseItem(
   timestamp: number | null
 ): NativeChatMessage | null {
   if (payload.type === 'message') {
-    const role =
-      payload.role === 'assistant' ? 'assistant' : payload.role === 'user' ? 'user' : null
-    if (!role) {
-      return null
-    }
-    const blocks = claudeContentBlocks(payload.content)
-    if (blocks.length === 0) {
-      return null
-    }
-    return { id, role, blocks, timestamp, source: 'transcript' }
+    return codexResponseMessage(payload, id, timestamp)
   }
   if (payload.type === 'reasoning') {
     const text = extractString(payload.text) ?? codexSummaryText(payload.summary)
@@ -108,6 +107,50 @@ function codexResponseItem(
   return null
 }
 
+function codexResponseMessage(
+  payload: Record<string, unknown>,
+  id: string,
+  timestamp: number | null
+): NativeChatMessage | null {
+  const role =
+    payload.role === 'assistant' ? 'assistant' : payload.role === 'user' ? 'user' : null
+  if (!role) {
+    return null
+  }
+  const phase = extractString(payload.phase)
+  // commentary always has an event_msg twin; decoding both doubles the chat.
+  if (phase === CODEX_RESPONSE_MESSAGE_PHASE_COMMENTARY) {
+    return null
+  }
+  // Response-API text blocks (input_text/output_text) dual-write to event_msg
+  // or item_completed — except final_answer goal digests, which often do not.
+  // Skip the dual-written copy so chat does not render every turn twice.
+  if (
+    phase !== CODEX_RESPONSE_MESSAGE_PHASE_FINAL &&
+    contentUsesResponseApiTextBlocks(payload.content)
+  ) {
+    return null
+  }
+  const blocks = codexTurnItemBlocks(payload.content)
+  if (blocks.length === 0) {
+    return null
+  }
+  return { id, role, blocks, timestamp, source: 'transcript' }
+}
+
+function contentUsesResponseApiTextBlocks(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false
+  }
+  for (const value of content) {
+    const item = asRecord(value)
+    if (item?.type === 'input_text' || item?.type === 'output_text') {
+      return true
+    }
+  }
+  return false
+}
+
 function codexEventMessage(
   payload: Record<string, unknown>,
   id: string,
@@ -125,6 +168,9 @@ function codexEventMessage(
   if (payload.type === 'item_completed') {
     return codexCompletedTurnItem(payload, id, timestamp)
   }
+  if (payload.type === 'thread_goal_updated') {
+    return codexThreadGoalUpdated(payload, id, timestamp)
+  }
   if (payload.type === 'user_message') {
     const text = extractString(payload.message)
     return text
@@ -138,6 +184,26 @@ function codexEventMessage(
       : null
   }
   return null
+}
+
+function codexThreadGoalUpdated(
+  payload: Record<string, unknown>,
+  id: string,
+  timestamp: number | null
+): NativeChatMessage | null {
+  const goal = asRecord(payload.goal)
+  const objective =
+    extractString(goal?.objective) ?? extractString(payload.objective) ?? extractString(payload.goal)
+  if (!objective?.trim()) {
+    return null
+  }
+  return {
+    id,
+    role: 'system',
+    blocks: [{ type: 'text', text: `Goal: ${objective.trim()}` }],
+    timestamp,
+    source: 'transcript'
+  }
 }
 
 function codexCompletedTurnItem(

--- a/src/main/native-chat/transcript-reader-codex-history-mode.test.ts
+++ b/src/main/native-chat/transcript-reader-codex-history-mode.test.ts
@@ -247,4 +247,132 @@ describe('Codex transcript history modes', () => {
       blocks: [{ type: 'tool-result', output: 'ok' }]
     })
   })
+
+  // Why: goal mode writes Active-goal / handoff digests as response_item
+  // final_answer with output_text only — no event_msg twin — so the prior
+  // claudeContentBlocks path dropped them and mobile showed only "agent is working".
+  it('keeps goal-mode final_answer digests from response_item output_text', async () => {
+    const filePath = await writeCodexFixture([
+      {
+        timestamp: '2026-08-11T17:00:00.000Z',
+        type: 'session_meta',
+        payload: { id: 'session-1', history_mode: 'legacy' }
+      },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'thread_goal_updated',
+          goal: { objective: 'Process all assigned PRs and issues' }
+        }
+      },
+      {
+        type: 'event_msg',
+        payload: { type: 'user_message', message: 'Continue' }
+      },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'agent_message',
+          phase: 'commentary',
+          message: 'Resuming the supervised batch.'
+        }
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          phase: 'commentary',
+          content: [{ type: 'output_text', text: 'Resuming the supervised batch.' }]
+        }
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          id: 'goal-digest-1',
+          role: 'assistant',
+          phase: 'final_answer',
+          content: [
+            {
+              type: 'output_text',
+              text: '## Active goal\n\nProcess all assigned PRs and issues\n\n- 4 workers live'
+            }
+          ]
+        }
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: '<codex_internal_context source="goal">\nContinue working toward the active thread goal.\n</codex_internal_context>'
+            }
+          ]
+        }
+      }
+    ])
+
+    const result = await readNativeChatTranscript('codex', 'session-1', { filePath })
+    expect(result).toMatchObject({
+      messages: [
+        {
+          role: 'system',
+          blocks: [{ type: 'text', text: 'Goal: Process all assigned PRs and issues' }]
+        },
+        { role: 'user', blocks: [{ type: 'text', text: 'Continue' }] },
+        {
+          role: 'assistant',
+          blocks: [{ type: 'text', text: 'Resuming the supervised batch.' }]
+        },
+        {
+          id: 'goal-digest-1',
+          role: 'assistant',
+          blocks: [
+            {
+              type: 'text',
+              text: '## Active goal\n\nProcess all assigned PRs and issues\n\n- 4 workers live'
+            }
+          ]
+        }
+      ]
+    })
+    expect('messages' in result && result.messages).toHaveLength(4)
+  })
+
+  it('does not double-render commentary response_item copies of event_msg', () => {
+    const commentary = decodeCodexTranscriptLine(
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          phase: 'commentary',
+          content: [{ type: 'output_text', text: 'Still working' }]
+        }
+      }),
+      'fallback-commentary'
+    )
+    const finalAnswer = decodeCodexTranscriptLine(
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          phase: 'final_answer',
+          content: [{ type: 'output_text', text: '## Handoff summary\n\n### Goal\n\nDone' }]
+        }
+      }),
+      'fallback-final'
+    )
+
+    expect(commentary).toBeNull()
+    expect(finalAnswer).toMatchObject({
+      role: 'assistant',
+      blocks: [{ type: 'text', text: '## Handoff summary\n\n### Goal\n\nDone' }]
+    })
+  })
 })

--- a/src/shared/harness-injected-user-turns.test.ts
+++ b/src/shared/harness-injected-user-turns.test.ts
@@ -29,7 +29,9 @@ describe('isKnownHarnessInjectedUserTurnText', () => {
       '<bash-input>ls</bash-input>',
       '<bash-stdout>file.txt</bash-stdout>',
       '<bash-stderr>err</bash-stderr>',
-      '<user-prompt-submit-hook>hook context</user-prompt-submit-hook>'
+      '<user-prompt-submit-hook>hook context</user-prompt-submit-hook>',
+      '<codex_internal_context source="goal">\nContinue working toward the active thread goal.\n</codex_internal_context>',
+      '<goal_context>keep going</goal_context>'
     ]
     for (const text of injected) {
       expect(isKnownHarnessInjectedUserTurnText(text), text).toBe(true)

--- a/src/shared/harness-injected-user-turns.ts
+++ b/src/shared/harness-injected-user-turns.ts
@@ -10,7 +10,9 @@
 // `<user_query>` envelope is a genuine user turn, and misclassifying it would
 // hide the turn (drop it from transcripts, demote its session title, or leave
 // the agent visibly done after an interrupt).
-const LEADING_TAG_NAME = /^<([a-z][a-z0-9-]*)(?:[\s>]|$)/
+// Why: Codex goal reinjections use snake_case tags (`codex_internal_context`),
+// not only kebab-case Claude harness tags.
+const LEADING_TAG_NAME = /^<([a-z][a-z0-9_-]*)(?:[\s>]|$)/
 
 // Consumers must only treat tags we have observed from harnesses as machinery;
 // arbitrary kebab tags can be genuine user code.
@@ -19,11 +21,14 @@ const KNOWN_HARNESS_TAG_NAMES = new Set([
   'bash-input',
   'bash-stderr',
   'bash-stdout',
+  // Codex goal-mode reinjects the objective as a synthetic user turn.
+  'codex_internal_context',
   'command-args',
   'command-message',
   'command-name',
   'cross-session-message',
   'fork-boilerplate',
+  'goal_context',
   'local-command-caveat',
   'local-command-stderr',
   'local-command-stdout',


### PR DESCRIPTION
## Summary
- Codex goal mode writes Active-goal / handoff digests as `response_item` messages with `phase: final_answer` and Response-API `output_text` blocks. Those never had an `event_msg` twin, and the shared Claude content mapper dropped `output_text`, so native chat (desktop + mobile) kept the working indicator while goal progress was missing.
- Decode `final_answer` via `codexTurnItemBlocks`, keep dual-written `commentary` on the `event_msg` path only, surface `thread_goal_updated` as a system `Goal: …` row, and classify `codex_internal_context` / `goal_context` reinjections as harness noise.
- Decoder-only; no RPC/opcode/wire shape changes. Shared by desktop IPC and mobile `nativeChat.subscribe`.

## Evidence
From a live Orca-managed Codex goal session (`rollout-2026-08-11T10-32-53-…jsonl`):
- 80 `commentary` assistant turns dual-wrote to `event_msg` (already visible)
- 4 goal digests (`## Active goal`, `## Handoff summary`, `## Active orchestration`) existed **only** as `response_item` `final_answer` + `output_text` and were previously dropped
- Fixture regression now asserts goal digests + `thread_goal_updated` render without duplicating commentary

## Related
- Fixes #13629
- Related (not duplicated): #13494 (broader empty transcript), #13663 / #13687 (SSH transcript host ownership), #13320 / #13393 (paginated history)

## Emulator QA
- Windows host: `orca emulator devices` → empty; `orca emulator list` → `spawn serve-sim ENOENT` (no iOS Simulator / no Android AVD in this session). No raw serve-sim invoked.
- Validation is fixture + unit tests on the shared host decoder used by mobile RPC.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/transcript-reader-codex-history-mode.test.ts src/main/native-chat/transcript-reader.test.ts src/shared/harness-injected-user-turns.test.ts`
- [x] `pnpm exec oxlint` on touched files
- [x] `pnpm run check:max-lines-ratchet`
- [x] `git diff --check`
- [ ] Manual: pair mobile to a host with an active Codex `/goal` session; confirm Active-goal digests and Goal: system row appear while agent is working