### PR TITLE
fix(terminal): preserve Fish readiness escape bytes

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -120,7 +120,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The Fish chunk oracle patch SHA-256 fd49a4d3d91bd5f0d10c1b1f44f4cfbd92cef9155a5505b415c8680184cdc765 is byte-identical across runs. Scan target e4c278eb52, latest main bc2e30000b, and candidate b19ca10a4c with shared scanner integration disabled each failed only the ESC-introducer split in both local and daemon owners (2 failures, 161 passes). Candidate b19ca10a4c passed all 163 local/daemon cases plus the independent headless-xterm render oracle. The original exec-readiness oracle SHA-256 b13b08006a38b2adc2acb51ae9342909514e55ab4822fac4fbb76cd49b344cc6 remains 14/14 green."
+        "evidence": "The Fish chunk oracle patch SHA-256 fd49a4d3d91bd5f0d10c1b1f44f4cfbd92cef9155a5505b415c8680184cdc765 is byte-identical across runs. Scan target e4c278eb52, latest main 150cc6f50c, and candidate ae7f30318a with shared scanner integration disabled each failed only the ESC-introducer split in both local and daemon owners (2 failures, 161 passes). Candidate ae7f30318a passed all 163 local/daemon cases plus the independent headless-xterm render oracle. The original exec-readiness oracle SHA-256 b13b08006a38b2adc2acb51ae9342909514e55ab4822fac4fbb76cd49b344cc6 remains 14/14 green."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -20,7 +20,7 @@
       "surfaces": ["queued terminal startup commands", "zsh, bash, and Fish startup output"],
       "platforms": ["macos", "linux"],
       "providers": ["local", "local-daemon", "ssh-daemon", "ssh-relay", "paired-runtime"],
-      "coveredPlatforms": ["macos"],
+      "coveredPlatforms": ["macos", "linux"],
       "coveredProviders": ["local", "local-daemon", "ssh-relay"],
       "coverageNotes": "Real macOS node-pty integration covers zsh 5.9 .zshenv/.zprofile and bash 3.2 profile replacement shells, including exec -a names, same-shell and child-process silent reads, a blocking zle-line-init hook, non-shell readline replacements, and a non-shell image renamed zsh. A real Fish PTY proves marker stripping is byte-exact and does not render bracketed-paste control text. An Ubuntu 20.04 container confirms compatible zsh/bash termios. Deterministic owner contracts cover local, daemon, and SSH relay identity/readiness composition plus provider- and renderer-owned delivery. Renderer-owned relay fallback publishes the existing ready marker, so mixed client/host versions need no new wire capability. Live SSH, paired-runtime, and WSL remain gaps.",
       "motivatingLinks": [
@@ -31,7 +31,8 @@
       "oracle": "Split Fish output immediately after the ready marker and after the following ESC introducer; local and daemon owners must emit the exact ESC [ ? 2004 h bytes and headless xterm must not render literal control text. Run the real generated wrappers under node-pty with disposable zsh, bash, and Fish startup files. Plain and exec -a replacement shells must receive one queued command at their first completed line editor without waiting for the 15-second timeout. The identical oracle must time out without the startup identity and prompt fallback. Same-shell reads, child-process reads, a blocking zle-line-init hook, sqlite3, and sqlite3 renamed zsh must not trigger prompt fallback. Relay owner coverage must use the same lossless scanner composition and release through the same prompt contract.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/line-editor-ready-output-scanner.test.ts src/main/shell-startup-identity-scanner.test.ts src/main/shell-startup-output-scanner.test.ts src/main/shell-prompt-readiness-probe.test.ts src/shared/pty-slave-line-discipline-echo.test.ts src/shared/shell-process-readiness.test.ts src/main/daemon/session.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/providers/local-pty-provider.test.ts src/relay/pty-shell-launch.test.ts src/relay/pty-handler.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/relay/pty-handler.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/relay/pty-handler.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=1 src/main/daemon/shell-ready.test.ts src/main/shell-startup-output-scanner.test.ts"
       ],
       "testFiles": [
         "src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts",
@@ -91,9 +92,18 @@
       "evidenceRuns": [
         {
           "date": "2026-08-12",
+          "runner": "manual",
+          "platform": "linux",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=1 src/main/daemon/shell-ready.test.ts src/main/shell-startup-output-scanner.test.ts",
+          "result": "passed",
+          "durationSeconds": 7,
+          "summary": "A clean Debian 12 arm64 container with real Fish 3.6 and node-pty passed exact marker-stripped output plus headless-xterm rendering."
+        },
+        {
+          "date": "2026-08-12",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/line-editor-ready-output-scanner.test.ts src/main/shell-startup-identity-scanner.test.ts src/main/shell-prompt-readiness-probe.test.ts src/shared/pty-slave-line-discipline-echo.test.ts src/shared/shell-process-readiness.test.ts src/main/daemon/session.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/providers/local-pty-provider.test.ts src/relay/pty-shell-launch.test.ts src/relay/pty-handler.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/line-editor-ready-output-scanner.test.ts src/main/shell-startup-identity-scanner.test.ts src/main/shell-startup-output-scanner.test.ts src/main/shell-prompt-readiness-probe.test.ts src/shared/pty-slave-line-discipline-echo.test.ts src/shared/shell-process-readiness.test.ts src/main/daemon/session.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/providers/local-pty-provider.test.ts src/relay/pty-shell-launch.test.ts src/relay/pty-handler.test.ts",
           "result": "passed",
           "durationSeconds": 4,
           "summary": "All real exec, silent-read, line-init-hook, renamed-image, disabled-bracketed-paste, and relay-owner oracles plus identity, foreground, executable-image, protocol, and line-editor contracts passed."
@@ -109,7 +119,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "Oracle SHA-256 b13b08006a38b2adc2acb51ae9342909514e55ab4822fac4fbb76cd49b344cc6 is byte-identical across runs. Latest main 09ec516ae5 and the candidate with its production implementation reverted both failed exactly the three zsh .zprofile/.zshenv and bash exec cases by deterministic 5-second timeout; the zle-line-init oracle also exposed unsafe baseline delivery, while all ten other safety controls passed. The candidate passed all 14 on macOS."
+        "evidence": "The Fish chunk oracle patch SHA-256 fd49a4d3d91bd5f0d10c1b1f44f4cfbd92cef9155a5505b415c8680184cdc765 is byte-identical across runs. Scan target e4c278eb52, latest main d9b390f4fd, and candidate 1f9715c87b with the fix commit reverted each failed the ESC-introducer split in both local and daemon owners while passing both marker-only splits. Candidate 1f9715c87b passed all four cases plus the independent headless-xterm render oracle. The original exec-readiness oracle SHA-256 b13b08006a38b2adc2acb51ae9342909514e55ab4822fac4fbb76cd49b344cc6 remains 14/14 green."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -17,23 +17,27 @@
       "protection": "partial",
       "owner": "terminal-session-readiness",
       "layer": "posix-pty-and-shell-startup",
-      "surfaces": ["queued terminal startup commands", "zsh and bash startup files"],
+      "surfaces": ["queued terminal startup commands", "zsh, bash, and Fish startup output"],
       "platforms": ["macos", "linux"],
       "providers": ["local", "local-daemon", "ssh-daemon", "ssh-relay", "paired-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "local-daemon", "ssh-relay"],
-      "coverageNotes": "Real macOS node-pty integration covers zsh 5.9 .zshenv/.zprofile and bash 3.2 profile replacement shells, including exec -a names, same-shell and child-process silent reads, a blocking zle-line-init hook, non-shell readline replacements, and a non-shell image renamed zsh. An Ubuntu 20.04 container confirms compatible zsh/bash termios. Deterministic owner contracts cover local, daemon, and SSH relay identity stripping plus provider- and renderer-owned delivery. Renderer-owned relay fallback publishes the existing ready marker, so mixed client/host versions need no new wire capability. Live SSH, paired-runtime, and WSL remain gaps.",
-      "motivatingLinks": ["https://github.com/stablyai/orca/issues/13767"],
-      "invariant": "Before user startup files run, the wrapper publishes its shell PID. If a later exec discards the ready marker, prompt fallback releases queued startup input only after the launched shell's actual executable image with that exact PID owns the PTY foreground, emits its post-hook line-editor enable sequence, and exposes zle/readline termios; startup reads, line-init hooks, child foreground processes, and non-shell readline replacements cannot trigger early fallback release.",
-      "oracle": "Run the real generated wrappers under node-pty with disposable zsh and bash startup files. Plain and exec -a replacement shells must receive one queued command at their first completed line editor without waiting for the 15-second timeout. The identical oracle must time out without the startup identity and prompt fallback. Same-shell reads, child-process reads, a blocking zle-line-init hook, sqlite3, and sqlite3 renamed zsh must not trigger prompt fallback. Relay owner coverage must strip the identity and release through the same prompt contract.",
+      "coverageNotes": "Real macOS node-pty integration covers zsh 5.9 .zshenv/.zprofile and bash 3.2 profile replacement shells, including exec -a names, same-shell and child-process silent reads, a blocking zle-line-init hook, non-shell readline replacements, and a non-shell image renamed zsh. A real Fish PTY proves marker stripping is byte-exact and does not render bracketed-paste control text. An Ubuntu 20.04 container confirms compatible zsh/bash termios. Deterministic owner contracts cover local, daemon, and SSH relay identity/readiness composition plus provider- and renderer-owned delivery. Renderer-owned relay fallback publishes the existing ready marker, so mixed client/host versions need no new wire capability. Live SSH, paired-runtime, and WSL remain gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/13767",
+        "https://linear.app/stably/issue/STA-4068"
+      ],
+      "invariant": "Shell startup scanning preserves every non-Orca output byte in order across arbitrary PTY chunk boundaries. Before user startup files run, the wrapper publishes its shell PID. If a later exec discards the ready marker, prompt fallback releases queued startup input only after the launched shell's actual executable image with that exact PID owns the PTY foreground, emits its post-hook line-editor enable sequence, and exposes zle/readline termios; startup reads, line-init hooks, child foreground processes, and non-shell readline replacements cannot trigger early fallback release.",
+      "oracle": "Split Fish output immediately after the ready marker and after the following ESC introducer; local and daemon owners must emit the exact ESC [ ? 2004 h bytes and headless xterm must not render literal control text. Run the real generated wrappers under node-pty with disposable zsh, bash, and Fish startup files. Plain and exec -a replacement shells must receive one queued command at their first completed line editor without waiting for the 15-second timeout. The identical oracle must time out without the startup identity and prompt fallback. Same-shell reads, child-process reads, a blocking zle-line-init hook, sqlite3, and sqlite3 renamed zsh must not trigger prompt fallback. Relay owner coverage must use the same lossless scanner composition and release through the same prompt contract.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/line-editor-ready-output-scanner.test.ts src/main/shell-startup-identity-scanner.test.ts src/main/shell-prompt-readiness-probe.test.ts src/shared/pty-slave-line-discipline-echo.test.ts src/shared/shell-process-readiness.test.ts src/main/daemon/session.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/providers/local-pty-provider.test.ts src/relay/pty-shell-launch.test.ts src/relay/pty-handler.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/line-editor-ready-output-scanner.test.ts src/main/shell-startup-identity-scanner.test.ts src/main/shell-startup-output-scanner.test.ts src/main/shell-prompt-readiness-probe.test.ts src/shared/pty-slave-line-discipline-echo.test.ts src/shared/shell-process-readiness.test.ts src/main/daemon/session.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/providers/local-pty-provider.test.ts src/relay/pty-shell-launch.test.ts src/relay/pty-handler.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/relay/pty-handler.test.ts"
       ],
       "testFiles": [
         "src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts",
         "src/main/line-editor-ready-output-scanner.test.ts",
         "src/main/shell-startup-identity-scanner.test.ts",
+        "src/main/shell-startup-output-scanner.test.ts",
         "src/main/shell-prompt-readiness-probe.test.ts",
         "src/shared/pty-slave-line-discipline-echo.test.ts",
         "src/shared/shell-process-readiness.test.ts",
@@ -45,6 +49,25 @@
         "src/relay/pty-handler.test.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/shell-startup-output-scanner.test.ts",
+          "assertions": [
+            "Fish bracketed-paste output stays byte-exact across marker and ESC chunk splits",
+            "identity and readiness markers strip together without reordering prompt output",
+            "incomplete scanner prefixes drain in byte order"
+          ]
+        },
+        {
+          "file": "src/main/daemon/session.test.ts",
+          "assertions": [
+            "daemon output is byte-exact for both Fish chunk splits",
+            "headless xterm never renders literal bracketed-paste control text"
+          ]
+        },
+        {
+          "file": "src/main/providers/local-pty-provider.test.ts",
+          "assertions": ["local PTY output is byte-exact for both Fish chunk splits"]
+        },
         {
           "file": "src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts",
           "assertions": [
@@ -90,7 +113,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The normal ready-marker path cancels before external probing. A missing marker triggers a debounced stty read only after a line-editor enable sequence, followed by narrow PID status and executable-image inspection only when termios matches. Slow ordinary startup output triggers zero probes; rejected protocol emissions are capped at four probes per startup. There is no per-command hook or steady-state polling."
+        "evidence": "One bounded composition pass replaces two sequential scanner passes at each owner and retains only the existing bounded prefixes. The normal ready-marker path cancels before external probing. A missing marker triggers a debounced stty read only after a line-editor enable sequence, followed by narrow PID status and executable-image inspection only when termios matches. Slow ordinary startup output triggers zero probes; rejected protocol emissions are capped at four probes per startup. There is no per-command hook or steady-state polling."
       },
       "promotionCriteria": [
         "Collect Linux, SSH-daemon, and paired-runtime live evidence.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -54,7 +54,8 @@
           "file": "src/main/shell-startup-output-scanner.test.ts",
           "assertions": [
             "Fish bracketed-paste output stays byte-exact across marker and ESC chunk splits",
-            "identity and readiness markers strip together without reordering prompt output",
+            "every byte after readiness is preserved across every chunk boundary, even when it resembles an identity marker",
+            "pre-ready identity and readiness markers strip across every chunk boundary without reordering prompt output",
             "incomplete scanner prefixes drain in byte order"
           ]
         },
@@ -105,8 +106,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/line-editor-ready-output-scanner.test.ts src/main/shell-startup-identity-scanner.test.ts src/main/shell-startup-output-scanner.test.ts src/main/shell-prompt-readiness-probe.test.ts src/shared/pty-slave-line-discipline-echo.test.ts src/shared/shell-process-readiness.test.ts src/main/daemon/session.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/providers/local-pty-provider.test.ts src/relay/pty-shell-launch.test.ts src/relay/pty-handler.test.ts",
           "result": "passed",
-          "durationSeconds": 4,
-          "summary": "All real exec, silent-read, line-init-hook, renamed-image, disabled-bracketed-paste, and relay-owner oracles plus identity, foreground, executable-image, protocol, and line-editor contracts passed."
+          "durationSeconds": 6,
+          "summary": "473 tests passed with one local Fish skip, including every-boundary scanner composition, real exec, silent-read, line-init-hook, renamed-image, disabled-bracketed-paste, and relay-owner oracles."
         }
       ],
       "runtimeBudget": {
@@ -119,11 +120,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The Fish chunk oracle patch SHA-256 fd49a4d3d91bd5f0d10c1b1f44f4cfbd92cef9155a5505b415c8680184cdc765 is byte-identical across runs. Scan target e4c278eb52, latest main d9b390f4fd, and candidate 1f9715c87b with the fix commit reverted each failed the ESC-introducer split in both local and daemon owners while passing both marker-only splits. Candidate 1f9715c87b passed all four cases plus the independent headless-xterm render oracle. The original exec-readiness oracle SHA-256 b13b08006a38b2adc2acb51ae9342909514e55ab4822fac4fbb76cd49b344cc6 remains 14/14 green."
+        "evidence": "The Fish chunk oracle patch SHA-256 fd49a4d3d91bd5f0d10c1b1f44f4cfbd92cef9155a5505b415c8680184cdc765 is byte-identical across runs. Scan target e4c278eb52, latest main bc2e30000b, and candidate b19ca10a4c with shared scanner integration disabled each failed only the ESC-introducer split in both local and daemon owners (2 failures, 161 passes). Candidate b19ca10a4c passed all 163 local/daemon cases plus the independent headless-xterm render oracle. The original exec-readiness oracle SHA-256 b13b08006a38b2adc2acb51ae9342909514e55ab4822fac4fbb76cd49b344cc6 remains 14/14 green."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "One bounded composition pass replaces two sequential scanner passes at each owner and retains only the existing bounded prefixes. The normal ready-marker path cancels before external probing. A missing marker triggers a debounced stty read only after a line-editor enable sequence, followed by narrow PID status and executable-image inspection only when termios matches. Slow ordinary startup output triggers zero probes; rejected protocol emissions are capped at four probes per startup. There is no per-command hook or steady-state polling."
+        "evidence": "Two bounded linear scans partition identity ownership at the exact ready-marker boundary and retain only the existing bounded prefixes. The normal ready-marker path cancels before external probing. A missing marker triggers a debounced stty read only after a line-editor enable sequence, followed by narrow PID status and executable-image inspection only when termios matches. Slow ordinary startup output triggers zero probes; rejected protocol emissions are capped at four probes per startup. There is no per-command hook or steady-state polling."
       },
       "promotionCriteria": [
         "Collect Linux, SSH-daemon, and paired-runtime live evidence.",

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SESSION_FORCE_KILL_RETRY_MS, Session } from './session'
+import { HeadlessEmulator } from './headless-emulator'
 import type { SessionState, ShellReadyState } from './types'
 import type { TuiAgent } from '../../shared/types'
 
@@ -428,6 +429,29 @@ describe('Session', () => {
       ])
       expect(session.getSnapshot()?.snapshotAnsi).toContain('hello % ')
       expect(session.getSnapshot()?.snapshotAnsi).not.toContain('orca-shell-ready')
+    })
+
+    it.each([
+      ['after the ready marker', ['\x1b]777;orca-shell-ready\x07', '\x1b[?2004hfish> ']],
+      ['after the ESC introducer', ['\x1b]777;orca-shell-ready\x07\x1b', '[?2004hfish> ']]
+    ])('preserves Fish bracketed-paste output split %s', (_boundary, chunks) => {
+      createSession({ shellReadySupported: true })
+      const received: string[] = []
+      session.attachClient({
+        onData: (data) => received.push(data),
+        onExit: () => {}
+      })
+
+      for (const chunk of chunks) {
+        subprocess.simulateData(chunk)
+      }
+
+      const output = received.join('')
+      expect(output).toBe('\x1b[?2004hfish> ')
+      const rendered = new HeadlessEmulator({ cols: 80, rows: 24 })
+      expect(rendered.writeSync(output)).toBe(true)
+      expect(rendered.getVisibleLines().join('\n')).not.toContain('[?2004h')
+      rendered.dispose()
     })
 
     it('publishes an absolute output sequence with live snapshots', () => {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -8,17 +8,11 @@ import {
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { PostReadyFlushGate } from './post-ready-flush-gate'
 import {
-  createShellReadyScanState,
-  drainShellReadyHeldBytes,
-  scanForShellReady,
-  type ShellReadyScanState
-} from '../shell-ready-marker-scanner'
-import {
-  createShellStartupIdentityScanState,
-  drainShellStartupIdentityHeldBytes,
-  scanForShellStartupIdentity,
-  type ShellStartupIdentityScanState
-} from '../shell-startup-identity-scanner'
+  createShellStartupOutputScanState,
+  drainShellStartupOutputScanState,
+  scanShellStartupOutput,
+  type ShellStartupOutputScanState
+} from '../shell-startup-output-scanner'
 import {
   createShellPromptReadinessProbe,
   type ShellPromptReadinessProbe
@@ -136,8 +130,7 @@ export class Session {
   private preReadyStdinQueue: string[] = []
   private releaseStartupDeviceAttributesResponder: (() => void) | null = null
   private startupDeviceAttributesQueryFilter: StartupDeviceAttributesQueryFilter | null = null
-  private shellReadyScanState: ShellReadyScanState | null = null
-  private shellStartupIdentityScanState: ShellStartupIdentityScanState | null = null
+  private shellStartupOutputScanState: ShellStartupOutputScanState | null = null
   private shellStartupPid: number | null = null
   private shellPromptReadinessProbe: ShellPromptReadinessProbe | null = null
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
@@ -184,8 +177,7 @@ export class Session {
 
     if (opts.shellReadySupported) {
       this._shellState = 'pending'
-      this.shellReadyScanState = createShellReadyScanState()
-      this.shellStartupIdentityScanState = createShellStartupIdentityScanState()
+      this.shellStartupOutputScanState = createShellStartupOutputScanState()
       // Why: `write` queues everything until the ready marker, including the renderer's DA1
       // reply — and a shell that withholds its first prompt until DA1 is answered (fish) then
       // never emits the marker that would release it. Answer from the daemon, past the queue.
@@ -636,7 +628,7 @@ export class Session {
     }
     this.shellPromptReadinessProbe?.dispose()
     this.shellPromptReadinessProbe = null
-    this.shellReadyScanState = null
+    this.shellStartupOutputScanState = null
     this.preReadyStdinQueue = []
     this.postReadyFlushGate.clear()
     this.disposeSubprocessHandle()
@@ -682,18 +674,13 @@ export class Session {
     }
 
     let releaseStartupDeviceAttributes = false
-    if (this._shellState === 'pending' && this.shellStartupIdentityScanState) {
-      const scanned = scanForShellStartupIdentity(this.shellStartupIdentityScanState, data)
+    if (this._shellState === 'pending' && this.shellStartupOutputScanState) {
+      const scanned = scanShellStartupOutput(this.shellStartupOutputScanState, data)
       data = scanned.output
       if (scanned.shellPid) {
         this.shellStartupPid = scanned.shellPid
-        this.shellStartupIdentityScanState = null
       }
-    }
-    if (this._shellState === 'pending' && this.shellReadyScanState) {
-      const scanned = scanForShellReady(this.shellReadyScanState, data)
-      data = scanned.output
-      if (scanned.matched) {
+      if (scanned.ready) {
         this.transitionToReady(scanned.postMarkerBytesObserved)
         releaseStartupDeviceAttributes = true
       }
@@ -773,20 +760,11 @@ export class Session {
   }
 
   private releaseHeldShellReadyBytes(): string {
-    if (!this.shellReadyScanState && !this.shellStartupIdentityScanState) {
+    if (!this.shellStartupOutputScanState) {
       return ''
     }
-    let heldBytes = this.shellStartupIdentityScanState
-      ? drainShellStartupIdentityHeldBytes(this.shellStartupIdentityScanState)
-      : ''
-    this.shellStartupIdentityScanState = null
-    if (this.shellReadyScanState && heldBytes) {
-      heldBytes = scanForShellReady(this.shellReadyScanState, heldBytes).output
-    }
-    if (this.shellReadyScanState) {
-      heldBytes += drainShellReadyHeldBytes(this.shellReadyScanState)
-    }
-    this.shellReadyScanState = null
+    const heldBytes = drainShellStartupOutputScanState(this.shellStartupOutputScanState)
+    this.shellStartupOutputScanState = null
     // Why: scanning strips marker bytes before fan-out; if readiness never completes, release any held prefix before timeout/exit discards it.
     this.startupIngress.accept(heldBytes)
     return heldBytes
@@ -813,8 +791,7 @@ export class Session {
 
   private transitionToReady(postMarkerBytesObserved = false): void {
     this._shellState = 'ready'
-    this.shellReadyScanState = null
-    this.shellStartupIdentityScanState = null
+    this.shellStartupOutputScanState = null
     this.shellPromptReadinessProbe?.dispose()
     this.shellPromptReadinessProbe = null
     if (this.shellReadyTimer) {

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -6,6 +6,12 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import type * as ShellReadyModule from './shell-ready'
 import { getZshShellReadyMarkerRegistrationBlock } from '../shell-templates'
 import { fishRequirementViolation, resolveFishBinary } from '../../shared/fish-binary-requirement'
+import {
+  createShellStartupOutputScanState,
+  drainShellStartupOutputScanState,
+  scanShellStartupOutput
+} from '../shell-startup-output-scanner'
+import { HeadlessEmulator } from './headless-emulator'
 
 async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
   vi.resetModules()
@@ -296,6 +302,8 @@ describePosix('daemon shell-ready launch config', () => {
           }
         })
         let output = ''
+        let scannedOutput = ''
+        const startupScanState = createShellStartupOutputScanState()
         let commandWritten = false
         let erasureProbeWritten = false
         let queryCarry = ''
@@ -321,6 +329,7 @@ describePosix('daemon shell-ready launch config', () => {
         }, 50)
         proc.onData((chunk) => {
           output += chunk
+          scannedOutput += scanShellStartupOutput(startupScanState, chunk).output
           // Why: fish stalls its first prompt 10s waiting on these and re-queries
           // each prompt, so answer every occurrence — an unanswered query makes
           // fish swallow the post-marker command as its reply.
@@ -350,9 +359,15 @@ describePosix('daemon shell-ready launch config', () => {
         clearTimeout(deadline)
         clearInterval(sentinelPoll)
         proc.kill()
+        scannedOutput += drainShellStartupOutputScanState(startupScanState)
 
         expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
         expect(output.split(SHELL_READY_MARKER_OUTPUT)).toHaveLength(2)
+        expect(scannedOutput).toBe(output.replace(SHELL_READY_MARKER_OUTPUT, ''))
+        const rendered = new HeadlessEmulator({ cols: 80, rows: 24 })
+        expect(rendered.writeSync(scannedOutput)).toBe(true)
+        expect(rendered.getVisibleLines().join('\n')).not.toContain('[?2004h')
+        rendered.dispose()
         expect(existsSync(sentinel)).toBe(true)
         // Why: asserts the erase directly rather than inferring it from the marker
         // count, which only holds once enough prompts have been drawn to expose it.

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -658,6 +658,23 @@ describe('LocalPtyProvider', () => {
       }
     })
 
+    it.each([
+      ['after the ready marker', ['\x1b]777;orca-shell-ready\x07', '\x1b[?2004hfish> ']],
+      ['after the ESC introducer', ['\x1b]777;orca-shell-ready\x07\x1b', '[?2004hfish> ']]
+    ])('preserves Fish bracketed-paste output split %s', async (_boundary, chunks) => {
+      process.env.SHELL = '/usr/bin/fish'
+      const received: string[] = []
+      provider.configure({ onData: (_id, data) => received.push(data) })
+
+      await provider.spawn({ cols: 80, rows: 24, command: 'printf ready' })
+      const dataCallback = mockProc.onData.mock.calls[0]?.[0] as (data: string) => void
+      for (const chunk of chunks) {
+        dataCallback(chunk)
+      }
+
+      expect(received.join('')).toBe('\x1b[?2004hfish> ')
+    })
+
     it('releases held marker-prefix bytes when local shell readiness times out', async () => {
       vi.useFakeTimers()
       const onData = vi.fn()

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -29,9 +29,6 @@ import { prepareMacosTccLoginShell } from './macos-tcc-login-shell'
 import {
   getMarkerlessShellLaunchConfig,
   getShellReadyLaunchConfig,
-  createShellReadyScanState,
-  drainShellReadyHeldBytes,
-  scanForShellReady,
   writeStartupCommandWhenShellReady,
   STARTUP_COMMAND_READY_MAX_WAIT_MS
 } from './local-pty-shell-ready'
@@ -76,10 +73,10 @@ import {
   readPtySlavePath
 } from '../../shared/pty-slave-line-discipline-echo'
 import {
-  createShellStartupIdentityScanState,
-  drainShellStartupIdentityHeldBytes,
-  scanForShellStartupIdentity
-} from '../shell-startup-identity-scanner'
+  createShellStartupOutputScanState,
+  drainShellStartupOutputScanState,
+  scanShellStartupOutput
+} from '../shell-startup-output-scanner'
 import {
   createShellPromptReadinessProbe,
   type ShellPromptReadinessProbe
@@ -961,11 +958,8 @@ export class LocalPtyProvider implements IPtyProvider {
     let shellReadyTimeout: ReturnType<typeof setTimeout> | null = null
     let shellStartupPid: number | null = null
     let shellPromptReadinessProbe: ShellPromptReadinessProbe | null = null
-    let shellStartupIdentityScanState = shellReadyLaunch?.supportsReadyMarker
-      ? createShellStartupIdentityScanState()
-      : null
-    const shellReadyScanState = shellReadyLaunch?.supportsReadyMarker
-      ? createShellReadyScanState()
+    let shellStartupOutputScanState = shellReadyLaunch?.supportsReadyMarker
+      ? createShellStartupOutputScanState()
       : null
     const shellReadyPromise = args.command
       ? new Promise<ShellReadySignal>((resolve) => {
@@ -987,23 +981,17 @@ export class LocalPtyProvider implements IPtyProvider {
       resolve(signal)
     }
     const releaseHeldShellReadyBytes = (): void => {
-      if (!shellReadyScanState) {
+      if (!shellStartupOutputScanState) {
         return
       }
-      let heldBytes = shellStartupIdentityScanState
-        ? drainShellStartupIdentityHeldBytes(shellStartupIdentityScanState)
-        : ''
-      shellStartupIdentityScanState = null
-      if (heldBytes) {
-        heldBytes = scanForShellReady(shellReadyScanState, heldBytes).output
-      }
-      heldBytes += drainShellReadyHeldBytes(shellReadyScanState)
+      const heldBytes = drainShellStartupOutputScanState(shellStartupOutputScanState)
+      shellStartupOutputScanState = null
       if (heldBytes.length === 0) {
         return
       }
       startupIngress.accept(heldBytes)
     }
-    if (shellReadyScanState) {
+    if (shellStartupOutputScanState) {
       shellPromptReadinessProbe = createShellPromptReadinessProbe({
         slavePath: readPtySlavePath(proc),
         shellPath,
@@ -1048,18 +1036,13 @@ export class LocalPtyProvider implements IPtyProvider {
     const disposables: { dispose: () => void }[] = []
     const onDataDisposable = proc.onData((rawData) => {
       let data = rawData
-      if (shellStartupIdentityScanState && resolveShellReady) {
-        const scanned = scanForShellStartupIdentity(shellStartupIdentityScanState, data)
+      if (shellStartupOutputScanState && resolveShellReady) {
+        const scanned = scanShellStartupOutput(shellStartupOutputScanState, data)
         data = scanned.output
         if (scanned.shellPid) {
           shellStartupPid = scanned.shellPid
-          shellStartupIdentityScanState = null
         }
-      }
-      if (shellReadyScanState && resolveShellReady) {
-        const scanned = scanForShellReady(shellReadyScanState, data)
-        data = scanned.output
-        if (scanned.matched) {
+        if (scanned.ready) {
           finishShellReady({ postMarkerBytesObserved: scanned.postMarkerBytesObserved })
         }
       }

--- a/src/main/shell-ready-marker-scanner.ts
+++ b/src/main/shell-ready-marker-scanner.ts
@@ -11,6 +11,10 @@ export type ShellReadyScanResult = {
   postMarkerBytesObserved: boolean
 }
 
+type ShellReadyBoundaryScanResult = ShellReadyScanResult & {
+  postMarkerOutputIndex: number | null
+}
+
 export function createShellReadyScanState(): ShellReadyScanState {
   return { matchPos: 0, heldBytes: '' }
 }
@@ -22,7 +26,10 @@ export function drainShellReadyHeldBytes(state: ShellReadyScanState): string {
   return heldBytes
 }
 
-export function scanForShellReady(state: ShellReadyScanState, data: string): ShellReadyScanResult {
+export function scanForShellReadyBoundary(
+  state: ShellReadyScanState,
+  data: string
+): ShellReadyBoundaryScanResult {
   let output = ''
 
   for (let i = 0; i < data.length; i += 1) {
@@ -49,7 +56,8 @@ export function scanForShellReady(state: ShellReadyScanState, data: string): She
       return {
         output: output + remaining,
         matched: true,
-        postMarkerBytesObserved: remaining.length > 0
+        postMarkerBytesObserved: remaining.length > 0,
+        postMarkerOutputIndex: output.length
       }
     } else {
       output += state.heldBytes
@@ -64,5 +72,15 @@ export function scanForShellReady(state: ShellReadyScanState, data: string): She
     }
   }
 
-  return { output, matched: false, postMarkerBytesObserved: false }
+  return {
+    output,
+    matched: false,
+    postMarkerBytesObserved: false,
+    postMarkerOutputIndex: null
+  }
+}
+
+export function scanForShellReady(state: ShellReadyScanState, data: string): ShellReadyScanResult {
+  const { postMarkerOutputIndex: _, ...result } = scanForShellReadyBoundary(state, data)
+  return result
 }

--- a/src/main/shell-startup-output-scanner.test.ts
+++ b/src/main/shell-startup-output-scanner.test.ts
@@ -6,6 +6,42 @@ import {
 } from './shell-startup-output-scanner'
 
 const READY_MARKER = '\x1b]777;orca-shell-ready\x07'
+const IDENTITY_MARKER = '\x1b]777;orca-shell-start:12345\x07'
+
+function scanChunks(chunks: string[]): {
+  output: string
+  shellPid: number | null
+  ready: boolean
+  postMarkerBytesObserved: boolean
+} {
+  const state = createShellStartupOutputScanState()
+  let output = ''
+  let shellPid: number | null = null
+  let ready = false
+  let postMarkerBytesObserved = false
+
+  for (const chunk of chunks) {
+    const scanned = scanShellStartupOutput(state, chunk)
+    output += scanned.output
+    shellPid ??= scanned.shellPid
+    ready ||= scanned.ready
+    postMarkerBytesObserved ||= scanned.postMarkerBytesObserved
+  }
+  return { output, shellPid, ready, postMarkerBytesObserved }
+}
+
+function expectEverySplitToProduce(
+  input: string,
+  expected: Omit<ReturnType<typeof scanChunks>, 'postMarkerBytesObserved'>
+): void {
+  for (let split = 0; split <= input.length; split += 1) {
+    const { postMarkerBytesObserved: _, ...scanned } = scanChunks([
+      input.slice(0, split),
+      input.slice(split)
+    ])
+    expect(scanned, `split ${split}`).toEqual(expected)
+  }
+}
 
 describe('shell startup output scanner', () => {
   it.each([
@@ -22,12 +58,30 @@ describe('shell startup output scanner', () => {
     expect(output).toBe('\x1b[?2004hfish> ')
   })
 
+  it('preserves every post-ready byte at every chunk boundary', () => {
+    expectEverySplitToProduce(`${READY_MARKER}${IDENTITY_MARKER}prompt`, {
+      output: `${IDENTITY_MARKER}prompt`,
+      shellPid: null,
+      ready: true
+    })
+    expectEverySplitToProduce(`${READY_MARKER}\x1b[?2004hfish> `, {
+      output: '\x1b[?2004hfish> ',
+      shellPid: null,
+      ready: true
+    })
+  })
+
+  it('strips pre-ready markers at every chunk boundary', () => {
+    expectEverySplitToProduce(`${IDENTITY_MARKER}${READY_MARKER}prompt`, {
+      output: 'prompt',
+      shellPid: 12345,
+      ready: true
+    })
+  })
+
   it('strips identity and readiness markers from one chunk', () => {
     const state = createShellStartupOutputScanState()
-    const scanned = scanShellStartupOutput(
-      state,
-      `\x1b]777;orca-shell-start:12345\x07${READY_MARKER}prompt`
-    )
+    const scanned = scanShellStartupOutput(state, `${IDENTITY_MARKER}${READY_MARKER}prompt`)
 
     expect(scanned).toEqual({
       output: 'prompt',

--- a/src/main/shell-startup-output-scanner.test.ts
+++ b/src/main/shell-startup-output-scanner.test.ts
@@ -108,4 +108,14 @@ describe('shell startup output scanner', () => {
 
     expect(drainShellStartupOutputScanState(state)).toBe('\x1b]777;orca-shell-st')
   })
+
+  it('drains simultaneous identity and readiness prefixes in input order', () => {
+    const state = createShellStartupOutputScanState()
+    expect(scanShellStartupOutput(state, '\x1b]777;orca-shell-st').output).toBe('')
+    expect(scanShellStartupOutput(state, '\x1b]777;orca-shell-rea').output).toBe('')
+
+    expect(drainShellStartupOutputScanState(state)).toBe(
+      '\x1b]777;orca-shell-st\x1b]777;orca-shell-rea'
+    )
+  })
 })

--- a/src/main/shell-startup-output-scanner.test.ts
+++ b/src/main/shell-startup-output-scanner.test.ts
@@ -37,6 +37,17 @@ describe('shell startup output scanner', () => {
     })
   })
 
+  it('counts an identity-held byte as post-marker output', () => {
+    const state = createShellStartupOutputScanState()
+
+    expect(scanShellStartupOutput(state, `${READY_MARKER}\x1b`)).toEqual({
+      output: '\x1b',
+      shellPid: null,
+      ready: true,
+      postMarkerBytesObserved: true
+    })
+  })
+
   it('drains every incomplete scanner prefix in byte order', () => {
     const state = createShellStartupOutputScanState()
     expect(scanShellStartupOutput(state, '\x1b]777;orca-shell-st').output).toBe('')

--- a/src/main/shell-startup-output-scanner.test.ts
+++ b/src/main/shell-startup-output-scanner.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createShellStartupOutputScanState,
+  drainShellStartupOutputScanState,
+  scanShellStartupOutput
+} from './shell-startup-output-scanner'
+
+const READY_MARKER = '\x1b]777;orca-shell-ready\x07'
+
+describe('shell startup output scanner', () => {
+  it.each([
+    ['after the ready marker', [READY_MARKER, '\x1b[?2004hfish> ']],
+    ['after the ESC introducer', [`${READY_MARKER}\x1b`, '[?2004hfish> ']]
+  ])('preserves Fish output split %s', (_boundary, chunks) => {
+    const state = createShellStartupOutputScanState()
+    let output = ''
+
+    for (const chunk of chunks) {
+      output += scanShellStartupOutput(state, chunk).output
+    }
+
+    expect(output).toBe('\x1b[?2004hfish> ')
+  })
+
+  it('strips identity and readiness markers from one chunk', () => {
+    const state = createShellStartupOutputScanState()
+    const scanned = scanShellStartupOutput(
+      state,
+      `\x1b]777;orca-shell-start:12345\x07${READY_MARKER}prompt`
+    )
+
+    expect(scanned).toEqual({
+      output: 'prompt',
+      shellPid: 12345,
+      ready: true,
+      postMarkerBytesObserved: true
+    })
+  })
+
+  it('drains every incomplete scanner prefix in byte order', () => {
+    const state = createShellStartupOutputScanState()
+    expect(scanShellStartupOutput(state, '\x1b]777;orca-shell-st').output).toBe('')
+
+    expect(drainShellStartupOutputScanState(state)).toBe('\x1b]777;orca-shell-st')
+  })
+})

--- a/src/main/shell-startup-output-scanner.ts
+++ b/src/main/shell-startup-output-scanner.ts
@@ -1,7 +1,7 @@
 import {
   createShellReadyScanState,
   drainShellReadyHeldBytes,
-  scanForShellReady,
+  scanForShellReadyBoundary,
   type ShellReadyScanState
 } from './shell-ready-marker-scanner'
 import {
@@ -34,30 +34,30 @@ export function scanShellStartupOutput(
   state: ShellStartupOutputScanState,
   data: string
 ): ShellStartupOutputScanResult {
+  const readiness = scanForShellReadyBoundary(state.ready, data)
+  const postMarkerOutputIndex = readiness.postMarkerOutputIndex ?? readiness.output.length
+  const identityInput = readiness.output.slice(0, postMarkerOutputIndex)
   let shellPid: number | null = null
+  let output = identityInput
   if (state.identity) {
-    const identity = scanForShellStartupIdentity(state.identity, data)
-    data = identity.output
+    const identity = scanForShellStartupIdentity(state.identity, identityInput)
+    output = identity.output
     shellPid = identity.shellPid
     if (shellPid) {
       state.identity = null
     }
   }
 
-  const readiness = scanForShellReady(state.ready, data)
-  let output = readiness.output
-  let postMarkerBytesObserved = readiness.postMarkerBytesObserved
   if (readiness.matched && state.identity) {
-    const heldOutput = drainShellStartupIdentityHeldBytes(state.identity)
-    output += heldOutput
-    postMarkerBytesObserved ||= heldOutput.length > 0
+    output += drainShellStartupIdentityHeldBytes(state.identity)
     state.identity = null
   }
+  output += readiness.output.slice(postMarkerOutputIndex)
   return {
     output,
     shellPid,
     ready: readiness.matched,
-    postMarkerBytesObserved
+    postMarkerBytesObserved: readiness.postMarkerBytesObserved
   }
 }
 
@@ -65,7 +65,7 @@ export function drainShellStartupOutputScanState(state: ShellStartupOutputScanSt
   let output = state.identity ? drainShellStartupIdentityHeldBytes(state.identity) : ''
   state.identity = null
   if (output) {
-    output = scanForShellReady(state.ready, output).output
+    output = scanForShellReadyBoundary(state.ready, output).output
   }
   return output + drainShellReadyHeldBytes(state.ready)
 }

--- a/src/main/shell-startup-output-scanner.ts
+++ b/src/main/shell-startup-output-scanner.ts
@@ -62,10 +62,7 @@ export function scanShellStartupOutput(
 }
 
 export function drainShellStartupOutputScanState(state: ShellStartupOutputScanState): string {
-  let output = state.identity ? drainShellStartupIdentityHeldBytes(state.identity) : ''
+  const output = state.identity ? drainShellStartupIdentityHeldBytes(state.identity) : ''
   state.identity = null
-  if (output) {
-    output = scanForShellReadyBoundary(state.ready, output).output
-  }
   return output + drainShellReadyHeldBytes(state.ready)
 }

--- a/src/main/shell-startup-output-scanner.ts
+++ b/src/main/shell-startup-output-scanner.ts
@@ -1,0 +1,68 @@
+import {
+  createShellReadyScanState,
+  drainShellReadyHeldBytes,
+  scanForShellReady,
+  type ShellReadyScanState
+} from './shell-ready-marker-scanner'
+import {
+  createShellStartupIdentityScanState,
+  drainShellStartupIdentityHeldBytes,
+  scanForShellStartupIdentity,
+  type ShellStartupIdentityScanState
+} from './shell-startup-identity-scanner'
+
+export type ShellStartupOutputScanState = {
+  ready: ShellReadyScanState
+  identity: ShellStartupIdentityScanState | null
+}
+
+export type ShellStartupOutputScanResult = {
+  output: string
+  shellPid: number | null
+  ready: boolean
+  postMarkerBytesObserved: boolean
+}
+
+export function createShellStartupOutputScanState(): ShellStartupOutputScanState {
+  return {
+    ready: createShellReadyScanState(),
+    identity: createShellStartupIdentityScanState()
+  }
+}
+
+export function scanShellStartupOutput(
+  state: ShellStartupOutputScanState,
+  data: string
+): ShellStartupOutputScanResult {
+  let shellPid: number | null = null
+  if (state.identity) {
+    const identity = scanForShellStartupIdentity(state.identity, data)
+    data = identity.output
+    shellPid = identity.shellPid
+    if (shellPid) {
+      state.identity = null
+    }
+  }
+
+  const readiness = scanForShellReady(state.ready, data)
+  let output = readiness.output
+  if (readiness.matched && state.identity) {
+    output += drainShellStartupIdentityHeldBytes(state.identity)
+    state.identity = null
+  }
+  return {
+    output,
+    shellPid,
+    ready: readiness.matched,
+    postMarkerBytesObserved: readiness.postMarkerBytesObserved
+  }
+}
+
+export function drainShellStartupOutputScanState(state: ShellStartupOutputScanState): string {
+  let output = state.identity ? drainShellStartupIdentityHeldBytes(state.identity) : ''
+  state.identity = null
+  if (output) {
+    output = scanForShellReady(state.ready, output).output
+  }
+  return output + drainShellReadyHeldBytes(state.ready)
+}

--- a/src/main/shell-startup-output-scanner.ts
+++ b/src/main/shell-startup-output-scanner.ts
@@ -46,15 +46,18 @@ export function scanShellStartupOutput(
 
   const readiness = scanForShellReady(state.ready, data)
   let output = readiness.output
+  let postMarkerBytesObserved = readiness.postMarkerBytesObserved
   if (readiness.matched && state.identity) {
-    output += drainShellStartupIdentityHeldBytes(state.identity)
+    const heldOutput = drainShellStartupIdentityHeldBytes(state.identity)
+    output += heldOutput
+    postMarkerBytesObserved ||= heldOutput.length > 0
     state.identity = null
   }
   return {
     output,
     shellPid,
     ready: readiness.matched,
-    postMarkerBytesObserved: readiness.postMarkerBytesObserved
+    postMarkerBytesObserved
   }
 }
 

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -27,19 +27,13 @@ import {
 } from '../shared/cross-platform-path'
 import { splitWorktreeId } from '../shared/worktree-id'
 import { PhysicalExitTracker } from '../shared/physical-exit-tracker'
+import { SHELL_READY_MARKER_PREFIX } from '../main/shell-ready-marker-scanner'
 import {
-  createShellReadyScanState,
-  drainShellReadyHeldBytes,
-  scanForShellReady,
-  SHELL_READY_MARKER_PREFIX,
-  type ShellReadyScanState
-} from '../main/shell-ready-marker-scanner'
-import {
-  createShellStartupIdentityScanState,
-  drainShellStartupIdentityHeldBytes,
-  scanForShellStartupIdentity,
-  type ShellStartupIdentityScanState
-} from '../main/shell-startup-identity-scanner'
+  createShellStartupOutputScanState,
+  drainShellStartupOutputScanState,
+  scanShellStartupOutput,
+  type ShellStartupOutputScanState
+} from '../main/shell-startup-output-scanner'
 import {
   createShellPromptReadinessProbe,
   type ShellPromptReadinessProbe
@@ -196,8 +190,7 @@ type ManagedStartupCommand = {
   providerDelivery: boolean
   delivered: boolean
   waitForShellReady: boolean
-  scanState: ShellReadyScanState | null
-  identityScanState: ShellStartupIdentityScanState | null
+  outputScanState: ShellStartupOutputScanState | null
   shellPid: number | null
   promptProbe: ShellPromptReadinessProbe | null
   timer: ReturnType<typeof setTimeout> | null
@@ -658,17 +651,11 @@ export class PtyHandler {
   }
 
   private drainStartupScanBytes(startup: ManagedStartupCommand): string {
-    let heldBytes = startup.identityScanState
-      ? drainShellStartupIdentityHeldBytes(startup.identityScanState)
-      : ''
-    startup.identityScanState = null
-    if (startup.scanState && heldBytes) {
-      heldBytes = scanForShellReady(startup.scanState, heldBytes).output
+    if (!startup.outputScanState) {
+      return ''
     }
-    if (startup.scanState) {
-      heldBytes += drainShellReadyHeldBytes(startup.scanState)
-      startup.scanState = null
-    }
+    const heldBytes = drainShellStartupOutputScanState(startup.outputScanState)
+    startup.outputScanState = null
     return heldBytes
   }
 
@@ -767,18 +754,13 @@ export class PtyHandler {
     }
     managed.pty.onData((data: string) => {
       const startup = managed.startupCommand
-      if (startup?.identityScanState && !startup.delivered) {
-        const scanned = scanForShellStartupIdentity(startup.identityScanState, data)
+      if (startup?.waitForShellReady && startup.outputScanState && !startup.delivered) {
+        const scanned = scanShellStartupOutput(startup.outputScanState, data)
         data = scanned.output
         if (scanned.shellPid) {
           startup.shellPid = scanned.shellPid
-          startup.identityScanState = null
         }
-      }
-      if (startup?.waitForShellReady && startup.scanState && !startup.delivered) {
-        const scanned = scanForShellReady(startup.scanState, data)
-        data = scanned.output
-        if (scanned.matched) {
+        if (scanned.ready) {
           if (startup.providerDelivery) {
             this.scheduleStartupCommandResolution(managed, STARTUP_COMMAND_WRITE_DELAY_MS)
           } else {
@@ -1644,13 +1626,9 @@ export class PtyHandler {
               providerDelivery: shouldProviderDeliverCommand,
               delivered: false,
               waitForShellReady: shellLaunch.env.ORCA_SHELL_READY_MARKER === '1',
-              scanState:
+              outputScanState:
                 shellLaunch.env.ORCA_SHELL_READY_MARKER === '1'
-                  ? createShellReadyScanState()
-                  : null,
-              identityScanState:
-                shellLaunch.env.ORCA_SHELL_READY_MARKER === '1'
-                  ? createShellStartupIdentityScanState()
+                  ? createShellStartupOutputScanState()
                   : null,
               shellPid: null,
               promptProbe: null,


### PR DESCRIPTION
Linear: https://linear.app/stably/issue/STA-4068/p2-fish-readiness-can-drop-esc-before-bracketed-paste-enable-after-pr
Follow-up to merged #14027 (`90b8554fc9`).

## Invariant

Shell startup scanning must preserve every non-Orca byte exactly and in raw order across arbitrary PTY chunk boundaries. Identity scanning owns only bytes before the ready marker; every byte after readiness belongs to the terminal.

Gate: `terminal-session.shell-ready-exec-prompt-fallback`.

## Deterministic reproduction

The local-provider and daemon-session oracles feed identical Fish output at two boundaries:

1. `OSC 777 ready BEL` | `ESC [ ? 2004 h fish> `
2. `OSC 777 ready BEL ESC` | `[ ? 2004 h fish> `

Both assert exact forwarded bytes `ESC [ ? 2004 h fish> `. The daemon oracle independently renders them through headless xterm and asserts that the first prompt contains no literal `[?2004h`. Oracle patch SHA-256: `fd49a4d3d91bd5f0d10c1b1f44f4cfbd92cef9155a5505b415c8680184cdc765`.

| Ref | Marker split | ESC split |
| --- | --- | --- |
| scan target `e4c278eb52` | local + daemon pass | local + daemon fail: ESC missing |
| latest main `150cc6f50c` | local + daemon pass | local + daemon fail: ESC missing |
| candidate `ae7f30318a` | local + daemon pass | local + daemon pass |
| candidate with shared integration disabled | local + daemon pass | local + daemon fail: ESC missing |

The focused matrix was 2 failures / 161 passes on target, latest main, and disabled candidate; candidate passed 163/163.

Exhaustive shared-scanner tests also cover every two-way split for:

- `READY + identity-looking bytes + prompt`: post-ready bytes remain literal and PID stays null.
- `IDENTITY + READY + prompt`: markers strip and PID is returned.
- incomplete identity plus incomplete readiness prefixes: teardown drains them in original order.

## Root cause and fix

#14027 composed two independent scanners. Fish emits a ready marker but no identity marker. If a PTY chunk ended in the ESC immediately after readiness, the identity scanner retained the ESC as a possible marker prefix; readiness completed; local/daemon teardown discarded that state; xterm then received bare `[?2004h` and printed it.

This PR makes one shared composition authoritative for local, daemon, and SSH relay paths. It locates readiness first, limits identity scanning to the exact pre-ready region, preserves all post-ready bytes, and drains held prefixes in input order.

Alternatives considered:

- Disable identity scanning for Fish: fixes one shell but leaves composition unsafe.
- Add local/daemon drains: duplicates ordering rules and can drift from relay.
- Shared ordered composition (chosen): fixes the invariant once without a shell special case or wire change.

## Compatibility and performance

- No RPC, stream opcode, persistence, renderer, mobile, Git-provider, filesystem, or workspace contract changes.
- Bash/Zsh retain PID-based exec recovery. Fish becomes lossless. PowerShell, cmd, ConPTY, WSL, and native Windows readiness behavior is unchanged.
- SSH relay uses the same scanner; paired and folder workspaces inherit host-owned behavior without local-path assumptions.
- State remains bounded to 65 UTF-16 units. No polling, subprocesses, timers, listeners, retries, fanout, or steady-state work were added.
- Synthetic pre-ready floods measured 104–149 MiB/s (about 1.8 ms/MiB slower than identity-first parsing); typical startup chunks remain sub-microsecond and no user-visible/resource regression was established.

## Validation

- full readiness gate at final behavior: 13 files, 474 passed, 1 local Fish skip
- exact local/daemon oracle on latest-main rebase: 163/163
- isolated Debian 12 arm64, real Fish 3.6 + real node-pty: exact marker stripping and clean headless-xterm rendering passed on the chunk-invariant candidate; the final follow-up changes teardown drain order only
- full TypeScript typecheck: passed
- full lint, native/type-aware audits, localization, reliability manifest (77/77), and max-lines ratchet: passed
- exhaustive adversarial partitions: post-ready identity 1,770; pre-ready identity 1,770; Fish 741; pre-output composition 2,850; lookalikes 1,596
- performance/resource review: clean
- PR CI: running on final pushed head

Residual live gaps remain physical SSH, paired-runtime, WSL, and native Windows/ConPTY. They share no changed wire shape; deterministic relay owner tests cover the modified ownership. A pre-existing relay explicit-shutdown path can discard a held incomplete marker while destroying the PTY; it does not affect a surviving first prompt and is intentionally out of scope.
