### PR TITLE
fix(ssh): settle cleared PTY reattach work

### DIFF
--- a/src/main/ssh/ssh-pty-targeted-reattach-queue.test.ts
+++ b/src/main/ssh/ssh-pty-targeted-reattach-queue.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  SSH_PTY_REATTACH_CANCELLED,
+  SshPtyTargetedReattachQueue
+} from './ssh-pty-targeted-reattach-queue'
+
+function deferredBoolean(): {
+  promise: Promise<boolean>
+  resolve: (value: boolean) => void
+} {
+  let resolve!: (value: boolean) => void
+  const promise = new Promise<boolean>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+describe('SshPtyTargetedReattachQueue', () => {
+  it('settles cleared waiters without resetting active work accounting', async () => {
+    const queue = new SshPtyTargetedReattachQueue(1)
+    const oldGate = deferredBoolean()
+    const replacementGate = deferredBoolean()
+    const oldTask = vi.fn(() => oldGate.promise)
+    const clearedTask = vi.fn().mockResolvedValue(true)
+    const replacementTask = vi.fn(() => replacementGate.promise)
+
+    const oldRun = queue.run('pty-1', oldTask)
+    const clearedRun = queue.run('pty-2', clearedTask)
+    queue.clear()
+
+    await expect(clearedRun).resolves.toBe(SSH_PTY_REATTACH_CANCELLED)
+    expect(clearedTask).not.toHaveBeenCalled()
+
+    const replacementRun = queue.run('pty-1', replacementTask)
+    expect(replacementTask).not.toHaveBeenCalled()
+
+    oldGate.resolve(false)
+    await expect(oldRun).resolves.toBe(false)
+    expect(replacementTask).toHaveBeenCalledOnce()
+    expect(queue.has('pty-1')).toBe(true)
+
+    replacementGate.resolve(true)
+    await expect(replacementRun).resolves.toBe(true)
+    expect(queue.has('pty-1')).toBe(false)
+  })
+})

--- a/src/main/ssh/ssh-pty-targeted-reattach-queue.ts
+++ b/src/main/ssh/ssh-pty-targeted-reattach-queue.ts
@@ -1,4 +1,8 @@
-type TargetedReattach = Readonly<{ start: () => void }>
+export const SSH_PTY_REATTACH_CANCELLED = Symbol('ssh-pty-reattach-cancelled')
+
+export type SshPtyTargetedReattachResult = boolean | typeof SSH_PTY_REATTACH_CANCELLED
+
+type TargetedReattach = Readonly<{ start: () => void; cancel: () => void }>
 
 // Why bounded: every rejected frame asks for its own attach round trip, so a relay that starts
 // rejecting across many PTYs at once fans out one concurrent reattach per PTY. The bulk reconnect
@@ -14,8 +18,8 @@ export class SshPtyTargetedReattachQueue {
     return this.running.has(key)
   }
 
-  run(key: string, task: () => Promise<boolean>): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
+  run(key: string, task: () => Promise<boolean>): Promise<SshPtyTargetedReattachResult> {
+    return new Promise<SshPtyTargetedReattachResult>((resolve, reject) => {
       const entry: TargetedReattach = {
         start: () => {
           this.active++
@@ -29,7 +33,8 @@ export class SshPtyTargetedReattachQueue {
               reject(error instanceof Error ? error : new Error(String(error)))
             }
           )
-        }
+        },
+        cancel: () => resolve(SSH_PTY_REATTACH_CANCELLED)
       }
       this.running.set(key, entry)
       if (this.active < this.maxConcurrency) {
@@ -43,7 +48,9 @@ export class SshPtyTargetedReattachQueue {
   // Why queued entries are dropped rather than started: each one is keyed to the provider generation
   // the teardown just ended, so running it would attach onto a mux that is already gone.
   clear(): void {
-    this.waiting.length = 0
+    for (const entry of this.waiting.splice(0)) {
+      entry.cancel()
+    }
     this.running.clear()
   }
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -127,7 +127,10 @@ import {
   rememberSshPtyConsumerRecovery
 } from './ssh-pty-consumer-recovery'
 import { classifySshPtyFrameRejection, SshPtyFrameRejectionLog } from './ssh-pty-frame-rejection'
-import { SshPtyTargetedReattachQueue } from './ssh-pty-targeted-reattach-queue'
+import {
+  SSH_PTY_REATTACH_CANCELLED,
+  SshPtyTargetedReattachQueue
+} from './ssh-pty-targeted-reattach-queue'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
 
@@ -1915,6 +1918,9 @@ export class SshRelaySession {
       )
       .then(
         (recovered) => {
+          if (recovered === SSH_PTY_REATTACH_CANCELLED) {
+            return
+          }
           if (recovered) {
             // Why only a completed reattach clears this: an accepted frame proves nothing about the
             // delivery that was rejected, and resetting on one lets a flapping PTY reattach forever.


### PR DESCRIPTION
## ELI5

When an SSH relay generation goes away, Orca clears queued requests to reattach individual terminals. It used to throw those queued entries away without completing the promises returned to their callers, leaving recovery state hanging forever. Cleared work now settles as “cancelled,” and the relay knows not to retry it against a provider that no longer exists.

## What Changed

- Add an internal `SSH_PTY_REATTACH_CANCELLED` sentinel distinct from success and recovery failure.
- Give each waiting queue entry an explicit cancellation callback.
- On queue clear, remove waiting entries and resolve their promises with the cancellation sentinel.
- Allow already-running tasks to finish rather than pretending they were aborted.
- Preserve the active concurrency count across clear/provider replacement so old running work still occupies its real slot.
- Keep identity checks that prevent an old task completion from deleting a replacement entry using the same PTY key.
- Teach the relay-session consumer to ignore cancellation rather than clearing recovery state or scheduling a retry.

## Why

`clear()` previously emptied the waiting array and map, but the promises returned by `run()` had no remaining resolve or reject path. Those permanently pending promises retained callbacks and recovery state after relay teardown. Resolving them as ordinary `false` would be equally wrong because the caller interprets failure as a reason to retry against the already-retired provider generation.

A distinct local sentinel makes teardown cancellation explicit without changing the remote protocol.

## Linked Issue

No linked issue — confirmed by the Clawpatch repository review.

## Visual Proof

N/A — no UI or terminal rendering change; this is main-process recovery promise settlement.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 2 files, 14/14 tests passed.
- [x] Regression proves a cleared waiter settles without executing, active work retains its slot, replacement work remains bounded, old completion cannot delete replacement identity, and replacement work later settles normally.
- [x] Relay rejected-delivery recovery behavior remained green.
- [x] Full rebased review set passed typecheck, lint/reliability gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Security/resource ownership:** removes indefinitely retained callbacks/state after relay teardown.
- **Cross-platform:** pure TypeScript queue bookkeeping; no platform branch or filesystem behavior.
- **SSH / remote wire:** entirely main-process-local. No opcode, frame, RPC parameter, or published content changes.
- **Performance:** no new polling or timers; clear performs one linear pass over already-bounded waiting entries.
- **Compatibility:** the result type changes only for this internal queue, and its sole production consumer is updated in the same PR.
- **Known limitation:** already-running tasks are not force-aborted and still depend on their underlying operation settling.
- **Rollback:** revert the three files; no persisted state or wire migration exists.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, wire, and compatibility impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
