### PR TITLE
fix(browser): route remote terminal links to owning host

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1459,6 +1459,136 @@
       "demotionRule": "Demote if a retired runtime transport can leave a renderer subscription without a close event, if a close is delivered more than once, if one failing teardown strands its sibling subscriptions, if payload frames from a retired transport reach the renderer, or if a revealed remote terminal can stay blank or reject input after a reconnect."
     },
     {
+      "id": "browser-session.remote-terminal-link-ownership",
+      "title": "Paired terminal links open one browser on their owning runtime",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "browser-runtime",
+      "layer": "renderer-paired-runtime-routing",
+      "surfaces": [
+        "paired remote terminal HTTP links",
+        "terminal link action destinations",
+        "runtime-owned managed browser creation"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["remote-runtime", "ssh"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["remote-runtime", "ssh"],
+      "coverageNotes": "A headed macOS desktop host and separate paired Electron client exercise a real mirrored terminal link, owner-asserted host browser creation, exact host/client page identity, rendered DOM, explicit browser-tab activation, client external-browser suppression, exact host/client close convergence, and continued original-PTY liveness. Unit contracts cover OSC, WebLinksAddon, click fallback, explicit System Browser routing, failed creation, incapable runtimes, and unchanged direct SSH behavior.",
+      "motivatingLinks": [
+        "https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1786567689897109",
+        "https://github.com/stablyai/orca/issues/12418"
+      ],
+      "invariant": "Selecting Orca Browser for an HTTP link in a runtime-owned terminal creates exactly one browser page on that owning runtime and exactly one mirrored client browser workspace, with matching remote page identity and no client external-browser call. Explicit System Browser remains client-owned, direct SSH remains system-browser-only, and unknown or mismatched owners fail closed.",
+      "oracle": "Use the focused routing contracts as the byte-identical baseline/candidate oracle. Require runtime OSC, WebLinksAddon, click fallback, action-menu, and modifier paths to target the exact owner without client fallback, while direct SSH and generic remote document links stay external. Separately run one byte-identical headed paired Electron journey on the candidate and with only runtime browser registration disabled. Require one new host browser tab, one new client mirror with exact page identity, rendered fixture DOM, explicit browser-tab activation, zero client shell.openExternal calls, exact close convergence, unchanged terminal counts, and continued output on the original PTY.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts src/renderer/src/lib/http-link-routing.test.ts src/renderer/src/lib/http-link-modifier-routing.test.ts src/renderer/src/lib/workspace-browser-tab-open.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts src/renderer/src/lib/workspace-browser-tab-open.test.ts",
+        "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 pnpm exec playwright test tests/e2e/paired-remote-terminal-browser-link.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
+      ],
+      "testFiles": [
+        "src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts",
+        "src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts",
+        "src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts",
+        "src/renderer/src/lib/http-link-routing.test.ts",
+        "src/renderer/src/lib/http-link-modifier-routing.test.ts",
+        "src/renderer/src/lib/workspace-browser-tab-open.test.ts",
+        "tests/e2e/paired-remote-terminal-browser-link.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts",
+          "assertions": [
+            "OSC, WebLinksAddon, and click-fallback activations route through the exact runtime owner",
+            "direct SSH continues to use only the system browser"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/workspace-browser-tab-open.test.ts",
+          "assertions": [
+            "an asserted runtime cannot fall back to a client browser",
+            "mismatched and incapable runtime owners fail closed"
+          ]
+        },
+        {
+          "file": "tests/e2e/paired-remote-terminal-browser-link.spec.ts",
+          "assertions": [
+            "one terminal action produces one host page and one client mirror with exact identity",
+            "the host browser renders the fixture while client external navigation stays empty",
+            "an explicit browser-tab click reveals the exact mirror",
+            "closing the mirror returns host and client inventories to baseline",
+            "the original remote PTY accepts and renders fresh output after browser close"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-12",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts src/renderer/src/lib/workspace-browser-tab-open.test.ts",
+          "result": "failed",
+          "durationSeconds": 2.58,
+          "summary": "Latest main e4c278eb523 failed 6/25 owner-routing assertions: runtime terminal links called the viewing client's external browser and the managed-browser helper did not enforce an asserted runtime owner."
+        },
+        {
+          "date": "2026-08-12",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts src/renderer/src/lib/http-link-routing.test.ts src/renderer/src/lib/http-link-modifier-routing.test.ts src/renderer/src/lib/workspace-browser-tab-open.test.ts",
+          "result": "passed",
+          "durationSeconds": 1.83,
+          "summary": "Candidate passed 84/84 across six focused routing, modifier, availability, owner assertion, failure, SSH, and system-browser contract files."
+        },
+        {
+          "date": "2026-08-12",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 pnpm exec playwright test tests/e2e/paired-remote-terminal-browser-link.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 32.9,
+          "summary": "Candidate created one host browser and one client mirror with matching page identity, rendered the fixture, activated on an explicit tab click, made zero client external-browser calls, converged both inventories after exact UI close, and delivered fresh output on the original remote PTY."
+        },
+        {
+          "date": "2026-08-12",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 pnpm exec playwright test tests/e2e/paired-remote-terminal-browser-link.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "failed",
+          "durationSeconds": 60,
+          "summary": "The byte-identical final Electron oracle failed at its exact host/client identity barrier when the sole source delta replaced src/renderer/src/store/index.ts registration lines 110-113 with registerRuntimeHttpLinkBrowserOpener(null); no host-owned browser appeared within the deterministic 60-second bound."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "six focused renderer contract files plus one isolated headed paired-runtime journey"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The focused contracts are deterministic and the headed paired-runtime journey passed locally after its PTY namespace oracle was corrected; longer CI and soak history is not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The focused owner-routing oracle is red on latest main e4c278eb523 and green on the candidate. The byte-identical headed Electron oracle is green on the candidate and red when the sole source delta replaces the runtime browser opener registration with registerRuntimeHttpLinkBrowserOpener(null); candidate evidence proves exact host/client identity, rendered content, explicit activation, exact close convergence, original-PTY survival, and absence of client external navigation."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The production change adds no timer, polling, retry, subprocess, stream opcode, RPC method, or host publication. Each link hover or activation performs bounded in-memory owner and capability lookups; an Orca Browser action issues the same single browser creation and snapshot reconciliation already used by the tab bar."
+      },
+      "promotionCriteria": [
+        "Collect Linux and physical Windows paired-server evidence.",
+        "Collect a live headless-serve terminal-link journey.",
+        "Collect 100 consecutive focused CI passes or 14 days without an unexplained flake."
+      ],
+      "knownGaps": [
+        "Live paired-server validation currently covers macOS only.",
+        "A live headless-serve journey and multiple simultaneous viewers are not exercised by the Electron journey.",
+        "Direct SSH intentionally retains its existing system-browser-only semantics.",
+        "Terminal-link activation does not change the existing asynchronous host/client focus policy."
+      ],
+      "demotionRule": "Demote if one runtime terminal link creates a client-owned or duplicate browser, targets a runtime other than the pane owner, invokes the client external browser for Orca Browser, or removes the source terminal."
+    },
+    {
       "id": "browser-session.remote-html-preview-ownership",
       "title": "Paired HTML previews keep one host page and one stable client split",
       "maturity": "experimental",

--- a/src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx
@@ -8,7 +8,8 @@ const { openHttpLinkMock } = vi.hoisted(() => ({ openHttpLinkMock: vi.fn() }))
 
 vi.mock('@/lib/http-link-routing', () => ({
   openHttpLink: openHttpLinkMock,
-  registerHttpLinkStoreAccessor: vi.fn()
+  registerHttpLinkStoreAccessor: vi.fn(),
+  registerRuntimeHttpLinkBrowserOpener: vi.fn()
 }))
 
 function makeReview(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo {

--- a/src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import {
+  registerHttpLinkStoreAccessor,
+  registerRuntimeHttpLinkBrowserOpener
+} from '@/lib/http-link-routing'
 import {
   closeTerminalLinkActionRequest,
   requestTerminalLinkAction,
@@ -12,6 +15,7 @@ import { handleTerminalHttpLink } from './terminal-url-link-hit-testing'
 const openUrl = vi.fn()
 const createBrowserTab = vi.fn()
 const setActiveWorktree = vi.fn()
+const openRuntimeBrowserTab = vi.fn(() => Promise.resolve())
 
 function plainEvent(): MouseEvent {
   return {
@@ -44,9 +48,11 @@ beforeEach(() => {
     setActiveWorktree,
     createBrowserTab
   }))
+  registerRuntimeHttpLinkBrowserOpener(openRuntimeBrowserTab)
 })
 
 afterEach(() => {
+  registerRuntimeHttpLinkBrowserOpener(null)
   vi.clearAllMocks()
   vi.unstubAllGlobals()
 })
@@ -181,6 +187,28 @@ describe('terminal link action routing', () => {
     expect(request.mock.calls[0][0].alternate).toBeUndefined()
   })
 
+  it('routes an explicit Orca Browser action to the owning runtime', () => {
+    const request = vi.fn()
+
+    handleTerminalHttpLink('https://example.com/path', plainEvent(), {
+      worktreeId: 'wt-1',
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' },
+      linkActionContext: actionContext(request),
+      actionDestinations: { primary: 'system', alternate: 'orca' }
+    })
+
+    request.mock.calls[0][0].primary.run()
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/path')
+    request.mock.calls[0][0].alternate.run()
+    expect(openRuntimeBrowserTab).toHaveBeenCalledWith({
+      workspaceId: 'wt-1',
+      url: 'https://example.com/path',
+      intent: { kind: 'url' },
+      expectedRuntimeEnvironmentId: 'env-1'
+    })
+    expect(createBrowserTab).not.toHaveBeenCalled()
+  })
+
   it('uses Shift+modifier for the alternate local destination', () => {
     const event = { ...plainEvent(), metaKey: true, shiftKey: true }
 
@@ -193,6 +221,19 @@ describe('terminal link action routing', () => {
       activate: true
     })
     expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('keeps Shift+modifier on the only capability-backed destination', () => {
+    const event = { ...plainEvent(), metaKey: true, shiftKey: true }
+
+    handleTerminalHttpLink('https://example.com/path', event, {
+      worktreeId: 'wt-1',
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' },
+      actionDestinations: { primary: 'system' }
+    })
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/path')
+    expect(openRuntimeBrowserTab).not.toHaveBeenCalled()
   })
 
   it('exposes the actual hidden OSC 8 destination', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getTerminalUrlOpenHint, terminalUrlOpenHintOptionsFor } from './terminal-link-open-hints'
+import {
+  getTerminalUrlOpenHint,
+  terminalHttpLinkActionDestinationsFor,
+  terminalUrlOpenHintOptionsFor
+} from './terminal-link-open-hints'
 
 function stubPlatform(isMac: boolean): void {
   vi.stubGlobal('navigator', { userAgent: isMac ? 'Mac OS X' : 'Windows NT 10.0' })
@@ -137,5 +141,43 @@ describe('terminalUrlOpenHintOptionsFor', () => {
 
     expect(options.modifierInverts).toBe(true)
     expect(getTerminalUrlOpenHint(options)).toContain('to open in Orca')
+  })
+
+  it('keeps inversion for a runtime pane when its host can open an Orca browser', () => {
+    const options = terminalUrlOpenHintOptionsFor(
+      {
+        openLinksInApp: false,
+        openLinksInAppModifierInverts: true
+      },
+      { kind: 'runtime', runtimeEnvironmentId: 'env-1' },
+      true
+    )
+
+    expect(options.modifierInverts).toBe(true)
+  })
+})
+
+describe('terminalHttpLinkActionDestinationsFor', () => {
+  it('offers both destinations for a capable runtime and follows the preference', () => {
+    const owner = { kind: 'runtime', runtimeEnvironmentId: 'env-1' } as const
+
+    expect(terminalHttpLinkActionDestinationsFor({ openLinksInApp: true }, owner, true)).toEqual({
+      primary: 'orca',
+      alternate: 'system'
+    })
+    expect(terminalHttpLinkActionDestinationsFor({ openLinksInApp: false }, owner, true)).toEqual({
+      primary: 'system',
+      alternate: 'orca'
+    })
+  })
+
+  it.each([
+    ['incapable runtime', { kind: 'runtime', runtimeEnvironmentId: 'env-1' } as const],
+    ['SSH', { kind: 'ssh', connectionId: 'ssh-1' } as const],
+    ['unknown owner', { kind: 'unknown' } as const]
+  ])('offers only the system browser for an %s', (_label, owner) => {
+    expect(terminalHttpLinkActionDestinationsFor({ openLinksInApp: true }, owner, false)).toEqual({
+      primary: 'system'
+    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
@@ -1,4 +1,5 @@
 import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
+import type { TerminalHttpLinkActionDestinations } from './terminal-url-link-hit-testing'
 
 export function isMacPlatform(): boolean {
   return navigator.userAgent.includes('Mac')
@@ -36,10 +37,22 @@ export type TerminalUrlOpenHintOptions = {
   showActions?: boolean
 }
 
-// Why: openHttpLink only routes to Orca when the source is local, so a remote pane
-// pins every link to the system browser and inverting cannot reach Orca there. The
-// clicked pane's owner decides that, not the global active runtime — a workspace-bound
-// remote pane is remote even when no runtime is globally active.
+export function terminalHttpLinkActionDestinationsFor(
+  settings: { openLinksInApp?: boolean } | null | undefined,
+  sourceOwner: HttpLinkSourceOwner,
+  canOpenRuntimeBrowser: boolean
+): TerminalHttpLinkActionDestinations {
+  const canOpenInOrca =
+    sourceOwner.kind === 'local' || (sourceOwner.kind === 'runtime' && canOpenRuntimeBrowser)
+  if (!canOpenInOrca) {
+    return { primary: 'system' }
+  }
+  return settings?.openLinksInApp === true
+    ? { primary: 'orca', alternate: 'system' }
+    : { primary: 'system', alternate: 'orca' }
+}
+
+// Why: only a capability-verified runtime can advertise the in-app destination.
 export function terminalUrlOpenHintOptionsFor(
   settings:
     | {
@@ -49,14 +62,15 @@ export function terminalUrlOpenHintOptionsFor(
       }
     | null
     | undefined,
-  sourceOwner?: HttpLinkSourceOwner
+  sourceOwner?: HttpLinkSourceOwner,
+  canOpenRuntimeBrowser = false
 ): TerminalUrlOpenHintOptions {
-  const sourceIsLocal = sourceOwner
-    ? sourceOwner.kind === 'local'
+  const sourceCanOpenInOrca = sourceOwner
+    ? sourceOwner.kind === 'local' || (sourceOwner.kind === 'runtime' && canOpenRuntimeBrowser)
     : !settings?.activeRuntimeEnvironmentId?.trim()
   return {
     openLinksInApp: settings?.openLinksInApp === true,
-    modifierInverts: settings?.openLinksInAppModifierInverts === true && sourceIsLocal
+    modifierInverts: settings?.openLinksInAppModifierInverts === true && sourceCanOpenInOrca
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts
@@ -1,6 +1,9 @@
 import type { IBufferLine, Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import {
+  registerHttpLinkStoreAccessor,
+  registerRuntimeHttpLinkBrowserOpener
+} from '@/lib/http-link-routing'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { handleTerminalWebLinkClick } from './terminal-web-link-click'
 import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
@@ -12,6 +15,7 @@ const ROWS = 24
 const openUrlMock = vi.fn()
 const setActiveWorktreeMock = vi.fn()
 const createBrowserTabMock = vi.fn()
+const openRuntimeBrowserTabMock = vi.fn(() => Promise.resolve())
 const runtimeSourceOwner = { kind: 'runtime', runtimeEnvironmentId: 'env-1' } as const
 const sshSourceOwner = { kind: 'ssh', connectionId: 'ssh-1' } as const
 
@@ -104,26 +108,34 @@ beforeEach(() => {
     setActiveWorktree: setActiveWorktreeMock,
     createBrowserTab: createBrowserTabMock
   }))
+  registerRuntimeHttpLinkBrowserOpener(openRuntimeBrowserTabMock)
 })
 
 afterEach(() => {
+  registerRuntimeHttpLinkBrowserOpener(null)
   vi.unstubAllGlobals()
 })
 
 describe('terminal HTTP links on a runtime-hosted pane', () => {
   const baseDeps = { worktreeId: 'wt-1', worktreePath: '/tmp', startupCwd: '/tmp' }
 
-  it('sends an OSC 8 hyperlink to the system browser', () => {
+  it('opens an OSC 8 hyperlink on the owning runtime', () => {
     expect(handleOscLink(URL, clickEvent(), { ...baseDeps, sourceOwner: runtimeSourceOwner })).toBe(
       true
     )
 
-    expect(openUrlMock).toHaveBeenCalledWith(URL)
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledWith({
+      workspaceId: 'wt-1',
+      url: URL,
+      intent: { kind: 'url' },
+      expectedRuntimeEnvironmentId: 'env-1'
+    })
+    expect(openUrlMock).not.toHaveBeenCalled()
     expect(createBrowserTabMock).not.toHaveBeenCalled()
     expect(setActiveWorktreeMock).not.toHaveBeenCalled()
   })
 
-  it('sends a WebLinksAddon click to the system browser', () => {
+  it('opens a WebLinksAddon click on the owning runtime', () => {
     const { terminal } = makeTerminal()
 
     expect(
@@ -134,11 +146,14 @@ describe('terminal HTTP links on a runtime-hosted pane', () => {
       })
     ).toBe(true)
 
-    expect(openUrlMock).toHaveBeenCalledWith(URL)
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedRuntimeEnvironmentId: 'env-1', url: URL })
+    )
+    expect(openUrlMock).not.toHaveBeenCalled()
     expect(createBrowserTabMock).not.toHaveBeenCalled()
   })
 
-  it('sends a click-fallback activation to the system browser', () => {
+  it('opens a click-fallback activation on the owning runtime', () => {
     const { terminal, registrations } = makeTerminal()
     const disposable = installHttpLinkClickFallback(terminal, {
       worktreeId: 'wt-1',
@@ -149,12 +164,15 @@ describe('terminal HTTP links on a runtime-hosted pane', () => {
       ([name, _listener, options]) => name === 'mouseup' && options === undefined
     )?.[1](clickEvent())
 
-    expect(openUrlMock).toHaveBeenCalledWith(URL)
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedRuntimeEnvironmentId: 'env-1', url: URL })
+    )
+    expect(openUrlMock).not.toHaveBeenCalled()
     expect(createBrowserTabMock).not.toHaveBeenCalled()
     disposable.dispose()
   })
 
-  it('never prompts for the in-app routing preference it could not honor', () => {
+  it('uses the persisted routing preference without prompting again', () => {
     const requestOpenLinksInAppPreference = vi.fn(() => Promise.resolve(true))
 
     handleOscLink(URL, clickEvent(), {
@@ -164,7 +182,8 @@ describe('terminal HTTP links on a runtime-hosted pane', () => {
     })
 
     expect(requestOpenLinksInAppPreference).not.toHaveBeenCalled()
-    expect(openUrlMock).toHaveBeenCalledWith(URL)
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
@@ -72,7 +72,7 @@ export function handleTerminalHttpLink(
 ): boolean {
   if (isTerminalHttpLinkActivation(event)) {
     const forceDestination = event?.shiftKey
-      ? deps.actionDestinations?.alternate
+      ? (deps.actionDestinations?.alternate ?? deps.actionDestinations?.primary)
       : deps.actionDestinations?.primary
     openTerminalHttpLink(url, {
       ...deps,
@@ -273,11 +273,11 @@ function rangeContainsBufferPosition(
 }
 
 export function openTerminalHttpLink(url: string, deps: UrlLinkHitTestDeps): void {
-  // Why: Orca browser tabs are local-only, so a link clicked in a runtime-hosted
-  // pane must be classified by its pane's host, not the global active runtime.
+  // Why: pane ownership beats the global active runtime for both local and remote routes.
   const sourceOwner = deps.sourceOwner ?? { kind: 'local' }
   if (deps.forceDestination) {
     openHttpLink(url, {
+      allowRuntimeInApp: true,
       worktreeId: deps.worktreeId,
       forceInApp: deps.forceDestination === 'orca',
       forceSystemBrowser: deps.forceDestination === 'system',
@@ -288,16 +288,20 @@ export function openTerminalHttpLink(url: string, deps: UrlLinkHitTestDeps): voi
   if (deps.modifierHeld) {
     // Why: the modifier states a destination outright, so it also skips the
     // one-time routing prompt; openHttpLink resolves which destination it means.
-    openHttpLink(url, { worktreeId: deps.worktreeId, modifierHeld: true, sourceOwner })
+    openHttpLink(url, {
+      allowRuntimeInApp: true,
+      worktreeId: deps.worktreeId,
+      modifierHeld: true,
+      sourceOwner
+    })
     return
   }
 
-  // Why: a runtime-hosted link can only reach the system browser, so prompting
-  // would persist an in-app preference this click cannot honor.
+  // Why: remote panes use the persisted routing preference and never prompt the viewing client.
   const preferenceDecision =
     sourceOwner.kind === 'local' ? deps.requestOpenLinksInAppPreference?.(url) : null
   if (preferenceDecision === null || preferenceDecision === undefined) {
-    openHttpLink(url, { worktreeId: deps.worktreeId, sourceOwner })
+    openHttpLink(url, { allowRuntimeInApp: true, worktreeId: deps.worktreeId, sourceOwner })
     return
   }
 
@@ -307,12 +311,18 @@ export function openTerminalHttpLink(url: string, deps: UrlLinkHitTestDeps): voi
   void Promise.resolve(preferenceDecision)
     .then((openInOrca) => {
       openHttpLink(url, {
+        allowRuntimeInApp: true,
         worktreeId: deps.worktreeId,
         forceSystemBrowser: !openInOrca,
         sourceOwner
       })
     })
     .catch(() => {
-      openHttpLink(url, { worktreeId: deps.worktreeId, forceSystemBrowser: true, sourceOwner })
+      openHttpLink(url, {
+        allowRuntimeInApp: true,
+        worktreeId: deps.worktreeId,
+        forceSystemBrowser: true,
+        sourceOwner
+      })
     })
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -32,7 +32,10 @@ import {
   getTerminalUrlOpenHint,
   installFilePathLinkClickFallback
 } from './terminal-link-handlers'
-import { terminalUrlOpenHintOptionsFor } from './terminal-link-open-hints'
+import {
+  terminalHttpLinkActionDestinationsFor,
+  terminalUrlOpenHintOptionsFor
+} from './terminal-link-open-hints'
 import { createTerminalHandleLinkProvider } from './terminal-handle-links'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { handleOscLink } from './terminal-osc-link-routing'
@@ -53,6 +56,7 @@ import {
   type HttpLinkSourceOwner
 } from '@/lib/http-link-routing'
 import { resolveTerminalHttpLinkSourceOwner } from './terminal-http-link-source-owner'
+import { canOpenWorkspaceBrowserTabOnRuntime } from '@/lib/workspace-browser-tab-open'
 import type {
   GlobalSettings,
   SetupSplitDirection,
@@ -742,15 +746,24 @@ export function useTerminalPaneLifecycle({
       resolvePaneLinkCwd(paneCwdRef.current, paneId, startupCwd)
     const getHttpLinkSourceOwnerForPane = (paneId: number) =>
       resolveTerminalHttpLinkSourceOwner(paneTransportsRef.current.get(paneId))
+    const canOpenRuntimeBrowserForPane = (paneId: number): boolean => {
+      const sourceOwner = getHttpLinkSourceOwnerForPane(paneId)
+      return (
+        sourceOwner.kind === 'runtime' &&
+        canOpenWorkspaceBrowserTabOnRuntime(
+          useAppStore.getState(),
+          worktreeId,
+          sourceOwner.runtimeEnvironmentId
+        )
+      )
+    }
     const getHttpLinkActionDestinations = (paneId: number): TerminalHttpLinkActionDestinations => {
       const sourceOwner = getHttpLinkSourceOwnerForPane(paneId)
-      if (sourceOwner.kind !== 'local') {
-        return { primary: 'system' }
-      }
-      const options = terminalUrlOpenHintOptionsFor(settingsRef.current, sourceOwner)
-      return options.openLinksInApp
-        ? { primary: 'orca', alternate: 'system' }
-        : { primary: 'system', alternate: 'orca' }
+      return terminalHttpLinkActionDestinationsFor(
+        settingsRef.current,
+        sourceOwner,
+        canOpenRuntimeBrowserForPane(paneId)
+      )
     }
     const getLinkActionContext = (paneId: number): TerminalLinkActionContext | null => {
       if (settingsRef.current?.terminalLinkActionPopoverEnabled === false) {
@@ -901,7 +914,8 @@ export function useTerminalPaneLifecycle({
       getTerminalUrlOpenHint({
         ...terminalUrlOpenHintOptionsFor(
           settingsRef.current,
-          getHttpLinkSourceOwnerForPane(paneId)
+          getHttpLinkSourceOwnerForPane(paneId),
+          canOpenRuntimeBrowserForPane(paneId)
         ),
         showActions: settingsRef.current?.terminalLinkActionPopoverEnabled !== false
       })

--- a/src/renderer/src/lib/http-link-modifier-routing.test.ts
+++ b/src/renderer/src/lib/http-link-modifier-routing.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   openHttpLink,
   registerHttpLinkStoreAccessor,
+  registerRuntimeHttpLinkBrowserOpener,
   resolveModifierRouting
 } from './http-link-routing'
 
@@ -58,6 +59,7 @@ describe('modifier routing across link source owners', () => {
   const openUrlMock = vi.fn()
   const setActiveWorktreeMock = vi.fn()
   const createBrowserTabMock = vi.fn()
+  const openRuntimeBrowserTabMock = vi.fn(() => Promise.resolve())
   const storeState = {
     settings: {} as {
       openLinksInApp?: boolean
@@ -71,10 +73,12 @@ describe('modifier routing across link source owners', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     registerHttpLinkStoreAccessor(() => storeState)
+    registerRuntimeHttpLinkBrowserOpener(openRuntimeBrowserTabMock)
     vi.stubGlobal('window', { api: { shell: { openUrl: openUrlMock } } })
   })
 
   afterEach(() => {
+    registerRuntimeHttpLinkBrowserOpener(null)
     vi.unstubAllGlobals()
   })
 
@@ -92,23 +96,40 @@ describe('modifier routing across link source owners', () => {
     })
   })
 
-  it('never lets a modifier pull a runtime-owned link into Orca', () => {
-    for (const inverts of [true, false]) {
-      vi.clearAllMocks()
-      storeState.settings = {
-        openLinksInApp: false,
-        openLinksInAppModifierInverts: inverts,
-        activeRuntimeEnvironmentId: null
-      }
-
-      openHttpLink('https://example.com/', {
-        worktreeId: 'wt-1',
-        modifierHeld: true,
-        sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
-      })
-
-      expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
-      expect(createBrowserTabMock).not.toHaveBeenCalled()
+  it('lets an inverting modifier reach Orca on the owning runtime', () => {
+    storeState.settings = {
+      openLinksInApp: false,
+      openLinksInAppModifierInverts: true,
+      activeRuntimeEnvironmentId: null
     }
+
+    openHttpLink('https://example.com/', {
+      allowRuntimeInApp: true,
+      worktreeId: 'wt-1',
+      modifierHeld: true,
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
+    })
+
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedRuntimeEnvironmentId: 'env-1' })
+    )
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy modifier on the system browser when inversion is off', () => {
+    storeState.settings = {
+      openLinksInApp: false,
+      openLinksInAppModifierInverts: false,
+      activeRuntimeEnvironmentId: null
+    }
+
+    openHttpLink('https://example.com/', {
+      worktreeId: 'wt-1',
+      modifierHeld: true,
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
+    })
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(openRuntimeBrowserTabMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -4,13 +4,19 @@ import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
 import {
   openHttpLink,
   registerHttpLinkStoreAccessor,
+  registerRuntimeHttpLinkBrowserOpener,
   resolveLocalhostHttpLinkDisplayUrl
 } from './http-link-routing'
+
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock } }))
 
 const openUrlMock = vi.fn()
 const registerLocalhostLabelMock = vi.fn()
 const setActiveWorktreeMock = vi.fn()
 const createBrowserTabMock = vi.fn()
+const openRuntimeBrowserTabMock = vi.fn(() => Promise.resolve())
 
 const storeState = {
   settings: undefined as
@@ -42,6 +48,7 @@ beforeEach(() => {
   storeState.settings = undefined
   storeState.workspacePortScansByKey = {}
   registerHttpLinkStoreAccessor(() => storeState)
+  registerRuntimeHttpLinkBrowserOpener(openRuntimeBrowserTabMock)
   vi.stubGlobal('window', {
     api: {
       shell: {
@@ -55,6 +62,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  registerRuntimeHttpLinkBrowserOpener(null)
   vi.unstubAllGlobals()
 })
 
@@ -155,10 +163,11 @@ describe('openHttpLink', () => {
     expect(openUrlMock).not.toHaveBeenCalled()
   })
 
-  it('routes explicit runtime and SSH document owners to the exact system URL', () => {
+  it('routes runtime and SSH document owners to their distinct destinations', () => {
     storeState.settings = { openLinksInApp: true, localhostWorktreeLabelsEnabled: true }
 
     openHttpLink('http://localhost:5180/runtime', {
+      allowRuntimeInApp: true,
       worktreeId: 'wt-1',
       sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
     })
@@ -167,16 +176,67 @@ describe('openHttpLink', () => {
       sourceOwner: { kind: 'ssh', connectionId: 'ssh-1' }
     })
 
-    expect(openUrlMock).toHaveBeenNthCalledWith(1, 'http://localhost:5180/runtime')
-    expect(openUrlMock).toHaveBeenNthCalledWith(2, 'http://localhost:5180/ssh')
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledWith({
+      workspaceId: 'wt-1',
+      url: 'http://localhost:5180/runtime',
+      intent: { kind: 'url' },
+      expectedRuntimeEnvironmentId: 'env-1'
+    })
+    expect(openUrlMock).toHaveBeenCalledWith('http://localhost:5180/ssh')
     expect(createBrowserTabMock).not.toHaveBeenCalled()
     expect(registerLocalhostLabelMock).not.toHaveBeenCalled()
   })
 
   // Why: runtimes bind per workspace, so activeRuntimeEnvironmentId is commonly
   // null while a pane is remote — ownership must come from the click source.
-  it('keeps a runtime-owned link out of Orca when no runtime is globally active', () => {
+  it('uses the pane runtime owner when no runtime is globally active', () => {
     storeState.settings = { openLinksInApp: true, activeRuntimeEnvironmentId: null }
+
+    openHttpLink('https://example.com/', {
+      allowRuntimeInApp: true,
+      worktreeId: 'wt-1',
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
+    })
+
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedRuntimeEnvironmentId: 'env-1' })
+    )
+    expect(openUrlMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed instead of falling back to the client system browser', async () => {
+    storeState.settings = { openLinksInApp: true }
+    openRuntimeBrowserTabMock.mockRejectedValueOnce(new Error('runtime unavailable'))
+
+    openHttpLink('https://example.com/', {
+      allowRuntimeInApp: true,
+      worktreeId: 'wt-1',
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
+    })
+
+    await vi.waitFor(() => expect(openRuntimeBrowserTabMock).toHaveBeenCalledOnce())
+    expect(openUrlMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).toHaveBeenCalledWith('runtime unavailable')
+  })
+
+  it('keeps an explicit runtime system-browser action on the viewing client', () => {
+    storeState.settings = { openLinksInApp: true }
+
+    openHttpLink('https://example.com/', {
+      worktreeId: 'wt-1',
+      forceSystemBrowser: true,
+      sourceOwner: { kind: 'runtime', runtimeEnvironmentId: 'env-1' }
+    })
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(openRuntimeBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps generic runtime-owned document links in the system browser', () => {
+    storeState.settings = { openLinksInApp: true }
 
     openHttpLink('https://example.com/', {
       worktreeId: 'wt-1',
@@ -184,8 +244,7 @@ describe('openHttpLink', () => {
     })
 
     expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
-    expect(createBrowserTabMock).not.toHaveBeenCalled()
-    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+    expect(openRuntimeBrowserTabMock).not.toHaveBeenCalled()
   })
 
   it('labels explicit local links from the local scan instead of a merged remote port', async () => {

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n/i18n'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import {
   parseLoopbackUrlWithPort,
@@ -146,7 +147,11 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
         intent: { kind: 'url' },
         expectedRuntimeEnvironmentId: sourceOwner.runtimeEnvironmentId
       }).catch((error) => {
-        toast.error(error instanceof Error ? error.message : 'Unable to open URL.')
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : translate('auto.lib.workspace.browser.tab.open.urlFailed', 'Unable to open URL.')
+        )
       })
     }
     return

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -5,9 +5,12 @@ import {
 } from '../../../shared/localhost-worktree-labels'
 import type { GlobalSettings } from '../../../shared/types'
 import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import { toast } from 'sonner'
 
 export type OpenHttpLinkOptions = {
   worktreeId?: string | null
+  /** Terminal-only opt-in for routing a runtime-owned source through its managed browser. */
+  allowRuntimeInApp?: boolean
   /** Unconditional: always use the system browser regardless of settings. */
   forceSystemBrowser?: boolean
   /** Unconditional for local sources: open inside Orca regardless of settings. */
@@ -43,6 +46,15 @@ type StoreAccessor = () => {
   workspacePortScansByKey?: Record<string, WorkspacePortScanResult>
 }
 
+type RuntimeHttpLinkBrowserRequest = {
+  workspaceId: string
+  url: string
+  intent: { kind: 'url' }
+  expectedRuntimeEnvironmentId: string
+}
+
+type RuntimeHttpLinkBrowserOpener = (request: RuntimeHttpLinkBrowserRequest) => Promise<void>
+
 type LocalhostLinkRepo = {
   id: string
   displayName: string
@@ -61,9 +73,16 @@ type LocalhostLinkWorktree = {
 // the break, several renderer test files that load this module first see
 // `createEditorSlice` as undefined at store/index.ts initialization.
 let storeAccessor: StoreAccessor | null = null
+let runtimeHttpLinkBrowserOpener: RuntimeHttpLinkBrowserOpener | null = null
 
 export function registerHttpLinkStoreAccessor(fn: StoreAccessor): void {
   storeAccessor = fn
+}
+
+export function registerRuntimeHttpLinkBrowserOpener(
+  fn: RuntimeHttpLinkBrowserOpener | null
+): void {
+  runtimeHttpLinkBrowserOpener = fn
 }
 
 // Scope: http(s) URLs only. file: URIs and in-worktree markdown targets are
@@ -93,7 +112,14 @@ export function resolveModifierRouting(
 }
 
 export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void {
-  const { worktreeId, forceSystemBrowser, forceInApp, modifierHeld, sourceOwner } = opts
+  const {
+    worktreeId,
+    allowRuntimeInApp,
+    forceSystemBrowser,
+    forceInApp,
+    modifierHeld,
+    sourceOwner
+  } = opts
   if (sourceOwner?.kind === 'unknown') {
     return
   }
@@ -106,14 +132,27 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     openLinksInApp,
     state?.settings?.openLinksInAppModifierInverts === true
   )
-  const routeToOrca =
-    sourceIsLocal &&
+  const wantsOrca =
     !forceSystemBrowser &&
     !modifier.wantsSystemBrowser &&
     Boolean(worktreeId) &&
     (forceInApp || openLinksInApp || modifier.wantsOrca)
 
-  if (routeToOrca && worktreeId && state) {
+  if (wantsOrca && allowRuntimeInApp && worktreeId && sourceOwner?.kind === 'runtime') {
+    if (runtimeHttpLinkBrowserOpener) {
+      void runtimeHttpLinkBrowserOpener({
+        workspaceId: worktreeId,
+        url,
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: sourceOwner.runtimeEnvironmentId
+      }).catch((error) => {
+        toast.error(error instanceof Error ? error.message : 'Unable to open URL.')
+      })
+    }
+    return
+  }
+
+  if (wantsOrca && sourceIsLocal && worktreeId && state) {
     // Why: http clicks from inside a worktree should not push a worktree-switch
     // history entry — the user isn't changing worktrees, they're opening a tab
     // in the one they're already in. activateAndRevealWorktree is reserved for

--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -4,7 +4,10 @@ import {
   toRuntimeExecutionHostId,
   toSshExecutionHostId
 } from '../../../shared/execution-host'
-import { openWorkspaceBrowserTab } from './workspace-browser-tab-open'
+import {
+  canOpenWorkspaceBrowserTabOnRuntime,
+  openWorkspaceBrowserTab
+} from './workspace-browser-tab-open'
 
 const mocks = vi.hoisted(() => ({
   createRemote: vi.fn(),
@@ -94,6 +97,10 @@ describe('openWorkspaceBrowserTab', () => {
       defaultBrowserSessionProfileIdByHostId: {}
     }
 
+    expect(canOpenWorkspaceBrowserTabOnRuntime(mocks.state as never, WORKSPACE_ID, 'hub-a')).toBe(
+      true
+    )
+
     await openWorkspaceBrowserTab({
       workspaceId: WORKSPACE_ID,
       url: 'https://example.com/docs?token=secret',
@@ -111,6 +118,50 @@ describe('openWorkspaceBrowserTab', () => {
       failureLogMode: 'operation-only'
     })
     expect(createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('fails closed instead of opening on a runtime other than the asserted owner', async () => {
+    mocks.state = {
+      ...ownerState(toRuntimeExecutionHostId('hub-b')),
+      ...browserCapableRuntime('hub-b'),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+
+    await expect(
+      openWorkspaceBrowserTab({
+        workspaceId: WORKSPACE_ID,
+        url: 'https://example.com/',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: 'hub-a'
+      })
+    ).rejects.toThrow('Unable to open URL.')
+    expect(mocks.createRemote).not.toHaveBeenCalled()
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to a client browser for an incapable asserted runtime', async () => {
+    mocks.state = {
+      ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+
+    expect(canOpenWorkspaceBrowserTabOnRuntime(mocks.state as never, WORKSPACE_ID, 'hub-a')).toBe(
+      false
+    )
+    await expect(
+      openWorkspaceBrowserTab({
+        workspaceId: WORKSPACE_ID,
+        url: 'https://example.com/',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: 'hub-a'
+      })
+    ).rejects.toThrow('Unable to open URL.')
+    expect(mocks.createRemote).not.toHaveBeenCalled()
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
   })
 
   // Two dev servers on one host must not share a tab title.

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -21,6 +21,36 @@ export type OpenWorkspaceBrowserTabRequest = {
   targetGroupId?: string
   url: string
   intent: WorkspaceBrowserTabIntent
+  expectedRuntimeEnvironmentId?: string
+}
+
+function isExpectedRuntimeBrowserRoute(
+  availability: ClientCreationActionAvailability,
+  route: ReturnType<typeof resolveWorktreeOperationRoute>,
+  expectedRuntimeEnvironmentId: string
+): boolean {
+  if (availability.state !== 'enabled' || availability.provider !== 'paired-runtime' || !route) {
+    return false
+  }
+  const environmentId = route.runtimeEnvironmentId?.trim() || null
+  if (environmentId !== expectedRuntimeEnvironmentId.trim()) {
+    return false
+  }
+  const host = parseExecutionHostId(route.executionHostId)
+  return (
+    !route.executionHostId ||
+    Boolean(host && (host.kind !== 'runtime' || host.environmentId === environmentId))
+  )
+}
+
+export function canOpenWorkspaceBrowserTabOnRuntime(
+  state: AppState,
+  workspaceId: string,
+  expectedRuntimeEnvironmentId: string
+): boolean {
+  const availability = getClientCreationActionPolicy(state, workspaceId)['managed-browser']
+  const route = resolveWorktreeOperationRoute(state, workspaceId)
+  return isExpectedRuntimeBrowserRoute(availability, route, expectedRuntimeEnvironmentId)
 }
 
 // Why: concurrent URL tabs are indistinguishable under a shared "Open URL"
@@ -133,6 +163,13 @@ export async function openWorkspaceBrowserTab(
     throw openFailure(presentation.error, 'no active worktree route')
   }
   const environmentId = route.runtimeEnvironmentId?.trim() || null
+  const expectedEnvironmentId = request.expectedRuntimeEnvironmentId?.trim() || null
+  if (
+    expectedEnvironmentId &&
+    !isExpectedRuntimeBrowserRoute(availability, route, expectedEnvironmentId)
+  ) {
+    throw openFailure(presentation.error, 'asserted runtime cannot provide this managed browser')
+  }
   const host = parseExecutionHostId(route.executionHostId)
   if (!environmentId) {
     if (!host || host.kind === 'runtime') {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -46,7 +46,10 @@ import { createRemoteServerUpdatesSlice } from './slices/remote-server-updates'
 import { createTerminalQuickCommandHostsSlice } from './slices/terminal-quick-command-hosts'
 import { e2eConfig } from '@/lib/e2e-config'
 import type { createWebRuntimeSessionTerminal } from '@/runtime/web-runtime-session'
-import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import {
+  registerHttpLinkStoreAccessor,
+  registerRuntimeHttpLinkBrowserOpener
+} from '@/lib/http-link-routing'
 import { installStoreListenerCensus } from './store-listener-census'
 import {
   registerRendererMemoryProfileContributor,
@@ -104,6 +107,10 @@ export const useAppStore = create<AppState>()((...a) => {
 })
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())
+registerRuntimeHttpLinkBrowserOpener(async (request) => {
+  const { openWorkspaceBrowserTab } = await import('@/lib/workspace-browser-tab-open')
+  await openWorkspaceBrowserTab(request)
+})
 
 // Why: names the fattest store slices in renderer_memory_highwater breadcrumbs
 // so OOM crash reports identify what grew without a local repro.

--- a/tests/e2e/paired-remote-terminal-browser-link.spec.ts
+++ b/tests/e2e/paired-remote-terminal-browser-link.spec.ts
@@ -1,0 +1,368 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+import {
+  readPanelNavigationObserver,
+  startPanelNavigationObserver,
+  stopPanelNavigationObserver
+} from './helpers/plugin-panel-navigation-observer'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  execInTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+const PAGE_MARKER = 'remote terminal browser owner'
+const TERMINAL_MARKER = 'remote-terminal-still-live-after-browser-close'
+
+async function readTabInventory(
+  page: Page,
+  environmentId: string,
+  worktreeId: string
+): Promise<{
+  clientBrowserWorkspaces: number
+  clientBrowserTabs: number
+  clientTerminalTabs: number
+  hostBrowserTabs: number
+  hostTerminalTabs: number
+}> {
+  return page.evaluate(
+    async ({ environmentId, worktreeId }) => {
+      const state = window.__store?.getState()
+      const response = await window.api.runtimeEnvironments.call({
+        selector: environmentId,
+        method: 'session.tabs.list',
+        params: { worktree: `id:${worktreeId}` },
+        timeoutMs: 15_000
+      })
+      return {
+        clientBrowserWorkspaces: (state?.browserTabsByWorktree[worktreeId] ?? []).length,
+        clientBrowserTabs: (state?.unifiedTabsByWorktree[worktreeId] ?? []).filter(
+          (tab) => tab.contentType === 'browser'
+        ).length,
+        clientTerminalTabs: (state?.tabsByWorktree[worktreeId] ?? []).length,
+        hostBrowserTabs: response.ok
+          ? response.result.tabs.filter((tab) => tab.type === 'browser').length
+          : -1,
+        hostTerminalTabs: response.ok
+          ? response.result.tabs.filter((tab) => tab.type === 'terminal').length
+          : -1
+      }
+    },
+    { environmentId, worktreeId }
+  )
+}
+
+async function startPageServer(): Promise<{ server: Server; url: string }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    response.end(`<!doctype html><html><body><h1>${PAGE_MARKER}</h1></body></html>`)
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address() as AddressInfo
+  return { server, url: `http://127.0.0.1:${address.port}/remote-terminal` }
+}
+
+async function closePageServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+async function findTerminalLinkTarget(page: Page, link: string): Promise<{ x: number; y: number }> {
+  return page.evaluate((targetLink) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId = worktreeId ? state?.activeTabIdByWorktree?.[worktreeId] : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const screen = pane?.terminal.element?.querySelector<HTMLElement>('.xterm-screen') ?? null
+    if (!pane || !screen) {
+      throw new Error('paired terminal screen unavailable')
+    }
+    const buffer = pane.terminal.buffer.active
+    for (let row = 0; row < pane.terminal.rows; row += 1) {
+      const text = buffer.getLine(buffer.viewportY + row)?.translateToString(false) ?? ''
+      const column = text.indexOf(targetLink)
+      if (column === -1) {
+        continue
+      }
+      const cell = pane.terminal.dimensions?.css.cell
+      if (!cell?.width || !cell.height) {
+        throw new Error('paired terminal cell dimensions unavailable')
+      }
+      const rect = screen.getBoundingClientRect()
+      return {
+        x: rect.left + (column + targetLink.length / 2) * cell.width,
+        y: rect.top + (row + 0.5) * cell.height
+      }
+    }
+    throw new Error('paired terminal link unavailable')
+  }, link)
+}
+
+function remoteTerminalHandle(ptyId: string): string {
+  const separator = ptyId.indexOf('@@')
+  if (!ptyId.startsWith('remote:') || separator === -1) {
+    throw new Error(`Expected runtime-owned PTY id, received ${ptyId}`)
+  }
+  return decodeURIComponent(ptyId.slice(separator + 2))
+}
+
+test('opens a paired-runtime terminal link on its owning host', async ({
+  orcaPage,
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(240_000)
+  const fixture = await startPageServer()
+  let client: PairedElectronClient | null = null
+  let observerActive = false
+  try {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage)
+    const hostPtyId = await waitForActivePanePtyId(orcaPage)
+    await execInTerminal(orcaPage, hostPtyId, `printf '%s\\n' ${JSON.stringify(fixture.url)}`)
+    await waitForTerminalOutput(orcaPage, fixture.url)
+
+    const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+    client = await launchPairedElectronClient(offer, testInfo, 'Remote terminal browser link')
+    const page = client.page
+    const worktreeId = await expect
+      .poll(
+        () =>
+          page.evaluate((repoPath) => {
+            const state = window.__store?.getState()
+            return state?.allWorktrees().find((worktree) => worktree.path === repoPath)?.id ?? null
+          }, testRepoPath),
+        { timeout: 60_000, message: 'paired client never received the host worktree' }
+      )
+      .not.toBeNull()
+      .then(() =>
+        page.evaluate((repoPath) => {
+          const state = window.__store?.getState()
+          return state?.allWorktrees().find((worktree) => worktree.path === repoPath)?.id ?? null
+        }, testRepoPath)
+      )
+    if (!worktreeId) {
+      throw new Error('paired client worktree disappeared after discovery')
+    }
+    await page.evaluate(
+      async ({ environmentId, worktreeId }) => {
+        const state = window.__store?.getState()
+        state?.setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+        await state?.updateSettings({
+          openLinksInApp: true,
+          terminalLinkActionPopoverEnabled: true
+        })
+      },
+      { environmentId: client.environmentId, worktreeId }
+    )
+    await ensureTerminalVisible(page, 30_000)
+    await waitForActiveTerminalManager(page, 30_000)
+    await waitForTerminalOutput(page, fixture.url, 30_000)
+    const clientPtyId = await waitForActivePanePtyId(page, 30_000)
+    expect(clientPtyId.startsWith(`remote:${client.environmentId}@@`)).toBe(true)
+
+    const baseline = await readTabInventory(page, client.environmentId, worktreeId)
+    await startPanelNavigationObserver(client.app, page.url())
+    observerActive = true
+
+    const target = await findTerminalLinkTarget(page, fixture.url)
+    await page.mouse.move(target.x, target.y)
+    await expect(page.locator('.xterm-hover')).toHaveCount(1)
+    await page.mouse.click(target.x, target.y)
+    const actionPopover = page.locator('[data-terminal-link-action-popover]')
+    await expect(actionPopover).toBeVisible()
+    await expect(actionPopover.locator('[data-terminal-link-destination]')).toHaveText(fixture.url)
+    await expect(
+      actionPopover.getByRole('button').filter({ hasText: 'System Browser' })
+    ).toBeVisible()
+    const orcaBrowserAction = actionPopover.getByRole('button').filter({ hasText: 'Orca Browser' })
+    await expect(orcaBrowserAction).toBeVisible()
+    await orcaBrowserAction.click()
+
+    const identity = await expect
+      .poll(
+        () =>
+          page.evaluate(
+            async ({ environmentId, url, worktreeId }) => {
+              const state = window.__store?.getState()
+              const workspace = (state?.browserTabsByWorktree[worktreeId] ?? []).find(
+                (tab) => tab.url === url
+              )
+              const browserPage = workspace
+                ? (state?.browserPagesByWorkspace[workspace.id] ?? [])[0]
+                : null
+              const handle = browserPage
+                ? state?.remoteBrowserPageHandlesByPageId[browserPage.id]
+                : null
+              const response = await window.api.runtimeEnvironments.call({
+                selector: environmentId,
+                method: 'session.tabs.list',
+                params: { worktree: `id:${worktreeId}` },
+                timeoutMs: 15_000
+              })
+              const hostTab = response.ok
+                ? response.result.tabs.find((tab) => tab.type === 'browser' && tab.url === url)
+                : null
+              return workspace && browserPage && handle && hostTab?.type === 'browser'
+                ? {
+                    clientPageId: browserPage.id,
+                    clientRuntimeId: browserPage.browserRuntimeEnvironmentId,
+                    clientWorkspaceId: workspace.id,
+                    hostPageId: hostTab.browserPageId,
+                    hostTabId: hostTab.id,
+                    remoteEnvironmentId: handle.environmentId,
+                    remotePageId: handle.remotePageId
+                  }
+                : null
+            },
+            { environmentId: client!.environmentId, url: fixture.url, worktreeId }
+          ),
+        { timeout: 60_000, message: 'terminal link never became one host-owned browser tab' }
+      )
+      .not.toBeNull()
+      .then(() =>
+        page.evaluate(
+          async ({ environmentId, url, worktreeId }) => {
+            const state = window.__store!.getState()
+            const workspace = state.browserTabsByWorktree[worktreeId]!.find(
+              (tab) => tab.url === url
+            )!
+            const browserPage = state.browserPagesByWorkspace[workspace.id]![0]!
+            const handle = state.remoteBrowserPageHandlesByPageId[browserPage.id]!
+            const response = await window.api.runtimeEnvironments.call({
+              selector: environmentId,
+              method: 'session.tabs.list',
+              params: { worktree: `id:${worktreeId}` },
+              timeoutMs: 15_000
+            })
+            if (!response.ok) {
+              throw new Error('host tab inventory unavailable')
+            }
+            const hostTab = response.result.tabs.find(
+              (tab) => tab.type === 'browser' && tab.url === url
+            )!
+            return {
+              clientPageId: browserPage.id,
+              clientRuntimeId: browserPage.browserRuntimeEnvironmentId,
+              clientWorkspaceId: workspace.id,
+              hostPageId: hostTab.type === 'browser' ? hostTab.browserPageId : null,
+              hostTabId: hostTab.id,
+              remoteEnvironmentId: handle.environmentId,
+              remotePageId: handle.remotePageId
+            }
+          },
+          { environmentId: client!.environmentId, url: fixture.url, worktreeId }
+        )
+      )
+
+    expect(identity.clientRuntimeId).toBe(client.environmentId)
+    expect(identity.remoteEnvironmentId).toBe(client.environmentId)
+    expect(identity.remotePageId).toBe(identity.hostPageId)
+    const finalInventory = await readTabInventory(page, client.environmentId, worktreeId)
+    expect(finalInventory).toEqual({
+      clientBrowserWorkspaces: baseline.clientBrowserWorkspaces + 1,
+      clientBrowserTabs: baseline.clientBrowserTabs + 1,
+      clientTerminalTabs: baseline.clientTerminalTabs,
+      hostBrowserTabs: baseline.hostBrowserTabs + 1,
+      hostTerminalTabs: baseline.hostTerminalTabs
+    })
+    expect((await readPanelNavigationObserver(client.app)).externalUrls).toEqual([])
+
+    const content = await page.evaluate(
+      async ({ browserPageId, environmentId, worktreeId }) =>
+        window.api.runtimeEnvironments.call({
+          selector: environmentId,
+          method: 'browser.eval',
+          params: {
+            worktree: `id:${worktreeId}`,
+            page: browserPageId,
+            expression: 'document.querySelector("h1")?.textContent'
+          },
+          timeoutMs: 15_000
+        }),
+      {
+        browserPageId: identity.hostPageId!,
+        environmentId: client.environmentId,
+        worktreeId
+      }
+    )
+    expect(content).toMatchObject({ ok: true, result: { result: PAGE_MARKER } })
+
+    const browserTab = page.locator(`[data-tab-id="${identity.clientWorkspaceId}"]`)
+    await browserTab.click()
+    await expect
+      .poll(() =>
+        page.evaluate((worktreeId) => {
+          const state = window.__store?.getState()
+          return {
+            browserWorkspaceId: state?.activeBrowserTabIdByWorktree[worktreeId] ?? null,
+            tabType: state?.activeTabTypeByWorktree[worktreeId] ?? null
+          }
+        }, worktreeId)
+      )
+      .toEqual({ browserWorkspaceId: identity.clientWorkspaceId, tabType: 'browser' })
+    await expect(
+      page.locator(`[data-browser-overlay-tab-id="${identity.clientWorkspaceId}"]`)
+    ).toHaveCSS('opacity', '1')
+
+    await browserTab.hover()
+    await browserTab.locator('button').click()
+    await expect
+      .poll(() => readTabInventory(page, client!.environmentId, worktreeId), {
+        timeout: 30_000,
+        message: 'host and client browser inventories did not return to baseline'
+      })
+      .toEqual(baseline)
+
+    await ensureTerminalVisible(page, 30_000)
+    await waitForActiveTerminalManager(page, 30_000)
+    expect(await waitForActivePanePtyId(page, 30_000)).toBe(clientPtyId)
+    const send = await page.evaluate(
+      async ({ environmentId, terminal, text }) =>
+        window.api.runtimeEnvironments.call({
+          selector: environmentId,
+          method: 'terminal.send',
+          params: {
+            terminal,
+            text,
+            enter: true,
+            client: { id: 'remote-browser-close-e2e', type: 'desktop' }
+          },
+          timeoutMs: 15_000
+        }),
+      {
+        environmentId: client.environmentId,
+        terminal: remoteTerminalHandle(clientPtyId),
+        text: `printf '%s\\n' ${JSON.stringify(TERMINAL_MARKER)}`
+      }
+    )
+    expect(send).toMatchObject({ ok: true, result: { send: { accepted: true } } })
+    await waitForTerminalOutput(page, TERMINAL_MARKER, 30_000)
+    expect(await readTabInventory(page, client.environmentId, worktreeId)).toEqual(baseline)
+    expect((await readPanelNavigationObserver(client.app)).externalUrls).toEqual([])
+  } finally {
+    if (observerActive && client) {
+      await stopPanelNavigationObserver(client.app).catch(() => undefined)
+    }
+    await client?.dispose()
+    await closePageServer(fixture.server)
+  }
+})


### PR DESCRIPTION
## Summary

- Route the terminal-only “Orca Browser” action to the paired runtime that owns the terminal instead of calling `shell.openExternal` on the viewing client.
- Require an exact capability-backed runtime/workspace match and fail closed on unknown, mismatched, or incapable owners.
- Keep direct SSH system-browser-only and preserve existing routing for generic remote Markdown/editor links.
- Add focused routing contracts and a headed paired Electron journey covering creation, identity, rendering, explicit activation, close convergence, and continued PTY liveness.

Slack report: https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1786567689897109

## Root cause

Remote terminal links were deliberately advertised as system-browser-only. `openHttpLink()` also rejected every non-local source from managed-browser routing, so selecting a terminal HTTP link fell through to the viewing Electron client’s `shell.openExternal()` path. That policy predated safe host-owned browser creation.

## Design rationale

The fix is scoped to terminal links through an explicit `allowRuntimeInApp` opt-in. It reuses the existing managed-browser creation path, asserts the terminal’s runtime owner at the creation boundary, and only advertises “Orca Browser” when that exact paired runtime exposes the required capability. No RPC schema, stream opcode, host publication, focus policy, polling, retry, timer, or listener changes are introduced.

Alternatives considered:

- Changing all remote HTTP-link routing was broader and would alter Markdown/editor behavior.
- Falling back to client Chrome after a host creation failure would hide ownership errors and recreate the reported bug.
- Adding a new runtime RPC was unnecessary because the existing owner-aware browser creation path already provides authoritative creation and mirroring.

## Reproduction and red/green evidence

Invariant: selecting “Orca Browser” for an HTTP link in a runtime-owned terminal creates exactly one browser page on the owning runtime, exactly one client mirror with matching page identity, and zero client external-browser calls.

- Affected latest main `e4c278eb523`: focused owner-routing oracle failed 6/25 assertions. Runtime OSC, WebLinksAddon, and click-fallback paths invoked the viewing client’s external browser, and owner assertions were absent.
- Candidate: the expanded focused oracle passed 84/84 across six files.
- Candidate headed Electron journey: passed in 32.9s. It proved one host page, one exact client mirror, rendered fixture DOM, explicit tab activation, zero external opens, exact host/client close convergence, and fresh output on the original remote PTY.
- Fix disabled: replacing only the runtime browser opener registration with `registerRuntimeHttpLinkBrowserOpener(null)` made the byte-identical Electron journey fail at the host/client identity barrier; no host-owned browser appeared within 60 seconds.

## Validation

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts \
  src/renderer/src/components/terminal-pane/terminal-link-action-routing.test.ts \
  src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts \
  src/renderer/src/lib/http-link-routing.test.ts \
  src/renderer/src/lib/http-link-modifier-routing.test.ts \
  src/renderer/src/lib/workspace-browser-tab-open.test.ts
# 84 passed

ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 \
  pnpm exec playwright test tests/e2e/paired-remote-terminal-browser-link.spec.ts \
  --config tests/playwright.config.ts --project electron-headless --workers=1
# 1 passed

pnpm run typecheck
pnpm run check:reliability-gates
pnpm run check:max-lines-ratchet
pnpm exec oxlint <changed TypeScript files> --deny-warnings
pnpm exec oxfmt --check <changed TypeScript/JSONC files>
git diff --check
```

Final architecture/security, performance/resource/platform, and UX/readiness reviews were clean.

## Risks and gaps

- Live paired-server E2E currently covers macOS. Linux, physical Windows, headless `orca serve`, and multiple simultaneous viewers remain live-topology gaps.
- Direct SSH intentionally remains system-browser-only because it has no paired Orca browser runtime.
- The change preserves the existing asynchronous focus policy; explicitly clicking the browser tab focuses it.
- Mixed-version behavior fails closed when the owning runtime lacks managed-browser capability.
