### PR TITLE
feat(usage): show Kiro subscription credits

### DIFF
--- a/src/main/codex-accounts/service-reset-credit-test-fixtures.ts
+++ b/src/main/codex-accounts/service-reset-credit-test-fixtures.ts
@@ -35,6 +35,7 @@ export function createResetRateLimitState(
     antigravity: null,
     minimax: null,
     grok: null,
+    kiro: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/main/rate-limits/kiro-usage-fetcher.test.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
+import { execFile } from 'node:child_process'
+import { getSpawnArgsForWindows } from '../win32-utils'
 import { fetchKiroRateLimits, parseKiroUsageOutput } from './kiro-usage-fetcher'
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
+vi.mock('../win32-utils', () => ({ getSpawnArgsForWindows: vi.fn() }))
+
+const KIRO_USAGE_OUTPUT =
+  'Estimated Usage | resets on 2026-09-01 | KIRO PRO\nCredits (10 of 100 covered in plan)\n10%'
 
 describe('Kiro usage fetcher', () => {
   it('parses the official CLI usage command output', () => {
@@ -19,8 +27,7 @@ Credits (1233.74 of 2000 covered in plan)
 
   it('runs the local non-model usage command', async () => {
     const runner = vi.fn().mockResolvedValue({
-      stdout:
-        'Estimated Usage | resets on 2026-09-01 | KIRO PRO\nCredits (10 of 100 covered in plan)\n10%',
+      stdout: KIRO_USAGE_OUTPUT,
       stderr: ''
     })
 
@@ -30,6 +37,36 @@ Credits (1233.74 of 2000 covered in plan)
       '/tmp/kiro-cli',
       ['chat', '/usage', '--no-interactive', '--wrap', 'never'],
       undefined
+    )
+    expect(result.status).toBe('ok')
+  })
+
+  it('launches configured .cmd shims through the shared Windows batch launcher', async () => {
+    vi.mocked(getSpawnArgsForWindows).mockReturnValue({
+      spawnCmd: 'C:\\Windows\\System32\\cmd.exe',
+      spawnArgs: ['/d', '/c', 'C:\\Users\\me\\bin\\kiro-cli.cmd', 'chat']
+    })
+    vi.mocked(execFile).mockImplementation(
+      ((_command, _args, _options, callback) => {
+        callback(null, KIRO_USAGE_OUTPUT, '')
+        return undefined as never
+      }) as unknown as typeof execFile
+    )
+
+    const result = await fetchKiroRateLimits({ command: 'C:\\Users\\me\\bin\\kiro-cli.cmd' })
+
+    expect(getSpawnArgsForWindows).toHaveBeenCalledWith('C:\\Users\\me\\bin\\kiro-cli.cmd', [
+      'chat',
+      '/usage',
+      '--no-interactive',
+      '--wrap',
+      'never'
+    ])
+    expect(execFile).toHaveBeenCalledWith(
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/c', 'C:\\Users\\me\\bin\\kiro-cli.cmd', 'chat'],
+      expect.anything(),
+      expect.any(Function)
     )
     expect(result.status).toBe('ok')
   })

--- a/src/main/rate-limits/kiro-usage-fetcher.test.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fetchKiroRateLimits, parseKiroUsageOutput } from './kiro-usage-fetcher'
+
+describe('Kiro usage fetcher', () => {
+  it('parses the official CLI usage command output', () => {
+    const result = parseKiroUsageOutput(`
+\u001b[1mEstimated Usage | resets on 2026-09-01 | KIRO PRO+\u001b[0m
+Credits (1233.74 of 2000 covered in plan)
+\u001b[32m████ 61%\u001b[0m
+`)
+
+    expect(result).toMatchObject({ provider: 'kiro', status: 'ok', planType: 'KIRO PRO+' })
+    expect(result.monthly?.usedPercent).toBeCloseTo(61.687)
+    expect(result.monthly?.resetsAt).toBe(Date.parse('2026-09-01T00:00:00.000Z'))
+  })
+
+  it('runs the local non-model usage command', async () => {
+    const runner = vi.fn().mockResolvedValue({
+      stdout:
+        'Estimated Usage | resets on 2026-09-01 | KIRO PRO\nCredits (10 of 100 covered in plan)\n10%',
+      stderr: ''
+    })
+
+    const result = await fetchKiroRateLimits({ command: '/tmp/kiro-cli', runner })
+
+    expect(runner).toHaveBeenCalledWith(
+      '/tmp/kiro-cli',
+      ['chat', '/usage', '--no-interactive', '--wrap', 'never'],
+      undefined
+    )
+    expect(result.status).toBe('ok')
+  })
+
+  it('fails closed on unexpected output', () => {
+    expect(parseKiroUsageOutput('Please sign in first')).toMatchObject({
+      provider: 'kiro',
+      status: 'error',
+      usageMetadata: { failureKind: 'parse' }
+    })
+  })
+
+  it('reports a missing CLI without exposing process details', async () => {
+    const error = Object.assign(new Error('spawn /secret/path ENOENT'), { code: 'ENOENT' })
+    const result = await fetchKiroRateLimits({ runner: vi.fn().mockRejectedValue(error) })
+
+    expect(result).toMatchObject({ status: 'unavailable', error: 'Kiro CLI is not installed' })
+    expect(JSON.stringify(result)).not.toContain('/secret/path')
+  })
+
+  it('distinguishes a failed usage command from a missing CLI', async () => {
+    const result = await fetchKiroRateLimits({
+      runner: vi.fn().mockRejectedValue(new Error('command timed out'))
+    })
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: 'Kiro usage command failed',
+      usageMetadata: { failureKind: 'usage-unavailable' }
+    })
+    expect(JSON.stringify(result)).not.toContain('command timed out')
+  })
+})

--- a/src/main/rate-limits/kiro-usage-fetcher.test.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.test.ts
@@ -11,7 +11,10 @@ Credits (1233.74 of 2000 covered in plan)
 
     expect(result).toMatchObject({ provider: 'kiro', status: 'ok', planType: 'KIRO PRO+' })
     expect(result.monthly?.usedPercent).toBeCloseTo(61.687)
-    expect(result.monthly?.resetsAt).toBe(Date.parse('2026-09-01T00:00:00.000Z'))
+    expect(result.monthly).toMatchObject({
+      resetsAt: null,
+      resetDescription: '2026-09-01'
+    })
   })
 
   it('runs the local non-model usage command', async () => {

--- a/src/main/rate-limits/kiro-usage-fetcher.test.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { execFile } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { getSpawnArgsForWindows } from '../win32-utils'
-import { fetchKiroRateLimits, parseKiroUsageOutput } from './kiro-usage-fetcher'
+import { fetchKiroRateLimits, parseKiroUsageOutput, resolveKiroCommand } from './kiro-usage-fetcher'
 
 vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
 vi.mock('../win32-utils', () => ({ getSpawnArgsForWindows: vi.fn() }))
@@ -10,6 +13,21 @@ const KIRO_USAGE_OUTPUT =
   'Estimated Usage | resets on 2026-09-01 | KIRO PRO\nCredits (10 of 100 covered in plan)\n10%'
 
 describe('Kiro usage fetcher', () => {
+  it('uses the shared CLI resolver for version-manager installs', () => {
+    const homePath = mkdtempSync(join(tmpdir(), 'orca-kiro-command-'))
+    const command = join(homePath, '.volta', 'bin', 'kiro-cli')
+    mkdirSync(join(homePath, '.volta', 'bin'), { recursive: true })
+    writeFileSync(command, '#!/bin/sh\n')
+    chmodSync(command, 0o755)
+    vi.stubEnv('KIRO_CLI_PATH', '')
+    try {
+      expect(resolveKiroCommand({ platform: 'darwin', pathEnv: '', homePath })).toBe(command)
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(homePath, { recursive: true, force: true })
+    }
+  })
+
   it('parses the official CLI usage command output', () => {
     const result = parseKiroUsageOutput(`
 \u001b[1mEstimated Usage | resets on 2026-09-01 | KIRO PRO+\u001b[0m
@@ -46,12 +64,10 @@ Credits (1233.74 of 2000 covered in plan)
       spawnCmd: 'C:\\Windows\\System32\\cmd.exe',
       spawnArgs: ['/d', '/c', 'C:\\Users\\me\\bin\\kiro-cli.cmd', 'chat']
     })
-    vi.mocked(execFile).mockImplementation(
-      ((_command, _args, _options, callback) => {
-        callback(null, KIRO_USAGE_OUTPUT, '')
-        return undefined as never
-      }) as unknown as typeof execFile
-    )
+    vi.mocked(execFile).mockImplementation(((_command, _args, _options, callback) => {
+      callback(null, KIRO_USAGE_OUTPUT, '')
+      return undefined as never
+    }) as unknown as typeof execFile)
 
     const result = await fetchKiroRateLimits({ command: 'C:\\Users\\me\\bin\\kiro-cli.cmd' })
 

--- a/src/main/rate-limits/kiro-usage-fetcher.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import { getSpawnArgsForWindows } from '../win32-utils'
 
 const CLI_TIMEOUT_MS = 20_000
 const MONTHLY_WINDOW_MINUTES = 43_200
@@ -61,9 +62,12 @@ function resolveKiroCommand(): string {
 
 const runCommand: CommandRunner = (command, args, signal) =>
   new Promise((resolve, reject) => {
+    // Why: execFile cannot launch configured .cmd/.bat shims directly on
+    // Windows; route them through cmd.exe like the other usage fetchers.
+    const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, args)
     execFile(
-      command,
-      args,
+      spawnCmd,
+      spawnArgs,
       { encoding: 'utf8', timeout: CLI_TIMEOUT_MS, maxBuffer: 1024 * 1024, signal },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/main/rate-limits/kiro-usage-fetcher.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.ts
@@ -1,8 +1,6 @@
 import { execFile } from 'node:child_process'
-import { accessSync, constants } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
+import { resolveCliCommand, withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { getSpawnArgsForWindows } from '../win32-utils'
 
@@ -39,25 +37,18 @@ function result(
   }
 }
 
-function resolveKiroCommand(): string {
+export function resolveKiroCommand(
+  options: {
+    pathEnv?: string | null
+    platform?: NodeJS.Platform
+    homePath?: string
+  } = {}
+): string {
   const configured = process.env.KIRO_CLI_PATH?.trim()
-  const candidates = [
-    configured,
-    join(homedir(), 'bin', 'kiro-cli'),
-    join(homedir(), '.local', 'bin', 'kiro-cli')
-  ]
-  for (const candidate of candidates) {
-    if (!candidate) {
-      continue
-    }
-    try {
-      accessSync(candidate, constants.X_OK)
-      return candidate
-    } catch {
-      // Continue to the next known install location.
-    }
+  if (configured) {
+    return configured
   }
-  return process.platform === 'win32' ? 'kiro-cli.exe' : 'kiro-cli'
+  return resolveCliCommand('kiro-cli', options)
 }
 
 const runCommand: CommandRunner = (command, args, signal) =>
@@ -65,10 +56,11 @@ const runCommand: CommandRunner = (command, args, signal) =>
     // Why: execFile cannot launch configured .cmd/.bat shims directly on
     // Windows; route them through cmd.exe like the other usage fetchers.
     const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, args)
+    const env = withCliRuntimeOnPath(command, { ...process.env })
     execFile(
       spawnCmd,
       spawnArgs,
-      { encoding: 'utf8', timeout: CLI_TIMEOUT_MS, maxBuffer: 1024 * 1024, signal },
+      { encoding: 'utf8', timeout: CLI_TIMEOUT_MS, maxBuffer: 1024 * 1024, signal, env },
       (error, stdout, stderr) => {
         if (error) {
           reject(error)

--- a/src/main/rate-limits/kiro-usage-fetcher.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.ts
@@ -1,0 +1,135 @@
+import { execFile } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
+import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+
+const CLI_TIMEOUT_MS = 20_000
+const MONTHLY_WINDOW_MINUTES = 43_200
+
+type CommandResult = { stdout: string; stderr: string }
+type CommandRunner = (
+  command: string,
+  args: string[],
+  signal?: AbortSignal
+) => Promise<CommandResult>
+
+function result(
+  status: ProviderRateLimits['status'],
+  error: string | null,
+  monthly: RateLimitWindow | null = null,
+  planType: string | null = null,
+  failureKind?: 'cli-unavailable' | 'parse' | 'usage-unavailable'
+): ProviderRateLimits {
+  return {
+    provider: 'kiro',
+    session: null,
+    weekly: null,
+    monthly,
+    planType,
+    updatedAt: Date.now(),
+    error,
+    status,
+    usageMetadata: {
+      source: 'cli',
+      ...(failureKind ? { failureKind } : {})
+    }
+  }
+}
+
+function resolveKiroCommand(): string {
+  const configured = process.env.KIRO_CLI_PATH?.trim()
+  const candidates = [
+    configured,
+    join(homedir(), 'bin', 'kiro-cli'),
+    join(homedir(), '.local', 'bin', 'kiro-cli')
+  ]
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue
+    }
+    try {
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      // Continue to the next known install location.
+    }
+  }
+  return process.platform === 'win32' ? 'kiro-cli.exe' : 'kiro-cli'
+}
+
+const runCommand: CommandRunner = (command, args, signal) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { encoding: 'utf8', timeout: CLI_TIMEOUT_MS, maxBuffer: 1024 * 1024, signal },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve({ stdout, stderr })
+      }
+    )
+  })
+
+function parseResetDate(value: string): number | null {
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+export function parseKiroUsageOutput(output: string): ProviderRateLimits {
+  const readable = stripAnsiEscapeSequences(output).replace(/\r/g, '')
+  const header = readable.match(
+    /Estimated Usage\s*\|\s*resets on (\d{4}-\d{2}-\d{2})\s*\|\s*([^\n]+)/i
+  )
+  const credits = readable.match(/Credits\s*\(([\d,.]+)\s+of\s+([\d,.]+)\s+covered in plan\)/i)
+  const percent = readable.match(/(?:^|\s)(\d+(?:\.\d+)?)%\s*$/m)
+  const used = credits ? Number(credits[1].replaceAll(',', '')) : Number.NaN
+  const limit = credits ? Number(credits[2].replaceAll(',', '')) : Number.NaN
+  const usedPercent =
+    Number.isFinite(used) && Number.isFinite(limit) && limit > 0
+      ? Math.min(100, Math.max(0, (used / limit) * 100))
+      : percent
+        ? Math.min(100, Math.max(0, Number(percent[1])))
+        : null
+  if (!header || usedPercent === null || !Number.isFinite(usedPercent)) {
+    return result('error', 'Could not parse Kiro usage output', null, null, 'parse')
+  }
+  return result(
+    'ok',
+    null,
+    {
+      usedPercent,
+      windowMinutes: MONTHLY_WINDOW_MINUTES,
+      resetsAt: parseResetDate(header[1]),
+      resetDescription: header[1]
+    },
+    header[2].trim()
+  )
+}
+
+export async function fetchKiroRateLimits(
+  options: { signal?: AbortSignal; runner?: CommandRunner; command?: string } = {}
+): Promise<ProviderRateLimits> {
+  try {
+    const { stdout, stderr } = await (options.runner ?? runCommand)(
+      options.command ?? resolveKiroCommand(),
+      ['chat', '/usage', '--no-interactive', '--wrap', 'never'],
+      options.signal
+    )
+    return parseKiroUsageOutput(`${stdout}\n${stderr}`)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code
+    const unavailable = code === 'ENOENT'
+    return result(
+      unavailable ? 'unavailable' : 'error',
+      unavailable ? 'Kiro CLI is not installed' : 'Kiro usage command failed',
+      null,
+      null,
+      unavailable ? 'cli-unavailable' : 'usage-unavailable'
+    )
+  }
+}

--- a/src/main/rate-limits/kiro-usage-fetcher.ts
+++ b/src/main/rate-limits/kiro-usage-fetcher.ts
@@ -75,11 +75,6 @@ const runCommand: CommandRunner = (command, args, signal) =>
     )
   })
 
-function parseResetDate(value: string): number | null {
-  const timestamp = Date.parse(`${value}T00:00:00.000Z`)
-  return Number.isFinite(timestamp) ? timestamp : null
-}
-
 export function parseKiroUsageOutput(output: string): ProviderRateLimits {
   const readable = stripAnsiEscapeSequences(output).replace(/\r/g, '')
   const header = readable.match(
@@ -104,7 +99,9 @@ export function parseKiroUsageOutput(output: string): ProviderRateLimits {
     {
       usedPercent,
       windowMinutes: MONTHLY_WINDOW_MINUTES,
-      resetsAt: parseResetDate(header[1]),
+      // Kiro reports a calendar date without a time zone or time of day. Keep it as
+      // display metadata instead of inventing a UTC-midnight countdown.
+      resetsAt: null,
       resetDescription: header[1]
     },
     header[2].trim()

--- a/src/main/rate-limits/rate-limit-service-test-harness.ts
+++ b/src/main/rate-limits/rate-limit-service-test-harness.ts
@@ -9,6 +9,7 @@ import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+import { fetchKiroRateLimits } from './kiro-usage-fetcher'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 
 export type Deferred<T> = {
@@ -89,6 +90,7 @@ export function mockFreshBackgroundProviderFetches(): void {
   vi.mocked(fetchKimiRateLimits).mockImplementation(async () => okProvider('kimi', 0))
   vi.mocked(fetchMiniMaxRateLimits).mockImplementation(async () => okProvider('minimax', 0))
   vi.mocked(fetchGrokRateLimits).mockImplementation(async () => unavailableProvider('grok'))
+  vi.mocked(fetchKiroRateLimits).mockImplementation(async () => unavailableProvider('kiro'))
 }
 
 /** Shared `beforeEach` body: healthy stubs for every provider the service polls. */
@@ -106,6 +108,7 @@ export function resetRateLimitProviderMocks(): void {
     error: null,
     status: 'unavailable'
   })
+  vi.mocked(fetchKiroRateLimits).mockResolvedValue(unavailableProvider('kiro'))
   vi.mocked(hasMiniMaxSessionCookie).mockReturnValue(false)
   vi.mocked(readGrokAuthSession).mockReturnValue({ status: 'missing' })
 }

--- a/src/main/rate-limits/service-account-target-selection.test.ts
+++ b/src/main/rate-limits/service-account-target-selection.test.ts
@@ -32,6 +32,10 @@ vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./minimax-fetcher', () => ({
   fetchMiniMaxRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-antigravity-usage.test.ts
+++ b/src/main/rate-limits/service-antigravity-usage.test.ts
@@ -39,6 +39,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-inactive-account-previews.test.ts
+++ b/src/main/rate-limits/service-inactive-account-previews.test.ts
@@ -39,6 +39,10 @@ vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./minimax-fetcher', () => ({
   fetchMiniMaxRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-live-claude-usage.test.ts
+++ b/src/main/rate-limits/service-live-claude-usage.test.ts
@@ -36,6 +36,10 @@ vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./minimax-fetcher', () => ({
   fetchMiniMaxRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-minimax-usage.test.ts
+++ b/src/main/rate-limits/service-minimax-usage.test.ts
@@ -33,6 +33,10 @@ vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./minimax-fetcher', () => ({
   fetchMiniMaxRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -40,6 +40,10 @@ vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./minimax-fetcher', () => ({
   fetchMiniMaxRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -7,6 +7,7 @@ import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
+import { fetchKiroRateLimits } from './kiro-usage-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
 import {
@@ -303,6 +304,43 @@ describe('RateLimitService', () => {
 
     const completedState = service.getState()
     expect(completedState.grok?.status).toBe('ok')
+    expect(refreshResolved).toBe(true)
+  })
+
+  it('publishes other provider results before a slow Kiro CLI fetch completes', async () => {
+    const service = new RateLimitService()
+    const kiro = deferred<ProviderRateLimits>()
+    let refreshResolved = false
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValueOnce(okProvider('gemini', 30, Date.now()))
+    vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValueOnce(
+      okProvider('opencode-go', 40, Date.now())
+    )
+    vi.mocked(fetchKimiRateLimits).mockResolvedValueOnce(okProvider('kimi', 50, Date.now()))
+    vi.mocked(fetchMiniMaxRateLimits).mockResolvedValueOnce(okProvider('minimax', 60, Date.now()))
+    vi.mocked(fetchKiroRateLimits).mockReturnValueOnce(kiro.promise)
+
+    const refresh = service.refresh().then(() => {
+      refreshResolved = true
+    })
+    await flushMicrotasks()
+
+    const pendingKiroState = service.getState()
+    expect(pendingKiroState.claude?.status).toBe('ok')
+    expect(pendingKiroState.codex?.status).toBe('ok')
+    expect(pendingKiroState.gemini?.status).toBe('ok')
+    expect(pendingKiroState.opencodeGo?.status).toBe('ok')
+    expect(pendingKiroState.kimi?.status).toBe('ok')
+    expect(pendingKiroState.minimax?.status).toBe('ok')
+    expect(pendingKiroState.kiro?.status).toBe('fetching')
+    expect(refreshResolved).toBe(false)
+
+    kiro.resolve(okProvider('kiro', 70, Date.now()))
+    await refresh
+
+    expect(service.getState().kiro?.status).toBe('ok')
     expect(refreshResolved).toBe(true)
   })
 

--- a/src/main/rate-limits/service-window-activation.test.ts
+++ b/src/main/rate-limits/service-window-activation.test.ts
@@ -41,6 +41,10 @@ vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
 
+vi.mock('./kiro-usage-fetcher', () => ({
+  fetchKiroRateLimits: vi.fn()
+}))
+
 vi.mock('./minimax-fetcher', () => ({
   fetchMiniMaxRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service/service-full-cycle-application.ts
+++ b/src/main/rate-limits/service/service-full-cycle-application.ts
@@ -34,7 +34,8 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
         kimiResult,
         miniMaxResult
       ],
-      grokResultPromise
+      grokResultPromise,
+      kiroResultPromise
     } = prepared
     if (signal.aborted) {
       return
@@ -191,25 +192,39 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
         : this.state.minimax
     })
 
-    const grokResult = await grokResultPromise
+    await Promise.all([
+      this.applyDeferredProviderResult('grok', grokResultPromise, previousState, signal),
+      this.applyDeferredProviderResult('kiro', kiroResultPromise, previousState, signal)
+    ])
+  }
+
+  private async applyDeferredProviderResult(
+    provider: 'grok' | 'kiro',
+    resultPromise: Promise<
+      { status: 'fulfilled'; value: ProviderRateLimits } | { status: 'rejected'; reason: unknown }
+    >,
+    previousState: Pick<RateLimitServiceFullCycleApplication['state'], 'grok' | 'kiro'>,
+    signal: AbortSignal
+  ): Promise<void> {
+    const result = await resultPromise
     if (signal.aborted) {
       return
     }
-    const grok =
-      grokResult.status === 'fulfilled'
-        ? grokResult.value
+    const limits =
+      result.status === 'fulfilled'
+        ? result.value
         : ({
-            provider: 'grok',
+            provider,
             session: null,
             weekly: null,
             updatedAt: Date.now(),
-            error: grokResult.reason instanceof Error ? grokResult.reason.message : 'Unknown error',
+            error: result.reason instanceof Error ? result.reason.message : 'Unknown error',
             status: 'error'
           } satisfies ProviderRateLimits)
-    this.trackActiveFailureStreak('grok', grok)
+    this.trackActiveFailureStreak(provider, limits)
     this.updateState({
       ...this.state,
-      grok: this.applyStalePolicy(grok, previousState.grok)
+      [provider]: this.applyStalePolicy(limits, previousState[provider])
     })
   }
 }

--- a/src/main/rate-limits/service/service-full-cycle-preparation.ts
+++ b/src/main/rate-limits/service/service-full-cycle-preparation.ts
@@ -2,6 +2,7 @@ import { fetchClaudeRateLimits } from '../claude-fetcher'
 import { fetchCodexRateLimits } from '../codex-fetcher'
 import { fetchGeminiRateLimits } from '../gemini-usage-fetcher'
 import { fetchGrokRateLimits } from '../grok-fetcher'
+import { fetchKiroRateLimits } from '../kiro-usage-fetcher'
 import { readGrokAuthSession } from '../grok-auth'
 import { fetchMiniMaxRateLimits } from '../minimax-fetcher'
 import { fetchOpenCodeGoRateLimits } from '../opencode-go-usage-fetcher'
@@ -39,6 +40,9 @@ export type FetchAllCyclePrepared = {
     PromiseSettledResult<ProviderRateLimits>
   ]
   grokResultPromise: Promise<
+    { status: 'fulfilled'; value: ProviderRateLimits } | { status: 'rejected'; reason: unknown }
+  >
+  kiroResultPromise: Promise<
     { status: 'fulfilled'; value: ProviderRateLimits } | { status: 'rejected'; reason: unknown }
   >
 }
@@ -119,7 +123,8 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
       minimax: miniMaxConfigChanged
         ? this.withFetchingStatus(null, 'minimax')
         : this.withFetchingStatus(previousState.minimax, 'minimax'),
-      grok: this.withFetchingStatus(previousState.grok, 'grok')
+      grok: this.withFetchingStatus(previousState.grok, 'grok'),
+      kiro: this.withFetchingStatus(previousState.kiro, 'kiro')
     })
 
     const missingWslCodexHome =
@@ -128,6 +133,12 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
       signal,
       authReadResult: grokAuthReadResult
     }).then(
+      (value) => ({ status: 'fulfilled', value }) as const,
+      (reason) => ({ status: 'rejected', reason }) as const
+    )
+    // Why: Kiro invokes a CLI with a long timeout; keep it outside the shared
+    // allSettled batch so healthy provider snapshots can publish immediately.
+    const kiroResultPromise = fetchKiroRateLimits({ signal }).then(
       (value) => ({ status: 'fulfilled', value }) as const,
       (reason) => ({ status: 'rejected', reason }) as const
     )
@@ -198,7 +209,8 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
         kimiResult,
         miniMaxResult
       ],
-      grokResultPromise
+      grokResultPromise,
+      kiroResultPromise
     }
   }
 }

--- a/src/main/rate-limits/service/service-polling.ts
+++ b/src/main/rate-limits/service/service-polling.ts
@@ -78,7 +78,8 @@ export abstract class RateLimitServicePolling extends RateLimitServiceFetchQueue
       kimi: this.state.kimi,
       minimax: this.state.minimax,
       grok: this.state.grok,
-      antigravity: this.state.antigravity
+      antigravity: this.state.antigravity,
+      kiro: this.state.kiro
     }
     return Object.entries(byProvider).map(([provider, limits]) => ({
       provider: provider as ActiveRateLimitProvider,

--- a/src/main/rate-limits/service/service-result-policy.ts
+++ b/src/main/rate-limits/service/service-result-policy.ts
@@ -83,15 +83,7 @@ export abstract class RateLimitServiceResultPolicy extends RateLimitServiceFetch
 
   protected withFetchingStatus(
     current: ProviderRateLimits | null,
-    provider:
-      | 'claude'
-      | 'codex'
-      | 'gemini'
-      | 'opencode-go'
-      | 'kimi'
-      | 'minimax'
-      | 'grok'
-      | 'antigravity'
+    provider: ActiveRateLimitProvider
   ): ProviderRateLimits {
     if (!current) {
       return {

--- a/src/main/rate-limits/service/service-state.ts
+++ b/src/main/rate-limits/service/service-state.ts
@@ -31,7 +31,8 @@ export abstract class RateLimitServiceState {
     kimi: null,
     antigravity: null,
     minimax: null,
-    grok: null
+    grok: null,
+    kiro: null
   }
   protected grokAuthConfigured = readGrokAuthSession().status === 'ok'
   protected pollInterval: number = DEFAULT_POLL_MS
@@ -46,7 +47,8 @@ export abstract class RateLimitServiceState {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    kiro: 0
   }
   // Why: consecutive failures drive exponential backoff of the fast activation-retry lane; reset on any success/unavailable result.
   protected activeFailureStreakByProvider: Record<ActiveRateLimitProvider, number> = {
@@ -57,7 +59,8 @@ export abstract class RateLimitServiceState {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    kiro: 0
   }
   protected mainWindow: BrowserWindow | null = null
   protected detachWindowListeners: (() => void) | null = null

--- a/src/main/rate-limits/service/service-types.ts
+++ b/src/main/rate-limits/service/service-types.ts
@@ -105,6 +105,7 @@ export type InternalRateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  kiro: ProviderRateLimits | null
 }
 
 export function normalizePollingInterval(ms: number): number {

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -60,6 +60,7 @@ const StatusBarItem = z.enum([
   'kimi',
   'minimax',
   'grok',
+  'kiro',
   'ssh',
   'resource-usage',
   'ports'
@@ -166,6 +167,7 @@ const UiUpdateFields = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _kiroStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),

--- a/src/renderer/src/components/settings/appearance-status-bar-grok-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-grok-toggle-search.ts
@@ -1,5 +1,6 @@
 import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 import { translate } from '@/i18n/i18n'
+import { getKiroStatusBarToggleSearchEntry } from './appearance-status-bar-kiro-toggle-search'
 import { translateSearchKeyword } from './settings-search-keywords'
 
 export function getGrokStatusBarToggleSearchEntry(): {
@@ -34,4 +35,10 @@ export function getGrokStatusBarToggleSearchEntry(): {
       'Show Grok subscription credit usage when signed in via Grok CLI.'
     )
   }
+}
+
+export function getGrokAndKiroStatusBarToggleSearchEntries(): ReturnType<
+  typeof getGrokStatusBarToggleSearchEntry
+>[] {
+  return [getGrokStatusBarToggleSearchEntry(), getKiroStatusBarToggleSearchEntry()]
 }

--- a/src/renderer/src/components/settings/appearance-status-bar-kiro-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-kiro-toggle-search.ts
@@ -1,4 +1,4 @@
-import type { StatusBarItem } from '../../../../shared/types'
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 

--- a/src/renderer/src/components/settings/appearance-status-bar-kiro-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-kiro-toggle-search.ts
@@ -1,0 +1,37 @@
+import type { StatusBarItem } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getKiroStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'kiro',
+    title: translate('auto.components.settings.appearance.search.kiroUsageTitle', 'Kiro Usage'),
+    description: translate(
+      'auto.components.settings.appearance.search.kiroUsageDescription',
+      'Show Kiro subscription credit usage in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.kiro', 'kiro'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.kiroAws', 'aws'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.de586def95',
+        'subscription'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.kiroToggleDescription',
+      'Show Kiro subscription credit usage reported by Kiro CLI.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -3,8 +3,7 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
-import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
-import { getKiroStatusBarToggleSearchEntry } from './appearance-status-bar-kiro-toggle-search'
+import { getGrokAndKiroStatusBarToggleSearchEntries } from './appearance-status-bar-grok-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -200,8 +199,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show MiniMax subscription usage for the active workspace.'
       )
     },
-    getGrokStatusBarToggleSearchEntry(),
-    getKiroStatusBarToggleSearchEntry(),
+    ...getGrokAndKiroStatusBarToggleSearchEntries(),
     {
       id: 'ssh',
       title: translate('auto.components.settings.appearance.search.57fb424c56', 'Remote Hosts'),

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -4,6 +4,7 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
 import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
+import { getKiroStatusBarToggleSearchEntry } from './appearance-status-bar-kiro-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -200,6 +201,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
       )
     },
     getGrokStatusBarToggleSearchEntry(),
+    getKiroStatusBarToggleSearchEntry(),
     {
       id: 'ssh',
       title: translate('auto.components.settings.appearance.search.57fb424c56', 'Remote Hosts'),

--- a/src/renderer/src/components/stats/GrokUsagePane.test.tsx
+++ b/src/renderer/src/components/stats/GrokUsagePane.test.tsx
@@ -24,6 +24,7 @@ const mockStoreState = {
     kimi: null,
     antigravity: null,
     minimax: null,
+    kiro: null,
     grok: {
       provider: 'grok',
       session: null,

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -25,6 +25,6 @@ export { ClaudeSwitcherMenu } from './ClaudeSwitcherMenu'
 export { CodexSwitcherMenu } from './CodexSwitcherMenu'
 export { InlineUsageBars } from './InlineProviderUsage'
 export { ProviderDetailsMenu } from './ProviderDetailsMenu'
-export { ProviderSegment } from './StatusBarProviderSegment'
+export { getProviderLetter, ProviderSegment } from './StatusBarProviderSegment'
 
 export const StatusBar = React.memo(StatusBarSurface)

--- a/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
@@ -66,7 +66,7 @@ export function ProviderLetterBadge({ p }: { p: ProviderRateLimits }): React.JSX
   )
 }
 
-function getProviderLetter(provider: ProviderRateLimits['provider']): string {
+export function getProviderLetter(provider: ProviderRateLimits['provider']): string {
   switch (provider) {
     case 'claude':
       return 'C'
@@ -82,6 +82,8 @@ function getProviderLetter(provider: ProviderRateLimits['provider']): string {
       return 'M'
     case 'grok':
       return 'R'
+    case 'kiro':
+      return 'Q'
     case 'codex':
       return 'X'
   }

--- a/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
@@ -133,6 +133,18 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.grokUsageMenu', 'Grok Usage')}
           </DropdownMenuCheckboxItem>
         )}
+        {isStatusBarItemAvailable('kiro', detectedAgentIds) && (
+          <DropdownMenuCheckboxItem
+            checked={statusBarItems.includes('kiro')}
+            onCheckedChange={() => {
+              recordFeatureInteraction('usage-tracking')
+              toggleStatusBarItem('kiro')
+            }}
+          >
+            <AgentIcon agent="kiro" size={14} />
+            {translate('auto.components.status.bar.StatusBar.kiroUsageMenu', 'Kiro Usage')}
+          </DropdownMenuCheckboxItem>
+        )}
         <DropdownMenuCheckboxItem
           checked={statusBarItems.includes('ssh')}
           onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -20,6 +20,7 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('gemini', null)).toBe(true)
     expect(isStatusBarItemAvailable('antigravity', null)).toBe(true)
     expect(isStatusBarItemAvailable('grok', null)).toBe(true)
+    expect(isStatusBarItemAvailable('kiro', null)).toBe(true)
   })
 
   it('hides CLI items not detected on PATH', () => {
@@ -28,6 +29,7 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('gemini', ['claude', 'codex'])).toBe(false)
     expect(isStatusBarItemAvailable('antigravity', ['claude', 'codex'])).toBe(false)
     expect(isStatusBarItemAvailable('grok', ['claude', 'kimi'])).toBe(false)
+    expect(isStatusBarItemAvailable('kiro', ['claude', 'kimi'])).toBe(false)
   })
 
   it('shows CLI items detected on PATH', () => {
@@ -36,5 +38,6 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('gemini', ['gemini'])).toBe(true)
     expect(isStatusBarItemAvailable('antigravity', ['antigravity'])).toBe(true)
     expect(isStatusBarItemAvailable('grok', ['grok'])).toBe(true)
+    expect(isStatusBarItemAvailable('kiro', ['kiro'])).toBe(true)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -13,7 +13,8 @@ const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set([
   'gemini',
   'kimi',
   'antigravity',
-  'grok'
+  'grok',
+  'kiro'
 ])
 
 export function isStatusBarItemAvailable(

--- a/src/renderer/src/components/status-bar/status-bar-provider-letter.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-letter.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { getProviderLetter } from './StatusBar'
+
+describe('status bar provider labels', () => {
+  it('distinguishes Kiro from Kimi in the narrow status bar', () => {
+    expect(getProviderLetter('kimi')).toBe('K')
+    expect(getProviderLetter('kiro')).toBe('KI')
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-provider-letter.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-letter.test.ts
@@ -4,6 +4,6 @@ import { getProviderLetter } from './StatusBar'
 describe('status bar provider labels', () => {
   it('distinguishes Kiro from Kimi in the narrow status bar', () => {
     expect(getProviderLetter('kimi')).toBe('K')
-    expect(getProviderLetter('kiro')).toBe('KI')
+    expect(getProviderLetter('kiro')).toBe('Q')
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -373,7 +373,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          kiro: null
         },
         usageSettings()
       )

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -28,6 +28,8 @@ type UsageProviderSnapshots = {
   antigravity: ProviderRateLimits | null | undefined
   minimax: ProviderRateLimits | null | undefined
   grok: ProviderRateLimits | null | undefined
+  // Optional for renderer HMR against an older main process and persisted test fixtures.
+  kiro?: ProviderRateLimits | null
 }
 
 type UsageProviderId = ProviderRateLimits['provider']
@@ -165,7 +167,8 @@ export function isUsageEmptyState(
     isProviderSnapshotPending(providers.kimi) ||
     antigravitySnapshotPending ||
     isProviderSnapshotPending(providers.minimax) ||
-    isProviderSnapshotPending(providers.grok)
+    isProviderSnapshotPending(providers.grok) ||
+    (providers.kiro !== undefined && isProviderSnapshotPending(providers.kiro))
   ) {
     return false
   }
@@ -178,6 +181,7 @@ export function isUsageEmptyState(
     !isProviderConfigured(providers.kimi) &&
     !isProviderConfigured(providers.antigravity) &&
     !isProviderConfigured(providers.minimax) &&
-    !isProviderConfigured(providers.grok)
+    !isProviderConfigured(providers.grok) &&
+    !isProviderConfigured(providers.kiro)
   )
 }

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -27,6 +27,7 @@ import {
   clampUsedPercent,
   formatResetCreditExpiry,
   formatResetCountdown,
+  formatRateLimitResetLabel,
   getProviderUsageErrorMessage,
   getProviderUsageStatusLabel,
   getWindowSections,
@@ -69,6 +70,19 @@ describe('formatResetCountdown', () => {
 
   it('keeps the "in" preposition for future reset times', () => {
     expect(formatResetCountdown(12 * 60 * 60_000 + 41 * 60_000)).toBe('Resets in 12h 41m')
+  })
+})
+
+describe('formatRateLimitResetLabel', () => {
+  it('shows a date-only reset without inventing an exact countdown', () => {
+    expect(
+      formatRateLimitResetLabel({
+        usedPercent: 62,
+        windowMinutes: 43_200,
+        resetsAt: null,
+        resetDescription: '2026-09-01'
+      })
+    ).toBe('Resets on 2026-09-01')
   })
 })
 

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -84,6 +84,36 @@ describe('formatRateLimitResetLabel', () => {
       })
     ).toBe('Resets on 2026-09-01')
   })
+
+  it('keeps non-date reset descriptions instead of dropping the label', () => {
+    expect(
+      formatRateLimitResetLabel({
+        usedPercent: 62,
+        windowMinutes: 43_200,
+        resetsAt: null,
+        resetDescription: 'Thu'
+      })
+    ).toBe('Thu')
+    expect(
+      formatRateLimitResetLabel({
+        usedPercent: 62,
+        windowMinutes: 43_200,
+        resetsAt: null,
+        resetDescription: '2:30 PM'
+      })
+    ).toBe('2:30 PM')
+  })
+
+  it('omits the reset label when the window has no reset metadata', () => {
+    expect(
+      formatRateLimitResetLabel({
+        usedPercent: 62,
+        windowMinutes: 43_200,
+        resetsAt: null,
+        resetDescription: null
+      })
+    ).toBeNull()
+  })
 })
 
 describe('formatResetCreditExpiry', () => {

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -45,9 +45,12 @@ export function formatTimeAgo(ts: number): string {
   return `${hours}h ago`
 }
 
-export function formatRateLimitResetLabel(window: RateLimitWindow): string | null {
+export function formatRateLimitResetLabel(
+  window: RateLimitWindow,
+  now: number = Date.now()
+): string | null {
   if (window.resetsAt) {
-    return formatResetCountdown(window.resetsAt - Date.now())
+    return formatResetCountdown(window.resetsAt - now)
   }
   if (window.resetDescription) {
     if (/^\d{4}-\d{2}-\d{2}$/.test(window.resetDescription)) {
@@ -239,7 +242,7 @@ function ProviderRateLimitWindowSection({
   }
   const usedPct = clampUsedPercent(window.usedPercent)
   const displayedPct = getDisplayedUsagePercentage(usedPct, usagePercentageDisplay)
-  const resetLabel = formatRateLimitResetLabel(window)
+  const resetLabel = formatRateLimitResetLabel(window, now)
 
   return (
     <div className="space-y-1">

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -45,6 +45,18 @@ export function formatTimeAgo(ts: number): string {
   return `${hours}h ago`
 }
 
+export function formatRateLimitResetLabel(window: RateLimitWindow): string | null {
+  if (window.resetsAt) {
+    return formatResetCountdown(window.resetsAt - Date.now())
+  }
+  if (window.resetDescription && /^\d{4}-\d{2}-\d{2}$/.test(window.resetDescription)) {
+    return translate('auto.components.status.bar.tooltip.resetOnDate', 'Resets on {{value0}}', {
+      value0: window.resetDescription
+    })
+  }
+  return null
+}
+
 // Re-export so existing tooltip consumers/tests keep their import path; the
 // implementation is shared with mobile in src/shared/rate-limit-reset-format.
 export { formatResetCountdown }
@@ -223,7 +235,7 @@ function ProviderRateLimitWindowSection({
   }
   const usedPct = clampUsedPercent(window.usedPercent)
   const displayedPct = getDisplayedUsagePercentage(usedPct, usagePercentageDisplay)
-  const resetLabel = window.resetsAt ? formatResetCountdown(window.resetsAt - now) : null
+  const resetLabel = formatRateLimitResetLabel(window)
 
   return (
     <div className="space-y-1">

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -49,10 +49,14 @@ export function formatRateLimitResetLabel(window: RateLimitWindow): string | nul
   if (window.resetsAt) {
     return formatResetCountdown(window.resetsAt - Date.now())
   }
-  if (window.resetDescription && /^\d{4}-\d{2}-\d{2}$/.test(window.resetDescription)) {
-    return translate('auto.components.status.bar.tooltip.resetOnDate', 'Resets on {{value0}}', {
-      value0: window.resetDescription
-    })
+  if (window.resetDescription) {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(window.resetDescription)) {
+      return translate('auto.components.status.bar.tooltip.resetOnDate', 'Resets on {{value0}}', {
+        value0: window.resetDescription
+      })
+    }
+    // Producers may already send human-readable values ("Thu", "2:30 PM").
+    return window.resetDescription
   }
   return null
 }

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -97,6 +97,9 @@ export function ProviderIcon({ provider }: { provider: string }): React.JSX.Elem
   if (provider === 'grok') {
     return <AgentIcon agent="grok" size={13} />
   }
+  if (provider === 'kiro') {
+    return <AgentIcon agent="kiro" size={13} />
+  }
   return <ClaudeIcon size={13} />
 }
 

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -26,6 +26,9 @@ export function getProviderDisplayName(provider: ProviderRateLimits['provider'])
   if (provider === 'grok') {
     return 'Grok'
   }
+  if (provider === 'kiro') {
+    return 'Kiro'
+  }
   return provider
 }
 

--- a/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
+++ b/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
@@ -19,7 +19,9 @@ export function getUsageProviderAccountsSectionId(
     case 'grok':
       return 'accounts-grok'
     case 'kimi':
+    case 'kiro':
       // Why: Orca must not mutate Kimi's CLI-owned credential lifecycle.
+      // Kiro likewise owns its CLI credential lifecycle.
       return null
   }
 }

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -99,7 +99,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, kiro } = rateLimits
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -121,6 +121,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const visibleAntigravity = getVisibleUsageProvider('antigravity', antigravity, usageSettings)
   const visibleMiniMax = getVisibleUsageProvider('minimax', minimax, usageSettings)
   const visibleGrok = getVisibleUsageProvider('grok', grok, usageSettings)
+  const visibleKiro = getVisibleUsageProvider('kiro', kiro, usageSettings)
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
@@ -147,6 +148,10 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     visibleGrok !== null &&
     statusBarItems.includes('grok') &&
     isStatusBarItemAvailable('grok', detectedAgentIds)
+  const showKiro =
+    visibleKiro !== null &&
+    statusBarItems.includes('kiro') &&
+    isStatusBarItemAvailable('kiro', detectedAgentIds)
   // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
   const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
@@ -164,11 +169,12 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     showKimi ||
     showAntigravity ||
     showMiniMax ||
-    showGrok
+    showGrok ||
+    showKiro
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: include Settings so durable managed accounts count — a configured user isn't shown the empty state while snapshots hydrate.
   const isEmptyUsageState = isUsageEmptyState(
-    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
+    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, kiro },
     usageSettings
   )
   // Why: one-time nudge — once dismissed, stays hidden even if providers reconnect later.
@@ -181,7 +187,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     kimi?.status === 'fetching' ||
     antigravity?.status === 'fetching' ||
     minimax?.status === 'fetching' ||
-    grok?.status === 'fetching'
+    grok?.status === 'fetching' ||
+    kiro?.status === 'fetching'
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
@@ -200,7 +207,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     showOpencodeGo ? visibleOpencodeGo : null,
     showKimi ? visibleKimi : null,
     showMiniMax ? visibleMiniMax : null,
-    showGrok ? visibleGrok : null
+    showGrok ? visibleGrok : null,
+    showKiro ? visibleKiro : null
   ].filter((p): p is ProviderRateLimits => p !== null)
 
   const handleManageAccounts = (): void => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -141,7 +141,8 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "kiroToggleDescription": "Show Kiro subscription credit usage reported by Kiro CLI."
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
@@ -3724,7 +3725,8 @@
             "grokUsageMenu": "Grok Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
-            "codexSignInError": "Codex sign-in failed. Please try again."
+            "codexSignInError": "Codex sign-in failed. Please try again.",
+            "kiroUsageMenu": "Kiro Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -9086,6 +9088,10 @@
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
             "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "kiroUsageTitle": "Kiro Usage",
+            "kiroUsageDescription": "Show Kiro subscription credit usage in the status bar.",
+            "kiro": "kiro",
+            "kiroAws": "aws",
             "tray": {
               "tray": "tray",
               "system": "system tray",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3905,7 +3905,8 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "resetOnDate": "Resets on {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -25,6 +25,7 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     antigravity: null,
     minimax: null,
     grok: null,
+    kiro: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -139,7 +139,8 @@ describe('createUISlice hydratePersistedUI', () => {
       'kimi',
       'minimax',
       'antigravity',
-      'grok'
+      'grok',
+      'kiro'
     ])
     expect(setUI).toHaveBeenCalledWith({
       statusBarItems: [
@@ -149,13 +150,15 @@ describe('createUISlice hydratePersistedUI', () => {
         'kimi',
         'minimax',
         'antigravity',
-        'grok'
+        'grok',
+        'kiro'
       ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
-      _grokStatusBarDefaultAdded: true
+      _grokStatusBarDefaultAdded: true,
+      _kiroStatusBarDefaultAdded: true
     })
   })
 
@@ -171,7 +174,8 @@ describe('createUISlice hydratePersistedUI', () => {
         _kimiStatusBarDefaultAdded: true,
         _minimaxStatusBarDefaultAdded: true,
         _antigravityStatusBarDefaultAdded: true,
-        _grokStatusBarDefaultAdded: true
+        _grokStatusBarDefaultAdded: true,
+        _kiroStatusBarDefaultAdded: true
       })
     )
 

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -1,6 +1,5 @@
 import type { UISlice, UISliceGet, UISliceSet } from './ui-slice-contract'
 import type { AppState } from '../../types'
-import type { PersistedUIState } from '../../../../../shared/persisted-ui-state-types'
 import { normalizeRightSidebarRoute } from '../../right-sidebar-route'
 import {
   applyManualRepoOrder,
@@ -38,7 +37,6 @@ import { normalizeStatusBarUsageMode } from '../../../../../shared/status-bar-us
 import { normalizeBrowserPageZoomLevel } from '../../../../../shared/browser-page-zoom'
 import { normalizeKagiSessionLink } from '../../../../../shared/browser-url'
 import { isReleaseChannel } from '../../../../../shared/release-channel'
-import type { StatusBarItem } from '../../../../../shared/ui-chrome-types'
 import {
   filterSetupScriptPromptDismissalsToValidRepos,
   sanitizeSetupScriptPromptDismissals
@@ -64,36 +62,14 @@ import {
   clampPetSize
 } from './ui-slice-hydration-sanitizers'
 import { hydrateAgentReadState, sanitizeTaskResumeState } from './ui-slice-hydration-values'
+import {
+  addMissingStatusBarDefaults,
+  hasUnpersistedStatusBarDefaults,
+  STATUS_BAR_DEFAULT_MARKERS
+} from './ui-slice-status-bar-defaults'
 
 const MAX_LEFT_SIDEBAR_WIDTH = 500
 const MAX_RIGHT_SIDEBAR_WIDTH = 4000
-const DEFAULT_ON_PORTS_STATUS_BAR_ITEM: StatusBarItem = 'ports'
-const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
-const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
-const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
-const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
-
-function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
-  let items = migrateStatusBarItems(ui.statusBarItems)
-  const defaults = [
-    ['_portsStatusBarDefaultAdded', DEFAULT_ON_PORTS_STATUS_BAR_ITEM],
-    ['_kimiStatusBarDefaultAdded', DEFAULT_ON_KIMI_STATUS_BAR_ITEM],
-    ['_minimaxStatusBarDefaultAdded', DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM],
-    ['_antigravityStatusBarDefaultAdded', DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM],
-    ['_grokStatusBarDefaultAdded', DEFAULT_ON_GROK_STATUS_BAR_ITEM]
-  ] as const
-  for (const [flag, item] of defaults) {
-    if (!ui[flag] && !items.includes(item)) {
-      items = [...items, item]
-    }
-  }
-  if (typeof window !== 'undefined' && defaults.some(([flag]) => !ui[flag])) {
-    window.api.ui
-      .set({ statusBarItems: items, ...Object.fromEntries(defaults.map(([flag]) => [flag, true])) })
-      .catch(console.error)
-  }
-  return items
-}
 
 export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Partial<UISlice> {
   return {
@@ -114,7 +90,16 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
         const petId = ui.petId ?? ui.sidekickId
         // Migration: one-shot old-'recent'→'smart' runs in main (_sortBySmartMigrated), not here, so a deliberate 'recent' choice survives restart.
         const sortBy = ui.sortBy
-        const statusBarItemsWithGrok = hydrateStatusBarItems(ui)
+        const migratedStatusBarItems = migrateStatusBarItems(ui.statusBarItems)
+        const statusBarItems = addMissingStatusBarDefaults(ui, migratedStatusBarItems)
+        if (hasUnpersistedStatusBarDefaults(ui) && typeof window !== 'undefined') {
+          window.api.ui
+            .set({
+              statusBarItems,
+              ...STATUS_BAR_DEFAULT_MARKERS
+            })
+            .catch(console.error)
+        }
         const rightSidebarRoute = normalizeRightSidebarRoute(
           ui.rightSidebarTab,
           ui.rightSidebarExplorerView
@@ -198,7 +183,7 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
           workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
           workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
           syncTaskStatusFromWorkspaceBoard: ui.syncTaskStatusFromWorkspaceBoard === true,
-          statusBarItems: statusBarItemsWithGrok,
+          statusBarItems,
           statusBarVisible: ui.statusBarVisible ?? true,
           usagePercentageDisplay: normalizeUsagePercentageDisplay(ui.usagePercentageDisplay),
           statusBarUsageMode: normalizeStatusBarUsageMode(ui.statusBarUsageMode),

--- a/src/renderer/src/store/slices/ui/ui-slice-status-bar-defaults.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-status-bar-defaults.ts
@@ -1,0 +1,37 @@
+import type { PersistedUIState } from '../../../../../shared/persisted-ui-state-types'
+import type { StatusBarItem } from '../../../../../shared/ui-chrome-types'
+
+const STATUS_BAR_DEFAULTS = [
+  ['ports', '_portsStatusBarDefaultAdded'],
+  ['kimi', '_kimiStatusBarDefaultAdded'],
+  ['minimax', '_minimaxStatusBarDefaultAdded'],
+  ['antigravity', '_antigravityStatusBarDefaultAdded'],
+  ['grok', '_grokStatusBarDefaultAdded'],
+  ['kiro', '_kiroStatusBarDefaultAdded']
+] as const satisfies readonly (readonly [StatusBarItem, keyof PersistedUIState])[]
+
+export const STATUS_BAR_DEFAULT_MARKERS = {
+  _portsStatusBarDefaultAdded: true,
+  _kimiStatusBarDefaultAdded: true,
+  _minimaxStatusBarDefaultAdded: true,
+  _antigravityStatusBarDefaultAdded: true,
+  _grokStatusBarDefaultAdded: true,
+  _kiroStatusBarDefaultAdded: true
+} as const
+
+export function addMissingStatusBarDefaults(
+  ui: PersistedUIState,
+  items: StatusBarItem[]
+): StatusBarItem[] {
+  let result = items
+  for (const [item, marker] of STATUS_BAR_DEFAULTS) {
+    if (ui[marker] !== true && !result.includes(item)) {
+      result = [...result, item]
+    }
+  }
+  return result
+}
+
+export function hasUnpersistedStatusBarDefaults(ui: PersistedUIState): boolean {
+  return STATUS_BAR_DEFAULTS.some(([, marker]) => ui[marker] !== true)
+}

--- a/src/renderer/src/web/preload-api/web-rate-limits-api.ts
+++ b/src/renderer/src/web/preload-api/web-rate-limits-api.ts
@@ -12,6 +12,7 @@ export function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimi
     antigravity: null,
     minimax: null,
     grok: null,
+    kiro: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -116,6 +116,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on Kiro status item. */
+  _kiroStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */

--- a/src/shared/rate-limit-types.test.ts
+++ b/src/shared/rate-limit-types.test.ts
@@ -16,6 +16,7 @@ describe('RateLimitState', () => {
       antigravity: null,
       minimax: null,
       grok: null,
+      kiro: null,
       minimaxCookieConfigured: false,
       grokAuthConfigured: false,
       claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -55,6 +55,7 @@ export type ProviderRateLimits = {
     | 'minimax'
     | 'grok'
     | 'antigravity'
+    | 'kiro'
   /** 5-hour session window, null if not available. */
   session: RateLimitWindow | null
   /** 7-day weekly window, null if not available. */
@@ -124,6 +125,7 @@ export type RateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  kiro: ProviderRateLimits | null
   /**
    * True when a MiniMax session cookie is persisted on disk. The cookie lives
    * outside GlobalSettings, so this flag is the durable signal that the

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -9,6 +9,7 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'kimi',
   'minimax',
   'grok',
+  'kiro',
   'ssh',
   'resource-usage',
   'ports'

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -62,6 +62,7 @@ export type StatusBarItem =
   | 'kimi'
   | 'minimax'
   | 'grok'
+  | 'kiro'
   | 'ssh'
   | 'resource-usage'
   | 'ports'


### PR DESCRIPTION
## ELI5

Orca can already launch Kiro, but it cannot show how much of the current Kiro subscription credit allowance has been used. This adds a Kiro usage meter to the status bar using Kiro CLI's own local `/usage` command.

## What Changed

- Added a bounded Kiro usage fetcher that runs `kiro-cli chat /usage --no-interactive --wrap never` with no shell and a 20-second timeout.
- Parses the plan name, covered credits, usage percentage, and monthly reset date from ANSI-formatted CLI output. Date-only resets remain display metadata instead of being presented as a fabricated UTC-midnight countdown.
- Added Kiro to the shared rate-limit state, polling/stale-state handling, RPC schema, renderer store, status bar, provider menu, and settings search.
- Uses `Q` as Kiro's compact narrow-layout badge so it remains distinct from Kimi's `K`.
- Added a one-shot migration that enables the Kiro status item for existing profiles while preserving later user choices.
- Added focused parser, service, state, migration, visibility, and agent-gating coverage.

## Why

Kiro is already a first-class Orca agent, and the official CLI exposes subscription usage locally through `/usage`. Surfacing that existing information alongside Claude, Codex, Gemini, Grok, and other providers makes Orca's usage bar useful to Kiro users without copying credentials or depending on a private HTTP API.

## Linked Issue

Related to #9559. This PR surfaces local subscription usage; it does not add Kiro account management.

## Visual Proof

Both screenshots use a fresh isolated profile. The **before** image is current upstream `main` at `3246b73a`; the **after** image is the PR at the same visual baseline. The code is now rebased onto latest `main` (`e12b22c4`), with no settings UI change.

| Before | After |
|---|---|
| ![Appearance settings before Kiro usage](https://raw.githubusercontent.com/guanbear/orca/pr-assets-zcode-kiro/.github/pr-assets/14001-before.png) | ![Appearance settings with Kiro usage](https://raw.githubusercontent.com/guanbear/orca/pr-assets-zcode-kiro/.github/pr-assets/14001-after.png) |

The after view adds the Kiro usage toggle alongside Orca's existing provider meters. Compact layouts use `Q` so Kiro remains distinct from Kimi's `K`.

## How To Test

1. Install and sign in to the official `kiro-cli`.
2. Confirm `kiro-cli chat '/usage' --no-interactive --wrap never` returns the **Estimated Usage** view.
3. Launch Orca and enable **Kiro Usage** in the status-bar menu if it is hidden.
4. Confirm the meter shows the subscription plan, percentage used, and reset date.
5. Narrow the window and confirm Kiro uses `Q` while Kimi uses `K`.
6. Temporarily remove `kiro-cli` from `PATH` and confirm the provider degrades to unavailable without exposing a local path or subprocess error.

## Validation

- [x] Real local Kiro CLI `/usage` output parsed successfully with the current signed-in KIRO PRO+ account.
- [x] 325 directly affected parser, service, shared-state, and renderer tests pass after rebasing onto latest `main` (`e12b22c4`).
- [x] Changed-file lint and `git diff --check` pass after the compact-label follow-up.
- [x] Full Node, CLI, and renderer TypeScript check passes on the latest-main merge.
- [x] Changed-code quality, type-aware quality, and React Doctor report zero new findings across all 28 changed files.
- [x] Localization catalog, extraction/coverage, reliability, max-lines, and formatting gates pass.
- [x] TruffleHog reports the review bundle clean.
- [x] Independent Kiro/Claude Opus 5 High review reports no actionable findings and used no fallback.

## Security And Privacy

- Uses `execFile` with a fixed argument list, not a shell.
- Does not read, copy, persist, or log Kiro credentials.
- Does not log raw CLI failures or resolved executable paths.
- Parses only the bounded output of Kiro's local usage command.
- Supports `KIRO_CLI_PATH` and known install locations while preserving the same no-shell execution path.

## Review

- Security: reviewed the fixed-argument, no-shell CLI execution path and bounded output handling.
- Compatibility: unavailable or signed-out Kiro CLI states degrade without affecting other providers.
- Performance: refreshes use the existing provider polling/stale-state lifecycle and a 20-second subprocess timeout.
- UX: the compact `Q` badge remains distinct from Kimi's `K`; the full provider menu and tooltip still say Kiro.

## AI Disclosure

Implemented with OpenAI Codex. The final patch was independently reviewed by Kiro CLI using Claude Opus 5 with high reasoning; no fallback reviewer was used.

## Checklist

- [x] Focused implementation with no credential persistence or private API dependency.
- [x] Existing settings and migration behavior remain backward compatible.
- [x] Visual behavior and the N/A screenshot rationale are documented.
- [x] Self-reviewed for correctness, security, performance, and failure behavior.
- [x] Focused tests, changed-file lint, and diff checks pass on current `main`.

## Author

- GitHub: @guanbear
- X: @guanbear

