### PR TITLE
fix(terminal): never wipe a painted pane for a snapshot that carries no image

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -326,6 +326,7 @@ type MockTransport = {
   getPtyId: ReturnType<typeof vi.fn>
   getConnectionId: ReturnType<typeof vi.fn>
   serializeBuffer?: ReturnType<typeof vi.fn>
+  serializeBufferOutcome?: ReturnType<typeof vi.fn>
 }
 
 const scheduleRuntimeGraphSync = vi.fn()
@@ -15166,6 +15167,63 @@ describe('connectPanePty', () => {
       expect.stringContaining('remote snapshot with hidden remote output'),
       expect.any(Function)
     )
+    disposable.dispose()
+  })
+
+  it('preserves the painted normal buffer when a successful hidden restore has no image', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('remote:env-1@@terminal-1')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible remote output\r\n'
+    transport.serializeBuffer = vi.fn()
+    transport.serializeBufferOutcome = vi.fn().mockResolvedValue({
+      availability: { kind: 'snapshot' },
+      snapshot: {
+        data: '',
+        scrollbackAnsi: '',
+        cols: 120,
+        rows: 40,
+        seq: hidden.length + live.length,
+        source: 'headless'
+      }
+    })
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'remote:env-1@@terminal-1'
+    })
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+    const writeStart = pane.terminal.write.mock.calls.length
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    const restoreWrites = pane.terminal.write.mock.calls
+      .slice(writeStart)
+      .map(([data]) => String(data))
+    const paintedFrame = Array.from({ length: 8 }, (_, index) => `painted-frame-${index + 1}`).join(
+      '\r\n'
+    )
+    const actual = await renderHeadlessTerminalState([paintedFrame, ...restoreWrites], 120, 4)
+    const expected = await renderHeadlessTerminalState(
+      [paintedFrame, ...restoreWrites.filter((data) => data === live)],
+      120,
+      4
+    )
+    expect(actual).toEqual(expected)
+    expect(transport.serializeBufferOutcome).toHaveBeenCalledTimes(1)
+    expect(transport.serializeBuffer).not.toHaveBeenCalled()
     disposable.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7300,10 +7300,18 @@ export function connectPanePty(
               snapshot.alternateScreen === true &&
               snapshot.frameRestoreAnsi !== undefined &&
               shouldSkipAltFrameForWidthMismatch(snapshot.cols, readProposedTerminalCols(pane))
-            for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
-              skipAltFrame: skippedAltFrame
-            })) {
-              writeReplayData(replayChunk)
+            // Why: a success frame with no image is the host having nothing to say, not
+            // proof the pane is empty. The normal-buffer branch opens with
+            // \x1b[2J\x1b[3J\x1b[H, so applying it would wipe screen AND scrollback and
+            // leave exactly the blank pane this restore exists to repair.
+            const snapshotCarriesNoImage =
+              snapshot.alternateScreen !== true && snapshot.data === '' && !snapshot.scrollbackAnsi
+            if (!snapshotCarriesNoImage) {
+              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
+                skipAltFrame: skippedAltFrame
+              })) {
+                writeReplayData(replayChunk)
+              }
             }
             // Why: live agents own ?25l/?1004h; a forced ?1004l here would silence focus events until restart (agents enable focus reporting only at startup).
             writeReplayData(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7300,10 +7300,7 @@ export function connectPanePty(
               snapshot.alternateScreen === true &&
               snapshot.frameRestoreAnsi !== undefined &&
               shouldSkipAltFrameForWidthMismatch(snapshot.cols, readProposedTerminalCols(pane))
-            // Why: a success frame with no image is the host having nothing to say, not
-            // proof the pane is empty. The normal-buffer branch opens with
-            // \x1b[2J\x1b[3J\x1b[H, so applying it would wipe screen AND scrollback and
-            // leave exactly the blank pane this restore exists to repair.
+            // Why: an imageless success is not proof the pane is empty; normal replay clears screen and scrollback.
             const snapshotCarriesNoImage =
               snapshot.alternateScreen !== true && snapshot.data === '' && !snapshot.scrollbackAnsi
             if (!snapshotCarriesNoImage) {

--- a/src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts
@@ -638,6 +638,23 @@ describe('remote hidden-output restore outcomes', () => {
     drive.disposable.dispose()
   })
 
+  it('[modern] leaves the painted frame alone when the empty snapshot carries no image', async () => {
+    const serializeBuffer = vi.fn()
+    const serializeBufferOutcome = vi.fn().mockResolvedValue({
+      availability: { kind: 'snapshot' },
+      snapshot: { ...HOST_SNAPSHOT, data: '' }
+    })
+    const drive = await connectHiddenRemoteAgentPane(serializeBuffer, serializeBufferOutcome)
+    vi.useFakeTimers()
+    driveHiddenBacklogThenReveal(drive)
+    await flushAsyncTicks(20)
+
+    // \x1b[3J wipes xterm scrollback; a host answer with nothing in it must never
+    // cost the user the frame they can still see.
+    expect(drive.writtenChunks().join('')).not.toContain('\x1b[3J')
+    drive.disposable.dispose()
+  })
+
   it('[modern] waits for a reported outcome instead of applying the old elapsed-time deadline', async () => {
     const pendingOutcome = createDeferred<{
       availability: { kind: 'snapshot' }

--- a/src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts
@@ -638,23 +638,6 @@ describe('remote hidden-output restore outcomes', () => {
     drive.disposable.dispose()
   })
 
-  it('[modern] leaves the painted frame alone when the empty snapshot carries no image', async () => {
-    const serializeBuffer = vi.fn()
-    const serializeBufferOutcome = vi.fn().mockResolvedValue({
-      availability: { kind: 'snapshot' },
-      snapshot: { ...HOST_SNAPSHOT, data: '' }
-    })
-    const drive = await connectHiddenRemoteAgentPane(serializeBuffer, serializeBufferOutcome)
-    vi.useFakeTimers()
-    driveHiddenBacklogThenReveal(drive)
-    await flushAsyncTicks(20)
-
-    // \x1b[3J wipes xterm scrollback; a host answer with nothing in it must never
-    // cost the user the frame they can still see.
-    expect(drive.writtenChunks().join('')).not.toContain('\x1b[3J')
-    drive.disposable.dispose()
-  })
-
   it('[modern] waits for a reported outcome instead of applying the old elapsed-time deadline', async () => {
     const pendingOutcome = createDeferred<{
       availability: { kind: 'snapshot' }


### PR DESCRIPTION
## ELI5

When the app asks the host "give me this terminal's contents" and the host answers with nothing, we used to erase the pane and paint nothing in its place. Now we keep what's on screen.

## What Changed

One guard in the hidden-output restore path (`pty-connection.ts`): skip the replay writes when the snapshot carries no image at all — normal buffer, empty `data`, no `scrollbackAnsi`.

Retry and banner behavior are untouched. An empty image still counts as a successful, non-bannered recovery; this only stops the destructive paint.

## Why

`buildMainModelSnapshotReplayWrites` opens the normal-buffer branch with `ESC[2J ESC[3J ESC[H`. The `ESC[3J` wipes xterm **scrollback**, not just the screen. That is correct when the snapshot carries history to paint in its place. It is destructive when the image is empty: the pane loses everything and gets nothing back.

An empty image reaches that code because `outcome.snapshot` is an object, so it is truthy even when `data === ''`. The nearby "no answer" cases are already handled correctly — a null snapshot becomes `retry-worthy`, and a host-reported `no-serializable-buffer` is classified `retry-worthy` — so this is the one shape of "the host had nothing" that fell through to a wipe.

An empty image is the absence of an answer, not proof the pane is empty. Existing coverage pinned that this case must not banner and must not retry, but nothing pinned what it paints, which is how the wipe survived.

Scoped deliberately to the restore path. The two reattach call sites of the same builder are left alone — they paint into a pane that is being rebuilt anyway, and widening this would make the change harder to reason about.

## Linked Issue

No existing issue — found while reviewing the restore path for #14095 (the two interact; see below). Happy to file one if preferred.

## Visual Proof

`N/A` — no intentional repaint. The change is the absence of a destructive replay; a deterministic headless-terminal oracle verifies the retained screen and scrollback exactly.

## Testing

Added `preserves the painted normal buffer when a successful hidden restore has no image` to `pty-connection.test.ts`. It seeds a real headless normal buffer with eight painted lines and four scrollback rows, drives the production hidden-output restore with empty `data` and `scrollbackAnsi`, then compares all lines, visible lines, and `baseY` with the control path.

Verified red with the guard bypassed: the buffer collapsed to four blank rows with `baseY: 0`. Verified green with the guard restored.

```
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/remote-hidden-output-restore-outcomes.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --reporter=dot
-> 577 passed

pnpm exec tsc --noEmit -p config/tsconfig.tc.web.json
pnpm exec oxlint <three focused files>
pnpm exec oxfmt --check <three focused files>
-> clean
```

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — reproducing in-app needs a host that reports a successful empty-image snapshot; the deterministic provider/terminal test is the primary oracle.

## Reliability Contract

- **Invariant (`terminal-output.scrollback-restore`):** a successful normal-buffer hidden restore with no image preserves the already-painted screen and scrollback, while success classification remains non-retrying and non-bannered.
- **Failure source:** a truthy snapshot object with empty `data` reached the normal-buffer replay builder and emitted screen/scrollback clears.
- **Oracle:** exact headless-terminal normal-buffer equality after the production restore path; the existing outcome suite separately pins one request, no legacy fallback, and no loss banner.
- **Gate:** `config/reliability-gates.jsonc` entry `terminal-output.scrollback-restore` (experimental/partial); its focused `pty-connection.test.ts` command and the adjacent outcome suite pass.
- **Provider/platform coverage:** the decision runs after local/daemon/SSH/remote-runtime snapshot normalization and contains no provider, filesystem, shell, path, or platform branch. The modern remote-runtime outcome is covered directly; macOS/Linux/Windows, WSL, SSH, folders, worktrees, and relay wire shapes are unaffected.
- **Performance budget:** three scalar checks on an already-bounded restore path; the empty-image case skips replay construction, two xterm writes, and parsing. No polling, retry, subprocess, allocation-growth, or wake-loop change.
- **Diagnostics:** exact `allLines`, `visibleLines`, and `baseY` diffs identify any future destructive replay; existing lifecycle diagnostics remain unchanged.
- **Residual gap:** no packaged Electron fault-injection journey produces this uncommon host response. The deterministic lower-layer oracle proves the ANSI/buffer behavior without a broad UI flow.

## Relationship to #14095

Independent and reviewable alone, but they interact and **this one should land first or together**. #14095 makes a recovery re-subscribe re-request the retained buffer, so it drives this path far more often than a visibility flip does. Without this guard, a recovery whose snapshot came back empty would wipe the pane — producing the exact blank pane #14095 exists to fix.

Branched off `main`, not off #14095, so the two can merge in either order.

## Review

- **Cross-platform:** renderer-only, no platform-specific code.
- **SSH/remote:** applies to any transport reaching the hidden-output restore; strictly reduces destructive writes.
- **Backwards compatibility:** no wire or IPC change.
- **Performance:** one boolean decision on a rare path; skips work rather than adding it.

