### PR TITLE
fix(github): release refresh state when windows close

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -1115,6 +1115,34 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
   })
 
+  it('drops active-burst state when stale visibility discovers a destroyed window', async () => {
+    const {
+      _getPRRefreshActiveBurstScopeCountForTests,
+      enqueuePRRefresh,
+      refreshPRNow,
+      reportVisiblePRRefreshCandidates
+    } = await import('./pr-refresh-coordinator')
+    const candidate = makeCandidate({ cachedFetchedAt: Date.now() })
+    getPRForBranchOutcomeMock
+      .mockResolvedValueOnce({ kind: 'no-pr', fetchedAt: Date.now() })
+      .mockResolvedValueOnce({
+        kind: 'upstream-error',
+        errorType: 'network',
+        message: 'network down',
+        fetchedAt: Date.now()
+      })
+
+    reportVisiblePRRefreshCandidates([candidate], 1, 1)
+    enqueuePRRefresh(candidate, 'active', 80, 1)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(_getPRRefreshActiveBurstScopeCountForTests()).toBe(1)
+
+    getAllWebContentsMock.mockReturnValue([])
+    await refreshPRNow(candidate)
+
+    expect(_getPRRefreshActiveBurstScopeCountForTests()).toBe(0)
+  })
+
   it('clears visible retry backoff when a non-visible manual refresh steals the retry', async () => {
     const {
       _getPRRefreshErrorBackoffCountForTests,

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -249,6 +249,7 @@ function isVisibleKey(key: string): boolean {
   for (const windowId of Array.from(visibleByWindow.keys())) {
     if (!liveWindowIds.has(windowId)) {
       visibleByWindow.delete(windowId)
+      clearActiveBurstWindow(windowId)
     }
   }
   for (const visible of visibleByWindow.values()) {
@@ -904,6 +905,10 @@ export function reportVisiblePRRefreshCandidates(
 
 export function _getVisiblePRRefreshWindowCountForTests(): number {
   return visibleByWindow.size
+}
+
+export function _getPRRefreshActiveBurstScopeCountForTests(): number {
+  return activeStartsByScope.size
 }
 
 export function _getPRRefreshErrorBackoffCountForTests(): number {

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -467,6 +467,44 @@ describe('registerGitHubHandlers', () => {
     expect(candidate).not.toHaveProperty('localGitOptions')
   })
 
+  it('cleans active refresh state when its sender is destroyed before reporting visibility', async () => {
+    registerGitHubHandlers(store as never, stats as never)
+    let onDestroyed: (() => void) | undefined
+    const sender = {
+      id: 901,
+      once: vi.fn((event: string, listener: () => void) => {
+        if (event === 'destroyed') {
+          onDestroyed = listener
+        }
+      })
+    }
+
+    await handlers['gh:enqueuePRRefresh'](
+      { sender },
+      {
+        candidate: {
+          cacheKey: '/workspace/repo::feature/test',
+          repoPath: '/workspace/repo',
+          repoId: 'repo-1',
+          branch: 'feature/test',
+          repoKind: 'git'
+        },
+        reason: 'active',
+        priority: 80
+      }
+    )
+
+    expect(sender.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
+    expect(enqueuePRRefreshMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: '/workspace/repo' }),
+      'active',
+      80,
+      901
+    )
+    onDestroyed?.()
+    expect(clearVisiblePRRefreshWindowMock).toHaveBeenCalledWith(901)
+  })
+
   it('keeps manual PR refresh validation strict', async () => {
     registerGitHubHandlers(store as never, stats as never)
 

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -2,7 +2,7 @@
 the repo-path validation, preference-threading, and stats wiring patterns are
 reviewable as one surface. Splitting by feature area would risk drifting
 validation/gate conventions across handler files. */
-import { ipcMain } from 'electron'
+import { ipcMain, type WebContents } from 'electron'
 import { resolve } from 'node:path'
 import type {
   Repo,
@@ -113,7 +113,19 @@ import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import { sendToTrustedUIRenderer } from './ui'
 
-const prRefreshVisibilityCleanupRegistered = new Set<number>()
+const prRefreshWindowCleanupRegistered = new Set<number>()
+
+function registerPRRefreshWindowCleanup(sender: WebContents): void {
+  const senderId = sender.id
+  if (prRefreshWindowCleanupRegistered.has(senderId)) {
+    return
+  }
+  prRefreshWindowCleanupRegistered.add(senderId)
+  sender.once('destroyed', () => {
+    prRefreshWindowCleanupRegistered.delete(senderId)
+    clearVisiblePRRefreshWindow(senderId)
+  })
+}
 
 // Why: the app renderer owns the SWR cache; browser guests cannot consume this
 // event. Skip the origin because it already updated its cache optimistically.
@@ -342,7 +354,11 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       if (validation.kind === 'skipped') {
         return validation.result
       }
-      const senderWindowId = event?.sender?.id
+      const sender = event?.sender
+      const senderWindowId = sender?.id
+      if (sender) {
+        registerPRRefreshWindowCleanup(sender)
+      }
       enqueuePRRefresh(validation.candidate, args.reason, args.priority ?? 0, senderWindowId)
       return { kind: 'queued' }
     }
@@ -352,13 +368,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
     'gh:reportVisiblePRRefreshCandidates',
     (event, args: { candidates: GitHubPRRefreshCandidate[]; generation: number }) => {
       const senderId = event.sender.id
-      if (!prRefreshVisibilityCleanupRegistered.has(senderId)) {
-        prRefreshVisibilityCleanupRegistered.add(senderId)
-        event.sender.once('destroyed', () => {
-          prRefreshVisibilityCleanupRegistered.delete(senderId)
-          clearVisiblePRRefreshWindow(senderId)
-        })
-      }
+      registerPRRefreshWindowCleanup(event.sender)
       const candidates: GitHubPRRefreshCandidate[] = []
       const repos = store.getRepos()
       for (const candidate of args.candidates) {


### PR DESCRIPTION
## ELI5

Orca remembers which window started or can see a pull-request refresh. If a window closed before it reported visibility, part of that bookkeeping could live forever because nothing cleared it. Refresh state is now tied to the renderer window's lifetime from the first enqueue, and the fallback cleanup removes all state for dead windows.

## What Changed

- Add one idempotent `WebContents` lifecycle registrar shared by refresh enqueue and visibility-report IPC handlers.
- Register destruction cleanup as soon as an active refresh is enqueued, not only after the renderer reports visible candidates.
- On renderer destruction:
  - remove the lifecycle registration;
  - call the existing comprehensive per-window cleanup;
  - clear visibility and active-burst scope bookkeeping for that renderer ID.
- Extend the coordinator's stale-window fallback sweep so discovering a dead window also clears its active burst scopes.
- Add test-only visibility into the active-scope count for deterministic leak assertions.

## Why

An active refresh can be enqueued before the renderer publishes its visible-candidate generation. Previously, only that later visibility handler installed a `destroyed` listener. Closing the window in between left an `activeStartsByScope` entry keyed by a renderer ID that would never be used again. The coordinator's fallback window sweep removed visibility state but not the active-burst state, so repeated window churn could accumulate permanent entries and stale throttling history.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review.

## Visual Proof

N/A — window and PR UI behavior are unchanged. This is main-process scheduler lifecycle cleanup.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 2 files, 65/65 tests passed.
- [x] IPC regression destroys a sender after enqueue but before visibility reporting and verifies cleanup.
- [x] Coordinator regression verifies fallback stale-window discovery removes both visibility and active-burst state.
- [x] Full rebased review set passed typecheck, lint/reliability gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security:** no authorization, command, or GitHub credential surface changes.
- **Cross-platform:** Electron `WebContents` destruction and map cleanup are platform-independent.
- **SSH / WSL / folder workspaces:** cleanup is scoped only by renderer ID and applies equally to local and remote candidates without changing their execution route.
- **Git provider compatibility:** code is confined to the GitHub PR-refresh path; no generic GitLab/review model changes.
- **Performance:** one `once('destroyed')` listener per participating renderer, deduplicated by ID; cleanup reduces retained state.
- **Compatibility:** cleanup does not cancel an in-flight GitHub request or affect other windows. It removes only scheduling metadata owned by a destroyed renderer.
- **Rollback:** revert the four files; no persisted or wire state needs migration.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and provider impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
