### PR TITLE
feat(worktrees): automatically close merged workspaces

### DIFF
--- a/src/main/git/worktree-branch-merge-state-real-git.test.ts
+++ b/src/main/git/worktree-branch-merge-state-real-git.test.ts
@@ -1,0 +1,98 @@
+// Real-binary coverage: auto-close hinges on Git agreeing a branch landed, and a mocked runner
+// cannot prove the squash-merge path (patch-id + merge-tree) reaches the same verdict.
+import { execFile } from 'node:child_process'
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  hasWorktreeBranchUpstreamConfigured,
+  isWorktreeBranchMergedIntoBase
+} from './worktree-branch-merge-state'
+
+const execFileAsync = promisify(execFile)
+
+let repoPath = ''
+
+async function git(args: string[], cwd = repoPath): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd })
+  return stdout
+}
+
+async function commit(fileName: string, contents: string): Promise<void> {
+  await writeFile(join(repoPath, fileName), contents)
+  await git(['add', '-A'])
+  await git(['commit', '-qm', `add ${fileName}`])
+}
+
+beforeEach(async () => {
+  repoPath = await realpath(await mkdtemp(join(tmpdir(), 'orca-branch-merge-state-')))
+  await git(['init', '-q'])
+  // symbolic-ref rather than `init -b`: the latter needs Git 2.28, above the supported floor.
+  await git(['symbolic-ref', 'HEAD', 'refs/heads/main'])
+  await git(['config', 'user.email', 'merge-state@example.invalid'])
+  await git(['config', 'user.name', 'Merge State'])
+  await commit('seed.txt', 'seed\n')
+})
+
+afterEach(async () => {
+  await rm(repoPath, { recursive: true, force: true })
+})
+
+describe('isWorktreeBranchMergedIntoBase', () => {
+  it('reports a fast-forward-merged branch as merged', async () => {
+    await git(['checkout', '-q', '-b', 'feature'])
+    await commit('feature.txt', 'feature\n')
+    await git(['checkout', '-q', 'main'])
+    await git(['merge', '-q', '--no-ff', '-m', 'merge feature', 'feature'])
+
+    await expect(isWorktreeBranchMergedIntoBase(repoPath, 'feature')).resolves.toBe(true)
+  })
+
+  it('reports a squash-merged branch as merged even though its commits are rewritten', async () => {
+    await git(['checkout', '-q', '-b', 'squashed'])
+    await commit('one.txt', 'one\n')
+    await commit('two.txt', 'two\n')
+    await git(['checkout', '-q', 'main'])
+    await git(['merge', '-q', '--squash', 'squashed'])
+    await git(['commit', '-qm', 'squash squashed'])
+
+    await expect(isWorktreeBranchMergedIntoBase(repoPath, 'squashed')).resolves.toBe(true)
+  })
+
+  it('reports an unmerged branch as unmerged', async () => {
+    await git(['checkout', '-q', '-b', 'pending'])
+    await commit('pending.txt', 'pending\n')
+    await git(['checkout', '-q', 'main'])
+
+    await expect(isWorktreeBranchMergedIntoBase(repoPath, 'pending')).resolves.toBe(false)
+  })
+
+  it('resolves null for a branch Git does not know', async () => {
+    await expect(isWorktreeBranchMergedIntoBase(repoPath, 'missing')).resolves.toBe(false)
+    await expect(isWorktreeBranchMergedIntoBase(repoPath, '')).resolves.toBeNull()
+  })
+})
+
+describe('hasWorktreeBranchUpstreamConfigured', () => {
+  it('is false for a local-only branch and true once an upstream is configured', async () => {
+    await git(['checkout', '-q', '-b', 'local-only'])
+
+    await expect(hasWorktreeBranchUpstreamConfigured(repoPath, 'local-only')).resolves.toBe(false)
+
+    await git(['config', 'branch.local-only.remote', 'origin'])
+    await git(['config', 'branch.local-only.merge', 'refs/heads/local-only'])
+
+    await expect(hasWorktreeBranchUpstreamConfigured(repoPath, 'local-only')).resolves.toBe(true)
+  })
+
+  it('stays true after the remote branch itself is gone, which is the post-merge state', async () => {
+    await git(['checkout', '-q', '-b', 'landed'])
+    await git(['config', 'branch.landed.remote', 'origin'])
+    await git(['config', 'branch.landed.merge', 'refs/heads/landed'])
+
+    // No refs/remotes/origin/landed exists here — exactly what a merged-and-pruned PR leaves behind.
+    await expect(hasWorktreeBranchUpstreamConfigured(repoPath, 'landed')).resolves.toBe(true)
+  })
+})

--- a/src/main/git/worktree-branch-merge-state-real-git.test.ts
+++ b/src/main/git/worktree-branch-merge-state-real-git.test.ts
@@ -69,7 +69,7 @@ describe('isWorktreeBranchMergedIntoBase', () => {
     await expect(isWorktreeBranchMergedIntoBase(repoPath, 'pending')).resolves.toBe(false)
   })
 
-  it('resolves null for a branch Git does not know', async () => {
+  it('reports an unknown branch as unmerged and a detached HEAD as unprovable', async () => {
     await expect(isWorktreeBranchMergedIntoBase(repoPath, 'missing')).resolves.toBe(false)
     await expect(isWorktreeBranchMergedIntoBase(repoPath, '')).resolves.toBeNull()
   })

--- a/src/main/git/worktree-branch-merge-state.ts
+++ b/src/main/git/worktree-branch-merge-state.ts
@@ -11,6 +11,11 @@ export type WorktreeBranchMergeStateOptions = {
   timeout?: number
 }
 
+/**
+ * A `git` runner in the repo's own checkout, shaped for the shared branch-cleanup
+ * helpers. The `stdin` hook is what lets those helpers pipe a diff into
+ * `patch-id`, which is how a squash merge is proven.
+ */
 function createBranchCleanupExec(repoPath: string, options: WorktreeBranchMergeStateOptions) {
   return (argv: string[], execOptions?: { stdin?: string }) =>
     gitExecFileAsync(argv, {

--- a/src/main/git/worktree-branch-merge-state.ts
+++ b/src/main/git/worktree-branch-merge-state.ts
@@ -1,0 +1,88 @@
+import {
+  branchHasNoUnmergedChangesOnAnyTarget,
+  getBranchCleanupTargetRefs
+} from '../../shared/git-branch-cleanup'
+import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
+import { gitExecFileAsync } from './runner'
+
+export type WorktreeBranchMergeStateOptions = {
+  wslDistro?: string
+  signal?: AbortSignal
+  timeout?: number
+}
+
+function createBranchCleanupExec(repoPath: string, options: WorktreeBranchMergeStateOptions) {
+  return (argv: string[], execOptions?: { stdin?: string }) =>
+    gitExecFileAsync(argv, {
+      cwd: repoPath,
+      ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
+      ...(options.signal ? { signal: options.signal } : {}),
+      ...(options.timeout ? { timeout: options.timeout } : {}),
+      ...(execOptions?.stdin !== undefined ? { stdin: execOptions.stdin } : {})
+    })
+}
+
+/**
+ * Whether the branch's changes are already contained in one of the repo's
+ * cleanup targets (`branch.<name>.base`, `origin/HEAD`, or the primary
+ * checkout's HEAD). Resolves to null when Git could not prove it either way.
+ *
+ * Unlike the post-delete branch cleanup this never fetches: a background sweep
+ * must not reach the network, so a branch whose base ref is stale locally is
+ * reported unmerged until the next refresh.
+ */
+export async function isWorktreeBranchMergedIntoBase(
+  repoPath: string,
+  branchName: string,
+  options: WorktreeBranchMergeStateOptions = {}
+): Promise<boolean | null> {
+  if (!branchName) {
+    return null
+  }
+  const runGit = createBranchCleanupExec(repoPath, options)
+  try {
+    const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
+    return await withLocalGitCapabilityCacheForExecution(
+      {
+        cwd: repoPath,
+        ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
+        ...(options.signal ? { signal: options.signal } : {})
+      },
+      (capabilities) =>
+        branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs, capabilities)
+    )
+  } catch (error) {
+    console.warn(`[git] Failed to read merge state for branch "${branchName}"`, error)
+    return null
+  }
+}
+
+/**
+ * Whether the branch has an upstream configured. Read from config rather than
+ * the remote-tracking ref because merging a PR usually deletes the remote
+ * branch, and that must not read as "never published".
+ */
+export async function hasWorktreeBranchUpstreamConfigured(
+  repoPath: string,
+  branchName: string,
+  options: WorktreeBranchMergeStateOptions = {}
+): Promise<boolean | null> {
+  if (!branchName) {
+    return null
+  }
+  const runGit = createBranchCleanupExec(repoPath, options)
+  try {
+    // `--default` (Git 2.18) keeps a missing key an exit-0 answer instead of an error.
+    const { stdout } = await runGit([
+      'config',
+      '--get',
+      '--default',
+      '',
+      `branch.${branchName}.remote`
+    ])
+    return stdout.trim().length > 0
+  } catch (error) {
+    console.warn(`[git] Failed to read upstream config for branch "${branchName}"`, error)
+    return null
+  }
+}

--- a/src/main/ipc/merged-worktree-auto-close-scan.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
-import type { GitWorktreeInfo, Repo } from '../../shared/types'
-import { MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS } from '../../shared/merged-worktree-auto-close'
+import type { GitWorktreeInfo, GlobalSettings, Repo } from '../../shared/types'
+import { DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS } from '../../shared/merged-worktree-auto-close'
 
 const {
   listRepoWorktreesMock,
@@ -36,7 +36,7 @@ vi.mock('../git/worktree-branch-merge-state', () => ({
 import { scanMergedWorktreeAutoCloseCandidates } from './merged-worktree-auto-close-scan'
 
 const NOW = 1_800_000_000_000
-const CREATED_AT = NOW - MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS - 1
+const CREATED_AT = NOW - DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS - 1
 
 const REPO: Repo = {
   id: 'repo-1',
@@ -57,10 +57,13 @@ function gitWorktree(overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo 
   }
 }
 
-function createStore(overrides: Partial<Store> = {}): Store {
+function createStore(
+  settings: Partial<GlobalSettings> = {},
+  createdAt: number = CREATED_AT
+): Store {
   return {
-    getWorktreeMeta: () => ({ createdAt: CREATED_AT }),
-    ...overrides
+    getWorktreeMeta: () => ({ createdAt }),
+    getSettings: () => settings as GlobalSettings
   } as unknown as Store
 }
 
@@ -147,6 +150,30 @@ describe('scanMergedWorktreeAutoCloseCandidates', () => {
     await expect(
       scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
     ).resolves.toEqual([])
+  })
+
+  it('keeps a just-created workspace when the profile configured no grace window', async () => {
+    const store = createStore({}, NOW)
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(store, REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'recently-created' })
+  })
+
+  it('closes a just-created workspace once the profile sets the grace window to zero', async () => {
+    const store = createStore({ autoCloseMergedWorktreesGraceMinutes: 0 }, NOW)
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(store, REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'close' })
+  })
+
+  it('keeps a workspace younger than the grace window the profile configured', async () => {
+    const store = createStore({ autoCloseMergedWorktreesGraceMinutes: 30 }, NOW - 29 * 60_000)
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(store, REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'recently-created' })
   })
 
   it('passes the project WSL distro to the merge probe', async () => {

--- a/src/main/ipc/merged-worktree-auto-close-scan.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type { GitWorktreeInfo, Repo } from '../../shared/types'
+import { MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS } from '../../shared/merged-worktree-auto-close'
+
+const {
+  listRepoWorktreesMock,
+  getLocalProjectWorktreeGitOptionsMock,
+  getStatusMock,
+  isWorktreeBranchMergedIntoBaseMock,
+  hasWorktreeBranchUpstreamConfiguredMock
+} = vi.hoisted(() => ({
+  listRepoWorktreesMock: vi.fn(),
+  getLocalProjectWorktreeGitOptionsMock: vi.fn(),
+  getStatusMock: vi.fn(),
+  isWorktreeBranchMergedIntoBaseMock: vi.fn(),
+  hasWorktreeBranchUpstreamConfiguredMock: vi.fn()
+}))
+
+vi.mock('../repo-worktrees', () => ({
+  createFolderWorktree: vi.fn(),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: getLocalProjectWorktreeGitOptionsMock
+}))
+
+vi.mock('../git/status', () => ({ getStatus: getStatusMock }))
+
+vi.mock('../git/worktree-branch-merge-state', () => ({
+  isWorktreeBranchMergedIntoBase: isWorktreeBranchMergedIntoBaseMock,
+  hasWorktreeBranchUpstreamConfigured: hasWorktreeBranchUpstreamConfiguredMock
+}))
+
+import { scanMergedWorktreeAutoCloseCandidates } from './merged-worktree-auto-close-scan'
+
+const NOW = 1_800_000_000_000
+const CREATED_AT = NOW - MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS - 1
+
+const REPO: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
+function gitWorktree(overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo {
+  return {
+    path: '/workspaces/feature',
+    head: 'aaaaaaa',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    ...overrides
+  }
+}
+
+function createStore(overrides: Partial<Store> = {}): Store {
+  return {
+    getWorktreeMeta: () => ({ createdAt: CREATED_AT }),
+    ...overrides
+  } as unknown as Store
+}
+
+beforeEach(() => {
+  listRepoWorktreesMock.mockReset().mockResolvedValue([gitWorktree()])
+  getLocalProjectWorktreeGitOptionsMock.mockReset().mockReturnValue({})
+  getStatusMock.mockReset().mockResolvedValue({ entries: [] })
+  isWorktreeBranchMergedIntoBaseMock.mockReset().mockResolvedValue(true)
+  hasWorktreeBranchUpstreamConfiguredMock.mockReset().mockResolvedValue(true)
+})
+
+describe('scanMergedWorktreeAutoCloseCandidates', () => {
+  it('closes a merged, clean, published workspace', async () => {
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+
+    expect(decisions).toEqual([
+      {
+        worktreeId: 'repo-1::/workspaces/feature',
+        repoId: 'repo-1',
+        path: '/workspaces/feature',
+        branch: 'feature',
+        action: 'close'
+      }
+    ])
+    expect(isWorktreeBranchMergedIntoBaseMock).toHaveBeenCalledWith(
+      '/repo',
+      'feature',
+      expect.objectContaining({ timeout: expect.any(Number) })
+    )
+  })
+
+  it('keeps an unmerged workspace and never reads its status', async () => {
+    isWorktreeBranchMergedIntoBaseMock.mockResolvedValue(false)
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'not-merged' })
+    expect(getStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a merged workspace with uncommitted changes', async () => {
+    getStatusMock.mockResolvedValue({ entries: [{ path: 'src/a.ts' }] })
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'dirty-files' })
+  })
+
+  it('never probes Git for the primary checkout', async () => {
+    listRepoWorktreesMock.mockResolvedValue([
+      gitWorktree({ path: '/repo', branch: 'refs/heads/main', isMainWorktree: true })
+    ])
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'main-worktree' })
+    expect(hasWorktreeBranchUpstreamConfiguredMock).not.toHaveBeenCalled()
+    expect(isWorktreeBranchMergedIntoBaseMock).not.toHaveBeenCalled()
+    expect(getStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a workspace whose status could not be read', async () => {
+    getStatusMock.mockRejectedValue(new Error('git status exploded'))
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'status-check-failed' })
+  })
+
+  it('skips SSH-backed repos entirely', async () => {
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(
+      createStore(),
+      { ...REPO, connectionId: 'ssh-1' },
+      { now: NOW }
+    )
+
+    expect(decisions).toEqual([])
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('returns no decisions when the worktree list fails', async () => {
+    listRepoWorktreesMock.mockRejectedValue(new Error('git worktree list exploded'))
+
+    await expect(
+      scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+    ).resolves.toEqual([])
+  })
+
+  it('passes the project WSL distro to the merge probe', async () => {
+    getLocalProjectWorktreeGitOptionsMock.mockReturnValue({ wslDistro: 'Ubuntu' })
+
+    await scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+
+    expect(hasWorktreeBranchUpstreamConfiguredMock).toHaveBeenCalledWith(
+      '/repo',
+      'feature',
+      expect.objectContaining({ wslDistro: 'Ubuntu' })
+    )
+  })
+})

--- a/src/main/ipc/merged-worktree-auto-close-scan.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.test.ts
@@ -38,7 +38,10 @@ vi.mock('../git/worktree-branch-merge-state', () => ({
   hasWorktreeBranchUpstreamConfigured: hasWorktreeBranchUpstreamConfiguredMock
 }))
 
-import { scanMergedWorktreeAutoCloseCandidates } from './merged-worktree-auto-close-scan'
+import {
+  MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS,
+  scanMergedWorktreeAutoCloseCandidates
+} from './merged-worktree-auto-close-scan'
 
 const NOW = 1_800_000_000_000
 const CREATED_AT = NOW - DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS - 1
@@ -70,6 +73,14 @@ function createStore(
   return {
     getWorktreeMeta: () => ({ createdAt, ...meta }),
     getSettings: () => settings as GlobalSettings
+  } as unknown as Store
+}
+
+/** A workspace found on disk gets metadata with no recorded creation time. */
+function createStoreWithUnknownCreationTime(): Store {
+  return {
+    getWorktreeMeta: () => ({}),
+    getSettings: () => ({}) as GlobalSettings
   } as unknown as Store
 }
 
@@ -188,6 +199,35 @@ describe('scanMergedWorktreeAutoCloseCandidates', () => {
     await expect(
       scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
     ).resolves.toEqual([])
+  })
+
+  it('keeps a workspace whose creation time the metadata never recorded', async () => {
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(
+      createStoreWithUnknownCreationTime(),
+      REPO,
+      { now: NOW }
+    )
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'recently-created' })
+    expect(getStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('gives up on a status read that never settles', async () => {
+    // Why: an unbounded read holds the repo's in-flight sweep slot forever, which
+    // blocks every later sweep for that repo.
+    vi.useFakeTimers()
+    try {
+      getStatusMock.mockReturnValue(new Promise(() => {}))
+
+      const pending = scanMergedWorktreeAutoCloseCandidates(createStore(), REPO, { now: NOW })
+      await vi.advanceTimersByTimeAsync(MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS)
+
+      await expect(pending).resolves.toMatchObject([
+        { action: 'skip', reason: 'status-check-failed' }
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps a just-created workspace when the profile configured no grace window', async () => {

--- a/src/main/ipc/merged-worktree-auto-close-scan.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.test.ts
@@ -76,7 +76,7 @@ function createStore(
   } as unknown as Store
 }
 
-/** A workspace found on disk gets metadata with no recorded creation time. */
+// A workspace found on disk gets metadata with no recorded creation time.
 function createStoreWithUnknownCreationTime(): Store {
   return {
     getWorktreeMeta: () => ({}),

--- a/src/main/ipc/merged-worktree-auto-close-scan.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
-import type { GitWorktreeInfo, GlobalSettings, Repo } from '../../shared/types'
+import type { GitWorktreeInfo, GlobalSettings, Repo, WorktreeMeta } from '../../shared/types'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  toRuntimeExecutionHostId,
+  toSshExecutionHostId
+} from '../../shared/execution-host'
 import { DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS } from '../../shared/merged-worktree-auto-close'
 
 const {
@@ -59,10 +64,11 @@ function gitWorktree(overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo 
 
 function createStore(
   settings: Partial<GlobalSettings> = {},
-  createdAt: number = CREATED_AT
+  createdAt: number = CREATED_AT,
+  meta: Partial<WorktreeMeta> = {}
 ): Store {
   return {
-    getWorktreeMeta: () => ({ createdAt }),
+    getWorktreeMeta: () => ({ createdAt, ...meta }),
     getSettings: () => settings as GlobalSettings
   } as unknown as Store
 }
@@ -142,6 +148,38 @@ describe('scanMergedWorktreeAutoCloseCandidates', () => {
 
     expect(decisions).toEqual([])
     expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('skips a runtime-owned repo, which carries no connectionId', async () => {
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(
+      createStore(),
+      { ...REPO, executionHostId: toRuntimeExecutionHostId('env-1') },
+      { now: NOW }
+    )
+
+    expect(decisions).toEqual([])
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a workspace whose own metadata stamps it to another host', async () => {
+    // Why: `repoId::path` ids repeat across hosts, so a locally-owned repo can
+    // list a workspace an SSH connection owns. Nothing here can prove its merge.
+    const store = createStore({}, CREATED_AT, { hostId: toSshExecutionHostId('target-a') })
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(store, REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'skip', reason: 'remote-host' })
+    expect(hasWorktreeBranchUpstreamConfiguredMock).not.toHaveBeenCalled()
+    expect(isWorktreeBranchMergedIntoBaseMock).not.toHaveBeenCalled()
+    expect(getStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('closes a workspace whose metadata stamps it to this machine', async () => {
+    const store = createStore({}, CREATED_AT, { hostId: LOCAL_EXECUTION_HOST_ID })
+
+    const decisions = await scanMergedWorktreeAutoCloseCandidates(store, REPO, { now: NOW })
+
+    expect(decisions[0]).toMatchObject({ action: 'close' })
   })
 
   it('returns no decisions when the worktree list fails', async () => {

--- a/src/main/ipc/merged-worktree-auto-close-scan.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.ts
@@ -24,6 +24,7 @@ import {
   type MergedWorktreeAutoCloseRepoContext
 } from '../../shared/merged-worktree-auto-close'
 import { mergeWorktree } from './worktree-logic'
+import { withWorkspaceCleanupTimeout } from './workspace-cleanup-scan-primitives'
 
 /** Why bounded: the sweep runs behind a worktree list load and must never keep Git busy for it. */
 export const MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS = 10_000
@@ -164,10 +165,19 @@ async function readWorktreeCleanliness(
 ): Promise<boolean | null> {
   const sharedLinkPaths = getWorktreeSharedLinkPaths(repo)
   try {
-    const status = await getStatus(worktree.path, {
-      ...(signal ? { signal } : {}),
-      ...(sharedLinkPaths.length > 0 ? { sharedLinkPaths } : {})
-    })
+    // Why raced and not only aborted: `getStatus` accepts a signal but serves the
+    // read through a shared in-flight lease, so a stall started by another reader
+    // is not this signal's to cancel. Unbounded, that stall holds the repo's
+    // in-flight sweep slot and blocks every later sweep for the repo.
+    const status = await withWorkspaceCleanupTimeout(
+      (timeoutSignal) =>
+        getStatus(worktree.path, {
+          signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+          ...(sharedLinkPaths.length > 0 ? { sharedLinkPaths } : {})
+        }),
+      MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS,
+      'Timed out reading git status.'
+    )
     return status.entries.length === 0
   } catch (error) {
     console.warn(

--- a/src/main/ipc/merged-worktree-auto-close-scan.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.ts
@@ -13,6 +13,7 @@ import {
   decideMergedWorktreeAutoClose,
   getMergedWorktreeAutoCloseStructuralSkipReason,
   normalizeAutoCloseBranchName,
+  resolveMergedWorktreeAutoCloseGraceMs,
   type MergedWorktreeAutoCloseDecision,
   type MergedWorktreeAutoCloseEvidence,
   type MergedWorktreeAutoCloseRepoContext
@@ -27,6 +28,13 @@ export type MergedWorktreeAutoCloseScanOptions = {
   signal?: AbortSignal
 }
 
+/** The grace window this profile configured, in ms. */
+function getMergedWorktreeAutoCloseGraceMs(store: Store): number {
+  return resolveMergedWorktreeAutoCloseGraceMs(
+    store.getSettings().autoCloseMergedWorktreesGraceMinutes
+  )
+}
+
 /**
  * Decide, for one repo, which workspaces have landed and can be closed. Every
  * workspace the repo owns gets a decision so callers can report why a
@@ -38,6 +46,7 @@ export async function scanMergedWorktreeAutoCloseCandidates(
   options: MergedWorktreeAutoCloseScanOptions = {}
 ): Promise<MergedWorktreeAutoCloseDecision[]> {
   const now = options.now ?? Date.now()
+  const graceMs = getMergedWorktreeAutoCloseGraceMs(store)
   const repoContext: MergedWorktreeAutoCloseRepoContext = {
     isFolderRepo: isFolderRepo(repo),
     isRemoteRepo: Boolean(repo.connectionId)
@@ -71,12 +80,13 @@ export async function scanMergedWorktreeAutoCloseCandidates(
     const structuralSkip = getMergedWorktreeAutoCloseStructuralSkipReason(
       worktree,
       repoContext,
-      now
+      now,
+      graceMs
     )
     const evidence = structuralSkip
       ? UNREAD_MERGED_WORKTREE_AUTO_CLOSE_EVIDENCE
       : await readMergedWorktreeAutoCloseEvidence(repo, worktree, gitOptions, options.signal)
-    decisions.push(decideMergedWorktreeAutoClose(worktree, repoContext, evidence, now))
+    decisions.push(decideMergedWorktreeAutoClose(worktree, repoContext, evidence, now, graceMs))
   }
   return decisions
 }

--- a/src/main/ipc/merged-worktree-auto-close-scan.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.ts
@@ -29,6 +29,7 @@ import { withWorkspaceCleanupTimeout } from './workspace-cleanup-scan-primitives
 /** Why bounded: the sweep runs behind a worktree list load and must never keep Git busy for it. */
 export const MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS = 10_000
 
+/** `signal` cancels the sweep when the list that triggered it is abandoned. */
 export type MergedWorktreeAutoCloseScanOptions = {
   now?: number
   signal?: AbortSignal
@@ -133,6 +134,13 @@ const UNREAD_MERGED_WORKTREE_AUTO_CLOSE_EVIDENCE: MergedWorktreeAutoCloseEvidenc
   published: null
 }
 
+/**
+ * Read what Git can prove about one workspace: published, merged, clean.
+ *
+ * Ordered cheapest-first and short-circuiting, because each probe costs one or
+ * more `git` processes and any single "no" already keeps the workspace. A field
+ * left null means unread, not false — the decision treats the two differently.
+ */
 async function readMergedWorktreeAutoCloseEvidence(
   repo: Repo,
   worktree: Worktree,
@@ -158,6 +166,11 @@ async function readMergedWorktreeAutoCloseEvidence(
   return { merged, clean: await readWorktreeCleanliness(repo, worktree, signal), published }
 }
 
+/**
+ * Whether the workspace has no uncommitted or untracked work. Null when the
+ * status could not be read, so a failed probe never reads as "nothing to lose".
+ * Shared link paths are excluded the same way the cleanup surfaces exclude them.
+ */
 async function readWorktreeCleanliness(
   repo: Repo,
   worktree: Worktree,

--- a/src/main/ipc/merged-worktree-auto-close-scan.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.ts
@@ -1,0 +1,134 @@
+import type { Store } from '../persistence'
+import { listRepoWorktrees } from '../repo-worktrees'
+import { getStatus } from '../git/status'
+import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
+import {
+  hasWorktreeBranchUpstreamConfigured,
+  isWorktreeBranchMergedIntoBase
+} from '../git/worktree-branch-merge-state'
+import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+import { isFolderRepo } from '../../shared/repo-kind'
+import type { Repo, Worktree } from '../../shared/types'
+import {
+  decideMergedWorktreeAutoClose,
+  getMergedWorktreeAutoCloseStructuralSkipReason,
+  normalizeAutoCloseBranchName,
+  type MergedWorktreeAutoCloseDecision,
+  type MergedWorktreeAutoCloseEvidence,
+  type MergedWorktreeAutoCloseRepoContext
+} from '../../shared/merged-worktree-auto-close'
+import { mergeWorktree } from './worktree-logic'
+
+/** Why bounded: the sweep runs behind a worktree list load and must never keep Git busy for it. */
+export const MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS = 10_000
+
+export type MergedWorktreeAutoCloseScanOptions = {
+  now?: number
+  signal?: AbortSignal
+}
+
+/**
+ * Decide, for one repo, which workspaces have landed and can be closed. Every
+ * workspace the repo owns gets a decision so callers can report why a
+ * workspace stayed.
+ */
+export async function scanMergedWorktreeAutoCloseCandidates(
+  store: Store,
+  repo: Repo,
+  options: MergedWorktreeAutoCloseScanOptions = {}
+): Promise<MergedWorktreeAutoCloseDecision[]> {
+  const now = options.now ?? Date.now()
+  const repoContext: MergedWorktreeAutoCloseRepoContext = {
+    isFolderRepo: isFolderRepo(repo),
+    isRemoteRepo: Boolean(repo.connectionId)
+  }
+  if (repoContext.isFolderRepo || repoContext.isRemoteRepo) {
+    return []
+  }
+
+  const gitOptions = getLocalProjectWorktreeGitOptions(store, repo)
+  let worktrees: Worktree[]
+  try {
+    const gitWorktrees = await listRepoWorktrees(repo, {
+      ...gitOptions,
+      ...(options.signal ? { signal: options.signal } : {})
+    })
+    worktrees = gitWorktrees.map((gitWorktree) =>
+      mergeWorktree(
+        repo.id,
+        gitWorktree,
+        store.getWorktreeMeta(`${repo.id}::${gitWorktree.path}`),
+        repo.displayName
+      )
+    )
+  } catch (error) {
+    console.warn(`[worktree-auto-close] Failed to list worktrees for repo "${repo.id}"`, error)
+    return []
+  }
+
+  const decisions: MergedWorktreeAutoCloseDecision[] = []
+  for (const worktree of worktrees) {
+    const structuralSkip = getMergedWorktreeAutoCloseStructuralSkipReason(
+      worktree,
+      repoContext,
+      now
+    )
+    const evidence = structuralSkip
+      ? UNREAD_MERGED_WORKTREE_AUTO_CLOSE_EVIDENCE
+      : await readMergedWorktreeAutoCloseEvidence(repo, worktree, gitOptions, options.signal)
+    decisions.push(decideMergedWorktreeAutoClose(worktree, repoContext, evidence, now))
+  }
+  return decisions
+}
+
+const UNREAD_MERGED_WORKTREE_AUTO_CLOSE_EVIDENCE: MergedWorktreeAutoCloseEvidence = {
+  merged: null,
+  clean: null,
+  published: null
+}
+
+async function readMergedWorktreeAutoCloseEvidence(
+  repo: Repo,
+  worktree: Worktree,
+  gitOptions: { wslDistro?: string },
+  signal: AbortSignal | undefined
+): Promise<MergedWorktreeAutoCloseEvidence> {
+  const branchName = normalizeAutoCloseBranchName(worktree.branch)
+  const branchOptions = {
+    ...gitOptions,
+    ...(signal ? { signal } : {}),
+    timeout: MERGED_WORKTREE_AUTO_CLOSE_GIT_TIMEOUT_MS
+  }
+  const published = await hasWorktreeBranchUpstreamConfigured(repo.path, branchName, branchOptions)
+  if (published !== true) {
+    // Why: the merge probe can shell out several times per branch; an
+    // unpublished branch is already excluded, so do not pay for it.
+    return { merged: null, clean: null, published }
+  }
+  const merged = await isWorktreeBranchMergedIntoBase(repo.path, branchName, branchOptions)
+  if (merged !== true) {
+    return { merged, clean: null, published }
+  }
+  return { merged, clean: await readWorktreeCleanliness(repo, worktree, signal), published }
+}
+
+async function readWorktreeCleanliness(
+  repo: Repo,
+  worktree: Worktree,
+  signal: AbortSignal | undefined
+): Promise<boolean | null> {
+  const sharedLinkPaths = getWorktreeSharedLinkPaths(repo)
+  try {
+    const status = await getStatus(worktree.path, {
+      ...(signal ? { signal } : {}),
+      ...(sharedLinkPaths.length > 0 ? { sharedLinkPaths } : {})
+    })
+    return status.entries.length === 0
+  } catch (error) {
+    console.warn(
+      `[worktree-auto-close] Failed to read status for workspace "${worktree.id}"`,
+      error
+    )
+    return null
+  }
+}

--- a/src/main/ipc/merged-worktree-auto-close-scan.ts
+++ b/src/main/ipc/merged-worktree-auto-close-scan.ts
@@ -8,6 +8,11 @@ import {
 } from '../git/worktree-branch-merge-state'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 import { isFolderRepo } from '../../shared/repo-kind'
+import {
+  getRepoExecutionHostId,
+  getWorktreeExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID
+} from '../../shared/execution-host'
 import type { Repo, Worktree } from '../../shared/types'
 import {
   decideMergedWorktreeAutoClose,
@@ -47,9 +52,12 @@ export async function scanMergedWorktreeAutoCloseCandidates(
 ): Promise<MergedWorktreeAutoCloseDecision[]> {
   const now = options.now ?? Date.now()
   const graceMs = getMergedWorktreeAutoCloseGraceMs(store)
+  // Why the resolver and not `connectionId`: a runtime-owned repo carries
+  // `executionHostId: 'runtime:…'` and no connection, so a connection-only test
+  // reads it as local and lets the sweep probe a checkout this machine does not own.
   const repoContext: MergedWorktreeAutoCloseRepoContext = {
     isFolderRepo: isFolderRepo(repo),
-    isRemoteRepo: Boolean(repo.connectionId)
+    isRemoteRepo: getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID
   }
   if (repoContext.isFolderRepo || repoContext.isRemoteRepo) {
     return []
@@ -77,18 +85,45 @@ export async function scanMergedWorktreeAutoCloseCandidates(
 
   const decisions: MergedWorktreeAutoCloseDecision[] = []
   for (const worktree of worktrees) {
+    const worktreeContext = resolveMergedWorktreeAutoCloseWorktreeContext(
+      repoContext,
+      repo,
+      worktree
+    )
     const structuralSkip = getMergedWorktreeAutoCloseStructuralSkipReason(
       worktree,
-      repoContext,
+      worktreeContext,
       now,
       graceMs
     )
     const evidence = structuralSkip
       ? UNREAD_MERGED_WORKTREE_AUTO_CLOSE_EVIDENCE
       : await readMergedWorktreeAutoCloseEvidence(repo, worktree, gitOptions, options.signal)
-    decisions.push(decideMergedWorktreeAutoClose(worktree, repoContext, evidence, now, graceMs))
+    decisions.push(decideMergedWorktreeAutoClose(worktree, worktreeContext, evidence, now, graceMs))
   }
   return decisions
+}
+
+/**
+ * Narrow the repo's context to one workspace's own execution host.
+ *
+ * Why per workspace: worktree ids are `repoId::path` and repeat across hosts, so
+ * a locally-owned repo can still list a workspace whose persisted `hostId` names
+ * an SSH or runtime host. That workspace has no local merge proof, and a removal
+ * fenced to this machine would not reach it anyway.
+ */
+function resolveMergedWorktreeAutoCloseWorktreeContext(
+  repoContext: MergedWorktreeAutoCloseRepoContext,
+  repo: Repo,
+  worktree: Worktree
+): MergedWorktreeAutoCloseRepoContext {
+  if (repoContext.isRemoteRepo) {
+    return repoContext
+  }
+  return {
+    ...repoContext,
+    isRemoteRepo: getWorktreeExecutionHostId(worktree, repo) !== LOCAL_EXECUTION_HOST_ID
+  }
 }
 
 const UNREAD_MERGED_WORKTREE_AUTO_CLOSE_EVIDENCE: MergedWorktreeAutoCloseEvidence = {

--- a/src/main/ipc/merged-worktree-auto-close.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close.test.ts
@@ -191,6 +191,30 @@ describe('scheduleMergedWorktreeAutoCloseForRepo', () => {
     expect(scan).toHaveBeenCalledTimes(2)
   })
 
+  it('coalesces a second request onto the sweep already running', async () => {
+    // Why: the cooldown alone does not cover a sweep that is still running, and a
+    // second sweep would fan out a duplicate Git probe per branch.
+    const store = createStore(true)
+    let release: (decisions: MergedWorktreeAutoCloseDecision[]) => void = () => {}
+    const scan = vi.fn().mockReturnValue(
+      new Promise<MergedWorktreeAutoCloseDecision[]>((resolve) => {
+        release = resolve
+      })
+    )
+
+    const first = scheduleMergedWorktreeAutoCloseForRepo(store, runtime, REPO, { now: NOW, scan })
+    // Why past the cooldown: inside it the cooldown would coalesce this on its own,
+    // and the test would pass with no in-flight guard at all.
+    const second = scheduleMergedWorktreeAutoCloseForRepo(store, runtime, REPO, {
+      now: NOW + MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS,
+      scan
+    })
+    release([])
+
+    expect(await second).toEqual(await first)
+    expect(scan).toHaveBeenCalledTimes(1)
+  })
+
   it('resolves null instead of rejecting when the sweep fails', async () => {
     const scan = vi.fn().mockRejectedValue(new Error('scan exploded'))
 

--- a/src/main/ipc/merged-worktree-auto-close.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type { GlobalSettings, Repo } from '../../shared/types'
+import type { MergedWorktreeAutoCloseDecision } from '../../shared/merged-worktree-auto-close'
+import {
+  MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS,
+  autoCloseMergedWorktreesForRepo,
+  scheduleMergedWorktreeAutoCloseForRepo,
+  _resetMergedWorktreeAutoCloseStateForTests,
+  type MergedWorktreeAutoCloseRuntime
+} from './merged-worktree-auto-close'
+
+const NOW = 1_800_000_000_000
+
+const REPO: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
+const CLOSE_DECISION: MergedWorktreeAutoCloseDecision = {
+  worktreeId: 'repo-1::/workspaces/feature',
+  repoId: 'repo-1',
+  path: '/workspaces/feature',
+  branch: 'feature',
+  action: 'close'
+}
+
+const KEEP_DECISION: MergedWorktreeAutoCloseDecision = {
+  worktreeId: 'repo-1::/workspaces/wip',
+  repoId: 'repo-1',
+  path: '/workspaces/wip',
+  branch: 'wip',
+  action: 'skip',
+  reason: 'dirty-files'
+}
+
+function createStore(autoCloseMergedWorktrees: boolean): Store {
+  return {
+    getSettings: () => ({ autoCloseMergedWorktrees }) as GlobalSettings
+  } as unknown as Store
+}
+
+let removeManagedWorktree: ReturnType<typeof vi.fn>
+let runtime: MergedWorktreeAutoCloseRuntime
+
+function scanReturning(decisions: MergedWorktreeAutoCloseDecision[]) {
+  return vi.fn().mockResolvedValue(decisions)
+}
+
+beforeEach(() => {
+  _resetMergedWorktreeAutoCloseStateForTests()
+  removeManagedWorktree = vi.fn().mockResolvedValue({})
+  runtime = { removeManagedWorktree } as unknown as MergedWorktreeAutoCloseRuntime
+})
+
+describe('autoCloseMergedWorktreesForRepo', () => {
+  it('removes only the workspaces decided closable, and never with force', async () => {
+    const result = await autoCloseMergedWorktreesForRepo(createStore(true), runtime, REPO, {
+      now: NOW,
+      scan: scanReturning([CLOSE_DECISION, KEEP_DECISION])
+    })
+
+    expect(removeManagedWorktree).toHaveBeenCalledTimes(1)
+    expect(removeManagedWorktree).toHaveBeenCalledWith(
+      'id:repo-1::/workspaces/feature',
+      false,
+      false,
+      false
+    )
+    expect(result.closed).toEqual(['repo-1::/workspaces/feature'])
+    expect(result.failed).toEqual([])
+  })
+
+  it('reports a removal that Git refused instead of throwing', async () => {
+    removeManagedWorktree.mockRejectedValue(
+      new Error('Worktree has uncommitted or untracked changes.')
+    )
+
+    const result = await autoCloseMergedWorktreesForRepo(createStore(true), runtime, REPO, {
+      now: NOW,
+      scan: scanReturning([CLOSE_DECISION])
+    })
+
+    expect(result.closed).toEqual([])
+    expect(result.failed).toEqual([
+      {
+        worktreeId: 'repo-1::/workspaces/feature',
+        error: 'Worktree has uncommitted or untracked changes.'
+      }
+    ])
+  })
+})
+
+describe('scheduleMergedWorktreeAutoCloseForRepo', () => {
+  it('does nothing while the setting is off', async () => {
+    const scan = scanReturning([CLOSE_DECISION])
+
+    await expect(
+      scheduleMergedWorktreeAutoCloseForRepo(createStore(false), runtime, REPO, { now: NOW, scan })
+    ).resolves.toBeNull()
+    expect(scan).not.toHaveBeenCalled()
+    expect(removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('runs once per cooldown window', async () => {
+    const store = createStore(true)
+    const scan = scanReturning([])
+
+    await scheduleMergedWorktreeAutoCloseForRepo(store, runtime, REPO, { now: NOW, scan })
+    await scheduleMergedWorktreeAutoCloseForRepo(store, runtime, REPO, {
+      now: NOW + MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS - 1,
+      scan
+    })
+    expect(scan).toHaveBeenCalledTimes(1)
+
+    await scheduleMergedWorktreeAutoCloseForRepo(store, runtime, REPO, {
+      now: NOW + MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS,
+      scan
+    })
+    expect(scan).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves null instead of rejecting when the sweep fails', async () => {
+    const scan = vi.fn().mockRejectedValue(new Error('scan exploded'))
+
+    await expect(
+      scheduleMergedWorktreeAutoCloseForRepo(createStore(true), runtime, REPO, { now: NOW, scan })
+    ).resolves.toBeNull()
+  })
+})

--- a/src/main/ipc/merged-worktree-auto-close.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close.test.ts
@@ -74,6 +74,36 @@ describe('autoCloseMergedWorktreesForRepo', () => {
     expect(result.failed).toEqual([])
   })
 
+  it('reports every workspace it swept, including the ones it kept', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await autoCloseMergedWorktreesForRepo(createStore(true), runtime, REPO, {
+      now: NOW,
+      scan: scanReturning([CLOSE_DECISION, KEEP_DECISION])
+    })
+
+    expect(info).toHaveBeenCalledWith(
+      expect.stringContaining('[worktree-auto-close] swept "Repo" (repo-1)')
+    )
+    const line = info.mock.calls[0]?.[0] as string
+    expect(line).toContain('feature=closed')
+    expect(line).toContain('wip=skip:dirty-files')
+    info.mockRestore()
+  })
+
+  it('reports the error when a removal was refused', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    removeManagedWorktree.mockRejectedValue(new Error('Worktree is busy.'))
+
+    await autoCloseMergedWorktreesForRepo(createStore(true), runtime, REPO, {
+      now: NOW,
+      scan: scanReturning([CLOSE_DECISION])
+    })
+
+    expect(info.mock.calls[0]?.[0]).toContain('feature=close-failed(Worktree is busy.)')
+    info.mockRestore()
+  })
+
   it('reports a removal that Git refused instead of throwing', async () => {
     removeManagedWorktree.mockRejectedValue(
       new Error('Worktree has uncommitted or untracked changes.')

--- a/src/main/ipc/merged-worktree-auto-close.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
 import type { GlobalSettings, Repo } from '../../shared/types'
 import type { MergedWorktreeAutoCloseDecision } from '../../shared/merged-worktree-auto-close'
+import { LOCAL_EXECUTION_HOST_ID, toRuntimeExecutionHostId } from '../../shared/execution-host'
 import {
   MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS,
   autoCloseMergedWorktreesForRepo,
@@ -68,10 +69,28 @@ describe('autoCloseMergedWorktreesForRepo', () => {
       'id:repo-1::/workspaces/feature',
       false,
       false,
-      false
+      false,
+      LOCAL_EXECUTION_HOST_ID
     )
     expect(result.closed).toEqual(['repo-1::/workspaces/feature'])
     expect(result.failed).toEqual([])
+  })
+
+  it('never scans or removes for a repo another execution host owns', async () => {
+    // Why: `id:repo-1::/workspaces/feature` names a workspace on every host that
+    // has this repo, so an unfenced sweep can tear down the wrong one.
+    const scan = scanReturning([CLOSE_DECISION])
+
+    const result = await autoCloseMergedWorktreesForRepo(
+      createStore(true),
+      runtime,
+      { ...REPO, executionHostId: toRuntimeExecutionHostId('env-1') },
+      { now: NOW, scan }
+    )
+
+    expect(scan).not.toHaveBeenCalled()
+    expect(removeManagedWorktree).not.toHaveBeenCalled()
+    expect(result).toEqual({ closed: [], failed: [], decisions: [] })
   })
 
   it('reports every workspace it swept, including the ones it kept', async () => {

--- a/src/main/ipc/merged-worktree-auto-close.test.ts
+++ b/src/main/ipc/merged-worktree-auto-close.test.ts
@@ -104,6 +104,25 @@ describe('autoCloseMergedWorktreesForRepo', () => {
     info.mockRestore()
   })
 
+  it('keeps the sweep line on one physical line when the refusal message spans several', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    removeManagedWorktree.mockRejectedValue(
+      new Error(
+        "Command failed: git worktree remove /tmp/x\nfatal: '/tmp/x' contains modified or untracked files, use --force to delete it\n"
+      )
+    )
+
+    await autoCloseMergedWorktreesForRepo(createStore(true), runtime, REPO, {
+      now: NOW,
+      scan: scanReturning([CLOSE_DECISION])
+    })
+
+    const line = info.mock.calls[0]?.[0] as string
+    expect(line).toContain('feature=close-failed(Command failed: git worktree remove /tmp/x)')
+    expect(line.split('\n')).toHaveLength(1)
+    info.mockRestore()
+  })
+
   it('reports a removal that Git refused instead of throwing', async () => {
     removeManagedWorktree.mockRejectedValue(
       new Error('Worktree has uncommitted or untracked changes.')

--- a/src/main/ipc/merged-worktree-auto-close.ts
+++ b/src/main/ipc/merged-worktree-auto-close.ts
@@ -1,0 +1,121 @@
+import type { Store } from '../persistence'
+import type { Repo } from '../../shared/types'
+import type { MergedWorktreeAutoCloseDecision } from '../../shared/merged-worktree-auto-close'
+import { scanMergedWorktreeAutoCloseCandidates } from './merged-worktree-auto-close-scan'
+
+/** Why a cooldown: `worktrees:list` fires on every sidebar refresh, and the sweep shells out to Git per branch. */
+export const MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS = 5 * 60 * 1000
+
+/** Structural view of the runtime; `OrcaRuntimeService` satisfies it. */
+export type MergedWorktreeAutoCloseRuntime = {
+  removeManagedWorktree(
+    worktreeSelector: string,
+    force?: boolean,
+    runHooks?: boolean,
+    allowUnverifiedPtyStop?: boolean,
+    hostId?: string
+  ): Promise<unknown>
+}
+
+export type MergedWorktreeAutoCloseResult = {
+  closed: string[]
+  failed: { worktreeId: string; error: string }[]
+  decisions: MergedWorktreeAutoCloseDecision[]
+}
+
+export type MergedWorktreeAutoCloseOptions = {
+  now?: number
+  signal?: AbortSignal
+  scan?: typeof scanMergedWorktreeAutoCloseCandidates
+}
+
+const lastSweepAtByRepoId = new Map<string, number>()
+const sweepsInFlightByRepoId = new Map<string, Promise<MergedWorktreeAutoCloseResult>>()
+
+export function isMergedWorktreeAutoCloseEnabled(store: Store): boolean {
+  return store.getSettings().autoCloseMergedWorktrees === true
+}
+
+/**
+ * Close every workspace in the repo whose branch has landed. Removal goes
+ * through the runtime's managed delete, so Orca's own tracking state, PTYs and
+ * the now-orphaned branch are cleaned up exactly like a user-initiated delete.
+ */
+export async function autoCloseMergedWorktreesForRepo(
+  store: Store,
+  runtime: MergedWorktreeAutoCloseRuntime,
+  repo: Repo,
+  options: MergedWorktreeAutoCloseOptions = {}
+): Promise<MergedWorktreeAutoCloseResult> {
+  const scan = options.scan ?? scanMergedWorktreeAutoCloseCandidates
+  const decisions = await scan(store, repo, {
+    ...(options.now !== undefined ? { now: options.now } : {}),
+    ...(options.signal ? { signal: options.signal } : {})
+  })
+  const closed: string[] = []
+  const failed: MergedWorktreeAutoCloseResult['failed'] = []
+
+  for (const decision of decisions) {
+    if (decision.action !== 'close') {
+      continue
+    }
+    try {
+      // Why never force: Git's own non-force removal is the authoritative refusal
+      // for a workspace that turned dirty between the scan and this call.
+      await runtime.removeManagedWorktree(`id:${decision.worktreeId}`, false, false, false)
+      closed.push(decision.worktreeId)
+    } catch (error) {
+      failed.push({
+        worktreeId: decision.worktreeId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  return { closed, failed, decisions }
+}
+
+/**
+ * Run the sweep for a repo unless it is disabled, already running, or ran
+ * within the cooldown. Never rejects: callers fire this from lifecycle points
+ * whose own result must not depend on it.
+ */
+export function scheduleMergedWorktreeAutoCloseForRepo(
+  store: Store,
+  runtime: MergedWorktreeAutoCloseRuntime,
+  repo: Repo,
+  options: MergedWorktreeAutoCloseOptions = {}
+): Promise<MergedWorktreeAutoCloseResult | null> {
+  if (!isMergedWorktreeAutoCloseEnabled(store)) {
+    return Promise.resolve(null)
+  }
+  const inFlight = sweepsInFlightByRepoId.get(repo.id)
+  if (inFlight) {
+    return inFlight.catch(() => null)
+  }
+  const now = options.now ?? Date.now()
+  const lastSweepAt = lastSweepAtByRepoId.get(repo.id)
+  if (
+    lastSweepAt !== undefined &&
+    now - lastSweepAt < MERGED_WORKTREE_AUTO_CLOSE_REPO_COOLDOWN_MS
+  ) {
+    return Promise.resolve(null)
+  }
+  lastSweepAtByRepoId.set(repo.id, now)
+
+  const sweep = autoCloseMergedWorktreesForRepo(store, runtime, repo, { ...options, now })
+  sweepsInFlightByRepoId.set(repo.id, sweep)
+  return sweep
+    .catch((error): null => {
+      console.warn(`[worktree-auto-close] Sweep failed for repo "${repo.id}"`, error)
+      return null
+    })
+    .finally(() => {
+      sweepsInFlightByRepoId.delete(repo.id)
+    })
+}
+
+export function _resetMergedWorktreeAutoCloseStateForTests(): void {
+  lastSweepAtByRepoId.clear()
+  sweepsInFlightByRepoId.clear()
+}

--- a/src/main/ipc/merged-worktree-auto-close.ts
+++ b/src/main/ipc/merged-worktree-auto-close.ts
@@ -18,12 +18,14 @@ export type MergedWorktreeAutoCloseRuntime = {
   ): Promise<unknown>
 }
 
+/** What one sweep did: removed, refused, and the full decision list behind both. */
 export type MergedWorktreeAutoCloseResult = {
   closed: string[]
   failed: { worktreeId: string; error: string }[]
   decisions: MergedWorktreeAutoCloseDecision[]
 }
 
+/** `now` and `scan` are seams for tests; production passes neither. */
 export type MergedWorktreeAutoCloseOptions = {
   now?: number
   signal?: AbortSignal
@@ -33,6 +35,10 @@ export type MergedWorktreeAutoCloseOptions = {
 const lastSweepAtByRepoId = new Map<string, number>()
 const sweepsInFlightByRepoId = new Map<string, Promise<MergedWorktreeAutoCloseResult>>()
 
+/**
+ * Whether this profile opted into the automation. Strict `=== true` because the
+ * setting is optional, and an absent one must not authorize a removal.
+ */
 export function isMergedWorktreeAutoCloseEnabled(store: Store): boolean {
   return store.getSettings().autoCloseMergedWorktrees === true
 }
@@ -158,6 +164,7 @@ export function scheduleMergedWorktreeAutoCloseForRepo(
     })
 }
 
+/** Clear the cooldown and in-flight maps, which outlive a single test otherwise. */
 export function _resetMergedWorktreeAutoCloseStateForTests(): void {
   lastSweepAtByRepoId.clear()
   sweepsInFlightByRepoId.clear()

--- a/src/main/ipc/merged-worktree-auto-close.ts
+++ b/src/main/ipc/merged-worktree-auto-close.ts
@@ -69,7 +69,11 @@ export async function autoCloseMergedWorktreesForRepo(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       failed.push({ worktreeId: decision.worktreeId, error: message })
-      outcomeByWorktreeId.set(decision.worktreeId, `close-failed(${message})`)
+      // Why first-line-only: Git refusal messages span multiple lines, and the
+      // sweep log promises one physical line per sweep — the grep target must
+      // hold precisely in the failure case an operator searches for.
+      const firstLine = message.split('\n', 1)[0].trim()
+      outcomeByWorktreeId.set(decision.worktreeId, `close-failed(${firstLine})`)
     }
   }
 

--- a/src/main/ipc/merged-worktree-auto-close.ts
+++ b/src/main/ipc/merged-worktree-auto-close.ts
@@ -54,6 +54,7 @@ export async function autoCloseMergedWorktreesForRepo(
   })
   const closed: string[] = []
   const failed: MergedWorktreeAutoCloseResult['failed'] = []
+  const outcomeByWorktreeId = new Map<string, string>()
 
   for (const decision of decisions) {
     if (decision.action !== 'close') {
@@ -64,15 +65,42 @@ export async function autoCloseMergedWorktreesForRepo(
       // for a workspace that turned dirty between the scan and this call.
       await runtime.removeManagedWorktree(`id:${decision.worktreeId}`, false, false, false)
       closed.push(decision.worktreeId)
+      outcomeByWorktreeId.set(decision.worktreeId, 'closed')
     } catch (error) {
-      failed.push({
-        worktreeId: decision.worktreeId,
-        error: error instanceof Error ? error.message : String(error)
-      })
+      const message = error instanceof Error ? error.message : String(error)
+      failed.push({ worktreeId: decision.worktreeId, error: message })
+      outcomeByWorktreeId.set(decision.worktreeId, `close-failed(${message})`)
     }
   }
 
+  logMergedWorktreeAutoCloseSweep(repo, decisions, outcomeByWorktreeId)
   return { closed, failed, decisions }
+}
+
+/**
+ * Report every sweep, including the all-skipped ones.
+ *
+ * Why unconditional: this ran silently for weeks while never reaching the
+ * removal at all, and no log distinguished "swept and kept everything" from
+ * "never swept". One line per sweep per repo, rate-limited by the cooldown.
+ */
+function logMergedWorktreeAutoCloseSweep(
+  repo: Repo,
+  decisions: MergedWorktreeAutoCloseDecision[],
+  outcomeByWorktreeId: Map<string, string>
+): void {
+  const outcomes = decisions
+    .map((decision) => {
+      const outcome =
+        decision.action === 'close'
+          ? (outcomeByWorktreeId.get(decision.worktreeId) ?? 'close')
+          : `skip:${decision.reason}`
+      return `${decision.branch || decision.path}=${outcome}`
+    })
+    .join(', ')
+  console.info(
+    `[worktree-auto-close] swept "${repo.displayName}" (${repo.id}): ${outcomes || 'no workspaces'}`
+  )
 }
 
 /**

--- a/src/main/ipc/merged-worktree-auto-close.ts
+++ b/src/main/ipc/merged-worktree-auto-close.ts
@@ -1,6 +1,7 @@
 import type { Store } from '../persistence'
 import type { Repo } from '../../shared/types'
 import type { MergedWorktreeAutoCloseDecision } from '../../shared/merged-worktree-auto-close'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { scanMergedWorktreeAutoCloseCandidates } from './merged-worktree-auto-close-scan'
 
 /** Why a cooldown: `worktrees:list` fires on every sidebar refresh, and the sweep shells out to Git per branch. */
@@ -47,6 +48,14 @@ export async function autoCloseMergedWorktreesForRepo(
   repo: Repo,
   options: MergedWorktreeAutoCloseOptions = {}
 ): Promise<MergedWorktreeAutoCloseResult> {
+  // Why fenced up front: the only merge proof this sweep can read is a local one,
+  // and `id:` selectors are `repoId::path` ids that repeat across execution hosts.
+  // A repo owned elsewhere is not swept at all, so no probe and no removal can
+  // land on another host's workspace.
+  const hostId = getRepoExecutionHostId(repo)
+  if (hostId !== LOCAL_EXECUTION_HOST_ID) {
+    return { closed: [], failed: [], decisions: [] }
+  }
   const scan = options.scan ?? scanMergedWorktreeAutoCloseCandidates
   const decisions = await scan(store, repo, {
     ...(options.now !== undefined ? { now: options.now } : {}),
@@ -63,7 +72,9 @@ export async function autoCloseMergedWorktreesForRepo(
     try {
       // Why never force: Git's own non-force removal is the authoritative refusal
       // for a workspace that turned dirty between the scan and this call.
-      await runtime.removeManagedWorktree(`id:${decision.worktreeId}`, false, false, false)
+      // Why the host: it pins the `id:` selector to the owner the sweep proved, so
+      // a same-id workspace on another connection cannot be the one that is torn down.
+      await runtime.removeManagedWorktree(`id:${decision.worktreeId}`, false, false, false, hostId)
       closed.push(decision.worktreeId)
       outcomeByWorktreeId.set(decision.worktreeId, 'closed')
     } catch (error) {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type { CreateWorktreeResult, GitWorktreeInfo, Repo, Worktree } from '../../shared/types'
 import type { ProviderRequestId } from '../../shared/detected-worktree-provider-contract'
-import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  toRuntimeExecutionHostId,
+  toSshExecutionHostId
+} from '../../shared/execution-host'
 import * as localWorktreeFilesystem from '../local-worktree-filesystem'
 
 const ORIGINAL_PLATFORM = process.platform
@@ -2469,6 +2473,35 @@ describe('registerWorktreeHandlers', () => {
     expect(scheduleMergedWorktreeAutoCloseForRepoMock).toHaveBeenCalledTimes(1)
   })
 
+  it('never sweeps a runtime-owned repo behind the legacy detected list', async () => {
+    // Why this shape: the legacy call names no execution host, so only pinning the
+    // owner resolution to the local host can rule a runtime-owned repo out.
+    scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
+    store.getRepos.mockReturnValue([
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        executionHostId: toRuntimeExecutionHostId('env-1')
+      }
+    ])
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'def456',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).not.toHaveBeenCalled()
+  })
+
   it('never sweeps a local repo behind an SSH-host detected list', async () => {
     scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
     const sshHostId = toSshExecutionHostId('target-a')
@@ -2493,6 +2526,57 @@ describe('registerWorktreeHandlers', () => {
       executionHostId: sshHostId,
       expectedAuthority: getSshProviderAuthority('target-a')
     })
+
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).not.toHaveBeenCalled()
+  })
+
+  it('sweeps landed workspaces behind the legacy worktrees:list fallback', async () => {
+    scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'def456',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await handlers['worktrees:list'](null, { repoId: 'repo-1' })
+
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).toHaveBeenCalledTimes(1)
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).toHaveBeenCalledWith(
+      store,
+      runtimeStub,
+      expect.objectContaining({ id: 'repo-1' })
+    )
+  })
+
+  it('never sweeps a runtime-owned repo behind worktrees:list', async () => {
+    // Why runtime-owned: it carries an executionHostId and no connectionId, so the
+    // SSH branch never runs and only the host resolver can rule it out.
+    scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
+    const runtimeRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      executionHostId: toRuntimeExecutionHostId('env-1')
+    }
+    store.getRepo.mockReturnValue({ ...runtimeRepo, worktreeBaseRef: null })
+    store.getRepos.mockReturnValue([runtimeRepo])
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'def456',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await handlers['worktrees:list'](null, { repoId: 'repo-1' })
 
     expect(scheduleMergedWorktreeAutoCloseForRepoMock).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -224,6 +224,14 @@ vi.mock('../terminal-history-deletion', () => ({
   deleteWorktreeHistoryDir: deleteWorktreeHistoryDirMock
 }))
 
+const { scheduleMergedWorktreeAutoCloseForRepoMock } = vi.hoisted(() => ({
+  scheduleMergedWorktreeAutoCloseForRepoMock: vi.fn()
+}))
+
+vi.mock('./merged-worktree-auto-close', () => ({
+  scheduleMergedWorktreeAutoCloseForRepo: scheduleMergedWorktreeAutoCloseForRepoMock
+}))
+
 const { advertisedUrlWatcherForgetWorktreeMock } = vi.hoisted(() => ({
   advertisedUrlWatcherForgetWorktreeMock: vi.fn()
 }))
@@ -2412,6 +2420,81 @@ describe('registerWorktreeHandlers', () => {
       branchNameOverride: 'feature/add-feature',
       pushTarget: { remoteName: 'origin', branchName: 'feature/add-feature' }
     })
+  })
+
+  it('sweeps landed workspaces behind the local host-qualified detected list', async () => {
+    // Why this path: the desktop renderer lists through `worktrees:listDetected`
+    // with an execution host, so a sweep wired only into `worktrees:list` never
+    // ran in the app.
+    scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'def456',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    const result = await handlers['worktrees:listDetected'](ipcEvent, {
+      providerRequestId: 'request-sweep' as ProviderRequestId,
+      repoId: 'repo-1',
+      executionHostId: LOCAL_EXECUTION_HOST_ID
+    })
+
+    expect(result).toMatchObject({ status: 'complete' })
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).toHaveBeenCalledTimes(1)
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).toHaveBeenCalledWith(
+      store,
+      runtimeStub,
+      expect.objectContaining({ id: 'repo-1' })
+    )
+  })
+
+  it('sweeps landed workspaces behind the legacy detected list', async () => {
+    scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'def456',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('never sweeps a local repo behind an SSH-host detected list', async () => {
+    scheduleMergedWorktreeAutoCloseForRepoMock.mockClear()
+    const sshHostId = toSshExecutionHostId('target-a')
+    const provider = { listWorktrees: vi.fn().mockResolvedValue([]) }
+    store.getRepos.mockImplementation(() => [
+      {
+        id: 'repo-1',
+        path: '/remote/repo',
+        displayName: 'remote repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: 'target-a'
+      }
+    ])
+    getSshGitProviderMock.mockImplementation((targetId) =>
+      targetId === 'target-a' ? provider : undefined
+    )
+
+    await handlers['worktrees:listDetected'](ipcEvent, {
+      providerRequestId: 'request-ssh-sweep' as ProviderRequestId,
+      repoId: 'repo-1',
+      executionHostId: sshHostId,
+      expectedAuthority: getSshProviderAuthority('target-a')
+    })
+
+    expect(scheduleMergedWorktreeAutoCloseForRepoMock).not.toHaveBeenCalled()
   })
 
   it('lists detected worktrees through the selected WSL project runtime', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1809,6 +1809,29 @@ export function registerWorktreeHandlers(
   options?: { onWorktreeLifecycle?: (event: RuntimeWorktreeLifecycleEvent) => void }
 ): void {
   const detectedWorktreeCancellations = createSenderScopedRequestCancellations()
+  /**
+   * Run the landed-workspace sweep behind a workspace list.
+   *
+   * Why not only `worktrees:list`: the desktop renderer lists through
+   * `worktrees:listDetected` and only falls back to `worktrees:list` when the
+   * preload has no `listDetected`. Wiring the sweep into the fallback alone
+   * left it never running on desktop.
+   *
+   * Never awaited — a list must not wait on Git merge probes — and
+   * cooldown-gated inside the scheduler.
+   */
+  const scheduleMergedWorktreeAutoCloseForListedRepo = (
+    repoId: string,
+    executionHostId?: ExecutionHostId
+  ): void => {
+    if (executionHostId !== undefined && executionHostId !== LOCAL_EXECUTION_HOST_ID) {
+      return
+    }
+    const repo = findExactRepoOwner(store, repoId)
+    if (repo) {
+      void scheduleMergedWorktreeAutoCloseForRepo(store, runtime, repo)
+    }
+  }
   // Remove previously registered handlers so re-register works when macOS re-activates and creates a new window.
   ipcMain.removeHandler('worktrees:listAll')
   ipcMain.removeHandler('worktrees:list')
@@ -2121,9 +2144,13 @@ export function registerWorktreeHandlers(
                 }
               : undefined
           )
-          return abortedResult
+          const listed = abortedResult
             ? await Promise.race([providerResult, abortedResult])
             : await providerResult
+          if (listed.status === 'complete') {
+            scheduleMergedWorktreeAutoCloseForListedRepo(args.repoId, args.executionHostId)
+          }
+          return listed
         } finally {
           if (timeout) {
             clearTimeout(timeout)
@@ -2157,6 +2184,9 @@ export function registerWorktreeHandlers(
               isCurrentSshProviderAuthority(authority))),
         provider
       )
+      if (result && !('providerAbortStatus' in result) && result.authoritative) {
+        scheduleMergedWorktreeAutoCloseForListedRepo(repo.id)
+      }
       return result && !('providerAbortStatus' in result)
         ? result
         : {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1827,7 +1827,11 @@ export function registerWorktreeHandlers(
     if (executionHostId !== undefined && executionHostId !== LOCAL_EXECUTION_HOST_ID) {
       return
     }
-    const repo = findExactRepoOwner(store, repoId)
+    // Why the explicit host: with no host argument a single SSH- or runtime-owned
+    // candidate still resolves as the owner, and the legacy call shape supplies no
+    // host at all — so the guard above would pass and the sweep would run on a repo
+    // this machine does not own.
+    const repo = findExactRepoOwner(store, repoId, LOCAL_EXECUTION_HOST_ID)
     if (repo) {
       void scheduleMergedWorktreeAutoCloseForRepo(store, runtime, repo)
     }
@@ -1971,7 +1975,9 @@ export function registerWorktreeHandlers(
       // through (`worktrees:changed` makes the renderer re-list), so the sweep is
       // event-driven without a timer of its own. It is cooldown-gated and never
       // awaited — a list must not wait on Git merge probes.
-      void scheduleMergedWorktreeAutoCloseForRepo(store, runtime, repo)
+      // Why through the helper: `store.getRepo` returns any owner for the id, so
+      // routing both listing entry points through it keeps one ownership rule.
+      scheduleMergedWorktreeAutoCloseForListedRepo(repo.id, getRepoExecutionHostId(repo))
       return buildDetectedGitWorktrees(store, repo, gitWorktrees)
         .filter((worktree) => worktree.visible)
         .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -117,6 +117,7 @@ import {
   notifyWorktreesChanged
 } from './worktree-remote'
 import { registerWorktreeChangeInvalidator } from './worktree-change-invalidators'
+import { scheduleMergedWorktreeAutoCloseForRepo } from './merged-worktree-auto-close'
 import {
   invalidateAuthorizedRootsCache,
   isENOENT,
@@ -1943,6 +1944,11 @@ export function registerWorktreeHandlers(
         pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
+      // Why here: this is the one point every worktree-graph change funnels back
+      // through (`worktrees:changed` makes the renderer re-list), so the sweep is
+      // event-driven without a timer of its own. It is cooldown-gated and never
+      // awaited — a list must not wait on Git merge probes.
+      void scheduleMergedWorktreeAutoCloseForRepo(store, runtime, repo)
       return buildDetectedGitWorktrees(store, repo, gitWorktrees)
         .filter((worktree) => worktree.visible)
         .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))

--- a/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.test.tsx
+++ b/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { GlobalSettings } from '../../../../shared/types'
 import { getDefaultSettings } from '../../../../shared/constants'
+import { MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES } from '../../../../shared/merged-worktree-auto-close'
 import { AutoCloseMergedWorkspacesSetting } from './AutoCloseMergedWorkspacesSetting'
 
 function render(settings: GlobalSettings): string {
@@ -31,6 +32,7 @@ describe('AutoCloseMergedWorkspacesSetting', () => {
     expect(html).toContain('Wait before closing')
     expect(html).toContain('value="10"')
     expect(html).toContain('min="0"')
+    expect(html).toContain(`max="${MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES}"`)
   })
 
   it('shows the configured window, including zero', () => {

--- a/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.test.tsx
+++ b/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/types'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { AutoCloseMergedWorkspacesSetting } from './AutoCloseMergedWorkspacesSetting'
+
+function render(settings: GlobalSettings): string {
+  return renderToStaticMarkup(
+    React.createElement(AutoCloseMergedWorkspacesSetting, { settings, updateSettings: () => {} })
+  )
+}
+
+describe('AutoCloseMergedWorkspacesSetting', () => {
+  it('is off for a default profile', () => {
+    expect(render(getDefaultSettings('/home/test'))).toContain('data-state="unchecked"')
+  })
+
+  it('is on once the profile opts in', () => {
+    const html = render({ ...getDefaultSettings('/home/test'), autoCloseMergedWorktrees: true })
+    expect(html).toContain('data-state="checked"')
+  })
+})

--- a/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.test.tsx
+++ b/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.test.tsx
@@ -20,4 +20,33 @@ describe('AutoCloseMergedWorkspacesSetting', () => {
     const html = render({ ...getDefaultSettings('/home/test'), autoCloseMergedWorktrees: true })
     expect(html).toContain('data-state="checked"')
   })
+
+  it('hides the grace window while the automation is off', () => {
+    expect(render(getDefaultSettings('/home/test'))).not.toContain('Wait before closing')
+  })
+
+  it('offers the grace window in minutes once the automation is on', () => {
+    const html = render({ ...getDefaultSettings('/home/test'), autoCloseMergedWorktrees: true })
+
+    expect(html).toContain('Wait before closing')
+    expect(html).toContain('value="10"')
+    expect(html).toContain('min="0"')
+  })
+
+  it('shows the configured window, including zero', () => {
+    const html = render({
+      ...getDefaultSettings('/home/test'),
+      autoCloseMergedWorktrees: true,
+      autoCloseMergedWorktreesGraceMinutes: 0
+    })
+
+    expect(html).toContain('value="0"')
+  })
+
+  it('falls back to the default window when the profile never wrote one', () => {
+    const settings = { ...getDefaultSettings('/home/test'), autoCloseMergedWorktrees: true }
+    delete settings.autoCloseMergedWorktreesGraceMinutes
+
+    expect(render(settings)).toContain('value="10"')
+  })
 })

--- a/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.tsx
+++ b/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.tsx
@@ -1,0 +1,70 @@
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { Label } from '../ui/label'
+import { Switch } from '../ui/switch'
+import { SearchableSetting } from './SearchableSetting'
+import { matchesSettingsSearch } from './settings-search'
+
+export const AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS = [
+  'auto close',
+  'merged',
+  'cleanup',
+  'delete workspace',
+  'remove worktree',
+  'landed',
+  'squash merge',
+  'stale workspace',
+  'worktree'
+]
+
+function getAutoCloseMergedWorkspacesTitle(): string {
+  return translate(
+    'auto.components.settings.GitPane.autoCloseMergedWorkspacesTitle',
+    'Close Merged Workspaces Automatically'
+  )
+}
+
+function getAutoCloseMergedWorkspacesDescription(): string {
+  return translate(
+    'auto.components.settings.GitPane.autoCloseMergedWorkspacesDescription',
+    'Delete a local workspace once its branch has landed in the base branch, including squash merges. Orca keeps the workspace when it has uncommitted or untracked changes, when its branch was never pushed, when it is pinned, and always keeps the project checkout itself.'
+  )
+}
+
+export function autoCloseMergedWorkspacesMatchesSearch(searchQuery: string): boolean {
+  return matchesSettingsSearch(searchQuery, {
+    title: getAutoCloseMergedWorkspacesTitle(),
+    description: getAutoCloseMergedWorkspacesDescription(),
+    keywords: AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS
+  })
+}
+
+export function AutoCloseMergedWorkspacesSetting({
+  settings,
+  updateSettings
+}: {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}): React.JSX.Element {
+  const title = getAutoCloseMergedWorkspacesTitle()
+  const description = getAutoCloseMergedWorkspacesDescription()
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={description}
+      keywords={AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS}
+      className="flex items-center justify-between gap-4 py-2"
+    >
+      <div className="space-y-0.5">
+        <Label>{title}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch
+        aria-label={title}
+        checked={settings.autoCloseMergedWorktrees === true}
+        onCheckedChange={(checked) => void updateSettings({ autoCloseMergedWorktrees: checked })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.tsx
+++ b/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.tsx
@@ -1,9 +1,18 @@
 import type { GlobalSettings } from '../../../../shared/types'
+import {
+  DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
+  MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
+  MIN_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
+  resolveMergedWorktreeAutoCloseGraceMs
+} from '../../../../shared/merged-worktree-auto-close'
 import { translate } from '@/i18n/i18n'
 import { Label } from '../ui/label'
 import { Switch } from '../ui/switch'
+import { NumberField } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
+
+const MS_PER_MINUTE = 60 * 1000
 
 export const AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS = [
   'auto close',
@@ -14,7 +23,8 @@ export const AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS = [
   'landed',
   'squash merge',
   'stale workspace',
-  'worktree'
+  'worktree',
+  'grace period'
 ]
 
 function getAutoCloseMergedWorkspacesTitle(): string {
@@ -48,23 +58,55 @@ export function AutoCloseMergedWorkspacesSetting({
 }): React.JSX.Element {
   const title = getAutoCloseMergedWorkspacesTitle()
   const description = getAutoCloseMergedWorkspacesDescription()
+  const enabled = settings.autoCloseMergedWorktrees === true
+  // Why resolve rather than read: the sweep decides on the resolved window, so
+  // the field must show the same value a stale or absent setting resolves to.
+  const graceMinutes =
+    resolveMergedWorktreeAutoCloseGraceMs(settings.autoCloseMergedWorktreesGraceMinutes) /
+    MS_PER_MINUTE
 
   return (
     <SearchableSetting
       title={title}
       description={description}
       keywords={AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS}
-      className="flex items-center justify-between gap-4 py-2"
+      className="py-2"
     >
-      <div className="space-y-0.5">
-        <Label>{title}</Label>
-        <p className="text-xs text-muted-foreground">{description}</p>
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-0.5">
+          <Label>{title}</Label>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+        <Switch
+          aria-label={title}
+          checked={enabled}
+          onCheckedChange={(checked) => void updateSettings({ autoCloseMergedWorktrees: checked })}
+        />
       </div>
-      <Switch
-        aria-label={title}
-        checked={settings.autoCloseMergedWorktrees === true}
-        onCheckedChange={(checked) => void updateSettings({ autoCloseMergedWorktrees: checked })}
-      />
+      {enabled ? (
+        <NumberField
+          label={translate(
+            'auto.components.settings.GitPane.autoCloseMergedWorkspacesGraceLabel',
+            'Wait before closing'
+          )}
+          description={translate(
+            'auto.components.settings.GitPane.autoCloseMergedWorkspacesGraceDescription',
+            'How many minutes a workspace must have existed before Orca may close it. Set this to 0 to close a workspace as soon as its branch has landed. The default protects a workspace created from a branch that was already merged.'
+          )}
+          value={graceMinutes}
+          defaultValue={DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES}
+          min={MIN_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES}
+          max={MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES}
+          step={1}
+          suffix={translate(
+            'auto.components.settings.GitPane.autoCloseMergedWorkspacesGraceSuffix',
+            'minutes'
+          )}
+          onChange={(minutes) =>
+            void updateSettings({ autoCloseMergedWorktreesGraceMinutes: minutes })
+          }
+        />
+      ) : null}
     </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.tsx
+++ b/src/renderer/src/components/settings/AutoCloseMergedWorkspacesSetting.tsx
@@ -27,6 +27,7 @@ export const AUTO_CLOSE_MERGED_WORKSPACES_KEYWORDS = [
   'grace period'
 ]
 
+/** Read through `translate` on every call so a language switch re-renders the title. */
 function getAutoCloseMergedWorkspacesTitle(): string {
   return translate(
     'auto.components.settings.GitPane.autoCloseMergedWorkspacesTitle',
@@ -34,6 +35,10 @@ function getAutoCloseMergedWorkspacesTitle(): string {
   )
 }
 
+/**
+ * The description doubles as search text, so it names every rail that keeps a
+ * workspace — a user searching "pinned" or "uncommitted" should land here.
+ */
 function getAutoCloseMergedWorkspacesDescription(): string {
   return translate(
     'auto.components.settings.GitPane.autoCloseMergedWorkspacesDescription',
@@ -41,6 +46,7 @@ function getAutoCloseMergedWorkspacesDescription(): string {
   )
 }
 
+/** Whether the settings search should reveal this row. */
 export function autoCloseMergedWorkspacesMatchesSearch(searchQuery: string): boolean {
   return matchesSettingsSearch(searchQuery, {
     title: getAutoCloseMergedWorkspacesTitle(),
@@ -49,6 +55,11 @@ export function autoCloseMergedWorkspacesMatchesSearch(searchQuery: string): boo
   })
 }
 
+/**
+ * The Git-settings row for the landed-workspace automation: the opt-in switch,
+ * and the grace window it reveals only while the automation is on — a window
+ * with nothing to delay is noise.
+ */
 export function AutoCloseMergedWorkspacesSetting({
   settings,
   updateSettings

--- a/src/renderer/src/components/settings/GitPane.tsx
+++ b/src/renderer/src/components/settings/GitPane.tsx
@@ -15,6 +15,10 @@ import {
   CompareAgainstUpstreamSetting,
   compareAgainstUpstreamMatchesSearch
 } from './CompareAgainstUpstreamSetting'
+import {
+  AutoCloseMergedWorkspacesSetting,
+  autoCloseMergedWorkspacesMatchesSearch
+} from './AutoCloseMergedWorkspacesSetting'
 import { getAutoRenameBranchSearchEntries } from './auto-rename-branch-search'
 import {
   KEEP_LOCAL_MAIN_UP_TO_DATE_SECTION_ID,
@@ -307,6 +311,13 @@ export function GitPane({
     compareAgainstUpstreamMatchesSearch(searchQuery) ? (
       <CompareAgainstUpstreamSetting
         key="compare-against-upstream"
+        settings={settings}
+        updateSettings={updateSettings}
+      />
+    ) : null,
+    autoCloseMergedWorkspacesMatchesSearch(searchQuery) ? (
+      <AutoCloseMergedWorkspacesSetting
+        key="auto-close-merged-workspaces"
         settings={settings}
         updateSettings={updateSettings}
       />

--- a/src/renderer/src/components/settings/git-search.ts
+++ b/src/renderer/src/components/settings/git-search.ts
@@ -121,6 +121,35 @@ export const getGitPaneSearchEntries = createLocalizedCatalog(() => [
       )
     ]
   },
+  {
+    title: translate(
+      'auto.components.settings.git.search.autoCloseMergedWorkspacesTitle',
+      'Close Merged Workspaces Automatically'
+    ),
+    description: translate(
+      'auto.components.settings.git.search.autoCloseMergedWorkspacesDescription',
+      'Delete a local workspace once its branch has landed in the base branch, including squash merges. Orca keeps the workspace when it has uncommitted or untracked changes, when its branch was never pushed, when it is pinned, and always keeps the project checkout itself.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.git.search.autoClose', 'auto close'),
+      ...translateSearchKeyword('auto.components.settings.git.search.merged', 'merged'),
+      ...translateSearchKeyword('auto.components.settings.git.search.cleanup', 'cleanup'),
+      ...translateSearchKeyword(
+        'auto.components.settings.git.search.deleteWorkspace',
+        'delete workspace'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.git.search.removeWorktree',
+        'remove worktree'
+      ),
+      ...translateSearchKeyword('auto.components.settings.git.search.landed', 'landed'),
+      ...translateSearchKeyword('auto.components.settings.git.search.squashMerge', 'squash merge'),
+      ...translateSearchKeyword(
+        'auto.components.settings.git.search.staleWorkspace',
+        'stale workspace'
+      )
+    ]
+  },
   ...getAutoRenameBranchSearchEntries(),
   {
     title: translate('auto.components.settings.git.search.bc7d9f69ce', 'Orca Attribution'),

--- a/src/renderer/src/components/settings/git-search.ts
+++ b/src/renderer/src/components/settings/git-search.ts
@@ -147,7 +147,8 @@ export const getGitPaneSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword(
         'auto.components.settings.git.search.staleWorkspace',
         'stale workspace'
-      )
+      ),
+      ...translateSearchKeyword('auto.components.settings.git.search.gracePeriod', 'grace period')
     ]
   },
   ...getAutoRenameBranchSearchEntries(),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6390,7 +6390,9 @@
           "compareAgainstUpstreamTitle": "Default Compare Base",
           "compareAgainstUpstreamDescription": "Choose which base Source Control uses by default for committed-change comparisons. Branch upstream follows the current branch automatically and falls back to the repository default branch when no upstream exists. You can still change the compare base per worktree from that worktree's Git panel. Pull Request and rebase targets don't change.",
           "compareBaseRepositoryDefault": "Repository default",
-          "compareBaseBranchUpstream": "Branch upstream"
+          "compareBaseBranchUpstream": "Branch upstream",
+          "autoCloseMergedWorkspacesTitle": "Close Merged Workspaces Automatically",
+          "autoCloseMergedWorkspacesDescription": "Delete a local workspace once its branch has landed in the base branch, including squash merges. Orca keeps the workspace when it has uncommitted or untracked changes, when its branch was never pushed, when it is pinned, and always keeps the project checkout itself."
         },
         "HiddenExperimentalGroup": {
           "d0f914a528": "Placeholder toggle",
@@ -8707,7 +8709,9 @@
             "upstream": "upstream",
             "localChanges": "local changes",
             "originMaster": "origin/master",
-            "committedChanges": "committed changes"
+            "committedChanges": "committed changes",
+            "autoCloseMergedWorkspacesTitle": "Close Merged Workspaces Automatically",
+            "autoCloseMergedWorkspacesDescription": "Delete a local workspace once its branch has landed in the base branch, including squash merges. Orca keeps the workspace when it has uncommitted or untracked changes, when its branch was never pushed, when it is pinned, and always keeps the project checkout itself."
           }
         },
         "input": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6392,7 +6392,10 @@
           "compareBaseRepositoryDefault": "Repository default",
           "compareBaseBranchUpstream": "Branch upstream",
           "autoCloseMergedWorkspacesTitle": "Close Merged Workspaces Automatically",
-          "autoCloseMergedWorkspacesDescription": "Delete a local workspace once its branch has landed in the base branch, including squash merges. Orca keeps the workspace when it has uncommitted or untracked changes, when its branch was never pushed, when it is pinned, and always keeps the project checkout itself."
+          "autoCloseMergedWorkspacesDescription": "Delete a local workspace once its branch has landed in the base branch, including squash merges. Orca keeps the workspace when it has uncommitted or untracked changes, when its branch was never pushed, when it is pinned, and always keeps the project checkout itself.",
+          "autoCloseMergedWorkspacesGraceLabel": "Wait before closing",
+          "autoCloseMergedWorkspacesGraceDescription": "How many minutes a workspace must have existed before Orca may close it. Set this to 0 to close a workspace as soon as its branch has landed. The default protects a workspace created from a branch that was already merged.",
+          "autoCloseMergedWorkspacesGraceSuffix": "minutes"
         },
         "HiddenExperimentalGroup": {
           "d0f914a528": "Placeholder toggle",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -180,6 +180,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     localBaseRefSuggestionDismissed: false,
     autoRenameBranchFromWork: true,
     autoRenameBranchFromWorkDefaultedOn: true,
+    autoCloseMergedWorktrees: false,
     branchPrefix: 'git-username',
     branchPrefixCustom: '',
     enableGitHubAttribution: false,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -34,6 +34,7 @@ import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES } from './merged-worktree-auto-close'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -181,6 +182,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     autoRenameBranchFromWork: true,
     autoRenameBranchFromWorkDefaultedOn: true,
     autoCloseMergedWorktrees: false,
+    autoCloseMergedWorktreesGraceMinutes: DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
     branchPrefix: 'git-username',
     branchPrefixCustom: '',
     enableGitHubAttribution: false,

--- a/src/shared/merged-worktree-auto-close.test.ts
+++ b/src/shared/merged-worktree-auto-close.test.ts
@@ -155,6 +155,24 @@ describe('decideMergedWorktreeAutoClose', () => {
     expect(decision).toMatchObject({ action: 'skip', reason: 'recently-created' })
   })
 
+  it('keeps a workspace whose creation time was never recorded', () => {
+    // Why: a workspace discovered on disk gets metadata without `createdAt`, and
+    // an unprovable age must not read as old enough to delete.
+    const { createdAt: _createdAt, ...withoutCreatedAt } = worktree()
+
+    expect(
+      decideMergedWorktreeAutoClose(withoutCreatedAt, LOCAL_GIT_REPO, LANDED, NOW)
+    ).toMatchObject({ action: 'skip', reason: 'recently-created' })
+  })
+
+  it('closes a workspace of unknown age once the grace window is zero', () => {
+    const { createdAt: _createdAt, ...withoutCreatedAt } = worktree()
+
+    expect(
+      decideMergedWorktreeAutoClose(withoutCreatedAt, LOCAL_GIT_REPO, LANDED, NOW, 0)
+    ).toMatchObject({ action: 'close' })
+  })
+
   it('keeps a branch that was never published, which is how a no-commit workspace reads', () => {
     const decision = decideMergedWorktreeAutoClose(
       worktree(),

--- a/src/shared/merged-worktree-auto-close.test.ts
+++ b/src/shared/merged-worktree-auto-close.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS,
+  decideMergedWorktreeAutoClose,
+  type MergedWorktreeAutoCloseEvidence,
+  type MergedWorktreeAutoCloseRepoContext,
+  type MergedWorktreeAutoCloseSubject
+} from './merged-worktree-auto-close'
+
+const NOW = 1_800_000_000_000
+
+const LOCAL_GIT_REPO: MergedWorktreeAutoCloseRepoContext = {
+  isFolderRepo: false,
+  isRemoteRepo: false
+}
+
+const LANDED: MergedWorktreeAutoCloseEvidence = { merged: true, clean: true, published: true }
+
+function worktree(
+  overrides: Partial<MergedWorktreeAutoCloseSubject> = {}
+): MergedWorktreeAutoCloseSubject {
+  return {
+    id: 'repo-1::/workspaces/feature',
+    repoId: 'repo-1',
+    path: '/workspaces/feature',
+    branch: 'refs/heads/feature',
+    isMainWorktree: false,
+    isPinned: false,
+    createdAt: NOW - MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS - 1,
+    ...overrides
+  }
+}
+
+describe('decideMergedWorktreeAutoClose', () => {
+  it('closes a published, merged, clean workspace and reports its short branch', () => {
+    expect(decideMergedWorktreeAutoClose(worktree(), LOCAL_GIT_REPO, LANDED, NOW)).toEqual({
+      worktreeId: 'repo-1::/workspaces/feature',
+      repoId: 'repo-1',
+      path: '/workspaces/feature',
+      branch: 'feature',
+      action: 'close'
+    })
+  })
+
+  it('keeps a workspace whose branch is not merged', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree(),
+      LOCAL_GIT_REPO,
+      { ...LANDED, merged: false },
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'not-merged' })
+  })
+
+  it('keeps a merged workspace that has uncommitted or untracked changes', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree(),
+      LOCAL_GIT_REPO,
+      { ...LANDED, clean: false },
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'dirty-files' })
+  })
+
+  it('never closes the primary checkout even when it reads as merged and clean', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree({ isMainWorktree: true, branch: 'refs/heads/main' }),
+      LOCAL_GIT_REPO,
+      LANDED,
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'main-worktree' })
+  })
+
+  it('keeps a pinned workspace', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree({ isPinned: true }),
+      LOCAL_GIT_REPO,
+      LANDED,
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'pinned' })
+  })
+
+  it('keeps folder and SSH workspaces, which have no local merge proof', () => {
+    expect(
+      decideMergedWorktreeAutoClose(
+        worktree(),
+        { isFolderRepo: true, isRemoteRepo: false },
+        LANDED,
+        NOW
+      )
+    ).toMatchObject({ action: 'skip', reason: 'folder-repo' })
+    expect(
+      decideMergedWorktreeAutoClose(
+        worktree(),
+        { isFolderRepo: false, isRemoteRepo: true },
+        LANDED,
+        NOW
+      )
+    ).toMatchObject({ action: 'skip', reason: 'remote-host' })
+  })
+
+  it('keeps a detached-HEAD workspace', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree({ branch: '' }),
+      LOCAL_GIT_REPO,
+      LANDED,
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'detached-head' })
+  })
+
+  it('keeps a workspace created inside the grace window', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree({ createdAt: NOW - MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS + 1 }),
+      LOCAL_GIT_REPO,
+      LANDED,
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'recently-created' })
+  })
+
+  it('keeps a branch that was never published, which is how a no-commit workspace reads', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree(),
+      LOCAL_GIT_REPO,
+      { merged: true, clean: true, published: false },
+      NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'never-published' })
+  })
+
+  it('keeps a workspace when Git could not prove the merge or read the status', () => {
+    expect(
+      decideMergedWorktreeAutoClose(worktree(), LOCAL_GIT_REPO, { ...LANDED, merged: null }, NOW)
+    ).toMatchObject({ action: 'skip', reason: 'merge-check-failed' })
+    expect(
+      decideMergedWorktreeAutoClose(worktree(), LOCAL_GIT_REPO, { ...LANDED, clean: null }, NOW)
+    ).toMatchObject({ action: 'skip', reason: 'status-check-failed' })
+  })
+})

--- a/src/shared/merged-worktree-auto-close.test.ts
+++ b/src/shared/merged-worktree-auto-close.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
-  MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS,
+  DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
+  DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS,
+  MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
   decideMergedWorktreeAutoClose,
+  resolveMergedWorktreeAutoCloseGraceMs,
   type MergedWorktreeAutoCloseEvidence,
   type MergedWorktreeAutoCloseRepoContext,
   type MergedWorktreeAutoCloseSubject
@@ -26,7 +29,7 @@ function worktree(
     branch: 'refs/heads/feature',
     isMainWorktree: false,
     isPinned: false,
-    createdAt: NOW - MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS - 1,
+    createdAt: NOW - DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS - 1,
     ...overrides
   }
 }
@@ -116,12 +119,37 @@ describe('decideMergedWorktreeAutoClose', () => {
     expect(decision).toMatchObject({ action: 'skip', reason: 'detached-head' })
   })
 
-  it('keeps a workspace created inside the grace window', () => {
+  it('keeps a workspace created inside the default grace window', () => {
     const decision = decideMergedWorktreeAutoClose(
-      worktree({ createdAt: NOW - MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS + 1 }),
+      worktree({ createdAt: NOW - DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS + 1 }),
       LOCAL_GIT_REPO,
       LANDED,
       NOW
+    )
+
+    expect(decision).toMatchObject({ action: 'skip', reason: 'recently-created' })
+  })
+
+  it('closes a just-created landed workspace when the grace window is zero', () => {
+    const decision = decideMergedWorktreeAutoClose(
+      worktree({ createdAt: NOW }),
+      LOCAL_GIT_REPO,
+      LANDED,
+      NOW,
+      0
+    )
+
+    expect(decision).toMatchObject({ action: 'close' })
+  })
+
+  it('keeps a workspace still inside a configured grace window', () => {
+    const graceMs = 60_000
+    const decision = decideMergedWorktreeAutoClose(
+      worktree({ createdAt: NOW - graceMs + 1 }),
+      LOCAL_GIT_REPO,
+      LANDED,
+      NOW,
+      graceMs
     )
 
     expect(decision).toMatchObject({ action: 'skip', reason: 'recently-created' })
@@ -145,5 +173,35 @@ describe('decideMergedWorktreeAutoClose', () => {
     expect(
       decideMergedWorktreeAutoClose(worktree(), LOCAL_GIT_REPO, { ...LANDED, clean: null }, NOW)
     ).toMatchObject({ action: 'skip', reason: 'status-check-failed' })
+  })
+})
+
+describe('resolveMergedWorktreeAutoCloseGraceMs', () => {
+  it('falls back to the default when the profile never wrote the setting', () => {
+    expect(resolveMergedWorktreeAutoCloseGraceMs(undefined)).toBe(
+      DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS
+    )
+    expect(DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES).toBe(10)
+  })
+
+  it('turns zero minutes into no grace at all', () => {
+    expect(resolveMergedWorktreeAutoCloseGraceMs(0)).toBe(0)
+  })
+
+  it('converts configured minutes to milliseconds', () => {
+    expect(resolveMergedWorktreeAutoCloseGraceMs(3)).toBe(3 * 60_000)
+  })
+
+  it('clamps a value outside the range the control can produce', () => {
+    expect(resolveMergedWorktreeAutoCloseGraceMs(-5)).toBe(0)
+    expect(
+      resolveMergedWorktreeAutoCloseGraceMs(MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES + 1)
+    ).toBe(MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES * 60_000)
+  })
+
+  it('falls back to the default for a value that is not a finite number', () => {
+    expect(resolveMergedWorktreeAutoCloseGraceMs(Number.NaN)).toBe(
+      DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS
+    )
   })
 })

--- a/src/shared/merged-worktree-auto-close.ts
+++ b/src/shared/merged-worktree-auto-close.ts
@@ -99,7 +99,12 @@ export function getMergedWorktreeAutoCloseStructuralSkipReason(
   }
   // Why the `graceMs > 0` guard: with no grace at all a workspace whose
   // recorded creation time sits slightly ahead of the clock must still close.
-  if (graceMs > 0 && worktree.createdAt !== undefined && now - worktree.createdAt < graceMs) {
+  //
+  // Why an unknown creation time counts as inside the window: a workspace found
+  // on disk gets metadata without `createdAt`, and reading that absence as "old
+  // enough" deleted a merged, clean checkout on the very first sweep after it
+  // was discovered. Unknown age means the window cannot be proven expired.
+  if (graceMs > 0 && (worktree.createdAt === undefined || now - worktree.createdAt < graceMs)) {
     return 'recently-created'
   }
   return null

--- a/src/shared/merged-worktree-auto-close.ts
+++ b/src/shared/merged-worktree-auto-close.ts
@@ -1,0 +1,122 @@
+/** Why a grace window: a workspace created from an already-merged PR branch is
+ *  merged from its first second; the user still needs it. */
+export const MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS = 10 * 60 * 1000
+
+export type MergedWorktreeAutoCloseSkipReason =
+  | 'main-worktree'
+  | 'folder-repo'
+  | 'pinned'
+  | 'remote-host'
+  | 'detached-head'
+  | 'recently-created'
+  | 'never-published'
+  | 'not-merged'
+  | 'dirty-files'
+  | 'merge-check-failed'
+  | 'status-check-failed'
+
+export type MergedWorktreeAutoCloseSubject = {
+  id: string
+  repoId: string
+  path: string
+  branch: string
+  isMainWorktree: boolean
+  isPinned: boolean
+  createdAt?: number
+}
+
+export type MergedWorktreeAutoCloseEvidence = {
+  /** null when Git could not prove the branch merged either way. */
+  merged: boolean | null
+  /** null when the worktree's status could not be read. */
+  clean: boolean | null
+  /** null when the branch's upstream configuration could not be read. */
+  published: boolean | null
+}
+
+export type MergedWorktreeAutoCloseDecision = {
+  worktreeId: string
+  repoId: string
+  path: string
+  branch: string
+} & ({ action: 'close' } | { action: 'skip'; reason: MergedWorktreeAutoCloseSkipReason })
+
+export type MergedWorktreeAutoCloseRepoContext = {
+  isFolderRepo: boolean
+  isRemoteRepo: boolean
+}
+
+/**
+ * Reasons that rule a workspace out before any Git evidence is read, so the
+ * sweep never spends a status or merge probe on a workspace it cannot close.
+ */
+export function getMergedWorktreeAutoCloseStructuralSkipReason(
+  worktree: MergedWorktreeAutoCloseSubject,
+  repo: MergedWorktreeAutoCloseRepoContext,
+  now: number
+): MergedWorktreeAutoCloseSkipReason | null {
+  if (worktree.isMainWorktree) {
+    return 'main-worktree'
+  }
+  if (repo.isFolderRepo) {
+    return 'folder-repo'
+  }
+  // Why: proving a squash merge needs `patch-id` over stdin, which the SSH git
+  // provider contract does not carry; remote workspaces stay manual for now.
+  if (repo.isRemoteRepo) {
+    return 'remote-host'
+  }
+  if (worktree.isPinned) {
+    return 'pinned'
+  }
+  if (!normalizeAutoCloseBranchName(worktree.branch)) {
+    return 'detached-head'
+  }
+  if (
+    worktree.createdAt !== undefined &&
+    now - worktree.createdAt < MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS
+  ) {
+    return 'recently-created'
+  }
+  return null
+}
+
+export function decideMergedWorktreeAutoClose(
+  worktree: MergedWorktreeAutoCloseSubject,
+  repo: MergedWorktreeAutoCloseRepoContext,
+  evidence: MergedWorktreeAutoCloseEvidence,
+  now: number
+): MergedWorktreeAutoCloseDecision {
+  const identity = {
+    worktreeId: worktree.id,
+    repoId: worktree.repoId,
+    path: worktree.path,
+    branch: normalizeAutoCloseBranchName(worktree.branch)
+  }
+  const structuralSkip = getMergedWorktreeAutoCloseStructuralSkipReason(worktree, repo, now)
+  if (structuralSkip) {
+    return { ...identity, action: 'skip', reason: structuralSkip }
+  }
+  // Why: an unpublished branch that reads as merged is usually a workspace that
+  // never committed — its tip is still the base it was branched from.
+  if (evidence.published !== true) {
+    return { ...identity, action: 'skip', reason: 'never-published' }
+  }
+  if (evidence.merged === null) {
+    return { ...identity, action: 'skip', reason: 'merge-check-failed' }
+  }
+  if (!evidence.merged) {
+    return { ...identity, action: 'skip', reason: 'not-merged' }
+  }
+  if (evidence.clean === null) {
+    return { ...identity, action: 'skip', reason: 'status-check-failed' }
+  }
+  if (!evidence.clean) {
+    return { ...identity, action: 'skip', reason: 'dirty-files' }
+  }
+  return { ...identity, action: 'close' }
+}
+
+export function normalizeAutoCloseBranchName(branch: string): string {
+  return branch.trim().replace(/^refs\/heads\//, '')
+}

--- a/src/shared/merged-worktree-auto-close.ts
+++ b/src/shared/merged-worktree-auto-close.ts
@@ -26,6 +26,7 @@ export function resolveMergedWorktreeAutoCloseGraceMs(graceMinutes: number | und
   return clamped * MS_PER_MINUTE
 }
 
+/** Why a workspace stayed. Logged verbatim, so each name reads on its own. */
 export type MergedWorktreeAutoCloseSkipReason =
   | 'main-worktree'
   | 'folder-repo'
@@ -39,6 +40,10 @@ export type MergedWorktreeAutoCloseSkipReason =
   | 'merge-check-failed'
   | 'status-check-failed'
 
+/**
+ * The fields the decision reads. Narrower than `Worktree` on purpose — the rule
+ * lives in shared code, and nothing here needs the full workspace shape.
+ */
 export type MergedWorktreeAutoCloseSubject = {
   id: string
   repoId: string
@@ -58,6 +63,7 @@ export type MergedWorktreeAutoCloseEvidence = {
   published: boolean | null
 }
 
+/** One workspace's verdict, carrying enough identity to remove it and to log it. */
 export type MergedWorktreeAutoCloseDecision = {
   worktreeId: string
   repoId: string
@@ -65,6 +71,11 @@ export type MergedWorktreeAutoCloseDecision = {
   branch: string
 } & ({ action: 'close' } | { action: 'skip'; reason: MergedWorktreeAutoCloseSkipReason })
 
+/**
+ * The owning repo's traits, resolved per workspace: `isRemoteRepo` is true both
+ * for a repo another execution host owns and for a locally-owned repo's
+ * workspace stamped to another host. Neither can be proven merged here.
+ */
 export type MergedWorktreeAutoCloseRepoContext = {
   isFolderRepo: boolean
   isRemoteRepo: boolean
@@ -110,6 +121,13 @@ export function getMergedWorktreeAutoCloseStructuralSkipReason(
   return null
 }
 
+/**
+ * The single verdict for one workspace, and the only place that says "close".
+ *
+ * Every path returns a reason, so a caller can report why a workspace stayed
+ * without re-deriving it. Unproven evidence (`null`) keeps the workspace and is
+ * reported apart from a proven "no": a failed probe is not a clean checkout.
+ */
 export function decideMergedWorktreeAutoClose(
   worktree: MergedWorktreeAutoCloseSubject,
   repo: MergedWorktreeAutoCloseRepoContext,
@@ -152,6 +170,11 @@ export function decideMergedWorktreeAutoClose(
   return { ...identity, action: 'close' }
 }
 
+/**
+ * The short branch name. `git worktree list` reports `refs/heads/x` while the
+ * config keys and merge probes want `x`, and a detached HEAD reports an empty
+ * string — which is why an empty result is the detached-HEAD test.
+ */
 export function normalizeAutoCloseBranchName(branch: string): string {
   return branch.trim().replace(/^refs\/heads\//, '')
 }

--- a/src/shared/merged-worktree-auto-close.ts
+++ b/src/shared/merged-worktree-auto-close.ts
@@ -1,6 +1,30 @@
+const MS_PER_MINUTE = 60 * 1000
+
 /** Why a grace window: a workspace created from an already-merged PR branch is
- *  merged from its first second; the user still needs it. */
-export const MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS = 10 * 60 * 1000
+ *  merged from its first second; the user still needs it. Configurable because a
+ *  user who never works that way wants a landed workspace gone on the next sweep. */
+export const DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES = 10
+export const MIN_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES = 0
+export const MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES = 24 * 60
+
+export const DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS =
+  DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES * MS_PER_MINUTE
+
+/**
+ * Settings store the window in minutes. A profile that never wrote the setting,
+ * or wrote a value no control can produce, gets the default rather than a
+ * window that would delete a checkout the user still needs.
+ */
+export function resolveMergedWorktreeAutoCloseGraceMs(graceMinutes: number | undefined): number {
+  if (graceMinutes === undefined || !Number.isFinite(graceMinutes)) {
+    return DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS
+  }
+  const clamped = Math.min(
+    MAX_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES,
+    Math.max(MIN_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MINUTES, graceMinutes)
+  )
+  return clamped * MS_PER_MINUTE
+}
 
 export type MergedWorktreeAutoCloseSkipReason =
   | 'main-worktree'
@@ -53,7 +77,8 @@ export type MergedWorktreeAutoCloseRepoContext = {
 export function getMergedWorktreeAutoCloseStructuralSkipReason(
   worktree: MergedWorktreeAutoCloseSubject,
   repo: MergedWorktreeAutoCloseRepoContext,
-  now: number
+  now: number,
+  graceMs: number = DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS
 ): MergedWorktreeAutoCloseSkipReason | null {
   if (worktree.isMainWorktree) {
     return 'main-worktree'
@@ -72,10 +97,9 @@ export function getMergedWorktreeAutoCloseStructuralSkipReason(
   if (!normalizeAutoCloseBranchName(worktree.branch)) {
     return 'detached-head'
   }
-  if (
-    worktree.createdAt !== undefined &&
-    now - worktree.createdAt < MERGED_WORKTREE_AUTO_CLOSE_MIN_AGE_MS
-  ) {
+  // Why the `graceMs > 0` guard: with no grace at all a workspace whose
+  // recorded creation time sits slightly ahead of the clock must still close.
+  if (graceMs > 0 && worktree.createdAt !== undefined && now - worktree.createdAt < graceMs) {
     return 'recently-created'
   }
   return null
@@ -85,7 +109,8 @@ export function decideMergedWorktreeAutoClose(
   worktree: MergedWorktreeAutoCloseSubject,
   repo: MergedWorktreeAutoCloseRepoContext,
   evidence: MergedWorktreeAutoCloseEvidence,
-  now: number
+  now: number,
+  graceMs: number = DEFAULT_MERGED_WORKTREE_AUTO_CLOSE_GRACE_MS
 ): MergedWorktreeAutoCloseDecision {
   const identity = {
     worktreeId: worktree.id,
@@ -93,7 +118,12 @@ export function decideMergedWorktreeAutoClose(
     path: worktree.path,
     branch: normalizeAutoCloseBranchName(worktree.branch)
   }
-  const structuralSkip = getMergedWorktreeAutoCloseStructuralSkipReason(worktree, repo, now)
+  const structuralSkip = getMergedWorktreeAutoCloseStructuralSkipReason(
+    worktree,
+    repo,
+    now,
+    graceMs
+  )
   if (structuralSkip) {
     return { ...identity, action: 'skip', reason: structuralSkip }
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2794,6 +2794,10 @@ export type GlobalSettings = {
   /** One-shot migration guard for the default-on rollout. Existing profiles
    *  without the guard are flipped on once; later explicit opt-outs stick. */
   autoRenameBranchFromWorkDefaultedOn?: boolean
+  /** When enabled, Orca deletes a local workspace once its branch has landed in
+   *  the repo's base and the checkout is clean. Defaults off: unlike the other
+   *  automations this one removes a checkout. */
+  autoCloseMergedWorktrees?: boolean
   branchPrefix: BranchPrefixStrategy
   branchPrefixCustom: string
   enableGitHubAttribution: boolean

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2798,6 +2798,10 @@ export type GlobalSettings = {
    *  the repo's base and the checkout is clean. Defaults off: unlike the other
    *  automations this one removes a checkout. */
   autoCloseMergedWorktrees?: boolean
+  /** How many minutes a workspace must have existed before the auto-close sweep
+   *  may delete it. Zero closes a landed workspace on the next sweep; the
+   *  10-minute default protects a checkout made from an already-merged branch. */
+  autoCloseMergedWorktreesGraceMinutes?: number
   branchPrefix: BranchPrefixStrategy
   branchPrefixCustom: string
   enableGitHubAttribution: boolean


### PR DESCRIPTION
### Summary

When a workspace's branch has landed in its base, Orca can now close the workspace automatically: terminals are torn down, the git worktree is removed, tracking state and caches are purged, and the orphaned branch is deleted — the exact same managed-removal path used by manual deletion. Off by default.

### Behavior

- **Trigger**: runs when the app loads the worktree list (`worktrees:listDetected`, both host-qualified and legacy branches; `worktrees:list` kept for web/older preloads). Event-driven — no new timer. Fire-and-forget with a 5-minute per-repo cooldown and in-flight dedupe.
- **"Merged" detection** reuses the repo's existing branch-cleanup proof (`branchHasNoUnmergedChangesOnAnyTarget`): merge-tree equality, `git cherry` patch equivalence, and stable patch-id matching — so **squash merges and rebase-then-merge are recognized**, including the post-PR state where the remote branch was already deleted.
- **Settings** (Settings → Git):
  - `Close merged workspaces` toggle — default **OFF** (this deletes checkouts; existing profiles must opt in).
  - `Wait before closing` grace window — default **10 minutes**, range 0–1440; `0` closes on the next sweep. Shown only while the toggle is on.
- **Safety rails** (skip reasons, in order): `main-worktree`, `folder-repo`, `remote-host`, `pinned`, `detached-head`, `recently-created` (grace window), `never-published`, `merge-check-failed`, `not-merged`, `status-check-failed`, `dirty-files`. Removal is always non-force: Git's own refusal is the last word if a checkout turns dirty between scan and delete.
- **Observability**: every sweep logs one line naming each workspace's decision, skip reason, or `close-failed(<first line of the refusal>)`. Silence previously hid a dead code path for the entire desktop platform; the log is unconditional by design.

### Test evidence

- Unit/integration: 6 feature suites, 298 tests; broader touched-area regression 154 files / 1605 tests; full typecheck and lint clean.
- Live E2E on a real repo (desktop dev build): merged workspace auto-closed on list load, terminals torn down, branch deleted, primary untouched.
- Overnight QA (3 harness rounds driving the real production path — runner → scan → decision → real git → real removeWorktree — against throwaway repos, with negative controls proving the harness itself): **R1 merge-mode matrix 5/5** (ff, no-ff, squash+remote-delete, rebase, unmerged-kept) · **R2 safety rails 9/9** (dirty×2, never-published, detached HEAD, primary never probed, toggle off, grace boundaries, non-force assert) · **R3 edge cases 7/7** (post-merge new commits kept, post-PR close, 3-at-once sweep, multi-slash branch names, cooldown no-op/expiry, all three log forms captured verbatim, mixed sweep).

### Limitations

- SSH and folder workspaces are skipped (no local squash proof without stdin `patch-id` support in `IGitProvider.exec`).
- No network fetch: a branch merged only on the remote reads as unmerged until the local base ref updates; it is simply kept.
- Local-only merges never auto-close (the `never-published` rail gates on `branch.<name>.remote`; the same config-only signal means a branch pointed at a remote it never reached also reads as published — the merge proof still gates actual closing).
- The base branch is resolved per branch-cleanup convention (`branch.<name>.base`, `origin/HEAD`, primary HEAD) rather than a per-repo setting.
- A cooldown-suppressed sweep logs nothing, so a closable workspace can linger up to 5 minutes with no log line explaining why.
