### PR TITLE
fix(sidebar): stop sibling session rows indenting when a lineage expands

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.sibling-disclosure-gutter.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.sibling-disclosure-gutter.test.tsx
@@ -1,0 +1,152 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearWorktreeAgentExpansionStateForTests,
+  seedWorktreeAgentExpansionStateForTests
+} from './worktree-card-agents-expansion-state'
+
+function mockAgent(
+  paneKey: string,
+  extras: {
+    prompt?: string
+    parentPaneKey?: string
+  } = {}
+): unknown {
+  return {
+    paneKey,
+    tab: { id: paneKey.split(':')[0] },
+    agentType: 'codex',
+    state: 'working',
+    startedAt: 1000,
+    entry: {
+      prompt: extras.prompt ?? paneKey,
+      state: 'working',
+      stateStartedAt: 1000,
+      stateHistory: [],
+      orchestration: extras.parentPaneKey
+        ? { parentPaneKey: extras.parentPaneKey }
+        : undefined
+    }
+  }
+}
+
+const siblingLineage = [
+  mockAgent('tab-parent:1', { prompt: 'Parent session' }),
+  mockAgent('tab-child:1', { prompt: 'Sub-agent', parentPaneKey: 'tab-parent:1' }),
+  mockAgent('tab-sibling:1', { prompt: 'Sibling session' })
+]
+
+let mockAgents: unknown[] = siblingLineage
+let mockAgentActivityDisplayMode: 'compact' | 'full' = 'full'
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      agentActivityDisplayMode: mockAgentActivityDisplayMode,
+      acknowledgedAgentsByPaneKey: {},
+      cacheTimerByKey: {},
+      dropAgentStatus: vi.fn(),
+      dismissRetainedAgent: vi.fn(),
+      acknowledgeAgents: vi.fn(),
+      agentSendPopoverTargetMode: null,
+      agentStatusByPaneKey: {},
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sendPromptToSidebarAgentTarget: vi.fn(),
+      settings: { promptCacheTimerEnabled: false, promptCacheTtlMs: 60_000 }
+    })
+}))
+
+vi.mock('./useWorktreeAgentRows', () => ({
+  useWorktreeAgentRows: vi.fn(() => mockAgents)
+}))
+
+vi.mock('@/components/dashboard/useNow', () => ({
+  useNow: vi.fn(() => 2000)
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
+  activateTabAndFocusPane: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/dashboard/DashboardAgentRow', () => ({
+  default: ({
+    agent,
+    reserveDisclosureGutter
+  }: {
+    agent: { paneKey: string }
+    reserveDisclosureGutter?: boolean
+  }) => (
+    <div
+      data-testid="agent-row"
+      data-pane-key={agent.paneKey}
+      data-reserve-disclosure-gutter={reserveDisclosureGutter ? 'true' : 'false'}
+    />
+  )
+}))
+
+vi.mock('./worktree-card-compact-agents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./worktree-card-compact-agents')>()
+  return {
+    ...actual,
+    CompactAgentRow: ({
+      agent,
+      reserveDisclosureGutter
+    }: {
+      agent: { paneKey: string }
+      reserveDisclosureGutter?: boolean
+    }) => (
+      <div
+        data-testid="compact-agent-row"
+        data-pane-key={agent.paneKey}
+        data-reserve-disclosure-gutter={reserveDisclosureGutter ? 'true' : 'false'}
+      />
+    )
+  }
+})
+
+describe('WorktreeCardAgents sibling disclosure gutter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgents = siblingLineage
+    mockAgentActivityDisplayMode = 'full'
+    clearWorktreeAgentExpansionStateForTests()
+  })
+
+  it('keeps full-mode sibling roots unshifted when another root has children', async () => {
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-gutter" />)
+
+    expect(markup).toContain('data-pane-key="tab-parent:1" data-reserve-disclosure-gutter="false"')
+    expect(markup).toContain('data-pane-key="tab-sibling:1" data-reserve-disclosure-gutter="false"')
+    expect(markup).toContain('data-pane-key="tab-child:1" data-reserve-disclosure-gutter="false"')
+    expect(markup).not.toContain('data-reserve-disclosure-gutter="true"')
+  })
+
+  it('keeps compact sibling roots unshifted when the lineage list is expanded', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    seedWorktreeAgentExpansionStateForTests('wt-gutter', {
+      compactRootListExpanded: true,
+      collapsedLineageParents: new Set()
+    })
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-gutter" />)
+
+    expect(markup).toContain('data-testid="compact-agent-row"')
+    expect(markup).toContain('data-pane-key="tab-parent:1" data-reserve-disclosure-gutter="false"')
+    expect(markup).toContain('data-pane-key="tab-sibling:1" data-reserve-disclosure-gutter="false"')
+    expect(markup).toContain('data-pane-key="tab-child:1" data-reserve-disclosure-gutter="false"')
+    expect(markup).not.toContain('data-reserve-disclosure-gutter="true"')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -230,11 +230,6 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     e.stopPropagation()
   }, [])
 
-  // Why: root leaf siblings reserve a leading spacer when any root has a chevron, keeping the state-dot column aligned (descendants already indent).
-  const anyRootHasChildren = rootAgents.some(
-    (agent) => (childrenByParentPaneKey.get(agent.paneKey) ?? []).length > 0
-  )
-
   const renderAgentBranch = (
     agent: DashboardAgentRowData,
     ancestorPaneKeys: ReadonlySet<string> = new Set()
@@ -245,7 +240,6 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     }
     const childAgents = childrenByParentPaneKey.get(agent.paneKey) ?? []
     const hasChildAgents = childAgents.length > 0
-    const isRootAgent = ancestorPaneKeys.size === 0
     // Why: spawned child agents are actionable work, so show them as soon as the parent appears (disclosure still folds noise).
     const expanded = !collapsedLineageParents.has(agent.paneKey)
     const sendTarget = isAgentSendTargetModeActive
@@ -277,8 +271,6 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           onToggleChildAgents={
             hasChildAgents ? () => toggleLineageParent(agent.paneKey) : undefined
           }
-          // Why: keep leaf rows aligned with parent rows — see anyRootHasChildren above.
-          reserveDisclosureGutter={isRootAgent && anyRootHasChildren && !hasChildAgents}
           isFocusedPane={agent.paneKey === focusedAgentPaneKey}
           sendTargetStatus={sendTarget?.status}
           sendTargetDisabledReason={sendTarget?.disabledReason}
@@ -307,7 +299,6 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     }
     const childAgents = childrenByParentPaneKey.get(agent.paneKey) ?? []
     const hasChildAgents = childAgents.length > 0
-    const isRootAgent = ancestorPaneKeys.size === 0
     const expanded = !collapsedLineageParents.has(agent.paneKey)
     const sendTarget = isAgentSendTargetModeActive
       ? (sendTargetsByPaneKey.get(agent.paneKey) ?? {
@@ -333,7 +324,6 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           onToggleChildAgents={
             hasChildAgents ? () => toggleLineageParent(agent.paneKey) : undefined
           }
-          reserveDisclosureGutter={isRootAgent && anyRootHasChildren && !hasChildAgents}
           isFocusedPane={agent.paneKey === focusedAgentPaneKey}
           cacheTimerActive={cacheTimerActive}
         />


### PR DESCRIPTION
## Summary

- Expanding a session with sub-agents reserved a 16px disclosure gutter on **every sibling root** (`anyRootHasChildren && !hasChildAgents`) so state-dots lined up with the parent chevron.
- That is the measured 20px shift in #14084 (`size-4` + `gap-1`): sibling titles move to the sub-agent column, the expanded parent looks like the only top-level row, and description lines (outside the title flex) stay put.
- Stop reserving that sibling spacer. Only the parent that actually has children gets a chevron; descendants still indent via `.worktree-agent-lineage-children`.

Closes #14084

Not the same fix as open #11796 (compact *descendant* indent). This PR only removes the sibling-root gutter.

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.sibling-disclosure-gutter.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.expansion-remount.test.tsx`
- [x] New tests: full + compact sibling roots keep `reserveDisclosureGutter=false` when another root has children
- [ ] Manual: Projects sidebar, several sessions in one project, expand one with sub-agents — sibling sessions stay at the original left edge; only the child rows indent

## Notes

Renderer-only layout. Same `WorktreeCardAgents` path for folder workspaces and git worktrees; no SSH/RPC/Git/keyboard changes.