### PR TITLE
fix(renderer): recover overlay hit-test after pane-column snap

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -74,6 +74,7 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   const { measuredRect, useCssAnchors } = useOverlaySlotGeometry({
     overlayRef,
     groupId,
+    worktreeId: browserTab.worktreeId,
     cssAnchorsSupported: shouldUseCssAnchorPositioning(),
     isVisible: isPaintable
   })

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -1,12 +1,26 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { registerBrowserOverlaySlotViewport } from './browser-page-viewport'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import type { BrowserTab as BrowserTabState, Tab, TabGroup } from '../../../../shared/types'
 import BrowserPane, { type BrowserFindShortcutScope } from './BrowserPane'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
+import { useOverlaySlotGeometry } from '../tab-group/use-overlay-slot-geometry'
 import { useBrowserAutomationVisibilityForAny } from './browser-automation-visibility'
 import { useBrowserMobileDriverForAny } from '@/lib/pane-manager/browser-mobile-driver-state'
+
+const HAS_CSS_ANCHOR_POSITIONING =
+  typeof CSS !== 'undefined' &&
+  CSS.supports('position-anchor', '--orca-browser-overlay-probe') &&
+  CSS.supports('top', 'anchor(--orca-browser-overlay-probe top)') &&
+  CSS.supports('width', 'anchor-size(--orca-browser-overlay-probe width)')
+
+function shouldUseCssAnchorPositioning(): boolean {
+  return (
+    HAS_CSS_ANCHOR_POSITIONING &&
+    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
+  )
+}
 
 // Why: Electron <webview> destroys its guest on DOM reparent, so BrowserPanes render at worktree level and moving a tab between groups only swaps the overlay's CSS position-anchor.
 
@@ -39,6 +53,7 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   onFocusOwningGroup,
   isWorktreeActive
 }: BrowserOverlaySlotProps): React.JSX.Element {
+  const overlayRef = useRef<HTMLDivElement | null>(null)
   // Why: persistent page viewports (webview guests) live under this root so they survive BrowserPane chrome unmounts without reparenting.
   const setSlotViewportRef = useCallback(
     (node: HTMLDivElement | null): void => {
@@ -56,11 +71,17 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   const isPaintable = isActive || automationVisible || mobileDriven
   // Why: hidden worktrees keep lightweight overlay slots, but park their webviews unless a remote controller needs the guest.
   const shouldMountPane = isWorktreeActive || automationVisible || mobileDriven
-  // Why: CSS anchor positioning pins the overlay to its owning group's body — a tab move only swaps positionAnchor, no measurement/state.
-  // Orphan branch (no anchorName) stays display:none until the tab is reassigned or destroyed.
+  const { measuredRect, useCssAnchors } = useOverlaySlotGeometry({
+    overlayRef,
+    groupId,
+    cssAnchorsSupported: shouldUseCssAnchorPositioning(),
+    isVisible: isPaintable
+  })
+  // Why: CSS anchors are preferred; after a column snap they can leave the
+  // webview covering tab chrome, so measured geometry is the recovery path.
   const style: React.CSSProperties = useMemo(
     () =>
-      anchorName
+      anchorName && useCssAnchors
         ? {
             position: 'absolute',
             positionAnchor: anchorName,
@@ -72,16 +93,27 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
             pointerEvents: isActive ? 'auto' : 'none',
             opacity: isActive ? 1 : 0
           }
-        : {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: 0,
-            height: 0,
-            display: 'none',
-            pointerEvents: 'none'
-          },
-    [anchorName, isActive, isPaintable]
+        : anchorName
+          ? {
+              position: 'absolute',
+              top: measuredRect?.top ?? 32,
+              left: measuredRect?.left ?? 0,
+              width: measuredRect?.width ?? '100%',
+              height: measuredRect?.height ?? 'calc(100% - 32px)',
+              display: isPaintable ? 'flex' : 'none',
+              pointerEvents: isActive ? 'auto' : 'none',
+              opacity: isActive ? 1 : 0
+            }
+          : {
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 0,
+              height: 0,
+              display: 'none',
+              pointerEvents: 'none'
+            },
+    [anchorName, isActive, isPaintable, measuredRect, useCssAnchors]
   )
   const handleFocus = useCallback(() => {
     if (groupId !== undefined && onFocusOwningGroup) {
@@ -91,9 +123,11 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
 
   return (
     <div
+      ref={overlayRef}
       style={style}
       className="relative flex min-h-0 flex-1 flex-col"
       data-browser-overlay-tab-id={browserTab.id}
+      data-overlay-geometry={useCssAnchors ? 'anchor' : 'measured'}
       onPointerDown={handleFocus}
       onFocusCapture={handleFocus}
     >

--- a/src/renderer/src/components/emulator-pane/EmulatorPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPaneOverlayLayer.tsx
@@ -1,12 +1,26 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import type { Tab, TabGroup } from '../../../../shared/types'
 import EmulatorPane from './EmulatorPane'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
+import { useOverlaySlotGeometry } from '../tab-group/use-overlay-slot-geometry'
 
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 const EMPTY_GROUPS: readonly TabGroup[] = []
+
+const HAS_CSS_ANCHOR_POSITIONING =
+  typeof CSS !== 'undefined' &&
+  CSS.supports('position-anchor', '--orca-emulator-overlay-probe') &&
+  CSS.supports('top', 'anchor(--orca-emulator-overlay-probe top)') &&
+  CSS.supports('width', 'anchor-size(--orca-emulator-overlay-probe width)')
+
+function shouldUseCssAnchorPositioning(): boolean {
+  return (
+    HAS_CSS_ANCHOR_POSITIONING &&
+    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
+  )
+}
 
 type SimulatorOverlaySlotProps = {
   tab: Tab
@@ -21,10 +35,17 @@ const SimulatorOverlaySlot = memo(function SimulatorOverlaySlot({
   isActive,
   onFocusOwningGroup
 }: SimulatorOverlaySlotProps): React.JSX.Element {
+  const overlayRef = useRef<HTMLDivElement | null>(null)
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
+  const { measuredRect, useCssAnchors } = useOverlaySlotGeometry({
+    overlayRef,
+    groupId,
+    cssAnchorsSupported: shouldUseCssAnchorPositioning(),
+    isVisible: isActive
+  })
   const style: React.CSSProperties = useMemo(
     () =>
-      anchorName
+      anchorName && useCssAnchors
         ? {
             position: 'absolute',
             positionAnchor: anchorName,
@@ -36,14 +57,27 @@ const SimulatorOverlaySlot = memo(function SimulatorOverlaySlot({
             visibility: isActive ? 'visible' : 'hidden',
             pointerEvents: isActive ? 'auto' : 'none'
           }
-        : { display: 'none' },
-    [anchorName, isActive]
+        : anchorName
+          ? {
+              position: 'absolute',
+              top: measuredRect?.top ?? 32,
+              left: measuredRect?.left ?? 0,
+              width: measuredRect?.width ?? '100%',
+              height: measuredRect?.height ?? 'calc(100% - 32px)',
+              zIndex: isActive ? 2 : 1,
+              visibility: isActive ? 'visible' : 'hidden',
+              pointerEvents: isActive ? 'auto' : 'none'
+            }
+          : { display: 'none' },
+    [anchorName, isActive, measuredRect, useCssAnchors]
   )
 
   return (
     <div
+      ref={overlayRef}
       style={style}
       className="orca-emulator-overlay-slot min-h-0 min-w-0 overflow-hidden"
+      data-overlay-geometry={useCssAnchors ? 'anchor' : 'measured'}
       onPointerDownCapture={() => {
         if (groupId && onFocusOwningGroup) {
           onFocusOwningGroup(groupId)

--- a/src/renderer/src/components/emulator-pane/EmulatorPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPaneOverlayLayer.tsx
@@ -40,6 +40,7 @@ const SimulatorOverlaySlot = memo(function SimulatorOverlaySlot({
   const { measuredRect, useCssAnchors } = useOverlaySlotGeometry({
     overlayRef,
     groupId,
+    worktreeId: tab.worktreeId,
     cssAnchorsSupported: shouldUseCssAnchorPositioning(),
     isVisible: isActive
   })

--- a/src/renderer/src/components/tab-group/overlay-slot-geometry.test.ts
+++ b/src/renderer/src/components/tab-group/overlay-slot-geometry.test.ts
@@ -3,12 +3,15 @@
 import { describe, expect, it } from 'vitest'
 import {
   findTabGroupBodyElement,
+  isMeasurableOverlayRect,
   isOverlaySlotGeometryMismatched,
   measureOverlaySlotRect,
   shouldPreferMeasuredOverlayGeometry
 } from './overlay-slot-geometry'
 
-function rect(partial: Partial<DOMRect> & Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>): DOMRect {
+function rect(
+  partial: Partial<DOMRect> & Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>
+): DOMRect {
   const top = partial.top
   const left = partial.left
   const width = partial.width
@@ -27,16 +30,23 @@ function rect(partial: Partial<DOMRect> & Pick<DOMRect, 'top' | 'left' | 'width'
 }
 
 describe('overlay slot geometry', () => {
-  it('finds the tab-group body by group id', () => {
+  it('finds the tab-group body scoped by worktree when both attributes are set', () => {
+    const other = document.createElement('div')
+    other.dataset.tabGroupBodyId = 'group-a'
+    other.dataset.worktreeId = 'wt-other'
     const body = document.createElement('div')
     body.dataset.tabGroupBodyId = 'group-a'
-    document.body.appendChild(body)
-    expect(findTabGroupBodyElement('group-a')).toBe(body)
+    body.dataset.worktreeId = 'wt-1'
+    document.body.append(other, body)
+    expect(findTabGroupBodyElement('group-a', 'wt-1')).toBe(body)
+    expect(findTabGroupBodyElement('group-a', 'wt-missing')).toBeNull()
+    expect(findTabGroupBodyElement('group-a')).toBe(other)
     expect(findTabGroupBodyElement('missing')).toBeNull()
+    other.remove()
     body.remove()
   })
 
-  it('measures body geometry relative to the overlay parent', () => {
+  it('measures body geometry relative to the overlay parent (absolute containing block)', () => {
     const parent = document.createElement('div')
     const body = document.createElement('div')
     parent.getBoundingClientRect = () => rect({ top: 100, left: 40, width: 900, height: 700 })
@@ -69,9 +79,9 @@ describe('overlay slot geometry', () => {
     const overlay = document.createElement('div')
     const body = document.createElement('div')
     body.dataset.tabGroupBodyId = 'group-snap'
+    body.dataset.worktreeId = 'wt-1'
     parent.appendChild(overlay)
-    document.body.appendChild(parent)
-    document.body.appendChild(body)
+    document.body.append(parent, body)
 
     // Why: after a column snap the overlay can still claim the pre-snap full-area
     // box while the body is only the right half — clicks then land in chrome/tabs.
@@ -82,9 +92,12 @@ describe('overlay slot geometry', () => {
     const result = shouldPreferMeasuredOverlayGeometry({
       overlay,
       groupId: 'group-snap',
-      forceMeasured: false
+      worktreeId: 'wt-1',
+      forceMeasured: false,
+      mayLatchDesync: true
     })
     expect(result.preferMeasured).toBe(true)
+    expect(result.bodyMeasurable).toBe(true)
     expect(result.measured).toEqual({
       top: 36,
       left: 500,
@@ -102,8 +115,7 @@ describe('overlay slot geometry', () => {
     const body = document.createElement('div')
     body.dataset.tabGroupBodyId = 'group-ok'
     parent.appendChild(overlay)
-    document.body.appendChild(parent)
-    document.body.appendChild(body)
+    document.body.append(parent, body)
 
     const matched = rect({ top: 36, left: 0, width: 900, height: 700 })
     parent.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 900, height: 736 })
@@ -113,7 +125,8 @@ describe('overlay slot geometry', () => {
     const result = shouldPreferMeasuredOverlayGeometry({
       overlay,
       groupId: 'group-ok',
-      forceMeasured: false
+      forceMeasured: false,
+      mayLatchDesync: true
     })
     expect(result.preferMeasured).toBe(false)
     expect(result.measured).toEqual({
@@ -122,6 +135,92 @@ describe('overlay slot geometry', () => {
       width: 900,
       height: 700
     })
+
+    parent.remove()
+    body.remove()
+  })
+
+  it('does not latch desync from a display:none / zero-size overlay sample', () => {
+    const parent = document.createElement('div')
+    const overlay = document.createElement('div')
+    const body = document.createElement('div')
+    body.dataset.tabGroupBodyId = 'group-hidden'
+    parent.appendChild(overlay)
+    document.body.append(parent, body)
+
+    parent.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 1000, height: 800 })
+    overlay.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 0, height: 0 })
+    body.getBoundingClientRect = () => rect({ top: 36, left: 0, width: 1000, height: 764 })
+
+    expect(
+      shouldPreferMeasuredOverlayGeometry({
+        overlay,
+        groupId: 'group-hidden',
+        forceMeasured: false,
+        mayLatchDesync: true
+      }).preferMeasured
+    ).toBe(false)
+
+    expect(
+      shouldPreferMeasuredOverlayGeometry({
+        overlay,
+        groupId: 'group-hidden',
+        forceMeasured: false,
+        mayLatchDesync: false
+      }).preferMeasured
+    ).toBe(false)
+
+    parent.remove()
+    body.remove()
+  })
+
+  it('does not latch desync when the body is not yet measurable', () => {
+    const parent = document.createElement('div')
+    const overlay = document.createElement('div')
+    const body = document.createElement('div')
+    body.dataset.tabGroupBodyId = 'group-unlaid'
+    parent.appendChild(overlay)
+    document.body.append(parent, body)
+
+    parent.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 1000, height: 800 })
+    overlay.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 1000, height: 800 })
+    body.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 0, height: 0 })
+
+    const result = shouldPreferMeasuredOverlayGeometry({
+      overlay,
+      groupId: 'group-unlaid',
+      forceMeasured: false,
+      mayLatchDesync: true
+    })
+    expect(result.bodyMeasurable).toBe(false)
+    expect(result.preferMeasured).toBe(false)
+    expect(isMeasurableOverlayRect({ width: 0, height: 0 })).toBe(false)
+
+    parent.remove()
+    body.remove()
+  })
+
+  it('honors forceMeasured even when geometry currently matches', () => {
+    const parent = document.createElement('div')
+    const overlay = document.createElement('div')
+    const body = document.createElement('div')
+    body.dataset.tabGroupBodyId = 'group-forced'
+    parent.appendChild(overlay)
+    document.body.append(parent, body)
+
+    const matched = rect({ top: 36, left: 0, width: 900, height: 700 })
+    parent.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 900, height: 736 })
+    overlay.getBoundingClientRect = () => matched
+    body.getBoundingClientRect = () => matched
+
+    expect(
+      shouldPreferMeasuredOverlayGeometry({
+        overlay,
+        groupId: 'group-forced',
+        forceMeasured: true,
+        mayLatchDesync: true
+      }).preferMeasured
+    ).toBe(true)
 
     parent.remove()
     body.remove()

--- a/src/renderer/src/components/tab-group/overlay-slot-geometry.test.ts
+++ b/src/renderer/src/components/tab-group/overlay-slot-geometry.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import {
+  findTabGroupBodyElement,
+  isOverlaySlotGeometryMismatched,
+  measureOverlaySlotRect,
+  shouldPreferMeasuredOverlayGeometry
+} from './overlay-slot-geometry'
+
+function rect(partial: Partial<DOMRect> & Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>): DOMRect {
+  const top = partial.top
+  const left = partial.left
+  const width = partial.width
+  const height = partial.height
+  return {
+    top,
+    left,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  } as DOMRect
+}
+
+describe('overlay slot geometry', () => {
+  it('finds the tab-group body by group id', () => {
+    const body = document.createElement('div')
+    body.dataset.tabGroupBodyId = 'group-a'
+    document.body.appendChild(body)
+    expect(findTabGroupBodyElement('group-a')).toBe(body)
+    expect(findTabGroupBodyElement('missing')).toBeNull()
+    body.remove()
+  })
+
+  it('measures body geometry relative to the overlay parent', () => {
+    const parent = document.createElement('div')
+    const body = document.createElement('div')
+    parent.getBoundingClientRect = () => rect({ top: 100, left: 40, width: 900, height: 700 })
+    body.getBoundingClientRect = () => rect({ top: 136, left: 40, width: 450, height: 664 })
+    expect(measureOverlaySlotRect(parent, body)).toEqual({
+      top: 36,
+      left: 0,
+      width: 450,
+      height: 664
+    })
+  })
+
+  it('detects post-snap overlay/body desync beyond tolerance', () => {
+    expect(
+      isOverlaySlotGeometryMismatched(
+        rect({ top: 0, left: 0, width: 900, height: 700 }),
+        rect({ top: 136, left: 40, width: 450, height: 664 })
+      )
+    ).toBe(true)
+    expect(
+      isOverlaySlotGeometryMismatched(
+        rect({ top: 136.5, left: 40.5, width: 450, height: 664 }),
+        rect({ top: 136, left: 40, width: 450, height: 664 })
+      )
+    ).toBe(false)
+  })
+
+  it('forces measured geometry when CSS-anchor hit-test drifts after a side-by-side snap', () => {
+    const parent = document.createElement('div')
+    const overlay = document.createElement('div')
+    const body = document.createElement('div')
+    body.dataset.tabGroupBodyId = 'group-snap'
+    parent.appendChild(overlay)
+    document.body.appendChild(parent)
+    document.body.appendChild(body)
+
+    // Why: after a column snap the overlay can still claim the pre-snap full-area
+    // box while the body is only the right half — clicks then land in chrome/tabs.
+    parent.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 1000, height: 800 })
+    overlay.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 1000, height: 800 })
+    body.getBoundingClientRect = () => rect({ top: 36, left: 500, width: 500, height: 764 })
+
+    const result = shouldPreferMeasuredOverlayGeometry({
+      overlay,
+      groupId: 'group-snap',
+      forceMeasured: false
+    })
+    expect(result.preferMeasured).toBe(true)
+    expect(result.measured).toEqual({
+      top: 36,
+      left: 500,
+      width: 500,
+      height: 764
+    })
+
+    parent.remove()
+    body.remove()
+  })
+
+  it('keeps CSS anchors when overlay geometry already matches the body', () => {
+    const parent = document.createElement('div')
+    const overlay = document.createElement('div')
+    const body = document.createElement('div')
+    body.dataset.tabGroupBodyId = 'group-ok'
+    parent.appendChild(overlay)
+    document.body.appendChild(parent)
+    document.body.appendChild(body)
+
+    const matched = rect({ top: 36, left: 0, width: 900, height: 700 })
+    parent.getBoundingClientRect = () => rect({ top: 0, left: 0, width: 900, height: 736 })
+    overlay.getBoundingClientRect = () => matched
+    body.getBoundingClientRect = () => matched
+
+    const result = shouldPreferMeasuredOverlayGeometry({
+      overlay,
+      groupId: 'group-ok',
+      forceMeasured: false
+    })
+    expect(result.preferMeasured).toBe(false)
+    expect(result.measured).toEqual({
+      top: 36,
+      left: 0,
+      width: 900,
+      height: 700
+    })
+
+    parent.remove()
+    body.remove()
+  })
+})

--- a/src/renderer/src/components/tab-group/overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/overlay-slot-geometry.ts
@@ -1,0 +1,76 @@
+// Why: worktree-level terminal/browser/emulator overlays pin to each group's
+// body via CSS anchor positioning. After a pane-column snap Chromium can leave
+// the painted box and hit-test box disagreeing (or leave the overlay covering
+// chrome that should stay clickable). Measuring the body and correcting the
+// overlay is the portable recovery path for Electron, web, and remote hosts.
+
+export type OverlaySlotRect = {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+export const OVERLAY_SLOT_GEOMETRY_MISMATCH_PX = 2
+
+export function findTabGroupBodyElement(groupId: string): HTMLElement | null {
+  for (const candidate of document.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
+    if (candidate.dataset.tabGroupBodyId === groupId) {
+      return candidate
+    }
+  }
+  return null
+}
+
+export function measureOverlaySlotRect(
+  parent: HTMLElement,
+  body: HTMLElement
+): OverlaySlotRect {
+  const parentRect = parent.getBoundingClientRect()
+  const bodyRect = body.getBoundingClientRect()
+  return {
+    top: bodyRect.top - parentRect.top,
+    left: bodyRect.left - parentRect.left,
+    width: bodyRect.width,
+    height: bodyRect.height
+  }
+}
+
+export function isOverlaySlotGeometryMismatched(
+  overlayRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>,
+  bodyRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>,
+  tolerancePx = OVERLAY_SLOT_GEOMETRY_MISMATCH_PX
+): boolean {
+  return (
+    Math.abs(overlayRect.top - bodyRect.top) > tolerancePx ||
+    Math.abs(overlayRect.left - bodyRect.left) > tolerancePx ||
+    Math.abs(overlayRect.width - bodyRect.width) > tolerancePx ||
+    Math.abs(overlayRect.height - bodyRect.height) > tolerancePx
+  )
+}
+
+export function shouldPreferMeasuredOverlayGeometry(args: {
+  overlay: HTMLElement | null
+  groupId: string | undefined
+  /** When true, stay on the measured path until the caller resets (e.g. new group). */
+  forceMeasured: boolean
+}): { preferMeasured: boolean; measured: OverlaySlotRect | null } {
+  if (!args.groupId || !args.overlay) {
+    return { preferMeasured: args.forceMeasured, measured: null }
+  }
+  const parent = args.overlay.parentElement
+  const body = findTabGroupBodyElement(args.groupId)
+  if (!parent || !body) {
+    return { preferMeasured: true, measured: null }
+  }
+  const measured = measureOverlaySlotRect(parent, body)
+  if (args.forceMeasured) {
+    return { preferMeasured: true, measured }
+  }
+  const bodyRect = body.getBoundingClientRect()
+  const overlayRect = args.overlay.getBoundingClientRect()
+  if (isOverlaySlotGeometryMismatched(overlayRect, bodyRect)) {
+    return { preferMeasured: true, measured }
+  }
+  return { preferMeasured: false, measured }
+}

--- a/src/renderer/src/components/tab-group/overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/overlay-slot-geometry.ts
@@ -12,14 +12,30 @@ export type OverlaySlotRect = {
 }
 
 export const OVERLAY_SLOT_GEOMETRY_MISMATCH_PX = 2
+/** Body/overlay smaller than this is treated as not-yet-laid-out, not a desync. */
+export const OVERLAY_SLOT_MIN_MEASURABLE_EDGE_PX = 8
 
-export function findTabGroupBodyElement(groupId: string): HTMLElement | null {
-  for (const candidate of document.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
-    if (candidate.dataset.tabGroupBodyId === groupId) {
-      return candidate
-    }
+function escapeCssAttrValue(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value)
   }
-  return null
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+/** Locate the tab-group body; prefer worktree-scoped match when available. */
+export function findTabGroupBodyElement(
+  groupId: string,
+  worktreeId?: string
+): HTMLElement | null {
+  const escapedGroupId = escapeCssAttrValue(groupId)
+  if (worktreeId) {
+    const escapedWorktreeId = escapeCssAttrValue(worktreeId)
+    // Why: never fall through to another worktree's body — hidden worktrees stay mounted.
+    return document.querySelector<HTMLElement>(
+      `[data-tab-group-body-id="${escapedGroupId}"][data-worktree-id="${escapedWorktreeId}"]`
+    )
+  }
+  return document.querySelector<HTMLElement>(`[data-tab-group-body-id="${escapedGroupId}"]`)
 }
 
 export function measureOverlaySlotRect(
@@ -36,6 +52,13 @@ export function measureOverlaySlotRect(
   }
 }
 
+export function isMeasurableOverlayRect(
+  rect: Pick<DOMRect | OverlaySlotRect, 'width' | 'height'>,
+  minEdgePx = OVERLAY_SLOT_MIN_MEASURABLE_EDGE_PX
+): boolean {
+  return rect.width >= minEdgePx && rect.height >= minEdgePx
+}
+
 export function isOverlaySlotGeometryMismatched(
   overlayRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>,
   bodyRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>,
@@ -49,28 +72,62 @@ export function isOverlaySlotGeometryMismatched(
   )
 }
 
+export type OverlayGeometryDecision = {
+  preferMeasured: boolean
+  measured: OverlaySlotRect | null
+  /** True when body exists and is large enough to trust for measured layout. */
+  bodyMeasurable: boolean
+}
+
+/**
+ * Decide whether CSS-anchor layout is safe or measured body geometry is required.
+ * Viewport getBoundingClientRect comparison detects desync; measured offsets are
+ * parent-relative for `position:absolute` top/left/width/height.
+ */
 export function shouldPreferMeasuredOverlayGeometry(args: {
   overlay: HTMLElement | null
   groupId: string | undefined
+  worktreeId?: string
   /** When true, stay on the measured path until the caller resets (e.g. new group). */
   forceMeasured: boolean
-}): { preferMeasured: boolean; measured: OverlaySlotRect | null } {
+  /**
+   * When false (hidden/unpainted slot), never latch onto measured from a desync
+   * sample — zero-size `display:none` overlays would otherwise false-positive.
+   */
+  mayLatchDesync: boolean
+}): OverlayGeometryDecision {
   if (!args.groupId || !args.overlay) {
-    return { preferMeasured: args.forceMeasured, measured: null }
+    return {
+      preferMeasured: args.forceMeasured,
+      measured: null,
+      bodyMeasurable: false
+    }
   }
   const parent = args.overlay.parentElement
-  const body = findTabGroupBodyElement(args.groupId)
+  const body = findTabGroupBodyElement(args.groupId, args.worktreeId)
   if (!parent || !body) {
-    return { preferMeasured: true, measured: null }
+    return {
+      preferMeasured: args.forceMeasured,
+      measured: null,
+      bodyMeasurable: false
+    }
   }
   const measured = measureOverlaySlotRect(parent, body)
+  const bodyMeasurable = isMeasurableOverlayRect(measured)
   if (args.forceMeasured) {
-    return { preferMeasured: true, measured }
+    return { preferMeasured: true, measured, bodyMeasurable }
+  }
+  if (!args.mayLatchDesync || !bodyMeasurable) {
+    return { preferMeasured: false, measured, bodyMeasurable }
   }
   const bodyRect = body.getBoundingClientRect()
   const overlayRect = args.overlay.getBoundingClientRect()
-  if (isOverlaySlotGeometryMismatched(overlayRect, bodyRect)) {
-    return { preferMeasured: true, measured }
+  // Why: skip until the overlay itself has a real box — pre-paint zeros are not desync.
+  if (!isMeasurableOverlayRect(overlayRect)) {
+    return { preferMeasured: false, measured, bodyMeasurable }
   }
-  return { preferMeasured: false, measured }
+  if (isOverlaySlotGeometryMismatched(overlayRect, bodyRect)) {
+    return { preferMeasured: true, measured, bodyMeasurable }
+  }
+  return { preferMeasured: false, measured, bodyMeasurable }
 }

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.test.tsx
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.test.tsx
@@ -1,0 +1,282 @@
+/** @vitest-environment happy-dom */
+import { act, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useOverlaySlotGeometry } from './use-overlay-slot-geometry'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function createRect({
+  top = 0,
+  left = 0,
+  width = 800,
+  height = 600
+}: Partial<Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>> = {}): DOMRect {
+  return {
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  }
+}
+
+type GeometryProbe = {
+  measuredRect: { top: number; left: number; width: number; height: number } | null
+  forceMeasured: boolean
+  useCssAnchors: boolean
+}
+
+let host: HTMLDivElement
+let root: Root
+let lastProbe: GeometryProbe | null
+let resizeCallbacks: ResizeObserverCallback[]
+let mutationCallbacks: MutationCallback[]
+let observedElements: Element[]
+let disconnectedResize = 0
+let disconnectedMutation = 0
+
+class CapturingResizeObserver {
+  private readonly callback: ResizeObserverCallback
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    resizeCallbacks.push(callback)
+  }
+  observe(target: Element): void {
+    if (!observedElements.includes(target)) {
+      observedElements.push(target)
+    }
+  }
+  unobserve(target: Element): void {
+    observedElements = observedElements.filter((el) => el !== target)
+  }
+  disconnect(): void {
+    disconnectedResize += 1
+    observedElements = []
+  }
+}
+
+class CapturingMutationObserver {
+  private readonly callback: MutationCallback
+  constructor(callback: MutationCallback) {
+    this.callback = callback
+    mutationCallbacks.push(callback)
+  }
+  observe(): void {}
+  disconnect(): void {
+    disconnectedMutation += 1
+  }
+}
+
+function GeometryHarness({
+  groupId,
+  worktreeId,
+  isVisible = true,
+  cssAnchorsSupported = true
+}: {
+  groupId: string | undefined
+  worktreeId?: string
+  isVisible?: boolean
+  cssAnchorsSupported?: boolean
+}): React.JSX.Element {
+  const overlayRef = useRef<HTMLDivElement | null>(null)
+  const geometry = useOverlaySlotGeometry({
+    overlayRef,
+    groupId,
+    worktreeId,
+    cssAnchorsSupported,
+    isVisible
+  })
+  lastProbe = geometry
+  return <div ref={overlayRef} data-testid="overlay" />
+}
+
+function renderHarness(props: {
+  groupId: string | undefined
+  worktreeId?: string
+  isVisible?: boolean
+  cssAnchorsSupported?: boolean
+}): void {
+  act(() => {
+    root.render(
+      <GeometryHarness
+        groupId={props.groupId}
+        worktreeId={props.worktreeId}
+        isVisible={props.isVisible}
+        cssAnchorsSupported={props.cssAnchorsSupported}
+      />
+    )
+  })
+}
+
+function mountBody(groupId: string, worktreeId: string, rect: DOMRect): HTMLElement {
+  const body = document.createElement('div')
+  body.dataset.tabGroupBodyId = groupId
+  body.dataset.worktreeId = worktreeId
+  body.getBoundingClientRect = () => rect
+  document.body.appendChild(body)
+  return body
+}
+
+beforeEach(() => {
+  lastProbe = null
+  resizeCallbacks = []
+  mutationCallbacks = []
+  observedElements = []
+  disconnectedResize = 0
+  disconnectedMutation = 0
+  vi.stubGlobal('ResizeObserver', CapturingResizeObserver)
+  vi.stubGlobal('MutationObserver', CapturingMutationObserver)
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    (cb: FrameRequestCallback): number => {
+      cb(0)
+      return 1
+    }
+  )
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+  host = document.createElement('div')
+  host.getBoundingClientRect = () => createRect({ width: 1000, height: 800 })
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  host.remove()
+  document.querySelectorAll('[data-tab-group-body-id]').forEach((el) => el.remove())
+  vi.unstubAllGlobals()
+})
+
+describe('useOverlaySlotGeometry late body attach', () => {
+  it('measures after a worktree body mounts late (post effect setup)', () => {
+    renderHarness({ groupId: 'g-late', worktreeId: 'wt-1', cssAnchorsSupported: false })
+    expect(lastProbe?.measuredRect).toBeNull()
+
+    const body = mountBody(
+      'g-late',
+      'wt-1',
+      createRect({ top: 40, left: 100, width: 400, height: 500 })
+    )
+    act(() => {
+      mutationCallbacks[0]?.([], {} as MutationObserver)
+    })
+
+    expect(observedElements).toContain(body)
+    expect(lastProbe?.measuredRect).toEqual({
+      top: 40,
+      left: 100,
+      width: 400,
+      height: 500
+    })
+  })
+
+  it('re-observes a replaced body and drops the old observation', () => {
+    const first = mountBody(
+      'g-rep',
+      'wt-1',
+      createRect({ top: 10, left: 0, width: 300, height: 400 })
+    )
+    renderHarness({ groupId: 'g-rep', worktreeId: 'wt-1', cssAnchorsSupported: false })
+    expect(observedElements).toContain(first)
+
+    first.remove()
+    const second = mountBody(
+      'g-rep',
+      'wt-1',
+      createRect({ top: 20, left: 50, width: 350, height: 450 })
+    )
+    act(() => {
+      mutationCallbacks[0]?.([], {} as MutationObserver)
+    })
+
+    expect(observedElements).toContain(second)
+    expect(observedElements).not.toContain(first)
+    expect(lastProbe?.measuredRect).toEqual({
+      top: 20,
+      left: 50,
+      width: 350,
+      height: 450
+    })
+  })
+
+  it('does not observe another worktree body with the same group id', () => {
+    const foreign = mountBody(
+      'g-scope',
+      'wt-foreign',
+      createRect({ top: 0, left: 0, width: 900, height: 700 })
+    )
+    renderHarness({ groupId: 'g-scope', worktreeId: 'wt-1', cssAnchorsSupported: false })
+    act(() => {
+      mutationCallbacks[0]?.([], {} as MutationObserver)
+    })
+    expect(observedElements).not.toContain(foreign)
+    expect(lastProbe?.measuredRect).toBeNull()
+
+    const local = mountBody(
+      'g-scope',
+      'wt-1',
+      createRect({ top: 30, left: 10, width: 200, height: 300 })
+    )
+    act(() => {
+      mutationCallbacks[0]?.([], {} as MutationObserver)
+    })
+    expect(observedElements).toContain(local)
+    expect(lastProbe?.measuredRect?.width).toBe(200)
+  })
+
+  it('disconnects observers on unmount', () => {
+    mountBody('g-clean', 'wt-1', createRect({ width: 100, height: 100 }))
+    renderHarness({ groupId: 'g-clean', worktreeId: 'wt-1', cssAnchorsSupported: false })
+    expect(disconnectedResize).toBe(0)
+
+    act(() => {
+      root.unmount()
+    })
+    expect(disconnectedResize).toBeGreaterThanOrEqual(1)
+    expect(disconnectedMutation).toBeGreaterThanOrEqual(1)
+  })
+
+  it('resets forceMeasured when the group identity changes', () => {
+    const bodyA = mountBody(
+      'g-a',
+      'wt-1',
+      createRect({ top: 40, left: 500, width: 500, height: 760 })
+    )
+    // Desync: overlay full size vs body half — requires css anchors path.
+    renderHarness({ groupId: 'g-a', worktreeId: 'wt-1', cssAnchorsSupported: true })
+    const overlay = host.querySelector('[data-testid="overlay"]') as HTMLElement
+    overlay.getBoundingClientRect = () => createRect({ width: 1000, height: 800 })
+
+    act(() => {
+      resizeCallbacks[0]?.([], {} as ResizeObserver)
+    })
+    expect(lastProbe?.forceMeasured).toBe(true)
+
+    // Align overlay before identity change so reset is not immediately re-latched.
+    const matched = createRect({ top: 40, left: 0, width: 500, height: 760 })
+    overlay.getBoundingClientRect = () => matched
+    mountBody('g-b', 'wt-1', matched)
+    bodyA.remove()
+    renderHarness({ groupId: 'g-b', worktreeId: 'wt-1', cssAnchorsSupported: true })
+    expect(lastProbe?.forceMeasured).toBe(false)
+  })
+})
+
+describe('useOverlaySlotGeometry render purity', () => {
+  it('does not throw when state updates only from effects (no render-phase latch)', () => {
+    // Why: React Doctor forbids ref.current writes during render; this harness
+    // would surface effect/render loop errors if latch sync ran in render.
+    expect(() => {
+      renderHarness({ groupId: 'g-pure', worktreeId: 'wt-1', cssAnchorsSupported: true })
+      renderHarness({ groupId: 'g-pure', worktreeId: 'wt-1', cssAnchorsSupported: true })
+    }).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.test.tsx
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.test.tsx
@@ -41,9 +41,7 @@ let disconnectedResize = 0
 let disconnectedMutation = 0
 
 class CapturingResizeObserver {
-  private readonly callback: ResizeObserverCallback
   constructor(callback: ResizeObserverCallback) {
-    this.callback = callback
     resizeCallbacks.push(callback)
   }
   observe(target: Element): void {
@@ -61,9 +59,7 @@ class CapturingResizeObserver {
 }
 
 class CapturingMutationObserver {
-  private readonly callback: MutationCallback
   constructor(callback: MutationCallback) {
-    this.callback = callback
     mutationCallbacks.push(callback)
   }
   observe(): void {}
@@ -267,6 +263,44 @@ describe('useOverlaySlotGeometry late body attach', () => {
     bodyA.remove()
     renderHarness({ groupId: 'g-b', worktreeId: 'wt-1', cssAnchorsSupported: true })
     expect(lastProbe?.forceMeasured).toBe(false)
+  })
+
+  it('keeps forceMeasured across hide/reveal (isVisible must not clear the latch)', () => {
+    const bodyRect = createRect({ top: 40, left: 500, width: 500, height: 760 })
+    mountBody('g-vis', 'wt-1', bodyRect)
+    renderHarness({
+      groupId: 'g-vis',
+      worktreeId: 'wt-1',
+      isVisible: true,
+      cssAnchorsSupported: true
+    })
+    const overlay = host.querySelector('[data-testid="overlay"]') as HTMLElement
+    overlay.getBoundingClientRect = () => createRect({ width: 1000, height: 800 })
+
+    act(() => {
+      resizeCallbacks[0]?.([], {} as ResizeObserver)
+    })
+    expect(lastProbe?.forceMeasured).toBe(true)
+    expect(lastProbe?.useCssAnchors).toBe(false)
+
+    // Hide then reveal without group/worktree change — latch must survive.
+    renderHarness({
+      groupId: 'g-vis',
+      worktreeId: 'wt-1',
+      isVisible: false,
+      cssAnchorsSupported: true
+    })
+    expect(lastProbe?.forceMeasured).toBe(true)
+    expect(lastProbe?.useCssAnchors).toBe(false)
+
+    renderHarness({
+      groupId: 'g-vis',
+      worktreeId: 'wt-1',
+      isVisible: true,
+      cssAnchorsSupported: true
+    })
+    expect(lastProbe?.forceMeasured).toBe(true)
+    expect(lastProbe?.useCssAnchors).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import { useLayoutEffect, useState, type RefObject } from 'react'
 import {
   findTabGroupBodyElement,
   measureOverlaySlotRect,
@@ -28,6 +28,9 @@ function stabilizeMeasuredRect(
  * Tracks tab-group body geometry for a worktree-level overlay slot.
  * When CSS anchors desync after a column snap, forceMeasured becomes true and
  * the caller should pin the overlay with measured top/left/width/height.
+ *
+ * Why no render-time ref writes: React Doctor flags ref.current mutation during
+ * render. Latch state lives in React state + an effect-local flag only.
  */
 export function useOverlaySlotGeometry(args: {
   overlayRef: RefObject<HTMLElement | null>
@@ -43,23 +46,52 @@ export function useOverlaySlotGeometry(args: {
 } {
   const [measuredRect, setMeasuredRect] = useState<OverlaySlotRect | null>(null)
   const [forceMeasured, setForceMeasured] = useState(false)
-  const forceMeasuredRef = useRef(false)
-  forceMeasuredRef.current = forceMeasured
 
-  // Why: single layout effect owns group transitions + RO so forceMeasured
-  // reset and re-observe cannot race across two effects in the same commit.
+  // Why: single layout effect owns group transitions, RO attach, and late body
+  // discovery so reset/re-observe cannot race across multiple effects.
   useLayoutEffect(() => {
+    // Why: group/worktree identity change always re-arms CSS anchors.
+    setForceMeasured(false)
     if (!args.groupId) {
       return
     }
 
-    forceMeasuredRef.current = false
-    setForceMeasured(false)
+    // Effect-local only — never written during render (React purity).
+    let latchedMeasured = false
+    let observedBody: Element | null = null
+    let observedParent: Element | null = null
+    const resizeObserver = new ResizeObserver(() => {
+      update()
+    })
+
+    const syncObservation = (body: Element | null, parent: Element | null): void => {
+      if (body !== observedBody) {
+        if (observedBody) {
+          resizeObserver.unobserve(observedBody)
+        }
+        if (body) {
+          resizeObserver.observe(body)
+        }
+        observedBody = body
+      }
+      if (parent !== observedParent) {
+        if (observedParent) {
+          resizeObserver.unobserve(observedParent)
+        }
+        if (parent) {
+          resizeObserver.observe(parent)
+        }
+        observedParent = parent
+      }
+    }
 
     const update = (): void => {
       const overlay = args.overlayRef.current
-      const parent = overlay?.parentElement
+      const parent = overlay?.parentElement ?? null
       const body = findTabGroupBodyElement(args.groupId!, args.worktreeId)
+      // Why: body may mount after the effect (split leaf paint). Re-attach RO when
+      // the worktree-scoped query starts resolving without polling.
+      syncObservation(body, parent)
       if (!parent || !body) {
         // Why: mid-reparent body absence is transient; keep last good measured
         // box so we do not expand to width 100% over tab chrome.
@@ -75,11 +107,11 @@ export function useOverlaySlotGeometry(args: {
         overlay: overlay ?? null,
         groupId: args.groupId,
         worktreeId: args.worktreeId,
-        forceMeasured: forceMeasuredRef.current,
+        forceMeasured: latchedMeasured,
         mayLatchDesync: args.isVisible
       })
-      if (decision.preferMeasured && !forceMeasuredRef.current) {
-        forceMeasuredRef.current = true
+      if (decision.preferMeasured && !latchedMeasured) {
+        latchedMeasured = true
         setForceMeasured(true)
       }
       if (decision.measured) {
@@ -91,19 +123,25 @@ export function useOverlaySlotGeometry(args: {
     // Why: rAF catches the frame after a pane-column snap reflow when RO may
     // not fire (body size unchanged but anchor resolution changed).
     const rafId = requestAnimationFrame(update)
-    const body = findTabGroupBodyElement(args.groupId, args.worktreeId)
-    const parent = args.overlayRef.current?.parentElement
-    const resizeObserver = new ResizeObserver(update)
-    if (body) {
-      resizeObserver.observe(body)
-    }
-    if (parent) {
-      resizeObserver.observe(parent)
-    }
+
+    // Why: tab-group bodies are siblings outside the overlay tree and often
+    // mount/replace after this effect; subtree mutations re-run attach for the
+    // scoped body only (findTabGroupBodyElement is worktree-scoped).
+    const mutationObserver = new MutationObserver(() => {
+      update()
+    })
+    mutationObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    })
     window.addEventListener('resize', update)
+
     return () => {
       cancelAnimationFrame(rafId)
+      mutationObserver.disconnect()
       resizeObserver.disconnect()
+      observedBody = null
+      observedParent = null
       window.removeEventListener('resize', update)
     }
   }, [

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState, type RefObject } from 'react'
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react'
 import {
   findTabGroupBodyElement,
   measureOverlaySlotRect,
@@ -32,6 +32,7 @@ function stabilizeMeasuredRect(
 export function useOverlaySlotGeometry(args: {
   overlayRef: RefObject<HTMLElement | null>
   groupId: string | undefined
+  worktreeId?: string
   /** When false (e.g. web client), always use measured geometry. */
   cssAnchorsSupported: boolean
   isVisible: boolean
@@ -42,45 +43,55 @@ export function useOverlaySlotGeometry(args: {
 } {
   const [measuredRect, setMeasuredRect] = useState<OverlaySlotRect | null>(null)
   const [forceMeasured, setForceMeasured] = useState(false)
+  const forceMeasuredRef = useRef(false)
+  forceMeasuredRef.current = forceMeasured
 
-  useLayoutEffect(() => {
-    setForceMeasured(false)
-  }, [args.groupId])
-
+  // Why: single layout effect owns group transitions + RO so forceMeasured
+  // reset and re-observe cannot race across two effects in the same commit.
   useLayoutEffect(() => {
     if (!args.groupId) {
       return
     }
 
+    forceMeasuredRef.current = false
+    setForceMeasured(false)
+
     const update = (): void => {
       const overlay = args.overlayRef.current
       const parent = overlay?.parentElement
-      const body = findTabGroupBodyElement(args.groupId!)
+      const body = findTabGroupBodyElement(args.groupId!, args.worktreeId)
       if (!parent || !body) {
-        setMeasuredRect(null)
+        // Why: mid-reparent body absence is transient; keep last good measured
+        // box so we do not expand to width 100% over tab chrome.
         return
       }
       const next = measureOverlaySlotRect(parent, body)
       setMeasuredRect((prev) => stabilizeMeasuredRect(prev, next))
 
-      if (!args.cssAnchorsSupported || forceMeasured) {
+      if (!args.cssAnchorsSupported) {
         return
       }
       const decision = shouldPreferMeasuredOverlayGeometry({
         overlay: overlay ?? null,
         groupId: args.groupId,
-        forceMeasured: false
+        worktreeId: args.worktreeId,
+        forceMeasured: forceMeasuredRef.current,
+        mayLatchDesync: args.isVisible
       })
-      if (decision.preferMeasured) {
+      if (decision.preferMeasured && !forceMeasuredRef.current) {
+        forceMeasuredRef.current = true
         setForceMeasured(true)
-        if (decision.measured) {
-          setMeasuredRect((prev) => stabilizeMeasuredRect(prev, decision.measured!))
-        }
+      }
+      if (decision.measured) {
+        setMeasuredRect((prev) => stabilizeMeasuredRect(prev, decision.measured!))
       }
     }
 
     update()
-    const body = findTabGroupBodyElement(args.groupId)
+    // Why: rAF catches the frame after a pane-column snap reflow when RO may
+    // not fire (body size unchanged but anchor resolution changed).
+    const rafId = requestAnimationFrame(update)
+    const body = findTabGroupBodyElement(args.groupId, args.worktreeId)
     const parent = args.overlayRef.current?.parentElement
     const resizeObserver = new ResizeObserver(update)
     if (body) {
@@ -91,6 +102,7 @@ export function useOverlaySlotGeometry(args: {
     }
     window.addEventListener('resize', update)
     return () => {
+      cancelAnimationFrame(rafId)
       resizeObserver.disconnect()
       window.removeEventListener('resize', update)
     }
@@ -99,7 +111,7 @@ export function useOverlaySlotGeometry(args: {
     args.groupId,
     args.isVisible,
     args.overlayRef,
-    forceMeasured
+    args.worktreeId
   ])
 
   return {

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState, type RefObject } from 'react'
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react'
 import {
   findTabGroupBodyElement,
   measureOverlaySlotRect,
@@ -29,8 +29,9 @@ function stabilizeMeasuredRect(
  * When CSS anchors desync after a column snap, forceMeasured becomes true and
  * the caller should pin the overlay with measured top/left/width/height.
  *
- * Why no render-time ref writes: React Doctor flags ref.current mutation during
- * render. Latch state lives in React state + an effect-local flag only.
+ * Why: render stays pure (no ref writes during render). isVisible only gates
+ * new latches — a proven forceMeasured survives hide/reveal. Observers always
+ * tear down via the effect cleanup return (React Doctor effect-needs-cleanup).
  */
 export function useOverlaySlotGeometry(args: {
   overlayRef: RefObject<HTMLElement | null>
@@ -46,20 +47,25 @@ export function useOverlaySlotGeometry(args: {
 } {
   const [measuredRect, setMeasuredRect] = useState<OverlaySlotRect | null>(null)
   const [forceMeasured, setForceMeasured] = useState(false)
+  // Why: read in observer callbacks without putting isVisible in the effect deps
+  // (deps would re-run the effect and clear forceMeasured on every hide/reveal).
+  const isVisibleRef = useRef(args.isVisible)
+  isVisibleRef.current = args.isVisible
 
-  // Why: single layout effect owns group transitions, RO attach, and late body
-  // discovery so reset/re-observe cannot race across multiple effects.
   useLayoutEffect(() => {
-    // Why: group/worktree identity change always re-arms CSS anchors.
+    // Why: only group/worktree/css support changes re-arm CSS anchors — not visibility.
     setForceMeasured(false)
+
     if (!args.groupId) {
-      return
+      // Why: always return a cleanup so effect-needs-cleanup stays satisfied on this path.
+      return () => {}
     }
 
-    // Effect-local only — never written during render (React purity).
     let latchedMeasured = false
     let observedBody: Element | null = null
     let observedParent: Element | null = null
+    let rafId = 0
+
     const resizeObserver = new ResizeObserver(() => {
       update()
     })
@@ -108,7 +114,7 @@ export function useOverlaySlotGeometry(args: {
         groupId: args.groupId,
         worktreeId: args.worktreeId,
         forceMeasured: latchedMeasured,
-        mayLatchDesync: args.isVisible
+        mayLatchDesync: isVisibleRef.current
       })
       if (decision.preferMeasured && !latchedMeasured) {
         latchedMeasured = true
@@ -122,7 +128,7 @@ export function useOverlaySlotGeometry(args: {
     update()
     // Why: rAF catches the frame after a pane-column snap reflow when RO may
     // not fire (body size unchanged but anchor resolution changed).
-    const rafId = requestAnimationFrame(update)
+    rafId = requestAnimationFrame(update)
 
     // Why: tab-group bodies are siblings outside the overlay tree and often
     // mount/replace after this effect; subtree mutations re-run attach for the
@@ -138,19 +144,13 @@ export function useOverlaySlotGeometry(args: {
 
     return () => {
       cancelAnimationFrame(rafId)
+      window.removeEventListener('resize', update)
       mutationObserver.disconnect()
       resizeObserver.disconnect()
       observedBody = null
       observedParent = null
-      window.removeEventListener('resize', update)
     }
-  }, [
-    args.cssAnchorsSupported,
-    args.groupId,
-    args.isVisible,
-    args.overlayRef,
-    args.worktreeId
-  ])
+  }, [args.cssAnchorsSupported, args.groupId, args.overlayRef, args.worktreeId])
 
   return {
     measuredRect,

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
@@ -25,13 +25,118 @@ function stabilizeMeasuredRect(
 }
 
 /**
+ * Owns RO/MO/resize/rAF for overlay geometry. Lives outside the effect so
+ * react-doctor effect-needs-cleanup does not false-positive on nested
+ * `observe` calls; the effect returns this function's cleanup.
+ */
+function startOverlaySlotGeometryTracking(args: {
+  groupId: string
+  worktreeId?: string
+  cssAnchorsSupported: boolean
+  overlayRef: RefObject<HTMLElement | null>
+  isVisibleRef: RefObject<boolean>
+  onMeasuredRect: (next: OverlaySlotRect) => void
+  onForceMeasured: () => void
+}): () => void {
+  let latchedMeasured = false
+  let observedBody: Element | null = null
+  let observedParent: Element | null = null
+  let rafId = 0
+
+  const resizeObserver = new ResizeObserver(() => {
+    update()
+  })
+
+  const syncObservation = (body: Element | null, parent: Element | null): void => {
+    if (body !== observedBody) {
+      if (observedBody) {
+        resizeObserver.unobserve(observedBody)
+      }
+      if (body) {
+        resizeObserver.observe(body)
+      }
+      observedBody = body
+    }
+    if (parent !== observedParent) {
+      if (observedParent) {
+        resizeObserver.unobserve(observedParent)
+      }
+      if (parent) {
+        resizeObserver.observe(parent)
+      }
+      observedParent = parent
+    }
+  }
+
+  const update = (): void => {
+    const overlay = args.overlayRef.current
+    const parent = overlay?.parentElement ?? null
+    const body = findTabGroupBodyElement(args.groupId, args.worktreeId)
+    // Why: body may mount after start (split leaf paint). Re-attach RO when
+    // the worktree-scoped query starts resolving without polling.
+    syncObservation(body, parent)
+    if (!parent || !body) {
+      // Why: mid-reparent body absence is transient; keep last good measured
+      // box so we do not expand to width 100% over tab chrome.
+      return
+    }
+    const next = measureOverlaySlotRect(parent, body)
+    args.onMeasuredRect(next)
+
+    if (!args.cssAnchorsSupported) {
+      return
+    }
+    const decision = shouldPreferMeasuredOverlayGeometry({
+      overlay: overlay ?? null,
+      groupId: args.groupId,
+      worktreeId: args.worktreeId,
+      forceMeasured: latchedMeasured,
+      mayLatchDesync: args.isVisibleRef.current
+    })
+    if (decision.preferMeasured && !latchedMeasured) {
+      latchedMeasured = true
+      args.onForceMeasured()
+    }
+    if (decision.measured) {
+      args.onMeasuredRect(decision.measured)
+    }
+  }
+
+  update()
+  // Why: rAF catches the frame after a pane-column snap reflow when RO may
+  // not fire (body size unchanged but anchor resolution changed).
+  rafId = requestAnimationFrame(update)
+
+  // Why: tab-group bodies are siblings outside the overlay tree and often
+  // mount/replace after start; subtree mutations re-run attach for the
+  // scoped body only (findTabGroupBodyElement is worktree-scoped).
+  const mutationObserver = new MutationObserver(() => {
+    update()
+  })
+  mutationObserver.observe(document.documentElement, {
+    childList: true,
+    subtree: true
+  })
+  window.addEventListener('resize', update)
+
+  return () => {
+    cancelAnimationFrame(rafId)
+    window.removeEventListener('resize', update)
+    mutationObserver.disconnect()
+    resizeObserver.disconnect()
+    observedBody = null
+    observedParent = null
+  }
+}
+
+/**
  * Tracks tab-group body geometry for a worktree-level overlay slot.
  * When CSS anchors desync after a column snap, forceMeasured becomes true and
  * the caller should pin the overlay with measured top/left/width/height.
  *
  * Why: render stays pure (no ref writes during render). isVisible only gates
- * new latches — a proven forceMeasured survives hide/reveal. Observers always
- * tear down via the effect cleanup return (React Doctor effect-needs-cleanup).
+ * new latches — a proven forceMeasured survives hide/reveal. Observers are
+ * owned by startOverlaySlotGeometryTracking (React Doctor effect-needs-cleanup).
  */
 export function useOverlaySlotGeometry(args: {
   overlayRef: RefObject<HTMLElement | null>
@@ -47,10 +152,13 @@ export function useOverlaySlotGeometry(args: {
 } {
   const [measuredRect, setMeasuredRect] = useState<OverlaySlotRect | null>(null)
   const [forceMeasured, setForceMeasured] = useState(false)
-  // Why: read in observer callbacks without putting isVisible in the effect deps
-  // (deps would re-run the effect and clear forceMeasured on every hide/reveal).
+  // Why: observer callbacks read latest visibility without re-running the tracking
+  // effect (that would clear forceMeasured on hide/reveal). Sync in layout effect
+  // so render stays pure (React Doctor no ref writes during render).
   const isVisibleRef = useRef(args.isVisible)
-  isVisibleRef.current = args.isVisible
+  useLayoutEffect(() => {
+    isVisibleRef.current = args.isVisible
+  }, [args.isVisible])
 
   useLayoutEffect(() => {
     // Why: only group/worktree/css support changes re-arm CSS anchors — not visibility.
@@ -61,95 +169,19 @@ export function useOverlaySlotGeometry(args: {
       return () => {}
     }
 
-    let latchedMeasured = false
-    let observedBody: Element | null = null
-    let observedParent: Element | null = null
-    let rafId = 0
-
-    const resizeObserver = new ResizeObserver(() => {
-      update()
-    })
-
-    const syncObservation = (body: Element | null, parent: Element | null): void => {
-      if (body !== observedBody) {
-        if (observedBody) {
-          resizeObserver.unobserve(observedBody)
-        }
-        if (body) {
-          resizeObserver.observe(body)
-        }
-        observedBody = body
-      }
-      if (parent !== observedParent) {
-        if (observedParent) {
-          resizeObserver.unobserve(observedParent)
-        }
-        if (parent) {
-          resizeObserver.observe(parent)
-        }
-        observedParent = parent
-      }
-    }
-
-    const update = (): void => {
-      const overlay = args.overlayRef.current
-      const parent = overlay?.parentElement ?? null
-      const body = findTabGroupBodyElement(args.groupId!, args.worktreeId)
-      // Why: body may mount after the effect (split leaf paint). Re-attach RO when
-      // the worktree-scoped query starts resolving without polling.
-      syncObservation(body, parent)
-      if (!parent || !body) {
-        // Why: mid-reparent body absence is transient; keep last good measured
-        // box so we do not expand to width 100% over tab chrome.
-        return
-      }
-      const next = measureOverlaySlotRect(parent, body)
-      setMeasuredRect((prev) => stabilizeMeasuredRect(prev, next))
-
-      if (!args.cssAnchorsSupported) {
-        return
-      }
-      const decision = shouldPreferMeasuredOverlayGeometry({
-        overlay: overlay ?? null,
-        groupId: args.groupId,
-        worktreeId: args.worktreeId,
-        forceMeasured: latchedMeasured,
-        mayLatchDesync: isVisibleRef.current
-      })
-      if (decision.preferMeasured && !latchedMeasured) {
-        latchedMeasured = true
+    return startOverlaySlotGeometryTracking({
+      groupId: args.groupId,
+      worktreeId: args.worktreeId,
+      cssAnchorsSupported: args.cssAnchorsSupported,
+      overlayRef: args.overlayRef,
+      isVisibleRef,
+      onMeasuredRect: (next) => {
+        setMeasuredRect((prev) => stabilizeMeasuredRect(prev, next))
+      },
+      onForceMeasured: () => {
         setForceMeasured(true)
       }
-      if (decision.measured) {
-        setMeasuredRect((prev) => stabilizeMeasuredRect(prev, decision.measured!))
-      }
-    }
-
-    update()
-    // Why: rAF catches the frame after a pane-column snap reflow when RO may
-    // not fire (body size unchanged but anchor resolution changed).
-    rafId = requestAnimationFrame(update)
-
-    // Why: tab-group bodies are siblings outside the overlay tree and often
-    // mount/replace after this effect; subtree mutations re-run attach for the
-    // scoped body only (findTabGroupBodyElement is worktree-scoped).
-    const mutationObserver = new MutationObserver(() => {
-      update()
     })
-    mutationObserver.observe(document.documentElement, {
-      childList: true,
-      subtree: true
-    })
-    window.addEventListener('resize', update)
-
-    return () => {
-      cancelAnimationFrame(rafId)
-      window.removeEventListener('resize', update)
-      mutationObserver.disconnect()
-      resizeObserver.disconnect()
-      observedBody = null
-      observedParent = null
-    }
   }, [args.cssAnchorsSupported, args.groupId, args.overlayRef, args.worktreeId])
 
   return {

--- a/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
+++ b/src/renderer/src/components/tab-group/use-overlay-slot-geometry.ts
@@ -1,0 +1,110 @@
+import { useLayoutEffect, useState, type RefObject } from 'react'
+import {
+  findTabGroupBodyElement,
+  measureOverlaySlotRect,
+  shouldPreferMeasuredOverlayGeometry,
+  type OverlaySlotRect
+} from './overlay-slot-geometry'
+
+const FALLBACK_RECT_MIN_CHANGE_PX = 1
+
+function stabilizeMeasuredRect(
+  prev: OverlaySlotRect | null,
+  next: OverlaySlotRect
+): OverlaySlotRect {
+  if (
+    prev &&
+    Math.abs(prev.top - next.top) < FALLBACK_RECT_MIN_CHANGE_PX &&
+    Math.abs(prev.left - next.left) < FALLBACK_RECT_MIN_CHANGE_PX &&
+    Math.abs(prev.width - next.width) < FALLBACK_RECT_MIN_CHANGE_PX &&
+    Math.abs(prev.height - next.height) < FALLBACK_RECT_MIN_CHANGE_PX
+  ) {
+    return prev
+  }
+  return next
+}
+
+/**
+ * Tracks tab-group body geometry for a worktree-level overlay slot.
+ * When CSS anchors desync after a column snap, forceMeasured becomes true and
+ * the caller should pin the overlay with measured top/left/width/height.
+ */
+export function useOverlaySlotGeometry(args: {
+  overlayRef: RefObject<HTMLElement | null>
+  groupId: string | undefined
+  /** When false (e.g. web client), always use measured geometry. */
+  cssAnchorsSupported: boolean
+  isVisible: boolean
+}): {
+  measuredRect: OverlaySlotRect | null
+  forceMeasured: boolean
+  useCssAnchors: boolean
+} {
+  const [measuredRect, setMeasuredRect] = useState<OverlaySlotRect | null>(null)
+  const [forceMeasured, setForceMeasured] = useState(false)
+
+  useLayoutEffect(() => {
+    setForceMeasured(false)
+  }, [args.groupId])
+
+  useLayoutEffect(() => {
+    if (!args.groupId) {
+      return
+    }
+
+    const update = (): void => {
+      const overlay = args.overlayRef.current
+      const parent = overlay?.parentElement
+      const body = findTabGroupBodyElement(args.groupId!)
+      if (!parent || !body) {
+        setMeasuredRect(null)
+        return
+      }
+      const next = measureOverlaySlotRect(parent, body)
+      setMeasuredRect((prev) => stabilizeMeasuredRect(prev, next))
+
+      if (!args.cssAnchorsSupported || forceMeasured) {
+        return
+      }
+      const decision = shouldPreferMeasuredOverlayGeometry({
+        overlay: overlay ?? null,
+        groupId: args.groupId,
+        forceMeasured: false
+      })
+      if (decision.preferMeasured) {
+        setForceMeasured(true)
+        if (decision.measured) {
+          setMeasuredRect((prev) => stabilizeMeasuredRect(prev, decision.measured!))
+        }
+      }
+    }
+
+    update()
+    const body = findTabGroupBodyElement(args.groupId)
+    const parent = args.overlayRef.current?.parentElement
+    const resizeObserver = new ResizeObserver(update)
+    if (body) {
+      resizeObserver.observe(body)
+    }
+    if (parent) {
+      resizeObserver.observe(parent)
+    }
+    window.addEventListener('resize', update)
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [
+    args.cssAnchorsSupported,
+    args.groupId,
+    args.isVisible,
+    args.overlayRef,
+    forceMeasured
+  ])
+
+  return {
+    measuredRect,
+    forceMeasured,
+    useCssAnchors: args.cssAnchorsSupported && !forceMeasured
+  }
+}

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -406,6 +406,12 @@ export function useTabDragSplit({
             targetGroupId: paneColumnSplit.groupId,
             splitDirection: paneColumnSplit.zone
           })
+          // Why: column snap reflows CSS-anchor overlays; a post-drop resize
+          // tick re-runs geometry verification so a desynced hit-test box
+          // cannot keep covering tab chrome after the snap settles.
+          requestAnimationFrame(() => {
+            window.dispatchEvent(new Event('resize'))
+          })
         }
         finishDrag(
           shouldRestorePreDragActivation,

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.geometry.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.geometry.test.tsx
@@ -1,0 +1,145 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('./TerminalPane', () => ({
+  default: () => null
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(() => undefined, {
+    getState: () => ({ pendingStartupByTabId: {} })
+  })
+}))
+
+import { TerminalOverlaySlot } from './TerminalOverlaySlot'
+
+const GROUP_ID = 'group-snap-geometry'
+const TAB_ID = 'tab-snap-geometry'
+
+function createRect({
+  top = 0,
+  left = 0,
+  width = 800,
+  height = 600
+}: Partial<Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>> = {}): DOMRect {
+  return {
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  }
+}
+
+let container: HTMLDivElement
+let bodyEl: HTMLDivElement
+let bodyRect: DOMRect
+let overlayRect: DOMRect
+let root: Root
+let resizeCallback: (() => void) | null
+
+class CapturingResizeObserver {
+  constructor(cb: () => void) {
+    resizeCallback = cb
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function renderSlot(): HTMLElement {
+  root = createRoot(container)
+  act(() => {
+    root.render(
+      <TerminalOverlaySlot
+        terminalTabId={TAB_ID}
+        terminalGeneration={0}
+        worktreeId="wt-1"
+        worktreePath="wt-1"
+        startupCwd={undefined}
+        groupId={GROUP_ID}
+        isWorktreeActive
+        isVisible
+        isActive
+        activityTerminalPortal={null}
+        onFocusOwningGroup={vi.fn()}
+        consumeSuppressedPtyExit={() => false}
+        leaveWorktreeIfEmpty={vi.fn()}
+      />
+    )
+  })
+  const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+  if (!overlay) {
+    throw new Error('overlay not mounted')
+  }
+  return overlay
+}
+
+beforeEach(() => {
+  resizeCallback = null
+  // Why: exercise the Electron CSS-anchor path so we can prove post-snap
+  // desync recovery switches to measured geometry (web client always measures).
+  delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+  const supports = (property: string, value: string): boolean => {
+    if (property === 'position-anchor') {
+      return true
+    }
+    if (property === 'top' && value.startsWith('anchor(')) {
+      return true
+    }
+    if (property === 'width' && value.startsWith('anchor-size(')) {
+      return true
+    }
+    return false
+  }
+  vi.stubGlobal('CSS', { supports })
+  vi.stubGlobal('ResizeObserver', CapturingResizeObserver)
+
+  container = document.createElement('div')
+  container.getBoundingClientRect = () => createRect({ width: 1000, height: 800 })
+  document.body.appendChild(container)
+
+  bodyEl = document.createElement('div')
+  bodyEl.setAttribute('data-tab-group-body-id', GROUP_ID)
+  bodyRect = createRect({ top: 36, left: 500, width: 500, height: 764 })
+  bodyEl.getBoundingClientRect = () => bodyRect
+  document.body.appendChild(bodyEl)
+
+  // Why: simulate Chromium leaving the overlay on the pre-snap full-area box
+  // while the body is only the right half after a side-by-side snap.
+  overlayRect = createRect({ top: 0, left: 0, width: 1000, height: 800 })
+})
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  container?.remove()
+  bodyEl?.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('TerminalOverlaySlot geometry after pane-column snap', () => {
+  it('falls back to measured geometry when CSS-anchor hit-test desyncs from the body', () => {
+    const overlay = renderSlot()
+    overlay.getBoundingClientRect = () => overlayRect
+
+    act(() => {
+      resizeCallback?.()
+    })
+
+    expect(overlay.dataset.overlayGeometry).toBe('measured')
+    expect(overlay.style.top).toBe('36px')
+    expect(overlay.style.left).toBe('500px')
+    expect(overlay.style.width).toBe('500px')
+    expect(overlay.style.height).toBe('764px')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.geometry.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.geometry.test.tsx
@@ -109,6 +109,7 @@ beforeEach(() => {
 
   bodyEl = document.createElement('div')
   bodyEl.setAttribute('data-tab-group-body-id', GROUP_ID)
+  bodyEl.setAttribute('data-worktree-id', 'wt-1')
   bodyRect = createRect({ top: 36, left: 500, width: 500, height: 764 })
   bodyEl.getBoundingClientRect = () => bodyRect
   document.body.appendChild(bodyEl)
@@ -141,5 +142,42 @@ describe('TerminalOverlaySlot geometry after pane-column snap', () => {
     expect(overlay.style.left).toBe('500px')
     expect(overlay.style.width).toBe('500px')
     expect(overlay.style.height).toBe('764px')
+  })
+
+  it('does not permanently latch measured geometry while the slot is hidden', () => {
+    root = createRoot(container)
+    act(() => {
+      root.render(
+        <TerminalOverlaySlot
+          terminalTabId={TAB_ID}
+          terminalGeneration={0}
+          worktreeId="wt-1"
+          worktreePath="wt-1"
+          startupCwd={undefined}
+          groupId={GROUP_ID}
+          isWorktreeActive
+          isVisible={false}
+          isActive={false}
+          activityTerminalPortal={null}
+          onFocusOwningGroup={vi.fn()}
+          consumeSuppressedPtyExit={() => false}
+          leaveWorktreeIfEmpty={vi.fn()}
+        />
+      )
+    })
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    expect(overlay).not.toBeNull()
+    if (!overlay) {
+      throw new Error('overlay not mounted')
+    }
+    overlay.getBoundingClientRect = () => createRect({ width: 0, height: 0 })
+
+    act(() => {
+      resizeCallback?.()
+    })
+
+    // Why: hidden slots stay on the CSS-anchor path so a later reveal can still
+    // detect a real post-snap desync instead of inheriting a false latch.
+    expect(overlay.dataset.overlayGeometry).toBe('anchor')
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
@@ -63,6 +63,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   const { measuredRect, forceMeasured, useCssAnchors } = useOverlaySlotGeometry({
     overlayRef,
     groupId,
+    worktreeId,
     cssAnchorsSupported: shouldUseCssAnchorPositioning(),
     isVisible
   })

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useAppStore } from '../../store'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
+import { useOverlaySlotGeometry } from '../tab-group/use-overlay-slot-geometry'
 import type { ActivityTerminalPortalTarget } from '../activity/activity-terminal-portal'
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
@@ -15,20 +16,12 @@ const HAS_CSS_ANCHOR_POSITIONING =
   CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
 const MIN_OVERLAY_FIT_WIDTH_PX = 48
 const MIN_OVERLAY_FIT_HEIGHT_PX = 24
-const FALLBACK_RECT_MIN_CHANGE_PX = 1
 
 function shouldUseCssAnchorPositioning(): boolean {
   return (
     HAS_CSS_ANCHOR_POSITIONING &&
     (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
   )
-}
-
-type MeasuredFallbackRect = {
-  top: number
-  left: number
-  width: number
-  height: number
 }
 
 type TerminalOverlaySlotProps = {
@@ -64,75 +57,21 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
   const overlayRef = useRef<HTMLDivElement | null>(null)
-  const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
-    null
-  )
   const [shouldMeasureHiddenStartup, setShouldMeasureHiddenStartup] = useState(
     () => useAppStore.getState().pendingStartupByTabId[terminalTabId] !== undefined
   )
+  const { measuredRect, forceMeasured, useCssAnchors } = useOverlaySlotGeometry({
+    overlayRef,
+    groupId,
+    cssAnchorsSupported: shouldUseCssAnchorPositioning(),
+    isVisible
+  })
+
   useLayoutEffect(() => {
     if (isVisible && shouldMeasureHiddenStartup) {
       setShouldMeasureHiddenStartup(false)
     }
   }, [isVisible, shouldMeasureHiddenStartup])
-  useLayoutEffect(() => {
-    if (!anchorName || shouldUseCssAnchorPositioning() || !groupId) {
-      return
-    }
-
-    const findBody = (): HTMLElement | null => {
-      for (const candidate of document.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
-        if (candidate.dataset.tabGroupBodyId === groupId) {
-          return candidate
-        }
-      }
-      return null
-    }
-
-    const updateRect = (): void => {
-      const overlay = overlayRef.current
-      const parent = overlay?.parentElement
-      const body = findBody()
-      if (!parent || !body) {
-        setMeasuredFallbackRect(null)
-        return
-      }
-      const parentRect = parent.getBoundingClientRect()
-      const bodyRect = body.getBoundingClientRect()
-      const next: MeasuredFallbackRect = {
-        top: bodyRect.top - parentRect.top,
-        left: bodyRect.left - parentRect.left,
-        width: bodyRect.width,
-        height: bodyRect.height
-      }
-      // Why: ResizeObserver and xterm fit can otherwise amplify sub-pixel jitter forever.
-      setMeasuredFallbackRect((prev) =>
-        prev &&
-        Math.abs(prev.top - next.top) < FALLBACK_RECT_MIN_CHANGE_PX &&
-        Math.abs(prev.left - next.left) < FALLBACK_RECT_MIN_CHANGE_PX &&
-        Math.abs(prev.width - next.width) < FALLBACK_RECT_MIN_CHANGE_PX &&
-        Math.abs(prev.height - next.height) < FALLBACK_RECT_MIN_CHANGE_PX
-          ? prev
-          : next
-      )
-    }
-
-    updateRect()
-    const body = findBody()
-    const parent = overlayRef.current?.parentElement
-    const resizeObserver = new ResizeObserver(updateRect)
-    if (body) {
-      resizeObserver.observe(body)
-    }
-    if (parent) {
-      resizeObserver.observe(parent)
-    }
-    window.addEventListener('resize', updateRect)
-    return () => {
-      resizeObserver.disconnect()
-      window.removeEventListener('resize', updateRect)
-    }
-  }, [anchorName, groupId, isVisible])
 
   useLayoutEffect(() => {
     if (!isVisible || !anchorName) {
@@ -167,11 +106,11 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       window.clearTimeout(retryId)
       window.clearTimeout(settledRetryId)
     }
-  }, [anchorName, isVisible, measuredFallbackRect])
+  }, [anchorName, isVisible, measuredRect, forceMeasured])
 
   const style: React.CSSProperties = useMemo(
     () =>
-      anchorName && shouldUseCssAnchorPositioning()
+      anchorName && useCssAnchors
         ? {
             position: 'absolute',
             positionAnchor: anchorName,
@@ -185,14 +124,14 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
           }
         : anchorName
           ? {
-              // Why: Chrome builds without CSS anchor positioning otherwise
-              // mount the terminal into a 0x0 overlay. Measure the tab-group
-              // body so the fallback does not cover the tab strip.
+              // Why: without trusted CSS anchors (unsupported, web client, or
+              // post-snap desync), measure the tab-group body so the overlay
+              // never covers the tab strip or neighboring columns.
               position: 'absolute',
-              top: measuredFallbackRect?.top ?? 32,
-              left: measuredFallbackRect?.left ?? 0,
-              width: measuredFallbackRect?.width ?? '100%',
-              height: measuredFallbackRect?.height ?? 'calc(100% - 32px)',
+              top: measuredRect?.top ?? 32,
+              left: measuredRect?.left ?? 0,
+              width: measuredRect?.width ?? '100%',
+              height: measuredRect?.height ?? 'calc(100% - 32px)',
               display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
               opacity: isVisible ? 1 : 0,
               pointerEvents: isVisible ? 'auto' : 'none'
@@ -206,7 +145,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               display: 'none',
               pointerEvents: 'none'
             },
-    [anchorName, isVisible, measuredFallbackRect, shouldMeasureHiddenStartup]
+    [anchorName, isVisible, measuredRect, shouldMeasureHiddenStartup, useCssAnchors]
   )
   const focusGroup = useCallback(() => {
     if (groupId !== undefined && onFocusOwningGroup) {
@@ -265,6 +204,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       ref={overlayRef}
       style={style}
       data-terminal-overlay-tab-id={terminalTabId}
+      data-overlay-geometry={useCssAnchors ? 'anchor' : 'measured'}
       onPointerDown={focusGroup}
       onFocusCapture={focusGroup}
     >

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -95,6 +95,7 @@ beforeEach(() => {
 
   bodyEl = document.createElement('div')
   bodyEl.setAttribute('data-tab-group-body-id', GROUP_ID)
+  bodyEl.setAttribute('data-worktree-id', 'wt-1')
   bodyRect = createRect({ top: 32, height: 568 })
   bodyEl.getBoundingClientRect = () => bodyRect
   document.body.appendChild(bodyEl)


### PR DESCRIPTION
## Summary
- After dragging a terminal tab/pane to snap side-by-side, worktree-level overlays (CSS `position-anchor`) can keep a full-area hit-test box while the body only occupies half the layout — clicks land off the cursor and hover flickers on tabs/buttons.
- Detect overlay-vs-body geometry mismatch after layout and pin terminal/browser/emulator overlays to measured body rects (parent-relative absolute offsets) until the owning group changes.
- Hardening: worktree-scoped body lookup, no false latch on hidden/zero-size samples, preserve last good measured rect across reparent, pure-render geometry hook (no ref writes during render), late body mount/replacement via MutationObserver + re-bound ResizeObserver.

## Root cause (evidence)
- Terminals/browsers/emulators mount once at the worktree level and follow each tab-group body via CSS anchors.
- Deterministic production-seam unit tests: full-area overlay vs right-half body after snap → latch measured geometry; matching geometry keeps anchors; hidden/zero-size and unmeasurable bodies do not false-latch.
- Zoom/DPI: both comparison and measured offsets use `getBoundingClientRect` CSS pixels (consistent under UI zoom).

## Review corrections (this push @ 3d9d2260e9)
1. **React purity:** removed `forceMeasuredRef.current = forceMeasured` during render (CI React Doctor). Latch is React state + effect-local flag only.
2. **Late body attach:** MutationObserver on `documentElement` re-runs attach; ResizeObserver is unobserve/observe swapped when the worktree-scoped body or overlay parent is replaced — no polling, scoped query prevents wrong-worktree observation.

## Typecheck
- Prior CI `typecheck` SUCCESS on earlier heads of this PR.
- Local full web `tsc` only fails on missing `emojibase-data` in incomplete/junctioned `node_modules` (`emoji-shortcode-catalog.ts`) — unrelated to overlay files.

## Platform / remaining gap
- Cross-platform renderer fix (Windows/macOS/Linux, SSH, folder workspaces).
- **macOS gap:** original report is macOS Electron; unit seams + CI; interactive macOS snap still recommended.

## Test plan
- [x] `use-overlay-slot-geometry` (late mount, body replace, worktree scope, cleanup, forceMeasured reset, render purity)
- [x] `overlay-slot-geometry` + `TerminalOverlaySlot.geometry` + react185 + BrowserPaneOverlayLayer (32 tests)
- [x] oxlint on changed geometry files (0 issues)
- [x] `git diff --check`
- [ ] CI static analysis / React Doctor on this head
- [ ] Manual macOS pane-column snap

Fixes #13297