### PR TITLE
fix: roll review notes back to the persisted list

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -305,6 +305,12 @@ jobs:
         with:
           native-runtime: node
 
+      # Same as the sharded `test` job: importing host/renderer wire modules
+      # loads Electron, and Electron's own installer has no retry. The dedicated
+      # script retries GitHub CDN flakes instead of failing the suite at import.
+      - name: Install Electron package binary for tests
+        run: node config/scripts/install-electron-package-binary.mjs
+
       # A path filter that matches nothing exits 1 ("No test files found"), so this
       # lane cannot report success while running zero tests.
       - name: Old/new client and server terminal journey

--- a/src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts
+++ b/src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts
@@ -366,13 +366,17 @@ describe('fish never receives a color-scheme report it did not query (#9993)', (
       // screen. Why a line and not the first chunk: leaked replies carry no newline, so a
       // once('data') child reports them alone whenever they arrive in their own read —
       // which is what the issue's own `sys.stdin.readline()` repro measures.
+      // CHILD-READY is the settle signal: fish can emit extra ?2031l during startup, so
+      // a global withdraw count of 2 is not proof the node child owns the tty.
+      // Accept CR or LF: a PTY without ICRNL never turns the harness' \r into \n.
       const childScript = path.join(configHome, 'read-stdin.mjs')
       writeFileSync(
         childScript,
-        "let buffered = ''\n" +
+        "process.stdout.write('CHILD-READY\\n')\n" +
+          "let buffered = ''\n" +
           "process.stdin.on('data', (d) => {\n" +
           "  buffered += d.toString('utf8')\n" +
-          "  if (!buffered.includes('\\n')) return\n" +
+          "  if (!buffered.includes('\\n') && !buffered.includes('\\r')) return\n" +
           "  process.stdout.write('CHILD-READ:' + JSON.stringify(buffered) + '\\n')\n" +
           '  process.exit(0)\n' +
           '})\n'
@@ -436,16 +440,22 @@ describe('fish never receives a color-scheme report it did not query (#9993)', (
           .paneMode2031Ref.current
         expect(await waitUntil(() => paneMode2031.get(1) === true, 5_000)).toBe(true)
 
+        // Startup can already have emitted ?2031l (prompt paint / DA1). Count from here
+        // so those do not make the sleep/child waits succeed before either owns the tty.
+        const withdrawsAtPrompt = countOf(rendered, WITHDRAW_2031)
         // Type-ahead is the deterministic leak shape: queue the child command while an
         // external command still owns the tty, so fish repaints the prompt (`?2031h`) and
         // consumes the buffered line in the same breath — handoff lands sub-millisecond
         // after the subscribe, inside any reply's flight time.
         term.write('sleep 0.4\r')
-        // Withdrawal #1: `sleep` owns the tty now, so the next line is typed ahead.
-        expect(await waitUntil(() => countOf(rendered, WITHDRAW_2031) >= 1, 5_000)).toBe(true)
+        expect(
+          await waitUntil(() => countOf(rendered, WITHDRAW_2031) >= withdrawsAtPrompt + 1, 5_000)
+        ).toBe(true)
         term.write('"$ORCA_NODE_BIN" "$ORCA_CHILD_SCRIPT"\r')
-        // Withdrawal #2: fish re-armed for the prompt and handed the tty to the child.
-        expect(await waitUntil(() => countOf(rendered, WITHDRAW_2031) >= 2, 5_000)).toBe(true)
+        expect(
+          await waitUntil(() => countOf(rendered, WITHDRAW_2031) >= withdrawsAtPrompt + 2, 5_000)
+        ).toBe(true)
+        expect(await waitUntil(() => rendered.includes('CHILD-READY'), 10_000)).toBe(true)
 
         const renderedBeforeChildInput = rendered.length
         // Canonical mode buffers this in the tty, so it queues behind anything already
@@ -455,7 +465,8 @@ describe('fish never receives a color-scheme report it did not query (#9993)', (
           await waitUntil(
             () => rendered.slice(renderedBeforeChildInput).includes('CHILD-READ:'),
             10_000
-          )
+          ),
+          `child produced no CHILD-READ; rendered=${JSON.stringify(rendered.slice(-400))}`
         ).toBe(true)
 
         const childRead =

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -156,17 +156,23 @@ function settingsForWorktreeOwner(state: AppState, worktreeId: string): AppState
 // Why: IPC writes aren't ordered, so serialize per worktree to stop an older snapshot from overwriting a newer one on disk.
 const persistQueueByWorktree = new Map<string, Promise<PersistOutcome>>()
 
-// Why: the list storage actually holds, so a failed write rolls back to disk rather than to an earlier optimistic list
-// that a preceding queued write may also have failed to persist. Cleared once the queue drains and state matches disk again.
-const durableCommentsByQueue = new Map<string, DiffComment[] | undefined>()
+type QueueDurability = {
+  // Why: what storage actually holds, so a failed write rolls back to disk rather than to a still-optimistic list.
+  comments: DiffComment[] | undefined
+  // Why: a write snapshots state at dequeue time, so it can carry mutations queued behind it all the way to disk.
+  persistedSeq: number
+  enqueuedSeq: number
+}
+
+// Why: dropped once the queue drains and state matches disk again.
+const durabilityByQueue = new Map<string, QueueDurability>()
 
 type PersistOutcome =
   | { ok: true }
   | { ok: false; error: unknown; durable: DiffComment[] | undefined }
 
-// Why: chain each write onto the prior promise so writes land in call order; the chain resolves outcomes instead of
-// rejecting so a failure can carry the durable list back to its own caller without breaking the chain.
-// Why: queued work reads the latest list at dequeue time, and the returned promise settles for THIS write so callers can roll back.
+// Why: chain each write onto the prior one so writes land in call order; outcomes resolve rather than reject so a
+// failure carries the durable list back to its own caller without breaking the chain.
 function enqueuePersist(
   worktreeId: string,
   get: () => AppState,
@@ -174,15 +180,21 @@ function enqueuePersist(
 ): Promise<PersistOutcome> {
   const folderExecutionHostId = mutation.folderExecutionHostId
   const queueKey = folderExecutionHostId ? `${folderExecutionHostId}\0${worktreeId}` : worktreeId
-  // Why: an empty queue means nothing is in flight, so the pre-mutation list is what storage holds.
-  if (!durableCommentsByQueue.has(queueKey)) {
-    durableCommentsByQueue.set(queueKey, mutation.previous)
+  let existing = durabilityByQueue.get(queueKey)
+  if (!existing) {
+    // Why: an empty queue means nothing is in flight, so the pre-mutation list is what storage holds.
+    existing = { comments: mutation.previous, persistedSeq: 0, enqueuedSeq: 0 }
+    durabilityByQueue.set(queueKey, existing)
   }
+  const durability = existing
+  const seq = ++durability.enqueuedSeq
   const prior =
     persistQueueByWorktree.get(queueKey) ?? Promise.resolve<PersistOutcome>({ ok: true })
   const run = async (): Promise<PersistOutcome> => {
     const scope = parseWorkspaceKey(worktreeId)
     const state = get()
+    // Why: enqueue follows the state mutation synchronously, so this snapshot already covers every enqueued mutation.
+    const covered = durability.enqueuedSeq
     const latest =
       scope?.type === 'folder'
         ? (
@@ -199,9 +211,14 @@ function enqueuePersist(
         ? persist(state, state.settings, worktreeId, latest, folderExecutionHostId)
         : persist(state, settingsForWorktreeOwner(state, worktreeId), worktreeId, latest))
     } catch (error) {
-      return { ok: false, error, durable: durableCommentsByQueue.get(queueKey) }
+      // Why: an earlier queued write may have snapshotted this mutation and landed it, so it isn't lost after all.
+      if (durability.persistedSeq >= seq) {
+        return { ok: true }
+      }
+      return { ok: false, error, durable: durability.comments }
     }
-    durableCommentsByQueue.set(queueKey, latest)
+    durability.comments = latest
+    durability.persistedSeq = covered
     return { ok: true }
   }
   const next = prior.then(run, run)
@@ -211,7 +228,7 @@ function enqueuePersist(
   const cleanup = (): void => {
     if (persistQueueByWorktree.get(queueKey) === next) {
       persistQueueByWorktree.delete(queueKey)
-      durableCommentsByQueue.delete(queueKey)
+      durabilityByQueue.delete(queueKey)
     }
   }
   next.then(cleanup, cleanup)

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -154,36 +154,55 @@ function settingsForWorktreeOwner(state: AppState, worktreeId: string): AppState
 }
 
 // Why: IPC writes aren't ordered, so serialize per worktree to stop an older snapshot from overwriting a newer one on disk.
-const persistQueueByWorktree = new Map<string, Promise<void>>()
+const persistQueueByWorktree = new Map<string, Promise<PersistOutcome>>()
 
-// Why: chain each write onto the prior promise so writes land in call order; both then handlers keep the chain alive past a failure.
+// Why: the list storage actually holds, so a failed write rolls back to disk rather than to an earlier optimistic list
+// that a preceding queued write may also have failed to persist. Cleared once the queue drains and state matches disk again.
+const durableCommentsByQueue = new Map<string, DiffComment[] | undefined>()
+
+type PersistOutcome =
+  | { ok: true }
+  | { ok: false; error: unknown; durable: DiffComment[] | undefined }
+
+// Why: chain each write onto the prior promise so writes land in call order; the chain resolves outcomes instead of
+// rejecting so a failure can carry the durable list back to its own caller without breaking the chain.
 // Why: queued work reads the latest list at dequeue time, and the returned promise settles for THIS write so callers can roll back.
 function enqueuePersist(
   worktreeId: string,
   get: () => AppState,
-  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
-): Promise<void> {
+  mutation: CommentMutation
+): Promise<PersistOutcome> {
+  const folderExecutionHostId = mutation.folderExecutionHostId
   const queueKey = folderExecutionHostId ? `${folderExecutionHostId}\0${worktreeId}` : worktreeId
-  const prior = persistQueueByWorktree.get(queueKey) ?? Promise.resolve()
-  const run = async (): Promise<void> => {
+  // Why: an empty queue means nothing is in flight, so the pre-mutation list is what storage holds.
+  if (!durableCommentsByQueue.has(queueKey)) {
+    durableCommentsByQueue.set(queueKey, mutation.previous)
+  }
+  const prior =
+    persistQueueByWorktree.get(queueKey) ?? Promise.resolve<PersistOutcome>({ ok: true })
+  const run = async (): Promise<PersistOutcome> => {
     const scope = parseWorkspaceKey(worktreeId)
-    if (scope?.type === 'folder') {
-      const state = get()
-      const folderWorkspace = findFolderWorkspaceOwner(
-        state,
-        scope.folderWorkspaceId,
-        folderExecutionHostId
-      )
-      const latest = (folderWorkspace?.diffComments ?? []).map(normalizeDiffComment)
-      await persist(state, state.settings, worktreeId, latest, folderExecutionHostId)
-      return
-    }
-    const repoId = getRepoIdFromWorktreeId(worktreeId)
-    const repoList = get().worktreesByRepo[repoId]
-    const target = repoList?.find((w) => w.id === worktreeId)
-    const latest = (target?.diffComments ?? []).map(normalizeDiffComment)
     const state = get()
-    await persist(state, settingsForWorktreeOwner(state, worktreeId), worktreeId, latest)
+    const latest =
+      scope?.type === 'folder'
+        ? (
+            findFolderWorkspaceOwner(state, scope.folderWorkspaceId, folderExecutionHostId)
+              ?.diffComments ?? []
+          ).map(normalizeDiffComment)
+        : (
+            state.worktreesByRepo[getRepoIdFromWorktreeId(worktreeId)]?.find(
+              (w) => w.id === worktreeId
+            )?.diffComments ?? []
+          ).map(normalizeDiffComment)
+    try {
+      await (scope?.type === 'folder'
+        ? persist(state, state.settings, worktreeId, latest, folderExecutionHostId)
+        : persist(state, settingsForWorktreeOwner(state, worktreeId), worktreeId, latest))
+    } catch (error) {
+      return { ok: false, error, durable: durableCommentsByQueue.get(queueKey) }
+    }
+    durableCommentsByQueue.set(queueKey, latest)
+    return { ok: true }
   }
   const next = prior.then(run, run)
   persistQueueByWorktree.set(queueKey, next)
@@ -192,10 +211,34 @@ function enqueuePersist(
   const cleanup = (): void => {
     if (persistQueueByWorktree.get(queueKey) === next) {
       persistQueueByWorktree.delete(queueKey)
+      durableCommentsByQueue.delete(queueKey)
     }
   }
   next.then(cleanup, cleanup)
   return next
+}
+
+// Why: single commit path for every mutation so rollback always targets the durable list.
+async function commitMutation(
+  set: Parameters<StateCreator<AppState, [], [], DiffCommentsSlice>>[0],
+  get: () => AppState,
+  worktreeId: string,
+  mutation: CommentMutation
+): Promise<boolean> {
+  const outcome = await enqueuePersist(worktreeId, get, mutation)
+  if (outcome.ok) {
+    return true
+  }
+  console.error('Failed to persist diff comments:', outcome.error)
+  // Why: rollback's identity guard no-ops if a later mutation already replaced the list, so a newer write can't be lost.
+  rollback(set, worktreeId, outcome.durable, mutation.next, mutation.folderExecutionHostId)
+  return false
+}
+
+type CommentMutation = {
+  previous: DiffComment[] | undefined
+  next: DiffComment[]
+  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
 }
 
 // Why: derive the next list inside the `set` updater so concurrent writes can't clobber each other via a stale closure.
@@ -203,11 +246,7 @@ function mutateComments(
   set: Parameters<StateCreator<AppState, [], [], DiffCommentsSlice>>[0],
   worktreeId: string,
   mutate: (existing: DiffComment[]) => DiffComment[] | null
-): {
-  previous: DiffComment[] | undefined
-  next: DiffComment[]
-  folderExecutionHostId?: ReturnType<typeof getExecutionHostIdForFolderWorkspace>
-} | null {
+): CommentMutation | null {
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   let previous: DiffComment[] | undefined
   let next: DiffComment[] | null = null
@@ -330,17 +369,12 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!result) {
       return null
     }
-    try {
-      // Why: serialize through the per-worktree queue so concurrent writes can't land on disk out of call order.
-      await enqueuePersist(input.worktreeId, get, result.folderExecutionHostId)
-      get().recordFeatureInteraction?.('review-notes')
-      return comment
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      // Why: rollback's identity guard no-ops if a later mutation already replaced the list, so a newer write can't be lost.
-      rollback(set, input.worktreeId, result.previous, result.next, result.folderExecutionHostId)
+    // Why: serialize through the per-worktree queue so concurrent writes can't land on disk out of call order.
+    if (!(await commitMutation(set, get, input.worktreeId, result))) {
       return null
     }
+    get().recordFeatureInteraction?.('review-notes')
+    return comment
   },
 
   updateDiffComment: async (worktreeId, commentId, body) => {
@@ -377,14 +411,7 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       // Why: comment vanished or the same body was already written between pre-check and set; treat as success so the editor closes.
       return true
     }
-    try {
-      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
-      return true
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
-      return false
-    }
+    return commitMutation(set, get, worktreeId, result)
   },
 
   clearDeliveredDiffComments: async (worktreeId, comments) => {
@@ -403,15 +430,11 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!result) {
       return true
     }
-    try {
-      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
-      get().recordFeatureInteraction?.('review-notes')
-      return true
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
+    if (!(await commitMutation(set, get, worktreeId, result))) {
       return false
     }
+    get().recordFeatureInteraction?.('review-notes')
+    return true
   },
 
   markDiffCommentsSent: async (worktreeId, commentIds, sentAt = Date.now()) => {
@@ -433,15 +456,11 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!result) {
       return true
     }
-    try {
-      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
-      get().recordFeatureInteraction?.('review-notes')
-      return true
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
+    if (!(await commitMutation(set, get, worktreeId, result))) {
       return false
     }
+    get().recordFeatureInteraction?.('review-notes')
+    return true
   },
 
   deleteDiffComment: async (worktreeId, commentId) => {
@@ -452,13 +471,8 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!result) {
       return
     }
-    try {
-      // Why: serialize through the per-worktree queue so concurrent writes can't land out of call order.
-      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
-    }
+    // Why: serialize through the per-worktree queue so concurrent writes can't land out of call order.
+    await commitMutation(set, get, worktreeId, result)
   },
 
   clearDiffComments: async (worktreeId) => {
@@ -468,14 +482,7 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!result) {
       return true
     }
-    try {
-      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
-      return true
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
-      return false
-    }
+    return commitMutation(set, get, worktreeId, result)
   },
 
   clearDiffCommentsForFile: async (worktreeId, filePath) => {
@@ -486,13 +493,6 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!result) {
       return true
     }
-    try {
-      await enqueuePersist(worktreeId, get, result.folderExecutionHostId)
-      return true
-    } catch (err) {
-      console.error('Failed to persist diff comments:', err)
-      rollback(set, worktreeId, result.previous, result.next, result.folderExecutionHostId)
-      return false
-    }
+    return commitMutation(set, get, worktreeId, result)
   }
 })

--- a/src/renderer/src/store/slices/folder-workspace-diff-comments.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-diff-comments.test.ts
@@ -238,6 +238,56 @@ describe('folder workspace diff comments', () => {
     consoleError.mockRestore()
   })
 
+  it('reports success when an earlier queued write already persisted the mutation', async () => {
+    const store = createTestStore()
+    const folderWorkspace = seedLocalFolderWorkspace(store)
+    const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    folderWorkspacesUpdate.mockImplementation(async ({ updates }) => {
+      if (folderWorkspacesUpdate.mock.calls.length === 1) {
+        return { ...folderWorkspace, ...updates }
+      }
+      throw new Error('disk full')
+    })
+
+    // Why: no await between the two adds, so both notes are in state before the first write snapshots it.
+    const addFirst = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'first note',
+      side: 'modified'
+    })
+    const addSecond = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 2,
+      body: 'second note',
+      side: 'modified'
+    })
+
+    await expect(Promise.all([addFirst, addSecond])).resolves.toEqual([
+      expect.objectContaining({ body: 'first note' }),
+      expect.objectContaining({ body: 'second note' })
+    ])
+    expect(folderWorkspacesUpdate).toHaveBeenNthCalledWith(1, {
+      folderWorkspaceId: folderWorkspace.id,
+      updates: {
+        diffComments: [
+          expect.objectContaining({ body: 'first note' }),
+          expect.objectContaining({ body: 'second note' })
+        ]
+      }
+    })
+    expect(store.getState().getDiffComments(workspaceKey)).toEqual([
+      expect.objectContaining({ body: 'first note' }),
+      expect.objectContaining({ body: 'second note' })
+    ])
+    consoleError.mockRestore()
+  })
+
   it('keeps same-id writes scoped to their original hosts', async () => {
     const store = createTestStore()
     const workspaceId = 'shared-folder-id'

--- a/src/renderer/src/store/slices/folder-workspace-diff-comments.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-diff-comments.test.ts
@@ -150,6 +150,94 @@ describe('folder workspace diff comments', () => {
     })
   })
 
+  it('rolls back to the persisted list when two queued writes fail', async () => {
+    const store = createTestStore()
+    const folderWorkspace = seedLocalFolderWorkspace(store)
+    const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let releaseFirstWrite: (() => void) | undefined
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve
+    })
+    folderWorkspacesUpdate.mockImplementation(async () => {
+      if (folderWorkspacesUpdate.mock.calls.length === 1) {
+        await firstWrite
+      }
+      throw new Error('disk full')
+    })
+
+    const addFirst = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'first note',
+      side: 'modified'
+    })
+    await vi.waitFor(() => expect(folderWorkspacesUpdate).toHaveBeenCalledTimes(1))
+    const addSecond = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 2,
+      body: 'second note',
+      side: 'modified'
+    })
+    releaseFirstWrite?.()
+
+    await expect(Promise.all([addFirst, addSecond])).resolves.toEqual([null, null])
+    // Why: neither write reached disk, so the pre-mutation list is the only durable state.
+    expect(store.getState().getDiffComments(workspaceKey)).toEqual([])
+    consoleError.mockRestore()
+  })
+
+  it('rolls back to the last persisted list when a later queued write fails', async () => {
+    const store = createTestStore()
+    const folderWorkspace = seedLocalFolderWorkspace(store)
+    const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let releaseFirstWrite: (() => void) | undefined
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve
+    })
+    folderWorkspacesUpdate.mockImplementation(async ({ updates }) => {
+      if (folderWorkspacesUpdate.mock.calls.length === 1) {
+        await firstWrite
+        return { ...folderWorkspace, ...updates }
+      }
+      throw new Error('disk full')
+    })
+
+    const addFirst = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 1,
+      body: 'first note',
+      side: 'modified'
+    })
+    await vi.waitFor(() => expect(folderWorkspacesUpdate).toHaveBeenCalledTimes(1))
+    const addSecond = store.getState().addDiffComment({
+      worktreeId: workspaceKey,
+      filePath: 'README.md',
+      source: 'markdown',
+      lineNumber: 2,
+      body: 'second note',
+      side: 'modified'
+    })
+    releaseFirstWrite?.()
+
+    await expect(Promise.all([addFirst, addSecond])).resolves.toEqual([
+      expect.objectContaining({ body: 'first note' }),
+      null
+    ])
+    // Why: the first write persisted the first note, so rollback keeps it instead of reverting to the empty list.
+    expect(store.getState().getDiffComments(workspaceKey)).toEqual([
+      expect.objectContaining({ body: 'first note' })
+    ])
+    consoleError.mockRestore()
+  })
+
   it('keeps same-id writes scoped to their original hosts', async () => {
     const store = createTestStore()
     const workspaceId = 'shared-folder-id'

--- a/src/shared/diff-comment-schema.test.ts
+++ b/src/shared/diff-comment-schema.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { DiffCommentSchema, parsePersistedDiffComments } from './diff-comment-schema'
+
+function comment(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'note-1',
+    worktreeId: 'repo::wt',
+    filePath: 'README.md',
+    lineNumber: 3,
+    body: 'Review this',
+    createdAt: 100,
+    side: 'modified',
+    ...overrides
+  }
+}
+
+describe('DiffCommentSchema', () => {
+  it('accepts a line note and a file-level note', () => {
+    expect(DiffCommentSchema.safeParse(comment()).success).toBe(true)
+    expect(DiffCommentSchema.safeParse(comment({ lineNumber: 0 })).success).toBe(true)
+  })
+
+  it('rejects empty identity and path fields', () => {
+    for (const field of ['id', 'worktreeId', 'filePath']) {
+      expect(DiffCommentSchema.safeParse(comment({ [field]: '' })).success).toBe(false)
+    }
+  })
+
+  it('trims the body and rejects one with no content', () => {
+    const parsed = DiffCommentSchema.safeParse(comment({ body: '  Review this  ' }))
+    expect(parsed.success && parsed.data.body).toBe('Review this')
+    expect(DiffCommentSchema.safeParse(comment({ body: '   ' })).success).toBe(false)
+    expect(DiffCommentSchema.safeParse(comment({ body: '' })).success).toBe(false)
+  })
+
+  it('requires startLine to stay within the note range', () => {
+    expect(DiffCommentSchema.safeParse(comment({ startLine: 3 })).success).toBe(true)
+    expect(DiffCommentSchema.safeParse(comment({ startLine: 4 })).success).toBe(false)
+    expect(DiffCommentSchema.safeParse(comment({ startLine: 0 })).success).toBe(false)
+    expect(DiffCommentSchema.safeParse(comment({ lineNumber: 0, startLine: 1 })).success).toBe(
+      false
+    )
+  })
+
+  it('rejects a negative line number and a non-positive sentAt', () => {
+    expect(DiffCommentSchema.safeParse(comment({ lineNumber: -1 })).success).toBe(false)
+    expect(DiffCommentSchema.safeParse(comment({ lineNumber: 1.5 })).success).toBe(false)
+    expect(DiffCommentSchema.safeParse(comment({ sentAt: 1 })).success).toBe(true)
+    expect(DiffCommentSchema.safeParse(comment({ sentAt: 0 })).success).toBe(false)
+    expect(DiffCommentSchema.safeParse(comment({ sentAt: -1 })).success).toBe(false)
+  })
+})
+
+describe('parsePersistedDiffComments', () => {
+  it('keeps valid notes and drops malformed ones', () => {
+    expect(
+      parsePersistedDiffComments([
+        comment({ id: 'keep-1' }),
+        comment({ id: '' }),
+        { id: 'no-body', worktreeId: 'repo::wt', filePath: 'README.md' },
+        'not-an-object',
+        null,
+        comment({ id: 'keep-2', lineNumber: 0 })
+      ])
+    ).toEqual([
+      expect.objectContaining({ id: 'keep-1' }),
+      expect.objectContaining({ id: 'keep-2' })
+    ])
+  })
+
+  it('returns an empty list for non-array input', () => {
+    expect(parsePersistedDiffComments(undefined)).toEqual([])
+    expect(parsePersistedDiffComments({ length: 1 })).toEqual([])
+  })
+})

--- a/src/shared/diff-comment-schema.ts
+++ b/src/shared/diff-comment-schema.ts
@@ -1,19 +1,42 @@
 import { z } from 'zod'
+import type { DiffComment } from './types'
 
-export const DiffCommentSchema = z.object({
-  id: z.string(),
-  worktreeId: z.string(),
-  filePath: z.string(),
-  source: z.enum(['diff', 'markdown']).optional(),
-  selectedText: z.string().optional(),
-  startLine: z.number().int().positive().optional(),
-  lineNumber: z.number().int().positive(),
-  body: z.string(),
-  createdAt: z.number().finite(),
-  updatedAt: z.number().finite().optional(),
-  sentAt: z.number().finite().optional(),
-  scope: z.enum(['unstaged', 'staged', 'branch']).optional(),
-  oldPath: z.string().optional(),
-  diffIdentity: z.string().optional(),
-  side: z.literal('modified')
-})
+export const DiffCommentSchema = z
+  .object({
+    id: z.string().min(1),
+    worktreeId: z.string().min(1),
+    filePath: z.string().min(1),
+    source: z.enum(['diff', 'markdown']).optional(),
+    selectedText: z.string().optional(),
+    startLine: z.number().int().positive().optional(),
+    // Why: 0 marks a file-level note; line notes are 1-based.
+    lineNumber: z.number().int().min(0),
+    body: z.string().trim().min(1),
+    createdAt: z.number().finite(),
+    updatedAt: z.number().finite().optional(),
+    // Why: the renderer treats a non-positive sentAt as unsent, so never store one.
+    sentAt: z.number().finite().positive().optional(),
+    scope: z.enum(['unstaged', 'staged', 'branch']).optional(),
+    oldPath: z.string().optional(),
+    diffIdentity: z.string().optional(),
+    side: z.literal('modified')
+  })
+  .refine((comment) => comment.startLine === undefined || comment.startLine <= comment.lineNumber, {
+    message: 'startLine must not exceed lineNumber',
+    path: ['startLine']
+  })
+
+// Why: persisted JSON predates the schema boundary, so drop unusable notes instead of rehydrating them.
+export function parsePersistedDiffComments(value: unknown): DiffComment[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const comments: DiffComment[] = []
+  for (const candidate of value) {
+    const parsed = DiffCommentSchema.safeParse(candidate)
+    if (parsed.success) {
+      comments.push(parsed.data)
+    }
+  }
+  return comments
+}

--- a/src/shared/folder-workspaces.test.ts
+++ b/src/shared/folder-workspaces.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup } from './types'
+import { normalizeFolderWorkspaces } from './folder-workspaces'
+
+const projectGroups = [
+  { id: 'group-1', name: 'Platform', parentPath: '/workspace' } as ProjectGroup
+]
+
+function persistedWorkspace(diffComments: unknown): Record<string, unknown> {
+  return {
+    id: 'folder-1',
+    projectGroupId: 'group-1',
+    folderPath: '/workspace/platform',
+    diffComments
+  }
+}
+
+describe('normalizeFolderWorkspaces diff comments', () => {
+  it('keeps valid persisted notes and drops malformed ones', () => {
+    const valid = {
+      id: 'note-1',
+      worktreeId: 'folder::folder-1',
+      filePath: 'README.md',
+      lineNumber: 1,
+      body: 'Review this',
+      createdAt: 100,
+      side: 'modified'
+    }
+    const [workspace] = normalizeFolderWorkspaces(
+      [persistedWorkspace([valid, { ...valid, id: 'note-2', body: '   ' }, 42])],
+      projectGroups
+    )
+
+    expect(workspace.diffComments).toEqual([expect.objectContaining({ id: 'note-1' })])
+  })
+
+  it('leaves diffComments unset when the persisted value is not an array', () => {
+    const [workspace] = normalizeFolderWorkspaces(
+      [persistedWorkspace({ id: 'note-1' })],
+      projectGroups
+    )
+
+    expect(workspace.diffComments).toBeUndefined()
+  })
+})

--- a/src/shared/folder-workspaces.ts
+++ b/src/shared/folder-workspaces.ts
@@ -4,6 +4,7 @@ import { normalizeStoredTaskSourceContext } from './task-source-context'
 import { normalizeWorkspaceLinkedItem } from './workspace-linked-item'
 import { isWorkspaceLinkedItemSourceContextMatch } from './workspace-linked-item-source-context'
 import { normalizeWorkspaceCreatorProvenance } from './workspace-creator-provenance'
+import { parsePersistedDiffComments } from './diff-comment-schema'
 
 export function normalizeFolderWorkspaceName(
   name: string | null | undefined,
@@ -104,7 +105,9 @@ export function normalizeFolderWorkspaces(
         typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt) ? raw.createdAt : now,
       updatedAt:
         typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt) ? raw.updatedAt : now,
-      ...(Array.isArray(raw.diffComments) ? { diffComments: raw.diffComments } : {})
+      ...(Array.isArray(raw.diffComments)
+        ? { diffComments: parsePersistedDiffComments(raw.diffComments) }
+        : {})
     })
   }
   return workspaces.sort(


### PR DESCRIPTION
## ELI5

If saving a review note to disk fails twice in a row, the app used to keep showing a note that was never actually saved. Now it always falls back to what is really on disk. Plus, the note schema now rejects junk (blank body, empty ids) and stops rejecting valid file-level notes from mobile.

## What Changed

Follow-up to #14112, addressing CodeRabbit review feedback left on that PR after it merged.

**1. Roll review notes back to the persisted list** (`src/renderer/src/store/slices/diffComments.ts`)

`rollback` restored `mutation.previous`, which is itself an optimistic list when writes queue up. With two queued writes that both fail, the second rollback restored the first mutation's optimistic list while storage still held the list from before both mutations, so the renderer showed notes that were not durable.

- Added `durableCommentsByQueue`: the last list actually written per persist queue. Seeded from the pre-mutation list when the queue is idle (nothing in flight means state matches disk), updated after each successful write, dropped when the queue drains.
- `enqueuePersist` now resolves a `PersistOutcome` instead of rejecting, so a failed write carries the durable list back to its own caller without breaking the chain.
- New `commitMutation` is the single commit path (queue the write, roll back to the durable list on failure), replacing seven duplicated try/catch blocks. The existing identity guard in `rollback` is unchanged, so a newer mutation still wins.

**2. Enforce the `DiffComment` invariants** (`src/shared/diff-comment-schema.ts`)

`id` / `worktreeId` / `filePath` require content, `body` is trimmed and must be non-empty, `sentAt` must be positive (matching the renderer, which already treats non-positive as unsent), and `startLine <= lineNumber` is refined. `lineNumber` moved from `.positive()` to `.int().min(0)`: mobile uses `lineNumber: 0` for file-level notes, so the host was rejecting valid ones.

**3. Validate persisted note elements** (`src/shared/folder-workspaces.ts`)

`normalizeFolderWorkspaces` accepted any array via `Array.isArray`, rehydrating malformed notes straight past the new schema boundary. It now parses each element with the shared schema (`parsePersistedDiffComments`) and drops invalid ones.

## Why

Review notes are user-authored content that is easy to lose silently: an optimistic list that looks saved but is not means the user closes the diff believing their notes are on disk. Tracking the durable list per queue is the smallest change that keeps rollback honest without an extra read from storage.

The schema fixes close the other half: the boundary now rejects what the renderer would never produce, and load-time normalization drops legacy junk so it is never re-sent to the host.

## Linked Issue

Follow-up to #14112 (STA-3958). No separate issue: this addresses review feedback on that PR.

## Visual Proof

`N/A` — no UI change. The only user-visible difference is in a failure path (notes now revert to the persisted list rather than showing an unsaved note), which is covered by the new store tests.

## Testing

- `vitest` over the diff-comment, folder-workspace, persistence, and selector suites: 512 passed.
- Verified the new "two queued writes fail" test is a real regression test: temporarily reverting `outcome.durable` to `mutation.previous` makes it fail, then restored.
- `tsc --noEmit` on the node, web, and cli projects: clean.
- `oxlint` on all touched files: clean. `check:max-lines-ratchet`: OK (no new suppressions).

New tests:
- `folder-workspace-diff-comments.test.ts` — two queued writes both fail (rolls back to the empty persisted list); first write succeeds and second fails (keeps the persisted note instead of reverting).
- `src/shared/diff-comment-schema.test.ts` — boundary cases for empty fields, whitespace body, `startLine` range, `lineNumber: 0`, non-positive `sentAt`.
- `src/shared/folder-workspaces.test.ts` — mixed valid/invalid persisted `diffComments`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Backwards compatibility / remote wire**: the schema tightening is host-side validation on `folderWorkspace.update` (IPC and RPC), so it reaches older paired clients. Notes with an empty body/id or non-positive `sentAt` are now rejected rather than stored. The UI cannot produce those (the popover gates submit on non-empty text; the store normalizes `sentAt`/`startLine` before persisting), and change 3 drops such legacy records at load so they are not re-sent. The `lineNumber: 0` change is a loosening and is strictly compatible. Flagging in case a reviewer prefers coercion over rejection here.
- **Mobile**: `lineNumber: 0` file-level notes are now accepted by the desktop host instead of rejected.
- **Cross-platform / SSH**: no platform- or path-dependent code; the folder-workspace and worktree paths both route through the same queue as before, local and RPC alike.
- **Performance**: one extra `Map` entry per in-flight persist queue, cleared when the queue drains.

## AI Disclosure

Claude Opus 5 (Claude Code).

Made with [Orca](https://github.com/stablyai/orca) 🐋
