### PR TITLE
fix(codex): suppress auto-review-owned permission attention (#13600)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -327,7 +327,11 @@ import {
   type SyntheticAgentTitleProfile
 } from '../shared/synthetic-agent-title'
 import type { AgentStatusState } from '../shared/agent-status-types'
-import { resolveTuiAgentPermissionMode } from '../shared/tui-agent-permissions'
+import {
+  parseExplicitCodexApprovalReviewer,
+  resolveCodexApprovalReviewer
+} from '../shared/codex-approval-reviewer'
+import { shouldSuppressCodexPermissionSyntheticTitle } from '../shared/codex-auto-review-attention'
 import { isAskUserQuestionTool } from '../shared/agent-question-answered-intent'
 import type { TerminalSideEffectBatch } from '../shared/terminal-side-effect-facts'
 import {
@@ -1526,7 +1530,8 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       providerSessionOnly,
       promptInteractionKey,
       restoredUnconfirmed,
-      isReplay
+      isReplay,
+      hookEventName
     }) => {
       if (mainWindow?.isDestroyed()) {
         return
@@ -1550,13 +1555,24 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
       const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
+      const launchConfig = runtime?.getAgentStatusLaunchConfigForPaneKey(paneKey, { launchToken })
+      const resolvedReviewer =
+        payload.agentType === 'codex'
+          ? resolveCodexApprovalReviewer(launchConfig?.agentArgs)
+          : 'unknown'
+      const codexApprovalReviewer = parseExplicitCodexApprovalReviewer(
+        resolvedReviewer === 'unknown' ? undefined : resolvedReviewer
+      )
       const suppressSyntheticCodexAutoApprovalTitle =
         payload.agentType === 'codex' &&
         (payload.state === 'waiting' || payload.state === 'blocked')
-          ? shouldSuppressCodexAutoApprovalSyntheticTitleFromHook({
+          ? shouldSuppressCodexPermissionSyntheticTitle({
               agentType: payload.agentType,
               state: payload.state,
-              launchConfig: runtime?.getAgentStatusLaunchConfigForPaneKey(paneKey, { launchToken })
+              hookEventName,
+              toolName: payload.toolName,
+              reviewer: codexApprovalReviewer ?? 'unknown',
+              launchConfig
             })
           : false
       const statusEvent = {
@@ -1564,6 +1580,8 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
         paneKey,
         ...(launchToken ? { launchToken } : {}),
         ...(terminalHandle ? { terminalHandle } : {}),
+        ...(hookEventName ? { hookEventName } : {}),
+        ...(codexApprovalReviewer ? { codexApprovalReviewer } : {}),
         tabId,
         worktreeId,
         connectionId,
@@ -2075,32 +2093,6 @@ function driveSyntheticTitleFromHook(
   sendSyntheticTitle(ptyId, `\x1b]0;${label}\x07${needsUserInput ? '\x07' : ''}`, {
     force: true
   })
-}
-
-function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
-  agentType: string | null | undefined
-  state: AgentStatusState
-  launchConfig:
-    | {
-        agentArgs?: string | null
-        agentEnv?: Record<string, string> | null
-      }
-    | null
-    | undefined
-}): boolean {
-  if (args.agentType !== 'codex' || (args.state !== 'waiting' && args.state !== 'blocked')) {
-    return false
-  }
-  if (!args.launchConfig) {
-    return false
-  }
-  return (
-    resolveTuiAgentPermissionMode({
-      agent: 'codex',
-      agentArgs: args.launchConfig.agentArgs,
-      agentEnv: args.launchConfig.agentEnv
-    }) === 'yolo'
-  )
 }
 
 void app.whenReady().then(async () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -1757,6 +1757,71 @@ describe('agent completion coordinator', () => {
     expect(dispatchAttention).not.toHaveBeenCalled()
   })
 
+  it('drops auto-review-owned PermissionRequest attention without waiting on the quiet window (#13600)', () => {
+    // Why: ownership suppress must beat the fixed 1.5s debounce when auto-review
+    // takes longer than the quiet window (WSL repro path).
+    const dispatchAttention = vi.fn()
+    const dispatchHookLifecycle = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion: vi.fn(),
+      dispatchAttention,
+      dispatchHookLifecycle,
+      isLive: () => true,
+      shouldSuppressHookCompletion: (payload) =>
+        payload.agentType === 'codex' &&
+        (payload.state === 'waiting' || payload.state === 'blocked') &&
+        payload.toolName !== 'request_user_input'
+    })
+
+    const turn = { prompt: 'curl example.com', agentType: 'codex' as const }
+    coordinator.observeHookStatus({ state: 'working', ...turn })
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      ...turn,
+      toolName: 'exec_command',
+      toolInput: 'curl -L https://example.com/'
+    })
+
+    // Why: working still updates lifecycle; only the suppressed waiting pause must not notify.
+    expect(dispatchHookLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'working', agentType: 'codex' })
+    )
+    expect(dispatchAttention).not.toHaveBeenCalled()
+    // Why: auto-review can exceed 1.5s; suppressed ownership must never arm the timer.
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS * 4)
+    expect(dispatchAttention).not.toHaveBeenCalled()
+  })
+
+  it('still notifies genuinely user-blocked Codex pauses when suppression does not match', () => {
+    const dispatchAttention = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion: vi.fn(),
+      dispatchAttention,
+      isLive: () => true,
+      shouldSuppressHookCompletion: () => false
+    })
+
+    const turn = { prompt: 'curl example.com', agentType: 'codex' as const }
+    coordinator.observeHookStatus({ state: 'working', ...turn })
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      ...turn,
+      toolName: 'exec_command',
+      toolInput: 'curl -L https://example.com/'
+    })
+    expect(dispatchAttention).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS)
+    expect(dispatchAttention).toHaveBeenCalledTimes(1)
+  })
+
   it('dispatches the debounced Codex attention notification after the quiet window elapses', () => {
     const dispatchAttention = vi.fn()
     const coordinator = createAgentCompletionCoordinator({

--- a/src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.test.ts
@@ -256,4 +256,117 @@ describe('Codex auto-approval status suppression', () => {
       })
     ).toBe(false)
   })
+
+  it('suppresses auto-review-owned PermissionRequest waits without a fixed quiet window', () => {
+    registerCodexLaunchConfig({
+      agentArgs: `-c 'approvals_reviewer="auto_review"'`,
+      launchToken
+    })
+
+    expect(
+      shouldSuppressCodexAutoApprovalStatus(
+        {
+          state: 'waiting',
+          prompt: 'curl example.com',
+          agentType: 'codex',
+          toolName: 'exec_command',
+          hookEventName: 'PermissionRequest'
+        },
+        { paneKey, tabId: 'tab-1', launchToken }
+      )
+    ).toBe(true)
+    expect(
+      shouldSuppressCodexAutoApprovalStatus(
+        {
+          state: 'waiting',
+          prompt: 'curl example.com',
+          agentType: 'codex',
+          toolName: 'exec_command',
+          hookEventName: 'PermissionRequest',
+          codexApprovalReviewer: 'auto_review'
+        },
+        { paneKey, tabId: 'tab-1' }
+      )
+    ).toBe(true)
+  })
+
+  it('preserves genuinely user-blocked Codex permission waits under manual review', () => {
+    registerCodexLaunchConfig({
+      agentArgs: `-c 'approvals_reviewer="user"'`,
+      launchToken
+    })
+
+    expect(
+      shouldSuppressCodexAutoApprovalStatus(
+        {
+          state: 'waiting',
+          prompt: 'curl example.com',
+          agentType: 'codex',
+          toolName: 'exec_command',
+          hookEventName: 'PermissionRequest'
+        },
+        { paneKey, tabId: 'tab-1', launchToken }
+      )
+    ).toBe(false)
+  })
+
+  it('fails open when auto-review ownership cannot be proven from launch args', () => {
+    registerCodexLaunchConfig({
+      agentArgs: '--ask-for-approval on-request',
+      launchToken
+    })
+
+    expect(
+      shouldSuppressCodexAutoApprovalStatus(
+        {
+          state: 'waiting',
+          prompt: 'curl example.com',
+          agentType: 'codex',
+          toolName: 'exec_command',
+          hookEventName: 'PermissionRequest'
+        },
+        { paneKey, tabId: 'tab-1', launchToken }
+      )
+    ).toBe(false)
+  })
+
+  it('suppresses --approve-for-me launch ownership the same as approvals_reviewer=auto_review', () => {
+    registerCodexLaunchConfig({
+      agentArgs: '--approve-for-me',
+      launchToken
+    })
+
+    expect(
+      shouldSuppressCodexAutoApprovalStatus(
+        {
+          state: 'waiting',
+          prompt: 'curl example.com',
+          agentType: 'codex',
+          toolName: 'exec_command',
+          hookEventName: 'PermissionRequest'
+        },
+        { paneKey, tabId: 'tab-1', launchToken }
+      )
+    ).toBe(true)
+  })
+
+  it('keeps request_user_input waits under auto-review so user questions still notify', () => {
+    registerCodexLaunchConfig({
+      agentArgs: `-c 'approvals_reviewer="auto_review"'`,
+      launchToken
+    })
+
+    expect(
+      shouldSuppressCodexAutoApprovalStatus(
+        {
+          state: 'waiting',
+          prompt: 'pick a region',
+          agentType: 'codex',
+          toolName: 'request_user_input',
+          hookEventName: 'PermissionRequest'
+        },
+        { paneKey, tabId: 'tab-1', launchToken }
+      )
+    ).toBe(false)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.ts
+++ b/src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.ts
@@ -1,11 +1,18 @@
 import { isAskUserQuestionTool } from '../../../../shared/agent-question-answered-intent'
 import type { AgentProviderSessionMetadata } from '../../../../shared/agent-session-resume'
+import type { AgentStatusIpcPayload } from '../../../../shared/agent-status-types'
+import { resolveCodexApprovalReviewer } from '../../../../shared/codex-approval-reviewer'
+import {
+  isCodexPermissionAttentionState,
+  shouldSuppressCodexAutoReviewPermissionAttention
+} from '../../../../shared/codex-auto-review-attention'
 import { getSyntheticAgentTitleProfile } from '../../../../shared/synthetic-agent-title'
 import { resolveTuiAgentPermissionMode } from '../../../../shared/tui-agent-permissions'
 import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
 import { useAppStore } from '@/store'
 
-const CODEX_AUTO_APPROVED_PERMISSION_STATES = ['waiting', 'blocked'] as const
+type CodexAutoApprovalStatusPayload = AgentCompletionStatusSnapshot &
+  Pick<AgentStatusIpcPayload, 'hookEventName' | 'codexApprovalReviewer'>
 
 export type CodexAutoApprovalStatusContext = {
   paneKey: string
@@ -16,38 +23,50 @@ export type CodexAutoApprovalStatusContext = {
   existingProviderSession?: AgentProviderSessionMetadata
 }
 
-function isCodexAutoApprovedPermissionState(
-  state: AgentCompletionStatusSnapshot['state']
-): state is (typeof CODEX_AUTO_APPROVED_PERMISSION_STATES)[number] {
-  return CODEX_AUTO_APPROVED_PERMISSION_STATES.some((permissionState) => permissionState === state)
-}
-
-export function shouldSuppressCodexAutoApprovalStatus(
-  payload: AgentCompletionStatusSnapshot,
-  context: CodexAutoApprovalStatusContext
-): boolean {
-  if (payload.agentType !== 'codex' || !isCodexAutoApprovedPermissionState(payload.state)) {
-    return false
-  }
-  // Why: request_user_input waits are real questions the user must answer — yolo auto-approval never resolves them, so they must keep driving status.
-  if (isAskUserQuestionTool(payload.toolName)) {
-    return false
-  }
-
+function getCodexLaunchConfig(context: CodexAutoApprovalStatusContext) {
   const state = useAppStore.getState()
   if (typeof state.getAgentLaunchConfigForStatusMetadata !== 'function') {
-    return false
+    return undefined
   }
-
-  const launchConfig = state.getAgentLaunchConfigForStatusMetadata({
+  return state.getAgentLaunchConfigForStatusMetadata({
     paneKey: context.paneKey,
     agentType: 'codex',
     tabId: context.tabId,
     terminalHandle: context.terminalHandle,
     launchToken: context.launchToken,
     providerSession: context.providerSession,
-    existingProviderSession: context.existingProviderSession
+    existingProviderSession:
+      context.existingProviderSession ??
+      state.agentStatusByPaneKey[context.paneKey]?.providerSession
   })
+}
+
+export function shouldSuppressCodexAutoApprovalStatus(
+  payload: CodexAutoApprovalStatusPayload,
+  context: CodexAutoApprovalStatusContext
+): boolean {
+  if (payload.agentType !== 'codex' || !isCodexPermissionAttentionState(payload.state)) {
+    return false
+  }
+  // Why: request_user_input waits are real questions the user must answer — yolo/auto-review never resolve them.
+  if (isAskUserQuestionTool(payload.toolName)) {
+    return false
+  }
+  const launchConfig = getCodexLaunchConfig(context)
+  const reviewer =
+    payload.codexApprovalReviewer ?? resolveCodexApprovalReviewer(launchConfig?.agentArgs)
+  if (
+    shouldSuppressCodexAutoReviewPermissionAttention({
+      agentType: payload.agentType,
+      state: payload.state,
+      hookEventName: payload.hookEventName,
+      toolName: payload.toolName,
+      reviewer
+    })
+  ) {
+    return true
+  }
+
   if (!launchConfig) {
     return false
   }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3260,16 +3260,25 @@ export function useIpcEvents(): void {
         return 'dropped'
       }
       if (
-        shouldSuppressCodexAutoApprovalStatus(statusPayload, {
-          paneKey,
-          tabId: ownerTabId,
-          terminalHandle: data.terminalHandle,
-          launchToken: data.launchToken,
-          providerSession: data.providerSession,
-          existingProviderSession: existingStatus?.providerSession
-        })
+        shouldSuppressCodexAutoApprovalStatus(
+          {
+            ...statusPayload,
+            ...(data.hookEventName ? { hookEventName: data.hookEventName } : {}),
+            ...(data.codexApprovalReviewer
+              ? { codexApprovalReviewer: data.codexApprovalReviewer }
+              : {})
+          },
+          {
+            paneKey,
+            tabId: ownerTabId,
+            terminalHandle: data.terminalHandle,
+            launchToken: data.launchToken,
+            providerSession: data.providerSession,
+            existingProviderSession: existingStatus?.providerSession
+          }
+        )
       ) {
-        // Why: Codex yolo permission hooks are not user-actionable; they must not drive status, titles, badges, or notifications.
+        // Why: Codex yolo and proven auto-review PermissionRequest hooks are not user-actionable (#13600).
         return 'dropped'
       }
       const terminalTitle = resolveAgentStatusTerminalTitle(statusPayload, title)

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -3,6 +3,7 @@
 // a narrow interrupt fallback synthesizes a final `done` when an agent misses its cancellation hook.
 
 import type { AgentProviderSessionMetadata } from './agent-session-resume'
+import type { ExplicitCodexApprovalReviewer } from './codex-approval-reviewer'
 import {
   normalizeInteractivePromptField,
   normalizeOptionalField,
@@ -240,6 +241,10 @@ export type AgentStatusIpcPayload = ParsedAgentStatusPayload & {
   promptInteractionKey?: string
   /** See AgentStatusEntry.restoredUnconfirmed — hydrated nonterminal provenance. */
   restoredUnconfirmed?: boolean
+  /** Hook discriminator (e.g. PermissionRequest) for ownership-aware attention. */
+  hookEventName?: string
+  /** Launch-proven Codex reviewer ownership; omit when unknown so consumers fail open. */
+  codexApprovalReviewer?: ExplicitCodexApprovalReviewer
 }
 
 /** Wire shape for ordinary pane teardown or a stamped SSH disconnect batch. */

--- a/src/shared/codex-approval-reviewer.test.ts
+++ b/src/shared/codex-approval-reviewer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseExplicitCodexApprovalReviewer,
+  resolveCodexApprovalReviewer
+} from './codex-approval-reviewer'
+
+describe('Codex approval reviewer', () => {
+  it('accepts only explicit reviewer values from hook transport', () => {
+    expect(parseExplicitCodexApprovalReviewer('auto_review')).toBe('auto_review')
+    expect(parseExplicitCodexApprovalReviewer('user')).toBe('user')
+    expect(parseExplicitCodexApprovalReviewer('guardian_subagent')).toBeUndefined()
+    expect(parseExplicitCodexApprovalReviewer('AUTO_REVIEW')).toBeUndefined()
+  })
+
+  it('uses the last explicit reviewer declaration', () => {
+    expect(
+      resolveCodexApprovalReviewer(
+        `-c approvals_reviewer=auto_review -c 'approvals_reviewer="user"'`
+      )
+    ).toBe('user')
+    expect(resolveCodexApprovalReviewer(`-c approvals_reviewer=guardian_subagent`)).toBe(
+      'auto_review'
+    )
+    expect(resolveCodexApprovalReviewer('--ask-for-approval on-request')).toBe('unknown')
+  })
+
+  it('treats --approve-for-me as auto-review ownership', () => {
+    expect(resolveCodexApprovalReviewer('--approve-for-me')).toBe('auto_review')
+    expect(resolveCodexApprovalReviewer("codex '--approve-for-me'")).toBe('auto_review')
+  })
+
+  it('lets an explicit user reviewer override --approve-for-me', () => {
+    expect(
+      resolveCodexApprovalReviewer(`--approve-for-me -c approvals_reviewer=user`)
+    ).toBe('user')
+  })
+})

--- a/src/shared/codex-approval-reviewer.ts
+++ b/src/shared/codex-approval-reviewer.ts
@@ -1,0 +1,33 @@
+export type CodexApprovalReviewer = 'auto_review' | 'user' | 'unknown'
+export type ExplicitCodexApprovalReviewer = Exclude<CodexApprovalReviewer, 'unknown'>
+export const ORCA_CODEX_APPROVAL_REVIEWER_ENV = 'ORCA_CODEX_APPROVAL_REVIEWER' as const
+
+export function parseExplicitCodexApprovalReviewer(
+  value: unknown
+): ExplicitCodexApprovalReviewer | undefined {
+  return value === 'auto_review' || value === 'user' ? value : undefined
+}
+
+/**
+ * Resolve who owns Codex permission pauses from launch argv.
+ * Why: PermissionRequest fires before auto-review decides (#13600/#8387); launch
+ * ownership is the durable signal until Codex exposes a per-request reviewer.
+ */
+export function resolveCodexApprovalReviewer(
+  agentArgs: string | null | undefined
+): CodexApprovalReviewer {
+  const args = agentArgs ?? ''
+  let reviewer: CodexApprovalReviewer = 'unknown'
+
+  // Why: Orca Auto preset and vendor CLI flag both mean "Approve for me" (quoted or bare).
+  if (/(?:^|[\s'"])--approve-for-me(?:[\s'"]|$)/.test(args)) {
+    reviewer = 'auto_review'
+  }
+
+  for (const match of args.matchAll(
+    /\bapprovals_reviewer\s*=\s*(?:\\?["'])?(auto_review|guardian_subagent|user)\b/gi
+  )) {
+    reviewer = match[1]?.toLowerCase() === 'user' ? 'user' : 'auto_review'
+  }
+  return reviewer
+}

--- a/src/shared/codex-auto-review-attention.test.ts
+++ b/src/shared/codex-auto-review-attention.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import {
+  shouldSuppressCodexAutoReviewPermissionAttention,
+  shouldSuppressCodexPermissionSyntheticTitle
+} from './codex-auto-review-attention'
+
+describe('Codex auto-review attention', () => {
+  it('suppresses only confirmed auto-review PermissionRequest attention', () => {
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'exec_command',
+        reviewer: 'auto_review'
+      })
+    ).toBe(true)
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'blocked',
+        hookEventName: 'PermissionRequest',
+        toolName: 'Bash',
+        reviewer: 'auto_review'
+      })
+    ).toBe(true)
+  })
+
+  it('fails open for user-owned or unknown reviewer', () => {
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'exec_command',
+        reviewer: 'user'
+      })
+    ).toBe(false)
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'exec_command',
+        reviewer: 'unknown'
+      })
+    ).toBe(false)
+  })
+
+  it('suppresses auto-review waits when hook name is absent (Codex waiting ≈ permission)', () => {
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: undefined,
+        toolName: 'exec_command',
+        reviewer: 'auto_review'
+      })
+    ).toBe(true)
+  })
+
+  it('fails open for explicit non-permission hooks under auto-review', () => {
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'AfterToolUse',
+        toolName: 'exec_command',
+        reviewer: 'auto_review'
+      })
+    ).toBe(false)
+  })
+
+  it('never suppresses genuine request_user_input waits under auto-review', () => {
+    expect(
+      shouldSuppressCodexAutoReviewPermissionAttention({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'request_user_input',
+        reviewer: 'auto_review'
+      })
+    ).toBe(false)
+  })
+
+  it('suppresses the synthetic permission title for auto-review and yolo PermissionRequest', () => {
+    expect(
+      shouldSuppressCodexPermissionSyntheticTitle({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'exec_command',
+        reviewer: 'auto_review',
+        launchConfig: {
+          agentArgs: `-c 'approvals_reviewer="auto_review"'`,
+          agentEnv: {}
+        }
+      })
+    ).toBe(true)
+    expect(
+      shouldSuppressCodexPermissionSyntheticTitle({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'exec_command',
+        reviewer: 'user',
+        launchConfig: {
+          agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+          agentEnv: {}
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('keeps real questions and non-permission hooks visible under yolo', () => {
+    const yoloLaunchConfig = {
+      agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+      agentEnv: {}
+    }
+    expect(
+      shouldSuppressCodexPermissionSyntheticTitle({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        toolName: 'request_user_input',
+        reviewer: 'auto_review',
+        launchConfig: yoloLaunchConfig
+      })
+    ).toBe(false)
+    expect(
+      shouldSuppressCodexPermissionSyntheticTitle({
+        agentType: 'codex',
+        state: 'waiting',
+        hookEventName: 'AfterToolUse',
+        toolName: 'exec_command',
+        reviewer: 'user',
+        launchConfig: yoloLaunchConfig
+      })
+    ).toBe(false)
+  })
+})

--- a/src/shared/codex-auto-review-attention.ts
+++ b/src/shared/codex-auto-review-attention.ts
@@ -1,0 +1,77 @@
+import { isAskUserQuestionTool } from './agent-question-answered-intent'
+import type { CodexApprovalReviewer } from './codex-approval-reviewer'
+import { resolveTuiAgentPermissionMode } from './tui-agent-permissions'
+
+const CODEX_PERMISSION_REQUEST_HOOK = 'PermissionRequest'
+const CODEX_PERMISSION_STATES = new Set(['waiting', 'blocked'])
+
+export function isCodexPermissionAttentionState(state: string): boolean {
+  return CODEX_PERMISSION_STATES.has(state)
+}
+
+/**
+ * Suppress OS/status attention only when ownership is proven auto-review.
+ * Why: fail open for user ownership or unknown reviewer (#13600). Codex waiting
+ * without request_user_input is PermissionRequest-shaped, so missing hook names
+ * still suppress under proven auto_review; an explicit non-permission hook fails open.
+ */
+export function shouldSuppressCodexAutoReviewPermissionAttention(args: {
+  agentType: string | null | undefined
+  state: string
+  hookEventName: string | undefined
+  toolName: string | undefined
+  reviewer: CodexApprovalReviewer
+}): boolean {
+  if (
+    args.agentType !== 'codex' ||
+    !isCodexPermissionAttentionState(args.state) ||
+    isAskUserQuestionTool(args.toolName) ||
+    args.reviewer !== 'auto_review'
+  ) {
+    return false
+  }
+  // Why: an explicit non-permission hook must stay visible even under auto_review.
+  if (args.hookEventName !== undefined && args.hookEventName !== CODEX_PERMISSION_REQUEST_HOOK) {
+    return false
+  }
+  return true
+}
+
+export function shouldSuppressCodexPermissionSyntheticTitle(args: {
+  agentType: string | null | undefined
+  state: string
+  hookEventName: string | undefined
+  toolName: string | undefined
+  reviewer: CodexApprovalReviewer
+  launchConfig:
+    | {
+        agentArgs?: string | null
+        agentEnv?: Record<string, string> | null
+      }
+    | null
+    | undefined
+}): boolean {
+  if (
+    args.agentType !== 'codex' ||
+    !isCodexPermissionAttentionState(args.state) ||
+    isAskUserQuestionTool(args.toolName)
+  ) {
+    return false
+  }
+  // Why: yolo never needs a permission title; keep request_user_input visible above.
+  if (
+    args.launchConfig &&
+    resolveTuiAgentPermissionMode({
+      agent: 'codex',
+      agentArgs: args.launchConfig.agentArgs,
+      agentEnv: args.launchConfig.agentEnv
+    }) === 'yolo'
+  ) {
+    // Why: synthetic titles for yolo only for PermissionRequest when known; unknown hook still yolo-suppresses for parity with status path.
+    if (args.hookEventName !== undefined && args.hookEventName !== CODEX_PERMISSION_REQUEST_HOOK) {
+      return false
+    }
+    return true
+  }
+  return shouldSuppressCodexAutoReviewPermissionAttention(args)
+}


### PR DESCRIPTION
## Summary

Codex **Approve for me** no longer raises false *Attention requested* OS notifications when the auto-reviewer owns the permission pause.

- Root cause after #8519: `PermissionRequest` still maps to `waiting` before auto-review decides; the 1.5s quiet window is too short when WSL/auto-review takes longer, so the OS banner still fires.
- Prefer **launch ownership** over a longer timer: resolve `approvals_reviewer=auto_review|guardian_subagent`, `--approve-for-me`, or an explicit IPC `codexApprovalReviewer` stamp.
- Proven auto-review `PermissionRequest` pauses are dropped before status/title/attention fanout; unknown ownership **fails open** (still debounced for Codex).
- `request_user_input` and explicit `approvals_reviewer=user` remain user-actionable.

Related prior art: open PR #11046 (ownership transport) did not land and does not close #13600; this is a focused ownership consume on current main.

## Validation

```
npx vitest run --config config/vitest.config.ts \
  src/shared/codex-approval-reviewer.test.ts \
  src/shared/codex-auto-review-attention.test.ts \
  src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.test.ts \
  src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
# 4 files, 103 tests passed

npx oxlint <changed files>  # 0 warnings / 0 errors
npx tsc --noEmit -p config/tsconfig.web.json --composite false  # exit 0
npx tsc --noEmit -p config/tsconfig.node.json --composite false # exit 0
```

## Limitations

- Mid-session TUI flips to Approve for me that never appear in launch `agentArgs` still fail open (1.5s debounce remains as belt-and-suspenders).
- High-risk auto-review escalations that stay on `PermissionRequest` without a new hook may suppress until Codex exposes a per-request reviewer (same Codex gap as openai/codex#28833).

Fixes #13600