### PR TITLE
fix(browser): sanitize reserved Windows download names

### DIFF
--- a/src/main/browser/browser-download-destination.test.ts
+++ b/src/main/browser/browser-download-destination.test.ts
@@ -86,6 +86,40 @@ describe('BrowserDownloadDestinationReservations', () => {
     expect(macReservations.reserve('report.csv').filename).toBe('report (1).csv')
   })
 
+  it('rewrites Windows reserved device basenames', () => {
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => false),
+      platform: 'win32'
+    })
+
+    expect(reservations.reserve('CON').filename).toBe('_CON')
+    expect(reservations.reserve('con.txt').filename).toBe('_con.txt')
+    expect(reservations.reserve('NUL.tar.gz').filename).toBe('_NUL.tar.gz')
+    expect(reservations.reserve('AUX.json').filename).toBe('_AUX.json')
+    expect(reservations.reserve('PRN').filename).toBe('_PRN')
+    expect(reservations.reserve('CLOCK$.csv').filename).toBe('_CLOCK$.csv')
+    expect(reservations.reserve('CONIN$.txt').filename).toBe('_CONIN$.txt')
+    expect(reservations.reserve('CONOUT$.log').filename).toBe('_CONOUT$.log')
+    expect(reservations.reserve('COM1.log').filename).toBe('_COM1.log')
+    expect(reservations.reserve('COM¹.log').filename).toBe('_COM¹.log')
+    expect(reservations.reserve('LPT9.csv').filename).toBe('_LPT9.csv')
+    expect(reservations.reserve('LPT³.csv').filename).toBe('_LPT³.csv')
+    expect(reservations.reserve('COM10.log').filename).toBe('COM10.log')
+    expect(reservations.reserve('LPT0.csv').filename).toBe('LPT0.csv')
+    expect(reservations.reserve('CONSOLE.txt').filename).toBe('CONSOLE.txt')
+  })
+
+  it('preserves Windows device-like names on other platforms', () => {
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => false),
+      platform: 'linux'
+    })
+
+    expect(reservations.reserve('CON.txt').filename).toBe('CON.txt')
+  })
+
   it('fails after bounded collision attempts', () => {
     const reservations = new BrowserDownloadDestinationReservations({
       downloadsPath,

--- a/src/main/browser/browser-download-destination.ts
+++ b/src/main/browser/browser-download-destination.ts
@@ -5,6 +5,8 @@ import { app } from 'electron'
 
 const MAX_BROWSER_DOWNLOAD_COLLISION_ATTEMPTS = 1_000
 const WINDOWS_RESERVED_FILENAME_CHARS = new Set(['<', '>', ':', '"', '|', '?', '*'])
+const WINDOWS_RESERVED_FILENAME =
+  /^(?:con|prn|aux|nul|clock\$|conin\$|conout\$|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/iu
 
 export type BrowserDownloadDestination = {
   filename: string
@@ -18,7 +20,7 @@ type BrowserDownloadDestinationOptions = {
   platform?: NodeJS.Platform
 }
 
-function normalizeFilename(filename: string): string {
+function normalizeFilename(filename: string, platform: NodeJS.Platform): string {
   // Normalize separators first so basename strips paths from any platform.
   const normalizedSeparators = filename.replace(/\\/g, '/')
   const rawBasename = path.posix.basename(normalizedSeparators).trim()
@@ -32,7 +34,12 @@ function normalizeFilename(filename: string): string {
     .join('')
     .replace(/[. ]+$/g, '')
     .trim()
-  return safeName || 'download'
+  if (!safeName) {
+    return 'download'
+  }
+  return platform === 'win32' && WINDOWS_RESERVED_FILENAME.test(safeName)
+    ? `_${safeName}`
+    : safeName
 }
 
 function buildCollisionCandidate(filename: string, suffix: number): string {
@@ -65,7 +72,7 @@ export class BrowserDownloadDestinationReservations {
   }
 
   reserve(filename: string): BrowserDownloadDestination {
-    const safeFilename = normalizeFilename(filename)
+    const safeFilename = normalizeFilename(filename, this.platform)
     const downloadsPath = this.downloadsPath()
 
     for (let attempt = 0; attempt < MAX_BROWSER_DOWNLOAD_COLLISION_ATTEMPTS; attempt += 1) {


### PR DESCRIPTION
## ELI5

Windows reserves filenames such as `CON`, `NUL`, and `COM1` for devices. Orca could choose one of those names for a browser download and then fail when Windows refused to create it. Orca now adds a leading underscore to only those reserved names before reserving the destination.

## What Changed

- Make download filename normalization aware of the target platform.
- Detect the complete Windows device-name family:
  - `CON`, `PRN`, `AUX`, and `NUL`;
  - `CLOCK$`, `CONIN$`, and `CONOUT$`;
  - `COM1` through `COM9` and `LPT1` through `LPT9`;
  - the Windows-recognized superscript aliases `¹`, `²`, and `³`.
- Match names case-insensitively and before an extension, so `con.txt` and `NUL.tar.gz` are safe too.
- Prefix exact reserved basenames with `_` before the existing collision-selection loop.
- Preserve near-matches such as `COM10`, `LPT0`, and `CONSOLE`, and preserve all names on non-Windows platforms.

## Why

The existing sanitizer removed separators, forbidden characters, and trailing dots/spaces, but that is not enough on Windows. Device names remain reserved even with an extension, so a path can be syntactically clean and still be impossible to create. Normalizing before collision reservation prevents a predictable download failure without changing ordinary filenames.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review.

## Visual Proof

N/A — no rendered UI changes. The behavior is filesystem-level filename selection and is covered by deterministic tests.

## Testing

- [x] Automated tests added/updated
- [x] Focused branch run: `browser-download-destination.test.ts` — 8/8 tests passed.
- [x] Full rebased review set: `pnpm run typecheck`, `pnpm run lint`, `pnpm run test`, and `pnpm run build:desktop` passed.
- [x] Full Vitest result: 4,748 files passed, 19 skipped; 50,934 tests passed, 114 skipped.

The regression covers casing, extensions, all special device families, superscript aliases, near-misses, and non-Windows behavior.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** no new input reaches the filesystem; this further constrains an existing untrusted filename.
- **Cross-platform:** the reserved-name rewrite is guarded by `platform === 'win32'`; macOS and Linux behavior is byte-for-byte unchanged.
- **SSH / remote / folder workspaces:** browser downloads remain local to the Electron host; no workspace-kind assumption or wire change was added.
- **Performance:** one anchored regular-expression test per reserved filename, before the existing bounded collision loop.
- **Compatibility:** ordinary names and collision suffixes are unchanged. Only names that Windows cannot create are rewritten.
- **Rollback:** revert the two files; no persisted migration is required, though reserved-name downloads would fail again.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
