### PR TITLE
fix(mobile): use 'unsupported' for the no-review-creation test premise

### DIFF
--- a/mobile/src/source-control/mobile-create-pr-action.test.ts
+++ b/mobile/src/source-control/mobile-create-pr-action.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type {
   HostedReviewCreationBlockedReason,
-  HostedReviewCreationEligibility,
-  HostedReviewProvider
+  HostedReviewCreationEligibility
 } from '../../../src/shared/hosted-review'
 import {
   buildMobileCreatePrAction,
@@ -146,7 +145,7 @@ describe('buildMobileCreatePrAction', () => {
 
   it('keeps a disabled status row for providers without review creation', () => {
     const { descriptor } = action({
-      eligibility: eligibility({ provider: 'bitbucket' as HostedReviewProvider })
+      eligibility: eligibility({ provider: 'unsupported' })
     })
 
     expect(descriptor).toMatchObject({
@@ -211,7 +210,7 @@ describe('cold-mount layout stability (issue #8411)', () => {
       'unsupported provider',
       {
         kind: 'ready',
-        eligibility: eligibility({ provider: 'bitbucket' as HostedReviewProvider })
+        eligibility: eligibility({ provider: 'unsupported' })
       } satisfies MobileCreatePrEligibilityState
     ],
     ['eligibility error', { kind: 'error' } satisfies MobileCreatePrEligibilityState]

--- a/mobile/src/source-control/mobile-create-pr-action.ts
+++ b/mobile/src/source-control/mobile-create-pr-action.ts
@@ -72,7 +72,7 @@ export function buildMobileCreatePrAction({
   }
   // Why: mirror desktop's structural provider gate (supportsHostedReviewCreation)
   // instead of relying on the host always emitting a hidden blockedReason for
-  // non-creatable providers like bitbucket.
+  // non-creatable providers.
   if (!supportsHostedReviewCreation(eligibility.provider)) {
     return {
       visible: true,


### PR DESCRIPTION
## ELI5

A mobile test needed an example of "a git provider that can't create pull requests," and picked Bitbucket. Then we shipped Bitbucket PR creation, so Bitbucket *can* create them now — and the test started failing. Swapped in `'unsupported'`, which is the only provider left that genuinely can't.

## What Changed

- `mobile-create-pr-action.test.ts`: both `provider: 'bitbucket' as HostedReviewProvider` stand-ins → `provider: 'unsupported'` (the cast is no longer needed, so the now-unused `HostedReviewProvider` import goes too).
- `mobile-create-pr-action.ts`: dropped the stale "like bitbucket" example from the provider-gate comment.

No production logic changes.

## Why

`Mobile Checks → verify` is currently **red on main**:

```
FAIL src/source-control/mobile-create-pr-action.test.ts > buildMobileCreatePrAction
     > keeps a disabled status row for providers without review creation
AssertionError: expected { visible: true, …(5) } to match object { visible: true, disabled: true, …(1) }
Test Files  1 failed | 435 passed (436)
```

#5832 (`63271a5933`, Bitbucket PR creation, merged Aug 11) added `'bitbucket'` to `supportsHostedReviewCreation` in `src/shared/hosted-review-creation-providers.ts`. The mobile test used `'bitbucket'` as its stand-in for a provider *without* review creation, so `mobile-create-pr-action.ts:76` stopped taking the disabled branch. A desktop-side feature broke a mobile test through shared code.

`'unsupported'` is now the only `HostedReviewProvider` member outside `HostedReviewCreationProvider`, so it is the correct — and only — stand-in. That also makes the test resilient: it now tests the structural gate rather than a specific vendor's current capabilities.

Note this was invisible on main because `Mobile Checks` is `pull_request`-only, so it never runs on main. The same assertion failure reproduces on unrelated branches — e.g. runs [31569913259](https://github.com/stablyai/orca/actions/runs/31569913259) and [31580384888](https://github.com/stablyai/orca/actions/runs/31580384888).

## Linked Issue

N/A — pre-existing main breakage found while cutting the next mobile TestFlight build.

## Visual Proof

`N/A` — test-only change plus a comment; no UI or behavior change. The production gate is byte-identical apart from comment text.

## Testing

```
pnpm vitest run --config vitest.config.ts src/source-control/mobile-create-pr-action.test.ts
Test Files  1 passed (1)
     Tests  23 passed (23)
```

- `npx oxlint` on both changed files: clean.
- Verified `'unsupported'` is the only `HostedReviewProvider` not in `HostedReviewCreationProvider`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

N/A — internal contributor.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Test-only; no runtime, wire-format, platform, or SSH impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
