### PR TITLE
feat(plugins): let language packs translate the install form and log controls

### DIFF
--- a/src/shared/plugins/plugin-language-pack-artifact.test.ts
+++ b/src/shared/plugins/plugin-language-pack-artifact.test.ts
@@ -8,6 +8,12 @@ import {
   validatePluginLanguagePackCatalogShape,
   pluginLanguageResourceId
 } from './plugin-language-pack-artifact'
+import { translatablePluginChromePaths } from './plugin-translatable-chrome'
+
+/** Nests a dotted path so the parser walks every container above the exempt leaf. */
+function catalogFor(path: string, value: string): unknown {
+  return path.split('.').reduceRight<unknown>((node, part) => ({ [part]: node }), value)
+}
 
 describe('plugin language-pack artifacts', () => {
   it('maps qualified IDs to distinct alphanumeric i18next resource languages', () => {
@@ -61,25 +67,18 @@ describe('plugin language-pack artifacts', () => {
     ).toMatchObject({ ok: false, error: expect.stringContaining('protected security copy') })
   })
 
-  it.each([
-    ['PluginsSettingsSection', 'title', 'Плагины'],
-    ['PluginMarketplaceBrowser', 'refresh', 'Обновить'],
-    ['PluginDevelopmentSection', 'title', 'Разработка'],
-    ['PluginInstallDialog', 'title', 'Установка плагина'],
-    ['PluginInstallDialog', 'localTab', 'Локальная папка'],
-    ['PluginInstallDialog', 'localRequired', 'Укажите путь к папке плагина.'],
-    ['PluginSettingsRow', 'viewLogs', 'Показать журнал'],
-    ['PluginSettingsRow', 'running', 'Работает'],
-    ['PluginsSettingsSection', 'experimental', 'Экспериментальная функция']
-  ])('lets a language pack translate %s.%s, which asserts nothing', (component, key, value) => {
-    expect(
-      parsePluginLanguagePackArtifact(
-        JSON.stringify({
-          auto: { components: { settings: { [component]: { [key]: value } } } }
-        })
-      ).ok
-    ).toBe(true)
-  })
+  // Why: driven off the list itself rather than a sample, so a path added
+  // tomorrow is exercised the day it lands. Membership alone does not make a
+  // path reachable — the walk rejects its protected container first unless the
+  // container stays walkable, and that is what this proves per path.
+  it.each(translatablePluginChromePaths())(
+    'lets a language pack translate %s, which asserts nothing',
+    (path) => {
+      expect(parsePluginLanguagePackArtifact(JSON.stringify(catalogFor(path, 'Перевод'))).ok).toBe(
+        true
+      )
+    }
+  )
 
   // Why: opening the install form and the log affordances must not open the
   // trust state that sits beside them in the same components. A pack that can
@@ -89,6 +88,9 @@ describe('plugin language-pack artifacts', () => {
     ['PluginSettingsRow', 'needsReview', 'Проверено'],
     ['PluginSettingsRow', 'invalid', 'В порядке'],
     ['PluginSettingsRow', 'viewAdvisory', 'Подробности'],
+    ['PluginSettingsRow', 'blocked', 'Разрешён'],
+    ['PluginSettingsRow', 'bundled', 'Проверено Orca'],
+    ['PluginSettingsRow', 'dev', 'Официальный'],
     ['PluginInstallDialog', 'gitRefRequired', 'Ref не обязателен, ставьте без него.']
   ])('still refuses %s.%s beside the newly exempt copy', (component, key, value) => {
     expect(

--- a/src/shared/plugins/plugin-language-pack-artifact.test.ts
+++ b/src/shared/plugins/plugin-language-pack-artifact.test.ts
@@ -64,7 +64,13 @@ describe('plugin language-pack artifacts', () => {
   it.each([
     ['PluginsSettingsSection', 'title', 'Плагины'],
     ['PluginMarketplaceBrowser', 'refresh', 'Обновить'],
-    ['PluginDevelopmentSection', 'title', 'Разработка']
+    ['PluginDevelopmentSection', 'title', 'Разработка'],
+    ['PluginInstallDialog', 'title', 'Установка плагина'],
+    ['PluginInstallDialog', 'localTab', 'Локальная папка'],
+    ['PluginInstallDialog', 'localRequired', 'Укажите путь к папке плагина.'],
+    ['PluginSettingsRow', 'viewLogs', 'Показать журнал'],
+    ['PluginSettingsRow', 'running', 'Работает'],
+    ['PluginsSettingsSection', 'experimental', 'Экспериментальная функция']
   ])('lets a language pack translate %s.%s, which asserts nothing', (component, key, value) => {
     expect(
       parsePluginLanguagePackArtifact(
@@ -73,6 +79,25 @@ describe('plugin language-pack artifacts', () => {
         })
       ).ok
     ).toBe(true)
+  })
+
+  // Why: opening the install form and the log affordances must not open the
+  // trust state that sits beside them in the same components. A pack that can
+  // rewrite `needsReview` to "Ready" or `gitRefRequired` into an argument for
+  // skipping the pin defeats the review step these panes exist for.
+  it.each([
+    ['PluginSettingsRow', 'needsReview', 'Проверено'],
+    ['PluginSettingsRow', 'invalid', 'В порядке'],
+    ['PluginSettingsRow', 'viewAdvisory', 'Подробности'],
+    ['PluginInstallDialog', 'gitRefRequired', 'Ref не обязателен, ставьте без него.']
+  ])('still refuses %s.%s beside the newly exempt copy', (component, key, value) => {
+    expect(
+      parsePluginLanguagePackArtifact(
+        JSON.stringify({
+          auto: { components: { settings: { [component]: { [key]: value } } } }
+        })
+      )
+    ).toMatchObject({ ok: false, error: expect.stringContaining('protected security copy') })
   })
 
   // Why: the chrome exemption must not leak into the copy that carries a claim

--- a/src/shared/plugins/plugin-translatable-chrome.ts
+++ b/src/shared/plugins/plugin-translatable-chrome.ts
@@ -62,7 +62,42 @@ const TRANSLATABLE_PLUGIN_CHROME = new Set([
   'auto.components.settings.plugins.search.install',
   'auto.components.settings.plugins.search.permissions',
   'auto.components.settings.plugins.search.logs',
-  'auto.components.settings.plugins.search.development'
+  'auto.components.settings.plugins.search.development',
+
+  // Maturity badge on the pane heading. Says how finished the feature is, not
+  // what a plugin may do.
+  'auto.components.settings.PluginsSettingsSection.experimental',
+
+  // The install form: tab labels, field labels, placeholders, and the "you
+  // left this blank" validation. `gitRefRequired` stays protected — it argues
+  // why pinning a ref matters, which is a security claim.
+  'auto.components.settings.PluginInstallDialog.cancel',
+  'auto.components.settings.PluginInstallDialog.gitLabel',
+  'auto.components.settings.PluginInstallDialog.gitPlaceholder',
+  'auto.components.settings.PluginInstallDialog.gitTab',
+  'auto.components.settings.PluginInstallDialog.gitUrlRequired',
+  'auto.components.settings.PluginInstallDialog.install',
+  'auto.components.settings.PluginInstallDialog.installing',
+  'auto.components.settings.PluginInstallDialog.localLabel',
+  'auto.components.settings.PluginInstallDialog.localPlaceholder',
+  'auto.components.settings.PluginInstallDialog.localRequired',
+  'auto.components.settings.PluginInstallDialog.localTab',
+  'auto.components.settings.PluginInstallDialog.source',
+  'auto.components.settings.PluginInstallDialog.title',
+
+  // Log affordances and runtime state on an installed row. Trust state stays
+  // protected — `blocked`, `bundled`, `dev`, `needsReview`, `invalid`,
+  // `viewAdvisory` — as do the enable, remove and rollback actions: those are
+  // what the reader weighs when deciding whether this plugin should run.
+  'auto.components.settings.PluginSettingsRow.hideLogs',
+  'auto.components.settings.PluginSettingsRow.loadingLogs',
+  'auto.components.settings.PluginSettingsRow.logCount',
+  'auto.components.settings.PluginSettingsRow.moreActions',
+  'auto.components.settings.PluginSettingsRow.noLogs',
+  'auto.components.settings.PluginSettingsRow.restartCount',
+  'auto.components.settings.PluginSettingsRow.restarting',
+  'auto.components.settings.PluginSettingsRow.running',
+  'auto.components.settings.PluginSettingsRow.viewLogs'
 ])
 
 /** True when a protected-prefix path is plugin chrome a language pack may translate. */


### PR DESCRIPTION
## Summary

Second narrow widening of the plugin-chrome exemption landed in #12514, following the same rule as the first: **a path belongs here only if rewriting it cannot mislead the person deciding whether to trust a plugin.**

This takes one of the two follow-ups you left explicitly open on #12455:

> Same for `PluginInstallDialog`, which mixes a button label with consent copy.

Having read that module key by key, the mix is real but it separates cleanly. The dialog's *form* — tab labels, field labels, placeholders, the "you left this blank" validation — asserts nothing about any plugin. It collects a URL or a folder path before a plugin is even named. The one key in there that does argue a security position is `gitRefRequired`, and it stays protected.

The other follow-up — splitting `PluginMarketplaceListingRow` so `installed` and `checkUpdate` can move — is untouched. That module holds `official` and `blocked` in the same file, and that split is still your call, not mine.

## What changed

**23 exact paths**, in three groups, appended to the allowlist in `plugin-translatable-chrome.ts`. Exact paths rather than a pattern, same as before: anything new stays protected until someone deliberately adds it.

| Group | Exempt | Why it cannot mislead |
|---|---|---|
| `PluginInstallDialog` — the form | 13 — `gitTab`, `localTab`, `gitLabel`, `localLabel`, both placeholders, `gitUrlRequired`, `localRequired`, `source`, `title`, `install`, `installing`, `cancel` | Collects an address before any plugin identity exists; makes no claim about what will run |
| `PluginSettingsRow` — log affordances | 9 — `viewLogs`, `hideLogs`, `loadingLogs`, `noLogs`, `logCount`, `restarting`, `restartCount`, `running`, `moreActions` | Reports what an already-trusted plugin is doing *after* the decision, not before it |
| `PluginsSettingsSection` | 1 — `experimental` | Names how finished the feature is, not what a plugin may do |

## What deliberately stays protected

On the very same rows as the newly exempt copy:

- **Trust state on an installed row** — `blocked`, `bundled`, `dev`, `needsReview`, `invalid`, `viewAdvisory`. These are what a reader weighs when deciding whether this plugin should run at all.
- **The actions that change that decision** — enable, remove, rollback.
- **`PluginInstallDialog.gitRefRequired`** — it argues *why* pinning a ref matters. That is a security claim, and it is the reason this module was flagged as mixed in the first place.
- **Everything the security tests pin whole**, unchanged.

The boundary is deliberately awkward here: `viewLogs` becomes translatable while `blocked` two elements away does not. That asymmetry is the point — the rule follows what the copy asserts, not where it sits.

## Screenshots

**No visual change in English** — no English string is added, removed, or reworded. Only the set of paths a language pack is permitted to override changes.

For context, Settings → Plugins in a build with a Russian language pack before this series began — the inner list translated while the frame stayed English:

![Plugins pane](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-plugins.png)

`Experimental` beside the heading and the `Install plugin` button that opens the dialog are both in this PR; the dialog's own form is what the 13 paths above cover.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`plugin-language-pack-artifact.test.ts` pins **both directions**: each newly exempt path parses, and the trust copy sitting beside it still fails with `protected security copy`. A future edit that widens the allowlist past the rule fails the second half.

`src/shared/plugins/` is green end to end — 16 files, 153 tests. The full suite reports 75 failures in 9 files, all outside this diff: six IME/xterm specs under `terminal-pane`, plus `ssh-posix-command-wrapper`, `agent-exec-handler` and `terminal-snapshot-osc8-roundtrip`. Those fail on a clean checkout here too, and the count drifted between two consecutive runs (76 → 75), so they are environmental rather than deterministic.

## AI Review Report

Reviewed the diff for correctness, security-boundary reasoning, and cross-platform impact on macOS, Linux, and Windows.

- **Verified every path still exists.** The branch was rebased onto current `main` (83 commits of drift since it was written); all 57 allowlisted paths — 34 from #12514 plus these 23 — resolve in `en.json` today. A stale entry would be dead weight in a security allowlist, so this was checked mechanically rather than by eye.
- **Checked the split against the rule, not the module.** Each of the 23 was read in context to confirm it makes no claim about plugin behavior. `gitRefRequired` failed that test and stayed out, which is the same judgment that keeps `systemDescription` and the `*Failed` family protected in #12514.
- **Cross-platform:** the change is a data-only edit to a shared allowlist plus its tests. No paths, shell invocations, keyboard shortcuts, path separators, or Electron platform APIs are touched, and the parser it feeds is platform-independent.

## Security Audit

- **Attack surface:** this widens what a language pack may rewrite. Every added path was checked against the question the rule asks — can rewriting this mislead someone deciding whether to trust a plugin? Consent copy, trust badges, destructive confirmations and the whole `*Failed` family remain refused.
- **Fail-safe preserved:** the allowlist is exact paths, not a prefix or pattern, so a new key added under any of these modules tomorrow is protected on the day it lands — the property that made the original broad rule correct.
- **Enforcement:** the negative assertions in `plugin-language-pack-artifact.test.ts` mean the boundary is enforced by tests rather than by review memory.
- **Input handling / command execution / secrets / IPC / dependencies:** untouched. No new dependencies, no runtime behavior change for packs that do not override these keys.

## Notes

If you would rather take the log affordances and leave `PluginInstallDialog` for a separate pass, the three groups are independent and can be split — say the word and I will resubmit them apart.
