### PR TITLE
fix(codex): write settings baselines atomically

### DIFF
--- a/src/main/codex/config-settings-baseline.test.ts
+++ b/src/main/codex/config-settings-baseline.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const fsMock = vi.hoisted(() => ({ renameSync: vi.fn() }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  fsMock.renameSync.mockImplementation(actual.renameSync)
+  return { ...actual, renameSync: fsMock.renameSync }
+})
+
+import { writeCodexSettingsBaseline } from './config-settings-baseline'
+
+let runtimeHomePath: string | undefined
+
+afterEach(() => {
+  if (runtimeHomePath) {
+    rmSync(runtimeHomePath, { recursive: true, force: true })
+    runtimeHomePath = undefined
+  }
+  vi.clearAllMocks()
+})
+
+describe('writeCodexSettingsBaseline', () => {
+  it('preserves the previous baseline when atomic replacement fails', () => {
+    runtimeHomePath = mkdtempSync(join(tmpdir(), 'orca-codex-settings-baseline-'))
+    const baselinePath = join(runtimeHomePath, '.orca-config-settings-baseline.json')
+    writeCodexSettingsBaseline(runtimeHomePath, {
+      settings: new Map([['model', '"previous"']]),
+      conflicts: new Map()
+    })
+    const previous = readFileSync(baselinePath, 'utf-8')
+    fsMock.renameSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('injected replacement failure'), { code: 'EIO' })
+    })
+
+    expect(() =>
+      writeCodexSettingsBaseline(runtimeHomePath!, {
+        settings: new Map([['model', '"next"']]),
+        conflicts: new Map()
+      })
+    ).toThrow('injected replacement failure')
+    expect(readFileSync(baselinePath, 'utf-8')).toBe(previous)
+    expect(readdirSync(runtimeHomePath).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+})

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -1,6 +1,7 @@
-import { existsSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
+import { writeFileAtomically } from '../codex-accounts/fs-utils'
 
 const SETTINGS_BASELINE_FILE = '.orca-config-settings-baseline.json'
 
@@ -68,7 +69,7 @@ export function writeCodexSettingsBaseline(
   if (existsSync(baselinePath) && readAgentStateFileSync(baselinePath) === serialized) {
     return
   }
-  writeFileSync(baselinePath, serialized, { encoding: 'utf-8', mode: 0o600 })
+  writeFileAtomically(baselinePath, serialized, { mode: 0o600 })
 }
 
 function getCodexSettingsBaselinePath(runtimeHomePath: string): string {


### PR DESCRIPTION
## ELI5

Orca keeps a small JSON snapshot so it can tell which Codex settings changed. That snapshot was written directly, so a crash or failed write could leave half a JSON file and erase the last good comparison point. It is now replaced atomically: the old snapshot stays intact until the new one is fully ready.

## What Changed

- Replace the direct baseline `writeFileSync` with the existing `writeFileAtomically` primitive.
- Preserve the existing `0600` target permissions.
- Preserve the byte-identical no-op fast path when the baseline content has not changed.
- Add a failure-injection regression test that forces final rename failure.
- Prove the previous baseline remains byte-for-byte intact and the temporary sibling is cleaned up.

## Why

A direct write can truncate `.orca-config-settings-baseline.json` before all replacement bytes are durable. The reader treats malformed JSON as no baseline, which removes the anchors used by later Codex settings synchronization and conflict decisions. Orca already has a cross-platform atomic replacement utility with temporary-file cleanup and Windows permission recovery; using it here avoids a second partial-write implementation.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review.

## Visual Proof

N/A — no UI behavior changes; this protects an internal Codex synchronization record.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 2 files, 11/11 tests passed.
- [x] Covered baseline save failure, prior-byte preservation, temporary-file cleanup, normal settings upgrade, and unchanged-content behavior.
- [x] Full rebased review set passed typecheck, lint/reliability gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security/data integrity:** replacement is all-or-old rather than allowing truncated JSON; restrictive permissions remain in place.
- **Cross-platform:** uses the existing repository primitive, including Windows-specific replacement/permission recovery.
- **SSH / WSL / folder workspaces:** the function writes the path selected by existing Codex environment routing; no local-only path assumption was added.
- **Performance:** unchanged content still skips the write; changed content adds one temporary sibling write and rename.
- **Compatibility:** schema and reader behavior are unchanged. This does not serialize independent processes; successful concurrent writers remain last-writer-wins.
- **Rollback:** revert the two files. No baseline migration or cleanup is required.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
