### PR TITLE
fix(clipboard): reject UNC image paths from Windows clipboard

### DIFF
--- a/src/main/window/clipboard-windows-image-file.test.ts
+++ b/src/main/window/clipboard-windows-image-file.test.ts
@@ -78,30 +78,28 @@ function fileHandle(
 }
 
 describe('readWindowsClipboardImageFileAsPng', () => {
-  it.each([
-    'C:\\Users\\alice\\图片\\shot.PNG',
-    '\\\\server\\share\\shot.jpeg',
-    '\\\\?\\C:\\Users\\alice\\shot.jpg',
-    '\\\\?\\UNC\\server\\share\\shot.png'
-  ])('decodes and converts a bounded FileNameW path: %s', async (filePath) => {
-    const source = filePath.toLowerCase().endsWith('.png') ? pngHeader() : jpegHeader()
-    const png = Buffer.from([9, 8, 7])
-    const handle = fileHandle(source, { chunkSize: 3 })
-    const openFile = vi.fn().mockResolvedValue(handle)
-    const createImageFromBuffer = vi.fn(() => image(png) as never)
+  it.each(['C:\\Users\\alice\\图片\\shot.PNG', '\\\\?\\C:\\Users\\alice\\shot.jpg'])(
+    'decodes and converts a bounded FileNameW path: %s',
+    async (filePath) => {
+      const source = filePath.toLowerCase().endsWith('.png') ? pngHeader() : jpegHeader()
+      const png = Buffer.from([9, 8, 7])
+      const handle = fileHandle(source, { chunkSize: 3 })
+      const openFile = vi.fn().mockResolvedValue(handle)
+      const createImageFromBuffer = vi.fn(() => image(png) as never)
 
-    await expect(
-      readWindowsClipboardImageFileAsPng(clipboardFormats(filePath), {
-        createImageFromBuffer,
-        openFile
-      })
-    ).resolves.toEqual(png)
+      await expect(
+        readWindowsClipboardImageFileAsPng(clipboardFormats(filePath), {
+          createImageFromBuffer,
+          openFile
+        })
+      ).resolves.toEqual(png)
 
-    expect(openFile).toHaveBeenCalledWith(filePath)
-    expect(handle.read.mock.calls.length).toBeGreaterThan(1)
-    expect(handle.close).toHaveBeenCalledOnce()
-    expect(createImageFromBuffer).toHaveBeenCalledWith(source)
-  })
+      expect(openFile).toHaveBeenCalledWith(filePath)
+      expect(handle.read.mock.calls.length).toBeGreaterThan(1)
+      expect(handle.close).toHaveBeenCalledOnce()
+      expect(createImageFromBuffer).toHaveBeenCalledWith(source)
+    }
+  )
 
   it.each([
     ['empty', Buffer.alloc(0)],
@@ -111,6 +109,8 @@ describe('readWindowsClipboardImageFileAsPng', () => {
     ['drive-relative path', fileNameW('C:shot.png')],
     ['rooted drive-relative path', fileNameW('\\shot.png')],
     ['device namespace', fileNameW('\\\\.\\pipe\\shot.png')],
+    ['UNC share', fileNameW('\\\\server\\share\\shot.png')],
+    ['extended UNC share', fileNameW('\\\\?\\UNC\\server\\share\\shot.png')],
     ['UNC named-pipe namespace', fileNameW('\\\\server\\pipe\\shot.png')],
     ['extended UNC named-pipe namespace', fileNameW('\\\\?\\UNC\\server\\pipe\\shot.png')],
     ['multiple paths', Buffer.from('C:\\one.png\0C:\\two.png\0', 'utf16le')],

--- a/src/main/window/clipboard-windows-image-file.ts
+++ b/src/main/window/clipboard-windows-image-file.ts
@@ -28,23 +28,11 @@ const JPEG_START_OF_FRAME_MARKERS = new Set([
   0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
 ])
 
-function isOrdinaryUncShare(share: string | undefined): boolean {
-  return typeof share === 'string' && share.toLowerCase() !== 'pipe'
-}
-
-function isFullyQualifiedWindowsPath(filePath: string): boolean {
+function isLocalDriveWindowsPath(filePath: string): boolean {
   if (/^[A-Za-z]:[\\/]/.test(filePath)) {
     return true
   }
-  if (/^\\\\\?\\[A-Za-z]:\\/.test(filePath)) {
-    return true
-  }
-  const extendedUnc = /^\\\\\?\\UNC\\[^\\/]+\\([^\\/]+)(?:\\|$)/i.exec(filePath)
-  if (extendedUnc) {
-    return isOrdinaryUncShare(extendedUnc[1])
-  }
-  const unc = /^[/\\]{2}(?![?.][/\\])[^/\\]+[/\\]([^/\\]+)(?:[/\\]|$)/.exec(filePath)
-  return isOrdinaryUncShare(unc?.[1])
+  return /^\\\\\?\\[A-Za-z]:\\/.test(filePath)
 }
 
 function decodeFileNameW(value: Buffer): string | null {
@@ -62,7 +50,7 @@ function decodeFileNameW(value: Buffer): string | null {
     end -= 2
   }
   const filePath = value.subarray(0, end).toString('utf16le')
-  if (!filePath || filePath.includes('\0') || !isFullyQualifiedWindowsPath(filePath)) {
+  if (!filePath || filePath.includes('\0') || !isLocalDriveWindowsPath(filePath)) {
     return null
   }
   return IMAGE_FILE_EXTENSION_SET.has(win32.extname(filePath).toLowerCase()) ? filePath : null


### PR DESCRIPTION
## ELI5

On Windows, merely opening a path such as `\\attacker\share\image.png` can contact another machine and expose Windows authentication material. Clipboard contents are untrusted, so Orca now accepts only local drive-qualified image paths for this fallback and refuses network/UNC paths before opening anything.

## What Changed

- Replace the broad “fully qualified Windows path” test with a local-drive-only predicate.
- Continue accepting standard drive paths such as `C:\Users\alice\image.png`.
- Continue accepting extended local-drive paths such as `\\?\C:\Users\alice\image.png`.
- Reject before `openFile`:
  - ordinary UNC shares;
  - extended UNC shares;
  - named-pipe/device paths;
  - relative and malformed paths.
- Preserve the existing extension allowlist, stable file-read checks, source byte limits, and decoded image-dimension limits.

## Why

`FileNameW` comes from the system clipboard and can be supplied by another application. Passing a UNC path to the filesystem can trigger SMB resolution, leak NTLM credentials, or stall paste on network I/O. This fallback is only needed to read a local image file copied from Explorer, so network shares are outside the safe default boundary.

## Linked Issue

No linked issue — confirmed as a high-severity path by the Clawpatch repository review.

## Visual Proof

N/A — no visual change. Unsupported clipboard paths now return no image from the fallback.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 2 files, 49/49 tests passed.
- [x] Regression cases prove ordinary and extended UNC paths never reach `openFile`.
- [x] Local drive and extended drive paths remain accepted.
- [x] Clipboard IPC integration remained green.
- [x] Full rebased review set passed typecheck, lint, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** prevents untrusted clipboard data from initiating direct UNC/SMB access.
- **Cross-platform:** this fallback already runs only on Windows; macOS and Linux are unaffected.
- **SSH / remote:** remote image upload begins only after local clipboard extraction; no SSH provider or remote wire behavior changed.
- **Compatibility:** copying an image file directly from an UNC share may no longer work when the clipboard has no bitmap representation. Mapped drives remain a residual network path because Windows presents them as drive-qualified paths.
- **Performance:** rejecting paths before I/O removes potentially slow network resolution.
- **Rollback:** a normal revert restores UNC behavior and the associated credential/network risk; explicit user confirmation would be safer than a raw rollback.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, path, and compatibility impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
