### PR TITLE
test(agent-hooks): stop the GROK_HOME probe test from spawning a real shell

### DIFF
--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -1,5 +1,38 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { resolveRelayGrokHome } from './managed-hook-runtime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeChildProcess from 'node:child_process'
+
+// Why: the probe spawns a real login shell, and `resolveRelayGrokHome` swallows every
+// spawn failure into its fallback. Left unmocked this asserts the runner's scheduling
+// latency, not the parser: on a loaded sharded CI box the 8s timeout expires and the
+// first case silently flips to the fallback path.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeChildProcess>()
+  return { ...actual, execFile: vi.fn() }
+})
+
+const { execFile } = await import('node:child_process')
+const execFileMock = vi.mocked(execFile)
+const { resolveRelayGrokHome } = await import('./managed-hook-runtime')
+
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void
+
+function stubProbeOutput(stdout: string): void {
+  execFileMock.mockImplementation(((...args: unknown[]) => {
+    ;(args.at(-1) as ExecFileCallback)(null, { stdout, stderr: '' })
+    return undefined
+  }) as unknown as typeof execFile)
+}
+
+function stubProbeFailure(error: Error): void {
+  execFileMock.mockImplementation(((...args: unknown[]) => {
+    ;(args.at(-1) as ExecFileCallback)(error)
+    return undefined
+  }) as unknown as typeof execFile)
+}
+
+beforeEach(() => {
+  execFileMock.mockReset()
+})
 
 afterEach(() => {
   vi.unstubAllEnvs()
@@ -8,14 +41,39 @@ afterEach(() => {
 describe.runIf(process.platform !== 'win32')('resolveRelayGrokHome', () => {
   it('uses the login-shell GROK_HOME and normalizes trailing separators', async () => {
     vi.stubEnv('SHELL', '/bin/sh')
-    vi.stubEnv('GROK_HOME', '/srv/grok///')
+    stubProbeOutput('/srv/grok///\n')
 
     await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/srv/grok')
+
+    const [shell, args] = execFileMock.mock.calls[0] ?? []
+    expect(shell).toBe('/bin/sh')
+    // `sh`/`dash` reject `-lc`, so the mode choice is part of the contract under test.
+    expect(args?.[0]).toBe('-c')
+  })
+
+  it('passes -lc to a login shell that supports it', async () => {
+    vi.stubEnv('SHELL', '/bin/zsh')
+    stubProbeOutput('/srv/grok\n')
+
+    await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/srv/grok')
+
+    const [shell, args] = execFileMock.mock.calls[0] ?? []
+    expect(shell).toBe('/bin/zsh')
+    expect(args?.[0]).toBe('-lc')
   })
 
   it('falls back when the login-shell GROK_HOME is not an absolute POSIX path', async () => {
     vi.stubEnv('SHELL', '/bin/sh')
-    vi.stubEnv('GROK_HOME', '../relative')
+    stubProbeOutput('../relative\n')
+
+    await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/home/orca/.grok')
+  })
+
+  // Why: this is the branch that made the old test flaky — pin it so a probe failure is
+  // an asserted fallback rather than an invisible substitution for a real answer.
+  it('falls back when the probe fails or times out', async () => {
+    vi.stubEnv('SHELL', '/bin/sh')
+    stubProbeFailure(Object.assign(new Error('spawn timed out'), { killed: true }))
 
     await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/home/orca/.grok')
   })


### PR DESCRIPTION
## ELI5

A test was starting a real shell to read an environment variable. On a busy CI machine the shell was too slow, the code quietly used its backup answer, and the test failed for a reason that had nothing to do with the code. Now the test fakes the shell, so it measures the logic instead of the machine's mood.

## What Changed

`src/main/agent-hooks/managed-hook-runtime.test.ts` only — no production code.

Stubs `node:child_process` so `resolveRelayGrokHome` no longer spawns anything. Keeps the two original cases, and adds two:

- probe failure / timeout resolves to the fallback (the branch that was absorbing the flake)
- `-c` for `sh`/`dash` versus `-lc` for other login shells (previously implicit in the real spawn)

## Why

`resolveRelayGrokHome` deliberately runs the user's login shell (`printenv GROK_HOME`) with an 8s timeout and folds **every** failure into `defaultGrokHome`. That is correct for production, but it makes an unmocked test assert the runner's scheduling latency rather than the parser: when the spawn misses the timeout the probe silently returns the fallback, and the assertion flips.

Observed on unrelated PRs, on both node 24 and node 26 shards:

```
AssertionError: expected '/home/orca/.grok' to be '/srv/grok'
 ❯ src/main/agent-hooks/managed-hook-runtime.test.ts:13:53
```

The failing job's teardown is the corroboration — those are this test's own `sh` and `head`, still alive when the job ended:

```
Terminate orphan process: pid (5535) (sh)
Terminate orphan process: pid (5536) (head)
```

It passes locally every time, which is exactly the signature of a load-sensitive spawn rather than a defect.

Fixing the test rather than the code on purpose: the shell probe is the feature (agent PTYs start login shells, so the hook installer must read the same profile-derived `GROK_HOME`), and the swallow-and-fallback is intended production behavior. What was wrong was a unit test depending on process spawning.

## Linked Issue

No existing issue — found while triaging CI reds on #14095 / #14099, where this failure appeared and was unrelated to either change.

## Visual Proof

`N/A` — test-only change, no UI or behavior change.

## Testing

```
npx vitest run --config config/vitest.config.ts src/main/agent-hooks/managed-hook-runtime.test.ts
-> 4 passed (test time 2ms, no processes spawned)

npx vitest run --config config/vitest.config.ts src/main/agent-hooks
-> 39 files, 599 passed, 4 skipped
```

Mutation-tested so the rewrite is not vacuous — both fail as expected:

| mutation | result |
|---|---|
| drop trailing-separator normalization | `expected '/srv/grok///' to be '/srv/grok'` |
| always pass `-lc` | `expected '-lc' to be '-c'` |

`tsc --noEmit -p config/tsconfig.node.json` clean; oxlint, react-doctor config, and oxfmt clean.

- [x] Automated tests added/updated
- [x] I manually tested these changes locally

## Review

- **Cross-platform:** the suite is already `describe.runIf(process.platform !== 'win32')`; stubbing removes a POSIX-shell dependency rather than adding one.
- **SSH/remote, mobile, wire:** untouched — test-only.
- **Backwards compatibility / performance:** no production code changed. Test wall time drops from a real 8s-timeout-bounded spawn to ~2ms.
