### PR TITLE
fix(terminal): keep underscores visible when ligatures are enabled (#13473)

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-ligatures-addon.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ligatures-addon.test.ts
@@ -142,6 +142,27 @@ describe('TerminalLigaturesAddon', () => {
     expect(addonMock.joiner).toHaveBeenCalledTimes(2)
   })
 
+  it('drops pure-underscore joiner ranges so underscores stay visible (#13473)', () => {
+    const harness = createTerminalHarness()
+    // Simulate a font whose `calt` connects underscores into one glyph:
+    // the upstream joiner reports `___` as a single ligature cluster.
+    addonMock.joiner.mockImplementation((text: string) => {
+      const ranges: [number, number][] = []
+      if (text === '___') {
+        ranges.push([0, 2])
+      }
+      if (text.includes('=>')) {
+        ranges.push([text.indexOf('='), text.indexOf('>')])
+      }
+      return ranges
+    })
+    new TerminalLigaturesAddon().activate(harness.terminal)
+    const joiner = harness.getRegisteredJoiner()
+
+    expect(joiner('___')).toEqual([])
+    expect(joiner('a => b')).toEqual([[2, 3]])
+  })
+
   it('deregisters the wrapped joiner through the real terminal', () => {
     const harness = createTerminalHarness()
     const addon = new TerminalLigaturesAddon()

--- a/src/renderer/src/lib/pane-manager/terminal-ligatures-addon.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ligatures-addon.ts
@@ -84,12 +84,17 @@ function createCachedCharacterJoiner(
     }
     const generationBeforeJoin = cache.generation
     const ranges = joiner(text)
-    // Why: the addon refreshes when async font discovery completes. If that
-    // happened during this call, do not repopulate the cleared fallback data.
+    // Why (#13473): some programming fonts (e.g. JetBrains Mono) ship a `calt`
+    // feature that connects runs of underscores into a single glyph, which the
+    // canvas renderer then draws as one near-invisible cluster. Drop joiner
+    // ranges that are purely underscores so each `_` renders on its own cell;
+    // real ligatures (=>, !=, …) are untouched because they contain non-underscore
+    // characters.
+    const filtered = ranges.filter(([start, end]) => !/^_+$/.test(text.slice(start, end + 1)))
     if (cache.generation === generationBeforeJoin) {
-      cache.set(text, ranges)
+      cache.set(text, filtered)
     }
-    return ranges
+    return filtered
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #13473 — underscores are invisible in terminals when ligatures are enabled.

Some programming fonts (e.g. JetBrains Mono) ship a `calt` feature that connects runs of underscores into a single glyph. The `@xterm/addon-ligatures` joiner reports `___` as one ligature cluster, and the canvas renderer draws it as a near-invisible block.

## Root cause

`TerminalLigaturesAddon` wraps the upstream joiner but passed every reported range through unchanged. The font-ligatures package treats a pure-underscore run as a ligature, so xterm merged consecutive `_` cells into one.

## Fix

Filter out joiner ranges that are purely `_` characters in `src/renderer/src/lib/pane-manager/terminal-ligatures-addon.ts`. Each `_` then lands on its own cell. Real ligatures (`=>`, `!=`, `===`, …) are untouched because they contain non-underscore characters.

## Verification

- Added regression test in `terminal-ligatures-addon.test.ts` (simulates a font reporting `___` as a cluster; asserts the range is dropped while `=>` still joins).
- `oxlint` (both configs) clean, pre-commit hook green.

## Notes

- `Closes #13473`
- No new dependency, single-file fix in the existing joiner wrapper.
- One known ceiling: this drops *all* pure-underscore clusters. A font that legitimately ligates underscores (rare) would lose that. None of the known ligature fonts in `shared/terminal-ligatures.ts` do, so this is safe.

@AmethystLiang @nwparker — this is the underscore issue you flagged. Happy to adjust if you'd prefer handling it at the `font-feature-settings` level instead.
