### PR TITLE
fix(grok): treat team-account billing 412 as usage unavailable

### DIFF
--- a/src/main/rate-limits/grok-billing-error.test.ts
+++ b/src/main/rate-limits/grok-billing-error.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyGrokBillingHttpFailure,
+  isMissingPersonalTeamError,
+  parseGrokBillingErrorDetail
+} from './grok-billing-error'
+
+describe('parseGrokBillingErrorDetail', () => {
+  it('reads the xAI error string', () => {
+    expect(parseGrokBillingErrorDetail('{"error":"No personal team."}')).toBe('No personal team.')
+  })
+
+  it('returns null for empty, non-JSON, or error-less bodies', () => {
+    expect(parseGrokBillingErrorDetail('')).toBeNull()
+    expect(parseGrokBillingErrorDetail('<html>nope</html>')).toBeNull()
+    expect(parseGrokBillingErrorDetail('{"code":"x"}')).toBeNull()
+  })
+})
+
+describe('isMissingPersonalTeamError', () => {
+  it('matches the credits and default billing wordings', () => {
+    expect(isMissingPersonalTeamError('No personal team.')).toBe(true)
+    expect(isMissingPersonalTeamError('resolve_personal_team_id(), No personal team.')).toBe(true)
+    expect(isMissingPersonalTeamError('If-Match failed')).toBe(false)
+    expect(isMissingPersonalTeamError(null)).toBe(false)
+  })
+})
+
+describe('classifyGrokBillingHttpFailure', () => {
+  it('treats a 412 personal-team miss as unavailable', () => {
+    const result = classifyGrokBillingHttpFailure(
+      412,
+      JSON.stringify({
+        code: "The system is not in a state required for the operation's execution",
+        error: 'No personal team.'
+      })
+    )
+    expect(result.status).toBe('unavailable')
+    expect(result.error).toMatch(/team accounts/i)
+    expect(result.error).not.toMatch(/HTTP 412/)
+    expect(result.usageMetadata).toEqual({
+      failureKind: 'usage-unavailable',
+      source: 'oauth'
+    })
+  })
+
+  it('keeps unexpected 412s as errors and includes the upstream detail', () => {
+    expect(classifyGrokBillingHttpFailure(412, '{"error":"If-Match failed"}')).toEqual({
+      status: 'error',
+      error: 'Grok usage request failed (HTTP 412): If-Match failed'
+    })
+  })
+
+  it('includes the upstream error on generic HTTP failures', () => {
+    expect(classifyGrokBillingHttpFailure(500, '{"error":"Access denied"}')).toEqual({
+      status: 'error',
+      error: 'Grok usage request failed (HTTP 500): Access denied'
+    })
+  })
+
+  it('falls back to the status-only message when the body has no error', () => {
+    expect(classifyGrokBillingHttpFailure(502, '<html>nope</html>')).toEqual({
+      status: 'error',
+      error: 'Grok usage request failed (HTTP 502)'
+    })
+  })
+})

--- a/src/main/rate-limits/grok-billing-error.ts
+++ b/src/main/rate-limits/grok-billing-error.ts
@@ -1,0 +1,59 @@
+import type { UsageRateLimitMetadata } from '../../shared/rate-limit-types'
+
+export type GrokBillingHttpFailure = {
+  status: 'unavailable' | 'error'
+  error: string
+  usageMetadata?: UsageRateLimitMetadata
+}
+
+export function isMissingPersonalTeamError(detail: string | null): boolean {
+  return Boolean(detail && /no personal team/i.test(detail))
+}
+
+export function parseGrokBillingErrorDetail(raw: string): string | null {
+  const text = raw.trim()
+  if (!text) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (typeof parsed !== 'object' || parsed === null || !('error' in parsed)) {
+      return null
+    }
+    const error = (parsed as { error?: unknown }).error
+    return typeof error === 'string' && error.trim() ? error.trim() : null
+  } catch {
+    return null
+  }
+}
+
+// Why: team/org Grok CLI sessions 412 because GetGrokCreditsConfig
+// resolve_personal_team_id() has nothing to resolve — not a transient
+// refresh failure, and not an auth problem (#14060).
+export function classifyGrokBillingHttpFailure(
+  status: number,
+  rawBody: string
+): GrokBillingHttpFailure {
+  const detail = parseGrokBillingErrorDetail(rawBody)
+  if (status === 412 && isMissingPersonalTeamError(detail)) {
+    return {
+      status: 'unavailable',
+      error:
+        'Grok usage is unavailable for team accounts — the billing API requires a personal team',
+      usageMetadata: { failureKind: 'usage-unavailable', source: 'oauth' }
+    }
+  }
+  const suffix = detail ? `: ${detail}` : ''
+  return {
+    status: 'error',
+    error: `Grok usage request failed (HTTP ${status})${suffix}`
+  }
+}
+
+export async function readGrokBillingErrorBody(res: Response): Promise<string> {
+  try {
+    return await res.text()
+  } catch {
+    return ''
+  }
+}

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -28,10 +28,12 @@ vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
 import { fetchGrokRateLimits } from './grok-fetcher'
 
 function jsonResponse(body: unknown, status = 200): Response {
+  const raw = JSON.stringify(body)
   return {
     ok: status >= 200 && status < 300,
     status,
-    json: async () => body
+    json: async () => body,
+    text: async () => raw
   } as Response
 }
 
@@ -188,6 +190,28 @@ describe('fetchGrokRateLimits', () => {
       })
     )
     expect(netFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fall back to monthly billing after a team-account 412', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          code: "The system is not in a state required for the operation's execution",
+          error: 'No personal team.'
+        },
+        412
+      )
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('unavailable')
+    expect(result.error).toMatch(/team accounts/i)
+    expect(result.usageMetadata).toEqual({
+      failureKind: 'usage-unavailable',
+      source: 'oauth'
+    })
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 
   // Why: 'unavailable' would make applyStalePolicy discard the last good

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -10,6 +10,7 @@ import {
   type GrokAuthReadResult,
   type GrokAuthSession
 } from './grok-auth'
+import { classifyGrokBillingHttpFailure, readGrokBillingErrorBody } from './grok-billing-error'
 
 // Why: billing URL and headers must match Grok CLI or xAI rejects the request.
 const GROK_CLI_PROXY_BASE =
@@ -206,10 +207,8 @@ async function fetchBillingData(
     }
   }
   if (!res.ok) {
-    return {
-      kind: 'result',
-      result: result('error', `Grok usage request failed (HTTP ${res.status})`)
-    }
+    const failure = classifyGrokBillingHttpFailure(res.status, await readGrokBillingErrorBody(res))
+    return { kind: 'result', result: result(failure.status, failure.error, failure.usageMetadata) }
   }
   const data: unknown = await res.json()
   return {


### PR DESCRIPTION
## ELI5

If you sign into Grok CLI with a work/team account, Orca's Usage panel used to say the refresh broke (HTTP 412). The Grok billing API only works for personal SuperGrok teams, so that was never going to return numbers. Orca now says usage is unavailable for team accounts instead of pretending the refresh failed.

## What Changed

- Classify cli-chat-proxy `412` bodies that contain `No personal team` as `status: 'unavailable'` with `failureKind: 'usage-unavailable'`.
- Keep unexpected 412s and other billing HTTP failures as `error`.
- Include the upstream `error` string on generic billing HTTP failures so the next opaque status is readable.
- Extract the classifier into `grok-billing-error.ts` so `grok-fetcher.ts` stays under the 300-line budget.

## Why

`GET /v1/billing?format=credits` (and the default `/billing` view) resolve a personal team. Team/org Grok CLI sessions (`principal_type: Team`) have none, so xAI returns 412 Precondition Failed. Mapping that to `error` made the status bar say **Refresh failed**, which looks like a transient Orca/network bug. `unavailable` is the same status we already use when a signed-in plan has no visible quota.

This does not invent team-quota numbers. xAI does not expose a team-scoped billing route on this proxy.

## Linked Issue

Fixes #14060

## Visual Proof

N/A — no layout or control changes. The existing Usage pane and status-bar chip already render `error` / `unavailable`; only the status and copy change:

- Before: `Refresh failed` / `Grok usage request failed (HTTP 412)`
- After: `Usage unavailable` / `Grok usage is unavailable for team accounts — the billing API requires a personal team`

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Ran on macOS (Node 25, `engine-strict` off; repo wants Node 24):

- `pnpm exec oxlint` on the four touched files
- `pnpm run typecheck:node`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/grok-fetcher.test.ts src/main/rate-limits/grok-billing-error.test.ts` (20 passed)

Did not run the full `pnpm test` / `pnpm build` Electron suite locally.

Did not click Refresh inside a running Orca build; classification is covered by unit tests against the live 412 body.

## AI Disclosure

Drafted with Grok 4.6 (xAI). Reproduced the 412 against `cli-chat-proxy.grok.com` with a team session (no tokens or account identifiers in this PR).

## Review

- Security: billing error body is parsed only for the `error` string; nothing is logged or persisted.
- Cross-platform: file/path/shortcut unchanged. Same `net.fetch` path on macOS / Linux / Windows.
- Remote SSH: usage still reads the host `~/.grok/auth.json`; this PR does not change that.
- Mobile: unused. Same rate-limit payload over the wire (`unavailable` + error string is already a valid `ProviderRateLimits`).
- Performance: one extra `res.text()` on non-OK billing responses only.
- Agents: Grok TUI/chat is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local: targeted oxlint + `typecheck:node` + the two Vitest files. Full lint/test/build left to CI.

## Author

- X / Twitter: