### PR TITLE
feat(onboarding): install a selected agent from the onboarding step

### DIFF
--- a/src/renderer/src/components/onboarding/AgentStep.tsx
+++ b/src/renderer/src/components/onboarding/AgentStep.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef, useState } from 'react'
-import { Check, ExternalLink, Info } from 'lucide-react'
+import { Check, ExternalLink, Info, Terminal } from 'lucide-react'
 import { getAgentCatalog, AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -7,6 +7,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { TuiAgent } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
+import { OnboardingInlineCommandTerminal } from './OnboardingInlineCommandTerminal'
 
 const AGENT_GRID_MAX_ROWS = 4
 
@@ -103,6 +104,9 @@ export function AgentStep({
           value0: fallbackRest.length
         }
       )
+  // Why a single id rather than a boolean: each open installer spawns a real PTY, so only one runs
+  // at a time and switching agents tears the previous one down.
+  const [installTerminalAgent, setInstallTerminalAgent] = useState<TuiAgent | null>(null)
   const agentGridScrollRef = useRef<HTMLDivElement>(null)
   const agentGridScrollMaxHeight = useAgentGridScrollMaxHeight(
     agentGridScrollRef,
@@ -128,15 +132,49 @@ export function AgentStep({
               "isn't on your PATH yet. Orca will set it as your default and you can install it any time."
             )}
           </span>
-          <button
-            type="button"
-            className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-400/40 bg-amber-400/10 px-2 py-1 font-medium text-amber-800 hover:bg-amber-400/20 dark:text-amber-100"
-            onClick={() => void window.api.shell.openUrl(selectedEntry.homepageUrl)}
-          >
-            {translate('auto.components.onboarding.AgentStep.9c163bb0e0', 'Install instructions')}
-            <ExternalLink className="size-3" />
-          </button>
+          <div className="flex shrink-0 items-center gap-2">
+            {selectedEntry.installCommand && (
+              <button
+                type="button"
+                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-400/40 bg-amber-400/10 px-2 py-1 font-medium text-amber-800 hover:bg-amber-400/20 dark:text-amber-100"
+                onClick={() =>
+                  setInstallTerminalAgent((current) =>
+                    current === selectedEntry.id ? null : selectedEntry.id
+                  )
+                }
+              >
+                {installTerminalAgent === selectedEntry.id
+                  ? translate('auto.components.onboarding.AgentStep.hideInstall', 'Hide installer')
+                  : translate('auto.components.onboarding.AgentStep.installNow', 'Install')}
+                <Terminal className="size-3" />
+              </button>
+            )}
+            <button
+              type="button"
+              className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-400/40 bg-amber-400/10 px-2 py-1 font-medium text-amber-800 hover:bg-amber-400/20 dark:text-amber-100"
+              onClick={() => void window.api.shell.openUrl(selectedEntry.homepageUrl)}
+            >
+              {translate('auto.components.onboarding.AgentStep.9c163bb0e0', 'Install instructions')}
+              <ExternalLink className="size-3" />
+            </button>
+          </div>
         </div>
+      )}
+      {selectedEntry?.installCommand && installTerminalAgent === selectedEntry.id && (
+        <OnboardingInlineCommandTerminal
+          command={selectedEntry.installCommand}
+          worktreeId={`onboarding-agent-install-${selectedEntry.id}`}
+          title={selectedEntry.label}
+          description={translate(
+            'auto.components.onboarding.AgentStep.installTerminalDescription',
+            'Running the published install command for this agent. It is detected again automatically once it lands on your PATH.'
+          )}
+          ariaLabel={translate(
+            'auto.components.onboarding.AgentStep.installTerminalAria',
+            'Agent install terminal'
+          )}
+          terminalHeightPx={220}
+        />
       )}
       <section className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
         <SectionHeader

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12170,7 +12170,11 @@
           "showMoreAgents": "Show {{value0}} more agents→",
           "yoloPermissionsLabel": "Yolo / Dangerously skip permissions",
           "yoloPermissionsInfo": "Agent permission info",
-          "yoloPermissionsTooltip": "Skip permission checks for agents for less interruptions"
+          "yoloPermissionsTooltip": "Skip permission checks for agents for less interruptions",
+          "hideInstall": "Hide installer",
+          "installNow": "Install",
+          "installTerminalDescription": "Running the published install command for this agent. It is detected again automatically once it lands on your PATH.",
+          "installTerminalAria": "Agent install terminal"
         },
         "FeatureSetupInlineTerminal": {
           "789b59936e": "Press Enter to run the command and confirm npx if asked. You can also set this up later in Settings.",

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -27,6 +27,44 @@ export type AgentCatalogEntry = {
   faviconDomain?: string
   /** Homepage/install docs URL, sourced from the README agent badge list. */
   homepageUrl: string
+  /**
+   * Official one-line install command for the current platform, when the agent publishes one that
+   * is unambiguous. Absent for agents installed through a downloader, an account flow, or a
+   * platform-specific package manager — those keep pointing at `homepageUrl` instead.
+   */
+  installCommand?: string
+}
+
+/**
+ * Per-platform install commands, taken from each agent's own published docs.
+ *
+ * Deliberately partial. An entry only belongs here when the vendor documents a single command that
+ * works on a stock machine; anything needing a package manager choice, an account step, or a
+ * platform we cannot verify is left out so onboarding never prints a command that fails.
+ */
+const AGENT_INSTALL_COMMANDS: Partial<Record<TuiAgent, Partial<Record<NodeJS.Platform, string>>>> =
+  {
+    claude: {
+      darwin: 'npm install -g @anthropic-ai/claude-code',
+      linux: 'npm install -g @anthropic-ai/claude-code',
+      win32: 'npm install -g @anthropic-ai/claude-code'
+    },
+    antigravity: {
+      darwin: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
+      linux: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
+      // Why a different shape on Windows: Antigravity ships a PowerShell installer rather than the
+      // POSIX script, so reusing the curl line here would simply fail.
+      win32: 'irm https://antigravity.google/cli/install.ps1 | iex'
+    },
+    opencode: {
+      darwin: 'npm install -g opencode-ai',
+      linux: 'npm install -g opencode-ai',
+      win32: 'npm install -g opencode-ai'
+    }
+  }
+
+function getAgentInstallCommand(agent: TuiAgent): string | undefined {
+  return AGENT_INSTALL_COMMANDS[agent]?.[getCatalogPlatform()]
 }
 
 function getCatalogPlatform(): NodeJS.Platform {
@@ -48,7 +86,8 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     id: 'claude',
     label: translate('auto.lib.agent.catalog.0708ed89f1', 'Claude'),
     cmd: 'claude',
-    homepageUrl: 'https://docs.anthropic.com/claude/docs/claude-code'
+    homepageUrl: 'https://docs.anthropic.com/claude/docs/claude-code',
+    installCommand: getAgentInstallCommand('claude')
   },
   {
     id: 'claude-agent-teams',
@@ -88,7 +127,8 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     id: 'opencode',
     label: translate('auto.lib.agent.catalog.e7a4ca5103', 'OpenCode'),
     cmd: 'opencode',
-    homepageUrl: 'https://opencode.ai/docs/cli/'
+    homepageUrl: 'https://opencode.ai/docs/cli/',
+    installCommand: getAgentInstallCommand('opencode')
   },
   {
     id: 'mimo-code',
@@ -146,7 +186,8 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     label: translate('auto.lib.agent.catalog.691dd11789', 'Antigravity'),
     cmd: 'agy',
     faviconDomain: 'antigravity.google',
-    homepageUrl: 'https://antigravity.google/docs/cli-overview'
+    homepageUrl: 'https://antigravity.google/docs/cli-overview',
+    installCommand: getAgentInstallCommand('antigravity')
   },
   {
     id: 'aider',


### PR DESCRIPTION
## The gap

When no agent is on PATH, onboarding ends the thread rather than closing it. It names the selected agent, says it *"isn't on your PATH yet"*, and offers a link to install instructions — so a new user has to leave Orca, find a docs page, work out the right command for their platform, and come back.

That is the first thing someone sees. It also lands hardest on the users least equipped for it: Claude Code has no free tier, and Gemini CLI's free personal sign-in rail was switched off on 18 June 2026, so a user arriving with no paid account has the furthest to travel from that screen.

## The change

An **Install** button beside the existing "Install instructions" link, for agents whose vendor publishes an unambiguous one-line install command.

It runs the command in the existing `OnboardingInlineCommandTerminal` — the same component the feature-setup flow already uses — so the user sees exactly what will execute, and nothing runs without a click. Detection already re-runs on its own, so the agent lights up in the grid once it lands on PATH.

Where there is no known command, the row is unchanged and still points at `homepageUrl`.

## Shape

- `AgentCatalogEntry` gains an optional `installCommand`, resolved per platform through the catalog's existing `getCatalogPlatform()`.
- Antigravity ships a PowerShell installer rather than the POSIX script, so Windows gets `irm … | iex` instead of a curl line that would fail there.
- The table is deliberately partial — **Claude Code, Antigravity, OpenCode**. An agent only belongs there when the vendor documents a single command that works on a stock machine; anything needing a package-manager choice, an account step, or a platform I could not verify keeps pointing at `homepageUrl`.
- No rate limits or pricing appear anywhere in the copy. Those change without notice — Google has already cut the Antigravity free allowance once — and a stale number baked into onboarding is worse than none.

95 insertions across 3 files, including 4 new `en.json` keys via `pnpm sync:localization-catalog`.

## Verification

All four checks from `CONTRIBUTING.md`, on this branch:

| | |
|---|---|
| `pnpm lint` | pass |
| `pnpm typecheck` | pass |
| `pnpm test` | pass — 50730 passed, 0 failed (4730 files) |
| `pnpm build` | pass |

Behaviour checked by hand on macOS: with an agent absent the button appears and the terminal runs the command; with it present the banner does not render at all, so the button cannot appear for an installed agent; toggling to another agent tears the previous terminal down, since each open installer holds a real PTY.

Windows and Linux command strings come from each vendor's published docs and are platform-selected by the existing helper, but I have only exercised the macOS path directly — worth a second pair of eyes on the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)