### PR TITLE
fix(terminal): keep a DA1 answerer for parked panes with raw-byte sidecars

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -247,6 +247,7 @@ jobs:
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            src/main/runtime/fish-parked-pane-prompt-latency.node-pty.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
   test:
@@ -283,6 +284,7 @@ jobs:
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            --exclude=src/main/runtime/fish-parked-pane-prompt-latency.node-pty.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}

--- a/src/main/ipc/pty-hidden-delivery-gate.test.ts
+++ b/src/main/ipc/pty-hidden-delivery-gate.test.ts
@@ -50,9 +50,9 @@ describe('pty hidden delivery gate', () => {
     expect(shouldSuppressHiddenRendererPtyView(PTY_ID, {})).toBe(true)
     setRendererPtyDeliveryInterest(PTY_ID, true)
     expect(shouldSuppressHiddenRendererPtyView(PTY_ID, {})).toBe(true)
-    expect(
-      shouldSuppressHiddenRendererPtyView(PTY_ID, { terminalHiddenDeliveryGate: false })
-    ).toBe(false)
+    expect(shouldSuppressHiddenRendererPtyView(PTY_ID, { terminalHiddenDeliveryGate: false })).toBe(
+      false
+    )
   })
 
   it('routes a suppressed PTY sidecar-only exactly while interest is registered', () => {

--- a/src/main/ipc/pty-hidden-delivery-gate.test.ts
+++ b/src/main/ipc/pty-hidden-delivery-gate.test.ts
@@ -6,9 +6,12 @@ import {
   isHiddenPtyDeliveryGateEnabled,
   markHiddenRendererPty,
   recordHiddenRendererPtyDataDrop,
+  recordHiddenRendererPtyViewGap,
   resetRendererScopedHiddenPtyDeliveryState,
   setRendererPtyDeliveryInterest,
+  shouldDeliverHiddenRendererPtyDataToSidecarsOnly,
   shouldDropHiddenRendererPtyData,
+  shouldSuppressHiddenRendererPtyView,
   unmarkHiddenRendererPty
 } from './pty-hidden-delivery-gate'
 
@@ -39,6 +42,38 @@ describe('pty hidden delivery gate', () => {
     expect(shouldDropHiddenRendererPtyData(PTY_ID, {})).toBe(false)
     setRendererPtyDeliveryInterest(PTY_ID, false)
     expect(shouldDropHiddenRendererPtyData(PTY_ID, {})).toBe(true)
+  })
+
+  it('suppresses the view for every hidden PTY, delivery interest or not', () => {
+    expect(shouldSuppressHiddenRendererPtyView(PTY_ID, {})).toBe(false)
+    markHiddenRendererPty(PTY_ID)
+    expect(shouldSuppressHiddenRendererPtyView(PTY_ID, {})).toBe(true)
+    setRendererPtyDeliveryInterest(PTY_ID, true)
+    expect(shouldSuppressHiddenRendererPtyView(PTY_ID, {})).toBe(true)
+    expect(
+      shouldSuppressHiddenRendererPtyView(PTY_ID, { terminalHiddenDeliveryGate: false })
+    ).toBe(false)
+  })
+
+  it('routes a suppressed PTY sidecar-only exactly while interest is registered', () => {
+    markHiddenRendererPty(PTY_ID)
+    expect(shouldDeliverHiddenRendererPtyDataToSidecarsOnly(PTY_ID, {})).toBe(false)
+    setRendererPtyDeliveryInterest(PTY_ID, true)
+    expect(shouldDeliverHiddenRendererPtyDataToSidecarsOnly(PTY_ID, {})).toBe(true)
+    // Exactly one of drop / sidecar-only ever holds, so bytes are never both dropped and sent.
+    expect(shouldDropHiddenRendererPtyData(PTY_ID, {})).toBe(false)
+    unmarkHiddenRendererPty(PTY_ID)
+    expect(shouldDeliverHiddenRendererPtyDataToSidecarsOnly(PTY_ID, {})).toBe(false)
+  })
+
+  it('latches the restore marker for sidecar-only sends too (the view missed those bytes)', () => {
+    markHiddenRendererPty(PTY_ID)
+    setRendererPtyDeliveryInterest(PTY_ID, true)
+    expect(recordHiddenRendererPtyViewGap(PTY_ID).shouldEmitRestoreMarker).toBe(true)
+    expect(recordHiddenRendererPtyViewGap(PTY_ID).shouldEmitRestoreMarker).toBe(false)
+    expect(unmarkHiddenRendererPty(PTY_ID).droppedWhileHidden).toBe(true)
+    // Why: the sidecar send is not a drop — the diagnostics counters must stay clean.
+    expect(getHiddenRendererPtyDeliveryDebug().hiddenDeliveryDroppedChunks).toBe(0)
   })
 
   it('requests the restore marker exactly once per drop episode, re-armed by unmark', () => {

--- a/src/main/ipc/pty-hidden-delivery-gate.ts
+++ b/src/main/ipc/pty-hidden-delivery-gate.ts
@@ -97,9 +97,7 @@ export function shouldDropHiddenRendererPtyData(
   id: string,
   settings: HiddenPtyDeliveryGateSettings | null | undefined
 ): boolean {
-  return (
-    shouldSuppressHiddenRendererPtyView(id, settings) && !deliveryInterestRendererPtys.has(id)
-  )
+  return shouldSuppressHiddenRendererPtyView(id, settings) && !deliveryInterestRendererPtys.has(id)
 }
 
 /** Bytes a sidecar still needs while the view is suppressed: sent, but flagged

--- a/src/main/ipc/pty-hidden-delivery-gate.ts
+++ b/src/main/ipc/pty-hidden-delivery-gate.ts
@@ -6,8 +6,13 @@
  * main then drops renderer-bound delivery AFTER model ingestion — the runtime
  * already parsed the chunk, and reveal restores from the model snapshot via
  * the existing seq-guarded machinery. Any renderer party that still needs raw
- * bytes (dispatcher sidecars) registers delivery
- * interest, which suppresses the gate for that PTY.
+ * bytes (dispatcher sidecars) registers delivery interest; those bytes are
+ * still sent, but flagged sidecar-only so no view renders or replies to them.
+ *
+ * The view suppression, not the send, is what main's query authority keys on:
+ * a sidecar is not an xterm, so inferring "delivered ⇒ a renderer xterm will
+ * answer" left parked panes with a live sidecar unanswered (fish blocks ~10s
+ * on DA1 at every prompt paint).
  */
 import type { GlobalSettings } from '../../shared/types'
 
@@ -77,15 +82,33 @@ export function setRendererPtyDeliveryInterest(id: string, interested: boolean):
   }
 }
 
+/** No renderer VIEW may render or reply to this PTY's bytes: hidden panes are
+ *  starved by design and parked panes have no xterm at all. Delivery interest
+ *  does not lift this — it only decides whether the bytes still travel (to
+ *  sidecars) or are dropped outright. */
+export function shouldSuppressHiddenRendererPtyView(
+  id: string,
+  settings: HiddenPtyDeliveryGateSettings | null | undefined
+): boolean {
+  return isHiddenPtyDeliveryGateEnabled(settings) && hiddenRendererPtys.has(id)
+}
+
 export function shouldDropHiddenRendererPtyData(
   id: string,
   settings: HiddenPtyDeliveryGateSettings | null | undefined
 ): boolean {
   return (
-    isHiddenPtyDeliveryGateEnabled(settings) &&
-    hiddenRendererPtys.has(id) &&
-    !deliveryInterestRendererPtys.has(id)
+    shouldSuppressHiddenRendererPtyView(id, settings) && !deliveryInterestRendererPtys.has(id)
   )
+}
+
+/** Bytes a sidecar still needs while the view is suppressed: sent, but flagged
+ *  so the dispatcher routes them past the primary (xterm) handler. */
+export function shouldDeliverHiddenRendererPtyDataToSidecarsOnly(
+  id: string,
+  settings: HiddenPtyDeliveryGateSettings | null | undefined
+): boolean {
+  return shouldSuppressHiddenRendererPtyView(id, settings) && deliveryInterestRendererPtys.has(id)
 }
 
 /** Record one gated drop. Returns whether the caller should emit the one-shot
@@ -96,6 +119,14 @@ export function recordHiddenRendererPtyDataDrop(
 ): { shouldEmitRestoreMarker: boolean } {
   droppedHiddenDeliveryChars += chars
   droppedHiddenDeliveryChunks += 1
+  return recordHiddenRendererPtyViewGap(id)
+}
+
+/** Same restore latch as a drop, for bytes that were sent sidecar-only: the
+ *  view missed them either way, so reveal must repaint from the model. */
+export function recordHiddenRendererPtyViewGap(id: string): {
+  shouldEmitRestoreMarker: boolean
+} {
   if (droppedSinceHiddenPtys.has(id)) {
     return { shouldEmitRestoreMarker: false }
   }

--- a/src/main/ipc/pty-pending-data-drain-contract.ts
+++ b/src/main/ipc/pty-pending-data-drain-contract.ts
@@ -7,6 +7,9 @@ export type PendingPtyData = {
   transformed?: true
   containsBackgroundOutput?: boolean
   droppedOutput?: true
+  /** Ingested while no renderer view could see this PTY, so main answered its
+   *  queries: the send must stay sidecar-only even if the pane reveals first. */
+  viewSuppressed?: true
   droppedMode2031Data?: string
   droppedMode2031ScanState?: Mode2031ReplyScanState
   projectionAdmissionIds?: readonly string[]

--- a/src/main/ipc/pty-pending-data-drain-contract.ts
+++ b/src/main/ipc/pty-pending-data-drain-contract.ts
@@ -10,6 +10,13 @@ export type PendingPtyData = {
   /** Ingested while no renderer view could see this PTY, so main answered its
    *  queries: the send must stay sidecar-only even if the pane reveals first. */
   viewSuppressed?: true
+  /** Authority transitions within data/rawLength; delivery never crosses one. */
+  viewSuppressionBoundaries?: {
+    dataOffset: number
+    rawOffset: number
+    viewSuppressed: boolean
+  }[]
+  emitViewGapRestoreMarker?: true
   droppedMode2031Data?: string
   droppedMode2031ScanState?: Mode2031ReplyScanState
   projectionAdmissionIds?: readonly string[]

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -14755,7 +14755,7 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  it('keeps a visible dropped sentinel out of xterm after hidden authority takes over', async () => {
+  it('preserves visible-to-hidden query authority across a pending-cap drop', async () => {
     vi.useFakeTimers()
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const mockProc = createMockProc()
@@ -14778,16 +14778,62 @@ describe('registerPtyHandlers', () => {
       setInterest(null, { id: spawn.id, interested: true })
       setHidden(null, { id: spawn.id, hidden: true })
       mockProc.emitData('\x1b[0c')
+      setHidden(null, { id: spawn.id, hidden: false })
+      mockProc.emitData('\x1b[5n')
+      setHidden(null, { id: spawn.id, hidden: true })
+      mockProc.emitData('\x1b[>q')
 
       mainWindow.webContents.send.mockClear()
       ackData(null, { id: spawn.id, charCount: 512 * 1024 })
       vi.advanceTimersByTime(2)
-      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
-        id: spawn.id,
-        data: '\x1b[6n\x1b[0c',
-        droppedOutput: true,
-        sidecarOnly: true
-      })
+      expect(
+        mainWindow.webContents.send.mock.calls.filter((call: unknown[]) => call[0] === 'pty:data')
+      ).toEqual([
+        ['pty:data', { id: spawn.id, data: '\x1b[6n', droppedOutput: true }],
+        ['pty:data', { id: spawn.id, data: '\x1b[0c', droppedOutput: true, sidecarOnly: true }],
+        ['pty:data', { id: spawn.id, data: '\x1b[5n', droppedOutput: true }],
+        ['pty:data', { id: spawn.id, data: '\x1b[>q', droppedOutput: true, sidecarOnly: true }]
+      ])
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('preserves hidden-to-visible query authority across a pending-cap drop', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const ackData = getPtyAckDataListener()
+      const setHidden = getPtySetHiddenRendererPtyListener()
+      const setInterest = getPtySetDeliveryInterestListener()
+
+      mockProc.emitData('x'.repeat(600 * 1024))
+      vi.advanceTimersByTime(34)
+      setInterest(null, { id: spawn.id, interested: true })
+      setHidden(null, { id: spawn.id, hidden: true })
+      mockProc.emitData(`${'y'.repeat(3 * 1024 * 1024)}\x1b[6n`)
+      setHidden(null, { id: spawn.id, hidden: false })
+      mockProc.emitData('\x1b[0c')
+
+      mainWindow.webContents.send.mockClear()
+      ackData(null, { id: spawn.id, charCount: 512 * 1024 })
+      vi.advanceTimersByTime(2)
+      expect(
+        mainWindow.webContents.send.mock.calls.filter((call: unknown[]) => call[0] === 'pty:data')
+      ).toEqual([
+        ['pty:data', { id: spawn.id, data: '\x1b[6n', droppedOutput: true, sidecarOnly: true }],
+        ['pty:data', { id: spawn.id, data: '\x1b[0c', droppedOutput: true }]
+      ])
     } finally {
       errorSpy.mockRestore()
       vi.useRealTimers()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -14755,6 +14755,45 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('keeps a visible dropped sentinel out of xterm after hidden authority takes over', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const ackData = getPtyAckDataListener()
+      const setHidden = getPtySetHiddenRendererPtyListener()
+      const setInterest = getPtySetDeliveryInterestListener()
+
+      mockProc.emitData('x'.repeat(600 * 1024))
+      vi.advanceTimersByTime(34)
+      mockProc.emitData(`${'y'.repeat(3 * 1024 * 1024)}\x1b[6n`)
+      setInterest(null, { id: spawn.id, interested: true })
+      setHidden(null, { id: spawn.id, hidden: true })
+      mockProc.emitData('\x1b[0c')
+
+      mainWindow.webContents.send.mockClear()
+      ackData(null, { id: spawn.id, charCount: 512 * 1024 })
+      vi.advanceTimersByTime(2)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawn.id,
+        data: '\x1b[6n\x1b[0c',
+        droppedOutput: true,
+        sidecarOnly: true
+      })
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it('scales the pending-output cap with the scrollback setting', async () => {
     vi.useFakeTimers()
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -16788,6 +16827,119 @@ describe('registerPtyHandlers', () => {
         )
         expect(dataSends).toHaveLength(1)
         expect(dataSends[0][1]).toMatchObject({ data: 'parked bytes', sidecarOnly: true })
+
+        mainWindow.webContents.send.mockClear()
+        setHidden(null, { id: spawnResult.id, hidden: true })
+        setHidden(null, { id: spawnResult.id, hidden: false })
+        expect(mainWindow.webContents.send).not.toHaveBeenCalledWith(
+          'pty:modelRestoreNeeded',
+          expect.anything()
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it.each([
+      {
+        direction: 'hidden to visible',
+        arrange: (
+          setHidden: ReturnType<typeof getPtySetHiddenRendererPtyListener>,
+          setInterest: ReturnType<typeof getPtySetDeliveryInterestListener>,
+          id: string
+        ) => {
+          setHidden(null, { id, hidden: true })
+          setInterest(null, { id, interested: true })
+        },
+        transition: (
+          setHidden: ReturnType<typeof getPtySetHiddenRendererPtyListener>,
+          _setInterest: ReturnType<typeof getPtySetDeliveryInterestListener>,
+          id: string
+        ) => setHidden(null, { id, hidden: false }),
+        firstSidecarOnly: true,
+        secondSidecarOnly: false
+      },
+      {
+        direction: 'visible to hidden',
+        arrange: () => {},
+        transition: (
+          setHidden: ReturnType<typeof getPtySetHiddenRendererPtyListener>,
+          setInterest: ReturnType<typeof getPtySetDeliveryInterestListener>,
+          id: string
+        ) => {
+          setInterest(null, { id, interested: true })
+          setHidden(null, { id, hidden: true })
+        },
+        firstSidecarOnly: false,
+        secondSidecarOnly: true
+      }
+    ])('splits queued $direction view authority', async (scenario) => {
+      vi.useFakeTimers()
+      const mockProc = createMockProc()
+      spawnMock.mockReturnValue(mockProc.proc)
+
+      try {
+        registerPtyHandlers(mainWindow as never)
+        const spawnResult = (await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: '/tmp'
+        })) as { id: string }
+        const setHidden = getPtySetHiddenRendererPtyListener()
+        const setInterest = getPtySetDeliveryInterestListener()
+        scenario.arrange(setHidden, setInterest, spawnResult.id)
+        mainWindow.webContents.send.mockClear()
+
+        mockProc.emitData('first-query\x1b[c')
+        scenario.transition(setHidden, setInterest, spawnResult.id)
+        mockProc.emitData('second-query\x1b[c')
+        vi.advanceTimersByTime(50)
+
+        const payloads = mainWindow.webContents.send.mock.calls
+          .filter((call: unknown[]) => call[0] === 'pty:data')
+          .map((call: unknown[]) => call[1] as { data: string; sidecarOnly?: boolean })
+        expect(payloads.map(({ data }) => data)).toEqual([
+          'first-query\x1b[c',
+          'second-query\x1b[c'
+        ])
+        expect(payloads.map(({ sidecarOnly }) => sidecarOnly === true)).toEqual([
+          scenario.firstSidecarOnly,
+          scenario.secondSidecarOnly
+        ])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('bounds queued view-authority transitions with the snapshot sentinel', async () => {
+      vi.useFakeTimers()
+      const mockProc = createMockProc()
+      spawnMock.mockReturnValue(mockProc.proc)
+
+      try {
+        registerPtyHandlers(mainWindow as never)
+        const spawnResult = (await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: '/tmp'
+        })) as { id: string }
+        const setHidden = getPtySetHiddenRendererPtyListener()
+        getPtySetDeliveryInterestListener()(null, { id: spawnResult.id, interested: true })
+
+        for (let index = 0; index < 258; index++) {
+          setHidden(null, { id: spawnResult.id, hidden: index % 2 === 0 })
+          mockProc.emitData('x')
+        }
+        mainWindow.webContents.send.mockClear()
+        vi.advanceTimersByTime(50)
+
+        expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+          id: spawnResult.id,
+          data: '',
+          droppedOutput: true,
+          sidecarOnly: true
+        })
       } finally {
         vi.useRealTimers()
       }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -16715,7 +16715,7 @@ describe('registerPtyHandlers', () => {
       }
     })
 
-    it('suppresses the gate while renderer delivery interest is registered', async () => {
+    it('routes hidden bytes sidecar-only while renderer delivery interest is registered', async () => {
       vi.useFakeTimers()
       const mockProc = createMockProc()
       spawnMock.mockReturnValue(mockProc.proc)
@@ -16735,20 +16735,59 @@ describe('registerPtyHandlers', () => {
         setInterest(null, { id: spawnResult.id, interested: true })
         mockProc.emitData('sidecar bytes')
         vi.advanceTimersByTime(2)
+        // Why the flag: the sidecar gets the bytes, the view does not — so main
+        // stays the query answerer for a pane whose xterm is unmounted.
         expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
           id: spawnResult.id,
-          data: 'sidecar bytes'
+          data: 'sidecar bytes',
+          sidecarOnly: true
+        })
+        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+          id: spawnResult.id,
+          reason: 'hidden-drop'
         })
 
         setInterest(null, { id: spawnResult.id, interested: false })
         mainWindow.webContents.send.mockClear()
         mockProc.emitData('gated bytes')
         vi.advanceTimersByTime(2)
-        expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
-        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
-          id: spawnResult.id,
-          reason: 'hidden-drop'
-        })
+        // Nothing reaches the renderer now, and the restore latch was already
+        // consumed by the sidecar-only send, so no second marker.
+        expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('keeps queued sidecar-only bytes sidecar-only when the pane reveals before the flush', async () => {
+      vi.useFakeTimers()
+      const mockProc = createMockProc()
+      spawnMock.mockReturnValue(mockProc.proc)
+
+      try {
+        registerPtyHandlers(mainWindow as never)
+        const spawnResult = (await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: '/tmp'
+        })) as { id: string }
+        const setHidden = getPtySetHiddenRendererPtyListener()
+        const setInterest = getPtySetDeliveryInterestListener()
+
+        setHidden(null, { id: spawnResult.id, hidden: true })
+        setInterest(null, { id: spawnResult.id, interested: true })
+        mockProc.emitData('parked bytes')
+        mainWindow.webContents.send.mockClear()
+        // Reveal lands between ingestion and flush; main already answered this
+        // chunk's queries, so the now-mounted xterm must never parse it.
+        setHidden(null, { id: spawnResult.id, hidden: false })
+        vi.advanceTimersByTime(50)
+
+        const dataSends = mainWindow.webContents.send.mock.calls.filter(
+          (call: unknown[]) => call[0] === 'pty:data'
+        )
+        expect(dataSends).toHaveLength(1)
+        expect(dataSends[0][1]).toMatchObject({ data: 'parked bytes', sidecarOnly: true })
       } finally {
         vi.useRealTimers()
       }
@@ -17135,7 +17174,7 @@ describe('registerPtyHandlers', () => {
         vi.advanceTimersByTime(50)
         expect(mainWindow.webContents.send).toHaveBeenLastCalledWith(
           'pty:data',
-          expect.objectContaining({ id: result.id, data: 'sidecar bytes' })
+          expect.objectContaining({ id: result.id, data: 'sidecar bytes', sidecarOnly: true })
         )
 
         // Why: the renderer reload killed the sidecar's ref count without a release IPC — the leaked hold must not force-feed the PTY forever.
@@ -17145,12 +17184,10 @@ describe('registerPtyHandlers', () => {
         daemon.emitData(result.id, 'gated after reload')
         vi.advanceTimersByTime(50)
 
-        expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
-        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
-          id: result.id,
-          reason: 'hidden-drop',
-          markerSeq: 42
-        })
+        // Fully dropped now, not merely sidecar-routed. The marker latch is
+        // deliberately preserved across a reload (the new renderer's first
+        // unmark re-emits), so the drop itself is silent.
+        expect(mainWindow.webContents.send).not.toHaveBeenCalled()
       } finally {
         vi.useRealTimers()
       }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2568,6 +2568,8 @@ export function registerPtyHandlers(
   const PTY_BATCH_DRAIN_CONTINUE_MS = 1
   const PTY_BATCH_FLUSH_CHUNK_CHARS = 16 * 1024
   const PTY_BATCH_FLUSH_MAX_WRITES = 2
+  // Bounds metadata under pathological visibility churn; overflow heals through the snapshot sentinel.
+  const PTY_PENDING_VIEW_AUTHORITY_BOUNDARY_MAX = 256
   const PTY_RENDERER_IN_FLIGHT_HIGH_WATER_CHARS = 512 * 1024
   const PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS = 8 * 1024 * 1024
   // Why: cap unbounded pendingData growth when the renderer can't receive (frozen/reloading); beyond it bytes drop and the pane heals from the main buffer snapshot via the droppedOutput sentinel (#7630).
@@ -3081,12 +3083,6 @@ export function registerPtyHandlers(
     payload: PtyDataPayload,
     projectionAdmissionIds?: readonly string[]
   ): { sent: boolean; projectionsTransferred: boolean } {
-    // Why the caller decides: ownership was captured at ingestion (same tick and
-    // module state as the runtime's reply decision), so a reveal that lands
-    // before the flush cannot hand these bytes to an xterm main already answered for.
-    if (payload.sidecarOnly === true && recordHiddenRendererPtyViewGap(id).shouldEmitRestoreMarker) {
-      sendModelRestoreNeededMarker(id, 'hidden-drop', runtime?.getPtyOutputSequence(id))
-    }
     const charCount = getPtyPayloadCharCount(payload)
     const accounting = rendererDeliveryAccountingByPty.get(id)
     const hadAccounting = accounting !== undefined
@@ -3238,20 +3234,22 @@ export function registerPtyHandlers(
     return (pending.droppedMode2031Data ?? '') + pendingSubscribe + state.tail
   }
 
-  function dropOversizedPendingPtyData(id: string, pending: PendingPtyData): PendingPtyData {
+  function dropPendingPtyData(
+    id: string,
+    pending: PendingPtyData,
+    reason: 'pending-cap' | 'view-authority-churn'
+  ): PendingPtyData {
     const capChars = pendingDataCapChars()
-    if (pending.droppedOutput === true || pending.data.length <= capChars) {
-      return pending
-    }
     if (!pendingDataDropWarnedPtys.has(id)) {
       pendingDataDropWarnedPtys.add(id)
       console.error(
-        `[pty] dropped ${pending.data.length} buffered chars for ${id}: renderer not receiving and per-PTY pending cap exceeded; pane will restore from the main-owned snapshot`
+        `[pty] dropped ${pending.data.length} buffered chars for ${id}: ${reason}; pane will restore from the main-owned snapshot`
       )
       // Why: field visibility for cap tuning (issue #2836 / #7017); no pty id since session ids can embed workspace paths.
       recordCrashBreadcrumb('terminal_pending_output_dropped', {
         droppedChars: pending.data.length,
-        capChars
+        capChars,
+        reason
       })
     }
     if (isHiddenPtyDeliveryGateEnabled(getSettings?.()) && !pendingOverflowMarkedPtys.has(id)) {
@@ -3266,10 +3264,20 @@ export function registerPtyHandlers(
     return {
       data: extractDroppedPtyQueryBytes(pending.data).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS),
       droppedOutput: true,
-      ...(pending.viewSuppressed === true ? { viewSuppressed: true as const } : {}),
+      ...(pending.viewSuppressed === true ||
+      pending.viewSuppressionBoundaries?.some((boundary) => boundary.viewSuppressed)
+        ? { viewSuppressed: true as const }
+        : {}),
       droppedMode2031Data: mode2031.data,
       droppedMode2031ScanState: mode2031.state
     }
+  }
+
+  function dropOversizedPendingPtyData(id: string, pending: PendingPtyData): PendingPtyData {
+    if (pending.droppedOutput === true || pending.data.length <= pendingDataCapChars()) {
+      return pending
+    }
+    return dropPendingPtyData(id, pending, 'pending-cap')
   }
 
   function updatePendingProjectionAdmissions(
@@ -3315,7 +3323,8 @@ export function registerPtyHandlers(
     rawLength = data.length,
     transformed = false,
     projectionSemanticsId?: string,
-    viewSuppressed = false
+    viewSuppressed = false,
+    emitViewGapRestoreMarker = false
   ): PendingPtyData {
     // Why stay dropped at O(1): once over the cap the restore sentinel supersedes interim bytes; queries still get carved out (bounded) so replies survive the whole episode.
     if (existing?.droppedOutput === true) {
@@ -3334,6 +3343,8 @@ export function registerPtyHandlers(
       return {
         ...existing,
         data: existing.data + salvaged,
+        ...(viewSuppressed ? { viewSuppressed: true as const } : {}),
+        ...(emitViewGapRestoreMarker ? { emitViewGapRestoreMarker: true as const } : {}),
         droppedMode2031Data: mode2031.data || existing.droppedMode2031Data,
         droppedMode2031ScanState: mode2031.state
       }
@@ -3341,9 +3352,6 @@ export function registerPtyHandlers(
     const projectionState = compactPendingProjectionState(existing ?? {}, projectionSemanticsId)
     const nextContainsBackgroundOutput =
       existing?.containsBackgroundOutput === true || containsBackgroundOutput
-    // Why sticky: one byte main already answered for taints the whole coalesced
-    // entry — the view heals from the model snapshot, a double reply does not.
-    const nextViewSuppressed = existing?.viewSuppressed === true || viewSuppressed
     if (!existing) {
       const pending: PendingPtyData = {
         data,
@@ -3351,25 +3359,118 @@ export function registerPtyHandlers(
         ...(rawLength !== data.length ? { rawLength } : {}),
         ...(transformed ? { transformed: true } : {}),
         ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {}),
-        ...(nextViewSuppressed ? { viewSuppressed: true as const } : {})
+        ...(viewSuppressed ? { viewSuppressed: true as const } : {}),
+        ...(emitViewGapRestoreMarker ? { emitViewGapRestoreMarker: true as const } : {})
       }
       updatePendingProjectionAdmissions(pending, projectionState)
       return dropOversizedPendingPtyData(id, pending)
     }
     const existingRawLength = existing.rawLength ?? existing.data.length
+    const boundaries = existing.viewSuppressionBoundaries
+      ? existing.viewSuppressionBoundaries.slice()
+      : []
+    const previousViewSuppressed =
+      boundaries.at(-1)?.viewSuppressed ?? existing.viewSuppressed === true
+    if (previousViewSuppressed !== viewSuppressed) {
+      boundaries.push({
+        dataOffset: existing.data.length,
+        rawOffset: existingRawLength,
+        viewSuppressed
+      })
+    }
     const next: PendingPtyData = {
       data: existing.data + data,
       ...(!preservesSeq || existing.transformed || transformed
         ? { rawLength: existingRawLength + rawLength, transformed: true as const }
         : {}),
       ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {}),
-      ...(nextViewSuppressed ? { viewSuppressed: true as const } : {})
+      ...(existing.viewSuppressed === true ? { viewSuppressed: true as const } : {}),
+      ...(boundaries.length > 0 ? { viewSuppressionBoundaries: boundaries } : {}),
+      ...(existing.emitViewGapRestoreMarker === true || emitViewGapRestoreMarker
+        ? { emitViewGapRestoreMarker: true as const }
+        : {})
     }
     updatePendingProjectionAdmissions(next, projectionState)
     if (typeof existing.startSeq === 'number') {
       next.startSeq = existing.startSeq
     }
+    if (boundaries.length > PTY_PENDING_VIEW_AUTHORITY_BOUNDARY_MAX) {
+      return dropPendingPtyData(id, next, 'view-authority-churn')
+    }
     return dropOversizedPendingPtyData(id, next)
+  }
+
+  function takePendingPtyDeliverySlice(pending: PendingPtyData): {
+    data: string
+    rawLength: number
+    transformed: boolean
+    viewSuppressed: boolean
+    remainder: PendingPtyData | undefined
+  } {
+    const boundary = pending.viewSuppressionBoundaries?.[0]
+    const dataLimit = boundary?.dataOffset ?? pending.data.length
+    const dataLength = pending.transformed
+      ? dataLimit
+      : Math.min(dataLimit, PTY_BATCH_FLUSH_CHUNK_CHARS)
+    const rawLength =
+      boundary && dataLength === boundary.dataOffset
+        ? boundary.rawOffset
+        : pending.transformed
+          ? (pending.rawLength ?? pending.data.length)
+          : dataLength
+    const data = pending.data.slice(0, dataLength)
+    const remainingData = pending.data.slice(dataLength)
+    if (!remainingData) {
+      return {
+        data,
+        rawLength,
+        transformed: pending.transformed === true,
+        viewSuppressed: pending.viewSuppressed === true,
+        remainder: undefined
+      }
+    }
+    const remainingRawLength = (pending.rawLength ?? pending.data.length) - rawLength
+    const remainingBoundaries = pending.viewSuppressionBoundaries
+      ?.filter((entry) => entry.dataOffset > dataLength)
+      .map((entry) => ({
+        dataOffset: entry.dataOffset - dataLength,
+        rawOffset: entry.rawOffset - rawLength,
+        viewSuppressed: entry.viewSuppressed
+      }))
+    const nextViewSuppressed =
+      boundary && boundary.dataOffset === dataLength
+        ? boundary.viewSuppressed
+        : pending.viewSuppressed === true
+    const remainder: PendingPtyData = {
+      data: remainingData,
+      ...(typeof pending.startSeq === 'number' ? { startSeq: pending.startSeq + rawLength } : {}),
+      ...(remainingRawLength !== remainingData.length ? { rawLength: remainingRawLength } : {}),
+      ...(pending.transformed === true ? { transformed: true as const } : {}),
+      ...(pending.containsBackgroundOutput === true ? { containsBackgroundOutput: true } : {}),
+      ...(nextViewSuppressed ? { viewSuppressed: true as const } : {}),
+      ...(remainingBoundaries && remainingBoundaries.length > 0
+        ? { viewSuppressionBoundaries: remainingBoundaries }
+        : {})
+    }
+    if (pending.projectionAdmissionIds) {
+      remainder.projectionAdmissionIds = pending.projectionAdmissionIds
+    }
+    if (pending.projectionAdmissionsTransferred) {
+      remainder.projectionAdmissionsTransferred = true
+    }
+    return {
+      data,
+      rawLength,
+      transformed: pending.transformed === true,
+      viewSuppressed: pending.viewSuppressed === true,
+      remainder
+    }
+  }
+
+  function emitPendingViewGapRestoreMarker(id: string, pending: PendingPtyData): void {
+    if (pending.emitViewGapRestoreMarker === true && isHiddenRendererPty(id)) {
+      sendModelRestoreNeededMarker(id, 'hidden-drop', runtime?.getPtyOutputSequence(id))
+    }
   }
 
   function schedulePendingDataFlush(delayMs: number): void {
@@ -3448,6 +3549,7 @@ export function registerPtyHandlers(
           pendingData.remove(selection)
           pendingOverflowMarkedPtys.delete(id)
           updateProducerFlowControl(id)
+          emitPendingViewGapRestoreMarker(id, pending)
           const drop = recordHiddenRendererPtyDataDrop(id, pending.data.length)
           if (pending.projectionAdmissionIds) {
             sshOutputIntake?.transferProjections(pending.projectionAdmissionIds, 'hidden-drop')
@@ -3465,6 +3567,7 @@ export function registerPtyHandlers(
         if (pending.droppedOutput === true) {
           pendingData.remove(selection)
           updateProducerFlowControl(id)
+          emitPendingViewGapRestoreMarker(id, pending)
           // Why droppedOutput sentinel: pending-cap drop means the pane must repaint from the snapshot, not continue a gapped stream (data = carved query bytes only).
           if (
             !sendPtyDataToRenderer(
@@ -3484,44 +3587,26 @@ export function registerPtyHandlers(
           writes++
           continue
         }
-        const { data } = pending
-        const indivisible = pending.transformed === true
-        const chunk = indivisible ? data : data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
-        const remaining = indivisible ? '' : data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
-        let nextPending: PendingPtyData | undefined
-        if (remaining) {
-          nextPending = { data: remaining }
-          if (typeof pending.startSeq === 'number') {
-            nextPending.startSeq = pending.startSeq + chunk.length
-          }
-          if (pending.containsBackgroundOutput === true) {
-            nextPending.containsBackgroundOutput = true
-          }
-          if (pending.viewSuppressed === true) {
-            nextPending.viewSuppressed = true
-          }
-          if (pending.projectionAdmissionIds) {
-            nextPending.projectionAdmissionIds = pending.projectionAdmissionIds
-          }
-          if (pending.projectionAdmissionsTransferred) {
-            nextPending.projectionAdmissionsTransferred = true
-          }
+        const slice = takePendingPtyDeliverySlice(pending)
+        const nextPending = slice.remainder
+        if (nextPending) {
           pendingData.replaceWithRemainder(selection, nextPending)
         } else {
           pendingData.remove(selection)
           pendingOverflowMarkedPtys.delete(id)
         }
         updateProducerFlowControl(id)
+        emitPendingViewGapRestoreMarker(id, pending)
         const delivery = sendPtyDataToRenderer(
           id,
           makePtyDataPayload(
             id,
-            chunk,
+            slice.data,
             pending.startSeq,
             pending.containsBackgroundOutput,
-            pending.rawLength,
-            pending.transformed,
-            pending.viewSuppressed === true
+            slice.rawLength,
+            slice.transformed,
+            slice.viewSuppressed
           ),
           pending.projectionAdmissionIds
         )
@@ -3626,6 +3711,7 @@ export function registerPtyHandlers(
       const remaining = pendingData.delete(payload.id)
       clearFlushTimerIfIdle()
       if (remaining) {
+        emitPendingViewGapRestoreMarker(payload.id, remaining)
         if (remaining.droppedOutput === true) {
           // Sentinel entry: only salvaged query bytes remain; keep the flag so the renderer knows the span was dropped.
           sendPtyDataToRenderer(
@@ -3638,7 +3724,7 @@ export function registerPtyHandlers(
             },
             remaining.projectionAdmissionIds
           )
-        } else {
+        } else if (!remaining.viewSuppressionBoundaries?.length) {
           sendPtyDataToRenderer(
             payload.id,
             makePtyDataPayload(
@@ -3652,6 +3738,35 @@ export function registerPtyHandlers(
             ),
             remaining.projectionAdmissionIds
           )
+        } else {
+          let unsettled: PendingPtyData | undefined = remaining
+          while (unsettled) {
+            const slice = takePendingPtyDeliverySlice(unsettled)
+            const delivery = sendPtyDataToRenderer(
+              payload.id,
+              makePtyDataPayload(
+                payload.id,
+                slice.data,
+                unsettled.startSeq,
+                unsettled.containsBackgroundOutput,
+                slice.rawLength,
+                slice.transformed,
+                slice.viewSuppressed
+              ),
+              unsettled.projectionAdmissionIds
+            )
+            if (slice.remainder) {
+              updatePendingProjectionAdmissions(
+                slice.remainder,
+                propagatePendingProjectionRemainder(
+                  slice.remainder,
+                  delivery,
+                  pendingProjectionAdmissionOptions()
+                )
+              )
+            }
+            unsettled = slice.remainder
+          }
         }
       }
       return release
@@ -3780,6 +3895,12 @@ export function registerPtyHandlers(
     if (projection?.desktopSpan) {
       sourceCreditPendingPtys.add(payload.id)
     }
+    const viewSuppressed = shouldDeliverHiddenRendererPtyDataToSidecarsOnly(
+      payload.id,
+      getSettings?.()
+    )
+    const emitViewGapRestoreMarker =
+      viewSuppressed && recordHiddenRendererPtyViewGap(payload.id).shouldEmitRestoreMarker
     const pending = appendPendingPtyData(
       payload.id,
       pendingData.get(payload.id),
@@ -3790,7 +3911,8 @@ export function registerPtyHandlers(
       rawLength,
       payload.transformed === true,
       projectionId,
-      shouldDeliverHiddenRendererPtyDataToSidecarsOnly(payload.id, getSettings?.())
+      viewSuppressed,
+      emitViewGapRestoreMarker
     )
     const shouldEmitPendingCapRestoreMarker =
       pending.droppedOutput === true &&
@@ -3802,7 +3924,11 @@ export function registerPtyHandlers(
       nextData,
       performance.now()
     )
-    if (isInteractiveOutput && rendererPtyDispatcherReady) {
+    if (
+      isInteractiveOutput &&
+      rendererPtyDispatcherReady &&
+      !pending.viewSuppressionBoundaries?.length
+    ) {
       if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
         setPendingPtyData(payload.id, pending)
         if (shouldEmitPendingCapRestoreMarker) {
@@ -3819,6 +3945,7 @@ export function registerPtyHandlers(
       }
       pendingOverflowMarkedPtys.delete(payload.id)
       try {
+        emitPendingViewGapRestoreMarker(payload.id, pending)
         sendPtyDataToRenderer(
           payload.id,
           {
@@ -4155,6 +4282,7 @@ export function registerPtyHandlers(
   const resetRendererPtyDeliveryGateState = (): void => {
     const gateDebug = getHiddenRendererPtyDeliveryDebug()
     resetRendererScopedHiddenPtyDeliveryState()
+    runtime?.resetLocalRendererTerminalViews?.()
     if (gateDebug.hiddenDeliveryGatedPtyCount > 0 || gateDebug.deliveryInterestPtyCount > 0) {
       invalidatePendingPtyDrainPolicy()
     }
@@ -7423,6 +7551,7 @@ export function registerPtyHandlers(
     } else {
       visibleRendererPtys.delete(args.id)
     }
+    runtime?.setLocalRendererTerminalViewVisible?.(args.id, args.visible)
     syncPtyBackgroundedDelivery(args.id, 'visibility-report')
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -170,9 +170,11 @@ import {
   isHiddenRendererPty,
   markHiddenRendererPty,
   recordHiddenRendererPtyDataDrop,
+  recordHiddenRendererPtyViewGap,
   resetHiddenRendererPtyDeliveryDebugCounters,
   resetRendererScopedHiddenPtyDeliveryState,
   setRendererPtyDeliveryInterest,
+  shouldDeliverHiddenRendererPtyDataToSidecarsOnly,
   shouldDropHiddenRendererPtyData,
   unmarkHiddenRendererPty
 } from './pty-hidden-delivery-gate'
@@ -2494,6 +2496,7 @@ export function registerPtyHandlers(
     transformed?: boolean
     background?: boolean
     droppedOutput?: boolean
+    sidecarOnly?: boolean
   }
 
   // Why: bounded batch windows amortize renderer IPC; keystroke echo/redraws bypass them below.
@@ -2910,9 +2913,13 @@ export function registerPtyHandlers(
     startSeq: number | undefined,
     containsBackgroundOutput: boolean | undefined,
     rawLength = data.length,
-    transformed = false
+    transformed = false,
+    viewSuppressed = false
   ): PtyDataPayload {
     const payload: PtyDataPayload = { id, data }
+    if (viewSuppressed) {
+      payload.sidecarOnly = true
+    }
     if (typeof startSeq === 'number') {
       payload.seq = startSeq + rawLength
     }
@@ -3074,6 +3081,12 @@ export function registerPtyHandlers(
     payload: PtyDataPayload,
     projectionAdmissionIds?: readonly string[]
   ): { sent: boolean; projectionsTransferred: boolean } {
+    // Why the caller decides: ownership was captured at ingestion (same tick and
+    // module state as the runtime's reply decision), so a reveal that lands
+    // before the flush cannot hand these bytes to an xterm main already answered for.
+    if (payload.sidecarOnly === true && recordHiddenRendererPtyViewGap(id).shouldEmitRestoreMarker) {
+      sendModelRestoreNeededMarker(id, 'hidden-drop', runtime?.getPtyOutputSequence(id))
+    }
     const charCount = getPtyPayloadCharCount(payload)
     const accounting = rendererDeliveryAccountingByPty.get(id)
     const hadAccounting = accounting !== undefined
@@ -3253,6 +3266,7 @@ export function registerPtyHandlers(
     return {
       data: extractDroppedPtyQueryBytes(pending.data).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS),
       droppedOutput: true,
+      ...(pending.viewSuppressed === true ? { viewSuppressed: true as const } : {}),
       droppedMode2031Data: mode2031.data,
       droppedMode2031ScanState: mode2031.state
     }
@@ -3300,7 +3314,8 @@ export function registerPtyHandlers(
     containsBackgroundOutput: boolean,
     rawLength = data.length,
     transformed = false,
-    projectionSemanticsId?: string
+    projectionSemanticsId?: string,
+    viewSuppressed = false
   ): PendingPtyData {
     // Why stay dropped at O(1): once over the cap the restore sentinel supersedes interim bytes; queries still get carved out (bounded) so replies survive the whole episode.
     if (existing?.droppedOutput === true) {
@@ -3326,13 +3341,17 @@ export function registerPtyHandlers(
     const projectionState = compactPendingProjectionState(existing ?? {}, projectionSemanticsId)
     const nextContainsBackgroundOutput =
       existing?.containsBackgroundOutput === true || containsBackgroundOutput
+    // Why sticky: one byte main already answered for taints the whole coalesced
+    // entry — the view heals from the model snapshot, a double reply does not.
+    const nextViewSuppressed = existing?.viewSuppressed === true || viewSuppressed
     if (!existing) {
       const pending: PendingPtyData = {
         data,
         ...(typeof startSeq === 'number' ? { startSeq } : {}),
         ...(rawLength !== data.length ? { rawLength } : {}),
         ...(transformed ? { transformed: true } : {}),
-        ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
+        ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {}),
+        ...(nextViewSuppressed ? { viewSuppressed: true as const } : {})
       }
       updatePendingProjectionAdmissions(pending, projectionState)
       return dropOversizedPendingPtyData(id, pending)
@@ -3343,7 +3362,8 @@ export function registerPtyHandlers(
       ...(!preservesSeq || existing.transformed || transformed
         ? { rawLength: existingRawLength + rawLength, transformed: true as const }
         : {}),
-      ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
+      ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {}),
+      ...(nextViewSuppressed ? { viewSuppressed: true as const } : {})
     }
     updatePendingProjectionAdmissions(next, projectionState)
     if (typeof existing.startSeq === 'number') {
@@ -3452,7 +3472,8 @@ export function registerPtyHandlers(
               {
                 id,
                 data: pending.data + getDroppedMode2031RendererData(pending),
-                droppedOutput: true
+                droppedOutput: true,
+                ...(pending.viewSuppressed === true ? { sidecarOnly: true } : {})
               },
               pending.projectionAdmissionIds
             ).sent
@@ -3476,6 +3497,9 @@ export function registerPtyHandlers(
           if (pending.containsBackgroundOutput === true) {
             nextPending.containsBackgroundOutput = true
           }
+          if (pending.viewSuppressed === true) {
+            nextPending.viewSuppressed = true
+          }
           if (pending.projectionAdmissionIds) {
             nextPending.projectionAdmissionIds = pending.projectionAdmissionIds
           }
@@ -3496,7 +3520,8 @@ export function registerPtyHandlers(
             pending.startSeq,
             pending.containsBackgroundOutput,
             pending.rawLength,
-            pending.transformed
+            pending.transformed,
+            pending.viewSuppressed === true
           ),
           pending.projectionAdmissionIds
         )
@@ -3608,7 +3633,8 @@ export function registerPtyHandlers(
             {
               id: payload.id,
               data: remaining.data,
-              droppedOutput: true
+              droppedOutput: true,
+              ...(remaining.viewSuppressed === true ? { sidecarOnly: true } : {})
             },
             remaining.projectionAdmissionIds
           )
@@ -3621,7 +3647,8 @@ export function registerPtyHandlers(
               remaining.startSeq,
               remaining.containsBackgroundOutput,
               remaining.rawLength,
-              remaining.transformed
+              remaining.transformed,
+              remaining.viewSuppressed === true
             ),
             remaining.projectionAdmissionIds
           )
@@ -3762,7 +3789,8 @@ export function registerPtyHandlers(
       containsBackgroundOutput,
       rawLength,
       payload.transformed === true,
-      projectionId
+      projectionId,
+      shouldDeliverHiddenRendererPtyDataToSidecarsOnly(payload.id, getSettings?.())
     )
     const shouldEmitPendingCapRestoreMarker =
       pending.droppedOutput === true &&
@@ -3804,7 +3832,8 @@ export function registerPtyHandlers(
               : {}),
             ...(pending.transformed ? { transformed: true } : {}),
             ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
-            ...(pending.droppedOutput === true ? { droppedOutput: true } : {})
+            ...(pending.droppedOutput === true ? { droppedOutput: true } : {}),
+            ...(pending.viewSuppressed === true ? { sidecarOnly: true } : {})
           },
           pending.projectionAdmissionIds
         )

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -24,7 +24,14 @@ import type {
   PtyRendererDeliveryHealthReply,
   PtyRendererDeliveryStateReport
 } from '../../shared/pty-renderer-delivery-health'
-import { extractHiddenStartupRendererQueryData } from '../../shared/terminal-reply-query-extraction'
+import {
+  EMPTY_TERMINAL_REPLY_QUERY_SCAN_STATE,
+  scanTerminalReplyQuerySequences
+} from '../../shared/terminal-reply-query-scan'
+import {
+  isStatefulRendererReplyCsiQuery,
+  isStatelessRendererReplyCsiQuery
+} from '../../shared/terminal-reply-query-extraction'
 import {
   INITIAL_MODE_2031_REPLY_SCAN_STATE,
   scanMode2031ReplyDecision,
@@ -3202,13 +3209,88 @@ export function registerPtyHandlers(
   // Why capped: keeps O(1) memory per PTY; salvaged query bytes are tiny, so past the cap a pathological stream can degrade to the plain sentinel.
   const DROPPED_QUERY_SALVAGE_MAX_CHARS = 4096
 
-  // Why carve out queries: a bulk drop must not swallow reply-eliciting probes (DSR/CPR, DA1/DA2, DECRQM, OSC 10/11) the program blocks on; snapshot heals content so replies can't double-fire.
-  function extractDroppedPtyQueryBytes(data: string): string {
+  function isDroppedPtyRendererQuery(data: string): boolean {
+    return (
+      data.startsWith('\x1b]') ||
+      isStatelessRendererReplyCsiQuery(data) ||
+      isStatefulRendererReplyCsiQuery(data)
+    )
+  }
+
+  function scanDroppedPtyRendererQueries(data: string) {
     if (!data.includes('\x1b')) {
-      return ''
+      return []
     }
-    const extracted = extractHiddenStartupRendererQueryData(data, '')
-    return extracted.statelessQueryData + extracted.statefulQueryData + extracted.oscColorQueryData
+    return scanTerminalReplyQuerySequences(
+      data,
+      0,
+      EMPTY_TERMINAL_REPLY_QUERY_SCAN_STATE
+    ).queries.filter(({ data: query }) => isDroppedPtyRendererQuery(query))
+  }
+
+  function appendDroppedPtyQueryBytes(
+    pending: PendingPtyData,
+    queryData: string,
+    viewSuppressed: boolean
+  ): void {
+    if (!queryData) {
+      return
+    }
+    const remainingCapacity = DROPPED_QUERY_SALVAGE_MAX_CHARS - pending.data.length
+    if (queryData.length > remainingCapacity) {
+      return
+    }
+    const boundaries = pending.viewSuppressionBoundaries ?? []
+    const previousViewSuppressed =
+      boundaries.at(-1)?.viewSuppressed ?? pending.viewSuppressed === true
+    if (pending.data.length > 0 && previousViewSuppressed !== viewSuppressed) {
+      boundaries.push({
+        dataOffset: pending.data.length,
+        rawOffset: pending.data.length,
+        viewSuppressed
+      })
+      pending.viewSuppressionBoundaries = boundaries
+    } else if (pending.data.length === 0 && viewSuppressed) {
+      pending.viewSuppressed = true
+    }
+    pending.data += queryData
+  }
+
+  // Why carve out queries: a bulk drop must not swallow reply-eliciting probes (DSR/CPR, DA1/DA2, DECRQM, OSC 10/11) the program blocks on; snapshot heals content so replies can't double-fire.
+  function appendDroppedPtyQueries(
+    pending: PendingPtyData,
+    data: string,
+    viewSuppressed: boolean
+  ): void {
+    for (const query of scanDroppedPtyRendererQueries(data)) {
+      appendDroppedPtyQueryBytes(pending, query.data, viewSuppressed)
+    }
+  }
+
+  function salvageDroppedPtyQueries(pending: PendingPtyData): PendingPtyData {
+    const salvaged: PendingPtyData = { data: '', droppedOutput: true }
+    const queries = scanDroppedPtyRendererQueries(pending.data)
+    const boundaries = pending.viewSuppressionBoundaries ?? []
+    let boundaryIndex = 0
+    let viewSuppressed = pending.viewSuppressed === true
+    for (const query of queries) {
+      while (
+        boundaryIndex < boundaries.length &&
+        boundaries[boundaryIndex]!.dataOffset < query.endSeq
+      ) {
+        viewSuppressed = boundaries[boundaryIndex]!.viewSuppressed
+        boundaryIndex += 1
+      }
+      appendDroppedPtyQueryBytes(salvaged, query.data, viewSuppressed)
+    }
+    if (
+      salvaged.data.length === 0 &&
+      (pending.viewSuppressed === true ||
+        pending.viewSuppressionBoundaries?.some((boundary) => boundary.viewSuppressed))
+    ) {
+      salvaged.viewSuppressed = true
+    }
+    return salvaged
   }
 
   function scanDroppedMode2031Data(
@@ -3262,12 +3344,7 @@ export function registerPtyHandlers(
     const mode2031 = scanDroppedMode2031Data(pending.data, INITIAL_MODE_2031_REPLY_SCAN_STATE)
     // Why no trimmed content tail: a mid-stream gap would corrupt the pane; the droppedOutput sentinel repaints from the snapshot and realigns by sequence (only query bytes ride along).
     return {
-      data: extractDroppedPtyQueryBytes(pending.data).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS),
-      droppedOutput: true,
-      ...(pending.viewSuppressed === true ||
-      pending.viewSuppressionBoundaries?.some((boundary) => boundary.viewSuppressed)
-        ? { viewSuppressed: true as const }
-        : {}),
+      ...salvageDroppedPtyQueries(pending),
       droppedMode2031Data: mode2031.data,
       droppedMode2031ScanState: mode2031.state
     }
@@ -3335,19 +3412,14 @@ export function registerPtyHandlers(
         data,
         existing.droppedMode2031ScanState ?? INITIAL_MODE_2031_REPLY_SCAN_STATE
       )
-      const remainingQueryCapacity = Math.max(
-        0,
-        DROPPED_QUERY_SALVAGE_MAX_CHARS - existing.data.length
-      )
-      const salvaged = extractDroppedPtyQueryBytes(data).slice(0, remainingQueryCapacity)
-      return {
+      const next = {
         ...existing,
-        data: existing.data + salvaged,
-        ...(viewSuppressed ? { viewSuppressed: true as const } : {}),
         ...(emitViewGapRestoreMarker ? { emitViewGapRestoreMarker: true as const } : {}),
         droppedMode2031Data: mode2031.data || existing.droppedMode2031Data,
         droppedMode2031ScanState: mode2031.state
       }
+      appendDroppedPtyQueries(next, data, viewSuppressed)
+      return next
     }
     const projectionState = compactPendingProjectionState(existing ?? {}, projectionSemanticsId)
     const nextContainsBackgroundOutput =
@@ -3467,6 +3539,37 @@ export function registerPtyHandlers(
     }
   }
 
+  function sendDroppedPendingPtyData(
+    id: string,
+    pending: PendingPtyData
+  ): {
+    sent: boolean
+    writes: number
+  } {
+    const mode2031Data = getDroppedMode2031RendererData(pending)
+    let unsettled: PendingPtyData | undefined = {
+      ...pending,
+      data: pending.data + mode2031Data
+    }
+    let writes = 0
+    while (unsettled) {
+      const slice = takePendingPtyDeliverySlice(unsettled)
+      if (
+        !sendPtyDataToRenderer(id, {
+          id,
+          data: slice.data,
+          droppedOutput: true,
+          ...(slice.viewSuppressed ? { sidecarOnly: true } : {})
+        }).sent
+      ) {
+        return { sent: false, writes }
+      }
+      writes += 1
+      unsettled = slice.remainder
+    }
+    return { sent: true, writes }
+  }
+
   function emitPendingViewGapRestoreMarker(id: string, pending: PendingPtyData): void {
     if (pending.emitViewGapRestoreMarker === true && isHiddenRendererPty(id)) {
       sendModelRestoreNeededMarker(id, 'hidden-drop', runtime?.getPtyOutputSequence(id))
@@ -3569,22 +3672,12 @@ export function registerPtyHandlers(
           updateProducerFlowControl(id)
           emitPendingViewGapRestoreMarker(id, pending)
           // Why droppedOutput sentinel: pending-cap drop means the pane must repaint from the snapshot, not continue a gapped stream (data = carved query bytes only).
-          if (
-            !sendPtyDataToRenderer(
-              id,
-              {
-                id,
-                data: pending.data + getDroppedMode2031RendererData(pending),
-                droppedOutput: true,
-                ...(pending.viewSuppressed === true ? { sidecarOnly: true } : {})
-              },
-              pending.projectionAdmissionIds
-            ).sent
-          ) {
+          const delivery = sendDroppedPendingPtyData(id, pending)
+          if (!delivery.sent) {
             sendFailed = true
             break
           }
-          writes++
+          writes += delivery.writes
           continue
         }
         const slice = takePendingPtyDeliverySlice(pending)
@@ -3714,16 +3807,7 @@ export function registerPtyHandlers(
         emitPendingViewGapRestoreMarker(payload.id, remaining)
         if (remaining.droppedOutput === true) {
           // Sentinel entry: only salvaged query bytes remain; keep the flag so the renderer knows the span was dropped.
-          sendPtyDataToRenderer(
-            payload.id,
-            {
-              id: payload.id,
-              data: remaining.data,
-              droppedOutput: true,
-              ...(remaining.viewSuppressed === true ? { sidecarOnly: true } : {})
-            },
-            remaining.projectionAdmissionIds
-          )
+          sendDroppedPendingPtyData(payload.id, remaining)
         } else if (!remaining.viewSuppressionBoundaries?.length) {
           sendPtyDataToRenderer(
             payload.id,

--- a/src/main/runtime/fish-parked-pane-prompt-latency.node-pty.test.ts
+++ b/src/main/runtime/fish-parked-pane-prompt-latency.node-pty.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Real-fish regression for the parked-pane DA1 stall.
+ *
+ * fish re-emits DA1 (`ESC [ 0 c`) at EVERY prompt paint and BLOCKS on the reply
+ * for up to 10s. Its "give up after one timeout" latch only arms when the
+ * timeout happens during the startup probe, so a reply source that disappears
+ * later stalls every subsequent prompt, indefinitely.
+ *
+ * The configuration under test is a PARKED pane (xterm unmounted, so no
+ * renderer responder exists) whose PTY still has a raw-byte sidecar registered
+ * — a background agent launch, an automation observer, a draft-readiness
+ * probe. Before the fix, that sidecar's delivery interest made main's query
+ * authority yield ("the chunk was delivered, so a renderer xterm will answer
+ * it") to a renderer that had no xterm at all, and nobody answered.
+ *
+ * Real production code under test, in production's two stages:
+ *   1. the daemon Session's startup DA1 responder + query filter, released at
+ *      shell-ready (session.ts) — WITHOUT it fish times out on its startup
+ *      probe, latches "give up on DA1", and no later stall is observable;
+ *   2. the main-side reply-ownership predicate (shouldModelAnswerHiddenPtyQueries)
+ *      driving a runtime HeadlessEmulator wired as createPtyHeadlessTerminalState
+ *      wires it.
+ * Nothing here answers DA1 out of band — if stage 2's predicate says "not
+ * mine", fish waits out its 10s cap.
+ *
+ * The assertion is PROMPT LATENCY, the observable symptom: a user's parked fish
+ * pane taking 10s to redraw its prompt after every command.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fishRequirementViolation, resolveFishBinary } from '../../shared/fish-binary-requirement'
+import type { TerminalViewAttributes } from '../../shared/terminal-view-attributes'
+import { HeadlessEmulator } from '../daemon/headless-emulator'
+import {
+  installDeviceAttributesResponder,
+  StartupDeviceAttributesQueryFilter,
+  STARTUP_DA1_RESPONSE
+} from '../daemon/startup-device-attributes-responder'
+import {
+  _resetHiddenRendererPtyDeliveryGateForTest,
+  markHiddenRendererPty,
+  setRendererPtyDeliveryInterest
+} from '../ipc/pty-hidden-delivery-gate'
+import { shouldModelAnswerHiddenPtyQueries } from './terminal-model-query-authority'
+
+const FISH = resolveFishBinary(4)
+const itWithFish = FISH.available ? it : it.skip
+
+const PTY_ID = 'fish-parked-pty'
+const PROMPT_MARK = 'ORCA-DA1> '
+// Well under fish's 10s DA1 cap, and far above the ~30ms an answered prompt takes.
+const PROMPT_LATENCY_BUDGET_MS = 1_000
+const PROMPT_WAIT_MS = 15_000
+const SETTINGS = {
+  terminalMainSideEffectAuthority: true,
+  terminalHiddenDeliveryGate: true,
+  terminalModelQueryAuthority: true
+} as const
+
+const VIEW_ATTRIBUTES: TerminalViewAttributes = {
+  foreground: [238, 238, 238],
+  background: [17, 17, 17],
+  cursor: [238, 238, 238],
+  ansi: Array.from({ length: 256 }, () => [128, 128, 128] as [number, number, number]),
+  colorSchemeMode: 'dark',
+  cursorStyle: 'block',
+  cursorBlink: false
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('a parked fish pane keeps painting prompts (DA1 must always have an answerer)', () => {
+  let configHome: string | null = null
+  let cleanup: (() => void) | null = null
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = null
+    _resetHiddenRendererPtyDeliveryGateForTest()
+    if (configHome) {
+      rmSync(configHome, { recursive: true, force: true })
+      configHome = null
+    }
+  })
+
+  // Always runs, so the CI lane cannot report green with the regression below skipped.
+  it('has the fish this suite needs when CI requires one', () => {
+    expect(fishRequirementViolation(FISH)).toBeNull()
+  })
+
+  itWithFish(
+    'answers DA1 from the model while a sidecar holds delivery interest',
+    async () => {
+      const nodePty = await import('node-pty')
+
+      configHome = mkdtempSync(path.join(tmpdir(), 'orca-fish-da1-'))
+      mkdirSync(path.join(configHome, 'fish'), { recursive: true })
+      // Why a bare prompt: fish core re-probes DA1 on every paint regardless of
+      // what the prompt function prints, so nothing here shapes the measurement.
+      writeFileSync(
+        path.join(configHome, 'fish/config.fish'),
+        [
+          'set -g fish_greeting ""',
+          `function fish_prompt; printf '${PROMPT_MARK}'; end`,
+          'function fish_right_prompt; end',
+          ''
+        ].join('\n')
+      )
+
+      const term = nodePty.spawn(FISH.path as string, ['-l', '-i'], {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 30,
+        cwd: configHome,
+        env: {
+          PATH: process.env.PATH ?? '/usr/bin:/bin',
+          HOME: configHome,
+          TERM: 'xterm-256color',
+          COLORTERM: 'truecolor',
+          LANG: 'en_US.UTF-8',
+          XDG_CONFIG_HOME: configHome,
+          XDG_DATA_HOME: path.join(configHome, 'data')
+        }
+      })
+
+      // Parked tab: the pane's xterm is unmounted (hidden mark) but a background
+      // agent / automation sidecar still consumes raw bytes (delivery interest).
+      markHiddenRendererPty(PTY_ID)
+      setRendererPtyDeliveryInterest(PTY_ID, true)
+
+      // Stage 1 — daemon Session: answers DA1 past the shell-ready input queue and
+      // strips the query from downstream output, then hands DA1 back at ready.
+      const daemonEmulator = new HeadlessEmulator({ cols: 120, rows: 30 })
+      const startupFilter = new StartupDeviceAttributesQueryFilter()
+      let releaseStartupResponder: (() => void) | null = installDeviceAttributesResponder({
+        parser: daemonEmulator.responderParser,
+        response: STARTUP_DA1_RESPONSE,
+        reply: (data) => term.write(data)
+      })
+
+      // Stage 2 — main runtime model, the only post-startup answerer for a pane
+      // with no xterm.
+      const emulator = new HeadlessEmulator({
+        cols: 120,
+        rows: 30,
+        onQueryReply: (reply) => term.write(reply)
+      })
+      emulator.installViewAttributeResponder(() => VIEW_ATTRIBUTES)
+      emulator.applyPushedViewAttributes(VIEW_ATTRIBUTES)
+
+      let promptCount = 0
+      let writeChain: Promise<void> = Promise.resolve()
+      term.onData((chunk) => {
+        void daemonEmulator.write(chunk)
+        const downstream = releaseStartupResponder ? startupFilter.accept(chunk) : chunk
+        // Mirrors OrcaRuntimeService.onPtyData: ownership is captured per chunk at
+        // ingestion and rides that chunk's write-chain link.
+        const forwardQueryReplies = shouldModelAnswerHiddenPtyQueries({
+          ptyId: PTY_ID,
+          settings: SETTINGS,
+          hasRemoteViewSubscriber: false
+        })
+        writeChain = writeChain.then(() => emulator.write(downstream, { forwardQueryReplies }))
+        promptCount += chunk.split(PROMPT_MARK).length - 1
+        if (promptCount > 0 && releaseStartupResponder) {
+          // Shell-ready: the startup barrier is done, so DA1 goes back to whoever
+          // owns the view. Production releases here too (session.ts).
+          releaseStartupResponder()
+          releaseStartupResponder = null
+        }
+      })
+
+      cleanup = () => {
+        try {
+          term.kill()
+        } catch {
+          /* already gone */
+        }
+        releaseStartupResponder?.()
+        emulator.dispose()
+        daemonEmulator.dispose()
+      }
+
+      const waitForPromptCount = async (target: number): Promise<boolean> => {
+        const deadline = Date.now() + PROMPT_WAIT_MS
+        while (Date.now() < deadline) {
+          if (promptCount >= target) {
+            return true
+          }
+          await sleep(10)
+        }
+        return false
+      }
+
+      expect(await waitForPromptCount(1)).toBe(true)
+
+      // Why three: the pre-fix failure is not the first prompt (the startup probe
+      // has its own responder in production) but every prompt after it.
+      const latenciesMs: number[] = []
+      for (let round = 0; round < 3; round += 1) {
+        const target = promptCount + 1
+        const startedAt = Date.now()
+        term.write('\r')
+        const painted = await waitForPromptCount(target)
+        latenciesMs.push(Date.now() - startedAt)
+        expect(painted).toBe(true)
+      }
+
+      expect(Math.max(...latenciesMs)).toBeLessThan(PROMPT_LATENCY_BUDGET_MS)
+    },
+    120_000
+  )
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3039,6 +3039,8 @@ export class OrcaRuntimeService {
   // Preview windows consume the raw stream but deliberately leave terminal
   // query replies to main's headless emulator.
   private rawTerminalViewSubscriberCounts = new Map<string, number>()
+  // Positive presence distinguishes a visible desktop xterm from a headless host.
+  private localRendererTerminalViewPtys = new Set<string>()
   // Why a sticky promise per PTY: the daemon only emits data for sessions this
   // app has attached, so the first remote view subscriber of a never-attached
   // local daemon session triggers a main-side attach. The map dedupes
@@ -11035,6 +11037,18 @@ export class OrcaRuntimeService {
     return (this.mobileSubscribers.get(ptyId)?.size ?? 0) > 0
   }
 
+  setLocalRendererTerminalViewVisible(ptyId: string, visible: boolean): void {
+    if (visible) {
+      this.localRendererTerminalViewPtys.add(ptyId)
+    } else {
+      this.localRendererTerminalViewPtys.delete(ptyId)
+    }
+  }
+
+  resetLocalRendererTerminalViews(): void {
+    this.localRendererTerminalViewPtys.clear()
+  }
+
   isMobileTerminalQueryReplyAuthority(ptyId: string, clientId: string): boolean {
     // Why: a passive phone watching desktop-sized output must not race the
     // desktop xterm. Mobile becomes reply authority only with the mobile floor.
@@ -11438,7 +11452,9 @@ export class OrcaRuntimeService {
     return shouldModelAnswerHiddenPtyQueries({
       ptyId,
       settings: this.store?.getSettings(),
-      hasRemoteViewSubscriber: this.hasRemoteTerminalViewSubscriber(ptyId)
+      hasRemoteViewSubscriber: this.hasRemoteTerminalViewSubscriber(ptyId),
+      hasRawViewSubscriber: this.hasRawTerminalViewSubscriber(ptyId),
+      hasLocalRendererView: this.localRendererTerminalViewPtys.has(ptyId)
     })
   }
 
@@ -13637,6 +13653,7 @@ export class OrcaRuntimeService {
     this.mobileSubscribers.delete(ptyId)
     this.remoteTerminalViewSubscriberCounts.delete(ptyId)
     this.rawTerminalViewSubscriberCounts.delete(ptyId)
+    this.localRendererTerminalViewPtys.delete(ptyId)
     this.mobileDisplayModes.delete(ptyId)
     this.resizeListeners.delete(ptyId)
     this.lastRendererSizes.delete(ptyId)

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -140,8 +140,7 @@ type TerminalMultiplexStream = {
   supportsOutputPause: boolean
   supportsWriteUnavailable: boolean
   outputPaused: boolean
-  /** Releases whichever presence this stream currently holds — view (query
-   *  authority) while it receives output, raw-only while it is paused. */
+  /** Releases the stream's current view or raw-only presence. */
   releaseViewPresence: () => void
   /** null until this stream registers presence at all. */
   holdsViewAuthority: boolean | null
@@ -419,15 +418,7 @@ function assertTerminalSendExactPtyBinding(
   throw new Error('terminal_guard_not_writable')
 }
 
-/**
- * Query authority follows what the client can actually SEE. A paused stream
- * receives no bytes, so its remote xterm cannot answer DA1/DSR/OSC probes —
- * holding view presence there leaves nobody answering and fish blocks ~10s at
- * every prompt paint. Raw presence still pins the provider so unpausing
- * resumes the same PTY. Both flags flip synchronously in main, so the model
- * takes over exactly for the chunks the client never receives (no double
- * answer, no gap).
- */
+// Why: a paused client cannot answer terminal probes; raw presence retains its PTY without claiming view authority.
 function setRemoteStreamViewAuthority(
   runtime: OrcaRuntimeService,
   stream: TerminalMultiplexStream,
@@ -2217,14 +2208,18 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           if (typeof payload?.paused !== 'boolean' || stream.outputPaused === payload.paused) {
             return
           }
-          stream.outputPaused = payload.paused
-          if (stream.outputPaused) {
+          if (payload.paused) {
+            // Pre-pause bytes were ingested under view authority, so retire the
+            // batch before the pause guard and retain ACK-blocked bytes for resume.
             stream.outputBatcher.flush()
-            stream.ackPendingOutput = []
-            stream.ackPendingOutputBytes = 0
-            stream.ackPendingOutputOverflowed = false
+            flushAckPendingOutput(stream)
+            stream.outputPaused = true
+            setRemoteStreamViewAuthority(runtime, stream, false)
+          } else {
+            stream.outputPaused = false
+            setRemoteStreamViewAuthority(runtime, stream, true)
+            flushAckPendingOutput(stream)
           }
-          setRemoteStreamViewAuthority(runtime, stream, !stream.outputPaused)
           return
         }
         if (frame.opcode === TerminalStreamOpcode.Resize && stream.client) {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -140,6 +140,11 @@ type TerminalMultiplexStream = {
   supportsOutputPause: boolean
   supportsWriteUnavailable: boolean
   outputPaused: boolean
+  /** Releases whichever presence this stream currently holds — view (query
+   *  authority) while it receives output, raw-only while it is paused. */
+  releaseViewPresence: () => void
+  /** null until this stream registers presence at all. */
+  holdsViewAuthority: boolean | null
   supportsDesktopViewportClaims: boolean
   desktopClaimTail: Promise<boolean>
   // Whether THIS stream registered the width driver, so detach won't release a peer stream's floor.
@@ -412,6 +417,30 @@ function assertTerminalSendExactPtyBinding(
     // Fall through to the stable guarded-send result below.
   }
   throw new Error('terminal_guard_not_writable')
+}
+
+/**
+ * Query authority follows what the client can actually SEE. A paused stream
+ * receives no bytes, so its remote xterm cannot answer DA1/DSR/OSC probes —
+ * holding view presence there leaves nobody answering and fish blocks ~10s at
+ * every prompt paint. Raw presence still pins the provider so unpausing
+ * resumes the same PTY. Both flags flip synchronously in main, so the model
+ * takes over exactly for the chunks the client never receives (no double
+ * answer, no gap).
+ */
+function setRemoteStreamViewAuthority(
+  runtime: OrcaRuntimeService,
+  stream: TerminalMultiplexStream,
+  holdsViewAuthority: boolean
+): void {
+  if (stream.holdsViewAuthority === holdsViewAuthority) {
+    return
+  }
+  stream.holdsViewAuthority = holdsViewAuthority
+  stream.releaseViewPresence()
+  stream.releaseViewPresence = holdsViewAuthority
+    ? runtime.registerRemoteTerminalViewSubscriber(stream.ptyId)
+    : runtime.registerRawTerminalViewSubscriber(stream.ptyId)
 }
 
 function appendPendingMultiplexOutput(
@@ -2195,6 +2224,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             stream.ackPendingOutputBytes = 0
             stream.ackPendingOutputOverflowed = false
           }
+          setRemoteStreamViewAuthority(runtime, stream, !stream.outputPaused)
           return
         }
         if (frame.opcode === TerminalStreamOpcode.Resize && stream.client) {
@@ -2522,6 +2552,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           supportsOutputPause: request.capabilities?.outputPause === 1,
           supportsWriteUnavailable: request.capabilities?.writeUnavailable === 1,
           outputPaused: false,
+          releaseViewPresence: () => {},
+          holdsViewAuthority: null,
           supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,
           desktopClaimTail: Promise.resolve(true),
           registeredRemoteDesktopDriver: false,
@@ -2577,10 +2609,12 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             }
             stream.outputBatcher.push(data, meta)
           })
-          // Why: a multiplexed stream feeds a remote xterm view with query authority, so the main model responder yields while attached (terminal-query-authority.md).
-          const releaseViewSubscriber = runtime.registerRemoteTerminalViewSubscriber(ptyId)
+          // Why: a multiplexed stream feeds a remote xterm view with query authority, so the main model responder yields while attached (terminal-query-authority.md) — until the client pauses output, which hands authority back.
+          setRemoteStreamViewAuthority(runtime, stream, !stream.outputPaused)
           stream.unsubscribeData = () => {
-            releaseViewSubscriber()
+            stream.releaseViewPresence()
+            stream.releaseViewPresence = () => {}
+            stream.holdsViewAuthority = null
             unsubscribeStreamData()
           }
 

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1819,11 +1819,14 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         }
         sendAckGatedOutput(stream, chunk)
       }
-      const sendAckRecoverySnapshot = async (stream: TerminalMultiplexStream): Promise<void> => {
+      const sendAckRecoverySnapshot = async (
+        stream: TerminalMultiplexStream,
+        allowWhilePaused = false
+      ): Promise<void> => {
         if (
           closed ||
           streams.get(stream.streamId) !== stream ||
-          stream.outputPaused ||
+          (stream.outputPaused && !allowWhilePaused) ||
           stream.ackRecoverySnapshotInFlight
         ) {
           return
@@ -1832,7 +1835,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         let replacement: RemoteTerminalSourceRangeReplacementReservation | null = null
         try {
           const serialized = await serializeBudgetedRequestedSnapshot(runtime, stream.ptyId, 0)
-          if (closed || streams.get(stream.streamId) !== stream || stream.outputPaused) {
+          if (
+            closed ||
+            streams.get(stream.streamId) !== stream ||
+            (stream.outputPaused && !allowWhilePaused)
+          ) {
             return
           }
           if (!serialized) {
@@ -1941,19 +1948,20 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         } finally {
           if (streams.get(stream.streamId) === stream) {
             stream.ackRecoverySnapshotInFlight = false
-            flushAllAckPendingOutput()
+            flushAllAckPendingOutput(allowWhilePaused)
           }
         }
       }
       const flushAckPendingOutput = (
         stream: TerminalMultiplexStream,
-        maxChunks = Number.POSITIVE_INFINITY
+        maxChunks = Number.POSITIVE_INFINITY,
+        allowWhilePaused = false
       ): number => {
-        if (stream.outputPaused) {
+        if (stream.outputPaused && !allowWhilePaused) {
           return 0
         }
         if (stream.ackPendingOutputOverflowed) {
-          void sendAckRecoverySnapshot(stream)
+          void sendAckRecoverySnapshot(stream, allowWhilePaused)
           return 0
         }
         let flushed = 0
@@ -1976,7 +1984,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         }
         return flushed
       }
-      const flushAllAckPendingOutput = (): void => {
+      const flushAllAckPendingOutput = (allowWhilePaused = false): void => {
         const ordered = Array.from(streams.values())
         ackFlushCursorStreamId = drainTerminalMultiplexRoundRobin({
           streams: ordered,
@@ -1986,7 +1994,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             if (streams.get(stream.streamId) !== stream) {
               return false
             }
-            if (flushAckPendingOutput(stream, 1) > 0) {
+            if (flushAckPendingOutput(stream, 1, allowWhilePaused) > 0) {
               return true
             }
             return false
@@ -2008,7 +2016,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         )
         stream.ackInFlightBytes -= acknowledged
         ackTotalInFlightBytes = Math.max(0, ackTotalInFlightBytes - acknowledged)
-        flushAllAckPendingOutput()
+        // Why allowed while paused: queued pre-pause bytes retain remote reply authority.
+        flushAllAckPendingOutput(true)
       }
       const acknowledgeSourceRanges = (
         stream: TerminalMultiplexStream,
@@ -2209,8 +2218,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             return
           }
           if (payload.paused) {
-            // Pre-pause bytes were ingested under view authority, so retire the
-            // batch before the pause guard and retain ACK-blocked bytes for resume.
+            // Why flush first: pre-pause bytes retain remote reply authority through the ACK queue.
             stream.outputBatcher.flush()
             flushAckPendingOutput(stream)
             stream.outputPaused = true

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -4602,6 +4602,126 @@ describe('terminal multiplex RPC', () => {
     await harness.dispatchPromise
   })
 
+  it('settles the pre-pause batch and preserves ACK-pending bytes for resume', async () => {
+    let dataListener: ((data: string, meta?: RuntimeTerminalDataMeta) => void) | undefined
+    const releaseView = vi.fn()
+    const sendBinary = vi.fn(() => true)
+    const harness = startDesktopMultiplexSubscribe(
+      {
+        registerRemoteTerminalViewSubscriber: vi.fn(() => releaseView),
+        registerRawTerminalViewSubscriber: vi.fn(() => vi.fn()),
+        subscribeToTerminalData: vi.fn((_ptyId, listener) => {
+          dataListener = listener
+          return vi.fn()
+        })
+      },
+      undefined,
+      sendBinary
+    )
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+    sendDesktopMultiplexSubscribe(harness.handlers, { ackOutput: 1, outputPause: 1 })
+    await vi.waitFor(() => expect(dataListener).toBeDefined())
+    await vi.waitFor(() =>
+      expect(
+        harness.messages.some((message) => JSON.parse(message).result?.type === 'subscribed')
+      ).toBe(true)
+    )
+    harness.binaryFrames.splice(0)
+    sendBinary.mockClear()
+
+    dataListener?.('five-ms-batch', { seq: 13, rawLength: 13 })
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: SET_OUTPUT_PAUSED_OPCODE,
+          streamId: 7,
+          seq: 2,
+          payload: encodeTerminalStreamJson({ paused: true })
+        })
+      )!
+    )
+    expect(
+      harness.binaryFrames
+        .map(decodeTerminalStreamFrame)
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+        .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        .join('')
+    ).toBe('five-ms-batch')
+    expect(sendBinary.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      releaseView.mock.invocationCallOrder[0]!
+    )
+
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: SET_OUTPUT_PAUSED_OPCODE,
+          streamId: 7,
+          seq: 3,
+          payload: encodeTerminalStreamJson({ paused: false })
+        })
+      )!
+    )
+    harness.binaryFrames.splice(0)
+    dataListener?.('x'.repeat(TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES), {
+      seq: 13 + TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
+      rawLength: TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES
+    })
+    dataListener?.('ack-pending', {
+      seq: 24 + TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
+      rawLength: 11
+    })
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: SET_OUTPUT_PAUSED_OPCODE,
+          streamId: 7,
+          seq: 4,
+          payload: encodeTerminalStreamJson({ paused: true })
+        })
+      )!
+    )
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Ack,
+          streamId: 7,
+          seq: 5,
+          payload: encodeTerminalStreamJson({
+            bytes: TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES
+          })
+        })
+      )!
+    )
+    expect(
+      harness.binaryFrames
+        .map(decodeTerminalStreamFrame)
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+        .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        .join('')
+    ).not.toContain('ack-pending')
+
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: SET_OUTPUT_PAUSED_OPCODE,
+          streamId: 7,
+          seq: 6,
+          payload: encodeTerminalStreamJson({ paused: false })
+        })
+      )!
+    )
+    expect(
+      harness.binaryFrames
+        .map(decodeTerminalStreamFrame)
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+        .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        .join('')
+    ).toContain('ack-pending')
+
+    harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
+    await harness.dispatchPromise
+  })
+
   it('cancels a pending desktop PTY wait when its multiplex slot unsubscribes', async () => {
     let resolvePty: (ptyId: string) => void = () => {}
     let waitSignal: AbortSignal | undefined

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -34,6 +34,8 @@ function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeSe
     // Why: every multiplex stream registers as a remote view subscriber for
     // Phase-5 query-authority suppression (terminal-query-authority.md).
     registerRemoteTerminalViewSubscriber: () => () => {},
+    // Why: a paused stream swaps view presence for raw presence — it can no longer answer queries.
+    registerRawTerminalViewSubscriber: () => () => {},
     // Why: the multiplex subscribe path resolves handles via
     // resolveLiveLeafForHandle (#7718). Default to a live pty so tests that
     // only stub the legacy resolveLeafForHandle still bind; tests that need a
@@ -4552,6 +4554,50 @@ describe('terminal multiplex RPC', () => {
         .filter((frame) => frame?.opcode === TerminalStreamOpcode.Error)
         .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
     ).toEqual([])
+    harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
+    await harness.dispatchPromise
+  })
+
+  // Why: a paused stream receives no bytes, so its remote xterm cannot answer
+  // DA1/DSR/OSC probes. Holding view presence there left NOBODY answering and a
+  // remote fish pane blocked ~10s at every prompt paint.
+  it('hands query authority back to the model while a stream pauses output', async () => {
+    const releaseView = vi.fn()
+    const releaseRaw = vi.fn()
+    const registerRemoteTerminalViewSubscriber = vi.fn().mockReturnValue(releaseView)
+    const registerRawTerminalViewSubscriber = vi.fn().mockReturnValue(releaseRaw)
+    const harness = startDesktopMultiplexSubscribe({
+      registerRemoteTerminalViewSubscriber,
+      registerRawTerminalViewSubscriber
+    })
+    await vi.waitFor(() =>
+      expect(harness.messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    sendDesktopMultiplexSubscribe(harness.handlers, { ackOutput: 1, outputPause: 1 })
+    await vi.waitFor(() => expect(registerRemoteTerminalViewSubscriber).toHaveBeenCalledTimes(1))
+
+    const setPaused = (paused: boolean, seq: number): void => {
+      harness.handlers.get(7)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: SET_OUTPUT_PAUSED_OPCODE,
+            streamId: 7,
+            seq,
+            payload: encodeTerminalStreamJson({ paused })
+          })
+        )!
+      )
+    }
+
+    setPaused(true, 2)
+    expect(releaseView).toHaveBeenCalledTimes(1)
+    // Raw presence still pins the provider, without claiming reply ownership.
+    expect(registerRawTerminalViewSubscriber).toHaveBeenCalledTimes(1)
+
+    setPaused(false, 3)
+    expect(releaseRaw).toHaveBeenCalledTimes(1)
+    expect(registerRemoteTerminalViewSubscriber).toHaveBeenCalledTimes(2)
+
     harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
     await harness.dispatchPromise
   })

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -4602,14 +4602,15 @@ describe('terminal multiplex RPC', () => {
     await harness.dispatchPromise
   })
 
-  it('settles the pre-pause batch and preserves ACK-pending bytes for resume', async () => {
+  it('settles ACK-pending pre-pause bytes when credit arrives while paused', async () => {
     let dataListener: ((data: string, meta?: RuntimeTerminalDataMeta) => void) | undefined
     const releaseView = vi.fn()
+    const registerRaw = vi.fn(() => vi.fn())
     const sendBinary = vi.fn(() => true)
     const harness = startDesktopMultiplexSubscribe(
       {
         registerRemoteTerminalViewSubscriber: vi.fn(() => releaseView),
-        registerRawTerminalViewSubscriber: vi.fn(() => vi.fn()),
+        registerRawTerminalViewSubscriber: registerRaw,
         subscribeToTerminalData: vi.fn((_ptyId, listener) => {
           dataListener = listener
           return vi.fn()
@@ -4680,6 +4681,12 @@ describe('terminal multiplex RPC', () => {
         })
       )!
     )
+    expect(releaseView).toHaveBeenCalledTimes(2)
+    expect(registerRaw).toHaveBeenCalledTimes(2)
+    dataListener?.('post-pause-query\x1b[6n', {
+      seq: 42 + TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
+      rawLength: 'post-pause-query\x1b[6n'.length
+    })
     harness.handlers.get(7)?.(
       decodeTerminalStreamFrame(
         encodeTerminalStreamFrame({
@@ -4698,7 +4705,21 @@ describe('terminal multiplex RPC', () => {
         .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
         .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
         .join('')
-    ).not.toContain('ack-pending')
+    ).toContain('ack-pending')
+    expect(
+      harness.binaryFrames
+        .map(decodeTerminalStreamFrame)
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+        .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        .join('')
+    ).not.toContain('post-pause-query')
+
+    const sentPendingCountBeforeResume = harness.binaryFrames
+      .map(decodeTerminalStreamFrame)
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+      .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+      .filter((data) => data === 'ack-pending').length
+    expect(sentPendingCountBeforeResume).toBe(1)
 
     harness.handlers.get(7)?.(
       decodeTerminalStreamFrame(
@@ -4715,8 +4736,8 @@ describe('terminal multiplex RPC', () => {
         .map(decodeTerminalStreamFrame)
         .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
         .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
-        .join('')
-    ).toContain('ack-pending')
+        .filter((data) => data === 'ack-pending')
+    ).toHaveLength(1)
 
     harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
     await harness.dispatchPromise

--- a/src/main/runtime/terminal-model-query-authority.test.ts
+++ b/src/main/runtime/terminal-model-query-authority.test.ts
@@ -57,17 +57,20 @@ describe('shouldModelAnswerHiddenPtyQueries', () => {
       hasRemoteViewSubscriber: false
     })
 
-  it('answers only for hidden-marked PTYs (the delivery decision is the reply decision)', () => {
+  it('answers only for hidden-marked PTYs (the view-delivery decision is the reply decision)', () => {
     expect(answer('pty-1')).toBe(false)
     markHiddenRendererPty('pty-1')
     expect(answer('pty-1')).toBe(true)
     expect(answer('pty-other')).toBe(false)
   })
 
-  it('yields to registered renderer delivery interest (chunk is delivered to a sidecar)', () => {
+  // Regression: a sidecar is not an xterm. Yielding to delivery interest left a
+  // parked pane (xterm unmounted) with a live sidecar unanswered — fish then
+  // blocked ~10s on DA1 at every prompt paint, forever.
+  it('keeps answering when only a raw-byte sidecar holds delivery interest', () => {
     markHiddenRendererPty('pty-1')
     setRendererPtyDeliveryInterest('pty-1', true)
-    expect(answer('pty-1')).toBe(false)
+    expect(answer('pty-1')).toBe(true)
     setRendererPtyDeliveryInterest('pty-1', false)
     expect(answer('pty-1')).toBe(true)
   })

--- a/src/main/runtime/terminal-model-query-authority.test.ts
+++ b/src/main/runtime/terminal-model-query-authority.test.ts
@@ -86,6 +86,27 @@ describe('shouldModelAnswerHiddenPtyQueries', () => {
     ).toBe(false)
   })
 
+  it('answers for a raw-only headless stream but yields to a visible local xterm', () => {
+    expect(
+      shouldModelAnswerHiddenPtyQueries({
+        ptyId: 'pty-headless',
+        settings: ALL_ON,
+        hasRemoteViewSubscriber: false,
+        hasRawViewSubscriber: true,
+        hasLocalRendererView: false
+      })
+    ).toBe(true)
+    expect(
+      shouldModelAnswerHiddenPtyQueries({
+        ptyId: 'pty-headless',
+        settings: ALL_ON,
+        hasRemoteViewSubscriber: false,
+        hasRawViewSubscriber: true,
+        hasLocalRendererView: true
+      })
+    ).toBe(false)
+  })
+
   it('stays silent under any kill switch', () => {
     markHiddenRendererPty('pty-1')
     expect(answer('pty-1', { terminalModelQueryAuthority: false })).toBe(false)

--- a/src/main/runtime/terminal-model-query-authority.ts
+++ b/src/main/runtime/terminal-model-query-authority.ts
@@ -2,17 +2,19 @@
  * Phase 5 of the terminal model/view architecture: main-side terminal query
  * authority.
  *
- * The delivery decision is the reply decision: main answers a query iff the
- * hidden-delivery gate dropped the chunk that carried it. This module owns
- * the responder kill-switch predicate and the main-side mirror of the
- * renderer's native-Windows-ConPTY determination, recorded per PTY at spawn
- * so the runtime emulator can register the DA1 override before byte zero.
+ * The VIEW delivery decision is the reply decision: main answers a query iff
+ * the hidden-delivery gate withheld the chunk from every renderer view — a
+ * hidden pane's xterm is starved, a parked pane has none, and a sidecar-only
+ * chunk reaches raw-byte watchers that never reply. This module owns the
+ * responder kill-switch predicate and the main-side mirror of the renderer's
+ * native-Windows-ConPTY determination, recorded per PTY at spawn so the
+ * runtime emulator can register the DA1 override before byte zero.
  */
 import type { GlobalSettings } from '../../shared/types'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import {
   isHiddenPtyDeliveryGateEnabled,
-  shouldDropHiddenRendererPtyData
+  shouldSuppressHiddenRendererPtyView
 } from '../ipc/pty-hidden-delivery-gate'
 
 export type TerminalModelQueryAuthoritySettings = Pick<
@@ -30,10 +32,10 @@ export function isTerminalModelQueryAuthorityEnabled(
 
 /** Per-chunk reply-ownership predicate, evaluated once at ingestion in
  *  OrcaRuntimeService.onPtyData — the same module state and tick as the
- *  hidden-gate drop sites, so "chunk dropped" and "main answers" cannot
- *  diverge for live chunks. Remote view subscribers (mobile/web/remote
- *  desktop xterms on the multiplexed stream) keep view authority, so main
- *  yields while one is attached. */
+ *  hidden-gate suppression sites, so "no view saw the chunk" and "main
+ *  answers" cannot diverge for live chunks. Remote view subscribers
+ *  (mobile/web/remote desktop xterms on the multiplexed stream) keep view
+ *  authority, so main yields while one is attached and unpaused. */
 export function shouldModelAnswerHiddenPtyQueries(opts: {
   ptyId: string
   settings: TerminalModelQueryAuthoritySettings | null | undefined
@@ -42,7 +44,7 @@ export function shouldModelAnswerHiddenPtyQueries(opts: {
   return (
     isTerminalModelQueryAuthorityEnabled(opts.settings) &&
     !opts.hasRemoteViewSubscriber &&
-    shouldDropHiddenRendererPtyData(opts.ptyId, opts.settings)
+    shouldSuppressHiddenRendererPtyView(opts.ptyId, opts.settings)
   )
 }
 

--- a/src/main/runtime/terminal-model-query-authority.ts
+++ b/src/main/runtime/terminal-model-query-authority.ts
@@ -40,11 +40,14 @@ export function shouldModelAnswerHiddenPtyQueries(opts: {
   ptyId: string
   settings: TerminalModelQueryAuthoritySettings | null | undefined
   hasRemoteViewSubscriber: boolean
+  hasRawViewSubscriber?: boolean
+  hasLocalRendererView?: boolean
 }): boolean {
   return (
     isTerminalModelQueryAuthorityEnabled(opts.settings) &&
     !opts.hasRemoteViewSubscriber &&
-    shouldSuppressHiddenRendererPtyView(opts.ptyId, opts.settings)
+    (shouldSuppressHiddenRendererPtyView(opts.ptyId, opts.settings) ||
+      (opts.hasRawViewSubscriber === true && opts.hasLocalRendererView !== true))
   )
 }
 

--- a/src/main/runtime/terminal-query-responder.test.ts
+++ b/src/main/runtime/terminal-query-responder.test.ts
@@ -265,6 +265,21 @@ describe('reply ownership matrix', () => {
     expect(runtime.hasRawTerminalViewSubscriber('pty-preview')).toBe(false)
   })
 
+  it('gives a raw-only headless stream exactly one answerer', async () => {
+    const { runtime, replies } = createResponderRuntime()
+    const release = runtime.registerRawTerminalViewSubscriber('pty-headless')
+
+    runtime.onPtyData('pty-headless', DA1, Date.now())
+    await settle(runtime, 'pty-headless')
+    expect(replies).toEqual([{ ptyId: 'pty-headless', data: '\x1b[?1;2c' }])
+
+    runtime.setLocalRendererTerminalViewVisible('pty-headless', true)
+    runtime.onPtyData('pty-headless', DA1, Date.now())
+    await settle(runtime, 'pty-headless')
+    expect(replies).toHaveLength(1)
+    release()
+  })
+
   it('treats mobile subscriber records as remote view subscribers', async () => {
     const { runtime } = createResponderRuntime()
     await runtime.handleMobileSubscribe('pty-mob', 'client-1', { cols: 40, rows: 20 })

--- a/src/main/runtime/terminal-query-responder.test.ts
+++ b/src/main/runtime/terminal-query-responder.test.ts
@@ -190,7 +190,10 @@ describe('reply ownership matrix', () => {
     expect(replies).toEqual([])
   })
 
-  it('never answers while renderer delivery interest holds the chunk delivered', async () => {
+  // Regression: delivery interest routes bytes to raw-byte sidecars, never to a
+  // view — a parked pane has no xterm at all, so yielding here left DA1
+  // unanswered and fish blocked ~10s at every prompt paint.
+  it('still answers while renderer delivery interest holds — a sidecar is not an xterm', async () => {
     const { runtime, replies } = createResponderRuntime()
     markHiddenRendererPty('pty-i')
     setRendererPtyDeliveryInterest('pty-i', true)
@@ -198,7 +201,7 @@ describe('reply ownership matrix', () => {
     runtime.onPtyData('pty-i', DA1, Date.now())
     await settle(runtime, 'pty-i')
 
-    expect(replies).toEqual([])
+    expect(replies).toEqual([{ ptyId: 'pty-i', data: '\x1b[?1;2c' }])
   })
 
   it.each([
@@ -793,7 +796,7 @@ describe('view-attribute replay guard and suppression', () => {
     expect(replies).toEqual([])
   })
 
-  it('never answers while renderer delivery interest holds the chunk delivered', async () => {
+  it('answers a view-attribute query while only a sidecar holds delivery interest', async () => {
     const { runtime, replies } = createResponderRuntime()
     markHiddenRendererPty('pty-vint')
     setRendererPtyDeliveryInterest('pty-vint', true)
@@ -802,7 +805,8 @@ describe('view-attribute replay guard and suppression', () => {
     runtime.onPtyData('pty-vint', '\x1b]11;?\x07', Date.now())
     await settle(runtime, 'pty-vint')
 
-    expect(replies).toEqual([])
+    expect(replies).toHaveLength(1)
+    expect(replies[0]?.ptyId).toBe('pty-vint')
   })
 
   it('yields view-attribute replies while a remote view subscriber is attached', async () => {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1112,6 +1112,18 @@ export type PluginMarketplaceHostInstallPreview = {
   blockedByKillList?: { reason: string; advisoryUrl?: string }
 }
 
+export type PtyDataPayload = {
+  id: string
+  data: string
+  seq?: number
+  rawLength?: number
+  transformed?: boolean
+  background?: boolean
+  droppedOutput?: boolean
+  /** Hidden-gated bytes delivered to raw-byte sidecars without the view. */
+  sidecarOnly?: boolean
+}
+
 export type PreloadApi = {
   app: AppApi
   orcaProfiles: {
@@ -1618,20 +1630,7 @@ export type PreloadApi = {
       rendererDispatcherReadyForcedCount: number
     }>
     resetRendererDeliveryDebug: () => Promise<void>
-    onData: (
-      callback: (data: {
-        id: string
-        data: string
-        seq?: number
-        rawLength?: number
-        transformed?: boolean
-        background?: boolean
-        droppedOutput?: boolean
-        /** Hidden-gated bytes for raw-byte sidecars only; the view must not
-         *  render or reply to them (main answered their queries). */
-        sidecarOnly?: boolean
-      }) => void
-    ) => () => void
+    onData: (callback: (data: PtyDataPayload) => void) => () => void
     onReplay: (callback: (data: { id: string; data: string }) => void) => () => void
     /** Out-of-band main→renderer signal that renderer-bound bytes were
      *  dropped (hidden-delivery gate / pending cap); the pane restores from

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1627,6 +1627,9 @@ export type PreloadApi = {
         transformed?: boolean
         background?: boolean
         droppedOutput?: boolean
+        /** Hidden-gated bytes for raw-byte sidecars only; the view must not
+         *  render or reply to them (main answered their queries). */
+        sidecarOnly?: boolean
       }) => void
     ) => () => void
     onReplay: (callback: (data: { id: string; data: string }) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1175,6 +1175,7 @@ const api = {
           transformed?: boolean
           background?: boolean
           droppedOutput?: boolean
+          sidecarOnly?: boolean
         }
       ) => callback(data)
       ipcRenderer.on('pty:data', listener)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -222,7 +222,8 @@ import type {
   PluginHostInstallSource,
   PluginHostListEntry,
   PluginHostLogLine,
-  PreloadApi
+  PreloadApi,
+  PtyDataPayload
 } from './api-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
 import { createBrowserFindSubscriptions } from './browser-find-subscriptions'
@@ -1154,30 +1155,8 @@ const api = {
     getSize: (id: string): Promise<{ cols: number; rows: number } | null> =>
       ipcRenderer.invoke('pty:getSize', { id }),
 
-    onData: (
-      callback: (data: {
-        id: string
-        data: string
-        seq?: number
-        rawLength?: number
-        transformed?: boolean
-        background?: boolean
-        droppedOutput?: boolean
-      }) => void
-    ): (() => void) => {
-      const listener = (
-        _event: Electron.IpcRendererEvent,
-        data: {
-          id: string
-          data: string
-          seq?: number
-          rawLength?: number
-          transformed?: boolean
-          background?: boolean
-          droppedOutput?: boolean
-          sidecarOnly?: boolean
-        }
-      ) => callback(data)
+    onData: (callback: (data: PtyDataPayload) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: PtyDataPayload) => callback(data)
       ipcRenderer.on('pty:data', listener)
       return () => ipcRenderer.removeListener('pty:data', listener)
     },

--- a/src/preload/pty-snapshot-capability-ipc.test.ts
+++ b/src/preload/pty-snapshot-capability-ipc.test.ts
@@ -69,4 +69,23 @@ describe('PTY snapshot capability preload IPC', () => {
       expect.anything()
     )
   })
+
+  it('forwards the sidecar-only PTY data bit through the public preload API', async () => {
+    await import('./index')
+    const api = exposeInMainWorld.mock.calls.find(([name]) => name === 'api')?.[1] as PreloadApi
+    const callback = vi.fn()
+    api.pty.onData(callback)
+    const listener = on.mock.calls.find(([channel]) => channel === 'pty:data')?.[1] as (
+      event: unknown,
+      payload: { id: string; data: string; sidecarOnly?: boolean }
+    ) => void
+
+    listener({}, { id: 'pty-contract', data: 'raw', sidecarOnly: true })
+
+    expect(callback).toHaveBeenCalledWith({
+      id: 'pty-contract',
+      data: 'raw',
+      sidecarOnly: true
+    })
+  })
 })

--- a/src/renderer/src/components/terminal-pane/pty-data-delivery-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-data-delivery-routing.test.ts
@@ -1,0 +1,64 @@
+// Why: a sidecar-flagged chunk must reach raw-byte watchers and NOTHING else —
+// the view already restores from main's model snapshot, and letting a mounted
+// xterm parse it would put a second DA1/OSC reply on the shell's stdin.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { routeDispatchedPtyData } from './pty-data-delivery-routing'
+import { ptyDataHandlers, ptyDataSidecars } from './pty-shutdown-data-suspension'
+import { drainPreHandlerPtyData, clearPreHandlerPtyState } from './pty-pre-handler-buffer'
+
+const PTY_ID = 'pty-sidecar-only'
+const originalWindow = (globalThis as { window?: typeof window }).window
+
+describe('routeDispatchedPtyData', () => {
+  beforeEach(() => {
+    ;(globalThis as { window: unknown }).window = {
+      api: { pty: { ackData: vi.fn() } }
+    }
+  })
+
+  afterEach(() => {
+    ptyDataHandlers.delete(PTY_ID)
+    ptyDataSidecars.delete(PTY_ID)
+    clearPreHandlerPtyState(PTY_ID)
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: unknown }).window
+    }
+  })
+
+  it('feeds both the primary handler and sidecars for ordinary chunks', () => {
+    const primary = vi.fn()
+    const sidecar = vi.fn()
+    ptyDataHandlers.set(PTY_ID, primary)
+    ptyDataSidecars.set(PTY_ID, new Set([sidecar]))
+
+    routeDispatchedPtyData({ id: PTY_ID, data: 'hello' })
+
+    expect(primary).toHaveBeenCalledWith('hello', undefined)
+    expect(sidecar).toHaveBeenCalledWith('hello')
+  })
+
+  it('feeds only sidecars when main flags the chunk sidecar-only', () => {
+    const primary = vi.fn()
+    const sidecar = vi.fn()
+    ptyDataHandlers.set(PTY_ID, primary)
+    ptyDataSidecars.set(PTY_ID, new Set([sidecar]))
+
+    routeDispatchedPtyData({ id: PTY_ID, data: '\x1b[0c', sidecarOnly: true })
+
+    expect(primary).not.toHaveBeenCalled()
+    expect(sidecar).toHaveBeenCalledWith('\x1b[0c')
+  })
+
+  it('does not stash a sidecar-only chunk for a pane that mounts later', () => {
+    const sidecar = vi.fn()
+    ptyDataSidecars.set(PTY_ID, new Set([sidecar]))
+
+    routeDispatchedPtyData({ id: PTY_ID, data: '\x1b[0c', sidecarOnly: true })
+
+    const lateHandler = vi.fn()
+    drainPreHandlerPtyData(PTY_ID, lateHandler)
+    expect(lateHandler).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-data-delivery-routing.ts
+++ b/src/renderer/src/components/terminal-pane/pty-data-delivery-routing.ts
@@ -1,0 +1,110 @@
+/**
+ * Routes one inbound `pty:data` payload to its renderer consumers: the primary
+ * (xterm / eager-buffer) handler and the raw-byte sidecars.
+ *
+ * Split from the dispatcher because the two consumers no longer receive the
+ * same chunks — main flags hidden-gated bytes `sidecarOnly`, and the view must
+ * neither render nor reply to those (main answered their queries).
+ */
+import { deliverPtyDataWithDeferredAck } from './terminal-pty-ack-gate'
+import { bufferPreHandlerPtyData } from './pty-pre-handler-buffer'
+import { recordPtyDataReceived } from './terminal-delivery-watchdog'
+import {
+  bufferPtyShutdownData,
+  isPtyDataHandlerShutdownPending,
+  ptyDataHandlers,
+  ptyDataSidecars
+} from './pty-shutdown-data-suspension'
+
+export type PtyDataMeta = {
+  seq?: number
+  rawLength?: number
+  transformed?: boolean
+  background?: boolean
+  /** Main dropped this PTY's buffered output at the pending cap; repaint from the main-owned snapshot, not the live stream. */
+  droppedOutput?: boolean
+  /** Hidden-gated bytes forwarded for raw-byte sidecars only; no view may render or reply to them (main owns the query reply). */
+  sidecarOnly?: boolean
+}
+
+export type PtyDataPushPayload = {
+  id: string
+  data: string
+  seq?: number
+  rawLength?: number
+  transformed?: boolean
+  background?: boolean
+  droppedOutput?: boolean
+  sidecarOnly?: boolean
+}
+
+function ptyDataMetaFromPayload(payload: PtyDataPushPayload): PtyDataMeta | undefined {
+  let meta: PtyDataMeta | undefined
+  if (typeof payload.seq === 'number') {
+    meta ??= {}
+    meta.seq = payload.seq
+  }
+  if (typeof payload.rawLength === 'number') {
+    meta ??= {}
+    meta.rawLength = payload.rawLength
+  }
+  if (payload.transformed === true) {
+    meta ??= {}
+    meta.transformed = true
+  }
+  if (payload.background === true) {
+    meta ??= {}
+    meta.background = true
+  }
+  if (payload.droppedOutput === true) {
+    meta ??= {}
+    meta.droppedOutput = true
+  }
+  if (payload.sidecarOnly === true) {
+    meta ??= {}
+    meta.sidecarOnly = true
+  }
+  return meta
+}
+
+function dispatchToPrimaryPtyDataHandler(
+  ptyId: string,
+  data: string,
+  meta: PtyDataMeta | undefined
+): void {
+  const handler = ptyDataHandlers.get(ptyId)
+  if (handler) {
+    handler(data, meta)
+    return
+  }
+  bufferPreHandlerPtyData(ptyId, data, meta)
+}
+
+export function routeDispatchedPtyData(payload: PtyDataPushPayload): void {
+  const meta = ptyDataMetaFromPayload(payload)
+  const chars = payload.rawLength ?? payload.data.length
+  const dispatch = (): void => {
+    if (isPtyDataHandlerShutdownPending(payload.id)) {
+      // Why: teardown output is speculative until the owner verifies sleep; retain it (sidecars included) so a failed attempt resumes without losing terminal data.
+      bufferPtyShutdownData(payload.id, payload.data, meta)
+      return
+    }
+    // Why skipped: main withheld these bytes from every view and answered their
+    // queries itself, so feeding a (hidden or stale) xterm would repaint a gapped
+    // stream and put a second DA1/OSC reply on the shell's stdin.
+    if (payload.sidecarOnly !== true) {
+      dispatchToPrimaryPtyDataHandler(payload.id, payload.data, meta)
+    }
+    const sidecars = ptyDataSidecars.get(payload.id)
+    if (sidecars && sidecars.size > 0) {
+      // Why: snapshot before iterating — watchers often unsubscribe (or subscribe siblings) mid-iteration, and mutating the live Set would skip or double-fire.
+      const snapshot = Array.from(sidecars)
+      for (const watcher of snapshot) {
+        watcher(payload.data)
+      }
+    }
+  }
+  recordPtyDataReceived(payload.id, chars)
+  // Why deferred: main budgets by bytes PARSED not received; ACK fires when xterm consumes, and undelivered chunks settle at return so no PTY stays backpressured.
+  deliverPtyDataWithDeferredAck(payload.id, chars, dispatch)
+}

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -2,13 +2,11 @@
 import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
 import {
   clearProcessedPtyCharTotal,
-  deliverPtyDataWithDeferredAck,
   exposeE2eTerminalPtyAckGate,
   getProcessedPtyCharTotals
 } from './terminal-pty-ack-gate'
 import { clampUtf8Tail, type EagerBufferChunk } from './pty-eager-buffer-clamp'
 import {
-  bufferPreHandlerPtyData,
   clearPreHandlerPtyState,
   drainPreHandlerPtyData,
   drainPreHandlerPtyExit
@@ -17,21 +15,20 @@ import { deliverPtyExitToHandlers } from './pty-exit-delivery'
 import {
   clearReceivedPtyCharTotal,
   isPtyPushDeliveryBlackholed,
-  recordPtyDataReceived,
   startTerminalDeliveryWatchdog
 } from './terminal-delivery-watchdog'
 import { recordTerminalFreezeBreadcrumb } from './terminal-freeze-breadcrumbs'
 import { installTerminalFreezeReport } from './terminal-freeze-report'
 import {
-  bufferPtyShutdownData,
   bufferPtyShutdownReplayData,
-  isPtyDataHandlerShutdownPending,
   ptyDataHandlers,
-  ptyDataSidecars,
   ptyExitHandlers,
   ptyReplayHandlers
 } from './pty-shutdown-data-suspension'
+import { routeDispatchedPtyData } from './pty-data-delivery-routing'
 import { markCommittedPtyShutdowns } from './pty-shutdown-exit-deferral'
+
+export { type PtyDataMeta } from './pty-data-delivery-routing'
 
 export {
   ptyDataHandlers,
@@ -48,15 +45,6 @@ export {
 
 // ── Singleton PTY event dispatcher ───────────────────────────────────
 // One global IPC listener per channel (routed by PTY ID) avoids the N-listener MaxListenersExceededWarning with many panes.
-
-export type PtyDataMeta = {
-  seq?: number
-  rawLength?: number
-  transformed?: boolean
-  background?: boolean
-  /** Main dropped this PTY's buffered output at the pending cap; repaint from the main-owned snapshot, not the live stream. */
-  droppedOutput?: boolean
-}
 
 /** Sidecar PTY-data observers, invoked AFTER the primary handler so a side-effect-only watcher can't delay xterm rendering. */
 /** Per-PTY replay handlers on a dedicated pty:replay channel so the renderer can engage the replay guard and suppress xterm auto-replies. */
@@ -104,67 +92,10 @@ function attachPtyPushListeners(): void {
       if (isPtyPushDeliveryBlackholed()) {
         return
       }
-      handleDispatchedPtyData(payload)
+      routeDispatchedPtyData(payload)
     })
   )
   attachPtySecondaryPushListeners(unsubscribes)
-}
-
-function handleDispatchedPtyData(payload: {
-  id: string
-  data: string
-  seq?: number
-  rawLength?: number
-  transformed?: boolean
-  background?: boolean
-  droppedOutput?: boolean
-}): void {
-  let meta: PtyDataMeta | undefined
-  if (typeof payload.seq === 'number') {
-    meta ??= {}
-    meta.seq = payload.seq
-  }
-  if (typeof payload.rawLength === 'number') {
-    meta ??= {}
-    meta.rawLength = payload.rawLength
-  }
-  if (payload.transformed === true) {
-    meta ??= {}
-    meta.transformed = true
-  }
-  if (payload.background === true) {
-    meta ??= {}
-    meta.background = true
-  }
-  if (payload.droppedOutput === true) {
-    meta ??= {}
-    meta.droppedOutput = true
-  }
-  const chars = payload.rawLength ?? payload.data.length
-  const dispatch = (): void => {
-    if (isPtyDataHandlerShutdownPending(payload.id)) {
-      // Why: teardown output is speculative until the owner verifies sleep; retain it so a failed attempt resumes without losing terminal data.
-      bufferPtyShutdownData(payload.id, payload.data, meta)
-      return
-    }
-    const handler = ptyDataHandlers.get(payload.id)
-    if (handler) {
-      handler(payload.data, meta)
-    } else {
-      bufferPreHandlerPtyData(payload.id, payload.data, meta)
-    }
-    const sidecars = ptyDataSidecars.get(payload.id)
-    if (sidecars && sidecars.size > 0) {
-      // Why: snapshot before iterating — watchers often unsubscribe (or subscribe siblings) mid-iteration, and mutating the live Set would skip or double-fire.
-      const snapshot = Array.from(sidecars)
-      for (const watcher of snapshot) {
-        watcher(payload.data)
-      }
-    }
-  }
-  recordPtyDataReceived(payload.id, chars)
-  // Why deferred: main budgets by bytes PARSED not received; ACK fires when xterm consumes, and undelivered chunks settle at return so no PTY stays backpressured.
-  deliverPtyDataWithDeferredAck(payload.id, chars, dispatch)
 }
 
 function attachPtySecondaryPushListeners(unsubscribes: (() => void)[]): void {

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
@@ -189,7 +189,11 @@ function deliverShutdownEvent(
     replayHandler(event.data)
     return
   }
-  dataHandler(event.data, event.meta)
+  // Why conditional: a sidecar-only chunk was withheld from the view and already
+  // answered by main; a rollback must not hand it to the pane's xterm.
+  if (event.meta?.sidecarOnly !== true) {
+    dataHandler(event.data, event.meta)
+  }
   for (const sidecar of Array.from(ptyDataSidecars.get(ptyId) ?? [])) {
     sidecar(event.data)
   }


### PR DESCRIPTION
## ELI5

fish asks the terminal "what are you?" (DA1) every single time it draws a prompt, and it refuses to draw until someone answers — waiting up to 10 seconds. In a parked tab there is no visible terminal to answer, so main answers on its behalf. But main was skipping that whenever *anything* in the renderer was still receiving the bytes — including a background watcher that only sniffs output and never replies. Result: a parked fish pane where every prompt took 10.0s, forever. Now "hidden" means no view sees the bytes at all, so main always knows the question is its to answer.

## What Changed

- `pty-hidden-delivery-gate.ts`: new `shouldSuppressHiddenRendererPtyView` (gate on + hidden, delivery interest irrelevant). `shouldDropHiddenRendererPtyData` is now suppression **without** interest; the new `shouldDeliverHiddenRendererPtyDataToSidecarsOnly` is suppression **with** it.
- `terminal-model-query-authority.ts`: the predicate keys on view suppression instead of "the gate dropped the chunk".
- `pty.ts`: a suppressed PTY with sidecar interest is still delivered, now stamped `sidecarOnly: true`, and latches the same restore marker a drop would (the view missed those bytes either way). The flag is decided **at ingestion** — the same tick and module state as the runtime's reply decision — and stored on the pending entry (sticky across coalescing, remainders, and the pending-cap sentinel), so a reveal that lands before the flush cannot hand an already-answered chunk to a newly mounted xterm.
- `pty-data-delivery-routing.ts` (new, split out of `pty-dispatcher.ts`): routes `sidecarOnly` chunks to raw-byte sidecars only, never to the primary handler or the pre-handler buffer. Shutdown-suspension rollback skips the view for those chunks too.
- `rpc/methods/terminal.ts`: `SetOutputPaused` swaps the stream's **view** presence for **raw** presence (`registerRawTerminalViewSubscriber`, which exists for exactly this: pin the provider without taking reply ownership) and swaps back on unpause. Both flags flip synchronously in the host, so the model covers precisely the chunks the client never receives.

## Why

The unstated assumption in the old predicate was "chunk delivered to the renderer ⇒ a renderer xterm will answer it". That is false twice over:

1. `deliveryInterest` is claimed by raw-byte **sidecars** (`pty-data-sidecar-subscriptions.ts`), which never reply, and
2. parking **unmounts** the pane's xterm entirely (`terminal-parked-tab-watchers.ts`).

So a parked tab whose PTY has a long-lived sidecar (background agent session, automation observer) had zero answerers post-startup. It never self-heals: fish's "give up after one DA1 timeout" latch only arms when the timeout happens during the *startup* probe, which the daemon's startup responder always answers.

Keying on **view** suppression instead restores the invariant the design wanted — the view-delivery decision *is* the reply decision — and keeps exactly one owner in every state:

| state | bytes to a view? | who answers |
| --- | --- | --- |
| visible pane | yes | renderer xterm |
| hidden, no sidecar | dropped | main |
| hidden + sidecar | sidecar only | main |
| parked (+/- sidecar) | no | main |
| remote stream attached | yes | remote xterm |
| remote stream paused | no | main |

The remote-pause gap is the same bug on the paired path: the client tells the host to pause output (`pty-connection.ts`), the host goes silent, and the client receives nothing — but the view subscriber stayed registered, so the host model kept yielding to an xterm that could not answer.

## Linked Issue

Fixes #

## Visual Proof

N/A — no UI surface changes. The observable effect is timing, captured as a measured regression test (below).

## Testing

**Re-verified reachability first.** Both halves of the failing configuration are real code paths: `subscribeToPtyData` acquires delivery interest for every sidecar (`agent-draft-readiness.ts`, `automation-session-observer.ts`, `launch-agent-background-session.ts`, `claude-model-switch-confirmation.ts`), and the parked byte watcher acquires the hidden claim while the pane's xterm is unmounted. Driving that exact state through the real predicate + a real runtime `HeadlessEmulator` reproduces the stall.

**New real-fish regression test** — `src/main/runtime/fish-parked-pane-prompt-latency.node-pty.test.ts` (fish 4.7.1 locally). It runs production's two stages: the daemon Session's startup DA1 responder + query filter released at shell-ready, then the main-side authority predicate driving a real `HeadlessEmulator`. Nothing answers DA1 out of band. It measures **prompt latency**, the observable symptom.

- Pre-fix (predicate reverted to `shouldDropHiddenRendererPtyData`): `AssertionError: expected 10021 to be less than 1000`, suite 20.37s.
- Post-fix: passes, 82ms of test time for 3 prompts.
- The startup stage is load-bearing: without it fish times out on its startup probe, latches "give up on DA1", and the later stall is unobservable (measured — the same test passed in 10.35s before I added stage 1).

Registered in **both** the `shell_contracts` run list and the shard `--exclude` list in `.github/workflows/pr.yml`; `pr-workflow-parallelism.test.mjs` passes.

**Other tests**
- `terminal-model-query-authority.test.ts` — the old "yields to registered renderer delivery interest" case is inverted, which is the point of the change; same for two `terminal-query-responder.test.ts` cases, which now assert the model's DA1/OSC-11 replies do go out.
- `pty.test.ts` — hidden + interest now asserts `sidecarOnly: true` plus the restore marker; new test proves a chunk ingested while parked stays `sidecarOnly` even when the pane reveals before the flush (verified it fails if the flag is re-evaluated at send time).
- `pty-hidden-delivery-gate.test.ts` — drop and sidecar-only are mutually exclusive; the sidecar send latches the restore marker without polluting the drop counters.
- `pty-data-delivery-routing.test.ts` (new) — `sidecarOnly` reaches sidecars only, and is not stashed for a pane that mounts later.
- `terminal-multiplex.test.ts` — new test: pausing releases view presence and takes raw presence; unpausing swaps back. Verified it fails without the fix (`expected "vi.fn()" to be called 1 times, but got 0 times`).

**Commands run (real output observed)**
- `npx tsc --noEmit -p config/tsconfig.node.json` — clean
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- `npx oxlint` — no errors
- `node config/scripts/check-max-lines-ratchet.mjs` — `max-lines ratchet OK — 347 grandfathered suppression(s), no new bypasses`
- `vitest src/main/ src/preload/ src/renderer/src/components/terminal-pane/` (minus the shell-contract lane) — **24057 passed**, 87 skipped
- `vitest src/renderer/ src/shared/` — **26832 passed**, 21 skipped
- full `shell_contracts` lane incl. the new test — **137 passed**, 1 skipped (run twice)

Platform: macOS. Linux/Windows are covered by CI; no platform-conditional code was added.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new privilege or IO surface; `sidecarOnly` is an optional boolean on an existing in-process IPC push payload.
- **Cross-platform** — no platform branches added. The ConPTY DA1 override path is untouched.
- **Remote SSH / paired** — SSH PTYs transit local main and use the same gate, so they are covered by the same fix. The paired path is fixed separately via the pause/raw-presence swap; no wire change (`SetOutputPaused` is an existing capability-negotiated opcode and its semantics are unchanged on the wire — only host-side bookkeeping moved).
- **Mobile** — mobile subscribers keep view authority through `hasRemoteTerminalViewSubscriber`; only the *paused* case changed.
- **Backwards compatibility** — `sidecarOnly` is main→renderer IPC within one app version; the web preload shim ignores it.
- **Performance** — one extra boolean per pending entry and one predicate call per ingested chunk for gated PTYs. Sidecar bytes stay inside the existing batching and credit/backpressure pipeline rather than bypassing it.

**Known gap, deliberately not fixed here:** a PTY that has *never* been marked hidden by any pane or park watcher (the window between a background agent spawn and its background worktree mount) still has no post-startup answerer. That window is bounded — the daemon's startup responder covers the startup probe, and `requestBackgroundTerminalWorktreeMount` mounts a hidden pane (or a cold-park watcher starts) shortly after, at which point main answers. It is a transient first-prompt delay, not the persistent per-prompt stall this PR fixes, and closing it would mean marking eager pre-mount buffers hidden — a much larger change to restore semantics. Worth a follow-up if it shows up in the field.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## AI Disclosure

Claude Opus 4.5 (Claude Code).

Made with [Orca](https://github.com/stablyai/orca) 🐋
