### PR TITLE
fix(daemon): record a caller-driven disconnect as an authenticated drop

### DIFF
--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -567,6 +567,44 @@ describe('DaemonClient', () => {
       client = new DaemonClient({ socketPath, tokenPath })
       expect(() => client.disconnect()).not.toThrow()
     })
+
+    it('records an authenticated disconnect when the caller disconnects', async () => {
+      await startMockDaemon()
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await client.ensureConnected()
+      expect(client.hasObservedAuthenticatedDisconnect()).toBe(false)
+
+      client.disconnect()
+
+      expect(client.hasObservedAuthenticatedDisconnect()).toBe(true)
+    })
+
+    it('does not record an authenticated disconnect when the caller never authenticated', async () => {
+      // Why: a missing token before any authenticated session can still hide a live daemon, so it
+      // must stay ineligible for the retired-endpoint recovery this flag gates.
+      await startMockDaemon({ rejectVersion: true })
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await expect(client.ensureConnected()).rejects.toThrow('Version mismatch')
+
+      client.disconnect()
+
+      expect(client.hasObservedAuthenticatedDisconnect()).toBe(false)
+    })
+
+    it('clears the recorded disconnect once reconnected', async () => {
+      await startMockDaemon()
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await client.ensureConnected()
+      client.disconnect()
+      expect(client.hasObservedAuthenticatedDisconnect()).toBe(true)
+
+      await client.ensureConnected()
+
+      expect(client.hasObservedAuthenticatedDisconnect()).toBe(false)
+    })
   })
 
   describe('notify (fire-and-forget)', () => {

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -258,6 +258,12 @@ export class DaemonClient {
   disconnect(): void {
     this.connectionAttemptGeneration++
     this.connected = false
+    // Why: the daemon unlinks its token once its last authenticated client drops, so a caller-driven
+    // disconnect leaves the same retired-endpoint evidence a socket close does. Recording it here is
+    // what makes the next connect's missing-token ENOENT eligible for a respawn instead of surfacing raw.
+    if (this.daemonIdentity) {
+      this.observedAuthenticatedDisconnect = true
+    }
     this.daemonIdentity = null
     this.disconnectArmed = false
     this.cleanupActiveSocketListeners()

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -595,6 +595,42 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
+    it('respawns when the daemon retires its token after a caller-driven disconnect', async () => {
+      // Why: the daemon unlinks its token when its last authenticated client drops, so the drop that
+      // triggers retirement is often our own disconnect() — which observes no socket close. Losing
+      // that evidence left the reconnect's ENOENT ineligible for respawn and surfaced it raw.
+      let respawnServer: DaemonServer | undefined
+      const respawn = vi.fn(async () => {
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+      const healingAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const { id } = await healingAdapter.spawn({ cols: 80, rows: 24 })
+        const client = (healingAdapter as unknown as { client: DaemonClient }).client
+
+        client.disconnect()
+        // Retire the daemon only after the client detached, so no close event reaches it.
+        await server.shutdown()
+        expect(existsSync(tokenPath)).toBe(false)
+        expect(client.isConnected()).toBe(false)
+
+        await expect(
+          healingAdapter.spawn({ sessionId: id, cols: 80, rows: 24 })
+        ).resolves.toMatchObject({ id })
+        expect(respawn).toHaveBeenCalledTimes(1)
+      } finally {
+        warn.mockRestore()
+        healingAdapter.dispose()
+        await respawnServer?.shutdown()
+      }
+    })
+
     it('does not spawn a daemon per keystroke after respawn fails', async () => {
       const respawn = vi.fn(async () => {
         throw new Error('daemon unavailable')


### PR DESCRIPTION
## ELI5

When Orca's terminal daemon shuts down it deletes its own password file (the token). It only shuts down after the last client lets go — and usually *we* are the one that lets go, on purpose. Orca only wrote down "we were connected and then got dropped" when the daemon hung up on us, never when we hung up first. Without that note, the next reconnect found the deleted token and gave up with a raw `ENOENT` instead of starting a fresh daemon.

## What Changed

`DaemonClient.disconnect()` now records the authenticated disconnect when it tears down a connection that had a daemon identity — the same rule `handleDisconnect()` already applies at `client.ts:478`.

## Why

`daemon-server.ts:381` `unlinkOwnedEndpointArtifacts()` unlinks the token on every daemon exit, and a daemon retires once its last fully-authenticated client drops. So the drop that *causes* retirement is frequently our own `disconnect()`, which observes no socket close — and `handleDisconnect()` early-returns once `disconnect()` has disarmed it, so nothing recorded the drop.

`daemon-pty-adapter.ts:2129` gates the missing-token respawn on `isMissingTokenFileError(err) && client.hasObservedAuthenticatedDisconnect()`. With the flag stuck false, the gate rejected exactly the case it exists for: the next `ensureConnected()` read a token the retired daemon had already removed, and `readFileSync` at `client.ts:122` threw a raw `ENOENT` straight through `withDaemonRetry` to the pane.

Reported in Slack from a floating terminal on 1.4.181-hourly.202608112119 (macOS 26.3.1):

```
DaemonProtocolError: Disconnected
ENOENT: no such file or directory, open '~/Library/Application Support/orca/daemon/daemon-v32.token'
```

The gate keeps its guard: a token missing before any authenticated session still stays ineligible, because it can front a daemon that is mid-startup.

## Linked Issue

No GitHub issue — reported in Slack (`#eng`, 2026-08-11). Search for an existing open issue found none.

## Visual Proof

`N/A` — no UI change. The user-visible difference is that the pane recovers instead of showing the error above.

## Testing

`client.test.ts`, `daemon-pty-adapter.test.ts` (194 tests) pass; `typecheck:node` and the changed-code quality gate (oxlint + type-aware + React Doctor) are clean on macOS.

New coverage:
- `client.test.ts` — `disconnect()` records the drop after authenticating, does **not** record it when the handshake never authenticated, and a successful reconnect clears it.
- `daemon-pty-adapter.test.ts` — end-to-end on the real `DaemonServer`: authenticate, `client.disconnect()`, then `server.shutdown()` (which unlinks the token) with no close event reaching the client. The adapter must respawn and re-attach.

Negative control: with only the `client.ts` change reverted, that adapter test fails with the reported error, on the reported path —

```
Error: ENOENT: no such file or directory, open '.../test.token'
 ❯ DaemonClient.doConnect src/main/daemon/client.ts:122:19
 ❯ DaemonPtyAdapter.doSpawn src/main/daemon/daemon-pty-adapter.ts:461:16
 ❯ DaemonPtyAdapter.withDaemonRetry src/main/daemon/daemon-pty-adapter.ts:2126:20
```

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Main-process daemon lifecycle only; no wire-format, renderer, or IPC change. Platform-independent (no path or platform branching). SSH and remote panes route through their own providers and are untouched. Strictly widens when a respawn is allowed — it cannot suppress one — and the pre-authentication guard is preserved and tested.

## AI Disclosure

Claude Opus 5.
