### PR TITLE
fix(daemon): let the connect prove a retired daemon, not the token read

### DIFF
--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -335,6 +335,36 @@ describe('DaemonClient', () => {
       client = new DaemonClient({ socketPath, tokenPath })
       await expect(client.ensureConnected()).rejects.toThrow()
     })
+
+    it('fails a retired endpoint at the connect, not at the token read', async () => {
+      // Why: the daemon unlinks its token on exit. Failing at the open produced an error no
+      // endpoint-gone predicate could classify, because they all key on syscall 'connect'.
+      rmSync(tokenPath)
+
+      const error = (await client_ensureConnectedError()) as NodeJS.ErrnoException
+
+      expect(error.syscall).toBe('connect')
+      expect(['ENOENT', 'ECONNREFUSED']).toContain(error.code)
+    })
+
+    it('still attempts the handshake when the token is gone but a daemon is listening', async () => {
+      // Why: a missing token is not proof of death — it can be rotated or externally removed while
+      // the daemon is alive. The daemon must get the chance to reject it.
+      const hellos: HelloMessage[] = []
+      await startMockDaemon({ onHello: (msg) => hellos.push(msg) })
+      rmSync(tokenPath)
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await client.ensureConnected()
+
+      expect(hellos.length).toBeGreaterThan(0)
+      expect(hellos[0]?.token).toBe('')
+    })
+
+    async function client_ensureConnectedError(): Promise<unknown> {
+      client = new DaemonClient({ socketPath, tokenPath })
+      return client.ensureConnected().catch((err: unknown) => err)
+    }
   })
 
   describe('RPC', () => {

--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -337,19 +337,18 @@ describe('DaemonClient', () => {
     })
 
     it('fails a retired endpoint at the connect, not at the token read', async () => {
-      // Why: the daemon unlinks its token on exit. Failing at the open produced an error no
-      // endpoint-gone predicate could classify, because they all key on syscall 'connect'.
       rmSync(tokenPath)
+      client = new DaemonClient({ socketPath, tokenPath })
 
-      const error = (await client_ensureConnectedError()) as NodeJS.ErrnoException
+      const error = (await client
+        .ensureConnected()
+        .catch((err: unknown) => err)) as NodeJS.ErrnoException
 
       expect(error.syscall).toBe('connect')
       expect(['ENOENT', 'ECONNREFUSED']).toContain(error.code)
     })
 
     it('still attempts the handshake when the token is gone but a daemon is listening', async () => {
-      // Why: a missing token is not proof of death — it can be rotated or externally removed while
-      // the daemon is alive. The daemon must get the chance to reject it.
       const hellos: HelloMessage[] = []
       await startMockDaemon({ onHello: (msg) => hellos.push(msg) })
       rmSync(tokenPath)
@@ -360,11 +359,6 @@ describe('DaemonClient', () => {
       expect(hellos.length).toBeGreaterThan(0)
       expect(hellos[0]?.token).toBe('')
     })
-
-    async function client_ensureConnectedError(): Promise<unknown> {
-      client = new DaemonClient({ socketPath, tokenPath })
-      return client.ensureConnected().catch((err: unknown) => err)
-    }
   })
 
   describe('RPC', () => {

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -114,12 +114,31 @@ export class DaemonClient {
     }
   }
 
+  /**
+   * Why absence is a value, not a throw: the daemon unlinks its token on exit but leaves its socket,
+   * so throwing here preempts the connect — and the connect is what proves the endpoint gone
+   * (ENOENT/ECONNREFUSED with syscall 'connect'), which every recovery predicate keys on. Reading
+   * totally lets a dead daemon fail as a connect, and a live one reject the empty token as
+   * 'Invalid token' rather than being declared dead by a missing file. checkDaemonHealth has always
+   * read it this way; this client was the outlier.
+   */
+  private readToken(): string {
+    try {
+      return readFileSync(this.tokenPath, 'utf-8').trim()
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | null)?.code === 'ENOENT') {
+        return ''
+      }
+      throw error
+    }
+  }
+
   private async doConnect(
     timeoutMs: number,
     attemptGeneration: number,
     sharedBudget: boolean
   ): Promise<void> {
-    const token = readFileSync(this.tokenPath, 'utf-8').trim()
+    const token = this.readToken()
     const deadlineMs = Date.now() + timeoutMs
     const remainingMs = (): number =>
       sharedBudget ? Math.max(1, deadlineMs - Date.now()) : timeoutMs

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -114,14 +114,7 @@ export class DaemonClient {
     }
   }
 
-  /**
-   * Why absence is a value, not a throw: the daemon unlinks its token on exit but leaves its socket,
-   * so throwing here preempts the connect — and the connect is what proves the endpoint gone
-   * (ENOENT/ECONNREFUSED with syscall 'connect'), which every recovery predicate keys on. Reading
-   * totally lets a dead daemon fail as a connect, and a live one reject the empty token as
-   * 'Invalid token' rather than being declared dead by a missing file. checkDaemonHealth has always
-   * read it this way; this client was the outlier.
-   */
+  // Why: a missing token must not preempt the connect that proves whether the endpoint is gone.
   private readToken(): string {
     try {
       return readFileSync(this.tokenPath, 'utf-8').trim()

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -595,6 +595,42 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
+    it('respawns after a retired daemon regardless of how the connection ended', async () => {
+      // Why this shape: the daemon retires when its last authenticated client drops, and that drop
+      // is often our own disconnect() — which observes no socket close. Once the token read stops
+      // preempting the connect, the retired endpoint fails as a connect and isDaemonGoneError
+      // classifies it, so recovery no longer depends on having witnessed the drop.
+      let respawnServer: DaemonServer | undefined
+      const respawn = vi.fn(async () => {
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+      const healingAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const { id } = await healingAdapter.spawn({ cols: 80, rows: 24 })
+        const client = (healingAdapter as unknown as { client: DaemonClient }).client
+
+        client.disconnect()
+        await server.shutdown()
+        expect(existsSync(tokenPath)).toBe(false)
+        expect(client.hasObservedAuthenticatedDisconnect()).toBe(false)
+
+        await expect(
+          healingAdapter.spawn({ sessionId: id, cols: 80, rows: 24 })
+        ).resolves.toMatchObject({ id })
+        expect(respawn).toHaveBeenCalledTimes(1)
+      } finally {
+        warn.mockRestore()
+        healingAdapter.dispose()
+        await respawnServer?.shutdown()
+      }
+    })
+
     it('does not spawn a daemon per keystroke after respawn fails', async () => {
       const respawn = vi.fn(async () => {
         throw new Error('daemon unavailable')

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -2119,13 +2119,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return 'unavailable'
   }
 
-  // Why: on daemon-death errors, respawn a fresh daemon and retry once rather than leaving terminals broken until app restart.
-  /**
-   * Why a file check and not an errno shape: the client reads the token totally now, so a retired
-   * endpoint fails at the connect rather than the open. The fact worth auditing is unchanged — the
-   * token is gone after we were authenticated — and the filesystem answers it directly. An absent
-   * token before any authenticated session still proves nothing; a daemon may be mid-startup.
-   */
+  // Why: the token read no longer throws, so audit its absence directly after an authenticated drop.
   private isRetiredEndpointTokenMissing(): boolean {
     return this.client.hasObservedAuthenticatedDisconnect() && !existsSync(this.tokenPath)
   }
@@ -2142,11 +2136,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
           ['token_file']
         )
       }
-      if (
-        this.respawnAdoptionClosed ||
-        !this.respawnFn ||
-        (!isDaemonGoneError(err) && !missingRetiredEndpointToken)
-      ) {
+      if (this.respawnAdoptionClosed || !this.respawnFn || !isDaemonGoneError(err)) {
         throw err
       }
       if (!this.respawnPromise) {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1473,8 +1473,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       )
       return processes
     } catch (error) {
-      const missingAuthenticatedToken =
-        isMissingTokenFileError(error) && this.client.hasObservedAuthenticatedDisconnect()
+      const missingAuthenticatedToken = this.isRetiredEndpointTokenMissing()
       const missingNamedPipe = isMissingWindowsNamedPipeError(error)
       this.observeAuditFailure(
         missingAuthenticatedToken
@@ -2121,13 +2120,21 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   // Why: on daemon-death errors, respawn a fresh daemon and retry once rather than leaving terminals broken until app restart.
+  /**
+   * Why a file check and not an errno shape: the client reads the token totally now, so a retired
+   * endpoint fails at the connect rather than the open. The fact worth auditing is unchanged — the
+   * token is gone after we were authenticated — and the filesystem answers it directly. An absent
+   * token before any authenticated session still proves nothing; a daemon may be mid-startup.
+   */
+  private isRetiredEndpointTokenMissing(): boolean {
+    return this.client.hasObservedAuthenticatedDisconnect() && !existsSync(this.tokenPath)
+  }
+
   private async withDaemonRetry<T>(fn: () => Promise<T>): Promise<T> {
     try {
       return await fn()
     } catch (err) {
-      // Why: the token is removed only after an authenticated drop; an initial missing token may still hide a live daemon.
-      const missingRetiredEndpointToken =
-        isMissingTokenFileError(err) && this.client.hasObservedAuthenticatedDisconnect()
+      const missingRetiredEndpointToken = this.isRetiredEndpointTokenMissing()
       if (missingRetiredEndpointToken) {
         this.observeAuditFailure(
           'token_missing_after_authenticated_disconnect',
@@ -2531,14 +2538,6 @@ export function isDaemonGoneError(err: unknown): boolean {
     // reaches whoever owns it; surfacing this to the user would strand the request instead.
     msg === DAEMON_ENDPOINT_LOST_MESSAGE
   )
-}
-
-function isMissingTokenFileError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false
-  }
-  const errno = err as NodeJS.ErrnoException
-  return errno.code === 'ENOENT' && errno.syscall === 'open'
 }
 
 function isMissingWindowsNamedPipeError(err: unknown): boolean {

--- a/src/main/daemon/daemon-self-retirement-respawn.test.ts
+++ b/src/main/daemon/daemon-self-retirement-respawn.test.ts
@@ -213,17 +213,33 @@ describe('daemon self-retirement respawn', () => {
     expect(respawn).not.toHaveBeenCalled()
   })
 
-  it('does not treat an initial missing token as respawn authority', async () => {
+  // Why these two replace "does not treat an initial missing token as respawn authority": that guard
+  // was added alongside the token unlink, to stop an absent token from authorizing a respawn. The
+  // token read no longer preempts the connect, so authority comes from whether anything is accepting
+  // on the endpoint — a strictly stronger signal. The hazard the old guard covered is the first test
+  // here: a daemon that has bound its socket but not yet written its token must not be replaced.
+  it('does not respawn a listening daemon whose token is absent', async () => {
+    await startServer()
+    rmSync(tokenPath)
     const respawn = vi.fn(async () => {})
     const adapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
 
-    await expect(adapter.spawn({ sessionId: 'missing', cols: 80, rows: 24 })).rejects.toMatchObject(
-      {
-        code: 'ENOENT'
-      }
-    )
+    await expect(
+      adapter.spawn({ sessionId: 'startup-window', cols: 80, rows: 24 })
+    ).rejects.toThrow(/Invalid token/i)
 
     expect(respawn).not.toHaveBeenCalled()
+    adapter.dispose()
+  })
+
+  it('respawns when nothing is accepting on the endpoint', async () => {
+    const respawn = vi.fn(async () => {})
+    const adapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
+
+    // Fails after the respawn attempt because the mock respawn starts no replacement.
+    await expect(adapter.spawn({ sessionId: 'missing', cols: 80, rows: 24 })).rejects.toThrow()
+
+    expect(respawn).toHaveBeenCalledTimes(1)
     adapter.dispose()
   })
 })

--- a/src/main/daemon/daemon-self-retirement-respawn.test.ts
+++ b/src/main/daemon/daemon-self-retirement-respawn.test.ts
@@ -213,11 +213,6 @@ describe('daemon self-retirement respawn', () => {
     expect(respawn).not.toHaveBeenCalled()
   })
 
-  // Why these two replace "does not treat an initial missing token as respawn authority": that guard
-  // was added alongside the token unlink, to stop an absent token from authorizing a respawn. The
-  // token read no longer preempts the connect, so authority comes from whether anything is accepting
-  // on the endpoint — a strictly stronger signal. The hazard the old guard covered is the first test
-  // here: a daemon that has bound its socket but not yet written its token must not be replaced.
   it('does not respawn a listening daemon whose token is absent', async () => {
     await startServer()
     rmSync(tokenPath)
@@ -226,6 +221,30 @@ describe('daemon self-retirement respawn', () => {
 
     await expect(
       adapter.spawn({ sessionId: 'startup-window', cols: 80, rows: 24 })
+    ).rejects.toThrow(/Invalid token/i)
+
+    expect(respawn).not.toHaveBeenCalled()
+    adapter.dispose()
+  })
+
+  it('does not let stale disconnect evidence authorize respawning a listening daemon', async () => {
+    const original = await startServer()
+    const respawn = vi.fn(async () => {})
+    const adapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
+    await adapter.listProcesses()
+    const client = (
+      adapter as unknown as {
+        client: { hasObservedAuthenticatedDisconnect(): boolean }
+      }
+    ).client
+
+    await original.shutdown()
+    await waitFor(() => client.hasObservedAuthenticatedDisconnect())
+    await startServer()
+    rmSync(tokenPath)
+
+    await expect(
+      adapter.spawn({ sessionId: 'replacement-startup-window', cols: 80, rows: 24 })
     ).rejects.toThrow(/Invalid token/i)
 
     expect(respawn).not.toHaveBeenCalled()


### PR DESCRIPTION
## ELI5

When the terminal daemon exits it deletes its password file but leaves its socket behind. Orca read that password file *before* dialing the socket, so a dead daemon tripped on the missing file first — and every piece of recovery code we have is written to recognize a failed *dial*, not a failed file read. So nothing recognized it, and the pane showed a raw filesystem error. Now Orca dials first and lets the dial answer the question.

## What Changed

`DaemonClient` reads its token file totally: a missing token yields an empty string instead of throwing, so the connect proceeds and decides.

Because the failure lands where the existing predicates already look, no new error class, no new predicate, and no new recovery path is added.

The audit signal that recorded "token gone after we were authenticated" now checks the file directly instead of inferring it from an errno shape, which keeps that evidence intact.

## Why

`daemon-server.ts:381` unlinks the token on exit but deliberately leaves the socket. `client.ts` read the token as the first statement of `doConnect`, before `connectSocket`. So a retired daemon always failed at the `open`:

- `isDaemonGoneError` (`daemon-pty-adapter.ts:2521`) requires `syscall === 'connect'` → false → `withDaemonRetry` never respawned.
- `isDaemonEndpointGoneError` (`daemon-errors.ts:39`) requires the same → false → `ipc/pty.ts:858` never produced `TerminalHostGoneError`, so the pane never got the copy written for a daemon that exited.

The user-visible result, reported from a floating terminal on 1.4.181-hourly.202608112119:

```
DaemonProtocolError: Disconnected
ENOENT: no such file or directory, open '~/Library/Application Support/orca/daemon/daemon-v32.token'
```

With the read made total, each case lands where it should:

| Situation | Before | After |
| --- | --- | --- |
| Daemon retired | raw `ENOENT`/`open`, unclassifiable | `ENOENT`/`ECONNREFUSED` on connect → respawn + retry |
| Retired, respawn impossible (legacy adapter) | same raw errno | classified gone → "The terminal daemon that owned this session exited…" |
| Daemon **alive**, token rotated or removed | declared dead | `Invalid token` from the daemon — correctly not dead |

That last row is the point. Absence of a file is not proof of death; the endpoint is. `checkDaemonHealth` (`daemon-health.ts:78-84`) has always read the token totally and resolved `unreachable` — this client was the outlier.

### The replaced guard

`daemon-self-retirement-respawn.test.ts` asserted "does not treat an initial missing token as respawn authority". That guard arrived in the same commit that introduced the token unlink — it exists because that change made a missing token possible, so it is an artifact of this shape rather than an independent contract.

It is replaced by two tests that pin the stronger contract, so the hazard it covered is still proven covered:

- a daemon that has **bound its socket but not yet written its token** must not be replaced — it now rejects the empty token, and no respawn occurs;
- a respawn happens when **nothing is accepting on the endpoint**, which was already the behavior whenever a token happened to exist.

## Linked Issue

No GitHub issue — reported in Slack (`#eng`, 2026-08-11).

## Visual Proof

`N/A` — no UI change. The user-visible difference is that the pane recovers, or explains itself, instead of printing errno.

## Testing

Full `src/main/daemon` suite: **1421 passed, 3 skipped, 0 failed** (98 files). `typecheck:node` clean. Changed-code quality gate (oxlint + type-aware + React Doctor) clean on 5 files.

`src/main/ipc/pty.test.ts` has 10 failures — **pre-existing**, verified identical with this change stashed; they are MiMo/Pi environment tests unrelated to the daemon.

Negative control: reverting only `client.ts` fails exactly the 5 new/replaced tests.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Main-process only; no wire-format, IPC, or renderer change. Platform-independent — the Windows named-pipe classification is untouched, and its own predicate still matches. The blast radius is the five `DaemonClient` construction sites; all already funnel connect failures through `catch`, so a missing token costs one failed connect and reaches the same verdict it reached before. No secret is logged or surfaced; an empty token is rejected by the daemon exactly as any wrong token is.

## AI Disclosure

Claude Opus 5.
