### PR TITLE
fix(browser): preserve partitioned Google cookies on import

### DIFF
--- a/src/main/browser/browser-cookie-import-google-exclusion.test.ts
+++ b/src/main/browser/browser-cookie-import-google-exclusion.test.ts
@@ -166,7 +166,7 @@ describe('native Chromium import excludes the Google cookie family', () => {
     createChromiumCookieTestDatabase(targetCookiesPath, rows).close()
   }
 
-  it('bulk clears once and restores the live Google cookies before importing', async () => {
+  it('never clears or reconstructs live Google cookies before importing', async () => {
     const sourceCookiesPath = seedSource([
       { domain: '.google.com', name: 'SID', value: 'transplanted-sid' },
       { domain: '.example.com', name: 'session', value: 'new' }
@@ -186,13 +186,10 @@ describe('native Chromium import excludes the Google cookie family', () => {
       googleCookiesSkipped: 1,
       domains: ['example.com']
     })
-    expect(clearStorageDataMock).toHaveBeenCalledOnce()
-    expect(clearStorageDataMock).toHaveBeenCalledWith({ storages: ['cookies'] })
-    expect(cookiesRemoveMock).not.toHaveBeenCalled()
-    expect(cookiesSetMock.mock.calls.map(([details]) => details.domain)).toEqual([
-      '.google.com',
-      '.example.com'
-    ])
+    expect(clearStorageDataMock).not.toHaveBeenCalled()
+    expect(cookiesRemoveMock).toHaveBeenCalledOnce()
+    expect(cookiesRemoveMock).toHaveBeenCalledWith('https://example.com/', 'stale')
+    expect(cookiesSetMock.mock.calls.map(([details]) => details.domain)).toEqual(['.example.com'])
   })
 
   it('reports an excluded Google row even when its encrypted value is invalid', async () => {
@@ -270,24 +267,29 @@ describe('native Chromium import excludes the Google cookie family', () => {
     ])
   })
 
-  it('fails the import and restores the full snapshot when the bulk clear rejects', async () => {
+  it('fails the import without reconstructing Google cookies when selective removal rejects', async () => {
     const sourceCookiesPath = seedSource([
       { domain: '.example.com', name: 'session', value: 'new' }
     ])
     seedTarget([{ domain: '.example.com', name: 'stale', value: 'stale' }])
     cookiesGetMock.mockResolvedValue([
       existingCookie('.google.com', 'SID'),
-      existingCookie('.example.com', 'stale')
+      existingCookie('.example.com', 'removed-first'),
+      existingCookie('.other.test', 'stale')
     ])
-    clearStorageDataMock.mockRejectedValue(new Error('cookie store unavailable'))
+    cookiesRemoveMock.mockImplementation(async (_url: string, name: string) => {
+      if (name === 'stale') {
+        throw new Error('cookie store unavailable')
+      }
+    })
 
     const result = await importCookiesFromBrowser(chromeBrowser(sourceCookiesPath), 'persist:test')
 
     expect(result).toMatchObject({ ok: false })
     expect(result.ok || result.reason).toContain('Could not clear existing cookies')
-    expect(clearStorageDataMock).toHaveBeenCalledOnce()
-    expect(cookiesRemoveMock).not.toHaveBeenCalled()
-    expect(cookiesSetMock.mock.calls.map(([details]) => details.name)).toEqual(['SID', 'stale'])
+    expect(clearStorageDataMock).not.toHaveBeenCalled()
+    expect(cookiesRemoveMock.mock.calls.map(([, name]) => name)).toEqual(['removed-first', 'stale'])
+    expect(cookiesSetMock.mock.calls.map(([details]) => details.name)).toEqual(['removed-first'])
     expect(setPendingCookieImportMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -1,0 +1,152 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { build as buildVite } from 'vite'
+
+const electronBinary = createRequire(import.meta.url)('electron') as string
+const fixtureRoots: string[] = []
+
+afterAll(() => {
+  for (const root of fixtureRoots) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+})
+
+type FixtureResult = {
+  before: Record<string, unknown>
+  after: Record<string, unknown>
+  electronCookieKeys: string[]
+  remainingNames: string[]
+}
+
+function buildFixtureMain(policyPath: string, resultPath: string): string {
+  return `
+const { app, BrowserWindow, session } = require('electron')
+const { writeFileSync } = require('node:fs')
+const { isNonTransplantableCookieDomain, removeAllCookiesExcept } = require(${JSON.stringify(policyPath)})
+const resultPath = ${JSON.stringify(resultPath)}
+let currentStep = 'starting'
+const mark = (step) => {
+  currentStep = step
+  writeFileSync(resultPath, JSON.stringify({ step }))
+}
+
+async function run() {
+  const timeout = setTimeout(() => {
+    writeFileSync(resultPath, JSON.stringify({ step: 'timed out after ' + currentStep }))
+    app.exit(1)
+  }, 15000)
+  await app.whenReady()
+  mark('ready')
+  const partition = 'persist:partition-cookie-test'
+  const targetSession = session.fromPartition(partition)
+  const window = new BrowserWindow({ show: false, webPreferences: { partition } })
+  mark('window created')
+  await window.loadURL('data:text/html,<title>cookie fixture</title>')
+  mark('window loaded')
+  const debug = window.webContents.debugger
+  debug.attach('1.3')
+  mark('debugger attached')
+  await debug.sendCommand('Network.enable')
+  mark('network enabled')
+  await debug.sendCommand('Network.setCookie', {
+    url: 'https://accounts.google.com/',
+    name: 'partitioned-google',
+    value: 'live-value',
+    secure: true,
+    httpOnly: true,
+    sameSite: 'None',
+    partitionKey: { topLevelSite: 'https://example.com', hasCrossSiteAncestor: true }
+  })
+  mark('partitioned cookie set')
+  await targetSession.cookies.set({
+    url: 'https://stale.example/',
+    name: 'stale',
+    value: 'remove-me',
+    secure: true
+  })
+  mark('ordinary cookie set')
+
+  const beforeCookies = (await debug.sendCommand('Network.getAllCookies')).cookies
+  const before = beforeCookies.find((cookie) => cookie.name === 'partitioned-google')
+  const electronCookie = (await targetSession.cookies.get({ name: 'partitioned-google' }))[0]
+  if (!before || !electronCookie) throw new Error('Partitioned fixture cookie was not created')
+  mark('cookies read')
+
+  await removeAllCookiesExcept(targetSession.cookies, (cookie) =>
+    isNonTransplantableCookieDomain(cookie.domain || '')
+  )
+  mark('selective removal complete')
+
+  const afterCookies = (await debug.sendCommand('Network.getAllCookies')).cookies
+  const after = afterCookies.find((cookie) => cookie.name === 'partitioned-google')
+  if (!after) throw new Error('Partitioned Google cookie was removed')
+  clearTimeout(timeout)
+  writeFileSync(resultPath, JSON.stringify({
+    before,
+    after,
+    electronCookieKeys: Object.keys(electronCookie).sort(),
+    remainingNames: afterCookies.map((cookie) => cookie.name).sort()
+  }))
+  debug.detach()
+  window.destroy()
+  app.exit(0)
+}
+
+run().catch((error) => {
+  writeFileSync(resultPath, JSON.stringify({ step: currentStep, error: String(error?.stack || error) }))
+  app.exit(1)
+})
+`
+}
+
+async function runFixture(): Promise<FixtureResult> {
+  const root = mkdtempSync(join(tmpdir(), 'orca-partition-cookie-'))
+  fixtureRoots.push(root)
+  const policyPath = join(root, 'browser-cookie-import-policy.cjs')
+  const resultPath = join(root, 'result.json')
+  const fixturePath = join(root, 'main.cjs')
+  await buildVite({
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      emptyOutDir: false,
+      lib: {
+        entry: join(process.cwd(), 'src/main/browser/browser-cookie-import-policy.ts'),
+        formats: ['cjs'],
+        fileName: () => 'browser-cookie-import-policy.cjs'
+      },
+      outDir: root,
+      target: 'node20',
+      rollupOptions: { external: ['electron'] }
+    }
+  })
+  writeFileSync(fixturePath, buildFixtureMain(policyPath, resultPath))
+  const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
+  const run = spawnSync(electronBinary, [fixturePath, `--user-data-dir=${join(root, 'profile')}`], {
+    encoding: 'utf8',
+    env,
+    timeout: 60_000
+  })
+  const fixtureResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
+  expect(run.error).toBeUndefined()
+  expect(run.status, `${fixtureResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
+  return JSON.parse(fixtureResult) as FixtureResult
+}
+
+describe('native Chromium excluded partition cookie under Electron', () => {
+  it('survives selective clearing unchanged without a lossy Electron reconstruction', async () => {
+    const result = await runFixture()
+
+    expect(result.before.partitionKey).toEqual({
+      topLevelSite: 'https://example.com',
+      hasCrossSiteAncestor: true
+    })
+    expect(result.electronCookieKeys).not.toContain('partitionKey')
+    expect(result.after).toEqual(result.before)
+    expect(result.remainingNames).toEqual(['partitioned-google'])
+  }, 90_000)
+})

--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -126,7 +126,13 @@ async function runFixture(): Promise<FixtureResult> {
   })
   writeFileSync(fixturePath, buildFixtureMain(policyPath, resultPath))
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
-  const run = spawnSync(electronBinary, [fixturePath, `--user-data-dir=${join(root, 'profile')}`], {
+  const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
+  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
+  const args =
+    process.platform === 'linux'
+      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
+      : electronArgs
+  const run = spawnSync(executable, args, {
     encoding: 'utf8',
     env,
     timeout: 60_000

--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { build as buildVite } from 'vite'
+import { createChromiumCookieTestDatabase } from './browser-cookie-import-test-database'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 const fixtureRoots: string[] = []
@@ -19,14 +20,19 @@ type FixtureResult = {
   before: Record<string, unknown>
   after: Record<string, unknown>
   electronCookieKeys: string[]
+  importResult: Record<string, unknown>
   remainingNames: string[]
 }
 
-function buildFixtureMain(policyPath: string, resultPath: string): string {
+function buildFixtureMain(
+  importPath: string,
+  resultPath: string,
+  sourceCookiesPath: string
+): string {
   return `
 const { app, BrowserWindow, session } = require('electron')
 const { writeFileSync } = require('node:fs')
-const { isNonTransplantableCookieDomain, removeAllCookiesExcept } = require(${JSON.stringify(policyPath)})
+const { importCookiesFromBrowser } = require(${JSON.stringify(importPath)})
 const resultPath = ${JSON.stringify(resultPath)}
 let currentStep = 'starting'
 const mark = (step) => {
@@ -76,10 +82,15 @@ async function run() {
   if (!before || !electronCookie) throw new Error('Partitioned fixture cookie was not created')
   mark('cookies read')
 
-  await removeAllCookiesExcept(targetSession.cookies, (cookie) =>
-    isNonTransplantableCookieDomain(cookie.domain || '')
-  )
-  mark('selective removal complete')
+  const importResult = await importCookiesFromBrowser({
+    family: 'chrome',
+    label: 'Chromium fixture',
+    cookiesPath: ${JSON.stringify(sourceCookiesPath)},
+    profiles: [{ name: 'Default', directory: 'Default' }],
+    selectedProfile: 'Default'
+  }, partition)
+  if (!importResult.ok) throw new Error('Native import failed: ' + importResult.reason)
+  mark('native import complete')
 
   const afterCookies = (await debug.sendCommand('Network.getAllCookies')).cookies
   const after = afterCookies.find((cookie) => cookie.name === 'partitioned-google')
@@ -89,6 +100,7 @@ async function run() {
     before,
     after,
     electronCookieKeys: Object.keys(electronCookie).sort(),
+    importResult,
     remainingNames: afterCookies.map((cookie) => cookie.name).sort()
   }))
   debug.detach()
@@ -106,25 +118,45 @@ run().catch((error) => {
 async function runFixture(): Promise<FixtureResult> {
   const root = mkdtempSync(join(tmpdir(), 'orca-partition-cookie-'))
   fixtureRoots.push(root)
-  const policyPath = join(root, 'browser-cookie-import-policy.cjs')
+  const importPath = join(root, 'browser-cookie-import.cjs')
+  const registryStubPath = join(root, 'browser-session-registry.cjs')
   const resultPath = join(root, 'result.json')
+  const sourceCookiesPath = join(root, 'source', 'Network', 'Cookies')
   const fixturePath = join(root, 'main.cjs')
+  createChromiumCookieTestDatabase(sourceCookiesPath, [
+    { domain: '.example.com', name: 'imported', value: 'new-value' }
+  ]).close()
+  writeFileSync(
+    registryStubPath,
+    'exports.browserSessionRegistry = { clearPendingCookieImport() {}, setPendingCookieImport() {} }\n'
+  )
   await buildVite({
     configFile: false,
     logLevel: 'silent',
+    plugins: [
+      {
+        name: 'stub-browser-session-registry',
+        resolveId(source, importer) {
+          return source === './browser-session-registry' &&
+            importer?.endsWith('browser-cookie-import.ts')
+            ? registryStubPath
+            : null
+        }
+      }
+    ],
     build: {
       emptyOutDir: false,
       lib: {
-        entry: join(process.cwd(), 'src/main/browser/browser-cookie-import-policy.ts'),
+        entry: join(process.cwd(), 'src/main/browser/browser-cookie-import.ts'),
         formats: ['cjs'],
-        fileName: () => 'browser-cookie-import-policy.cjs'
+        fileName: () => 'browser-cookie-import.cjs'
       },
       outDir: root,
       target: 'node20',
-      rollupOptions: { external: ['electron'] }
+      rollupOptions: { external: ['electron', /^node:/] }
     }
   })
-  writeFileSync(fixturePath, buildFixtureMain(policyPath, resultPath))
+  writeFileSync(fixturePath, buildFixtureMain(importPath, resultPath, sourceCookiesPath))
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
   const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
   const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
@@ -153,6 +185,10 @@ describe('native Chromium excluded partition cookie under Electron', () => {
     })
     expect(result.electronCookieKeys).not.toContain('partitionKey')
     expect(result.after).toEqual(result.before)
-    expect(result.remainingNames).toEqual(['partitioned-google'])
+    expect(result.importResult).toMatchObject({
+      ok: true,
+      summary: { importedCookies: 1, domains: ['example.com'] }
+    })
+    expect(result.remainingNames).toEqual(['imported', 'partitioned-google'])
   }, 90_000)
 })

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { DatabaseSync } from 'node:sqlite'
 import type { Cookie } from 'electron'
 import {
-  bulkClearCookiesExcept,
   isGoogleSourceBoundCookie,
   isNonTransplantableCookieDomain,
   NON_TRANSPLANTABLE_HOST_KEY_SQL,
   normalizeCookieDomain,
+  removeAllCookiesExcept,
   replaceCookiesForImportedDomains
 } from './browser-cookie-import-policy'
 
@@ -207,87 +207,110 @@ describe('NON_TRANSPLANTABLE_HOST_KEY_SQL', () => {
   })
 })
 
-describe('bulkClearCookiesExcept', () => {
-  it('bulk clears a large jar once and restores only excluded cookies', async () => {
-    const existing = [
-      cookie('.google.com', 'SID'),
-      cookie('accounts.google.com', 'ACCOUNT'),
-      ...Array.from({ length: 1_000 }, (_, index) =>
-        cookie(`site-${index}.example`, `session-${index}`)
-      )
-    ]
-    const get = vi.fn().mockResolvedValue(existing)
+describe('removeAllCookiesExcept', () => {
+  it('never removes or reconstructs excluded Google cookies', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValue([
+        cookie('.google.com', 'SID'),
+        cookie('accounts.google.com', 'ACCOUNT'),
+        cookie('.example.com', 'session'),
+        cookie('other.test', 'tracker', '/scoped')
+      ])
+    const remove = vi.fn().mockResolvedValue(undefined)
     const set = vi.fn().mockResolvedValue(undefined)
-    const clearStorageData = vi.fn().mockResolvedValue(undefined)
 
-    await bulkClearCookiesExcept({ cookies: { get, set }, clearStorageData }, (existingCookie) =>
+    await removeAllCookiesExcept({ get, remove, set }, (existingCookie) =>
       isNonTransplantableCookieDomain(existingCookie.domain ?? '')
     )
 
-    expect(get).toHaveBeenCalledOnce()
-    expect(get).toHaveBeenCalledWith({})
-    expect(clearStorageData).toHaveBeenCalledOnce()
-    expect(clearStorageData).toHaveBeenCalledWith({ storages: ['cookies'] })
-    expect(set.mock.calls.map(([details]) => details.name)).toEqual(['SID', 'ACCOUNT'])
+    expect(remove.mock.calls).toEqual([
+      ['https://example.com/', 'session'],
+      ['https://other.test/scoped', 'tracker']
+    ])
+    expect(set).not.toHaveBeenCalled()
   })
 
-  it('restores the complete snapshot when the bulk clear rejects', async () => {
-    const existing = [
-      cookie('.google.com', 'SID'),
-      cookie('.example.com', 'first'),
-      cookie('.other.test', 'second')
-    ]
-    const get = vi.fn().mockResolvedValue(existing)
+  it('restores removed non-Google cookies when another removal fails', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValue([
+        cookie('.google.com', 'SID'),
+        cookie('.example.com', 'first', '/one'),
+        cookie('.example.com', 'second', '/two'),
+        cookie('.example.com', 'third', '/three')
+      ])
+    const remove = vi.fn().mockImplementation(async (_url: string, name: string) => {
+      if (name === 'second') {
+        throw new Error('store unavailable')
+      }
+    })
     const set = vi.fn().mockResolvedValue(undefined)
-    const clearStorageData = vi.fn().mockRejectedValue(new Error('store unavailable'))
 
     await expect(
-      bulkClearCookiesExcept({ cookies: { get, set }, clearStorageData }, () => true)
+      removeAllCookiesExcept({ get, remove, set }, (existingCookie) =>
+        isNonTransplantableCookieDomain(existingCookie.domain ?? '')
+      )
     ).rejects.toThrow('Could not clear existing cookies')
-
-    expect(clearStorageData).toHaveBeenCalledOnce()
-    expect(set.mock.calls.map(([details]) => details.name)).toEqual(['SID', 'first', 'second'])
+    expect(remove).toHaveBeenCalledTimes(3)
+    expect(set.mock.calls.map(([details]) => details.name).sort()).toEqual(['first', 'third'])
   })
 
-  it('rolls back the complete snapshot when excluded-cookie restoration fails', async () => {
-    const existing = [cookie('.google.com', 'SID'), cookie('.example.com', 'session')]
-    const get = vi.fn().mockResolvedValue(existing)
-    let googleAttempts = 0
-    const set = vi.fn().mockImplementation(async ({ name }: { name?: string }) => {
-      if (name === 'SID' && googleAttempts++ === 0) {
-        throw new Error('transient restore failure')
-      }
-    })
-    const clearStorageData = vi.fn().mockResolvedValue(undefined)
-
-    await expect(
-      bulkClearCookiesExcept(
-        { cookies: { get, set }, clearStorageData },
-        (existingCookie) => existingCookie.domain === '.google.com'
+  it('bounds parallel removals so large cookie jars do not clear serially or fan out', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValue(
+        Array.from({ length: 12 }, (_, index) => cookie('.example.com', `${index}`))
       )
-    ).rejects.toThrow('Could not preserve excluded cookies')
+    let releaseRemovals: (() => void) | undefined
+    const removalsReleased = new Promise<void>((resolve) => {
+      releaseRemovals = resolve
+    })
+    let active = 0
+    let maxActive = 0
+    const remove = vi.fn().mockImplementation(async () => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      await removalsReleased
+      active--
+    })
+    const set = vi.fn().mockResolvedValue(undefined)
 
-    expect(clearStorageData).toHaveBeenCalledOnce()
-    expect(set.mock.calls.map(([details]) => details.name)).toEqual(['SID', 'SID', 'session'])
+    const clearing = removeAllCookiesExcept({ get, remove, set }, () => false)
+    await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(8))
+    expect(maxActive).toBe(8)
+    releaseRemovals?.()
+    await clearing
+
+    expect(remove).toHaveBeenCalledTimes(12)
+    expect(set).not.toHaveBeenCalled()
   })
 
-  it('reports when the complete-snapshot rollback also fails', async () => {
-    const existing = [cookie('.google.com', 'SID'), cookie('.example.com', 'session')]
-    const get = vi.fn().mockResolvedValue(existing)
-    const set = vi.fn().mockImplementation(async ({ name }: { name?: string }) => {
-      if (name === 'SID') {
-        throw new Error('persistent restore failure')
-      }
+  it('serializes cookies that share Electron removal coordinates', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValue([
+        cookie('.example.com', 'session'),
+        { ...cookie('example.com', 'session'), hostOnly: true }
+      ])
+    let releaseFirst: (() => void) | undefined
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve
     })
-    const clearStorageData = vi.fn().mockResolvedValue(undefined)
+    const remove = vi
+      .fn()
+      .mockImplementationOnce(() => firstReleased)
+      .mockResolvedValueOnce(undefined)
+    const set = vi.fn().mockResolvedValue(undefined)
 
-    await expect(
-      bulkClearCookiesExcept(
-        { cookies: { get, set }, clearStorageData },
-        (existingCookie) => existingCookie.domain === '.google.com'
-      )
-    ).rejects.toThrow('Cookie preservation and rollback failed')
+    const clearing = removeAllCookiesExcept({ get, remove, set }, () => false)
+    await vi.waitFor(() => expect(remove).toHaveBeenCalledOnce())
+    releaseFirst?.()
+    await clearing
 
-    expect(set.mock.calls.map(([details]) => details.name)).toEqual(['SID', 'SID', 'session'])
+    expect(remove.mock.calls).toEqual([
+      ['https://example.com/', 'session'],
+      ['https://example.com/', 'session']
+    ])
   })
 })

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -1,5 +1,6 @@
-import type { Cookie, Cookies, Session } from 'electron'
+import type { Cookie, Cookies } from 'electron'
 import { parse as parseDomain } from 'psl'
+import { mapSettledWithConcurrency } from '../../shared/map-with-concurrency'
 
 const GOOGLE_SOURCE_BOUND_COOKIE_NAMES = new Set([
   'SIDCC',
@@ -63,6 +64,7 @@ export function normalizeCookieImportDomain(domain: string): string | null {
 // its cookies via the accounts.youtube.com relay, so excluding it would silently drop imports
 // users actually asked for.
 const NON_TRANSPLANTABLE_DOMAINS = ['google.com'] as const
+const COOKIE_CLEAR_CONCURRENCY = 8
 
 export function isNonTransplantableCookieDomain(domain: string): boolean {
   const normalized = normalizeCookieDomain(domain)
@@ -194,55 +196,52 @@ export async function restoreImportedDomainCookies(
   }
 }
 
-type CookieClearSession = {
-  cookies: Pick<Cookies, 'get' | 'set'>
-  clearStorageData: Session['clearStorageData']
-}
-
-async function restoreCookieClearSnapshot(
-  store: Pick<Cookies, 'set'>,
-  snapshot: readonly Cookie[],
-  originalError: unknown,
-  rollbackMessage: string
-): Promise<never> {
-  try {
-    await restoreImportedDomainCookies(store, snapshot)
-  } catch (rollbackError) {
-    throw new AggregateError([originalError, rollbackError], rollbackMessage)
-  }
-  throw originalError
-}
-
-// Why: after a bulk clear starts, Electron cannot reveal whether a rejected operation mutated
-// the jar, so keep the complete snapshot until excluded cookies have been restored.
-export async function bulkClearCookiesExcept(
-  targetSession: CookieClearSession,
+// Why: Electron cannot round-trip partition identity, so excluded cookies must never be removed.
+export async function removeAllCookiesExcept(
+  store: Pick<Cookies, 'get' | 'remove' | 'set'>,
   isExcluded: (cookie: Cookie) => boolean
 ): Promise<void> {
-  const snapshot = await targetSession.cookies.get({})
-  const excludedCookies = snapshot.filter(isExcluded)
-
-  try {
-    await targetSession.clearStorageData({ storages: ['cookies'] })
-  } catch (clearError) {
-    await restoreCookieClearSnapshot(
-      targetSession.cookies,
-      snapshot,
-      new AggregateError([clearError], 'Could not clear existing cookies'),
-      'Cookie bulk clear and rollback failed'
-    )
+  const existingCookies = await store.get({})
+  const removableGroups = new Map<string, { cookie: Cookie; url: string }[]>()
+  for (const cookie of existingCookies) {
+    if (isExcluded(cookie)) {
+      continue
+    }
+    const domain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null
+    const url = domain ? cookieRemovalUrl(cookie, domain) : null
+    if (!url) {
+      continue
+    }
+    const key = JSON.stringify([url, cookie.name])
+    const group = removableGroups.get(key) ?? []
+    group.push({ cookie, url })
+    removableGroups.set(key, group)
   }
 
-  try {
-    await restoreImportedDomainCookies(targetSession.cookies, excludedCookies)
-  } catch (preservationError) {
-    await restoreCookieClearSnapshot(
-      targetSession.cookies,
-      snapshot,
-      new AggregateError([preservationError], 'Could not preserve excluded cookies'),
-      'Cookie preservation and rollback failed'
-    )
+  const removedCookies: Cookie[] = []
+  const results = await mapSettledWithConcurrency(
+    [...removableGroups.values()],
+    COOKIE_CLEAR_CONCURRENCY,
+    async (group) => {
+      // Why: identical removal coordinates must stay ordered instead of racing.
+      for (const { cookie, url } of group) {
+        await store.remove(url, cookie.name)
+        removedCookies.push(cookie)
+      }
+    }
+  )
+  const failures = results.flatMap((result) =>
+    result.status === 'rejected' ? [result.reason] : []
+  )
+  if (failures.length === 0) {
+    return
   }
+  try {
+    await restoreImportedDomainCookies(store, removedCookies)
+  } catch (restoreError) {
+    throw new AggregateError([...failures, restoreError], 'Cookie clearing and rollback failed')
+  }
+  throw new AggregateError(failures, 'Could not clear existing cookies')
 }
 
 export async function replaceCookiesForImportedDomains(

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -511,8 +511,7 @@ describe('importCookiesFromBrowser Chromium', () => {
         ['', '-wal', '-shm'].map((suffix) => readFileSync(sourceCookiesPath + suffix))
       ).toEqual(sourceFilesBefore)
       expect(cookiesRemoveMock).not.toHaveBeenCalled()
-      expect(clearStorageDataMock).toHaveBeenCalledOnce()
-      expect(clearStorageDataMock).toHaveBeenCalledWith({ storages: ['cookies'] })
+      expect(clearStorageDataMock).not.toHaveBeenCalled()
       // Why: STA-3514 — imports must never impersonate the source browser; the
       // session keeps the engine UA the registry set at startup.
       expect(setUserAgentMock).not.toHaveBeenCalled()

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -75,12 +75,12 @@ import type {
 } from '../../shared/types'
 import { browserSessionRegistry } from './browser-session-registry'
 import {
-  bulkClearCookiesExcept,
   isGoogleSourceBoundCookie,
   isNonTransplantableCookieDomain,
   NON_TRANSPLANTABLE_HOST_KEY_SQL,
   normalizeCookieDomain,
   normalizeCookieImportDomain,
+  removeAllCookiesExcept,
   replaceCookiesForImportedDomains,
   restoreImportedDomainCookies,
   type CookieImportMode
@@ -1780,11 +1780,9 @@ export async function importCookiesFromBrowser(
     // Why: clear stale cookies first; mixing them with the imported set makes sites reject the
     // session. Non-transplantable families are exempt — nothing was imported for them, and their
     // live session is the only one that works.
-    await bulkClearCookiesExcept(targetSession, (cookie) =>
+    await removeAllCookiesExcept(targetSession.cookies, (cookie) =>
       isNonTransplantableCookieDomain(cookie.domain ?? '')
     )
-    // Why: after excluded cookies survive this boundary, restart staging owns later set failures;
-    // restoring stale non-Google cookies would recreate the mixed jar this import must replace.
     diag(
       `  cleared existing session cookies before loading ${decryptedCookies.length} imported cookies`
     )


### PR DESCRIPTION
## Summary

- replace native Chromium bulk cookie clearing with bounded selective removal
- skip Google-family destination cookies before any destructive operation, so excluded cookies are never cleared or reconstructed
- preserve file, Firefox, Safari, Google exclusion/accounting, and toast behavior

## Electron coverage

A real Electron 43 process creates a partitioned accounts.google.com cookie through Chromium CDP, runs the production selective-removal implementation, and verifies the complete CDP cookie remains unchanged while a stale non-Google cookie is removed. The test also pins the public API gap: Electron Cookies.get exposes the cookie but omits partitionKey, so snapshot/restore cannot preserve partition identity. Linux runs the same fixture through Xvfb with the required sandbox override.

## Performance

This intentionally restores the O(N) bounded-concurrency removal path. The real-Electron measurements recorded for #13966 were 3.6 ms at 100 cookies, 195.2 ms at 1,000, and 2,226.6 ms at 3,300 versus 1.0 ms, 8.8 ms, and 35.8 ms for bulk clear (3.5x to 62.1x slower); correctness takes priority because the bulk path can invalidate active Google sessions.

## Validation

- 60 focused tests across five files, including the real Electron partition test
- node typecheck
- standard, native-plugin, and type-aware focused oxlint
- changed-code quality and React Doctor gate
- max-lines ratchet and git diff checks

Fixes STA-4013.
