### PR TITLE
fix(i18n): restore meaning in five mistranslated Korean strings

### DIFF
--- a/config/scripts/locale-ko-key-overrides.json
+++ b/config/scripts/locale-ko-key-overrides.json
@@ -5029,5 +5029,17 @@
   },
   "auto.components.right.sidebar.AiVaultPanel.noAgentsSelected": {
     "ko": "선택된 에이전트가 없습니다"
+  },
+  "auto.components.settings.DeveloperPermissionsPane.f903bf20b5": {
+    "ko": "터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다."
+  },
+  "components.native-chat.approval.allow": {
+    "ko": "허용"
+  },
+  "components.native-chat.approval.deny": {
+    "ko": "거부"
+  },
+  "auto.components.sidebar.AddRemoteHostDialog.sshImportSynced": {
+    "ko": "{{value0}} 호스트{{value1}}을(를) Orca에 추가했습니다."
   }
 }

--- a/config/scripts/locale-search-keyword-overrides.mjs
+++ b/config/scripts/locale-search-keyword-overrides.mjs
@@ -97,7 +97,9 @@ export const SEARCH_KEYWORD_OVERRIDES = {
     compose: '작성',
     verify: '검증',
     keep: '유지',
-    'check #': '체크 #'
+    'check #': '체크 #',
+    // Pairs with the existing `frozen` → '정지됨' rendering; MT read this as thawing ice ('녹이다').
+    unfreeze: '정지 해제'
   },
   zh: {
     dark: '深色',

--- a/src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts
+++ b/src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts
@@ -18,7 +18,21 @@ const correctedValues = {
   'auto.components.right.sidebar.source.control.discard.confirmation.40e9357b2a':
     '이렇게 하면 HEAD에서 파일을 복원하고 파일 삭제를 취소합니다. 이 작업은 취소할 수 없습니다.',
   'auto.components.right.sidebar.source.control.primary.action.5a477d80cb':
-    '모든 변경 사항 스테이징'
+    '모든 변경 사항 스테이징',
+  // MT dropped the second English sentence, so the macOS caveat was invisible in Korean.
+  'auto.components.settings.DeveloperPermissionsPane.f903bf20b5':
+    '터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다.',
+  // Agent approval buttons: '부인하다' is courtroom-register denial, not a UI action.
+  'components.native-chat.approval.allow': '허용',
+  'components.native-chat.approval.deny': '거부',
+  // English says "Added ... to Orca"; the Korean claimed a sync instead.
+  'auto.components.sidebar.AddRemoteHostDialog.sshImportSynced':
+    '{{value0}} 호스트{{value1}}을(를) Orca에 추가했습니다.'
+} as const
+
+// Settings-search keyword, so it lives in SEARCH_KEYWORD_OVERRIDES rather than the key overrides.
+const correctedSearchKeywords = {
+  'auto.components.settings.terminal.search.d4daf4f612': '정지 해제'
 } as const
 
 function getLocaleValue(path: string): unknown {
@@ -48,5 +62,20 @@ describe('Korean UI semantic mistranslation fixes', () => {
     for (const [path, expected] of Object.entries(correctedValues)) {
       expect(overrides[path]?.ko, path).toBe(expected)
     }
+  })
+
+  it('keeps the corrected settings-search keywords in the Korean catalog', () => {
+    for (const [path, expected] of Object.entries(correctedSearchKeywords)) {
+      expect(getLocaleValue(path), path).toBe(expected)
+    }
+  })
+
+  it('pins unfreeze to the frozen-state wording in the search keyword overrides', async () => {
+    const { SEARCH_KEYWORD_OVERRIDES } =
+      (await import('../../../../config/scripts/locale-search-keyword-overrides.mjs')) as {
+        SEARCH_KEYWORD_OVERRIDES: Record<string, Record<string, string>>
+      }
+
+    expect(SEARCH_KEYWORD_OVERRIDES.ko?.unfreeze).toBe('정지 해제')
   })
 })

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5094,7 +5094,7 @@
           "pairingCommand": "orca serve --pairing-address <host>",
           "pairingHelpSuffix": "한 다음 출력된 페어링 URL을 붙여넣으세요.",
           "sshImportAlreadySynced": "~/.ssh/config가 이미 동기화되어 있습니다.",
-          "sshImportSynced": "{{value0}} 호스트{{value1}}을(를) 동기화했습니다.",
+          "sshImportSynced": "{{value0}} 호스트{{value1}}을(를) Orca에 추가했습니다.",
           "sshImportFailed": "SSH 구성을 가져오지 못했습니다.",
           "sshPersistenceDefault": "이 호스트의 원격 터미널은 종료하거나 릴레이를 재설정할 때까지 계속 실행됩니다.",
           "advanced": "고급",
@@ -5753,7 +5753,7 @@
           "b2210b1b4f": "블루투스",
           "dfbc12c8c8": "USB 장치와 통신하는 하드웨어 디버깅 및 장치 도구입니다.",
           "bf51e4a542": "USB 장치",
-          "f903bf20b5": "네트워크의 개발 서버를 검색하고 액세스합니다.",
+          "f903bf20b5": "터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다.",
           "e7bb06007c": "LAN",
           "4a73f5217a": "다른 로컬 앱을 제어하는 ​​스크립트를 위한 Apple 이벤트.",
           "e119f0d66b": "자동화",
@@ -8896,7 +8896,7 @@
             "46d99ef4bb": "불투명도",
             "4c643695aa": "terminal 배경의 투명도를 제어합니다.",
             "b36fd2416d": "배경 불투명도",
-            "d4daf4f612": "녹이다",
+            "d4daf4f612": "정지 해제",
             "88561b3499": "정지됨",
             "0a05629060": "복구",
             "f66a7cf715": "터미널",
@@ -14425,8 +14425,8 @@
       },
       "approval": {
         "title": "{{value0}}을(를) 허용하시겠습니까?",
-        "allow": "허용하다",
-        "deny": "부인하다"
+        "allow": "허용",
+        "deny": "거부"
       },
       "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요"
     },


### PR DESCRIPTION
## ELI5

Five Korean strings in the app say something different from the English. One of them lost an entire sentence — the warning that macOS won't tell Orca whether a permission is actually on — so Korean users trust a status indicator the English text explicitly says not to trust. This fixes those five and adds tests so they can't silently revert.

## What Changed

Five values in the Korean catalog, routed through the existing override sources so a catalog regeneration cannot undo them.

| key | en | before | after |
|---|---|---|---|
| `...DeveloperPermissionsPane.f903bf20b5` | Allows terminals and development tools to connect to services on your local network. **macOS does not report this permission's current status to Orca.** | 네트워크의 개발 서버를 검색하고 액세스합니다. | 터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다. |
| `components.native-chat.approval.allow` | Allow | 허용하다 | 허용 |
| `components.native-chat.approval.deny` | Deny | 부인하다 | 거부 |
| `...AddRemoteHostDialog.sshImportSynced` | Added {{value0}} host{{value1}} to Orca. | …동기화했습니다 ("synced") | …Orca에 추가했습니다 ("added to Orca") |
| `...terminal.search.d4daf4f612` | unfreeze | 녹이다 (to melt) | 정지 해제 |

Files:
- `src/renderer/src/i18n/locales/ko.json` — the five runtime values
- `config/scripts/locale-ko-key-overrides.json` — four reviewed key overrides (+12 lines)
- `config/scripts/locale-search-keyword-overrides.mjs` — `unfreeze` belongs to `SEARCH_KEYWORD_OVERRIDES`, not the key overrides, since it is a settings-search keyword
- `src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts` — pins all five in both the catalog and the override source

No English, no schema, no behavior, no other locale.

## Why

These are semantic defects, not wording preferences:

1. **The dropped sentence is a trust caveat.** 148 chars to 25. The English tells the user macOS does not report this permission's status; the Korean silently omits it, so the on-screen indicator reads as authoritative when the English says it isn't.
2. **`부인하다` is courtroom register** — what you do to an allegation, not to an agent's request. On the dialog gating a potentially destructive action, the refuse button did not read as refusal. `허용하다` is likewise a verb infinitive where a button label belongs.
3. **`sshImportSynced` reported an operation that didn't happen** — English "Added … to Orca", Korean "synced".
4. **`unfreeze` → `녹이다`** is thawing ice. Its pair `frozen` already renders `정지됨`, so searching Korean settings for the frozen-terminal recovery action couldn't find it. Fixing it as a keyword override keeps it consistent with that pair.

**Why the existing rounds missed these.** `locale-ko-phrase-fixes.mjs` (round 4) and `-round5.mjs` are regex substitutions gated on `whenEnIncludes`, which is the right tool for recurring term drift (`검토`→`리뷰`, `기술`→`스킬`). These five share no token, and #1 is an *omission* — no substitution rule can detect missing text.

## Linked Issue

Fixes #14139

## Visual Proof

Settings → macOS Permissions → **Local Network**, Korean UI, dark theme. The only difference between the two is that item's description.

| Before | After |
|---|---|
| <img width="480" alt="before — Local Network description in Korean, one line" src="https://raw.githubusercontent.com/kojw1017/orca/pr-14140-assets/before-lan-permission.png"> | <img width="480" alt="after — Local Network description in Korean, both sentences restored" src="https://raw.githubusercontent.com/kojw1017/orca/pr-14140-assets/after-lan-permission.png"> |

`Before` is the released build; `After` is this branch on `pnpm dev`, captured over CDP. Two incidental differences that are not from this change: the daemon warning card at the top is absent in the dev instance, and `After` is cropped to the section.

**Layout risk on the one string that grew (25 to 79 chars): none, now verified visually rather than argued.** It renders in `DeveloperPermissionsPane.tsx:368` as `<p className="text-xs text-muted-foreground">` with no fixed height, and the same panel already ships longer Korean descriptions: 129 chars (`7ca17b62c8`) and 84 chars (`6326a4c5cc`). It wraps to two lines exactly as its neighbours do. The other four strings got shorter or stayed the same length.

The remaining three fixes are button and toast labels, covered by the table at the top of this PR.

## Testing

- `vitest run src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts config/scripts/locale-ko-key-overrides.test.mjs config/scripts/locale-translation-policy-ko-round5.test.mjs` — 3 files, 8 tests, pass
- `vitest run config/scripts src/renderer/src/i18n` — 858 pass. I ran the same command on a clean `main` first: **identical 4 pre-existing failures** (`electron-builder-config`, `electron-builder-mac-channel-config`, `I18nProvider`, `package-electron-runtime-contract` — the last from `windows-native-registry` being unresolvable on macOS). Pass count went 856 → 858, which is exactly the two tests this PR adds.
- `pnpm verify:localization-catalog` — passes; interpolation placeholders verified intact (`{{value0}}` / `{{value1}}` preserved in `sshImportSynced`)
- `pnpm verify:localization-extraction`, `pnpm verify:localization-coverage` — pass
- `oxlint` + `oxfmt --check` — clean on all changed files
- `tsc --noEmit -p config/tsconfig.tc.web.json` — zero errors in the changed files. There are pre-existing errors in `src/renderer/src/components/editor/*` from a `@tiptap/core` 3.30.0 vs 3.22.5 peer mismatch in the lockfile, unrelated to this change and present on clean `main`.
- Platform: macOS only, which is the full surface here — these are catalog data values with no platform-, SSH-, remote-, agent-, or provider-specific path. `pnpm-lock.yaml` deliberately not included.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 via Claude Code, used for the en/ko catalog diffing that surfaced the candidates and for drafting. Every Korean value here is my own as a native speaker and daily Orca user — the machine found the suspects, I decided the wording. I also ruled out four false positives it flagged: `Cursor`→`커서` (correctly the terminal cursor, not the editor), `Diverged`→`분기됨` (correct), the 685 keys ko is missing versus en (es/ja are 690, zh 680 — English fallback by design), and placeholder mismatches (0 across the catalog).

## Review

- **Security** — no code paths, no user input, no credentials. Data values only.
- **Cross-platform** — catalog JSON plus one keyword override map; no platform branch, no path handling, no shortcut.
- **Remote SSH / mobile** — untouched. Desktop renderer catalog; nothing crosses the client↔host wire and no published content changes.
- **Backwards compatibility** — keys unchanged, only values. Interpolation variables preserved, so `verify-localization-catalog`'s mismatch check stays green.
- **Performance** — none; same key count, +72 bytes in the catalog.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: —
