### PR TITLE
test(wire): select stable desktop release baselines

### DIFF
--- a/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { resolveBaselineReleaseRef } from './release-checkout'
+import { resolveBaselineReleaseRef, selectLatestStableReleaseTag } from './release-checkout'
 import {
   JOURNEY_INPUTS,
   JOURNEY_STEPS,
@@ -92,6 +92,18 @@ function expectWireCompatible(record: JourneyRecord): void {
 }
 
 describe('cross-version remote terminal wire', () => {
+  it('ignores legacy, mobile, and prerelease tags when selecting the baseline', () => {
+    expect(
+      selectLatestStableReleaseTag([
+        'v799',
+        'mobile-v9.0.0',
+        'v1.4.177-rc.3',
+        'v1.4.175',
+        'v1.4.176'
+      ])
+    ).toBe('v1.4.176')
+  })
+
   it(
     'skews current code against a real published release',
     () => {

--- a/tests/e2e/cross-version-wire/release-checkout.ts
+++ b/tests/e2e/cross-version-wire/release-checkout.ts
@@ -21,6 +21,7 @@ const CHECKOUT_FORMAT = 1
 const ARCHIVE_PATHS = ['src/main', 'src/shared', 'src/preload', 'src/renderer', 'src/types']
 
 const BASELINE_REF_ENV = 'ORCA_CROSS_VERSION_BASELINE_REF'
+const STABLE_DESKTOP_RELEASE_TAG = /^v\d+\.\d+\.\d+$/
 
 export type ReleaseCheckout = {
   /** The ref as requested, e.g. `v1.4.169`. */
@@ -61,7 +62,7 @@ function compareReleaseTags(a: string, b: string): number {
 
 /**
  * The version point the harness pairs current code against. An explicit
- * {@link BASELINE_REF_ENV} wins; otherwise the newest non-prerelease `v*` tag.
+ * {@link BASELINE_REF_ENV} wins; otherwise the newest stable desktop release tag.
  *
  * Throws rather than skipping: a cross-version lane that quietly runs nothing is
  * the exact failure this harness exists to prevent.
@@ -80,16 +81,24 @@ export function resolveBaselineReleaseRef(): string {
         `Run it inside a git checkout, or pin a ref with ${BASELINE_REF_ENV}.`
     )
   }
-  const releases = tags.filter((tag) => !tag.includes('-')).sort(compareReleaseTags)
-  const latest = releases.at(-1)
+  const latest = selectLatestStableReleaseTag(tags)
   if (!latest) {
     throw new Error(
-      `Cross-version harness found no release tags matching v[0-9]* (saw ${tags.length} tag(s) total). ` +
+      `Cross-version harness found no stable desktop release tags matching vX.Y.Z (saw ${tags.length} tag(s) total). ` +
         'CI checkouts default to a shallow clone with no tags: use `actions/checkout` with `fetch-depth: 0`, ' +
         `or pin a ref with ${BASELINE_REF_ENV}.`
     )
   }
   return latest
+}
+
+export function selectLatestStableReleaseTag(tags: string[]): string | null {
+  return (
+    tags
+      .filter((tag) => STABLE_DESKTOP_RELEASE_TAG.test(tag))
+      .sort(compareReleaseTags)
+      .at(-1) ?? null
+  )
 }
 
 function resolveCommit(ref: string): string {


### PR DESCRIPTION
## ELI5

The compatibility test automatically picks an older Orca release to talk to current code. Its broad tag search could choose an unrelated legacy tag such as `v799` instead of a desktop release like `v1.4.176`, making the test fail for the wrong reason or validate the wrong baseline. Automatic selection now accepts only stable desktop tags shaped exactly like `vX.Y.Z`.

## What Changed

- Add a pure `selectLatestStableReleaseTag` selector.
- Restrict automatic candidates to exact `^v\d+\.\d+\.\d+$` stable desktop tags.
- Keep the existing numeric version comparator for the filtered candidates.
- Ignore legacy one-component tags, mobile tag families, and prereleases/RCs during automatic discovery.
- Improve the no-baseline error to name the expected `vX.Y.Z` convention and retain the full-history checkout guidance.
- Keep `ORCA_CROSS_VERSION_BASELINE_REF` ahead of automatic selection, so explicit branches, SHAs, nonstandard tags, and prereleases remain available when deliberately pinned.

## Why

The old selector listed broad `v[0-9]*` tags and excluded only names containing `-`. That admits non-semver legacy tags such as `v799`, which the numeric comparator can rank above the current desktop series. The harness can then extract a revision without the expected source tree or test a release family unrelated to the desktop remote-wire contract.

A compatibility lane should fail loudly when no valid baseline exists, not silently pick an irrelevant release.

## Linked Issue

No linked issue — found while validating the Clawpatch changes against the real cross-version lane.

## Visual Proof

N/A — test infrastructure only; no product UI or runtime behavior changes.

## Testing

- [x] Automated tests added/updated
- [x] Independent branch run: 5/5 cross-version terminal-wire unit tests passed.
- [x] Regression mixes `v799`, mobile, RC, and stable desktop tags and selects `v1.4.176`.
- [x] Real repository tag enumeration was checked: the selector resolves the latest stable desktop tag rather than the legacy family.
- [x] Full rebased review set passed typecheck, lint/reliability gates, 50,934 tests, and `build:desktop`.

## AI Disclosure

N/A (internal repository review).

## Review

- **Remote wire compatibility:** no terminal frame, decoder, RPC, capability, or runtime behavior changes. Only test-harness baseline discovery changes.
- **Git compatibility:** uses the existing tag-listing commands and sort implementation; no new Git subcommand or option was added, preserving the Git 2.25 baseline.
- **Cross-platform / SSH:** selector logic is platform-independent and runs against the same repository checkout in CI.
- **Performance:** filters an in-memory tag list once; archive and test work are unchanged.
- **Compatibility:** if desktop releases adopt a new tag convention, automatic discovery fails with an actionable message. The explicit environment override remains the escape hatch.
- **Rollback:** revert the two files; no product or persisted state is involved, but broad selection can again choose a legacy release.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, Git compatibility, remote wire scope, and performance
- [x] Cross-platform, SSH/remote, and backwards compatibility considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build:desktop` pass on the complete rebased review set

## Author

- X / Twitter: @nwparker_

Made with [Orca](https://github.com/stablyai/orca) 🐋
