### PR TITLE
fix(github): complete issue lists and preserve diagnostics

### DIFF
--- a/src/main/github/issues.test.ts
+++ b/src/main/github/issues.test.ts
@@ -80,6 +80,16 @@ import {
 
 import { _resetOriginGitHubApiRepositoryCache } from './github-api-repository'
 
+function githubIssuePayload(number: number): Record<string, unknown> {
+  return {
+    number,
+    title: `Issue ${number}`,
+    state: 'open',
+    html_url: `https://github.com/stablyai/orca/issues/${number}`,
+    labels: []
+  }
+}
+
 // The origin-repository cache is module-level state; reset it so slugs
 // resolved by one test cannot leak into the next.
 beforeEach(() => {
@@ -238,10 +248,130 @@ describe('issue source operations', () => {
         'api',
         '--cache',
         '120s',
-        'repos/stablyai/orca/issues?per_page=5&state=open&sort=updated&direction=desc'
+        'repos/stablyai/orca/issues?per_page=100&page=1&state=open&sort=updated&direction=desc'
       ],
       { cwd: '/repo-root', host: 'github.com' }
     )
+  })
+
+  it('continues past a full page of pull requests to collect issues', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    const pullRequests = Array.from({ length: 100 }, (_, index) => ({
+      ...githubIssuePayload(index + 1),
+      pull_request: {}
+    }))
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify(pullRequests) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([githubIssuePayload(101), githubIssuePayload(102)])
+      })
+
+    const result = await listIssues('/repo-root', 2)
+
+    expect(result.items.map((issue) => issue.number)).toEqual([101, 102])
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      [
+        'api',
+        '--cache',
+        '120s',
+        'repos/stablyai/orca/issues?per_page=100&page=2&state=open&sort=updated&direction=desc'
+      ],
+      { cwd: '/repo-root', host: 'github.com' }
+    )
+  })
+
+  it('fills the requested issue count across mixed GitHub pages', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    const firstPage = [
+      githubIssuePayload(1),
+      ...Array.from({ length: 99 }, (_, index) => ({
+        ...githubIssuePayload(index + 100),
+        pull_request: {}
+      }))
+    ]
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify(firstPage) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          githubIssuePayload(2),
+          githubIssuePayload(3),
+          githubIssuePayload(4)
+        ])
+      })
+
+    const result = await listIssues('/repo-root', 3)
+
+    expect(result.items.map((issue) => issue.number)).toEqual([1, 2, 3])
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates issues that move across page boundaries', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    const firstPage = [
+      githubIssuePayload(1),
+      ...Array.from({ length: 99 }, (_, index) => ({
+        ...githubIssuePayload(index + 100),
+        pull_request: {}
+      }))
+    ]
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify(firstPage) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([githubIssuePayload(1), githubIssuePayload(2)])
+      })
+
+    const result = await listIssues('/repo-root', 2)
+
+    expect(result.items.map((issue) => issue.number)).toEqual([1, 2])
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops issue pagination after a short GitHub page', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        { ...githubIssuePayload(1), pull_request: {} },
+        githubIssuePayload(2)
+      ])
+    })
+
+    const result = await listIssues('/repo-root', 3)
+
+    expect(result.items.map((issue) => issue.number)).toEqual([2])
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('threads Enterprise host and WSL options through every issue page', async () => {
+    const localGitOptions = { wslDistro: 'Ubuntu' }
+    resolveIssueSourceMock.mockResolvedValueOnce({
+      source: { owner: 'team', repo: 'orca', host: 'github.acme-corp.com' },
+      fellBack: false
+    })
+    const pullRequests = Array.from({ length: 100 }, (_, index) => ({
+      ...githubIssuePayload(index + 1),
+      pull_request: {}
+    }))
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify(pullRequests) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify([githubIssuePayload(101)]) })
+
+    await listIssues('/repo-root', 1, undefined, null, localGitOptions)
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(
+      ghExecFileAsyncMock.mock.calls.every(
+        (call) => call[1]?.host === 'github.acme-corp.com' && call[1]?.wslDistro === 'Ubuntu'
+      )
+    ).toBe(true)
+  })
+
+  it('returns no GitHub issues without requesting a page for a nonpositive limit', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+
+    await expect(listIssues('/repo-root', 0)).resolves.toEqual({ items: [] })
+
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('surfaces a classified permission_denied error instead of collapsing to empty', async () => {
@@ -250,7 +380,9 @@ describe('issue source operations', () => {
     // render as a banner with retry, not a silent empty list.
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockRejectedValueOnce(
-      new Error('HTTP 403: Resource not accessible by integration')
+      Object.assign(new Error('gh exited with 1.'), {
+        stderr: 'HTTP 403: Resource not accessible by integration'
+      })
     )
 
     const result = await listIssues('/repo-root', 5)
@@ -496,6 +628,43 @@ describe('issue source operations', () => {
       ['api', '-X', 'PATCH', 'repos/stablyai/orca/issues/924', '--raw-field', 'body=Updated body'],
       { cwd: '/repo-root', host: 'github.com' }
     )
+  })
+
+  it('classifies structured gh permission diagnostics for issue mutations', async () => {
+    getIssueOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    ghExecFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('gh exited with 1.'), {
+        stderr: 'HTTP 403: Resource not accessible by integration'
+      })
+    )
+
+    const updateResult = await updateIssue('/repo-root', 924, { body: 'Updated body' })
+    const commentResult = await addIssueComment('/repo-root', 924, 'Comment')
+
+    expect(updateResult).toEqual({
+      ok: false,
+      error: "You don't have permission to edit this issue. Check your GitHub token scopes."
+    })
+    expect(commentResult).toEqual({
+      ok: false,
+      error: "You don't have permission to edit this issue. Check your GitHub token scopes."
+    })
+  })
+
+  it('treats structured already-closed and already-open diagnostics as success', async () => {
+    getIssueOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    ghExecFileAsyncMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error('gh exited with 1.'), { stderr: 'issue is already closed' })
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error('gh exited with 1.'), { stderr: 'issue is already open' })
+      )
+
+    await expect(updateIssue('/repo-root', 924, { state: 'closed' })).resolves.toEqual({
+      ok: true
+    })
+    await expect(updateIssue('/repo-root', 924, { state: 'open' })).resolves.toEqual({ ok: true })
   })
 
   it('closes issues with completed, not planned, and duplicate reasons', async () => {

--- a/src/main/github/issues.ts
+++ b/src/main/github/issues.ts
@@ -145,25 +145,37 @@ export async function listIssues(
   await acquire()
   try {
     if (ownerRepo) {
-      const { stdout } = await ghExecFileAsync(
-        [
-          'api',
-          '--cache',
-          '120s',
-          `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues?per_page=${limit}&state=open&sort=updated&direction=desc`
-        ],
-        ghOptions
-      )
-      const data = JSON.parse(stdout) as Record<string, unknown>[]
-      // Why: the GitHub REST `/repos/{owner}/{repo}/issues` endpoint returns
-      // pull requests alongside issues (PRs carry a `pull_request` key).
-      // Strip them here so `listIssues` only returns true issues, matching the
-      // filter applied in `listRecentWorkItems` (src/main/github/client.ts).
-      return {
-        items: data
-          .filter((d) => !('pull_request' in d))
-          .map((d) => mapIssueInfo(d as Parameters<typeof mapIssueInfo>[0]))
+      const requestedLimit = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0
+      const items: IssueInfo[] = []
+      const seenIssueNumbers = new Set<number>()
+      const pageSize = 100
+      let page = 1
+      while (items.length < requestedLimit) {
+        const { stdout } = await ghExecFileAsync(
+          [
+            'api',
+            '--cache',
+            '120s',
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues?per_page=${pageSize}&page=${page}&state=open&sort=updated&direction=desc`
+          ],
+          ghOptions
+        )
+        const data = JSON.parse(stdout) as Record<string, unknown>[]
+        // GitHub mixes pull requests into this endpoint, so fill from later pages.
+        for (const issue of data
+          .filter((entry) => !('pull_request' in entry))
+          .map((entry) => mapIssueInfo(entry as Parameters<typeof mapIssueInfo>[0]))) {
+          if (!seenIssueNumbers.has(issue.number)) {
+            seenIssueNumbers.add(issue.number)
+            items.push(issue)
+          }
+        }
+        if (data.length < pageSize) {
+          break
+        }
+        page += 1
       }
+      return { items: items.slice(0, requestedLimit) }
     }
     // Fallback for non-GitHub remotes
     const { stdout } = await ghExecFileAsync(
@@ -175,10 +187,9 @@ export async function listIssues(
       items: data.map((d) => mapIssueInfo(d as Parameters<typeof mapIssueInfo>[0]))
     }
   } catch (err) {
-    const stderr = err instanceof Error ? err.message : String(err)
     return {
       items: [],
-      error: classifyListIssuesError(stderr)
+      error: classifyListIssuesError(githubIssueErrorMessage(err))
     }
   } finally {
     release()
@@ -353,10 +364,10 @@ export async function updateIssue(
         await ghExecFileAsync(['issue', 'reopen', String(issueNumber), '--repo', repo], ghOptions)
       }
     } catch (err) {
-      const stderr = err instanceof Error ? err.message : String(err)
+      const message = githubIssueErrorMessage(err)
       // Treat "already closed/open" as a no-op
-      if (!stderr.toLowerCase().includes('already')) {
-        errors.push(classifyGhError(stderr).message)
+      if (!message.toLowerCase().includes('already')) {
+        errors.push(classifyGhError(message).message)
       }
     } finally {
       release()
@@ -378,8 +389,7 @@ export async function updateIssue(
         ghOptions
       )
     } catch (err) {
-      const stderr = err instanceof Error ? err.message : String(err)
-      errors.push(classifyGhError(stderr).message)
+      errors.push(classifyGhError(githubIssueErrorMessage(err)).message)
     } finally {
       release()
     }
@@ -415,8 +425,7 @@ export async function updateIssue(
     try {
       await ghExecFileAsync(editArgs, ghOptions)
     } catch (err) {
-      const stderr = err instanceof Error ? err.message : String(err)
-      errors.push(classifyGhError(stderr).message)
+      errors.push(classifyGhError(githubIssueErrorMessage(err)).message)
     } finally {
       release()
     }
@@ -494,8 +503,7 @@ export async function addIssueComment(
     }
     return { ok: true, comment }
   } catch (err) {
-    const stderr = err instanceof Error ? err.message : String(err)
-    return { ok: false, error: classifyGhError(stderr).message }
+    return { ok: false, error: classifyGhError(githubIssueErrorMessage(err)).message }
   } finally {
     release()
   }


### PR DESCRIPTION
## ELI5

GitHub's “issues” API also returns pull requests. Orca asked for (say) 20 rows and filtered PRs afterward, so a PR-heavy repository could show only a few issues—or none—even when more issues existed on the next page. Orca now keeps paging until it fills the requested issue count, and it also preserves GitHub's real error message instead of replacing it with `gh exited with 1`.

## What Changed

### Complete issue listing

- Normalize the requested limit to a nonnegative integer and avoid API work for a nonpositive limit.
- Read GitHub's repository issues endpoint in 100-entry pages with explicit page numbers.
- Filter pull requests from each page, continue until enough true issues are collected, and stop when a short raw page proves exhaustion.
- Deduplicate by issue number so live `updated` ordering changes across page requests cannot return the same issue twice.
- Truncate to exactly the caller's requested limit.
- Reuse the existing resolved execution options on every request, preserving GitHub Enterprise host and WSL/connection-backed execution.

### Actionable command diagnostics

- Route list, state, body, field-edit, and comment failures through the existing structured exec-error extractor.
- Prefer the runner's `stderr`, then `stdout`, then generic `Error.message` contract.
- Preserve specific 403/404/rate-limit/validation classifications when the process error itself is only `gh exited with 1`.
- Use the extracted message for the documented idempotent “already open/closed” success case.

## Why

The REST `/repos/{owner}/{repo}/issues` endpoint intentionally mixes issues and pull requests. Filtering after a single `per_page=limit` request makes the product result count depend on unrelated PR activity.

Separately, `ghExecFileAsync` returns structured subprocess diagnostics. Catch blocks that read only `Error.message` discard the actionable GitHub response, causing real permission and state errors to become generic unknown failures. Both defects are in the same issue operations module and share one focused regression suite, so they are kept together here.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review.

## Visual Proof

N/A — no layout or interaction changes. Existing issue views receive complete data and more specific errors.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 24/24 `issues.test.ts` tests passed.
- [x] Pagination tests cover PR-heavy pages, exhaustion, exact limits, duplicates across moving boundaries, nonpositive limits, and preserved execution options.
- [x] Error tests model generic process messages plus structured stderr for list, mutation, comment, permission, and already-state paths.
- [x] Full rebased review set passed typecheck, lint/reliability gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** no token or command construction changes; more precise permission failures are retained without logging secrets.
- **Git provider compatibility:** this is explicitly inside the GitHub-only issue implementation. The non-GitHub fallback path and generic review terminology are unchanged.
- **GitHub Enterprise / WSL / SSH routing:** every page reuses the same resolved `gh` options, host, environment, and connection context as the first.
- **Performance/rate limits:** PR-heavy repositories may make additional cached REST requests. Pages use GitHub's maximum size, retain the 120-second cache, and stop as soon as the requested count is full or data is exhausted.
- **Compatibility:** public result types and successful mutation behavior are unchanged. “Already open/closed” becomes the intended idempotent no-op when that text arrives via structured output.
- **Rollback:** a normal revert needs no data repair, but restores underfilled lists and generic error classification.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, rate limits, and performance
- [x] Cross-platform, SSH/remote, Enterprise, and provider impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
