### PR TITLE
feat(git): multi-branch Git Graph view with worktree overlay

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1296,7 +1296,11 @@ export function registerFilesystemHandlers(
       _event,
       args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
     ): Promise<GitHistoryResult> => {
-      const options: GitHistoryOptions = { limit: args.limit, baseRef: args.baseRef }
+      const options: GitHistoryOptions = {
+        limit: args.limit,
+        baseRef: args.baseRef,
+        ...(args.allRefs === true ? { allRefs: true } : {})
+      }
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -71,8 +71,11 @@ export const GitCommitCompare = WorktreeSelector.extend({
 })
 
 export const GitHistory = WorktreeSelector.extend({
-  limit: z.number().int().min(1).max(200).optional(),
-  baseRef: z.string().nullable().optional()
+  // Why: 1000 is the all-refs graph ceiling (GIT_GRAPH_MAX_LIMIT); the shared
+  // loader still clamps HEAD-scoped requests to 200.
+  limit: z.number().int().min(1).max(1000).optional(),
+  baseRef: z.string().nullable().optional(),
+  allRefs: z.boolean().optional()
 })
 
 export const GitBranchDiff = GitFilePath.extend({

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -684,12 +684,35 @@ describe('git RPC methods', () => {
     const response = await dispatcher.dispatch(
       makeRequest('git.history', {
         worktree: 'id:wt-1',
-        limit: 201
+        limit: 1001
       })
     )
 
     expect(response.ok).toBe(false)
     expect(runtime.getRuntimeGitHistory).not.toHaveBeenCalled()
+  })
+
+  it('accepts all-refs graph limits and forwards the allRefs flag', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitHistory: vi.fn().mockResolvedValue({ items: [] })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.history', {
+        worktree: 'id:wt-1',
+        limit: 500,
+        allRefs: true
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.getRuntimeGitHistory).toHaveBeenCalledWith('id:wt-1', {
+      limit: 500,
+      baseRef: undefined,
+      allRefs: true
+    })
   })
 
   it('checks out a branch', async () => {

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -132,7 +132,8 @@ export const GIT_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) =>
       runtime.getRuntimeGitHistory(params.worktree, {
         limit: params.limit,
-        baseRef: params.baseRef
+        baseRef: params.baseRef,
+        ...(params.allRefs === true ? { allRefs: true } : {})
       })
   }),
   defineMethod({

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -426,7 +426,8 @@ export class GitHandler {
     const worktreePath = params.worktreePath as string
     return loadGitHistoryFromExecutor(this.git.bind(this), worktreePath, {
       limit: typeof params.limit === 'number' ? params.limit : undefined,
-      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
+      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null,
+      ...(params.allRefs === true ? { allRefs: true } : {})
     })
   }
 

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -28,6 +28,7 @@ import {
 import { getDiffContentSignature } from './diff-content-signature'
 import { translate } from '@/i18n/i18n'
 import { CheckRunDetailsPanel } from './CheckRunDetailsPanel'
+import { GitGraphView } from '../git-graph/GitGraphView'
 import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
@@ -641,6 +642,10 @@ export function EditorContent({
         }}
       />
     )
+  }
+
+  if (activeFile.mode === 'git-graph') {
+    return <GitGraphView worktreeId={activeFile.worktreeId} />
   }
 
   if (activeFile.mode === 'conflict-review') {

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -292,7 +292,7 @@ function EditorPanelInner({
   }
   const handleOpenContainingFolder = (): void => {
     // Why: virtual editor tabs use synthetic ids instead of on-disk paths.
-    if (activeFile.mode === 'check-details') {
+    if (activeFile.mode === 'check-details' || activeFile.mode === 'git-graph') {
       return
     }
     if (

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
@@ -48,7 +48,7 @@ export function EditorPanelHeaderPath({
   const skipMenuFocusRestoreRef = useRef(false)
   const headerCopyState = getEditorHeaderCopyState(activeFile)
   const canCopyHeaderPath = headerCopyState.copyText !== null
-  const isVirtualEditorTab = activeFile.mode === 'check-details'
+  const isVirtualEditorTab = activeFile.mode === 'check-details' || activeFile.mode === 'git-graph'
   const markdownPreviewShortcutLabel = useShortcutLabel('editor.markdownPreview')
   const {
     canRename,

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -97,42 +97,44 @@ export function EditorPanelShell({
 }: EditorPanelShellProps): JSX.Element {
   return (
     <div ref={panelRef} className="flex flex-col flex-1 min-w-0 min-h-0">
-      {!model.isCombinedDiff && activeFile.mode !== 'check-details' && (
-        <EditorPanelHeader
-          activeFile={activeFile}
-          copiedPathVisible={copiedPathVisible}
-          isSingleDiff={model.isSingleDiff}
-          isDiffSurface={model.isDiffSurface}
-          isMarkdown={model.isMarkdown}
-          isCsv={model.isCsv}
-          isNotebook={model.isNotebook}
-          hasEditorToggle={model.hasEditorToggle}
-          availableEditorToggleModes={model.availableEditorToggleModes}
-          effectiveToggleValue={model.effectiveToggleValue}
-          canOpenPreviewToSide={model.canOpenPreviewToSide}
-          canShowMarkdownPreview={model.canShowMarkdownPreview}
-          canShowMarkdownTableOfContents={model.canShowMarkdownTableOfContents}
-          isMarkdownTableOfContentsDisabled={model.isMarkdownTableOfContentsDisabled}
-          shouldShowMarkdownExportAction={model.shouldShowMarkdownExportAction}
-          canExportMarkdownToPdf={model.canExportMarkdownToPdf}
-          showMarkdownTableOfContents={showMarkdownTableOfContents}
-          canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
-          markdownFrontmatterVisible={markdownFrontmatterVisible}
-          sideBySide={sideBySide}
-          openFileState={model.openFileState}
-          onCopyPath={onCopyPath}
-          onOpenDiffTargetFile={onOpenDiffTargetFile}
-          onOpenPreviewToSide={onOpenPreviewToSide}
-          onOpenMarkdownPreview={onOpenMarkdownPreview}
-          onOpenContainingFolder={onOpenContainingFolder}
-          onToggleSideBySide={onToggleSideBySide}
-          onEditorToggleChange={onEditorToggleChange}
-          onToggleMarkdownTableOfContents={onToggleMarkdownTableOfContents}
-          onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
-          onExportMarkdownToPdf={onExportMarkdownToPdf}
-          createMarkdownArtifactRequest={createMarkdownArtifactRequest}
-        />
-      )}
+      {!model.isCombinedDiff &&
+        activeFile.mode !== 'check-details' &&
+        activeFile.mode !== 'git-graph' && (
+          <EditorPanelHeader
+            activeFile={activeFile}
+            copiedPathVisible={copiedPathVisible}
+            isSingleDiff={model.isSingleDiff}
+            isDiffSurface={model.isDiffSurface}
+            isMarkdown={model.isMarkdown}
+            isCsv={model.isCsv}
+            isNotebook={model.isNotebook}
+            hasEditorToggle={model.hasEditorToggle}
+            availableEditorToggleModes={model.availableEditorToggleModes}
+            effectiveToggleValue={model.effectiveToggleValue}
+            canOpenPreviewToSide={model.canOpenPreviewToSide}
+            canShowMarkdownPreview={model.canShowMarkdownPreview}
+            canShowMarkdownTableOfContents={model.canShowMarkdownTableOfContents}
+            isMarkdownTableOfContentsDisabled={model.isMarkdownTableOfContentsDisabled}
+            shouldShowMarkdownExportAction={model.shouldShowMarkdownExportAction}
+            canExportMarkdownToPdf={model.canExportMarkdownToPdf}
+            showMarkdownTableOfContents={showMarkdownTableOfContents}
+            canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
+            markdownFrontmatterVisible={markdownFrontmatterVisible}
+            sideBySide={sideBySide}
+            openFileState={model.openFileState}
+            onCopyPath={onCopyPath}
+            onOpenDiffTargetFile={onOpenDiffTargetFile}
+            onOpenPreviewToSide={onOpenPreviewToSide}
+            onOpenMarkdownPreview={onOpenMarkdownPreview}
+            onOpenContainingFolder={onOpenContainingFolder}
+            onToggleSideBySide={onToggleSideBySide}
+            onEditorToggleChange={onEditorToggleChange}
+            onToggleMarkdownTableOfContents={onToggleMarkdownTableOfContents}
+            onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
+            onExportMarkdownToPdf={onExportMarkdownToPdf}
+            createMarkdownArtifactRequest={createMarkdownArtifactRequest}
+          />
+        )}
       <Suspense fallback={<EditorLoadingFallback />}>
         <EditorContent
           activeFile={activeFile}

--- a/src/renderer/src/components/editor/editor-cmd-save-target.ts
+++ b/src/renderer/src/components/editor/editor-cmd-save-target.ts
@@ -5,7 +5,8 @@ export const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>([
   'editor',
   'diff',
   'conflict-review',
-  'check-details'
+  'check-details',
+  'git-graph'
 ])
 
 type EditorCmdSaveState = {

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -33,6 +33,15 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
     }
   }
 
+  if (file.mode === 'git-graph') {
+    return {
+      copyText: null,
+      copyToastLabel: 'Git graph copied',
+      pathLabel: 'Git Graph',
+      pathTitle: 'Git Graph'
+    }
+  }
+
   const isCombinedDiff =
     file.mode === 'diff' &&
     (file.diffSource === 'combined-all' ||

--- a/src/renderer/src/components/editor/editor-labels.ts
+++ b/src/renderer/src/components/editor/editor-labels.ts
@@ -33,6 +33,10 @@ export function getEditorDisplayLabel(
     return file.checkRunDetails?.check.name ?? getBaseLabel(file, variant)
   }
 
+  if (file.mode === 'git-graph') {
+    return 'Git Graph'
+  }
+
   if (file.mode === 'markdown-preview') {
     return `${getBaseLabel(file, variant)} (preview)`
   }

--- a/src/renderer/src/components/editor/useClosedEditorTabCleanup.ts
+++ b/src/renderer/src/components/editor/useClosedEditorTabCleanup.ts
@@ -76,5 +76,7 @@ function disposeClosedEditorTab(prevId: string, prevFile: OpenFile): void {
       break
     case 'check-details':
       break
+    case 'git-graph':
+      break
   }
 }

--- a/src/renderer/src/components/git-graph/GitGraphRow.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphRow.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { GitHistoryItem, GitHistoryItemRef } from '../../../../shared/git-history'
+import type { GitHistoryItemViewModel } from '../../../../shared/git-history-graph'
+import { dedupeRemoteTrackingRefs } from '../../../../shared/git-history-ref-display'
+import { GitHistoryGraphSvg, graphColor } from '../right-sidebar/GitHistoryGraphSvg'
+import { formatGitHistoryTimestamp } from '../right-sidebar/git-history-format'
+import { GitGraphWorktreeBadge } from './GitGraphWorktreeBadge'
+import type { GitGraphWorktreeOverlayEntry } from './git-graph-worktree-overlay'
+
+export const GIT_GRAPH_ROW_HEIGHT = 24
+
+const MAX_VISIBLE_REFS = 3
+
+function GitGraphRefPill({ itemRef }: { itemRef: GitHistoryItemRef }): React.JSX.Element {
+  const refLabel = itemRef.category ? `${itemRef.name} (${itemRef.category})` : itemRef.name
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="max-w-[9rem] shrink-0 truncate rounded-full border bg-background px-1.5 py-0.5 text-[10px] leading-none"
+          style={{
+            borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
+            color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
+          }}
+        >
+          {itemRef.name}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+        {refLabel}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export const GitGraphRow = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    viewModel: GitHistoryItemViewModel
+    worktreeOverlay: ReadonlyMap<string, GitGraphWorktreeOverlayEntry>
+    onOpenCommit?: (item: GitHistoryItem) => void
+  }
+>(function GitGraphRow(
+  { viewModel, worktreeOverlay, onOpenCommit, className, style, ...rootProps },
+  ref
+): React.JSX.Element {
+  const item = viewModel.historyItem
+  const refs = dedupeRemoteTrackingRefs(item.references ?? [])
+  const visibleRefs = refs.slice(0, MAX_VISIBLE_REFS)
+  const hiddenRefs = refs.slice(MAX_VISIBLE_REFS)
+  const rowTooltip = item.message || item.subject
+  const timestampLabel = formatGitHistoryTimestamp(item.timestamp)
+
+  return (
+    <button
+      {...rootProps}
+      ref={ref}
+      type="button"
+      style={style}
+      className={cn(
+        'grid h-6 w-full min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto_auto_auto] items-center gap-x-2 px-3 text-left text-xs transition-colors',
+        onOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
+        viewModel.kind === 'HEAD' && 'bg-accent/20',
+        className
+      )}
+      data-testid="git-graph-row"
+      aria-label={translate(
+        'auto.components.git.graph.GitGraphRow.openCommit',
+        'Open commit {{value0}}: {{value1}}',
+        { value0: item.displayId ?? item.id, value1: item.subject }
+      )}
+      onClick={onOpenCommit ? () => onOpenCommit(item) : undefined}
+    >
+      <GitHistoryGraphSvg viewModel={viewModel} />
+      {refs.length > 0 ? (
+        <span className="flex max-w-[40%] shrink-0 items-center gap-1 overflow-hidden">
+          {visibleRefs.map((itemRef) => {
+            const overlayEntry =
+              itemRef.category === 'branches' ? worktreeOverlay.get(itemRef.id) : undefined
+            return (
+              <React.Fragment key={itemRef.id}>
+                <GitGraphRefPill itemRef={itemRef} />
+                {overlayEntry && <GitGraphWorktreeBadge entry={overlayEntry} />}
+              </React.Fragment>
+            )
+          })}
+          {hiddenRefs.length > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="shrink-0 text-[10px] leading-none text-muted-foreground">
+                  +{hiddenRefs.length}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+                {hiddenRefs.map((itemRef) => itemRef.name).join(', ')}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </span>
+      ) : (
+        <span />
+      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="block min-w-0 truncate text-foreground">{item.subject}</span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+          {rowTooltip}
+        </TooltipContent>
+      </Tooltip>
+      <span className="max-w-[9rem] shrink-0 truncate text-[11px] text-muted-foreground">
+        {item.author ?? ''}
+      </span>
+      <span className="w-14 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+        {timestampLabel}
+      </span>
+      <span className="w-16 shrink-0 text-right font-mono text-[11px] text-muted-foreground">
+        {item.displayId ?? ''}
+      </span>
+    </button>
+  )
+})

--- a/src/renderer/src/components/git-graph/GitGraphRow.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphRow.tsx
@@ -41,10 +41,13 @@ export const GitGraphRow = React.forwardRef<
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
     viewModel: GitHistoryItemViewModel
     worktreeOverlay: ReadonlyMap<string, GitGraphWorktreeOverlayEntry>
+    // Shared across all rows so subjects align into one column even though
+    // each row's own SVG only spans its active lanes.
+    laneColumnWidth: number
     onOpenCommit?: (item: GitHistoryItem) => void
   }
 >(function GitGraphRow(
-  { viewModel, worktreeOverlay, onOpenCommit, className, style, ...rootProps },
+  { viewModel, worktreeOverlay, laneColumnWidth, onOpenCommit, className, style, ...rootProps },
   ref
 ): React.JSX.Element {
   const item = viewModel.historyItem
@@ -61,7 +64,7 @@ export const GitGraphRow = React.forwardRef<
       type="button"
       style={style}
       className={cn(
-        'grid h-6 w-full min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto_auto_auto] items-center gap-x-2 px-3 text-left text-xs transition-colors',
+        'grid h-6 w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto_auto_auto_auto] items-center gap-x-2 px-3 text-left text-xs transition-colors',
         onOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
         viewModel.kind === 'HEAD' && 'bg-accent/20',
         className
@@ -74,16 +77,26 @@ export const GitGraphRow = React.forwardRef<
       )}
       onClick={onOpenCommit ? () => onOpenCommit(item) : undefined}
     >
-      <GitHistoryGraphSvg viewModel={viewModel} />
+      <span className="shrink-0" style={{ width: laneColumnWidth }}>
+        <GitHistoryGraphSvg viewModel={viewModel} />
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="block min-w-0 truncate text-foreground">{item.subject}</span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+          {rowTooltip}
+        </TooltipContent>
+      </Tooltip>
       {refs.length > 0 ? (
-        <span className="flex max-w-[40%] shrink-0 items-center gap-1 overflow-hidden">
+        <span className="flex min-w-0 shrink items-center justify-end gap-1 overflow-hidden">
           {visibleRefs.map((itemRef) => {
             const overlayEntry =
               itemRef.category === 'branches' ? worktreeOverlay.get(itemRef.id) : undefined
             return (
               <React.Fragment key={itemRef.id}>
-                <GitGraphRefPill itemRef={itemRef} />
                 {overlayEntry && <GitGraphWorktreeBadge entry={overlayEntry} />}
+                <GitGraphRefPill itemRef={itemRef} />
               </React.Fragment>
             )
           })}
@@ -103,14 +116,6 @@ export const GitGraphRow = React.forwardRef<
       ) : (
         <span />
       )}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="block min-w-0 truncate text-foreground">{item.subject}</span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
-          {rowTooltip}
-        </TooltipContent>
-      </Tooltip>
       <span className="max-w-[9rem] shrink-0 truncate text-[11px] text-muted-foreground">
         {item.author ?? ''}
       </span>

--- a/src/renderer/src/components/git-graph/GitGraphView.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphView.tsx
@@ -1,0 +1,177 @@
+import React, { useMemo, useRef } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '@/store'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { buildGitGraphRows } from '../../../../shared/git-graph-lane-layout'
+import { GitHistoryCommitContextMenu } from '../right-sidebar/GitHistoryCommitContextMenu'
+import { useGitHistoryCommitActions } from '../right-sidebar/useGitHistoryCommitActions'
+import { GIT_GRAPH_ROW_HEIGHT, GitGraphRow } from './GitGraphRow'
+import { buildGitGraphWorktreeOverlay } from './git-graph-worktree-overlay'
+import { useGitGraphHistory } from './useGitGraphHistory'
+
+const EMPTY_WORKTREES: never[] = []
+
+// Whole-repo graph in the center pane: every branch, remote, and tag with
+// Orca's worktree overlay on decorated branches.
+export function GitGraphView({ worktreeId }: { worktreeId: string }): React.JSX.Element {
+  const {
+    state,
+    remoteUnsupported,
+    worktreePath,
+    activeRepoSettings,
+    refresh,
+    loadMore,
+    canLoadMore
+  } = useGitGraphHistory(worktreeId)
+
+  const repoId = useAppStore((s) => s.getKnownWorktreeById(worktreeId)?.repoId ?? null)
+  const repoDisplayName = useAppStore((s) => {
+    if (!repoId) {
+      return null
+    }
+    return s.repos.find((candidate) => candidate.id === repoId)?.displayName ?? null
+  })
+  const repoWorktrees = useAppStore((s) =>
+    repoId ? (s.worktreesByRepo[repoId] ?? EMPTY_WORKTREES) : EMPTY_WORKTREES
+  )
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+
+  const worktreeOverlay = useMemo(
+    () => buildGitGraphWorktreeOverlay(repoWorktrees, activeWorktreeId),
+    [activeWorktreeId, repoWorktrees]
+  )
+
+  const result = state.result
+  const rows = useMemo(
+    () => (result ? buildGitGraphRows(result.items, result.currentRef) : []),
+    [result]
+  )
+
+  const { openHistoryCommitDiff, handleCommitAction } = useGitHistoryCommitActions({
+    activeWorktreeId: worktreeId,
+    worktreePath,
+    activeRepoSettings,
+    resolveSplitTargetGroupId: () => undefined
+  })
+
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => GIT_GRAPH_ROW_HEIGHT,
+    getItemKey: (index) => rows[index]!.historyItem.id,
+    overscan: 20
+  })
+
+  const loading = state.status === 'loading' || state.status === 'refreshing'
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-3">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground/70">
+          {translate('auto.components.git.graph.GitGraphView.title', 'Git Graph')}
+        </span>
+        {repoDisplayName && (
+          <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+            {repoDisplayName}
+          </span>
+        )}
+        {result && (
+          <span className="text-[10px] font-medium tabular-nums text-muted-foreground">
+            {result.items.length}
+            {result.hasMore ? '+' : ''}
+          </span>
+        )}
+        <div className="flex-1" />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={translate(
+                'auto.components.git.graph.GitGraphView.refresh',
+                'Refresh graph'
+              )}
+              onClick={refresh}
+            >
+              <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate('auto.components.git.graph.GitGraphView.refresh', 'Refresh graph')}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {remoteUnsupported && (
+        <div className="shrink-0 border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+          {translate(
+            'auto.components.git.graph.GitGraphView.remoteUnsupported',
+            'The remote host runs an older Orca and returned current-branch history only. Update Orca on the host to see all branches.'
+          )}
+        </div>
+      )}
+
+      {state.status === 'error' && (
+        <div className="shrink-0 border-b border-border px-3 py-1.5 text-[11px] text-destructive">
+          {state.error}
+        </div>
+      )}
+
+      {(state.status === 'idle' || state.status === 'loading') && !result && (
+        <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+          <RefreshCw className="size-4 animate-spin" />
+          <span>
+            {translate('auto.components.git.graph.GitGraphView.loading', 'Loading graph...')}
+          </span>
+        </div>
+      )}
+
+      {result && rows.length === 0 && state.status !== 'loading' && (
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          {translate('auto.components.git.graph.GitGraphView.empty', 'No commits yet')}
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+          <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const viewModel = rows[virtualRow.index]!
+              return (
+                <ContextMenu key={virtualRow.key}>
+                  <ContextMenuTrigger asChild>
+                    <GitGraphRow
+                      viewModel={viewModel}
+                      worktreeOverlay={worktreeOverlay}
+                      onOpenCommit={(item) => void openHistoryCommitDiff(item)}
+                      className="absolute left-0 top-0"
+                      style={{ transform: `translateY(${virtualRow.start}px)` }}
+                    />
+                  </ContextMenuTrigger>
+                  <GitHistoryCommitContextMenu
+                    item={viewModel.historyItem}
+                    onAction={handleCommitAction}
+                  />
+                </ContextMenu>
+              )
+            })}
+          </div>
+          {canLoadMore && (
+            <div className="flex justify-center py-2">
+              <Button type="button" variant="ghost" size="sm" onClick={loadMore}>
+                {translate('auto.components.git.graph.GitGraphView.loadMore', 'Load more commits')}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/git-graph/GitGraphView.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphView.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { buildGitGraphRows } from '../../../../shared/git-graph-lane-layout'
 import { GitHistoryCommitContextMenu } from '../right-sidebar/GitHistoryCommitContextMenu'
+import { SWIMLANE_WIDTH } from '../right-sidebar/GitHistoryGraphSvg'
 import { useGitHistoryCommitActions } from '../right-sidebar/useGitHistoryCommitActions'
 import { GIT_GRAPH_ROW_HEIGHT, GitGraphRow } from './GitGraphRow'
 import { buildGitGraphWorktreeOverlay } from './git-graph-worktree-overlay'
@@ -51,6 +52,13 @@ export function GitGraphView({ worktreeId }: { worktreeId: string }): React.JSX.
     () => (result ? buildGitGraphRows(result.items, result.currentRef) : []),
     [result]
   )
+  const laneColumnWidth = useMemo(() => {
+    let maxLanes = 1
+    for (const row of rows) {
+      maxLanes = Math.max(maxLanes, row.inputSwimlanes.length, row.outputSwimlanes.length)
+    }
+    return SWIMLANE_WIDTH * (maxLanes + 1)
+  }, [rows])
 
   const { openHistoryCommitDiff, handleCommitAction } = useGitHistoryCommitActions({
     activeWorktreeId: worktreeId,
@@ -150,6 +158,7 @@ export function GitGraphView({ worktreeId }: { worktreeId: string }): React.JSX.
                     <GitGraphRow
                       viewModel={viewModel}
                       worktreeOverlay={worktreeOverlay}
+                      laneColumnWidth={laneColumnWidth}
                       onOpenCommit={(item) => void openHistoryCommitDiff(item)}
                       className="absolute left-0 top-0"
                       style={{ transform: `translateY(${virtualRow.start}px)` }}

--- a/src/renderer/src/components/git-graph/GitGraphWorktreeBadge.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphWorktreeBadge.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getWorktreeStatusLabel } from '@/lib/worktree-status'
+import { useWorktreeActivityStatus } from '@/components/sidebar/use-worktree-activity-status'
+import StatusIndicator from '@/components/sidebar/StatusIndicator'
+import { translate } from '@/i18n/i18n'
+import type { GitGraphWorktreeOverlayEntry } from './git-graph-worktree-overlay'
+
+// The graph's Orca differentiator: branches with a workspace show a live
+// activity dot and jump straight to that worktree on click.
+export function GitGraphWorktreeBadge({
+  entry
+}: {
+  entry: GitGraphWorktreeOverlayEntry
+}): React.JSX.Element {
+  const activity = useWorktreeActivityStatus(entry.worktreeId)
+  const workspaceStatusLabel = useAppStore((s) => {
+    if (!entry.workspaceStatus) {
+      return null
+    }
+    return (
+      s.workspaceStatuses.find((candidate) => candidate.id === entry.workspaceStatus)?.label ?? null
+    )
+  })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="flex max-w-[10rem] shrink-0 items-center gap-1 rounded-full border border-border bg-background px-1.5 py-0.5 text-[10px] leading-none text-foreground transition-colors hover:bg-accent"
+          aria-label={translate(
+            'auto.components.git.graph.GitGraphWorktreeBadge.openWorktree',
+            'Open worktree {{value0}}',
+            { value0: entry.displayName }
+          )}
+          onClick={(event) => {
+            event.stopPropagation()
+            activateAndRevealWorktree(entry.worktreeId)
+          }}
+        >
+          <StatusIndicator status={activity} aria-hidden="true" />
+          <span className="truncate">{entry.displayName}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+        <div className="font-medium">{entry.displayName}</div>
+        <div>
+          {entry.isActiveWorkspace
+            ? translate(
+                'auto.components.git.graph.GitGraphWorktreeBadge.currentWorkspace',
+                'Current workspace'
+              )
+            : getWorktreeStatusLabel(activity)}
+          {workspaceStatusLabel ? ` · ${workspaceStatusLabel}` : ''}
+        </div>
+        {!entry.isActiveWorkspace && (
+          <div className="text-background/70">
+            {translate(
+              'auto.components.git.graph.GitGraphWorktreeBadge.clickToOpen',
+              'Click to open this worktree'
+            )}
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/git-graph/git-graph-tab.ts
+++ b/src/renderer/src/components/git-graph/git-graph-tab.ts
@@ -1,0 +1,7 @@
+export const GIT_GRAPH_TAB_LABEL = 'Git Graph'
+
+// Why: one graph tab per workspace — the view always renders live repo state,
+// so reopening must focus the existing tab instead of stacking duplicates.
+export function buildGitGraphTabId(worktreeId: string): string {
+  return `${worktreeId}::git-graph`
+}

--- a/src/renderer/src/components/git-graph/git-graph-worktree-overlay.test.ts
+++ b/src/renderer/src/components/git-graph/git-graph-worktree-overlay.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import { buildGitGraphWorktreeOverlay } from './git-graph-worktree-overlay'
+
+function worktree(overrides: Partial<Worktree> & Pick<Worktree, 'id' | 'branch'>): Worktree {
+  return {
+    repoId: 'repo-1',
+    displayName: overrides.id,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    path: `/tmp/${overrides.id}`,
+    head: 'a'.repeat(40),
+    isBare: false,
+    isMainWorktree: false,
+    ...overrides
+  } as Worktree
+}
+
+describe('buildGitGraphWorktreeOverlay', () => {
+  it('keys entries by full branch ref and carries display metadata', () => {
+    const overlay = buildGitGraphWorktreeOverlay(
+      [
+        worktree({
+          id: 'repo-1::/tmp/feature',
+          branch: 'refs/heads/feature',
+          displayName: 'Feature work',
+          workspaceStatus: 'in-progress'
+        })
+      ],
+      null
+    )
+
+    expect(overlay.get('refs/heads/feature')).toEqual({
+      worktreeId: 'repo-1::/tmp/feature',
+      displayName: 'Feature work',
+      workspaceStatus: 'in-progress',
+      isActiveWorkspace: false
+    })
+  })
+
+  it('marks the active workspace and omits missing workspaceStatus', () => {
+    const overlay = buildGitGraphWorktreeOverlay(
+      [worktree({ id: 'repo-1::/tmp/main', branch: 'refs/heads/main' })],
+      'repo-1::/tmp/main'
+    )
+
+    const entry = overlay.get('refs/heads/main')
+    expect(entry?.isActiveWorkspace).toBe(true)
+    expect(entry && 'workspaceStatus' in entry).toBe(false)
+  })
+
+  it('skips detached and archived worktrees', () => {
+    const overlay = buildGitGraphWorktreeOverlay(
+      [
+        worktree({ id: 'repo-1::/tmp/detached', branch: '' }),
+        worktree({ id: 'repo-1::/tmp/archived', branch: 'refs/heads/old', isArchived: true })
+      ],
+      null
+    )
+
+    expect(overlay.size).toBe(0)
+  })
+
+  it('keeps the first entry when two worktrees claim one branch', () => {
+    const overlay = buildGitGraphWorktreeOverlay(
+      [
+        worktree({ id: 'repo-1::/tmp/first', branch: 'refs/heads/shared' }),
+        worktree({ id: 'repo-1::/tmp/second', branch: 'refs/heads/shared' })
+      ],
+      null
+    )
+
+    expect(overlay.get('refs/heads/shared')?.worktreeId).toBe('repo-1::/tmp/first')
+  })
+})

--- a/src/renderer/src/components/git-graph/git-graph-worktree-overlay.ts
+++ b/src/renderer/src/components/git-graph/git-graph-worktree-overlay.ts
@@ -1,0 +1,34 @@
+import type { Worktree } from '../../../../shared/types'
+
+export type GitGraphWorktreeOverlayEntry = {
+  worktreeId: string
+  displayName: string
+  workspaceStatus?: string
+  isActiveWorkspace: boolean
+}
+
+// Keyed by the full branch ref id ('refs/heads/x') so lookups match
+// GitHistoryItemRef.id for local branches directly.
+export function buildGitGraphWorktreeOverlay(
+  worktrees: readonly Worktree[],
+  activeWorktreeId: string | null
+): Map<string, GitGraphWorktreeOverlayEntry> {
+  const overlay = new Map<string, GitGraphWorktreeOverlayEntry>()
+  for (const worktree of worktrees) {
+    // Detached worktrees have no branch ref to decorate; archived ones are
+    // parked and would only add noise to the graph.
+    if (!worktree.branch || worktree.isArchived) {
+      continue
+    }
+    if (overlay.has(worktree.branch)) {
+      continue
+    }
+    overlay.set(worktree.branch, {
+      worktreeId: worktree.id,
+      displayName: worktree.displayName,
+      ...(worktree.workspaceStatus ? { workspaceStatus: worktree.workspaceStatus } : {}),
+      isActiveWorkspace: worktree.id === activeWorktreeId
+    })
+  }
+  return overlay
+}

--- a/src/renderer/src/components/git-graph/useGitGraphHistory.ts
+++ b/src/renderer/src/components/git-graph/useGitGraphHistory.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useAppStore } from '@/store'
+import { getRuntimeGitHistory } from '@/runtime/runtime-git-client'
+import { getConnectionId } from '@/lib/connection-context'
+import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
+import { translate } from '@/i18n/i18n'
+import {
+  GIT_GRAPH_DEFAULT_LIMIT,
+  GIT_GRAPH_MAX_LIMIT,
+  GIT_HISTORY_MAX_LIMIT,
+  type GitHistoryResult
+} from '../../../../shared/git-history'
+
+export type GitGraphHistoryState =
+  | { status: 'idle' | 'loading'; result?: GitHistoryResult; error?: string }
+  | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: string }
+  | { status: 'error'; result?: GitHistoryResult; error: string }
+
+export function useGitGraphHistory(worktreeId: string): {
+  state: GitGraphHistoryState
+  // True when the remote host predates allRefs and served HEAD-only history.
+  remoteUnsupported: boolean
+  worktreePath: string | null
+  activeRepoSettings: ReturnType<typeof getRepoOwnerRoutedSettings>
+  refresh: () => void
+  loadMore: () => void
+  canLoadMore: boolean
+} {
+  const worktree = useAppStore((s) => s.getKnownWorktreeById(worktreeId) ?? null)
+  const repo = useAppStore((s) => {
+    const repoId = worktree?.repoId
+    return repoId ? (s.repos.find((candidate) => candidate.id === repoId) ?? null) : null
+  })
+  const settings = useAppStore((s) => s.settings)
+  const activeRepoSettings = useMemo(
+    () =>
+      getRepoOwnerRoutedSettings(
+        settings,
+        repo
+          ? { id: repo.id, connectionId: repo.connectionId, executionHostId: repo.executionHostId }
+          : null
+      ),
+    [repo, settings]
+  )
+
+  const worktreePath = worktree?.path ?? null
+  const [state, setState] = useState<GitGraphHistoryState>({ status: 'idle' })
+  const [limit, setLimit] = useState(GIT_GRAPH_DEFAULT_LIMIT)
+  const requestSeqRef = useRef(0)
+
+  const result = state.result
+  const remoteUnsupported = Boolean(result && result.allRefs !== true)
+
+  const load = useCallback(
+    async (requestedLimit: number): Promise<void> => {
+      if (!worktreePath) {
+        return
+      }
+      const requestId = requestSeqRef.current + 1
+      requestSeqRef.current = requestId
+      setState((prev) =>
+        prev.result ? { status: 'refreshing', result: prev.result } : { status: 'loading' }
+      )
+      try {
+        const connectionId = getConnectionId(worktreeId) ?? undefined
+        // Why: route the history read by the repo OWNER host, not the focused runtime.
+        const next = await getRuntimeGitHistory(
+          { settings: activeRepoSettings, worktreeId, worktreePath, connectionId },
+          { limit: requestedLimit, allRefs: true }
+        )
+        if (requestSeqRef.current !== requestId) {
+          return
+        }
+        setState({ status: 'ready', result: next })
+      } catch (error) {
+        if (requestSeqRef.current !== requestId) {
+          return
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : translate(
+                'auto.components.git.graph.useGitGraphHistory.loadFailed',
+                'Failed to load the repository graph'
+              )
+        setState((prev) =>
+          prev.result
+            ? { status: 'error', result: prev.result, error: message }
+            : { status: 'error', error: message }
+        )
+      }
+    },
+    [activeRepoSettings, worktreeId, worktreePath]
+  )
+
+  // Why: reload only on workspace identity change — refetching on every routed
+  // settings identity churn would thrash remote hosts.
+  const loadRef = useRef(load)
+  loadRef.current = load
+  useEffect(() => {
+    setLimit(GIT_GRAPH_DEFAULT_LIMIT)
+    void loadRef.current(GIT_GRAPH_DEFAULT_LIMIT)
+  }, [worktreeId, worktreePath])
+
+  const refresh = useCallback(() => {
+    void load(limit)
+  }, [limit, load])
+
+  // Old hosts clamp (and old runtime schemas reject) limits above the
+  // single-branch ceiling, so cap growth until the allRefs echo confirms.
+  const maxLimit = remoteUnsupported ? GIT_HISTORY_MAX_LIMIT : GIT_GRAPH_MAX_LIMIT
+  const canLoadMore = Boolean(result?.hasMore) && limit < maxLimit
+
+  const loadMore = useCallback(() => {
+    const nextLimit = Math.min(limit * 2, maxLimit)
+    if (nextLimit === limit) {
+      return
+    }
+    setLimit(nextLimit)
+    void load(nextLimit)
+  }, [limit, load, maxLimit])
+
+  return {
+    state,
+    remoteUnsupported,
+    worktreePath,
+    activeRepoSettings,
+    refresh,
+    loadMore,
+    canLoadMore
+  }
+}

--- a/src/renderer/src/components/right-sidebar/GitHistoryGraphSvg.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryGraphSvg.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../shared/git-history-graph'
 
 const SWIMLANE_HEIGHT = 24
-const SWIMLANE_WIDTH = 11
+export const SWIMLANE_WIDTH = 11
 const SWIMLANE_CURVE_RADIUS = 5
 const SWIMLANE_NODE_Y = SWIMLANE_HEIGHT / 2
 const CIRCLE_RADIUS = 3.5

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -60,6 +60,29 @@ describe('GitHistoryPanel', () => {
     }
   )
 
+  it('renders the graph-view entry point only when a handler is wired', () => {
+    const withHandler = renderToStaticMarkup(
+      <GitHistoryPanel
+        state={{ status: 'ready', result: makeHistoryResult() }}
+        collapsed={false}
+        onToggle={vi.fn()}
+        onRefresh={vi.fn()}
+        onOpenGraph={vi.fn()}
+      />
+    )
+    expect(withHandler).toContain('Open git graph')
+
+    const withoutHandler = renderToStaticMarkup(
+      <GitHistoryPanel
+        state={{ status: 'ready', result: makeHistoryResult() }}
+        collapsed={false}
+        onToggle={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    )
+    expect(withoutHandler).not.toContain('Open git graph')
+  })
+
   // The dense row is subject-only; author and date now surface on expand, so the
   // collapsed row shows the subject and short id (the short id via aria-label).
   it('renders the commit subject row', () => {

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, CircleHelp, RefreshCw } from 'lucide-react'
+import { ChevronDown, CircleHelp, GitBranch, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -45,6 +45,7 @@ export function GitHistoryPanel({
   collapsed,
   onToggle,
   onRefresh,
+  onOpenGraph,
   onOpenCommit,
   onLoadCommitFiles,
   onOpenCommitFile,
@@ -54,6 +55,7 @@ export function GitHistoryPanel({
   collapsed: boolean
   onToggle: () => void
   onRefresh: () => void
+  onOpenGraph?: () => void
   onOpenCommit?: (item: GitHistoryItem) => void
   onLoadCommitFiles?: (item: GitHistoryItem) => Promise<GitBranchChangeEntry[]>
   onOpenCommitFile?: (
@@ -274,6 +276,34 @@ export function GitHistoryPanel({
               )}
             </TooltipContent>
           </Tooltip>
+          {onOpenGraph && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="my-auto h-auto w-auto p-0.5 text-muted-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent [&_svg]:size-3"
+                  aria-label={translate(
+                    'auto.components.right.sidebar.GitHistoryPanel.openGraph',
+                    'Open git graph'
+                  )}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onOpenGraph()
+                  }}
+                >
+                  <GitBranch className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {translate(
+                  'auto.components.right.sidebar.GitHistoryPanel.openGraphTooltip',
+                  'Open the all-branches graph'
+                )}
+              </TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -940,6 +940,7 @@ function SourceControlInner(): React.JSX.Element {
   const setPendingEditorReveal = useAppStore((s) => s.setPendingEditorReveal)
   const openConflictFile = useAppStore((s) => s.openConflictFile)
   const openConflictReview = useAppStore((s) => s.openConflictReview)
+  const openGitGraph = useAppStore((s) => s.openGitGraph)
   const openBranchDiff = useAppStore((s) => s.openBranchDiff)
   const createEmptySplitGroup = useAppStore((s) => s.createEmptySplitGroup)
   const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
@@ -6302,6 +6303,7 @@ function SourceControlInner(): React.JSX.Element {
                 collapsed={collapsedSections.has('history')}
                 onToggle={() => toggleSection('history')}
                 onRefresh={() => void refreshGitHistory()}
+                onOpenGraph={activeWorktreeId ? () => openGitGraph(activeWorktreeId) : undefined}
                 onOpenCommit={(item) => void openHistoryCommitDiff(item)}
                 onLoadCommitFiles={loadCommitFiles}
                 onOpenCommitFile={openCommitFile}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -15,6 +15,7 @@ import {
   FolderInput,
   FolderPlus,
   FolderX,
+  GitBranch,
   Loader2,
   Plus,
   Server,
@@ -663,6 +664,7 @@ type VirtualizedWorktreeViewportProps = {
   handleCreateForRepo: (projectId: string) => void
   handleOpenRepoSettings: (projectId: string, sectionId?: string) => void
   handleOpenWorktreeVisibility: (projectId: string) => void
+  handleOpenRepoGitGraph: (repo: Repo) => void
   handleShowImportedWorktrees: (projectId: string) => void
   handleKeepImportedWorktreesHidden: (projectId: string) => void
   importedWorktreeCardActionState: ReadonlyMap<string, ImportedWorktreeCardActionState>
@@ -1330,6 +1332,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   handleCreateForRepo,
   handleOpenRepoSettings,
   handleOpenWorktreeVisibility,
+  handleOpenRepoGitGraph,
   handleShowImportedWorktrees,
   handleKeepImportedWorktreesHidden,
   importedWorktreeCardActionState,
@@ -4597,6 +4600,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                             onClick={stopRepoHeaderMenuEvent}
                             onKeyDown={stopRepoHeaderMenuEvent}
                           >
+                            {row.repo && isGitRepoKind(row.repo) ? (
+                              <DropdownMenuItem
+                                onSelect={() => {
+                                  if (row.repo) {
+                                    handleOpenRepoGitGraph(row.repo)
+                                  }
+                                }}
+                              >
+                                <GitBranch className="size-3.5" />
+                                {translate(
+                                  'auto.components.sidebar.WorktreeList.openGitGraph',
+                                  'Open Git Graph'
+                                )}
+                              </DropdownMenuItem>
+                            ) : null}
                             <DropdownMenuItem
                               onSelect={() => {
                                 if (row.repo) {
@@ -6057,6 +6075,26 @@ const WorktreeList = React.memo(function WorktreeList({
     [openModal]
   )
 
+  // Why: the graph is repo-scoped but tabs live in a workspace — reuse the
+  // active workspace when it belongs to this repo, else jump to the main
+  // (or first live) worktree so the tab lands somewhere sensible.
+  const handleOpenRepoGitGraph = useCallback((repo: Repo) => {
+    const state = useAppStore.getState()
+    const repoWorktrees = state.worktreesByRepo[repo.id] ?? []
+    const target =
+      repoWorktrees.find((candidate) => candidate.id === state.activeWorktreeId) ??
+      repoWorktrees.find((candidate) => candidate.isMainWorktree && !candidate.isArchived) ??
+      repoWorktrees.find((candidate) => !candidate.isArchived) ??
+      repoWorktrees[0]
+    if (!target) {
+      return
+    }
+    if (target.id !== state.activeWorktreeId) {
+      activateAndRevealWorktree(target.id)
+    }
+    state.openGitGraph(target.id)
+  }, [])
+
   const setImportedWorktreeCardState = useCallback(
     (projectId: string, state: ImportedWorktreeCardActionState | null) => {
       setImportedWorktreeCardActionState((previous) => {
@@ -6855,6 +6893,7 @@ const WorktreeList = React.memo(function WorktreeList({
         handleCreateForRepo={handleCreateForRepo}
         handleOpenRepoSettings={handleOpenRepoSettings}
         handleOpenWorktreeVisibility={handleOpenWorktreeVisibility}
+        handleOpenRepoGitGraph={handleOpenRepoGitGraph}
         handleShowImportedWorktrees={handleShowImportedWorktrees}
         handleKeepImportedWorktreesHidden={handleKeepImportedWorktreesHidden}
         importedWorktreeCardActionState={importedWorktreeCardActionState}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
-import { GitCompareArrows, Eye, ShieldAlert, Pin, ListChecks } from 'lucide-react'
+import { GitCompareArrows, Eye, GitBranch, ShieldAlert, Pin, ListChecks } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { basename, normalizeRelativePath } from '@/lib/path'
@@ -87,6 +87,7 @@ export default function EditorFileTab({
   const isDiff = file.mode === 'diff'
   const isConflictReview = file.mode === 'conflict-review'
   const isCheckDetails = file.mode === 'check-details'
+  const isGitGraph = file.mode === 'git-graph'
   const isMarkdownPreviewTab = file.mode === 'markdown-preview'
   // Why: only deleted/renamed mean the file is gone from its path, which is
   // what strikethrough conveys. 'changed' keeps a normal label — its surface
@@ -267,6 +268,10 @@ export default function EditorFileTab({
         />
       ) : isCheckDetails ? (
         <ListChecks
+          className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+        />
+      ) : isGitGraph ? (
+        <GitBranch
           className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
         />
       ) : isDiff ? (

--- a/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
+++ b/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
@@ -37,7 +37,8 @@ function TabIcon({ item }: { item: RecentTabSwitcherItem }): React.JSX.Element {
   if (
     item.contentType === 'diff' ||
     item.contentType === 'conflict-review' ||
-    item.contentType === 'check-details'
+    item.contentType === 'check-details' ||
+    item.contentType === 'git-graph'
   ) {
     return <GitCompare className={className} />
   }

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -162,7 +162,8 @@ export function useTabGroupWorkspaceModel({
             item.contentType === 'editor' ||
             item.contentType === 'diff' ||
             item.contentType === 'conflict-review' ||
-            item.contentType === 'check-details'
+            item.contentType === 'check-details' ||
+            item.contentType === 'git-graph'
         )
         .map((item) => {
           const file = worktreeState.openFiles.find((candidate) => candidate.id === item.entityId)
@@ -193,7 +194,8 @@ export function useTabGroupWorkspaceModel({
           (item.contentType === 'editor' ||
             item.contentType === 'diff' ||
             item.contentType === 'conflict-review' ||
-            item.contentType === 'check-details')
+            item.contentType === 'check-details' ||
+            item.contentType === 'git-graph')
       )
       if (!otherReference) {
         const file = useAppStore.getState().openFiles.find((candidate) => candidate.id === entityId)
@@ -488,7 +490,8 @@ export function useTabGroupWorkspaceModel({
         item.contentType === 'editor' ||
         item.contentType === 'diff' ||
         item.contentType === 'conflict-review' ||
-        item.contentType === 'check-details'
+        item.contentType === 'check-details' ||
+        item.contentType === 'git-graph'
       ) {
         closeItem(item.id)
       }

--- a/src/renderer/src/components/terminal/terminal-tab-bulk-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-bulk-actions.ts
@@ -12,7 +12,8 @@ const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>([
   'editor',
   'diff',
   'conflict-review',
-  'check-details'
+  'check-details',
+  'git-graph'
 ])
 
 type TerminalTabBulkActionState = ReturnType<typeof useAppStore.getState>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4846,7 +4846,8 @@
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "failedNestWorkspace": "Failed to nest workspace",
           "sidebarRowMissing": "Target no longer exists",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "Failed to unnest workspace",
+          "openGitGraph": "Open Git Graph"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10827,7 +10827,9 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "error",
             "e5e81e59a6": "Resize commits",
-            "6d1e0a7c3b": "Failed to load commit files"
+            "6d1e0a7c3b": "Failed to load commit files",
+            "openGraph": "Open git graph",
+            "openGraphTooltip": "Open the all-branches graph"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "Close",
@@ -15069,6 +15071,29 @@
           "openLink": "Open link",
           "updating": "Updating…",
           "update": "Update shared content"
+        }
+      },
+      "git": {
+        "graph": {
+          "GitGraphRow": {
+            "openCommit": "Open commit {{value0}}: {{value1}}"
+          },
+          "GitGraphView": {
+            "title": "Git Graph",
+            "refresh": "Refresh graph",
+            "remoteUnsupported": "The remote host runs an older Orca and returned current-branch history only. Update Orca on the host to see all branches.",
+            "loading": "Loading graph...",
+            "empty": "No commits yet",
+            "loadMore": "Load more commits"
+          },
+          "GitGraphWorktreeBadge": {
+            "openWorktree": "Open worktree {{value0}}",
+            "currentWorkspace": "Current workspace",
+            "clickToOpen": "Click to open this worktree"
+          },
+          "useGitGraphHistory": {
+            "loadFailed": "Failed to load the repository graph"
+          }
         }
       }
     },

--- a/src/renderer/src/lib/workspace-tab-palette-search.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.ts
@@ -22,6 +22,7 @@ export type WorkspaceTabContentType =
   | 'diff'
   | 'conflict-review'
   | 'check-details'
+  | 'git-graph'
 
 export type SearchableWorkspaceTab = {
   tab: Tab & { contentType: WorkspaceTabContentType }
@@ -137,7 +138,8 @@ function isWorkspaceTabContentType(
     contentType === 'editor' ||
     contentType === 'diff' ||
     contentType === 'conflict-review' ||
-    contentType === 'check-details'
+    contentType === 'check-details' ||
+    contentType === 'git-graph'
   )
 }
 

--- a/src/renderer/src/runtime/mobile-session-tab-close.ts
+++ b/src/renderer/src/runtime/mobile-session-tab-close.ts
@@ -1,6 +1,12 @@
 import type { AppState } from '../store/types'
 
-const EDITOR_SESSION_CONTENT_TYPES = new Set(['editor', 'diff', 'conflict-review', 'check-details'])
+const EDITOR_SESSION_CONTENT_TYPES = new Set([
+  'editor',
+  'diff',
+  'conflict-review',
+  'check-details',
+  'git-graph'
+])
 
 export function closeMobileSessionTabInStore(
   store: Pick<AppState, 'unifiedTabsByWorktree' | 'openFiles' | 'closeFile' | 'closeUnifiedTab'>,

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -24,6 +24,7 @@ import {
   type CheckRunDetailsTabPatch,
   type OpenCheckRunDetailsState
 } from '@/components/editor/check-run-details-tab'
+import { GIT_GRAPH_TAB_LABEL, buildGitGraphTabId } from '@/components/git-graph/git-graph-tab'
 import { openHttpLink, type HttpLinkSourceOwner } from '@/lib/http-link-routing'
 import { getConnectionIdForFileFromState } from '@/lib/connection-owner-resolution'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
@@ -295,7 +296,7 @@ export type OpenFile = {
   readOnly?: boolean
   /** Why: explicit live tail, only meaningful for a read-only local log. */
   liveTail?: boolean
-  mode: 'edit' | 'diff' | 'conflict-review' | 'markdown-preview' | 'check-details'
+  mode: 'edit' | 'diff' | 'conflict-review' | 'markdown-preview' | 'check-details' | 'git-graph'
 }
 
 export type ActivityBarPosition = 'top' | 'side'
@@ -612,6 +613,7 @@ export type EditorSlice = {
     state: CheckRunDetailsTabPatch
   ) => void
   reloadOpenCheckRunDetailsTab: (fileId: string) => Promise<void>
+  openGitGraph: (worktreeId: string) => void
   openBranchAllDiffs: (
     worktreeId: string,
     worktreePath: string,
@@ -768,7 +770,7 @@ function openWorkspaceEditorItem(
   fileId: string,
   worktreeId: string,
   label: string,
-  contentType: 'editor' | 'diff' | 'conflict-review' | 'check-details',
+  contentType: 'editor' | 'diff' | 'conflict-review' | 'check-details' | 'git-graph',
   isPreview?: boolean,
   targetGroupId?: string
 ): string {
@@ -800,7 +802,8 @@ function isEditorTabContentType(contentType: Tab['contentType']): boolean {
     contentType === 'editor' ||
     contentType === 'diff' ||
     contentType === 'conflict-review' ||
-    contentType === 'check-details'
+    contentType === 'check-details' ||
+    contentType === 'git-graph'
   )
 }
 
@@ -1729,14 +1732,21 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     let editorItemWorktreeId = file.worktreeId
     let editorItemFileId = file.filePath
     let editorItemLabel = file.relativePath
-    let editorItemContentType: 'editor' | 'diff' | 'conflict-review' | 'check-details' =
+    let editorItemContentType:
+      | 'editor'
+      | 'diff'
+      | 'conflict-review'
+      | 'check-details'
+      | 'git-graph' =
       file.mode === 'conflict-review'
         ? 'conflict-review'
         : file.mode === 'check-details'
           ? 'check-details'
-          : file.mode === 'diff'
-            ? 'diff'
-            : 'editor'
+          : file.mode === 'git-graph'
+            ? 'git-graph'
+            : file.mode === 'diff'
+              ? 'diff'
+              : 'editor'
     let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
       const worktreeId = file.worktreeId
@@ -2361,7 +2371,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           (entry.contentType === 'editor' ||
             entry.contentType === 'diff' ||
             entry.contentType === 'conflict-review' ||
-            entry.contentType === 'check-details')
+            entry.contentType === 'check-details' ||
+            entry.contentType === 'git-graph')
       )
       if (unifiedTab) {
         get().closeUnifiedTab(unifiedTab.id)
@@ -2416,7 +2427,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           (item.contentType === 'editor' ||
             item.contentType === 'diff' ||
             item.contentType === 'conflict-review' ||
-            item.contentType === 'check-details') &&
+            item.contentType === 'check-details' ||
+            item.contentType === 'git-graph') &&
           (!activeWorktreeId || item.worktreeId === activeWorktreeId)
       )
       .map((item) => item.id)
@@ -3881,6 +3893,34 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     void openWorkspaceEditorItem(get(), id, worktreeId, label, 'check-details')
   },
 
+  // Why: the sidebar graph panel only fits the active branch; the whole-repo
+  // graph gets the center pane, one live tab per workspace.
+  openGitGraph: (worktreeId) => {
+    const id = buildGitGraphTabId(worktreeId)
+    set((s) => {
+      const activation = {
+        activeFileId: id,
+        activeTabType: 'editor' as const,
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' as const }
+      }
+      if (s.openFiles.some((f) => f.id === id)) {
+        return activation
+      }
+      const newFile: OpenFile = {
+        id,
+        filePath: id,
+        relativePath: GIT_GRAPH_TAB_LABEL,
+        worktreeId,
+        language: 'plaintext',
+        isDirty: false,
+        mode: 'git-graph'
+      }
+      return { openFiles: [...s.openFiles, newFile], ...activation }
+    })
+    void openWorkspaceEditorItem(get(), id, worktreeId, GIT_GRAPH_TAB_LABEL, 'git-graph')
+  },
+
   // Why: sidebar detail fetches can finish after the full-details tab is open; update the snapshot without stealing focus.
   patchOpenCheckRunDetails: (worktreeId, contextKey, check, state) => {
     const id = buildCheckRunDetailsTabId(worktreeId, check)
@@ -5314,7 +5354,11 @@ function reconcileOpenFilesForStatus(
       return [file]
     }
 
-    if (file.mode === 'conflict-review' || file.mode === 'check-details') {
+    if (
+      file.mode === 'conflict-review' ||
+      file.mode === 'check-details' ||
+      file.mode === 'git-graph'
+    ) {
       return [file]
     }
 

--- a/src/renderer/src/store/slices/tab-group-state.ts
+++ b/src/renderer/src/store/slices/tab-group-state.ts
@@ -156,7 +156,10 @@ export function updateGroup(groups: TabGroup[], updated: TabGroup): TabGroup[] {
 
 export function isTransientEditorContentType(contentType: TabContentType): boolean {
   return (
-    contentType === 'diff' || contentType === 'conflict-review' || contentType === 'check-details'
+    contentType === 'diff' ||
+    contentType === 'conflict-review' ||
+    contentType === 'check-details' ||
+    contentType === 'git-graph'
   )
 }
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -334,7 +334,8 @@ function isReplaceablePreviewContentType(contentType: Tab['contentType']): boole
     contentType === 'editor' ||
     contentType === 'diff' ||
     contentType === 'conflict-review' ||
-    contentType === 'check-details'
+    contentType === 'check-details' ||
+    contentType === 'git-graph'
   )
 }
 
@@ -479,7 +480,8 @@ function deriveActiveSurfaceForWorktree(
       activeUnifiedTab.contentType === 'editor' ||
       activeUnifiedTab.contentType === 'diff' ||
       activeUnifiedTab.contentType === 'conflict-review' ||
-      activeUnifiedTab.contentType === 'check-details'
+      activeUnifiedTab.contentType === 'check-details' ||
+      activeUnifiedTab.contentType === 'git-graph'
         ? activeUnifiedTab.entityId
         : fileStillOpen
           ? restoredFileId

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -5671,7 +5671,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           activeUnifiedTab.contentType === 'editor' ||
           activeUnifiedTab.contentType === 'diff' ||
           activeUnifiedTab.contentType === 'conflict-review' ||
-          activeUnifiedTab.contentType === 'check-details'
+          activeUnifiedTab.contentType === 'check-details' ||
+          activeUnifiedTab.contentType === 'git-graph'
             ? activeUnifiedTab.entityId
             : fileStillOpen
               ? restoredFileId
@@ -5970,7 +5971,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeUnifiedTab?.contentType === 'editor' ||
         activeUnifiedTab?.contentType === 'diff' ||
         activeUnifiedTab?.contentType === 'conflict-review' ||
-        activeUnifiedTab?.contentType === 'check-details'
+        activeUnifiedTab?.contentType === 'check-details' ||
+        activeUnifiedTab?.contentType === 'git-graph'
           ? activeUnifiedTab.entityId
           : fileStillOpen
             ? restoredFileId

--- a/src/shared/git-graph-lane-layout.test.ts
+++ b/src/shared/git-graph-lane-layout.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHistoryItem, GitHistoryItemRef } from './git-history-types'
+import { GIT_HISTORY_LANE_COLORS, GIT_HISTORY_REF_COLOR } from './git-history-types'
+import { buildGitGraphColorMap, buildGitGraphRows } from './git-graph-lane-layout'
+import { getGitHistoryItemLaneIndex, getGitHistoryMergeParentLaneIndex } from './git-history-graph'
+
+function item(
+  id: string,
+  parentIds: string[],
+  references: GitHistoryItemRef[] = []
+): GitHistoryItem {
+  return { id, parentIds, subject: id, message: id, displayId: id, references }
+}
+
+function branch(name: string, revision: string): GitHistoryItemRef {
+  return { id: `refs/heads/${name}`, name, revision, category: 'branches' }
+}
+
+function remote(name: string, revision: string): GitHistoryItemRef {
+  return { id: `refs/remotes/${name}`, name, revision, category: 'remote branches' }
+}
+
+function tag(name: string, revision: string): GitHistoryItemRef {
+  return { id: `refs/tags/${name}`, name, revision, category: 'tags' }
+}
+
+const [LANE_1, LANE_2] = GIT_HISTORY_LANE_COLORS
+
+describe('buildGitGraphColorMap', () => {
+  it('keeps the HEAD accent for the current branch and cycles lanes for the rest', () => {
+    const currentRef = branch('main', 'A')
+    const colorMap = buildGitGraphColorMap(
+      [
+        item('A', ['C'], [currentRef]),
+        item('B', ['C'], [branch('feature', 'B')]),
+        item('C', [], [branch('release', 'C')])
+      ],
+      currentRef
+    )
+
+    expect(colorMap.get('refs/heads/main')).toBe(GIT_HISTORY_REF_COLOR)
+    expect(colorMap.get('refs/heads/feature')).toBe(LANE_1)
+    expect(colorMap.get('refs/heads/release')).toBe(LANE_2)
+  })
+
+  it('is stable: identical input produces identical assignments', () => {
+    const items = [item('A', ['B'], [branch('one', 'A')]), item('B', [], [branch('two', 'B')])]
+    expect(buildGitGraphColorMap(items)).toEqual(buildGitGraphColorMap(items))
+  })
+
+  it('shares one color between a local branch and its remote-tracking ref', () => {
+    const colorMap = buildGitGraphColorMap([
+      item('A', ['B'], [branch('feature', 'A')]),
+      item('B', ['C'], [remote('origin/feature', 'B')]),
+      item('C', [], [remote('upstream/feature', 'C')])
+    ])
+
+    expect(colorMap.get('refs/heads/feature')).toBe(LANE_1)
+    expect(colorMap.get('refs/remotes/origin/feature')).toBe(LANE_1)
+    expect(colorMap.get('refs/remotes/upstream/feature')).toBe(LANE_1)
+  })
+
+  it('extends the shared color to remote-tracking refs of the current branch', () => {
+    const currentRef = branch('main', 'A')
+    const colorMap = buildGitGraphColorMap(
+      [item('A', ['B'], [currentRef]), item('B', [], [remote('origin/main', 'B')])],
+      currentRef
+    )
+
+    expect(colorMap.get('refs/remotes/origin/main')).toBe(GIT_HISTORY_REF_COLOR)
+  })
+
+  it('gives a remote-only branch its own lane color', () => {
+    const colorMap = buildGitGraphColorMap([
+      item('A', ['B'], [branch('main', 'A')]),
+      item('B', [], [remote('origin/experiment', 'B')])
+    ])
+
+    expect(colorMap.get('refs/remotes/origin/experiment')).toBe(LANE_2)
+  })
+
+  it('keeps ambiguous nested remote refs on separate colors instead of guessing', () => {
+    const colorMap = buildGitGraphColorMap([
+      item('A', ['C'], [branch('bar/main', 'A')]),
+      item('B', ['C'], [remote('foo/bar/main', 'B')]),
+      item('C', [], [])
+    ])
+
+    expect(colorMap.get('refs/heads/bar/main')).toBe(LANE_1)
+    expect(colorMap.get('refs/remotes/foo/bar/main')).toBe(LANE_2)
+  })
+
+  it('maps tags to explicit undefined so pills inherit the lane color', () => {
+    const colorMap = buildGitGraphColorMap([item('A', [], [tag('v1.0.0', 'A')])])
+
+    expect(colorMap.has('refs/tags/v1.0.0')).toBe(true)
+    expect(colorMap.get('refs/tags/v1.0.0')).toBeUndefined()
+  })
+
+  it('does not let tags consume lane palette slots', () => {
+    const colorMap = buildGitGraphColorMap([
+      item('A', ['B'], [tag('v2.0.0', 'A')]),
+      item('B', [], [branch('feature', 'B')])
+    ])
+
+    expect(colorMap.get('refs/heads/feature')).toBe(LANE_1)
+  })
+
+  it('wraps around the palette when branches outnumber lane colors', () => {
+    const items = Array.from({ length: GIT_HISTORY_LANE_COLORS.length + 1 }, (_, index) =>
+      item(`C${index}`, [], [branch(`branch-${index}`, `C${index}`)])
+    )
+    const colorMap = buildGitGraphColorMap(items)
+
+    expect(colorMap.get('refs/heads/branch-0')).toBe(LANE_1)
+    expect(colorMap.get(`refs/heads/branch-${GIT_HISTORY_LANE_COLORS.length}`)).toBe(LANE_1)
+  })
+})
+
+describe('buildGitGraphRows', () => {
+  it('lays out two unmerged parallel branches on separate lanes', () => {
+    const currentRef = branch('main', 'A')
+    const rows = buildGitGraphRows(
+      [item('A', ['C'], [currentRef]), item('B', ['C'], [branch('feature', 'B')]), item('C', [])],
+      currentRef
+    )
+
+    expect(rows.map((row) => row.kind)).toEqual(['HEAD', 'node', 'node'])
+    expect(rows[0]!.outputSwimlanes).toEqual([{ id: 'C', color: GIT_HISTORY_REF_COLOR }])
+    // The feature tip was not in any input lane, so it opens a lane to the right.
+    expect(getGitHistoryItemLaneIndex(rows[1]!)).toBe(1)
+    expect(rows[1]!.outputSwimlanes).toEqual([
+      { id: 'C', color: GIT_HISTORY_REF_COLOR },
+      { id: 'C', color: LANE_1 }
+    ])
+    // Both lanes converge on the shared root and close there.
+    expect(getGitHistoryItemLaneIndex(rows[2]!)).toBe(0)
+    expect(rows[2]!.outputSwimlanes).toEqual([])
+  })
+
+  it('routes a merge commit to both parents and keeps branch colors', () => {
+    const currentRef = branch('main', 'M')
+    const rows = buildGitGraphRows(
+      [
+        item('M', ['A', 'B'], [currentRef]),
+        item('A', ['C']),
+        item('B', ['C'], [branch('feature', 'B')]),
+        item('C', [])
+      ],
+      currentRef
+    )
+
+    expect(rows[0]!.outputSwimlanes).toEqual([
+      { id: 'A', color: GIT_HISTORY_REF_COLOR },
+      { id: 'B', color: LANE_1 }
+    ])
+    expect(getGitHistoryMergeParentLaneIndex(rows[0]!, 'B')).toBe(1)
+    // The merged-in branch keeps its color down its own lane.
+    expect(getGitHistoryItemLaneIndex(rows[2]!)).toBe(1)
+    expect(rows[2]!.outputSwimlanes[1]).toEqual({ id: 'C', color: LANE_1 })
+  })
+
+  it('opens one extra lane per parent of an octopus merge', () => {
+    const currentRef = branch('main', 'M')
+    const rows = buildGitGraphRows(
+      [
+        item('M', ['A', 'B', 'C'], [currentRef]),
+        item('A', ['R']),
+        item('B', ['R'], [branch('two', 'B')]),
+        item('C', ['R'], [branch('three', 'C')]),
+        item('R', [])
+      ],
+      currentRef
+    )
+
+    expect(rows[0]!.outputSwimlanes).toEqual([
+      { id: 'A', color: GIT_HISTORY_REF_COLOR },
+      { id: 'B', color: LANE_1 },
+      { id: 'C', color: LANE_2 }
+    ])
+    expect(getGitHistoryMergeParentLaneIndex(rows[0]!, 'B')).toBe(1)
+    expect(getGitHistoryMergeParentLaneIndex(rows[0]!, 'C')).toBe(2)
+    // All three lanes collapse into the shared root.
+    expect(rows[4]!.inputSwimlanes).toHaveLength(3)
+    expect(rows[4]!.outputSwimlanes).toEqual([])
+  })
+
+  it('keeps disconnected orphan histories on independent lanes', () => {
+    const rows = buildGitGraphRows([
+      item('A', ['R1'], [branch('main', 'A')]),
+      item('R1', []),
+      item('B', ['R2'], [branch('orphan', 'B')]),
+      item('R2', [])
+    ])
+
+    // First root closes its lane before the orphan tip appears.
+    expect(rows[1]!.outputSwimlanes).toEqual([])
+    // The orphan tip starts from an empty board on lane 0 with its own color.
+    expect(rows[2]!.inputSwimlanes).toEqual([])
+    expect(getGitHistoryItemLaneIndex(rows[2]!)).toBe(0)
+    expect(rows[2]!.outputSwimlanes).toEqual([{ id: 'R2', color: LANE_2 }])
+  })
+
+  it('keeps interleaved orphan histories on parallel lanes without crossing', () => {
+    const rows = buildGitGraphRows([
+      item('A', ['R1'], [branch('main', 'A')]),
+      item('B', ['R2'], [branch('orphan', 'B')]),
+      item('R1', []),
+      item('R2', [])
+    ])
+
+    expect(getGitHistoryItemLaneIndex(rows[0]!)).toBe(0)
+    expect(getGitHistoryItemLaneIndex(rows[1]!)).toBe(1)
+    expect(rows[1]!.outputSwimlanes).toEqual([
+      { id: 'R1', color: LANE_1 },
+      { id: 'R2', color: LANE_2 }
+    ])
+    // R1 closes lane 0; R2's lane shifts left and closes last.
+    expect(rows[2]!.outputSwimlanes).toEqual([{ id: 'R2', color: LANE_2 }])
+    expect(rows[3]!.outputSwimlanes).toEqual([])
+  })
+
+  it('leaves lanes open for parents truncated past the load limit', () => {
+    const rows = buildGitGraphRows([
+      item('A', ['Z'], [branch('main', 'A')]),
+      item('B', ['Z'], [branch('feature', 'B')])
+    ])
+
+    // Z was cut off by the limit: both lanes still point at it after the last row.
+    expect(rows[1]!.outputSwimlanes).toEqual([
+      { id: 'Z', color: LANE_1 },
+      { id: 'Z', color: LANE_2 }
+    ])
+  })
+
+  it('marks the current branch tip as HEAD and detached heads as plain nodes', () => {
+    const currentRef = branch('main', 'A')
+    const attached = buildGitGraphRows([item('A', [], [currentRef])], currentRef)
+    expect(attached[0]!.kind).toBe('HEAD')
+
+    const detachedRef: GitHistoryItemRef = {
+      id: 'A',
+      name: 'A',
+      revision: 'A',
+      category: 'commits'
+    }
+    const detached = buildGitGraphRows([item('A', [], [])], detachedRef)
+    expect(detached[0]!.kind).toBe('HEAD')
+  })
+
+  it('colors tag pills with the lane color of their commit', () => {
+    const currentRef = branch('main', 'A')
+    const rows = buildGitGraphRows(
+      [item('A', ['B'], [currentRef]), item('B', [], [tag('v1.0.0', 'B')])],
+      currentRef
+    )
+
+    const tagRef = rows[1]!.historyItem.references?.find((ref) => ref.id === 'refs/tags/v1.0.0')
+    expect(tagRef?.color).toBe(GIT_HISTORY_REF_COLOR)
+  })
+
+  it('never inserts boundary rows into the all-refs graph', () => {
+    const currentRef = branch('main', 'A')
+    const rows = buildGitGraphRows(
+      [item('A', ['B'], [currentRef]), item('B', [], [remote('origin/main', 'B')])],
+      currentRef
+    )
+
+    expect(rows).toHaveLength(2)
+    expect(rows.every((row) => row.kind === 'HEAD' || row.kind === 'node')).toBe(true)
+  })
+})

--- a/src/shared/git-graph-lane-layout.test.ts
+++ b/src/shared/git-graph-lane-layout.test.ts
@@ -79,15 +79,15 @@ describe('buildGitGraphColorMap', () => {
     expect(colorMap.get('refs/remotes/origin/experiment')).toBe(LANE_2)
   })
 
-  it('keeps ambiguous nested remote refs on separate colors instead of guessing', () => {
+  it('shares one color across slashed branch names and their remote refs', () => {
     const colorMap = buildGitGraphColorMap([
-      item('A', ['C'], [branch('bar/main', 'A')]),
-      item('B', ['C'], [remote('foo/bar/main', 'B')]),
+      item('A', ['C'], [branch('feat/orca-cli', 'A')]),
+      item('B', ['C'], [remote('origin/feat/orca-cli', 'B')]),
       item('C', [], [])
     ])
 
-    expect(colorMap.get('refs/heads/bar/main')).toBe(LANE_1)
-    expect(colorMap.get('refs/remotes/foo/bar/main')).toBe(LANE_2)
+    expect(colorMap.get('refs/heads/feat/orca-cli')).toBe(LANE_1)
+    expect(colorMap.get('refs/remotes/origin/feat/orca-cli')).toBe(LANE_1)
   })
 
   it('maps tags to explicit undefined so pills inherit the lane color', () => {

--- a/src/shared/git-graph-lane-layout.ts
+++ b/src/shared/git-graph-lane-layout.ts
@@ -1,0 +1,87 @@
+import {
+  GIT_HISTORY_LANE_COLORS,
+  GIT_HISTORY_REF_COLOR,
+  type GitHistoryGraphColorId,
+  type GitHistoryItem,
+  type GitHistoryItemRef
+} from './git-history-types'
+import { buildGitHistoryViewModels, type GitHistoryItemViewModel } from './git-history-graph'
+import { splitRemoteBranchName } from './git-remote-branch-name'
+
+export type { GitHistoryItemViewModel } from './git-history-graph'
+
+// Why: a local branch and its remote-tracking refs should share one lane color
+// even when they sit on different commits, matching how users think of "the
+// branch" as one line of work.
+function logicalBranchKey(ref: GitHistoryItemRef): string | null {
+  if (ref.category === 'branches') {
+    return ref.name
+  }
+  if (ref.category === 'remote branches') {
+    // Why: without configured remote names, `foo/bar/main` could be remote
+    // `foo` branch `bar/main` or remote `foo/bar` branch `main` — keep
+    // ambiguous refs on their own color instead of guessing a grouping.
+    if (ref.name.split('/').length > 2) {
+      return ref.id
+    }
+    return splitRemoteBranchName(ref.name)?.branchName ?? ref.id
+  }
+  return null
+}
+
+// Assigns each branch a stable lane color by topological order of its tip:
+// the current branch keeps the HEAD accent, other branches cycle the lane
+// palette, and tags inherit whichever lane color their commit lands on.
+export function buildGitGraphColorMap(
+  items: readonly GitHistoryItem[],
+  currentRef?: GitHistoryItemRef
+): Map<string, GitHistoryGraphColorId | undefined> {
+  const colorMap = new Map<string, GitHistoryGraphColorId | undefined>()
+  const colorByLogicalBranch = new Map<string, GitHistoryGraphColorId>()
+  let laneColorIndex = 0
+
+  if (currentRef) {
+    colorMap.set(currentRef.id, GIT_HISTORY_REF_COLOR)
+    const currentKey = logicalBranchKey(currentRef)
+    if (currentKey !== null) {
+      colorByLogicalBranch.set(currentKey, GIT_HISTORY_REF_COLOR)
+    }
+  }
+
+  for (const item of items) {
+    for (const ref of item.references ?? []) {
+      if (colorMap.has(ref.id)) {
+        continue
+      }
+      const key = logicalBranchKey(ref)
+      if (key === null) {
+        if (ref.category === 'tags') {
+          // Why: an explicit undefined entry makes the view model resolve the
+          // tag pill to its commit's lane color instead of the neutral border.
+          colorMap.set(ref.id, undefined)
+        }
+        continue
+      }
+      let color = colorByLogicalBranch.get(key)
+      if (color === undefined) {
+        color = GIT_HISTORY_LANE_COLORS[laneColorIndex % GIT_HISTORY_LANE_COLORS.length]!
+        laneColorIndex += 1
+        colorByLogicalBranch.set(key, color)
+      }
+      colorMap.set(ref.id, color)
+    }
+  }
+
+  return colorMap
+}
+
+// Lays out the whole-repo graph: swimlane assignment comes from the shared
+// view-model builder, colors from the stable per-branch map above. Boundary
+// rows never apply here — with every ref in the walk there is no hidden
+// upstream to synthesize.
+export function buildGitGraphRows(
+  items: GitHistoryItem[],
+  currentRef?: GitHistoryItemRef
+): GitHistoryItemViewModel[] {
+  return buildGitHistoryViewModels(items, buildGitGraphColorMap(items, currentRef), currentRef)
+}

--- a/src/shared/git-graph-lane-layout.ts
+++ b/src/shared/git-graph-lane-layout.ts
@@ -18,12 +18,11 @@ function logicalBranchKey(ref: GitHistoryItemRef): string | null {
     return ref.name
   }
   if (ref.category === 'remote branches') {
-    // Why: without configured remote names, `foo/bar/main` could be remote
-    // `foo` branch `bar/main` or remote `foo/bar` branch `main` — keep
-    // ambiguous refs on their own color instead of guessing a grouping.
-    if (ref.name.split('/').length > 2) {
-      return ref.id
-    }
+    // Why: slashed branch names (feat/x) make every remote-tracking ref look
+    // "nested" (origin/feat/x), and that is the common case — assume the first
+    // segment is the remote. Worst case a mis-split shares a color, which is
+    // harmless; ref-display keeps its stricter rule because there a bad guess
+    // hides a pill.
     return splitRemoteBranchName(ref.name)?.branchName ?? ref.id
   }
   return null

--- a/src/shared/git-history-graph.ts
+++ b/src/shared/git-history-graph.ts
@@ -110,20 +110,20 @@ export function buildGitHistoryViewModels(
     const outputSwimlanes: GitHistoryGraphNode[] = []
     let firstParentAdded = false
 
-    if (historyItem.parentIds.length > 0) {
-      for (const node of inputSwimlanes) {
-        if (node.id === historyItem.id) {
-          if (!firstParentAdded) {
-            outputSwimlanes.push({
-              id: historyItem.parentIds[0]!,
-              color: getLabelColorIdentifier(historyItem, colorMap) ?? node.color
-            })
-            firstParentAdded = true
-          }
-          continue
+    // Why: root commits close only their own lane — copying the others keeps
+    // unrelated histories (orphan branches, subtree merges) visually continuous.
+    for (const node of inputSwimlanes) {
+      if (node.id === historyItem.id) {
+        if (!firstParentAdded && historyItem.parentIds.length > 0) {
+          outputSwimlanes.push({
+            id: historyItem.parentIds[0]!,
+            color: getLabelColorIdentifier(historyItem, colorMap) ?? node.color
+          })
+          firstParentAdded = true
         }
-        outputSwimlanes.push(cloneNode(node))
+        continue
       }
+      outputSwimlanes.push(cloneNode(node))
     }
 
     for (let index = firstParentAdded ? 1 : 0; index < historyItem.parentIds.length; index += 1) {

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -23,6 +23,11 @@ export const GIT_HISTORY_LANE_COLORS: readonly GitHistoryGraphColorId[] = [
 export const GIT_HISTORY_DEFAULT_LIMIT = 50
 export const GIT_HISTORY_MAX_LIMIT = 200
 
+export const GIT_GRAPH_DEFAULT_LIMIT = 100
+// Why: all-refs graph loads capture whole-repo history; the single-branch cap
+// of 200 starves busy repos while old hosts still clamp to their own maximum.
+export const GIT_GRAPH_MAX_LIMIT = 1000
+
 export type GitHistoryRefCategory = 'branches' | 'remote branches' | 'tags' | 'commits'
 
 export type GitHistoryItemRef = {
@@ -56,6 +61,9 @@ export type GitHistoryItem = {
 export type GitHistoryOptions = {
   limit?: number
   baseRef?: string | null
+  // Wire compat: optional so old hosts strip it and answer with HEAD-only
+  // history; the missing `allRefs` echo on the result reveals the downgrade.
+  allRefs?: boolean
 }
 
 export type GitHistoryResult = {
@@ -68,6 +76,8 @@ export type GitHistoryResult = {
   hasOutgoingChanges: boolean
   hasMore: boolean
   limit: number
+  // Echoed by hosts that honored `options.allRefs`; absent from old hosts.
+  allRefs?: boolean
 }
 
 export type GitHistoryExecutor = (

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { GitHistoryExecutor } from './git-history'
 import {
+  GIT_GRAPH_MAX_LIMIT,
   GIT_HISTORY_MAX_LIMIT,
   loadGitHistoryFromExecutor,
   parseGitHistoryLog
@@ -242,6 +243,46 @@ describe('git history loader', () => {
     expect(result.items).toHaveLength(GIT_HISTORY_MAX_LIMIT)
     expect(result.limit).toBe(GIT_HISTORY_MAX_LIMIT)
     expect(result.hasMore).toBe(true)
+  })
+
+  it('walks every branch, remote, and tag when allRefs is requested', async () => {
+    const { executor, calls } = createHistoryExecutor()
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, allRefs: true })
+
+    const logCall = calls.find((args) => args[0] === 'log')
+    expect(logCall).toEqual(
+      expect.arrayContaining(['--branches', '--remotes', '--tags', HEAD_OID, '-n51'])
+    )
+    expect(logCall).not.toContain('--all')
+    expect(result.allRefs).toBe(true)
+  })
+
+  it('omits the allRefs echo from HEAD-scoped results', async () => {
+    const { executor } = createHistoryExecutor()
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50 })
+
+    expect(result.allRefs).toBeUndefined()
+  })
+
+  it('raises the limit ceiling for allRefs graph loads', async () => {
+    const { executor, calls } = createHistoryExecutor(2)
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 500,
+      allRefs: true
+    })
+
+    const logCall = calls.find((args) => args[0] === 'log')
+    expect(logCall).toContain('-n501')
+    expect(result.limit).toBe(500)
+
+    const clamped = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: GIT_GRAPH_MAX_LIMIT + 500,
+      allRefs: true
+    })
+    expect(clamped.limit).toBe(GIT_GRAPH_MAX_LIMIT)
   })
 
   it('returns an empty result for unborn repositories without running git log', async () => {

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -5,6 +5,7 @@ import {
   shortGitHash
 } from './git-history-log-parser'
 import {
+  GIT_GRAPH_MAX_LIMIT,
   GIT_HISTORY_DEFAULT_LIMIT,
   GIT_HISTORY_MAX_LIMIT,
   type GitHistoryExecutor,
@@ -24,6 +25,8 @@ export type {
   GitHistoryResult
 } from './git-history-types'
 export {
+  GIT_GRAPH_DEFAULT_LIMIT,
+  GIT_GRAPH_MAX_LIMIT,
   GIT_HISTORY_BASE_REF_COLOR,
   GIT_HISTORY_DEFAULT_LIMIT,
   GIT_HISTORY_LANE_COLORS,
@@ -33,12 +36,12 @@ export {
 } from './git-history-types'
 export { compareGitHistoryItemRefsByCategory, parseGitHistoryLog } from './git-history-log-parser'
 
-function clampHistoryLimit(limit: number | undefined): number {
+function clampHistoryLimit(limit: number | undefined, allRefs: boolean): number {
   if (!Number.isFinite(limit)) {
     return GIT_HISTORY_DEFAULT_LIMIT
   }
   return Math.min(
-    GIT_HISTORY_MAX_LIMIT,
+    allRefs ? GIT_GRAPH_MAX_LIMIT : GIT_HISTORY_MAX_LIMIT,
     Math.max(1, Math.trunc(limit ?? GIT_HISTORY_DEFAULT_LIMIT))
   )
 }
@@ -169,7 +172,8 @@ export async function loadGitHistoryFromExecutor(
   cwd: string,
   options: GitHistoryOptions = {}
 ): Promise<GitHistoryResult> {
-  const limit = clampHistoryLimit(options.limit)
+  const allRefs = options.allRefs === true
+  const limit = clampHistoryLimit(options.limit, allRefs)
   const headOid = await resolveCommit(git, cwd, 'HEAD')
   if (!headOid) {
     return {
@@ -192,9 +196,10 @@ export async function loadGitHistoryFromExecutor(
       ? rawBaseRef
       : undefined
 
-  // Why: this panel is scoped to the active workspace. Upstream and base refs
-  // stay as comparison metadata so old workspaces do not list newly fetched upstream/base commits.
-  const historyRevisions = [headOid]
+  // Why: the sidebar panel is scoped to the active workspace, so upstream and
+  // base refs stay as comparison metadata; the graph view opts into every
+  // branch, remote, and tag. `--all` is avoided to keep notes/replace/stash out.
+  const historyRevisions = allRefs ? ['--branches', '--remotes', '--tags', headOid] : [headOid]
 
   let mergeBase: string | undefined
   if (remoteRef?.revision && currentRef.revision && remoteRef.revision !== currentRef.revision) {
@@ -235,6 +240,7 @@ export async function loadGitHistoryFromExecutor(
     hasIncomingChanges,
     hasOutgoingChanges,
     hasMore: parsed.length > limit,
-    limit
+    limit,
+    ...(allRefs ? { allRefs: true } : {})
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -838,6 +838,7 @@ export type TabContentType =
   | 'diff'
   | 'conflict-review'
   | 'check-details'
+  | 'git-graph'
   | 'browser'
   | 'simulator'
 

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -116,6 +116,7 @@ const tabContentTypeSchema = z.enum([
   'diff',
   'conflict-review',
   'check-details',
+  'git-graph',
   'browser',
   'simulator'
 ])


### PR DESCRIPTION
## What

A whole-repo commit graph in the center pane — every branch, remote, and tag with colored lanes, decorated ref pills, and Orca's differentiator: branches checked out in an Orca worktree show a live badge (agent working spinner / waiting / done, plus the workspace status in the tooltip) and jump to that worktree on click.

Entry points: the project's "..." menu in the sidebar (git repos only) and a button in the Commits panel header. The view opens as a virtual editor tab (one per workspace, `check-details` pattern), is virtualized, loads incrementally (100 → 1000 commits via load-more), and reuses the existing commit context menu; row click opens the commit diff.

## How

- **Data**: `loadGitHistoryFromExecutor` gains an optional `allRefs` flag that widens the walk to `--branches --remotes --tags HEAD` (Git 2.25-safe; `--all` avoided to keep notes/replace/stash out) with a raised 1000-commit ceiling. HEAD-scoped requests keep today's 200 cap.
- **Wire compat**: hosts that honor `allRefs` echo it on the result. Old hosts strip the unknown field (relay reads params loosely; the runtime RPC schema is non-strict) and answer with HEAD-only history — the client detects the missing echo, caps limits at the old ceiling, and shows an update notice instead of failing.
- **Lane layout**: new pure module `git-graph-lane-layout.ts` assigns each branch a stable lane color by topological tip order; a local branch shares its color with its remote-tracking refs (first path segment assumed to be the remote — slashed branch names make every remote ref look nested, and a mis-split only shares a color). Tags inherit their commit's lane color without consuming palette slots. Colors come from the existing `--git-graph-*` tokens.
- **Shared fix**: the swimlane builder previously closed *all* lanes at any root commit; it now closes only the root's own lane, keeping disconnected histories (orphan branches, subtree merges) visually continuous. This also benefits the existing sidebar panel.
- Folder workspaces never expose the entry points; localization keys are synced to `en.json` per the catalog workflow.

## Tests

- `git-graph-lane-layout.test.ts`: merges, octopus, parallel/orphan/interleaved histories, truncated parents, color stability and grouping.
- Loader (`allRefs` echo, revision args, limit ceilings), RPC params (1000 cap + `allRefs` forwarding), worktree overlay matching, and Commits-panel entry-point tests.
- `pnpm lint`, `pnpm run tc`, and the touched suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)