### PR TITLE
fix(browser): disable unsupported FedCM

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -119,6 +119,7 @@ import {
   configureElectronNetworkCompatibility,
   configureDevUserDataPath,
   configureOrcaUserDataPathEnv,
+  disableUnsupportedChromiumFeatures,
   enableMainProcessGpuFeatures,
   installDevParentDisconnectQuit,
   installDevParentSignalQuit,
@@ -846,6 +847,7 @@ if (hasSingleInstanceLock) {
     platform: process.platform,
     ...getMainProcessLifecycleIdentity()
   })
+  disableUnsupportedChromiumFeatures()
   configureElectronNetworkCompatibility()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -396,6 +396,46 @@ describe('configureElectronNetworkCompatibility', () => {
   })
 })
 
+describe('disableUnsupportedChromiumFeatures', () => {
+  it('disables FedCM before Chromium sessions are created', async () => {
+    const { app } = await import('electron')
+    const { disableUnsupportedChromiumFeatures } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    disableUnsupportedChromiumFeatures()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('disable-features', 'FedCm')
+  })
+
+  it('preserves existing disabled Chromium features', async () => {
+    const { app } = await import('electron')
+    const { disableUnsupportedChromiumFeatures } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.getSwitchValue).mockReturnValueOnce('ExistingFeature')
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    disableUnsupportedChromiumFeatures()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'disable-features',
+      'FedCm,ExistingFeature'
+    )
+  })
+
+  it('does not duplicate FedCM when disable-features already includes it', async () => {
+    const { app } = await import('electron')
+    const { disableUnsupportedChromiumFeatures } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.getSwitchValue).mockReturnValueOnce('FedCm,ExistingFeature')
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    disableUnsupportedChromiumFeatures()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'disable-features',
+      'FedCm,ExistingFeature'
+    )
+  })
+})
+
 describe('enableMainProcessGpuFeatures', () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   const originalE2EUserDataDir = process.env.ORCA_E2E_USER_DATA_DIR

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -66,6 +66,20 @@ export function configureElectronNetworkCompatibility(
   app.commandLine.appendSwitch('disable-http2')
 }
 
+export function disableUnsupportedChromiumFeatures(): void {
+  appendDisabledChromiumFeatures(['FedCm'])
+}
+
+function appendDisabledChromiumFeatures(features: string[]): void {
+  const existingFeatures = app.commandLine
+    .getSwitchValue('disable-features')
+    .split(',')
+    .map((feature) => feature.trim())
+    .filter(Boolean)
+  const disabledFeatures = Array.from(new Set([...features, ...existingFeatures])).join(',')
+  app.commandLine.appendSwitch('disable-features', disabledFeatures)
+}
+
 function getProcessPathDelimiter(): string {
   return process.platform === 'win32' ? ';' : ':'
 }
@@ -300,11 +314,7 @@ export function enableMainProcessGpuFeatures(): void {
     app.commandLine.appendSwitch('enable-features', features)
   }
 
-  const existingDisabledFeatures = app.commandLine.getSwitchValue('disable-features')
   // Why: IntensiveWakeUpThrottling clamps hidden-page timers to 1/min after 5min, delaying agent-done/bell notifications ~60s.
   // This opt-out is skipped under GPU fallback (win32-only today); if throttling ever reaches Windows it must move out of this path.
-  const disabledFeatures = ['IntensiveWakeUpThrottling', existingDisabledFeatures]
-    .filter(Boolean)
-    .join(',')
-  app.commandLine.appendSwitch('disable-features', disabledFeatures)
+  appendDisabledChromiumFeatures(['IntensiveWakeUpThrottling'])
 }

--- a/tests/e2e/browser-fedcm-fallback.spec.ts
+++ b/tests/e2e/browser-fedcm-fallback.spec.ts
@@ -1,0 +1,139 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, getActiveWorktreeId } from './helpers/store'
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+async function startFedCmFallbackServer(): Promise<{
+  url: string
+  close: () => Promise<void>
+}> {
+  const server = createServer((request, response) => {
+    const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    const pathname = new URL(request.url ?? '/', origin).pathname
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    if (pathname === '/popup') {
+      response.end(
+        '<!doctype html><html><head><title>Popup fallback</title></head><body>Popup fallback<script>window.opener?.postMessage("popup-opener-live", window.location.origin)</script></body></html>'
+      )
+      return
+    }
+    response.end(`
+      <!doctype html>
+      <html>
+        <head><title>FedCM fallback oracle</title></head>
+        <body>
+          <output id="capabilities"></output>
+          <button id="sign-in">Sign in</button>
+          <output id="path">pending</output>
+          <script>
+            const hasIdentityCredential = 'IdentityCredential' in window
+            const hasIdentityProvider = 'IdentityProvider' in window
+            window.popupMessages = []
+            window.addEventListener('message', (event) => {
+              window.popupMessages.push(event.data)
+            })
+            document.querySelector('#capabilities').textContent = JSON.stringify({
+              hasIdentityCredential,
+              hasIdentityProvider
+            })
+            document.querySelector('#sign-in').addEventListener('click', () => {
+              if (hasIdentityCredential && hasIdentityProvider) {
+                document.querySelector('#path').textContent = 'fedcm-selected'
+                return
+              }
+              const popup = window.open('/popup', 'google-auth', 'width=480,height=640')
+              document.querySelector('#path').textContent = popup ? 'popup-live' : 'popup-blocked'
+            })
+          </script>
+        </body>
+      </html>
+    `)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return { url: `http://127.0.0.1:${port}/`, close: () => closeServer(server) }
+}
+
+test('embedded browser omits unusable FedCM and reaches the popup fallback', async ({
+  electronApp,
+  orcaPage
+}) => {
+  const server = await startFedCmFallbackServer()
+  try {
+    await ensureTerminalVisible(orcaPage)
+    const worktreeId = await getActiveWorktreeId(orcaPage)
+    expect(worktreeId).not.toBeNull()
+    const browserTabId = await orcaPage.evaluate(
+      ({ targetWorktreeId, url }) => {
+        const tab = window.__store!.getState().createBrowserTab(targetWorktreeId!, url, {
+          title: 'FedCM fallback oracle',
+          activate: true
+        })
+        return tab.id
+      },
+      { targetWorktreeId: worktreeId, url: server.url }
+    )
+    const readGuest = async <T>(expression: string): Promise<T> =>
+      orcaPage.evaluate(
+        async ({ targetBrowserTabId, script }) => {
+          const slot = document.querySelector(
+            `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+          )
+          const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+          if (!webview) {
+            throw new Error(`Missing webview for browser tab ${targetBrowserTabId}`)
+          }
+          return (await webview.executeJavaScript(script)) as T
+        },
+        { targetBrowserTabId: browserTabId, script: expression }
+      )
+
+    await expect
+      .poll(() => readGuest<string>('document.title'), { timeout: 10_000 })
+      .toBe('FedCM fallback oracle')
+    const capabilities = await readGuest<{
+      hasIdentityCredential: boolean
+      hasIdentityProvider: boolean
+    }>('JSON.parse(document.querySelector("#capabilities").textContent)')
+    expect.soft(capabilities).toEqual({
+      hasIdentityCredential: false,
+      hasIdentityProvider: false
+    })
+
+    await readGuest<void>('document.querySelector("#sign-in").click()')
+    const path = await readGuest<string>('document.querySelector("#path").textContent')
+    expect.soft(path).toBe('popup-live')
+    await expect
+      .poll(() =>
+        electronApp.evaluate(async ({ webContents }) => {
+          const popup = webContents.getAllWebContents().find((contents) => {
+            return contents.getURL().endsWith('/popup')
+          })
+          if (!popup) {
+            return null
+          }
+          return {
+            openerLive: await popup.executeJavaScript('Boolean(window.opener)'),
+            title: await popup.executeJavaScript('document.title'),
+            url: popup.getURL()
+          }
+        })
+      )
+      .toEqual({
+        openerLive: true,
+        title: 'Popup fallback',
+        url: `${server.url}popup`
+      })
+    await expect
+      .poll(() => readGuest<string[]>('window.popupMessages'))
+      .toEqual(['popup-opener-live'])
+  } finally {
+    await server.close()
+  }
+})


### PR DESCRIPTION
## ELI5

Orca's embedded browser claimed it could use Google's newer FedCM sign-in even though Electron could not finish that flow. Google therefore skipped the working popup route; Orca now truthfully hides that unsupported capability so Google uses its popup fallback.

## What Changed

- Disable Chromium's `FedCm` feature process-wide before sessions or WebContents are created.
- Preserve and deduplicate existing `disable-features` values, including the existing `IntensiveWakeUpThrottling` opt-out.
- Add focused unit coverage for switch composition and a real Electron webview E2E oracle for capability exposure, popup creation, opener connectivity, and messaging.

## Why

Electron exposed `IdentityCredential` and `IdentityProvider`, so legacy Google `gapi.auth2` selected FedCM; the token request then failed and no popup was attempted. Capability exposure is Chromium-owned process state, so early main-process configuration is the authoritative boundary.

A renderer property-deletion shim was rejected because it is frame- and timing-dependent and cannot cover every guest, popup, or offscreen page authoritatively. Permission/session blocking was rejected because it still advertises FedCM, which is the signal that diverts gapi into the broken path.

## Linked Issue

Fixes #12854

## Visual Proof

Candidate full Orca view showing both FedCM capability flags false and the popup fallback path:

![Orca FedCM fallback oracle](https://github.com/user-attachments/assets/bb655bda-c4bd-4732-adfc-2c7687708f0b)

Visible popup fallback:

![Popup fallback](https://github.com/user-attachments/assets/2843c17f-8e5c-40df-8fc4-a7d372e648a2)

The production UI is unchanged; these images show the preserved popup interaction and backing oracle state.

## Testing

Final merge base: `09ec516ae50b7b83fa65343d9ad96159e3fe71fc`

Exact oracle command, unchanged across runs:

```bash
pnpm exec electron-vite build --mode e2e
SKIP_BUILD=1 pnpm exec playwright test tests/e2e/browser-fedcm-fallback.spec.ts \
  --config tests/playwright.config.ts --project electron-headless --workers=1
```

- Affected final main / candidate with the startup call disabled: **RED**. Both constructors were present, the page selected `fedcm-selected`, and no popup WebContents appeared; three independent assertions failed.
- Candidate `6422233186`: **GREEN**, `1 passed`. Both constructors were absent, the page selected `popup-live`, the popup URL/title and live `window.opener` were verified, and the popup delivered `postMessage` to its opener.
- Candidate with only `disableUnsupportedChromiumFeatures()` reverted/disabled on the final merge base: **RED** with the same failures; restoring the exact reviewed source returned **GREEN**, `1 passed`.

Local validation on macOS:

- `pnpm run typecheck:node`
- `pnpm exec vitest run src/main/startup/configure-process.test.ts src/main/browser/browser-manager.test.ts src/main/browser/popup-origin-bar-window.test.ts` — 121 passed
- targeted `oxlint --deny-warnings`
- targeted `oxfmt --check`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`
- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Real Electron/CDP validation used an isolated profile and free ports. The full view and popup were visibly checked; CDP independently verified URL/title, `window.opener !== null`, and opener `postMessage`. Only worker-launched processes were cleaned up. A live Google credential/client-ID exchange was not run because no credential was available.

## AI Disclosure

OpenAI Codex assisted with reproduction, implementation, testing, and review under human-directed issue ownership.

## Review

Fresh architecture/platform/readiness and performance/resource/test-reliability review rounds were clean. Security/UX validation was proportional because there is no UI source change; existing popup security suites and the real popup/opener oracle passed. Elegance review found each hunk necessary and the centralized switch-merging helper the smallest durable implementation.

The switch is startup-only and applies consistently to macOS, Linux, and Windows. It changes no RPC/wire format, Git/provider behavior, SSH, WSL, folder-workspace, worktree, mobile, or paired-runtime contract. Linux E2E GPU fallback remains intact, and the implementation adds no renderer hot path, timers, listeners, polling, or persistent resources.

This PR addresses only #12854. It does not merge or close the distinct popup/session issues #7374, #8718, #12718, #6268, #8416, or the completed/reverted work in #7392, #8343, #8659, and #8332.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted local equivalents passed; full CI covers the complete matrix)

## Author

- Jinwoo Hong
