### PR TITLE
fix(clipboard): secure and expire local pasted images

### DIFF
--- a/src/main/window/clipboard-image-temp-file.test.ts
+++ b/src/main/window/clipboard-image-temp-file.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { opendirMock, rmMock, statMock, writeFileMock, randomUUIDMock } = vi.hoisted(() => ({
+  opendirMock: vi.fn(),
+  rmMock: vi.fn(),
+  statMock: vi.fn(),
+  writeFileMock: vi.fn(),
+  randomUUIDMock: vi.fn(() => '00000000-0000-4000-8000-000000000000')
+}))
+
+vi.mock('node:fs/promises', () => ({
+  opendir: opendirMock,
+  rm: rmMock,
+  stat: statMock,
+  writeFile: writeFileMock
+}))
+
+vi.mock('node:crypto', () => ({ randomUUID: randomUUIDMock }))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp' }
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  requireSshFilesystemProvider: vi.fn()
+}))
+
+import {
+  cleanupExpiredLocalClipboardImages,
+  saveClipboardImageBufferAsTempFile
+} from './clipboard-image-temp-file'
+
+function tempDirectory(entries: { isFile: () => boolean; name: string }[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* entries
+    },
+    close: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('local clipboard image temp files', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(1760000000000)
+    opendirMock.mockReset()
+    rmMock.mockReset().mockResolvedValue(undefined)
+    statMock.mockReset()
+    writeFileMock.mockReset().mockResolvedValue(undefined)
+    randomUUIDMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('creates a non-overwritable owner-only image file', async () => {
+    const png = Buffer.from([1, 2, 3])
+
+    await expect(saveClipboardImageBufferAsTempFile(png)).resolves.toBe(
+      '/tmp/orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png'
+    )
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      '/tmp/orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png',
+      png,
+      { flag: 'wx', mode: 0o600 }
+    )
+  })
+
+  it('removes a saved image after its ownership window expires', async () => {
+    vi.useFakeTimers()
+
+    await saveClipboardImageBufferAsTempFile(Buffer.from([1, 2, 3]))
+    expect(rmMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+    expect(rmMock).toHaveBeenCalledWith(
+      '/tmp/orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png',
+      { force: true }
+    )
+  })
+
+  it('removes only expired owned image files during startup cleanup', async () => {
+    const directory = tempDirectory([
+      { isFile: () => true, name: 'orca-paste-expired.png' },
+      { isFile: () => true, name: 'orca-paste-recent.png' },
+      { isFile: () => true, name: 'other-app.png' },
+      { isFile: () => false, name: 'orca-paste-directory.png' }
+    ])
+    opendirMock.mockResolvedValue(directory)
+    statMock.mockImplementation(async (filePath: string) => ({
+      mtimeMs: filePath.endsWith('expired.png') ? 1760000000000 - 60 * 60 * 1000 : 1760000000000
+    }))
+
+    await cleanupExpiredLocalClipboardImages(1760000000000)
+
+    expect(rmMock).toHaveBeenCalledOnce()
+    expect(rmMock).toHaveBeenCalledWith('/tmp/orca-paste-expired.png', { force: true })
+    expect(statMock).not.toHaveBeenCalledWith('/tmp/other-app.png')
+    expect(directory.close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/window/clipboard-image-temp-file.ts
+++ b/src/main/window/clipboard-image-temp-file.ts
@@ -1,4 +1,5 @@
-import fs from 'node:fs/promises'
+import type { Dir } from 'node:fs'
+import { opendir, rm, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 
@@ -13,6 +14,9 @@ export type SaveClipboardImageAsTempFileArgs = {
 }
 
 const REMOTE_CLIPBOARD_IMAGE_TEMP_DIR = '/tmp'
+const LOCAL_CLIPBOARD_IMAGE_TTL_MS = 60 * 60 * 1000
+const LOCAL_CLIPBOARD_IMAGE_CLEANUP_CONCURRENCY = 8
+const CLIPBOARD_IMAGE_FILE_PREFIX = 'orca-paste-'
 
 function joinRemotePath(basePath: string, fileName: string): string {
   if (isWindowsAbsolutePathLike(basePath)) {
@@ -27,7 +31,7 @@ export async function saveClipboardImageBufferAsTempFile(
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
 
-  const fileName = `orca-paste-${Date.now()}-${randomUUID()}.png`
+  const fileName = `${CLIPBOARD_IMAGE_FILE_PREFIX}${Date.now()}-${randomUUID()}.png`
 
   if (args?.connectionId) {
     const provider = requireSshFilesystemProvider(args.connectionId)
@@ -40,6 +44,55 @@ export async function saveClipboardImageBufferAsTempFile(
   }
 
   const tempPath = path.join(app.getPath('temp'), fileName)
-  await fs.writeFile(tempPath, buffer)
+  await writeFile(tempPath, buffer, { flag: 'wx', mode: 0o600 })
+  scheduleLocalClipboardImageCleanup(tempPath)
   return tempPath
+}
+
+export async function cleanupExpiredLocalClipboardImages(nowMs = Date.now()): Promise<void> {
+  const tempDir = app.getPath('temp')
+  let directory: Dir
+  try {
+    directory = await opendir(tempDir)
+  } catch {
+    return
+  }
+
+  const pending = new Set<Promise<void>>()
+  try {
+    for await (const entry of directory) {
+      if (!entry.isFile() || !entry.name.startsWith(CLIPBOARD_IMAGE_FILE_PREFIX)) {
+        continue
+      }
+      const cleanup = cleanupExpiredLocalClipboardImage(path.join(tempDir, entry.name), nowMs)
+      pending.add(cleanup)
+      void cleanup.finally(() => pending.delete(cleanup))
+      if (pending.size >= LOCAL_CLIPBOARD_IMAGE_CLEANUP_CONCURRENCY) {
+        await Promise.race(pending)
+      }
+    }
+  } catch {
+    // Best-effort cleanup must not block clipboard handler registration.
+  } finally {
+    await directory.close().catch(() => undefined)
+  }
+  await Promise.all(pending)
+}
+
+async function cleanupExpiredLocalClipboardImage(filePath: string, nowMs: number): Promise<void> {
+  try {
+    const fileStats = await stat(filePath)
+    if (nowMs - fileStats.mtimeMs >= LOCAL_CLIPBOARD_IMAGE_TTL_MS) {
+      await rm(filePath, { force: true })
+    }
+  } catch {
+    // Stale clipboard images should not make startup cleanup noisy.
+  }
+}
+
+function scheduleLocalClipboardImageCleanup(filePath: string): void {
+  const timer = setTimeout(() => {
+    void rm(filePath, { force: true }).catch(() => undefined)
+  }, LOCAL_CLIPBOARD_IMAGE_TTL_MS)
+  timer.unref?.()
 }

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -567,7 +567,7 @@ describe('registerClipboardHandlers', () => {
     await expect(
       handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), undefined)
     ).resolves.toBe(expectedPath)
-    expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
+    expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png, expect.any(Object))
     expect(clipboardReadBufferMock).not.toHaveBeenCalled()
     expect(fsOpenMock).not.toHaveBeenCalled()
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -16,6 +16,7 @@ import {
   type ReadClipboardTextOptions
 } from '../../shared/clipboard-text'
 import {
+  cleanupExpiredLocalClipboardImages,
   saveClipboardImageBufferAsTempFile,
   type SaveClipboardImageAsTempFileArgs
 } from './clipboard-image-temp-file'
@@ -85,6 +86,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:writeFile')
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
 
+  void cleanupExpiredLocalClipboardImages()
   void cleanupExpiredRemoteClipboardFiles()
   scheduleLegacyRemoteClipboardFileCleanup()
 


### PR DESCRIPTION
## ELI5

Pasting an image into a terminal makes a temporary PNG so command-line tools can read it. Those files were created with normal overwrite behavior, inherited permissions, and no Orca cleanup. They are now owner-only, non-overwritable, and automatically removed after an hour or on a later Orca startup.

## What Changed

- Create local clipboard-image files with exclusive `wx` semantics, preventing replacement of an existing path.
- Request owner-only `0600` permissions at creation time.
- Schedule best-effort removal after one hour with an unreferenced timer, so cleanup does not keep Orca alive.
- Scan the local temp directory when clipboard handlers register and remove expired Orca paste images left by a previous process.
- Restrict startup cleanup to regular files with the `orca-paste-` prefix.
- Bound startup cleanup to eight concurrent stat/remove operations.
- Treat scan/stat/remove failures as best-effort cleanup failures rather than blocking clipboard IPC registration.
- Leave SSH-provider and paired-runtime upload routing unchanged.

## Why

Clipboard images can contain private screenshots, credentials, or customer data. A normal temp write inherits the process umask and permits overwriting an existing target; no cleanup path leaves that material behind indefinitely. The filename already contains a timestamp and UUID, so exclusive creation plus a bounded ownership window is a narrow hardening of the existing workflow.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review.

## Visual Proof

N/A — terminal paste UI and interaction are unchanged; this changes only temporary-file lifecycle and permissions.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 4 files, 45/45 tests passed.
- [x] Dedicated tests prove exact `{ flag: 'wx', mode: 0o600 }` creation, one-hour timer removal, and startup expiry filtering.
- [x] Clipboard IPC, dashboard-popout authority, and runtime clipboard RPC integration remained green.
- [x] Full rebased review set passed typecheck, lint/reliability/max-lines gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** narrows file permissions, prevents accidental overwrite, and bounds retention of sensitive images.
- **macOS/Linux:** `0600` is applied at creation; the timer and startup sweep cover normal and crashed sessions.
- **Windows:** POSIX mode is advisory, so protection primarily comes from the per-user temp ACL; exclusive creation and cleanup still apply.
- **SSH / paired runtime:** remote upload paths are deliberately unchanged. Startup cleanup scans only the local Electron temp directory.
- **Performance:** registration performs a streaming directory scan with concurrency capped at eight; cleanup errors never block startup.
- **Compatibility:** a consumer waiting more than one hour can lose the temporary file. If observed, extend the TTL without reverting exclusive creation or permission hardening.
- **Rollback:** a revert needs no data migration, but existing orphaned files would remain until OS cleanup.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, path, and lifecycle impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
