### PR TITLE
fix(terminal): claim the paired-runtime viewport the pane measured

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5354,6 +5354,56 @@ describe('connectPanePty', () => {
     expect(claims).toEqual([[96, 30, { claim: true }]])
   })
 
+  it('resizes a direct-SSH PTY after spawn without claiming the viewport', async () => {
+    // Why: explicit viewport claims exist only on paired runtimes. A direct-SSH PTY has one owner, so
+    // a claim flag on its resize would be an unsupported option riding a supported path.
+    const frameCallbacks: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const runNextFrame = (): void => {
+      const callback = frameCallbacks.shift()
+      if (!callback) {
+        throw new Error('expected a queued animation frame')
+      }
+      callback(0)
+    }
+
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    const sshPtyId = toAppSshPtyId('ssh-a', 'pty-viewport-claim')
+    const transport = createMockTransport(sshPtyId)
+    transport.getConnectionId.mockReturnValue('ssh-a')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      repos: [{ id: 'repo1', connectionId: 'ssh-a' }],
+      sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]]),
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+    const pane = createPane(1)
+    pane.terminal.cols = 80
+    pane.terminal.rows = 24
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    runNextFrame()
+    await flushAsyncTicks()
+
+    pane.terminal.cols = 96
+    pane.terminal.rows = 30
+    runNextFrame()
+    setDriverForPty(sshPtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    expect(transport.resize).toHaveBeenCalledWith(96, 30)
+    const claims = (
+      transport.resize.mock.calls as [number, number, { claim?: boolean } | undefined][]
+    ).filter((call) => call[2]?.claim === true)
+    expect(claims).toEqual([])
+  })
+
   it('waits for setup-split geometry before spawning the initial startup command', async () => {
     const frameCallbacks: FrameRequestCallback[] = []
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5257,6 +5257,47 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('claims the viewport when the post-spawn reconcile settles a paired-runtime grid', async () => {
+    // Why: a paired-runtime client advertises explicit viewport claims, so a plain Resize frame only
+    // registers passive viewer geometry. Without a claim the PTY stays at the runtime's spawn grid
+    // (120x40) and the TUI paints against stale columns until a manual pane resize.
+    const frameCallbacks: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const runNextFrame = (): void => {
+      const callback = frameCallbacks.shift()
+      if (!callback) {
+        throw new Error('expected a queued animation frame')
+      }
+      callback(0)
+    }
+
+    const { connectPanePty } = await import('./pty-connection')
+    const ptyId = 'remote:env-1@@pty-post-spawn-claim'
+    const transport = createMockTransport(ptyId)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+    const pane = createPane(1)
+    pane.terminal.cols = 80
+    pane.terminal.rows = 24
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    runNextFrame()
+    await flushAsyncTicks()
+
+    pane.terminal.cols = 96
+    pane.terminal.rows = 30
+    runNextFrame()
+
+    expect(transport.resize).toHaveBeenCalledWith(96, 30, { claim: true })
+  })
+
   it('waits for setup-split geometry before spawning the initial startup command', async () => {
     const frameCallbacks: FrameRequestCallback[] = []
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
@@ -9029,6 +9070,514 @@ describe('connectPanePty', () => {
     expect(transport.resize).toHaveBeenCalledWith(120, 40)
     expect(signalPty).toHaveBeenCalledWith('tab-pty', 'SIGWINCH')
     expect(writes.join('')).toContain('live-after-snapshot')
+  })
+
+  it('claims the viewport with the reattach grid of a visible paired-runtime pane', async () => {
+    // Why: the snapshot pins xterm to the source grid, so the reattach push is the pane's first
+    // authoritative grid. A plain Resize frame only registers passive viewer geometry on a
+    // claim-capable runtime, leaving the PTY at the runtime's grid until a manual resize.
+    const { connectPanePty } = await import('./pty-connection')
+    const { safeFit } = await import('@/lib/pane-manager/pane-tree-ops')
+    const remotePtyId = 'remote:env-1@@terminal-1'
+    const transport = createMockTransport(remotePtyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      transport.getPtyId.mockReturnValue(remotePtyId)
+      callbacks.onReplayData?.('current screen from initial subscribe\r\n')
+      return { id: remotePtyId, isReattach: true, replay: '' }
+    })
+    transport.serializeBuffer = vi.fn().mockResolvedValue({
+      data: 'restored paired screen\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 4_096,
+      source: 'headless'
+    })
+    transportFactoryQueue.push(transport)
+    await parkTabForReveal('tab-1', remotePtyId)
+    mockStoreState = {
+      ...mockStoreState,
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          'env-1',
+          {
+            checkedAt: Date.now(),
+            status: { capabilities: ['terminal.paired-parking.v1'] }
+          }
+        ]
+      ])
+    }
+
+    const pane = createPane(1)
+    const { parseCallbacks } = captureCallbackTerminalWrites(pane)
+    pane.fitAddon.proposeDimensions = vi.fn(() => undefined) as never
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    for (let step = 0; step < 30; step += 1) {
+      parseCallbacks.shift()?.()
+      await flushAsyncTicks(2)
+    }
+    transport.resize.mockClear()
+
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 })) as never
+    safeFit(pane as never)
+    await flushAsyncTicks(12)
+
+    expect(transport.resize).toHaveBeenCalledWith(120, 40, { claim: true })
+  })
+
+  it('claims the measured viewport when a visible pane attaches its restored paired-runtime PTY', async () => {
+    // Why: an app restart attaches the restored remote leaf directly — no reconcile, no reattach
+    // push, and remote PTYs skip size reassertion. The attach viewport only registers passive
+    // geometry, so without a claim the PTY keeps the runtime's grid until a manual resize.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty'
+    const transport = createMockTransport(remotePtyId)
+    // Why: the remote transport signals onConnect once its stream is subscribed, and the runtime's
+    // first driver frame follows it — the first moment a claim may reach the runtime.
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const pane = createPane(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    expect(transport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: remotePtyId, cols: 120, rows: 40 })
+    )
+    expect(transport.resize).toHaveBeenCalledWith(120, 40, { claim: true })
+  })
+
+  it('keeps a hidden pane attaching its restored paired-runtime PTY a passive viewer', async () => {
+    // Why: the visible-pane ownership rule is the whole gate — a background pane must not take the
+    // viewport from the client the user is looking at.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-hidden'
+    const transport = createMockTransport(remotePtyId)
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const pane = createPane(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId },
+      isVisibleRef: { current: false }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    expect(transport.attach).toHaveBeenCalled()
+    expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
+  })
+
+  it('claims once per attach so a recovery resubscribe does not re-take the viewport', async () => {
+    // Why: onConnect fires again on every recovery resubscribe; ownership is taken by the pane's own
+    // attach, not re-taken behind the user's back each time the stream comes back.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-resubscribe'
+    const transport = createMockTransport(remotePtyId)
+    const attached: { callbacks?: ConnectCallbacks } = {}
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        attached.callbacks = callbacks
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const pane = createPane(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+    attached.callbacks?.onConnect?.()
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    const claims = (
+      transport.resize.mock.calls as [number, number, { claim?: boolean } | undefined][]
+    ).filter((call) => call[2]?.claim === true)
+    expect(claims).toEqual([[120, 40, { claim: true }]])
+  })
+
+  it('drops a paired-runtime attach claim that arrives after the pane is disposed', async () => {
+    // Why: onConnect can land a tick after teardown; a claim from a pane that no longer exists would
+    // take the viewport from whichever client owns it now.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-disposed'
+    const transport = createMockTransport(remotePtyId)
+    const attached: { callbacks?: ConnectCallbacks } = {}
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        attached.callbacks = callbacks
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const pane = createPane(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+    })
+
+    const binding = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    expect(attached.callbacks).toBeTypeOf('object')
+
+    binding.dispose()
+    attached.callbacks?.onConnect?.()
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
+  })
+
+  it('keeps a visible pane attaching a mobile-owned paired-runtime PTY a passive viewer', async () => {
+    // Why: mobile presence owns the PTY grid while it drives; the desktop pane renders that grid and
+    // must not take it back on attach, or the phone's session reflows under the user.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-mobile'
+    setDriverForPty(remotePtyId, { kind: 'mobile', clientId: 'phone-1' })
+    try {
+      const transport = createMockTransport(remotePtyId)
+      transport.attach.mockImplementation(
+        ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+          transport.getPtyId.mockReturnValue(existingPtyId)
+          callbacks?.onConnect?.()
+        }
+      )
+      transportFactoryQueue.push(transport)
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+      } as StoreState
+      const pane = createPane(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, deps as never)
+      await flushAsyncTicks(20)
+      // Why: the runtime re-states the driver after the subscription; that frame releases the claim.
+      setDriverForPty(remotePtyId, { kind: 'mobile', clientId: 'phone-1' })
+      await flushAsyncTicks(4)
+
+      expect(transport.attach).toHaveBeenCalled()
+      expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
+    } finally {
+      setDriverForPty(remotePtyId, { kind: 'idle' })
+    }
+  })
+
+  it('defers a restored attach claim until the initial driver state shows mobile owns the PTY', async () => {
+    // Why: the runtime completes the subscription before it sends the first driver frame, and an
+    // unknown local driver reads as idle. Claiming at onConnect therefore takes the grid from a phone
+    // that is already driving this PTY.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-driver-late-mobile'
+    const transport = createMockTransport(remotePtyId)
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(transport.attach).toHaveBeenCalled()
+    expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
+
+    try {
+      setDriverForPty(remotePtyId, { kind: 'mobile', clientId: 'phone-1' })
+      await flushAsyncTicks(4)
+      expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
+    } finally {
+      setDriverForPty(remotePtyId, { kind: 'idle' })
+    }
+  })
+
+  it('drops the deferred attach claim when the pane is disposed before the driver state arrives', async () => {
+    // Why: the claim now waits on a driver frame that may land long after teardown; a pane that no
+    // longer exists must neither claim nor keep listening.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-disposed-before-driver'
+    const transport = createMockTransport(remotePtyId)
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+    })
+
+    const binding = connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    binding.dispose()
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
+  })
+
+  it('claims a restored attach exactly once when the initial driver state reports idle', async () => {
+    // Why: deferring must not lose the claim — the ordinary case is an idle driver frame arriving
+    // just after the subscription completes, and that is when the pane takes its measured grid.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-driver-late-idle'
+    const transport = createMockTransport(remotePtyId)
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    const claims = (
+      transport.resize.mock.calls as [number, number, { claim?: boolean } | undefined][]
+    ).filter((call) => call[2]?.claim === true)
+    expect(claims).toEqual([[120, 40, { claim: true }]])
+  })
+
+  it('withdraws paired-runtime viewport authority when the pane hides, mobile takes over, or it is disposed', async () => {
+    // Why: the transport replays a recovery-blocked claim after the outage. It can only tell whether
+    // this pane still owns the grid by asking the pane, so the predicate must track the same
+    // visibility, mobile-driver, and teardown state the live claim sites use.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@tab-pty-authority'
+    const transport = createMockTransport(remotePtyId)
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: remotePtyId }] }
+    } as StoreState
+    const visibility = { current: true }
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: remotePtyId },
+      isVisibleRef: visibility
+    })
+
+    const binding = connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    const isAuthoritative = createdTransportOptions.at(-1)?.isViewportClaimAuthoritative as
+      | (() => boolean)
+      | undefined
+    expect(isAuthoritative?.()).toBe(true)
+
+    visibility.current = false
+    expect(isAuthoritative?.()).toBe(false)
+
+    visibility.current = true
+    setDriverForPty(remotePtyId, { kind: 'mobile', clientId: 'phone-1' })
+    try {
+      expect(isAuthoritative?.()).toBe(false)
+    } finally {
+      setDriverForPty(remotePtyId, { kind: 'idle' })
+    }
+
+    binding.dispose()
+    expect(isAuthoritative?.()).toBe(false)
+  })
+
+  it('claims the measured viewport when a remount adopts a pending paired-runtime spawn', async () => {
+    // Why: a StrictMode remount attaches to the PTY the first mount spawned, so this successor pane
+    // never runs the post-spawn reconcile that claims elsewhere. Its attach viewport only registers
+    // passive geometry, leaving the PTY at the runtime's spawn grid until a manual resize.
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const remotePtyId = 'remote:env-1@@pending-spawn-adopt'
+    const pendingSpawn = createDeferred<string>()
+    const firstTransport = createMockTransport()
+    firstTransport.connect.mockReturnValueOnce(pendingSpawn.promise)
+    const remountTransport = createMockTransport()
+    remountTransport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        remountTransport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(firstTransport, remountTransport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    } as StoreState
+
+    const firstBinding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps() as never
+    )
+    await flushAsyncTicks()
+    firstBinding.dispose()
+    connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+
+    pendingSpawn.resolve(remotePtyId)
+    await flushAsyncTicks(12)
+    setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    expect(remountTransport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: remotePtyId })
+    )
+    expect(remountTransport.resize).toHaveBeenCalledWith(120, 40, { claim: true })
+  })
+
+  it('keeps the reattach grid of a hidden paired-runtime pane a passive viewport registration', async () => {
+    // Why: a hidden pane is a passive viewer — its grid must register geometry so detach can release
+    // it, but claiming would take viewport ownership away from the client the user is looking at.
+    const { connectPanePty } = await import('./pty-connection')
+    const { safeFit } = await import('@/lib/pane-manager/pane-tree-ops')
+    const remotePtyId = 'remote:env-1@@terminal-1'
+    const transport = createMockTransport(remotePtyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      transport.getPtyId.mockReturnValue(remotePtyId)
+      callbacks.onReplayData?.('current screen from initial subscribe\r\n')
+      return { id: remotePtyId, isReattach: true, replay: '' }
+    })
+    transport.serializeBuffer = vi.fn().mockResolvedValue({
+      data: 'restored paired screen\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 4_096,
+      source: 'headless'
+    })
+    transportFactoryQueue.push(transport)
+    await parkTabForReveal('tab-1', remotePtyId)
+    mockStoreState = {
+      ...mockStoreState,
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          'env-1',
+          {
+            checkedAt: Date.now(),
+            status: { capabilities: ['terminal.paired-parking.v1'] }
+          }
+        ]
+      ])
+    }
+
+    const pane = createPane(1)
+    const { parseCallbacks } = captureCallbackTerminalWrites(pane)
+    pane.fitAddon.proposeDimensions = vi.fn(() => undefined) as never
+    const deps = createDeps({ isVisibleRef: { current: false } })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    for (let step = 0; step < 30; step += 1) {
+      parseCallbacks.shift()?.()
+      await flushAsyncTicks(2)
+    }
+    transport.resize.mockClear()
+
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 })) as never
+    safeFit(pane as never)
+    await flushAsyncTicks(12)
+
+    expect(transport.resize).toHaveBeenCalledWith(120, 40)
+    expect(transport.resize).not.toHaveBeenCalledWith(120, 40, { claim: true })
   })
 
   it('forwards the destination grid on reveal when the reattach fit was deferred by a display:none pane', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5257,6 +5257,52 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('defers the post-spawn claim until the initial driver state shows mobile owns the PTY', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const runNextFrame = (): void => {
+      const callback = frameCallbacks.shift()
+      if (!callback) {
+        throw new Error('expected a queued animation frame')
+      }
+      callback(0)
+    }
+
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    const ptyId = 'remote:env-1@@pty-post-spawn-driver-late-mobile'
+    const transport = createMockTransport(ptyId)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+    const pane = createPane(1)
+    pane.terminal.cols = 80
+    pane.terminal.rows = 24
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    runNextFrame()
+    await flushAsyncTicks()
+
+    pane.terminal.cols = 96
+    pane.terminal.rows = 30
+    runNextFrame()
+    expect(transport.resize).not.toHaveBeenCalledWith(96, 30, { claim: true })
+
+    try {
+      setDriverForPty(ptyId, { kind: 'mobile', clientId: 'phone-1' })
+      await flushAsyncTicks(4)
+      expect(transport.resize).not.toHaveBeenCalledWith(96, 30, { claim: true })
+    } finally {
+      setDriverForPty(ptyId, { kind: 'idle' })
+    }
+  })
+
   it('claims the viewport when the post-spawn reconcile settles a paired-runtime grid', async () => {
     // Why: a paired-runtime client advertises explicit viewport claims, so a plain Resize frame only
     // registers passive viewer geometry. Without a claim the PTY stays at the runtime's spawn grid
@@ -5275,6 +5321,7 @@ describe('connectPanePty', () => {
     }
 
     const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
     const ptyId = 'remote:env-1@@pty-post-spawn-claim'
     const transport = createMockTransport(ptyId)
     transportFactoryQueue.push(transport)
@@ -5294,8 +5341,17 @@ describe('connectPanePty', () => {
     pane.terminal.cols = 96
     pane.terminal.rows = 30
     runNextFrame()
+    expect(transport.resize).not.toHaveBeenCalledWith(96, 30, { claim: true })
 
-    expect(transport.resize).toHaveBeenCalledWith(96, 30, { claim: true })
+    setDriverForPty(ptyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+    setDriverForPty(ptyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    const claims = (
+      transport.resize.mock.calls as [number, number, { claim?: boolean } | undefined][]
+    ).filter((call) => call[2]?.claim === true)
+    expect(claims).toEqual([[96, 30, { claim: true }]])
   })
 
   it('waits for setup-split geometry before spawning the initial startup command', async () => {
@@ -9422,6 +9478,47 @@ describe('connectPanePty', () => {
     setDriverForPty(remotePtyId, { kind: 'idle' })
     await flushAsyncTicks(4)
     setDriverForPty(remotePtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+
+    const claims = (
+      transport.resize.mock.calls as [number, number, { claim?: boolean } | undefined][]
+    ).filter((call) => call[2]?.claim === true)
+    expect(claims).toEqual([[120, 40, { claim: true }]])
+  })
+
+  it('retargets the unsettled attach claim when recovery replaces the PTY', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    enableActiveRuntimeEnvironment('env-1')
+    const firstPtyId = 'remote:env-1@@tab-pty-driver-first'
+    const successorPtyId = 'remote:env-1@@tab-pty-driver-successor'
+    const transport = createMockTransport(firstPtyId)
+    let attachCallbacks: ConnectCallbacks | undefined
+    transport.attach.mockImplementation(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        attachCallbacks = callbacks
+        transport.getPtyId.mockReturnValue(existingPtyId)
+        callbacks?.onConnect?.()
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: firstPtyId }] }
+    } as StoreState
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: firstPtyId }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    transport.getPtyId.mockReturnValue(successorPtyId)
+    attachCallbacks?.onConnect?.()
+    setDriverForPty(successorPtyId, { kind: 'idle' })
+    await flushAsyncTicks(4)
+    setDriverForPty(firstPtyId, { kind: 'idle' })
     await flushAsyncTicks(4)
 
     const claims = (

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4234,8 +4234,43 @@ export function connectPanePty(
   // stays a passive viewer so it cannot take ownership from the active client.
   const claimsRemoteRuntimeViewport = (ptyId: string | null | undefined): boolean =>
     isRemoteRuntimePtyId(ptyId) && deps.isVisibleRef.current
-  // Why: the attach claim waits for this PTY's first driver frame; teardown must drop that listener.
+  // Why: paired-runtime ownership is unknown until the subscription's first driver frame. One waiter
+  // follows the transport's current PTY across recovery/rebind and teardown drops it.
+  let settledInitialDriverStatePtyId: string | null = null
+  let waitingForInitialDriverStatePtyId: string | null = null
   let stopWaitingForInitialDriverState: (() => void) | null = null
+  const afterInitialDriverState = (ptyId: string, callback: () => void): void => {
+    if (settledInitialDriverStatePtyId === ptyId || waitingForInitialDriverStatePtyId === ptyId) {
+      return
+    }
+    stopWaitingForInitialDriverState?.()
+    waitingForInitialDriverStatePtyId = ptyId
+    stopWaitingForInitialDriverState = onDriverChange((event) => {
+      if (event.ptyId !== ptyId) {
+        return
+      }
+      stopWaitingForInitialDriverState?.()
+      stopWaitingForInitialDriverState = null
+      waitingForInitialDriverStatePtyId = null
+      settledInitialDriverStatePtyId = ptyId
+      callback()
+    })
+  }
+  const claimCurrentRemoteViewport = (ptyId: string): void => {
+    if (
+      disposed ||
+      transport.getPtyId() !== ptyId ||
+      !claimsRemoteRuntimeViewport(ptyId) ||
+      shouldSuppressDesktopPtyResize()
+    ) {
+      return
+    }
+    const cols = pane.terminal.cols
+    const rows = pane.terminal.rows
+    if (cols > 0 && rows > 0) {
+      transport.resize(cols, rows, { claim: true })
+    }
+  }
 
   const forwardPtyResize = (cols: number, rows: number): void => {
     if (!isRendererPtyResizeAuthoritative()) {
@@ -4567,7 +4602,7 @@ export function connectPanePty(
           return
         }
         if (claimsRemoteRuntimeViewport(ptyId)) {
-          transport.resize(cols, rows, { claim: true })
+          afterInitialDriverState(ptyId, () => claimCurrentRemoteViewport(ptyId))
           return
         }
         transport.resize(cols, rows)
@@ -5873,46 +5908,21 @@ export function connectPanePty(
     // grid it measured instead of waiting for a manual resize; once per attach, so a later recovery
     // resubscribe does not re-take ownership on its own.
     type AttachCallbacks = Parameters<typeof transport.attach>[0]['callbacks']
-    const claimAttachedRemoteViewport = (attachedPtyId: string | null): void => {
-      if (
-        transport.getPtyId() !== attachedPtyId ||
-        !claimsRemoteRuntimeViewport(attachedPtyId) ||
-        shouldSuppressDesktopPtyResize()
-      ) {
-        return
-      }
-      const claimCols = pane.terminal.cols
-      const claimRows = pane.terminal.rows
-      if (claimCols > 0 && claimRows > 0) {
-        transport.resize(claimCols, claimRows, { claim: true })
-      }
-    }
     const claimRemoteViewportOnFirstConnect = (callbacks: AttachCallbacks): AttachCallbacks => {
-      let claimed = false
       return {
         ...callbacks,
         onConnect: (): void => {
           callbacks.onConnect?.()
-          if (claimed || disposed) {
+          if (disposed) {
             return
           }
-          claimed = true
           const attachedPtyId = transport.getPtyId()
-          if (!isRemoteRuntimePtyId(attachedPtyId)) {
+          if (typeof attachedPtyId !== 'string' || !isRemoteRuntimePtyId(attachedPtyId)) {
             return
           }
-          // Why: the runtime completes the subscription before it sends this PTY's first driver
-          // frame, and an unknown local driver reads as idle — claiming now would take the grid from
-          // a phone already driving it. Wait for that frame, then re-test every ownership term.
-          stopWaitingForInitialDriverState?.()
-          stopWaitingForInitialDriverState = onDriverChange((event) => {
-            if (event.ptyId !== attachedPtyId) {
-              return
-            }
-            stopWaitingForInitialDriverState?.()
-            stopWaitingForInitialDriverState = null
-            claimAttachedRemoteViewport(attachedPtyId)
-          })
+          // Why: settlement, not connect occurrence, is the one-shot boundary. Recovery can replace
+          // the PTY before its first driver frame, so each connect retargets the one current waiter.
+          afterInitialDriverState(attachedPtyId, () => claimCurrentRemoteViewport(attachedPtyId))
         }
       }
     }
@@ -9423,6 +9433,7 @@ export function connectPanePty(
       terminalRecoveryInstance.unregister()
       stopWaitingForInitialDriverState?.()
       stopWaitingForInitialDriverState = null
+      waitingForInitialDriverStatePtyId = null
       unregisterUndeliverableWriteHandler()
       unsubscribeRemoteDesktopActivationClaim()
       cancelHiddenOutputSnapshotScrollRestore()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -76,7 +76,7 @@ import {
   getFitOverrideForPty,
   onOverrideChange
 } from '@/lib/pane-manager/mobile-fit-overrides'
-import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
+import { isPtyLocked, onDriverChange } from '@/lib/pane-manager/mobile-driver-state'
 import { reconcilePtySizeAcrossFrames, type PtySizeReconcileHandle } from './pty-size-reconcile'
 import { shouldClaimRemoteDesktopViewport } from './remote-desktop-viewport-claim'
 import { getAppliedSizeReadE2eDelayMs } from './pty-applied-size-read-e2e-delay'
@@ -3838,6 +3838,12 @@ export function connectPanePty(
           onAgentBecameWorking,
           onAgentExited
         }),
+    // Why: a claim the transport queued during an outage replays after it; by then this pane may be
+    // hidden, disposed, or mobile-driven, and only the pane knows.
+    isViewportClaimAuthoritative: (): boolean =>
+      !disposed &&
+      claimsRemoteRuntimeViewport(transport.getPtyId()) &&
+      !shouldSuppressDesktopPtyResize(),
     // Why: local IPC terminals are now model-owned in main: OrcaRuntimeService
     // parses OSC 9999 before renderer delivery and forwards through the hook
     // server with local/SSH identity. Remote-runtime streams do not pass through
@@ -4222,6 +4228,15 @@ export function connectPanePty(
     return false
   }
 
+  // Why: a paired-runtime client advertises explicit viewport claims, so its plain Resize frames only
+  // register passive viewer geometry. A grid this pane fitted itself must claim, or the PTY keeps the
+  // runtime's spawn grid until a manual resize. Only a visible pane is authoritative — a hidden one
+  // stays a passive viewer so it cannot take ownership from the active client.
+  const claimsRemoteRuntimeViewport = (ptyId: string | null | undefined): boolean =>
+    isRemoteRuntimePtyId(ptyId) && deps.isVisibleRef.current
+  // Why: the attach claim waits for this PTY's first driver frame; teardown must drop that listener.
+  let stopWaitingForInitialDriverState: (() => void) | null = null
+
   const forwardPtyResize = (cols: number, rows: number): void => {
     if (!isRendererPtyResizeAuthoritative()) {
       return
@@ -4309,7 +4324,11 @@ export function connectPanePty(
         const reattachCols = pane.terminal.cols
         const reattachRows = pane.terminal.rows
         if (reattachCols > 0 && reattachRows > 0) {
-          transport.resize(reattachCols, reattachRows)
+          if (claimsRemoteRuntimeViewport(reattachPtyId)) {
+            transport.resize(reattachCols, reattachRows, { claim: true })
+          } else {
+            transport.resize(reattachCols, reattachRows)
+          }
         }
         // Why: POSIX only sends SIGWINCH on an actual dimension change; signal explicitly so restored TUIs repaint at the correct cursor after replay.
         if (!isRemoteRuntimePtyId(reattachPtyId)) {
@@ -4544,9 +4563,14 @@ export function connectPanePty(
         return cols > 0 && rows > 0 ? { cols, rows } : null
       },
       resize: (cols, rows) => {
-        if (!shouldSuppressDesktopPtyResize()) {
-          transport.resize(cols, rows)
+        if (shouldSuppressDesktopPtyResize()) {
+          return
         }
+        if (claimsRemoteRuntimeViewport(ptyId)) {
+          transport.resize(cols, rows, { claim: true })
+          return
+        }
+        transport.resize(cols, rows)
       },
       // Why: confirm the PTY actually applied the size we forwarded before the
       // reconcile hands off. transport.resize is fire-and-forget for daemon/SSH
@@ -5840,6 +5864,55 @@ export function connectPanePty(
               handleRemoteOutputPauseChanged(paused, supported)
             }
           }
+        }
+      }
+    }
+
+    // Why: attach hands its viewport to subscribe, which only registers passive geometry, and remote
+    // PTYs get no size reassertion. Claim once the stream is live so a visible restored pane owns the
+    // grid it measured instead of waiting for a manual resize; once per attach, so a later recovery
+    // resubscribe does not re-take ownership on its own.
+    type AttachCallbacks = Parameters<typeof transport.attach>[0]['callbacks']
+    const claimAttachedRemoteViewport = (attachedPtyId: string | null): void => {
+      if (
+        transport.getPtyId() !== attachedPtyId ||
+        !claimsRemoteRuntimeViewport(attachedPtyId) ||
+        shouldSuppressDesktopPtyResize()
+      ) {
+        return
+      }
+      const claimCols = pane.terminal.cols
+      const claimRows = pane.terminal.rows
+      if (claimCols > 0 && claimRows > 0) {
+        transport.resize(claimCols, claimRows, { claim: true })
+      }
+    }
+    const claimRemoteViewportOnFirstConnect = (callbacks: AttachCallbacks): AttachCallbacks => {
+      let claimed = false
+      return {
+        ...callbacks,
+        onConnect: (): void => {
+          callbacks.onConnect?.()
+          if (claimed || disposed) {
+            return
+          }
+          claimed = true
+          const attachedPtyId = transport.getPtyId()
+          if (!isRemoteRuntimePtyId(attachedPtyId)) {
+            return
+          }
+          // Why: the runtime completes the subscription before it sends this PTY's first driver
+          // frame, and an unknown local driver reads as idle — claiming now would take the grid from
+          // a phone already driving it. Wait for that frame, then re-test every ownership term.
+          stopWaitingForInitialDriverState?.()
+          stopWaitingForInitialDriverState = onDriverChange((event) => {
+            if (event.ptyId !== attachedPtyId) {
+              return
+            }
+            stopWaitingForInitialDriverState?.()
+            stopWaitingForInitialDriverState = null
+            claimAttachedRemoteViewport(attachedPtyId)
+          })
         }
       }
     }
@@ -9093,7 +9166,7 @@ export function connectPanePty(
             existingPtyId: attachPtyId,
             cols,
             rows,
-            callbacks: outputCallbacks.callbacks
+            callbacks: claimRemoteViewportOnFirstConnect(outputCallbacks.callbacks)
           })
           const attachedPtyId = transport.getPtyId() ?? attachPtyId
           bindActivePanePty(attachedPtyId, {
@@ -9148,7 +9221,7 @@ export function connectPanePty(
               existingPtyId: spawnedPtyId,
               cols,
               rows,
-              callbacks: outputCallbacks.callbacks
+              callbacks: claimRemoteViewportOnFirstConnect(outputCallbacks.callbacks)
             })
             const attachedPtyId = transport.getPtyId() ?? spawnedPtyId
             // Why: this reuses a PTY spawned by an earlier mount, so no later spawn event will bind this remounted pane's DOM/container.
@@ -9348,6 +9421,8 @@ export function connectPanePty(
       pendingReattachFit = null
       // Why: park/reconnect/remount doesn't advance the recovery epoch, so invalidate this xterm or its delayed retry could hit the next instance.
       terminalRecoveryInstance.unregister()
+      stopWaitingForInitialDriverState?.()
+      stopWaitingForInitialDriverState = null
       unregisterUndeliverableWriteHandler()
       unsubscribeRemoteDesktopActivationClaim()
       cancelHiddenOutputSnapshotScrollRestore()

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -250,4 +250,9 @@ export type IpcPtyTransportOptions = {
   onAgentBecameWorking?: () => void
   onAgentExited?: () => void
   onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
+  /**
+   * Whether this pane may still take viewport ownership. Read when a recovery replays a claim the
+   * outage blocked: a pane hidden, disposed, or driven by mobile since then registers geometry only.
+   */
+  isViewportClaimAuthoritative?: () => boolean
 }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -157,6 +157,15 @@ describe('createRemoteRuntimePtyTransport', () => {
       .findLast((frame) => frame?.opcode === opcode)
   }
 
+  // Why: a never-settling acknowledged write is itself a failure mode; race it so a hang shows up as
+  // an assertion on 'pending' instead of a suite timeout.
+  function settledPromptly<T>(pending: Promise<T> | undefined): Promise<T | 'pending'> {
+    return Promise.race<T | 'pending'>([
+      pending ?? Promise.resolve('pending'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 50))
+    ])
+  }
+
   function emitSnapshotFrame(
     streamId: number,
     opcode:
@@ -5190,6 +5199,139 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(runtimeSubscribe).toHaveBeenCalledTimes(1)
   })
 
+  it('retires the attachment when connect subscribe rejects with a fatal error', async () => {
+    // Why: connect sets connected and PTY identity before awaiting subscribe. A fatal rejection never
+    // installs a stream and nothing else retires the attachment, so a live identity would let later
+    // claim/input calls take the grid over a one-shot RPC and park an acknowledged write forever.
+    runtimeSubscribe.mockRejectedValue(
+      Object.assign(new Error('Remote Orca runtime rejected the pairing token.'), {
+        code: 'unauthorized'
+      })
+    )
+    const onError = vi.fn()
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await expect(
+      transport.connect({ url: '', cols: 80, rows: 24, callbacks: { onError } })
+    ).resolves.toBeUndefined()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(transport.getPtyId()).toBeNull()
+    expect(transport.claimViewport?.(101, 33)).toBe(false)
+    expect(transport.sendInput('x')).toBe(false)
+    await expect(settledPromptly(transport.sendInputAccepted?.('x'))).resolves.toBe(false)
+    expect(
+      runtimeCall.mock.calls.some(([request]) => request.method === 'terminal.updateViewport')
+    ).toBe(false)
+    transport.destroy?.()
+  })
+
+  it('retires the attachment when an adopted pane subscribe rejects with a fatal error', async () => {
+    runtimeSubscribe.mockRejectedValue(
+      Object.assign(new Error('Remote Orca runtime rejected the pairing token.'), {
+        code: 'unauthorized'
+      })
+    )
+    const onError = vi.fn()
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:terminal-1',
+      cols: 80,
+      rows: 24,
+      callbacks: { onError }
+    })
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(transport.getPtyId()).toBeNull()
+    expect(transport.claimViewport?.(101, 33)).toBe(false)
+    expect(transport.sendInput('x')).toBe(false)
+    await expect(settledPromptly(transport.sendInputAccepted?.('x'))).resolves.toBe(false)
+    transport.destroy?.()
+  })
+
+  it('ignores a stale same-handle fatal subscribe rejection after a newer subscribe recovered', async () => {
+    // Why: web-surface recovery deliberately overlaps two subscribes for one handle. Matching the fatal
+    // rejection on handle/ptyId alone lets the older attempt's teardown retire the attachment the newer
+    // attempt just recovered.
+    const staleSubscribe = { reject: null as ((error: Error) => void) | null }
+    const liveStream = {
+      streamId: 2,
+      sendInput: vi.fn(() => true),
+      resize: vi.fn(() => true),
+      claimViewport: vi.fn(() => true),
+      setOutputPaused: vi.fn(() => true),
+      serializeBuffer: vi.fn(async () => null),
+      close: vi.fn()
+    }
+    const subscribeTerminal = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            staleSubscribe.reject = reject
+          })
+      )
+      .mockImplementationOnce(async (args: { callbacks: { onSubscribed?: () => void } }) => {
+        args.callbacks.onSubscribed?.()
+        return liveStream
+      })
+    vi.doMock('../../runtime/remote-runtime-terminal-multiplexer', () => ({
+      REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE: 'remote_terminal_snapshot_too_large',
+      getRemoteRuntimeTerminalMultiplexer: vi.fn(() => ({ subscribeTerminal }))
+    }))
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    resolvedPaneHandle = 'terminal-1'
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-1',
+      cols: 80,
+      rows: 24,
+      callbacks: { onError }
+    })
+    await vi.waitFor(() => expect(subscribeTerminal).toHaveBeenCalledOnce())
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-1',
+      cols: 80,
+      rows: 24,
+      callbacks: { onError }
+    })
+    await vi.waitFor(() => expect(subscribeTerminal).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(transport.isConnected()).toBe(true))
+
+    staleSubscribe.reject?.(
+      Object.assign(new Error('Remote Orca runtime rejected the pairing token.'), {
+        code: 'unauthorized'
+      })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(transport.getPtyId()).toBe('remote:env-1@@terminal-1')
+    expect(transport.isConnected()).toBe(true)
+    expect(transport.claimViewport?.(101, 33)).toBe(true)
+    expect(liveStream.claimViewport).toHaveBeenCalledWith(101, 33)
+    expect(liveStream.close).not.toHaveBeenCalled()
+    transport.destroy?.()
+  })
+
   it('recovers repeated partitions without changing PTY identity or accepting detached input', async () => {
     const callbacksByEpoch: NonNullable<typeof subscriptionCallbacks>[] = []
     const unsubscribeByEpoch: ReturnType<typeof vi.fn>[] = []
@@ -5512,6 +5654,62 @@ describe('createRemoteRuntimePtyTransport', () => {
         subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
       ).toContain(TerminalStreamOpcode.ClaimViewport)
     })
+    transport.destroy?.()
+  })
+
+  it('drops a blocked claim when a recoverable resubscribe retry turns fatal', async () => {
+    // Why: the recoverable side keeps the claim for the retry. Once the retry itself fails fatally the
+    // pane no longer owns the grid, so the stale intent must not survive to take the viewport over the
+    // one-shot RPC, and acknowledged writes must settle instead of parking on a claim that never lands.
+    let attempt = 0
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        attempt += 1
+        if (attempt === 2) {
+          throw Object.assign(new Error('Could not connect to the remote Orca runtime.'), {
+            code: 'remote_runtime_unavailable'
+          })
+        }
+        if (attempt === 3) {
+          throw Object.assign(new Error('Remote Orca runtime rejected the pairing token.'), {
+            code: 'unauthorized'
+          })
+        }
+        subscriptionCallbacks = callbacks
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const onError = vi.fn()
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({ url: '', cols: 80, rows: 24, callbacks: { onError } })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    subscriptionSendBinary.mockClear()
+    runtimeCall.mockClear()
+
+    subscriptionCallbacks?.onClose?.()
+    expect(transport.resize(132, 43, { claim: true })).toBe(true)
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3), { timeout: 5000 })
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+
+    expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+    await expect(settledPromptly(transport.sendInputAccepted?.('x'))).resolves.toBe(false)
+    transport.claimViewport?.(101, 33)
+    await expect(settledPromptly(transport.sendInputAccepted?.('y'))).resolves.toBe(false)
+    expect(
+      subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+    ).not.toContain(TerminalStreamOpcode.ClaimViewport)
+    expect(
+      runtimeCall.mock.calls.some(([request]) => request.method === 'terminal.updateViewport')
+    ).toBe(false)
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(3)
     transport.destroy?.()
   })
 

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -5161,6 +5161,35 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects claims and acknowledged input after a fatal transport close', async () => {
+    const unsubscribe = vi.fn()
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        subscriptionCallbacks = callbacks
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe, sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+    await transport.connect({ url: '', callbacks: {} })
+    subscriptionSendBinary.mockClear()
+
+    subscriptionCallbacks?.onError?.({
+      code: 'unauthorized',
+      message: 'Remote Orca runtime rejected the pairing token.'
+    })
+
+    expect(transport.claimViewport?.(101, 33)).toBe(false)
+    await expect(transport.sendInputAccepted?.('x')).resolves.toBe(false)
+    expect(subscriptionSendBinary).not.toHaveBeenCalled()
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(1)
+  })
+
   it('recovers repeated partitions without changing PTY identity or accepting detached input', async () => {
     const callbacksByEpoch: NonNullable<typeof subscriptionCallbacks>[] = []
     const unsubscribeByEpoch: ReturnType<typeof vi.fn>[] = []

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -5396,6 +5396,130 @@ describe('createRemoteRuntimePtyTransport', () => {
     })
   })
 
+  it('replays an authoritative resize as a claim when recovery blocked it', async () => {
+    // Why: recovery drops the resize before it reaches the wire. Remembering the geometry alone
+    // downgrades the pane's own grid to passive viewer registration on resubscribe, so the PTY keeps
+    // the grid it had before the outage.
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({ url: '', cols: 80, rows: 24, callbacks: {} })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    subscriptionSendBinary.mockClear()
+
+    subscriptionCallbacks?.onClose?.()
+    expect(transport.resize(132, 43, { claim: true })).toBe(true)
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => {
+      expect(
+        subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+      ).toContain(TerminalStreamOpcode.ClaimViewport)
+    })
+  })
+
+  it('replays an activity claim that recovery blocked', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({ url: '', cols: 80, rows: 24, callbacks: {} })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    subscriptionSendBinary.mockClear()
+
+    subscriptionCallbacks?.onClose?.()
+    expect(transport.claimViewport?.(132, 43)).toBe(true)
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => {
+      expect(
+        subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+      ).toContain(TerminalStreamOpcode.ClaimViewport)
+    })
+  })
+
+  it('keeps a blocked claim through a recoverable resubscribe failure and replays it on the retry', async () => {
+    // Why: a recoverable retry does not end this pane's ownership of the grid it measured. Dropping
+    // the intent on the failed attempt downgrades the replay to passive registration, so the PTY
+    // keeps its pre-outage grid until the user resizes.
+    let attempt = 0
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        attempt += 1
+        if (attempt === 2) {
+          throw Object.assign(new Error('Could not connect to the remote Orca runtime.'), {
+            code: 'remote_runtime_unavailable'
+          })
+        }
+        subscriptionCallbacks = callbacks
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({ url: '', cols: 80, rows: 24, callbacks: {} })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    subscriptionSendBinary.mockClear()
+
+    subscriptionCallbacks?.onClose?.()
+    expect(transport.resize(132, 43, { claim: true })).toBe(true)
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3), { timeout: 5000 })
+    await vi.waitFor(() => {
+      expect(
+        subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+      ).toContain(TerminalStreamOpcode.ClaimViewport)
+    })
+    transport.destroy?.()
+  })
+
+  it('registers geometry instead of claiming when the pane loses desktop authority during recovery', async () => {
+    // Why: the pane can be hidden, disposed, or taken over by mobile while the claim waits for a
+    // stream. Replaying it then takes the grid from whoever owns it now; the measured geometry is
+    // still wanted as passive viewer registration.
+    let authoritative = true
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      isViewportClaimAuthoritative: () => authoritative
+    })
+
+    await transport.connect({ url: '', cols: 80, rows: 24, callbacks: {} })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    subscriptionSendBinary.mockClear()
+
+    subscriptionCallbacks?.onClose?.()
+    expect(transport.resize(132, 43, { claim: true })).toBe(true)
+    authoritative = false
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(latestSubscribePayload().viewport).toEqual({ cols: 132, rows: 43 })
+    )
+    for (let tick = 0; tick < 20; tick += 1) {
+      await Promise.resolve()
+    }
+    expect(
+      subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+    ).not.toContain(TerminalStreamOpcode.ClaimViewport)
+    transport.destroy?.()
+  })
+
   it('replays a viewport that changed during the subscribe round-trip once the stream is current', async () => {
     // Why: a resize landing while the subscribe is in flight takes the one-shot
     // RPC fallback, which is refresh-only (no leak) and no-ops before the stream
@@ -5916,6 +6040,38 @@ describe('createRemoteRuntimePtyTransport', () => {
         cols: 120,
         rows: 40
       })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('claims the viewport for a resize marked authoritative and only registers a plain one', async () => {
+    // Why: startup reconcile and reattach push their fitted grid through resize(), so the claim flag
+    // is the only thing separating an authoritative grid from passive viewer geometry on the wire.
+    vi.useFakeTimers()
+    try {
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'pane:1'
+      })
+
+      await transport.connect({ url: '', callbacks: {} })
+      subscriptionSendBinary.mockClear()
+
+      expect(transport.resize(101, 33, { claim: true })).toBe(true)
+      await vi.runOnlyPendingTimersAsync()
+      expect(
+        subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+      ).toEqual([TerminalStreamOpcode.ClaimViewport, TerminalStreamOpcode.Resize])
+
+      subscriptionSendBinary.mockClear()
+      expect(transport.resize(90, 30)).toBe(true)
+      await vi.runOnlyPendingTimersAsync()
+      expect(
+        subscriptionSendBinary.mock.calls.map((call) => decodeTerminalStreamFrame(call[0])?.opcode)
+      ).toEqual([TerminalStreamOpcode.Resize])
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1357,14 +1357,14 @@ export function createRemoteRuntimePtyTransport(
     publishedHandleWaitEpoch = null
   }
 
-  function isCurrentRemoteTerminal(targetHandle: string, targetPtyId: string | null): boolean {
+  function isSameRemoteTerminal(targetHandle: string, targetPtyId: string | null): boolean {
     return (
-      !destroyed &&
-      connected &&
-      handle === targetHandle &&
-      remotePtyId === targetPtyId &&
-      targetPtyId !== null
+      !destroyed && handle === targetHandle && remotePtyId === targetPtyId && targetPtyId !== null
     )
+  }
+
+  function isCurrentRemoteTerminal(targetHandle: string, targetPtyId: string | null): boolean {
+    return connected && isSameRemoteTerminal(targetHandle, targetPtyId)
   }
 
   function retireRemoteTerminalId(): void {
@@ -1509,7 +1509,7 @@ export function createRemoteRuntimePtyTransport(
     targetHandle: string,
     targetPtyId: string | null
   ): boolean {
-    if (!isCurrentRemoteTerminal(targetHandle, targetPtyId)) {
+    if (!isSameRemoteTerminal(targetHandle, targetPtyId)) {
       return true
     }
     if (multiplexedStreamHandle !== targetHandle) {
@@ -1891,7 +1891,9 @@ export function createRemoteRuntimePtyTransport(
               scheduleResubscribeAfterTransportClose()
             }
           } else {
+            connected = false
             connecting = false
+            clearPendingViewportClaim()
             recovery.cancel()
             setAttachmentUnavailable()
             emitRecoveryState()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -163,7 +163,8 @@ export function createRemoteRuntimePtyTransport(
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
-    onAgentStatus
+    onAgentStatus,
+    isViewportClaimAuthoritative
   } = opts
   let connected = false
   let attachmentReady = false
@@ -344,13 +345,18 @@ export function createRemoteRuntimePtyTransport(
     authoritativeHostPlatform = terminal.hostPlatform ?? authoritativeHostPlatform
   }
   const viewportClaimReadyWaiters = new Set<(ready: boolean) => void>()
-  const clearPendingViewportClaim = (): void => {
-    pendingViewportClaim = false
+  // Why: bytes queued behind a claim have unknown delivery after a partition and must never replay,
+  // but the claim itself is this pane's own grid — a recoverable retry still owns it.
+  const dropClaimQueuedInput = (): void => {
     pendingClaimInput = ''
     for (const resolve of viewportClaimReadyWaiters) {
       resolve(false)
     }
     viewportClaimReadyWaiters.clear()
+  }
+  const clearPendingViewportClaim = (): void => {
+    pendingViewportClaim = false
+    dropClaimQueuedInput()
   }
   // Why: tab/leaf ids are shared by paired viewers; the instance suffix keeps one viewer's refresh off peer records.
   const clientId = `desktop:${tabId ?? 'tab'}:${leafId ?? 'leaf'}:${createBrowserUuid()}`
@@ -1509,8 +1515,9 @@ export function createRemoteRuntimePtyTransport(
     if (multiplexedStreamHandle !== targetHandle) {
       closeMultiplexedStream()
     }
-    clearPendingViewportClaim()
+    dropClaimQueuedInput()
     if (!isRecoverableRemoteRuntimeConnectionError(toRemoteRuntimeClientErrorLike(error))) {
+      clearPendingViewportClaim()
       return false
     }
     if (recovery.currentPhase === 'disconnected') {
@@ -1629,7 +1636,7 @@ export function createRemoteRuntimePtyTransport(
       // Why: bytes queued before a partition have unknown delivery; never replay them on a replacement stream.
       inputBatcher.clear()
       viewportBatcher.clear()
-      clearPendingViewportClaim()
+      dropClaimQueuedInput()
     }
     strengthenRecoveryReplacementPolicy(handle, replacementPolicy)
     if (
@@ -1667,7 +1674,7 @@ export function createRemoteRuntimePtyTransport(
     void resubscribeAfterTransportClose(resubscribeHandle, replacementPolicy, recoveryEpoch)
       .catch((error) => {
         if (!destroyed && connected && handle && recovery.isCurrent(recoveryEpoch)) {
-          clearPendingViewportClaim()
+          dropClaimQueuedInput()
           const clientError = toRemoteRuntimeClientErrorLike(error)
           if (isRecoverableRemoteRuntimeConnectionError(clientError)) {
             retryScheduled = recovery.schedule(recoveryEpoch, (nextEpoch) => {
@@ -1677,6 +1684,7 @@ export function createRemoteRuntimePtyTransport(
               scheduleResubscribeAfterTransportClose(currentReplacementPolicy, nextEpoch)
             })
           } else {
+            clearPendingViewportClaim()
             recovery.markDisconnected()
             // Why: stale/gone/SSH-expired handling lives in handleRemoteTerminalError; its
             // fallthrough surfaces the message, so routing here keeps those recoveries alive.
@@ -1715,7 +1723,7 @@ export function createRemoteRuntimePtyTransport(
     if (!recoveryWasActive) {
       inputBatcher.clear()
       viewportBatcher.clear()
-      clearPendingViewportClaim()
+      dropClaimQueuedInput()
     }
     recovery.schedule(recoveryEpoch, (nextEpoch) => {
       scheduleResubscribeAfterTransportClose('reuse', nextEpoch)
@@ -1817,7 +1825,7 @@ export function createRemoteRuntimePtyTransport(
             setAttachmentReady(false)
             multiplexedStream = null
             multiplexedStreamHandle = null
-            clearPendingViewportClaim()
+            dropClaimQueuedInput()
             // Why: repeated same-handle end/reuse cycles must eventually stop on a replacement boundary.
             scheduleResubscribeAfterTransportClose(
               replacementPolicyAfterWebStreamEnd(subscribedHandle)
@@ -1910,6 +1918,12 @@ export function createRemoteRuntimePtyTransport(
     if (subscriptionAttached) {
       resetRecoveryReplacementPolicy()
       markRecoveryHealthy()
+    }
+    // Why: the pane may have gone hidden, been disposed, or lost the PTY to mobile while the claim
+    // waited for a stream; a stale replay would take the grid from whoever owns it now. The subscribe
+    // frame already carried the geometry, so dropping the intent leaves it a passive registration.
+    if (pendingViewportClaim && isViewportClaimAuthoritative?.() === false) {
+      clearPendingViewportClaim()
     }
     // Why: a viewport change during the subscribe round-trip hit the no-op one-shot fallback; replay the latest viewport so the PTY isn't stuck at subscribe-time size.
     if (pendingViewportClaim && desiredViewport) {
@@ -2380,6 +2394,7 @@ export function createRemoteRuntimePtyTransport(
       }
       rememberViewport(cols, rows)
       if (recoveryBlocksIo()) {
+        pendingViewportClaim = true
         return true
       }
       viewportBatcher.clear()
@@ -2403,6 +2418,11 @@ export function createRemoteRuntimePtyTransport(
       }
       rememberViewport(cols, rows)
       if (recoveryBlocksIo()) {
+        // Why: remembering geometry alone downgrades an authoritative grid to passive registration on
+        // resubscribe; keep the claim intent so the replay re-takes the viewport.
+        if (meta?.claim) {
+          pendingViewportClaim = true
+        }
         return true
       }
       if (meta?.claim) {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -836,10 +836,16 @@ export function createRemoteRuntimePtyTransport(
       onPtySpawn?.(remotePtyId)
     }
 
+    // Why: a concurrent attach can replace handle/id while this subscribe is in flight; the failure
+    // must be matched against the terminal it was issued for, not whatever is current on rejection.
+    const subscribedPtyId = remotePtyId
+    // Why: subscribeToHandle stamps its generation synchronously, so read it once the attempt is running.
+    const subscribePending = subscribeToHandle()
+    const subscribedGeneration = subscriptionGeneration
     try {
-      await subscribeToHandle()
+      await subscribePending
     } catch (error) {
-      if (!recoverAfterSubscribeFailure(error, hostHandle, remotePtyId)) {
+      if (!recoverAfterSubscribeFailure(error, hostHandle, subscribedPtyId, subscribedGeneration)) {
         throw error
       }
     }
@@ -1119,10 +1125,21 @@ export function createRemoteRuntimePtyTransport(
       onPtySpawn?.(remotePtyId)
     }
     emitRecoveryState()
+    const subscribedHandle = handle
+    const subscribedPtyId = remotePtyId
+    const subscribePending = subscribeToHandle()
+    const subscribedGeneration = subscriptionGeneration
     try {
-      await subscribeToHandle()
+      await subscribePending
     } catch (error) {
-      if (!recoverAfterSubscribeFailure(error, handle, remotePtyId)) {
+      if (
+        !recoverAfterSubscribeFailure(
+          error,
+          subscribedHandle,
+          subscribedPtyId,
+          subscribedGeneration
+        )
+      ) {
         throw error
       }
     }
@@ -1440,8 +1457,12 @@ export function createRemoteRuntimePtyTransport(
           const reattachEpoch = recovery.begin()
           clearPublishedHandleWait()
           const reusedPtyId = remotePtyId
-          void subscribeToHandle(reattachEpoch, true).catch((error) => {
-            if (!recoverAfterSubscribeFailure(error, previousHandle, reusedPtyId)) {
+          const reattachPending = subscribeToHandle(reattachEpoch, true)
+          const reattachGeneration = subscriptionGeneration
+          void reattachPending.catch((error) => {
+            if (
+              !recoverAfterSubscribeFailure(error, previousHandle, reusedPtyId, reattachGeneration)
+            ) {
               handleRemoteTerminalError(error)
             }
           })
@@ -1454,8 +1475,13 @@ export function createRemoteRuntimePtyTransport(
         rebindRemoteTerminalHandle(update.terminalHandle)
         const reboundHandle = handle
         const reboundPtyId = remotePtyId
-        void subscribeToHandle().catch((error) => {
-          if (reboundHandle && !recoverAfterSubscribeFailure(error, reboundHandle, reboundPtyId)) {
+        const reboundPending = subscribeToHandle()
+        const reboundGeneration = subscriptionGeneration
+        void reboundPending.catch((error) => {
+          if (
+            reboundHandle &&
+            !recoverAfterSubscribeFailure(error, reboundHandle, reboundPtyId, reboundGeneration)
+          ) {
             handleRemoteTerminalError(error)
           }
         })
@@ -1507,7 +1533,8 @@ export function createRemoteRuntimePtyTransport(
   function recoverAfterSubscribeFailure(
     error: unknown,
     targetHandle: string,
-    targetPtyId: string | null
+    targetPtyId: string | null,
+    targetGeneration: number
   ): boolean {
     if (!isSameRemoteTerminal(targetHandle, targetPtyId)) {
       return true
@@ -1517,7 +1544,12 @@ export function createRemoteRuntimePtyTransport(
     }
     dropClaimQueuedInput()
     if (!isRecoverableRemoteRuntimeConnectionError(toRemoteRuntimeClientErrorLike(error))) {
-      clearPendingViewportClaim()
+      // Why: same-handle recovery overlaps subscribe attempts, so handle/ptyId identity alone cannot
+      // tell a dead attempt from the live one; only the failing attempt's own generation may retire it.
+      if (targetGeneration !== subscriptionGeneration) {
+        return true
+      }
+      retireAttachmentAfterFatalSubscribe(targetPtyId)
       return false
     }
     if (recovery.currentPhase === 'disconnected') {
@@ -1525,6 +1557,23 @@ export function createRemoteRuntimePtyTransport(
     }
     scheduleResubscribeAfterTransportClose()
     return true
+  }
+
+  // Why: a fatal subscribe rejection never installs a stream, so no stream callback will ever retire
+  // this attachment. Leaving connected and PTY identity live lets a later claim take the grid over the
+  // one-shot RPC and parks an acknowledged write on a claim waiter nothing can resolve.
+  function retireAttachmentAfterFatalSubscribe(stalePtyId: string | null): void {
+    recovery.cancel()
+    clearPublishedHandleWait()
+    connected = false
+    connecting = false
+    clearPendingViewportClaim()
+    unregisterShutdownHandlers(stalePtyId)
+    handle = null
+    remotePtyId = null
+    closeMultiplexedStream()
+    setAttachmentUnavailable()
+    emitRecoveryState()
   }
 
   // Why: after a transport drop the host may have re-minted this handle; re-derive from the snapshot so we don't mirror/type into whatever PTY now sits behind the stale one (#7718).
@@ -2145,10 +2194,21 @@ export function createRemoteRuntimePtyTransport(
         }
         emitRecoveryState()
 
+        const subscribedHandle = handle
+        const subscribedPtyId = remotePtyId
+        const subscribePending = subscribeToHandle()
+        const subscribedGeneration = subscriptionGeneration
         try {
-          await subscribeToHandle()
+          await subscribePending
         } catch (error) {
-          if (!recoverAfterSubscribeFailure(error, handle, remotePtyId)) {
+          if (
+            !recoverAfterSubscribeFailure(
+              error,
+              subscribedHandle,
+              subscribedPtyId,
+              subscribedGeneration
+            )
+          ) {
             throw error
           }
         }


### PR DESCRIPTION
## ELI5

Two Orca clients can watch the same remote terminal, so the server only resizes the real shell when a client says "this grid is mine". A restored or freshly spawned pane was sending its grid without that flag, so the shell kept whatever size the remote runtime started it at and the text wrapped wrong until you dragged the pane. Now the pane says "mine" — but only when it is the one you are looking at, and never when your phone is driving the session.

## What Changed

Three pushes that carry a pane's own fitted grid now claim the viewport instead of registering it passively: the post-spawn size reconcile, the restored-terminal reattach push, and the restored-leaf attach after an app restart. Each claims only when the pane is the authoritative desktop viewer — a remote-runtime PTY, visible, not driven by mobile. Hidden and mobile-owned panes stay passive viewers, exactly as before.

Three ownership races around that claim are closed with it:

- **A claim blocked by an outage survives a recoverable retry.** Recovery cleared the claim intent along with the queued input on every path, including ones that retry immediately, so the replay downgraded to a passive `Resize` and the shell kept its pre-outage grid. Queued bytes still drop (unknown delivery); the intent does not.
- **Recovery re-tests live authority before replaying a claim.** A pane that went hidden, was disposed, or lost the PTY to a phone during the outage now registers geometry only. The resubscribe frame still carries that geometry, so nothing is lost for a passive resize.
- **The restored attach waits for the PTY's first driver frame.** The runtime completes the subscription before it sends initial driver state, and unknown driver state reads as idle locally — so the attach claim could fire while a phone was already driving the PTY. It now waits for that frame, then re-checks PTY identity, visibility, mobile suppression, and dimensions.

Nothing was added to the wire: no protocol field, RPC, stream opcode, poll, retry counter, second queue, or acknowledgment. The claim reuses the existing `resize(cols, rows, { claim: true })` operation, and the only new state is one transport option carrying the pane's authority predicate.

## Why

A paired client advertises explicit viewport claims, so the host treats its plain `Resize` frames as passive viewer geometry and applies a PTY layout only for `ClaimViewport`. A pane that fitted its own grid therefore had no way to tell the runtime about it. Manual resizes already went through a path that claims, which is why the bug looked like "correct only after a resize".

Scoping the claim to remote-runtime PTYs is deliberate. For local and direct-SSH PTYs the same flag would send a `pty:claimViewport` IPC that makes the *host* reclaim width from its own remote viewers, which would change the passive-peer contract in the other direction.

## Linked Issue

Fixes #14088

## Visual Proof

`N/A` — no UI surface changes. The visible effect is terminal text wrapping at the correct width, which needs the two-client fixture described in #14088 to stage; see Testing.

## Testing

Unit and integration only, on macOS. No new end-to-end run: these are recovery and ordering races that the existing deterministic paired journey does not stage, and that journey is not a discriminating oracle for the underlying bug (it passes with and without the fix, because its client creates the terminal itself so both grids already match). Building the fixture that would discriminate is tracked in #14088.

What was run:

| Command | Result |
| --- | --- |
| `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` | 580 passed |
| `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts` | 122 passed |
| `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane src/renderer/src/runtime/remote-runtime-terminal-multiplexer.test.ts src/main/runtime/remote-desktop-driver.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts` | 265 files, 3424 passed, 1 skipped |
| `pnpm run typecheck` (node + cli + web) | clean |
| `node config/scripts/check-changed-code-quality.mjs` | 0 new findings across 5 changed files |
| `node config/scripts/check-max-lines-ratchet.mjs` | OK, no new bypasses |
| `node config/scripts/check-reliability-gates.mjs` | 75 gates passed |

Every behavior change landed test-first, and each negative guard was mutation-checked — removing the visibility term, the mobile-suppression term, the driver-frame wait, the one-shot flag, or the teardown cleanup each turns its guard red. The claim invariant is proven at the seam in both directions: the transport emits `ClaimViewport` only for an authoritative resize, and the existing server-side arbitration test proves a plain `Resize` lands as `claim=false`.

- [ ] I manually tested these changes locally — not run in the app; verification is the automated suites above
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform:** no platform-dependent code; all changes are renderer transport logic.
- **Remote/SSH:** local and direct-SSH PTYs are deliberately untouched (see Why).
- **Mobile:** the mobile-presence contract is strengthened, not relaxed — a mobile-driven PTY is now protected at attach time, which it was not before.
- **Backwards compatibility:** no wire change. The claim rides the existing `ClaimViewport` opcode on an already-live stream, so mixed client/host versions behave as they do today.
- **Performance:** one extra listener per restored attach, removed on the first driver frame or on teardown.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm typecheck` and the suites above pass locally; `oxlint` ran on the changed files at commit. `pnpm build` was not run locally — CI covers it

