### PR TITLE
fix(worktrees): stop list/ps crashing on corrupt workspace layout paths

### DIFF
--- a/src/main/git/worktree-path-comparison.ts
+++ b/src/main/git/worktree-path-comparison.ts
@@ -21,6 +21,9 @@ export function areWorktreePathsEqual(
 }
 
 function looksLikeWindowsPath(pathValue: string): boolean {
+  if (typeof pathValue !== 'string' || pathValue.length === 0) {
+    return false
+  }
   return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
 }
 

--- a/src/main/ipc/worktree-path-comparison.ts
+++ b/src/main/ipc/worktree-path-comparison.ts
@@ -96,7 +96,8 @@ export function dedupeWorktreesByPath<T extends { path: string }>(
 }
 
 function looksLikePosixAbsolutePath(pathValue: string): boolean {
-  return pathValue.startsWith('/') && !pathValue.startsWith('//')
+  // Why: list/ps path equality must tolerate corrupt/missing path fields without throwing.
+  return typeof pathValue === 'string' && pathValue.startsWith('/') && !pathValue.startsWith('//')
 }
 
 function normalizeWindowsWorktreePathForComparison(pathValue: string): string {

--- a/src/main/persistence/applying-settings/terminal-settings-migrations.test.ts
+++ b/src/main/persistence/applying-settings/terminal-settings-migrations.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { migrateAgentYoloDefaults } from './terminal-settings-migrations'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import {
+  buildWorkspaceDirHistoryForUpdate,
+  migrateAgentYoloDefaults
+} from './terminal-settings-migrations'
+
+function makeSettings(
+  values: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces' | 'workspaceDirHistory'>
+): GlobalSettings {
+  return values as GlobalSettings
+}
 
 describe('migrateAgentYoloDefaults', () => {
   it('keeps newly added agent defaults manual for already migrated profiles', () => {
@@ -11,5 +21,57 @@ describe('migrateAgentYoloDefaults', () => {
 
     expect(migrated.agentDefaultArgs?.droid).toBe('')
     expect(migrated.agentDefaultEnv?.goose).toEqual({})
+  })
+})
+
+describe('buildWorkspaceDirHistoryForUpdate', () => {
+  it('does not normalize or record a corrupt current workspace path', () => {
+    const current = makeSettings({
+      workspaceDir: undefined as unknown as string,
+      nestWorkspaces: false,
+      workspaceDirHistory: [{ path: '/old/workspaces', nestWorkspaces: false }]
+    })
+
+    expect(
+      buildWorkspaceDirHistoryForUpdate(current, {
+        workspaceDir: '/new/workspaces'
+      })
+    ).toBeNull()
+  })
+
+  it('does not record a whitespace-only current workspace path', () => {
+    const current = makeSettings({
+      workspaceDir: '   ',
+      nestWorkspaces: false,
+      workspaceDirHistory: [{ path: '/old/workspaces', nestWorkspaces: false }]
+    })
+
+    expect(
+      buildWorkspaceDirHistoryForUpdate(current, {
+        workspaceDir: '/new/workspaces'
+      })
+    ).toBeNull()
+  })
+
+  it('filters corrupt history before recording the previous valid layout', () => {
+    const current = makeSettings({
+      workspaceDir: '/current/workspaces',
+      nestWorkspaces: false,
+      workspaceDirHistory: [
+        null as never,
+        { path: '', nestWorkspaces: true },
+        { path: 42 as unknown as string, nestWorkspaces: false },
+        { path: '/old/workspaces', nestWorkspaces: true }
+      ]
+    })
+
+    expect(
+      buildWorkspaceDirHistoryForUpdate(current, {
+        workspaceDir: '/new/workspaces'
+      })
+    ).toEqual([
+      { path: '/old/workspaces', nestWorkspaces: true },
+      { path: '/current/workspaces', nestWorkspaces: false }
+    ])
   })
 })

--- a/src/main/persistence/applying-settings/terminal-settings-migrations.ts
+++ b/src/main/persistence/applying-settings/terminal-settings-migrations.ts
@@ -18,6 +18,10 @@ export function buildWorkspaceDirHistoryForUpdate(
   if (!('workspaceDir' in updates) && !('nestWorkspaces' in updates)) {
     return null
   }
+  // Corrupt persisted paths must not enter history and later crash worktree layout classification (#14016).
+  if (typeof current.workspaceDir !== 'string' || current.workspaceDir.trim().length === 0) {
+    return null
+  }
   const nextPath = updates.workspaceDir ?? current.workspaceDir
   const nextNestWorkspaces = updates.nestWorkspaces ?? current.nestWorkspaces
   if (
@@ -32,7 +36,9 @@ export function buildWorkspaceDirHistoryForUpdate(
     path: current.workspaceDir,
     nestWorkspaces: current.nestWorkspaces
   }
-  const existing = current.workspaceDirHistory ?? []
+  const existing = (current.workspaceDirHistory ?? []).filter(
+    (layout) => typeof layout?.path === 'string' && layout.path.trim().length > 0
+  )
   const next = [...existing]
   const previousKey = getWorkspaceLayoutHistoryKey(previousLayout)
   if (!next.some((layout) => getWorkspaceLayoutHistoryKey(layout) === previousKey)) {

--- a/src/shared/cross-platform-path.test.ts
+++ b/src/shared/cross-platform-path.test.ts
@@ -4,12 +4,28 @@ import {
   isCaseInsensitiveRuntimeRoot,
   isPathInsideOrEqual,
   isRuntimePathAbsolute,
+  isWindowsAbsolutePathLike,
   isWslUncPathForCallerLinuxPath,
   isWslUncPathForLinuxMountedPath,
   normalizeRuntimePathForComparison,
   relativePathInsideRoot,
   resolveRuntimePath
 } from './cross-platform-path'
+
+describe('isWindowsAbsolutePathLike', () => {
+  it('classifies drive and UNC roots', () => {
+    expect(isWindowsAbsolutePathLike('D:\\orca\\workspaces')).toBe(true)
+    expect(isWindowsAbsolutePathLike('//server/share/repo')).toBe(true)
+    expect(isWindowsAbsolutePathLike('/home/ada/repo')).toBe(false)
+  })
+
+  it('returns false for non-strings instead of throwing (#14016)', () => {
+    expect(isWindowsAbsolutePathLike(undefined as unknown as string)).toBe(false)
+    expect(isWindowsAbsolutePathLike(null as unknown as string)).toBe(false)
+    expect(isWindowsAbsolutePathLike('')).toBe(false)
+    expect(isRuntimePathAbsolute(undefined as unknown as string)).toBe(false)
+  })
+})
 
 describe('local Windows WSL aliases', () => {
   it('matches UNC aliases and mounted drives without folding Linux path case', () => {

--- a/src/shared/cross-platform-path.ts
+++ b/src/shared/cross-platform-path.ts
@@ -3,6 +3,11 @@ import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from './wsl-paths'
 const SLASH_CHAR_CODE = '/'.charCodeAt(0)
 
 export function isWindowsAbsolutePathLike(value: string): boolean {
+  // Why: persisted settings/history can carry non-strings; callers treat this as a
+  // pure classifier and must not throw (worktree list/ps #14016).
+  if (typeof value !== 'string' || value.length === 0) {
+    return false
+  }
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\') || value.startsWith('//')
 }
 
@@ -138,11 +143,12 @@ export function getLocalWindowsWslPathIdentity(value: string): LocalWindowsWslPa
   }
 }
 
-export function isRuntimePathAbsolute(
-  value: string,
-  pathFlavor: 'posix' | 'windows' = isWindowsPathFlavor(value) ? 'windows' : 'posix'
-): boolean {
-  if (pathFlavor === 'windows') {
+export function isRuntimePathAbsolute(value: string, pathFlavor?: 'posix' | 'windows'): boolean {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false
+  }
+  const flavor = pathFlavor ?? (isWindowsPathFlavor(value) ? 'windows' : 'posix')
+  if (flavor === 'windows') {
     return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\') || value.startsWith('/')
   }
   return value.startsWith('/')
@@ -263,6 +269,9 @@ function trimRuntimePathTrailingSlash(value: string): string {
 }
 
 function isWindowsPathFlavor(value: string): boolean {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false
+  }
   return /^[A-Za-z]:[\\/]/.test(value) || value.includes('\\') || value.startsWith('//')
 }
 

--- a/src/shared/worktree/ownership.test.ts
+++ b/src/shared/worktree/ownership.test.ts
@@ -312,8 +312,10 @@ describe('worktree ownership classification', () => {
 
     const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
     const wslRoot = '//wsl.localhost/Ubuntu/home/dev/orca/workspaces'
-    expect(layouts).toContainEqual({ path: wslRoot, nestWorkspaces: true })
-    expect(layouts).toContainEqual({ path: wslRoot, nestWorkspaces: false })
+    expect(layouts.filter(({ path }) => path === wslRoot)).toEqual([
+      { path: wslRoot, nestWorkspaces: true },
+      { path: wslRoot, nestWorkspaces: false }
+    ])
   })
 
   it('builds known layouts from large workspace history lists', () => {

--- a/src/shared/worktree/ownership.test.ts
+++ b/src/shared/worktree/ownership.test.ts
@@ -268,6 +268,27 @@ describe('worktree ownership classification', () => {
     ).toBe('external')
   })
 
+  it('skips corrupt workspaceDirHistory paths without throwing (#14016)', () => {
+    const repo = makeRepo({ path: 'D:/orca/workspaces/repo' })
+    const settings = makeSettings({
+      workspaceDir: 'D:/orca/workspaces',
+      nestWorkspaces: false,
+      workspaceDirHistory: [
+        { path: undefined as unknown as string, nestWorkspaces: false },
+        { path: null as unknown as string, nestWorkspaces: true },
+        { path: '', nestWorkspaces: false },
+        { path: 'D:/old/workspaces', nestWorkspaces: true }
+      ]
+    })
+
+    expect(() => buildKnownOrcaWorkspaceLayouts(settings, repo)).not.toThrow()
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+    expect(layouts.map((layout) => layout.path)).toContain('D:/old/workspaces')
+    expect(
+      layouts.every((layout) => typeof layout.path === 'string' && layout.path.length > 0)
+    ).toBe(true)
+  })
+
   it('builds known layouts from large workspace history lists', () => {
     const repo = makeRepo()
     const workspaceDirHistory = Array.from(

--- a/src/shared/worktree/ownership.test.ts
+++ b/src/shared/worktree/ownership.test.ts
@@ -274,6 +274,8 @@ describe('worktree ownership classification', () => {
       workspaceDir: 'D:/orca/workspaces',
       nestWorkspaces: false,
       workspaceDirHistory: [
+        null as never,
+        undefined as never,
         { path: undefined as unknown as string, nestWorkspaces: false },
         { path: null as unknown as string, nestWorkspaces: true },
         { path: '', nestWorkspaces: false },
@@ -287,6 +289,31 @@ describe('worktree ownership classification', () => {
     expect(
       layouts.every((layout) => typeof layout.path === 'string' && layout.path.length > 0)
     ).toBe(true)
+  })
+
+  it('keeps valid workspace history when the current workspace path is corrupt (#14016)', () => {
+    const repo = makeRepo()
+    const settings = makeSettings({
+      workspaceDir: undefined as unknown as string,
+      workspaceDirHistory: [{ path: '/old/workspaces', nestWorkspaces: false }]
+    })
+
+    expect(buildKnownOrcaWorkspaceLayouts(settings, repo)).toEqual([
+      { path: '/old/workspaces', nestWorkspaces: false }
+    ])
+  })
+
+  it('ignores corrupt history entries when deriving WSL layout modes (#14016)', () => {
+    const repo = makeRepo({ path: '//wsl.localhost/Ubuntu/home/dev/repo' })
+    const settings = makeSettings({
+      workspaceDir: undefined as unknown as string,
+      workspaceDirHistory: [null as never, { path: '/old/workspaces', nestWorkspaces: false }]
+    })
+
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+    const wslRoot = '//wsl.localhost/Ubuntu/home/dev/orca/workspaces'
+    expect(layouts).toContainEqual({ path: wslRoot, nestWorkspaces: true })
+    expect(layouts).toContainEqual({ path: wslRoot, nestWorkspaces: false })
   })
 
   it('builds known layouts from large workspace history lists', () => {

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -37,30 +37,23 @@ export function buildKnownOrcaWorkspaceLayouts(
   for (const basePath of resolveConfiguredWorktreeBasePaths(repo)) {
     layouts.push({ path: basePath, nestWorkspaces: settings.nestWorkspaces })
   }
-  if (
-    isUsableWorkspaceLayoutPath(settings.workspaceDir) &&
-    shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)
-  ) {
+  if (shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)) {
     layouts.push({
       path: repo
         ? resolveWorkspaceLayoutPath(repo.path, settings.workspaceDir)
         : settings.workspaceDir,
       nestWorkspaces: settings.nestWorkspaces
     })
-    appendWorkspaceLayouts(
-      layouts,
-      (settings.workspaceDirHistory ?? [])
-        .filter(
-          (layout) =>
-            isUsableWorkspaceLayoutPath(layout?.path) &&
-            shouldIncludeWorkspaceLayout(repo, layout.path)
-        )
-        .map((layout) => ({
-          ...layout,
-          path: repo ? resolveWorkspaceLayoutPath(repo.path, layout.path) : layout.path
-        }))
-    )
   }
+  appendWorkspaceLayouts(
+    layouts,
+    (settings.workspaceDirHistory ?? [])
+      .filter((layout) => shouldIncludeWorkspaceLayout(repo, layout?.path))
+      .map((layout) => ({
+        ...layout,
+        path: repo ? resolveWorkspaceLayoutPath(repo.path, layout.path) : layout.path
+      }))
+  )
 
   const wslLayouts = repo ? buildWslWorkspaceLayouts(repo.path, settings) : []
   appendWorkspaceLayouts(layouts, wslLayouts)
@@ -87,15 +80,11 @@ function appendWorkspaceLayouts(
   }
 }
 
-function isUsableWorkspaceLayoutPath(pathValue: unknown): pathValue is string {
-  return typeof pathValue === 'string' && pathValue.trim().length > 0
-}
-
 function shouldIncludeWorkspaceLayout(
   repo: Pick<Repo, 'path' | 'connectionId'> | undefined,
-  layoutPath: string
-): boolean {
-  if (!isUsableWorkspaceLayoutPath(layoutPath)) {
+  layoutPath: unknown
+): layoutPath is string {
+  if (typeof layoutPath !== 'string' || !layoutPath.trim()) {
     return false
   }
   return !repo?.connectionId || !isRuntimePathAbsoluteForRepo(repo.path, layoutPath)
@@ -115,8 +104,8 @@ function buildWslWorkspaceLayouts(
     return []
   }
   const root = `//wsl.localhost/${parsed.distro}${linuxHome}/orca/workspaces`
-  const historicalModes = (settings.workspaceDirHistory ?? []).map(
-    (layout) => layout.nestWorkspaces
+  const historicalModes = (settings.workspaceDirHistory ?? []).flatMap((layout) =>
+    typeof layout?.nestWorkspaces === 'boolean' ? [layout.nestWorkspaces] : []
   )
   const modes = [settings.nestWorkspaces, ...historicalModes]
   return [...new Set(modes)].map((nestWorkspaces) => ({ path: root, nestWorkspaces }))

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -37,7 +37,10 @@ export function buildKnownOrcaWorkspaceLayouts(
   for (const basePath of resolveConfiguredWorktreeBasePaths(repo)) {
     layouts.push({ path: basePath, nestWorkspaces: settings.nestWorkspaces })
   }
-  if (settings.workspaceDir && shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)) {
+  if (
+    isUsableWorkspaceLayoutPath(settings.workspaceDir) &&
+    shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)
+  ) {
     layouts.push({
       path: repo
         ? resolveWorkspaceLayoutPath(repo.path, settings.workspaceDir)
@@ -47,7 +50,11 @@ export function buildKnownOrcaWorkspaceLayouts(
     appendWorkspaceLayouts(
       layouts,
       (settings.workspaceDirHistory ?? [])
-        .filter((layout) => shouldIncludeWorkspaceLayout(repo, layout.path))
+        .filter(
+          (layout) =>
+            isUsableWorkspaceLayoutPath(layout?.path) &&
+            shouldIncludeWorkspaceLayout(repo, layout.path)
+        )
         .map((layout) => ({
           ...layout,
           path: repo ? resolveWorkspaceLayoutPath(repo.path, layout.path) : layout.path
@@ -80,10 +87,17 @@ function appendWorkspaceLayouts(
   }
 }
 
+function isUsableWorkspaceLayoutPath(pathValue: unknown): pathValue is string {
+  return typeof pathValue === 'string' && pathValue.trim().length > 0
+}
+
 function shouldIncludeWorkspaceLayout(
   repo: Pick<Repo, 'path' | 'connectionId'> | undefined,
   layoutPath: string
 ): boolean {
+  if (!isUsableWorkspaceLayoutPath(layoutPath)) {
+    return false
+  }
   return !repo?.connectionId || !isRuntimePathAbsoluteForRepo(repo.path, layoutPath)
 }
 


### PR DESCRIPTION
## Summary

Corrupt or missing saved workspace paths can crash `worktree.list` / `worktree.ps` before returning results. Ignore unusable path entries, preserve valid historical layouts when the current workspace directory is invalid, and avoid adding invalid paths to history.

Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`. The guards now follow the current split path-classification and settings-migration modules, including WSL layout history. No RPC field or shell command changes.

Fixes #14016

## Validation

- Focused path/ownership/migration/fuzz suites: 70 passed.
- Changed-file lint/format, Node and CLI non-composite typechecks, and diff checks passed.
- Built the repository-patched node-pty source and passed the native runtime preflight before the broad run.
- Full Vitest run (Docker-only suite excluded): 76,574 passed, 34 failed, 404 skipped; 1 unhandled error. This is not a green full-suite result.
- All 34 failing test names reproduced on pristine main with the same dependencies. Missing local tags v1.4.184/v1.4.190 caused six failures, two failed suites and the unhandled rejection; after fetching those tags, all 23 tests in the three affected cross-version suites passed. The other 28 failures remain reproduced baseline failures. The entire full suite was not repeated after the tag repair.
- Cursor reviewed the exact candidate. Codex independently checked the source, ran the broad suite, and compared its failures with pristine main before publication.
- Default composite typecheck (known baseline TS2883), full build and live Windows/SSH/UI smoke were not run. No Docker was run.
