### PR TITLE
docs: remove stale orchestration toggle requirement

### DIFF
--- a/skill-guides/orchestration.md
+++ b/skill-guides/orchestration.md
@@ -48,7 +48,6 @@ Do not use orchestration merely because the user says "hand off", "handoff", "ha
 
 - `orca status --json` should show a running runtime.
 - `orca` must be on PATH (`orca-ide` on Linux).
-- The orchestration experimental feature must be enabled in Settings > Experimental.
 - `orca orchestration` commands are RPC calls to the running Orca runtime.
 
 ## Contract Migration


### PR DESCRIPTION
## Summary

Remove the stale prerequisite that asks users to enable an orchestration toggle which no longer exists.

Fixes #14031.

## Validation

- Confirmed `skill-guides/orchestration.md` no longer references Settings > Experimental.
- Ran `git diff --check`.