### PR TITLE
perf(renderer): parallelize runtime catalog and worktree refresh

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -10279,6 +10279,78 @@ describe('runtime host catalog refresh on reposChanged', () => {
       vi.useRealTimers()
     }
   })
+
+  // Why: the catalog fetches carry 15s RPC timeouts; serializing them ahead of the
+  // worktree refresh stalled lineage convergence for 30s on a connected-but-wedged host.
+  it('refreshes worktrees and lineage without waiting on a stalled catalog fetch', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    try {
+      const fetchRuntimeEnvironmentRepos = vi.fn(() => Promise.resolve([{ id: 'repo-1' }]))
+      // Never settles, standing in for a host that accepted the connection but stopped answering.
+      const fetchProjectGroups = vi.fn(() => new Promise<void>(() => {}))
+      const fetchFolderWorkspaces = vi.fn(() => Promise.resolve())
+      const fetchWorktrees = vi.fn(() => Promise.resolve())
+      const fetchWorktreeLineage = vi.fn(() => Promise.resolve())
+      const state = {
+        settings: { activeRuntimeEnvironmentId: 'env-1' as string | null },
+        repos: [],
+        worktreesByRepo: {},
+        folderWorkspaces: [],
+        projectGroups: [],
+        runtimeEnvironments: [],
+        runtimeStatusByEnvironmentId: new Map(),
+        tabsByWorktree: {},
+        ptyIdsByTabId: {},
+        remountTerminalTabForRecovery: vi.fn(),
+        markEnvironmentSshStateStale: vi.fn(),
+        fetchRepos: vi.fn(() => Promise.resolve()),
+        fetchRuntimeEnvironmentRepos,
+        fetchProjectGroups,
+        fetchFolderWorkspaces,
+        fetchWorktrees,
+        fetchWorktreeLineage
+      }
+
+      vi.doMock('react', async () => {
+        const actual = await vi.importActual<typeof ReactModule>('react')
+        return { ...actual, useEffect: (effect: () => void | (() => void)) => void effect() }
+      })
+      vi.doMock('../store', () => ({
+        useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => state }
+      }))
+      const noopListener = (): (() => void) => () => {}
+      const autoStubNamespace = new Proxy(
+        {},
+        {
+          get:
+            () =>
+            (...args: unknown[]) => {
+              if (typeof args[0] === 'function') {
+                return noopListener()
+              }
+              return new Promise(() => {})
+            }
+        }
+      )
+      const api = new Proxy({} as Record<string, unknown>, {
+        get: (target, prop: string) => target[prop] ?? autoStubNamespace
+      })
+      vi.stubGlobal('window', { api })
+
+      const { useIpcEvents } = await import('./useIpcEvents')
+      useIpcEvents()
+      await vi.advanceTimersByTimeAsync(300)
+
+      expect(fetchProjectGroups).toHaveBeenCalled()
+      // Folder workspaces still wait on their groups; worktrees and lineage must not.
+      expect(fetchFolderWorkspaces).not.toHaveBeenCalled()
+      expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', expect.anything())
+      expect(fetchWorktreeLineage).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('parked terminal recovery on repos:changed', () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -940,14 +940,20 @@ export function useIpcEvents(): void {
         // Why: the host emits one reposChanged for group/folder-workspace edits too, so those
         // catalogs go stale without this; groups first because folder workspaces resolve owners from them.
         const runtimeOwner = { runtimeEnvironmentId: environmentId }
-        await useAppStore.getState().fetchProjectGroups(runtimeOwner)
-        await useAppStore.getState().fetchFolderWorkspaces(runtimeOwner)
-        await refreshRuntimeProjectWorktreesAndLineage(
-          environmentId,
-          repos,
-          (repoId, options) => useAppStore.getState().fetchWorktrees(repoId, options),
-          (options) => useAppStore.getState().fetchWorktreeLineage(options)
-        )
+        // Why: catalogs and worktrees are independent; serializing them put two 15s RPC
+        // timeouts ahead of worktree/lineage convergence on a wedged host.
+        await Promise.all([
+          (async () => {
+            await useAppStore.getState().fetchProjectGroups(runtimeOwner)
+            await useAppStore.getState().fetchFolderWorkspaces(runtimeOwner)
+          })(),
+          refreshRuntimeProjectWorktreesAndLineage(
+            environmentId,
+            repos,
+            (repoId, options) => useAppStore.getState().fetchWorktrees(repoId, options),
+            (options) => useAppStore.getState().fetchWorktreeLineage(options)
+          )
+        ])
       },
       onError: (error) => {
         console.error('Failed to refresh runtime projects:', error)


### PR DESCRIPTION
Follow-up to #13787, from readiness review of #13787 + #13632.

## Summary

The scheduled runtime refresh awaited the project-group catalog, then the folder-workspace catalog, and only then started `refreshRuntimeProjectWorktreesAndLineage`. Both catalog calls are `callRuntimeRpc(..., { timeoutMs: 15_000 })` (`repos.ts:1297`, `repos.ts:1332`), so against a host that is connected but has stopped answering, worktree/lineage convergence was delayed by up to 30s on top of the repo fetch's own 15s.

The two work streams are independent: `refreshRuntimeProjectWorktreesAndLineage` takes `repos` plus two callbacks and never reads `projectGroups` or `folderWorkspaces`. This runs them concurrently.

Groups still precede folder workspaces — `fetchFolderWorkspaceCatalogForTarget` resolves each workspace's owning group from `get().projectGroups` (`repos.ts:2311`). Only the catalog-vs-worktree serialization is removed.

### ELI5

Orca was reading a remote machine's folder list, then its project list, and only then checking its worktrees — one after another. If that machine went quiet, the worktree check sat waiting on the earlier two for half a minute. Now the folder/project reads and the worktree check run side by side.

## Why now

Two independent reviewers flagged this during readiness review; #13632 raises the stakes by removing the local all-host sweep, which makes this scheduler chain the only refresh path for remote catalogs.

## Testing

- [x] `oxlint` + `oxfmt --check` clean
- [x] `useIpcEvents.test.ts` + `runtime-project-refresh-scheduler.test.ts` — 121 passed
- [x] New regression: a never-settling `fetchProjectGroups` must not block `fetchWorktrees`/`fetchWorktreeLineage`. Verified it fails against the serialized code (`expected "vi.fn()" to be called with arguments: [ 'repo-1', Anything ]`) and passes with the fix.
- [x] #13787's groups-before-folder-workspaces ordering test still passes unchanged.

## Notes

- No wire change; same RPCs, same triggers, different scheduling.
- Renderer-only; identical on macOS, Linux, Windows.
- No new input handling, IPC surface, paths, or auth.

Made with [Orca](https://github.com/stablyai/orca) 🐋
