### PR TITLE
fix(speech): harden OpenAI API key persistence

### DIFF
--- a/src/main/speech/openai-api-key-store.test.ts
+++ b/src/main/speech/openai-api-key-store.test.ts
@@ -1,12 +1,25 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const safeStorageMock = vi.hoisted(() => ({
-  decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
-  encryptString: vi.fn((value: string) => Buffer.from(value)),
+  decryptString: vi.fn((value: Buffer) => {
+    if (value[0] !== 0 || value[1] !== 0xff || value[2] !== 0x13) {
+      throw new Error('not safeStorage ciphertext')
+    }
+    return value.subarray(3).toString('utf8')
+  }),
+  encryptString: vi.fn((value: string) => encryptedPayload(value)),
   isEncryptionAvailable: vi.fn(() => true)
 }))
 
@@ -36,15 +49,23 @@ function mkdtempLike(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix))
 }
 
-function writeStoredOpenAiKey(value: string): void {
+function encryptedPayload(value: string): Buffer {
+  return Buffer.concat([Buffer.from([0, 0xff, 0x13]), Buffer.from(value)])
+}
+
+function openAiKeyPath(): string {
+  return join(tempHome, '.orca', 'openai-speech-token.enc')
+}
+
+function writeStoredOpenAiKey(value: string | Buffer): void {
   const orcaDir = join(tempHome, '.orca')
   mkdirSync(orcaDir, { recursive: true })
-  writeFileSync(join(orcaDir, 'openai-speech-token.enc'), value)
+  writeFileSync(openAiKeyPath(), value)
 }
 
 describe('OpenAI speech API key store', () => {
   it('checks configured status without decrypting or touching safeStorage', async () => {
-    writeStoredOpenAiKey('encrypted-key')
+    writeStoredOpenAiKey(encryptedPayload('encrypted-key'))
     const store = await loadStoreModule()
 
     expect(store.hasOpenAiSpeechApiKey()).toBe(true)
@@ -53,15 +74,17 @@ describe('OpenAI speech API key store', () => {
   })
 
   it('decrypts only when the key is read for an API request', async () => {
-    writeStoredOpenAiKey('encrypted-key')
+    const encrypted = encryptedPayload('encrypted-key')
+    writeStoredOpenAiKey(encrypted)
     const store = await loadStoreModule()
 
     expect(store.readOpenAiSpeechApiKey()).toBe('encrypted-key')
     expect(safeStorageMock.decryptString).toHaveBeenCalledOnce()
+    expect(safeStorageMock.decryptString).toHaveBeenCalledWith(encrypted)
   })
 
   it('caches the decrypted key so repeated dictations do not repeatedly touch safeStorage', async () => {
-    writeStoredOpenAiKey('encrypted-key')
+    writeStoredOpenAiKey(encryptedPayload('encrypted-key'))
     const store = await loadStoreModule()
 
     expect(store.readOpenAiSpeechApiKey()).toBe('encrypted-key')
@@ -76,6 +99,89 @@ describe('OpenAI speech API key store', () => {
 
     expect(store.readOpenAiSpeechApiKey()).toBe('saved-key')
     expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+    expect(readFileSync(openAiKeyPath(), 'utf8')).toMatch(/^orca-openai-speech-key:v1:encrypted:/)
+  })
+
+  it('reads enveloped plaintext after safeStorage becomes available', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const unavailableStore = await loadStoreModule()
+    unavailableStore.saveOpenAiSpeechApiKey('plaintext-key')
+
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+    safeStorageMock.decryptString.mockClear()
+    const availableStore = await loadStoreModule()
+
+    expect(availableStore.readOpenAiSpeechApiKey()).toBe('plaintext-key')
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('fails closed for enveloped ciphertext until safeStorage returns', async () => {
+    const availableStore = await loadStoreModule()
+    availableStore.saveOpenAiSpeechApiKey('encrypted-key')
+
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const unavailableStore = await loadStoreModule()
+    expect(() => unavailableStore.readOpenAiSpeechApiKey()).toThrow(/could not be decrypted/)
+
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+    const recoveredStore = await loadStoreModule()
+    expect(recoveredStore.readOpenAiSpeechApiKey()).toBe('encrypted-key')
+  })
+
+  it('rejects malformed envelope payloads', async () => {
+    writeStoredOpenAiKey('orca-openai-speech-key:v1:plaintext:not-base64!')
+    const store = await loadStoreModule()
+
+    expect(() => store.readOpenAiSpeechApiKey()).toThrow(/could not be decrypted/)
+  })
+
+  it('migrates legacy plaintext when safeStorage decryption rejects it', async () => {
+    writeStoredOpenAiKey('legacy-plaintext-key')
+    const store = await loadStoreModule()
+
+    expect(store.readOpenAiSpeechApiKey()).toBe('legacy-plaintext-key')
+  })
+
+  it('reads the legacy JSON encrypted-key format', async () => {
+    const encrypted = encryptedPayload('legacy-json-key')
+    writeStoredOpenAiKey(JSON.stringify({ encryptedKeyBase64: encrypted.toString('base64') }))
+    const store = await loadStoreModule()
+
+    expect(store.readOpenAiSpeechApiKey()).toBe('legacy-json-key')
+  })
+
+  it('does not decode legacy ciphertext as plaintext while safeStorage is unavailable', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    writeStoredOpenAiKey(encryptedPayload('encrypted-key'))
+    const store = await loadStoreModule()
+
+    expect(() => store.readOpenAiSpeechApiKey()).toThrow(/could not be decrypted/)
+  })
+
+  it.runIf(process.platform !== 'win32')(
+    'restricts an existing credential file when saving',
+    async () => {
+      writeStoredOpenAiKey('old-key')
+      chmodSync(openAiKeyPath(), 0o644)
+      const store = await loadStoreModule()
+
+      store.saveOpenAiSpeechApiKey('new-key')
+
+      expect(statSync(openAiKeyPath()).mode & 0o777).toBe(0o600)
+    }
+  )
+
+  it('writes plaintext in a versioned envelope when encryption is unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const store = await loadStoreModule()
+
+    store.saveOpenAiSpeechApiKey('plaintext-key')
+
+    expect(readFileSync(openAiKeyPath(), 'utf8')).toMatch(/^orca-openai-speech-key:v1:plaintext:/)
+    warn.mockRestore()
   })
 
   it('reports missing status without creating storage files', async () => {

--- a/src/main/speech/openai-api-key-store.ts
+++ b/src/main/speech/openai-api-key-store.ts
@@ -1,37 +1,60 @@
 import { safeStorage } from 'electron'
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { hardenExistingSecureFile, writeSecureFile } from '../../shared/secure-file'
 
 type StoredOpenAiKey = {
   encryptedKeyBase64: string
 }
 
+type OpenAiKeyEnvelope = {
+  kind: 'encrypted' | 'plaintext'
+  payload: Buffer
+}
+
 const OPENAI_SPEECH_TOKEN_FILE = 'openai-speech-token.enc'
+const OPENAI_SPEECH_KEY_ENVELOPE_PREFIX = 'orca-openai-speech-key:v1:'
 let cachedOpenAiSpeechApiKey: string | null = null
+let warnedOpenAiKeyStatusHardenFailure = false
 
 function getOrcaDir(): string {
   return join(homedir(), '.orca')
-}
-
-function ensureOrcaDir(): void {
-  const dir = getOrcaDir()
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
 }
 
 function getOpenAiKeyPath(): string {
   return join(getOrcaDir(), OPENAI_SPEECH_TOKEN_FILE)
 }
 
-function readLegacyJsonStoredOpenAiKey(): StoredOpenAiKey | null {
-  const keyPath = getOpenAiKeyPath()
-  if (!existsSync(keyPath)) {
+function encodeOpenAiKeyEnvelope(kind: OpenAiKeyEnvelope['kind'], payload: Buffer): string {
+  return `${OPENAI_SPEECH_KEY_ENVELOPE_PREFIX}${kind}:${payload.toString('base64')}`
+}
+
+function decodeOpenAiKeyEnvelope(raw: Buffer): OpenAiKeyEnvelope | null {
+  const text = raw.toString('utf8')
+  if (!text.startsWith(OPENAI_SPEECH_KEY_ENVELOPE_PREFIX)) {
     return null
   }
+  const rest = text.slice(OPENAI_SPEECH_KEY_ENVELOPE_PREFIX.length)
+  const separator = rest.indexOf(':')
+  if (separator === -1) {
+    throw new Error('OpenAI API key could not be decrypted')
+  }
+  const kind = rest.slice(0, separator)
+  const encodedPayload = rest.slice(separator + 1)
+  if (kind !== 'encrypted' && kind !== 'plaintext') {
+    throw new Error('OpenAI API key could not be decrypted')
+  }
+  const payload = Buffer.from(encodedPayload, 'base64')
+  if (!encodedPayload || !payload.length || payload.toString('base64') !== encodedPayload) {
+    throw new Error('OpenAI API key could not be decrypted')
+  }
+  return { kind, payload }
+}
+
+function readLegacyJsonStoredOpenAiKey(raw: Buffer): StoredOpenAiKey | null {
   try {
-    const parsed = JSON.parse(readFileSync(keyPath, 'utf8')) as Partial<StoredOpenAiKey>
+    const parsed = JSON.parse(raw.toString('utf8')) as Partial<StoredOpenAiKey>
     if (typeof parsed.encryptedKeyBase64 !== 'string' || parsed.encryptedKeyBase64 === '') {
       return null
     }
@@ -41,10 +64,54 @@ function readLegacyJsonStoredOpenAiKey(): StoredOpenAiKey | null {
   }
 }
 
+function decodeLegacyPlaintextKey(raw: Buffer): string {
+  let plaintext: string
+  try {
+    plaintext = new TextDecoder('utf-8', { fatal: true }).decode(raw)
+  } catch {
+    throw new Error('OpenAI API key could not be decrypted')
+  }
+  if (!plaintext || [...plaintext].some((char) => char.charCodeAt(0) < 32 || char === '\u007f')) {
+    throw new Error('OpenAI API key could not be decrypted')
+  }
+  return plaintext
+}
+
+function readOpenAiKeyEnvelope(envelope: OpenAiKeyEnvelope): string {
+  if (envelope.kind === 'plaintext') {
+    return decodeLegacyPlaintextKey(envelope.payload)
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('OpenAI API key could not be decrypted')
+  }
+  return safeStorage.decryptString(envelope.payload)
+}
+
+function readLegacyRawOpenAiKey(raw: Buffer): string {
+  if (safeStorage.isEncryptionAvailable()) {
+    try {
+      return safeStorage.decryptString(raw)
+    } catch {
+      return decodeLegacyPlaintextKey(raw)
+    }
+  }
+  return decodeLegacyPlaintextKey(raw)
+}
+
 export function hasOpenAiSpeechApiKey(): boolean {
-  // Why: Settings and model-state refresh call this on startup; checking file
-  // existence avoids decrypting safeStorage and triggering macOS keychain prompts.
-  return existsSync(getOpenAiKeyPath())
+  const keyPath = getOpenAiKeyPath()
+  if (!existsSync(keyPath)) {
+    return false
+  }
+  try {
+    hardenExistingSecureFile(keyPath)
+  } catch (error) {
+    if (!warnedOpenAiKeyStatusHardenFailure) {
+      warnedOpenAiKeyStatusHardenFailure = true
+      console.warn('[speech] Failed to harden OpenAI speech key file while checking status', error)
+    }
+  }
+  return true
 }
 
 export function saveOpenAiSpeechApiKey(apiKey: string): void {
@@ -52,9 +119,11 @@ export function saveOpenAiSpeechApiKey(apiKey: string): void {
   if (!trimmed) {
     throw new Error('OpenAI API key is required')
   }
-  ensureOrcaDir()
   if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(getOpenAiKeyPath(), safeStorage.encryptString(trimmed), { mode: 0o600 })
+    writeSecureFile(
+      getOpenAiKeyPath(),
+      encodeOpenAiKeyEnvelope('encrypted', safeStorage.encryptString(trimmed))
+    )
     cachedOpenAiSpeechApiKey = trimmed
     return
   }
@@ -62,7 +131,10 @@ export function saveOpenAiSpeechApiKey(apiKey: string): void {
   console.warn(
     '[speech] safeStorage encryption unavailable — storing OpenAI speech key in plaintext'
   )
-  writeFileSync(getOpenAiKeyPath(), trimmed, { encoding: 'utf8', mode: 0o600 })
+  writeSecureFile(
+    getOpenAiKeyPath(),
+    encodeOpenAiKeyEnvelope('plaintext', Buffer.from(trimmed, 'utf8'))
+  )
   cachedOpenAiSpeechApiKey = trimmed
 }
 
@@ -76,17 +148,25 @@ export function readOpenAiSpeechApiKey(): string {
     throw new Error('OpenAI API key is not configured')
   }
   try {
+    hardenExistingSecureFile(keyPath)
+  } catch (error) {
+    console.warn('[speech] Failed to harden OpenAI speech key file while reading', error)
+  }
+  try {
     const raw = readFileSync(keyPath)
-    const legacyJson = readLegacyJsonStoredOpenAiKey()
+    const envelope = decodeOpenAiKeyEnvelope(raw)
+    if (envelope) {
+      cachedOpenAiSpeechApiKey = readOpenAiKeyEnvelope(envelope)
+      return cachedOpenAiSpeechApiKey
+    }
+    const legacyJson = readLegacyJsonStoredOpenAiKey(raw)
     if (legacyJson) {
       cachedOpenAiSpeechApiKey = safeStorage.decryptString(
         Buffer.from(legacyJson.encryptedKeyBase64, 'base64')
       )
       return cachedOpenAiSpeechApiKey
     }
-    cachedOpenAiSpeechApiKey = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(raw)
-      : raw.toString('utf8')
+    cachedOpenAiSpeechApiKey = readLegacyRawOpenAiKey(raw)
     return cachedOpenAiSpeechApiKey
   } catch {
     throw new Error('OpenAI API key could not be decrypted')


### PR DESCRIPTION
## ELI5

Orca used to decide whether the saved OpenAI speech key was encrypted by asking whether encryption happened to be available *right now*. If that availability changed between save and read, ciphertext could be treated like a key or plaintext could be sent to the decryptor. The file now says what format it contains, is written atomically with restrictive permissions, and fails closed when encrypted data cannot be decrypted.

## What Changed

- Persist a versioned `orca-openai-speech-key:v1` envelope that explicitly identifies encrypted versus plaintext payloads.
- Encode payload bytes as canonical base64 and reject empty, malformed, noncanonical, or unknown envelope variants.
- For encrypted envelopes, require current `safeStorage` availability and fail closed if decryption is unavailable or fails.
- For plaintext envelopes, decode as strict UTF-8 without invoking `safeStorage`.
- Preserve read compatibility with all existing formats:
  - raw `safeStorage` ciphertext;
  - raw legacy plaintext;
  - legacy JSON containing `encryptedKeyBase64`.
- Use Orca's shared secure atomic writer so a failed replacement leaves the previous credential intact.
- Harden an existing credential file during status and read paths without decrypting it during status checks.
- Keep the decrypted in-memory cache, and update it only after the secure write succeeds.

## Why

Persisted bytes need to be self-describing. `safeStorage.isEncryptionAvailable()` describes the current runtime, not the format of a file written earlier. Availability can change across desktop sessions, keychain state, headless Linux environments, or packaging/runtime transitions. Inferring format from current availability can turn a recoverable configuration state into an invalid API key or an attempted decrypt of plaintext.

The old save path also supplied `0600` only when creating the file. Overwriting an existing permissive file does not necessarily repair its mode, and a direct write can truncate the only stored credential on interruption.

## Linked Issue

No linked issue — combines two findings at the same credential persistence boundary from the Clawpatch repository review.

## Visual Proof

N/A — Settings UI and speech interaction are unchanged; this is storage-format, permission, and recovery behavior.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 13/13 key-store tests passed.
- [x] Coverage includes both `safeStorage` availability transitions, malformed envelopes, encrypted fail-closed behavior, all legacy formats, cache behavior, plaintext fallback, atomic save behavior, and existing-file mode repair.
- [x] Full rebased review set passed all TypeScript targets, the complete lint/reliability suite, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** encrypted payloads are never interpreted as plaintext once explicitly enveloped; existing files are hardened; malformed state fails closed.
- **Cross-platform:** shared secure-file handling provides POSIX permissions and the repository's Windows ACL/error-recovery behavior. `safeStorage` remains Electron-owned.
- **SSH / remote / folder workspaces:** the key remains local to the desktop user's Orca home; no workspace or wire behavior changes.
- **Performance:** status still checks existence without decrypting. Hardening is one bounded metadata/permission operation and failures are warning-only there.
- **Backward compatibility:** new Orca reads old files. Older Orca cannot read the new v1 envelope after a new save. Before downgrading or reverting, clear the speech key in Settings and re-enter it after installing the older build.
- **Rollback:** code rollback needs no schema migration, but the downgrade caveat above is required. A failed new-format write preserves the previous file and cache value.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and backwards compatibility considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
