### PR TITLE
fix: persist review notes for folder workspaces

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -41,6 +41,7 @@ import { isTuiAgent } from '../../shared/tui-agent-config'
 import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
 import { WorkspaceLinkedItemSchema } from '../../shared/workspace-linked-item-schema'
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-linked-item-source-context'
+import { DiffCommentSchema } from '../../shared/diff-comment-schema'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'node:child_process'
 import { access, mkdir, readdir, rm } from 'node:fs/promises'
@@ -951,7 +952,8 @@ const FolderWorkspaceUpdateArgs = z.object({
       createdWithAgent: z.string().refine(isTuiAgent).optional(),
       pendingFirstAgentMessageRename: z.boolean().optional(),
       firstAgentMessageRenameError: z.string().nullable().optional(),
-      lastActivityAt: z.number().finite().optional()
+      lastActivityAt: z.number().finite().optional(),
+      diffComments: z.array(DiffCommentSchema).optional()
     })
     .superRefine(assertFolderWorkspaceLinkedSourceContextMatch)
 })

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -5044,7 +5044,19 @@ describe('Store', () => {
     const updated = store.updateFolderWorkspace(workspace.id, {
       comment: 'Coordinate api and web',
       isPinned: true,
-      lastActivityAt: 123
+      lastActivityAt: 123,
+      diffComments: [
+        {
+          id: 'note-1',
+          worktreeId: folderWorkspaceKey(workspace.id),
+          filePath: 'README.md',
+          source: 'markdown',
+          lineNumber: 1,
+          body: 'Review this paragraph',
+          createdAt: 100,
+          side: 'modified'
+        }
+      ]
     })
 
     expect(workspace.folderPath).toBe('/workspace/platform')
@@ -5056,9 +5068,16 @@ describe('Store', () => {
       linkedTask,
       comment: 'Coordinate api and web',
       isPinned: true,
-      lastActivityAt: 123
+      lastActivityAt: 123,
+      diffComments: [expect.objectContaining({ id: 'note-1', body: 'Review this paragraph' })]
     })
     expect(store.getFolderWorkspaces()).toHaveLength(1)
+    store.flush()
+
+    const restored = await createStore()
+    expect(restored.getFolderWorkspace(workspace.id)?.diffComments).toEqual([
+      expect.objectContaining({ id: 'note-1', body: 'Review this paragraph' })
+    ])
   })
 
   it('round-trips Jira item and source context for repo-less folder workspaces', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4551,6 +4551,7 @@ export class Store {
         | 'pendingFirstAgentMessageRename'
         | 'firstAgentMessageRenameError'
         | 'lastActivityAt'
+        | 'diffComments'
       >
     >
   ): FolderWorkspace | null {
@@ -4623,6 +4624,9 @@ export class Store {
     }
     if (updates.lastActivityAt !== undefined && Number.isFinite(updates.lastActivityAt)) {
       workspace.lastActivityAt = updates.lastActivityAt
+    }
+    if (updates.diffComments !== undefined) {
+      workspace.diffComments = updates.diffComments
     }
     workspace.updatedAt = Date.now()
     this.scheduleSave()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18491,6 +18491,7 @@ export class OrcaRuntimeService {
         | 'pendingFirstAgentMessageRename'
         | 'firstAgentMessageRenameError'
         | 'lastActivityAt'
+        | 'diffComments'
       >
     >
   ): Promise<FolderWorkspace | null> {

--- a/src/main/runtime/rpc/methods/folder-workspace.ts
+++ b/src/main/runtime/rpc/methods/folder-workspace.ts
@@ -6,6 +6,7 @@ import { TaskSourceContextSchema } from '../../../../shared/task-source-context-
 import { WorkspaceLinkedItemSchema } from '../../../../shared/workspace-linked-item-schema'
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../../../shared/workspace-linked-item-source-context'
 import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
+import { DiffCommentSchema } from '../../../../shared/diff-comment-schema'
 
 const FolderWorkspaceLinkedTask = WorkspaceLinkedItemSchema.nullable()
 
@@ -59,7 +60,8 @@ const FolderWorkspaceUpdate = z.object({
       createdWithAgent: z.string().refine(isTuiAgent).optional(),
       pendingFirstAgentMessageRename: z.boolean().optional(),
       firstAgentMessageRenameError: z.string().nullable().optional(),
-      lastActivityAt: OptionalFiniteNumber
+      lastActivityAt: OptionalFiniteNumber,
+      diffComments: z.array(DiffCommentSchema).optional()
     })
     .superRefine(assertLinkedTaskSourceContextMatch)
 })

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1332,6 +1332,7 @@ export type PreloadApi = {
           | 'pendingFirstAgentMessageRename'
           | 'firstAgentMessageRenameError'
           | 'lastActivityAt'
+          | 'diffComments'
         >
       >
     }) => Promise<FolderWorkspace | null>

--- a/src/renderer/src/lib/folder-workspace-runtime-owner.ts
+++ b/src/renderer/src/lib/folder-workspace-runtime-owner.ts
@@ -16,7 +16,7 @@ type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 export type FolderWorkspaceRuntimeOwnerState = SingleRuntimeLegacyOwnerState & {
   folderWorkspaces?: readonly Pick<
     FolderWorkspace,
-    'id' | 'projectGroupId' | 'connectionId' | 'executionHostId'
+    'id' | 'projectGroupId' | 'connectionId' | 'executionHostId' | 'diffComments'
   >[]
   projectGroups?: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[]
   restoredRuntimeHostIdByWorkspaceSessionKey?: Record<string, ExecutionHostId>
@@ -41,7 +41,10 @@ export function findFolderWorkspaceOwner(
   state: FolderWorkspaceRuntimeOwnerState,
   folderWorkspaceId: string,
   executionHostId?: ExecutionHostId
-): Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId' | 'executionHostId'> | null {
+): Pick<
+  FolderWorkspace,
+  'id' | 'projectGroupId' | 'connectionId' | 'executionHostId' | 'diffComments'
+> | null {
   return findIndexedFolderWorkspaceOwner(
     state.folderWorkspaces,
     folderWorkspaceId,

--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -12,7 +12,7 @@ type DetectedWorktreeListing = { worktrees: readonly WorktreeOwnerRecord[] }
 type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
 type FolderWorkspaceOwnerRecord = Pick<
   FolderWorkspace,
-  'id' | 'projectGroupId' | 'connectionId' | 'executionHostId'
+  'id' | 'projectGroupId' | 'connectionId' | 'executionHostId' | 'diffComments'
 >
 type ProjectGroupOwnerRecord = Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>
 

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -1,12 +1,18 @@
 /* eslint-disable max-lines -- Why: keeps note mutation, rollback, persistence ordering, and sent-state transitions under shared queue/rollback invariants. */
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { DiffComment, Worktree } from '../../../../shared/types'
+import type { DiffComment, FolderWorkspace, Worktree } from '../../../../shared/types'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  findFolderWorkspaceOwner,
+  getExecutionHostIdForFolderWorkspace,
+  getRuntimeEnvironmentIdForFolderWorkspace
+} from '@/lib/folder-workspace-runtime-owner'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 
 export type DiffCommentsSlice = {
   getDiffComments: (worktreeId: string | null | undefined) => DiffComment[]
@@ -89,10 +95,41 @@ function deliverySnapshotMatches(
 const EMPTY_COMMENTS: readonly DiffComment[] = Object.freeze([])
 
 async function persist(
+  state: AppState,
   settings: AppState['settings'],
   worktreeId: string,
-  diffComments: DiffComment[]
+  diffComments: DiffComment[],
+  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
 ): Promise<void> {
+  const scope = parseWorkspaceKey(worktreeId)
+  if (scope?.type === 'folder') {
+    const executionHostId =
+      folderExecutionHostId ?? getExecutionHostIdForFolderWorkspace(state, scope.folderWorkspaceId)
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForFolderWorkspace(
+      state,
+      scope.folderWorkspaceId,
+      executionHostId
+    )
+    const target = getActiveRuntimeTarget({ activeRuntimeEnvironmentId: runtimeEnvironmentId })
+    const updated =
+      target.kind === 'local'
+        ? await window.api.folderWorkspaces.update({
+            folderWorkspaceId: scope.folderWorkspaceId,
+            updates: { diffComments }
+          })
+        : (
+            await callRuntimeRpc<{ folderWorkspace: FolderWorkspace | null }>(
+              target,
+              'folderWorkspace.update',
+              { folderWorkspaceId: scope.folderWorkspaceId, updates: { diffComments } },
+              { timeoutMs: 15_000 }
+            )
+          ).folderWorkspace
+    if (!updated?.diffComments) {
+      throw new Error('Failed to persist folder workspace review notes')
+    }
+    return
+  }
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'local') {
     await window.api.worktrees.updateMeta({
@@ -121,22 +158,40 @@ const persistQueueByWorktree = new Map<string, Promise<void>>()
 
 // Why: chain each write onto the prior promise so writes land in call order; both then handlers keep the chain alive past a failure.
 // Why: queued work reads the latest list at dequeue time, and the returned promise settles for THIS write so callers can roll back.
-function enqueuePersist(worktreeId: string, get: () => AppState): Promise<void> {
-  const prior = persistQueueByWorktree.get(worktreeId) ?? Promise.resolve()
+function enqueuePersist(
+  worktreeId: string,
+  get: () => AppState,
+  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
+): Promise<void> {
+  const queueKey = folderExecutionHostId ? `${folderExecutionHostId}\0${worktreeId}` : worktreeId
+  const prior = persistQueueByWorktree.get(queueKey) ?? Promise.resolve()
   const run = async (): Promise<void> => {
+    const scope = parseWorkspaceKey(worktreeId)
+    if (scope?.type === 'folder') {
+      const state = get()
+      const folderWorkspace = findFolderWorkspaceOwner(
+        state,
+        scope.folderWorkspaceId,
+        folderExecutionHostId
+      )
+      const latest = (folderWorkspace?.diffComments ?? []).map(normalizeDiffComment)
+      await persist(state, state.settings, worktreeId, latest, folderExecutionHostId)
+      return
+    }
     const repoId = getRepoIdFromWorktreeId(worktreeId)
     const repoList = get().worktreesByRepo[repoId]
     const target = repoList?.find((w) => w.id === worktreeId)
     const latest = (target?.diffComments ?? []).map(normalizeDiffComment)
-    await persist(settingsForWorktreeOwner(get(), worktreeId), worktreeId, latest)
+    const state = get()
+    await persist(state, settingsForWorktreeOwner(state, worktreeId), worktreeId, latest)
   }
   const next = prior.then(run, run)
-  persistQueueByWorktree.set(worktreeId, next)
+  persistQueueByWorktree.set(queueKey, next)
   // Why: clear the queue entry only if still the tail, so later enqueues chain onto the real in-flight promise.
   // Why: then(cleanup, cleanup) not finally, so a rejection is consumed here rather than re-thrown as unhandledRejection.
   const cleanup = (): void => {
-    if (persistQueueByWorktree.get(worktreeId) === next) {
-      persistQueueByWorktree.delete(worktreeId)
+    if (persistQueueByWorktree.get(queueKey) === next) {
+      persistQueueByWorktree.delete(queueKey)
     }
   }
   next.then(cleanup, cleanup)
@@ -148,11 +203,35 @@ function mutateComments(
   set: Parameters<StateCreator<AppState, [], [], DiffCommentsSlice>>[0],
   worktreeId: string,
   mutate: (existing: DiffComment[]) => DiffComment[] | null
-): { previous: DiffComment[] | undefined; next: DiffComment[] } | null {
+): {
+  previous: DiffComment[] | undefined
+  next: DiffComment[]
+  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
+} | null {
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   let previous: DiffComment[] | undefined
   let next: DiffComment[] | null = null
+  let folderExecutionHostId: ReturnType<typeof getExecutionHostIdForFolderWorkspace> | undefined
   set((s) => {
+    const scope = parseWorkspaceKey(worktreeId)
+    if (scope?.type === 'folder') {
+      const target = findFolderWorkspaceOwner(s, scope.folderWorkspaceId)
+      if (!target) {
+        return {}
+      }
+      folderExecutionHostId = getExecutionHostIdForFolderWorkspace(s, scope.folderWorkspaceId)
+      previous = target.diffComments
+      const computed = mutate(previous ?? [])
+      if (computed === null) {
+        return {}
+      }
+      next = computed
+      return {
+        folderWorkspaces: s.folderWorkspaces.map((workspace) =>
+          workspace === target ? { ...workspace, diffComments: computed } : workspace
+        )
+      }
+    }
     const repoList = s.worktreesByRepo[repoId]
     if (!repoList) {
       return {}
@@ -175,7 +254,7 @@ function mutateComments(
   if (next === null) {
     return null
   }
-  return { previous, next }
+  return { previous, next, folderExecutionHostId }
 }
 
 // Why: on IPC-write failure, roll back optimistic state so the renderer matches disk (identity-guarded below).
@@ -183,10 +262,23 @@ function rollback(
   set: Parameters<StateCreator<AppState, [], [], DiffCommentsSlice>>[0],
   worktreeId: string,
   previous: DiffComment[] | undefined,
-  expectedCurrent: DiffComment[]
+  expectedCurrent: DiffComment[],
+  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
 ): void {
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   set((s) => {
+    const scope = parseWorkspaceKey(worktreeId)
+    if (scope?.type === 'folder') {
+      const target = findFolderWorkspaceOwner(s, scope.folderWorkspaceId, folderExecutionHostId)
+      if (!target || target.diffComments !== expectedCurrent) {
+        return {}
+      }
+      return {
+        folderWorkspaces: s.folderWorkspaces.map((workspace) =>
+          workspace === target ? { ...workspace, diffComments: previous } : workspace
+        )
+      }
+    }
     const repoList = s.worktreesByRepo[repoId]
     if (!repoList) {
       return {}
@@ -216,7 +308,11 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!worktreeId) {
       return EMPTY_COMMENTS as DiffComment[]
     }
-    const worktree = findWorktreeById(get().worktreesByRepo, worktreeId)
+    const scope = parseWorkspaceKey(worktreeId)
+    const worktree =
+      scope?.type === 'folder'
+        ? findFolderWorkspaceOwner(get(), scope.folderWorkspaceId)
+        : findWorktreeById(get().worktreesByRepo, worktreeId)
     if (!worktree?.diffComments) {
       // Why: cast the frozen sentinel to the mutable return type; runtime freeze makes accidental mutation throw.
       return EMPTY_COMMENTS as DiffComment[]
@@ -236,13 +332,13 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     }
     try {
       // Why: serialize through the per-worktree queue so concurrent writes can't land on disk out of call order.
-      await enqueuePersist(input.worktreeId, get)
+      await enqueuePersist(input.worktreeId, get, result.folderExecutionHostId)
       get().recordFeatureInteraction?.('review-notes')
       return comment
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
       // Why: rollback's identity guard no-ops if a later mutation already replaced the list, so a newer write can't be lost.
-      rollback(set, input.worktreeId, result.previous, result.next)
+      rollback(set, input.worktreeId, result.previous, result.next, result.folderExecutionHostId)
       return null
     }
   },
@@ -255,10 +351,7 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     }
 
     // Why: distinguish "comment missing" (false; keep draft, likely edit-while-deleted) from "body unchanged" (true; close editor) before mutating.
-    const repoId = getRepoIdFromWorktreeId(worktreeId)
-    const repoList = get().worktreesByRepo[repoId]
-    const target = repoList?.find((w) => w.id === worktreeId)
-    const existing = target?.diffComments ?? []
+    const existing = get().getDiffComments(worktreeId)
     const existingIdx = existing.findIndex((c) => c.id === commentId)
     if (existingIdx === -1) {
       return false
@@ -285,11 +378,11 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       return true
     }
     try {
-      await enqueuePersist(worktreeId, get)
+      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
       return true
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next)
+      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
       return false
     }
   },
@@ -311,12 +404,12 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       return true
     }
     try {
-      await enqueuePersist(worktreeId, get)
+      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
       get().recordFeatureInteraction?.('review-notes')
       return true
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next)
+      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
       return false
     }
   },
@@ -341,12 +434,12 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       return true
     }
     try {
-      await enqueuePersist(worktreeId, get)
+      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
       get().recordFeatureInteraction?.('review-notes')
       return true
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next)
+      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
       return false
     }
   },
@@ -361,10 +454,10 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     }
     try {
       // Why: serialize through the per-worktree queue so concurrent writes can't land out of call order.
-      await enqueuePersist(worktreeId, get)
+      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next)
+      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
     }
   },
 
@@ -376,11 +469,11 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       return true
     }
     try {
-      await enqueuePersist(worktreeId, get)
+      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
       return true
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next)
+      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
       return false
     }
   },
@@ -394,11 +487,11 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       return true
     }
     try {
-      await enqueuePersist(worktreeId, get)
+      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
       return true
     } catch (err) {
       console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next)
+      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
       return false
     }
   }

--- a/src/renderer/src/store/slices/folder-workspace-diff-comments.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-diff-comments.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import type { AppState } from '../types'
+import type { FolderWorkspace, ProjectGroup } from '../../../../shared/types'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createDiffCommentsSlice } from './diffComments'
+
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+const folderWorkspacesUpdate = vi.fn()
+
+globalThis.window = {
+  api: {
+    folderWorkspaces: { update: folderWorkspacesUpdate },
+    runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+  }
+} as never
+
+function createTestStore() {
+  return create<AppState>()((...args) => {
+    const slice = createDiffCommentsSlice(...args)
+    return {
+      ...slice,
+      settings: null,
+      activeWorktreeId: null,
+      activeWorkspaceExecutionHostId: null,
+      folderWorkspaces: [],
+      projectGroups: [],
+      runtimeEnvironments: [],
+      restoredRuntimeHostIdByWorkspaceSessionKey: {},
+      worktreesByRepo: {}
+    } as unknown as AppState
+  })
+}
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-1',
+    projectGroupId: 'group-1',
+    folderPath: '/workspace',
+    executionHostId: 'local',
+    diffComments: [],
+    ...overrides
+  } as FolderWorkspace
+}
+
+function seedLocalFolderWorkspace(store: ReturnType<typeof createTestStore>): FolderWorkspace {
+  const folderWorkspace = makeFolderWorkspace()
+  const projectGroup = {
+    id: folderWorkspace.projectGroupId,
+    parentPath: '/workspace',
+    executionHostId: 'local'
+  } as ProjectGroup
+  store.setState({
+    activeWorktreeId: folderWorkspaceKey(folderWorkspace.id),
+    activeWorkspaceExecutionHostId: 'local',
+    projectGroups: [projectGroup],
+    folderWorkspaces: [folderWorkspace]
+  })
+  return folderWorkspace
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearRuntimeCompatibilityCacheForTests()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+})
+
+describe('folder workspace diff comments', () => {
+  it('adds and persists a review note', async () => {
+    const store = createTestStore()
+    const folderWorkspace = seedLocalFolderWorkspace(store)
+    folderWorkspacesUpdate.mockImplementation(async ({ updates }) => ({
+      ...folderWorkspace,
+      ...updates
+    }))
+
+    const saved = await store.getState().addDiffComment({
+      worktreeId: folderWorkspaceKey(folderWorkspace.id),
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'folder note',
+      side: 'modified'
+    })
+
+    expect(saved).toEqual(expect.objectContaining({ body: 'folder note' }))
+    expect(store.getState().getDiffComments(folderWorkspaceKey(folderWorkspace.id))).toEqual([
+      expect.objectContaining({ body: 'folder note' })
+    ])
+    expect(folderWorkspacesUpdate).toHaveBeenCalledWith({
+      folderWorkspaceId: folderWorkspace.id,
+      updates: { diffComments: [expect.objectContaining({ body: 'folder note' })] }
+    })
+  })
+
+  it('preserves a second note while the first write is in flight', async () => {
+    const store = createTestStore()
+    const folderWorkspace = seedLocalFolderWorkspace(store)
+    let releaseFirstWrite: (() => void) | undefined
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve
+    })
+    folderWorkspacesUpdate.mockImplementation(async ({ updates }) => {
+      if (folderWorkspacesUpdate.mock.calls.length === 1) {
+        await firstWrite
+      }
+      return { ...folderWorkspace, ...updates }
+    })
+
+    const addFirst = store.getState().addDiffComment({
+      worktreeId: folderWorkspaceKey(folderWorkspace.id),
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'first note',
+      side: 'modified'
+    })
+    await vi.waitFor(() => expect(folderWorkspacesUpdate).toHaveBeenCalledTimes(1))
+    const addSecond = store.getState().addDiffComment({
+      worktreeId: folderWorkspaceKey(folderWorkspace.id),
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 2,
+      body: 'second note',
+      side: 'modified'
+    })
+    releaseFirstWrite?.()
+
+    await Promise.all([addFirst, addSecond])
+    expect(store.getState().getDiffComments(folderWorkspaceKey(folderWorkspace.id))).toEqual([
+      expect.objectContaining({ body: 'first note' }),
+      expect.objectContaining({ body: 'second note' })
+    ])
+    expect(folderWorkspacesUpdate).toHaveBeenLastCalledWith({
+      folderWorkspaceId: folderWorkspace.id,
+      updates: {
+        diffComments: [
+          expect.objectContaining({ body: 'first note' }),
+          expect.objectContaining({ body: 'second note' })
+        ]
+      }
+    })
+  })
+
+  it('keeps same-id writes scoped to their original hosts', async () => {
+    const store = createTestStore()
+    const workspaceId = 'shared-folder-id'
+    const workspaceKey = folderWorkspaceKey(workspaceId)
+    const localWorkspace = makeFolderWorkspace({
+      id: workspaceId,
+      projectGroupId: 'local-group',
+      folderPath: '/workspace/local'
+    })
+    const runtimeWorkspace = makeFolderWorkspace({
+      id: workspaceId,
+      projectGroupId: 'runtime-group',
+      folderPath: '/workspace/runtime',
+      executionHostId: 'runtime:env-owner'
+    })
+    let resolveLocal!: () => void
+    folderWorkspacesUpdate.mockImplementation(
+      ({ updates }) =>
+        new Promise<FolderWorkspace>((resolve) => {
+          resolveLocal = () => resolve({ ...localWorkspace, ...updates })
+        })
+    )
+    runtimeEnvironmentCall.mockImplementation(async (args: RuntimeEnvironmentCallRequest) => ({
+      id: 'rpc-folder-update',
+      ok: true,
+      result: {
+        folderWorkspace: {
+          ...runtimeWorkspace,
+          ...(
+            args as RuntimeEnvironmentCallRequest & {
+              params: { updates?: Partial<FolderWorkspace> }
+            }
+          ).params.updates
+        }
+      },
+      _meta: { runtimeId: 'remote-runtime' }
+    }))
+    store.setState({
+      activeWorktreeId: workspaceKey,
+      activeWorkspaceExecutionHostId: 'local',
+      folderWorkspaces: [localWorkspace, runtimeWorkspace]
+    })
+
+    const localAdd = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'LOCAL.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'local note',
+      side: 'modified'
+    })
+    await vi.waitFor(() => expect(folderWorkspacesUpdate).toHaveBeenCalledOnce())
+
+    store.setState({ activeWorkspaceExecutionHostId: 'runtime:env-owner' })
+    const runtimeAdd = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'REMOTE.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'runtime note',
+      side: 'modified'
+    })
+    await vi.waitFor(() =>
+      expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selector: 'env-owner',
+          method: 'folderWorkspace.update',
+          params: expect.objectContaining({
+            updates: {
+              diffComments: [expect.objectContaining({ body: 'runtime note' })]
+            }
+          })
+        })
+      )
+    )
+
+    store.setState({ activeWorkspaceExecutionHostId: 'local' })
+    resolveLocal()
+    await expect(Promise.all([localAdd, runtimeAdd])).resolves.toEqual([
+      expect.objectContaining({ body: 'local note' }),
+      expect.objectContaining({ body: 'runtime note' })
+    ])
+    expect(store.getState().getDiffComments(workspaceKey)).toEqual([
+      expect.objectContaining({ body: 'local note' })
+    ])
+    store.setState({ activeWorkspaceExecutionHostId: 'runtime:env-owner' })
+    expect(store.getState().getDiffComments(workspaceKey)).toEqual([
+      expect.objectContaining({ body: 'runtime note' })
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -160,6 +160,7 @@ type FolderWorkspaceUpdates = Partial<
     | 'pendingFirstAgentMessageRename'
     | 'firstAgentMessageRenameError'
     | 'lastActivityAt'
+    | 'diffComments'
   >
 >
 
@@ -2691,6 +2692,20 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               )
             ).folderWorkspace
       if (!updated) {
+        await reconcileFailedFolderWorkspaceUpdate({
+          target,
+          folderWorkspaceId,
+          updateIdentity,
+          ownerHostId,
+          ticket: updateTicket,
+          coordinator: folderWorkspaceUpdates,
+          set,
+          get
+        })
+        return false
+      }
+      if (updates.diffComments !== undefined && updated.diffComments === undefined) {
+        // Why: older paired runtimes strip this optional field; reconcile instead of showing an unsaved note.
         await reconcileFailedFolderWorkspaceUpdate({
           target,
           folderWorkspaceId,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -861,6 +861,7 @@ function getFolderWorkspaceMetaUpdates(
     | 'createdWithAgent'
     | 'pendingFirstAgentMessageRename'
     | 'firstAgentMessageRenameError'
+    | 'diffComments'
   >
 > {
   const next: Partial<
@@ -878,6 +879,7 @@ function getFolderWorkspaceMetaUpdates(
       | 'createdWithAgent'
       | 'pendingFirstAgentMessageRename'
       | 'firstAgentMessageRenameError'
+      | 'diffComments'
     >
   > = {}
   if (updates.displayName !== undefined) {
@@ -918,6 +920,9 @@ function getFolderWorkspaceMetaUpdates(
   }
   if (updates.firstAgentMessageRenameError !== undefined) {
     next.firstAgentMessageRenameError = updates.firstAgentMessageRenameError
+  }
+  if (updates.diffComments !== undefined) {
+    next.diffComments = updates.diffComments
   }
   return next
 }

--- a/src/renderer/src/store/worktree-diff-comments-selector.test.ts
+++ b/src/renderer/src/store/worktree-diff-comments-selector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { DiffComment, Worktree } from '../../../shared/types'
+import type { DiffComment, FolderWorkspace, Worktree } from '../../../shared/types'
 import type { AppState } from './types'
 import {
   selectWorktreeDiffComments,
@@ -7,7 +7,6 @@ import {
 } from './worktree-diff-comments-selector'
 import { getIndexedWorktreeById } from './worktree-repo-index'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
-import type { FolderWorkspace } from '../../../shared/types'
 
 function makeComment(id: string): DiffComment {
   return {

--- a/src/renderer/src/store/worktree-diff-comments-selector.test.ts
+++ b/src/renderer/src/store/worktree-diff-comments-selector.test.ts
@@ -6,6 +6,8 @@ import {
   selectWorktreeDiffCommentsOrEmpty
 } from './worktree-diff-comments-selector'
 import { getIndexedWorktreeById } from './worktree-repo-index'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import type { FolderWorkspace } from '../../../shared/types'
 
 function makeComment(id: string): DiffComment {
   return {
@@ -83,5 +85,26 @@ describe('selectWorktreeDiffComments', () => {
     expect(selectWorktreeDiffCommentsOrEmpty({ worktreesByRepo: next }, null)).toBe(
       selectWorktreeDiffCommentsOrEmpty({ worktreesByRepo: next }, undefined)
     )
+  })
+
+  it('reads review notes from a folder workspace', () => {
+    const comments = [makeComment('folder-comment')]
+    const folderWorkspace = {
+      id: 'folder-1',
+      executionHostId: 'local',
+      diffComments: comments
+    } as FolderWorkspace
+
+    expect(
+      selectWorktreeDiffComments(
+        {
+          worktreesByRepo: {},
+          activeWorktreeId: folderWorkspaceKey(folderWorkspace.id),
+          activeWorkspaceExecutionHostId: 'local',
+          folderWorkspaces: [folderWorkspace]
+        },
+        folderWorkspaceKey(folderWorkspace.id)
+      )
+    ).toBe(comments)
   })
 })

--- a/src/renderer/src/store/worktree-diff-comments-selector.ts
+++ b/src/renderer/src/store/worktree-diff-comments-selector.ts
@@ -1,15 +1,35 @@
 import type { DiffComment } from '../../../shared/types'
 import type { AppState } from './types'
 import { getIndexedWorktreeById } from './worktree-repo-index'
+import { findFolderWorkspaceOwner } from '@/lib/folder-workspace-runtime-owner'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 
 const EMPTY_DIFF_COMMENTS = Object.freeze([]) as unknown as DiffComment[]
 
+type DiffCommentSelectorState = Pick<AppState, 'worktreesByRepo'> &
+  Partial<
+    Pick<
+      AppState,
+      | 'activeWorkspaceExecutionHostId'
+      | 'activeWorktreeId'
+      | 'folderWorkspaces'
+      | 'projectGroups'
+      | 'restoredRuntimeHostIdByWorkspaceSessionKey'
+      | 'runtimeEnvironments'
+      | 'settings'
+    >
+  >
+
 export function selectWorktreeDiffComments(
-  state: Pick<AppState, 'worktreesByRepo'>,
+  state: DiffCommentSelectorState,
   worktreeId: string | null | undefined
 ): DiffComment[] | undefined {
   if (!worktreeId) {
     return undefined
+  }
+  const scope = parseWorkspaceKey(worktreeId)
+  if (scope?.type === 'folder') {
+    return findFolderWorkspaceOwner(state, scope.folderWorkspaceId)?.diffComments
   }
   // Why: mounted Monaco and diff surfaces rerun this selector on every store
   // write, so share the immutable-snapshot index instead of rescanning all worktrees.
@@ -17,7 +37,7 @@ export function selectWorktreeDiffComments(
 }
 
 export function selectWorktreeDiffCommentsOrEmpty(
-  state: Pick<AppState, 'worktreesByRepo'>,
+  state: Parameters<typeof selectWorktreeDiffComments>[0],
   worktreeId: string | null | undefined
 ): DiffComment[] {
   return selectWorktreeDiffComments(state, worktreeId) ?? EMPTY_DIFF_COMMENTS

--- a/src/shared/diff-comment-schema.ts
+++ b/src/shared/diff-comment-schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const DiffCommentSchema = z.object({
+  id: z.string(),
+  worktreeId: z.string(),
+  filePath: z.string(),
+  source: z.enum(['diff', 'markdown']).optional(),
+  selectedText: z.string().optional(),
+  startLine: z.number().int().positive().optional(),
+  lineNumber: z.number().int().positive(),
+  body: z.string(),
+  createdAt: z.number().finite(),
+  updatedAt: z.number().finite().optional(),
+  sentAt: z.number().finite().optional(),
+  scope: z.enum(['unstaged', 'staged', 'branch']).optional(),
+  oldPath: z.string().optional(),
+  diffIdentity: z.string().optional(),
+  side: z.literal('modified')
+})

--- a/src/shared/folder-workspace-worktree.ts
+++ b/src/shared/folder-workspace-worktree.ts
@@ -40,6 +40,7 @@ export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Wor
     pendingFirstAgentMessageRename: folderWorkspace.pendingFirstAgentMessageRename,
     firstAgentMessageRenameError: folderWorkspace.firstAgentMessageRenameError,
     workspaceStatus: folderWorkspace.workspaceStatus,
+    diffComments: folderWorkspace.diffComments,
     path: folderWorkspace.folderPath,
     head: '',
     branch: '',

--- a/src/shared/folder-workspaces.ts
+++ b/src/shared/folder-workspaces.ts
@@ -103,7 +103,8 @@ export function normalizeFolderWorkspaces(
       createdAt:
         typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt) ? raw.createdAt : now,
       updatedAt:
-        typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt) ? raw.updatedAt : now
+        typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt) ? raw.updatedAt : now,
+      ...(Array.isArray(raw.diffComments) ? { diffComments: raw.diffComments } : {})
     })
   }
   return workspaces.sort(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -357,6 +357,7 @@ export type FolderWorkspace = {
   lastActivityAt: number
   createdAt: number
   updatedAt: number
+  diffComments?: DiffComment[]
 }
 
 export type WorkspaceLinkedItem = {


### PR DESCRIPTION
## Summary

Fixes STA-3958 by making Add Note persistence work for folder workspaces. Markdown and diff review notes now route through the local or RPC owner-aware persistence path, with schema validation at the boundary.

The change also prevents concurrent and cross-host stale writes from overwriting newer review notes.

## Validation

- 484 focused Vitest checks
- Node, CLI, and web typechecks
- Quality max-lines check
- Electron visual validation of the note-added and folder-workspace note flows

## Visual evidence

Screenshots will be attached to this PR (not committed):
- `.playwright-cli/sta3958-note-added.png`
- `.playwright-cli/sta3958-folder-note.png`

Related issue: STA-3958

### Attached screenshots

![sta3958-note-added.png](https://github.com/stablyai/orca/blob/9d957042ec8b2ee0444a19ea52d87ff7be826fe2/sta3958-note-added.png?raw=true)

![sta3958-folder-note.png](https://github.com/stablyai/orca/blob/44a78e3b7dd1ad6a45b329bb38d0398d06550ad6/sta3958-folder-note.png?raw=true)