### PR TITLE
fix(mobile): use native monospace font on iOS

### DIFF
--- a/mobile/src/theme/mobile-mono-font-family.ios.ts
+++ b/mobile/src/theme/mobile-mono-font-family.ios.ts
@@ -1,0 +1,2 @@
+// React Native iOS treats "monospace" as an unknown family and falls back to SF Pro.
+export const mobileMonoFontFamily = 'ui-monospace' as const

--- a/mobile/src/theme/mobile-mono-font-family.test.ts
+++ b/mobile/src/theme/mobile-mono-font-family.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { mobileMonoFontFamily as defaultMonoFontFamily } from './mobile-mono-font-family'
+import { mobileMonoFontFamily as iosMonoFontFamily } from './mobile-mono-font-family.ios'
+
+describe('mobile monospace font family', () => {
+  it('uses the native monospaced system design on iOS', () => {
+    expect(iosMonoFontFamily).toBe('ui-monospace')
+  })
+
+  it('keeps the generic monospace family on other platforms', () => {
+    expect(defaultMonoFontFamily).toBe('monospace')
+  })
+})

--- a/mobile/src/theme/mobile-mono-font-family.ts
+++ b/mobile/src/theme/mobile-mono-font-family.ts
@@ -1,0 +1,1 @@
+export const mobileMonoFontFamily = 'monospace' as const

--- a/mobile/src/theme/mobile-theme.ts
+++ b/mobile/src/theme/mobile-theme.ts
@@ -1,3 +1,5 @@
+import { mobileMonoFontFamily } from './mobile-mono-font-family'
+
 // Orca mobile design tokens — matches desktop graphite/dark palette.
 // All screen files should import from here instead of using inline hex values.
 
@@ -69,5 +71,5 @@ export const typography = {
   titleSize: 18,
   bodySize: 14,
   metaSize: 12,
-  monoFamily: 'monospace' as const
+  monoFamily: mobileMonoFontFamily
 } as const


### PR DESCRIPTION
## ELI5

The iOS app asked React Native for a font named `monospace`. iOS does not recognize that name in native text, so it silently displayed the proportional system font. This change asks iOS for its built-in monospaced system design instead.

## Summary

Native mobile code surfaces now use a real monospaced system face on iOS. Android and web retain their existing `monospace` behavior.

## What Changed

- Added a Metro-resolved iOS font token that uses `ui-monospace`.
- Kept `monospace` as the default token for non-iOS platforms.
- Routed `typography.monoFamily` through the platform-specific token.
- Added regression tests for the iOS and default values.

## Why

Native code previews, diffs, inline code, and other consumers of `typography.monoFamily` passed the literal family name `monospace`. React Native's iOS renderer does not recognize that family, so it fell back to the proportional system font. The platform-specific `ui-monospace` value selects Apple's native monospaced system design without requiring users to install a font.

## Linked Issue

N/A — no linked issue. The bug was reported directly and confirmed through source inspection.

## Screenshots / Visual Proof

**Before:** the iOS code preview falls back to a proportional system font.

<img width="390" alt="Before: iOS code preview using a proportional fallback font" src="https://github.com/user-attachments/assets/6379d13a-f50d-479d-902d-8024459840f0" />

## Testing

- [x] `pnpm lint` — passed with Node 24.14.0 and pnpm 10.24.0; only pre-existing React exhaustive-deps warnings were reported.
- [x] `pnpm typecheck` — passed as part of `pnpm build`; the mobile `tsc --noEmit` check also passed.
- [x] `pnpm test` — root suite: 4,604 files passed, 15 skipped; 49,330 tests passed, 99 skipped. Mobile suite: 439 files and 3,429 tests passed.
- [x] `pnpm build` — desktop and native builds passed with Node 24.14.0 and pnpm 10.24.0.
- [x] Added focused regression tests for both the iOS and non-iOS font-family values.

Additional validation:

- Focused theme tests: 4 passed.
- Changed-file formatting check: passed.
- `git diff --check`: passed.

## AI Disclosure

Codex assisted with root-cause analysis, implementation, tests, cross-platform review, validation, and PR preparation.

## AI Review Report

The review checked Metro platform-file resolution, React Native iOS font-family handling, shared-token consumers, test coverage, and unintended platform changes. It verified that iOS selects `mobile-mono-font-family.ios.ts`, while Android and web continue using the default `monospace` token.

Cross-platform compatibility was reviewed explicitly:

- The macOS, Linux, and Windows desktop renderer is untouched.
- Android and web retain their existing font-family value.
- No keyboard shortcuts, shortcut labels, paths, shell behavior, Electron behavior, remote wire formats, or Git commands are changed.

No code defect was found in the final diff. Full lint, build, root tests, and mobile tests passed; unrelated pre-existing warnings are documented above.

## Security Audit

This change only selects a static platform-specific font-family string. It adds no user input, command execution, path handling, authentication, secrets, dependencies, IPC, network behavior, or remote-wire changes. No security follow-up is required.

## Review

Suggested review focus:

- Confirm `ui-monospace` is the desired native iOS system face.
- Confirm Metro selects the `.ios.ts` token for native iOS bundles.
- Confirm changing the shared mono token is appropriate for all native mobile code-like surfaces.

## Checklist

- [x] The change is limited to the mobile monospace token and its tests.
- [x] Non-iOS behavior is preserved.
- [x] Regression coverage was added.
- [x] Relevant type, lint, formatting, build, and test checks passed.
- [x] No unrelated workspace changes are included.
- [x] Comments explain non-obvious behavior concisely.

## Author

Yongqi Zhuo (@Yongqi-Zhuo)

## Notes

Users do not need to install SF Mono or another font on iPhone. iOS supplies the selected monospaced system design.
