### PR TITLE
fix(daemon): classify a retired daemon token as an absent endpoint

### DIFF
--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { DaemonClient } from './client'
+import { DaemonEndpointTokenGoneError, isDaemonEndpointGoneError } from './daemon-errors'
 import { encodeNdjson, NDJSON_MAX_LINE_BYTES, NdjsonLineTooLongError } from './ndjson'
 import type { HelloMessage, DaemonRequest, DaemonEvent } from './types'
 import { getDaemonSocketPath } from './daemon-spawner'
@@ -334,6 +335,41 @@ describe('DaemonClient', () => {
 
       client = new DaemonClient({ socketPath, tokenPath })
       await expect(client.ensureConnected()).rejects.toThrow()
+    })
+
+    it('classifies a token retired after an authenticated disconnect as endpoint gone', async () => {
+      const serverSockets: Socket[] = []
+      await startMockDaemon()
+      server.on('connection', (socket) => serverSockets.push(socket))
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      const disconnected = vi.fn()
+      client.onDisconnected(disconnected)
+      await client.ensureConnected()
+      await waitFor(() => serverSockets.length >= 2)
+      for (const socket of serverSockets) {
+        socket.destroy()
+      }
+      await waitFor(() => disconnected.mock.calls.length > 0, 3000)
+
+      rmSync(tokenPath)
+      const error = await client.ensureConnected().catch((err: unknown) => err)
+
+      expect(error).toBeInstanceOf(DaemonEndpointTokenGoneError)
+      expect(isDaemonEndpointGoneError(error)).toBe(true)
+    })
+
+    it('leaves a missing token unclassified before any authenticated session', async () => {
+      // Why: the daemon writes its token during startup, so an unread token here can still front a
+      // daemon that is about to come up — classifying it gone would retire live panes.
+      rmSync(tokenPath)
+      client = new DaemonClient({ socketPath, tokenPath })
+
+      const error = await client.ensureConnected().catch((err: unknown) => err)
+
+      expect(error).toMatchObject({ code: 'ENOENT', syscall: 'open' })
+      expect(error).not.toBeInstanceOf(DaemonEndpointTokenGoneError)
+      expect(isDaemonEndpointGoneError(error)).toBe(false)
     })
   })
 

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -18,7 +18,7 @@ import type {
   DaemonEvent
 } from './types'
 import { addNodePtyRecoveryHint } from './node-pty-error-hints'
-import { decodeDaemonResponseError } from './daemon-errors'
+import { DaemonEndpointTokenGoneError, decodeDaemonResponseError } from './daemon-errors'
 
 const CONNECT_TIMEOUT_MS = 5000
 const CONNECTION_ATTEMPT_WAIT_MS = CONNECT_TIMEOUT_MS * 4
@@ -114,12 +114,29 @@ export class DaemonClient {
     }
   }
 
+  /**
+   * Why classify here: the daemon leaves its socket behind on exit but unlinks its token, so a
+   * retired endpoint fails at this read — before the connect whose ENOENT/ECONNREFUSED is what
+   * callers classify. Without this the caller sees a raw errno for a daemon that provably exited.
+   */
+  private readToken(): string {
+    try {
+      return readFileSync(this.tokenPath, 'utf-8').trim()
+    } catch (error) {
+      const errno = error as NodeJS.ErrnoException
+      // A token missing before any authenticated session can still front a live daemon mid-startup.
+      throw errno?.code === 'ENOENT' && this.observedAuthenticatedDisconnect
+        ? new DaemonEndpointTokenGoneError(this.tokenPath, error)
+        : error
+    }
+  }
+
   private async doConnect(
     timeoutMs: number,
     attemptGeneration: number,
     sharedBudget: boolean
   ): Promise<void> {
-    const token = readFileSync(this.tokenPath, 'utf-8').trim()
+    const token = this.readToken()
     const deadlineMs = Date.now() + timeoutMs
     const remainingMs = (): number =>
       sharedBudget ? Math.max(1, deadlineMs - Date.now()) : timeoutMs

--- a/src/main/daemon/daemon-errors.test.ts
+++ b/src/main/daemon/daemon-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DaemonEndpointTokenGoneError,
   DaemonProtocolError,
   decodeDaemonResponseError,
   isDaemonEndpointGoneError,
@@ -41,6 +42,26 @@ describe('isDaemonEndpointGoneError', () => {
 
   it('ignores a missing token file, which does not prove the endpoint is gone', () => {
     expect(isDaemonEndpointGoneError(socketError('ENOENT', 'open'))).toBe(false)
+  })
+
+  it('recognizes a token retired after this client was authenticated', () => {
+    expect(
+      isDaemonEndpointGoneError(
+        new DaemonEndpointTokenGoneError(
+          '/tmp/orca/daemon-v32.token',
+          socketError('ENOENT', 'open')
+        )
+      )
+    ).toBe(true)
+  })
+
+  it('keeps the errno shape recovery paths match a missing token on', () => {
+    // Why: a respawn+retry keyed on code/syscall must still win over this classification.
+    const err = new DaemonEndpointTokenGoneError('/tmp/orca/daemon-v32.token', null)
+
+    expect(err.code).toBe('ENOENT')
+    expect(err.syscall).toBe('open')
+    expect(err.path).toBe('/tmp/orca/daemon-v32.token')
   })
 
   it('ignores connect failures that are not proof of absence', () => {

--- a/src/main/daemon/daemon-errors.ts
+++ b/src/main/daemon/daemon-errors.ts
@@ -35,8 +35,31 @@ export class TerminalHostGoneError extends Error {
   }
 }
 
-// Connect ENOENT/ECONNREFUSED proves the endpoint is absent; open ENOENT can be a missing token file.
+/**
+ * A daemon token file that is gone after this client was authenticated to that daemon. Only a
+ * daemon's own shutdown unlinks the token, so the endpoint it named is provably retired.
+ *
+ * Keeps the errno shape of the underlying `open` failure: recovery paths that retry a respawn on a
+ * missing token match on `code`/`syscall`, and they must keep winning over this classification.
+ */
+export class DaemonEndpointTokenGoneError extends Error implements NodeJS.ErrnoException {
+  readonly code = 'ENOENT'
+  readonly syscall = 'open'
+  readonly path: string
+
+  constructor(tokenPath: string, cause: unknown) {
+    super(`ENOENT: no such file or directory, open '${tokenPath}'`, { cause })
+    this.name = 'DaemonEndpointTokenGoneError'
+    this.path = tokenPath
+  }
+}
+
+// Connect ENOENT/ECONNREFUSED proves the endpoint is absent. A bare open ENOENT does not — an
+// unread token can still front a live daemon — so only the authenticated-disconnect form counts.
 export function isDaemonEndpointGoneError(err: unknown): boolean {
+  if (err instanceof DaemonEndpointTokenGoneError) {
+    return true
+  }
   const candidate = err as { code?: unknown; syscall?: unknown } | null
   return (
     typeof candidate === 'object' &&


### PR DESCRIPTION
## ELI5

When the terminal daemon exits it deletes its password file (the token) but leaves its socket behind. Orca reads the token *before* it dials the socket — so a dead daemon trips on the missing token first. Orca only knows how to say "the daemon that owned this terminal exited" when the *dial* fails, so instead the pane showed a raw filesystem error and a "file an issue" link. This teaches Orca to recognize the missing token as the same thing.

## What Changed

- New `DaemonEndpointTokenGoneError` in `daemon-errors.ts`, recognized by `isDaemonEndpointGoneError()`.
- `DaemonClient` throws it when the token read fails with `ENOENT` **and** this client has already observed an authenticated disconnect.

## Why

`daemon-server.ts:381` leaves the socket in place on exit — deliberately, per its comment — but unlinks the token. `client.ts` reads the token as the first statement of `doConnect()`, before `connectSocket()`. So on the most common daemon-exited shape, the failure is an `open` `ENOENT` and the connect that would have returned `ENOENT`/`ECONNREFUSED` never happens.

`isDaemonEndpointGoneError()` keys on `syscall === 'connect'`, so `ipc/pty.ts:858` never converted this to `TerminalHostGoneError`, and the pane fell through to raw errno text plus the issue link instead of the copy written for it: *"The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered."*

Reported in Slack from a floating terminal on 1.4.181-hourly.202608112119 (macOS 26.3.1):

```
DaemonProtocolError: Disconnected
ENOENT: no such file or directory, open '~/Library/Application Support/orca/daemon/daemon-v32.token'
```

**When this shape appeared.** `7adda25b0a` (#9277, 2026-07-19, "retire empty current-generation daemons") added the token unlink to shutdown and deleted `unlinkSync(this.socketPath)` in the same commit. Before it, a retired daemon left a stale-but-readable token, so a reconnect got all the way to `connect` and failed `ENOENT` there — the shape `isDaemonEndpointGoneError` was later written for. After it, the failure moved to the `open`. (#9277 sits on a pre-import lineage and is not an ancestor of `main`; the behavior reached `main` through the history import, so `git merge-base` won't relate them.)

Two properties keep this narrow:

- **Gated on an authenticated disconnect.** Only a daemon's own shutdown unlinks its token, so after we were authenticated to it the endpoint is provably retired. Before that, an unread token can still front a daemon mid-startup — classifying *that* as gone would retire live panes' persisted owners. The existing assertion that a bare `open`/`ENOENT` is **not** endpoint-gone is unchanged and still passing.
- **Keeps the errno shape.** The error carries `code`/`syscall`/`path`, so `daemon-pty-adapter.ts:2129`'s respawn-and-retry still matches it first. Recovery keeps winning; this only changes what the user sees when recovery is impossible (`respawnAdoptionClosed`, or no respawn function).

This is the second of two PRs from the same report. #14097 restores the respawn on this path; this one fixes what the user sees when respawn can't run.

## Linked Issue

No GitHub issue — reported in Slack (`#eng`, 2026-08-11). Search for an existing open issue found none.

## Visual Proof

`N/A` — no layout change. The text inside the existing terminal error toast changes from the raw errno string plus "If this persists, please file an issue" to the existing explained-host-gone copy, which is already rendered by `TerminalErrorToast`.

## Testing

`client.test.ts` and `daemon-errors.test.ts` (37 tests) pass; `typecheck:node` and the changed-code quality gate (oxlint + type-aware + React Doctor) are clean on macOS.

New coverage:
- `client.test.ts` — after a real authenticated socket-close disconnect with the token removed, `ensureConnected()` rejects with `DaemonEndpointTokenGoneError` and `isDaemonEndpointGoneError()` accepts it; before any authenticated session the same missing token still rejects as an unclassified `ENOENT`/`open`.
- `daemon-errors.test.ts` — classification, plus an explicit assertion that the errno shape recovery paths match on is preserved.

Negative control: with only the two source files reverted, all 4 new tests fail.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Main-process only; no wire-format or renderer change (the renderer already humanizes `terminal_host_gone`, including across the paired-runtime RPC boundary, which is covered by an existing test). Platform-independent — the Windows named-pipe form of endpoint-gone is untouched and still tested. Cannot fire before authentication, so a daemon that is still starting is never declared gone.

## AI Disclosure

Claude Opus 5.
