### PR TITLE
fix: decouple Floating Workspace shell selection

### DIFF
--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { Repo, Worktree } from '../../../shared/types'
 import type { AppState } from '@/store/types'
 import {
@@ -471,6 +472,38 @@ describe('local preflight context', () => {
         reason: 'project-override',
         cacheKey: 'repo-1:windows-host'
       }
+    })
+  })
+
+  it('does not assign the active project runtime to the floating workspace', () => {
+    const state = {
+      ...makeState({ repoPath: 'C:\\Users\\alice\\repo', worktreePath: 'C:\\Users\\alice\\repo' }),
+      projects: [{ id: 'repo-1', localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' } }]
+    } as unknown as AppState
+
+    expect(
+      getLocalProjectExecutionRuntimeContext(state, FLOATING_TERMINAL_WORKTREE_ID, 'win32')
+    ).toBeUndefined()
+  })
+
+  it('keeps the active project runtime fallback for a detected-only worktree', () => {
+    const state = {
+      ...makeState({ repoPath: 'C:\\Users\\alice\\repo' }),
+      detectedWorktreesByRepo: {
+        'repo-1': {
+          repoId: 'repo-1',
+          authoritative: true,
+          source: 'git',
+          worktrees: [{ id: 'repo-1::detected', repoId: 'repo-1', path: 'C:\\detected' }]
+        }
+      },
+      projects: [{ id: 'repo-1', localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' } }]
+    } as unknown as AppState
+
+    expect(
+      getLocalProjectExecutionRuntimeContext(state, 'repo-1::detected', 'win32')
+    ).toMatchObject({
+      runtime: { kind: 'wsl', distro: 'Ubuntu', projectId: 'repo-1' }
     })
   })
 

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '@/store/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { parseWslUncPath } from '../../../shared/wsl-paths'
 import {
   deriveGlobalWindowsRuntimeDefaultFromLegacySettings,
@@ -39,10 +40,12 @@ type LocalProjectRuntimeWslContext = {
   availableWslDistros?: readonly string[] | null
 }
 
+/** Extracts a WSL distribution name from supported UNC path forms. */
 export function getWslDistroFromPath(path?: string | null): string | null {
   return path ? (parseWslUncPath(path)?.distro ?? null) : null
 }
 
+/** Resolves the owning local project's Windows runtime for project-scoped targets. */
 export function getLocalProjectExecutionRuntimeContext(
   state: LocalProjectRuntimeState,
   worktreeId?: string | null,
@@ -53,6 +56,9 @@ export function getLocalProjectExecutionRuntimeContext(
     return undefined
   }
 
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return undefined
+  }
   const worktree = getLocalWorktree(state, worktreeId)
   const repo = getLocalRuntimeRepoForWorktree(state, worktree)
   if (!isLocalRuntimeRepo(repo) || !isLocalRuntimeWorktree(worktree)) {


### PR DESCRIPTION
## ELI5

Floating Workspace is not a project, so it should not inherit whichever Windows or WSL runtime the active project uses. The runtime resolver now recognizes Floating Workspace directly and leaves its shell chooser independent.

## What Changed

- Return no project runtime for `FLOATING_TERMINAL_WORKTREE_ID` at the central project-runtime authority boundary.
- Preserve the existing active-project fallback for detected-only worktrees that are selectable before primary catalog hydration.
- Add regression coverage for both behaviors.
- Add concise contracts for the touched exported runtime helpers.

## Why

`getLocalProjectExecutionRuntimeContext` accepted the Floating Workspace synthetic ID, found no real worktree, then fell back to `activeRepoId`. That false authority made the TabBar filter Floating Workspace shells to the active project's Windows/WSL runtime.

The central sentinel guard covers menu modeling, creation, restore, spawn, restart, resume, and other resolver callers. A Floating Panel-only override would miss lifecycle paths, while a TabBar-only special case would mask only the menu symptom. A broad unresolved-ID guard was rejected because detected-only local worktrees intentionally retain the active project's runtime until primary catalog hydration.

## Linked Issue

Fixes #13512

## Visual Proof

N/A — this diff changes runtime authority only; it does not change layout, styling, or component rendering. Physical Windows interaction validation was still completed on an Ubuntu 24.04 WSL project:

- Floating Workspace offered PowerShell, CMD Prompt, Git Bash, and WSL.
- Selecting PowerShell recorded `shellOverride: "pwsh.exe"`.
- The rendered terminal returned `ISSUE13512:Win32NT:Core`.
- Retained local evidence: `issue-13512-wsl-project-floating-shell-menu.png` and `issue-13512-floating-powershell-running.png` (not committed per template policy).

## Testing

Invariant: the Floating Workspace synthetic ID must not resolve to the active project's runtime.

Byte-identical oracle:

`pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/local-preflight-context.test.ts -t 'does not assign the active project runtime to the floating workspace'`

On final `origin/main` `346e59c879`:

- baseline implementation blob verified identical to main: RED, received `repo-1:wsl:Ubuntu` instead of `undefined`
- candidate: GREEN
- candidate with the Floating Workspace guard disabled: RED with the identical received runtime
- restored candidate: GREEN

Additional validation:

- focused runtime, TabBar shell-menu, and PTY routing suites: 606/606 passed
- local runtime suite, including detected-only ownership: 30/30 passed
- `pnpm typecheck`: passed
- touched-file oxlint and diff checks: passed
- reliability gate manifest: passed (74 gates)
- max-lines ratchet: passed; no bypasses
- physical Windows/WSL Electron validation: passed
- all 44 final CI checks: terminal with zero failures
- full `pnpm lint` passed code-quality, type-aware, reliability, max-lines, and bundled-guide stages, then stopped on repository-wide stale generated skill manifests unrelated to this diff

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI Codex was used for investigation, implementation, validation, review orchestration, and PR preparation. All generated changes were verified with deterministic tests, physical Windows validation, and independent specialist review.

## Review

Fresh exact-head reviews are clean for security/adversarial correctness, architecture/elegance, performance/resources, Windows/WSL and macOS/Linux compatibility, SSH/remote and folder/git workspaces, remote wire compatibility, shell UX/accessibility, and release readiness. CodeRabbit generated no actionable comments and reports 100% docstring coverage.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

CI covers the repository-wide test/build matrix. The local full-lint caveat is the unrelated stale generated manifests documented above.

## Author

- GitHub: @Jinwoo-H
