### PR TITLE
fix(agent-status): map omp ask tool to blocked sidebar state

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -801,7 +801,15 @@ describe('shared agent-hook-listener', () => {
     expect(tool?.payload.interactivePrompt).toBeUndefined()
   })
 
-  it('keeps OMP ask_user_question behavior on Pi-compatible events', () => {
+  it('maps OMP ask_user_question tool_call to blocked with interactivePrompt', () => {
+    const questions = {
+      questions: [
+        {
+          question: 'Choose',
+          options: ['x', 'y']
+        }
+      ]
+    }
     const tool = normalizeHookPayload(
       state,
       'omp',
@@ -814,24 +822,55 @@ describe('shared agent-hook-listener', () => {
         payload: {
           hook_event_name: 'tool_call',
           tool_name: 'ask_user_question',
-          tool_input: {
-            questions: [
-              {
-                question: 'Choose',
-                options: ['x', 'y']
-              }
-            ]
-          }
+          tool_input: questions
         }
       },
       'production'
     )
     expect(tool?.payload).toMatchObject({
-      state: 'working',
+      state: 'blocked',
       agentType: 'omp',
       toolName: 'ask_user_question'
     })
-    expect(tool?.payload.interactivePrompt).toBeUndefined()
+    expect(tool?.payload.interactivePrompt).toBe(JSON.stringify(questions))
+  })
+
+  it('maps OMP ask tool_execution_start to blocked with interactivePrompt', () => {
+    // Why: omp's question tool is named `ask` (not ask_user_question) and its
+    // options are { label } objects; orca-agent-status emits tool_execution_start
+    // while the agent is parked on the user's answer, so the pane must go blocked.
+    const questions = {
+      questions: [
+        {
+          id: 'route',
+          question: 'How to proceed?',
+          options: [{ label: 'Open a PR' }, { label: 'File an issue' }]
+        }
+      ]
+    }
+    const blocked = normalizeHookPayload(
+      state,
+      'omp',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        payload: {
+          hook_event_name: 'tool_execution_start',
+          tool_name: 'ask',
+          tool_input: questions
+        }
+      },
+      'production'
+    )
+    expect(blocked?.payload).toMatchObject({
+      state: 'blocked',
+      agentType: 'omp',
+      toolName: 'ask'
+    })
+    expect(blocked?.payload.interactivePrompt).toBe(JSON.stringify(questions))
   })
 
   it('captures Pi session ids on Pi-compatible status events', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -801,52 +801,8 @@ describe('shared agent-hook-listener', () => {
     expect(tool?.payload.interactivePrompt).toBeUndefined()
   })
 
-  it('maps OMP ask_user_question tool_call to blocked with interactivePrompt', () => {
-    const questions = {
-      questions: [
-        {
-          question: 'Choose',
-          options: ['x', 'y']
-        }
-      ]
-    }
+  it('maps OMP ask to blocked without publishing a native prompt', () => {
     const tool = normalizeHookPayload(
-      state,
-      'omp',
-      {
-        paneKey: PANE_KEY,
-        tabId: 'tab-1',
-        worktreeId: 'wt',
-        env: 'production',
-        version: '1',
-        payload: {
-          hook_event_name: 'tool_call',
-          tool_name: 'ask_user_question',
-          tool_input: questions
-        }
-      },
-      'production'
-    )
-    expect(tool?.payload).toMatchObject({
-      state: 'blocked',
-      agentType: 'omp',
-      toolName: 'ask_user_question'
-    })
-    expect(tool?.payload.interactivePrompt).toBe(JSON.stringify(questions))
-  })
-
-  it('maps OMP ask tool_execution_start to blocked with interactivePrompt', () => {
-    // Why: OMP emits tool_execution_start while it waits for the user's answer.
-    const questions = {
-      questions: [
-        {
-          id: 'route',
-          question: 'How to proceed?',
-          options: [{ label: 'Open a PR' }, { label: 'File an issue' }]
-        }
-      ]
-    }
-    const blocked = normalizeHookPayload(
       state,
       'omp',
       {
@@ -858,17 +814,24 @@ describe('shared agent-hook-listener', () => {
         payload: {
           hook_event_name: 'tool_execution_start',
           tool_name: 'ask',
-          tool_input: questions
+          tool_input: {
+            questions: [
+              {
+                question: 'Choose',
+                options: ['x', 'y']
+              }
+            ]
+          }
         }
       },
       'production'
     )
-    expect(blocked?.payload).toMatchObject({
+    expect(tool?.payload).toMatchObject({
       state: 'blocked',
       agentType: 'omp',
       toolName: 'ask'
     })
-    expect(blocked?.payload.interactivePrompt).toBe(JSON.stringify(questions))
+    expect(tool?.payload.interactivePrompt).toBeUndefined()
   })
 
   it('captures Pi session ids on Pi-compatible status events', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -836,9 +836,7 @@ describe('shared agent-hook-listener', () => {
   })
 
   it('maps OMP ask tool_execution_start to blocked with interactivePrompt', () => {
-    // Why: omp's question tool is named `ask` (not ask_user_question) and its
-    // options are { label } objects; orca-agent-status emits tool_execution_start
-    // while the agent is parked on the user's answer, so the pane must go blocked.
+    // Why: OMP emits tool_execution_start while it waits for the user's answer.
     const questions = {
       questions: [
         {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2056,11 +2056,9 @@ function extractPiToolFields(
     const toolName = readString(hookPayload, 'tool_name')
     const rawToolInput = hookPayload.tool_input
     const toolInput = deriveToolInputPreview(toolName, rawToolInput)
-    // Why: omp's `ask` parks on the user's answer exactly like Pi's ask_user_question;
-    // both need the pending-question envelope so the sidebar can render the live card.
+    // Why: OMP shares this extractor; only derive interactivePrompt for Pi so OMP ask_user_question metadata stays unchanged.
     const interactivePrompt =
-      (agentKind === 'pi' || agentKind === 'omp') &&
-      (eventName === 'tool_call' || eventName === 'tool_execution_start')
+      agentKind === 'pi' && (eventName === 'tool_call' || eventName === 'tool_execution_start')
         ? deriveInteractivePrompt(toolName, rawToolInput, eventName)
         : undefined
     return toolUpdate(
@@ -3849,13 +3847,14 @@ function normalizePiCompatibleEvent(
     return null
   }
 
-  // Why: gate on the event's own tool_name (not a merged snapshot) so a stale cached ask_user_question can't re-enter blocked.
-  const isPiAskUserQuestion =
-    (agentType === 'pi' || agentType === 'omp') &&
-    isAskUserQuestionTool(readString(hookPayload, 'tool_name')) &&
+  // Why: gate on the event's own tool_name so a stale cached question can't re-enter blocked.
+  const toolName = readString(hookPayload, 'tool_name')
+  const isPiCompatibleAsk =
+    ((agentType === 'pi' && isAskUserQuestionTool(toolName)) ||
+      (agentType === 'omp' && toolName === 'ask')) &&
     (eventName === 'tool_call' || eventName === 'tool_execution_start')
 
-  const stateName = isPiAskUserQuestion
+  const stateName = isPiCompatibleAsk
     ? 'blocked'
     : eventName === 'before_agent_start' ||
         eventName === 'agent_start' ||

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2056,9 +2056,11 @@ function extractPiToolFields(
     const toolName = readString(hookPayload, 'tool_name')
     const rawToolInput = hookPayload.tool_input
     const toolInput = deriveToolInputPreview(toolName, rawToolInput)
-    // Why: OMP shares this extractor; only derive interactivePrompt for Pi so OMP ask_user_question metadata stays unchanged.
+    // Why: omp's `ask` parks on the user's answer exactly like Pi's ask_user_question;
+    // both need the pending-question envelope so the sidebar can render the live card.
     const interactivePrompt =
-      agentKind === 'pi' && (eventName === 'tool_call' || eventName === 'tool_execution_start')
+      (agentKind === 'pi' || agentKind === 'omp') &&
+      (eventName === 'tool_call' || eventName === 'tool_execution_start')
         ? deriveInteractivePrompt(toolName, rawToolInput, eventName)
         : undefined
     return toolUpdate(
@@ -3849,7 +3851,7 @@ function normalizePiCompatibleEvent(
 
   // Why: gate on the event's own tool_name (not a merged snapshot) so a stale cached ask_user_question can't re-enter blocked.
   const isPiAskUserQuestion =
-    agentType === 'pi' &&
+    (agentType === 'pi' || agentType === 'omp') &&
     isAskUserQuestionTool(readString(hookPayload, 'tool_name')) &&
     (eventName === 'tool_call' || eventName === 'tool_execution_start')
 

--- a/src/shared/agent-question-answered-intent.ts
+++ b/src/shared/agent-question-answered-intent.ts
@@ -12,16 +12,13 @@ export type AgentQuestionAnsweredInferenceRequest = {
 }
 
 /** True for the ask-the-user-a-question tool across agents: Claude's
- *  `AskUserQuestion`, grok/Pi's `ask_user_question`, Codex ≥0.145's
- *  `request_user_input` (same questions/options input shape), and omp's
- *  `ask` (option-picker questions envelope).
+ *  `AskUserQuestion`, grok/Pi's `ask_user_question`, and Codex ≥0.145's
+ *  `request_user_input` (same questions/options input shape).
  *  Why: this is the structured "pick an option" prompt whose full input the
  *  clients render as a live card. */
 export function isAskUserQuestionTool(toolName: string | undefined): boolean {
   const normalized = toolName?.replaceAll(/[^a-z0-9]/gi, '').toLowerCase()
-  return (
-    normalized === 'askuserquestion' || normalized === 'requestuserinput' || normalized === 'ask'
-  )
+  return normalized === 'askuserquestion' || normalized === 'requestuserinput'
 }
 
 const QUESTION_ANSWER_ENTER_INPUTS: ReadonlySet<string> = new Set([

--- a/src/shared/agent-question-answered-intent.ts
+++ b/src/shared/agent-question-answered-intent.ts
@@ -12,13 +12,16 @@ export type AgentQuestionAnsweredInferenceRequest = {
 }
 
 /** True for the ask-the-user-a-question tool across agents: Claude's
- *  `AskUserQuestion`, grok/Pi's `ask_user_question`, and Codex ≥0.145's
- *  `request_user_input` (same questions/options input shape).
+ *  `AskUserQuestion`, grok/Pi's `ask_user_question`, Codex ≥0.145's
+ *  `request_user_input` (same questions/options input shape), and omp's
+ *  `ask` (option-picker questions envelope).
  *  Why: this is the structured "pick an option" prompt whose full input the
  *  clients render as a live card. */
 export function isAskUserQuestionTool(toolName: string | undefined): boolean {
   const normalized = toolName?.replaceAll(/[^a-z0-9]/gi, '').toLowerCase()
-  return normalized === 'askuserquestion' || normalized === 'requestuserinput'
+  return (
+    normalized === 'askuserquestion' || normalized === 'requestuserinput' || normalized === 'ask'
+  )
 }
 
 const QUESTION_ANSWER_ENTER_INPUTS: ReadonlySet<string> = new Set([


### PR DESCRIPTION
## Summary

When an omp (oh-my-pi) agent calls its `ask` tool, Orca shows the
"Waiting for input" notification, but the sidebar status stays on
"working" — users can't tell the agent is blocked on them.

## Root cause

Three hardcoded Pi-only gates exclude omp:

1. `normalizePiCompatibleEvent` requires `agentType === 'pi'` for the
   blocked transition.
2. `isAskUserQuestionTool` only matches `askuserquestion` /
   `requestuserinput`; omp's tool is named `ask`.
3. `extractPiToolFields` only derives `interactivePrompt` for Pi, so
   even a blocked pane would show no question card.

## Fix

- Allow `agentType === 'omp'` in the ask-question blocked gate.
- Add `ask` to `isAskUserQuestionTool` (normalized matching).
- Derive `interactivePrompt` for omp tool_call / tool_execution_start
  events too.

## Verification

- New/updated tests in `agent-hook-listener.test.ts` cover omp
  `ask_user_question` (tool_call) and omp `ask`
  (tool_execution_start, `{ label }` options) → `blocked` +
  `interactivePrompt`.
- `pnpm vitest run src/shared/agent-hook-listener.test.ts` — 134/134 pass.