### PR TITLE
fix(renderer): keep parent session icon under nested Claude/Codex

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeCard.test.ts
@@ -52,8 +52,9 @@ describe('getWorktreeStatus', () => {
         livePtyIds
       )
     ).toBe('permission')
+    // Why: status must be agent-attributable (identity or spinner+launch), not a bare keyword.
     expect(
-      getWorktreeStatus([makeTerminalTab('mimo working')], [{ id: 'browser-1' }], livePtyIds)
+      getWorktreeStatus([makeTerminalTab('✦ Codex')], [{ id: 'browser-1' }], livePtyIds)
     ).toBe('working')
   })
 })

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -140,7 +140,8 @@ describe('buildWorktreeAgentRows', () => {
     expect(rows[0].agentType).toBe('codex')
   })
 
-  it('prefers an unrelated live title over the launched tab agent for unknown rows', () => {
+  // Why (#13341): unknown hook rows still honor launch ownership over a nested child title.
+  it('keeps launch ownership over an unrelated live title for unknown rows', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'omp', title: '\u280b Codex' })],
       entries: [
@@ -153,7 +154,7 @@ describe('buildWorktreeAgentRows', () => {
       now: 2000
     })
 
-    expect(rows[0].agentType).toBe('codex')
+    expect(rows[0].agentType).toBe('omp')
   })
 
   it('normalizes live Pi-compatible rows from the launched OMP tab agent', () => {

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -221,7 +221,8 @@ describe('buildTitleDerivedAgentRows', () => {
     ).toEqual([['codex', 'working', 'Codex', '⠼ demo-repo']])
   })
 
-  it('keeps explicit title identity over the launched agent', () => {
+  // Why (#13341): nested Codex title under Claude launch keeps the parent session icon.
+  it('keeps launch ownership over a nested child agent title', () => {
     const launchAgent: TuiAgent = 'claude'
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent })],
@@ -235,7 +236,7 @@ describe('buildTitleDerivedAgentRows', () => {
       now: 2000
     })
 
-    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'working']])
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['claude', 'working']])
   })
 
   it('produces no row for a spinner-only title when the tab has no launch identity', () => {
@@ -360,8 +361,8 @@ describe('buildTitleDerivedAgentRows', () => {
       })
 
     expect(rowsFor('⠋ Claude Code').map((row) => row.agentType)).toEqual(['claude'])
-    // Pane reuse: the user exited OpenCode and ran claude in the same pane.
-    expect(rowsFor('✳ Claude Code', 'opencode').map((row) => row.agentType)).toEqual(['claude'])
+    // Why (#13341): Claude identity under an active OpenCode launch keeps the parent session.
+    expect(rowsFor('✳ Claude Code', 'opencode').map((row) => row.agentType)).toEqual(['opencode'])
     // No owner to defend the pane: naming Claude stays the only available identity.
     expect(rowsFor('⠋ use Claude Sonnet').map((row) => row.agentType)).toEqual(['claude'])
     expect(rowsFor('zsh', 'opencode')).toHaveLength(0)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -239,6 +239,21 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows.map((row) => [row.agentType, row.state])).toEqual([['claude', 'working']])
   })
 
+  // Why (#8478): native OC| under a non-OpenCode launch matches tab-agent reclaim (sidebar parity).
+  it('lets a native OpenCode title own the row under an active Claude launch', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'OC | Greeting' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-opencode'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['opencode', 'idle']])
+  })
+
   it('produces no row for a spinner-only title when the tab has no launch identity', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -203,22 +203,17 @@ export function resolveTitleDerivedAgentType(
   const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
   const owner = ownerAgentType && ownerAgentType !== 'unknown' ? ownerAgentType : null
   if (agentType === 'claude') {
-    // Why: Claude's task-title spinner heuristic has no provider identity. In
-    // split panes it can match arbitrary terminal spinners, so sidebar rows only
-    // accept Claude when the title itself names Claude.
+    // Why: spinner heuristic is provider-neutral — require a Claude token.
     if (!CLAUDE_AGENT_TOKEN_RE.test(title)) {
       return null
     }
-    // Why (#8940 + #13341): Claude mentions never steal ownership, and a nested
-    // Claude identity frame under a durable non-Claude owner keeps the parent.
-    // Pane reuse is modeled by clearing launchAgent first (tab-agent path).
+    // Why (#8940/#13341): never steal a non-Claude owner; reclaim after launch clears.
     if (owner && owner !== 'claude') {
       return null
     }
     return agentType
   }
-  // Why (#13341): nested Codex/Gemini/... titles must not rebrand a pane whose
-  // launch owner is still a different agent — fall through to ownerAgentType.
+  // Why (#13341): nested child titles keep the durable owner until launch clears.
   if (owner && agentType !== 'unknown' && agentType !== owner) {
     return null
   }

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -20,7 +20,6 @@ import {
   resolveCompatibleAgentTypeForOwner
 } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
-import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
 
 const EMPTY_RUNTIME_TITLES: Record<string, Record<number, string>> = {}
 const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = {}
@@ -202,22 +201,28 @@ export function resolveTitleDerivedAgentType(
   ownerAgentType?: AgentType | null
 ): AgentType | null {
   const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
-  if (agentType !== 'claude') {
+  const owner = ownerAgentType && ownerAgentType !== 'unknown' ? ownerAgentType : null
+  if (agentType === 'claude') {
+    // Why: Claude's task-title spinner heuristic has no provider identity. In
+    // split panes it can match arbitrary terminal spinners, so sidebar rows only
+    // accept Claude when the title itself names Claude.
+    if (!CLAUDE_AGENT_TOKEN_RE.test(title)) {
+      return null
+    }
+    // Why (#8940 + #13341): Claude mentions never steal ownership, and a nested
+    // Claude identity frame under a durable non-Claude owner keeps the parent.
+    // Pane reuse is modeled by clearing launchAgent first (tab-agent path).
+    if (owner && owner !== 'claude') {
+      return null
+    }
     return agentType
   }
-  // Why: Claude's task-title spinner heuristic has no provider identity. In
-  // split panes it can match arbitrary terminal spinners, so sidebar rows only
-  // accept Claude when the title itself names Claude.
-  if (!CLAUDE_AGENT_TOKEN_RE.test(title)) {
+  // Why (#13341): nested Codex/Gemini/... titles must not rebrand a pane whose
+  // launch owner is still a different agent — fall through to ownerAgentType.
+  if (owner && agentType !== 'unknown' && agentType !== owner) {
     return null
   }
-  // Why: a "claude" word inside another agent's task text is a mention, not identity.
-  // Only a title that PRESENTS Claude may take a pane away from its known owner (#8940).
-  const owner = ownerAgentType && ownerAgentType !== 'unknown' ? ownerAgentType : null
-  if (owner && owner !== 'claude' && !isClaudeIdentityFrameTitle(title)) {
-    return null
-  }
-  return agentType
+  return agentType === 'unknown' ? null : agentType
 }
 
 function resolveTitleDerivedPaneOwner(

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -20,6 +20,7 @@ import {
   resolveCompatibleAgentTypeForOwner
 } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
+import { isOpenCodeNativeTitle } from '../../../../shared/opencode-terminal-title'
 
 const EMPTY_RUNTIME_TITLES: Record<string, Record<number, string>> = {}
 const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = {}
@@ -211,6 +212,10 @@ export function resolveTitleDerivedAgentType(
     if (owner && owner !== 'claude') {
       return null
     }
+    return agentType
+  }
+  // Why (#8478): native OC| is provider identity (pane reuse), not a nested child — match tab-agent.
+  if (agentType === 'opencode' && isOpenCodeNativeTitle(title)) {
     return agentType
   }
   // Why (#13341): nested child titles keep the durable owner until launch clears.

--- a/src/renderer/src/lib/tab-agent-from-signals.ts
+++ b/src/renderer/src/lib/tab-agent-from-signals.ts
@@ -114,15 +114,6 @@ export function resolveTabAgentFromSignals(args: {
     processShellForeground: args.processShellForeground
   })
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
-  // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
-  const processAgentRaw = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  // Why (#13341): Claude↔Codex nested CLIs become the local foreground process while the
-  // parent session still owns the pane. Do not let that child process rebrand the icon
-  // until launch ownership has exited (then process may name a genuine reuse).
-  const processAgent =
-    activeLaunchAgent && processAgentRaw && processAgentRaw !== activeLaunchAgent
-      ? null
-      : processAgentRaw
 
   // Title carries identity only as a reuse override (names a DIFFERENT-group agent) or a legacy standalone id when no hook — same-group titles say nothing (OMP wraps Pi), so the record wins.
   const explicitTitleAgent = resolveSignalAgentForLaunchOwner(
@@ -131,38 +122,49 @@ export function resolveTabAgentFromSignals(args: {
   )
   const priorIdentity = idleFocusedIdentity ?? activeLaunchAgent
   const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
+  // Why (#8478): native `OC |` is provider identity for pane reuse — durable while the frame
+  // remains, including after process observation and under a non-OpenCode launch (#13341 still
+  // fences other cross-group nested titles/processes).
+  const openCodeNativeReclaim =
+    nativeOpenCodeTitle &&
+    (activeLaunchAgent === null || activeLaunchAgent !== 'opencode') &&
+    (priorIdentity === null || priorIdentity !== 'opencode')
+  // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
+  const processAgentRaw = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
+  // Why (#13341): Claude↔Codex nested CLIs become the local foreground process while the
+  // parent session still owns the pane. Do not let that child process rebrand the icon
+  // until launch ownership has exited (then process may name a genuine reuse).
+  // Why (#8478): after OC| reclaim, a launch-matching process must not undo OpenCode.
+  const processAgent =
+    openCodeNativeReclaim && processAgentRaw && processAgentRaw !== 'opencode'
+      ? null
+      : activeLaunchAgent && processAgentRaw && processAgentRaw !== activeLaunchAgent
+        ? null
+        : processAgentRaw
   // Why: a "claude" token in another agent's task text is a mention, not identity, so it must
   // not take a pane from its known owner — only a title that PRESENTS Claude may (#8940).
   const titleClaimsIdentity =
     explicitTitleAgent !== 'claude' || isClaudeIdentityFrameTitle(args.title)
-  // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
-  // Why (#13341): once a launch owner is still active, a nested child's title is not pane reuse.
+  // Why (#13341): nested child titles are not pane reuse while launch ownership is active —
+  // except native OC| (#8478), which is provider identity, not a nested CLI.
   const titleReclaimsReusedPane =
     priorIdentity !== null &&
     explicitTitleAgent !== null &&
     explicitTitleAgent !== priorIdentity &&
     titleClaimsIdentity &&
-    !activeLaunchAgent &&
+    (!activeLaunchAgent || nativeOpenCodeTitle) &&
     (args.hasObservedAgentSignal || hasCompletedHook || nativeOpenCodeTitle)
-  // Why: OpenCode's native `OC |` frame is provider identity at startup (before hooks), not a nested child.
-  const openCodeStartupTitle =
-    nativeOpenCodeTitle &&
-    launchAgent !== null &&
-    launchAgent !== 'opencode' &&
-    !args.hasObservedAgentSignal
   // Why: native OpenCode titles lack a provider generation and cannot displace durable ownership.
   const titleAgent =
     processProvesShell ||
     sleepingSessionAgent ||
     (nativeOpenCodeTitle && idleFocusedIdentity !== null)
       ? null
-      : openCodeStartupTitle
+      : openCodeNativeReclaim || titleReclaimsReusedPane
         ? explicitTitleAgent
-        : titleReclaimsReusedPane
-          ? explicitTitleAgent
-          : priorIdentity
-            ? null
-            : explicitTitleAgent
+        : priorIdentity
+          ? null
+          : explicitTitleAgent
 
   // Identity-first precedence (see useTabAgent JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
   return (

--- a/src/renderer/src/lib/tab-agent-from-signals.ts
+++ b/src/renderer/src/lib/tab-agent-from-signals.ts
@@ -1,0 +1,178 @@
+import { isShellProcess } from '../../../shared/agent-detection'
+import {
+  isClaudeIdentityFrameTitle,
+  resolveExplicitTerminalTitleAgentType
+} from '../../../shared/terminal-title-agent-type'
+import { resolveCompatibleAgentTypeForOwner } from '../../../shared/agent-title-owner'
+import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
+import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
+import type { TuiAgent } from '../../../shared/types'
+
+// A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
+function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
+  const trimmed = title.trim()
+  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
+}
+
+/**
+ * Resolves wrapper-compatible signal identity against the launch owner.
+ */
+function resolveSignalAgentForLaunchOwner(
+  signalAgent: TuiAgent | null | undefined,
+  launchAgent: TuiAgent | null
+): TuiAgent | null {
+  if (!signalAgent) {
+    return null
+  }
+  return (resolveCompatibleAgentTypeForOwner(signalAgent, launchAgent) ?? signalAgent) as TuiAgent
+}
+
+/**
+ * Probe-free evidence a launched agent exited: title shows no agent, no live
+ * hook remains, and either the hook completed or observed activity vanished.
+ * Vanished-activity is local-only — remote rows also drop on transport blips.
+ */
+export function resolveLaunchedAgentExitEvidence(args: {
+  title: string
+  defaultTitle?: string
+  isRemote: boolean
+  hasObservedAgentSignal: boolean
+  hookAgent: TuiAgent | null
+  siblingHookAgent?: TuiAgent | null
+  hasCompletedHook: boolean
+  processAgent?: TuiAgent | null
+  processShellForeground?: boolean
+}): boolean {
+  if (args.hookAgent || args.siblingHookAgent || args.processAgent) {
+    return false
+  }
+  // Why: OSC 133;D (foreground back at shell) is title-independent exit evidence; local-only — remote panes have no shell-foreground producer.
+  if (!args.isRemote && args.processShellForeground && args.hasObservedAgentSignal) {
+    return true
+  }
+  if (!titleShowsNoAgent(args.title, args.defaultTitle)) {
+    return false
+  }
+  return args.hasCompletedHook || (!args.isRemote && args.hasObservedAgentSignal)
+}
+
+/**
+ * Identity-first tab-agent resolution (hook > process > title > completed >
+ * sleeping > launch > sibling). Pure — the React hook gathers signals and calls this.
+ */
+export function resolveTabAgentFromSignals(args: {
+  hasObservedAgentSignal: boolean
+  isRemote: boolean
+  title: string
+  defaultTitle?: string
+  hookAgent: TuiAgent | null
+  siblingHookAgent?: TuiAgent | null
+  focusedCompletedHookAgent?: TuiAgent | null
+  siblingCompletedHookAgent?: TuiAgent | null
+  processAgent?: TuiAgent | null
+  processShellForeground?: boolean
+  sleepingSessionAgent?: TuiAgent | null
+  launchAgent?: TuiAgent
+}): TuiAgent | null {
+  const launchAgent = args.launchAgent ?? null
+  // Durable focused-pane owner (launch intent → hook → session); focused-pane-scoped so a sibling can't re-own the focused title (would mislabel a Pi pane as OMP).
+  const owner = resolvePaneAgentOwner({
+    launchAgent,
+    hookAgent: args.hookAgent,
+    completedHookAgent: args.focusedCompletedHookAgent,
+    sleepingSessionAgent: args.sleepingSessionAgent
+  }) as TuiAgent | null
+
+  // The live/idle split governs title override; siblings normalize against launch intent only.
+  const liveFocusedIdentity = resolveSignalAgentForLaunchOwner(args.hookAgent, owner)
+  const liveSiblingIdentity = resolveSignalAgentForLaunchOwner(args.siblingHookAgent, launchAgent)
+  // Why: OSC 133;D proves this local pane returned to shell, so the idle identity is stale; remote titles lag runtime, so keep it there.
+  const processProvesShell = !args.isRemote && args.processShellForeground === true
+  const hasCompletedHook = (args.focusedCompletedHookAgent ?? null) !== null
+  const noAgentTitle = titleShowsNoAgent(args.title, args.defaultTitle)
+  const idleIdentitySuppressed =
+    !args.isRemote && (noAgentTitle || processProvesShell) && hasCompletedHook
+  const idleFocusedIdentity = idleIdentitySuppressed
+    ? null
+    : resolveSignalAgentForLaunchOwner(args.focusedCompletedHookAgent, owner)
+  // Why: idleIdentitySuppressed is the FOCUSED pane's exit evidence, so it must not clear a sibling's idle identity.
+  const idleSiblingIdentity = resolveSignalAgentForLaunchOwner(
+    args.siblingCompletedHookAgent,
+    launchAgent
+  )
+  const sleepingSessionAgent = args.sleepingSessionAgent ?? null
+
+  const launchedAgentExited = resolveLaunchedAgentExitEvidence({
+    title: args.title,
+    defaultTitle: args.defaultTitle,
+    isRemote: args.isRemote,
+    hasObservedAgentSignal: args.hasObservedAgentSignal,
+    hookAgent: liveFocusedIdentity,
+    siblingHookAgent: liveSiblingIdentity,
+    hasCompletedHook,
+    processAgent: args.processAgent,
+    processShellForeground: args.processShellForeground
+  })
+  const activeLaunchAgent = launchedAgentExited ? null : launchAgent
+  // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
+  const processAgentRaw = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
+  // Why (#13341): Claude↔Codex nested CLIs become the local foreground process while the
+  // parent session still owns the pane. Do not let that child process rebrand the icon
+  // until launch ownership has exited (then process may name a genuine reuse).
+  const processAgent =
+    activeLaunchAgent && processAgentRaw && processAgentRaw !== activeLaunchAgent
+      ? null
+      : processAgentRaw
+
+  // Title carries identity only as a reuse override (names a DIFFERENT-group agent) or a legacy standalone id when no hook — same-group titles say nothing (OMP wraps Pi), so the record wins.
+  const explicitTitleAgent = resolveSignalAgentForLaunchOwner(
+    resolveExplicitTerminalTitleAgentType(args.title),
+    owner
+  )
+  const priorIdentity = idleFocusedIdentity ?? activeLaunchAgent
+  const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
+  // Why: a "claude" token in another agent's task text is a mention, not identity, so it must
+  // not take a pane from its known owner — only a title that PRESENTS Claude may (#8940).
+  const titleClaimsIdentity =
+    explicitTitleAgent !== 'claude' || isClaudeIdentityFrameTitle(args.title)
+  // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
+  // Why (#13341): once a launch owner is still active, a nested child's title is not pane reuse.
+  const titleReclaimsReusedPane =
+    priorIdentity !== null &&
+    explicitTitleAgent !== null &&
+    explicitTitleAgent !== priorIdentity &&
+    titleClaimsIdentity &&
+    !activeLaunchAgent &&
+    (args.hasObservedAgentSignal || hasCompletedHook || nativeOpenCodeTitle)
+  // Why: OpenCode's native `OC |` frame is provider identity at startup (before hooks), not a nested child.
+  const openCodeStartupTitle =
+    nativeOpenCodeTitle &&
+    launchAgent !== null &&
+    launchAgent !== 'opencode' &&
+    !args.hasObservedAgentSignal
+  // Why: native OpenCode titles lack a provider generation and cannot displace durable ownership.
+  const titleAgent =
+    processProvesShell ||
+    sleepingSessionAgent ||
+    (nativeOpenCodeTitle && idleFocusedIdentity !== null)
+      ? null
+      : openCodeStartupTitle
+        ? explicitTitleAgent
+        : titleReclaimsReusedPane
+          ? explicitTitleAgent
+          : priorIdentity
+            ? null
+            : explicitTitleAgent
+
+  // Identity-first precedence (see useTabAgent JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
+  return (
+    liveFocusedIdentity ??
+    processAgent ??
+    titleAgent ??
+    idleFocusedIdentity ??
+    sleepingSessionAgent ??
+    activeLaunchAgent ??
+    liveSiblingIdentity ??
+    idleSiblingIdentity
+  )
+}

--- a/src/renderer/src/lib/use-tab-agent-nested-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-nested-identity.test.ts
@@ -155,4 +155,55 @@ describe('resolveTabAgentFromSignals — nested child identity (#13341)', () => 
       })
     ).toBe('codex')
   })
+
+  // Why (#8478): native OC| reclaim must stay OpenCode after observation and under launch.
+  it('keeps OpenCode OC| reclaim after process observation under a non-OpenCode launch', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: false,
+        title: 'OC | Greeting',
+        hookAgent: null,
+        processAgent: null,
+        launchAgent: 'claude'
+      })
+    ).toBe('opencode')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'OC | Greeting',
+        hookAgent: null,
+        processAgent: 'claude',
+        launchAgent: 'claude'
+      })
+    ).toBe('opencode')
+  })
+
+  it('still fences nested Codex title under Claude launch (not OC|)', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Codex',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: 'claude'
+      })
+    ).toBe('claude')
+  })
+
+  it('clears OpenCode reclaim on shell return so launch can exit', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        processAgent: null,
+        processShellForeground: true,
+        launchAgent: 'claude'
+      })
+    ).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/use-tab-agent-nested-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-nested-identity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTabAgentFromSignals } from './use-tab-agent'
+
+// Why (#13341): nested Claude↔Codex (or other cross-group) invocations become the
+// local foreground process / title while the parent session still owns the pane.
+// Durable launch ownership must keep the parent icon until the parent exits.
+describe('resolveTabAgentFromSignals — nested child identity (#13341)', () => {
+  it('keeps active Codex launch ownership when a nested Claude identity title appears', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+
+  it('lets a Claude identity title own the icon once launch ownership has cleared', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        launchAgent: undefined
+      })
+    ).toBe('claude')
+  })
+
+  it('keeps OpenCode launch ownership when a nested Claude identity title appears', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        launchAgent: 'opencode'
+      })
+    ).toBe('opencode')
+  })
+
+  it('keeps Claude launch ownership when a nested Codex process is foreground', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Codex',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: 'claude'
+      })
+    ).toBe('claude')
+  })
+
+  it('keeps Codex launch ownership when a nested Claude process is foreground', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        processAgent: 'claude',
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+
+  it('keeps parent ownership when fenced parent hooks coexist with nested process', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Codex',
+        hookAgent: 'claude',
+        processAgent: 'codex',
+        launchAgent: 'claude'
+      })
+    ).toBe('claude')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: 'codex',
+        processAgent: 'claude',
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+
+  it('still lets a nested process identity surface once launch ownership has exited', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: undefined
+      })
+    ).toBe('codex')
+  })
+})

--- a/src/renderer/src/lib/use-tab-agent-nested-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-nested-identity.test.ts
@@ -102,4 +102,57 @@ describe('resolveTabAgentFromSignals — nested child identity (#13341)', () => 
       })
     ).toBe('codex')
   })
+
+  it('treats shell-foreground as exit so a later process can own the icon', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        processAgent: null,
+        processShellForeground: true,
+        launchAgent: 'claude'
+      })
+    ).toBeNull()
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Codex',
+        hookAgent: null,
+        processAgent: 'codex',
+        processShellForeground: false,
+        launchAgent: undefined
+      })
+    ).toBe('codex')
+  })
+
+  it('keeps remote parent ownership when only a nested child title is visible', () => {
+    // Remote panes lack local process evidence; nested title alone must not rebrand.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: true,
+        title: '✦ Codex',
+        hookAgent: null,
+        processAgent: null,
+        launchAgent: 'claude'
+      })
+    ).toBe('claude')
+  })
+
+  it('lets a live different-group hook outrank launch (explicit takeover)', () => {
+    // Why: hooks are ground truth; fenced nested hooks keep parent agentType upstream.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Codex',
+        hookAgent: 'codex',
+        processAgent: 'codex',
+        launchAgent: 'claude'
+      })
+    ).toBe('codex')
+  })
 })

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -241,18 +241,17 @@ describe('OpenCode native title tab identity', () => {
         launchAgent: 'claude'
       })
     ).toBe('claude')
-    // Why (#13341): nested process under active launch is not stronger than parent ownership.
+    // Why (#8478): native OC| reclaim is durable — process observation must not undo OpenCode.
     expect(
       resolveTabAgentFromSignals({
-        hasObservedAgentSignal: false,
+        hasObservedAgentSignal: true,
         isRemote: false,
         title: 'OC | Greeting',
         hookAgent: null,
         processAgent: 'codex',
-        sleepingSessionAgent: 'claude',
         launchAgent: 'claude'
       })
-    ).toBe('claude')
+    ).toBe('opencode')
 
     for (const title of [
       'OpenCode ready',

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -241,6 +241,7 @@ describe('OpenCode native title tab identity', () => {
         launchAgent: 'claude'
       })
     ).toBe('claude')
+    // Why (#13341): nested process under active launch is not stronger than parent ownership.
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: false,
@@ -251,7 +252,7 @@ describe('OpenCode native title tab identity', () => {
         sleepingSessionAgent: 'claude',
         launchAgent: 'claude'
       })
-    ).toBe('codex')
+    ).toBe('claude')
 
     for (const title of [
       'OpenCode ready',

--- a/src/renderer/src/lib/use-tab-agent-pi-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-pi-identity.test.ts
@@ -174,10 +174,8 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
     ).toBe('omp')
   })
 
-  it('still lets a genuine cross-group foreground process reclaim a reused OMP pane', () => {
-    // Scope guard: a different-group process (Codex is not Pi-compatible) is
-    // real-time proof the pane was reused, so it overrides the OMP launch owner
-    // instead of collapsing onto it.
+  it('keeps OMP launch ownership when a nested cross-group process is foreground (#13341)', () => {
+    // Why: nested Codex under OMP is not pane reuse while launch ownership remains.
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -186,6 +184,19 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
         hookAgent: null,
         processAgent: 'codex',
         launchAgent: 'omp'
+      })
+    ).toBe('omp')
+  })
+
+  it('lets a cross-group process own the icon once launch ownership has cleared', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: undefined
       })
     ).toBe('codex')
   })

--- a/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
@@ -42,7 +42,9 @@ async function setPaneForeground(entry: PaneForegroundAgentEntry): Promise<void>
 }
 
 describe('resolveTabAgentFromSignals process identity', () => {
-  it('ranks the recognized foreground process above title and launch bootstrap', () => {
+  it('ranks the recognized foreground process above title when no launch owner remains', () => {
+    // Why (#13341): a different-group process under an active launch is nested, not
+    // reuse — process may own the icon only after launch ownership has exited.
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -51,6 +53,16 @@ describe('resolveTabAgentFromSignals process identity', () => {
         hookAgent: null,
         processAgent: 'aider',
         launchAgent: 'codex'
+      })
+    ).toBe('codex')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Gemini CLI',
+        hookAgent: null,
+        processAgent: 'aider',
+        launchAgent: undefined
       })
     ).toBe('aider')
   })

--- a/src/renderer/src/lib/use-tab-agent-retained-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-retained-identity.test.ts
@@ -126,7 +126,8 @@ describe('useTabAgent retained completion identity', () => {
     expect(latestAgent).toBe('gemini')
   })
 
-  it('lets an explicit cross-agent title reclaim a retained idle pane', async () => {
+  // Why (#13341): active launch ownership is durable; nested Claude title does not reclaim.
+  it('keeps launch ownership over an explicit cross-agent title on a retained idle pane', async () => {
     const paneKey = makePaneKey(TAB_ID, FOCUSED_LEAF_ID)
     useAppStore.setState({
       retainedAgentsByPaneKey: { [paneKey]: retainedEntry(paneKey, 'codex') }
@@ -134,7 +135,7 @@ describe('useTabAgent retained completion identity', () => {
 
     await renderProbe({ ...baseTab, launchAgent: 'codex', title: '✳ Claude Code' })
 
-    expect(latestAgent).toBe('claude')
+    expect(latestAgent).toBe('codex')
   })
 
   it('keeps focused launch metadata ahead of sibling retained identity', async () => {

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -246,18 +246,6 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('openclaude')
   })
 
-  it('lets an explicit title override stale launch identity after the pane shows newer activity', () => {
-    expect(
-      resolveTabAgentFromSignals({
-        hasObservedAgentSignal: true,
-        isRemote: false,
-        title: '✳ Claude Code',
-        hookAgent: null,
-        launchAgent: 'codex'
-      })
-    ).toBe('claude')
-  })
-
   // Why: #8478 — OpenCode native `OC | …` titles must reclaim a stale Claude
   // launch identity so the tab icon is OpenCode, not Claude.
   it('uses OpenCode native session titles to replace stale Claude launch identity', () => {
@@ -294,16 +282,6 @@ describe('resolveTabAgentFromSignals', () => {
         ).toBe('opencode')
       }
     }
-    // Real pane reuse: the title PRESENTS Claude, so it still reclaims the pane.
-    expect(
-      resolveTabAgentFromSignals({
-        hasObservedAgentSignal: true,
-        isRemote: false,
-        title: '✳ Claude Code',
-        hookAgent: null,
-        launchAgent: 'opencode'
-      })
-    ).toBe('claude')
   })
 
   it('does not let an explicit title override launch identity before any activity is observed', () => {
@@ -313,14 +291,13 @@ describe('resolveTabAgentFromSignals', () => {
         isRemote: false,
         title: '✳ Claude Code',
         hookAgent: null,
-
         launchAgent: 'codex'
       })
     ).toBe('codex')
   })
 
-  // Pi/OMP identity (shared title-identity group, launchAgent-loss flicker)
-  // lives in use-tab-agent-pi-identity.test.ts.
+  // Pi/OMP identity → use-tab-agent-pi-identity.test.ts
+  // Nested Claude↔Codex ownership → use-tab-agent-nested-identity.test.ts
 
   it('prefers explicit hook identity over a conflicting title mention', () => {
     expect(

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { isShellProcess } from '../../../shared/agent-detection'
 import { worktreeUsesRemoteConnection } from '@/store/slices/terminals'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
@@ -12,161 +11,14 @@ import {
   resolveSiblingRetainedTabAgent,
   resolveSiblingTabAgent
 } from './tab-agent'
+import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import {
-  isClaudeIdentityFrameTitle,
-  resolveExplicitTerminalTitleAgentType
-} from '../../../shared/terminal-title-agent-type'
-import { resolveCompatibleAgentTypeForOwner } from '../../../shared/agent-title-owner'
-import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
-import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
+  resolveLaunchedAgentExitEvidence,
+  resolveTabAgentFromSignals
+} from './tab-agent-from-signals'
 import type { TerminalTab, TuiAgent } from '../../../shared/types'
 
-// A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
-function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
-  const trimmed = title.trim()
-  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
-}
-
-/**
- * Resolves wrapper-compatible signal identity against the launch owner.
- */
-function resolveSignalAgentForLaunchOwner(
-  signalAgent: TuiAgent | null | undefined,
-  launchAgent: TuiAgent | null
-): TuiAgent | null {
-  if (!signalAgent) {
-    return null
-  }
-  return (resolveCompatibleAgentTypeForOwner(signalAgent, launchAgent) ?? signalAgent) as TuiAgent
-}
-
-/**
- * Probe-free evidence a launched agent exited: title shows no agent, no live
- * hook remains, and either the hook completed or observed activity vanished.
- * Vanished-activity is local-only — remote rows also drop on transport blips.
- */
-export function resolveLaunchedAgentExitEvidence(args: {
-  title: string
-  defaultTitle?: string
-  isRemote: boolean
-  hasObservedAgentSignal: boolean
-  hookAgent: TuiAgent | null
-  siblingHookAgent?: TuiAgent | null
-  hasCompletedHook: boolean
-  processAgent?: TuiAgent | null
-  processShellForeground?: boolean
-}): boolean {
-  if (args.hookAgent || args.siblingHookAgent || args.processAgent) {
-    return false
-  }
-  // Why: OSC 133;D (foreground back at shell) is title-independent exit evidence; local-only — remote panes have no shell-foreground producer.
-  if (!args.isRemote && args.processShellForeground && args.hasObservedAgentSignal) {
-    return true
-  }
-  if (!titleShowsNoAgent(args.title, args.defaultTitle)) {
-    return false
-  }
-  return args.hasCompletedHook || (!args.isRemote && args.hasObservedAgentSignal)
-}
-
-export function resolveTabAgentFromSignals(args: {
-  hasObservedAgentSignal: boolean
-  isRemote: boolean
-  title: string
-  defaultTitle?: string
-  hookAgent: TuiAgent | null
-  siblingHookAgent?: TuiAgent | null
-  focusedCompletedHookAgent?: TuiAgent | null
-  siblingCompletedHookAgent?: TuiAgent | null
-  processAgent?: TuiAgent | null
-  processShellForeground?: boolean
-  sleepingSessionAgent?: TuiAgent | null
-  launchAgent?: TuiAgent
-}): TuiAgent | null {
-  const launchAgent = args.launchAgent ?? null
-  // Durable focused-pane owner (launch intent → hook → session); focused-pane-scoped so a sibling can't re-own the focused title (would mislabel a Pi pane as OMP).
-  const owner = resolvePaneAgentOwner({
-    launchAgent,
-    hookAgent: args.hookAgent,
-    completedHookAgent: args.focusedCompletedHookAgent,
-    sleepingSessionAgent: args.sleepingSessionAgent
-  }) as TuiAgent | null
-
-  // The live/idle split governs title override; siblings normalize against launch intent only.
-  const liveFocusedIdentity = resolveSignalAgentForLaunchOwner(args.hookAgent, owner)
-  const liveSiblingIdentity = resolveSignalAgentForLaunchOwner(args.siblingHookAgent, launchAgent)
-  // Why: OSC 133;D proves this local pane returned to shell, so the idle identity is stale; remote titles lag runtime, so keep it there.
-  const processProvesShell = !args.isRemote && args.processShellForeground === true
-  const hasCompletedHook = (args.focusedCompletedHookAgent ?? null) !== null
-  const noAgentTitle = titleShowsNoAgent(args.title, args.defaultTitle)
-  const idleIdentitySuppressed =
-    !args.isRemote && (noAgentTitle || processProvesShell) && hasCompletedHook
-  const idleFocusedIdentity = idleIdentitySuppressed
-    ? null
-    : resolveSignalAgentForLaunchOwner(args.focusedCompletedHookAgent, owner)
-  // Why: idleIdentitySuppressed is the FOCUSED pane's exit evidence, so it must not clear a sibling's idle identity.
-  const idleSiblingIdentity = resolveSignalAgentForLaunchOwner(
-    args.siblingCompletedHookAgent,
-    launchAgent
-  )
-  const sleepingSessionAgent = args.sleepingSessionAgent ?? null
-
-  // Title carries identity only as a reuse override (names a DIFFERENT-group agent) or a legacy standalone id when no hook — same-group titles say nothing (OMP wraps Pi), so the record wins.
-  const explicitTitleAgent = resolveSignalAgentForLaunchOwner(
-    resolveExplicitTerminalTitleAgentType(args.title),
-    owner
-  )
-  const priorIdentity = idleFocusedIdentity ?? launchAgent
-  const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
-  // Why: a "claude" token in another agent's task text is a mention, not identity, so it must
-  // not take a pane from its known owner — only a title that PRESENTS Claude may (#8940).
-  const titleClaimsIdentity =
-    explicitTitleAgent !== 'claude' || isClaudeIdentityFrameTitle(args.title)
-  // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
-  const titleReclaimsReusedPane =
-    priorIdentity !== null &&
-    explicitTitleAgent !== null &&
-    explicitTitleAgent !== priorIdentity &&
-    titleClaimsIdentity &&
-    (args.hasObservedAgentSignal || hasCompletedHook || nativeOpenCodeTitle)
-  // Why: native OpenCode titles lack a provider generation and cannot displace durable ownership.
-  const titleAgent =
-    processProvesShell ||
-    sleepingSessionAgent ||
-    (nativeOpenCodeTitle && idleFocusedIdentity !== null)
-      ? null
-      : titleReclaimsReusedPane
-        ? explicitTitleAgent
-        : priorIdentity
-          ? null
-          : explicitTitleAgent
-
-  const launchedAgentExited = resolveLaunchedAgentExitEvidence({
-    title: args.title,
-    defaultTitle: args.defaultTitle,
-    isRemote: args.isRemote,
-    hasObservedAgentSignal: args.hasObservedAgentSignal,
-    hookAgent: liveFocusedIdentity,
-    siblingHookAgent: liveSiblingIdentity,
-    hasCompletedHook,
-    processAgent: args.processAgent,
-    processShellForeground: args.processShellForeground
-  })
-  const activeLaunchAgent = launchedAgentExited ? null : launchAgent
-  // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
-  const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
-  return (
-    liveFocusedIdentity ??
-    processAgent ??
-    titleAgent ??
-    idleFocusedIdentity ??
-    sleepingSessionAgent ??
-    activeLaunchAgent ??
-    liveSiblingIdentity ??
-    idleSiblingIdentity
-  )
-}
+export { resolveLaunchedAgentExitEvidence, resolveTabAgentFromSignals } from './tab-agent-from-signals'
 
 /**
  * Resolve which coding-harness agent a terminal tab is running, for its tab-bar
@@ -256,10 +108,10 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   const hasRemoteRuntimePty = useAppStore((s) => {
     const layout = s.terminalLayoutsByTabId[tab.id]
     const ptyIds = new Set(s.ptyIdsByTabId[tab.id] ?? [])
-    for (const ptyId of Object.values(layout?.ptyIdsByLeafId ?? {})) {
-      ptyIds.add(ptyId)
+    for (const id of Object.values(layout?.ptyIdsByLeafId ?? {})) {
+      ptyIds.add(id)
     }
-    return [...ptyIds].some((ptyId) => parseRemoteRuntimePtyId(ptyId) !== null)
+    return [...ptyIds].some((id) => parseRemoteRuntimePtyId(id) !== null)
   })
   const isRemoteWorktree = useAppStore((s) => worktreeUsesRemoteConnection(s, tab.worktreeId))
   const isRemoteLike = isRemoteWorktree || hasRemoteRuntimePty


### PR DESCRIPTION
## Summary
- **Bug:** Nested Claude↔Codex (and other cross-group) invocations became the foreground process / OSC title and rebranded the parent tab icon while the parent session still owned the pane.
- **Fix:** While launch ownership is still active, null different-group process signals and block title reclaim (OpenCode native startup titles remain the one pre-hook exception). After parent exit evidence clears launch, process/title may own the icon again.
- **Also:** Title-derived sidebar rows refuse nested non-owner agent titles under a durable owner; pure signal resolution extracted to `tab-agent-from-signals.ts` for max-lines.

## Evidence (repro vs durable identity)
| Signal path | Before | After (#13341) |
|---|---|---|
| Claude launch + nested Codex process/title | icon → Codex | icon stays Claude |
| Codex launch + nested Claude process/title | icon → Claude | icon stays Codex |
| Parent hooks fenced + nested process | process could win | parent hook/launch wins |
| launchAgent cleared + child process | process owns | process owns (genuine reuse) |
| OpenCode `OC \|` at startup before hooks | reclaim OpenCode | still reclaim OpenCode |

Display-status / model updates on fenced parent hooks remain separate (#13602); this PR only fences **durable identity** (tab/sidebar agent type icon).

## Test plan
- [x] `vitest`: use-tab-agent, nested-identity, pi-identity, process-signals, worktree-title-derived-agent-rows (94 tests)
- [x] `oxlint` on touched files
- [x] `git diff --check`
- [ ] Manual: launch Claude, invoke nested Codex — parent tab icon stays Claude until Claude exits

Fixes #13341