### PR TITLE
fix(mobile): abandon stuck relay recovery on revoked credentials

### DIFF
--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -244,18 +244,25 @@ describe('mobile relay pairing recovery', () => {
   // no recoverable reason — the credentials will never become valid again.
   it('abandons a journal immediately when every credential is permanently rejected', async () => {
     const saved = journal()
-    const rejected = () =>
-      client(async () => {
+    const seenCredentials: (string | undefined)[] = []
+    const connectRelay = vi.fn((args: { credential?: string }) => {
+      seenCredentials.push(args.credential)
+      return client(async () => {
         throw new RelayOuterError(MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL)
       })
+    })
     const deps = {
-      ...dependencies({ journal: saved, connectRelay: vi.fn(() => rejected()) }),
+      ...dependencies({ journal: saved, connectRelay }),
       // Why: pin now inside the invite lifetime so the time-based abandon branch
       // cannot be the reason recovery returns 'abandoned'.
       now: () => now
     }
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('abandoned')
+    // Why: prove both the pending-resume and valid-invite candidates were tried;
+    // without this the test would still pass if recoveryCredentials silently
+    // dropped one and only one permanent rejection was counted.
+    expect(seenCredentials).toEqual([saved.secrets.pendingResumeToken, undefined])
     expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
   })
 
@@ -263,21 +270,27 @@ describe('mobile relay pairing recovery', () => {
   // launch; only all-permanent is enough to abandon.
   it('keeps the journal when at least one credential had a transient failure', async () => {
     const saved = journal()
-    const connectRelay = vi.fn((args: { credential?: string }) =>
-      args.credential
+    const seenCredentials: (string | undefined)[] = []
+    const connectRelay = vi.fn((args: { credential?: string }) => {
+      seenCredentials.push(args.credential)
+      return args.credential
         ? client(async () => {
             throw new RelayOuterError(MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL)
           })
         : client(async () => {
             throw new Error('relay unreachable')
           })
-    )
+    })
     const deps = {
       ...dependencies({ journal: saved, connectRelay }),
       now: () => now
     }
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')
+    // Why: prove the resume candidate rejected permanently while the invite
+    // candidate produced a transient error; otherwise the test would pass even
+    // if only one path was exercised.
+    expect(seenCredentials).toEqual([saved.secrets.pendingResumeToken, undefined])
     expect(deps.clearJournal).not.toHaveBeenCalled()
   })
 

--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -238,10 +238,7 @@ describe('mobile relay pairing recovery', () => {
     expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
   })
 
-  // Why: when the desktop has revoked the device behind the journal (e.g. the
-  // user rotated the QR), every recovery credential comes back BAD_OUTER_CREDENTIAL.
-  // Waiting out the invite TTL + grace strand the user on "recovery pending" for
-  // no recoverable reason — the credentials will never become valid again.
+  // Why: desktop-revoked journal → every credential returns 4401; abandon must not wait on the TTL.
   it('abandons a journal immediately when every credential is permanently rejected', async () => {
     const saved = journal()
     const seenCredentials: (string | undefined)[] = []
@@ -253,21 +250,17 @@ describe('mobile relay pairing recovery', () => {
     })
     const deps = {
       ...dependencies({ journal: saved, connectRelay }),
-      // Why: pin now inside the invite lifetime so the time-based abandon branch
-      // cannot be the reason recovery returns 'abandoned'.
+      // Why: pin now inside invite lifetime so the TTL-based abandon branch cannot be the cause.
       now: () => now
     }
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('abandoned')
-    // Why: prove both the pending-resume and valid-invite candidates were tried;
-    // without this the test would still pass if recoveryCredentials silently
-    // dropped one and only one permanent rejection was counted.
+    // Why: lock in recoveryCredentials' order/contents, not just the final result.
     expect(seenCredentials).toEqual([saved.secrets.pendingResumeToken, undefined])
     expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
   })
 
-  // Why: one transient failure leaves the door open to reconciling on the next
-  // launch; only all-permanent is enough to abandon.
+  // Why: any transient credential keeps the journal retryable on a later launch.
   it('keeps the journal when at least one credential had a transient failure', async () => {
     const saved = journal()
     const seenCredentials: (string | undefined)[] = []
@@ -287,9 +280,7 @@ describe('mobile relay pairing recovery', () => {
     }
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')
-    // Why: prove the resume candidate rejected permanently while the invite
-    // candidate produced a transient error; otherwise the test would pass even
-    // if only one path was exercised.
+    // Why: lock in resume-permanent + invite-transient, not just the final result.
     expect(seenCredentials).toEqual([saved.secrets.pendingResumeToken, undefined])
     expect(deps.clearJournal).not.toHaveBeenCalled()
   })

--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MOBILE_RELAY_CLOSE_CODE } from '../../../src/shared/mobile-relay-close-codes'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { createMobileRelayPairingJournal } from './mobile-relay-pairing-journal'
 import {
   recoverMobileRelayPairing,
@@ -234,6 +236,49 @@ describe('mobile relay pairing recovery', () => {
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('abandoned')
     expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
+  })
+
+  // Why: when the desktop has revoked the device behind the journal (e.g. the
+  // user rotated the QR), every recovery credential comes back BAD_OUTER_CREDENTIAL.
+  // Waiting out the invite TTL + grace strand the user on "recovery pending" for
+  // no recoverable reason — the credentials will never become valid again.
+  it('abandons a journal immediately when every credential is permanently rejected', async () => {
+    const saved = journal()
+    const rejected = () =>
+      client(async () => {
+        throw new RelayOuterError(MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL)
+      })
+    const deps = {
+      ...dependencies({ journal: saved, connectRelay: vi.fn(() => rejected()) }),
+      // Why: pin now inside the invite lifetime so the time-based abandon branch
+      // cannot be the reason recovery returns 'abandoned'.
+      now: () => now
+    }
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('abandoned')
+    expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
+  })
+
+  // Why: one transient failure leaves the door open to reconciling on the next
+  // launch; only all-permanent is enough to abandon.
+  it('keeps the journal when at least one credential had a transient failure', async () => {
+    const saved = journal()
+    const connectRelay = vi.fn((args: { credential?: string }) =>
+      args.credential
+        ? client(async () => {
+            throw new RelayOuterError(MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL)
+          })
+        : client(async () => {
+            throw new Error('relay unreachable')
+          })
+    )
+    const deps = {
+      ...dependencies({ journal: saved, connectRelay }),
+      now: () => now
+    }
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')
+    expect(deps.clearJournal).not.toHaveBeenCalled()
   })
 
   it('keeps a just-expired journal so a brief outage cannot discard it', async () => {

--- a/mobile/src/transport/mobile-relay-pairing-recovery.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.ts
@@ -5,7 +5,9 @@ import {
   type DeviceCredentialInstalled,
   type MobileRelayEndpoint
 } from '../../../src/shared/mobile-relay-credential-contract'
+import { MOBILE_RELAY_CLOSE_CODE } from '../../../src/shared/mobile-relay-close-codes'
 import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { loadHosts, saveHost } from './host-store'
 import {
   promotePairingJournalCredential,
@@ -104,6 +106,12 @@ async function runRecovery(
   // of an authoritatively committed install must not look like "nothing to
   // reconcile" — that journal is the only record left to retry the write from.
   let observedCommitted = false
+  // Why: BAD_OUTER_CREDENTIAL is the cell's authoritative "this credential will
+  // never validate" signal (desktop revoked the device, invite was minted for a
+  // different host, etc.). Track it per-credential so we can abandon the journal
+  // once every path is provably dead instead of stranding the user on
+  // "recovery pending" until the invite TTL + grace window elapses.
+  let permanentFailures = 0
   for (const credential of credentials) {
     let client: PairingCandidateClient | null = null
     try {
@@ -141,12 +149,27 @@ async function runRecovery(
         await publishCommitted(journal, reconciled, dependencies)
         return 'recovered'
       }
-    } catch {
+    } catch (error) {
       // Why: ambiguous pairing state advances only by credential priority and
       // authoritative status; a transport failure never rewrites the journal.
+      if (
+        error instanceof RelayOuterError &&
+        error.code === MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL
+      ) {
+        permanentFailures += 1
+      }
     } finally {
       client?.close()
     }
+  }
+  // Why: when every credential was authoritatively rejected there is no future
+  // launch that could possibly reconcile — the desktop has moved on and the
+  // relay will keep rejecting these tokens forever. Drop the journal now so a
+  // fresh scan can proceed; the time-based branch below stays as the fallback
+  // for transient outages that never produced a permanent signal.
+  if (!observedCommitted && permanentFailures === credentials.length) {
+    await dependencies.clearJournal(journal.metadata.journalId).catch(() => {})
+    return 'abandoned'
   }
   // Why: past invite expiry no credential can still establish what happened, so
   // retaining the journal cannot reconcile anything — it only fails every later

--- a/mobile/src/transport/mobile-relay-pairing-recovery.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.ts
@@ -106,11 +106,7 @@ async function runRecovery(
   // of an authoritatively committed install must not look like "nothing to
   // reconcile" — that journal is the only record left to retry the write from.
   let observedCommitted = false
-  // Why: BAD_OUTER_CREDENTIAL is the cell's authoritative "this credential will
-  // never validate" signal (desktop revoked the device, invite was minted for a
-  // different host, etc.). Track it per-credential so we can abandon the journal
-  // once every path is provably dead instead of stranding the user on
-  // "recovery pending" until the invite TTL + grace window elapses.
+  // Why: BAD_OUTER_CREDENTIAL is permanent — count per-credential so all-rejected abandons without waiting on the TTL.
   let permanentFailures = 0
   for (const credential of credentials) {
     let client: PairingCandidateClient | null = null
@@ -162,11 +158,7 @@ async function runRecovery(
       client?.close()
     }
   }
-  // Why: when every credential was authoritatively rejected there is no future
-  // launch that could possibly reconcile — the desktop has moved on and the
-  // relay will keep rejecting these tokens forever. Drop the journal now so a
-  // fresh scan can proceed; the time-based branch below stays as the fallback
-  // for transient outages that never produced a permanent signal.
+  // Why: all-permanent means no future launch can reconcile; abandon now and let the TTL branch below handle transient-only outages.
   if (!observedCommitted && permanentFailures === credentials.length) {
     await dependencies.clearJournal(journal.metadata.journalId).catch(() => {})
     return 'abandoned'


### PR DESCRIPTION
## ELI5

When you scan a QR to pair your phone with Orca and the pairing fails partway, the phone keeps a "to-do" note (journal) about it so it can finish up later. If you then make a new QR on your computer, the old note becomes useless — but the phone keeps trying to use it forever, blocking every new scan with a "recovery pending" error for ~20 minutes. This PR makes the phone recognize when the old note has been definitively rejected and throw it away immediately, so the new scan works right away.

## What Changed

`mobile/src/transport/mobile-relay-pairing-recovery.ts` `runRecovery`:
- Added `permanentFailures` counter inside the per-credential loop
- The `catch` block now classifies `RelayOuterError` with code `MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL (4401)` as permanent (desktop revoked the device); other errors (transport, `HOST_OFFLINE` 4404, `PEER_DROPPED` 4408, `LIMIT_EXCEEDED` 4429, `DRAINING` 4503) still get swallowed as transient
- After the loop, before the existing time-based abandon, a new branch abandons the journal when `permanentFailures === credentials.length`
- Existing 10-minute TTL + grace fallback preserved for transient outages that never produce a permanent signal

## Why

`mobile-relay-pairing-journal-store.ts:32-38` correctly refuses to overwrite a journal that has `winner`/`authorizationMode` set (an in-flight install might be reconcilable later). But once the desktop has revoked the device behind that journal, **no** future launch can ever reconcile it — the credentials will be rejected by the cell forever. Stranding the user on `"recovery pending"` for the full invite TTL window provides no recoverability and blocks every new scan.

`BAD_OUTER_CREDENTIAL` is the cell's authoritative "this credential will never validate" signal (see `mobileRelayRecoveryFor` in `mobile-relay-close-codes.ts:29-30` which returns `disable-relay-credential`, not a retry kind). Treating it as permanent is consistent with how the live connection path already handles it.

## Linked Issue

Fixes #14005

## Visual Proof

N/A — pure logic change in the recovery state machine. No UI surface changes; the user-visible effect is that the error message `"mobile relay pairing recovery pending"` no longer appears in the scenario described in the linked issue.

## Testing

- [x] `pnpm test --run src/transport/mobile-relay-pairing-recovery.test.ts` — 8/8 passing
- [x] Added `abandons a journal immediately when every credential is permanently rejected` (drives new behavior; also asserts both resume and invite candidates were attempted)
- [x] Added `keeps the journal when at least one credential had a transient failure` (regression guard; also asserts both candidates attempted)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] Manual end-to-end verification on device — not performed; reproducing requires a specific relay outage window. Unit tests cover the state machine transitions.

## AI Disclosure

The bug was diagnosed interactively with Claude Code (Anthropic). Implementation, test design, and PR write-up were co-authored with `Co-Authored-By: Claude Opus 4.6` trailing lines on each commit. All code was reviewed by the PR author.

## Review

- **Security**: No new trust boundary changes. `BAD_OUTER_CREDENTIAL` is relay-sourced and was already trusted as input to `mobileRelayRecoveryFor`.
- **Cross-platform (Linux/Windows/Mac)**: Change is in shared mobile code path; no platform-specific behavior touched.
- **Remote SSH**: N/A — relay pairing is a separate transport from SSH.
- **Mobile**: This is a mobile-only file (`mobile/src/transport/...`). Change is internal to the recovery state machine; no API or wire-protocol change.
- **Backwards compatibility**: The `'abandoned'` return value already existed; no caller-side change required. The new branch fires only when every credential returned `4401`, which previously left the journal stuck — there is no scenario where old behavior was "correct" and new behavior regresses it.
- **Performance**: One extra `===` comparison per recovery run. Negligible.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A for this change)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass; `pnpm build` deferred to CI

## Author

- X / Twitter: @StillTogether2