### PR TITLE
fix(renderer): keep commit tooltip lines intact

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -94,7 +94,12 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
                 {item.subject}
               </span>
             </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+            <TooltipContent
+              side="bottom"
+              sideOffset={6}
+              collisionPadding={8}
+              className="max-w-[min(76ch,var(--radix-tooltip-content-available-width))] break-words text-wrap whitespace-pre-wrap"
+            >
               {rowTooltip}
             </TooltipContent>
           </Tooltip>

--- a/tests/e2e/git-history-tooltip-wrap.spec.ts
+++ b/tests/e2e/git-history-tooltip-wrap.spec.ts
@@ -1,0 +1,144 @@
+import { execFileSync } from 'node:child_process'
+import { rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+import { openSourceControlForWorktree } from './helpers/worktree-registration'
+
+const subject = 'brew-install: source shared brew context before resolving prefixes'
+const reportedLine = 'Sources bin/lib/brew-context.sh, mirroring the brew-install update:'
+const conventionalLine = 'Keep this conventional commit-message body line intact through column 72'
+const unbrokenLine = `https://example.com/${'commit-message-segment-'.repeat(8)}`
+const commitMessage = `${subject}
+
+${reportedLine}
+${conventionalLine}
+${unbrokenLine}
+the resolved prefix list now feeds both the cask audit and the formula
+path checks, so a missing context aborts before any network call runs.
+
+Verified by running the full tap audit locally with both prefixes set.`
+
+function createCommitWorktree(repoPath: string): { branchName: string; worktreePath: string } {
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const branchName = `e2e-tooltip-wrap-${suffix}`
+  const worktreePath = path.join(os.tmpdir(), branchName)
+  execFileSync('git', ['worktree', 'add', worktreePath, '-b', branchName], {
+    cwd: repoPath,
+    stdio: 'pipe'
+  })
+  return { branchName, worktreePath }
+}
+
+async function cleanupCommitWorktree(
+  repoPath: string,
+  worktreePath: string,
+  branchName: string
+): Promise<void> {
+  try {
+    execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
+      cwd: repoPath,
+      stdio: 'pipe'
+    })
+  } catch {
+    rmSync(worktreePath, { recursive: true, force: true })
+    execFileSync('git', ['worktree', 'prune'], { cwd: repoPath, stdio: 'pipe' })
+  }
+  execFileSync('git', ['branch', '-D', branchName], { cwd: repoPath, stdio: 'pipe' })
+}
+
+test('keeps conventional commit-message lines intact in the history tooltip', async ({
+  orcaPage,
+  testRepoPath,
+  registerPostElectronShutdownCleanup
+}) => {
+  const fixture = createCommitWorktree(testRepoPath)
+  registerPostElectronShutdownCleanup(() =>
+    cleanupCommitWorktree(testRepoPath, fixture.worktreePath, fixture.branchName)
+  )
+  execFileSync('git', ['commit', '--allow-empty', '--file', '-'], {
+    cwd: fixture.worktreePath,
+    input: commitMessage,
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+
+  await orcaPage.setViewportSize({ width: 1440, height: 900 })
+  await waitForSessionReady(orcaPage)
+  await openSourceControlForWorktree(orcaPage, testRepoPath, fixture.worktreePath)
+
+  const commitsToggle = orcaPage.getByRole('button', { name: /Commits/ })
+  await expect(commitsToggle).toBeVisible()
+  await commitsToggle.click()
+
+  const row = orcaPage.getByTestId('git-history-row').filter({ hasText: subject })
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  const trigger = row.locator('[data-slot="tooltip-trigger"]').filter({ hasText: subject })
+  await trigger.hover({ position: { x: 20, y: 10 } })
+  await trigger.hover({ position: { x: 40, y: 10 } })
+
+  const tooltip = orcaPage
+    .locator('[data-slot="tooltip-content"]')
+    .filter({ hasText: reportedLine })
+  await expect(tooltip).toBeVisible()
+  await expect(tooltip).toContainText(commitMessage)
+  await orcaPage.evaluate(async () => {
+    await document.fonts.ready
+  })
+
+  const layout = await tooltip.evaluate(
+    (element, targetLines) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      let textNode: Text | null = null
+      while (walker.nextNode()) {
+        const candidate = walker.currentNode as Text
+        if (targetLines.every((line) => candidate.data.includes(line))) {
+          textNode = candidate
+          break
+        }
+      }
+      if (!textNode) {
+        throw new Error('Commit message text node was not found in the tooltip')
+      }
+
+      const visualLineCounts = targetLines.map((targetLine) => {
+        const start = textNode.data.indexOf(targetLine)
+        const range = document.createRange()
+        range.setStart(textNode, start)
+        range.setEnd(textNode, start + targetLine.length)
+        const rectTops = Array.from(range.getClientRects())
+          .filter((rect) => rect.width > 0.5)
+          .map((rect) => rect.top)
+        const visualLineTops = rectTops.reduce<number[]>((tops, top) => {
+          if (!tops.some((existing) => Math.abs(existing - top) < 2)) {
+            tops.push(top)
+          }
+          return tops
+        }, [])
+        return visualLineTops.length
+      })
+
+      const style = getComputedStyle(element)
+      const tooltipRect = element.getBoundingClientRect()
+      return {
+        visualLineCounts,
+        tooltipLeft: tooltipRect.left,
+        tooltipRight: tooltipRect.right,
+        tooltipWidth: tooltipRect.width,
+        viewportWidth: window.innerWidth,
+        overflowContained: element.scrollWidth <= element.clientWidth,
+        textWrap: style.textWrap,
+        whiteSpace: style.whiteSpace
+      }
+    },
+    [reportedLine, conventionalLine]
+  )
+
+  expect(layout.whiteSpace).toBe('pre-wrap')
+  expect(layout.tooltipWidth).toBeGreaterThan(0)
+  expect(layout.tooltipLeft).toBeGreaterThanOrEqual(0)
+  expect(layout.tooltipRight).toBeLessThanOrEqual(layout.viewportWidth)
+  expect(layout.visualLineCounts).toEqual([1, 1])
+  expect(layout.overflowContained).toBe(true)
+  expect(layout.textWrap).toBe('wrap')
+})


### PR DESCRIPTION
## Summary

Fixes https://github.com/stablyai/orca/issues/13793 / STA-3893.

The Source Control commit-history tooltip is the one tooltip rendering a pre-formatted, multiline commit message, but it inherited the shared tooltip label defaults: `max-w-96` plus balanced text wrapping. That made authored 67- and 72-character commit-message lines soft-wrap early even when the viewport had enough room.

This keeps the ownership local to `GitHistoryRow`: commit-message tooltip content now uses a semantic `76ch` cap, Radix's available-width collision bound, plain wrapping instead of `text-balance`, and `break-words` for long SHA/URL-like tokens. Shared `TooltipContent` remains tuned for short labels.

Reference: PR #13811 identified the same local width/wrap direction; this PR adds the deterministic regression oracle and full red/green/revert evidence.

## Before / after proof

Before on affected main: the reported 67-character line splits before `update:`.

![before-latest-main.png](https://github.com/user-attachments/assets/8adc7ce9-ccb8-4f04-a402-45f66bbf0622)

After candidate: the reported line and representative 72-character line stay on one visual line while explicit paragraph breaks remain.

![after-candidate-light.png](https://github.com/user-attachments/assets/8a26fbaf-d991-4368-bbc2-2469596e63ab)

## Deterministic oracle

Falsifiable invariant: at a sufficiently wide viewport, the reported line and representative conventional-width commit prose through 72 characters render as one visual line; explicit newlines remain hard breaks. The 76ch readable-measure cap is intentionally not a guarantee for every possible 72-glyph proportional-font string.

Observable failure: the reported 67-character line and a 72-character fixture render as two visual lines on affected main / disabled-fix control.

Authoritative subsystem: `src/renderer/src/components/right-sidebar/GitHistoryRow.tsx` tooltip presentation, not Git parsing, provider behavior, IPC, or remote transport.

Same byte-identical Playwright/Electron oracle:

- affected latest-main behavior: RED `[2, 2]`
- candidate fix: GREEN `[1, 1]`
- candidate with the fix reverted/disabled: RED `[2, 2]`

The test also asserts exact tooltip text/newlines, `white-space: pre-wrap`, `text-wrap: wrap`, viewport containment, and no overflow from a long unbroken URL.

## Validation

Post-rebase onto `origin/main` `36d45af062`:

- `pnpm exec playwright test tests/e2e/git-history-tooltip-wrap.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` ✅
- `pnpm typecheck` ✅
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/GitHistoryRow.tsx tests/e2e/git-history-tooltip-wrap.spec.ts` ✅
- `pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/GitHistoryRow.tsx tests/e2e/git-history-tooltip-wrap.spec.ts` ✅
- `git diff --check` ✅

Pre-rebase full validation also passed:

- `pnpm lint` ✅ (only existing WorktreeJumpPalette hook warnings in the first oxlint phase)
- focused E2E oracle ✅
- two read-only internal review lanes returned CLEAN ✅

## Scope and compatibility

- UI-only CSS/class change; no IPC, persistence, RPC, stream, Git command, provider, or mobile wire surface changed.
- Neutral for macOS/Linux/Windows, SSH/remote, folder workspaces, git worktrees, WSL, GitLab/other providers, and Git 2.25 because the fix changes only renderer tooltip presentation for already-loaded commit text.
- Alternative rejected: changing shared `TooltipContent` would affect ~180 short-label tooltips; a dedicated component is premature while `GitHistoryRow` is the only multiline/pre-wrap tooltip consumer; raw viewport math is less correct than Radix's available-width variable.

