### PR TITLE
fix(stats): wrap long usage breakdown model names

### DIFF
--- a/src/renderer/src/components/stats/UsageBreakdownSection.test.tsx
+++ b/src/renderer/src/components/stats/UsageBreakdownSection.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { UsageBreakdownSection } from './UsageBreakdownSection'
+
+afterEach(cleanup)
+
+describe('UsageBreakdownSection', () => {
+  it('wraps long model identifiers instead of truncating them', () => {
+    const firstModel = 'fireworks-ai/accounts/fireworks/models/deepseek-v3p2'
+    const secondModel = 'fireworks-ai/accounts/fireworks/models/qwen3-coder-480b'
+
+    render(
+      <UsageBreakdownSection
+        title="By model"
+        topLabel="Top model:"
+        topValue={firstModel}
+        eventsOrTurns="events"
+        rows={[
+          { key: firstModel, label: firstModel, tokens: 1_000, sessions: 1, eventsOrTurns: 2 },
+          { key: secondModel, label: secondModel, tokens: 2_000, sessions: 2, eventsOrTurns: 4 }
+        ]}
+      />
+    )
+
+    for (const model of [firstModel, secondModel]) {
+      const label = screen.getByText(model)
+      expect(label).toHaveClass('min-w-0', 'break-words')
+      expect(label).not.toHaveClass('truncate')
+    }
+  })
+})

--- a/src/renderer/src/components/stats/UsageBreakdownSection.tsx
+++ b/src/renderer/src/components/stats/UsageBreakdownSection.tsx
@@ -44,7 +44,7 @@ export function UsageBreakdownSection({
         {rows.slice(0, 5).map((row) => (
           <div key={row.key} className="space-y-1">
             <div className="flex items-center justify-between gap-3 text-sm">
-              <span className="truncate text-foreground">{row.label}</span>
+              <span className="min-w-0 break-words text-foreground">{row.label}</span>
               <span className="shrink-0 text-muted-foreground">{formatTokens(row.tokens)}</span>
             </div>
             <div className="text-xs text-muted-foreground">


### PR DESCRIPTION
Fixes https://github.com/stablyai/orca/issues/14048

## Summary
- wrap long model identifiers in usage breakdown rows
- preserve fixed, aligned token totals
- cover Fireworks-style model IDs with a component regression test

Closes STA-4005

## Validation
- `pnpm exec vitest run src/renderer/src/components/stats/UsageBreakdownSection.test.tsx --config config/vitest.config.ts`
- `pnpm run typecheck:web`
- `pnpm run check:code-quality:changed`
- Rendered Electron validation with three long Fireworks model IDs