### PR TITLE
fix(terminal): repaint a recovered remote pane from the host's retained buffer

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5828,6 +5828,11 @@ export function connectPanePty(
               reportRemoteRendererSerializerReady()
             }
           },
+          onStreamRecovered: (): void => {
+            if (isCurrent()) {
+              markHiddenOutputRestoreNeeded()
+            }
+          },
           onData: (data: string, meta?: PtyDataMeta): void => {
             if (isCurrent()) {
               dataCallback(data, meta, generation)

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -104,6 +104,9 @@ type PtyCallbacks = {
   /** Called before an adopted PTY can publish buffered/live bytes. */
   onReattachDetermined?: () => void
   onConnect?: () => void
+  /** A stream re-established after loss carries only new bytes, so the pane must
+   *  re-pull the host's retained buffer or an idle/exited pane paints nothing. */
+  onStreamRecovered?: () => void
   onDisconnect?: () => void
   onData?: (data: string, meta?: PtyDataMeta) => void
   onReplayData?: (data: string, meta?: PtyReplayDataMeta) => void

--- a/src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts
@@ -32,6 +32,7 @@ function leafIdForPane(paneId: number): string {
 type ConnectCallbacks = {
   onReattachDetermined?: () => void
   onConnect?: () => void
+  onStreamRecovered?: () => void
   onData?: (
     data: string,
     meta?: { seq?: number; rawLength?: number; background?: boolean; droppedOutput?: boolean }
@@ -379,6 +380,7 @@ type RemotePaneDrive = {
   disposable: { dispose: () => void }
   deliver: (data: string, seq: number) => void
   setOutputPaused: (paused: boolean) => void
+  recoverStream: () => void
   writtenChunks: () => string[]
 }
 
@@ -396,9 +398,11 @@ async function connectHiddenRemoteAgentPane(
   const capturedOutputPauseCallback: {
     current: ((paused: boolean, supported: boolean) => void) | null
   } = { current: null }
+  const capturedStreamRecoveredCallback: { current: (() => void) | null } = { current: null }
   transport.connect.mockImplementation(async ({ callbacks }: { callbacks?: ConnectCallbacks }) => {
     capturedDataCallback.current = callbacks?.onData ?? null
     capturedOutputPauseCallback.current = callbacks?.onOutputPauseChanged ?? null
+    capturedStreamRecoveredCallback.current = callbacks?.onStreamRecovered ?? null
     return REMOTE_PTY_ID
   })
   transportFactoryQueue.push(transport)
@@ -415,6 +419,7 @@ async function connectHiddenRemoteAgentPane(
     disposable,
     deliver: (data, seq) => capturedDataCallback.current?.(data, { seq, rawLength: data.length }),
     setOutputPaused: (paused) => capturedOutputPauseCallback.current?.(paused, true),
+    recoverStream: () => capturedStreamRecoveredCallback.current?.(),
     writtenChunks: () => pane.terminal.write.mock.calls.map(([data]) => String(data))
   }
 }
@@ -616,6 +621,24 @@ describe('remote hidden-output restore outcomes', () => {
     }
     delete (globalThis as unknown as { window?: unknown }).window
     resetAgentStartupDelayedDeliveryForTests()
+  })
+
+  it('[modern] repaints a recovered visible pane from the retained host buffer', async () => {
+    const serializeBuffer = vi.fn()
+    const serializeBufferOutcome = vi.fn().mockResolvedValue({
+      availability: { kind: 'snapshot' },
+      snapshot: HOST_SNAPSHOT
+    })
+    const drive = await connectHiddenRemoteAgentPane(serializeBuffer, serializeBufferOutcome)
+    ;(drive.deps.isVisibleRef as { current: boolean }).current = true
+
+    drive.recoverStream()
+    await flushAsyncTicks(20)
+
+    expect(serializeBufferOutcome).toHaveBeenCalledTimes(1)
+    expect(drive.writtenChunks().join('')).toContain(HOST_SNAPSHOT_MARKER)
+    expect(serializeBuffer).not.toHaveBeenCalled()
+    drive.disposable.dispose()
   })
 
   it('[modern] accepts an empty snapshot as successful recovery without a loss banner', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -5054,6 +5054,64 @@ describe('createRemoteRuntimePtyTransport', () => {
     transport.destroy?.()
   })
 
+  it('re-arms the retained-buffer restore when a recovery subscribe replays no snapshot', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onReplayData = vi.fn()
+    const onStreamRecovered = vi.fn()
+    const onConnect = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({
+      url: '',
+      callbacks: { onReplayData, onStreamRecovered, onConnect }
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const firstStreamId = latestSubscribePayload().streamId
+    emitSnapshot(firstStreamId, 'INITIAL_SNAPSHOT')
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'subscribed',
+        streamId: firstStreamId,
+        capabilities: { outputPause: 1 }
+      }
+    })
+    await vi.waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1))
+    // The first subscribe already carries the host snapshot; re-arming there would cost
+    // every pane a redundant restore request on open.
+    expect(onStreamRecovered).not.toHaveBeenCalled()
+
+    subscriptionCallbacks?.onClose?.()
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(
+        subscriptionSendBinary.mock.calls
+          .map((call) => decodeTerminalStreamFrame(call[0]))
+          .filter((frame) => frame?.opcode === TerminalStreamOpcode.Subscribe)
+      ).toHaveLength(2)
+    )
+    const reconnectStreamId = latestSubscribePayload().streamId
+    // An exited-but-preserved pane has nothing to push and will never emit live bytes,
+    // so without the re-arm the pane stays blank until a visibility flip.
+    emitSnapshot(reconnectStreamId, '')
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'subscribed',
+        streamId: reconnectStreamId,
+        capabilities: { outputPause: 1 }
+      }
+    })
+
+    await vi.waitFor(() => expect(onStreamRecovered).toHaveBeenCalledTimes(1))
+    expect(onReplayData.mock.calls.map((call) => call[0])).toEqual(['INITIAL_SNAPSHOT'])
+    transport.destroy?.()
+  })
+
   it('backs off before retrying a capacity-rejected terminal stream', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -5109,6 +5109,33 @@ describe('createRemoteRuntimePtyTransport', () => {
 
     await vi.waitFor(() => expect(onStreamRecovered).toHaveBeenCalledTimes(1))
     expect(onReplayData.mock.calls.map((call) => call[0])).toEqual(['INITIAL_SNAPSHOT'])
+
+    subscriptionCallbacks?.onClose?.()
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() =>
+      expect(
+        subscriptionSendBinary.mock.calls
+          .map((call) => decodeTerminalStreamFrame(call[0]))
+          .filter((frame) => frame?.opcode === TerminalStreamOpcode.Subscribe)
+      ).toHaveLength(3)
+    )
+    const populatedReconnectStreamId = latestSubscribePayload().streamId
+    emitSnapshot(populatedReconnectStreamId, 'RECOVERY_SNAPSHOT')
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'subscribed',
+        streamId: populatedReconnectStreamId,
+        capabilities: { outputPause: 1 }
+      }
+    })
+
+    await vi.waitFor(() => expect(onConnect).toHaveBeenCalledTimes(3))
+    expect(onStreamRecovered).toHaveBeenCalledTimes(1)
+    expect(onReplayData.mock.calls.map((call) => call[0])).toEqual([
+      'INITIAL_SNAPSHOT',
+      'RECOVERY_SNAPSHOT'
+    ])
     transport.destroy?.()
   })
 

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1806,6 +1806,12 @@ export function createRemoteRuntimePtyTransport(
           markRecoveryHealthy()
           emitRecoveryState()
           storedCallbacks.onConnect?.()
+          // Why: a recovery subscribe replays nothing when the host's push snapshot is
+          // empty (idle or exited pane), so ask for the retained buffer instead of
+          // waiting for bytes that an exited process will never send.
+          if (expectedRecoveryEpoch !== undefined) {
+            storedCallbacks.onStreamRecovered?.()
+          }
           storedCallbacks.onStatus?.('shell')
         },
         onEnd: () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1735,6 +1735,7 @@ export function createRemoteRuntimePtyTransport(
     setAttachmentReady(false)
     let transportClosed = false
     let subscriptionAttached = false
+    let subscriptionSnapshotHadContent = false
     // Why: viewport handed to subscribe; a resize during the round-trip falls back to the refresh-only one-shot RPC, replayed through the stream below once current.
     const subscribedViewport = desiredViewport
     const isCurrentSubscription = (): boolean =>
@@ -1760,6 +1761,7 @@ export function createRemoteRuntimePtyTransport(
         onSnapshot: (data, meta) => {
           // Why: an empty snapshot can still carry a pending mid-escape tail that must replay so the next live chunk completes it.
           if ((data || meta?.pendingEscapeTailAnsi) && isCurrentSubscription()) {
+            subscriptionSnapshotHadContent = true
             if (subscribedPtyId && bufferPtyShutdownReplayData(subscribedPtyId, data)) {
               return
             }
@@ -1809,7 +1811,7 @@ export function createRemoteRuntimePtyTransport(
           // Why: a recovery subscribe replays nothing when the host's push snapshot is
           // empty (idle or exited pane), so ask for the retained buffer instead of
           // waiting for bytes that an exited process will never send.
-          if (expectedRecoveryEpoch !== undefined) {
+          if (expectedRecoveryEpoch !== undefined && !subscriptionSnapshotHadContent) {
             storedCallbacks.onStreamRecovered?.()
           }
           storedCallbacks.onStatus?.('shell')


### PR DESCRIPTION
## ELI5

You come back to a terminal on a remote host and it's completely blank, even though the host still has all the output. Switch worktrees once and it comes back. This makes the pane redraw itself as soon as the connection recovers, instead of waiting for you to click around.

## What Changed

When a remote-runtime pane's stream is re-established after loss, the transport now tells the pane so it can re-pull the buffer the host is still holding.

- `pty-transport-types.ts` — new optional `onStreamRecovered` callback.
- `remote-runtime-pty-transport.ts` — fire it from `onSubscribed`, **only** when `expectedRecoveryEpoch !== undefined` (the recovery subscribe paths). The initial subscribe is deliberately untouched.
- `pty-connection.ts` — wire it to `markHiddenOutputRestoreNeeded()`, which already issues the tagged snapshot request when the pane is in the foreground.

Three lines of behavior change. No wire/protocol change: this is renderer-internal, and `onStreamRecovered` is optional, so every other transport is unaffected.

## Why

A recovery subscribe only carries new bytes. The host's unsolicited push snapshot is dropped when empty (`remote-runtime-pty-transport.ts`, the `if ((data || meta?.pendingEscapeTailAnsi) && ...)` guard in `onSnapshot`), and nothing on the reconnect path re-armed the restore — all eight `markHiddenOutputRestoreNeeded()` call sites were byte-path, output-pause, or backlog-drop triggers.

So the pane painted nothing and waited for output. Two ways that never arrives:

1. the pane is idle, or
2. **its PTY has exited and is preserved with its buffer** — `connected: false, orphaned: false`, host-side buffer fully intact.

Case 2 is what I hit in the field. On the reported host, both panes of the affected worktree were exited-but-preserved, last output ~25h earlier, with the host still holding the complete scrollback. Input appears dead too, but that part is correct — the process really is gone. The bug is purely the missing repaint.

The only existing recovery was the *tagged* restore triggered by a visibility flip (`pty-connection.ts`, `requestHiddenOutputRestoreIfNeeded`) — i.e. the worktree switch users learn to do.

Chose the transport seam over `onConnect` because six different call sites build those callbacks; a generation counter there would misfire on non-recovery connects. `expectedRecoveryEpoch` is already the transport's own "this is a re-establishment" signal.

## Linked Issue

Fixes #9562

## Visual Proof

Not attached — the only recording of this is a user's full workspace (private worktree, branch, and agent-session names), and evidence like that shouldn't go to a public host. Happy to attach a synthetic before/after if a reviewer wants one.

Observed sequence, remote paired-runtime worktree:

| before | after |
|---|---|
| reveal pane → empty, bare cursor | reveal pane → host's retained buffer repaints |
| stays blank until a worktree switch | no worktree switch needed |

## Testing

Added `re-arms the retained-buffer restore when a recovery subscribe replays no snapshot` to `remote-runtime-pty-transport.test.ts`. It drives a real transport close → resubscribe with an **empty** reconnect snapshot and asserts `onStreamRecovered` fires exactly once, that nothing was replayed, and that the *initial* subscribe does not re-arm.

Verified red before the fix / green after (removed the emit, test fails `expected 1, got 0`; restored, passes). It sits next to the existing `reapplies negotiated output pause across reconnect...` test, which pins the non-empty snapshot branch — this covers the complementary empty branch, which had no coverage.

```
npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane src/renderer/src/runtime
→ 4068 passed, 1 pre-existing failure (fish-color-scheme-child-stdin.node-pty.test.ts,
  confirmed failing on a clean tree — live fish/node-pty, unrelated)
```

`tsc --noEmit -p config/tsconfig.tc.web.json` clean; oxlint + oxfmt clean.

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — **not** end-to-end in the app; the diagnosis was verified against live host state via `orca terminal list`, and the fix by the deterministic transport test. Reproducing in-app needs a remote host whose PTYs have exited and been preserved.

## Review

- **Cross-platform:** renderer-only, no platform-specific code.
- **SSH/remote:** SSH panes route through local main and a different transport; `onStreamRecovered` is optional and unset there, so behavior is unchanged. Only paired remote runtimes are affected.
- **Backwards compatibility:** no wire change; nothing crosses the client/host boundary.
- **Performance:** at most one extra snapshot request per recovery subscribe, and only when the pane is foreground. No change on the open path.

## Known Gap (not in this PR)

The same recording shows a **second, separate** defect: after reveal, the replayed buffer paints at the *old, narrower* grid and only corrects on a later layout change. Remote PTYs have no reveal-time `ptySizeReassertion` repair. Deliberately left out to keep this focused; worth its own issue.
