### PR TITLE
chore(repo): ignore generated Clawpatch state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,10 @@ playwright-report/
 /.agents/skills/
 /skills-lock.json
 
+# Generated Clawpatch state includes machine-local paths and review records.
+/.clawpatch/
+/mobile/.clawpatch/
+
 # Agent hook runtime endpoints (machine-local secrets)
 /agent-hooks/
 validation-screenshots/


### PR DESCRIPTION
## ELI5

Clawpatch builds a local map of the repository and keeps review notes next to that map. Those files describe this machine and this review run; they are useful locally, but they are not source code and should never accidentally enter a product commit.

## What Changed

- Ignore `/.clawpatch/` at the repository root.
- Ignore `/mobile/.clawpatch/` for the separately mapped mobile project.
- Keep the rules root-anchored so a legitimately named nested fixture is not hidden.
- Document why the generated state is intentionally local.

## Why

Clawpatch state includes generated feature records, run metadata, local filesystem paths, and review artifacts. Tracking it would create large machine-specific diffs, expose workstation paths, and make future repository reviews noisy. Root and mobile have separate Clawpatch projects, so both generated locations need an explicit rule.

## Linked Issue

No linked issue — discovered while running a Clawpatch repository review.

## Visual Proof

N/A — repository hygiene only; no UI or interaction changes.

## Testing

- [x] Automated checks added/updated, or explained why not below
- [x] Verified with `git check-ignore -v --no-index .clawpatch/reports/final-review.html mobile/.clawpatch/project.json`.
- [x] `git diff --check` passed.

No product test is needed because this changes only Git's ignore rules.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** reduces the chance of committing machine-local paths and review records.
- **Cross-platform:** Git's root-anchored slash syntax behaves consistently on macOS, Linux, and Windows.
- **SSH / folder workspaces / mobile:** no runtime behavior changes; the second rule covers the independent mobile map.
- **Compatibility and performance:** no application code, wire data, dependencies, or generated product assets change.
- **Rollback:** a normal revert is sufficient, but would make generated Clawpatch state visible to Git again.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Relevant local checks pass

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
