### PR TITLE
fix(sidebar): route project group rename/delete to the owner host

### DIFF
--- a/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
@@ -131,6 +131,63 @@ describe('project group deletion store routing', () => {
     expect(projectGroupsDelete).not.toHaveBeenCalled()
   })
 
+  it('deletes a remote-owned group even when the focused runtime is local (#14007)', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-remote-group',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const remoteOwnedGroup: ProjectGroup = {
+      ...projectGroup,
+      id: 'folder-scan-root',
+      name: 'platform',
+      parentPath: '/home/user/platform',
+      createdFrom: 'folder-scan',
+      executionHostId: 'runtime:env-remote'
+    }
+    const store = createTestStore()
+    store.setState({
+      // Why: multi-host sidebar can show a remote folder-scan group while focus is local.
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [remoteOwnedGroup],
+      repos: []
+    })
+
+    await expect(store.getState().deleteProjectGroup(remoteOwnedGroup.id)).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-remote',
+      method: 'projectGroup.delete',
+      params: { groupId: remoteOwnedGroup.id },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsDelete).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
+  it('keeps local delete when a local group is selected under a focused remote runtime', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const localGroup: ProjectGroup = {
+      ...projectGroup,
+      executionHostId: 'local'
+    }
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [localGroup],
+      repos: []
+    })
+
+    await expect(store.getState().deleteProjectGroup(localGroup.id)).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: localGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'projectGroup.delete' })
+    )
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
   it('deletes only the group when contained project removal is not requested', async () => {
     projectGroupsDelete.mockResolvedValue(true)
     const groupedRepo = { ...remoteRepo, id: 'direct', projectGroupId: projectGroup.id }

--- a/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
@@ -166,6 +166,82 @@ describe('project group deletion store routing', () => {
     expect(store.getState().projectGroups).toEqual([])
   })
 
+  it('removes a group whose persisted execution host needs normalization', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-normalized-host-group',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const remoteOwnedGroup: ProjectGroup = {
+      ...projectGroup,
+      executionHostId: ' runtime:env-remote ' as never
+    }
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [remoteOwnedGroup],
+      repos: []
+    })
+
+    await expect(store.getState().deleteProjectGroup(remoteOwnedGroup.id)).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-remote',
+      method: 'projectGroup.delete',
+      params: { groupId: remoteOwnedGroup.id },
+      timeoutMs: 15_000
+    })
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
+  it('removes an SSH-owned group through the local project-group store', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const sshOwnedGroup: ProjectGroup = {
+      ...projectGroup,
+      connectionId: 'ssh-1',
+      executionHostId: 'ssh:ssh-1'
+    }
+    const sshOwnedRepo: Repo = {
+      ...remoteRepo,
+      connectionId: 'ssh-1',
+      executionHostId: 'ssh:ssh-1',
+      projectGroupId: sshOwnedGroup.id
+    }
+    const sshOwnedWorkspace: FolderWorkspace = {
+      id: 'ssh-folder-workspace',
+      projectGroupId: sshOwnedGroup.id,
+      name: 'SSH workspace',
+      folderPath: '/srv/workspace',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [sshOwnedGroup],
+      folderWorkspaces: [sshOwnedWorkspace],
+      repos: [sshOwnedRepo]
+    })
+
+    await expect(store.getState().deleteProjectGroup(sshOwnedGroup.id)).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: sshOwnedGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'projectGroup.delete' })
+    )
+    expect(store.getState().projectGroups).toEqual([])
+    expect(store.getState().folderWorkspaces).toEqual([])
+    expect(store.getState().repos).toMatchObject([{ id: sshOwnedRepo.id, projectGroupId: null }])
+  })
+
   it('keeps local delete when a local group is selected under a focused remote runtime', async () => {
     projectGroupsDelete.mockResolvedValue(true)
     const localGroup: ProjectGroup = {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1024,6 +1024,45 @@ function getProjectGroupHostIdentity(group: ProjectGroup): string {
   return JSON.stringify([getProjectGroupHostId(group), group.id])
 }
 
+function projectGroupMatchesOwnerHost(
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>,
+  ownerHostId: string
+): boolean {
+  if (!group.executionHostId && !group.connectionId?.trim()) {
+    return true
+  }
+  return getProjectGroupHostId(group) === ownerHostId
+}
+
+/** Route group mutations to the group's owner host, not whichever runtime is focused. */
+function settingsForProjectGroupOwner(
+  state: Pick<AppState, 'projectGroups' | 'settings'>,
+  groupId: string
+) {
+  const group = state.projectGroups.find((entry) => entry.id === groupId)
+  if (!group) {
+    return state.settings
+  }
+  // Why: pre-host-stamp / local-only rows keep focused-host routing.
+  if (!group.executionHostId && !group.connectionId?.trim()) {
+    return state.settings
+  }
+  const parsed = parseExecutionHostId(getProjectGroupHostId(group))
+  if (parsed?.kind === 'runtime') {
+    return state.settings
+      ? { ...state.settings, activeRuntimeEnvironmentId: parsed.environmentId }
+      : ({ activeRuntimeEnvironmentId: parsed.environmentId } as AppState['settings'])
+  }
+  // Why: a local/SSH group must not hit a focused paired runtime that never stored it.
+  if (
+    (parsed?.kind === 'local' || parsed?.kind === 'ssh' || group.connectionId?.trim()) &&
+    state.settings?.activeRuntimeEnvironmentId
+  ) {
+    return { ...state.settings, activeRuntimeEnvironmentId: null }
+  }
+  return state.settings
+}
+
 function catalogOwnsHost(catalogHostId: string, rowHostId: string): boolean {
   if (catalogHostId !== LOCAL_EXECUTION_HOST_ID) {
     return catalogHostId === rowHostId
@@ -2779,8 +2818,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateProjectGroup: async (groupId, updates) => {
     try {
-      // Why: project groups are focused-host-scoped by design; all CRUD routes by the focused host and the list is replaced, not merged.
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: all-host catalog shows groups from every host; mutations must hit the owner (folder workspaces already do).
+      const target = getActiveRuntimeTarget(settingsForProjectGroupOwner(get(), groupId))
       const updated =
         target.kind === 'local'
           ? await window.api.projectGroups.update({ groupId, updates })
@@ -2796,8 +2835,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return false
       }
       const ownedGroup = projectGroupWithFetchedOwner(updated, target)
+      const ownerHostId = getRuntimeTargetHostId(target)
       set((s) => ({
-        projectGroups: s.projectGroups.map((group) => (group.id === groupId ? ownedGroup : group)),
+        projectGroups: s.projectGroups.map((group) =>
+          group.id === groupId && projectGroupMatchesOwnerHost(group, ownerHostId)
+            ? ownedGroup
+            : group
+        ),
         folderWorkspacePathStatuses: {}
       }))
       return true
@@ -2809,8 +2853,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   deleteProjectGroup: async (groupId) => {
     try {
-      // Why: project groups are focused-host-scoped by design (see updateProjectGroup).
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: multi-host sidebars list remote groups while focus may be local (or vice versa).
+      const ownerSettings = settingsForProjectGroupOwner(get(), groupId)
+      const target = getActiveRuntimeTarget(ownerSettings)
+      const ownerHostId = getRuntimeTargetHostId(target)
       const deleted =
         target.kind === 'local'
           ? await window.api.projectGroups.delete({ groupId })
@@ -2826,14 +2872,27 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return false
       }
       set((s) => {
-        const deletedGroupIds = getProjectGroupSubtreeIds(s.projectGroups, groupId)
+        const hostGroups = s.projectGroups.filter((group) =>
+          projectGroupMatchesOwnerHost(group, ownerHostId)
+        )
+        const deletedGroupIds = getProjectGroupSubtreeIds(hostGroups, groupId)
         return {
-          projectGroups: s.projectGroups.filter((group) => !deletedGroupIds.has(group.id)),
+          projectGroups: s.projectGroups.filter(
+            (group) =>
+              !(deletedGroupIds.has(group.id) && projectGroupMatchesOwnerHost(group, ownerHostId))
+          ),
           folderWorkspaces: s.folderWorkspaces.filter(
-            (workspace) => !deletedGroupIds.has(workspace.projectGroupId)
+            (workspace) =>
+              !(
+                deletedGroupIds.has(workspace.projectGroupId) &&
+                getFolderWorkspaceHostId(workspace, s.projectGroups) === ownerHostId
+              )
           ),
           repos: s.repos.map((repo) =>
-            repo.projectGroupId && deletedGroupIds.has(repo.projectGroupId)
+            repo.projectGroupId &&
+            deletedGroupIds.has(repo.projectGroupId) &&
+            (getRepoExecutionHostId(repo) === ownerHostId ||
+              (!repo.executionHostId && !repo.connectionId))
               ? { ...repo, projectGroupId: null }
               : repo
           ),

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1013,11 +1013,15 @@ function mergeProjectCompatibilityForHostRepoChange({
   })
 }
 
-function getProjectGroupHostId(group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>) {
-  if (group.executionHostId) {
-    return group.executionHostId
+function getProjectGroupHostId(
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+): ExecutionHostId {
+  const explicitHost = parseExecutionHostId(group.executionHostId)
+  if (explicitHost) {
+    return explicitHost.id
   }
-  return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
+  const connectionId = group.connectionId?.trim()
+  return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
 }
 
 function getProjectGroupHostIdentity(group: ProjectGroup): string {
@@ -1031,7 +1035,7 @@ function projectGroupMatchesOwnerHost(
   if (!group.executionHostId && !group.connectionId?.trim()) {
     return true
   }
-  return getProjectGroupHostId(group) === ownerHostId
+  return catalogOwnsHost(ownerHostId, getProjectGroupHostId(group))
 }
 
 /** Route group mutations to the group's owner host, not whichever runtime is focused. */
@@ -2885,13 +2889,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             (workspace) =>
               !(
                 deletedGroupIds.has(workspace.projectGroupId) &&
-                getFolderWorkspaceHostId(workspace, s.projectGroups) === ownerHostId
+                catalogOwnsHost(ownerHostId, getFolderWorkspaceHostId(workspace, s.projectGroups))
               )
           ),
           repos: s.repos.map((repo) =>
             repo.projectGroupId &&
             deletedGroupIds.has(repo.projectGroupId) &&
-            (getRepoExecutionHostId(repo) === ownerHostId ||
+            (catalogOwnsHost(ownerHostId, getRepoExecutionHostId(repo)) ||
               (!repo.executionHostId && !repo.connectionId))
               ? { ...repo, projectGroupId: null }
               : repo


### PR DESCRIPTION
## ELI5

Project groups can appear in a multi-host sidebar even when their owning machine is not the focused runtime. Rename and delete now go to the machine that owns the group, so the action no longer fails or changes the wrong host.

## What Changed

- Resolve `updateProjectGroup` and `deleteProjectGroup` from the selected group's canonical `executionHostId` instead of the focused runtime.
- Normalize persisted host IDs and fall back to a trimmed SSH `connectionId` or local ownership when an explicit ID is invalid.
- Treat local and direct-SSH rows as one local project-group catalog while keeping paired runtime environments strictly isolated.
- Apply the same owner matching to group, folder-workspace, and repo deletion cascades so no dangling `projectGroupId` remains.
- Keep `moveProjectToGroup` on its existing repo-owner route; no wire or RPC shape changes.

## Why

The renderer merges project groups from every host, but mutations previously used the focused runtime. A local group selected while a paired runtime was active was sent to that runtime, which did not contain the group and returned failure. Routing by the persisted owner fixes the source of the error. Canonical matching is also required after a successful mutation so whitespace-padded legacy IDs and direct-SSH rows are removed from renderer state without touching another runtime's row.

## Linked Issue

Fixes #14007
Fixes #14849

## Visual Proof

N/A — this changes store/RPC routing and state reconciliation only; there is no layout or visual-state change to capture.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS:

- 26 `repos*.test.ts` files / 182 tests
- RED→GREEN coverage for a whitespace-padded runtime owner
- RED→GREEN coverage for an SSH group delete cascade across group, folder workspace, and repo membership
- `pnpm run typecheck:web`
- `oxlint --deny-warnings` and `oxfmt --check` on touched files
- `pnpm run check:code-quality:changed` — 0 findings

Not run:

- Live Linux, Windows, paired-runtime, or SSH UI smoke tests
- Full `pnpm test`: local Node 24.18.0 native-runtime preflight is blocked before Vitest by the patched `node-pty` build layout
- Full `pnpm lint` and `pnpm build`; focused lint/typecheck/tests and the changed-code gate cover this two-file store change

## AI Disclosure

- OpenAI Codex implemented the change and tests.
- Claude Sonnet performed two strict read-only diff reviews. Round 1 found the SSH cascade integrity gap; after a new RED→GREEN fix, Round 2 returned `PASS`.
- CodeRabbit's actionable owner-normalization thread was verified against the source before implementation.

## Review

- Security: no new input surface, permissions, persistence schema, or secrets.
- Cross-platform: no OS-specific paths, shortcuts, or commands; host IDs use existing shared parsing.
- Remote/SSH: direct SSH remains in the local catalog; paired runtimes remain exact-match isolated.
- Folder workspaces: deletion cascades use the same owner-catalog semantics as groups and repos.
- Wire compatibility: no RPC method, parameter, response, or stream change.
- Performance: constant-time parsing/comparison within existing catalog scans; no new I/O.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (limitations documented above)

## Author

- GitHub: @bbingz
