### PR TITLE
Forward Unix launcher signals to orca serve supervisor

### DIFF
--- a/resources/darwin/bin/orca
+++ b/resources/darwin/bin/orca
@@ -30,6 +30,4 @@ export ORCA_NODE_REPL_EXTERNAL_MODULE="${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 
-export ELECTRON_RUN_AS_NODE=1
-# Why: preserve signal delivery by replacing the launcher with the CLI supervisor.
-exec "$ELECTRON" "$CLI" "$@"
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$CLI" "$@"

--- a/resources/darwin/bin/orca
+++ b/resources/darwin/bin/orca
@@ -30,4 +30,7 @@ export ORCA_NODE_REPL_EXTERNAL_MODULE="${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+export ELECTRON_RUN_AS_NODE=1
+# Why: replace the launcher so SIGINT/SIGTERM reach the CLI supervisor, which
+# forwards them to the Electron serve process and releases its listener.
+exec "$ELECTRON" "$CLI" "$@"

--- a/resources/darwin/bin/orca
+++ b/resources/darwin/bin/orca
@@ -31,6 +31,5 @@ unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 
 export ELECTRON_RUN_AS_NODE=1
-# Why: replace the launcher so SIGINT/SIGTERM reach the CLI supervisor, which
-# forwards them to the Electron serve process and releases its listener.
+# Why: preserve signal delivery by replacing the launcher with the CLI supervisor.
 exec "$ELECTRON" "$CLI" "$@"

--- a/resources/linux/bin/orca-ide
+++ b/resources/linux/bin/orca-ide
@@ -38,4 +38,7 @@ export ORCA_NODE_REPL_EXTERNAL_MODULE="${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+export ELECTRON_RUN_AS_NODE=1
+# Why: replace the launcher so SIGINT/SIGTERM reach the CLI supervisor, which
+# forwards them to the Electron serve process and releases its listener.
+exec "$ELECTRON" "$CLI" "$@"

--- a/resources/linux/bin/orca-ide
+++ b/resources/linux/bin/orca-ide
@@ -39,6 +39,5 @@ unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 
 export ELECTRON_RUN_AS_NODE=1
-# Why: replace the launcher so SIGINT/SIGTERM reach the CLI supervisor, which
-# forwards them to the Electron serve process and releases its listener.
+# Why: preserve signal delivery by replacing the launcher with the CLI supervisor.
 exec "$ELECTRON" "$CLI" "$@"

--- a/resources/linux/bin/orca-ide
+++ b/resources/linux/bin/orca-ide
@@ -38,6 +38,4 @@ export ORCA_NODE_REPL_EXTERNAL_MODULE="${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 
-export ELECTRON_RUN_AS_NODE=1
-# Why: preserve signal delivery by replacing the launcher with the CLI supervisor.
-exec "$ELECTRON" "$CLI" "$@"
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$CLI" "$@"

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -97,8 +97,7 @@ describe('CliInstaller', () => {
       expect(installed.pathConfigured).toBe(true)
 
       const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
-      expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
-      expect(launcherContent).toContain('exec "$ELECTRON" "$CLI" "$@"')
+      expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$CLI" "$@"')
       expect(launcherContent).toContain(`export ORCA_USER_DATA_PATH='${fixture.userDataPath}'`)
       expect(launcherContent).toContain('export ORCA_APP_EXECUTABLE="$ELECTRON"')
       expect(launcherContent).toContain(join(fixture.appPath, 'out', 'cli', 'index.js'))
@@ -131,8 +130,7 @@ describe('CliInstaller', () => {
       expect(installed.detail).toContain('.local')
 
       const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
-      expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
-      expect(launcherContent).toContain('exec "$ELECTRON" "$CLI" "$@"')
+      expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$CLI" "$@"')
       expect(launcherContent).toContain(`export ORCA_USER_DATA_PATH='${fixture.userDataPath}'`)
 
       const removed = await installer.remove()

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -98,6 +98,7 @@ describe('CliInstaller', () => {
 
       const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
       expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
+      expect(launcherContent).toContain('exec "$ELECTRON" "$CLI" "$@"')
       expect(launcherContent).toContain(`export ORCA_USER_DATA_PATH='${fixture.userDataPath}'`)
       expect(launcherContent).toContain('export ORCA_APP_EXECUTABLE="$ELECTRON"')
       expect(launcherContent).toContain(join(fixture.appPath, 'out', 'cli', 'index.js'))
@@ -131,6 +132,7 @@ describe('CliInstaller', () => {
 
       const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
       expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
+      expect(launcherContent).toContain('exec "$ELECTRON" "$CLI" "$@"')
       expect(launcherContent).toContain(`export ORCA_USER_DATA_PATH='${fixture.userDataPath}'`)
 
       const removed = await installer.remove()

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -959,9 +959,7 @@ export ORCA_NODE_OPTIONS="\${NODE_OPTIONS-}"
 export ORCA_NODE_REPL_EXTERNAL_MODULE="\${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
-export ELECTRON_RUN_AS_NODE=1
-# Why: preserve signal delivery by replacing the launcher with the CLI supervisor.
-exec "$ELECTRON" "$CLI" "$@"
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$CLI" "$@"
 `
 }
 

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -960,7 +960,7 @@ export ORCA_NODE_REPL_EXTERNAL_MODULE="\${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
 export ELECTRON_RUN_AS_NODE=1
-# Why: preserve signal delivery by replacing the generated launcher process.
+# Why: preserve signal delivery by replacing the launcher with the CLI supervisor.
 exec "$ELECTRON" "$CLI" "$@"
 `
 }

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -959,7 +959,9 @@ export ORCA_NODE_OPTIONS="\${NODE_OPTIONS-}"
 export ORCA_NODE_REPL_EXTERNAL_MODULE="\${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+export ELECTRON_RUN_AS_NODE=1
+# Why: preserve signal delivery by replacing the generated launcher process.
+exec "$ELECTRON" "$CLI" "$@"
 `
 }
 

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -70,6 +70,43 @@ describe('packaged CLI assets', () => {
     }
   })
 
+  it('retries an incomplete listener-state write', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-listener-state-'))
+    const statePath = join(root, 'listener-state.json')
+    const expectedState = { pid: 1234, port: 5678 }
+    await writeFile(statePath, '{"pid":', 'utf8')
+    const completedWrite = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        writeFile(statePath, JSON.stringify(expectedState), 'utf8').then(resolve, reject)
+      }, 50)
+    })
+
+    try {
+      await expect(waitForListenerState(statePath)).resolves.toEqual(expectedState)
+    } finally {
+      await completedWrite
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    { state: { pid: '1234', port: 5678 }, reason: 'non-numeric pid' },
+    { state: { pid: 0, port: 5678 }, reason: 'non-positive pid' },
+    { state: { pid: 1234, port: '5678' }, reason: 'non-numeric port' },
+    { state: { pid: 1234, port: 65_536 }, reason: 'out-of-range port' }
+  ])('rejects $reason in listener state', async ({ state }) => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-listener-state-'))
+    const statePath = join(root, 'listener-state.json')
+    try {
+      await writeFile(statePath, JSON.stringify(state), 'utf8')
+      await expect(waitForListenerState(statePath)).rejects.toThrow(
+        'Invalid launcher listener state'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   itRunsUnixShell(
     'delivers SIGTERM to the Linux executable and releases its listener',
     async () => {
@@ -259,9 +296,25 @@ async function waitForListenerState(path: string): Promise<{ pid: number; port: 
   const deadline = Date.now() + 5_000
   while (Date.now() < deadline) {
     try {
-      return JSON.parse(await readFile(path, 'utf8')) as { pid: number; port: number }
+      const state: unknown = JSON.parse(await readFile(path, 'utf8'))
+      if (
+        typeof state !== 'object' ||
+        state === null ||
+        !('pid' in state) ||
+        typeof state.pid !== 'number' ||
+        !Number.isInteger(state.pid) ||
+        state.pid <= 0 ||
+        !('port' in state) ||
+        typeof state.port !== 'number' ||
+        !Number.isInteger(state.port) ||
+        state.port <= 0 ||
+        state.port > 65_535
+      ) {
+        throw new Error('Invalid launcher listener state')
+      }
+      return { pid: state.pid, port: state.port }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      if (!(error instanceof SyntaxError) && (error as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw error
       }
       await new Promise((resolve) => setTimeout(resolve, 10))

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -1,5 +1,4 @@
 import { execFile, spawn } from 'node:child_process'
-import { once } from 'node:events'
 import { copyFile, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
@@ -11,6 +10,7 @@ import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
 const require = createRequire(import.meta.url)
 const execFileAsync = promisify(execFile)
 const itRunsUnixShell = process.platform === 'win32' ? it.skip : it
+const unixTerminationSignals = ['SIGINT', 'SIGTERM'] as const
 const builderConfig = require('../../../config/electron-builder.config.cjs') as {
   files?: string[]
   asarUnpack?: string[]
@@ -107,9 +107,9 @@ describe('packaged CLI assets', () => {
     }
   })
 
-  itRunsUnixShell(
-    'delivers SIGTERM to the Linux executable and releases its listener',
-    async () => {
+  itRunsUnixShell.each(unixTerminationSignals)(
+    'delivers %s to the Linux executable and releases its listener',
+    async (signal) => {
       const root = await mkdtemp(join(tmpdir(), 'orca-linux-cli-signal-'))
       const appDir = join(root, 'Orca')
       const resourcesDir = join(appDir, 'resources')
@@ -151,18 +151,22 @@ process.on('SIGTERM', shutdown)
         const state = await waitForListenerState(statePath)
         executablePid = state.pid
         const launcherPid = launcher.pid
-        const launcherExit = once(launcher, 'exit')
-        launcher.kill('SIGTERM')
-        await launcherExit
+        launcher.kill(signal)
+        const launcherExit = await waitForChildExit(launcher, 5_000)
+        const exitCode = launcherExit?.[0]
+        const exitSignal = launcherExit?.[1]
 
-        expect(executablePid).toBe(launcherPid)
-        await expect(waitForPortRelease(state.port)).resolves.toBe(true)
+        expect.soft(executablePid).toBe(launcherPid)
+        expect.soft(launcherExit).not.toBeNull()
+        expect.soft(exitCode).toBe(0)
+        expect.soft(exitSignal).toBeNull()
+        expect.soft(await waitForPortRelease(state.port)).toBe(true)
       } finally {
-        if (launcher?.pid && isProcessAlive(launcher.pid)) {
-          process.kill(launcher.pid, 'SIGTERM')
+        if (launcher?.pid) {
+          await terminateSyntheticProcess(launcher.pid)
         }
-        if (executablePid && isProcessAlive(executablePid)) {
-          process.kill(executablePid, 'SIGTERM')
+        if (executablePid && executablePid !== launcher?.pid) {
+          await terminateSyntheticProcess(executablePid)
         }
         await rm(root, { recursive: true, force: true })
       }
@@ -350,4 +354,46 @@ function isProcessAlive(pid: number): boolean {
   } catch {
     return false
   }
+}
+
+function waitForChildExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number
+): Promise<readonly [number | null, NodeJS.Signals | null] | null> {
+  return new Promise((resolve) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      clearTimeout(timeout)
+      resolve([code, signal])
+    }
+    const timeout = setTimeout(() => {
+      child.off('exit', onExit)
+      resolve(null)
+    }, timeoutMs)
+    child.once('exit', onExit)
+  })
+}
+
+async function terminateSyntheticProcess(pid: number): Promise<void> {
+  if (!isProcessAlive(pid)) {
+    return
+  }
+  process.kill(pid, 'SIGTERM')
+  if (await waitForProcessExit(pid, 1_000)) {
+    return
+  }
+  process.kill(pid, 'SIGKILL')
+  if (!(await waitForProcessExit(pid, 1_000))) {
+    throw new Error(`Failed to terminate synthetic launcher process ${pid}`)
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return true
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return !isProcessAlive(pid)
 }

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -2,7 +2,7 @@ import { execFile, spawn } from 'node:child_process'
 import { copyFile, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join, sep } from 'node:path'
+import { dirname, join, sep } from 'node:path'
 import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
 import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
@@ -20,6 +20,24 @@ const builderConfig = require('../../../config/electron-builder.config.cjs') as 
 }
 const linuxLauncherAsset = new URL('../../../resources/linux/bin/orca-ide', import.meta.url)
 const darwinLauncherAsset = new URL('../../../resources/darwin/bin/orca', import.meta.url)
+const unixLauncherFixtures = [
+  {
+    name: 'Linux',
+    asset: linuxLauncherAsset,
+    appDir: ['Orca'],
+    launcher: ['resources', 'bin', 'orca-ide'],
+    executable: ['orca-ide'],
+    cli: ['resources', 'app.asar.unpacked', 'out', 'cli', 'index.js']
+  },
+  {
+    name: 'macOS',
+    asset: darwinLauncherAsset,
+    appDir: ['Orca.app'],
+    launcher: ['Contents', 'Resources', 'bin', 'orca'],
+    executable: ['Contents', 'MacOS', 'Orca'],
+    cli: ['Contents', 'Resources', 'app.asar.unpacked', 'out', 'cli', 'index.js']
+  }
+] as const
 
 describe('packaged CLI assets', () => {
   it('ships embedded skill guides with the CLI instead of source Markdown', () => {
@@ -107,68 +125,70 @@ describe('packaged CLI assets', () => {
     }
   })
 
-  itRunsUnixShell.each(unixTerminationSignals)(
-    'delivers %s to the Linux executable and releases its listener',
-    async (signal) => {
-      const root = await mkdtemp(join(tmpdir(), 'orca-linux-cli-signal-'))
-      const appDir = join(root, 'Orca')
-      const resourcesDir = join(appDir, 'resources')
-      const launcherDir = join(resourcesDir, 'bin')
-      const cliDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'cli')
-      const launcherPath = join(launcherDir, 'orca-ide')
-      const electronPath = join(appDir, 'orca-ide')
-      const statePath = join(root, 'listener-state.json')
-      let executablePid: number | null = null
-      let launcher: ReturnType<typeof spawn> | null = null
-      try {
-        await mkdir(launcherDir, { recursive: true })
-        await mkdir(cliDir, { recursive: true })
-        await copyFile(linuxLauncherAsset, launcherPath)
-        await writeFile(join(cliDir, 'index.js'), '', 'utf8')
-        await writeFile(
-          electronPath,
-          `#!/usr/bin/env node
+  itRunsUnixShell.each(unixLauncherFixtures)(
+    'delivers Unix termination signals to the $name executable and releases its listener',
+    async (launcherFixture) => {
+      for (const signal of unixTerminationSignals) {
+        const root = await mkdtemp(join(tmpdir(), 'orca-unix-cli-signal-'))
+        const appDir = join(root, ...launcherFixture.appDir)
+        const launcherPath = join(appDir, ...launcherFixture.launcher)
+        const electronPath = join(appDir, ...launcherFixture.executable)
+        const cliPath = join(appDir, ...launcherFixture.cli)
+        const statePath = join(root, `${signal}-listener-state.json`)
+        let executablePid: number | null = null
+        let launcher: ReturnType<typeof spawn> | null = null
+        try {
+          await mkdir(dirname(launcherPath), { recursive: true })
+          await mkdir(dirname(electronPath), { recursive: true })
+          await mkdir(dirname(cliPath), { recursive: true })
+          await copyFile(launcherFixture.asset, launcherPath)
+          await writeFile(cliPath, '', 'utf8')
+          await writeFile(
+            electronPath,
+            `#!/usr/bin/env node
 const fs = require('node:fs')
 const net = require('node:net')
 const server = net.createServer()
+const shutdown = () => server.close(() => process.exit(0))
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
 server.listen(0, '127.0.0.1', () => {
   fs.writeFileSync(process.env.ORCA_TEST_LISTENER_STATE, JSON.stringify({
     pid: process.pid,
     port: server.address().port
   }))
 })
-const shutdown = () => server.close(() => process.exit(0))
-process.on('SIGINT', shutdown)
-process.on('SIGTERM', shutdown)
 `,
-          { encoding: 'utf8', mode: 0o755 }
-        )
+            { encoding: 'utf8', mode: 0o755 }
+          )
 
-        launcher = spawn(launcherPath, [], {
-          env: { ...process.env, ORCA_TEST_LISTENER_STATE: statePath },
-          stdio: 'ignore'
-        })
-        const state = await waitForListenerState(statePath)
-        executablePid = state.pid
-        const launcherPid = launcher.pid
-        launcher.kill(signal)
-        const launcherExit = await waitForChildExit(launcher, 5_000)
-        const exitCode = launcherExit?.[0]
-        const exitSignal = launcherExit?.[1]
+          launcher = spawn(launcherPath, [], {
+            env: { ...process.env, ORCA_TEST_LISTENER_STATE: statePath },
+            stdio: 'ignore'
+          })
+          const state = await waitForListenerState(statePath)
+          executablePid = state.pid
+          const launcherPid = launcher.pid
+          const launcherExitPromise = waitForChildExit(launcher, 5_000)
+          launcher.kill(signal)
+          const launcherExit = await launcherExitPromise
+          const exitCode = launcherExit?.[0]
+          const exitSignal = launcherExit?.[1]
 
-        expect.soft(executablePid).toBe(launcherPid)
-        expect.soft(launcherExit).not.toBeNull()
-        expect.soft(exitCode).toBe(0)
-        expect.soft(exitSignal).toBeNull()
-        expect.soft(await waitForPortRelease(state.port)).toBe(true)
-      } finally {
-        if (launcher?.pid) {
-          await terminateSyntheticProcess(launcher.pid)
+          expect.soft(executablePid).toBe(launcherPid)
+          expect.soft(launcherExit).not.toBeNull()
+          expect.soft(exitCode).toBe(0)
+          expect.soft(exitSignal).toBeNull()
+          expect.soft(await waitForPortRelease(state.port)).toBe(true)
+        } finally {
+          if (launcher?.pid) {
+            await terminateSyntheticProcess(launcher.pid)
+          }
+          if (executablePid && executablePid !== launcher?.pid) {
+            await terminateSyntheticProcess(executablePid)
+          }
+          await rm(root, { recursive: true, force: true })
         }
-        if (executablePid && executablePid !== launcher?.pid) {
-          await terminateSyntheticProcess(executablePid)
-        }
-        await rm(root, { recursive: true, force: true })
       }
     }
   )
@@ -361,6 +381,10 @@ function waitForChildExit(
   timeoutMs: number
 ): Promise<readonly [number | null, NodeJS.Signals | null] | null> {
   return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve([child.exitCode, child.signalCode])
+      return
+    }
     const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
       clearTimeout(timeout)
       resolve([code, signal])
@@ -377,11 +401,19 @@ async function terminateSyntheticProcess(pid: number): Promise<void> {
   if (!isProcessAlive(pid)) {
     return
   }
-  process.kill(pid, 'SIGTERM')
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch {
+    return
+  }
   if (await waitForProcessExit(pid, 1_000)) {
     return
   }
-  process.kill(pid, 'SIGKILL')
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    return
+  }
   if (!(await waitForProcessExit(pid, 1_000))) {
     throw new Error(`Failed to terminate synthetic launcher process ${pid}`)
   }

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -1,5 +1,6 @@
-import { execFile } from 'node:child_process'
-import { copyFile, mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { execFile, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { copyFile, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
@@ -18,6 +19,7 @@ const builderConfig = require('../../../config/electron-builder.config.cjs') as 
   win?: { extraResources?: { from?: string; to?: string }[] }
 }
 const linuxLauncherAsset = new URL('../../../resources/linux/bin/orca-ide', import.meta.url)
+const darwinLauncherAsset = new URL('../../../resources/darwin/bin/orca', import.meta.url)
 
 describe('packaged CLI assets', () => {
   it('ships embedded skill guides with the CLI instead of source Markdown', () => {
@@ -59,6 +61,76 @@ describe('packaged CLI assets', () => {
     const launcherStats = await stat(linuxLauncherAsset)
     expect(launcherStats.mode & 0o111).not.toBe(0)
   })
+
+  itRunsUnixShell('replaces the shell process in packaged Unix launchers', async () => {
+    for (const launcher of [linuxLauncherAsset, darwinLauncherAsset]) {
+      const content = await readFile(launcher, 'utf8')
+      expect(content).toContain('export ELECTRON_RUN_AS_NODE=1')
+      expect(content).toContain('exec "$ELECTRON" "$CLI" "$@"')
+    }
+  })
+
+  itRunsUnixShell(
+    'delivers SIGTERM to the Linux executable and releases its listener',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-linux-cli-signal-'))
+      const appDir = join(root, 'Orca')
+      const resourcesDir = join(appDir, 'resources')
+      const launcherDir = join(resourcesDir, 'bin')
+      const cliDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'cli')
+      const launcherPath = join(launcherDir, 'orca-ide')
+      const electronPath = join(appDir, 'orca-ide')
+      const statePath = join(root, 'listener-state.json')
+      let executablePid: number | null = null
+      let launcher: ReturnType<typeof spawn> | null = null
+      try {
+        await mkdir(launcherDir, { recursive: true })
+        await mkdir(cliDir, { recursive: true })
+        await copyFile(linuxLauncherAsset, launcherPath)
+        await writeFile(join(cliDir, 'index.js'), '', 'utf8')
+        await writeFile(
+          electronPath,
+          `#!/usr/bin/env node
+const fs = require('node:fs')
+const net = require('node:net')
+const server = net.createServer()
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(process.env.ORCA_TEST_LISTENER_STATE, JSON.stringify({
+    pid: process.pid,
+    port: server.address().port
+  }))
+})
+const shutdown = () => server.close(() => process.exit(0))
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+`,
+          { encoding: 'utf8', mode: 0o755 }
+        )
+
+        launcher = spawn(launcherPath, [], {
+          env: { ...process.env, ORCA_TEST_LISTENER_STATE: statePath },
+          stdio: 'ignore'
+        })
+        const state = await waitForListenerState(statePath)
+        executablePid = state.pid
+        const launcherPid = launcher.pid
+        const launcherExit = once(launcher, 'exit')
+        launcher.kill('SIGTERM')
+        await launcherExit
+
+        expect(executablePid).toBe(launcherPid)
+        await expect(waitForPortRelease(state.port)).resolves.toBe(true)
+      } finally {
+        if (launcher?.pid && isProcessAlive(launcher.pid)) {
+          process.kill(launcher.pid, 'SIGTERM')
+        }
+        if (executablePid && isProcessAlive(executablePid)) {
+          process.kill(executablePid, 'SIGTERM')
+        }
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   itRunsUnixShell(
     'runs the Linux launcher from its packaged path and installed symlink',
@@ -182,3 +254,47 @@ exec node "$@"
     }
   })
 })
+
+async function waitForListenerState(path: string): Promise<{ pid: number; port: number }> {
+  const deadline = Date.now() + 5_000
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(await readFile(path, 'utf8')) as { pid: number; port: number }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  throw new Error('Timed out waiting for launcher listener state')
+}
+
+async function waitForPortRelease(port: number): Promise<boolean> {
+  const { createConnection } = await import('node:net')
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    const connected = await new Promise<boolean>((resolve) => {
+      const socket = createConnection({ host: '127.0.0.1', port })
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      socket.once('error', () => resolve(false))
+    })
+    if (!connected) {
+      return true
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return false
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -83,8 +83,7 @@ describe('packaged CLI assets', () => {
   itRunsUnixShell('replaces the shell process in packaged Unix launchers', async () => {
     for (const launcher of [linuxLauncherAsset, darwinLauncherAsset]) {
       const content = await readFile(launcher, 'utf8')
-      expect(content).toContain('export ELECTRON_RUN_AS_NODE=1')
-      expect(content).toContain('exec "$ELECTRON" "$CLI" "$@"')
+      expect(content).toContain('ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$CLI" "$@"')
     }
   })
 


### PR DESCRIPTION
## ELI5

The Unix launcher used to remain in front of Orca and absorb a stop signal. It now replaces itself with the CLI supervisor, so stopping the documented launcher reaches the process that can stop Electron and release the listener.

## What Changed

- Use shell `exec` in the packaged Linux and macOS CLI launchers.
- Generate Unix development launchers with the same process model.
- Keep `ELECTRON_RUN_AS_NODE=1` exported for the replacement CLI process.
- Add packaged-asset checks plus a functional synthetic listener test that verifies PID identity and listener release after `SIGTERM`.
- Retry incomplete listener-state writes within the test deadline and reject invalid PID or port values.

## Why

The CLI supervisor and serving Electron process already handle and forward `SIGINT`/`SIGTERM`. The shell launcher was a separate parent, so a signal sent only to its PID never reached those handlers. Replacing the shell fixes the process ownership boundary without adding process-tree killing, watchdogs, or service-specific behavior.

## Linked Issue

Fixes #14067

Related: #11935, #9563

## Visual Proof

N/A — this changes Unix process and signal behavior only.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Latest-main verification:

- `pnpm lint`
- `pnpm typecheck`
- CLI launcher suites: 2 files, 53 passed
- Current-main launcher plus non-overlapping rebase delta: 5 files, 78 passed
- Current-head complete Vitest attempt: 4,718 files / 50,613 tests passed; 3 files / 2 tests failed; 21 files / 173 tests skipped; 3 unhandled cleanup errors
  - `config/scripts/resolve-7za-path.test.mjs`: the cold-cache case still exited with status 1 in an isolated rerun; this test downloads a public toolset and is untouched by the PR
  - `src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts`: the complete run timed out; its 2 tests passed in isolation
  - `tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts`: the complete run timed out in `beforeAll`; its 4 tests passed in isolation
  - the two files named by the 3 unhandled cleanup errors passed together in isolation (36 tests)
- For comparison, the complete suite on the immediately preceding `main` passed: 4,719 files / 50,608 tests, with 21 files / 169 tests skipped
- `pnpm build`
- Disposable Linux packaged-layout smoke with isolated HOME/profile, loopback, random port, and no pairing:
  - the outer CLI supervisor and serving Electron process reached `ready`
  - `SIGTERM` to the documented outer PID stopped the process chain
  - the listener was released and no CLI/Electron child remained
  - no real authentication or profile files were read

## AI Disclosure

OpenAI Codex (GPT-5) was used for investigation, implementation, tests, and review. All claims above were checked against source, automated tests, or the disposable smoke environment.

## Review

- Security: no arguments or environment values are newly interpreted; no authentication changes.
- Cross-platform: packaged and generated POSIX launchers change; Windows launch behavior is untouched.
- Remote/SSH/mobile: listener shutdown becomes deterministic; terminal daemon ownership is unchanged.
- Performance: `exec` removes one shell process and adds no timers, polling, or retry behavior.
- Compatibility: command arguments, environment, exit status, and CLI supervisor logic are preserved.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A visual proof explained above
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — `pnpm test` has the unrelated failures documented above; the other gates pass

## Author

- X / Twitter: not provided
