### PR TITLE
Gate WSL transcript fs ops with timeout and capacity limits

### DIFF
--- a/src/main/ai-vault/session-scanner-discovery-wsl-gate.test.ts
+++ b/src/main/ai-vault/session-scanner-discovery-wsl-gate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
+import { walkSessionFiles } from './session-scanner-discovery'
+
+describe('walkSessionFiles WSL gate refusals', () => {
+  it('rethrows gate refusals instead of reporting an empty tree', async () => {
+    const refusal = new WslTranscriptFsError('timeout', 'slow share')
+    await expect(
+      walkSessionFiles('\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions', 'codex', [], {
+        extensions: new Set(['.jsonl']),
+        readDirectory: async () => {
+          throw refusal
+        }
+      })
+    ).rejects.toBe(refusal)
+  })
+
+  it('still treats ordinary readdir failures as an empty tree', async () => {
+    await expect(
+      walkSessionFiles('/missing/root', 'codex', [], {
+        extensions: new Set(['.jsonl']),
+        readDirectory: async () => {
+          throw Object.assign(new Error('no such directory'), { code: 'ENOENT' })
+        }
+      })
+    ).resolves.toEqual([])
+  })
+})

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -2,6 +2,7 @@ import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
 import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
 import { errorMessage } from './session-scanner-values'
 
@@ -64,8 +65,13 @@ export async function walkSessionFiles(
     entries = options.readDirectory
       ? await options.readDirectory(dirPath)
       : await readdir(dirPath, { withFileTypes: true })
-  } catch {
+  } catch (error) {
     options.signal?.throwIfAborted()
+    // Why: a gate refusal means the scan could not run, not that the tree is
+    // empty — swallowing it would misreport a stalled distro as "no transcript".
+    if (error instanceof WslTranscriptFsError) {
+      throw error
+    }
     return []
   }
 

--- a/src/main/ai-vault/session-title-request-paths.ts
+++ b/src/main/ai-vault/session-title-request-paths.ts
@@ -1,5 +1,6 @@
 import type { AiVaultSessionTitleRequest } from '../../shared/ai-vault-session-title'
 import { toHostReadableTranscriptPath } from '../native-chat/host-readable-transcript-path'
+import { wslTranscriptFsRefusal } from '../native-chat/wsl-transcript-fs-gate'
 
 export function resolveHostReadableAiVaultTitleRequests(
   requests: AiVaultSessionTitleRequest[],
@@ -10,7 +11,15 @@ export function resolveHostReadableAiVaultTitleRequests(
       if (!request.transcriptPath || signal?.aborted) {
         return request
       }
-      const transcriptPath = await toHostReadableTranscriptPath(request.transcriptPath)
+      let transcriptPath: string | null
+      try {
+        transcriptPath = await toHostReadableTranscriptPath(request.transcriptPath)
+      } catch (error) {
+        // Why: one stalled distro's path must not fail the whole titles batch;
+        // degrade to the id-only shape like any unreadable path.
+        void wslTranscriptFsRefusal(error) // rethrows anything that is not a gate refusal
+        transcriptPath = null
+      }
       return transcriptPath && !signal?.aborted
         ? { ...request, transcriptPath }
         : { agent: request.agent, sessionId: request.sessionId }

--- a/src/main/native-chat/host-readable-transcript-path-fs-gate.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path-fs-gate.test.ts
@@ -20,6 +20,7 @@ import {
   resetHostReadableTranscriptPathCacheForTests,
   toHostReadableTranscriptPath
 } from './host-readable-transcript-path'
+import { WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS } from './wsl-transcript-fs-gate'
 
 type AccessControl = {
   resolve: () => void
@@ -96,5 +97,28 @@ describe('WSL transcript filesystem gate', () => {
     expect(fsMocks.access).toHaveBeenCalledTimes(1)
     releaseWsl?.()
     await expect(wslProbe).resolves.toBe(firstUncPath)
+  })
+
+  // Last on purpose: the never-settling Ubuntu probe leaves its gate permit
+  // stuck for the rest of this module's lifetime.
+  it('falls through to the next distro when a probe exceeds the gate deadline', async () => {
+    vi.useFakeTimers()
+    const DEBIAN_HOME = '\\\\wsl.localhost\\Debian\\home\\ada'
+    const debianUncPath = '\\\\wsl.localhost\\Debian\\home\\ada\\.codex\\sessions\\first.jsonl'
+    try {
+      fsMocks.access.mockImplementation((path) =>
+        path === firstUncPath ? new Promise<void>(() => {}) : Promise.resolve()
+      )
+      const resolved = toHostReadableTranscriptPath(firstGuestPath, {
+        platform: 'win32',
+        listWslHomeDirs: async () => [UBUNTU_HOME, DEBIAN_HOME]
+      })
+
+      await vi.waitFor(() => expect(fsMocks.access).toHaveBeenCalledWith(firstUncPath))
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS)
+      await expect(resolved).resolves.toBe(debianUncPath)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -7,6 +7,7 @@ import {
   toHostReadableTranscriptPath,
   wslCodexSessionsDirs
 } from './host-readable-transcript-path'
+import { WslTranscriptFsError } from './wsl-transcript-fs-gate'
 
 const UBUNTU_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
 const DEBIAN_HOME = '\\\\wsl.localhost\\Debian\\home\\other'
@@ -107,6 +108,38 @@ describe('toHostReadableTranscriptPath', () => {
         listWslHomeDirs: async () => [UBUNTU_HOME]
       })
     ).resolves.toBeNull()
+  })
+
+  it('prefers a later distro hit over an earlier gate refusal', async () => {
+    // Guest path under Debian's $HOME so the refusing Debian probe ranks first.
+    await expect(
+      toHostReadableTranscriptPath('/home/other/x.jsonl', {
+        platform: 'win32',
+        pathExists: async (candidate) => {
+          if (candidate.includes('Debian')) {
+            throw new WslTranscriptFsError('timeout', 'slow share')
+          }
+          return candidate.includes('Ubuntu')
+        },
+        listWslHomeDirs: async () => [DEBIAN_HOME, UBUNTU_HOME]
+      })
+    ).resolves.toBe('\\\\wsl.localhost\\Ubuntu\\home\\other\\x.jsonl')
+  })
+
+  it('reports unavailability, not a miss, when a refused distro was never probed', async () => {
+    const refusal = new WslTranscriptFsError('timeout', 'slow share')
+    await expect(
+      toHostReadableTranscriptPath('/home/other/x.jsonl', {
+        platform: 'win32',
+        pathExists: async (candidate) => {
+          if (candidate.includes('Debian')) {
+            throw refusal
+          }
+          return false
+        },
+        listWslHomeDirs: async () => [DEBIAN_HOME, UBUNTU_HOME]
+      })
+    ).rejects.toBe(refusal)
   })
 
   it('does not translate guest paths off Windows', async () => {

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -4,7 +4,11 @@ import { isAbsolute } from 'node:path'
 import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
-import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+import {
+  runWslTranscriptFsTask,
+  wslTranscriptFsRefusal,
+  type WslTranscriptFsError
+} from './wsl-transcript-fs-gate'
 
 /**
  * True for guest-absolute Linux paths that Win32 cannot open as-is.
@@ -136,11 +140,21 @@ export async function toHostReadableTranscriptPath(
   const homeDirs = await wslHomeDirs(deps.listWslHomeDirs ?? defaultListWslHomeDirs)
   // Sequential on purpose: the ranked order picks the owning distro, and probing
   // every distro at once would fan out 9P calls to ones the user left stopped.
+  let unavailable: WslTranscriptFsError | undefined
   for (const distro of rankDistrosForGuestPath(homeDirs, path)) {
     const uncPath = toWindowsWslPath(path, distro)
-    if (await pathExists(uncPath)) {
-      return uncPath
+    try {
+      if (await pathExists(uncPath)) {
+        return uncPath
+      }
+    } catch (error) {
+      // Why: one stalled distro must not hide another distro's hit.
+      unavailable = wslTranscriptFsRefusal(error)
     }
+  }
+  // No hit and at least one distro never probed: "couldn't look", not "absent".
+  if (unavailable) {
+    throw unavailable
   }
   return null
 }

--- a/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WslTranscriptFsGateModule from './wsl-transcript-fs-gate'
 
 const WSL_SESSIONS_DIR = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions'
+const DEBIAN_SESSIONS_DIR = '\\\\wsl.localhost\\Debian\\home\\ada\\.codex\\sessions'
 const LOCAL_SESSIONS_DIR = 'C:\\Users\\ada\\.codex\\sessions'
 
 const mocks = vi.hoisted(() => ({
-  gate: vi.fn(async () => []),
+  gate: vi.fn(async (_options: { path: string }) => []),
   walk: vi.fn(
     async (
       dir: string,
@@ -18,7 +20,8 @@ const mocks = vi.hoisted(() => ({
   )
 }))
 
-vi.mock('./wsl-transcript-fs-gate', () => ({
+vi.mock('./wsl-transcript-fs-gate', async (importOriginal) => ({
+  ...(await importOriginal<typeof WslTranscriptFsGateModule>()),
   runWslTranscriptFsTask: mocks.gate
 }))
 vi.mock('../ai-vault/session-scanner-discovery', () => ({
@@ -26,6 +29,7 @@ vi.mock('../ai-vault/session-scanner-discovery', () => ({
 }))
 
 import { resolveSessionFilePath } from './session-file-resolver'
+import { WslTranscriptFsError } from './wsl-transcript-fs-gate'
 
 beforeEach(() => {
   mocks.gate.mockClear()
@@ -52,5 +56,78 @@ describe('Codex WSL scan gate', () => {
 
     expect(mocks.gate).not.toHaveBeenCalled()
     expect(mocks.walk).toHaveBeenCalledTimes(1)
+  })
+
+  it("still surfaces a later root's hit when an earlier root is gate-refused", async () => {
+    const hit = `${DEBIAN_SESSIONS_DIR}\\2026\\rollout-1-session-id.jsonl`
+    mocks.gate.mockImplementation(async (options) => {
+      if (options.path.includes('Ubuntu')) {
+        throw new WslTranscriptFsError('timeout', 'slow share')
+      }
+      return []
+    })
+    mocks.walk.mockImplementation(async (dir, _agent, _issues, options) => {
+      await options.readDirectory?.(dir)
+      return dir === DEBIAN_SESSIONS_DIR ? [hit] : []
+    })
+
+    await expect(
+      resolveSessionFilePath('codex', 'session-id', {
+        codexSessionsDirs: [WSL_SESSIONS_DIR, DEBIAN_SESSIONS_DIR]
+      })
+    ).resolves.toBe(hit)
+  })
+
+  it('reports unavailability, not a miss, when every scanned root is gate-refused', async () => {
+    const refusal = new WslTranscriptFsError('unavailable', 'stuck permits')
+    mocks.gate.mockRejectedValue(refusal)
+
+    await expect(
+      resolveSessionFilePath('codex', 'session-id', {
+        codexSessionsDirs: [WSL_SESSIONS_DIR]
+      })
+    ).rejects.toBe(refusal)
+  })
+
+  it('falls through a gate-refused hook path to an id-based hit', async () => {
+    const hit = `${DEBIAN_SESSIONS_DIR}\\2026\\rollout-1-session-id.jsonl`
+    mocks.gate.mockImplementation(async (options: { operation?: string; path: string }) => {
+      if (options.operation === 'access') {
+        throw new WslTranscriptFsError('timeout', 'slow share')
+      }
+      return []
+    })
+    mocks.walk.mockImplementation(async (dir, _agent, _issues, options) => {
+      await options.readDirectory?.(dir)
+      return dir === DEBIAN_SESSIONS_DIR ? [hit] : []
+    })
+
+    await expect(
+      resolveSessionFilePath('codex', 'session-id', {
+        transcriptPath: `${WSL_SESSIONS_DIR}\\2026\\rollout-1-session-id.jsonl`,
+        codexSessionsDirs: [DEBIAN_SESSIONS_DIR]
+      })
+    ).resolves.toBe(hit)
+  })
+
+  it('surfaces the hook-path refusal when the id search also misses', async () => {
+    const refusal = new WslTranscriptFsError('unavailable', 'stuck permits')
+    mocks.gate.mockImplementation(async (options: { operation?: string; path: string }) => {
+      if (options.operation === 'access') {
+        throw refusal
+      }
+      return []
+    })
+    mocks.walk.mockImplementation(async (dir, _agent, _issues, options) => {
+      await options.readDirectory?.(dir)
+      return []
+    })
+
+    await expect(
+      resolveSessionFilePath('codex', 'session-id', {
+        transcriptPath: `${WSL_SESSIONS_DIR}\\2026\\rollout-1-session-id.jsonl`,
+        codexSessionsDirs: [LOCAL_SESSIONS_DIR]
+      })
+    ).rejects.toBe(refusal)
   })
 })

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -1,7 +1,10 @@
 import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import type { AgentType } from '../../shared/native-chat-types'
-import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
+import {
+  resolveNativeChatTranscriptAgent,
+  type NativeChatTranscriptAgent
+} from '../../shared/native-chat-agent-support'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from '../ai-vault/session-scanner-omp-subagent-transcripts'
@@ -13,6 +16,7 @@ import {
 } from '../../shared/grok-session-paths'
 import { toHostReadableTranscriptPath, wslCodexSessionsDirs } from './host-readable-transcript-path'
 import { findWslCodexSessionPath } from './wsl-codex-session-path-scan'
+import { wslTranscriptFsRefusal, type WslTranscriptFsError } from './wsl-transcript-fs-gate'
 
 // Why: these mirror the path constants in ai-vault/session-scanner.ts. Reads
 // run in the main process against the runtime's own home directory; over SSH
@@ -95,14 +99,34 @@ export async function resolveSessionFilePath(
   // beats reconstructing a path from the session id. Route it through the host
   // readability check so a WSL guest path becomes an openable UNC on Windows;
   // stale/missing paths fall through to the id-based search.
+  let unavailable: WslTranscriptFsError | undefined
   const hookPath = options.transcriptPath?.trim()
   if (hookPath && extname(hookPath) === '.jsonl') {
-    const hostReadable = await toHostReadableTranscriptPath(hookPath, { signal })
-    if (hostReadable) {
-      return hostReadable
+    try {
+      const hostReadable = await toHostReadableTranscriptPath(hookPath, { signal })
+      if (hostReadable) {
+        return hostReadable
+      }
+    } catch (error) {
+      // Why: the id-based search may still hit; surface the refusal only when
+      // it does not, so a stalled distro reads as unavailable, never "missing".
+      unavailable = wslTranscriptFsRefusal(error)
     }
   }
 
+  const resolved = await resolveSessionFileById(transcriptAgent, sessionId, options, signal)
+  if (!resolved && unavailable) {
+    throw unavailable
+  }
+  return resolved
+}
+
+async function resolveSessionFileById(
+  transcriptAgent: NativeChatTranscriptAgent,
+  sessionId: string,
+  options: ResolveSessionFileOptions,
+  signal?: AbortSignal
+): Promise<string | null> {
   const trimmedId = sessionId.trim()
   if (!trimmedId) {
     return null
@@ -129,10 +153,7 @@ export async function resolveSessionFilePath(
   if (transcriptAgent === 'grok') {
     return resolveGrokSessionFile(trimmedId, options.grokSessionsDir ?? grokSessionsDir(), signal)
   }
-  if (transcriptAgent === 'omp') {
-    return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir(), signal)
-  }
-  return null
+  return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir(), signal)
 }
 
 async function resolveClaudeSessionFile(
@@ -178,6 +199,7 @@ async function findCodexRolloutInDirs(
   sessionsDirs: string[],
   signal?: AbortSignal
 ): Promise<string | null> {
+  let unavailable: WslTranscriptFsError | undefined
   for (const sessionsDir of sessionsDirs) {
     // Why: no existence pre-check — walkSessionFiles already yields [] for a
     // missing/unreadable root, and a sync probe would block the main thread on a
@@ -190,17 +212,26 @@ async function findCodexRolloutInDirs(
       }
     }
     const isWslRoot = isWslUncPath(sessionsDir)
-    const files = isWslRoot
-      ? await findWslCodexSessionPath(sessionsDir, sessionId, signal)
-      : (
-          await walkSessionFiles(sessionsDir, 'codex', [], {
-            ...scanOptions,
-            signal
-          })
-        )[0]
-    if (files) {
-      return files
+    try {
+      const files = isWslRoot
+        ? await findWslCodexSessionPath(sessionsDir, sessionId, signal)
+        : (
+            await walkSessionFiles(sessionsDir, 'codex', [], {
+              ...scanOptions,
+              signal
+            })
+          )[0]
+      if (files) {
+        return files
+      }
+    } catch (error) {
+      // Why: one stalled distro must not hide another root's hit.
+      unavailable = wslTranscriptFsRefusal(error)
     }
+  }
+  // No hit and at least one root never scanned: "couldn't look", not "missing".
+  if (unavailable) {
+    throw unavailable
   }
   return null
 }

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -153,7 +153,14 @@ async function resolveSessionFileById(
   if (transcriptAgent === 'grok') {
     return resolveGrokSessionFile(trimmedId, options.grokSessionsDir ?? grokSessionsDir(), signal)
   }
-  return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir(), signal)
+  if (transcriptAgent === 'omp') {
+    return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir(), signal)
+  }
+  // Why: a new transcript agent must pick its own resolver. Falling through to
+  // OMP's scan would search the wrong root with a foreign session id, so fail
+  // the build here instead of resolving silently wrong at runtime.
+  transcriptAgent satisfies never
+  return null
 }
 
 async function resolveClaudeSessionFile(

--- a/src/main/native-chat/transcript-read-cache.ts
+++ b/src/main/native-chat/transcript-read-cache.ts
@@ -2,6 +2,7 @@ import { stat } from 'node:fs/promises'
 import type { AgentType } from '../../shared/native-chat-types'
 import { resolveSessionFilePath } from './session-file-resolver'
 import { readNativeChatTranscript, type ReadTranscriptResult } from './transcript-reader'
+import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
 
 // Why: both the desktop IPC handler and the runtime RPC handler read the same
 // host-filesystem transcript, so a single process-global cache keyed by the
@@ -89,7 +90,14 @@ export async function readNativeChatTranscriptCached(
   /** Hook-reported authoritative transcript path, preferred over the id glob. */
   transcriptPath?: string
 ): Promise<ReadTranscriptResult> {
-  const filePath = await resolveSessionFilePath(agent, sessionId, { transcriptPath })
+  let filePath: string | null
+  try {
+    filePath = await resolveSessionFilePath(agent, sessionId, { transcriptPath })
+  } catch (err) {
+    // Why: gate refusal is transient unavailability — report it without caching
+    // or `notFound` so the next call re-resolves.
+    return { error: wslTranscriptFsRefusal(err).message }
+  }
   if (!filePath) {
     // Not cached (see below): a not-yet-flushed transcript should be re-checked
     // on the next call, not pinned as a settled miss (#8401).

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -7,6 +7,7 @@ import type {
 import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
 import { errorMessage } from '../ai-vault/session-scanner-values'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
+import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
@@ -41,7 +42,14 @@ export async function readNativeChatTranscript(
   sessionId: string,
   options: ReadTranscriptOptions = {}
 ): Promise<ReadTranscriptResult> {
-  const filePath = options.filePath ?? (await resolveSessionFilePath(agent, sessionId, options))
+  let filePath: string | null
+  try {
+    filePath = options.filePath ?? (await resolveSessionFilePath(agent, sessionId, options))
+  } catch (err) {
+    // Why: gate refusal is transient unavailability with retry guidance —
+    // `notFound` would settle callers into a false "missing" state.
+    return { error: wslTranscriptFsRefusal(err).message }
+  }
   if (!filePath) {
     return { error: `No transcript found for ${agent} session ${sessionId}`, notFound: true }
   }

--- a/src/main/native-chat/transcript-tail-reader-wsl-gate.test.ts
+++ b/src/main/native-chat/transcript-tail-reader-wsl-gate.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  resolve: vi.fn<() => Promise<string | null>>()
+}))
+
+vi.mock('./session-file-resolver', () => ({
+  resolveSessionFilePath: mocks.resolve
+}))
+
+import { readNativeChatTranscriptTail } from './transcript-tail-reader'
+import { WslTranscriptFsError } from './wsl-transcript-fs-gate'
+
+describe('native chat transcript tail under WSL gate refusals', () => {
+  beforeEach(() => {
+    mocks.resolve.mockReset()
+  })
+
+  it('reports a gate refusal as a retryable error, not a missing transcript', async () => {
+    mocks.resolve.mockRejectedValueOnce(new WslTranscriptFsError('timeout', 'slow share'))
+
+    await expect(
+      readNativeChatTranscriptTail({ agent: 'codex', sessionId: 'session-id', limit: 10 })
+    ).resolves.toEqual({ error: 'slow share' })
+  })
+
+  it('rethrows non-gate resolver failures', async () => {
+    mocks.resolve.mockRejectedValueOnce(new Error('resolver crashed'))
+
+    await expect(
+      readNativeChatTranscriptTail({ agent: 'codex', sessionId: 'session-id', limit: 10 })
+    ).rejects.toThrow('resolver crashed')
+  })
+})

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -17,6 +17,7 @@ import {
   nativeChatTurnLifecycleDecoderForAgent,
   type NativeChatTurnLifecycleDecoder
 } from './transcript-turn-lifecycle'
+import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
 
 export const MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES = 2 * 1024 * 1024
 const TAIL_CHUNK_BYTES = 64 * 1024
@@ -231,12 +232,20 @@ export async function readNativeChatTranscriptTail(
 > {
   const decode = nativeChatLineDecoderForAgent(args.agent)
   const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
-  const filePath =
-    args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args, signal))
-  signal?.throwIfAborted()
   if (!decode) {
     return { error: 'Transcript unavailable' }
   }
+  let filePath: string | null
+  try {
+    filePath =
+      args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args, signal))
+  } catch (error) {
+    signal?.throwIfAborted()
+    // Why: gate refusal is transient unavailability with retry guidance —
+    // `notFound` would settle callers into a false "missing" state.
+    return { error: wslTranscriptFsRefusal(error).message }
+  }
+  signal?.throwIfAborted()
   // Why: a new agent session can report its id before the first JSONL flush;
   // callers keep that miss in loading/retry rather than showing a false error.
   if (!filePath) {

--- a/src/main/native-chat/transcript-watch-resolve-poll.test.ts
+++ b/src/main/native-chat/transcript-watch-resolve-poll.test.ts
@@ -20,6 +20,7 @@ vi.mock('./host-readable-transcript-path', async (importOriginal) => ({
 }))
 
 import { subscribeNativeChatTranscript } from './transcript-watch'
+import { WslTranscriptFsError } from './wsl-transcript-fs-gate'
 
 const realPlatform = process.platform
 
@@ -123,6 +124,41 @@ describe('native chat transcript resolve polling', () => {
     await vi.advanceTimersByTimeAsync(35)
     expect(mocks.resolve.mock.calls.length).toBeGreaterThan(1)
     subscription.unsubscribe()
+  })
+
+  it('degrades a gate-refused initial resolve to the poll fallback instead of failing', async () => {
+    const engine = { unsubscribe: vi.fn(), watching: true }
+    mocks.resolve
+      .mockRejectedValueOnce(new WslTranscriptFsError('unavailable', 'stuck permits'))
+      .mockResolvedValue('/home/ada/found.jsonl')
+    mocks.install.mockImplementation((filePath: string) => (filePath ? engine : null))
+
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session-id',
+      resolvePollIntervalMs: 10,
+      onAppend: () => {}
+    })
+    expect(subscription.watching).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(20)
+    expect(
+      mocks.install.mock.calls.some(([filePath]) => filePath === '/home/ada/found.jsonl')
+    ).toBe(true)
+    subscription.unsubscribe()
+    expect(engine.unsubscribe).toHaveBeenCalled()
+  })
+
+  it('still fails subscribe on non-gate resolver errors', async () => {
+    mocks.resolve.mockRejectedValueOnce(new Error('resolver crashed'))
+
+    await expect(
+      subscribeNativeChatTranscript({
+        agent: 'claude',
+        sessionId: 'session-id',
+        onAppend: () => {}
+      })
+    ).rejects.toThrow('resolver crashed')
   })
 
   it('cancels queued WSL resolution when the subscription closes', async () => {

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -11,6 +11,7 @@ import type {
   SubscribeNativeChatTranscriptArgs
 } from './transcript-watch-contract'
 import { nativeChatLineDecoderForAgent } from './transcript-tail-reader'
+import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
 
 export { readNativeChatTranscriptTail } from './transcript-tail-reader'
 export { getActiveNativeChatWatcherCount } from './transcript-watch-engine'
@@ -207,7 +208,16 @@ export async function subscribeNativeChatTranscript(
     return { unsubscribe: () => {}, watching: false }
   }
 
-  const installed = await attemptInstall(args, decode, setupSignal)
+  let installed: NativeChatTranscriptSubscription | null
+  try {
+    installed = await attemptInstall(args, decode, setupSignal)
+  } catch (error) {
+    setupSignal?.throwIfAborted()
+    // Why: a gate-refused resolve (stalled WSL distro) must degrade to the
+    // resolve-poll fallback below, not fail the subscribe outright.
+    void wslTranscriptFsRefusal(error) // rethrows anything that is not a gate refusal
+    installed = null
+  }
   if (installed) {
     return installed
   }

--- a/src/main/native-chat/wsl-transcript-fs-gate.test.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it, vi } from 'vitest'
-import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
+import {
+  runWslTranscriptFsTask,
+  WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS,
+  WSL_TRANSCRIPT_FS_MAX_PENDING_TASKS,
+  WSL_TRANSCRIPT_FS_MAX_WAITERS_PER_TASK,
+  WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS,
+  WslTranscriptFsError
+} from './wsl-transcript-fs-gate'
+
+const SLOW_MESSAGE =
+  'WSL transcript files are temporarily unavailable because filesystem access is taking too long. Try again shortly or restart Orca if the issue continues.'
+const CAPACITY_MESSAGE =
+  'WSL transcript discovery is temporarily unavailable because too many filesystem requests are already waiting. Try again shortly or restart Orca if the issue continues.'
 
 function deferred<T>(): {
   promise: Promise<T>
@@ -28,6 +40,16 @@ function run(
 }
 
 describe('WSL transcript filesystem task scheduling', () => {
+  let warnSpy: MockInstance
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
   it('does not block an exact probe behind a running scan on the same route', async () => {
     const stalled = deferred<string>()
     const scanTask = vi.fn(() => stalled.promise)
@@ -97,8 +119,9 @@ describe('WSL transcript filesystem task scheduling', () => {
     const abandonedTask = vi.fn(async () => 'unused')
     const abandoned = run('\\\\wsl.localhost\\Fedora\\a', 'scan', abandonedTask, controller.signal)
 
-    controller.abort(new Error('closed subscription'))
-    await expect(abandoned).rejects.toThrow('closed subscription')
+    const reason = new Error('closed subscription')
+    controller.abort(reason)
+    await expect(abandoned).rejects.toBe(reason)
     ubuntu.resolve('ubuntu')
     debian.resolve('debian')
     await Promise.all([first, second])
@@ -125,8 +148,9 @@ describe('WSL transcript filesystem task scheduling', () => {
     const second = run('\\\\wsl.localhost\\Ubuntu\\shared', 'exact', task, secondController.signal)
     await vi.waitFor(() => expect(task).toHaveBeenCalledOnce())
 
-    firstController.abort(new Error('first closed'))
-    await expect(first).rejects.toThrow('first closed')
+    const reason = new Error('first closed')
+    firstController.abort(reason)
+    await expect(first).rejects.toBe(reason)
     pending.resolve('second')
     await expect(second).resolves.toBe('second')
     expect(task).toHaveBeenCalledOnce()
@@ -174,5 +198,437 @@ describe('WSL transcript filesystem task scheduling', () => {
     const tasks = paths.map((path, index) => run(path, 'exact', async () => String(index)))
 
     await expect(Promise.all(tasks)).resolves.toEqual(['0', '1', '2', '3'])
+  })
+
+  it.each([
+    ['exact', WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS],
+    ['scan', WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS]
+  ] as const)('rejects a stalled %s waiter at its deadline', async (priority, deadlineMs) => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    try {
+      const task = vi.fn(() => stalled.promise)
+      const pending = run(`\\\\wsl.localhost\\Deadline-${priority}\\a`, priority, task)
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: 'WslTranscriptFsError',
+        code: 'timeout',
+        message: SLOW_MESSAGE
+      })
+      let settled = false
+      void pending.then(
+        () => (settled = true),
+        () => (settled = true)
+      )
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(task).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(deadlineMs - 1)
+      expect(settled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      await rejected
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it.each([
+    ['exact', WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS],
+    ['scan', WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS]
+  ] as const)('completes healthy %s work below its deadline', async (priority, deadlineMs) => {
+    vi.useFakeTimers()
+    const work = deferred<string>()
+    try {
+      const pending = run(`\\\\wsl.localhost\\Healthy-${priority}\\a`, priority, () => work.promise)
+
+      await vi.advanceTimersByTimeAsync(deadlineMs - 1)
+      work.resolve('healthy')
+      await expect(pending).resolves.toBe('healthy')
+      expect(vi.getTimerCount()).toBe(0)
+      await vi.advanceTimersByTimeAsync(deadlineMs)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      work.resolve('healthy')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let one timed-out waiter settle a later shared waiter', async () => {
+    vi.useFakeTimers()
+    const work = deferred<string>()
+    const task = vi.fn(() => work.promise)
+    try {
+      const path = '\\\\wsl.localhost\\Ubuntu\\staggered'
+      const first = run(path, 'exact', task)
+      const firstRejected = expect(first).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(10_000)
+      const second = run(path, 'exact', task)
+
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS - 10_000)
+      await firstRejected
+      work.resolve('shared')
+      await expect(second).resolves.toBe('shared')
+      expect(task).toHaveBeenCalledOnce()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      work.resolve('shared')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects newest work when the pending queue is full', async () => {
+    vi.useFakeTimers()
+    const ubuntu = deferred<string>()
+    const debian = deferred<string>()
+    const queuedController = new AbortController()
+    try {
+      const ubuntuTask = vi.fn(() => ubuntu.promise)
+      const debianTask = vi.fn(() => debian.promise)
+      const first = run('\\\\wsl.localhost\\Ubuntu\\occupied', 'exact', ubuntuTask)
+      const second = run('\\\\wsl.localhost\\Debian\\occupied', 'exact', debianTask)
+      await vi.advanceTimersByTimeAsync(0)
+
+      const queued = Array.from({ length: WSL_TRANSCRIPT_FS_MAX_PENDING_TASKS }, (_, index) =>
+        run(
+          `\\\\wsl.localhost\\Queued-${index}\\a`,
+          'exact',
+          async () => String(index),
+          index === 0 ? queuedController.signal : undefined
+        )
+      )
+      const overflowTask = vi.fn(async () => 'overflow')
+      await expect(
+        run('\\\\wsl.localhost\\Overflow\\a', 'exact', overflowTask)
+      ).rejects.toMatchObject({ code: 'capacity', message: CAPACITY_MESSAGE })
+      expect(overflowTask).not.toHaveBeenCalled()
+
+      const reason = new Error('queued caller closed')
+      queuedController.abort(reason)
+      await expect(queued[0]).rejects.toBe(reason)
+      const replacement = run('\\\\wsl.localhost\\Replacement\\a', 'exact', async () => 'new')
+
+      ubuntu.resolve('ubuntu')
+      debian.resolve('debian')
+      await expect(
+        Promise.all([first, second, ...queued.slice(1), replacement])
+      ).resolves.toHaveLength(WSL_TRANSCRIPT_FS_MAX_PENDING_TASKS + 2)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      ubuntu.resolve('ubuntu')
+      debian.resolve('debian')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps callers waiting on shared work', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    const task = vi.fn(() => stalled.promise)
+    const firstController = new AbortController()
+    try {
+      const path = '\\\\wsl.localhost\\Ubuntu\\shared-cap'
+      const waiters = Array.from({ length: WSL_TRANSCRIPT_FS_MAX_WAITERS_PER_TASK }, (_, index) =>
+        run(path, 'exact', task, index === 0 ? firstController.signal : undefined)
+      )
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(run(path, 'exact', task)).rejects.toMatchObject({
+        code: 'capacity',
+        message: CAPACITY_MESSAGE
+      })
+      const reason = new Error('first waiter closed')
+      firstController.abort(reason)
+      await expect(waiters[0]).rejects.toBe(reason)
+      const replacement = run(path, 'exact', task)
+      stalled.resolve('shared')
+      await expect(Promise.all([...waiters.slice(1), replacement])).resolves.toEqual(
+        Array(WSL_TRANSCRIPT_FS_MAX_WAITERS_PER_TASK).fill('shared')
+      )
+      expect(task).toHaveBeenCalledOnce()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      stalled.resolve('shared')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails new work fast after both running permits stall', async () => {
+    vi.useFakeTimers()
+    const ubuntu = deferred<string>()
+    const debian = deferred<string>()
+    try {
+      const first = run('\\\\wsl.localhost\\Ubuntu\\stalled', 'exact', () => ubuntu.promise)
+      const second = run('\\\\wsl.localhost\\Debian\\stalled', 'exact', () => debian.promise)
+      const firstRejected = expect(first).rejects.toBeInstanceOf(WslTranscriptFsError)
+      const secondRejected = expect(second).rejects.toBeInstanceOf(WslTranscriptFsError)
+
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS)
+      await Promise.all([firstRejected, secondRejected])
+      const laterTask = vi.fn(async () => 'later')
+      await expect(
+        run('\\\\wsl.localhost\\Fedora\\later', 'exact', laterTask)
+      ).rejects.toMatchObject({ code: 'unavailable', message: SLOW_MESSAGE })
+      expect(laterTask).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      ubuntu.resolve('ubuntu')
+      debian.resolve('debian')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails only work needing a stuck lane fast, keeping the other permit usable', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    try {
+      const stuck = run('\\\\wsl.localhost\\Ubuntu\\lane-stuck', 'exact', () => stalled.promise)
+      const stuckRejected = expect(stuck).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS)
+      await stuckRejected
+
+      const sameLaneTask = vi.fn(async () => 'same-lane')
+      await expect(
+        run('\\\\wsl.localhost\\Ubuntu\\lane-stuck-sibling', 'exact', sameLaneTask)
+      ).rejects.toMatchObject({ code: 'unavailable', message: SLOW_MESSAGE })
+      expect(sameLaneTask).not.toHaveBeenCalled()
+      await expect(
+        run('\\\\wsl.localhost\\Debian\\healthy-lane', 'exact', async () => 'debian')
+      ).resolves.toBe('debian')
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails scans and same-route probes fast while a scan is stuck', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    try {
+      const stuckScan = run('\\\\wsl.localhost\\Ubuntu\\stuck-tree', 'scan', () => stalled.promise)
+      const stuckRejected = expect(stuckScan).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS)
+      await stuckRejected
+
+      const otherScanTask = vi.fn(async () => 'other-scan')
+      await expect(
+        run('\\\\wsl.localhost\\Debian\\other-tree', 'scan', otherScanTask)
+      ).rejects.toMatchObject({ code: 'unavailable' })
+      expect(otherScanTask).not.toHaveBeenCalled()
+      // The whole Ubuntu mount is hung — an exact probe there would only burn
+      // the remaining permit on it.
+      await expect(
+        run('\\\\wsl.localhost\\Ubuntu\\live-probe', 'exact', async () => 'exact')
+      ).rejects.toMatchObject({ code: 'unavailable' })
+      await expect(
+        run('\\\\wsl.localhost\\Debian\\live-probe', 'exact', async () => 'exact')
+      ).resolves.toBe('exact')
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a stuck exact probe from feeding a doomed scan the second permit', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    try {
+      const stuck = run('\\\\wsl.localhost\\Ubuntu\\hung-file', 'exact', () => stalled.promise)
+      const stuckRejected = expect(stuck).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS)
+      await stuckRejected
+
+      const doomedScanTask = vi.fn(async () => 'doomed')
+      await expect(
+        run('\\\\wsl.localhost\\Ubuntu\\tree', 'scan', doomedScanTask)
+      ).rejects.toMatchObject({ code: 'unavailable' })
+      expect(doomedScanTask).not.toHaveBeenCalled()
+      await expect(
+        run('\\\\wsl.localhost\\Debian\\tree', 'scan', async () => 'debian-scan')
+      ).resolves.toBe('debian-scan')
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('admits new work again once stuck work finally settles', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    try {
+      const stuck = run('\\\\wsl.localhost\\Ubuntu\\recovering', 'exact', () => stalled.promise)
+      const stuckRejected = expect(stuck).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS)
+      await stuckRejected
+      await expect(
+        run('\\\\wsl.localhost\\Ubuntu\\recovering-next', 'exact', async () => 'blocked')
+      ).rejects.toMatchObject({ code: 'unavailable' })
+
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(
+        run('\\\\wsl.localhost\\Ubuntu\\recovering-next', 'exact', async () => 'recovered')
+      ).resolves.toBe('recovered')
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('refuses to join in-flight work already past its own deadline', async () => {
+    vi.useFakeTimers()
+    const work = deferred<string>()
+    const task = vi.fn(() => work.promise)
+    try {
+      const path = '\\\\wsl.localhost\\Ubuntu\\join-stuck'
+      const first = run(path, 'exact', task)
+      const firstRejected = expect(first).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(10_000)
+      const second = run(path, 'exact', task)
+      const secondRejected = expect(second).rejects.toMatchObject({ code: 'timeout' })
+
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS - 10_000)
+      await firstRejected
+      const joinTask = vi.fn(async () => 'join')
+      await expect(run(path, 'exact', joinTask)).rejects.toMatchObject({ code: 'unavailable' })
+      expect(joinTask).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(10_000)
+      await secondRejected
+    } finally {
+      work.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails joins onto queued work fast when stuck I/O keeps it from running', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    const queuedTask = vi.fn(async () => 'queued')
+    try {
+      const stuck = run('\\\\wsl.localhost\\Ubuntu\\trap-hung', 'exact', () => stalled.promise)
+      const stuckRejected = expect(stuck).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(5_000)
+      // Queued behind the same route before the hang is detected.
+      const queuedPath = '\\\\wsl.localhost\\Ubuntu\\trap-queued'
+      const queued = run(queuedPath, 'exact', queuedTask)
+      const queuedRejected = expect(queued).rejects.toMatchObject({ code: 'timeout' })
+
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS - 5_000)
+      await stuckRejected
+      // Re-requests must not keep the doomed queued task alive with fresh
+      // deadlines — that would defeat the fail-fast for as long as I/O hangs.
+      await expect(run(queuedPath, 'exact', queuedTask)).rejects.toMatchObject({
+        code: 'unavailable'
+      })
+      await vi.advanceTimersByTimeAsync(5_000)
+      await queuedRejected
+      expect(queuedTask).not.toHaveBeenCalled()
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not feed a stuck route the other permit from the queue', async () => {
+    vi.useFakeTimers()
+    const scanWork = deferred<string>()
+    const debianWork = deferred<string>()
+    const ubuntuTask = vi.fn(async () => 'ubuntu')
+    try {
+      const scanU = run(
+        '\\\\wsl.localhost\\Ubuntu\\queued-route-tree',
+        'scan',
+        () => scanWork.promise
+      )
+      const exactD = run(
+        '\\\\wsl.localhost\\Debian\\queued-route-d',
+        'exact',
+        () => debianWork.promise
+      )
+      const scanRejected = expect(scanU).rejects.toMatchObject({ code: 'timeout' })
+      const exactDRejected = expect(exactD).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(35_000)
+      await exactDRejected
+
+      // Queued before Ubuntu's hang is detected at the 60s scan deadline.
+      const queuedU = run('\\\\wsl.localhost\\Ubuntu\\queued-route-file', 'exact', ubuntuTask)
+      const queuedURejected = expect(queuedU).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(25_000)
+      await scanRejected
+
+      debianWork.resolve('debian')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(ubuntuTask).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(5_000)
+      await queuedURejected
+      expect(ubuntuTask).not.toHaveBeenCalled()
+    } finally {
+      scanWork.resolve('late')
+      debianWork.resolve('debian')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('warns once per task that outlives its deadline while running', async () => {
+    vi.useFakeTimers()
+    const stalled = deferred<string>()
+    try {
+      const stuck = run('\\\\wsl.localhost\\Ubuntu\\logged', 'exact', () => stalled.promise)
+      const stuckRejected = expect(stuck).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS * 3)
+      await stuckRejected
+      expect(warnSpy).toHaveBeenCalledOnce()
+      expect(warnSpy.mock.calls[0][0]).toContain('exact')
+      expect(warnSpy.mock.calls[0][0]).toContain('logged')
+    } finally {
+      stalled.resolve('late')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not mark a scan permit stuck before the scan deadline', async () => {
+    vi.useFakeTimers()
+    const exactWork = deferred<string>()
+    const scanWork = deferred<string>()
+    try {
+      const exact = run(
+        '\\\\wsl.localhost\\Ubuntu\\stalled-exact',
+        'exact',
+        () => exactWork.promise
+      )
+      const scanTask = vi.fn(() => scanWork.promise)
+      const scanPath = '\\\\wsl.localhost\\Debian\\healthy-scan'
+      const scan = run(scanPath, 'scan', scanTask)
+      const exactRejected = expect(exact).rejects.toMatchObject({ code: 'timeout' })
+
+      await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS)
+      await exactRejected
+      const duplicateTask = vi.fn(async () => 'duplicate')
+      const duplicate = run(scanPath, 'scan', duplicateTask)
+
+      scanWork.resolve('scan')
+      await expect(Promise.all([scan, duplicate])).resolves.toEqual(['scan', 'scan'])
+      expect(scanTask).toHaveBeenCalledOnce()
+      expect(duplicateTask).not.toHaveBeenCalled()
+    } finally {
+      exactWork.resolve('late')
+      scanWork.resolve('scan')
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/native-chat/wsl-transcript-fs-gate.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.ts
@@ -1,6 +1,35 @@
 import { parseWslUncPath } from '../../shared/wsl-paths'
 
 const MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS = 2
+export const WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS = 30_000
+export const WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS = 60_000
+// Burst bounds keep polling fan-out from growing retained tasks or callers indefinitely.
+export const WSL_TRANSCRIPT_FS_MAX_PENDING_TASKS = 64
+export const WSL_TRANSCRIPT_FS_MAX_WAITERS_PER_TASK = 64
+const WSL_TRANSCRIPT_FS_SLOW_MESSAGE =
+  'WSL transcript files are temporarily unavailable because filesystem access is taking too long. Try again shortly or restart Orca if the issue continues.'
+const WSL_TRANSCRIPT_FS_CAPACITY_MESSAGE =
+  'WSL transcript discovery is temporarily unavailable because too many filesystem requests are already waiting. Try again shortly or restart Orca if the issue continues.'
+
+export type WslTranscriptFsFailureCode = 'timeout' | 'capacity' | 'unavailable'
+
+export class WslTranscriptFsError extends Error {
+  constructor(
+    readonly code: WslTranscriptFsFailureCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'WslTranscriptFsError'
+  }
+}
+
+/** Narrow a caught error to a gate refusal, rethrowing anything else. */
+export function wslTranscriptFsRefusal(error: unknown): WslTranscriptFsError {
+  if (error instanceof WslTranscriptFsError) {
+    return error
+  }
+  throw error
+}
 
 export type WslTranscriptFsTaskPriority = 'exact' | 'scan'
 
@@ -9,30 +38,39 @@ type TaskWaiter<T> = {
   reject: (error: unknown) => void
   signal?: AbortSignal
   onAbort?: () => void
+  timeout?: ReturnType<typeof setTimeout>
 }
 
 type ScheduledTask<T> = {
   key: string
   laneKey: string
+  route: string
   priority: WslTranscriptFsTaskPriority
   operation: (signal: AbortSignal) => Promise<T>
   controller: AbortController
   waiters: Set<TaskWaiter<T>>
   state: 'queued' | 'running' | 'settled'
+  // Set by the deadline timer, sharing the waiters' monotonic clock — wall time
+  // would misjudge stuckness across laptop sleep or NTP steps.
+  stuck: boolean
+  stuckTimer?: ReturnType<typeof setTimeout>
 }
 
 type UnknownScheduledTask = ScheduledTask<unknown>
 
-let activeTaskCount = 0
 let activeScanCount = 0
 const activeLaneKeys = new Set<string>()
 const queuedTasks: UnknownScheduledTask[] = []
 const inFlightTasks = new Map<string, UnknownScheduledTask>()
+const activeTasks = new Set<UnknownScheduledTask>()
 
 function abortReason(signal: AbortSignal): unknown {
   return signal.reason ?? new Error('WSL transcript filesystem task aborted')
 }
 
+// wsl$ and wsl.localhost spellings of one distro stay distinct routes on
+// purpose (provider spelling can change behavior), so a stuck spelling never
+// fast-fails its twin — the twin is bounded by its own waiter deadlines.
 function routeKey(path: string): string {
   const normalized = path.replace(/\\/g, '/')
   const match = normalized.match(/^\/\/(wsl\.localhost|wsl\$)\/([^/]+)/i)
@@ -55,11 +93,11 @@ function clearTask(task: UnknownScheduledTask): void {
   }
 }
 
-function abandonTaskIfUnused(task: UnknownScheduledTask): void {
+function abandonTaskIfUnused(task: UnknownScheduledTask, reason?: unknown): void {
   if (task.waiters.size > 0 || task.state === 'settled') {
     return
   }
-  task.controller.abort()
+  task.controller.abort(reason)
   // Running I/O keeps its permit; new callers need a reusable controller.
   clearTask(task)
   if (task.state === 'queued') {
@@ -69,24 +107,91 @@ function abandonTaskIfUnused(task: UnknownScheduledTask): void {
   }
 }
 
-function attachWaiter<T>(task: ScheduledTask<T>, signal?: AbortSignal): Promise<T> {
-  if (signal?.aborted) {
-    abandonTaskIfUnused(task as UnknownScheduledTask)
-    return Promise.reject(abortReason(signal))
+function removeWaiter<T>(task: ScheduledTask<T>, waiter: TaskWaiter<T>): boolean {
+  if (!task.waiters.delete(waiter)) {
+    return false
+  }
+  if (waiter.signal && waiter.onAbort) {
+    waiter.signal.removeEventListener('abort', waiter.onAbort)
+  }
+  if (waiter.timeout) {
+    clearTimeout(waiter.timeout)
+  }
+  return true
+}
+
+function timeoutMs(priority: WslTranscriptFsTaskPriority): number {
+  return priority === 'exact'
+    ? WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS
+    : WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS
+}
+
+function timeoutError(): WslTranscriptFsError {
+  return new WslTranscriptFsError('timeout', WSL_TRANSCRIPT_FS_SLOW_MESSAGE)
+}
+
+function capacityError(): WslTranscriptFsError {
+  return new WslTranscriptFsError('capacity', WSL_TRANSCRIPT_FS_CAPACITY_MESSAGE)
+}
+
+function unavailableError(): WslTranscriptFsError {
+  return new WslTranscriptFsError('unavailable', WSL_TRANSCRIPT_FS_SLOW_MESSAGE)
+}
+
+/**
+ * The stuck running task that would doom a new task's admission: one on the
+ * same route (the whole distro mount is hung, whatever the priority — spending
+ * the other permit on it escalates one bad distro into a global outage), one
+ * holding the single scan slot, or (with every permit stuck) any permit.
+ */
+function stuckBlocker(
+  route: string,
+  priority: WslTranscriptFsTaskPriority
+): UnknownScheduledTask | undefined {
+  const stuck = [...activeTasks].filter((task) => task.stuck)
+  if (stuck.length === MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS) {
+    return stuck[0]
+  }
+  return stuck.find(
+    (task) => task.route === route || (priority === 'scan' && task.priority === 'scan')
+  )
+}
+
+// Caller-abort pre-checks live in runWslTranscriptFsTask; nothing here yields
+// before the waiter is attached, so no aborted-signal recheck is needed.
+function attachWaiter<T>(
+  task: ScheduledTask<T>,
+  priority: WslTranscriptFsTaskPriority,
+  signal?: AbortSignal
+): Promise<T> {
+  if (task.waiters.size >= WSL_TRANSCRIPT_FS_MAX_WAITERS_PER_TASK) {
+    return Promise.reject(capacityError())
   }
   return new Promise<T>((resolve, reject) => {
     const waiter: TaskWaiter<T> = { resolve, reject, signal }
+    task.waiters.add(waiter)
     if (signal) {
       waiter.onAbort = () => {
-        if (!task.waiters.delete(waiter)) {
+        const reason = abortReason(signal)
+        if (!removeWaiter(task, waiter)) {
           return
         }
-        reject(abortReason(signal))
-        abandonTaskIfUnused(task as UnknownScheduledTask)
+        reject(reason)
+        abandonTaskIfUnused(task as UnknownScheduledTask, reason)
       }
       signal.addEventListener('abort', waiter.onAbort, { once: true })
     }
-    task.waiters.add(waiter)
+    // UNC/9P calls cannot be aborted; two blocked calls can retain both slots until settling or
+    // Orca restarts, while caller and queue retention remains bounded.
+    waiter.timeout = setTimeout(() => {
+      const error = timeoutError()
+      if (!removeWaiter(task, waiter)) {
+        return
+      }
+      reject(error)
+      abandonTaskIfUnused(task as UnknownScheduledTask, error)
+    }, timeoutMs(priority))
+    waiter.timeout.unref?.()
   })
 }
 
@@ -95,16 +200,15 @@ function settleTask<T>(task: ScheduledTask<T>, result: { value: T } | { error: u
     return
   }
   task.state = 'settled'
-  activeTaskCount -= 1
   if (task.priority === 'scan') {
     activeScanCount -= 1
   }
   activeLaneKeys.delete(task.laneKey)
+  activeTasks.delete(task as UnknownScheduledTask)
+  clearTimeout(task.stuckTimer)
   clearTask(task as UnknownScheduledTask)
   for (const waiter of task.waiters) {
-    if (waiter.signal && waiter.onAbort) {
-      waiter.signal.removeEventListener('abort', waiter.onAbort)
-    }
+    removeWaiter(task, waiter)
     if ('value' in result) {
       waiter.resolve(result.value)
     } else {
@@ -116,13 +220,21 @@ function settleTask<T>(task: ScheduledTask<T>, result: { value: T } | { error: u
 }
 
 function nextTaskIndex(): number {
+  // Tasks queued before their route hung must not be fed the other permit;
+  // their waiters drain by deadline while healthy routes use the slot.
+  const stuckRoutes = new Set(
+    [...activeTasks].filter((task) => task.stuck).map((task) => task.route)
+  )
   for (const priority of ['exact', 'scan'] as const) {
     // Why: keep one libuv slot available for a live transcript probe.
     if (priority === 'scan' && activeScanCount > 0) {
       continue
     }
     const index = queuedTasks.findIndex(
-      (task) => task.priority === priority && !activeLaneKeys.has(task.laneKey)
+      (task) =>
+        task.priority === priority &&
+        !activeLaneKeys.has(task.laneKey) &&
+        !stuckRoutes.has(task.route)
     )
     if (index !== -1) {
       return index
@@ -132,7 +244,7 @@ function nextTaskIndex(): number {
 }
 
 function pumpTasks(): void {
-  while (activeTaskCount < MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS) {
+  while (activeTasks.size < MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS) {
     const index = nextTaskIndex()
     if (index === -1) {
       return
@@ -142,11 +254,21 @@ function pumpTasks(): void {
       continue
     }
     task.state = 'running'
-    activeTaskCount += 1
     if (task.priority === 'scan') {
       activeScanCount += 1
     }
     activeLaneKeys.add(task.laneKey)
+    activeTasks.add(task)
+    // Anchored at run start: queue wait says nothing about the I/O itself, so
+    // the fail-fast may lag admission by at most one deadline period.
+    task.stuckTimer = setTimeout(() => {
+      task.stuck = true
+      console.warn(
+        `[wsl-transcript-fs-gate] ${task.priority} filesystem task still running after ` +
+          `${timeoutMs(task.priority)}ms and holding a permit: ${task.key}`
+      )
+    }, timeoutMs(task.priority))
+    task.stuckTimer.unref?.()
     void Promise.resolve()
       .then(() => {
         task.controller.signal.throwIfAborted()
@@ -169,28 +291,49 @@ export function runWslTranscriptFsTask<T>(
   },
   task: (signal: AbortSignal) => Promise<T>
 ): Promise<T> {
+  if (options.signal?.aborted) {
+    return Promise.reject(abortReason(options.signal))
+  }
   // Why: route spelling and Linux path case can change provider behavior, so
   // only byte-identical filesystem requests are safe to share.
   const key = JSON.stringify([options.operation, options.path])
   const existing = inFlightTasks.get(key) as ScheduledTask<T> | undefined
   if (existing) {
-    return attachWaiter(existing, options.signal)
+    // A stuck target — or a queued target that stuck I/O keeps from ever
+    // running — dooms every joiner to a slow timeout, and each fresh joiner
+    // would keep the queued task alive past its own abandonment. Fail fast.
+    if (
+      existing.stuck ||
+      (existing.state === 'queued' && stuckBlocker(existing.route, existing.priority))
+    ) {
+      return Promise.reject(unavailableError())
+    }
+    return attachWaiter(existing, options.priority, options.signal)
+  }
+  const route = routeKey(options.path)
+  // Fail fast when the permit, route, or scan slot this task needs is held by
+  // stuck I/O — queueing would only burn the caller's full deadline.
+  if (stuckBlocker(route, options.priority)) {
+    return Promise.reject(unavailableError())
+  }
+  if (queuedTasks.length >= WSL_TRANSCRIPT_FS_MAX_PENDING_TASKS) {
+    return Promise.reject(capacityError())
   }
 
   const scheduled: ScheduledTask<T> = {
     key,
-    laneKey: `${routeKey(options.path)}:${options.priority}`,
+    laneKey: `${route}:${options.priority}`,
+    route,
     priority: options.priority,
     operation: task,
     controller: new AbortController(),
     waiters: new Set(),
-    state: 'queued'
+    state: 'queued',
+    stuck: false
   }
   inFlightTasks.set(key, scheduled as UnknownScheduledTask)
-  const result = attachWaiter(scheduled, options.signal)
-  if (scheduled.state === 'queued' && scheduled.waiters.size > 0) {
-    queuedTasks.push(scheduled as UnknownScheduledTask)
-    queueMicrotask(pumpTasks)
-  }
+  const result = attachWaiter(scheduled, options.priority, options.signal)
+  queuedTasks.push(scheduled as UnknownScheduledTask)
+  queueMicrotask(pumpTasks)
   return result
 }


### PR DESCRIPTION
PR visulization: https://share.onorca.dev/a/ERRjcWfDlaLx 

## Problem

WSL filesystem operations over 9P protocol can hang indefinitely if a distro is stalled. Without protection, one slow distro stalls all transcript access, callers accumulate without bounds, and users see confusing "not found" errors instead of "temporarily unavailable."

## Solution

Added deadline-based admission control with per-operation timeouts (30s for file checks, 60s for scans) and capacity limits (64 pending tasks, 64 waiters per task). When I/O hangs, stuck-task detection prevents cascading failures — later operations fail fast rather than timing out. Gate refusals degrade gracefully: later distros/roots still surface their hits, and transient unavailability is distinguished from a permanently missing file.

## What Changed

- Added `WslTranscriptFsError` with failure codes: 'timeout', 'capacity', 'unavailable'
- Task scheduler enforces deadlines, queue bounds, and marks stalled I/O as stuck
- Stuck-work detection: callers waiting on stuck tasks fail fast instead of burning full deadline
- Resolver logic now distinguishes gate refusals from actual missing files
  - Hits on later distros/roots surface even after earlier gate refusals
  - Refusals when no distro was probed report unavailability, not a miss
- Guarded the transcript-agent dispatch with an exhaustiveness check so a future agent cannot silently fall through to the OMP session scan
- Gate refusals in title-request, tail-read, and watch-subscribe paths degrade to fallbacks
- Comprehensive test coverage for timeout, capacity, stuck-task, and graceful-degradation scenarios

## Why

WSL mounts can stall for extended periods (slow network, kernel issues, etc). Without protection, Orca's transcript access becomes completely blocked, and users can't tell if a session is actually missing or just inaccessible. Deadline-based gating ensures the app remains responsive and users get accurate error messages for transient issues.

## Visual Proof

N/A — No UI/interaction changes; this is infrastructure hardening for WSL filesystem access.

## Testing

- [x] Manually tested locally — end-to-end on Windows 11 + WSL2, see Validation below
- [ ] Automated tests added/updated, or explained why not below
  - Added 40+ test cases covering timeout enforcement, capacity rejection, stuck-task prevention, and graceful degradation across all resolver paths


## Scope of the guarantee

Two limits worth knowing when reviewing:

- **A route is a whole distro, not a path.** When a mount stalls, every WSL transcript on that distro fast-fails, not just the stalled path (measured: a healthy transcript refused in 15ms). This is deliberate — the `stuckBlocker` doc comment explains that spending the other permit on a hung mount would escalate one bad distro into a global outage. It does mean that on a single-distro machine, the common case, all WSL transcripts degrade together.
- **Recovery is bound to the underlying 9P call returning.** When it does, the route clears automatically (measured: recovered once a 45s stall settled). 9P calls cannot be aborted, so a call that never returns holds its permit until the process exits — which is what the "restart Orca if the issue continues" guidance covers.

## Validation

Exercised end-to-end on Windows 11 + WSL2 Ubuntu-24.04, driven through the real `nativeChat` IPC surface against a live 9P mount:

| Scenario | Result |
| --- | --- |
| Real WSL transcript read (guest path to UNC) | 2 messages, 166-1578ms |
| Genuinely missing file | `notFound: true` in 13ms, not mislabelled as unavailable |
| 250 concurrent distinct paths | 184 capacity refusals, none marked `notFound`; IPC round-trip stayed at 8ms |
| Read immediately after that flood | clean re-resolve — refusals are not cached |
| Stalled `access` (fault-injected, never returns) | deadline fired at 30.02s, then 15ms fast-fail on the same route |
| After the stalled I/O settled | route recovered automatically |
| `subscribe()` while the route was stuck | no error frame; degraded to resolve-poll and self-healed with a clean snapshot |

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
  - Windows/WSL only; SSH and local paths unaffected
- [x] `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass on Windows (the 22 failures in `src/main/native-chat` and `src/main/ai-vault` are byte-identical on `HEAD~1` — pre-existing)