### PR TITLE
perf(renderer): anchor spinner phase from animationstart only

### DIFF
--- a/src/renderer/src/components/AgentWorkingSpinner.test.tsx
+++ b/src/renderer/src/components/AgentWorkingSpinner.test.tsx
@@ -50,7 +50,99 @@ describe('AgentWorkingSpinner', () => {
     }
   })
 
-  it('anchors mount and restart animations to the shared document epoch', async () => {
+  // Why: animationstart fires on the first start and on every restart (class
+  // re-add, display:none reveal), so it alone keeps every ring phase-locked.
+  // A negative animation-delay cannot — it is static, so a restart replays the
+  // stale mount-time offset and the rings fan out across steps.
+  it('anchors every animation start to the shared document epoch', async () => {
+    const animation = {
+      animationName: 'agent-spinner-rotate',
+      startTime: 321
+    } as unknown as Animation
+    const getAnimations = vi.fn(() => [animation])
+    const originalGetAnimations = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'getAnimations'
+    )
+    Object.defineProperty(HTMLElement.prototype, 'getAnimations', {
+      configurable: true,
+      value: getAnimations
+    })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const fireAnimationStart = async (): Promise<void> => {
+      const event = new Event('animationstart', { bubbles: true })
+      Object.defineProperty(event, 'animationName', { value: 'agent-spinner-rotate' })
+      await act(async () => {
+        container.querySelector('[data-agent-spinner]')!.dispatchEvent(event)
+      })
+    }
+
+    try {
+      await act(async () => {
+        root.render(<AgentWorkingSpinner />)
+      })
+      // Why: mount must not query animations — that forces a synchronous style
+      // recalc per ring for a phase the first animationstart sets anyway.
+      expect(getAnimations).not.toHaveBeenCalled()
+
+      await fireAnimationStart()
+      expect(animation.startTime).toBe(0)
+
+      animation.startTime = 654
+      await fireAnimationStart()
+      expect(animation.startTime).toBe(0)
+      expect(getAnimations).toHaveBeenCalledTimes(2)
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+      if (originalGetAnimations === undefined) {
+        Reflect.deleteProperty(HTMLElement.prototype, 'getAnimations')
+      } else {
+        Object.defineProperty(HTMLElement.prototype, 'getAnimations', originalGetAnimations)
+      }
+    }
+  })
+
+  // Why: reduced motion resolves the rule to `animation: none`, so no animation
+  // exists to start and none to anchor. Pins that dropping the ref-time anchor
+  // adds no exposure here — both paths were already no-ops.
+  it('anchors nothing when reduced motion leaves no animation to start', async () => {
+    const getAnimations = vi.fn(() => [] as Animation[])
+    const originalGetAnimations = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'getAnimations'
+    )
+    Object.defineProperty(HTMLElement.prototype, 'getAnimations', {
+      configurable: true,
+      value: getAnimations
+    })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(<AgentWorkingSpinner />)
+      })
+      const el = container.querySelector('[data-agent-spinner]')
+
+      expect(el).not.toBeNull()
+      expect(getAnimations).not.toHaveBeenCalled()
+      expect(el!.className).toContain('motion-reduce:border-t-yellow-500')
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+      if (originalGetAnimations === undefined) {
+        Reflect.deleteProperty(HTMLElement.prototype, 'getAnimations')
+      } else {
+        Object.defineProperty(HTMLElement.prototype, 'getAnimations', originalGetAnimations)
+      }
+    }
+  })
+
+  it('ignores animation starts from other animations on the same element', async () => {
     const animation = {
       animationName: 'agent-spinner-rotate',
       startTime: 321
@@ -72,16 +164,14 @@ describe('AgentWorkingSpinner', () => {
       await act(async () => {
         root.render(<AgentWorkingSpinner />)
       })
-      expect(animation.startTime).toBe(0)
-
-      animation.startTime = 654
-      const restart = new Event('animationstart', { bubbles: true })
-      Object.defineProperty(restart, 'animationName', { value: 'agent-spinner-rotate' })
+      const unrelated = new Event('animationstart', { bubbles: true })
+      Object.defineProperty(unrelated, 'animationName', { value: 'compact-agent-expansion-reveal' })
       await act(async () => {
-        container.querySelector('[data-agent-spinner]')!.dispatchEvent(restart)
+        container.querySelector('[data-agent-spinner]')!.dispatchEvent(unrelated)
       })
-      expect(animation.startTime).toBe(0)
-      expect(getAnimations).toHaveBeenCalledTimes(2)
+
+      expect(getAnimations).not.toHaveBeenCalled()
+      expect(animation.startTime).toBe(321)
     } finally {
       act(() => root.unmount())
       container.remove()

--- a/src/renderer/src/components/AgentWorkingSpinner.tsx
+++ b/src/renderer/src/components/AgentWorkingSpinner.tsx
@@ -3,8 +3,10 @@ import { cn } from '@/lib/utils'
 
 const SPINNER_ANIMATION_NAME = 'agent-spinner-rotate'
 
-// Why: CSS assigns per-element start times after refs run; anchoring the Web
-// Animation timeline gives late mounts exact phase sync without recurring JS.
+// Why: anchoring the Web Animation timeline gives late mounts exact phase sync
+// without recurring JS. Driven only by animationstart — a ref-time call would
+// force a synchronous style recalc per mount for a phase animationstart fixes
+// one frame later anyway (measured: 24ms of blocking work per 200 mounts).
 function syncSpinnerPhase(el: HTMLSpanElement | null): void {
   if (el === null || typeof el.getAnimations !== 'function') {
     return
@@ -33,7 +35,6 @@ function handleSpinnerAnimationStart(event: React.AnimationEvent<HTMLSpanElement
 export function AgentWorkingSpinner({ className }: { className?: string }): React.JSX.Element {
   return (
     <span
-      ref={syncSpinnerPhase}
       onAnimationStart={handleSpinnerAnimationStart}
       data-agent-spinner=""
       className={cn(


### PR DESCRIPTION
## Summary

The working ring is phase-locked so every spinner ticks on the same compositor frame. That anchoring runs from two places today — a `ref` callback and an `onAnimationStart` handler — and both call `el.getAnimations()`. The ref call forces a synchronous style recalc at commit, per ring, to set a phase that `animationstart` sets one frame later anyway.

This drops the ref call and keeps `animationstart` as the sole anchor.

## Measured

Real Chromium, 200 rings, median of 6 reps with warmup discarded:

| | ref + animationstart (main) | animationstart only |
| --- | ---: | ---: |
| Synchronous blocking work at mount | **24 ms** | **0.1 ms** |
| Total to settled | 67.1 ms | 62.8 ms |

The work isn't eliminated so much as moved off the commit path: the deferred handler cost is comparable, but it runs between frames instead of blocking one. Total is a wash; the blocking chunk is what mattered.

Phase behaviour is **identical** to main in every case tested — 24 rings mounted one frame apart, counting distinct computed transforms (1 = locked):

| | main | this PR |
| --- | ---: | ---: |
| Cross-frame mount | 1 | 1 |
| After animation restart | 1 | 1 |
| After `display:none` reveal | 1 | 1 |
| Sampled per-frame during mount | 1 | 1 |

## Why not a negative `animation-delay` instead

A static delay computed once at mount is cheaper still (0.3 ms, no handler), and it was the original proposal. It is wrong: `animation-delay` is static, so a restart replays the stale mount-time offset and the rings fan out across steps. Measured on the same harness: **8 distinct phases after a restart, 3 after a `display:none` reveal**, versus 1 for the JS anchor. Phase loss is a steady-state cost, which dominates a one-time mount saving.

## Why not a shared JS clock

Benchmarked on a quiet machine at N = 1, 12, 40, 100, 200, 400. Style-recalc cost of a 12 Hz clock writing `style.transform` on N rings:

| N | 1 | 40 | 100 | 200 | 400 |
| --- | ---: | ---: | ---: | ---: | ---: |
| JS clock recalc | 3.9 ms | 11.6 ms | 23.8 ms | 44.4 ms | **83.1 ms** |
| CSS recalc | 0.1 ms | 0.3 ms | 0.6 ms | 1.3 ms | **0.6 ms** |

The clock is the variant that pays per element. This matches the production root-cause in #12359 (41 spinners → ~490 style writes/s → 97% of DOM mutation traffic, keystroke p90 363 ms → 19 ms once stopped) and explains the earlier result in #9380 that pointed the other way: that comparison was against *staggered* CSS, before phase-locking existed.

Caveat on scope: `TaskDuration` in that harness is noise for the CSS variants (rep-to-rep spread exceeds the across-N range), so it can establish the JS clock's per-element cost but cannot rank locked vs staggered CSS. Reported as measured, not inferred.

## Reduced motion

Under `prefers-reduced-motion` the rule resolves to `animation: none`, so there is no animation to start and none to anchor. On main both paths are already no-ops there — `getAnimations()` finds no match and `animationstart` never fires — so removing the ref call adds no exposure. Pinned by a test.

An attempt to verify this in a browser was inconclusive: `--force-prefers-reduced-motion` did not take (`matchMedia(...).matches === false`), so no browser-level result is claimed.

`motion-reduce:border-t-yellow-500` from #9515 is untouched — the static ring must render complete, not as a frozen 3/4 arc.

## Tests

6 in `AgentWorkingSpinner.test.tsx` (up from 4), 22 across the ring's consumers. New coverage: mount performs no `getAnimations()` call; every animation start re-anchors; unrelated animations on the same element are ignored; reduced motion anchors nothing. Verified the first two fail if the ref call is restored.

Made with [Orca](https://github.com/stablyai/orca) 🐋
