### PR TITLE
fix(ci): make the Electron install survive release-CDN blips

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -303,6 +303,12 @@ jobs:
         with:
           native-runtime: node
 
+      # Why: the harness loads main-process modules that require `electron`, and its
+      # index.js self-downloads with a single un-retried request when path.txt is
+      # absent. This installer retries and repairs path.txt instead.
+      - name: Install Electron package binary for tests
+        run: node config/scripts/install-electron-package-binary.mjs
+
       # A path filter that matches nothing exits 1 ("No test files found"), so this
       # lane cannot report success while running zero tests.
       - name: Old/new client and server terminal journey

--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -200,7 +200,7 @@ function isTransientDownloadError(error) {
     if (transientDownloadErrorCodes.has(candidate?.code)) {
       return true
     }
-    const statusCode = candidate?.statusCode ?? candidate?.response?.statusCode
+    const statusCode = getErrorStatusCode(candidate)
     if (
       statusCode === 408 ||
       statusCode === 425 ||
@@ -211,6 +211,13 @@ function isTransientDownloadError(error) {
     }
   }
   return false
+}
+
+// Why `status`: @electron/get v5 downloads through fetch and throws an HTTPError
+// holding a Response, which exposes `status`. Reading only got's `statusCode`
+// made every 5xx look permanent, so release-CDN 503s failed with zero retries.
+function getErrorStatusCode(candidate) {
+  return candidate?.statusCode ?? candidate?.response?.statusCode ?? candidate?.response?.status
 }
 
 function getErrorChain(error) {
@@ -225,7 +232,7 @@ function getErrorChain(error) {
 
 function formatDownloadError(error) {
   for (const candidate of getErrorChain(error)) {
-    const statusCode = candidate?.statusCode ?? candidate?.response?.statusCode
+    const statusCode = getErrorStatusCode(candidate)
     if (statusCode) {
       return `HTTP ${statusCode}`
     }

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -118,6 +118,51 @@ describe('install-electron-package-binary', () => {
     }
   })
 
+  // Why: the release CDN serves 503s during incidents, and @electron/get v5 reports
+  // them as a fetch Response (`status`). Reading only `statusCode` retried zero times.
+  it('retries transient Electron download failures reported as an HTTP status', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir, { downloadFailures: 1, downloadErrorStatus: 503 })
+      writeFakeExtractor(projectDir, { createExecutable: true })
+
+      const result = runInstallScript(projectDir, {
+        ORCA_ELECTRON_PACKAGE_RETRY_DELAYS_MS: '0,0'
+      })
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(
+        readFileSync(join(projectDir, 'electron-get.log'), 'utf8').trim().split('\n')
+      ).toHaveLength(2)
+      expect(result.stderr).toContain('Transient Electron download failure (HTTP 503)')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not retry an HTTP status that will not recover', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir, { downloadFailures: 5, downloadErrorStatus: 404 })
+      writeFakeExtractor(projectDir, { createExecutable: true })
+
+      const result = runInstallScript(projectDir, {
+        ORCA_ELECTRON_PACKAGE_RETRY_DELAYS_MS: '0,0'
+      })
+
+      expect(result.status).toBe(1)
+      expect(
+        readFileSync(join(projectDir, 'electron-get.log'), 'utf8').trim().split('\n')
+      ).toHaveLength(1)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('fails after exhausting transient Electron download retries', () => {
     const projectDir = mkTempProject()
 
@@ -279,7 +324,12 @@ module.exports = path.join(__dirname, 'dist', fs.readFileSync(pathFile, 'utf8'))
 
 function writeFakeElectronGet(
   projectDir,
-  { downloadNeverSettles = false, downloadFailures = 0, downloadErrorCode = 'ECONNRESET' } = {}
+  {
+    downloadNeverSettles = false,
+    downloadFailures = 0,
+    downloadErrorCode = 'ECONNRESET',
+    downloadErrorStatus = 0
+  } = {}
 ) {
   const getDir = join(projectDir, 'node_modules', 'electron', 'node_modules', '@electron', 'get')
   mkdirSync(getDir, { recursive: true })
@@ -299,6 +349,14 @@ exports.downloadArtifact = async function downloadArtifact(details) {
     return new Promise(() => {})
   }
   if (downloadAttempt <= ${JSON.stringify(downloadFailures)}) {
+    const status = ${JSON.stringify(downloadErrorStatus)}
+    if (status) {
+      // Mirrors @electron/get v5's HTTPError: a fetch Response, so \`status\` not \`statusCode\`.
+      const httpError = new Error('Response code ' + status + ' for https://example.invalid/e.zip')
+      httpError.name = 'HTTPError'
+      httpError.response = { status, url: 'https://example.invalid/e.zip' }
+      throw httpError
+    }
     const cause = Object.assign(new Error('download failed'), {
       code: ${JSON.stringify(downloadErrorCode)}
     })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -429,6 +429,23 @@ describe('Electron runtime package contract', () => {
     expect(installStep.run).toBe('node config/scripts/install-electron-package-binary.mjs')
   })
 
+  // Why: the cross-version harness imports main-process modules that require
+  // `electron`, whose index.js self-downloads once with no retry. Without this
+  // step the lane reds on any release-CDN blip.
+  it('installs the Electron package binary before the cross-version wire lane', () => {
+    const prWorkflow = readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8')
+    const steps = parse(prWorkflow).jobs['cross-version-wire'].steps
+    const installIndex = steps.findIndex(
+      (step) => step.run === 'node config/scripts/install-electron-package-binary.mjs'
+    )
+    const journeyIndex = steps.findIndex((step) =>
+      step.run?.includes('cross-version-terminal-wire.unit.test.ts')
+    )
+
+    expect(installIndex).toBeGreaterThanOrEqual(0)
+    expect(installIndex).toBeLessThan(journeyIndex)
+  })
+
   it('smokes the packaged CLI from outside the checkout in PR checks', () => {
     const prWorkflow = readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8')
     const parsedWorkflow = parse(prWorkflow)


### PR DESCRIPTION
Two related fixes for CI jobs that red on transient GitHub release-CDN failures rather than on anything in the diff under test.

## 1. 5xx download failures were never retried

`isTransientDownloadError` read only `error.statusCode` / `error.response.statusCode` — got's shape. But `@electron/get` **v5** downloads through `fetch` and throws an `HTTPError` holding a **Fetch `Response`**, which exposes **`.status`**:

```js
// @electron/get@5.0.0 FetchDownloader.js
export class HTTPError extends Error {
  constructor(response) {
    super(`Response code ${response.status} (${response.statusText}) for ${response.url}`)
    this.response = response
  }
}
```

So every 5xx was classified permanent and rethrown with **zero** retries. The asymmetry is plain in CI logs:

| Failure | Retries | Duration |
|---|---|---|
| `UND_ERR_SOCKET` (matched by `code`) | 3 attempts | ~4s |
| `503` (status not found) | **0 attempts** | ~0.12s |

Fixed by reading `response.status` too, via one shared accessor so the shape is defined in a single place.

The fake `@electron/get` in tests only ever raised code-bearing errors, which is exactly how this went uncovered — it can now raise a v5-shaped `HTTPError`. **The new 503 test fails without the source fix.**

## 2. The cross-version wire lane downloaded Electron with no retry at all

That lane installs with `--ignore-scripts` and `native-runtime: node`, so `node_modules/electron` never gets a `path.txt`. Its `beforeAll` imports main-process modules that transitively `require('electron')`, and `electron/index.js` resolves `getElectronPath()` **at require time**, self-downloading with a single un-retried request. A CDN blip surfaced as:

```
Error: Electron failed to install correctly. …
 Test Files  1 failed (1)
      Tests  4 skipped (4)
```

The "4 skipped" is misleading — the tests never ran, so a network failure reads as a test-logic failure.

The sharded `test` job already runs `install-electron-package-binary.mjs`, which retries and repairs a missing `path.txt` **without re-downloading**. This runs it in the cross-version lane too.

## Evidence this works

Observed on run 31636421412 **during a live CDN incident**: the cross-version lane's new step succeeded in ~3s (`Repaired Electron path.txt -> electron`) and the suite passed 4/4, while other jobs were taking 503s in the same minute.

## Testing

- Both new tests are verified as real guards — each fails against the unfixed code and passes with it.
- `install-electron-package-binary` + `package-electron-runtime-contract` + `rebuild-native-deps`: 41 passing.
- `oxlint` clean.
