### PR TITLE
feat(sidebar): filter workspaces by card status

### DIFF
--- a/src/renderer/src/app-shell/use-persisted-ui-writer.ts
+++ b/src/renderer/src/app-shell/use-persisted-ui-writer.ts
@@ -163,6 +163,7 @@ export function usePersistedUIWriter(): void {
       alwaysShowDefaultBranchWorkspace: s.alwaysShowDefaultBranchWorkspace,
       showDotfilesByWorktree: s.showDotfilesByWorktree,
       filterRepoIds: s.filterRepoIds,
+      filterWorkspaceStatuses: s.filterWorkspaceStatuses,
       // Why: dashboard auto-acks (fire on focus/visibility) and the in-memory ack cleanup
       // paths in agent-status.ts (close/dismiss) flow to disk through map identity changes.
       // Without persisting, agent rows that survive restart come back bold even when the

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -32,6 +32,7 @@ import SidebarStatusFilterSection from './SidebarStatusFilterSection'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { searchRepos } from '@/lib/repo-search'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
+import { getLiveSelectedWorkspaceStatusIds } from '../../../../shared/workspace-statuses'
 import { isSleepingSweepExemptionNarrowingList } from './visible-worktrees'
 import { translate } from '@/i18n/i18n'
 
@@ -118,7 +119,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
   // Why derive from the live catalog: a since-deleted custom status must not
   // inflate the count or keep the filter badge lit with no matching lane.
   const selectedStatusCount = useMemo(
-    () => workspaceStatuses.filter((status) => filterWorkspaceStatuses.includes(status.id)).length,
+    () => getLiveSelectedWorkspaceStatusIds(workspaceStatuses, filterWorkspaceStatuses).size,
     [workspaceStatuses, filterWorkspaceStatuses]
   )
   const hasStatusFilter = selectedStatusCount > 0

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -28,6 +28,7 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
 import { FilterToggleRow } from './FilterToggleRow'
+import SidebarStatusFilterSection from './SidebarStatusFilterSection'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { searchRepos } from '@/lib/repo-search'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
@@ -68,6 +69,9 @@ const SidebarFilter = React.memo(function SidebarFilter({
   )
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+  const setFilterWorkspaceStatuses = useAppStore((s) => s.setFilterWorkspaceStatuses)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const repos = useAppStore((s) => s.repos)
   const addRepo = useAppStore((s) => s.addRepo)
 
@@ -111,6 +115,13 @@ const SidebarFilter = React.memo(function SidebarFilter({
   }, [repos, filterRepoIds])
   const selectedCount = selectedRepoIdSet.size
   const hasRepoFilter = selectedCount > 0
+  // Why derive from the live catalog: a since-deleted custom status must not
+  // inflate the count or keep the filter badge lit with no matching lane.
+  const selectedStatusCount = useMemo(
+    () => workspaceStatuses.filter((status) => filterWorkspaceStatuses.includes(status.id)).length,
+    [workspaceStatuses, filterWorkspaceStatuses]
+  )
+  const hasStatusFilter = selectedStatusCount > 0
   const hasSleepingFilter = showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES
   // Why counted: turning the exemption off is the only way that row narrows the
   // list — but only while its parent row is on, which is also when it renders.
@@ -125,7 +136,8 @@ const SidebarFilter = React.memo(function SidebarFilter({
     hideCliCreatedWorkspaces ||
     hideDetachedHeadWorkspaces ||
     hasSleepingExemptionFilter ||
-    hasRepoFilter
+    hasRepoFilter ||
+    hasStatusFilter
   const activeFilterCount =
     (hasSleepingFilter ? 1 : 0) +
     (hideDefaultBranchWorkspace ? 1 : 0) +
@@ -133,6 +145,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     (hideCliCreatedWorkspaces ? 1 : 0) +
     (hideDetachedHeadWorkspaces ? 1 : 0) +
     (hasSleepingExemptionFilter ? 1 : 0) +
+    selectedStatusCount +
     selectedCount
 
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
@@ -150,6 +163,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     setHideDetachedHeadWorkspaces(false)
     setAlwaysShowDefaultBranchWorkspace(true)
     setFilterRepoIds([])
+    setFilterWorkspaceStatuses([])
   }, [
     setShowSleepingWorkspaces,
     setHideDefaultBranchWorkspace,
@@ -157,7 +171,8 @@ const SidebarFilter = React.memo(function SidebarFilter({
     setHideCliCreatedWorkspaces,
     setHideDetachedHeadWorkspaces,
     setAlwaysShowDefaultBranchWorkspace,
-    setFilterRepoIds
+    setFilterRepoIds,
+    setFilterWorkspaceStatuses
   ])
 
   // Why: derive ids from the live repos list at click time so a repo added
@@ -277,6 +292,13 @@ const SidebarFilter = React.memo(function SidebarFilter({
           checked={hideDetachedHeadWorkspaces}
           onChange={setHideDetachedHeadWorkspaces}
         />
+
+        {workspaceStatuses.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <SidebarStatusFilterSection preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen} />
+          </>
+        )}
 
         {canFilterRepos && (
           <>

--- a/src/renderer/src/components/sidebar/SidebarStatusFilterSection.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarStatusFilterSection.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import SidebarStatusFilterSection, {
+  toggleWorkspaceStatusFilter
+} from './SidebarStatusFilterSection'
+import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
+
+const catalog = cloneDefaultWorkspaceStatuses()
+const initialState = useAppStore.getInitialState()
+
+function renderSection() {
+  return render(
+    <DropdownMenu open>
+      <DropdownMenuContent forceMount>
+        <SidebarStatusFilterSection />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+beforeEach(() => {
+  useAppStore.setState({ workspaceStatuses: catalog, filterWorkspaceStatuses: [] }, false)
+})
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState(initialState, true)
+})
+
+describe('toggleWorkspaceStatusFilter', () => {
+  it('adds a status and keeps catalog order regardless of insertion order', () => {
+    const afterDone = toggleWorkspaceStatusFilter([], 'completed', catalog)
+    expect(afterDone).toEqual(['completed'])
+    // Adding Todo (first column) must sort ahead of the already-selected Done.
+    expect(toggleWorkspaceStatusFilter(afterDone, 'todo', catalog)).toEqual(['todo', 'completed'])
+  })
+
+  it('removes a selected status, leaving the rest in catalog order', () => {
+    expect(toggleWorkspaceStatusFilter(['todo', 'completed'], 'todo', catalog)).toEqual([
+      'completed'
+    ])
+  })
+
+  it('drops ids no longer present in the catalog', () => {
+    expect(toggleWorkspaceStatusFilter(['ghost', 'completed'], 'todo', catalog)).toEqual([
+      'todo',
+      'completed'
+    ])
+  })
+})
+
+describe('SidebarStatusFilterSection', () => {
+  it('shows the all-statuses label with nothing selected', () => {
+    const view = renderSection()
+    expect(view.baseElement.textContent).toContain('All statuses')
+  })
+
+  it('reflects a single selection with the status label', () => {
+    act(() => useAppStore.setState({ filterWorkspaceStatuses: ['completed'] }, false))
+    const view = renderSection()
+    // The sub-trigger shows the sole selected status label ("Done"), not a count.
+    expect(view.baseElement.textContent).toContain('Done')
+  })
+
+  it('reflects a multi selection with a count label', () => {
+    act(() => useAppStore.setState({ filterWorkspaceStatuses: ['todo', 'completed'] }, false))
+    const view = renderSection()
+    expect(view.baseElement.textContent).toContain('2 statuses')
+  })
+
+  it('renders nothing when the catalog is empty', () => {
+    act(() => useAppStore.setState({ workspaceStatuses: [] }, false))
+    const view = renderSection()
+    expect(view.baseElement.textContent).not.toContain('All statuses')
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarStatusFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarStatusFilterSection.tsx
@@ -1,0 +1,167 @@
+import React, { useCallback, useMemo } from 'react'
+import { useAppStore } from '@/store'
+import {
+  DropdownMenuCheckboxItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import { getWorkspaceStatusVisualMeta } from './workspace-status'
+import type { WorkspaceStatus, WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
+import { translate } from '@/i18n/i18n'
+
+/**
+ * Toggle a status id in the current selection, returning the next selection in
+ * catalog order (so persisted filter chips read like the board columns) and
+ * dropping ids no longer in the catalog. Pure so it is unit-testable without
+ * mounting the Radix submenu.
+ */
+export function toggleWorkspaceStatusFilter(
+  current: readonly WorkspaceStatus[],
+  statusId: WorkspaceStatus,
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus[] {
+  const next = new Set(current)
+  if (next.has(statusId)) {
+    next.delete(statusId)
+  } else {
+    next.add(statusId)
+  }
+  return statuses.filter((status) => next.has(status.id)).map((status) => status.id)
+}
+
+function getStatusFilterVisibilityLabel({
+  selectedCount,
+  selectedLabel
+}: {
+  selectedCount: number
+  selectedLabel: string | null
+}): string {
+  if (selectedCount === 0) {
+    return translate(
+      'auto.components.sidebar.SidebarStatusFilterSection.allStatuses',
+      'All statuses'
+    )
+  }
+  if (selectedCount === 1 && selectedLabel) {
+    return selectedLabel
+  }
+  return translate(
+    'auto.components.sidebar.SidebarStatusFilterSection.selectedStatusesCount',
+    '{{value0}} statuses',
+    { value0: selectedCount }
+  )
+}
+
+type SidebarStatusFilterSectionProps = {
+  preserveWorkspaceBoardOpen?: boolean
+}
+
+/**
+ * Filter workspaces by their card status (Todo / In progress / In review /
+ * Done, plus any custom statuses). Empty selection shows every status. Renders
+ * the same single-row sub-trigger shell as the Projects and Hosts filters.
+ *
+ * Why shared: mounted in both the sidebar options menu and the workspace board
+ * filter menu, which both drive the same `filterWorkspaceStatuses` store state.
+ */
+const SidebarStatusFilterSection = React.memo(function SidebarStatusFilterSection({
+  preserveWorkspaceBoardOpen = false
+}: SidebarStatusFilterSectionProps) {
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+  const setFilterWorkspaceStatuses = useAppStore((s) => s.setFilterWorkspaceStatuses)
+
+  // Why: derive from the live catalog so a since-deleted custom status can't
+  // inflate the count or falsely signal an applied filter.
+  const selectedStatusIdSet = useMemo(() => {
+    const set = new Set<string>()
+    for (const status of workspaceStatuses) {
+      if (filterWorkspaceStatuses.includes(status.id)) {
+        set.add(status.id)
+      }
+    }
+    return set
+  }, [workspaceStatuses, filterWorkspaceStatuses])
+  const selectedCount = selectedStatusIdSet.size
+  const hasStatusFilter = selectedCount > 0
+  const selectedLabel = useMemo(
+    () => workspaceStatuses.find((status) => selectedStatusIdSet.has(status.id))?.label ?? null,
+    [workspaceStatuses, selectedStatusIdSet]
+  )
+  const visibilityLabel = getStatusFilterVisibilityLabel({ selectedCount, selectedLabel })
+
+  const toggleStatus = useCallback(
+    (statusId: string) => {
+      setFilterWorkspaceStatuses(
+        toggleWorkspaceStatusFilter(filterWorkspaceStatuses, statusId, workspaceStatuses)
+      )
+    },
+    [filterWorkspaceStatuses, setFilterWorkspaceStatuses, workspaceStatuses]
+  )
+
+  const clearStatuses = useCallback(
+    () => setFilterWorkspaceStatuses([]),
+    [setFilterWorkspaceStatuses]
+  )
+
+  if (workspaceStatuses.length === 0) {
+    return null
+  }
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        <span className="flex flex-1 items-center justify-between gap-3">
+          <span>
+            {translate('auto.components.sidebar.SidebarStatusFilterSection.status', 'Status')}
+          </span>
+          <span className="min-w-0 truncate text-[11px] font-medium text-muted-foreground">
+            {visibilityLabel}
+          </span>
+        </span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent
+        className="w-56"
+        data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+      >
+        <div className="flex items-center justify-between px-2 py-1">
+          <span className="text-[11px] font-semibold text-muted-foreground">
+            {translate('auto.components.sidebar.SidebarStatusFilterSection.status', 'Status')}
+            {hasStatusFilter && (
+              <span className="ml-1.5 font-medium text-foreground">· {selectedCount}</span>
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={clearStatuses}
+            className="rounded-full px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
+            disabled={!hasStatusFilter}
+          >
+            {translate('auto.components.sidebar.SidebarStatusFilterSection.clear', 'Clear')}
+          </button>
+        </div>
+        {workspaceStatuses.map((status) => {
+          const meta = getWorkspaceStatusVisualMeta(status)
+          return (
+            <DropdownMenuCheckboxItem
+              key={status.id}
+              checked={selectedStatusIdSet.has(status.id)}
+              // Keep the menu open so several statuses can be toggled at once.
+              onSelect={(e) => e.preventDefault()}
+              onCheckedChange={() => toggleStatus(status.id)}
+            >
+              <span className="inline-flex min-w-0 flex-1 items-center gap-2">
+                <meta.icon className={cn('size-3.5 shrink-0', meta.tone)} />
+                <span className="truncate">{status.label}</span>
+              </span>
+            </DropdownMenuCheckboxItem>
+          )
+        })}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+})
+
+export default SidebarStatusFilterSection

--- a/src/renderer/src/components/sidebar/SidebarStatusFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarStatusFilterSection.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { getWorkspaceStatusVisualMeta } from './workspace-status'
+import { getLiveSelectedWorkspaceStatusIds } from '../../../../shared/workspace-statuses'
 import type { WorkspaceStatus, WorkspaceStatusDefinition } from '../../../../shared/worktree/types'
 import { translate } from '@/i18n/i18n'
 
@@ -75,15 +76,10 @@ const SidebarStatusFilterSection = React.memo(function SidebarStatusFilterSectio
 
   // Why: derive from the live catalog so a since-deleted custom status can't
   // inflate the count or falsely signal an applied filter.
-  const selectedStatusIdSet = useMemo(() => {
-    const set = new Set<string>()
-    for (const status of workspaceStatuses) {
-      if (filterWorkspaceStatuses.includes(status.id)) {
-        set.add(status.id)
-      }
-    }
-    return set
-  }, [workspaceStatuses, filterWorkspaceStatuses])
+  const selectedStatusIdSet = useMemo(
+    () => getLiveSelectedWorkspaceStatusIds(workspaceStatuses, filterWorkspaceStatuses),
+    [workspaceStatuses, filterWorkspaceStatuses]
+  )
   const selectedCount = selectedStatusIdSet.size
   const hasStatusFilter = selectedCount > 0
   const selectedLabel = useMemo(

--- a/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
@@ -47,6 +47,8 @@ type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
 function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
   return {
     filterRepoIds: [],
+    filterWorkspaceStatuses: [],
+    workspaceStatuses: [],
     showSleepingWorkspaces: true,
     tabsByWorktree: {},
     ptyIdsByTabId: {},
@@ -91,6 +93,7 @@ describe('#8873 default-branch workspace under "Hide sleeping"', () => {
     const filterKeys: readonly (keyof SidebarFilterState)[] = [
       'showSleepingWorkspaces',
       'filterRepoIds',
+      'filterWorkspaceStatuses',
       'hideDefaultBranchWorkspace',
       'hideAutomationGeneratedWorkspaces',
       'hideCliCreatedWorkspaces',

--- a/src/renderer/src/components/sidebar/sidebar-filter-actions.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-actions.ts
@@ -13,6 +13,7 @@ export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
   return (
     state.showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES ||
     state.filterRepoIds.length > 0 ||
+    state.filterWorkspaceStatuses.length > 0 ||
     state.hideDefaultBranchWorkspace ||
     state.hideAutomationGeneratedWorkspaces ||
     state.hideCliCreatedWorkspaces ||
@@ -31,6 +32,7 @@ export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
 export type ClearFilterActions = {
   resetShowSleepingWorkspaces: boolean
   resetFilterRepoIds: boolean
+  resetFilterWorkspaceStatuses: boolean
   resetHideDefaultBranchWorkspace: boolean
   resetHideAutomationGeneratedWorkspaces: boolean
   resetHideCliCreatedWorkspaces: boolean
@@ -54,6 +56,7 @@ export function computeClearFilterActions(state: SidebarFilterState): ClearFilte
   return {
     resetShowSleepingWorkspaces: state.showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES,
     resetFilterRepoIds: state.filterRepoIds.length > 0,
+    resetFilterWorkspaceStatuses: state.filterWorkspaceStatuses.length > 0,
     resetHideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
     resetHideAutomationGeneratedWorkspaces: state.hideAutomationGeneratedWorkspaces,
     resetHideCliCreatedWorkspaces: state.hideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
@@ -35,6 +35,7 @@ function filterState(overrides: Partial<FilterState> = {}): FilterState {
   return {
     showSleepingWorkspaces: true,
     filterRepoIds: [],
+    filterWorkspaceStatuses: [],
     hideDefaultBranchWorkspace: false,
     hideAutomationGeneratedWorkspaces: false,
     hideCliCreatedWorkspaces: false,
@@ -113,6 +114,12 @@ describe('sidebarHasActiveFilters', () => {
     expect(sidebarHasActiveFilters(filterState({ filterRepoIds: ['repo1'] }))).toBe(true)
   })
 
+  it('returns true when only a workspace-status filter is selected', () => {
+    expect(sidebarHasActiveFilters(filterState({ filterWorkspaceStatuses: ['completed'] }))).toBe(
+      true
+    )
+  })
+
   it('counts an opted-out default-branch exemption as an active filter', () => {
     expect(sidebarHasActiveFilters(filterState({ alwaysShowDefaultBranchWorkspace: false }))).toBe(
       true
@@ -149,6 +156,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState())).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -166,6 +174,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ hideDefaultBranchWorkspace: true }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: true,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -182,6 +191,7 @@ describe('computeClearFilterActions', () => {
     ).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: true,
       resetHideCliCreatedWorkspaces: false,
@@ -196,6 +206,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ hideCliCreatedWorkspaces: true }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: true,
@@ -210,10 +221,28 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ hideDetachedHeadWorkspaces: true }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: true,
+      resetHideWorkspacesFromOtherDevices: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
+      resetVisibleWorkspaceHostIds: false
+    })
+  })
+
+  it('flags only the workspace-status filter for reset when it is the sole filter', () => {
+    expect(
+      computeClearFilterActions(filterState({ filterWorkspaceStatuses: ['completed'] }))
+    ).toEqual({
+      resetShowSleepingWorkspaces: false,
+      resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: true,
+      resetHideDefaultBranchWorkspace: false,
+      resetHideAutomationGeneratedWorkspaces: false,
+      resetHideCliCreatedWorkspaces: false,
+      resetHideDetachedHeadWorkspaces: false,
       resetHideWorkspacesFromOtherDevices: false,
       resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: false
@@ -237,6 +266,7 @@ describe('computeClearFilterActions', () => {
     expect(computeClearFilterActions(filterState({ workspaceHostScope: 'ssh:host-1' }))).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -253,6 +283,7 @@ describe('computeClearFilterActions', () => {
     ).toEqual({
       resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: false,
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
@@ -277,6 +308,7 @@ describe('computeClearFilterActions', () => {
     ).toEqual({
       resetShowSleepingWorkspaces: true,
       resetFilterRepoIds: true,
+      resetFilterWorkspaceStatuses: false,
       resetHideDefaultBranchWorkspace: true,
       resetHideAutomationGeneratedWorkspaces: true,
       resetHideCliCreatedWorkspaces: false,

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -46,6 +46,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
   const settings = useAppStore((s) => s.settings)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const tabsByWorktree = useAppStore((s) => (!showSleepingWorkspaces ? s.tabsByWorktree : null))
   const ptyIdsByTabId = useAppStore((s) => (!showSleepingWorkspaces ? s.ptyIdsByTabId : null))
   const browserTabsByWorktree = useAppStore((s) =>
@@ -77,6 +79,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     return new Set(
       computeVisibleWorktrees(worktreesByRepo, sortedIds, {
         filterRepoIds,
+        filterWorkspaceStatuses,
+        workspaceStatuses,
         showSleepingWorkspaces,
         tabsByWorktree,
         ptyIdsByTabId,
@@ -105,6 +109,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     allWorktrees,
     browserTabsByWorktree,
     filterRepoIds,
+    filterWorkspaceStatuses,
+    workspaceStatuses,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/visible-worktree-kinds.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-kinds.ts
@@ -1,5 +1,5 @@
 import type { ExecutionHostId, ExecutionHostScope } from '../../../../shared/execution-host'
-import type { Worktree } from '../../../../shared/worktree/types'
+import type { Worktree, WorkspaceStatus } from '../../../../shared/worktree/types'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 
 /**
@@ -52,6 +52,8 @@ export function isDetachedHeadWorkspace(worktree: Worktree): boolean {
 export type SidebarFilterState = {
   showSleepingWorkspaces: boolean
   filterRepoIds: readonly string[]
+  /** Selected workspace-status ids; empty means every status is shown. */
+  filterWorkspaceStatuses: readonly WorkspaceStatus[]
   hideDefaultBranchWorkspace: boolean
   hideAutomationGeneratedWorkspaces: boolean
   hideCliCreatedWorkspaces: boolean

--- a/src/renderer/src/components/sidebar/visible-worktree-lineage-ancestors.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-lineage-ancestors.ts
@@ -1,0 +1,50 @@
+import type { Worktree } from '../../../../shared/worktree/types'
+import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
+import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import {
+  getCyclicProjectedWorktreeLineageIds,
+  getLineageRenderInfo
+} from './worktree-lineage-projection'
+
+/**
+ * Re-inject the valid ancestors of every visible worktree so a filtered-in
+ * child is never rendered as an orphan. Sidebar lineage is structural: if a
+ * child survives the filters, its valid parent chain must be rendered too so
+ * the nesting stays legible. Cycles are broken via the projected cyclic set.
+ *
+ * Extracted from visible-worktrees so that module stays under its line budget.
+ */
+export function addVisibleLineageAncestors(
+  worktrees: Worktree[],
+  worktreeById: Map<string, Worktree>,
+  lineageById: Record<string, WorktreeLineage>
+): Worktree[] {
+  const result: Worktree[] = []
+  const included = new Set<string>()
+  const visiting = new Set<string>()
+  const cyclicLineageIds = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeById)
+
+  const addWithAncestors = (worktree: Worktree): void => {
+    const identity = getWorktreeHostIdentity(worktree)
+    if (included.has(identity) || visiting.has(identity)) {
+      return
+    }
+    visiting.add(identity)
+    const lineage = getLineageRenderInfo(worktree, lineageById, worktreeById, cyclicLineageIds)
+    if (lineage.state === 'valid') {
+      // Why: sidebar lineage is structural. If a filtered child is visible,
+      // its valid parent must be rendered too so the hierarchy remains legible.
+      addWithAncestors(lineage.parent)
+    }
+    visiting.delete(identity)
+    if (!included.has(identity)) {
+      included.add(identity)
+      result.push(worktree)
+    }
+  }
+
+  for (const worktree of worktrees) {
+    addWithAncestors(worktree)
+  }
+  return result
+}

--- a/src/renderer/src/components/sidebar/visible-worktrees-status-filter.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees-status-filter.test.ts
@@ -147,4 +147,19 @@ describe('computeVisibleWorktreeIds workspace-status filter', () => {
 
     expect(result).toEqual([repo1Done.id])
   })
+
+  it('fails open: a selected status with no loaded catalog keeps every workspace', () => {
+    // Before the catalog loads every row resolves to the fallback status, so
+    // applying the filter would wrongly hide a non-default selection.
+    const done = withStatus('done', 'completed')
+    const wip = withStatus('wip', 'in-progress')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [done, wip] },
+      [done.id, wip.id],
+      visibleOptions({ filterWorkspaceStatuses: ['completed'], workspaceStatuses: undefined })
+    )
+
+    expect(result).toEqual([done.id, wip.id])
+  })
 })

--- a/src/renderer/src/components/sidebar/visible-worktrees-status-filter.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees-status-filter.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { computeVisibleWorktreeIds } from './visible-worktrees'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+
+function makeWorktree(id: string, repoId = 'repo1'): Worktree {
+  return {
+    id,
+    repoId,
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+function makeRepo(id: string): Repo {
+  return { id, path: `/${id}`, displayName: id, badgeColor: '#000', addedAt: 0 }
+}
+
+const repoMap = new Map<string, Repo>([
+  ['repo1', makeRepo('repo1')],
+  ['repo2', makeRepo('repo2')]
+])
+
+const statusCatalog = [
+  { id: 'todo', label: 'Todo', color: 'neutral', icon: 'circle' },
+  {
+    id: 'in-progress',
+    label: 'In progress',
+    color: 'conductor-progress',
+    icon: 'conductor-progress'
+  },
+  { id: 'in-review', label: 'In review', color: 'conductor-review', icon: 'conductor-review' },
+  { id: 'completed', label: 'Done', color: 'conductor-done', icon: 'conductor-done' }
+]
+
+type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
+
+function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
+  return {
+    filterRepoIds: [],
+    filterWorkspaceStatuses: [],
+    workspaceStatuses: statusCatalog,
+    showSleepingWorkspaces: true,
+    tabsByWorktree: {},
+    ptyIdsByTabId: {},
+    browserTabsByWorktree: {},
+    worktreeIdsWithLiveAgent: new Set(),
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    hideWorkspacesFromOtherDevices: false,
+    pairedDeviceIdsByEnvironment: new Map(),
+    repoMap,
+    workspaceHostScope: 'all',
+    defaultHostId: LOCAL_EXECUTION_HOST_ID,
+    worktreeLineageById: {},
+    ...overrides
+  }
+}
+
+function withStatus(id: string, status: string | undefined, repoId = 'repo1'): Worktree {
+  return { ...makeWorktree(id, repoId), workspaceStatus: status }
+}
+
+describe('computeVisibleWorktreeIds workspace-status filter', () => {
+  it('shows every workspace when no status is selected', () => {
+    const done = withStatus('done', 'completed')
+    const wip = withStatus('wip', 'in-progress')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [done, wip] },
+      [done.id, wip.id],
+      visibleOptions()
+    )
+
+    expect(result).toEqual([done.id, wip.id])
+  })
+
+  it('keeps only workspaces whose status is selected', () => {
+    const done = withStatus('done', 'completed')
+    const wip = withStatus('wip', 'in-progress')
+    const todo = withStatus('todo', 'todo')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [done, wip, todo] },
+      [done.id, wip.id, todo.id],
+      visibleOptions({ filterWorkspaceStatuses: ['completed'] })
+    )
+
+    expect(result).toEqual([done.id])
+  })
+
+  it('supports selecting multiple statuses ("not completed" = todo + in-progress + in-review)', () => {
+    const done = withStatus('done', 'completed')
+    const wip = withStatus('wip', 'in-progress')
+    const review = withStatus('review', 'in-review')
+    const todo = withStatus('todo', 'todo')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [done, wip, review, todo] },
+      [done.id, wip.id, review.id, todo.id],
+      visibleOptions({ filterWorkspaceStatuses: ['todo', 'in-progress', 'in-review'] })
+    )
+
+    expect(result).toEqual([wip.id, review.id, todo.id])
+  })
+
+  it('treats an unset workspaceStatus as the catalog default (in-progress)', () => {
+    // A never-touched workspace resolves to the default id, so a filter for the
+    // default surfaces it even though the field is undefined.
+    const untouched = withStatus('untouched', undefined)
+    const done = withStatus('done', 'completed')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [untouched, done] },
+      [untouched.id, done.id],
+      visibleOptions({ filterWorkspaceStatuses: ['in-progress'] })
+    )
+
+    expect(result).toEqual([untouched.id])
+  })
+
+  it('combines with the repo filter (both must pass)', () => {
+    const repo1Done = withStatus('r1-done', 'completed', 'repo1')
+    const repo2Done = withStatus('r2-done', 'completed', 'repo2')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [repo1Done], repo2: [repo2Done] },
+      [repo1Done.id, repo2Done.id],
+      visibleOptions({ filterRepoIds: ['repo1'], filterWorkspaceStatuses: ['completed'] })
+    )
+
+    expect(result).toEqual([repo1Done.id])
+  })
+})

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -74,6 +74,8 @@ type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
 function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
   return {
     filterRepoIds: [],
+    filterWorkspaceStatuses: [],
+    workspaceStatuses: [],
     showSleepingWorkspaces: true,
     tabsByWorktree: {},
     ptyIdsByTabId: {},

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -154,9 +154,9 @@ export function computeVisibleWorktrees(
   // Why guarded on workspaceStatuses: resolving a worktree's effective status
   // needs the live catalog; without it every row would fall back to the
   // default id and silently narrow the list to a single status.
-  if (opts.filterWorkspaceStatuses && opts.filterWorkspaceStatuses.length > 0) {
+  if (opts.filterWorkspaceStatuses?.length && opts.workspaceStatuses) {
     const selectedStatuses = new Set(opts.filterWorkspaceStatuses)
-    const statuses = opts.workspaceStatuses ?? []
+    const statuses = opts.workspaceStatuses
     all = all.filter((w) => selectedStatuses.has(getWorkspaceStatus(w, statuses)))
   }
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -21,7 +21,12 @@ import {
   getVisibleWorkspaceHostIdSet,
   worktreeMatchesVisibleHost
 } from './visible-worktree-host-scope'
-import type { Worktree } from '../../../../shared/worktree/types'
+import type {
+  Worktree,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition
+} from '../../../../shared/worktree/types'
+import { getWorkspaceStatus } from '../../../../shared/workspace-statuses'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
@@ -33,10 +38,7 @@ import {
   type ExecutionHostId,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
-import {
-  getCyclicProjectedWorktreeLineageIds,
-  getLineageRenderInfo
-} from './worktree-lineage-projection'
+import { addVisibleLineageAncestors } from './visible-worktree-lineage-ancestors'
 import {
   computeRenderedSidebarWorktreeOrder,
   computeRenderedSidebarWorktrees
@@ -48,7 +50,6 @@ import {
 } from './workspace-creator-visibility'
 import { isDefaultBranchWorkspace } from './default-branch-workspace'
 import { getLineageAncestorIndex, getSortedWorktreeRankIndex } from './visible-worktree-indexes'
-import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 
 /**
  * Whether the "Hide sleeping" sweep must keep this row (#8873).
@@ -64,6 +65,13 @@ import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualif
  */
 type VisibleWorktreeOptions = {
   filterRepoIds: readonly string[]
+  /**
+   * Selected workspace-status ids; empty shows every status. Paired with
+   * `workspaceStatuses` so the predicate resolves each worktree's effective
+   * status (falling back to the catalog default) exactly like the board.
+   */
+  filterWorkspaceStatuses?: readonly WorkspaceStatus[]
+  workspaceStatuses?: readonly WorkspaceStatusDefinition[]
   showSleepingWorkspaces: boolean
   tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
   ptyIdsByTabId: Record<string, string[]> | null
@@ -142,6 +150,16 @@ export function computeVisibleWorktrees(
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
   }
 
+  // Filter by workspace (card) status. Empty selection shows every status.
+  // Why guarded on workspaceStatuses: resolving a worktree's effective status
+  // needs the live catalog; without it every row would fall back to the
+  // default id and silently narrow the list to a single status.
+  if (opts.filterWorkspaceStatuses && opts.filterWorkspaceStatuses.length > 0) {
+    const selectedStatuses = new Set(opts.filterWorkspaceStatuses)
+    const statuses = opts.workspaceStatuses ?? []
+    all = all.filter((w) => selectedStatuses.has(getWorkspaceStatus(w, statuses)))
+  }
+
   if (!opts.showSleepingWorkspaces) {
     // Why no !hideDefaultBranchWorkspace term: that filter already ran above, so
     // an explicit hide still wins over the exemption.
@@ -181,41 +199,6 @@ export function computeVisibleWorktrees(
   return opts.injectLineageAncestors === false
     ? all
     : addVisibleLineageAncestors(all, lineageAncestorById, opts.worktreeLineageById)
-}
-
-function addVisibleLineageAncestors(
-  worktrees: Worktree[],
-  worktreeById: Map<string, Worktree>,
-  lineageById: Record<string, WorktreeLineage>
-): Worktree[] {
-  const result: Worktree[] = []
-  const included = new Set<string>()
-  const visiting = new Set<string>()
-  const cyclicLineageIds = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeById)
-
-  const addWithAncestors = (worktree: Worktree): void => {
-    const identity = getWorktreeHostIdentity(worktree)
-    if (included.has(identity) || visiting.has(identity)) {
-      return
-    }
-    visiting.add(identity)
-    const lineage = getLineageRenderInfo(worktree, lineageById, worktreeById, cyclicLineageIds)
-    if (lineage.state === 'valid') {
-      // Why: sidebar lineage is structural. If a filtered child is visible,
-      // its valid parent must be rendered too so the hierarchy remains legible.
-      addWithAncestors(lineage.parent)
-    }
-    visiting.delete(identity)
-    if (!included.has(identity)) {
-      included.add(identity)
-      result.push(worktree)
-    }
-  }
-
-  for (const worktree of worktrees) {
-    addWithAncestors(worktree)
-  }
-  return result
 }
 
 export function computeVisibleWorktreeIds(
@@ -272,6 +255,8 @@ export function buildVisibleWorktreeOptionsFromState(
 ): VisibleWorktreeOptions {
   return {
     filterRepoIds: state.filterRepoIds,
+    filterWorkspaceStatuses: state.filterWorkspaceStatuses,
+    workspaceStatuses: state.workspaceStatuses,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
     ptyIdsByTabId: state.ptyIdsByTabId,

--- a/src/renderer/src/components/sidebar/workspace-options-menu-items.tsx
+++ b/src/renderer/src/components/sidebar/workspace-options-menu-items.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
+import { getLiveSelectedWorkspaceStatusIds } from '../../../../shared/workspace-statuses'
 import { isSleepingSweepExemptionNarrowingList } from './visible-worktrees'
 import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
 import SidebarStatusFilterSection from './SidebarStatusFilterSection'
@@ -54,7 +55,7 @@ export function useWorkspaceOptionsFilterBadge(): {
   // Why derive from the live catalog: a since-deleted custom status must not
   // inflate the count or keep the filter badge lit with no matching lane.
   const selectedStatusCount = useMemo(
-    () => workspaceStatuses.filter((status) => filterWorkspaceStatuses.includes(status.id)).length,
+    () => getLiveSelectedWorkspaceStatusIds(workspaceStatuses, filterWorkspaceStatuses).size,
     [workspaceStatuses, filterWorkspaceStatuses]
   )
 

--- a/src/renderer/src/components/sidebar/workspace-options-menu-items.tsx
+++ b/src/renderer/src/components/sidebar/workspace-options-menu-items.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
 import { isSleepingSweepExemptionNarrowingList } from './visible-worktrees'
 import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
+import SidebarStatusFilterSection from './SidebarStatusFilterSection'
 import SidebarWorkspaceFilterSection from './SidebarWorkspaceFilterSection'
 import { getSidebarHostVisibilityLabel, shouldShowHostScopeControls } from './sidebar-host-options'
 import { useSidebarHostScopeOptions } from './use-sidebar-host-scope-options'
@@ -35,6 +36,8 @@ export function useWorkspaceOptionsFilterBadge(): {
   const hideWorkspacesFromOtherDevices = useAppStore((s) => s.hideWorkspacesFromOtherDevices)
   const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const repos = useAppStore((s) => s.repos)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
 
@@ -48,12 +51,20 @@ export function useWorkspaceOptionsFilterBadge(): {
     return count
   }, [repos, filterRepoIds])
 
+  // Why derive from the live catalog: a since-deleted custom status must not
+  // inflate the count or keep the filter badge lit with no matching lane.
+  const selectedStatusCount = useMemo(
+    () => workspaceStatuses.filter((status) => filterWorkspaceStatuses.includes(status.id)).length,
+    [workspaceStatuses, filterWorkspaceStatuses]
+  )
+
   const hasSleepingFilter = showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES
   const hasSleepingExemptionFilter = isSleepingSweepExemptionNarrowingList(
     showSleepingWorkspaces,
     alwaysShowDefaultBranchWorkspace
   )
   const hasRepoFilter = selectedCount > 0
+  const hasStatusFilter = selectedStatusCount > 0
   const hasHostVisibilityFilter = visibleWorkspaceHostIds !== null
   const hasAnyFilter =
     hasSleepingFilter ||
@@ -64,6 +75,7 @@ export function useWorkspaceOptionsFilterBadge(): {
     hideWorkspacesFromOtherDevices ||
     hasSleepingExemptionFilter ||
     hasRepoFilter ||
+    hasStatusFilter ||
     hasHostVisibilityFilter
   const activeFilterCount =
     (hasSleepingFilter ? 1 : 0) +
@@ -74,7 +86,8 @@ export function useWorkspaceOptionsFilterBadge(): {
     (hideWorkspacesFromOtherDevices ? 1 : 0) +
     (hasSleepingExemptionFilter ? 1 : 0) +
     (hasHostVisibilityFilter ? 1 : 0) +
-    selectedCount
+    selectedCount +
+    selectedStatusCount
 
   return {
     hasAnyFilter,
@@ -89,6 +102,7 @@ export function WorkspaceOptionsMenuItems({
   preserveWorkspaceBoardOpen?: boolean
 }): JSX.Element {
   const repos = useAppStore((s) => s.repos)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const setWorkspaceHostScope = useAppStore((s) => s.setWorkspaceHostScope)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
@@ -114,9 +128,10 @@ export function WorkspaceOptionsMenuItems({
           'Workspace options'
         )}
       </DropdownMenuLabel>
-      {/* Why: host + project filters share one section and the same single-row
-          shell as Sort by (label left, value right) so the menu stays flat. */}
-      {(showHostScopeControls || repos.length > 1) && (
+      {/* Why: host + project + status filters share one section and the same
+          single-row shell as Sort by (label left, value right) so the menu
+          stays flat. Status is always available, so this section always shows. */}
+      {(showHostScopeControls || repos.length > 1 || workspaceStatuses.length > 0) && (
         <>
           <DropdownMenuLabel>
             {translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.showSection', 'Show')}
@@ -131,6 +146,7 @@ export function WorkspaceOptionsMenuItems({
               setVisibleWorkspaceHostIds={setVisibleWorkspaceHostIds}
             />
           )}
+          <SidebarStatusFilterSection preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen} />
           <SidebarRepositoryFilterSection preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen} />
           <DropdownMenuSeparator />
         </>

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-filters.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-filters.ts
@@ -9,6 +9,7 @@ export type SidebarWorktreeFilters = ReturnType<typeof useSidebarWorktreeFilters
 export function useSidebarWorktreeFilters() {
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const filterWorkspaceStatuses = useAppStore((s) => s.filterWorkspaceStatuses)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
@@ -30,6 +31,7 @@ export function useSidebarWorktreeFilters() {
     (s) => s.setAlwaysShowDefaultBranchWorkspace
   )
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
+  const setFilterWorkspaceStatuses = useAppStore((s) => s.setFilterWorkspaceStatuses)
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
 
   // Why: count hideDefaultBranchWorkspace as a filter so the Clear Filters escape hatch stays reachable when it alone empties the list.
@@ -37,6 +39,7 @@ export function useSidebarWorktreeFilters() {
     () => ({
       showSleepingWorkspaces,
       filterRepoIds,
+      filterWorkspaceStatuses,
       hideDefaultBranchWorkspace,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
@@ -49,6 +52,7 @@ export function useSidebarWorktreeFilters() {
     [
       showSleepingWorkspaces,
       filterRepoIds,
+      filterWorkspaceStatuses,
       hideDefaultBranchWorkspace,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
@@ -67,6 +71,9 @@ export function useSidebarWorktreeFilters() {
     }
     if (actions.resetFilterRepoIds) {
       setFilterRepoIds([])
+    }
+    if (actions.resetFilterWorkspaceStatuses) {
+      setFilterWorkspaceStatuses([])
     }
     if (actions.resetHideDefaultBranchWorkspace) {
       setHideDefaultBranchWorkspace(false)
@@ -92,6 +99,7 @@ export function useSidebarWorktreeFilters() {
   }, [
     setShowSleepingWorkspaces,
     setFilterRepoIds,
+    setFilterWorkspaceStatuses,
     setHideDefaultBranchWorkspace,
     setHideAutomationGeneratedWorkspaces,
     setHideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.test.tsx
@@ -46,6 +46,7 @@ describe('useVisibleSidebarWorktrees', () => {
         filterState: {
           showSleepingWorkspaces: true,
           filterRepoIds: [],
+          filterWorkspaceStatuses: [],
           hideDefaultBranchWorkspace: false,
           hideAutomationGeneratedWorkspaces: false,
           hideCliCreatedWorkspaces: false,
@@ -81,6 +82,7 @@ describe('useVisibleSidebarWorktrees', () => {
         filterState: {
           showSleepingWorkspaces: true,
           filterRepoIds: [],
+          filterWorkspaceStatuses: [],
           hideDefaultBranchWorkspace: false,
           hideAutomationGeneratedWorkspaces: false,
           hideCliCreatedWorkspaces: false,
@@ -112,6 +114,7 @@ describe('useVisibleSidebarWorktrees', () => {
       filterState: {
         showSleepingWorkspaces: true,
         filterRepoIds: [],
+        filterWorkspaceStatuses: [],
         hideDefaultBranchWorkspace: false,
         hideAutomationGeneratedWorkspaces: false,
         hideCliCreatedWorkspaces: false,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -37,6 +37,7 @@ export function useVisibleSidebarWorktrees(args: {
   const {
     showSleepingWorkspaces,
     filterRepoIds,
+    filterWorkspaceStatuses,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,
@@ -47,6 +48,7 @@ export function useVisibleSidebarWorktrees(args: {
     workspaceHostScope
   } = filterState
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const agentStatusEpoch = useAppStore((s) => (!showSleepingWorkspaces ? s.agentStatusEpoch : 0))
   // Why: skip the clock entirely when the epoch is the opt-out sentinel, so a
   // sleeping-workspaces list cannot evict the sample the live lists share.
@@ -77,6 +79,8 @@ export function useVisibleSidebarWorktrees(args: {
     void agentStatusEpoch
     return computeVisibleWorktrees(worktreesByRepo, sortedIds, {
       filterRepoIds,
+      filterWorkspaceStatuses,
+      workspaceStatuses,
       showSleepingWorkspaces,
       tabsByWorktree,
       ptyIdsByTabId,
@@ -110,6 +114,8 @@ export function useVisibleSidebarWorktrees(args: {
     agentStatusEpoch,
     agentStatusNow,
     filterRepoIds,
+    filterWorkspaceStatuses,
+    workspaceStatuses,
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5354,6 +5354,12 @@
           "19e32d0e5f": "Open folder picker to add a project",
           "abc62b6328": "Add Project"
         },
+        "SidebarStatusFilterSection": {
+          "allStatuses": "All statuses",
+          "selectedStatusesCount": "{{value0}} statuses",
+          "status": "Status",
+          "clear": "Clear"
+        },
         "SidebarWorkspaceFilterSection": {
           "c3fa13dc2e": "Hide default branch",
           "ed1611b65b": "Hide sleeping",

--- a/src/renderer/src/lib/worktree-activation-status-filter.test.ts
+++ b/src/renderer/src/lib/worktree-activation-status-filter.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../shared/worktree/types'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from './worktree-activation'
+import { cloneDefaultWorkspaceStatuses } from '../../../shared/workspace-statuses'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::/workspace/feature',
+    repoId: 'repo-1',
+    path: '/workspace/feature',
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function seedActiveWorktree(worktree: Worktree, extra: Record<string, unknown>): () => void {
+  const revealWorktreeInSidebar = vi.fn()
+  useAppStore.setState({
+    repos: [
+      {
+        id: worktree.repoId,
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000000',
+        addedAt: 0
+      }
+    ],
+    worktreesByRepo: { [worktree.repoId]: [worktree] },
+    activeRepoId: worktree.repoId,
+    activeView: 'terminal',
+    activeWorktreeId: worktree.id,
+    activeTabId: 'tab-1',
+    activeTabType: 'terminal',
+    tabsByWorktree: { [worktree.id]: [] },
+    ptyIdsByTabId: {},
+    everActivatedWorktreeIds: new Set([worktree.id]),
+    workspaceStatuses: cloneDefaultWorkspaceStatuses(),
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    refreshGitHubForWorktreeIfStale: vi.fn(),
+    revealWorktreeInSidebar,
+    ...extra
+  })
+  return () => expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+}
+
+describe('activateAndRevealWorktree workspace-status filter', () => {
+  it('clears a status filter that would hide the revealed worktree', () => {
+    // Unset status resolves to the catalog default (in-progress); filter is completed.
+    const worktree = makeWorktree()
+    const expectRevealed = seedActiveWorktree(worktree, {
+      filterWorkspaceStatuses: ['completed']
+    })
+
+    activateAndRevealWorktree(worktree.id)
+
+    expect(useAppStore.getState().filterWorkspaceStatuses).toEqual([])
+    expectRevealed()
+  })
+
+  it('leaves the status filter intact when the target matches it', () => {
+    const worktree = makeWorktree({ workspaceStatus: 'completed' })
+    seedActiveWorktree(worktree, { filterWorkspaceStatuses: ['completed'] })
+
+    activateAndRevealWorktree(worktree.id)
+
+    expect(useAppStore.getState().filterWorkspaceStatuses).toEqual(['completed'])
+  })
+})

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -22,6 +22,7 @@ import {
 } from './folder-workspace-path-status'
 import { toast } from 'sonner'
 import { isDetachedHeadWorkspace } from '@/components/sidebar/visible-worktrees'
+import { getWorkspaceStatus } from '../../../shared/workspace-statuses'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import { findFolderWorkspaceOwner } from './folder-workspace-runtime-owner'
 import type { WorktreeStartupPayload } from '@/lib/worktree-startup-payload'
@@ -294,6 +295,12 @@ export function activateAndRevealWorktree(
     if (state.hideDetachedHeadWorkspaces && isDetachedHeadWorkspace(wt)) {
       state.setHideDetachedHeadWorkspaces(false)
     }
+  }
+  if (
+    state.filterWorkspaceStatuses.length > 0 &&
+    !state.filterWorkspaceStatuses.includes(getWorkspaceStatus(wt, state.workspaceStatuses))
+  ) {
+    state.setFilterWorkspaceStatuses([])
   }
 
   // 6. Reveal in sidebar

--- a/src/renderer/src/store/slices/persisted-ui-write-baseline.test.ts
+++ b/src/renderer/src/store/slices/persisted-ui-write-baseline.test.ts
@@ -28,6 +28,7 @@ function makeBaseline(overrides: Partial<PersistedUIWriteBaseline> = {}): Persis
     alwaysShowDefaultBranchWorkspace: true,
     showDotfilesByWorktree: {},
     filterRepoIds: [],
+    filterWorkspaceStatuses: [],
     acknowledgedAgentsByPaneKey: {},
     activityClearedAtByPaneKey: {},
     manuallyUnreadTurnsByPaneKey: {},

--- a/src/renderer/src/store/slices/persisted-ui-write-baseline.ts
+++ b/src/renderer/src/store/slices/persisted-ui-write-baseline.ts
@@ -1,4 +1,5 @@
 import type { PersistedUIState } from '../../../../shared/persisted-ui-state-types'
+import type { WorkspaceStatus } from '../../../../shared/worktree/types'
 
 /**
  * Mirror-shaped snapshot of the fields the debounced persisted-UI writer owns.
@@ -28,6 +29,7 @@ export type PersistedUIWriteBaseline = {
   alwaysShowDefaultBranchWorkspace: boolean
   showDotfilesByWorktree: Record<string, boolean>
   filterRepoIds: readonly string[]
+  filterWorkspaceStatuses: readonly WorkspaceStatus[]
   acknowledgedAgentsByPaneKey: Record<string, number>
   activityClearedAtByPaneKey: Record<string, number>
   manuallyUnreadTurnsByPaneKey: Record<string, number>
@@ -57,6 +59,7 @@ const PERSISTED_UI_WRITE_BASELINE_FIELD_SET = {
   alwaysShowDefaultBranchWorkspace: true,
   showDotfilesByWorktree: true,
   filterRepoIds: true,
+  filterWorkspaceStatuses: true,
   acknowledgedAgentsByPaneKey: true,
   activityClearedAtByPaneKey: true,
   manuallyUnreadTurnsByPaneKey: true
@@ -96,7 +99,7 @@ function stringArrayEqual(a: readonly string[], b: readonly string[]): boolean {
 }
 
 function writeFieldEqual(field: keyof PersistedUIWriteBaseline, a: unknown, b: unknown): boolean {
-  if (field === 'filterRepoIds') {
+  if (field === 'filterRepoIds' || field === 'filterWorkspaceStatuses') {
     return stringArrayEqual(a as readonly string[], b as readonly string[])
   }
   if (
@@ -148,6 +151,9 @@ export function persistedUIWriteFieldsToWireUpdate(
       // Why: the store keeps this readonly for identity stability, but PersistedUI crosses to
       // main, which owns a mutable array — copy at the boundary rather than widening the wire type.
       update.filterRepoIds = [...(fields.filterRepoIds ?? [])]
+    } else if (field === 'filterWorkspaceStatuses') {
+      // Same readonly-store / mutable-main boundary as filterRepoIds.
+      update.filterWorkspaceStatuses = [...(fields.filterWorkspaceStatuses ?? [])]
     } else {
       assignSameNameWireField(
         update,
@@ -161,7 +167,7 @@ export function persistedUIWriteFieldsToWireUpdate(
 
 type SameNameWriteField = Exclude<
   keyof PersistedUIWriteBaseline,
-  'showSleepingWorkspaces' | 'filterRepoIds'
+  'showSleepingWorkspaces' | 'filterRepoIds' | 'filterWorkspaceStatuses'
 >
 
 // Compile check: every non-special mirror field must exist on PersistedUIState

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../../../../shared/ui-chrome-types'
 import type { UsagePercentageDisplay } from '../../../../../shared/usage-percentage-display'
 import type { AutomationHostFilter } from '../../../../../shared/automation-host-filter'
-import type { WorkspaceStatusDefinition } from '../../../../../shared/worktree/types'
+import type { WorkspaceStatus, WorkspaceStatusDefinition } from '../../../../../shared/worktree/types'
 import type { WorkspacePortScanResult } from '../../../../../shared/workspace-ports'
 import type { CustomPet } from '../../../../../shared/pet-types'
 import type { ReleaseChannel } from '../../../../../shared/release-channel'
@@ -64,6 +64,9 @@ export type UISlicePreferences = {
   toggleShowDotfilesForWorktree: (worktreeId: string) => void
   filterRepoIds: readonly string[]
   setFilterRepoIds: (ids: readonly string[]) => void
+  /** Selected workspace-status ids; empty means every status is shown. */
+  filterWorkspaceStatuses: WorkspaceStatus[]
+  setFilterWorkspaceStatuses: (ids: WorkspaceStatus[]) => void
   /** Agents-view scope filters, independent from workspace navigation filters. */
   agentsVisibleHostIds: VisibleWorkspaceHostIds
   setAgentsVisibleHostIds: (ids: VisibleWorkspaceHostIds) => void

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -27,7 +27,8 @@ import {
 import {
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
-  normalizeWorkspaceStatuses
+  normalizeWorkspaceStatuses,
+  sanitizeFilterWorkspaceStatuses
 } from '../../../../../shared/workspace-statuses'
 import { PET_SIZE_DEFAULT, PET_SIZE_MAX, PET_SIZE_MIN } from '../../../../../shared/pet-types'
 import { clampMarkdownTocPanelWidth } from '../../../../../shared/markdown-toc-panel-width'
@@ -197,6 +198,12 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
           _worktreeCardModeDefaulted: ui._worktreeCardModeDefaulted === true,
           agentActivityDisplayMode: normalizeAgentActivityDisplayMode(ui.agentActivityDisplayMode),
           workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
+          // Why: validate against the same normalized catalog so a filter for a
+          // since-deleted custom status can't hide every workspace on restart.
+          filterWorkspaceStatuses: sanitizeFilterWorkspaceStatuses(
+            ui.filterWorkspaceStatuses,
+            normalizeWorkspaceStatuses(ui.workspaceStatuses)
+          ),
           workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
           workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
           syncTaskStatusFromWorkspaceBoard: ui.syncTaskStatusFromWorkspaceBoard === true,

--- a/src/renderer/src/store/slices/ui/ui-slice-preference-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-preference-actions.ts
@@ -35,6 +35,7 @@ import {
   clampWorkspaceBoardOpacity,
   cloneDefaultWorkspaceStatuses,
   normalizeWorkspaceStatuses,
+  sanitizeFilterWorkspaceStatuses,
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT
 } from '../../../../../shared/workspace-statuses'
 
@@ -153,6 +154,10 @@ export function createUiPreferenceActions(set: UISliceSet, get: UISliceGet): Par
     filterRepoIds: [],
     setFilterRepoIds: (ids) => set({ filterRepoIds: ids }),
 
+    // Why: bare set — persists only via the debounced writer in use-persisted-ui-writer.ts.
+    filterWorkspaceStatuses: [],
+    setFilterWorkspaceStatuses: (ids) => set({ filterWorkspaceStatuses: ids }),
+
     agentsVisibleHostIds: null,
     setAgentsVisibleHostIds: (ids) => {
       const agentsVisibleHostIds = normalizeVisibleExecutionHostIds(ids)
@@ -238,8 +243,16 @@ export function createUiPreferenceActions(set: UISliceSet, get: UISliceGet): Par
     workspaceStatuses: cloneDefaultWorkspaceStatuses(),
     setWorkspaceStatuses: (statuses) => {
       const normalized = normalizeWorkspaceStatuses(statuses)
-      window.api.ui.set({ workspaceStatuses: normalized }).catch(console.error)
-      set({ workspaceStatuses: normalized })
+      // Why: drop filter ids for statuses this edit deleted/renamed, so a stale
+      // selection can't silently empty the sidebar while the badge reads "all".
+      const filterWorkspaceStatuses = sanitizeFilterWorkspaceStatuses(
+        get().filterWorkspaceStatuses,
+        normalized
+      )
+      window.api.ui
+        .set({ workspaceStatuses: normalized, filterWorkspaceStatuses })
+        .catch(console.error)
+      set({ workspaceStatuses: normalized, filterWorkspaceStatuses })
     },
 
     workspaceBoardOpacity: 1,

--- a/src/renderer/src/store/slices/workspace-status-filter-prune.test.ts
+++ b/src/renderer/src/store/slices/workspace-status-filter-prune.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
+
+// Why: setWorkspaceStatuses persists via window.api.ui.set; stub it so the
+// prune path runs without a real IPC bridge.
+const uiSet = vi.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+  uiSet.mockClear()
+  vi.stubGlobal('window', { api: { ui: { set: uiSet } } })
+})
+
+describe('setWorkspaceStatuses prunes filterWorkspaceStatuses', () => {
+  it('drops a filter id when its status is deleted from the catalog', () => {
+    const store = createTestStore()
+    const withCustom = [
+      ...cloneDefaultWorkspaceStatuses(),
+      { id: 'blocked', label: 'Blocked', color: 'rose', icon: 'ban' }
+    ]
+    store.setState({
+      workspaceStatuses: withCustom,
+      filterWorkspaceStatuses: ['blocked', 'completed']
+    })
+
+    // Delete the custom "blocked" status.
+    store.getState().setWorkspaceStatuses(cloneDefaultWorkspaceStatuses())
+
+    expect(store.getState().filterWorkspaceStatuses).toEqual(['completed'])
+    expect(uiSet).toHaveBeenCalledWith(
+      expect.objectContaining({ filterWorkspaceStatuses: ['completed'] })
+    )
+  })
+
+  it('leaves the filter untouched when every selected status survives', () => {
+    const store = createTestStore()
+    store.setState({
+      workspaceStatuses: cloneDefaultWorkspaceStatuses(),
+      filterWorkspaceStatuses: ['todo', 'completed']
+    })
+
+    store.getState().setWorkspaceStatuses(cloneDefaultWorkspaceStatuses())
+
+    expect(store.getState().filterWorkspaceStatuses).toEqual(['todo', 'completed'])
+  })
+
+  it('clears the filter when the sole selected status is removed', () => {
+    const store = createTestStore()
+    const withCustom = [
+      ...cloneDefaultWorkspaceStatuses(),
+      { id: 'blocked', label: 'Blocked', color: 'rose', icon: 'ban' }
+    ]
+    store.setState({ workspaceStatuses: withCustom, filterWorkspaceStatuses: ['blocked'] })
+
+    store.getState().setWorkspaceStatuses(cloneDefaultWorkspaceStatuses())
+
+    expect(store.getState().filterWorkspaceStatuses).toEqual([])
+  })
+})

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -270,6 +270,7 @@ export function getDefaultUIState(): PersistedUIState {
     alwaysShowDefaultBranchWorkspace: true,
     showDotfilesByWorktree: {},
     filterRepoIds: [],
+    filterWorkspaceStatuses: [],
     agentsVisibleHostIds: null,
     agentsFilterRepoIds: [],
     agentsShowChildAgents: false,

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -23,7 +23,7 @@ import type {
   WorkspaceHostScope,
   WorktreeCardProperty
 } from './ui-chrome-types'
-import type { WorkspaceStatusDefinition } from './worktree/types'
+import type { WorkspaceStatus, WorkspaceStatusDefinition } from './worktree/types'
 import type { PersistedAutomationHostFilter } from './automation-host-filter'
 
 export type PersistedUIState = {
@@ -75,6 +75,8 @@ export type PersistedUIState = {
   /** Per-worktree Explorer dotfile visibility. Missing entries inherit the default: show. */
   showDotfilesByWorktree?: Record<string, boolean>
   filterRepoIds: string[]
+  /** Selected workspace-status ids for the sidebar/board status filter; empty/absent means every status is shown. */
+  filterWorkspaceStatuses?: WorkspaceStatus[]
   /** Agents-view host scope; deliberately separate from visibleWorkspaceHostIds so a monitoring surface never inherits nav filters silently. `null` = all hosts. */
   agentsVisibleHostIds?: VisibleWorkspaceHostIds
   /** Agents-view project filter; empty = all projects. Separate from filterRepoIds (workspace nav). */

--- a/src/shared/rpc-contract/client-ui-workspace-filter-fields-params.ts
+++ b/src/shared/rpc-contract/client-ui-workspace-filter-fields-params.ts
@@ -7,5 +7,6 @@ export const ClientUiWorkspaceFilterFields = {
   hideDetachedHeadWorkspaces: z.boolean().optional(),
   hideWorkspacesFromOtherDevices: z.boolean().optional(),
   alwaysShowDefaultBranchWorkspace: z.boolean().optional(),
-  filterRepoIds: z.array(z.string()).optional()
+  filterRepoIds: z.array(z.string()).optional(),
+  filterWorkspaceStatuses: z.array(z.string()).optional()
 }

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -6,7 +6,8 @@ import {
   clampWorkspaceBoardColumnWidth,
   cloneDefaultWorkspaceStatuses,
   normalizePersistedWorkspaceStatuses,
-  normalizeWorkspaceStatuses
+  normalizeWorkspaceStatuses,
+  sanitizeFilterWorkspaceStatuses
 } from './workspace-statuses'
 
 describe('workspace status visuals', () => {
@@ -296,5 +297,40 @@ describe('workspace status visuals', () => {
     expect(clampWorkspaceBoardColumnWidth(100)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MIN)
     expect(clampWorkspaceBoardColumnWidth(321.6)).toBe(322)
     expect(clampWorkspaceBoardColumnWidth(900)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MAX)
+  })
+})
+
+describe('sanitizeFilterWorkspaceStatuses', () => {
+  const catalog = cloneDefaultWorkspaceStatuses()
+
+  it('returns an empty list for non-arrays or empty input', () => {
+    expect(sanitizeFilterWorkspaceStatuses(undefined, catalog)).toEqual([])
+    expect(sanitizeFilterWorkspaceStatuses(null, catalog)).toEqual([])
+    expect(sanitizeFilterWorkspaceStatuses('completed', catalog)).toEqual([])
+    expect(sanitizeFilterWorkspaceStatuses([], catalog)).toEqual([])
+  })
+
+  it('keeps only ids present in the live catalog', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['completed', 'ghost-status', 'todo'], catalog)).toEqual(
+      ['todo', 'completed']
+    )
+  })
+
+  it('drops non-string entries and de-dupes', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['completed', 42, 'completed', null], catalog)).toEqual([
+      'completed'
+    ])
+  })
+
+  it('orders the result by the catalog, not the input', () => {
+    // Input order is reversed; result must follow the board-column order.
+    expect(sanitizeFilterWorkspaceStatuses(['completed', 'todo'], catalog)).toEqual([
+      'todo',
+      'completed'
+    ])
+  })
+
+  it('returns empty when none of the ids survive against the catalog', () => {
+    expect(sanitizeFilterWorkspaceStatuses(['gone-1', 'gone-2'], catalog)).toEqual([])
   })
 })

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -268,6 +268,32 @@ export function getWorkspaceStatus(
     : getDefaultWorkspaceStatusId(statuses)
 }
 
+/**
+ * Sanitize a persisted/inbound list of status-filter ids against the live
+ * status catalog. Drops ids the catalog no longer defines (e.g. a custom
+ * status the user deleted) and de-dupes, so a stale filter can never hide
+ * every workspace with no matching lane. Order follows the catalog so the
+ * filter chips read in the same order as the board columns.
+ */
+export function sanitizeFilterWorkspaceStatuses(
+  value: unknown,
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const requested = new Set<string>()
+  for (const entry of value) {
+    if (typeof entry === 'string') {
+      requested.add(entry)
+    }
+  }
+  if (requested.size === 0) {
+    return []
+  }
+  return statuses.filter((status) => requested.has(status.id)).map((status) => status.id)
+}
+
 export function getWorkspaceStatusGroupKey(status: WorkspaceStatus): string {
   return `${WORKSPACE_STATUS_GROUP_PREFIX}${encodeURIComponent(status)}`
 }

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -269,6 +269,24 @@ export function getWorkspaceStatus(
 }
 
 /**
+ * Selected status ids intersected with the live catalog, so a since-deleted
+ * custom status can't inflate a count or falsely signal an applied filter.
+ */
+export function getLiveSelectedWorkspaceStatusIds(
+  statuses: readonly WorkspaceStatusDefinition[],
+  filterWorkspaceStatuses: readonly WorkspaceStatus[]
+): Set<WorkspaceStatus> {
+  const selected = new Set(filterWorkspaceStatuses)
+  const live = new Set<WorkspaceStatus>()
+  for (const status of statuses) {
+    if (selected.has(status.id)) {
+      live.add(status.id)
+    }
+  }
+  return live
+}
+
+/**
  * Sanitize a persisted/inbound list of status-filter ids against the live
  * status catalog. Drops ids the catalog no longer defines (e.g. a custom
  * status the user deleted) and de-dupes, so a stale filter can never hide


### PR DESCRIPTION
## ELI5

The sidebar can already **group** workspaces by status, but it couldn't **filter** by it — so grouping "by project" still showed every card no matter whether it was Todo, In progress, In review, or Done. This adds a status filter so you can say "show me only what's still in progress" or "hide everything that's done."

## What Changed

- New **multi-select status filter** in the sidebar options menu (⚙️) and the Workspace Board filter menu — one checkbox per workspace status, with its colored status icon, a count badge, and a Clear action.
- Empty selection = show all (no behavior change). Selecting statuses narrows the list:
  - Only Done → select Done
  - Only In progress → select In progress
  - Not completed → select Todo + In progress + In review
- Implemented as a predicate in the shared `computeVisibleWorktreeIds` pipeline, so it applies in **every** grouping mode (Project / Status / PR / None) and to **both** the sidebar list and the Workspace Board automatically.
- State `filterWorkspaceStatuses` is persisted via `PersistedUIState` (new optional field) and validated against the live status catalog on hydration and whenever the catalog changes, so a deleted custom status can't silently empty the list.
- Activating/revealing a workspace clears a status filter that would otherwise hide it, mirroring the existing repo-filter reveal behavior.
- Refactor: extracted `addVisibleLineageAncestors` into its own module so `visible-worktrees.ts` stays under the `max-lines` budget (no rule disable).

## Why

The Workspace Board and Agent Dashboard already filter by workspace status; the sidebar list did not, which is both a feature gap and an inconsistency across surfaces that share the same `workspaceStatus` model. This mirrors the multi-select workspace-status filter shipped for the Agent Dashboard in #11042, reusing the same model and visual metadata.

## Linked Issue

Fixes #13996

Related prior work (Agent Dashboard status filter this mirrors): #11042

## Visual Proof

⚠️ Not yet attached. This was developed in a headless environment where the Electron app can't be launched, so I could not capture before/after screenshots. I will add a short before/after clip of the sidebar status filter (grouped by project) before merge. Reviewers running locally can reproduce with the steps below.

## How to test

1. Open the sidebar options menu (the sliders icon in the sidebar header).
2. Under "Show", open the new **Status** submenu; select one or more statuses.
3. Confirm the sidebar list narrows to only workspaces with those statuses, in any grouping mode (Project / Status / PR / None).
4. Repeat from the Workspace Board's filter menu — the same selection drives both surfaces.
5. Delete a custom status you had filtered on (in the board) and confirm the list does not go silently empty.
6. With a status filter active, activate/reveal a workspace whose status isn't selected and confirm it's revealed (the filter clears).

- [x] I manually tested these changes locally — see note under Visual Proof; automated coverage below stands in for the full manual pass on this headless run.
- [x] Automated tests added/updated

Automated verification (all green): `pnpm typecheck` (web/node/cli), `oxlint` + `oxfmt --check`, focused Vitest suites (283 tests incl. new predicate/sanitizer/store-prune/reveal-clear/component tests), the localization catalog/extraction/coverage gates, and a clean `electron-vite` renderer build.

## AI Disclosure

Implemented with Claude Code (Claude Opus 5, 1M context). Research, implementation, multi-agent adversarial review, and fixes were AI-assisted; the diff was reviewed for correctness, wire/persistence compatibility, and UI/i18n consistency.

## Review

- **Security:** no new IPC surface beyond an optional string-array preference field validated by Zod.
- **Cross-platform:** pure store/UI logic, no platform-specific paths or shortcuts.
- **Remote SSH:** `filterWorkspaceStatuses` is a new **optional** client→host preference (backward-safe); old clients/hosts ignore it. No host-published payload changes.
- **Mobile:** unaffected; mobile omits the optional field so a desktop-set value is preserved, not clobbered (status filter UI is desktop-only for now).
- **Backwards compatibility:** old profiles hydrate to `[]` (show all). Added to the `ui.set` Zod schema so the schema-parity assertions hold.
- **Performance:** one extra `.filter()` predicate over an already-materialized list; no new subscriptions in hot paths.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — pending, see Visual Proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @your_handle
