### PR TITLE
fix(terminal): auto-dismiss paste focus-cancellation instead of sticky error banner

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -21,6 +21,9 @@ import {
   stripSshReconnectOwnedErrorLines
 } from './TerminalErrorToast'
 
+const PASTE_FOCUS_CANCEL =
+  'Paste cancelled: terminal focus changed before paste started.'
+
 beforeEach(() => {
   environmentMocks.resolveFooter.mockReset()
   environmentMocks.resolveFooter.mockResolvedValue(
@@ -203,6 +206,59 @@ describe('shouldOfferDaemonRestart', () => {
   it('does not match unrelated terminal spawn errors', () => {
     expect(shouldOfferDaemonRestart('SSH connection is not active.')).toBe(false)
     expect(shouldOfferDaemonRestart('node-pty: open_slave failed: EMFILE (errno 24)')).toBe(false)
+  })
+})
+
+describe('TerminalErrorToast paste cancellation surface', () => {
+  it('omits the issue link and environment footer for paste focus cancellation', async () => {
+    const view = render(
+      React.createElement(TerminalErrorToast, {
+        error: PASTE_FOCUS_CANCEL,
+        onDismiss: vi.fn()
+      })
+    )
+
+    expect(view.container.textContent).toContain(PASTE_FOCUS_CANCEL)
+    expect(view.container.textContent).not.toContain('file an issue')
+    await waitFor(() => expect(environmentMocks.resolveFooter).not.toHaveBeenCalled())
+  })
+
+  it('auto-dismisses a paste focus cancellation after a short delay', async () => {
+    vi.useFakeTimers()
+    const onDismiss = vi.fn()
+    try {
+      render(
+        React.createElement(TerminalErrorToast, {
+          error: PASTE_FOCUS_CANCEL,
+          onDismiss
+        })
+      )
+
+      expect(onDismiss).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(4_000)
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps durable paste failures until the user dismisses them', async () => {
+    vi.useFakeTimers()
+    const onDismiss = vi.fn()
+    try {
+      const view = render(
+        React.createElement(TerminalErrorToast, {
+          error: 'Paste failed.',
+          onDismiss
+        })
+      )
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(onDismiss).not.toHaveBeenCalled()
+      expect(view.container.textContent).toContain('file an issue')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -210,7 +210,7 @@ describe('shouldOfferDaemonRestart', () => {
 })
 
 describe('TerminalErrorToast paste cancellation surface', () => {
-  it('omits the issue link and environment footer for paste focus cancellation', async () => {
+  it('omits the issue link and environment footer for pure paste focus cancellation', async () => {
     const view = render(
       React.createElement(TerminalErrorToast, {
         error: PASTE_FOCUS_CANCEL,
@@ -223,7 +223,7 @@ describe('TerminalErrorToast paste cancellation surface', () => {
     await waitFor(() => expect(environmentMocks.resolveFooter).not.toHaveBeenCalled())
   })
 
-  it('auto-dismisses a paste focus cancellation after a short delay', async () => {
+  it('auto-dismisses pure paste focus cancellation after a short delay', async () => {
     vi.useFakeTimers()
     const onDismiss = vi.fn()
     try {
@@ -235,6 +235,28 @@ describe('TerminalErrorToast paste cancellation surface', () => {
       )
 
       expect(onDismiss).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(4_000)
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('auto-dismisses pure multi-line paste-cancel aggregates without stacking dismissals', async () => {
+    vi.useFakeTimers()
+    const onDismiss = vi.fn()
+    const pureCancels = [
+      PASTE_FOCUS_CANCEL,
+      'Paste cancelled: terminal disconnected before paste completed.'
+    ].join('\n')
+    try {
+      render(
+        React.createElement(TerminalErrorToast, {
+          error: pureCancels,
+          onDismiss
+        })
+      )
+
       await vi.advanceTimersByTimeAsync(4_000)
       expect(onDismiss).toHaveBeenCalledTimes(1)
     } finally {
@@ -259,6 +281,41 @@ describe('TerminalErrorToast paste cancellation surface', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not auto-dismiss mixed durable+cancel aggregates and keeps the issue link', async () => {
+    vi.useFakeTimers()
+    const onDismiss = vi.fn()
+    const mixed = `Paste failed.\n${PASTE_FOCUS_CANCEL}`
+    try {
+      const view = render(
+        React.createElement(TerminalErrorToast, {
+          error: mixed,
+          onDismiss
+        })
+      )
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(onDismiss).not.toHaveBeenCalled()
+      expect(view.container.textContent).toContain('Paste failed.')
+      expect(view.container.textContent).toContain(PASTE_FOCUS_CANCEL)
+      expect(view.container.textContent).toContain('file an issue')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retains the environment footer for mixed durable+cancel aggregates', async () => {
+    const mixed = `Paste failed.\n${PASTE_FOCUS_CANCEL}`
+    const view = render(
+      React.createElement(TerminalErrorToast, {
+        error: mixed,
+        onDismiss: vi.fn()
+      })
+    )
+
+    await waitFor(() => expect(view.container.textContent).toContain('Orca: 1.4.178-rc.2'))
+    expect(view.container.textContent).toContain('file an issue')
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react'
 import { translate } from '@/i18n/i18n'
 import { resolveClientEnvironmentFooter } from '@/lib/client-environment-info'
 import { hasClientEnvironmentFooter } from '../../../../shared/client-environment-info'
+import { isTransientTerminalPasteCancellationMessage } from './terminal-paste-errors'
+
+/** Auto-clear expected paste cancels if they still land on the durable surface. */
+const TRANSIENT_PASTE_CANCEL_DISMISS_MS = 4_000
 
 const SSH_PREFIX = 'SSH connection is not active'
 // Produced by pty-connection.ts reportError() when a PTY reattach can't reach its SSH host.
@@ -108,8 +112,11 @@ export function TerminalErrorToast({
 }): React.JSX.Element {
   const ssh = isSshError(error)
   const showDaemonRestart = !ssh && onRestartDaemon && shouldOfferDaemonRestart(error)
+  const isPasteCancel = isTransientTerminalPasteCancellationMessage(error)
   // Restart cannot recover a session after its owning daemon exits.
-  const showIssueLink = !ssh && !showDaemonRestart && !isExplainedTerminalError(error)
+  // Paste cancels are expected races — never ask the user to file an issue.
+  const showIssueLink =
+    !ssh && !showDaemonRestart && !isExplainedTerminalError(error) && !isPasteCancel
   const displayError = humanizeTerminalError(error)
   const [environmentFooter, setEnvironmentFooter] = useState<{
     error: string
@@ -118,7 +125,7 @@ export function TerminalErrorToast({
 
   // Why: a select-all copy should carry details loaded asynchronously from preload.
   useEffect(() => {
-    if (ssh || hasClientEnvironmentFooter(displayError)) {
+    if (ssh || isPasteCancel || hasClientEnvironmentFooter(displayError)) {
       return
     }
     let cancelled = false
@@ -130,7 +137,20 @@ export function TerminalErrorToast({
     return () => {
       cancelled = true
     }
-  }, [displayError, ssh])
+  }, [displayError, isPasteCancel, ssh])
+
+  // Why: durable banner is for actionable/fatal faults; paste cancels are one-shot.
+  useEffect(() => {
+    if (!isPasteCancel) {
+      return
+    }
+    const timerId = window.setTimeout(() => {
+      onDismiss()
+    }, TRANSIENT_PASTE_CANCEL_DISMISS_MS)
+    return () => {
+      window.clearTimeout(timerId)
+    }
+  }, [error, isPasteCancel, onDismiss])
 
   const footer = environmentFooter?.error === displayError ? environmentFooter.footer : ''
 

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -215,7 +215,7 @@ import {
   type TerminalPasteTextOptions
 } from './terminal-paste-coordinator'
 import { appendTerminalErrorMessage } from './terminal-error-accumulation'
-import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
+import { reportTerminalPasteExecutionOutcome } from './terminal-paste-errors'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import {
@@ -1946,7 +1946,7 @@ function TerminalPane(
         canContinue: () => isPanePasteTargetMounted(pane, transport, ptyId)
       })
       if (execution.status !== 'pasted') {
-        setTerminalError(formatTerminalPasteExecutionError(execution.reason))
+        reportTerminalPasteExecutionOutcome(execution.reason, setTerminalError)
         return
       }
       if (text) {
@@ -2739,7 +2739,7 @@ function TerminalPane(
           canContinue: targetStillMounted
         })
         if (execution.status !== 'pasted') {
-          setTerminalError(formatTerminalPasteExecutionError(execution.reason))
+          reportTerminalPasteExecutionOutcome(execution.reason, setTerminalError)
           return
         }
         recordTerminalUserInputForLeaf(tabId, clickedPane.leafId)

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const toastMessage = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    message: (...args: unknown[]) => toastMessage(...args)
+  }
+}))
+
+import {
+  TERMINAL_PASTE_CANCELLED_TOAST_ID,
+  formatTerminalPasteExecutionError,
+  isTransientTerminalPasteCancellation,
+  isTransientTerminalPasteCancellationMessage,
+  reportTerminalPasteExecutionOutcome
+} from './terminal-paste-errors'
+
+beforeEach(() => {
+  toastMessage.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('formatTerminalPasteExecutionError', () => {
+  it('formats focus-change cancellation without clipboard content', () => {
+    expect(formatTerminalPasteExecutionError('stale-target')).toBe(
+      'Paste cancelled: terminal focus changed before paste started.'
+    )
+  })
+
+  it('formats durable paste failures', () => {
+    expect(formatTerminalPasteExecutionError('payload-too-large')).toBe(
+      'Paste failed: clipboard text is too large for a safe terminal paste.'
+    )
+    expect(formatTerminalPasteExecutionError('pty-writer-unavailable')).toBe(
+      'Paste failed: terminal is not ready for large paste.'
+    )
+    expect(formatTerminalPasteExecutionError(undefined)).toBe('Paste failed.')
+  })
+})
+
+describe('isTransientTerminalPasteCancellation', () => {
+  it('treats focus, disconnect, and timeout cancels as transient', () => {
+    expect(isTransientTerminalPasteCancellation('stale-target')).toBe(true)
+    expect(isTransientTerminalPasteCancellation('target-disconnected')).toBe(true)
+    expect(isTransientTerminalPasteCancellation('operation-timeout')).toBe(true)
+  })
+
+  it('keeps hard paste failures durable', () => {
+    expect(isTransientTerminalPasteCancellation('payload-too-large')).toBe(false)
+    expect(isTransientTerminalPasteCancellation('pty-writer-unavailable')).toBe(false)
+    expect(isTransientTerminalPasteCancellation('paste-rejected')).toBe(false)
+    expect(isTransientTerminalPasteCancellation(undefined)).toBe(false)
+  })
+})
+
+describe('isTransientTerminalPasteCancellationMessage', () => {
+  it('matches Paste cancelled lines in aggregated surfaces', () => {
+    expect(
+      isTransientTerminalPasteCancellationMessage(
+        'Paste cancelled: terminal focus changed before paste started.'
+      )
+    ).toBe(true)
+    expect(
+      isTransientTerminalPasteCancellationMessage(
+        'Paste failed.\nPaste cancelled: terminal disconnected before paste completed.'
+      )
+    ).toBe(true)
+  })
+
+  it('ignores durable paste failures', () => {
+    expect(isTransientTerminalPasteCancellationMessage('Paste failed.')).toBe(false)
+    expect(
+      isTransientTerminalPasteCancellationMessage(
+        'Paste failed: clipboard text is too large for a safe terminal paste.'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('reportTerminalPasteExecutionOutcome', () => {
+  it('emits a one-shot auto-dismiss toast for focus-change cancellation', () => {
+    const onPersistentError = vi.fn()
+    reportTerminalPasteExecutionOutcome('stale-target', onPersistentError)
+
+    expect(onPersistentError).not.toHaveBeenCalled()
+    expect(toastMessage).toHaveBeenCalledTimes(1)
+    expect(toastMessage).toHaveBeenCalledWith(
+      'Paste cancelled: terminal focus changed before paste started.',
+      {
+        id: TERMINAL_PASTE_CANCELLED_TOAST_ID,
+        duration: 4_000
+      }
+    )
+  })
+
+  it('does not park focus-change cancellation on the durable error banner', () => {
+    const onPersistentError = vi.fn()
+    reportTerminalPasteExecutionOutcome('stale-target', onPersistentError)
+    reportTerminalPasteExecutionOutcome('target-disconnected', onPersistentError)
+    reportTerminalPasteExecutionOutcome('operation-timeout', onPersistentError)
+
+    expect(onPersistentError).not.toHaveBeenCalled()
+    expect(toastMessage).toHaveBeenCalledTimes(3)
+  })
+
+  it('routes durable paste failures to the persistent error surface', () => {
+    const onPersistentError = vi.fn()
+    reportTerminalPasteExecutionOutcome('payload-too-large', onPersistentError)
+
+    expect(toastMessage).not.toHaveBeenCalled()
+    expect(onPersistentError).toHaveBeenCalledWith(
+      'Paste failed: clipboard text is too large for a safe terminal paste.'
+    )
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.test.ts
@@ -60,26 +60,53 @@ describe('isTransientTerminalPasteCancellation', () => {
 })
 
 describe('isTransientTerminalPasteCancellationMessage', () => {
-  it('matches Paste cancelled lines in aggregated surfaces', () => {
+  it('matches a pure single paste-cancellation line', () => {
     expect(
       isTransientTerminalPasteCancellationMessage(
         'Paste cancelled: terminal focus changed before paste started.'
       )
     ).toBe(true)
+  })
+
+  it('matches multiple pure paste-cancellation lines without stacking classification', () => {
     expect(
       isTransientTerminalPasteCancellationMessage(
-        'Paste failed.\nPaste cancelled: terminal disconnected before paste completed.'
+        [
+          'Paste cancelled: terminal focus changed before paste started.',
+          'Paste cancelled: terminal disconnected before paste completed.',
+          'Paste cancelled: terminal did not accept paste before the safety timeout.'
+        ].join('\n')
       )
     ).toBe(true)
   })
 
-  it('ignores durable paste failures', () => {
+  it('keeps mixed durable+cancel aggregates durable (fail-closed)', () => {
+    expect(
+      isTransientTerminalPasteCancellationMessage(
+        'Paste failed.\nPaste cancelled: terminal disconnected before paste completed.'
+      )
+    ).toBe(false)
+    expect(
+      isTransientTerminalPasteCancellationMessage(
+        'Paste cancelled: terminal focus changed before paste started.\nPaste failed.'
+      )
+    ).toBe(false)
+    expect(
+      isTransientTerminalPasteCancellationMessage(
+        'node-pty: open_slave failed: EMFILE\nPaste cancelled: terminal focus changed before paste started.'
+      )
+    ).toBe(false)
+  })
+
+  it('ignores durable paste failures and empty aggregates', () => {
     expect(isTransientTerminalPasteCancellationMessage('Paste failed.')).toBe(false)
     expect(
       isTransientTerminalPasteCancellationMessage(
         'Paste failed: clipboard text is too large for a safe terminal paste.'
       )
     ).toBe(false)
+    expect(isTransientTerminalPasteCancellationMessage('')).toBe(false)
+    expect(isTransientTerminalPasteCancellationMessage('\n\n')).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
@@ -1,4 +1,16 @@
+import { toast } from 'sonner'
 import type { TerminalPasteExecutionReason } from './terminal-paste-model'
+
+/** Stable sonner id so repeated focus-churn cancels replace instead of stacking. */
+export const TERMINAL_PASTE_CANCELLED_TOAST_ID = 'terminal-paste-cancelled'
+
+const TRANSIENT_PASTE_CANCELLATION_REASONS: ReadonlySet<TerminalPasteExecutionReason> = new Set([
+  'stale-target',
+  'target-disconnected',
+  'operation-timeout'
+])
+
+const PASTE_CANCELLED_PREFIX = 'Paste cancelled:'
 
 export function formatTerminalPasteExecutionError(
   reason: TerminalPasteExecutionReason | undefined
@@ -19,4 +31,35 @@ export function formatTerminalPasteExecutionError(
     return 'Paste cancelled: terminal did not accept paste before the safety timeout.'
   }
   return 'Paste failed.'
+}
+
+/** Focus/disconnect/timeout cancels are expected races — one-shot notice, not a durable error. */
+export function isTransientTerminalPasteCancellation(
+  reason: TerminalPasteExecutionReason | undefined
+): boolean {
+  return reason != null && TRANSIENT_PASTE_CANCELLATION_REASONS.has(reason)
+}
+
+/** Defense for any path that still parked a cancel string on the durable error surface. */
+export function isTransientTerminalPasteCancellationMessage(message: string): boolean {
+  return message.split('\n').some((line) => line.startsWith(PASTE_CANCELLED_PREFIX))
+}
+
+/**
+ * Surfaces paste outcome to the user: cancellations auto-dismiss via sonner;
+ * real failures stay on the durable terminal error banner.
+ */
+export function reportTerminalPasteExecutionOutcome(
+  reason: TerminalPasteExecutionReason | undefined,
+  onPersistentError: (message: string) => void
+): void {
+  const message = formatTerminalPasteExecutionError(reason)
+  if (isTransientTerminalPasteCancellation(reason)) {
+    toast.message(message, {
+      id: TERMINAL_PASTE_CANCELLED_TOAST_ID,
+      duration: 4_000
+    })
+    return
+  }
+  onPersistentError(message)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-errors.ts
@@ -40,9 +40,14 @@ export function isTransientTerminalPasteCancellation(
   return reason != null && TRANSIENT_PASTE_CANCELLATION_REASONS.has(reason)
 }
 
-/** Defense for any path that still parked a cancel string on the durable error surface. */
+/**
+ * Defense for cancel strings still parked on the durable error surface.
+ * Fail-closed on aggregates: only pure cancel line sets are transient — one
+ * durable line mixed in (via appendTerminalErrorMessage) must keep the banner.
+ */
 export function isTransientTerminalPasteCancellationMessage(message: string): boolean {
-  return message.split('\n').some((line) => line.startsWith(PASTE_CANCELLED_PREFIX))
+  const lines = message.split('\n').filter((line) => line.length > 0)
+  return lines.length > 0 && lines.every((line) => line.startsWith(PASTE_CANCELLED_PREFIX))
 }
 
 /**

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -18,7 +18,7 @@ import {
   type TerminalPasteSource,
   type TerminalPasteTextOptions
 } from './terminal-paste-coordinator'
-import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
+import { reportTerminalPasteExecutionOutcome } from './terminal-paste-errors'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import { isTerminalPanePasteTargetCurrent } from './terminal-paste-target-state'
@@ -272,7 +272,7 @@ export function useTerminalPaneContextMenu({
       canContinue: () => isPanePasteTargetMounted(pane, transport, ptyId)
     })
     if (execution.status !== 'pasted') {
-      onPasteError(formatTerminalPasteExecutionError(execution.reason))
+      reportTerminalPasteExecutionOutcome(execution.reason, onPasteError)
       return false
     }
     if (text) {


### PR DESCRIPTION
## Summary

Paste cancellations caused by focus change (the Linux-reported case), disconnect, or safety timeout were parked on the durable `TerminalErrorToast` with a persistent red banner and **"If this persists, please file an issue"** CTA — leaving non-actionable UI with no automatic dismissal path.

This PR treats those outcomes as **expected one-shot races**:
- Route cancel reasons (`stale-target`, `target-disconnected`, `operation-timeout`) through a short-lived sonner toast (stable id so repeats replace instead of stacking).
- Keep real paste failures (`payload-too-large`, `pty-writer-unavailable`, etc.) on the durable terminal error banner.
- Defense-in-depth: if a cancel string still lands on the banner, omit the issue link, skip the environment footer, and auto-dismiss after 4s — **only when the entire nonempty aggregate is pure cancel lines**.

### Review fix (fail-closed aggregates)

`isTransientTerminalPasteCancellationMessage` previously used `.some()`, so a durable line plus one `Paste cancelled:` line (via `appendTerminalErrorMessage`) would skip diagnostics and auto-dismiss the whole actionable banner. Classification is now fail-closed: transient only when **every** nonempty line starts with `Paste cancelled:`.

Preserves a clear one-time cancellation signal without sticky non-actionable UI across keyboard/context-menu/middle-click paste paths (local, SSH, folder workspaces share the same renderer paths).

Fixes #13623

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts` on:
  - `terminal-paste-errors.test.ts`
  - `TerminalErrorToast.test.ts`
  - `terminal-paste-coordinator.test.ts`
  - `terminal-paste-target-state.test.ts`
  - `terminal-error-accumulation.test.ts`
  - **91 passed**
- [x] `pnpm exec oxlint` on changed files — 0 warnings / 0 errors
- [x] `pnpm run typecheck:web` — passed
- [ ] Manual Linux paste-focus churn (environment limitation: Windows worker)

## Notes / limitations

- Does not suppress the cancellation signal itself — only the sticky "file an issue" presentation.
- Hard paste failures still use the durable banner (with dismiss ×).
- Mixed durable+cancel aggregates stay durable (issue link + footer + no auto-dismiss).

Made with [Orca](https://github.com/stablyai/orca) 🐋