### PR TITLE
fix(terminal): answer a query in its own turn when the kernel is quiet (#13892)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -246,6 +246,8 @@ jobs:
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            src/shared/fish-query-reply-child-stdin.node-pty.test.ts \
+            src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
   test:
@@ -281,6 +283,8 @@ jobs:
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            --exclude=src/shared/fish-query-reply-child-stdin.node-pty.test.ts \
+            --exclude=src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -238,6 +238,12 @@ jobs:
           native-runtime: node
 
       - name: Test real shell contracts
+        # Why these are required, not optional: this lane is the only end-to-end guard for
+        # #9993 and #13892, and both suites SKIP when their prerequisite is missing — which
+        # would report green with nothing exercised.
+        env:
+          ORCA_REQUIRE_FISH: '1'
+          ORCA_REQUIRE_NODE_PTY_ECHO_STATE: '1'
         run: |
           pnpm exec vitest run --config config/vitest.config.ts \
             src/main/daemon/shell-ready.test.ts \

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -93,7 +93,7 @@ index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441
  //# sourceMappingURL=conpty_console_list_agent.js.map
 \ No newline at end of file
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088bf1865877 100644
+index 1ec12f796a822c78fba9ad7f6448c3987e325c23..68763e40312f4d60e2a7a432bf45b7bac33aa607 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -111,6 +111,20 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088b
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
+@@ -166,6 +170,13 @@ var UnixTerminal = /** @class */ (function (_super) {
+         enumerable: false,
+         configurable: true
+     });
++    /**
++     * Orca: slave ECHO bit, read synchronously off the master fd we already own.
++     * Guarded so an unpatched or prebuilt binding yields undefined, not a throw.
++     */
++    UnixTerminal.prototype.readEchoState = function () {
++        return typeof pty.echoState === 'function' ? pty.echoState(this._fd) : undefined;
++    };
+     /**
+      * openpty
+      */
 diff --git a/src/conpty_console_list_agent.ts b/src/conpty_console_list_agent.ts
 index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd8eeb4a79 100644
 --- a/src/conpty_console_list_agent.ts
@@ -130,7 +144,7 @@ index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd
  process.send!({ consoleProcessList });
  process.exit(0);
 diff --git a/src/unix/pty.cc b/src/unix/pty.cc
-index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d15c4dd44 100644
+index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..555d8835ad6539c7091445207b5009b66954a992 100644
 --- a/src/unix/pty.cc
 +++ b/src/unix/pty.cc
 @@ -23,7 +23,9 @@
@@ -210,7 +224,39 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    }
    if (pty_nonblock(master) == -1) {
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
-@@ -684,15 +716,73 @@ pty_getproc(int fd, char *tty) {
+@@ -575,6 +607,31 @@ Napi::Value PtyGetProc(const Napi::CallbackInfo& info) {
+   return name_;
+ }
+
++/**
++ * Slave line discipline ECHO bit -> 1 set, 0 clear, -1 unreadable.
++ *
++ * Orca: POSIX redirects a master's mode ioctls to the slave, so this reads the
++ * slave's ECHO with no fork and no extra fd. A kernel that did not redirect would
++ * answer from the master's own termios, whose ECHO defaults SET — so the degraded
++ * answer is "echoing", never a false "quiet".
++ */
++Napi::Value PtyEchoState(const Napi::CallbackInfo& info) {
++  Napi::Env env(info.Env());
++  Napi::HandleScope scope(env);
++
++  if (info.Length() != 1 || !info[0].IsNumber()) {
++    return Napi::Number::New(env, -1);
++  }
++
++  int fd = info[0].As<Napi::Number>().Int32Value();
++  struct termios tio;
++  if (tcgetattr(fd, &tio) == -1) {
++    return Napi::Number::New(env, -1);
++  }
++
++  return Napi::Number::New(env, (tio.c_lflag & ECHO) ? 1 : 0);
++}
++
+ /**
+  * Nonblocking FD
+  */
+@@ -684,15 +741,73 @@ pty_getproc(int fd, char *tty) {
  #endif
 
  #if defined(__APPLE__)
@@ -286,7 +332,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
-@@ -706,80 +796,118 @@ pty_posix_spawn(char** argv, char** env,
+@@ -706,80 +821,118 @@ pty_posix_spawn(char** argv, char** env,
                POSIX_SPAWN_SETSID;
    *master = posix_openpt(O_RDWR);
    if (*master == -1) {
@@ -429,3 +475,30 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    }
  }
  #endif
+@@ -793,6 +946,7 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+   exports.Set("open",    Napi::Function::New(env, PtyOpen));
+   exports.Set("resize",  Napi::Function::New(env, PtyResize));
+   exports.Set("process", Napi::Function::New(env, PtyGetProc));
++  exports.Set("echoState", Napi::Function::New(env, PtyEchoState));
+   return exports;
+ }
+
+diff --git a/src/unixTerminal.ts b/src/unixTerminal.ts
+index 98733dc0cd752b554bd94e45904ca341ad141bba..2711baeae9a61f17d2b5dfbe01cead23212460a9 100644
+--- a/src/unixTerminal.ts
++++ b/src/unixTerminal.ts
+@@ -174,6 +174,14 @@ export class UnixTerminal extends Terminal {
+   get fd(): number { return this._fd; }
+   get ptsName(): string { return this._pty; }
+
++  /**
++   * Orca: slave ECHO bit, read synchronously off the master fd we already own.
++   * Guarded so an unpatched or prebuilt binding yields undefined, not a throw.
++   */
++  public readEchoState(): number | undefined {
++    return typeof (pty as any).echoState === 'function' ? (pty as any).echoState(this._fd) : undefined;
++  }
++
+   /**
+    * openpty
+    */

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -15,7 +15,9 @@ const shellContractFiles = [
 ]
 const patchedNodePtyContractFiles = [
   'src/main/daemon/node-pty-fd-leak.test.ts',
-  'src/main/pty/omp-shell-wrapper.node-pty.test.ts'
+  'src/main/pty/omp-shell-wrapper.node-pty.test.ts',
+  'src/shared/fish-query-reply-child-stdin.node-pty.test.ts',
+  'src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts'
 ]
 const nativeShellContractFiles = [...shellContractFiles, ...patchedNodePtyContractFiles]
 const testFilePatterns = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: 8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
+    hash: 501c226bd90a60a3b61a1e87018cb41b231a5f54557894daa7726489f4e90d04
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -63,7 +63,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8)
+        version: 1.1.0(patch_hash=501c226bd90a60a3b61a1e87018cb41b231a5f54557894daa7726489f4e90d04)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12022,7 +12022,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8):
+  node-pty@1.1.0(patch_hash=501c226bd90a60a3b61a1e87018cb41b231a5f54557894daa7726489f4e90d04):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -3203,6 +3203,26 @@ describe('createPtySubprocess', () => {
       killSpy.mockRestore()
     })
   })
+
+  // First link of the daemon's #13892 chain: Session can only forward a probe this
+  // handle carries. See session-same-turn-query-reply-wiring.test.ts for the second.
+  describe('sync ECHO probe on the handle', () => {
+    itOnPosixHost('exposes the patched pty’s echoState as a usable probe', () => {
+      spawnMock.mockReturnValue({ ...mockPtyProcess(), readEchoState: () => 0 })
+
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+
+      expect(handle.echoSyncProbe?.()).toBe('quiet')
+    })
+
+    itOnPosixHost('omits the probe when node-pty lacks Orca’s patch', () => {
+      spawnMock.mockReturnValue(mockPtyProcess())
+
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+
+      expect(handle.echoSyncProbe).toBeUndefined()
+    })
+  })
 })
 
 describe('checkPtySpawnHealth (retry on transient failure)', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -74,7 +74,10 @@ import {
   expandWindowsPathEnvironmentVariables
 } from '../../shared/windows-environment-expansion'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
-import { readPtySlavePath } from '../../shared/pty-slave-line-discipline-echo'
+import {
+  createPtySlaveEchoSyncProbe,
+  readPtySlavePath
+} from '../../shared/pty-slave-line-discipline-echo'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -1059,10 +1062,12 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   })
 
   const slavePath = readPtySlavePath(proc)
+  const echoSyncProbe = createPtySlaveEchoSyncProbe(proc)
   return {
     pid: proc.pid,
     shellPath,
     ...(slavePath ? { slavePath } : {}),
+    ...(echoSyncProbe ? { echoSyncProbe } : {}),
     ...(startupCommandDeliveredInShellArgs ? { startupCommandDeliveredInShellArgs: true } : {}),
     getForegroundProcess: () => {
       // Why: node-pty's `.process` reports the live foreground name but reads a recycled pid on a reaped pty, so bail when dead.

--- a/src/main/daemon/session-same-turn-query-reply-wiring.test.ts
+++ b/src/main/daemon/session-same-turn-query-reply-wiring.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Wiring guard for #13892's only real-world delivery path.
+ *
+ * The fix is a sync ECHO probe that each PTY host must hand to `PtyStartupIngress`.
+ * Deleting that spread here — or in local-pty-provider or the relay's pty-handler —
+ * left the whole suite green, so the fix could be refactored away silently. Sibling
+ * guards live in `local-pty-provider.test.ts`, `pty-handler.test.ts` and
+ * `pty-subprocess.test.ts` (which builds the probe this host is handed).
+ *
+ * Asserted as behavior, not source text: with the probe wired and the kernel quiet the
+ * reply reaches the subprocess INSIDE the caller's turn. Without it the reply is queued
+ * behind a timer, which is exactly the deferral that strands it in the next child's stdin.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Session, type SubprocessHandle } from './session'
+import type { PtySlaveEchoSyncProbe } from '../../shared/pty-slave-line-discipline-echo'
+
+vi.mock('../pty-descendant-termination', () => ({ killWithDescendantSweep: vi.fn() }))
+
+const OSC11_REPLY = '\x1b]11;rgb:1e1e/1e1e/1e1e\x07'
+
+function createSubprocess(echoSyncProbe?: PtySlaveEchoSyncProbe): {
+  handle: SubprocessHandle
+  written: string[]
+} {
+  const written: string[] = []
+  return {
+    written,
+    handle: {
+      pid: 4242,
+      getForegroundProcess: () => null,
+      ...(echoSyncProbe ? { echoSyncProbe } : {}),
+      write: (data: string) => void written.push(data),
+      resize: () => {},
+      kill: () => {},
+      forceKill: () => {},
+      signal: () => {},
+      onData: () => {},
+      onExit: () => {},
+      dispose: () => {}
+    }
+  }
+}
+
+describe('Session hands its subprocess ECHO probe to the startup ingress (#13892)', () => {
+  let session: Session | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    session?.dispose()
+    session = null
+    vi.useRealTimers()
+  })
+
+  function start(echoSyncProbe?: PtySlaveEchoSyncProbe): { written: string[] } {
+    const subprocess = createSubprocess(echoSyncProbe)
+    session = new Session({
+      sessionId: 'echo-sync-probe-wiring',
+      cols: 80,
+      rows: 24,
+      subprocess: subprocess.handle,
+      shellReadySupported: false,
+      ownerBackend: 'posix-pty'
+    })
+    return subprocess
+  }
+
+  it('writes a live color reply in the caller’s own turn when the probe says quiet', () => {
+    const echoSyncProbe = vi.fn<PtySlaveEchoSyncProbe>(() => 'quiet')
+    const { written } = start(echoSyncProbe)
+
+    session?.write(OSC11_REPLY)
+
+    // Both matter: the probe must be CONSULTED (the spread exists) and its verdict must
+    // reach the wire now (the reply is not queued). Deleting the spread fails both.
+    expect(echoSyncProbe).toHaveBeenCalled()
+    expect(written).toEqual([OSC11_REPLY])
+  })
+
+  it('still defers when the probe says the slave would echo', () => {
+    const { written } = start(() => 'echoing')
+
+    session?.write(OSC11_REPLY)
+
+    expect(written).toEqual([])
+  })
+
+  it('defers when the host has no probe, so an unpatched node-pty keeps today’s behavior', () => {
+    const { written } = start()
+
+    session?.write(OSC11_REPLY)
+
+    expect(written).toEqual([])
+  })
+})

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -32,7 +32,10 @@ import type {
   TerminalSnapshot
 } from './types'
 import type { PtyOwnerBackend } from '../../shared/pty-owner-backend'
-import { createPtySlaveEchoProbe } from '../../shared/pty-slave-line-discipline-echo'
+import {
+  createPtySlaveEchoProbe,
+  type PtySlaveEchoSyncProbe
+} from '../../shared/pty-slave-line-discipline-echo'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
 // Why: Codex skips marker-gated command delivery; this only bounds older daemon/local paths that still report shell-ready for Codex.
@@ -63,6 +66,9 @@ export type SubprocessHandle = {
   /** Slave device path, so startup replies can read the line discipline's ECHO bit before
    *  writing. Absent on handles with no POSIX slave to read (ConPTY, tests). */
   slavePath?: string
+  /** Fork-free read of the same ECHO bit, so a reply that needs no wait is not deferred
+   *  into the next turn (#13892). Absent when node-pty lacks Orca's patch. */
+  echoSyncProbe?: PtySlaveEchoSyncProbe
   write(data: string): void
   resize(cols: number, rows: number): void
   /** Stop reading the PTY fd (node-pty pause()) so a flooding child blocks on write. Optional:
@@ -193,7 +199,8 @@ export class Session {
       ...(opts.ownerBackend ? { ownerBackend: opts.ownerBackend } : {}),
       write: (data) => this.subprocess.write(data),
       onEmission: (emission) => this.emitSubprocessOutput(emission),
-      ...(echoProbe ? { echoProbe } : {})
+      ...(echoProbe ? { echoProbe } : {}),
+      ...(this.subprocess.echoSyncProbe ? { echoSyncProbe: this.subprocess.echoSyncProbe } : {})
     })
     this.subprocess.onData((data) => this.handleSubprocessData(data))
     this.subprocess.onExit((code) => this.handleSubprocessExit(code))

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -2186,4 +2186,34 @@ describe('LocalPtyProvider', () => {
       await expect(shutdown).resolves.toBeUndefined()
     })
   })
+
+  // Wiring guard for #13892; see session-same-turn-query-reply-wiring.test.ts for why
+  // this is asserted per host rather than once on PtyStartupIngress.
+  describe('same-turn query reply wiring', () => {
+    const OSC11_REPLY = '\x1b]11;rgb:1e1e/1e1e/1e1e\x07'
+
+    it('hands the pty’s sync ECHO probe to the startup ingress', async () => {
+      const write = vi.fn()
+      const readEchoState = vi.fn(() => 0)
+      spawnMock.mockReturnValueOnce({ ...mockProc, write, readEchoState })
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      provider.write(id, OSC11_REPLY)
+
+      // Both matter: the probe must be CONSULTED, and a `quiet` verdict must reach the
+      // pty in this turn rather than behind the deferral timer.
+      expect(readEchoState).toHaveBeenCalled()
+      expect(write).toHaveBeenCalledWith(OSC11_REPLY)
+    })
+
+    it('still defers the reply when the pty reports the slave would echo', async () => {
+      const write = vi.fn()
+      spawnMock.mockReturnValueOnce({ ...mockProc, write, readEchoState: () => 1 })
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      provider.write(id, OSC11_REPLY)
+
+      expect(write).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -73,6 +73,7 @@ import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group
 import { readPtsName } from '../pty/node-pty-pts-name'
 import {
   createPtySlaveEchoProbe,
+  createPtySlaveEchoSyncProbe,
   readPtySlavePath
 } from '../../shared/pty-slave-line-discipline-echo'
 import {
@@ -935,6 +936,7 @@ export class LocalPtyProvider implements IPtyProvider {
       }
     }
     const startupEchoProbe = createPtySlaveEchoProbe(readPtySlavePath(proc))
+    const startupEchoSyncProbe = createPtySlaveEchoSyncProbe(proc)
     const startupIngress = new PtyStartupIngress({
       ...(args.startupIngress ? { intent: args.startupIngress } : {}),
       ownerBackend: resolvePtyOwnerBackend({
@@ -944,7 +946,8 @@ export class LocalPtyProvider implements IPtyProvider {
       }),
       write: (data) => proc.write(data),
       onEmission: emitIngressData,
-      ...(startupEchoProbe ? { echoProbe: startupEchoProbe } : {})
+      ...(startupEchoProbe ? { echoProbe: startupEchoProbe } : {}),
+      ...(startupEchoSyncProbe ? { echoSyncProbe: startupEchoSyncProbe } : {})
     })
     startupIngressByPty.set(id, startupIngress)
 

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -3592,6 +3592,36 @@ describe('PtyHandler', () => {
     expect(handler.activePtyCount).toBe(1)
     expect(handler.pendingPtyCreationCount).toBe(0)
   })
+
+  // Wiring guard for #13892; see session-same-turn-query-reply-wiring.test.ts for why
+  // this is asserted per host rather than once on PtyStartupIngress.
+  describe('same-turn query reply wiring', () => {
+    const OSC11_REPLY = '\x1b]11;rgb:1e1e/1e1e/1e1e\x07'
+
+    it('hands the pty’s sync ECHO probe to the startup ingress', async () => {
+      const write = vi.fn()
+      const readEchoState = vi.fn(() => 0)
+      mockPtySpawn.mockReturnValueOnce({ ...mockPtyInstance, write, readEchoState })
+      const { id } = await spawnPty()
+
+      dispatcher.callNotification('pty.data', { id, data: OSC11_REPLY })
+
+      // Both matter: the probe must be CONSULTED, and a `quiet` verdict must reach the
+      // pty in this turn rather than behind the deferral timer.
+      expect(readEchoState).toHaveBeenCalled()
+      expect(write).toHaveBeenCalledWith(OSC11_REPLY)
+    })
+
+    it('still defers the reply when the pty reports the slave would echo', async () => {
+      const write = vi.fn()
+      mockPtySpawn.mockReturnValueOnce({ ...mockPtyInstance, write, readEchoState: () => 1 })
+      const { id } = await spawnPty()
+
+      dispatcher.callNotification('pty.data', { id, data: OSC11_REPLY })
+
+      expect(write).not.toHaveBeenCalled()
+    })
+  })
 })
 
 describe('attachIdentityMismatches', () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -72,7 +72,11 @@ import {
   isAgentSessionSurfaceBinding,
   type AgentSessionOwnerBinding
 } from '../shared/agent-session-host-authority'
-import { createPtySlaveEchoProbe, readPtySlavePath } from '../shared/pty-slave-line-discipline-echo'
+import {
+  createPtySlaveEchoProbe,
+  createPtySlaveEchoSyncProbe,
+  readPtySlavePath
+} from '../shared/pty-slave-line-discipline-echo'
 
 // Why: only Linux compiles node-pty (no prebuilt), so the build-tools remedy is a closable setup gap
 // there and wrong advice anywhere node-pty ships one. The relay only sees an unloadable binding, never
@@ -690,12 +694,14 @@ export class PtyHandler {
       )
     }
     const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(managed.pty))
+    const echoSyncProbe = createPtySlaveEchoSyncProbe(managed.pty)
     managed.startupIngress ??= new PtyStartupIngress({
       ...(managed.startupIngressIntent ? { intent: managed.startupIngressIntent } : {}),
       ownerBackend: managed.ownerBackend,
       write: (data) => managed.pty.write(data),
       onEmission: emitIngressData,
-      ...(echoProbe ? { echoProbe } : {})
+      ...(echoProbe ? { echoProbe } : {}),
+      ...(echoSyncProbe ? { echoSyncProbe } : {})
     })
     managed.pty.onData((data: string) => {
       const startup = managed.startupCommand

--- a/src/shared/fish-query-reply-child-stdin.node-pty.test.ts
+++ b/src/shared/fish-query-reply-child-stdin.node-pty.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Real-fish regression for #13892: a terminal query reply Orca held back is overtaken
+ * by the DA1 answer written later in the same turn, so fish's read sentinel hands the
+ * tty to the child while the OSC 11 reply is still queued — and the CHILD READS IT.
+ *
+ * What is real here: node-pty running fish, `PtyStartupIngress`, `PtyStartupReplyDelivery`
+ * and both echo probes, plus the host's own write gate
+ * (`extractOnlyCookedEchoSafeQueryReplies` — copied from local-pty-provider.write, which
+ * is what decides whether a reply is deferred at all). Only the renderer is modelled: it
+ * answers queries strictly in the order they appear in the stream, so any inversion the
+ * child sees was produced by the delivery split and nothing else.
+ *
+ * The assertion is about a CHILD PROCESS'S STDIN, not the screen: a rendered-output check
+ * passes while the bytes are still being eaten by the next `npx` / `brew` confirm prompt.
+ * The child reads a full LINE because a leaked reply carries no newline, so a
+ * once('data') child would report it alone whenever it happened to land in its own read.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fishRequirementViolation, resolveFishBinary } from './fish-binary-requirement'
+import { PtyStartupIngress } from './pty-startup-ingress'
+import {
+  createPtySlaveEchoProbe,
+  createPtySlaveEchoSyncProbe,
+  readPtySlavePath
+} from './pty-slave-line-discipline-echo'
+import { extractOnlyCookedEchoSafeQueryReplies } from './terminal-query-reply'
+
+// Why fish 4: the DA1-sentinel handoff this measures lives in the 4.0 Rust tty_handoff.
+const FISH = resolveFishBinary(4)
+const itWithFish = FISH.available ? it : it.skip
+
+const PROMPT_MARK = 'ORCA13892> '
+
+/* oxlint-disable no-control-regex -- terminal query grammars are control sequences */
+/** Anchored at an ESC, first match wins; reply values match xterm.js's. */
+const QUERY_GRAMMARS = [
+  {
+    re: /^\x1b\]1[012];\?(\x07|\x1b\\)/,
+    reply: (m: RegExpExecArray) => `\x1b]11;rgb:1e1e/1e1e/1e1e${m[1]}`
+  },
+  { re: /^\x1b\[\?6n/, reply: () => '\x1b[?1;1;1R' },
+  { re: /^\x1b\[6n/, reply: () => '\x1b[1;1R' },
+  { re: /^\x1b\[\?996n/, reply: () => '\x1b[?997;1n' },
+  { re: /^\x1b\[>0?c/, reply: () => '\x1b[>0;276;0c' },
+  { re: /^\x1b\[0?c/, reply: () => '\x1b[?1;2c' },
+  { re: /^\x1b\[>0?q/, reply: () => '\x1bP>|Orca\x1b\\' },
+  { re: /^\x1b\[\?u/, reply: () => '\x1b[?0u' }
+] as const
+/** Still accumulating: no CSI final byte and no OSC/DCS terminator yet. */
+const PARTIAL_QUERY_RE =
+  /^(?:\x1b|\x1b\[[?>=]?[0-9;]*|\x1b\][0-9]*(?:;[^\x07\x1b]*)?\x1b?|\x1bP[^\x1b]*\x1b?)$/
+/* oxlint-enable no-control-regex */
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true
+    }
+    await sleep(10)
+  }
+  return false
+}
+
+describe('a held query reply never reaches the next child process (#13892)', () => {
+  let configHome: string | null = null
+
+  // Always runs, so the CI lane cannot report green with the regression below skipped.
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  afterEach(() => {
+    if (configHome) {
+      rmSync(configHome, { recursive: true, force: true })
+      configHome = null
+    }
+  })
+
+  itWithFish(
+    'answers OSC 11 in the query turn so the reply cannot land in the child’s stdin',
+    async () => {
+      const nodePty = await import('node-pty')
+
+      configHome = mkdtempSync(path.join(tmpdir(), 'orca-fish-13892-'))
+      mkdirSync(path.join(configHome, 'fish'), { recursive: true })
+      writeFileSync(
+        path.join(configHome, 'fish/config.fish'),
+        [
+          'set -g fish_greeting ""',
+          `function fish_prompt; printf '${PROMPT_MARK}'; end`,
+          'function fish_right_prompt; end',
+          ''
+        ].join('\n')
+      )
+      const childScript = path.join(configHome, 'read-stdin.mjs')
+      writeFileSync(
+        childScript,
+        "let buffered = ''\n" +
+          "process.stdin.on('data', (d) => {\n" +
+          "  buffered += d.toString('utf8')\n" +
+          "  if (!buffered.includes('\\n')) return\n" +
+          "  process.stdout.write('CHILD-READ:' + JSON.stringify(buffered) + '\\n')\n" +
+          '  process.exit(0)\n' +
+          '})\n'
+      )
+
+      const term = nodePty.spawn(FISH.path as string, ['-l', '-i'], {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 30,
+        cwd: configHome,
+        env: {
+          PATH: process.env.PATH ?? '/usr/bin:/bin',
+          HOME: configHome,
+          TERM: 'xterm-256color',
+          COLORTERM: 'truecolor',
+          LANG: 'en_US.UTF-8',
+          XDG_CONFIG_HOME: configHome,
+          XDG_DATA_HOME: path.join(configHome, 'data'),
+          ORCA_NODE_BIN: process.execPath,
+          ORCA_CHILD_SCRIPT: childScript
+        }
+      })
+
+      const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(term))
+      const echoSyncProbe = createPtySlaveEchoSyncProbe(term)
+      // Vacuity guard: without the patched binding there is no fast path to regress.
+      expect(
+        echoSyncProbe,
+        'node-pty must be built from source so Orca’s echoState patch is active'
+      ).toBeDefined()
+
+      let rendered = ''
+      const ingress = new PtyStartupIngress({
+        ownerBackend: 'posix-pty',
+        write: (data) => term.write(data),
+        onEmission: (emission) => {
+          rendered += emission.data
+          answerQueriesInOrder(emission.data)
+        },
+        ...(echoProbe ? { echoProbe } : {}),
+        ...(echoSyncProbe ? { echoSyncProbe } : {})
+      })
+
+      // VERBATIM from local-pty-provider.write(): only these replies are ever deferred.
+      const hostWrite = (data: string): void => {
+        if (extractOnlyCookedEchoSafeQueryReplies(data) && ingress.answerLiveQueryReply(data)) {
+          return
+        }
+        term.write(data)
+      }
+
+      let tail = ''
+      function answerQueriesInOrder(chunk: string): void {
+        let buffer = tail + chunk
+        tail = ''
+        let index = 0
+        while (index < buffer.length) {
+          const at = buffer.indexOf('\x1b', index)
+          if (at === -1) {
+            return
+          }
+          const rest = buffer.slice(at)
+          const grammar = QUERY_GRAMMARS.map((candidate) => ({
+            candidate,
+            match: candidate.re.exec(rest)
+          })).find((entry) => entry.match)
+          if (grammar?.match) {
+            hostWrite(grammar.candidate.reply(grammar.match))
+            index = at + grammar.match[0].length
+            continue
+          }
+          if (PARTIAL_QUERY_RE.test(rest)) {
+            tail = rest
+            return
+          }
+          index = at + 1
+        }
+      }
+
+      let exited = false
+      term.onExit(() => {
+        exited = true
+      })
+      term.onData((data) => ingress.accept(data))
+
+      try {
+        expect(await waitUntil(() => rendered.includes(PROMPT_MARK), 15_000)).toBe(true)
+        await sleep(500)
+
+        // Type-ahead is the deterministic shape: queue the child's command while an
+        // external command still owns the tty, so fish repaints its prompt (re-querying
+        // OSC 11) and hands the tty over in the same breath.
+        term.write('sleep 0.4\r')
+        await sleep(150)
+        term.write('"$ORCA_NODE_BIN" "$ORCA_CHILD_SCRIPT"\r')
+        await sleep(1_500)
+
+        const renderedBeforeChildInput = rendered.length
+        term.write('hello\r')
+        expect(
+          await waitUntil(
+            () => rendered.slice(renderedBeforeChildInput).includes('CHILD-READ:'),
+            10_000
+          )
+        ).toBe(true)
+
+        const childRead =
+          rendered.slice(renderedBeforeChildInput).match(/CHILD-READ:[^\r\n]*/)?.[0] ?? ''
+        // The merge-blocking assertion: the child's first LINE is what the user typed,
+        // with no escape byte in front of it. Pre-fix this reads
+        // `\u001b]11;rgb:1e1e/1e1e/1e1e\u001b\\hello\n`.
+        expect(childRead).toBe('CHILD-READ:"hello\\n"')
+      } finally {
+        term.write('exit\r')
+        await waitUntil(() => exited, 3_000)
+        try {
+          term.kill()
+        } catch {
+          // already gone
+        }
+      }
+    },
+    45_000
+  )
+})

--- a/src/shared/fish-query-reply-child-stdin.node-pty.test.ts
+++ b/src/shared/fish-query-reply-child-stdin.node-pty.test.ts
@@ -20,6 +20,11 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { fishRequirementViolation, resolveFishBinary } from './fish-binary-requirement'
+import {
+  NODE_PTY_SOURCE_BUILD_HINT,
+  nodePtyEchoStateRequirementViolation,
+  resolveNodePtyEchoStateSupport
+} from './node-pty-echo-state-requirement'
 import { PtyStartupIngress } from './pty-startup-ingress'
 import {
   createPtySlaveEchoProbe,
@@ -75,6 +80,13 @@ describe('a held query reply never reaches the next child process (#13892)', () 
     expect(fishRequirementViolation(FISH)).toBeNull()
   })
 
+  // Same contract for the other half of the setup: a prebuilt node-pty has no echoState,
+  // so the fix under test would be off and the regression below would run vacuously.
+  it('has the source-built node-pty this suite needs when CI requires one', async () => {
+    const lookup = resolveNodePtyEchoStateSupport(await import('node-pty'))
+    expect(nodePtyEchoStateRequirementViolation(lookup)).toBeNull()
+  })
+
   afterEach(() => {
     if (configHome) {
       rmSync(configHome, { recursive: true, force: true })
@@ -84,8 +96,14 @@ describe('a held query reply never reaches the next child process (#13892)', () 
 
   itWithFish(
     'answers OSC 11 in the query turn so the reply cannot land in the child’s stdin',
-    async () => {
+    async ({ skip }) => {
       const nodePty = await import('node-pty')
+      // Skip rather than red a developer whose node_modules predates the patch; CI
+      // sets ORCA_REQUIRE_NODE_PTY_ECHO_STATE=1 so the same state fails there.
+      const echoStateSupport = resolveNodePtyEchoStateSupport(nodePty)
+      if (!echoStateSupport.available) {
+        skip(echoStateSupport.reason)
+      }
 
       configHome = mkdtempSync(path.join(tmpdir(), 'orca-fish-13892-'))
       mkdirSync(path.join(configHome, 'fish'), { recursive: true })
@@ -130,11 +148,13 @@ describe('a held query reply never reaches the next child process (#13892)', () 
 
       const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(term))
       const echoSyncProbe = createPtySlaveEchoSyncProbe(term)
-      // Vacuity guard: without the patched binding there is no fast path to regress.
+      // Vacuity guard: a DEFINED probe proves nothing — the JS patch alone yields one that
+      // answers 'unknown' forever. Only a definite verdict off this live pty proves the
+      // native echoState is really being read, and so that there is a fast path to regress.
       expect(
-        echoSyncProbe,
-        'node-pty must be built from source so Orca’s echoState patch is active'
-      ).toBeDefined()
+        echoSyncProbe?.(),
+        `the sync probe gave no definite verdict, so #13892's same-turn reply is off. ${NODE_PTY_SOURCE_BUILD_HINT}`
+      ).toMatch(/^(quiet|echoing)$/)
 
       let rendered = ''
       const ingress = new PtyStartupIngress({

--- a/src/shared/node-pty-echo-state-requirement.test.ts
+++ b/src/shared/node-pty-echo-state-requirement.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  nodePtyEchoStateRequirementViolation,
+  REQUIRE_NODE_PTY_ECHO_STATE_ENV_VAR,
+  resolveNodePtyEchoStateSupport
+} from './node-pty-echo-state-requirement'
+
+// The exports an upstream node-pty prebuild carries — the shape the guard exists to catch.
+const PREBUILD_EXPORTS = { fork: () => {}, open: () => {}, resize: () => {}, process: () => {} }
+const SOURCE_BUILD_EXPORTS = { ...PREBUILD_EXPORTS, echoState: () => 0 }
+
+describe('node-pty echoState requirement', () => {
+  it('accepts a binding that actually exports echoState', () => {
+    const lookup = resolveNodePtyEchoStateSupport({ native: SOURCE_BUILD_EXPORTS }, 'darwin')
+    expect(lookup.available).toBe(true)
+    expect(lookup.nativeExports).toContain('echoState')
+  })
+
+  it('rejects an upstream prebuild whose JS patch would still hand back a probe', () => {
+    const lookup = resolveNodePtyEchoStateSupport({ native: PREBUILD_EXPORTS }, 'darwin')
+    expect(lookup.available).toBe(false)
+    expect(lookup.available ? '' : lookup.reason).toContain('fork, open, resize, process')
+    // The remedy must name the flag, because plain `pnpm rebuild node-pty` exits 0 on macOS.
+    expect(lookup.available ? '' : lookup.reason).toContain('npm_config_build_from_source=true')
+  })
+
+  it('rejects a module with no native binding at all', () => {
+    expect(resolveNodePtyEchoStateSupport({}, 'linux').available).toBe(false)
+    expect(resolveNodePtyEchoStateSupport(undefined, 'linux').available).toBe(false)
+  })
+
+  it('fails only when CI demanded the source build', () => {
+    const prebuild = resolveNodePtyEchoStateSupport({ native: PREBUILD_EXPORTS }, 'linux')
+    const sourceBuild = resolveNodePtyEchoStateSupport({ native: SOURCE_BUILD_EXPORTS }, 'linux')
+    expect(nodePtyEchoStateRequirementViolation(prebuild, {})).toBeNull()
+    expect(
+      nodePtyEchoStateRequirementViolation(prebuild, { [REQUIRE_NODE_PTY_ECHO_STATE_ENV_VAR]: '1' })
+    ).toContain('no echoState')
+    expect(
+      nodePtyEchoStateRequirementViolation(sourceBuild, {
+        [REQUIRE_NODE_PTY_ECHO_STATE_ENV_VAR]: '1'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/shared/node-pty-echo-state-requirement.ts
+++ b/src/shared/node-pty-echo-state-requirement.ts
@@ -1,0 +1,67 @@
+/**
+ * Decides whether the loaded node-pty really carries Orca's `echoState` binding, and
+ * how strict the suites that depend on it are about its absence.
+ *
+ * Why this is not "is the sync probe defined": the JS half of the patch ships in the
+ * pnpm patch, so `createPtySlaveEchoSyncProbe` hands back a probe as soon as
+ * node_modules is patched — even when the loaded NATIVE module is the upstream
+ * prebuild, whose exports are ['fork', 'open', 'resize', 'process']. `readEchoState()`
+ * then answers undefined, the probe maps it to 'unknown', #13892's same-turn fast path
+ * never fires, and a suite that only checked the probe exists would pass with the fix
+ * switched off.
+ */
+
+/** Env var CI sets to make a prebuilt or stale node-pty fail instead of skip. */
+export const REQUIRE_NODE_PTY_ECHO_STATE_ENV_VAR = 'ORCA_REQUIRE_NODE_PTY_ECHO_STATE'
+
+/** Spelled out because `pnpm rebuild node-pty` finds the shipped darwin prebuild and exits 0. */
+export const NODE_PTY_SOURCE_BUILD_HINT =
+  'Build node-pty from source with `npm_config_build_from_source=true pnpm rebuild node-pty` or `node config/scripts/rebuild-native-deps.mjs`; plain `pnpm rebuild node-pty` is not enough on macOS, where it finds the shipped darwin prebuild and exits 0.'
+
+export type NodePtyEchoStateLookup =
+  | { available: true; nativeExports: readonly string[] }
+  | { available: false; nativeExports: readonly string[]; reason: string }
+
+/** Pass the already-imported `node-pty` module; it exposes the raw binding as `native`. */
+export function resolveNodePtyEchoStateSupport(
+  nodePtyModule: unknown,
+  platform: NodeJS.Platform = process.platform
+): NodePtyEchoStateLookup {
+  const native = (nodePtyModule as { native?: unknown } | null | undefined)?.native
+  if (typeof native !== 'object' || native === null) {
+    return {
+      available: false,
+      nativeExports: [],
+      reason:
+        platform === 'win32'
+          ? 'ConPTY has no slave line discipline to read, so node-pty exposes no native binding'
+          : `node-pty exposed no native binding to read echoState from. ${NODE_PTY_SOURCE_BUILD_HINT}`
+    }
+  }
+  const nativeExports = Object.keys(native as Record<string, unknown>)
+  if (typeof (native as Record<string, unknown>).echoState !== 'function') {
+    return {
+      available: false,
+      nativeExports,
+      reason: `the loaded node-pty native binding exports [${nativeExports.join(', ')}] and has no echoState, so it is an upstream prebuild rather than a build of Orca's patch — every sync probe would answer 'unknown' and #13892's same-turn reply would be off. ${NODE_PTY_SOURCE_BUILD_HINT}`
+    }
+  }
+  return { available: true, nativeExports }
+}
+
+/**
+ * The message to fail with when CI demanded a source-built node-pty and did not get
+ * one, else null.
+ *
+ * Assert this in a test that always runs, so the requirement cannot vanish with the
+ * suite it guards.
+ */
+export function nodePtyEchoStateRequirementViolation(
+  lookup: NodePtyEchoStateLookup,
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  if (lookup.available || env[REQUIRE_NODE_PTY_ECHO_STATE_ENV_VAR] !== '1') {
+    return null
+  }
+  return `${REQUIRE_NODE_PTY_ECHO_STATE_ENV_VAR}=1 but the patched-node-pty tests would skip: ${lookup.reason}`
+}

--- a/src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts
+++ b/src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts
@@ -12,6 +12,11 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import {
+  NODE_PTY_SOURCE_BUILD_HINT,
+  nodePtyEchoStateRequirementViolation,
+  resolveNodePtyEchoStateSupport
+} from './node-pty-echo-state-requirement'
 import { PtyStartupIngress } from './pty-startup-ingress'
 import {
   createPtySlaveEchoProbe,
@@ -57,6 +62,13 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<b
 describe('a cooked querier still gets its answer (#12112)', () => {
   let workDir: string | null = null
 
+  // Always runs: a prebuilt node-pty has no echoState, so the fast path this suite
+  // proves cannot fire would be off anyway and every case below would be vacuous.
+  it('has the source-built node-pty this suite needs when CI requires one', async () => {
+    const lookup = resolveNodePtyEchoStateSupport(await import('node-pty'))
+    expect(nodePtyEchoStateRequirementViolation(lookup)).toBeNull()
+  })
+
   afterEach(() => {
     if (workDir) {
       rmSync(workDir, { recursive: true, force: true })
@@ -69,8 +81,14 @@ describe('a cooked querier still gets its answer (#12112)', () => {
   for (const rawDelayMs of [50, 250]) {
     itOnPosix(
       `delivers the reply to a querier that arms raw mode ${rawDelayMs}ms late`,
-      async () => {
+      async ({ skip }) => {
         const nodePty = await import('node-pty')
+        // Skip rather than red a developer whose node_modules predates the patch; CI
+        // sets ORCA_REQUIRE_NODE_PTY_ECHO_STATE=1 so the same state fails there.
+        const echoStateSupport = resolveNodePtyEchoStateSupport(nodePty)
+        if (!echoStateSupport.available) {
+          skip(echoStateSupport.reason)
+        }
         workDir = mkdtempSync(path.join(tmpdir(), 'orca-cooked-querier-'))
         const querierScript = path.join(workDir, 'cooked-querier.mjs')
         writeFileSync(querierScript, QUERIER_SOURCE)
@@ -85,10 +103,13 @@ describe('a cooked querier still gets its answer (#12112)', () => {
 
         const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(term))
         const echoSyncProbe = createPtySlaveEchoSyncProbe(term)
+        // Vacuity guard: a DEFINED probe proves nothing — the JS patch alone yields one
+        // that answers 'unknown' forever. The `verdictsAtQuery` assertion below is the
+        // real check; this one names the cause when the native binding is a prebuild.
         expect(
-          echoSyncProbe,
-          'node-pty must be built from source so Orca’s echoState patch is active'
-        ).toBeDefined()
+          echoSyncProbe?.(),
+          `the sync probe gave no definite verdict, so #13892's same-turn reply is off. ${NODE_PTY_SOURCE_BUILD_HINT}`
+        ).toMatch(/^(quiet|echoing)$/)
 
         let rendered = ''
         const verdictsAtQuery: PtySlaveLineDisciplineEcho[] = []

--- a/src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts
+++ b/src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The population the ECHO hold exists for: a program that queries while its tty is
+ * still COOKED and only arms raw mode later (#12112).
+ *
+ * This is the guard that kills "drop the reply when the hold expires" — the querier is
+ * blocked on the answer, so a dropped reply is a hung pane, not a cosmetic glitch. It is
+ * also what proves #13892's same-turn fast path cannot fire here: the sync probe reads
+ * `echoing` for as long as the querier stays cooked, so delivery behaves exactly as it
+ * did before the fast path existed, and the answer still arrives.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PtyStartupIngress } from './pty-startup-ingress'
+import {
+  createPtySlaveEchoProbe,
+  createPtySlaveEchoSyncProbe,
+  readPtySlavePath,
+  type PtySlaveLineDisciplineEcho
+} from './pty-slave-line-discipline-echo'
+import { extractOnlyCookedEchoSafeQueryReplies } from './terminal-query-reply'
+
+const OSC11_QUERY = '\x1b]11;?\x07'
+const OSC11_REPLY = '\x1b]11;rgb:1e1e/1e1e/1e1e\x07'
+const itOnPosix = process.platform === 'win32' ? it.skip : it
+
+/** Queries OSC 11 while cooked, arms raw only after `rawDelayMs`, then reports what it read. */
+const QUERIER_SOURCE = `
+const rawDelayMs = Number(process.argv[2])
+let received = ''
+process.stdout.write(${JSON.stringify(OSC11_QUERY)})
+setTimeout(() => {
+  process.stdin.setRawMode(true)
+  process.stdin.on('data', (chunk) => {
+    received += chunk.toString('utf8')
+    if (!received.includes('\\u0007') && !received.includes('\\u001b\\\\')) return
+    process.stdout.write('QUERIER-GOT:' + JSON.stringify(received) + '\\n')
+    process.exit(0)
+  })
+}, rawDelayMs)
+`
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true
+    }
+    await sleep(10)
+  }
+  return false
+}
+
+describe('a cooked querier still gets its answer (#12112)', () => {
+  let workDir: string | null = null
+
+  afterEach(() => {
+    if (workDir) {
+      rmSync(workDir, { recursive: true, force: true })
+      workDir = null
+    }
+  })
+
+  // 250ms outruns the 200ms probe budget, so the deadline flush answers instead of the
+  // probe; both must still deliver. A raw-delay under the budget is the probe's own path.
+  for (const rawDelayMs of [50, 250]) {
+    itOnPosix(
+      `delivers the reply to a querier that arms raw mode ${rawDelayMs}ms late`,
+      async () => {
+        const nodePty = await import('node-pty')
+        workDir = mkdtempSync(path.join(tmpdir(), 'orca-cooked-querier-'))
+        const querierScript = path.join(workDir, 'cooked-querier.mjs')
+        writeFileSync(querierScript, QUERIER_SOURCE)
+
+        const term = nodePty.spawn(process.execPath, [querierScript, String(rawDelayMs)], {
+          name: 'xterm-256color',
+          cols: 120,
+          rows: 30,
+          cwd: workDir,
+          env: { PATH: process.env.PATH ?? '/usr/bin:/bin', TERM: 'xterm-256color' }
+        })
+
+        const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(term))
+        const echoSyncProbe = createPtySlaveEchoSyncProbe(term)
+        expect(
+          echoSyncProbe,
+          'node-pty must be built from source so Orca’s echoState patch is active'
+        ).toBeDefined()
+
+        let rendered = ''
+        const verdictsAtQuery: PtySlaveLineDisciplineEcho[] = []
+        const ingress = new PtyStartupIngress({
+          ownerBackend: 'posix-pty',
+          write: (data) => term.write(data),
+          onEmission: (emission) => {
+            rendered += emission.data
+            if (!emission.data.includes(OSC11_QUERY)) {
+              return
+            }
+            verdictsAtQuery.push(echoSyncProbe?.() ?? 'unknown')
+            // The host gate, verbatim from local-pty-provider.write().
+            if (extractOnlyCookedEchoSafeQueryReplies(OSC11_REPLY)) {
+              ingress.answerLiveQueryReply(OSC11_REPLY)
+            }
+          },
+          ...(echoProbe ? { echoProbe } : {}),
+          ...(echoSyncProbe ? { echoSyncProbe } : {})
+        })
+
+        let exited = false
+        term.onExit(() => {
+          exited = true
+        })
+        term.onData((data) => ingress.accept(data))
+
+        try {
+          expect(await waitUntil(() => rendered.includes('QUERIER-GOT:'), 15_000)).toBe(true)
+          // The querier was cooked when it asked, so the fast path was never eligible.
+          expect(verdictsAtQuery).toEqual(['echoing'])
+          expect(rendered).toContain('QUERIER-GOT:')
+          expect(/QUERIER-GOT:"([^"]*)"/.exec(rendered)?.[1]).toContain('rgb:1e1e/1e1e/1e1e')
+        } finally {
+          await waitUntil(() => exited, 3_000)
+          try {
+            term.kill()
+          } catch {
+            // already gone
+          }
+        }
+      },
+      30_000
+    )
+  }
+})

--- a/src/shared/pty-slave-line-discipline-echo.test.ts
+++ b/src/shared/pty-slave-line-discipline-echo.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 const execFileMock = vi.hoisted(() => vi.fn())
 vi.mock('node:child_process', () => ({ execFile: execFileMock }))
 
-import { createPtySlaveEchoProbe, readPtySlavePath } from './pty-slave-line-discipline-echo'
+import {
+  createPtySlaveEchoProbe,
+  createPtySlaveEchoSyncProbe,
+  readPtySlavePath
+} from './pty-slave-line-discipline-echo'
 
 /** Replies to the next stty call with the given output, or an error when `output` is null. */
 function answerStty(output: string | null): void {
@@ -130,5 +134,53 @@ describe('createPtySlaveEchoProbe', () => {
     answerStty(RAW)
     await createPtySlaveEchoProbe('/dev/pts/3', 'linux')?.()
     expect(execFileMock.mock.calls[1]?.[1]).toEqual(['-a', '-F', '/dev/pts/3'])
+  })
+})
+
+describe('createPtySlaveEchoSyncProbe', () => {
+  it('maps the native ECHO bit to the same verdicts as the stty probe', () => {
+    expect(createPtySlaveEchoSyncProbe({ readEchoState: () => 1 }, 'darwin')?.()).toBe('echoing')
+    expect(createPtySlaveEchoSyncProbe({ readEchoState: () => 0 }, 'linux')?.()).toBe('quiet')
+  })
+
+  it('has no probe to offer where there is no line discipline or no patched node-pty', () => {
+    // ConPTY: the fast path must never engage on Windows.
+    expect(createPtySlaveEchoSyncProbe({ readEchoState: () => 0 }, 'win32')).toBeUndefined()
+    // An unpatched or prebuilt binding — an older relay host is exactly this shape.
+    expect(createPtySlaveEchoSyncProbe({}, 'darwin')).toBeUndefined()
+    expect(createPtySlaveEchoSyncProbe({ readEchoState: 'nope' }, 'darwin')).toBeUndefined()
+    expect(createPtySlaveEchoSyncProbe(undefined, 'darwin')).toBeUndefined()
+    expect(createPtySlaveEchoSyncProbe(null, 'darwin')).toBeUndefined()
+  })
+
+  it('never reads a failure as proof of quiet', () => {
+    // -1 is the addon's own "fd unreadable" answer; a throw is a reaped pty.
+    expect(createPtySlaveEchoSyncProbe({ readEchoState: () => -1 }, 'darwin')?.()).toBe('unknown')
+    expect(createPtySlaveEchoSyncProbe({ readEchoState: () => undefined }, 'darwin')?.()).toBe(
+      'unknown'
+    )
+    expect(
+      createPtySlaveEchoSyncProbe(
+        {
+          readEchoState: () => {
+            throw new Error('EBADF')
+          }
+        },
+        'darwin'
+      )?.()
+    ).toBe('unknown')
+  })
+
+  it('reads the bit through the terminal, so a live toggle is observed', () => {
+    const term = {
+      echo: 1,
+      readEchoState(): number {
+        return this.echo
+      }
+    }
+    const probe = createPtySlaveEchoSyncProbe(term, 'darwin')
+    expect(probe?.()).toBe('echoing')
+    term.echo = 0
+    expect(probe?.()).toBe('quiet')
   })
 })

--- a/src/shared/pty-slave-line-discipline-echo.ts
+++ b/src/shared/pty-slave-line-discipline-echo.ts
@@ -10,6 +10,9 @@ export type PtySlaveLineDisciplineEcho = 'echoing' | 'quiet' | 'unknown'
 
 export type PtySlaveEchoProbe = () => Promise<PtySlaveLineDisciplineEcho>
 
+/** Same verdict, read without a fork — cheap enough to consult inside a query's own turn. */
+export type PtySlaveEchoSyncProbe = () => PtySlaveLineDisciplineEcho
+
 const STTY_TIMEOUT_MS = 2_000
 // `stty -a` prints the lflags as a space-separated list where a disabled flag is
 // prefixed with `-`, so `echo` and `-echo` are the two tokens that matter.
@@ -69,6 +72,41 @@ function runStty(ptsName: string, platform: NodeJS.Platform): Promise<SttyProbeR
 export function readPtySlavePath(pty: unknown): string | undefined {
   const candidate = (pty as { ptsName?: unknown } | null | undefined)?.ptsName
   return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined
+}
+
+/**
+ * Fork-free ECHO read off the master fd Orca already owns (#13892).
+ *
+ * POSIX redirects a master's mode ioctls to the slave, so node-pty's patched
+ * `readEchoState` answers for the slave without a subprocess — which is what makes it
+ * usable inside the query's own event-loop turn, where the async probe is not. A host
+ * whose node-pty is unpatched (older relay, upstream prebuild) has no such method and
+ * gets no probe, so it keeps today's deferred behavior with no wire change.
+ */
+export function createPtySlaveEchoSyncProbe(
+  pty: unknown,
+  platform: NodeJS.Platform = process.platform
+): PtySlaveEchoSyncProbe | undefined {
+  if (platform === 'win32') {
+    return undefined
+  }
+  const readEchoState = (pty as { readEchoState?: unknown } | null | undefined)?.readEchoState
+  if (typeof readEchoState !== 'function') {
+    return undefined
+  }
+  return () => {
+    let state: unknown
+    try {
+      state = (readEchoState as (this: unknown) => unknown).call(pty)
+    } catch {
+      return 'unknown'
+    }
+    if (state === 1) {
+      return 'echoing'
+    }
+    // -1 (unreadable fd) and anything unexpected must not read as proof of quiet.
+    return state === 0 ? 'quiet' : 'unknown'
+  }
 }
 
 /**

--- a/src/shared/pty-startup-ingress-contract.ts
+++ b/src/shared/pty-startup-ingress-contract.ts
@@ -1,6 +1,6 @@
 import type { PtyOwnerBackend } from './pty-owner-backend'
 import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
-import type { PtySlaveEchoProbe } from './pty-slave-line-discipline-echo'
+import type { PtySlaveEchoProbe, PtySlaveEchoSyncProbe } from './pty-slave-line-discipline-echo'
 
 export type PtyIngressEmission = {
   data: string
@@ -20,6 +20,13 @@ export type PtyStartupIngressOptions = {
    * on backends with no line discipline to read (ConPTY, wsl.exe).
    */
   echoProbe?: PtySlaveEchoProbe
+  /**
+   * Same verdict without a fork, so it can be consulted inside the query's own turn.
+   * A `quiet` answer here writes the reply immediately rather than deferring it, which
+   * is what keeps a later reply in the same turn from overtaking it (#13892). Absent
+   * when the host's node-pty lacks Orca's patch, which degrades to `echoProbe` alone.
+   */
+  echoSyncProbe?: PtySlaveEchoSyncProbe
 }
 
 export type PtyIngressSourceSpan = {

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -55,7 +55,12 @@ export class PtyStartupIngress {
   constructor(options: PtyStartupIngressOptions) {
     this.intent = options.intent
     this.ownerBackend = options.ownerBackend ?? 'posix-pty'
-    this.delivery = new PtyStartupReplyDelivery(this.ownerBackend, options.write, options.echoProbe)
+    this.delivery = new PtyStartupReplyDelivery(
+      this.ownerBackend,
+      options.write,
+      options.echoProbe,
+      options.echoSyncProbe
+    )
     this.onEmission = options.onEmission
     this.queryOpen = options.intent !== undefined
     if (options.intent) {
@@ -368,12 +373,7 @@ export class PtyStartupIngress {
   }
 
   private emit(span: PtyIngressSourceSpan, transformed: boolean, data = span.data): void {
-    this.onEmission({
-      data,
-      rawStartSeq: span.rawStartSeq,
-      rawEndSeq: span.rawEndSeq,
-      transformed
-    })
+    this.onEmission({ data, rawStartSeq: span.rawStartSeq, rawEndSeq: span.rawEndSeq, transformed })
   }
 
   private clearDeadline(): void {

--- a/src/shared/pty-startup-reply-delivery.test.ts
+++ b/src/shared/pty-startup-reply-delivery.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The same-turn fast path (#13892) and the ordering property that bounds it.
+ *
+ * A held reply is overtaken by anything written later in the same turn — fish's DA1
+ * sentinel is exactly that — and the held bytes then land in the next child's stdin.
+ * So a reply the kernel cannot echo must be written inside the query's own turn.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { PtyStartupReplyDelivery } from './pty-startup-reply-delivery'
+import type { PtySlaveLineDisciplineEcho } from './pty-slave-line-discipline-echo'
+
+const OSC11_REPLY = '\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\'
+const OSC10_REPLY = '\x1b]10;rgb:ffff/ffff/ffff\x1b\\'
+
+function createDelivery(syncState: PtySlaveLineDisciplineEcho | null): {
+  delivery: PtyStartupReplyDelivery
+  written: string[]
+  asyncProbe: ReturnType<typeof vi.fn>
+} {
+  const written: string[] = []
+  // Present but never resolved, so anything reaching it is visibly a deferral.
+  const asyncProbe = vi.fn(() => new Promise<PtySlaveLineDisciplineEcho>(() => {}))
+  const delivery = new PtyStartupReplyDelivery(
+    'posix-pty',
+    (data) => written.push(data),
+    asyncProbe,
+    syncState === null ? undefined : () => syncState
+  )
+  return { delivery, written, asyncProbe }
+}
+
+describe('PtyStartupReplyDelivery same-turn fast path', () => {
+  it('writes inside the query turn when the kernel is provably quiet', () => {
+    const { delivery, written, asyncProbe } = createDelivery('quiet')
+
+    expect(delivery.answer(OSC11_REPLY)).toBe(true)
+
+    expect(written).toEqual([OSC11_REPLY])
+    expect(asyncProbe).not.toHaveBeenCalled()
+  })
+
+  it('still projects the software echo shapes a quiet kernel says nothing about', () => {
+    const { delivery, written } = createDelivery('quiet')
+
+    delivery.answer(OSC11_REPLY)
+
+    // readline rewrites OSC as BEL and echoes it at a raw ECHO-off prompt (#12112), so
+    // only the kernel's caret projection may retire on a `quiet` verdict.
+    expect(delivery.hasExpectedEcho).toBe(true)
+    expect(delivery.matchEcho(`\x07${written[0]?.slice(2, -2) ?? ''}`).kind).toBe('complete')
+    expect(delivery.matchEcho(OSC11_REPLY.replaceAll('\x1b', '^[')).kind).toBe('none')
+  })
+
+  it('defers exactly as before when the probe cannot prove quiet', () => {
+    for (const state of ['echoing', 'unknown', null] as const) {
+      const { delivery, written } = createDelivery(state)
+      expect(delivery.answer(OSC11_REPLY)).toBe(true)
+      expect(written).toEqual([])
+    }
+  })
+
+  it('queues behind a held reply rather than overtaking it', () => {
+    const written: string[] = []
+    // The tty goes raw between the two queries, which is precisely when a fast path
+    // without the empty-queue guard would deliver reply #2 ahead of reply #1.
+    const verdicts: PtySlaveLineDisciplineEcho[] = ['echoing', 'quiet']
+    const delivery = new PtyStartupReplyDelivery(
+      'posix-pty',
+      (data) => written.push(data),
+      undefined,
+      () => verdicts.shift() ?? 'quiet'
+    )
+
+    delivery.answer(OSC11_REPLY)
+    expect(written).toEqual([])
+    delivery.answer(OSC10_REPLY)
+    expect(written).toEqual([])
+
+    // Both land together, in query order, when the held queue flushes.
+    delivery.reset()
+    expect(written).toEqual([OSC11_REPLY, OSC10_REPLY])
+    delivery.close()
+  })
+
+  it('leaves ConPTY untouched: no probe is consulted and the write is immediate', () => {
+    const written: string[] = []
+    const syncProbe = vi.fn((): PtySlaveLineDisciplineEcho => 'quiet')
+    const delivery = new PtyStartupReplyDelivery(
+      'windows-conpty',
+      (data) => written.push(data),
+      undefined,
+      syncProbe
+    )
+
+    expect(delivery.answer(OSC11_REPLY)).toBe(true)
+    expect(written).toEqual([OSC11_REPLY])
+    expect(syncProbe).not.toHaveBeenCalled()
+  })
+
+  it('reports failure for the reply that failed, without deferring it first', () => {
+    const onFailed = vi.fn()
+    const delivery = new PtyStartupReplyDelivery(
+      'posix-pty',
+      () => {
+        throw new Error('pty gone')
+      },
+      undefined,
+      () => 'quiet'
+    )
+
+    expect(delivery.answer(OSC11_REPLY, onFailed)).toBe(false)
+    // The deferred path answers `true` and calls back later; a same-turn write knows now.
+    expect(onFailed).toHaveBeenCalledTimes(1)
+    expect(delivery.hasExpectedEcho).toBe(false)
+  })
+})

--- a/src/shared/pty-startup-reply-delivery.ts
+++ b/src/shared/pty-startup-reply-delivery.ts
@@ -1,5 +1,5 @@
 import type { PtyOwnerBackend } from './pty-owner-backend'
-import type { PtySlaveEchoProbe } from './pty-slave-line-discipline-echo'
+import type { PtySlaveEchoProbe, PtySlaveEchoSyncProbe } from './pty-slave-line-discipline-echo'
 
 // Why this module exists: a startup color reply is written to the PTY master, so
 // whatever line discipline sits between Orca and the querying program can echo it
@@ -7,7 +7,9 @@ import type { PtySlaveEchoProbe } from './pty-slave-line-discipline-echo'
 // bytes stripped; a POSIX tty echoes it while the querying program is still cooked.
 // A program that queries before clearing ECHO loses that race if Orca answers
 // inside the query's own turn, so on POSIX the write waits until the slave's ECHO
-// bit is observably clear, and recognized echo shapes cover what remains.
+// bit is observably clear, and recognized echo shapes cover what remains. When a
+// fork-free probe can prove ECHO is already clear, the wait is skipped outright —
+// see `answer()`, and #13892 for why deferring a reply that needs no wait is unsafe.
 //
 // Deliberately NO re-send on a matched echo: ECHO copies bytes to the master
 // without consuming them from the slave's input queue, so a program that arms raw
@@ -181,7 +183,8 @@ export class PtyStartupReplyDelivery {
   constructor(
     private readonly ownerBackend: PtyOwnerBackend,
     private readonly writeProvider: (data: string) => void,
-    private readonly echoProbe?: PtySlaveEchoProbe
+    private readonly echoProbe?: PtySlaveEchoProbe,
+    private readonly echoSyncProbe?: PtySlaveEchoSyncProbe
   ) {}
 
   get hasExpectedEcho(): boolean {
@@ -203,6 +206,15 @@ export class PtyStartupReplyDelivery {
     if (!defersWrite(this.ownerBackend)) {
       // Why: ConPTY answers the query itself unless Orca beats it in this turn.
       return this.writeReply(reply)
+    }
+    // Why answer in this turn when the kernel is already quiet: ANY deferral, however
+    // short, lets a reply written later in the same turn overtake this one — fish's DA1
+    // read sentinel does exactly that, and the held OSC reply then lands in the NEXT
+    // child's stdin (#13892). Measured: the leak reproduces at a 5ms defer, so only a
+    // same-turn write closes it. Requiring an empty queue is what preserves order: a
+    // reply arriving behind a held one still queues instead of jumping it.
+    if (this.pendingWrites.length === 0 && this.echoSyncProbe?.() === 'quiet') {
+      return this.writeReply(reply, onFailed, true)
     }
     if (this.pendingWrites.length >= MAX_TRACKED_REPLIES) {
       this.flushPendingWrites()

--- a/tests/tools/fish-query-reply-order/capture-reply-order-trace.mjs
+++ b/tests/tools/fish-query-reply-order/capture-reply-order-trace.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+/**
+ * Ground-truth repro harness for #13892: terminal query replies reach a POSIX pty
+ * OUT OF THE ORDER the queries were observed, so fish's DA1 read sentinel hands the
+ * tty to the child before the OSC 11 reply lands — and the child reads it as stdin.
+ *
+ * The pipeline below is Orca's, not a mock of it:
+ *
+ *   real fish (node-pty)
+ *     -> PtyStartupIngress.accept()                  (src/shared/pty-startup-ingress.ts)
+ *     -> onEmission                                   == what the renderer's xterm sees
+ *     -> renderer model: parse queries IN STREAM ORDER, emit one reply per query
+ *     -> providerWrite()                              == local-pty-provider.write() VERBATIM
+ *          echo-safe (OSC / private DSR) -> ingress.answerLiveQueryReply -> PtyStartupReplyDelivery
+ *          everything else               -> pty.write immediately
+ *
+ * The renderer model answers strictly in the order the queries appeared in the
+ * stream. It never reorders. Any inversion the trace shows is produced by the
+ * delivery split alone. (A previous harness for the sibling bug answered DA1 first
+ * unconditionally, which no real terminal does, and its evidence was worthless.)
+ *
+ * Usage:
+ *   node tests/tools/fish-query-reply-order/capture-reply-order-trace.mjs [options]
+ *
+ * Default mode now runs the SHIPPED fix, since providerWrite is still the host gate
+ * verbatim; the two modes below are the controls it was compared against.
+ *
+ *   --bypass-echo-safe  control: write every reply straight to the pty, in order
+ *   --order-fifo        control: the fix modelled in-harness instead of in src, so the
+ *                       two can be compared — an immediate reply may not overtake an
+ *                       echo-safe reply queued before it
+ *   --uniform-delay=<ms> control: every reply delayed by <ms>, still in order —
+ *                       separates "late" from "out of order"
+ *   --shell=<path>      fish binary (default /opt/homebrew/bin/fish)
+ *   --no-typeahead      type the command at an idle prompt instead of type-ahead
+ *   --settle=<ms>       quiet time after the first prompt (default 500)
+ *   --json              append a machine-readable summary line
+ */
+
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { createRequire, registerHooks } from 'node:module'
+import { spawnSync } from 'node:child_process'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../..')
+
+// The delivery class uses constructor parameter properties, which strip-only mode rejects.
+if (process.features.typescript !== 'transform') {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', import.meta.filename, ...process.argv.slice(2)],
+    { stdio: 'inherit' }
+  )
+  process.exit(result.status ?? 1)
+}
+
+// Orca's src/ uses extensionless relative imports; node's TS resolver does not.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    try {
+      return nextResolve(specifier, context)
+    } catch (error) {
+      if (specifier.startsWith('.')) {
+        return nextResolve(`${specifier}.ts`, context)
+      }
+      throw error
+    }
+  }
+})
+
+const require = createRequire(import.meta.url)
+const pty = require(path.join(REPO_ROOT, 'node_modules/node-pty'))
+const { PtyStartupIngress } = await import(path.join(REPO_ROOT, 'src/shared/pty-startup-ingress.ts'))
+const { extractOnlyCookedEchoSafeQueryReplies } = await import(
+  path.join(REPO_ROOT, 'src/shared/terminal-query-reply.ts')
+)
+const { createPtySlaveEchoProbe, createPtySlaveEchoSyncProbe, readPtySlavePath } = await import(
+  path.join(REPO_ROOT, 'src/shared/pty-slave-line-discipline-echo.ts')
+)
+const { resolvePtyOwnerBackend } = await import(
+  path.join(REPO_ROOT, 'src/shared/pty-owner-backend.ts')
+)
+
+// ---------------------------------------------------------------- args
+
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(`--${name}`)
+const opt = (name, fallback) => {
+  const hit = argv.find((a) => a.startsWith(`--${name}=`))
+  return hit === undefined ? fallback : hit.slice(name.length + 3)
+}
+
+const SHELL = opt('shell', '/opt/homebrew/bin/fish')
+const BYPASS_ECHO_SAFE = flag('bypass-echo-safe')
+const ORDER_FIFO = flag('order-fifo')
+const TYPEAHEAD = !flag('no-typeahead')
+const SETTLE_MS = Number(opt('settle', '500'))
+const TYPEAHEAD_AT_MS = Number(opt('typeahead-at', '150'))
+const EMIT_JSON = flag('json')
+const UNIFORM_DELAY_MS = Number(opt('uniform-delay', '-1'))
+const MODE =
+  UNIFORM_DELAY_MS >= 0
+    ? `uniform-delay-${UNIFORM_DELAY_MS}ms`
+    : BYPASS_ECHO_SAFE
+      ? 'bypass-echo-safe'
+      : ORDER_FIFO
+        ? 'order-fifo'
+        : 'main'
+
+if ([BYPASS_ECHO_SAFE, ORDER_FIFO, UNIFORM_DELAY_MS >= 0].filter(Boolean).length > 1) {
+  console.error('--bypass-echo-safe, --order-fifo and --uniform-delay are mutually exclusive')
+  process.exit(2)
+}
+
+const PROMPT_MARK = 'HARNESS> '
+const LEAK_FILE = path.join(mkdtempSync(path.join(tmpdir(), 'fish-reply-order-')), 'child-stdin.txt')
+const CHILD_CMD = `python3 -c 'import sys, os; d = sys.stdin.readline(); open(os.environ["ORCA_LEAK_OUT"], "w").write(d); print("GOT:", repr(d))'`
+
+// ---------------------------------------------------------------- tracing
+
+const t0 = process.hrtime.bigint()
+const ms = () => Number(process.hrtime.bigint() - t0) / 1e6
+const trace = []
+function log(dir, label, detail) {
+  const line = `[${ms().toFixed(3).padStart(10, ' ')}ms] ${dir.padEnd(16)} ${label}${detail ? ` ${detail}` : ''}`
+  trace.push(line)
+  console.log(line)
+}
+
+function esc(s) {
+  let out = ''
+  for (const ch of s) {
+    const c = ch.codePointAt(0)
+    if (ch === '\x1b') {
+      out += '\\e'
+    } else if (ch === '\n') {
+      out += '\\n'
+    } else if (ch === '\r') {
+      out += '\\r'
+    } else if (ch === '\t') {
+      out += '\\t'
+    } else if (c < 0x20 || c === 0x7f) {
+      out += `\\x${c.toString(16).padStart(2, '0')}`
+    } else {
+      out += ch
+    }
+  }
+  return out
+}
+const CHUNK_CAP = 900
+const escCapped = (s) => {
+  const e = esc(s)
+  return e.length > CHUNK_CAP ? `${e.slice(0, CHUNK_CAP)}…<+${e.length - CHUNK_CAP}>` : e
+}
+
+// ---------------------------------------------------------------- fish config
+
+const configHome = mkdtempSync(path.join(tmpdir(), 'fish-reply-order-cfg-'))
+mkdirSync(path.join(configHome, 'fish'), { recursive: true })
+writeFileSync(
+  path.join(configHome, 'fish/config.fish'),
+  [
+    'set -g fish_greeting ""',
+    `function fish_prompt; printf '${PROMPT_MARK}'; end`,
+    'function fish_right_prompt; end',
+    ''
+  ].join('\n')
+)
+const env = {
+  ...process.env,
+  TERM: 'xterm-256color',
+  COLORTERM: 'truecolor',
+  LANG: 'en_US.UTF-8',
+  XDG_CONFIG_HOME: configHome,
+  XDG_DATA_HOME: path.join(configHome, 'data'),
+  ORCA_LEAK_OUT: LEAK_FILE
+}
+delete env.FISH_HISTORY
+
+// ---------------------------------------------------------------- pty + Orca pipeline
+
+log(
+  'HARNESS',
+  'config',
+  JSON.stringify({ mode: MODE, shell: SHELL, typeahead: TYPEAHEAD, settleMs: SETTLE_MS, leakFile: LEAK_FILE })
+)
+
+const term = pty.spawn(SHELL, ['-l', '-i'], {
+  name: 'xterm-256color',
+  cols: 120,
+  rows: 30,
+  cwd: REPO_ROOT,
+  env
+})
+
+let rawOutput = ''
+let ptyWriteSeq = 0
+const replies = []
+/** Every byte that actually reaches the pty master, in real order. */
+function ptyWrite(data, route, replyRecord) {
+  const seq = ++ptyWriteSeq
+  if (replyRecord) {
+    replyRecord.writeSeq = seq
+    replyRecord.writtenAt = ms()
+    replyRecord.route = route
+  }
+  log('ORCA->PTY', `write#${seq} ${route}`, `"${esc(data)}"`)
+  term.write(data)
+}
+
+const ownerBackend = resolvePtyOwnerBackend({ platform: process.platform, shellPath: SHELL })
+const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(term))
+const echoSyncProbe = createPtySlaveEchoSyncProbe(term)
+log(
+  'HARNESS',
+  'pipeline',
+  JSON.stringify({
+    ownerBackend,
+    echoProbe: Boolean(echoProbe),
+    echoSyncProbe: Boolean(echoSyncProbe),
+    ptsName: readPtySlavePath(term) ?? null
+  })
+)
+
+// FIFO model: an immediate reply may not overtake an echo-safe reply queued ahead of it.
+const fifo = { deferred: 0, held: [] }
+
+const ingress = new PtyStartupIngress({
+  ownerBackend,
+  write: (data) => {
+    const record = deferredByReply.get(data)?.shift()
+    ptyWrite(data, `delivery-flush(${record?.echoSafe === false ? 'in-order' : 'echo-safe'})`, record)
+    if (!ORDER_FIFO) {
+      return
+    }
+    fifo.deferred = Math.max(0, fifo.deferred - 1)
+    if (fifo.deferred === 0) {
+      for (const pending of fifo.held.splice(0)) {
+        ptyWrite(pending.reply, 'immediate(fifo-released)', pending.record)
+      }
+    }
+  },
+  onEmission: (emission) => {
+    log('INGRESS->UI', `emit len=${emission.data.length}`, `"${escCapped(emission.data)}"`)
+    scanRendererStream(emission.data)
+  },
+  ...(echoProbe ? { echoProbe } : {}),
+  ...(echoSyncProbe ? { echoSyncProbe } : {})
+})
+
+/** Reply text -> records awaiting the delivery flush, so the trace can pair them up. */
+const deferredByReply = new Map()
+
+// VERBATIM from local-pty-provider.write() (src/main/providers/local-pty-provider.ts ~:1082).
+function providerWrite(data, record) {
+  if (extractOnlyCookedEchoSafeQueryReplies(data)) {
+    const queue = deferredByReply.get(data) ?? []
+    queue.push(record)
+    deferredByReply.set(data, queue)
+    if (ingress.answerLiveQueryReply(data)) {
+      return true
+    }
+    queue.pop()
+  }
+  ptyWrite(data, 'immediate', record)
+  return false
+}
+
+term.onData((data) => {
+  rawOutput += data
+  log('PTY->INGRESS', `read len=${data.length}`, `"${escCapped(data)}"`)
+  ingress.accept(data)
+})
+
+let exitInfo = null
+term.onExit((e) => {
+  exitInfo = e
+  log('PTY', 'exit', JSON.stringify(e))
+})
+
+// ------------------------------------------------- renderer (xterm) query -> reply model
+
+/* oxlint-disable no-control-regex -- terminal query grammars are control sequences by definition */
+// Anchored at an ESC, tried in order; first match wins. Reply values match xterm.js's.
+const QUERY_GRAMMARS = [
+  { name: 'OSC10', re: /^\x1b\]10;\?(\x07|\x1b\\)/, reply: (m) => `\x1b]10;rgb:ffff/ffff/ffff${m[1]}` },
+  { name: 'OSC11', re: /^\x1b\]11;\?(\x07|\x1b\\)/, reply: (m) => `\x1b]11;rgb:1e1e/1e1e/1e1e${m[1]}` },
+  { name: 'OSC12', re: /^\x1b\]12;\?(\x07|\x1b\\)/, reply: (m) => `\x1b]12;rgb:ffff/ffff/ffff${m[1]}` },
+  { name: 'DECXCPR', re: /^\x1b\[\?6n/, reply: () => '\x1b[?1;1;1R' },
+  { name: 'CPR', re: /^\x1b\[6n/, reply: () => '\x1b[1;1R' },
+  { name: 'DSR-2031', re: /^\x1b\[\?996n/, reply: () => '\x1b[?997;1n' },
+  { name: 'DSR', re: /^\x1b\[5n/, reply: () => '\x1b[0n' },
+  { name: 'DA2', re: /^\x1b\[>0?c/, reply: () => '\x1b[>0;276;0c' },
+  { name: 'DA3', re: /^\x1b\[=0?c/, reply: () => '\x1bP!|00000000\x1b\\' },
+  { name: 'DA1', re: /^\x1b\[0?c/, reply: () => '\x1b[?1;2c' },
+  { name: 'XTVERSION', re: /^\x1b\[>0?q/, reply: () => '\x1bP>|Orca(harness)\x1b\\' },
+  { name: 'KITTY-FLAGS', re: /^\x1b\[\?u/, reply: () => '\x1b[?0u' },
+  { name: 'XTWINOPS', re: /^\x1b\[(?:14|16|18)t/, reply: () => '\x1b[4;600;1200t' }
+]
+// A sequence still accumulating: no CSI final byte / no OSC-DCS terminator yet. Must be
+// exact — a loose "short tail" rule silently eats complete queries at a chunk boundary.
+const PARTIAL_QUERY_RE = new RegExp(
+  `${[
+    '^(?:\\u001b',
+    '\\u001b\\[[?>=]?[0-9;]*',
+    '\\u001b\\][0-9]*(?:;[^\\u0007\\u001b]*)?\\u001b?',
+    '\\u001bP[^\\u001b]*\\u001b?'
+  ].join('|')})$`
+)
+/* oxlint-enable no-control-regex */
+
+let rendererTail = ''
+let queryObservationSeq = 0
+
+// Single chained timer, so a uniform delay stays strictly FIFO.
+const uniformQueue = []
+let uniformTimer = null
+function drainUniformQueue() {
+  if (uniformTimer || uniformQueue.length === 0) {
+    return
+  }
+  const head = uniformQueue[0]
+  uniformTimer = setTimeout(
+    () => {
+      uniformTimer = null
+      uniformQueue.shift()
+      ptyWrite(head.reply, `uniform+${UNIFORM_DELAY_MS}ms`, head.record)
+      drainUniformQueue()
+    },
+    Math.max(0, head.dueAt - ms())
+  )
+}
+
+function emitReply(name, reply) {
+  const record = {
+    observeSeq: ++queryObservationSeq,
+    query: name,
+    reply,
+    observedAt: ms(),
+    echoSafe: extractOnlyCookedEchoSafeQueryReplies(reply) !== null,
+    writeSeq: null,
+    writtenAt: null,
+    route: null
+  }
+  replies.push(record)
+  log('UI QUERY', `#${record.observeSeq} ${name}`, `-> reply "${esc(reply)}" echoSafe=${record.echoSafe}`)
+
+  if (BYPASS_ECHO_SAFE) {
+    ptyWrite(reply, 'immediate(bypass)', record)
+    return
+  }
+  if (UNIFORM_DELAY_MS >= 0) {
+    uniformQueue.push({ reply, record, dueAt: ms() + UNIFORM_DELAY_MS })
+    drainUniformQueue()
+    return
+  }
+  if (ORDER_FIFO) {
+    if (record.echoSafe) {
+      fifo.deferred += 1
+      if (!providerWrite(reply, record)) {
+        fifo.deferred = Math.max(0, fifo.deferred - 1)
+      }
+      return
+    }
+    if (fifo.deferred > 0) {
+      log('FIFO', `hold #${record.observeSeq} ${name}`, `behind ${fifo.deferred} echo-safe reply(s)`)
+      fifo.held.push({ reply, record })
+      return
+    }
+    ptyWrite(reply, 'immediate', record)
+    return
+  }
+  providerWrite(reply, record)
+}
+
+/** Scans the emitted stream left-to-right and answers strictly in the order seen. */
+function scanRendererStream(chunk) {
+  let buf = rendererTail + chunk
+  rendererTail = ''
+  let i = 0
+  while (i < buf.length) {
+    const at = buf.indexOf('\x1b', i)
+    if (at === -1) {
+      break
+    }
+    const rest = buf.slice(at)
+    let matched = null
+    for (const grammar of QUERY_GRAMMARS) {
+      const m = grammar.re.exec(rest)
+      if (m) {
+        matched = { grammar, m }
+        break
+      }
+    }
+    if (matched) {
+      emitReply(matched.grammar.name, matched.grammar.reply(matched.m))
+      i = at + matched.m[0].length
+      continue
+    }
+    if (PARTIAL_QUERY_RE.test(rest)) {
+      rendererTail = rest // may still complete on the next emission
+      return
+    }
+    i = at + 1
+  }
+}
+
+// ---------------------------------------------------------------- driving
+
+const sleep = (n) => new Promise((r) => setTimeout(r, n))
+async function waitFor(pred, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (pred()) {
+      return true
+    }
+    await sleep(10)
+  }
+  log('HARNESS', 'TIMEOUT', `waiting for ${what}`)
+  return false
+}
+
+try {
+  await waitFor(() => rawOutput.includes(PROMPT_MARK), 15000, 'first prompt')
+  await sleep(SETTLE_MS)
+
+  if (TYPEAHEAD) {
+    log('HARNESS', 'MARK', '--- `sleep 0.4` so the next line is typed ahead ---')
+    ptyWrite('sleep 0.4\r', 'input')
+    await sleep(TYPEAHEAD_AT_MS)
+    log('HARNESS', 'MARK', '--- type-ahead: stdin-reading command + Enter while sleep owns the tty ---')
+    ptyWrite(`${CHILD_CMD}\r`, 'input')
+  } else {
+    log('HARNESS', 'MARK', '--- typing stdin-reading command at an idle prompt ---')
+    ptyWrite(`${CHILD_CMD}\r`, 'input')
+  }
+  await sleep(1500)
+
+  log('HARNESS', 'MARK', '--- sending hello + Enter to the child ---')
+  ptyWrite('hello\r', 'input')
+  await sleep(1500)
+
+  const childStdin = existsSync(LEAK_FILE) ? readFileSync(LEAK_FILE, 'utf8') : null
+  const leaked = childStdin !== null && childStdin.includes('\x1b')
+  const printedGot = (rawOutput.match(/GOT: '[^\r\n]*/) ?? [])[0] ?? null
+
+  const answered = replies.filter((r) => r.writeSeq !== null)
+  const inversions = []
+  for (let a = 0; a < answered.length; a += 1) {
+    for (let b = a + 1; b < answered.length; b += 1) {
+      if (answered[a].writeSeq > answered[b].writeSeq) {
+        inversions.push(`${answered[a].query}#${answered[a].observeSeq} after ${answered[b].query}#${answered[b].observeSeq}`)
+      }
+    }
+  }
+  const maxDeferMs = Math.max(
+    0,
+    ...answered.filter((r) => r.echoSafe).map((r) => r.writtenAt - r.observedAt)
+  )
+
+  log('HARNESS', 'RESULT mode', MODE)
+  log('HARNESS', 'RESULT child-stdin-bytes', childStdin === null ? '<child never read>' : `"${esc(childStdin)}"`)
+  log('HARNESS', 'RESULT printed-GOT-line', printedGot === null ? '<none>' : `"${esc(printedGot)}"`)
+  log('HARNESS', 'RESULT leaked-escape-bytes-into-child-stdin', String(leaked))
+  log('HARNESS', 'RESULT reply-order-inversions', `${inversions.length}${inversions.length ? ` [${inversions.slice(0, 8).join(', ')}]` : ''}`)
+  log(
+    'HARNESS',
+    'RESULT replies',
+    JSON.stringify({
+      observed: replies.length,
+      written: answered.length,
+      echoSafe: replies.filter((r) => r.echoSafe).length,
+      maxEchoSafeDeferMs: Number(maxDeferMs.toFixed(1))
+    })
+  )
+
+  ptyWrite('exit\r', 'input')
+  await waitFor(() => exitInfo !== null, 3000, 'shell exit')
+  try {
+    term.kill()
+  } catch {}
+
+  if (EMIT_JSON) {
+    console.log(
+      `\n__JSON__${JSON.stringify({
+        mode: MODE,
+        typeahead: TYPEAHEAD,
+        leaked,
+        childStdin,
+        printedGot,
+        inversions: inversions.length,
+        inversionDetail: inversions,
+        maxEchoSafeDeferMs: Number(maxDeferMs.toFixed(1)),
+        replies: replies.map((r) => ({
+          observeSeq: r.observeSeq,
+          query: r.query,
+          echoSafe: r.echoSafe,
+          writeSeq: r.writeSeq,
+          route: r.route,
+          deferMs: r.writtenAt === null ? null : Number((r.writtenAt - r.observedAt).toFixed(1))
+        }))
+      })}`
+    )
+  }
+} finally {
+  rmSync(configHome, { recursive: true, force: true })
+  rmSync(path.dirname(LEAK_FILE), { recursive: true, force: true })
+}
+
+process.exit(0)


### PR DESCRIPTION
## ELI5

fish asks the terminal "what colour is your background?" and, a moment later, "are you
there?". Orca used to hold the colour answer back for a fraction of a second (to avoid a
different bug) while sending the "are you there?" answer immediately. fish uses that second
answer as its signal that the prompt is done, so it handed the terminal to the program you
just launched — and the colour answer arrived a beat later, straight into that program's
stdin. Now Orca checks, without leaving the current turn, whether holding back is even
necessary; when it isn't, it answers immediately and nothing can overtake it.

## What Changed

1. `config/patches/node-pty@1.1.0.patch` (extends the existing patch; no new file target,
   no new module, no new prebuild artifact):
   - `src/unix/pty.cc`: new `PtyEchoState` exported as `echoState` — `tcgetattr(fd)` ->
     `1` (ECHO set) / `0` (clear) / `-1` (bad arg or error). `<termios.h>` was already
     reachable in this file (it uses `struct termios` and `tcsetattr`), so nothing was added.
   - `lib/unixTerminal.js` (and `src/unixTerminal.ts` for consistency): `readEchoState()`,
     guarded on `typeof pty.echoState === 'function'`. Typings untouched — step 2 reads it
     defensively, exactly as `readPtySlavePath` reads `ptsName` today.
2. `src/shared/pty-slave-line-discipline-echo.ts`: `PtySlaveEchoSyncProbe` and
   `createPtySlaveEchoSyncProbe(pty, platform)` — `undefined` on win32 or when
   `readEchoState` is absent; `1 -> 'echoing'`, `0 -> 'quiet'`, anything else (including a
   throw or `-1`) -> `'unknown'`.
3. `src/shared/pty-startup-reply-delivery.ts`: the sync probe is a 4th ctor param. In
   `answer()`, after the `!defersWrite(...)` early return and before the
   `MAX_TRACKED_REPLIES` branch:

   ```ts
   if (this.pendingWrites.length === 0 && this.echoSyncProbe?.() === 'quiet') {
     return this.writeReply(reply, onFailed, true)
   }
   ```

   Three load-bearing properties: `pendingWrites.length === 0` preserves ORDER (a reply
   arriving behind a held one queues instead of jumping, which also makes this mutually
   exclusive with the `MAX_TRACKED_REPLIES` branch); `kernelEchoImpossible = true` matches
   what today's `'quiet'` verdict passes, so the readline/BEL projection stays armed and only
   the kernel caret projection is skipped; and it fails OPEN — no probe, `'unknown'` or
   `'echoing'` is today's behavior byte for byte.
4. Wired at the three sites that already build the async probe: local provider, daemon
   session (via a new optional `echoSyncProbe` on `SubprocessHandle`, produced in
   `pty-subprocess.ts` next to `slavePath`, because the daemon's pty object lives there), and
   the relay pty handler.
5. Tests plus CI registration — both the `shell_contracts` run list and the shard
   `--exclude` list in `pr.yml`, and `pr-workflow-parallelism.test.mjs` so the registration
   itself is guarded — and the repro harness under `tests/tools/`.

## Why

### The earlier "deadline flush" framing was WRONG

The first hypothesis was that the 200 ms probe deadline flushes the reply into a tty that is
still cooked. That is factually wrong, and it was disproven with a native `tcgetattr` probe
sampling the slave's ECHO bit at the moment each query is observed: **`echoAtObserve=0` for
all 13 queries across 3 runs** — the tty is NEVER echoing when a query is observed. The
200 ms hold is pure PROBE LATENCY: the async probe is `execFile('stty')`, a subprocess per
poll. The leak also reproduces at a **5.0 ms** and a **15.6 ms** defer. So the real rule is:
**any deferral past the query's own event-loop turn is sufficient to lose the race**, because
DA1 (fish's read sentinel) is written in that same turn and overtakes the held OSC reply.
Every "fix the deadline branch" design is therefore dead, and so are these, all measured and
rejected:

- **Order-preserving FIFO** — binds DA1 to the `stty` fork. DA1 defer p90 102-172 ms with 8
  panes, max 228-309 ms, and fish BLOCKS on DA1 every prompt. Also failed to close the bug.
- **Drop-on-expiry** — fixes only 83%, and silently destroys answers a slow-to-raw querier is
  blocked on, i.e. reintroduces #12112's shape. Breaks 4 existing tests that encode "the wait
  always ends in a write".
- **Renderer-ordering** — premise factually wrong: `isCoalescibleInput` already excludes
  replyOnly items.
- **Do-nothing** — this is stdin corruption of the next child process.

### What the native patch does, and how it degrades

A POSIX pty master's *mode* ioctls are redirected to the slave, so `tcgetattr` on the master
fd Orca already owns reads the slave's ECHO bit with no fork and no extra fd. Verified by
direct C on macOS (master ECHO tracks the slave: 0 after clear, 1 after set) at 0.331
microseconds/op, and on Linux in `gcc:13`.

Degradation is the important half:

- **A kernel that does not redirect** would expose the master's own termios, whose ECHO
  defaults SET. That reads as `'echoing'`, i.e. today's deferral. It fails SAFE, never to a
  false `'quiet'`.
- **Unpatched or prebuilt node-pty** (an older relay host, a stale `node_modules`) —
  `readEchoState` is absent, `createPtySlaveEchoSyncProbe` returns `undefined`, the
  `echoSyncProbe` option is simply not passed, and delivery is byte-for-byte what ships
  today. **No wire change and no capability negotiation**: `echoSyncProbe` is a host-local
  function reference that is never serialized, and `PtyStartupIngressIntent` — the thing that
  actually crosses the client/host boundary — is untouched. A new client against an old host
  and an old client against a new host both keep working; per host, whoever owns the pty
  decides locally with what its own node-pty offers.
- **Windows / ConPTY** — `createPtySlaveEchoSyncProbe` returns `undefined` on win32, and
  `defersWrite()` already returns early for `windows-conpty` before the fast path is reached.
  Entirely unaffected; `src/unix/pty.cc` is not even compiled there.

### Measured result

| | main | this PR |
|---|---|---|
| canonical harness | `leaked=true`, childStdin `"ESC]11;rgb:1e1e/1e1e/1e1e ESC\ hello\n"` | `leaked=false`, childStdin `"hello\n"`, 4 consecutive runs |
| reply-order inversions | present | 0 |
| max echo-safe defer | 201-217 ms | 0.1-0.2 ms |
| DA1 defer | p90 102-172 ms under the rejected FIFO design | 0 ms p50/p90/max |
| 8 concurrent panes | leaks | 0 leaks 8/8, DA1 max 0 ms |
| #12112 (cooked querier) | answered | answered identically — the sync probe returns `'echoing'` at raw-delays 5/50/150/250/500 ms, so the fast path never fires |

It matches the pure-ordering ceiling (`--bypass-echo-safe`) exactly.

## Linked Issue

Fixes #13892

## Visual Proof

N/A — there is no UI change. The defect and the fix are both invisible on screen by
construction: the leaked bytes are consumed by a child process's **stdin**, which is exactly
why the regression test asserts on what a child process read rather than on what rendered.

## Testing

Everything below is real output from this branch on macOS arm64 (darwin 25.3.0), fish 4.

- `npm_config_build_from_source=true pnpm rebuild node-pty` — the patch applies and compiles:
  `CXX(target) Release/obj.target/pty/src/unix/pty.o` ... `gyp info ok`, with only node-pty's
  two pre-existing `kevent` `-Wmissing-field-initializers` warnings and none from the added
  code. The loaded binding exports `[ 'fork', 'open', 'resize', 'process', 'echoState' ]`
  from `build/Release/`.
- `npx tsc --noEmit -p config/tsconfig.node.json` — clean.
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` — clean.
- `npx oxlint` — no errors. `node config/scripts/check-max-lines-ratchet.mjs` — "max-lines
  ratchet OK — 347 grandfathered suppression(s), no new bypasses." No `max-lines` disable was
  added; `pty-startup-ingress.ts` was kept under its 300-line cap by collapsing a five-line
  `onEmission({...})` object literal that fits on one line.
- `npx vitest run --config config/vitest.config.ts src/shared src/main/providers
  src/main/daemon src/relay` — 698 files / 7916 tests passed. The one failure,
  `src/relay/agent-exec-handler.test.ts` (2 tests), **reproduces identically on a clean stash
  of this branch**: it asserts on a spawn env that this machine's ambient environment
  perturbs, and is unrelated to this change.
- The prior decisions this touches, run specifically, all green:
  `issue-12112-agent-pane-startup-color-reply-leak.repro.test.ts`,
  `src/shared/pty-startup-ingress.test.ts`,
  `src/shared/pty-startup-ingress-live-query-reply.test.ts`, `src/main/ipc/pty.test.ts`,
  `config/scripts/pr-workflow-parallelism.test.mjs` — 549 tests passed. Existing node-pty
  contract suites (`fish-color-scheme-child-stdin`, `omp-shell-wrapper`, `node-pty-fd-leak`)
  — 20 passed. No existing test was edited to match new behavior.
- `node tests/tools/fish-query-reply-order/capture-reply-order-trace.mjs --json`, 4 runs:
  `{"leaked":false,"childStdin":"hello\n","inversions":0,"maxEchoSafeDeferMs":0.1-0.2}`.

### Tests added

1. `src/shared/pty-slave-line-discipline-echo.test.ts` — the sync probe's mapping and every
   fail-open case: win32, missing method, non-function property, `null`/`undefined` pty,
   `-1`, `undefined`, and a throwing `readEchoState`, plus a live toggle read through the
   terminal.
2. `src/shared/pty-startup-reply-delivery.test.ts` — `answer()` takes the fast path ONLY when
   the queue is empty AND the probe says `'quiet'`; a non-empty queue still queues and the
   pair flushes in query order (the ordering property); `'echoing'` / `'unknown'` / no-probe
   defer exactly as before; the readline/BEL projection stays armed while the caret
   projection retires; ConPTY consults no probe; and a same-turn write reports its own
   failure instead of the deferred path's optimistic `true`.
3. `src/shared/fish-query-reply-child-stdin.node-pty.test.ts` — **real fish**, real
   `PtyStartupIngress` / `PtyStartupReplyDelivery` / both probes, and
   `local-pty-provider.write()`'s gate verbatim; the child reads a full LINE (a leaked reply
   carries no newline, so a `once('data')` child would report it alone whenever it landed in
   its own read); `itWithFish` plus `fishRequirementViolation` so CI cannot go green by
   skipping. **Proven to fail against pre-fix code**: with the fast-path condition disabled
   it fails with `expected 'CHILD-READ:"^[]11;rgb:1e1e/1e1e/1e1e^[\\hello\n"' to be
   'CHILD-READ:"hello\n"'` — the issue's exact payload; restored, it passes.
4. `src/shared/pty-cooked-querier-reply-delivery.node-pty.test.ts` — the durable version of
   the `slow-raw-querier` harness, and the guard that killed drop-on-expiry: a querier that
   asks while COOKED and arms raw mode 50 ms and 250 ms later (the second outruns the 200 ms
   probe budget, so the deadline flush answers instead of the probe) must still receive its
   reply, and the sync probe must read `'echoing'` at query time so the fast path is never
   eligible.

### Review hardening (second commit)

A reviewer found two ways this fix could be switched off with the suite still green. Both
are now closed by tests only — no runtime behavior changed.

**1. The production wiring was unguarded.** Deleting the `echoSyncProbe` spread at every
site left 2391 files / 29962 tests passing, so the fix's only real-world delivery path could
be refactored away silently. Each of the four links now proves the BEHAVIOR the spread buys
rather than matching source text — given a pty whose `readEchoState` says quiet, the probe is
consulted and the reply reaches the pty inside the caller's own turn:

| link | guard | deleting the spread |
|---|---|---|
| `pty-subprocess.ts` (builds the handle's probe) | `pty-subprocess.test.ts` — "sync ECHO probe on the handle" | `expected undefined to be 'quiet'` |
| `session.ts` | new `session-same-turn-query-reply-wiring.test.ts` | `expected "vi.fn()" to be called at least once` |
| `local-pty-provider.ts` | `local-pty-provider.test.ts` — "same-turn query reply wiring" | same |
| `relay/pty-handler.ts` | `pty-handler.test.ts` — "same-turn query reply wiring" | same |

Each deletion was actually performed and the failure observed, then reverted. Each host also
keeps a negative case: an `echoing` verdict (and, for the daemon, no probe at all) still
defers, so the guard cannot be satisfied by writing unconditionally.

**2. The vacuity guard could not detect a prebuilt binding.** The JS half of the patch ships
in the pnpm patch, so `createPtySlaveEchoSyncProbe` returns a DEFINED probe even when the
loaded native module is the upstream prebuild — exports `['fork','open','resize','process']`,
no `echoState`. `readEchoState()` then answers `undefined`, the probe maps it to `'unknown'`
forever, the fast path never fires, and the old `expect(probe).toBeDefined()` saw nothing.

New `src/shared/node-pty-echo-state-requirement.ts` mirrors `fish-binary-requirement.ts`: it
inspects node-pty's `native` binding for a real `echoState` export, both node-pty suites now
require a DEFINITE `'quiet' | 'echoing'` verdict off the live pty instead of a defined probe,
and an always-running requirement test fails when `ORCA_REQUIRE_NODE_PTY_ECHO_STATE=1`. The
`shell contracts` lane sets it (along with `ORCA_REQUIRE_FISH=1`, whose comment already
promised a test-time re-check that was never actually wired), so CI fails loudly while a
developer with a stale `node_modules` gets a skip naming the remedy — and the remedy names
the flag, because plain `pnpm rebuild node-pty` finds the shipped darwin prebuild and
exits 0.

Verified by simulating the prebuild (stripping `echoState` from the loaded binding): without
the env var both suites report `3 passed | 3 skipped`; with `ORCA_REQUIRE_NODE_PTY_ECHO_STATE=1`
both fail with `ORCA_REQUIRE_NODE_PTY_ECHO_STATE=1 but the patched-node-pty tests would skip:
the loaded node-pty native binding exports [fork, open, resize, process] and has no
echoState...`. Restored, both suites pass against real fish 4.7.1.

After the hardening commit, on the same machine: `npx tsc --noEmit -p
config/tsconfig.node.json` clean; `npx oxlint` exit 0 with no new warnings;
`node config/scripts/check-max-lines-ratchet.mjs` "OK — 347 grandfathered suppression(s), no
new bypasses" (no `max-lines` disable added, and `pty-startup-ingress.ts` untouched);
`npx vitest run --config config/vitest.config.ts src/shared src/main/providers
src/main/daemon src/relay` — **701 files / 7933 tests passed, 21 skipped, 0 failures** (the
`agent-exec-handler` noise above is this machine's ambient `GIT_CONFIG_COUNT`; unsetting it
makes that file pass unchanged); `config/scripts/pr-workflow-parallelism.test.mjs` 12 passed.

The tests read no ambient `process.env` beyond `PATH`, which they pass explicitly into the
pty rather than mutating.

Platforms: macOS verified end to end. Linux is covered by the `shell_contracts` CI lane
(where both new node-pty suites are registered) and always builds node-pty from source, so
`echoState` is present there. Windows is unaffected by construction (win32 short-circuit,
`defersWrite` early return, and `src/unix/pty.cc` not compiled). SSH/relay, WSL and folder
workspaces are unaffected: the probe is built per-pty by whichever host owns it.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude (Opus 5).

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH,
Mobile, general backwards compatibility, performance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Made with [Orca](https://github.com/stablyai/orca) 🐋

