### PR TITLE
feat(serve): serve favicon.ico and favicon.png from headless orca serve

### DIFF
--- a/config/build-plugins/web-favicon.ts
+++ b/config/build-plugins/web-favicon.ts
@@ -1,0 +1,36 @@
+import { copyFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Plugin } from 'vite'
+
+const FAVICON_FILES = [
+  { filename: 'favicon.ico', source: resolve('resources/build/icon.ico') },
+  { filename: 'favicon.png', source: resolve('resources/build/icon.png') }
+] as const
+
+// Why: serve-mode browsers request /favicon.ico automatically. Copy the
+// desktop icon beside web-index.html so the static handler serves it in
+// dev (`out/web`) and packaged (`app.asar/.../out/web`) runs without a
+// separate extraResources entry.
+export function createWebFaviconPlugin(): Plugin {
+  let outputDir: string | undefined
+  return {
+    name: 'orca-web-favicon',
+    apply: 'build',
+    outputOptions(outputOptions) {
+      if (outputOptions.dir) {
+        outputDir = outputOptions.dir
+      }
+      return outputOptions
+    },
+    closeBundle() {
+      if (!outputDir) {
+        return
+      }
+      for (const { filename, source } of FAVICON_FILES) {
+        try {
+          copyFileSync(source, resolve(outputDir, filename))
+        } catch {}
+      }
+    }
+  }
+}

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { createBootstrapFatalExitBanner } from './config/build-plugins/bootstrap-fatal-exit-banner'
 import { createPlainNodeEntryGuardPlugin } from './config/build-plugins/plain-node-entry-guard'
+import { createWebFaviconPlugin } from './config/build-plugins/web-favicon'
 import packageJson from './package.json' with { type: 'json' }
 
 const BUNDLED_MAIN_DEPENDENCIES = new Set([
@@ -293,7 +294,7 @@ export const electronViteConfig: UserConfig = {
         '@': resolve('src/renderer/src')
       }
     },
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), createWebFaviconPlugin()],
     worker: {
       format: 'es'
     },

--- a/src/main/runtime/rpc/static-web-client-handler.ts
+++ b/src/main/runtime/rpc/static-web-client-handler.ts
@@ -3,11 +3,12 @@ import { stat } from 'node:fs/promises'
 import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http'
 import { extname, isAbsolute, posix, relative, resolve } from 'node:path'
 
-const STATIC_WEB_ALLOWED_PATHS = new Set(['/web-index.html'])
+const STATIC_WEB_ALLOWED_PATHS = new Set(['/web-index.html', '/favicon.ico', '/favicon.png'])
 const STATIC_WEB_ALLOWED_PREFIXES = ['/assets/']
 const STATIC_WEB_CONTENT_TYPES = new Map([
   ['.css', 'text/css; charset=utf-8'],
   ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
   ['.js', 'text/javascript; charset=utf-8'],
   ['.json', 'application/json; charset=utf-8'],
   ['.png', 'image/png'],

--- a/src/main/runtime/rpc/ws-transport-static-web.test.ts
+++ b/src/main/runtime/rpc/ws-transport-static-web.test.ts
@@ -88,4 +88,33 @@ describe('WebSocketTransport static web client', () => {
     )
     expect(response.status).toBe(400)
   })
+
+  it('serves favicon.ico and favicon.png with the correct content-type', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'ws-transport-static-'))
+    writeFileSync(join(staticRoot, 'web-index.html'), '<html>web</html>')
+    writeFileSync(join(staticRoot, 'favicon.ico'), Buffer.from([0, 0, 1, 0, 0]))
+    writeFileSync(join(staticRoot, 'favicon.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    const transport = createStaticTransport(staticRoot)
+
+    await transport.start()
+
+    const icoResponse = await fetch(`http://127.0.0.1:${transport.resolvedPort}/favicon.ico`)
+    expect(icoResponse.status).toBe(200)
+    expect(icoResponse.headers.get('content-type')).toBe('image/x-icon')
+
+    const pngResponse = await fetch(`http://127.0.0.1:${transport.resolvedPort}/favicon.png`)
+    expect(pngResponse.status).toBe(200)
+    expect(pngResponse.headers.get('content-type')).toBe('image/png')
+  })
+
+  it('404s when favicon.ico is missing so browsers stop retrying', async () => {
+    const staticRoot = mkdtempSync(join(tmpdir(), 'ws-transport-static-'))
+    writeFileSync(join(staticRoot, 'web-index.html'), '<html>web</html>')
+    const transport = createStaticTransport(staticRoot)
+
+    await transport.start()
+
+    const response = await fetch(`http://127.0.0.1:${transport.resolvedPort}/favicon.ico`)
+    expect(response.status).toBe(404)
+  })
 })

--- a/src/renderer/web-index.html
+++ b/src/renderer/web-index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="alternate icon" href="/favicon.png" type="image/png" />
     <title>Orca Web</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- Allowlist `/favicon.ico` and `/favicon.png` in `static-web-client-handler.ts` with `image/x-icon` and `image/png` MIME so the bundled web client has a recognizable tab/bookmark icon.
- Add `<link rel="icon" href="/favicon.ico">` and PNG fallback in `src/renderer/web-index.html`.
- Copy the packaged desktop icon (`resources/build/icon.ico`, `resources/build/icon.png`) into the renderer build output via a new `closeBundle` plugin in `config/build-plugins/web-favicon.ts`, so `out/renderer/favicon.ico` lands next to `web-index.html` in both dev and packaged runs without an `extraResources` entry.

## Why

`orca serve` renders the web client but exposes no favicon — opening `http://<host>:<port>/` falls back to the browser's blank/letter mark. Two layers were missing: the served HTML never declared `<link rel="icon">`, and `static-web-client-handler.ts` whitelisted only `/web-index.html` and `/assets/`, so even a direct `GET /favicon.ico` returned 404.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `npx vitest run src/main/runtime/rpc/ws-transport-static-web.test.ts` — 6/6 (2 new tests)
- [x] `npx vitest run src/main/runtime/runtime-rpc.test.ts` — 90/90
- [x] `npx electron-vite build` — favicon.ico + favicon.png present, web-index.html contains `<link rel="icon">`