### PR TITLE
fix(browser): guide Google sign-in after cookie import (STA-4019)

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
@@ -102,7 +102,7 @@ export function BrowserImportHintButton({
               value2: browserProfile ? ` (${browserProfile})` : ''
             }
           ),
-          result.executionHostId
+          result.executionHostLabel
         )
         return
       }
@@ -123,7 +123,7 @@ export function BrowserImportHintButton({
           'Imported {{value0}} cookies from file.',
           { value0: result.summary.importedCookies }
         ),
-        result.executionHostId
+        result.executionHostLabel
       )
       return
     }

--- a/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
@@ -102,7 +102,7 @@ export function BrowserImportHintButton({
               value2: browserProfile ? ` (${browserProfile})` : ''
             }
           ),
-          result.profileId
+          result.executionHostId
         )
         return
       }
@@ -123,7 +123,7 @@ export function BrowserImportHintButton({
           'Imported {{value0}} cookies from file.',
           { value0: result.summary.importedCookies }
         ),
-        result.profileId
+        result.executionHostId
       )
       return
     }

--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -206,7 +206,7 @@ export function BrowserToolbarMenu({
                 value1: browser?.label ?? browserFamily
               }
             ),
-        result.profileId
+        result.executionHostId
       )
     } else {
       toast.error(result.reason)
@@ -223,7 +223,7 @@ export function BrowserToolbarMenu({
           'Imported {{value0}} cookies from file.',
           { value0: result.summary.importedCookies }
         ),
-        result.profileId
+        result.executionHostId
       )
     } else if (result.reason !== 'canceled') {
       toast.error(result.reason)

--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -206,7 +206,7 @@ export function BrowserToolbarMenu({
                 value1: browser?.label ?? browserFamily
               }
             ),
-        result.executionHostId
+        result.executionHostLabel
       )
     } else {
       toast.error(result.reason)
@@ -223,7 +223,7 @@ export function BrowserToolbarMenu({
           'Imported {{value0}} cookies from file.',
           { value0: result.summary.importedCookies }
         ),
-        result.executionHostId
+        result.executionHostLabel
       )
     } else if (result.reason !== 'canceled') {
       toast.error(result.reason)

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -82,7 +82,7 @@ export function BrowserProfileRow({
                 value2: profile.label
               }
             ),
-        result.profileId
+        result.executionHostId
       )
     } else {
       toast.error(result.reason)
@@ -99,7 +99,7 @@ export function BrowserProfileRow({
           'Imported {{value0}} cookies from file into {{value1}}.',
           { value0: result.summary.importedCookies, value1: profile.label }
         ),
-        result.profileId
+        result.executionHostId
       )
     } else if (result.reason !== 'canceled') {
       toast.error(result.reason)

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -82,7 +82,7 @@ export function BrowserProfileRow({
                 value2: profile.label
               }
             ),
-        result.executionHostId
+        result.executionHostLabel
       )
     } else {
       toast.error(result.reason)
@@ -99,7 +99,7 @@ export function BrowserProfileRow({
           'Imported {{value0}} cookies from file into {{value1}}.',
           { value0: result.summary.importedCookies, value1: profile.label }
         ),
-        result.executionHostId
+        result.executionHostLabel
       )
     } else if (result.reason !== 'canceled') {
       toast.error(result.reason)

--- a/src/renderer/src/components/settings/BrowserUseCookieImportStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseCookieImportStep.tsx
@@ -60,7 +60,7 @@ export function BrowserUseCookieImportStep({
             value2: browserProfile ? ` (${browserProfile})` : ''
           }
         ),
-        result.profileId
+        result.executionHostId
       )
     } else {
       toast.error(result.reason)
@@ -77,7 +77,7 @@ export function BrowserUseCookieImportStep({
           'Imported {{value0}} cookies from file.',
           { value0: result.summary.importedCookies }
         ),
-        result.profileId
+        result.executionHostId
       )
     } else if (result.reason !== 'canceled') {
       toast.error(result.reason)

--- a/src/renderer/src/components/settings/BrowserUseCookieImportStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseCookieImportStep.tsx
@@ -60,7 +60,7 @@ export function BrowserUseCookieImportStep({
             value2: browserProfile ? ` (${browserProfile})` : ''
           }
         ),
-        result.executionHostId
+        result.executionHostLabel
       )
     } else {
       toast.error(result.reason)
@@ -77,7 +77,7 @@ export function BrowserUseCookieImportStep({
           'Imported {{value0}} cookies from file.',
           { value0: result.summary.importedCookies }
         ),
-        result.executionHostId
+        result.executionHostLabel
       )
     } else if (result.reason !== 'canceled') {
       toast.error(result.reason)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -757,9 +757,7 @@
             "toast": {
               "restartFallbackUnavailableNone": "None of the {{value0}} cookies could be loaded, and the restart fallback was unavailable. The previous cookies for this profile were replaced. Try the import again.",
               "restartFallbackUnavailablePartial": "Imported {{value0}} of {{value1}} cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.",
-              "googleCookiesSkipped": "Google cookies were not imported. Open a browser in Orca with this profile, then sign into Google.",
-              "googleDirectSignInAction": "Sign in to Google",
-              "googleDirectSignInUnavailable": "Could not open the browser profile. Open it and sign in at accounts.google.com."
+              "googleCookiesSkipped": "Google cookies were not imported. Open a browser in Orca on {{value0}} with this profile, then sign into Google."
             }
           }
         }

--- a/src/renderer/src/lib/browser-cookie-import-toast.test.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.test.ts
@@ -1,18 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { successToastMock, warningToastMock, errorToastMock, getStateMock } = vi.hoisted(() => ({
+const { successToastMock, warningToastMock } = vi.hoisted(() => ({
   successToastMock: vi.fn(),
-  warningToastMock: vi.fn(),
-  errorToastMock: vi.fn(),
-  getStateMock: vi.fn()
+  warningToastMock: vi.fn()
 }))
 
 vi.mock('sonner', () => ({
-  toast: { success: successToastMock, warning: warningToastMock, error: errorToastMock }
-}))
-
-vi.mock('@/store', () => ({
-  useAppStore: { getState: getStateMock }
+  toast: { success: successToastMock, warning: warningToastMock }
 }))
 
 import type { BrowserCookieImportSummary } from '../../../shared/types'
@@ -29,13 +23,6 @@ describe('emitBrowserCookieImportToast', () => {
   beforeEach(() => {
     successToastMock.mockReset()
     warningToastMock.mockReset()
-    errorToastMock.mockReset()
-    getStateMock.mockReset()
-    getStateMock.mockReturnValue({
-      activeWorktreeId: 'worktree-1',
-      closeSettingsPage: vi.fn(),
-      openBrowserProfileTabInActiveWorkspace: vi.fn().mockResolvedValue(true)
-    })
   })
 
   it('shows the localized total-failure warning', () => {
@@ -49,7 +36,7 @@ describe('emitBrowserCookieImportToast', () => {
         }
       },
       'Imported 3 cookies.',
-      'profile-1'
+      'local'
     )
 
     expect(warningToastMock).toHaveBeenCalledWith(
@@ -58,45 +45,25 @@ describe('emitBrowserCookieImportToast', () => {
     expect(successToastMock).not.toHaveBeenCalled()
   })
 
-  it('shows the localized partial-failure warning', () => {
-    emitBrowserCookieImportToast(
-      {
-        ...summary,
-        warning: {
-          code: 'restart-fallback-unavailable',
-          loadedCookies: 2,
-          failedCookies: 1
-        }
-      },
-      'Imported 3 cookies.',
-      'profile-1'
-    )
-
-    expect(warningToastMock).toHaveBeenCalledWith(
-      'Imported 2 of 3 cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.'
-    )
-    expect(successToastMock).not.toHaveBeenCalled()
-  })
-
   it('shows success when the import has no warning', () => {
-    emitBrowserCookieImportToast(summary, 'Imported 3 cookies.', 'profile-1')
+    emitBrowserCookieImportToast(summary, 'Imported 3 cookies.', 'local')
 
     expect(successToastMock).toHaveBeenCalledWith('Imported 3 cookies.')
     expect(warningToastMock).not.toHaveBeenCalled()
   })
 
-  it('shows a separate Google sign-in warning after the concise success toast', () => {
+  it('shows separate host-specific Google guidance after success', () => {
     emitBrowserCookieImportToast(
       { ...summary, importedCookies: 2, skippedCookies: 1, googleCookiesSkipped: 1 },
       'Imported 2 cookies.',
-      'profile-1'
+      'runtime:import-host'
     )
 
     expect(successToastMock).toHaveBeenCalledWith('Imported 2 cookies.')
-    expect(warningToastMock.mock.calls[0][0]).toBe(
-      'Google cookies were not imported. Open a browser in Orca with this profile, then sign into Google.'
+    expect(warningToastMock).toHaveBeenCalledWith(
+      'Google cookies were not imported. Open a browser in Orca on import-host with this profile, then sign into Google.',
+      { duration: 12000 }
     )
-    expect(warningToastMock.mock.calls[0][1].action.label).toBe('Sign in to Google')
     expect(successToastMock.mock.invocationCallOrder[0]).toBeLessThan(
       warningToastMock.mock.invocationCallOrder[0]
     )
@@ -106,7 +73,7 @@ describe('emitBrowserCookieImportToast', () => {
     emitBrowserCookieImportToast(
       { ...summary, importedCookies: 2, skippedCookies: 1 },
       'Imported 2 cookies.',
-      'profile-1'
+      'local'
     )
 
     expect(successToastMock).toHaveBeenCalledWith('Imported 2 cookies.')
@@ -127,90 +94,18 @@ describe('emitBrowserCookieImportToast', () => {
         }
       },
       'Imported 1 cookie.',
-      'profile-1'
+      'runtime:import-host'
     )
 
     expect(successToastMock).not.toHaveBeenCalled()
-    expect(warningToastMock.mock.calls.map(([message]) => message)).toEqual([
-      'Imported 1 of 2 cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.',
-      'Google cookies were not imported. Open a browser in Orca with this profile, then sign into Google.'
+    expect(warningToastMock.mock.calls).toEqual([
+      [
+        'Imported 1 of 2 cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.'
+      ],
+      [
+        'Google cookies were not imported. Open a browser in Orca on import-host with this profile, then sign into Google.',
+        { duration: 12000 }
+      ]
     ])
-  })
-
-  it('opens Google with the imported profile from the warning action', async () => {
-    const closeSettingsPage = vi.fn()
-    const openBrowserProfileTabInActiveWorkspace = vi.fn().mockResolvedValue(true)
-    getStateMock.mockReturnValue({
-      activeWorktreeId: 'worktree-1',
-      closeSettingsPage,
-      openBrowserProfileTabInActiveWorkspace
-    })
-
-    emitBrowserCookieImportToast(
-      { ...summary, googleCookiesSkipped: 1 },
-      'Imported 2 cookies.',
-      'profile-1'
-    )
-    warningToastMock.mock.calls[0][1].action.onClick()
-
-    await vi.waitFor(() => expect(closeSettingsPage).toHaveBeenCalledTimes(1))
-    expect(openBrowserProfileTabInActiveWorkspace).toHaveBeenCalledWith(
-      'https://accounts.google.com/',
-      'profile-1'
-    )
-  })
-
-  it('keeps guidance but omits the action without an active worktree', () => {
-    getStateMock.mockReturnValue({ activeWorktreeId: null })
-
-    emitBrowserCookieImportToast(
-      { ...summary, googleCookiesSkipped: 1 },
-      'Imported 2 cookies.',
-      'profile-1'
-    )
-
-    expect(warningToastMock).toHaveBeenLastCalledWith(
-      'Google cookies were not imported. Open a browser in Orca with this profile, then sign into Google.'
-    )
-  })
-
-  it('reports when the profile tab cannot be opened', async () => {
-    const openBrowserProfileTabInActiveWorkspace = vi.fn().mockResolvedValue(false)
-    getStateMock.mockReturnValue({
-      activeWorktreeId: 'worktree-1',
-      closeSettingsPage: vi.fn(),
-      openBrowserProfileTabInActiveWorkspace
-    })
-
-    emitBrowserCookieImportToast(
-      { ...summary, googleCookiesSkipped: 1 },
-      'Imported 2 cookies.',
-      'profile-1'
-    )
-    warningToastMock.mock.calls[0][1].action.onClick()
-
-    await vi.waitFor(() => expect(errorToastMock).toHaveBeenCalledTimes(1))
-    expect(errorToastMock).toHaveBeenCalledWith(
-      'Could not open the browser profile. Open it and sign in at accounts.google.com.'
-    )
-  })
-
-  it('reports when opening the profile tab rejects', async () => {
-    getStateMock.mockReturnValue({
-      activeWorktreeId: 'worktree-1',
-      closeSettingsPage: vi.fn(),
-      openBrowserProfileTabInActiveWorkspace: vi
-        .fn()
-        .mockRejectedValue(new Error('runtime unavailable'))
-    })
-
-    emitBrowserCookieImportToast(
-      { ...summary, googleCookiesSkipped: 1 },
-      'Imported 2 cookies.',
-      'profile-1'
-    )
-    warningToastMock.mock.calls[0][1].action.onClick()
-
-    await vi.waitFor(() => expect(errorToastMock).toHaveBeenCalledTimes(1))
   })
 })

--- a/src/renderer/src/lib/browser-cookie-import-toast.test.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.test.ts
@@ -36,7 +36,7 @@ describe('emitBrowserCookieImportToast', () => {
         }
       },
       'Imported 3 cookies.',
-      'local'
+      'Local Mac'
     )
 
     expect(warningToastMock).toHaveBeenCalledWith(
@@ -46,7 +46,7 @@ describe('emitBrowserCookieImportToast', () => {
   })
 
   it('shows success when the import has no warning', () => {
-    emitBrowserCookieImportToast(summary, 'Imported 3 cookies.', 'local')
+    emitBrowserCookieImportToast(summary, 'Imported 3 cookies.', 'Local Mac')
 
     expect(successToastMock).toHaveBeenCalledWith('Imported 3 cookies.')
     expect(warningToastMock).not.toHaveBeenCalled()
@@ -56,12 +56,12 @@ describe('emitBrowserCookieImportToast', () => {
     emitBrowserCookieImportToast(
       { ...summary, importedCookies: 2, skippedCookies: 1, googleCookiesSkipped: 1 },
       'Imported 2 cookies.',
-      'runtime:import-host'
+      'Remote Mac'
     )
 
     expect(successToastMock).toHaveBeenCalledWith('Imported 2 cookies.')
     expect(warningToastMock).toHaveBeenCalledWith(
-      'Google cookies were not imported. Open a browser in Orca on import-host with this profile, then sign into Google.',
+      'Google cookies were not imported. Open a browser in Orca on Remote Mac with this profile, then sign into Google.',
       { duration: 12000 }
     )
     expect(successToastMock.mock.invocationCallOrder[0]).toBeLessThan(
@@ -73,7 +73,7 @@ describe('emitBrowserCookieImportToast', () => {
     emitBrowserCookieImportToast(
       { ...summary, importedCookies: 2, skippedCookies: 1 },
       'Imported 2 cookies.',
-      'local'
+      'Local Mac'
     )
 
     expect(successToastMock).toHaveBeenCalledWith('Imported 2 cookies.')
@@ -94,7 +94,7 @@ describe('emitBrowserCookieImportToast', () => {
         }
       },
       'Imported 1 cookie.',
-      'runtime:import-host'
+      'Remote Mac'
     )
 
     expect(successToastMock).not.toHaveBeenCalled()
@@ -103,7 +103,7 @@ describe('emitBrowserCookieImportToast', () => {
         'Imported 1 of 2 cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.'
       ],
       [
-        'Google cookies were not imported. Open a browser in Orca on import-host with this profile, then sign into Google.',
+        'Google cookies were not imported. Open a browser in Orca on Remote Mac with this profile, then sign into Google.',
         { duration: 12000 }
       ]
     ])

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -1,6 +1,5 @@
 import { toast } from 'sonner'
 import type { BrowserCookieImportSummary } from '../../../shared/types'
-import { getExecutionHostLabel, type ExecutionHostId } from '../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 
 type CookieImportWarning = NonNullable<BrowserCookieImportSummary['warning']>
@@ -27,7 +26,7 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
 
 function emitGoogleCookieImportWarning(
   summary: BrowserCookieImportSummary,
-  executionHostId: ExecutionHostId
+  executionHostLabel: string
 ): void {
   if (!summary.googleCookiesSkipped) {
     return
@@ -36,7 +35,7 @@ function emitGoogleCookieImportWarning(
     translate(
       'auto.lib.browser.cookie.import.toast.googleCookiesSkipped',
       'Google cookies were not imported. Open a browser in Orca on {{value0}} with this profile, then sign into Google.',
-      { value0: getExecutionHostLabel(executionHostId) }
+      { value0: executionHostLabel }
     ),
     { duration: 12000 }
   )
@@ -47,7 +46,7 @@ function emitGoogleCookieImportWarning(
 export function emitBrowserCookieImportToast(
   summary: BrowserCookieImportSummary,
   successMessage: string,
-  executionHostId: ExecutionHostId
+  executionHostLabel: string
 ): void {
   const warning = summary.warning
   if (warning) {
@@ -55,5 +54,5 @@ export function emitBrowserCookieImportToast(
   } else {
     toast.success(successMessage)
   }
-  emitGoogleCookieImportWarning(summary, executionHostId)
+  emitGoogleCookieImportWarning(summary, executionHostLabel)
 }

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -1,7 +1,7 @@
 import { toast } from 'sonner'
 import type { BrowserCookieImportSummary } from '../../../shared/types'
+import { getExecutionHostLabel, type ExecutionHostId } from '../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
-import { useAppStore } from '@/store'
 
 type CookieImportWarning = NonNullable<BrowserCookieImportSummary['warning']>
 
@@ -25,55 +25,21 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
   }
 }
 
-const GOOGLE_SIGN_IN_URL = 'https://accounts.google.com/'
-
-function googleSignInErrorMessage(): string {
-  return translate(
-    'auto.lib.browser.cookie.import.toast.googleDirectSignInUnavailable',
-    'Could not open the browser profile. Open it and sign in at accounts.google.com.'
-  )
-}
-
 function emitGoogleCookieImportWarning(
   summary: BrowserCookieImportSummary,
-  profileId: string
+  executionHostId: ExecutionHostId
 ): void {
   if (!summary.googleCookiesSkipped) {
     return
   }
-  const message = translate(
-    'auto.lib.browser.cookie.import.toast.googleCookiesSkipped',
-    'Google cookies were not imported. Open a browser in Orca with this profile, then sign into Google.'
+  toast.warning(
+    translate(
+      'auto.lib.browser.cookie.import.toast.googleCookiesSkipped',
+      'Google cookies were not imported. Open a browser in Orca on {{value0}} with this profile, then sign into Google.',
+      { value0: getExecutionHostLabel(executionHostId) }
+    ),
+    { duration: 12000 }
   )
-  if (!useAppStore.getState().activeWorktreeId) {
-    toast.warning(message)
-    return
-  }
-  toast.warning(message, {
-    duration: 12000,
-    action: {
-      label: translate(
-        'auto.lib.browser.cookie.import.toast.googleDirectSignInAction',
-        'Sign in to Google'
-      ),
-      onClick: () => {
-        void useAppStore
-          .getState()
-          .openBrowserProfileTabInActiveWorkspace(GOOGLE_SIGN_IN_URL, profileId)
-          .then((opened) => {
-            if (!opened) {
-              toast.error(googleSignInErrorMessage())
-              return
-            }
-            // Why: Settings would cover the newly opened browser tab.
-            useAppStore.getState().closeSettingsPage()
-          })
-          .catch(() => {
-            toast.error(googleSignInErrorMessage())
-          })
-      }
-    }
-  })
 }
 
 // Why: a degraded import returns ok:true with a warning, so every call site must route it to a
@@ -81,7 +47,7 @@ function emitGoogleCookieImportWarning(
 export function emitBrowserCookieImportToast(
   summary: BrowserCookieImportSummary,
   successMessage: string,
-  profileId: string
+  executionHostId: ExecutionHostId
 ): void {
   const warning = summary.warning
   if (warning) {
@@ -89,5 +55,5 @@ export function emitBrowserCookieImportToast(
   } else {
     toast.success(successMessage)
   }
-  emitGoogleCookieImportWarning(summary, profileId)
+  emitGoogleCookieImportWarning(summary, executionHostId)
 }

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -10,6 +10,7 @@ import {
 import { GRAB_BUDGET, type BrowserPageAnnotation } from '../../../../shared/browser-grab-types'
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { getExecutionHostLabel } from '../../../../shared/execution-host'
 
 const createWebRuntimeSessionBrowserTabMock = vi.hoisted(() => vi.fn())
 const runtimeEnvironmentCall = vi.fn()
@@ -842,7 +843,10 @@ describe('createBrowserSlice runtime guard', () => {
       })
     })
     const store = createTestStore()
-    store.setState({ browserSessionHostIdOverride: 'runtime:windows-2' })
+    store.setState({
+      browserSessionHostIdOverride: 'runtime:windows-2',
+      runtimeEnvironments: [{ id: 'windows-2', name: 'Windows Server' }] as never
+    })
 
     const importing = store
       .getState()
@@ -864,7 +868,8 @@ describe('createBrowserSlice runtime guard', () => {
     await expect(importing).resolves.toMatchObject({
       ok: true,
       profileId: 'windows-profile',
-      executionHostId: 'runtime:windows-2'
+      executionHostId: 'runtime:windows-2',
+      executionHostLabel: 'Windows Server'
     })
     expect(store.getState().browserSessionHostIdOverride).toBe('runtime:linux-3')
     expect(store.getState().browserSessionImportState).toBeNull()
@@ -1246,7 +1251,11 @@ describe('createBrowserSlice runtime guard', () => {
     const result = await store.getState().importCookiesToProfile('default')
 
     expect(mockApi.browser.sessionImportCookies).not.toHaveBeenCalled()
-    expect(result).toMatchObject({ ok: false, executionHostId: 'runtime:env-1' })
+    expect(result).toMatchObject({
+      ok: false,
+      executionHostId: 'runtime:env-1',
+      executionHostLabel: 'env-1'
+    })
     expect(store.getState().browserSessionImportState).toMatchObject({
       profileId: 'default',
       status: 'error'
@@ -1263,7 +1272,11 @@ describe('createBrowserSlice runtime guard', () => {
 
     const result = await store.getState().importCookiesFromBrowser('default', 'chrome', 'Default')
 
-    expect(result).toMatchObject({ ok: true, executionHostId: 'local' })
+    expect(result).toMatchObject({
+      ok: true,
+      executionHostId: 'local',
+      executionHostLabel: getExecutionHostLabel('local')
+    })
   })
 
   it('uses local browser IPC when no runtime environment is active', async () => {

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -1262,6 +1262,23 @@ describe('createBrowserSlice runtime guard', () => {
     })
   })
 
+  it('retains the host display label used by browser settings', async () => {
+    const store = createTestStore()
+    store.setState({
+      settings: {
+        ...settingsWithRuntime('env-1')!,
+        hostSettingOverrides: {
+          'runtime:env-1': { displayLabel: 'Production Browser Host' }
+        }
+      },
+      runtimeEnvironments: [{ id: 'env-1', name: 'Remote Mac' }] as never
+    })
+
+    const result = await store.getState().importCookiesToProfile('default')
+
+    expect(result.executionHostLabel).toBe('Production Browser Host')
+  })
+
   it('retains the local execution host for a successful browser import', async () => {
     mockApi.browser.sessionImportFromBrowser.mockResolvedValueOnce({
       ok: true,

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -861,7 +861,11 @@ describe('createBrowserSlice runtime guard', () => {
       _meta: { runtimeId: 'runtime-windows' }
     })
 
-    await expect(importing).resolves.toMatchObject({ ok: true, profileId: 'windows-profile' })
+    await expect(importing).resolves.toMatchObject({
+      ok: true,
+      profileId: 'windows-profile',
+      executionHostId: 'runtime:windows-2'
+    })
     expect(store.getState().browserSessionHostIdOverride).toBe('runtime:linux-3')
     expect(store.getState().browserSessionImportState).toBeNull()
     expect(runtimeEnvironmentCall.mock.calls).toHaveLength(callsBeforeCompletion)
@@ -1242,11 +1246,24 @@ describe('createBrowserSlice runtime guard', () => {
     const result = await store.getState().importCookiesToProfile('default')
 
     expect(mockApi.browser.sessionImportCookies).not.toHaveBeenCalled()
-    expect(result.ok).toBe(false)
+    expect(result).toMatchObject({ ok: false, executionHostId: 'runtime:env-1' })
     expect(store.getState().browserSessionImportState).toMatchObject({
       profileId: 'default',
       status: 'error'
     })
+  })
+
+  it('retains the local execution host for a successful browser import', async () => {
+    mockApi.browser.sessionImportFromBrowser.mockResolvedValueOnce({
+      ok: true,
+      profileId: 'default',
+      summary: { totalCookies: 2, importedCookies: 2, skippedCookies: 0, domains: [] }
+    })
+    const store = createTestStore()
+
+    const result = await store.getState().importCookiesFromBrowser('default', 'chrome', 'Default')
+
+    expect(result).toMatchObject({ ok: true, executionHostId: 'local' })
   })
 
   it('uses local browser IPC when no runtime environment is active', async () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -44,6 +44,7 @@ import type {
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { translate } from '@/i18n/i18n'
 import {
+  getExecutionHostLabel,
   getSettingsFocusedExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
@@ -123,13 +124,15 @@ export type RemoteBrowserPageHandle = {
 
 export type BrowserCookieImportExecutionResult = BrowserCookieImportResult & {
   executionHostId: ExecutionHostId
+  executionHostLabel: string
 }
 
 function retainCookieImportExecutionHost(
   result: BrowserCookieImportResult,
-  executionHostId: ExecutionHostId
+  executionHostId: ExecutionHostId,
+  executionHostLabel: string
 ): BrowserCookieImportExecutionResult {
-  return { ...result, executionHostId }
+  return { ...result, executionHostId, executionHostLabel }
 }
 
 export type BrowserSlice = {
@@ -267,6 +270,19 @@ function getBrowserSettingsHostId(
   state: Pick<AppState, 'browserSessionHostIdOverride' | 'settings'>
 ): ExecutionHostId {
   return state.browserSessionHostIdOverride ?? getSettingsFocusedExecutionHostId(state.settings)
+}
+
+function getBrowserSettingsHostLabel(state: AppState, hostId: ExecutionHostId): string {
+  const parsed = parseExecutionHostId(hostId)
+  if (parsed?.kind === 'runtime') {
+    const name = state.runtimeEnvironments
+      ?.find((environment) => environment.id === parsed.environmentId)
+      ?.name.trim()
+    if (name) {
+      return name
+    }
+  }
+  return getExecutionHostLabel(hostId)
 }
 
 function getBrowserSettingsRuntimeEnvironmentId(
@@ -2020,8 +2036,10 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
   },
 
   importCookiesToProfile: async (profileId) => {
-    const hostId = getBrowserSettingsHostId(get())
-    if (getBrowserSettingsRuntimeEnvironmentId(get())) {
+    const initialState = get()
+    const hostId = getBrowserSettingsHostId(initialState)
+    const executionHostLabel = getBrowserSettingsHostLabel(initialState, hostId)
+    if (getBrowserSettingsRuntimeEnvironmentId(initialState)) {
       const reason = translate(
         'auto.store.slices.browser.remoteCookieImportUnavailable',
         'Manual cookie file import is unavailable while a remote runtime is active.'
@@ -2034,7 +2052,11 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           error: reason
         })
       )
-      return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
+      return retainCookieImportExecutionHost(
+        { ok: false as const, reason },
+        hostId,
+        executionHostLabel
+      )
     }
     set((state) =>
       browserImportStateForHostUpdate(state, hostId, {
@@ -2073,7 +2095,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           })
         )
       }
-      return retainCookieImportExecutionHost(result, hostId)
+      return retainCookieImportExecutionHost(result, hostId, executionHostLabel)
     } catch (err) {
       const reason = String((err as Error)?.message ?? err)
       set((state) =>
@@ -2084,7 +2106,11 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           error: reason
         })
       )
-      return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
+      return retainCookieImportExecutionHost(
+        { ok: false as const, reason },
+        hostId,
+        executionHostLabel
+      )
     }
   },
 
@@ -2142,8 +2168,10 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
   },
 
   importCookiesFromBrowser: async (profileId, browserFamily, browserProfile?) => {
-    const hostId = getBrowserSettingsHostId(get())
-    const runtimeEnvironmentId = getBrowserSettingsRuntimeEnvironmentId(get())
+    const initialState = get()
+    const hostId = getBrowserSettingsHostId(initialState)
+    const executionHostLabel = getBrowserSettingsHostLabel(initialState, hostId)
+    const runtimeEnvironmentId = getBrowserSettingsRuntimeEnvironmentId(initialState)
     if (runtimeEnvironmentId) {
       set((state) =>
         browserImportStateForHostUpdate(state, hostId, {
@@ -2184,7 +2212,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
             })
           )
         }
-        return retainCookieImportExecutionHost(result, hostId)
+        return retainCookieImportExecutionHost(result, hostId, executionHostLabel)
       } catch (err) {
         const reason = String((err as Error)?.message ?? err)
         set((state) =>
@@ -2195,7 +2223,11 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
             error: reason
           })
         )
-        return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
+        return retainCookieImportExecutionHost(
+          { ok: false as const, reason },
+          hostId,
+          executionHostLabel
+        )
       }
     }
     set((state) =>
@@ -2237,7 +2269,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           })
         )
       }
-      return retainCookieImportExecutionHost(result, hostId)
+      return retainCookieImportExecutionHost(result, hostId, executionHostLabel)
     } catch (err) {
       const reason = String((err as Error)?.message ?? err)
       set((state) =>
@@ -2248,7 +2280,11 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           error: reason
         })
       )
-      return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
+      return retainCookieImportExecutionHost(
+        { ok: false as const, reason },
+        hostId,
+        executionHostLabel
+      )
     }
   },
 

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -121,6 +121,17 @@ export type RemoteBrowserPageHandle = {
   remotePageId: string
 }
 
+export type BrowserCookieImportExecutionResult = BrowserCookieImportResult & {
+  executionHostId: ExecutionHostId
+}
+
+function retainCookieImportExecutionHost(
+  result: BrowserCookieImportResult,
+  executionHostId: ExecutionHostId
+): BrowserCookieImportExecutionResult {
+  return { ...result, executionHostId }
+}
+
 export type BrowserSlice = {
   browserTabsByWorktree: Record<string, BrowserWorkspace[]>
   browserPagesByWorkspace: Record<string, BrowserPage[]>
@@ -205,7 +216,7 @@ export type BrowserSlice = {
     options?: BrowserSessionProfileCreateOptions
   ) => Promise<BrowserSessionProfile | null>
   deleteBrowserSessionProfile: (profileId: string) => Promise<boolean>
-  importCookiesToProfile: (profileId: string) => Promise<BrowserCookieImportResult>
+  importCookiesToProfile: (profileId: string) => Promise<BrowserCookieImportExecutionResult>
   clearBrowserSessionImportState: () => void
   detectedBrowsers: {
     family: string
@@ -219,7 +230,7 @@ export type BrowserSlice = {
     profileId: string,
     browserFamily: string,
     browserProfile?: string
-  ) => Promise<BrowserCookieImportResult>
+  ) => Promise<BrowserCookieImportExecutionResult>
   clearDefaultSessionCookies: () => Promise<boolean>
   browserUrlHistory: BrowserHistoryEntry[]
   addBrowserHistoryEntry: (url: string, title: string) => void
@@ -2023,7 +2034,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           error: reason
         })
       )
-      return { ok: false as const, reason }
+      return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
     }
     set((state) =>
       browserImportStateForHostUpdate(state, hostId, {
@@ -2062,7 +2073,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           })
         )
       }
-      return result
+      return retainCookieImportExecutionHost(result, hostId)
     } catch (err) {
       const reason = String((err as Error)?.message ?? err)
       set((state) =>
@@ -2073,7 +2084,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           error: reason
         })
       )
-      return { ok: false as const, reason }
+      return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
     }
   },
 
@@ -2173,7 +2184,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
             })
           )
         }
-        return result
+        return retainCookieImportExecutionHost(result, hostId)
       } catch (err) {
         const reason = String((err as Error)?.message ?? err)
         set((state) =>
@@ -2184,7 +2195,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
             error: reason
           })
         )
-        return { ok: false as const, reason }
+        return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
       }
     }
     set((state) =>
@@ -2226,7 +2237,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           })
         )
       }
-      return result
+      return retainCookieImportExecutionHost(result, hostId)
     } catch (err) {
       const reason = String((err as Error)?.message ?? err)
       set((state) =>
@@ -2237,7 +2248,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           error: reason
         })
       )
-      return { ok: false as const, reason }
+      return retainCookieImportExecutionHost({ ok: false as const, reason }, hostId)
     }
   },
 

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -51,6 +51,7 @@ import {
   toRuntimeExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
+import { getHostSettingOverride } from '../../../../shared/host-setting-overrides'
 import {
   getExecutionHostIdForWorktree,
   getRuntimeEnvironmentIdForWorktree
@@ -273,6 +274,10 @@ function getBrowserSettingsHostId(
 }
 
 function getBrowserSettingsHostLabel(state: AppState, hostId: ExecutionHostId): string {
+  const override = getHostSettingOverride(state.settings, hostId, 'displayLabel')
+  if (override) {
+    return override
+  }
   const parsed = parseExecutionHostId(hostId)
   if (parsed?.kind === 'runtime') {
     const name = state.runtimeEnvironments


### PR DESCRIPTION
## ELI5

Google cookies cannot be safely copied between browser profiles. Orca now clearly tells users to open an Orca browser on the computer or server where the import ran, keep the same profile selected, and sign into Google there.

## What Changed

- Always show a separate warning when Google cookies were skipped.
- Name the host that ran the import in the guidance.
- Keep only the import execution host in renderer-local results so a later host switch cannot make the message misleading.
- Remove the automatic Google sign-in CTA and all tab-opening/profile-routing machinery.

## Why

An automatic CTA tied recovery to the active workspace, which could be on a different host or browser profile. Guidance is the smallest predictable fix: it tells the user exactly where to complete sign-in without Orca opening or authenticating an unintended browser.

## Linked Issue

Fixes STA-4019: https://linear.app/stably/issue/STA-4019/p0-google-sign-in-cta-can-authenticate-on-wrong-hostprofile-after-pr

## Visual Proof

Real Chrome profile import in an isolated Electron instance. The Google warning is separate from the success toast, names **Local Mac**, and has no action:

![Google cookie import guidance](https://github.com/user-attachments/assets/0888b24d-b64e-402b-82eb-0e66058960b5)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/browser-cookie-import-toast.test.ts src/renderer/src/store/slices/browser.test.ts` — 49 passed
- `pnpm run typecheck:web`
- Focused `oxlint`
- Focused `oxfmt --check`
- Localization catalog, extraction, and coverage checks
- `pnpm run check:max-lines-ratchet`
- `git diff --check`
- Isolated Electron QA via CDP: real Chrome `stably.ai` profile import, 869 cookies imported, 72 Google cookies skipped

## AI Disclosure

Codex (GPT-5) implemented and validated this change under human-directed scope.

## Review

Remote/SSH and folder workspaces are handled by retaining the settings host at import start and rendering its existing execution-host label. No RPC or shared wire payload changes. Firefox import behavior is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshot attached for the UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and folder-workspace impact considered
- [ ] Full CI matrix pending

## Author

- X / Twitter: N/A
