### PR TITLE
fix(shell): resolve VS Code CLI from standard app installs

### DIFF
--- a/src/main/external-editor-launch.test.ts
+++ b/src/main/external-editor-launch.test.ts
@@ -32,6 +32,23 @@ describe('resolveExternalEditorLaunchSpec', () => {
     })
   })
 
+  it('falls back to the macOS Application CLI when PATH misses code', () => {
+    const macCli = '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+    resolveCliCommandMock.mockReturnValueOnce('code')
+
+    expect(
+      resolveExternalEditorLaunchSpec('code', '/tmp/workspace', {
+        platform: 'darwin',
+        fileExists: (candidate) => candidate === macCli
+      })
+    ).toEqual({
+      kind: 'executable',
+      hideWindowsConsole: true,
+      spawnCmd: macCli,
+      spawnArgs: ['/tmp/workspace']
+    })
+  })
+
   it('prefers the JetBrains *64.exe colocated with the resolved idea.cmd on Windows', () => {
     const installBin = 'C:\\Program Files\\JetBrains\\IntelliJ IDEA\\bin'
     resolveCliCommandMock.mockImplementation((command: string) =>
@@ -443,13 +460,32 @@ describe('resolveVsCodeRemoteSshLaunchSpec', () => {
   it.each(['code', 'code-insiders'])('builds exact Remote-SSH arguments for %s', (command) => {
     expect(
       resolveVsCodeRemoteSshLaunchSpec(command, '/home/Ada Lovelace/project', 'builder', {
-        platform: 'linux'
+        platform: 'linux',
+        // Why: keep bare names when no known install is present (Linux CI PATH).
+        fileExists: () => false
       })
     ).toEqual({
       kind: 'executable',
       hideWindowsConsole: true,
       spawnCmd: command,
       spawnArgs: ['--remote', 'ssh-remote+builder', '/home/Ada Lovelace/project']
+    })
+  })
+
+  it('falls back to the macOS Application CLI when PATH misses code', () => {
+    const macCli = '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+    resolveCliCommandMock.mockReturnValueOnce('code')
+
+    expect(
+      resolveVsCodeRemoteSshLaunchSpec('code', '/home/ada/project', 'user@host', {
+        platform: 'darwin',
+        fileExists: (candidate) => candidate === macCli
+      })
+    ).toEqual({
+      kind: 'executable',
+      hideWindowsConsole: true,
+      spawnCmd: macCli,
+      spawnArgs: ['--remote', 'ssh-remote+user@host', '/home/ada/project']
     })
   })
 

--- a/src/main/external-editor-launch.ts
+++ b/src/main/external-editor-launch.ts
@@ -13,6 +13,7 @@ import {
   isJetBrainsConsoleShim,
   resolveColocatedJetBrainsGuiExecutable
 } from './jetbrains-windows-gui-launchers'
+import { resolveKnownVsCodeCliPath } from './vscode-cli-install-paths'
 import { getCmdExePath, getSpawnArgsForWindows } from './win32-utils'
 
 export const EXTERNAL_EDITOR_CLI_COMMAND = 'code'
@@ -134,11 +135,14 @@ function resolveSimpleEditorCommand(
   platform: NodeJS.Platform,
   fileExists: (path: string) => boolean
 ): string {
-  return preferJetBrainsGuiExecutable(
-    resolveCliCommand(command, { platform }),
-    platform,
-    fileExists
-  )
+  const fromPath = resolveCliCommand(command, { platform })
+  // Why: GUI-launched Electron often lacks shell PATH; VS Code CLI still lives
+  // under the standard app install even when `code` is not on PATH.
+  // Use the post-resolution bare name so mocks/custom renames are not remapped.
+  const resolved = /[\\/]/.test(fromPath)
+    ? fromPath
+    : (resolveKnownVsCodeCliPath(fromPath, fileExists, { platform }) ?? fromPath)
+  return preferJetBrainsGuiExecutable(resolved, platform, fileExists)
 }
 
 function buildExecutableLaunchSpec(
@@ -232,7 +236,12 @@ export function resolveVsCodeRemoteSshLaunchSpec(
     if (isCompoundShellCommand(trimmed)) {
       return null
     }
-    editorCommand = resolveCliCommand(trimmed, { platform })
+    const fromPath = resolveCliCommand(trimmed, { platform })
+    // Why: same GUI PATH gap as local Open in VS Code — Remote-SSH needs the
+    // absolute CLI path or spawn fails with ENOENT before --remote runs.
+    editorCommand = /[\\/]/.test(fromPath)
+      ? fromPath
+      : (resolveKnownVsCodeCliPath(fromPath, fileExists, { platform }) ?? fromPath)
   }
 
   if (!isVsCodeLauncherExecutable(editorCommand)) {

--- a/src/main/vscode-cli-install-paths.test.ts
+++ b/src/main/vscode-cli-install-paths.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { listKnownVsCodeCliPaths, resolveKnownVsCodeCliPath } from './vscode-cli-install-paths'
+
+describe('listKnownVsCodeCliPaths', () => {
+  it('returns macOS Application bundle CLI paths for code', () => {
+    expect(
+      listKnownVsCodeCliPaths('code', {
+        platform: 'darwin',
+        homePath: '/Users/ada'
+      })
+    ).toEqual([
+      '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
+      '/Users/ada/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+    ])
+  })
+
+  it('returns Insiders macOS paths for code-insiders', () => {
+    expect(
+      listKnownVsCodeCliPaths('code-insiders', {
+        platform: 'darwin',
+        homePath: '/Users/ada'
+      })[0]
+    ).toBe('/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code')
+  })
+
+  it('returns Windows user and Program Files bin shims', () => {
+    expect(
+      listKnownVsCodeCliPaths('code', {
+        platform: 'win32',
+        env: {
+          LOCALAPPDATA: 'C:\\Users\\ada\\AppData\\Local',
+          ProgramFiles: 'C:\\Program Files'
+        }
+      })
+    ).toEqual([
+      'C:\\Users\\ada\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd',
+      'C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd'
+    ])
+  })
+
+  it('ignores non-VS Code launchers', () => {
+    expect(listKnownVsCodeCliPaths('cursor', { platform: 'darwin' })).toEqual([])
+    expect(listKnownVsCodeCliPaths('zed', { platform: 'linux' })).toEqual([])
+  })
+})
+
+describe('resolveKnownVsCodeCliPath', () => {
+  it('returns the first existing known path', () => {
+    const macPath = '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+    expect(
+      resolveKnownVsCodeCliPath('code', (candidate) => candidate === macPath, {
+        platform: 'darwin',
+        homePath: '/Users/ada'
+      })
+    ).toBe(macPath)
+  })
+
+  it('returns null when no known path exists', () => {
+    expect(
+      resolveKnownVsCodeCliPath('code', () => false, {
+        platform: 'darwin',
+        homePath: '/Users/ada'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/vscode-cli-install-paths.test.ts
+++ b/src/main/vscode-cli-install-paths.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import type * as NodePath from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
 import { listKnownVsCodeCliPaths, resolveKnownVsCodeCliPath } from './vscode-cli-install-paths'
 
 describe('listKnownVsCodeCliPaths', () => {
@@ -21,6 +22,31 @@ describe('listKnownVsCodeCliPaths', () => {
         homePath: '/Users/ada'
       })[0]
     ).toBe('/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code')
+  })
+
+  it('keeps macOS candidates POSIX when executed on a Windows host', async () => {
+    vi.resetModules()
+    vi.doMock('node:path', async () => {
+      const path = await vi.importActual<typeof NodePath>('node:path')
+      return { ...path, join: path.win32.join }
+    })
+    try {
+      const { listKnownVsCodeCliPaths: listPathsWithWindowsHost } =
+        await import('./vscode-cli-install-paths')
+
+      expect(
+        listPathsWithWindowsHost('code', {
+          platform: 'darwin',
+          homePath: '/Users/ada'
+        })
+      ).toEqual([
+        '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
+        '/Users/ada/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+      ])
+    } finally {
+      vi.doUnmock('node:path')
+      vi.resetModules()
+    }
   })
 
   it('returns Windows user and Program Files bin shims', () => {

--- a/src/main/vscode-cli-install-paths.ts
+++ b/src/main/vscode-cli-install-paths.ts
@@ -1,0 +1,75 @@
+import { homedir } from 'node:os'
+import { join, win32 } from 'node:path'
+import { getLauncherBaseName } from './editor-launcher-name'
+
+type KnownPathOptions = {
+  platform?: NodeJS.Platform
+  homePath?: string
+  env?: NodeJS.ProcessEnv
+}
+
+function isInsidersLauncher(baseName: string): boolean {
+  return baseName === 'code-insiders' || baseName === 'code - insiders'
+}
+
+function isVsCodeCliBaseName(baseName: string): boolean {
+  return baseName === 'code' || isInsidersLauncher(baseName)
+}
+
+/** Standard install locations when PATH resolution misses (GUI-launched Electron). */
+export function listKnownVsCodeCliPaths(command: string, options: KnownPathOptions = {}): string[] {
+  const baseName = getLauncherBaseName(command)
+  if (!isVsCodeCliBaseName(baseName)) {
+    return []
+  }
+
+  const platform = options.platform ?? process.platform
+  const homePath = options.homePath ?? homedir()
+  const env = options.env ?? process.env
+  const insiders = isInsidersLauncher(baseName)
+
+  if (platform === 'darwin') {
+    const app = insiders ? 'Visual Studio Code - Insiders.app' : 'Visual Studio Code.app'
+    const relative = join(app, 'Contents', 'Resources', 'app', 'bin', 'code')
+    return [join('/Applications', relative), join(homePath, 'Applications', relative)]
+  }
+
+  if (platform === 'win32') {
+    const binName = insiders ? 'code-insiders.cmd' : 'code.cmd'
+    const product = insiders ? 'Microsoft VS Code Insiders' : 'Microsoft VS Code'
+    const candidates: string[] = []
+    const localAppData = env.LOCALAPPDATA?.trim()
+    if (localAppData) {
+      candidates.push(win32.join(localAppData, 'Programs', product, 'bin', binName))
+    }
+    for (const root of [env.ProgramFiles, env['ProgramFiles(x86)']]) {
+      const trimmed = root?.trim()
+      if (trimmed) {
+        candidates.push(win32.join(trimmed, product, 'bin', binName))
+      }
+    }
+    return candidates
+  }
+
+  if (platform === 'linux') {
+    if (insiders) {
+      return ['/usr/share/code-insiders/bin/code-insiders', '/snap/bin/code-insiders']
+    }
+    return ['/usr/share/code/bin/code', '/usr/bin/code', '/snap/bin/code']
+  }
+
+  return []
+}
+
+export function resolveKnownVsCodeCliPath(
+  command: string,
+  fileExists: (path: string) => boolean,
+  options: KnownPathOptions = {}
+): string | null {
+  for (const candidate of listKnownVsCodeCliPaths(command, options)) {
+    if (fileExists(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}

--- a/src/main/vscode-cli-install-paths.ts
+++ b/src/main/vscode-cli-install-paths.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'node:os'
-import { join, win32 } from 'node:path'
+import { posix, win32 } from 'node:path'
 import { getLauncherBaseName } from './editor-launcher-name'
 
 type KnownPathOptions = {
@@ -30,8 +30,8 @@ export function listKnownVsCodeCliPaths(command: string, options: KnownPathOptio
 
   if (platform === 'darwin') {
     const app = insiders ? 'Visual Studio Code - Insiders.app' : 'Visual Studio Code.app'
-    const relative = join(app, 'Contents', 'Resources', 'app', 'bin', 'code')
-    return [join('/Applications', relative), join(homePath, 'Applications', relative)]
+    const relative = posix.join(app, 'Contents', 'Resources', 'app', 'bin', 'code')
+    return [posix.join('/Applications', relative), posix.join(homePath, 'Applications', relative)]
   }
 
   if (platform === 'win32') {


### PR DESCRIPTION
## Summary
- GUI-launched Orca often has a minimal `PATH`, so `spawn code` fails with `ENOENT` even when VS Code is installed under `/Applications`.
- After PATH/version-manager resolution, fall back to known VS Code (and Insiders) install locations on macOS, Windows, and Linux.
- Covers both local **Open in → VS Code** and SSH Remote-SSH launches (`resolveVsCodeRemoteSshLaunchSpec`).

## Test plan
- [x] `vitest` `vscode-cli-install-paths`, `external-editor-launch`, `shell` tests
- [ ] macOS: Open SSH worktree → VS Code without `code` on GUI PATH
- [ ] Still prefers PATH-resolved `code` when present

Closes #14008