### PR TITLE
fix(browser): never resurrect cookies after a failed import clear (STA-4061)

### DIFF
--- a/src/main/browser/browser-cookie-import-google-exclusion.test.ts
+++ b/src/main/browser/browser-cookie-import-google-exclusion.test.ts
@@ -267,7 +267,9 @@ describe('native Chromium import excludes the Google cookie family', () => {
     ])
   })
 
-  it('fails the import without reconstructing Google cookies when selective removal rejects', async () => {
+  // Why (STA-4061): reconstruction drops partition keys, so a rejected removal must not rebuild
+  // anything — not the excluded Google rows, and not the non-Google rows that were already gone.
+  it('fails the import without reconstructing any cookie when selective removal rejects', async () => {
     const sourceCookiesPath = seedSource([
       { domain: '.example.com', name: 'session', value: 'new' }
     ])
@@ -289,7 +291,7 @@ describe('native Chromium import excludes the Google cookie family', () => {
     expect(result.ok || result.reason).toContain('Could not clear existing cookies')
     expect(clearStorageDataMock).not.toHaveBeenCalled()
     expect(cookiesRemoveMock.mock.calls.map(([, name]) => name)).toEqual(['removed-first', 'stale'])
-    expect(cookiesSetMock.mock.calls.map(([details]) => details.name)).toEqual(['removed-first'])
+    expect(cookiesSetMock).not.toHaveBeenCalled()
     expect(setPendingCookieImportMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
@@ -1,0 +1,175 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { build as buildVite } from 'vite'
+
+const electronBinary = createRequire(import.meta.url)('electron') as string
+const fixtureRoots: string[] = []
+
+afterAll(() => {
+  for (const root of fixtureRoots) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+})
+
+type CdpCookie = { name: string; value: string; partitionKey?: Record<string, unknown> }
+
+type FixtureResult = {
+  beforePartitionKey: Record<string, unknown> | undefined
+  clearError: string | null
+  remainingChips: CdpCookie[]
+  remainingPlain: CdpCookie[]
+}
+
+const EXPECTED_PARTITION_KEY = {
+  topLevelSite: 'https://top.example',
+  hasCrossSiteAncestor: true
+}
+
+function buildFixtureMain(policyPath: string, resultPath: string): string {
+  return `
+const { app, BrowserWindow, session } = require('electron')
+const { writeFileSync } = require('node:fs')
+const { removeAllCookiesExcept, isNonTransplantableCookieDomain } = require(${JSON.stringify(policyPath)})
+const resultPath = ${JSON.stringify(resultPath)}
+let currentStep = 'starting'
+const mark = (step) => {
+  currentStep = step
+  writeFileSync(resultPath, JSON.stringify({ step }))
+}
+
+async function run() {
+  const timeout = setTimeout(() => {
+    writeFileSync(resultPath, JSON.stringify({ step: 'timed out after ' + currentStep }))
+    app.exit(1)
+  }, 20000)
+  await app.whenReady()
+  mark('ready')
+  const partition = 'persist:partition-rollback-cookie-test'
+  const targetSession = session.fromPartition(partition)
+  const window = new BrowserWindow({ show: false, webPreferences: { partition } })
+  mark('window created')
+  await window.loadURL('data:text/html,<title>cookie rollback fixture</title>')
+  mark('window loaded')
+  const debug = window.webContents.debugger
+  debug.attach('1.3')
+  mark('debugger attached')
+  await debug.sendCommand('Network.enable')
+  mark('network enabled')
+
+  // Only CDP can create a partitioned cookie; Electron's cookies API has no partitionKey.
+  await debug.sendCommand('Network.setCookie', {
+    url: 'https://app.acme-chips.test/',
+    name: 'chips-auth',
+    value: 'keep-me',
+    secure: true,
+    sameSite: 'None',
+    partitionKey: ${JSON.stringify(EXPECTED_PARTITION_KEY)}
+  })
+  const beforeChips = (await debug.sendCommand('Network.getAllCookies')).cookies
+    .find((cookie) => cookie.name === 'chips-auth')
+  if (!beforeChips || !beforeChips.partitionKey) throw new Error('CHIPS fixture cookie was not stored partitioned')
+  mark('partitioned cookie set')
+
+  await targetSession.cookies.set({ url: 'https://plain.example/', name: 'plain', value: 'stale', secure: true })
+  await targetSession.cookies.set({ url: 'https://victim.example/', name: 'victim', value: 'stale', secure: true })
+  mark('removable cookies set')
+
+  const store = {
+    get: (filter) => targetSession.cookies.get(filter),
+    set: (details) => targetSession.cookies.set(details),
+    // Why: one rejecting removal is what drove the old rollback; the rest still succeed.
+    remove: async (url, name) => {
+      if (name === 'victim') throw new Error('forced victim removal failure')
+      return targetSession.cookies.remove(url, name)
+    }
+  }
+
+  let clearError = null
+  try {
+    await removeAllCookiesExcept(store, (cookie) => isNonTransplantableCookieDomain(cookie.domain ?? ''))
+  } catch (error) {
+    clearError = String(error?.message || error)
+  }
+  mark('clear finished')
+
+  const afterCookies = (await debug.sendCommand('Network.getAllCookies')).cookies
+  const project = (name) => afterCookies
+    .filter((cookie) => cookie.name === name)
+    .map((cookie) => ({ name: cookie.name, value: cookie.value, partitionKey: cookie.partitionKey }))
+  clearTimeout(timeout)
+  writeFileSync(resultPath, JSON.stringify({
+    beforePartitionKey: beforeChips.partitionKey,
+    clearError,
+    remainingChips: project('chips-auth'),
+    remainingPlain: project('plain')
+  }))
+  debug.detach()
+  window.destroy()
+  app.exit(0)
+}
+
+run().catch((error) => {
+  writeFileSync(resultPath, JSON.stringify({ step: currentStep, error: String(error?.stack || error) }))
+  app.exit(1)
+})
+`
+}
+
+async function runFixture(): Promise<FixtureResult> {
+  const root = mkdtempSync(join(tmpdir(), 'orca-partition-rollback-'))
+  fixtureRoots.push(root)
+  const policyPath = join(root, 'browser-cookie-import-policy.cjs')
+  const resultPath = join(root, 'result.json')
+  const fixturePath = join(root, 'main.cjs')
+  await buildVite({
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      emptyOutDir: false,
+      lib: {
+        entry: join(process.cwd(), 'src/main/browser/browser-cookie-import-policy.ts'),
+        formats: ['cjs'],
+        fileName: () => 'browser-cookie-import-policy.cjs'
+      },
+      outDir: root,
+      target: 'node20',
+      rollupOptions: { external: ['electron', /^node:/] }
+    }
+  })
+  writeFileSync(fixturePath, buildFixtureMain(policyPath, resultPath))
+  const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
+  const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
+  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
+  const args =
+    process.platform === 'linux'
+      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
+      : electronArgs
+  const run = spawnSync(executable, args, {
+    encoding: 'utf8',
+    env,
+    timeout: 60_000
+  })
+  const fixtureResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
+  expect(run.error).toBeUndefined()
+  expect(run.status, `${fixtureResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
+  return JSON.parse(fixtureResult) as FixtureResult
+}
+
+describe('non-Google partitioned cookie under a failed Electron cookie clear', () => {
+  it('never resurrects a removed cookie without its partition key', async () => {
+    const result = await runFixture()
+
+    expect(result.beforePartitionKey).toEqual(EXPECTED_PARTITION_KEY)
+    expect(result.clearError).toContain('Could not clear existing cookies')
+    // STA-4061: rollback rebuilt this cookie through cookies.set, which drops partitionKey.
+    expect(
+      result.remainingChips.filter((cookie) => !cookie.partitionKey),
+      `chips-auth was downgraded to unpartitioned: ${JSON.stringify(result.remainingChips)}`
+    ).toEqual([])
+    expect(result.remainingPlain).toEqual([])
+  }, 90_000)
+})

--- a/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
@@ -160,15 +160,15 @@ async function runFixture(): Promise<FixtureResult> {
 }
 
 describe('non-Google partitioned cookie under a failed Electron cookie clear', () => {
-  it('never resurrects a removed cookie without its partition key', async () => {
+  it('never resurrects a removed partitioned cookie', async () => {
     const result = await runFixture()
 
     expect(result.beforePartitionKey).toEqual(EXPECTED_PARTITION_KEY)
     expect(result.clearError).toContain('Could not clear existing cookies')
     // STA-4061: rollback rebuilt this cookie through cookies.set, which drops partitionKey.
     expect(
-      result.remainingChips.filter((cookie) => !cookie.partitionKey),
-      `chips-auth was downgraded to unpartitioned: ${JSON.stringify(result.remainingChips)}`
+      result.remainingChips,
+      `chips-auth survived: ${JSON.stringify(result.remainingChips)}`
     ).toEqual([])
     expect(result.remainingPlain).toEqual([])
   }, 90_000)

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -220,7 +220,7 @@ describe('removeAllCookiesExcept', () => {
     const remove = vi.fn().mockResolvedValue(undefined)
     const set = vi.fn().mockResolvedValue(undefined)
 
-    await removeAllCookiesExcept({ get, remove, set }, (existingCookie) =>
+    await removeAllCookiesExcept({ get, remove }, (existingCookie) =>
       isNonTransplantableCookieDomain(existingCookie.domain ?? '')
     )
 
@@ -231,7 +231,9 @@ describe('removeAllCookiesExcept', () => {
     expect(set).not.toHaveBeenCalled()
   })
 
-  it('restores removed non-Google cookies when another removal fails', async () => {
+  // Why (STA-4061): reconstructing a removed cookie loses its partition key, and the snapshot
+  // cannot say which cookies had one, so a failed clear must stay failed.
+  it('never reconstructs removed cookies when another removal fails', async () => {
     const get = vi
       .fn()
       .mockResolvedValue([
@@ -248,12 +250,12 @@ describe('removeAllCookiesExcept', () => {
     const set = vi.fn().mockResolvedValue(undefined)
 
     await expect(
-      removeAllCookiesExcept({ get, remove, set }, (existingCookie) =>
+      removeAllCookiesExcept({ get, remove }, (existingCookie) =>
         isNonTransplantableCookieDomain(existingCookie.domain ?? '')
       )
-    ).rejects.toThrow('Could not clear existing cookies')
+    ).rejects.toThrow('the session was left partially cleared')
     expect(remove).toHaveBeenCalledTimes(3)
-    expect(set.mock.calls.map(([details]) => details.name).sort()).toEqual(['first', 'third'])
+    expect(set).not.toHaveBeenCalled()
   })
 
   it('bounds parallel removals so large cookie jars do not clear serially or fan out', async () => {
@@ -276,7 +278,7 @@ describe('removeAllCookiesExcept', () => {
     })
     const set = vi.fn().mockResolvedValue(undefined)
 
-    const clearing = removeAllCookiesExcept({ get, remove, set }, () => false)
+    const clearing = removeAllCookiesExcept({ get, remove }, () => false)
     await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(8))
     expect(maxActive).toBe(8)
     releaseRemovals?.()
@@ -301,9 +303,8 @@ describe('removeAllCookiesExcept', () => {
       .fn()
       .mockImplementationOnce(() => firstReleased)
       .mockResolvedValueOnce(undefined)
-    const set = vi.fn().mockResolvedValue(undefined)
 
-    const clearing = removeAllCookiesExcept({ get, remove, set }, () => false)
+    const clearing = removeAllCookiesExcept({ get, remove }, () => false)
     await vi.waitFor(() => expect(remove).toHaveBeenCalledOnce())
     releaseFirst?.()
     await clearing

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -197,8 +197,13 @@ export async function restoreImportedDomainCookies(
 }
 
 // Why: Electron cannot round-trip partition identity, so excluded cookies must never be removed.
+// Why (STA-4061): the same gap forbids rolling a partial clear back. cookies.get() omits
+// partitionKey and cookies.set() silently drops it, so every reconstruction is a coin flip that
+// can downgrade a partitioned (CHIPS) cookie into an unpartitioned one — and nothing in the
+// snapshot says which cookies are at risk. A partially cleared jar is a retryable import failure;
+// a downgraded cookie is unrecoverable auth-state corruption that survives restart.
 export async function removeAllCookiesExcept(
-  store: Pick<Cookies, 'get' | 'remove' | 'set'>,
+  store: Pick<Cookies, 'get' | 'remove'>,
   isExcluded: (cookie: Cookie) => boolean
 ): Promise<void> {
   const existingCookies = await store.get({})
@@ -218,7 +223,6 @@ export async function removeAllCookiesExcept(
     removableGroups.set(key, group)
   }
 
-  const removedCookies: Cookie[] = []
   const results = await mapSettledWithConcurrency(
     [...removableGroups.values()],
     COOKIE_CLEAR_CONCURRENCY,
@@ -226,22 +230,18 @@ export async function removeAllCookiesExcept(
       // Why: identical removal coordinates must stay ordered instead of racing.
       for (const { cookie, url } of group) {
         await store.remove(url, cookie.name)
-        removedCookies.push(cookie)
       }
     }
   )
   const failures = results.flatMap((result) =>
     result.status === 'rejected' ? [result.reason] : []
   )
-  if (failures.length === 0) {
-    return
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      'Could not clear existing cookies; the session was left partially cleared'
+    )
   }
-  try {
-    await restoreImportedDomainCookies(store, removedCookies)
-  } catch (restoreError) {
-    throw new AggregateError([...failures, restoreError], 'Cookie clearing and rollback failed')
-  }
-  throw new AggregateError(failures, 'Could not clear existing cookies')
 }
 
 export async function replaceCookiesForImportedDomains(


### PR DESCRIPTION
## ELI5

When importing cookies from another browser, Orca first clears the existing cookie jar. If part of that clear failed, it tried to undo itself by putting the deleted cookies back. But Electron can't see or set a cookie's "partition key" (the CHIPS marker that binds a cookie to one top-level site), so putting a cookie back quietly stripped that marker. A partitioned login cookie came back as a plain one — broken auth state that a restart can't repair, on a path that already told the user the import failed. This PR stops the undo entirely: a failed clear now just stays failed, which the user can retry.

## What Changed

`removeAllCookiesExcept` no longer rolls back a partial clear.

- Dropped the `restoreImportedDomainCookies` call and the `removedCookies` bookkeeping that fed it.
- `store` narrowed from `Pick<Cookies, 'get' | 'remove' | 'set'>` to `Pick<Cookies, 'get' | 'remove'>`, so the lossy reconstruction cannot be reintroduced here by accident.
- Failure message is now truthful about the resulting state: `Could not clear existing cookies; the session was left partially cleared` (it reaches the user via `summarizeCookieImportError`).
- New real-Electron regression test `browser-cookie-import-partition-rollback.electron.test.ts`: creates a **non-Google** CHIPS cookie over CDP, forces one removal to reject, and asserts no cookie is ever resurrected without its partition key.
- Updated the two existing tests that codified the old rollback (`browser-cookie-import-policy.test.ts`, `browser-cookie-import-google-exclusion.test.ts`).

Deliberately **not** in scope: the `clearStorageData` bulk fast path (STA-4065, owned separately), and `replaceCookiesForImportedDomains` — see *Follow-up* below.

## Why

Regression from #14086 (`fc7c2a1cd5a4`), which replaced `bulkClearCookiesExcept` with per-cookie removal plus a rollback.

The comment above `removeAllCookiesExcept` already stated the governing invariant — *"Electron cannot round-trip partition identity, so excluded cookies must never be removed"* — but only the `google.com` family (`NON_TRANSPLANTABLE_DOMAINS`) was excluded. Everything else was removed and, on any partial failure, rebuilt through `cookies.set`.

I probed Electron 43.1.0 against a real session jar to establish what is actually possible:

| Probe | Result |
|---|---|
| `cookies.get({})` | Returns partitioned cookies, **stripped of `partitionKey`**. Keys: `domain, hostOnly, httpOnly, name, path, sameSite, secure, session, value` |
| `cookies.get({ url })` | Returns partitioned cookies too — no unpartitioned-only view |
| `cookies.get({ domain })` | Same — no discrimination |
| `cookies.remove(url, name)` | **Does** delete partitioned cookies |
| partitioned + unpartitioned twin at same url+name | `get({})` returns 2 entries that are field-identical; one `remove()` deletes **both** |
| `cookies.set({ partitionKey })` | `partitionKey` is **silently ignored**, not rejected |

So there is no per-cookie fix available: Electron exposes no way to tell a partitioned cookie from an unpartitioned one, and no way to recreate one. Every cookie in the snapshot is potentially partitioned, and every `cookies.set` reconstruction is potentially a downgrade. Skipping "the cookies that can't be round-tripped" would mean skipping all of them.

That leaves not reconstructing at all, which is also the better trade on the merits. The cookies being removed are stale cookies the import is about to replace; leaving them removed is a bounded, visible, retryable failure (`importCookiesFromBrowser` already returns `{ok: false}` and the user re-runs the import). Recreating them unpartitioned is unbounded silent corruption that survives restart and that neither Orca nor the user can detect or repair.

## Linked Issue

STA-4061 — https://linear.app/stably/issue/STA-4061/p0-cookie-import-rollback-destroys-non-google-partition-identity-after

Regression from #14086.

Fixes #

## Visual Proof

No happy-path UI delta — this is a main-process failure-path change. Happy-path cookie-import screenshots (macOS Electron, no regression) plus red/green rollback-test output: https://github.com/stablyai/orca/pull/14132#issuecomment-5274961448

## Testing

Platform tested: **macOS** (Electron 43.1.0, main process). This is a main-process cookie-store change with no renderer, mobile, Windows/WSL, or SSH-specific behavior — it runs identically wherever Electron does.

Red/green on the new regression test, same command both times:

```
pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
```

**Before the fix (at `9772da844a`):**
```
AssertionError: chips-auth was downgraded to unpartitioned: [{"name":"chips-auth","value":"keep-me"}]
- Expected: []
+ Received: [ { "name": "chips-auth", "value": "keep-me" } ]
```
The cookie survived the failed clear with its value intact and **no `partitionKey`** — the corruption, reproduced end to end against a real Electron cookie jar.

**After the fix:** passes.

Full suite for the touched area:
```
pnpm exec vitest run --config config/vitest.config.ts src/main/browser/
  Test Files  36 passed (36)
       Tests  608 passed (608)
```

Also run clean:
- `pnpm run typecheck` — pass
- `oxlint src/main/browser/` — pass
- `pnpm run audit:code-quality:native` — pass
- `pnpm run audit:code-quality:type-aware` — pass
- `pnpm run check:max-lines-ratchet` — pass (no new suppressions)
- `oxfmt` — clean

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

N/A — internal.

## Review

- **Security:** strictly reduces writes to the cookie jar; no new cookie is ever created by the failure path. Removes a path that could silently weaken a cookie's isolation from partitioned to global.
- **Cross-platform:** no platform-conditional code; Electron cookie APIs behave the same on macOS/Linux/Windows. The new test follows the existing rig's `xvfb-run` handling for Linux CI.
- **Remote SSH / folder workspaces:** cookie import is a local main-process operation against an Electron session; unaffected.
- **Mobile:** unaffected — desktop main process only.
- **Backwards compatibility:** no wire, IPC, or persisted-format change. The only observable difference is on the already-failing path: the jar is left partially cleared rather than partially (and lossily) restored, and the failure string is more specific.
- **Performance:** strictly less work — the failure path no longer issues a `cookies.set` per removed cookie.

### Follow-up (not this PR)

`replaceCookiesForImportedDomains` and the `importValidatedCookies` set-failure path (`browser-cookie-import.ts:676`) still roll back through the same lossy `restoreImportedDomainCookies`, so they carry the same downgrade risk for cookies on imported domains. That is pre-existing behavior, not part of the #14086 regression, and it belongs in its own change — flagging it here so it isn't lost.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
