### PR TITLE
fix(mobile-ios): set app_platform for distribute-only TestFlight upload

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -253,6 +253,9 @@ platform :ios do
     upload_to_testflight(
       api_key: api_key,
       app_identifier: BUNDLE_ID,
+      # distribute_only means there is no local .ipa to sniff, so fastlane would
+      # otherwise fall through to an interactive platform prompt and crash in CI.
+      app_platform: "ios",
       app_version: version,
       build_number: build_number,
       distribute_only: true,


### PR DESCRIPTION
## ELI5

The job that hands a finished iOS build to our TestFlight testers has never worked. It asks fastlane to distribute a build that was already uploaded, but forgets to tell it "this is an iOS app" — so fastlane stops and asks a human, and CI has no human. One missing argument.

## What Changed

Pass `app_platform: "ios"` to `upload_to_testflight` in the `distribute_testflight` lane.

## Why

`Pilot::Manager#fetch_app_platform` resolves the platform in this order:

```ruby
result = config[:app_platform]
result ||= FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa]) if config[:ipa]
result ||= FastlaneCore::PkgFileAnalyser.fetch_app_platform(config[:pkg]) if config[:pkg]
result ||= UI.input("Please enter the app's platform (appletvos, ios, osx, xros): ")
```

The lane runs with `distribute_only: true`, so there is no `ipa`/`pkg` on disk — and `ios-distribute` runs on `ubuntu-latest` and never downloads the artifact. All three inference paths miss, fastlane falls through to `UI.input`, and non-interactive CI raises:

```
[!] Could not retrieve response as fastlane runs in non-interactive mode (FastlaneCore::Interface::FastlaneCrash)
  from pilot/lib/pilot/manager.rb:88:in `fetch_app_platform'
```

Setting `app_platform` short-circuits at the first line.

This job was introduced in #13419 and has **never** succeeded. In run [31371958284](https://github.com/stablyai/orca/actions/runs/31371958284) (0.0.43 build 1), `ios-build` succeeded and the binary reached App Store Connect — only distribution failed, 57s in, after the ASC API key, app lookup, and beta-group checks had all passed. Credentials and certs are healthy; this is purely a missing argument.

Note the existing `::error::` hint ("rerun only this failed job after the build becomes Ready") does not help for this failure — the crash happens before any processing poll, so build readiness is irrelevant.

## Linked Issue

N/A — release-infrastructure fix found while cutting the next TestFlight build.

## Visual Proof

`N/A` — CI-only fastlane configuration; no UI or in-app behavior changes.

## Testing

- `ruby -c mobile/fastlane/Fastfile` → `Syntax OK`
- Verified against the fastlane 2.237.0 resolution order quoted above, and against run 31371958284's per-job outcomes (`ios-build` success, `Distribute to external TestFlight testers` failure).
- End-to-end proof requires an actual `Mobile iOS Release` dispatch, which is the next step for this release.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No automated test: the lane is only exercised by a real App Store Connect upload, and there is no fastlane lane harness in this repo.

## AI Disclosure

N/A — internal contributor.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

No secrets touched. Runs only in the `ios-distribute` CI job; no runtime, desktop, SSH, or wire-format impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
