### PR TITLE
fix(mobile): resume browser screencast after transport reconnect

### DIFF
--- a/mobile/src/browser/MobileBrowserPane.tsx
+++ b/mobile/src/browser/MobileBrowserPane.tsx
@@ -55,6 +55,7 @@ import {
 } from './browser-touch-geometry'
 import { displayBrowserUrl, normalizeBrowserUrl } from './browser-url'
 import { resolveMobileBrowserAddressSync } from './mobile-browser-address-sync'
+import { useBrowserScreencastReconnectSignal } from './use-browser-screencast-reconnect-signal'
 
 export type MobileBrowserTab = {
   type: 'browser'
@@ -164,6 +165,7 @@ export function MobileBrowserPane({
   const [layout, setLayout] = useState<BrowserTouchLayout | null>(null)
   const [appActive, setAppActive] = useState(AppState.currentState === 'active')
   const streamGenerationRef = useRef(0)
+  const reconnectSignal = useBrowserScreencastReconnectSignal(client)
   const layoutRef = useRef<BrowserTouchLayout | null>(null)
   const frameMetadataRef = useRef<BrowserScreencastFrameMetadata | null>(
     cachedInitialFrame?.metadata ?? null
@@ -541,6 +543,7 @@ export function MobileBrowserPane({
     }
   }, [
     appActive,
+    reconnectSignal,
     applyFrameThrottled,
     clearFrameThrottle,
     client,

--- a/mobile/src/browser/mobile-browser-pane-source.test.ts
+++ b/mobile/src/browser/mobile-browser-pane-source.test.ts
@@ -24,4 +24,15 @@ describe('MobileBrowserPane source invariants', () => {
     expect(mirrorBlock).toContain('zoomRef.current = zoom')
     expect(mirrorBlock).toContain('}, [dialog, frameMetadata, layout, zoom])')
   })
+
+  it('re-subscribes the screencast stream when the transport reconnects', () => {
+    // Why: after a relay migrateTo / direct-socket reconnect the desktop tears down
+    // Page.startScreencast and only restarts it on a fresh browser.screencast
+    // subscribe. The pane must depend on a reconnect signal so its subscribe effect
+    // tears down and re-creates the stream (and resets the double-buffer render
+    // state); otherwise the display freezes on the last frame while input still lands.
+    expect(source).toContain('useBrowserScreencastReconnectSignal')
+    const depArray = sliceBetween('    appActive,', 'worktreeId\n  ])')
+    expect(depArray).toContain('reconnectSignal')
+  })
 })

--- a/mobile/src/browser/use-browser-screencast-reconnect-signal.test.tsx
+++ b/mobile/src/browser/use-browser-screencast-reconnect-signal.test.tsx
@@ -1,0 +1,100 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectionState } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { useBrowserScreencastReconnectSignal } from './use-browser-screencast-reconnect-signal'
+
+function createMockClient(initial: ConnectionState): {
+  client: RpcClient
+  emit: (next: ConnectionState) => void
+  listenerCount: () => number
+} {
+  let state: ConnectionState = initial
+  let listener: ((next: ConnectionState) => void) | null = null
+  const onStateChange = vi.fn((l: (next: ConnectionState) => void) => {
+    listener = l
+    return () => {
+      listener = null
+    }
+  })
+  const client = { getState: () => state, onStateChange } as unknown as RpcClient
+  return {
+    client,
+    emit: (next) => {
+      state = next
+      listener?.(next)
+    },
+    listenerCount: () => (listener ? 1 : 0)
+  }
+}
+
+describe('useBrowserScreencastReconnectSignal', () => {
+  // Why: the mobile browser pane freezes on the last decoded frame after a relay
+  // migrateTo / direct-socket reconnect because its render state is never reset.
+  // This signal drives that reset, so it must bump on a REconnect only.
+  let renderer: ReactTestRenderer | null = null
+  let signal = 0
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    signal = 0
+  })
+
+  function Harness({ client }: { client: RpcClient | null }): null {
+    signal = useBrowserScreencastReconnectSignal(client)
+    return null
+  }
+
+  it('returns 0 and does not bump on the first connect', () => {
+    const { client, emit } = createMockClient('disconnected')
+    act(() => {
+      renderer = create(createElement(Harness, { client }))
+    })
+    expect(signal).toBe(0)
+    act(() => emit('connected'))
+    expect(signal).toBe(0)
+  })
+
+  it('bumps once per reconnect (connected -> away -> connected)', () => {
+    const { client, emit } = createMockClient('connected')
+    act(() => {
+      renderer = create(createElement(Harness, { client }))
+    })
+    expect(signal).toBe(0)
+    act(() => emit('disconnected'))
+    act(() => emit('connected'))
+    expect(signal).toBe(1)
+    act(() => emit('reconnecting'))
+    act(() => emit('connected'))
+    expect(signal).toBe(2)
+  })
+
+  it('does not bump on a duplicate connected transition', () => {
+    const { client, emit } = createMockClient('connected')
+    act(() => {
+      renderer = create(createElement(Harness, { client }))
+    })
+    act(() => emit('connected'))
+    expect(signal).toBe(0)
+  })
+
+  it('is 0 and subscribes to nothing without a client', () => {
+    act(() => {
+      renderer = create(createElement(Harness, { client: null }))
+    })
+    expect(signal).toBe(0)
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { client, listenerCount } = createMockClient('connected')
+    act(() => {
+      renderer = create(createElement(Harness, { client }))
+    })
+    expect(listenerCount()).toBe(1)
+    act(() => renderer?.unmount())
+    expect(listenerCount()).toBe(0)
+    renderer = null
+  })
+})

--- a/mobile/src/browser/use-browser-screencast-reconnect-signal.test.tsx
+++ b/mobile/src/browser/use-browser-screencast-reconnect-signal.test.tsx
@@ -57,6 +57,22 @@ describe('useBrowserScreencastReconnectSignal', () => {
     expect(signal).toBe(0)
   })
 
+  it('records the first connect, then bumps on each later reconnect from disconnected', () => {
+    const { client, emit } = createMockClient('disconnected')
+    act(() => {
+      renderer = create(createElement(Harness, { client }))
+    })
+    expect(signal).toBe(0)
+    act(() => emit('connected')) // first connect: recorded, not yet a reconnect
+    expect(signal).toBe(0)
+    act(() => emit('disconnected'))
+    act(() => emit('connected')) // first reconnect after the initial connect
+    expect(signal).toBe(1)
+    act(() => emit('disconnected'))
+    act(() => emit('connected')) // a second reconnect bumps again
+    expect(signal).toBe(2)
+  })
+
   it('bumps once per reconnect (connected -> away -> connected)', () => {
     const { client, emit } = createMockClient('connected')
     act(() => {

--- a/mobile/src/browser/use-browser-screencast-reconnect-signal.ts
+++ b/mobile/src/browser/use-browser-screencast-reconnect-signal.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import type { RpcClient } from '../transport/rpc-client'
+
+// Why: the browser screencast pane must tear down and recreate its browser.screencast
+// subscription (resetting the double-buffer render state) when the transport reconnects,
+// or the display freezes on the last decoded frame while input RPCs keep landing.
+// Returns a value that changes only on a REconnect, to drive a subscribe-effect dep.
+export function useBrowserScreencastReconnectSignal(client: RpcClient | null): number {
+  const [reconnectSignal, setReconnectSignal] = useState(0)
+  useEffect(() => {
+    if (!client) {
+      return
+    }
+    let prev = client.getState()
+    let everConnected = prev === 'connected'
+    return client.onStateChange((next) => {
+      // Why: a fresh entry into 'connected' (direct-socket recovery or relay migrateTo)
+      // after we were already connected once is a reconnect — bump so dependents reset.
+      if (next === 'connected' && prev !== 'connected') {
+        if (everConnected) {
+          setReconnectSignal((value) => value + 1)
+        }
+        everConnected = true
+      }
+      prev = next
+    })
+  }, [client])
+  return reconnectSignal
+}


### PR DESCRIPTION
## ELI5

On mobile, the in-app browser shows the host's browser as a live picture stream. If the connection blips (network drop or relay switch) and reconnects, the picture used to freeze on the last frame — taps still worked, but the image never updated until the tab was reopened. The pane never restarted the picture stream after reconnecting. This PR makes the pane notice the reconnect and restart the stream, so the browser picture comes back to life.

## What Changed

- Adds `useBrowserScreencastReconnectSignal` — a hook returning a number that increments only on a **re**connect (connected → away → connected), derived from the logical RPC client's existing `onStateChange`. It ignores the very first connect.
- `MobileBrowserPane`'s `browser.screencast` subscribe effect now depends on this signal, so on every reconnect the effect tears down and recreates the stream and resets its double-buffer render state.

One new module + one effect-dependency line. No wire/RPC/stream-opcode changes and no new dependencies.

## Why

`MobileBrowserPane`'s screencast subscribe effect depended only on the stable logical client, so it never re-ran on a relay `migrateTo` / direct-socket reconnect. The host tears down `Page.startScreencast` on reconnect and only restarts it on a fresh `browser.screencast` subscribe — which never came. A single missed offscreen `<Image>` `onLoad` across the blip then left `pendingFrameLayerRef` stuck, so every later frame painted only the hidden layer: the display froze on the last decoded frame while input RPCs kept landing. Driving the effect off a reconnect-derived signal is the minimal fix — it reuses the client's own state events and changes no transport behavior.

## Linked Issue

Fixes #14274

## Visual Proof

No visual change. The change recovers a pane that was already frozen; there is no new UI to screenshot. See **Testing** for how the behavior is verified.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally

- `use-browser-screencast-reconnect-signal.test.tsx` — behavioral test (react-test-renderer + mock RPC client): the signal stays `0` on the first connect and on duplicate `connected` states, and increments once per reconnect — including across a `disconnected → connected → disconnected → connected` sequence from a fresh start and across repeated reconnect cycles.
- `mobile-browser-pane-source.test.ts` — source invariant that `MobileBrowserPane` consumes the reconnect signal in its screencast subscribe-effect dependency array.

Behavioral verification of the freeze→resume path needs a paired host and a live transport reconnect (relay migration or direct-socket drop/recover) on a real device/emulator; the unit tests pin the underlying invariant that drives it. Platforms in scope: mobile (iOS/Android). The hook is RN-agnostic and keys off the shared logical client.

Locally: `pnpm typecheck` and `pnpm lint` pass, and the screencast test files pass in isolation. The full `mobile/` suite has a pre-existing, unrelated failure in `src/transport/host-store.test.ts` (a zod schema-resolution error in a different subsystem; this PR does not touch it). CI is the source of truth for the full run.

A bounded pending-frame watchdog (force-swap the visible layer if the offscreen `onLoad` is missed outside a reconnect) is intentionally deferred to a follow-up to keep this change small.

## AI Disclosure

Developed with assistance from Claude (Anthropic). The root-cause analysis, approach, and tests were reviewed by the contributor.

## Review

- **Cross-platform:** uses only the logical client's `onStateChange` / `getState` (RN-agnostic); works for both direct-socket recovery and relay `migrateTo`. No platform-specific code.
- **Wire compatibility:** no RPC params, stream frames, or opcodes changed; host-side emission is unchanged, so paired clients/hosts of mixed versions are unaffected.
- **Performance:** no per-frame work added — the signal changes only on a reconnect.
- **UI quality:** no visual change; recovers an already-frozen pane.
- **Security:** no auth/transport surface changed.
- **SSH / remote / folder workspaces:** the fix keys off the logical client's state transitions, which are identical across local, relay, and SSH transports.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, and the in-scope `pnpm test` pass (CI covers the full suite and `pnpm build`)

## Author

- X / Twitter: _(optional — add your handle to be shouted out on merge)_
