### PR TITLE
fix(codex): parse deprecated hook flags structurally

### DIFF
--- a/src/main/codex/config-toml-deprecated-hook-flag.test.ts
+++ b/src/main/codex/config-toml-deprecated-hook-flag.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDeprecatedCodexHookFeatureFlag } from './config-toml-deprecated-hook-flag'
+
+describe('normalizeDeprecatedCodexHookFeatureFlag', () => {
+  it('normalizes an escaped quoted deprecated key', () => {
+    const config = ['[features]', '"codex\\u005fhooks" = true', ''].join('\n')
+
+    expect(normalizeDeprecatedCodexHookFeatureFlag(config)).toBe(
+      ['[features]', 'hooks = true', ''].join('\n')
+    )
+  })
+
+  it('ignores apparent feature structure inside multiline basic strings', () => {
+    const config = [
+      'instructions = """',
+      '[features]',
+      'hooks = false',
+      'codex_hooks = false',
+      '"""',
+      '',
+      '[features]',
+      'description = """',
+      'hooks = false',
+      'codex_hooks = false',
+      '"""',
+      'codex_hooks = true',
+      ''
+    ].join('\n')
+
+    expect(normalizeDeprecatedCodexHookFeatureFlag(config)).toBe(
+      config.replace(/codex_hooks = true\n$/, 'hooks = true\n')
+    )
+  })
+
+  it('ignores apparent feature structure inside multiline literal strings with CRLF', () => {
+    const config = [
+      "instructions = '''",
+      '[features]',
+      'hooks = false',
+      'codex_hooks = false',
+      "'''",
+      '',
+      '[features]',
+      "description = '''",
+      'hooks = false',
+      'codex_hooks = false',
+      "'''",
+      'hooks = true',
+      'codex_hooks = true',
+      ''
+    ].join('\r\n')
+
+    expect(normalizeDeprecatedCodexHookFeatureFlag(config)).toBe(
+      config.replace('hooks = true\r\ncodex_hooks = true\r\n', 'hooks = true\r\n')
+    )
+  })
+})

--- a/src/main/codex/config-toml-deprecated-hook-flag.ts
+++ b/src/main/codex/config-toml-deprecated-hook-flag.ts
@@ -1,18 +1,23 @@
-export function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
-  if (!config.includes('codex_hooks')) {
-    return config
-  }
+import {
+  createTomlLineScanState,
+  getTomlTableHeader,
+  isTomlStructuralLine,
+  updateTomlLineScanState
+} from './config-toml-line-scan'
+import { parseTomlKeyPath, parseTomlTableHeaderPath } from './config-toml-key-path'
 
+export function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
   const lines = config.split('\n')
   const featureSections: { start: number; end: number }[] = []
   let featureStart: number | null = null
+  let state = createTomlLineScanState()
 
   for (let index = 0; index <= lines.length; index += 1) {
     const line = lines[index]
-    // Why: CRLF configs keep a trailing \r after the split, so header anchors
-    // must tolerate it or Windows-shaped configs skip normalization entirely.
-    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?\r?$/.test(line)
-    if (!isHeader) {
+    const header =
+      line !== undefined && isTomlStructuralLine(state) ? getTomlTableHeader(line) : null
+    if (line !== undefined && !header) {
+      state = updateTomlLineScanState(state, line)
       continue
     }
 
@@ -20,8 +25,17 @@ export function normalizeDeprecatedCodexHookFeatureFlag(config: string): string 
       featureSections.push({ start: featureStart, end: index })
       featureStart = null
     }
-    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?\r?$/.test(line)) {
+    const table = header ? parseTomlTableHeaderPath(header) : null
+    if (
+      table &&
+      !table.isArray &&
+      table.segments.length === 1 &&
+      table.segments[0] === 'features'
+    ) {
       featureStart = index
+    }
+    if (line !== undefined) {
+      state = updateTomlLineScanState(state, line)
     }
   }
 
@@ -34,14 +48,22 @@ export function normalizeDeprecatedCodexHookFeatureFlag(config: string): string 
 function normalizeFeatureSectionLines(lines: string[], start: number, end: number): void {
   const deprecatedIndexes: number[] = []
   let hasHooksKey = false
+  let state = createTomlLineScanState()
   for (let index = start; index < end; index += 1) {
     const line = lines[index] ?? ''
-    if (/^[ \t]*hooks[ \t]*=/.test(line)) {
-      hasHooksKey = true
+    if (isTomlStructuralLine(state)) {
+      const parsed = parseTomlKeyPath(line)
+      const key = parsed?.segments.length === 1 ? parsed.segments[0] : null
+      if (parsed && line[parsed.end] === '=') {
+        if (key === 'hooks') {
+          hasHooksKey = true
+        }
+        if (key === 'codex_hooks') {
+          deprecatedIndexes.push(index)
+        }
+      }
     }
-    if (/^[ \t]*codex_hooks[ \t]*=/.test(line)) {
-      deprecatedIndexes.push(index)
-    }
+    state = updateTomlLineScanState(state, line)
   }
   if (deprecatedIndexes.length === 0) {
     return
@@ -52,14 +74,24 @@ function normalizeFeatureSectionLines(lines: string[], start: number, end: numbe
     if (firstDeprecatedIndex !== undefined) {
       // Why: Codex 0.133 warns on the old key. Mirror into Orca's runtime
       // config using the new key without rewriting the user's real config.
-      lines[firstDeprecatedIndex] = lines[firstDeprecatedIndex]!.replace(
-        /^([ \t]*)codex_hooks([ \t]*=)/,
-        '$1hooks$2'
-      )
+      lines[firstDeprecatedIndex] = renameDeprecatedHookKey(lines[firstDeprecatedIndex] ?? '')
     }
   }
 
   for (const index of deprecatedIndexes.toReversed()) {
     lines.splice(index, 1)
   }
+}
+
+function renameDeprecatedHookKey(line: string): string {
+  const parsed = parseTomlKeyPath(line)
+  if (!parsed || parsed.segments.length !== 1 || parsed.segments[0] !== 'codex_hooks') {
+    return line
+  }
+  const keyStart = /^[ \t]*/.exec(line)?.[0].length ?? 0
+  let keyEnd = parsed.end
+  while (line[keyEnd - 1] === ' ' || line[keyEnd - 1] === '\t') {
+    keyEnd -= 1
+  }
+  return `${line.slice(0, keyStart)}hooks${line.slice(keyEnd)}`
 }


### PR DESCRIPTION
## ELI5

Orca updates an old Codex setting named `codex_hooks` to `hooks` in its managed runtime copy. The old code searched line text, so a sentence inside a multiline string could look like a real setting, while a legally quoted TOML key could be missed. Orca now reads TOML structure before deciding what to rename or remove.

## What Changed

- Replace regex-only section/key recognition with Orca's shared TOML structural line scanner.
- Parse assignment key paths through the shared TOML key parser instead of comparing raw spelling.
- Recognize only the non-array top-level `features` table.
- Compare decoded single-segment keys, including legal quoted and escaped forms such as `"codex\u005fhooks"`.
- Rename the first deprecated key to canonical `hooks` only when `hooks` is absent.
- Remove deprecated duplicates when a canonical `hooks` entry already exists.
- Ignore section- and assignment-shaped text inside multiline basic strings, multiline literal strings, and arrays.
- Preserve indentation, value spacing, comments, and CRLF/LF line endings.

## Why

Line regexes cannot distinguish TOML syntax from text inside a string. A false `[features]` or `codex_hooks = ...` match can alter a managed runtime configuration even though the user wrote only string content. Raw regexes also do not decode equivalent quoted keys. Reusing the parser/scanner already used by Orca's other byte-preserving TOML transforms keeps these decisions consistent.

The user's real Codex configuration is not rewritten by this function; normalization remains limited to Orca's managed runtime mirror.

## Linked Issue

No linked issue — confirmed and then hardened by follow-up Clawpatch review.

## Visual Proof

N/A — no UI changes; the output is a managed TOML runtime copy.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 2 files, 36/36 tests passed.
- [x] Coverage includes escaped quoted keys, multiline basic strings, CRLF multiline literal strings, existing mirror normalization, and duplicate removal.
- [x] Full rebased review set passed typecheck, lint/reliability/max-lines gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security/data integrity:** structural parsing prevents string contents from being mistaken for configuration instructions.
- **Cross-platform:** line ending preservation covers LF and CRLF; no OS-specific path behavior changes.
- **SSH / WSL / folder workspaces:** transformation is content-only and runs wherever the existing managed Codex mirror is produced.
- **Performance:** one bounded structural scan plus key parsing for relevant assignments; configuration files are small and no external parser/process is invoked.
- **Compatibility:** uncommon quoted deprecated keys may be rewritten to the canonical bare spelling, but TOML meaning is unchanged. The real user file remains untouched.
- **Rollback:** revert the two files. The managed copy is regenerated on a later sync; no persistent user-data repair is required.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
