### PR TITLE
fix: connect mobile emulator in folder workspaces

### DIFF
--- a/src/cli/handlers/emulator.test.ts
+++ b/src/cli/handlers/emulator.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { callMock, remoteMock } = vi.hoisted(() => ({
   callMock: vi.fn(),
@@ -29,6 +29,9 @@ import { main } from '../index'
 import { okFixture, queueFixtures } from '../test-fixtures'
 
 describe('orca emulator CLI handlers', () => {
+  const originalWorkspaceId = process.env.ORCA_WORKSPACE_ID
+  const originalWorktreeId = process.env.ORCA_WORKTREE_ID
+
   beforeEach(() => {
     vi.restoreAllMocks()
     callMock.mockReset()
@@ -36,6 +39,19 @@ describe('orca emulator CLI handlers', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    if (originalWorkspaceId === undefined) {
+      delete process.env.ORCA_WORKSPACE_ID
+    } else {
+      process.env.ORCA_WORKSPACE_ID = originalWorkspaceId
+    }
+    if (originalWorktreeId === undefined) {
+      delete process.env.ORCA_WORKTREE_ID
+    } else {
+      process.env.ORCA_WORKTREE_ID = originalWorktreeId
+    }
   })
 
   it('resolves relative APK paths before calling the runtime', async () => {
@@ -69,6 +85,46 @@ describe('orca emulator CLI handlers', () => {
     expect(callMock).toHaveBeenCalledWith(
       'emulator.attach',
       { device: 'device-1', worktree: undefined, focus: false },
+      { timeoutMs: 180_000 }
+    )
+  })
+
+  it('uses the folder workspace exported by the current Orca terminal', async () => {
+    process.env.ORCA_WORKSPACE_ID = 'folder:folder-1'
+    process.env.ORCA_WORKTREE_ID = 'folder:folder-1'
+    callMock.mockResolvedValue(
+      okFixture('req_attach', {
+        attached: true,
+        info: { deviceUdid: 'device-1', streamUrl: 'scrcpy://device-1' }
+      })
+    )
+
+    await main(['emulator', 'attach', 'device-1'], '/folder/project')
+
+    expect(callMock).toHaveBeenCalledOnce()
+    expect(callMock).toHaveBeenCalledWith(
+      'emulator.attach',
+      { device: 'device-1', worktree: 'folder:folder-1', focus: false },
+      { timeoutMs: 180_000 }
+    )
+  })
+
+  it('uses the current git worktree exported by the Orca terminal', async () => {
+    process.env.ORCA_WORKSPACE_ID = 'folder:stale-parent'
+    process.env.ORCA_WORKTREE_ID = 'repo-1::/repo/project '
+    callMock.mockResolvedValue(
+      okFixture('req_attach', {
+        attached: true,
+        info: { deviceUdid: 'device-1', streamUrl: 'scrcpy://device-1' }
+      })
+    )
+
+    await main(['emulator', 'attach', 'device-1'], '/repo/project')
+
+    expect(callMock).toHaveBeenCalledOnce()
+    expect(callMock).toHaveBeenCalledWith(
+      'emulator.attach',
+      { device: 'device-1', worktree: 'repo-1::/repo/project ', focus: false },
       { timeoutMs: 180_000 }
     )
   })

--- a/src/cli/handlers/emulator.test.ts
+++ b/src/cli/handlers/emulator.test.ts
@@ -91,7 +91,7 @@ describe('orca emulator CLI handlers', () => {
 
   it('uses the folder workspace exported by the current Orca terminal', async () => {
     process.env.ORCA_WORKSPACE_ID = 'folder:folder-1'
-    process.env.ORCA_WORKTREE_ID = 'folder:folder-1'
+    delete process.env.ORCA_WORKTREE_ID
     callMock.mockResolvedValue(
       okFixture('req_attach', {
         attached: true,

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -237,6 +237,14 @@ export async function getEmulatorWorktreeSelector(
   if (client.isRemote) {
     return undefined
   }
+  const terminalWorktreeId = process.env.ORCA_WORKTREE_ID
+  if (terminalWorktreeId?.trim()) {
+    return terminalWorktreeId
+  }
+  const folderWorkspaceId = process.env.ORCA_WORKSPACE_ID?.trim()
+  if (folderWorkspaceId?.startsWith('folder:')) {
+    return folderWorkspaceId
+  }
   try {
     return await resolveCurrentWorktreeSelector(cwd, client)
   } catch {

--- a/src/main/emulator/emulator-bridge.test.ts
+++ b/src/main/emulator/emulator-bridge.test.ts
@@ -216,6 +216,95 @@ describe('EmulatorBridge helper ownership', () => {
     expect(bridge.getActiveForWorktree('wt-1')).toBeNull()
   })
 
+  it('does not clean up a failed attach while another start claim can register the device', async () => {
+    const waitForEndpointReady = vi.fn(async () => true)
+    execServeSimCommandMock.mockResolvedValue({
+      device: 'device-1',
+      streamUrl: 'http://127.0.0.1:3102/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3102'
+    })
+    const bridge = new EmulatorBridge({ waitForEndpointReady })
+
+    const failedLease = await bridge.acquireHelperForDevice('device-1')
+    const survivingLease = await bridge.acquireHelperForDevice('device-1')
+
+    await failedLease.release({ cleanupIfUnused: true })
+    bridge.registerActiveEmulator('wt-surviving', survivingLease.info, { managed: true })
+    await survivingLease.release()
+
+    expect(killServeSimHelperProcessesForDeviceMock).not.toHaveBeenCalled()
+    expect(shutdownSimulatorDeviceMock).not.toHaveBeenCalled()
+    expect(bridge.getActiveForWorktree('wt-surviving')).toMatchObject({
+      deviceUdid: 'device-1'
+    })
+  })
+
+  it('cleans up a failed attach when no start claim or registered workspace remains', async () => {
+    const waitForEndpointReady = vi.fn(async () => true)
+    execServeSimCommandMock.mockResolvedValue({
+      device: 'device-1',
+      streamUrl: 'http://127.0.0.1:3102/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3102'
+    })
+    const bridge = new EmulatorBridge({ waitForEndpointReady })
+
+    const lease = await bridge.acquireHelperForDevice('device-1')
+    await lease.release({ cleanupIfUnused: true })
+
+    expect(killServeSimHelperProcessesForDeviceMock).toHaveBeenCalledWith('device-1', {
+      helperPid: undefined,
+      includeOrphaned: true
+    })
+    expect(shutdownSimulatorDeviceMock).toHaveBeenCalledWith('device-1')
+  })
+
+  it('keeps a shared device alive when one registered workspace detaches', async () => {
+    const bridge = new EmulatorBridge()
+    bridge.registerActiveEmulator('wt-1', session('device-1'), { managed: true })
+    bridge.registerActiveEmulator('wt-2', session('device-1'), { managed: true })
+
+    await bridge.stopActiveManagedForWorktree('wt-1', { shutdownDevice: true })
+
+    expect(killServeSimHelperProcessesForDeviceMock).not.toHaveBeenCalled()
+    expect(shutdownSimulatorDeviceMock).not.toHaveBeenCalled()
+    expect(bridge.getActiveForWorktree('wt-1')).toBeNull()
+    expect(bridge.getActiveForWorktree('wt-2')).toMatchObject({ deviceUdid: 'device-1' })
+  })
+
+  it('keeps a device alive when its last registered workspace closes during another attach', async () => {
+    let finishStart:
+      | ((info: Awaited<ReturnType<typeof execServeSimCommandMock>>) => void)
+      | undefined
+    execServeSimCommandMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishStart = resolve
+        })
+    )
+    const bridge = new EmulatorBridge({ waitForEndpointReady: vi.fn(async () => true) })
+    bridge.registerActiveEmulator('wt-closing', session('device-1'), { managed: true })
+
+    const leasePromise = bridge.acquireHelperForDevice('device-1')
+    await vi.waitFor(() => expect(execServeSimCommandMock).toHaveBeenCalledOnce())
+    const shutdown = bridge.shutdownActiveManagedForWorktree('wt-closing')
+    await Promise.resolve()
+
+    expect(killServeSimHelperProcessesForDeviceMock).not.toHaveBeenCalled()
+    finishStart?.({
+      device: 'device-1',
+      streamUrl: 'http://127.0.0.1:3102/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3102'
+    })
+    const lease = await leasePromise
+    bridge.registerActiveEmulator('wt-attaching', lease.info, { managed: true })
+    await lease.release()
+    await shutdown
+
+    expect(killServeSimHelperProcessesForDeviceMock).not.toHaveBeenCalled()
+    expect(shutdownSimulatorDeviceMock).not.toHaveBeenCalled()
+    expect(bridge.getActiveForWorktree('wt-attaching')).toMatchObject({ deviceUdid: 'device-1' })
+  })
+
   it('reuses the active helper for the same requested device', async () => {
     const waitForEndpointReady = vi.fn(async () => true)
     const bridge = new EmulatorBridge({ waitForEndpointReady })
@@ -267,7 +356,7 @@ describe('EmulatorBridge helper ownership', () => {
     })
     const bridge = new EmulatorBridge({ waitForEndpointReady })
 
-    const info = await bridge.startHelperForDevice('device-1')
+    const { info } = await bridge.acquireHelperForDevice('device-1')
 
     expect(info.deviceUdid).toBe('device-1')
     expect(waitForEndpointReady).toHaveBeenCalledTimes(2)
@@ -309,7 +398,7 @@ describe('EmulatorBridge helper ownership', () => {
     })
     const bridge = new EmulatorBridge({ waitForEndpointReady })
 
-    await expect(bridge.startHelperForDevice('device-1')).rejects.toMatchObject({
+    await expect(bridge.acquireHelperForDevice('device-1')).rejects.toMatchObject({
       code: 'emulator_helper_failed'
     })
 
@@ -334,7 +423,7 @@ describe('EmulatorBridge helper ownership', () => {
     })
     const bridge = new EmulatorBridge({ waitForEndpointReady })
 
-    await expect(bridge.startHelperForDevice('device-1')).rejects.toMatchObject({
+    await expect(bridge.acquireHelperForDevice('device-1')).rejects.toMatchObject({
       code: 'emulator_helper_failed'
     })
 
@@ -368,7 +457,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     bridge.registerActiveEmulator('wt-1', session('device-1'), { managed: true })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -401,7 +491,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     bridge.registerActiveEmulator('wt-1', session('device-1'), { managed: true })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -435,7 +526,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     bridge.registerActiveEmulator('wt-other', session('device-1'), { managed: true })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -465,7 +557,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     bridge.registerActiveEmulator('wt-1', session('device-active'), { managed: true })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -499,7 +592,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     )
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -530,7 +624,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     )
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -551,7 +646,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     bridge.registerActiveEmulator('wt-1', session('device-1'), { managed: true })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -575,7 +671,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     const bridge = new EmulatorBridge()
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: false,
@@ -599,7 +696,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     const bridge = new EmulatorBridge({ waitForEndpointReady })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,
@@ -641,7 +739,8 @@ describe('RuntimeEmulatorCommands attach lifecycle', () => {
     const bridge = new EmulatorBridge({ waitForEndpointReady })
     const commands = new RuntimeEmulatorCommands({
       getEmulatorBridge: () => bridge,
-      resolveWorktreeSelector: vi.fn(async () => ({ id: 'wt-1' })),
+      resolveEmulatorWorkspaceId: vi.fn(async () => 'wt-1'),
+      resolveEmulatorCleanupWorkspaceId: vi.fn(async () => 'wt-1'),
       getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } }) as never,
       getSettings: () => ({
         mobileEmulatorEnabled: true,

--- a/src/main/emulator/emulator-bridge.ts
+++ b/src/main/emulator/emulator-bridge.ts
@@ -5,6 +5,11 @@ import type { SimulatorDevice } from './simctl-simulator-devices'
 import type { EmulatorBridgeOptions } from './emulator-bridge-types'
 import type { EmulatorGesturePoint } from './emulator-gesture-sender'
 import { EmulatorSessionRegistry } from './emulator-session-registry'
+import {
+  EmulatorStartLeaseRegistry,
+  type EmulatorStartLease
+} from './emulator-start-lease-registry'
+import { listAvailableEmulatorDevices } from './emulator-device-inventory'
 import { deriveAxUrlFromStreamUrl } from './serve-sim-detached-session'
 import { IosEmulatorBackend } from './backends/ios-emulator-backend'
 import { AndroidEmulatorBackend } from './backends/android-emulator-backend'
@@ -22,6 +27,7 @@ import type {
 // backend a command targets (by the session's recorded backend, else by device).
 export class EmulatorBridge {
   private readonly sessionRegistry = new EmulatorSessionRegistry()
+  private readonly startLeases = new EmulatorStartLeaseRegistry()
   private readonly backends: EmulatorBackend[]
   private readonly iosBackend: IosEmulatorBackend
   private readonly androidBackend: AndroidEmulatorBackend
@@ -41,19 +47,7 @@ export class EmulatorBridge {
   // Aggregated device list across host-supported backends (iOS simulators +
   // Android devices/AVDs), for the unified `orca emulator list`.
   async listAllDevices(): Promise<EmulatorDevice[]> {
-    const perBackend = await Promise.all(
-      this.backends.map(async (backend) => {
-        if (!backend.isSupportedOnHost()) {
-          return []
-        }
-        try {
-          return await backend.listDevices()
-        } catch {
-          return []
-        }
-      })
-    )
-    return perBackend.flat()
+    return listAvailableEmulatorDevices(this.backends)
   }
 
   // iOS-specific passthroughs kept for back-compat with the runtime + availability code.
@@ -85,14 +79,10 @@ export class EmulatorBridge {
     return this.sessionRegistry.getActiveForWorktree(worktreeId)
   }
 
-  getActiveBackendKind(worktreeId: string): EmulatorBackendKind | null {
-    return this.backendForActiveWorktree(worktreeId)?.kind ?? null
-  }
-
   // On a device switch, keep slow-to-boot Android emulators running for instant
   // switch-back; shut down other backends' devices so they are not leaked.
   async stopActiveForSwitch(worktreeId: string): Promise<string | null> {
-    const keepAlive = this.getActiveBackendKind(worktreeId) === 'android'
+    const keepAlive = this.backendForActiveWorktree(worktreeId)?.kind === 'android'
     return this.stopActiveForWorktreeInternal(worktreeId, { shutdownDevice: !keepAlive })
   }
 
@@ -146,18 +136,26 @@ export class EmulatorBridge {
     if (!session || (options.managedOnly && !session.managed)) {
       return null
     }
+    if (this.sessionRegistry.hasActiveWorktreeForSession(key)) {
+      return session.deviceUdid
+    }
     const backend = this.backendForKind(session.backend)
     if (!backend) {
       return null
     }
-    await backend.stopHelperForDevice(session.deviceUdid, {
-      helperPid: session.pid,
-      includeOrphaned: !options.managedOnly
-    })
-    if (options.shutdownDevice) {
-      await backend.shutdownDevice(session.deviceUdid).catch(() => {})
+    const sessionInfo = this.sessionRegistry.toSessionInfo(session)
+    await this.startLeases.cleanupWhenIdle(
+      backend,
+      sessionInfo,
+      (info) => this.sessionRegistry.hasActiveWorktreeForSession(info.deviceUdid),
+      {
+        includeOrphaned: !options.managedOnly,
+        shutdownDevice: options.shutdownDevice
+      }
+    )
+    if (!this.sessionRegistry.hasActiveWorktreeForSession(key)) {
+      this.sessionRegistry.clearSessionAndWorktrees(key)
     }
-    this.sessionRegistry.clearSessionAndWorktrees(key)
     return session.deviceUdid
   }
 
@@ -243,9 +241,11 @@ export class EmulatorBridge {
     return run(backend, device)
   }
 
-  async startHelperForDevice(device: string): Promise<EmulatorSessionInfo> {
+  async acquireHelperForDevice(device: string): Promise<EmulatorStartLease> {
     const backend = await this.backendForDevice(device)
-    return backend.startSession(device)
+    return this.startLeases.acquire(backend, device, (info) =>
+      this.sessionRegistry.hasActiveWorktreeForSession(info.deviceUdid)
+    )
   }
 
   async kill(device?: string, worktreeId?: string): Promise<string> {

--- a/src/main/emulator/emulator-device-inventory.ts
+++ b/src/main/emulator/emulator-device-inventory.ts
@@ -1,0 +1,19 @@
+import type { EmulatorBackend, EmulatorDevice } from './backends/emulator-backend'
+
+export async function listAvailableEmulatorDevices(
+  backends: EmulatorBackend[]
+): Promise<EmulatorDevice[]> {
+  const perBackend = await Promise.all(
+    backends.map(async (backend) => {
+      if (!backend.isSupportedOnHost()) {
+        return []
+      }
+      try {
+        return await backend.listDevices()
+      } catch {
+        return []
+      }
+    })
+  )
+  return perBackend.flat()
+}

--- a/src/main/emulator/emulator-session-registry.ts
+++ b/src/main/emulator/emulator-session-registry.ts
@@ -51,6 +51,14 @@ export class EmulatorSessionRegistry {
     return this.sessions.get(key)
   }
 
+  toSessionInfo(session: EmulatorSessionState): EmulatorSessionInfo {
+    return toSessionInfo(session)
+  }
+
+  hasActiveWorktreeForSession(key: string): boolean {
+    return [...this.activeByWorktree.values()].some((activeKey) => activeKey === key)
+  }
+
   listSessions(): EmulatorSessionState[] {
     return [...this.sessions.values()]
   }

--- a/src/main/emulator/emulator-start-lease-registry.test.ts
+++ b/src/main/emulator/emulator-start-lease-registry.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { EmulatorBackend } from './backends/emulator-backend'
+import { EmulatorStartLeaseRegistry } from './emulator-start-lease-registry'
+import type { EmulatorSessionInfo } from './emulator-types'
+
+function makeBackend(): {
+  backend: EmulatorBackend
+  resolveDeviceId: ReturnType<typeof vi.fn>
+  startSession: ReturnType<typeof vi.fn>
+  stopHelperForDevice: ReturnType<typeof vi.fn>
+  shutdownDevice: ReturnType<typeof vi.fn>
+} {
+  const resolveDeviceId = vi.fn(async () => {
+    throw new Error('shutdown AVD cannot resolve before boot')
+  })
+  const startSession = vi.fn(
+    async (): Promise<EmulatorSessionInfo> => ({
+      deviceUdid: 'emulator-5554',
+      streamUrl: 'scrcpy://emulator-5554',
+      wsUrl: '',
+      streamCodec: 'h264',
+      backend: 'android'
+    })
+  )
+  const stopHelperForDevice = vi.fn(async () => {})
+  const shutdownDevice = vi.fn(async () => {})
+  const backend: EmulatorBackend = {
+    kind: 'android',
+    streamCodec: 'h264',
+    capabilities: {
+      install: false,
+      launch: false,
+      permissions: false,
+      accessibilityTree: false,
+      logcat: false
+    },
+    isSupportedOnHost: () => true,
+    checkAvailability: vi.fn(),
+    listDevices: vi.fn(async () => []),
+    ownsDevice: vi.fn(async () => true),
+    resolveDeviceId,
+    startSession,
+    stopHelperForDevice,
+    shutdownDevice,
+    isSessionReusable: vi.fn(async () => true),
+    tap: vi.fn(async () => {}),
+    gesture: vi.fn(async () => {}),
+    type: vi.fn(async () => {}),
+    button: vi.fn(async () => {}),
+    rotate: vi.fn(async () => {}),
+    exec: vi.fn(async () => undefined)
+  }
+  return { backend, resolveDeviceId, startSession, stopHelperForDevice, shutdownDevice }
+}
+
+describe('EmulatorStartLeaseRegistry', () => {
+  it('lets the backend boot a shutdown device before a canonical id exists', async () => {
+    const { backend, resolveDeviceId, startSession } = makeBackend()
+    const registry = new EmulatorStartLeaseRegistry()
+
+    const lease = await registry.acquire(backend, 'Pixel_Tablet', () => false)
+    await lease.release()
+
+    expect(resolveDeviceId).not.toHaveBeenCalled()
+    expect(startSession).toHaveBeenCalledWith('Pixel_Tablet')
+    expect(lease.info.deviceUdid).toBe('emulator-5554')
+  })
+
+  it('waits for pending cleanup before starting a new lease', async () => {
+    const { backend, startSession, stopHelperForDevice, shutdownDevice } = makeBackend()
+    let finishCleanup: (() => void) | undefined
+    stopHelperForDevice.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCleanup = resolve
+        })
+    )
+    const registry = new EmulatorStartLeaseRegistry()
+    const first = await registry.acquire(backend, 'Pixel_Tablet', () => false)
+
+    const cleanup = first.release({ cleanupIfUnused: true })
+    await vi.waitFor(() => expect(stopHelperForDevice).toHaveBeenCalledOnce())
+    const second = registry.acquire(backend, 'Pixel_Tablet', () => false)
+    await Promise.resolve()
+    expect(startSession).toHaveBeenCalledOnce()
+
+    finishCleanup?.()
+    await cleanup
+    const secondLease = await second
+
+    expect(shutdownDevice).toHaveBeenCalledOnce()
+    expect(startSession).toHaveBeenCalledTimes(2)
+    await secondLease.release()
+  })
+
+  it('claims synchronously before an earlier lease can start cleanup', async () => {
+    const { backend, stopHelperForDevice, shutdownDevice } = makeBackend()
+    const registry = new EmulatorStartLeaseRegistry()
+    const first = await registry.acquire(backend, 'Pixel_Tablet', () => false)
+
+    const second = registry.acquire(backend, 'Pixel_Tablet', () => false)
+    await first.release({ cleanupIfUnused: true })
+
+    expect(stopHelperForDevice).not.toHaveBeenCalled()
+    const secondLease = await second
+    await secondLease.release()
+
+    expect(stopHelperForDevice).toHaveBeenCalledOnce()
+    expect(shutdownDevice).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/emulator/emulator-start-lease-registry.ts
+++ b/src/main/emulator/emulator-start-lease-registry.ts
@@ -1,0 +1,127 @@
+import type { EmulatorBackend } from './backends/emulator-backend'
+import type { EmulatorSessionInfo } from './emulator-types'
+
+export type EmulatorStartLease = {
+  info: EmulatorSessionInfo
+  release(options?: { cleanupIfUnused?: boolean }): Promise<void>
+}
+
+type PendingCleanup = {
+  info: EmulatorSessionInfo
+  isRegistered: (info: EmulatorSessionInfo) => boolean
+  includeOrphaned: boolean
+  shutdownDevice: boolean
+}
+
+export class EmulatorStartLeaseRegistry {
+  private readonly claimsByBackend = new Map<EmulatorBackend, number>()
+  private readonly cleanupByBackend = new Map<EmulatorBackend, Promise<void>>()
+  private readonly pendingCleanupByBackend = new Map<EmulatorBackend, Map<string, PendingCleanup>>()
+
+  async acquire(
+    backend: EmulatorBackend,
+    device: string,
+    isRegistered: (info: EmulatorSessionInfo) => boolean
+  ): Promise<EmulatorStartLease> {
+    this.claimsByBackend.set(backend, (this.claimsByBackend.get(backend) ?? 0) + 1)
+    try {
+      await this.cleanupByBackend.get(backend)
+      const info = await backend.startSession(device)
+      let released = false
+      return {
+        info,
+        release: async (options = {}) => {
+          if (released) {
+            return
+          }
+          released = true
+          if (options.cleanupIfUnused) {
+            this.addPendingCleanup(backend, info, isRegistered, {
+              includeOrphaned: true,
+              shutdownDevice: true
+            })
+          }
+          await this.release(backend)
+        }
+      }
+    } catch (error) {
+      await this.release(backend)
+      throw error
+    }
+  }
+
+  async cleanupWhenIdle(
+    backend: EmulatorBackend,
+    info: EmulatorSessionInfo,
+    isRegistered: (info: EmulatorSessionInfo) => boolean,
+    options: { includeOrphaned?: boolean; shutdownDevice?: boolean } = {}
+  ): Promise<void> {
+    this.addPendingCleanup(backend, info, isRegistered, options)
+    await this.drainCleanup(backend)
+  }
+
+  private async release(backend: EmulatorBackend): Promise<void> {
+    const remaining = this.decrement(backend)
+    if (remaining > 0) {
+      return
+    }
+    await this.drainCleanup(backend)
+  }
+
+  private async drainCleanup(backend: EmulatorBackend): Promise<void> {
+    await this.cleanupByBackend.get(backend)
+    if ((this.claimsByBackend.get(backend) ?? 0) > 0) {
+      return
+    }
+    const pending = this.pendingCleanupByBackend.get(backend)
+    this.pendingCleanupByBackend.delete(backend)
+    if (!pending) {
+      return
+    }
+    const cleanup = Promise.allSettled(
+      [...pending.values()].map(async ({ info, isRegistered, includeOrphaned, shutdownDevice }) => {
+        if (isRegistered(info)) {
+          return
+        }
+        await backend.stopHelperForDevice(info.deviceUdid, {
+          helperPid: info.helperPid,
+          includeOrphaned
+        })
+        if (shutdownDevice) {
+          await backend.shutdownDevice(info.deviceUdid)
+        }
+      })
+    )
+      .then(() => undefined)
+      .finally(() => this.cleanupByBackend.delete(backend))
+    this.cleanupByBackend.set(backend, cleanup)
+    await cleanup
+  }
+
+  private addPendingCleanup(
+    backend: EmulatorBackend,
+    info: EmulatorSessionInfo,
+    isRegistered: (info: EmulatorSessionInfo) => boolean,
+    options: { includeOrphaned?: boolean; shutdownDevice?: boolean }
+  ): void {
+    const pending = this.pendingCleanupByBackend.get(backend) ?? new Map()
+    const existing = pending.get(info.deviceUdid)
+    pending.set(info.deviceUdid, {
+      info,
+      isRegistered,
+      includeOrphaned: options.includeOrphaned === true || existing?.includeOrphaned === true,
+      shutdownDevice: options.shutdownDevice === true || existing?.shutdownDevice === true
+    })
+    this.pendingCleanupByBackend.set(backend, pending)
+  }
+
+  private decrement(backend: EmulatorBackend): number {
+    const next = Math.max(0, (this.claimsByBackend.get(backend) ?? 1) - 1)
+    if (next === 0) {
+      this.claimsByBackend.delete(backend)
+    } else {
+      this.claimsByBackend.set(backend, next)
+    }
+    return next
+  }
+}

--- a/src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts
+++ b/src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts
@@ -149,7 +149,10 @@ describe('RuntimeEmulatorCommands folder workspace routing', () => {
       runtime.emulatorShutdown({ worktree: FOLDER_WORKSPACE_KEY, managedOnly: true })
     ).resolves.toEqual({ ok: true, deviceUdid: undefined })
     finishHelperStart?.({ info: EMULATOR_INFO, release })
-    await expect(attach).rejects.toThrow('selector_not_found')
+    await expect(attach).rejects.toMatchObject({
+      code: 'emulator_no_active',
+      message: 'The workspace changed while the emulator was starting. Reattach the emulator.'
+    })
 
     expect(bridge.registerActiveEmulator).not.toHaveBeenCalled()
     expect(bridge.shutdownActiveManagedForWorktree).toHaveBeenCalledWith(FOLDER_WORKSPACE_KEY)

--- a/src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts
+++ b/src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { EmulatorSessionInfo } from '../emulator/emulator-types'
+import type { FolderWorkspace } from '../../shared/types'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const FOLDER_WORKSPACE_ID = 'folder-workspace-1'
+const FOLDER_WORKSPACE_KEY = `folder:${FOLDER_WORKSPACE_ID}`
+const EMULATOR_INFO: EmulatorSessionInfo = {
+  deviceUdid: 'emulator-5554',
+  streamUrl: 'scrcpy://emulator-5554',
+  wsUrl: '',
+  streamCodec: 'h264',
+  backend: 'android'
+}
+
+function makeFolderWorkspace(): FolderWorkspace {
+  return {
+    id: FOLDER_WORKSPACE_ID,
+    projectGroupId: 'project-group-1',
+    name: 'Mobile app',
+    folderPath: '/tmp/mobile-app',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+describe('RuntimeEmulatorCommands folder workspace routing', () => {
+  it.each([FOLDER_WORKSPACE_KEY, `id:${FOLDER_WORKSPACE_KEY}`])(
+    'registers and publishes an attached device for selector %s',
+    async (selector) => {
+      const bridge = {
+        acquireHelperForDevice: vi.fn(async () => ({
+          info: EMULATOR_INFO,
+          release: vi.fn(async () => {})
+        })),
+        getReusableActiveForWorktree: vi.fn(async () => null),
+        registerActiveEmulator: vi.fn(),
+        stopActiveForSwitch: vi.fn(async () => null)
+      }
+      const send = vi.fn()
+      const runtime = new OrcaRuntimeService({
+        getFolderWorkspaces: () => [makeFolderWorkspace()],
+        getAllWorktreeMeta: () => new Map(),
+        getRepo: () => null,
+        getRepos: () => [],
+        getSettings: () => ({
+          mobileEmulatorEnabled: true,
+          mobileEmulatorDefaultDeviceUdid: null,
+          androidSdkPath: null
+        })
+      } as never)
+      runtime.setEmulatorBridge(bridge as never)
+      Object.assign(runtime, {
+        getAuthoritativeWindow: () => ({ webContents: { send } })
+      })
+
+      await expect(
+        runtime.emulatorAttach({
+          device: 'emulator-5554',
+          worktree: selector,
+          focus: true
+        })
+      ).resolves.toEqual({ attached: true, info: EMULATOR_INFO })
+
+      expect(bridge.acquireHelperForDevice).toHaveBeenCalledOnce()
+      expect(bridge.registerActiveEmulator).toHaveBeenCalledWith(
+        FOLDER_WORKSPACE_KEY,
+        EMULATOR_INFO,
+        { managed: true }
+      )
+      expect(send.mock.calls).toEqual([
+        ['ui:emulatorAutoAttach', { worktreeId: FOLDER_WORKSPACE_KEY, info: EMULATOR_INFO }],
+        ['emulator:pane-focus', { worktreeId: FOLDER_WORKSPACE_KEY }]
+      ])
+    }
+  )
+
+  it.each([FOLDER_WORKSPACE_KEY, `id:${FOLDER_WORKSPACE_KEY}`])(
+    'cleans up an active emulator after selector %s is deleted',
+    async (selector) => {
+      let folderWorkspaces = [makeFolderWorkspace()]
+      const shutdownActiveManagedForWorktree = vi.fn(async () => EMULATOR_INFO.deviceUdid)
+      const runtime = new OrcaRuntimeService({
+        getFolderWorkspaces: () => folderWorkspaces,
+        getAllWorktreeMeta: () => new Map(),
+        getRepo: () => null,
+        getRepos: () => [],
+        getSettings: () => ({ androidSdkPath: null })
+      } as never)
+      runtime.setEmulatorBridge({ shutdownActiveManagedForWorktree } as never)
+
+      folderWorkspaces = []
+
+      await expect(
+        runtime.emulatorShutdown({ worktree: selector, managedOnly: true })
+      ).resolves.toEqual({ ok: true, deviceUdid: EMULATOR_INFO.deviceUdid })
+      expect(shutdownActiveManagedForWorktree).toHaveBeenCalledWith(FOLDER_WORKSPACE_KEY)
+    }
+  )
+
+  it('cleans up an attach that finishes after its folder workspace is deleted', async () => {
+    let folderWorkspaces = [makeFolderWorkspace()]
+    const release = vi.fn(async () => {})
+    let finishHelperStart:
+      | ((lease: { info: EmulatorSessionInfo; release: typeof release }) => void)
+      | undefined
+    const bridge = {
+      acquireHelperForDevice: vi.fn(
+        () =>
+          new Promise<{ info: EmulatorSessionInfo; release: typeof release }>((resolve) => {
+            finishHelperStart = resolve
+          })
+      ),
+      getReusableActiveForWorktree: vi.fn(async () => null),
+      registerActiveEmulator: vi.fn(),
+      shutdownActiveManagedForWorktree: vi.fn(async () => null),
+      stopActiveForSwitch: vi.fn(async () => null)
+    }
+    const runtime = new OrcaRuntimeService({
+      getFolderWorkspaces: () => folderWorkspaces,
+      getAllWorktreeMeta: () => new Map(),
+      getRepo: () => null,
+      getRepos: () => [],
+      getSettings: () => ({
+        mobileEmulatorEnabled: true,
+        mobileEmulatorDefaultDeviceUdid: null,
+        androidSdkPath: null
+      })
+    } as never)
+    runtime.setEmulatorBridge(bridge as never)
+    Object.assign(runtime, {
+      getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } })
+    })
+
+    const attach = runtime.emulatorAttach({
+      device: EMULATOR_INFO.deviceUdid,
+      worktree: FOLDER_WORKSPACE_KEY
+    })
+    await vi.waitFor(() => expect(bridge.acquireHelperForDevice).toHaveBeenCalledOnce())
+    folderWorkspaces = []
+    await expect(
+      runtime.emulatorShutdown({ worktree: FOLDER_WORKSPACE_KEY, managedOnly: true })
+    ).resolves.toEqual({ ok: true, deviceUdid: undefined })
+    finishHelperStart?.({ info: EMULATOR_INFO, release })
+    await expect(attach).rejects.toThrow('selector_not_found')
+
+    expect(bridge.registerActiveEmulator).not.toHaveBeenCalled()
+    expect(bridge.shutdownActiveManagedForWorktree).toHaveBeenCalledWith(FOLDER_WORKSPACE_KEY)
+    expect(release).toHaveBeenCalledWith({ cleanupIfUnused: true })
+  })
+})

--- a/src/main/runtime/orca-runtime-emulator.ts
+++ b/src/main/runtime/orca-runtime-emulator.ts
@@ -164,11 +164,20 @@ export class RuntimeEmulatorCommands {
       try {
         const currentWorktreeId = await this.resolveWorktreeId(params.worktree)
         if (currentWorktreeId !== worktreeId) {
-          throw new Error('selector_not_found')
+          throw new EmulatorError(
+            'emulator_no_active',
+            'The workspace changed while the emulator was starting. Reattach the emulator.'
+          )
         }
       } catch (error) {
         // Why: the workspace can disappear while a slow Android device boots.
         await lease.release({ cleanupIfUnused: true }).catch(() => {})
+        if (error instanceof Error && error.message === 'selector_not_found') {
+          throw new EmulatorError(
+            'emulator_no_active',
+            'The workspace changed while the emulator was starting. Reattach the emulator.'
+          )
+        }
         throw error
       }
       bridge.registerActiveEmulator(worktreeId, info, { managed: true })

--- a/src/main/runtime/orca-runtime-emulator.ts
+++ b/src/main/runtime/orca-runtime-emulator.ts
@@ -22,7 +22,8 @@ type EmulatorHostSettings = Pick<
 // Why: dedicated file for "one surface" separation (emulator), parallel to orca-runtime-browser.ts. Keeps OrcaRuntimeService focused; emulator routing easy to scan. No max-lines disable (split further if grows; per AGENTS + plan Phase 3).
 export type RuntimeEmulatorCommandHost = {
   getEmulatorBridge(): EmulatorBridge | null
-  resolveWorktreeSelector(selector: string): Promise<{ id: string }>
+  resolveEmulatorWorkspaceId(selector: string): Promise<string>
+  resolveEmulatorCleanupWorkspaceId(selector: string): Promise<string>
   getAuthoritativeWindow(): BrowserWindow
   getSettings(): EmulatorHostSettings
 }
@@ -157,13 +158,27 @@ export class RuntimeEmulatorCommands {
       // slow-to-boot Android emulator alive for instant switch-back.
       await bridge.stopActiveForSwitch(worktreeId)
     }
-    const info = await bridge.startHelperForDevice(device)
+    const lease = await bridge.acquireHelperForDevice(device)
+    const { info } = lease
     if (worktreeId) {
+      try {
+        const currentWorktreeId = await this.resolveWorktreeId(params.worktree)
+        if (currentWorktreeId !== worktreeId) {
+          throw new Error('selector_not_found')
+        }
+      } catch (error) {
+        // Why: the workspace can disappear while a slow Android device boots.
+        await lease.release({ cleanupIfUnused: true }).catch(() => {})
+        throw error
+      }
       bridge.registerActiveEmulator(worktreeId, info, { managed: true })
+      await lease.release()
       this.notifyRendererEmulatorAutoAttach(worktreeId, info)
       if (params.focus) {
         this.notifyRendererEmulatorPaneFocus(worktreeId)
       }
+    } else {
+      await lease.release()
     }
     // Default: no auto steal (mirror browser tab create/switch). --focus sends emulator:pane-focus only when requested.
     return { attached: true, info }
@@ -176,7 +191,7 @@ export class RuntimeEmulatorCommands {
 
   async emulatorUnregisterActive(params: { worktree?: string }): Promise<{ ok: true }> {
     const bridge = this.requireEmulatorBridge()
-    const worktreeId = await this.resolveWorktreeId(params.worktree)
+    const worktreeId = await this.resolveCleanupWorktreeId(params.worktree)
     if (worktreeId) {
       bridge.unregisterActiveEmulator(worktreeId)
     }
@@ -203,7 +218,11 @@ export class RuntimeEmulatorCommands {
   }
 
   private async resolveWorktreeId(worktree?: string): Promise<string | undefined> {
-    return worktree ? (await this.host.resolveWorktreeSelector(worktree)).id : undefined
+    return worktree ? await this.host.resolveEmulatorWorkspaceId(worktree) : undefined
+  }
+
+  private async resolveCleanupWorktreeId(worktree?: string): Promise<string | undefined> {
+    return worktree ? await this.host.resolveEmulatorCleanupWorkspaceId(worktree) : undefined
   }
 
   async emulatorInstall(
@@ -272,7 +291,7 @@ export class RuntimeEmulatorCommands {
     worktree?: string
   }): Promise<{ ok: true; deviceUdid: string }> {
     const bridge = this.requireEmulatorBridge()
-    const worktreeId = await this.resolveWorktreeId(params.worktree)
+    const worktreeId = await this.resolveCleanupWorktreeId(params.worktree)
     const killedUdid = await bridge.kill(params.device ?? params.emulator, worktreeId)
     return { ok: true, deviceUdid: killedUdid }
   }
@@ -284,7 +303,7 @@ export class RuntimeEmulatorCommands {
     managedOnly?: boolean
   }): Promise<{ ok: true; deviceUdid?: string }> {
     const bridge = this.requireEmulatorBridge()
-    const worktreeId = await this.resolveWorktreeId(params.worktree)
+    const worktreeId = await this.resolveCleanupWorktreeId(params.worktree)
     if (params.managedOnly && worktreeId && !params.device && !params.emulator) {
       const shutdownUdid = await bridge.shutdownActiveManagedForWorktree(worktreeId)
       return { ok: true, deviceUdid: shutdownUdid ?? undefined }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -28355,16 +28355,9 @@ export class OrcaRuntimeService {
   private async resolveFolderWorkspaceLaunchScope(
     selector: string
   ): Promise<TerminalWorkspaceLaunchScope | null> {
-    const workspaceSelector = selector.startsWith('id:') ? selector.slice(3) : selector
-    const parsed = parseWorkspaceKey(workspaceSelector)
-    if (parsed?.type !== 'folder') {
-      return null
-    }
-    const workspace = this.store
-      ?.getFolderWorkspaces?.()
-      .find((entry) => entry.id === parsed.folderWorkspaceId)
+    const workspace = this.resolveFolderWorkspaceSelector(selector)
     if (!workspace) {
-      throw new Error('selector_not_found')
+      return null
     }
     if (!this.store) {
       throw new Error('runtime_unavailable')
@@ -28382,6 +28375,36 @@ export class OrcaRuntimeService {
       repo: null,
       folderWorkspace: workspace
     }
+  }
+
+  private resolveFolderWorkspaceSelector(selector: string): FolderWorkspace | null {
+    const workspaceSelector = selector.startsWith('id:') ? selector.slice(3) : selector
+    const parsed = parseWorkspaceKey(workspaceSelector)
+    if (parsed?.type !== 'folder') {
+      return null
+    }
+    const workspace = this.store
+      ?.getFolderWorkspaces?.()
+      .find((entry) => entry.id === parsed.folderWorkspaceId)
+    if (!workspace) {
+      throw new Error('selector_not_found')
+    }
+    return workspace
+  }
+
+  private async resolveEmulatorWorkspaceId(selector: string): Promise<string> {
+    const folderWorkspace = this.resolveFolderWorkspaceSelector(selector)
+    return folderWorkspace
+      ? folderWorkspaceKey(folderWorkspace.id)
+      : (await this.resolveWorktreeSelector(selector)).id
+  }
+
+  private async resolveEmulatorCleanupWorkspaceId(selector: string): Promise<string> {
+    const workspaceSelector = selector.startsWith('id:') ? selector.slice(3) : selector
+    const parsed = parseWorkspaceKey(workspaceSelector)
+    return parsed?.type === 'folder'
+      ? folderWorkspaceKey(parsed.folderWorkspaceId)
+      : this.resolveEmulatorWorkspaceId(selector)
   }
 
   private folderWorkspaceToResolvedWorktree(folderWorkspace: FolderWorkspace): ResolvedWorktree {
@@ -35058,7 +35081,9 @@ export class OrcaRuntimeService {
 
   private readonly emulatorCommands = new RuntimeEmulatorCommands({
     getEmulatorBridge: () => this.emulatorBridge,
-    resolveWorktreeSelector: (selector) => this.resolveWorktreeSelector(selector),
+    resolveEmulatorWorkspaceId: (selector) => this.resolveEmulatorWorkspaceId(selector),
+    resolveEmulatorCleanupWorkspaceId: (selector) =>
+      this.resolveEmulatorCleanupWorkspaceId(selector),
     getAuthoritativeWindow: () => this.getAuthoritativeWindow(),
     getSettings: () => this.requireStore().getSettings()
   })


### PR DESCRIPTION
Closes https://github.com/stablyai/orca/issues/13831

## Problem and invariant

Successful `orca emulator attach` scoped to `folder:<id>` must register under that exact workspace identity and publish renderer auto-attach (plus optional focus) notifications for it.

On latest main (`346e59c879adfa7c55fd22485a221a42116de1d2`), the CLI discarded the folder identity and scanned for a Git worktree. Direct runtime calls then sent folder selectors through the worktree-only resolver, failing with `selector_not_found` before the emulator helper could register.

The authoritative boundary is the main-process runtime's workspace resolver, with the terminal-exported workspace identity as the CLI authority before cwd scanning.

## Fix

- Prefer the exact terminal-exported worktree identity, then a canonical folder workspace identity, before cwd-based discovery. Remote clients still omit local scope.
- Resolve folder selectors through the folder-workspace store and register the canonical `folder:<id>` key.
- Allow cleanup-only commands to address a deleted folder's canonical key while normal attach still requires the folder to exist.
- Revalidate the workspace after slow emulator startup so a deleted folder cannot receive a late registration.
- Coordinate in-flight starts and cleanup through backend leases, preserving Android cold boot and preventing one workspace from stopping a device another workspace is attaching to or already shares.

This keeps truth at the existing runtime/session owners rather than adding renderer fallback logic or broadening the RPC wire contract.

## Deterministic evidence

Byte-identical decisive oracle:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts \
  src/cli/handlers/emulator.test.ts \
  --reporter=verbose
```

- Latest main `346e59c879ad`: **red**, 7 failed / 7 passed. Folder attach and cleanup threw `selector_not_found`; CLI attach made an extra `worktree.list` call and lost terminal scope.
- Candidate `26b2ca5fb85e`: **green**, 14/14.
- Candidate with only the folder resolver and CLI environment lookup disabled: **red**, 5 failed / 9 passed with the same attach-routing and CLI-scope failures.

Expanded lifecycle oracle: 44/44 green across folder routing, CLI scoping, shared-device ownership, Android cold boot, failed-attach cleanup, and pane-close/in-flight-attach races.

Additional validation:

- `pnpm typecheck`
- full `pnpm lint` (including type-aware checks and max-lines ratchet)
- `git diff --check`
- three fresh architecture/adversarial, resource/security/platform, and readiness review lanes: clean

## Live proof

An isolated macOS Orca profile opened the real Mobile Emulator pane for a plain folder workspace and connected `Pixel_9_Pro_API_36`. The folder-scoped runtime command returned `sdk_gphone64_arm64`, and the pane showed the canonical “Plain folder” workspace as Connected with the live Android screen.

![folder-emulator-android-connected.png](https://github.com/user-attachments/assets/59981212-79d2-4746-9ffd-3cf8831c9699)

## Scope and remaining topology gaps

No RPC schema/opcode, persisted mobile state, Git/provider, or UI-style contract changed. This was not freshly exercised on physical Windows/WSL, direct SSH/paired runtimes, mixed client/server versions, or a live iOS simulator. Those paths do not own the reproduced selector failure; the live proof is macOS host + Android emulator.
