### PR TITLE
perf(browser): clear cookies in one bulk call that excludes the Google family (STA-4065)

### DIFF
--- a/src/main/browser/browser-cookie-import-google-exclusion.test.ts
+++ b/src/main/browser/browser-cookie-import-google-exclusion.test.ts
@@ -120,7 +120,7 @@ describe('file import excludes the Google cookie family', () => {
 })
 
 describe('native Chromium import excludes the Google cookie family', () => {
-  let clearStorageDataMock: ReturnType<typeof vi.fn>
+  let clearDataMock: ReturnType<typeof vi.fn>
   let cookiesGetMock: ReturnType<typeof vi.fn>
   let cookiesRemoveMock: ReturnType<typeof vi.fn>
   let cookiesSetMock: ReturnType<typeof vi.fn>
@@ -134,7 +134,7 @@ describe('native Chromium import excludes the Google cookie family', () => {
     execFileSyncMock.mockImplementation(() => {
       throw new Error('OS browser version lookup unavailable')
     })
-    clearStorageDataMock = vi.fn().mockResolvedValue(undefined)
+    clearDataMock = vi.fn().mockResolvedValue(undefined)
     cookiesGetMock = vi.fn().mockResolvedValue([])
     cookiesRemoveMock = vi.fn().mockResolvedValue(undefined)
     cookiesSetMock = vi.fn().mockResolvedValue(undefined)
@@ -145,7 +145,7 @@ describe('native Chromium import excludes the Google cookie family', () => {
         remove: cookiesRemoveMock,
         set: cookiesSetMock
       },
-      clearStorageData: clearStorageDataMock
+      clearData: clearDataMock
     })
     platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
   })
@@ -166,7 +166,7 @@ describe('native Chromium import excludes the Google cookie family', () => {
     createChromiumCookieTestDatabase(targetCookiesPath, rows).close()
   }
 
-  it('never clears or reconstructs live Google cookies before importing', async () => {
+  it('bulk clears while excluding live Google cookies before importing', async () => {
     const sourceCookiesPath = seedSource([
       { domain: '.google.com', name: 'SID', value: 'transplanted-sid' },
       { domain: '.example.com', name: 'session', value: 'new' }
@@ -186,9 +186,10 @@ describe('native Chromium import excludes the Google cookie family', () => {
       googleCookiesSkipped: 1,
       domains: ['example.com']
     })
-    expect(clearStorageDataMock).not.toHaveBeenCalled()
-    expect(cookiesRemoveMock).toHaveBeenCalledOnce()
-    expect(cookiesRemoveMock).toHaveBeenCalledWith('https://example.com/', 'stale')
+    expect(clearDataMock.mock.calls).toEqual([
+      [{ dataTypes: ['cookies'], excludeOrigins: ['https://google.com'] }]
+    ])
+    expect(cookiesRemoveMock).not.toHaveBeenCalled()
     expect(cookiesSetMock.mock.calls.map(([details]) => details.domain)).toEqual(['.example.com'])
   })
 
@@ -239,7 +240,7 @@ describe('native Chromium import excludes the Google cookie family', () => {
       domains: []
     })
     expect(execFileSyncMock).not.toHaveBeenCalled()
-    expect(clearStorageDataMock).not.toHaveBeenCalled()
+    expect(clearDataMock).not.toHaveBeenCalled()
     expect(cookiesSetMock).not.toHaveBeenCalled()
   })
 
@@ -284,12 +285,13 @@ describe('native Chromium import excludes the Google cookie family', () => {
         throw new Error('cookie store unavailable')
       }
     })
+    clearDataMock.mockRejectedValue(new Error('storage busy'))
 
     const result = await importCookiesFromBrowser(chromeBrowser(sourceCookiesPath), 'persist:test')
 
     expect(result).toMatchObject({ ok: false })
     expect(result.ok || result.reason).toContain('Could not clear existing cookies')
-    expect(clearStorageDataMock).not.toHaveBeenCalled()
+    expect(clearDataMock).toHaveBeenCalledOnce()
     expect(cookiesRemoveMock.mock.calls.map(([, name]) => name)).toEqual(['removed-first', 'stale'])
     expect(cookiesSetMock).not.toHaveBeenCalled()
     expect(setPendingCookieImportMock).not.toHaveBeenCalled()

--- a/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
@@ -20,8 +20,10 @@ type CdpCookie = { name: string; value: string; partitionKey?: Record<string, un
 type FixtureResult = {
   beforePartitionKey: Record<string, unknown> | undefined
   clearError: string | null
+  bulkClearCalls: number
   remainingChips: CdpCookie[]
   remainingPlain: CdpCookie[]
+  remainingExcluded: CdpCookie[]
 }
 
 const EXPECTED_PARTITION_KEY = {
@@ -76,6 +78,9 @@ async function run() {
 
   await targetSession.cookies.set({ url: 'https://plain.example/', name: 'plain', value: 'stale', secure: true })
   await targetSession.cookies.set({ url: 'https://victim.example/', name: 'victim', value: 'stale', secure: true })
+  // Why (STA-4065): an excluded cookie is what forces the per-cookie path; without one the bulk
+  // fast path clears the jar in a single call and never exercises a partial-failure clear.
+  await targetSession.cookies.set({ url: 'https://accounts.google.com/', name: 'SID', value: 'live', secure: true })
   mark('removable cookies set')
 
   const store = {
@@ -88,9 +93,18 @@ async function run() {
     }
   }
 
+  let bulkClearCalls = 0
+  const clearSession = {
+    cookies: store,
+    clearData: async (options) => {
+      bulkClearCalls++
+      return targetSession.clearData(options)
+    }
+  }
+
   let clearError = null
   try {
-    await removeAllCookiesExcept(store, (cookie) => isNonTransplantableCookieDomain(cookie.domain ?? ''))
+    await removeAllCookiesExcept(clearSession, (cookie) => isNonTransplantableCookieDomain(cookie.domain ?? ''))
   } catch (error) {
     clearError = String(error?.message || error)
   }
@@ -104,8 +118,10 @@ async function run() {
   writeFileSync(resultPath, JSON.stringify({
     beforePartitionKey: beforeChips.partitionKey,
     clearError,
+    bulkClearCalls,
     remainingChips: project('chips-auth'),
-    remainingPlain: project('plain')
+    remainingPlain: project('plain'),
+    remainingExcluded: project('SID')
   }))
   debug.detach()
   window.destroy()
@@ -164,6 +180,9 @@ describe('non-Google partitioned cookie under a failed Electron cookie clear', (
     const result = await runFixture()
 
     expect(result.beforePartitionKey).toEqual(EXPECTED_PARTITION_KEY)
+    // Why (STA-4065): a bulk clear here would make every assertion below vacuous.
+    expect(result.bulkClearCalls).toBe(0)
+    expect(result.remainingExcluded.map(({ name }) => name)).toEqual(['SID'])
     expect(result.clearError).toContain('Could not clear existing cookies')
     // STA-4061: rollback rebuilt this cookie through cookies.set, which drops partitionKey.
     expect(

--- a/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
@@ -78,8 +78,8 @@ async function run() {
 
   await targetSession.cookies.set({ url: 'https://plain.example/', name: 'plain', value: 'stale', secure: true })
   await targetSession.cookies.set({ url: 'https://victim.example/', name: 'victim', value: 'stale', secure: true })
-  // Why (STA-4065): an excluded cookie is what forces the per-cookie path; without one the bulk
-  // fast path clears the jar in a single call and never exercises a partial-failure clear.
+  // Why: keep a live excluded cookie in the partial-failure fixture so the fallback proves it
+  // preserves that cookie while deleting the removable ones it can reach.
   await targetSession.cookies.set({ url: 'https://accounts.google.com/', name: 'SID', value: 'live', secure: true })
   mark('removable cookies set')
 

--- a/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
@@ -35,7 +35,7 @@ function buildFixtureMain(policyPath: string, resultPath: string): string {
   return `
 const { app, BrowserWindow, session } = require('electron')
 const { writeFileSync } = require('node:fs')
-const { removeAllCookiesExcept, isNonTransplantableCookieDomain } = require(${JSON.stringify(policyPath)})
+const { removeTransplantableCookies } = require(${JSON.stringify(policyPath)})
 const resultPath = ${JSON.stringify(resultPath)}
 let currentStep = 'starting'
 const mark = (step) => {
@@ -93,18 +93,20 @@ async function run() {
     }
   }
 
+  // Why: the bulk clear is the ordinary path now, so rejecting it is what routes this fixture onto
+  // the per-cookie fallback where a partial failure — and the old rollback — could happen at all.
   let bulkClearCalls = 0
   const clearSession = {
     cookies: store,
-    clearData: async (options) => {
+    clearData: async () => {
       bulkClearCalls++
-      return targetSession.clearData(options)
+      throw new Error('forced bulk clear failure')
     }
   }
 
   let clearError = null
   try {
-    await removeAllCookiesExcept(clearSession, (cookie) => isNonTransplantableCookieDomain(cookie.domain ?? ''))
+    await removeTransplantableCookies(clearSession)
   } catch (error) {
     clearError = String(error?.message || error)
   }
@@ -180,8 +182,9 @@ describe('non-Google partitioned cookie under a failed Electron cookie clear', (
     const result = await runFixture()
 
     expect(result.beforePartitionKey).toEqual(EXPECTED_PARTITION_KEY)
-    // Why (STA-4065): a bulk clear here would make every assertion below vacuous.
-    expect(result.bulkClearCalls).toBe(0)
+    // Why (STA-4065): the fallback is only reachable once the bulk clear has been tried and failed;
+    // if it ever succeeded here the partial-failure assertions below would be vacuous.
+    expect(result.bulkClearCalls).toBe(1)
     expect(result.remainingExcluded.map(({ name }) => name)).toEqual(['SID'])
     expect(result.clearError).toContain('Could not clear existing cookies')
     // STA-4061: rollback rebuilt this cookie through cookies.set, which drops partitionKey.

--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -20,7 +20,6 @@ type FixtureResult = {
   before: Record<string, unknown>
   after: Record<string, unknown>
   electronCookieKeys: string[]
-  unfilteredNames: string[]
   importResult: Record<string, unknown>
   remainingNames: string[]
 }
@@ -75,13 +74,26 @@ async function run() {
     value: 'remove-me',
     secure: true
   })
+  // Why: the excluded origin is HTTPS, so prove registrable-domain matching also keeps HTTP.
+  await targetSession.cookies.set({
+    url: 'http://mail.google.com/',
+    name: 'http-google',
+    value: 'live-http-value',
+    secure: false
+  })
+  await targetSession.cookies.set({
+    url: 'https://google.com/',
+    domain: '.google.com',
+    name: 'domain-google',
+    value: 'live-domain-value',
+    secure: true
+  })
   mark('ordinary cookie set')
 
   const beforeCookies = (await debug.sendCommand('Network.getAllCookies')).cookies
   const before = beforeCookies.find((cookie) => cookie.name === 'partitioned-google')
   const electronCookie = (await targetSession.cookies.get({ name: 'partitioned-google' }))[0]
   if (!before || !electronCookie) throw new Error('Partitioned fixture cookie was not created')
-  const unfilteredNames = (await targetSession.cookies.get({})).map((cookie) => cookie.name).sort()
   mark('cookies read')
 
   const importResult = await importCookiesFromBrowser({
@@ -102,7 +114,6 @@ async function run() {
     before,
     after,
     electronCookieKeys: Object.keys(electronCookie).sort(),
-    unfilteredNames,
     importResult,
     remainingNames: afterCookies.map((cookie) => cookie.name).sort()
   }))
@@ -187,14 +198,16 @@ describe('native Chromium excluded partition cookie under Electron', () => {
       hasCrossSiteAncestor: true
     })
     expect(result.electronCookieKeys).not.toContain('partitionKey')
-    // Why: the bulk-clear fast path is gated on an unfiltered get() seeing every excluded cookie,
-    // so a partitioned one going missing here would silently arm a jar-wide wipe.
-    expect(result.unfilteredNames).toEqual(['partitioned-google', 'stale'])
     expect(result.after).toEqual(result.before)
     expect(result.importResult).toMatchObject({
       ok: true,
       summary: { importedCookies: 1, domains: ['example.com'] }
     })
-    expect(result.remainingNames).toEqual(['imported', 'partitioned-google'])
+    expect(result.remainingNames).toEqual([
+      'domain-google',
+      'http-google',
+      'imported',
+      'partitioned-google'
+    ])
   }, 90_000)
 })

--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -20,6 +20,7 @@ type FixtureResult = {
   before: Record<string, unknown>
   after: Record<string, unknown>
   electronCookieKeys: string[]
+  unfilteredNames: string[]
   importResult: Record<string, unknown>
   remainingNames: string[]
 }
@@ -80,6 +81,7 @@ async function run() {
   const before = beforeCookies.find((cookie) => cookie.name === 'partitioned-google')
   const electronCookie = (await targetSession.cookies.get({ name: 'partitioned-google' }))[0]
   if (!before || !electronCookie) throw new Error('Partitioned fixture cookie was not created')
+  const unfilteredNames = (await targetSession.cookies.get({})).map((cookie) => cookie.name).sort()
   mark('cookies read')
 
   const importResult = await importCookiesFromBrowser({
@@ -100,6 +102,7 @@ async function run() {
     before,
     after,
     electronCookieKeys: Object.keys(electronCookie).sort(),
+    unfilteredNames,
     importResult,
     remainingNames: afterCookies.map((cookie) => cookie.name).sort()
   }))
@@ -184,6 +187,9 @@ describe('native Chromium excluded partition cookie under Electron', () => {
       hasCrossSiteAncestor: true
     })
     expect(result.electronCookieKeys).not.toContain('partitionKey')
+    // Why: the bulk-clear fast path is gated on an unfiltered get() seeing every excluded cookie,
+    // so a partitioned one going missing here would silently arm a jar-wide wipe.
+    expect(result.unfilteredNames).toEqual(['partitioned-google', 'stale'])
     expect(result.after).toEqual(result.before)
     expect(result.importResult).toMatchObject({
       ok: true,

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -211,7 +211,7 @@ type CookieClearMocks = {
   get: Mock
   remove: Mock
   set: Mock
-  clearStorageData: Mock
+  clearData: Mock
 }
 
 describe('removeAllCookiesExcept', () => {
@@ -222,13 +222,13 @@ describe('removeAllCookiesExcept', () => {
       set: vi.fn().mockResolvedValue(undefined),
       ...overrides
     }
-    const clearStorageData = overrides.clearStorageData ?? vi.fn().mockResolvedValue(undefined)
+    const clearData = overrides.clearData ?? vi.fn().mockResolvedValue(undefined)
     return {
-      session: { cookies: store, clearStorageData },
+      session: { cookies: store, clearData },
       get: store.get,
       remove: store.remove,
       set: store.set,
-      clearStorageData
+      clearData
     }
   }
 
@@ -236,7 +236,7 @@ describe('removeAllCookiesExcept', () => {
     isNonTransplantableCookieDomain(existingCookie.domain ?? '')
 
   it('never removes or reconstructs excluded Google cookies', async () => {
-    const { session, remove, set, clearStorageData } = clearSession([
+    const { session, remove, set, clearData } = clearSession([
       cookie('.google.com', 'SID'),
       cookie('accounts.google.com', 'ACCOUNT'),
       cookie('.example.com', 'session'),
@@ -245,7 +245,7 @@ describe('removeAllCookiesExcept', () => {
 
     await removeAllCookiesExcept(session, excludesNonTransplantable)
 
-    expect(clearStorageData).not.toHaveBeenCalled()
+    expect(clearData).not.toHaveBeenCalled()
     expect(remove.mock.calls).toEqual([
       ['https://example.com/', 'session'],
       ['https://other.test/scoped', 'tracker']
@@ -254,7 +254,7 @@ describe('removeAllCookiesExcept', () => {
   })
 
   it('bulk clears in one call when the jar holds nothing to preserve', async () => {
-    const { session, remove, set, clearStorageData } = clearSession([
+    const { session, remove, set, clearData } = clearSession([
       cookie('.example.com', 'session'),
       cookie('other.test', 'tracker', '/scoped'),
       cookie('notgoogle.com', 'lookalike')
@@ -262,39 +262,41 @@ describe('removeAllCookiesExcept', () => {
 
     await removeAllCookiesExcept(session, excludesNonTransplantable)
 
-    expect(clearStorageData.mock.calls).toEqual([[{ storages: ['cookies'] }]])
+    expect(clearData.mock.calls).toEqual([
+      [{ dataTypes: ['cookies'], excludeOrigins: ['https://google.com'] }]
+    ])
     expect(remove).not.toHaveBeenCalled()
     expect(set).not.toHaveBeenCalled()
   })
 
   it('touches nothing when the jar is already empty', async () => {
-    const { session, remove, clearStorageData } = clearSession([])
+    const { session, remove, clearData } = clearSession([])
 
     await removeAllCookiesExcept(session, excludesNonTransplantable)
 
-    expect(clearStorageData).not.toHaveBeenCalled()
+    expect(clearData).not.toHaveBeenCalled()
     expect(remove).not.toHaveBeenCalled()
   })
 
   it('bulk clears cookies the per-cookie path could never address', async () => {
-    const { session, clearStorageData } = clearSession([
+    const { session, clearData } = clearSession([
       { ...cookie('.example.com', 'session'), domain: '' }
     ])
 
     await removeAllCookiesExcept(session, excludesNonTransplantable)
 
-    expect(clearStorageData).toHaveBeenCalledOnce()
+    expect(clearData).toHaveBeenCalledOnce()
   })
 
   it('falls back to per-cookie removal when the bulk clear rejects', async () => {
-    const { session, remove, clearStorageData } = clearSession(
+    const { session, remove, clearData } = clearSession(
       [cookie('.example.com', 'session'), cookie('other.test', 'tracker')],
-      { clearStorageData: vi.fn().mockRejectedValue(new Error('storage busy')) }
+      { clearData: vi.fn().mockRejectedValue(new Error('storage busy')) }
     )
 
     await removeAllCookiesExcept(session, excludesNonTransplantable)
 
-    expect(clearStorageData).toHaveBeenCalledOnce()
+    expect(clearData).toHaveBeenCalledOnce()
     expect(remove.mock.calls).toEqual([
       ['https://example.com/', 'session'],
       ['https://other.test/', 'tracker']

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -303,6 +303,28 @@ describe('removeTransplantableCookies', () => {
     ])
   })
 
+  it('re-reads the jar after a rejected bulk clear', async () => {
+    const beforeAttempt = [cookie('.removed.test', 'gone-before-fallback')]
+    const afterAttempt = [
+      cookie('.google.com', 'SID'),
+      cookie('.survivor.test', 'survived'),
+      cookie('.arrived.test', 'arrived-during-clear')
+    ]
+    const get = vi.fn().mockResolvedValueOnce(beforeAttempt).mockResolvedValueOnce(afterAttempt)
+    const { session, remove } = clearSession(beforeAttempt, {
+      get,
+      clearData: rejectingBulkClear()
+    })
+
+    await removeTransplantableCookies(session)
+
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(remove.mock.calls).toEqual([
+      ['https://survivor.test/', 'survived'],
+      ['https://arrived.test/', 'arrived-during-clear']
+    ])
+  })
+
   // Why: the fallback carries the same exclusion as the bulk call, so a rejected clearData must
   // not become the path that finally deletes a live Google session.
   it('still preserves Google cookies on the per-cookie fallback', async () => {

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -6,7 +6,7 @@ import {
   isNonTransplantableCookieDomain,
   NON_TRANSPLANTABLE_HOST_KEY_SQL,
   normalizeCookieDomain,
-  removeAllCookiesExcept,
+  removeTransplantableCookies,
   replaceCookiesForImportedDomains
 } from './browser-cookie-import-policy'
 
@@ -214,7 +214,9 @@ type CookieClearMocks = {
   clearData: Mock
 }
 
-describe('removeAllCookiesExcept', () => {
+describe('removeTransplantableCookies', () => {
+  const rejectingBulkClear = () => vi.fn().mockRejectedValue(new Error('storage busy'))
+
   function clearSession(cookies: Cookie[], overrides: Partial<CookieClearMocks> = {}) {
     const store = {
       get: vi.fn().mockResolvedValue(cookies),
@@ -232,10 +234,9 @@ describe('removeAllCookiesExcept', () => {
     }
   }
 
-  const excludesNonTransplantable = (existingCookie: Cookie): boolean =>
-    isNonTransplantableCookieDomain(existingCookie.domain ?? '')
-
-  it('never removes or reconstructs excluded Google cookies', async () => {
+  // Why (STA-4065): the bulk call is the ordinary path even when the jar holds cookies to keep —
+  // excludeOrigins preserves the whole google.com family, verified against real Electron.
+  it('clears a jar holding Google cookies in one call that excludes them', async () => {
     const { session, remove, set, clearData } = clearSession([
       cookie('.google.com', 'SID'),
       cookie('accounts.google.com', 'ACCOUNT'),
@@ -243,13 +244,12 @@ describe('removeAllCookiesExcept', () => {
       cookie('other.test', 'tracker', '/scoped')
     ])
 
-    await removeAllCookiesExcept(session, excludesNonTransplantable)
+    await removeTransplantableCookies(session)
 
-    expect(clearData).not.toHaveBeenCalled()
-    expect(remove.mock.calls).toEqual([
-      ['https://example.com/', 'session'],
-      ['https://other.test/scoped', 'tracker']
+    expect(clearData.mock.calls).toEqual([
+      [{ dataTypes: ['cookies'], excludeOrigins: ['https://google.com'] }]
     ])
+    expect(remove).not.toHaveBeenCalled()
     expect(set).not.toHaveBeenCalled()
   })
 
@@ -260,7 +260,7 @@ describe('removeAllCookiesExcept', () => {
       cookie('notgoogle.com', 'lookalike')
     ])
 
-    await removeAllCookiesExcept(session, excludesNonTransplantable)
+    await removeTransplantableCookies(session)
 
     expect(clearData.mock.calls).toEqual([
       [{ dataTypes: ['cookies'], excludeOrigins: ['https://google.com'] }]
@@ -272,7 +272,7 @@ describe('removeAllCookiesExcept', () => {
   it('touches nothing when the jar is already empty', async () => {
     const { session, remove, clearData } = clearSession([])
 
-    await removeAllCookiesExcept(session, excludesNonTransplantable)
+    await removeTransplantableCookies(session)
 
     expect(clearData).not.toHaveBeenCalled()
     expect(remove).not.toHaveBeenCalled()
@@ -283,7 +283,7 @@ describe('removeAllCookiesExcept', () => {
       { ...cookie('.example.com', 'session'), domain: '' }
     ])
 
-    await removeAllCookiesExcept(session, excludesNonTransplantable)
+    await removeTransplantableCookies(session)
 
     expect(clearData).toHaveBeenCalledOnce()
   })
@@ -291,16 +291,34 @@ describe('removeAllCookiesExcept', () => {
   it('falls back to per-cookie removal when the bulk clear rejects', async () => {
     const { session, remove, clearData } = clearSession(
       [cookie('.example.com', 'session'), cookie('other.test', 'tracker')],
-      { clearData: vi.fn().mockRejectedValue(new Error('storage busy')) }
+      { clearData: rejectingBulkClear() }
     )
 
-    await removeAllCookiesExcept(session, excludesNonTransplantable)
+    await removeTransplantableCookies(session)
 
     expect(clearData).toHaveBeenCalledOnce()
     expect(remove.mock.calls).toEqual([
       ['https://example.com/', 'session'],
       ['https://other.test/', 'tracker']
     ])
+  })
+
+  // Why: the fallback carries the same exclusion as the bulk call, so a rejected clearData must
+  // not become the path that finally deletes a live Google session.
+  it('still preserves Google cookies on the per-cookie fallback', async () => {
+    const { session, remove, set } = clearSession(
+      [
+        cookie('.google.com', 'SID'),
+        cookie('accounts.google.com', 'ACCOUNT'),
+        cookie('.example.com', 'session')
+      ],
+      { clearData: rejectingBulkClear() }
+    )
+
+    await removeTransplantableCookies(session)
+
+    expect(remove.mock.calls).toEqual([['https://example.com/', 'session']])
+    expect(set).not.toHaveBeenCalled()
   })
 
   // Why (STA-4061): reconstructing a removed cookie loses its partition key, and the snapshot
@@ -314,6 +332,7 @@ describe('removeAllCookiesExcept', () => {
         cookie('.example.com', 'third', '/three')
       ],
       {
+        clearData: rejectingBulkClear(),
         remove: vi.fn().mockImplementation(async (_url: string, name: string) => {
           if (name === 'second') {
             throw new Error('store unavailable')
@@ -322,7 +341,7 @@ describe('removeAllCookiesExcept', () => {
       }
     )
 
-    await expect(removeAllCookiesExcept(session, excludesNonTransplantable)).rejects.toThrow(
+    await expect(removeTransplantableCookies(session)).rejects.toThrow(
       'the session was left partially cleared'
     )
     expect(remove).toHaveBeenCalledTimes(3)
@@ -342,6 +361,7 @@ describe('removeAllCookiesExcept', () => {
         ...Array.from({ length: 12 }, (_, index) => cookie('.example.com', `${index}`))
       ],
       {
+        clearData: rejectingBulkClear(),
         remove: vi.fn().mockImplementation(async () => {
           active++
           maxActive = Math.max(maxActive, active)
@@ -351,7 +371,7 @@ describe('removeAllCookiesExcept', () => {
       }
     )
 
-    const clearing = removeAllCookiesExcept(session, excludesNonTransplantable)
+    const clearing = removeTransplantableCookies(session)
     await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(8))
     expect(maxActive).toBe(8)
     releaseRemovals?.()
@@ -373,6 +393,7 @@ describe('removeAllCookiesExcept', () => {
         { ...cookie('example.com', 'session'), hostOnly: true }
       ],
       {
+        clearData: rejectingBulkClear(),
         remove: vi
           .fn()
           .mockImplementationOnce(() => firstReleased)
@@ -380,7 +401,7 @@ describe('removeAllCookiesExcept', () => {
       }
     )
 
-    const clearing = removeAllCookiesExcept(session, excludesNonTransplantable)
+    const clearing = removeTransplantableCookies(session)
     await vi.waitFor(() => expect(remove).toHaveBeenCalledOnce())
     releaseFirst?.()
     await clearing

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type Mock } from 'vitest'
 import { DatabaseSync } from 'node:sqlite'
 import type { Cookie } from 'electron'
 import {
@@ -207,23 +207,45 @@ describe('NON_TRANSPLANTABLE_HOST_KEY_SQL', () => {
   })
 })
 
+type CookieClearMocks = {
+  get: Mock
+  remove: Mock
+  set: Mock
+  clearStorageData: Mock
+}
+
 describe('removeAllCookiesExcept', () => {
+  function clearSession(cookies: Cookie[], overrides: Partial<CookieClearMocks> = {}) {
+    const store = {
+      get: vi.fn().mockResolvedValue(cookies),
+      remove: vi.fn().mockResolvedValue(undefined),
+      set: vi.fn().mockResolvedValue(undefined),
+      ...overrides
+    }
+    const clearStorageData = overrides.clearStorageData ?? vi.fn().mockResolvedValue(undefined)
+    return {
+      session: { cookies: store, clearStorageData },
+      get: store.get,
+      remove: store.remove,
+      set: store.set,
+      clearStorageData
+    }
+  }
+
+  const excludesNonTransplantable = (existingCookie: Cookie): boolean =>
+    isNonTransplantableCookieDomain(existingCookie.domain ?? '')
+
   it('never removes or reconstructs excluded Google cookies', async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue([
-        cookie('.google.com', 'SID'),
-        cookie('accounts.google.com', 'ACCOUNT'),
-        cookie('.example.com', 'session'),
-        cookie('other.test', 'tracker', '/scoped')
-      ])
-    const remove = vi.fn().mockResolvedValue(undefined)
-    const set = vi.fn().mockResolvedValue(undefined)
+    const { session, remove, set, clearStorageData } = clearSession([
+      cookie('.google.com', 'SID'),
+      cookie('accounts.google.com', 'ACCOUNT'),
+      cookie('.example.com', 'session'),
+      cookie('other.test', 'tracker', '/scoped')
+    ])
 
-    await removeAllCookiesExcept({ get, remove }, (existingCookie) =>
-      isNonTransplantableCookieDomain(existingCookie.domain ?? '')
-    )
+    await removeAllCookiesExcept(session, excludesNonTransplantable)
 
+    expect(clearStorageData).not.toHaveBeenCalled()
     expect(remove.mock.calls).toEqual([
       ['https://example.com/', 'session'],
       ['https://other.test/scoped', 'tracker']
@@ -231,54 +253,103 @@ describe('removeAllCookiesExcept', () => {
     expect(set).not.toHaveBeenCalled()
   })
 
+  it('bulk clears in one call when the jar holds nothing to preserve', async () => {
+    const { session, remove, set, clearStorageData } = clearSession([
+      cookie('.example.com', 'session'),
+      cookie('other.test', 'tracker', '/scoped'),
+      cookie('notgoogle.com', 'lookalike')
+    ])
+
+    await removeAllCookiesExcept(session, excludesNonTransplantable)
+
+    expect(clearStorageData.mock.calls).toEqual([[{ storages: ['cookies'] }]])
+    expect(remove).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('touches nothing when the jar is already empty', async () => {
+    const { session, remove, clearStorageData } = clearSession([])
+
+    await removeAllCookiesExcept(session, excludesNonTransplantable)
+
+    expect(clearStorageData).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('bulk clears cookies the per-cookie path could never address', async () => {
+    const { session, clearStorageData } = clearSession([
+      { ...cookie('.example.com', 'session'), domain: '' }
+    ])
+
+    await removeAllCookiesExcept(session, excludesNonTransplantable)
+
+    expect(clearStorageData).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to per-cookie removal when the bulk clear rejects', async () => {
+    const { session, remove, clearStorageData } = clearSession(
+      [cookie('.example.com', 'session'), cookie('other.test', 'tracker')],
+      { clearStorageData: vi.fn().mockRejectedValue(new Error('storage busy')) }
+    )
+
+    await removeAllCookiesExcept(session, excludesNonTransplantable)
+
+    expect(clearStorageData).toHaveBeenCalledOnce()
+    expect(remove.mock.calls).toEqual([
+      ['https://example.com/', 'session'],
+      ['https://other.test/', 'tracker']
+    ])
+  })
+
   // Why (STA-4061): reconstructing a removed cookie loses its partition key, and the snapshot
   // cannot say which cookies had one, so a failed clear must stay failed.
   it('never reconstructs removed cookies when another removal fails', async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue([
+    const { session, remove, set } = clearSession(
+      [
         cookie('.google.com', 'SID'),
         cookie('.example.com', 'first', '/one'),
         cookie('.example.com', 'second', '/two'),
         cookie('.example.com', 'third', '/three')
-      ])
-    const remove = vi.fn().mockImplementation(async (_url: string, name: string) => {
-      if (name === 'second') {
-        throw new Error('store unavailable')
+      ],
+      {
+        remove: vi.fn().mockImplementation(async (_url: string, name: string) => {
+          if (name === 'second') {
+            throw new Error('store unavailable')
+          }
+        })
       }
-    })
-    const set = vi.fn().mockResolvedValue(undefined)
+    )
 
-    await expect(
-      removeAllCookiesExcept({ get, remove }, (existingCookie) =>
-        isNonTransplantableCookieDomain(existingCookie.domain ?? '')
-      )
-    ).rejects.toThrow('the session was left partially cleared')
+    await expect(removeAllCookiesExcept(session, excludesNonTransplantable)).rejects.toThrow(
+      'the session was left partially cleared'
+    )
     expect(remove).toHaveBeenCalledTimes(3)
     expect(set).not.toHaveBeenCalled()
   })
 
   it('bounds parallel removals so large cookie jars do not clear serially or fan out', async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue(
-        Array.from({ length: 12 }, (_, index) => cookie('.example.com', `${index}`))
-      )
     let releaseRemovals: (() => void) | undefined
     const removalsReleased = new Promise<void>((resolve) => {
       releaseRemovals = resolve
     })
     let active = 0
     let maxActive = 0
-    const remove = vi.fn().mockImplementation(async () => {
-      active++
-      maxActive = Math.max(maxActive, active)
-      await removalsReleased
-      active--
-    })
-    const set = vi.fn().mockResolvedValue(undefined)
+    const { session, remove, set } = clearSession(
+      [
+        cookie('.google.com', 'SID'),
+        ...Array.from({ length: 12 }, (_, index) => cookie('.example.com', `${index}`))
+      ],
+      {
+        remove: vi.fn().mockImplementation(async () => {
+          active++
+          maxActive = Math.max(maxActive, active)
+          await removalsReleased
+          active--
+        })
+      }
+    )
 
-    const clearing = removeAllCookiesExcept({ get, remove }, () => false)
+    const clearing = removeAllCookiesExcept(session, excludesNonTransplantable)
     await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(8))
     expect(maxActive).toBe(8)
     releaseRemovals?.()
@@ -289,22 +360,25 @@ describe('removeAllCookiesExcept', () => {
   })
 
   it('serializes cookies that share Electron removal coordinates', async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue([
-        cookie('.example.com', 'session'),
-        { ...cookie('example.com', 'session'), hostOnly: true }
-      ])
     let releaseFirst: (() => void) | undefined
     const firstReleased = new Promise<void>((resolve) => {
       releaseFirst = resolve
     })
-    const remove = vi
-      .fn()
-      .mockImplementationOnce(() => firstReleased)
-      .mockResolvedValueOnce(undefined)
+    const { session, remove } = clearSession(
+      [
+        cookie('.google.com', 'SID'),
+        cookie('.example.com', 'session'),
+        { ...cookie('example.com', 'session'), hostOnly: true }
+      ],
+      {
+        remove: vi
+          .fn()
+          .mockImplementationOnce(() => firstReleased)
+          .mockResolvedValueOnce(undefined)
+      }
+    )
 
-    const clearing = removeAllCookiesExcept({ get, remove }, () => false)
+    const clearing = removeAllCookiesExcept(session, excludesNonTransplantable)
     await vi.waitFor(() => expect(remove).toHaveBeenCalledOnce())
     releaseFirst?.()
     await clearing

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -211,32 +211,36 @@ export type CookieClearSession = {
 // can downgrade a partitioned (CHIPS) cookie into an unpartitioned one — and nothing in the
 // snapshot says which cookies are at risk. A partially cleared jar is a retryable import failure;
 // a downgraded cookie is unrecoverable auth-state corruption that survives restart.
-export async function removeAllCookiesExcept(
-  targetSession: CookieClearSession,
-  isExcluded: (cookie: Cookie) => boolean
+// Why (STA-4065): the exclusion is module state rather than a parameter so the predicate and the
+// origins the bulk clear preserves cannot drift apart — a caller-supplied predicate that disagreed
+// with NON_TRANSPLANTABLE_DOMAINS would silently delete a cookie the bulk call is meant to keep.
+export async function removeTransplantableCookies(
+  targetSession: CookieClearSession
 ): Promise<void> {
   const store = targetSession.cookies
   const existingCookies = await store.get({})
+  if (existingCookies.length === 0) {
+    return
+  }
 
-  // Why: an unfiltered get() is the whole jar, so no exclusion in it means nothing to preserve and
-  // one bulk clear can replace a remove() per cookie. An empty jar needs neither.
-  if (existingCookies.length > 0 && !existingCookies.some(isExcluded)) {
-    try {
-      // Why: exclusions protect a non-transplantable cookie arriving between snapshot and clear.
-      await targetSession.clearData({
-        dataTypes: ['cookies'],
-        excludeOrigins: NON_TRANSPLANTABLE_CLEAR_EXCLUDED_ORIGINS
-      })
-      return
-    } catch {
-      // Why: a rejected bulk clear can still have emptied part of the jar, so fall through to the
-      // per-cookie path and let it re-remove whatever survived.
-    }
+  // Why (STA-4065): measured on Electron 43, excludeOrigins preserves the whole registrable
+  // family — host, leading-dot, subdomain, and partitioned Google cookies — so one call replaces a
+  // remove() per cookie even when the jar holds cookies to keep. That is the ordinary case here:
+  // this import exists for Google, so a Google cookie is usually present.
+  try {
+    await targetSession.clearData({
+      dataTypes: ['cookies'],
+      excludeOrigins: NON_TRANSPLANTABLE_CLEAR_EXCLUDED_ORIGINS
+    })
+    return
+  } catch {
+    // Why: a rejected bulk clear can still have emptied part of the jar, so fall through to the
+    // per-cookie path and let it re-remove whatever survived.
   }
 
   const removableGroups = new Map<string, { cookie: Cookie; url: string }[]>()
   for (const cookie of existingCookies) {
-    if (isExcluded(cookie)) {
+    if (isNonTransplantableCookieDomain(cookie.domain ?? '')) {
       continue
     }
     const domain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -230,7 +230,7 @@ export async function removeAllCookiesExcept(
       return
     } catch {
       // Why: a rejected bulk clear can still have emptied part of the jar, so fall through to the
-      // per-cookie path, which re-removes whatever survived and keeps its rollback.
+      // per-cookie path and let it re-remove whatever survived.
     }
   }
 

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -1,4 +1,4 @@
-import type { Cookie, Cookies } from 'electron'
+import type { Cookie, Cookies, Session } from 'electron'
 import { parse as parseDomain } from 'psl'
 import { mapSettledWithConcurrency } from '../../shared/map-with-concurrency'
 
@@ -196,6 +196,12 @@ export async function restoreImportedDomainCookies(
   }
 }
 
+// Why (STA-4061): 'set' stays out so the lossy partition-dropping reconstruction cannot return.
+export type CookieClearSession = {
+  cookies: Pick<Cookies, 'get' | 'remove'>
+  clearStorageData: Session['clearStorageData']
+}
+
 // Why: Electron cannot round-trip partition identity, so excluded cookies must never be removed.
 // Why (STA-4061): the same gap forbids rolling a partial clear back. cookies.get() omits
 // partitionKey and cookies.set() silently drops it, so every reconstruction is a coin flip that
@@ -203,10 +209,24 @@ export async function restoreImportedDomainCookies(
 // snapshot says which cookies are at risk. A partially cleared jar is a retryable import failure;
 // a downgraded cookie is unrecoverable auth-state corruption that survives restart.
 export async function removeAllCookiesExcept(
-  store: Pick<Cookies, 'get' | 'remove'>,
+  targetSession: CookieClearSession,
   isExcluded: (cookie: Cookie) => boolean
 ): Promise<void> {
+  const store = targetSession.cookies
   const existingCookies = await store.get({})
+
+  // Why: an unfiltered get() is the whole jar, so no exclusion in it means nothing to preserve and
+  // one bulk clear can replace a remove() per cookie. An empty jar needs neither.
+  if (existingCookies.length > 0 && !existingCookies.some(isExcluded)) {
+    try {
+      await targetSession.clearStorageData({ storages: ['cookies'] })
+      return
+    } catch {
+      // Why: a rejected bulk clear can still have emptied part of the jar, so fall through to the
+      // per-cookie path, which re-removes whatever survived and keeps its rollback.
+    }
+  }
+
   const removableGroups = new Map<string, { cookie: Cookie; url: string }[]>()
   for (const cookie of existingCookies) {
     if (isExcluded(cookie)) {

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -59,6 +59,8 @@ export function normalizeCookieImportDomain(domain: string): string | null {
 // it is copied. Signing in directly inside Orca is the only path that produces a working
 // session, so an import must never write these cookies and never remove them either — the
 // live session is always more valuable than anything an import could put in its place.
+// Entries must be canonical lowercase ASCII (punycode) registrable domains, never subdomains or
+// public suffixes, because clearData derives one excluded origin and matches at that boundary.
 // Adding a site is one entry here.
 // youtube.com is deliberately NOT listed: YouTube accepts a transplanted session and re-issues
 // its cookies via the accounts.youtube.com relay, so excluding it would silently drop imports
@@ -218,8 +220,8 @@ export async function removeTransplantableCookies(
   targetSession: CookieClearSession
 ): Promise<void> {
   const store = targetSession.cookies
-  const existingCookies = await store.get({})
-  if (existingCookies.length === 0) {
+  const initialCookies = await store.get({})
+  if (initialCookies.length === 0) {
     return
   }
 
@@ -234,10 +236,11 @@ export async function removeTransplantableCookies(
     })
     return
   } catch {
-    // Why: a rejected bulk clear can still have emptied part of the jar, so fall through to the
-    // per-cookie path and let it re-remove whatever survived.
+    // Why: a rejected bulk clear can still have changed the jar, so the fallback must act on the
+    // survivors rather than stale removal coordinates from before the attempt.
   }
 
+  const existingCookies = await store.get({})
   const removableGroups = new Map<string, { cookie: Cookie; url: string }[]>()
   for (const cookie of existingCookies) {
     if (isNonTransplantableCookieDomain(cookie.domain ?? '')) {

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -64,6 +64,9 @@ export function normalizeCookieImportDomain(domain: string): string | null {
 // its cookies via the accounts.youtube.com relay, so excluding it would silently drop imports
 // users actually asked for.
 const NON_TRANSPLANTABLE_DOMAINS = ['google.com'] as const
+const NON_TRANSPLANTABLE_CLEAR_EXCLUDED_ORIGINS = NON_TRANSPLANTABLE_DOMAINS.map(
+  (root) => `https://${root}`
+)
 const COOKIE_CLEAR_CONCURRENCY = 8
 
 export function isNonTransplantableCookieDomain(domain: string): boolean {
@@ -199,7 +202,7 @@ export async function restoreImportedDomainCookies(
 // Why (STA-4061): 'set' stays out so the lossy partition-dropping reconstruction cannot return.
 export type CookieClearSession = {
   cookies: Pick<Cookies, 'get' | 'remove'>
-  clearStorageData: Session['clearStorageData']
+  clearData: Session['clearData']
 }
 
 // Why: Electron cannot round-trip partition identity, so excluded cookies must never be removed.
@@ -219,7 +222,11 @@ export async function removeAllCookiesExcept(
   // one bulk clear can replace a remove() per cookie. An empty jar needs neither.
   if (existingCookies.length > 0 && !existingCookies.some(isExcluded)) {
     try {
-      await targetSession.clearStorageData({ storages: ['cookies'] })
+      // Why: exclusions protect a non-transplantable cookie arriving between snapshot and clear.
+      await targetSession.clearData({
+        dataTypes: ['cookies'],
+        excludeOrigins: NON_TRANSPLANTABLE_CLEAR_EXCLUDED_ORIGINS
+      })
       return
     } catch {
       // Why: a rejected bulk clear can still have emptied part of the jar, so fall through to the

--- a/src/main/browser/browser-cookie-import-replacement.test.ts
+++ b/src/main/browser/browser-cookie-import-replacement.test.ts
@@ -168,7 +168,7 @@ describe('validated cookie replacement', () => {
 })
 
 describe('native Chromium integrity-cookie accounting', () => {
-  let clearStorageDataMock: ReturnType<typeof vi.fn>
+  let clearDataMock: ReturnType<typeof vi.fn>
   let cookiesSetMock: ReturnType<typeof vi.fn>
   let tmpDir: string
 
@@ -180,7 +180,7 @@ describe('native Chromium integrity-cookie accounting', () => {
     })
     clearPendingCookieImportMock.mockClear()
     setPendingCookieImportMock.mockClear()
-    clearStorageDataMock = vi.fn().mockResolvedValue(undefined)
+    clearDataMock = vi.fn().mockResolvedValue(undefined)
     cookiesSetMock = vi.fn().mockResolvedValue(undefined)
     sessionFromPartitionMock.mockReset().mockReturnValue({
       cookies: {
@@ -189,7 +189,7 @@ describe('native Chromium integrity-cookie accounting', () => {
         remove: vi.fn().mockResolvedValue(undefined),
         set: cookiesSetMock
       },
-      clearStorageData: clearStorageDataMock
+      clearData: clearDataMock
     })
   })
 
@@ -252,7 +252,7 @@ describe('native Chromium integrity-cookie accounting', () => {
         googleCookiesSkipped: 2,
         domains: []
       })
-      expect(clearStorageDataMock).not.toHaveBeenCalled()
+      expect(clearDataMock).not.toHaveBeenCalled()
       expect(cookiesSetMock).not.toHaveBeenCalled()
       expect(setPendingCookieImportMock).not.toHaveBeenCalled()
       expect(clearPendingCookieImportMock).not.toHaveBeenCalled()

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -423,7 +423,7 @@ describe('importCookiesFromBrowser Chromium', () => {
   let cookiesSetMock: ReturnType<typeof vi.fn>
   let cookiesRemoveMock: ReturnType<typeof vi.fn>
   let cookiesFlushStoreMock: ReturnType<typeof vi.fn>
-  let clearStorageDataMock: ReturnType<typeof vi.fn>
+  let clearDataMock: ReturnType<typeof vi.fn>
   let setUserAgentMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
@@ -431,7 +431,7 @@ describe('importCookiesFromBrowser Chromium', () => {
     cookiesSetMock = vi.fn().mockResolvedValue(undefined)
     cookiesRemoveMock = vi.fn().mockResolvedValue(undefined)
     cookiesFlushStoreMock = vi.fn().mockResolvedValue(undefined)
-    clearStorageDataMock = vi.fn().mockResolvedValue(undefined)
+    clearDataMock = vi.fn().mockResolvedValue(undefined)
     setUserAgentMock = vi.fn()
     appGetPathMock.mockReset()
     appGetPathMock.mockReturnValue(join(tmpDir, 'userData'))
@@ -450,7 +450,7 @@ describe('importCookiesFromBrowser Chromium', () => {
         remove: cookiesRemoveMock,
         flushStore: cookiesFlushStoreMock
       },
-      clearStorageData: clearStorageDataMock,
+      clearData: clearDataMock,
       setUserAgent: setUserAgentMock
     })
   })
@@ -511,7 +511,7 @@ describe('importCookiesFromBrowser Chromium', () => {
         ['', '-wal', '-shm'].map((suffix) => readFileSync(sourceCookiesPath + suffix))
       ).toEqual(sourceFilesBefore)
       expect(cookiesRemoveMock).not.toHaveBeenCalled()
-      expect(clearStorageDataMock).not.toHaveBeenCalled()
+      expect(clearDataMock).not.toHaveBeenCalled()
       // Why: STA-3514 — imports must never impersonate the source browser; the
       // session keeps the engine UA the registry set at startup.
       expect(setUserAgentMock).not.toHaveBeenCalled()

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -80,7 +80,7 @@ import {
   NON_TRANSPLANTABLE_HOST_KEY_SQL,
   normalizeCookieDomain,
   normalizeCookieImportDomain,
-  removeAllCookiesExcept,
+  removeTransplantableCookies,
   replaceCookiesForImportedDomains,
   restoreImportedDomainCookies,
   type CookieImportMode
@@ -1780,9 +1780,7 @@ export async function importCookiesFromBrowser(
     // Why: clear stale cookies first; mixing them with the imported set makes sites reject the
     // session. Non-transplantable families are exempt — nothing was imported for them, and their
     // live session is the only one that works.
-    await removeAllCookiesExcept(targetSession, (cookie) =>
-      isNonTransplantableCookieDomain(cookie.domain ?? '')
-    )
+    await removeTransplantableCookies(targetSession)
     diag(
       `  cleared existing session cookies before loading ${decryptedCookies.length} imported cookies`
     )

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1780,7 +1780,7 @@ export async function importCookiesFromBrowser(
     // Why: clear stale cookies first; mixing them with the imported set makes sites reject the
     // session. Non-transplantable families are exempt — nothing was imported for them, and their
     // live session is the only one that works.
-    await removeAllCookiesExcept(targetSession.cookies, (cookie) =>
+    await removeAllCookiesExcept(targetSession, (cookie) =>
       isNonTransplantableCookieDomain(cookie.domain ?? '')
     )
     diag(


### PR DESCRIPTION
## ELI5

Wiping the browser jar before a cookie import used to be one phone call. Since #14086 it is one phone call *per cookie* — 3,000 calls for a 3,000-cookie jar — because a few Google cookies must be left alone and it looked like Electron could only skip them one at a time. It turns out the single call can be told which cookies to spare. This PR makes it one phone call again, always, and hands it the list to leave alone.

## What Changed

`removeAllCookiesExcept(store, isExcluded)` becomes `removeTransplantableCookies(session)`:

- A non-empty jar is now **always** cleared with a single `clearData({ dataTypes: ['cookies'], excludeOrigins })`. There is no longer a gate that disables the bulk call when the jar holds cookies to preserve.
- The caller-supplied exclusion predicate is gone. The preserved set now has exactly one source of truth — `NON_TRANSPLANTABLE_DOMAINS` — which both `excludeOrigins` and the fallback filter derive from. A predicate that disagreed with that constant would have deleted the very cookies the bulk call is meant to keep, and the type system now makes that unrepresentable rather than merely unlikely.
- The per-cookie loop survives only as the fallback for a **rejected** bulk clear, carrying the same exclusion.
- An empty jar still calls neither.
- STA-4061's invariants are untouched: no rollback, and `cookies.set` remains unreachable from this path via `Pick<Cookies, 'get' | 'remove'>`.

One line at the call site in `browser-cookie-import.ts` now passes `targetSession` and no predicate.

## Why

PR #14086 (`fc7c2a1`) replaced a bulk clear with a per-cookie clear so that partitioned Google cookies survive an import — Electron cannot round-trip partition identity, so a removed-and-restored cookie comes back without its partition key. That is correct and must stay whenever something is excluded. But it applies unconditionally, including when the exclusion predicate matches nothing, where a jar-wide clear removes exactly the same set.

### Measured cost (STA-4065 notes latency was never measured, so it was)

Standalone Electron 43.1.0 / Chromium 150 main-process benchmark on macOS. Fresh `persist:` partition per trial, 3 trials each, 200 distinct eTLD+1 hosts, mixed secure/host-only/paths, jar size confirmed via `cookies.get({})` before each timed run. Removal URLs and grouping replicate `cookieRemovalUrl` + `mapSettledWithConcurrency(…, 8)` exactly.

| Cookies | Per-cookie `remove` × N, conc=8 (current) | Single `clearData` + `excludeOrigins` (shipped) | Speedup |
| ---: | ---: | ---: | ---: |
| 1,000 | **421 ms** median (403–478) | **7.6 ms** median (7.0–8.5) | ~56× |
| 3,000 | **1,764 ms** median (1,742–1,889) | **23.8 ms** median (20.9–25.6) | ~74× |

The exclusion costs essentially nothing: plain `clearData({dataTypes:['cookies']})` measured 9.3 ms / 22.7 ms and `clearStorageData({storages:['cookies']})` 7.9 ms / 21.3 ms over the same jars, so all three bulk calls are within noise of each other and all are two orders of magnitude below the per-cookie path.

The snapshot `get({})` itself is noise (1.5 ms at 1k, 4.8 ms at 3k), so the fast path costs nothing extra to decide. The per-cookie path degrades worse than linearly — 3× the cookies costs 4.2× the time (throughput falls from 2,375 to 1,700 removals/s) — so the gap widens on larger jars. The bulk clear left the jar at 0 immediately after `await` in every one of 30 timed trials (and still 0 after 50 ms), so it is empty-when-resolved on this build.

### Why the bulk call is safe with cookies to keep

The gate this PR removes was never what preserved Google cookies — `excludeOrigins` was. That was re-verified on real Electron 43.1.0 (Chrome 150) against a seeded `persist:` jar, reading the result back through CDP `Network.getAllCookies`:

| Seeded cookie | `excludeOrigins: ['https://google.com']` |
| --- | --- |
| `google.com` | **survived** |
| `accounts.google.com` | **survived** |
| `.google.com` (leading dot) | **survived** |
| `mail.google.com` | **survived** |
| partitioned CHIPS cookie on `accounts.google.com` | **survived** |
| `example.com` | deleted |
| `notgoogle.com` (lookalike) | deleted |
| partitioned CHIPS cookie on a non-Google host | deleted |

A real-Electron fixture additionally proves an **`http`-only, non-secure** `mail.google.com` cookie and a **domain-scoped** `.google.com` cookie both survive a real import, so the exclusion is not limited to secure host-only cookies. Listing every subdomain origin explicitly produced an identical result, so origin matching is applied at the registrable-domain level — exactly `isNonTransplantableCookieDomain`'s rule. The control run with `excludeOrigins: []` wiped the entire jar including both Google and CHIPS cookies, which proves the exclusion is what did the work rather than the jar happening to survive.

This also closes the TOCTOU that review found in the first revision, and closes it *better* than the gate did. The target partition can be live during an import, so a Google/CHIPS cookie set by an in-flight response after the snapshot but before the clear was invisible to any gate — no snapshot can see it. `excludeOrigins` is evaluated by Chromium at clear time, so a cookie that arrives in that window is still protected.

Scope note: **not** a partition-identity or rollback fix. STA-4061 (#14132) owns those and is already on `main`; this PR is rebased on it and preserves its invariants.

### Honest limitations

- `NON_TRANSPLANTABLE_DOMAINS` entries must be lowercase-ASCII **registrable** domains, never bare subdomains or public suffixes: `excludeOrigins` derives one `https://<entry>` origin per entry and Chromium applies the exclusion at the registrable-domain boundary. That invariant is now recorded at the constant, because it is not obvious from the call site.
- The fallback path is still per-cookie, so a rejected `clearData` on a 3,000-cookie jar still costs ~1.8 s. That is a degraded mode, not the normal one.

## Linked Issue

Fixes STA-4065 — https://linear.app/stably/issue/STA-4065

Rebased onto #14132 (STA-4061), which is now on `main`.

## Visual Proof

No UI change — this is a main-process clear-path speedup. Proof is from a live Orca Electron dev build of this branch (`Orca: brennanb2025/sta-4065-cookie-bulk-clear-fastpath`, CDP 9336), driven through the real Settings and browser-toolbar import surfaces.

### Import surface (Settings → Browser → Session & Cookies)

Chrome was detected with two profiles. Import was triggered from **stably.ai**.

![Settings import menu with Chrome profiles](https://github.com/user-attachments/assets/06ec939f-e9d2-4f64-9aca-2ecb64740897)

### Import completed

The Default profile flipped from “No cookies imported” to **Google Chrome (stably.ai)**. Store summary: **949 source cookies → 878 imported, 71 skipped** (Google / non-transplantable). 809 loaded in-memory; 69 need a restart (pre-existing fallback, not this PR).

![Profile after import](https://github.com/user-attachments/assets/3779f932-18a5-4677-a236-75cbd16970c0)

![Google-cookie skip toast after re-import](https://github.com/user-attachments/assets/f6f6c6e0-9301-4ebe-ad08-3c4e54a3d312)

### Fast-path evidence (honest: no HEAD~ before/after)

I did **not** disable the fast path or re-run HEAD~ in a second product build, so this is not a paired per-cookie vs `clearData` screenshot. What the running app *did* show:

A second import against the now-populated jar takes the `session.clearData({ dataTypes: ['cookies'], excludeOrigins: ['https://google.com'] })` path. (These screenshots predate the change that made the bulk call unconditional; that widening only makes this path fire *more* often, never less, so the timing below remains representative.) In-app `cookie-import-diag.log` timestamps for the **clear step only** (staging complete → “cleared existing session cookies”):

| Import | Jar at clear | Staging → cleared | Wall time |
| --- | --- | --- | ---: |
| 1 (empty jar; neither path) | 0 cookies | `01:38:24.967Z` → `01:38:24.969Z` | 2 ms |
| 2 (fast-path candidate) | ~809 cookies | `01:40:23.768Z` → `01:40:23.777Z` | **9 ms** |

9 ms to clear ~809 cookies matches the PR’s standalone `clearData` numbers (~7.6 ms median at 1,000) and is not the per-cookie path (~421 ms median at 1,000). The in-app log does not print `clearData` vs `remove`, so this is timing + predicate evidence, not a logged opcode.

### Browser still works after import

`https://example.com/` loads in the in-app browser. The toolbar **Import** hint is the other user-facing import surface.

![Browser loads example.com after import](https://github.com/user-attachments/assets/90b66e57-af57-4b93-a136-8be78000620f)

![Browser toolbar Import popover](https://github.com/user-attachments/assets/9421ad39-f8bf-4a3b-b90c-8f38ea80d416)

Imported cookies are live: `https://github.com/` opened as the signed-in **brennanb2025** dashboard (github.com was in the imported domain list).

![GitHub session after cookie import](https://github.com/user-attachments/assets/7f67dfdc-a96a-45f6-95d9-e0eb1e9516d7)

## Testing

macOS. Windows / Linux / SSH are unaffected: this is Electron main-process session API usage with no platform-conditional code, no filesystem paths, and no wire format.

- `npx vitest run --config config/vitest.config.ts src/main/browser/` — **36 files, 614 tests passed**
- `pnpm run typecheck:node` — clean
- `npx oxlint src/main/browser/` — clean; `npx oxfmt --check` — clean
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings across 5 changed files (native, type-aware, React Doctor)

Also fixed a test that my own change had quietly made vacuous: `browser-cookie-import.test.ts` mocked the session with `clearStorageData`, so its `expect(...).not.toHaveBeenCalled()` guard could no longer fail once the fast path moved to `clearData`. The mock now exposes `clearData`.

New/updated unit coverage in `browser-cookie-import-policy.test.ts`:
- **clears a jar holding Google cookies in one call that excludes them** — the widening's core claim; pins the exact `{ dataTypes: ['cookies'], excludeOrigins: ['https://google.com'] }` argument and asserts `remove` is never called
- bulk clears in one call when the jar holds nothing to preserve
- touches nothing when the jar is already empty
- bulk clears cookies the per-cookie path could never address (undeliverable removal URL)
- falls back to per-cookie removal when the bulk clear rejects
- **still preserves Google cookies on the per-cookie fallback** — a rejected `clearData` must not become the path that finally deletes a live Google session
- concurrency-bound, coordinate-serialization, and no-reconstruct tests retained, now driven through a rejecting bulk clear so they still reach the per-cookie path

- **re-reads the jar after a rejected bulk clear** — `clearData` can empty part of the jar before rejecting, so the fallback must act on survivors rather than pre-attempt coordinates

I verified the central new test is not vacuous by mutation: reinstating the old gate makes *exactly* `clears a jar holding Google cookies in one call that excludes them` fail, and nothing else.

### Two real bugs review caught in this revision

1. **Stale snapshot on the fallback.** A rejected `clearData` may already have emptied part of the jar. The per-cookie fallback was iterating the snapshot taken *before* the attempt — retrying removals for cookies that were already gone, and blind to any cookie that arrived during the clear. It now re-reads, on rejection only.
2. **Three vacuous fixtures.** `browser-cookie-import-google-exclusion.test.ts` and `browser-cookie-import-replacement.test.ts` mocked the session with `clearStorageData` after the implementation moved to `clearData`. The missing method threw a `TypeError`, the fallback's `catch` swallowed it, and those tests silently exercised the per-cookie path while asserting they covered exclusion. This predates the widening — it arrived with the `clearData` switch — and would have hidden a genuine regression in the bulk path.

Real-Electron coverage:
- `browser-cookie-import-partition.electron.test.ts` — unfiltered `cookies.get({})` returns a partitioned Google cookie
- `browser-cookie-import-partition-rollback.electron.test.ts` (STA-4061's fixture, carried forward) — now forces `clearData` to reject so the fixture still reaches the per-cookie partial-failure path, seeds a live Google cookie, and asserts the bulk call was attempted exactly once. Without this it would have passed **vacuously** under the new bulk path while testing nothing.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

N/A — internal.

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security / data loss:** the risk is an over-eager bulk clear wiping a cookie that must be preserved. Protection is `excludeOrigins`, evaluated by Chromium at clear time, measured on real Electron across host / leading-dot / subdomain / partitioned Google cookies plus a lookalike control. Removing the caller-supplied predicate leaves one source of truth for the preserved set.
- **Backwards compatibility:** no wire, IPC, or persisted format change. `removeAllCookiesExcept(store, isExcluded)` is renamed to `removeTransplantableCookies(session)`; it has exactly one non-test caller.
- **Performance:** the point of the PR; numbers above.
- **Cross-platform / SSH / Mobile:** main-process only, no platform branches; the browser cookie import is a desktop feature.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)



