### PR TITLE
fix(browser): remove credentials from grabbed URLs

### DIFF
--- a/src/main/browser/browser-grab-payload.test.ts
+++ b/src/main/browser/browser-grab-payload.test.ts
@@ -148,4 +148,31 @@ describe('clampGrabPayload', () => {
     expect(payload?.target.attributes.action).toBe('')
     expect(payload?.target.attributes.title).toBe('Safe label')
   })
+
+  it('strips credentials from page and attribute URLs', () => {
+    const payload = clampGrabPayload(
+      makeRawPayload({
+        page: {
+          ...(makeRawPayload().page as Record<string, unknown>),
+          sanitizedUrl: 'https://alice:s3cr3t@example.com/page?token=x#fragment'
+        },
+        target: {
+          ...(makeRawPayload().target as Record<string, unknown>),
+          htmlSnippet:
+            '<a href="https://bob:hunter2@example.net/path?q=1#fragment">Private link</a>',
+          attributes: {
+            href: 'https://bob:hunter2@example.net/path?q=1#fragment',
+            src: 'https://carol:p4ss@example.org/image.png?size=2',
+            action: 'https://dave:letmein@example.edu/submit#done'
+          }
+        }
+      })
+    )
+
+    expect(payload?.page.sanitizedUrl).toBe('https://example.com/page')
+    expect(payload?.target.attributes.href).toBe('https://example.net/path')
+    expect(payload?.target.attributes.src).toBe('https://example.org/image.png')
+    expect(payload?.target.attributes.action).toBe('https://example.edu/submit')
+    expect(payload?.target.htmlSnippet).toBe('<a href="https://example.net/path">Private link</a>')
+  })
 })

--- a/src/main/browser/browser-grab-payload.ts
+++ b/src/main/browser/browser-grab-payload.ts
@@ -6,6 +6,14 @@ import {
 } from '../../shared/browser-grab-types'
 
 const SAFE_GRAB_URL_PROTOCOLS = new Set(['http:', 'https:', 'file:'])
+const GRAB_HTML_URL_ATTRIBUTE =
+  /(\b(?:href|src|action)\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/giu
+const GRAB_HTML_ATTRIBUTE_ESCAPE: Record<string, string> = {
+  '&': '&amp;',
+  '"': '&quot;',
+  '<': '&lt;',
+  '>': '&gt;'
+}
 
 /**
  * Re-validate and clamp all string, array, and budget fields in a grab payload
@@ -59,8 +67,7 @@ export function clampGrabPayload(raw: unknown): BrowserGrabPayload | null {
     return GRAB_SECRET_PATTERNS.some((p) => lower.includes(p))
   }
 
-  // Why: mirror the guest-side URL sanitization. Strip query strings and
-  // fragments to prevent token leakage even if the guest is compromised.
+  // Why: mirror guest sanitization so compromised guests cannot forward URL secrets.
   const sanitizeUrl = (rawUrl: unknown): string => {
     const str = typeof rawUrl === 'string' ? rawUrl : ''
     if (!str) {
@@ -74,6 +81,8 @@ export function clampGrabPayload(raw: unknown): BrowserGrabPayload | null {
       if (!SAFE_GRAB_URL_PROTOCOLS.has(url.protocol)) {
         return ''
       }
+      url.username = ''
+      url.password = ''
       url.search = ''
       url.hash = ''
       return url.toString()
@@ -111,6 +120,24 @@ export function clampGrabPayload(raw: unknown): BrowserGrabPayload | null {
       }
     }
     return filtered
+  }
+
+  const sanitizeHtmlSnippet = (value: unknown): string => {
+    const snippet = clampStr(value, GRAB_BUDGET.htmlSnippetMaxLength)
+    if (!snippet || containsSecret(snippet)) {
+      return snippet ? '[redacted]' : ''
+    }
+    return snippet.replace(
+      GRAB_HTML_URL_ATTRIBUTE,
+      (_match, prefix: string, doubleQuoted?: string, singleQuoted?: string, unquoted?: string) => {
+        const sanitized = sanitizeUrl(doubleQuoted ?? singleQuoted ?? unquoted ?? '')
+        const escaped = sanitized.replace(
+          /[&"<>]/g,
+          (character) => GRAB_HTML_ATTRIBUTE_ESCAPE[character] ?? ''
+        )
+        return `${prefix}"${escaped}"`
+      }
+    )
   }
 
   const safeMetadataStr = (value: unknown, max: number): string => {
@@ -181,7 +208,7 @@ export function clampGrabPayload(raw: unknown): BrowserGrabPayload | null {
       ),
       sourceFile: safeNullableMetadataStr(target.sourceFile, GRAB_BUDGET.sourceFileMaxLength),
       textSnippet: clampStr(target.textSnippet, GRAB_BUDGET.textSnippetMaxLength),
-      htmlSnippet: clampStr(target.htmlSnippet, GRAB_BUDGET.htmlSnippetMaxLength),
+      htmlSnippet: sanitizeHtmlSnippet(target.htmlSnippet),
       attributes: safeAttributes(target.attributes),
       accessibility: {
         role: safeNullableMetadataStr(accessibility?.role, 500),

--- a/src/main/browser/grab-guest-script.test.ts
+++ b/src/main/browser/grab-guest-script.test.ts
@@ -56,6 +56,8 @@ describe('buildGuestOverlayScript', () => {
   it('arm script strips script tags from HTML snippets', () => {
     const script = buildGuestOverlayScript('arm')
     expect(script).toContain("querySelectorAll('script')")
+    expect(script).toContain("clone.querySelectorAll('*')")
+    expect(script).toContain('sanitizeCloneElement(descendants[j])')
   })
 
   it('arm script only allows safe attributes', () => {
@@ -111,9 +113,11 @@ describe('buildGuestOverlayScript', () => {
     expect(script).toContain('100vh')
   })
 
-  it('arm script sanitizes URLs by stripping query strings', () => {
+  it('arm script sanitizes URL credentials, query strings, and fragments', () => {
     const script = buildGuestOverlayScript('arm')
     expect(script).toContain('sanitizeUrl')
+    expect(script).toContain("u.username = ''")
+    expect(script).toContain("u.password = ''")
     expect(script).toContain("u.search = ''")
     expect(script).toContain("u.hash = ''")
   })

--- a/src/main/browser/grab-guest-script.ts
+++ b/src/main/browser/grab-guest-script.ts
@@ -109,6 +109,8 @@ const ARM_SCRIPT = `(function() {
       if (!SAFE_URL_PROTOCOLS.has(u.protocol)) {
         return '';
       }
+      u.username = '';
+      u.password = '';
       u.search = '';
       u.hash = '';
       return u.toString();
@@ -116,6 +118,31 @@ const ARM_SCRIPT = `(function() {
       // Why: returning the raw URL on parse failure could preserve javascript:
       // URIs or other non-http schemes. Return empty string instead.
       return '';
+    }
+  }
+
+  function isSafeAttributeName(name) {
+    return SAFE_ATTRS.has(name) || name.indexOf('aria-') === 0;
+  }
+
+  function sanitizeAttributeValue(name, value) {
+    if (containsSecret(value)) return '[redacted]';
+    if ((name === 'href' || name === 'src' || name === 'action') && value) {
+      return sanitizeUrl(value);
+    }
+    if (name === 'class') return clampStr(value, 200);
+    return value;
+  }
+
+  function sanitizeCloneElement(el) {
+    for (var i = el.attributes.length - 1; i >= 0; i--) {
+      var attr = el.attributes[i];
+      var name = attr.name.toLowerCase();
+      if (!isSafeAttributeName(name)) {
+        el.removeAttribute(attr.name);
+      } else {
+        el.setAttribute(name, sanitizeAttributeValue(name, attr.value));
+      }
     }
   }
 
@@ -246,6 +273,11 @@ const ARM_SCRIPT = `(function() {
     for (var i = 0; i < scripts.length; i++) {
       scripts[i].remove();
     }
+    sanitizeCloneElement(clone);
+    var descendants = clone.querySelectorAll('*');
+    for (var j = 0; j < descendants.length; j++) {
+      sanitizeCloneElement(descendants[j]);
+    }
     var html = clone.outerHTML || '';
     return clampStr(html, BUDGET.htmlSnippetMaxLength);
   }
@@ -255,21 +287,8 @@ const ARM_SCRIPT = `(function() {
     for (var i = 0; i < el.attributes.length; i++) {
       var attr = el.attributes[i];
       var name = attr.name.toLowerCase();
-      var isAria = name.indexOf('aria-') === 0;
-      if (!SAFE_ATTRS.has(name) && !isAria) continue;
-      var value = attr.value;
-      // Redact secret-looking values
-      if (containsSecret(value)) {
-        attrs[name] = '[redacted]';
-      } else if ((name === 'href' || name === 'src' || name === 'action') && value) {
-        // Strip query strings and fragments from URL-bearing attributes
-        attrs[name] = sanitizeUrl(value);
-      } else if (name === 'class') {
-        // Cap class list length
-        attrs[name] = clampStr(value, 200);
-      } else {
-        attrs[name] = value;
-      }
+      if (!isSafeAttributeName(name)) continue;
+      attrs[name] = sanitizeAttributeValue(name, attr.value);
     }
     return attrs;
   }


### PR DESCRIPTION
## ELI5

When Orca captures page context for a browser annotation, a URL like `https://alice:password@example.com/page?token=...` must not carry the username, password, query, or fragment into Orca or AI context. The structured fields already dropped some of that data; this closes the remaining credential path, including URLs embedded in the captured HTML preview.

## What Changed

- Clear `URL.username` and `URL.password` in the injected guest sanitizer, in addition to the existing query and fragment removal.
- Repeat the same sanitization in the main process because guest-page output is untrusted.
- Apply the policy to:
  - the page URL;
  - `href`, `src`, and `action` in the structured attribute map;
  - URL-bearing attributes inside `htmlSnippet`.
- Sanitize the cloned HTML before serialization:
  - remove script elements;
  - remove attributes outside the established allowlist (plus `aria-*`);
  - redact known secret-bearing values;
  - sanitize URL-bearing attributes on the selected element and every descendant.
- Keep the main-side protocol allowlist and reject malformed, executable, or embedded schemes.
- Escape sanitized attribute output before putting it back into the bounded HTML snippet.

## Why

The previous sanitizer removed `?query` and `#fragment`, but WHATWG URL serialization preserves basic-auth userinfo unless it is explicitly cleared. A page-controlled URL could therefore put credentials into the renderer and ultimately into an annotation prompt. Sanitizing only `target.attributes` was also incomplete because `htmlSnippet` separately serialized the original `outerHTML`.

Both layers are intentional: the guest removes secrets at the source, while main revalidates the payload at the trust boundary before renderer delivery.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review and its follow-up adversarial pass.

## Visual Proof

N/A — the annotation UI is unchanged. Only the sensitive contents of its captured context are reduced.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 3 files, 73/73 tests passed.
- [x] Covered `browser-grab-payload`, the injected guest script contract, and browser-manager grab integration.
- [x] Regression verifies credentials disappear from the page URL, structured attributes, and HTML snippet.
- [x] Full rebased review set passed typecheck, lint/reliability gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** this is a privacy/security hardening change at two trust boundaries. Unsafe schemes remain fail-closed.
- **Cross-platform:** URL and string handling are platform-independent; no OS branches or filesystem behavior changed.
- **SSH / remote / folder workspaces:** browser-grab payloads remain local main-to-renderer data; no remote wire or workspace routing changes.
- **Mobile:** the desktop Electron browser surface is affected; mobile code and payloads are untouched.
- **Performance:** sanitation is bounded by the existing 4 KiB HTML budget and walks only the cloned selected subtree already serialized by this feature.
- **Compatibility:** relative or unsupported URL values continue to be blanked by the existing policy. Annotation structure and types do not change.
- **Rollback:** a raw revert would restore credential disclosure. If canonical URL formatting causes a compatibility issue, adjust that behavior without removing userinfo stripping.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, mobile, and backwards compatibility considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
