### PR TITLE
fix(commit-message): stop Antigravity treating --sandbox as the commit prompt

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -571,10 +571,16 @@ describe('buildArgs (OpenCode)', () => {
 describe('buildArgs (Antigravity)', () => {
   const spec = getCommitMessageAgentSpec('antigravity')!
 
-  it('runs agy with --print, --sandbox, and --model flags', () => {
-    const args = spec.buildArgs({ prompt: '', model: 'Gemini 3.5 Flash (Medium)' })
-    expect(args).toEqual(['--print', '--sandbox', '--model', 'Gemini 3.5 Flash (Medium)'])
-    expect(spec.promptDelivery).toBe('stdin')
+  it('passes the prompt as the --print value so --sandbox is not consumed as the request', () => {
+    const prompt = 'Generate a concise git commit message for the staged changes.'
+    const args = spec.buildArgs({ prompt, model: 'Gemini 3.5 Flash (Medium)' })
+    const printIndex = args.indexOf('--print')
+
+    expect(spec.promptDelivery).toBe('argv')
+    expect(printIndex).toBe(0)
+    expect(args[printIndex + 1]).toBe(prompt)
+    expect(args[printIndex + 1]).not.toBe('--sandbox')
+    expect(args).toEqual(['--print', prompt, '--sandbox', '--model', 'Gemini 3.5 Flash (Medium)'])
   })
 
   it('uses dynamic model discovery via agy models', () => {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -701,8 +701,12 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     id: 'antigravity',
     label: 'Antigravity',
     binary: 'agy',
-    promptDelivery: 'stdin',
-    buildArgs: ({ model }) => ['--print', '--sandbox', '--model', model],
+    // Why: agy's --print/-p/--prompt is a required string flag. A valueless
+    // `--print --sandbox` makes `--sandbox` the user request (STA-4011).
+    // Keep the prompt immediately after --print so extra recipe args cannot
+    // land between the flag and its value.
+    promptDelivery: 'argv',
+    buildArgs: ({ prompt, model }) => ['--print', prompt, '--sandbox', '--model', model],
     modelSource: 'dynamic',
     modelDiscovery: { binary: 'agy', args: ['models'], parse: parseAntigravityModels },
     models: [

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -382,6 +382,38 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('plans Antigravity with the prompt as the --print value, not stdin', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'antigravity',
+        model: 'gemini-3.6-flash',
+        agentArgs: '--add-dir . --effort low --dangerously-skip-permissions'
+      },
+      'COMMIT PROMPT'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'agy',
+        args: [
+          '--print',
+          'COMMIT PROMPT',
+          '--sandbox',
+          '--model',
+          'gemini-3.6-flash',
+          '--add-dir',
+          '.',
+          '--effort',
+          'low',
+          '--dangerously-skip-permissions'
+        ],
+        stdinPayload: null,
+        label: 'Antigravity'
+      }
+    })
+  })
+
   it('rejects invalid per-action CLI arguments before spawning', () => {
     const result = planCommitMessageGeneration(
       {


### PR DESCRIPTION
## ELI5

When Orca asked Antigravity to write a commit message, it accidentally told the CLI that the job was `--sandbox` instead of the real prompt. This change puts the commit-message text in the flag Antigravity actually reads.

## What Changed

Antigravity commit-message generation now passes the prompt as the value of `--print` and keeps `--sandbox` as a later boolean flag:

```ts
['--print', prompt, '--sandbox', '--model', model]
```

`--print` stays immediately followed by the prompt so extra recipe CLI arguments cannot land between the flag and its value.

## Why

Linux `agy` 1.1.12 treats `--print` / `-p` / `--prompt` as a required string flag. Orca previously spawned:

```text
agy --print --sandbox --model <model>   # prompt on stdin
```

`--print` consumed `--sandbox` as the user request. That matches the report: Antigravity answered as if the user asked about `--sandbox`. A trailing `--print` with no value exits 2 and prints help; stdin is not the print-mode prompt.

## Linked Issue

Fixes #14059
Fixes STA-4011

## Visual Proof

N/A — no Source Control chrome change. The bug is the argv Orca passes to `agy`. Before/after invocation on a throwaway Linux SSH target with a real `demo-project` repo:

**Before (origin/main):**
```text
agy --print --sandbox --model Gemini 3.5 Flash (Medium) --add-dir . --model gemini-3.6-flash --effort low --dangerously-skip-permissions
# stdin: "You are generating a single git commit message..."
```

**After:**
```text
agy --print "<commit-generation prompt + staged patch>" --sandbox --model Gemini 3.5 Flash (Medium) --add-dir . --model gemini-3.6-flash --effort low --dangerously-skip-permissions
# stdin: empty
```

`--print`'s next token is the real prompt, not `--sandbox`.

## Testing

- Linux `agy` 1.1.12 on a throwaway Docker SSH target (`linux-arm64`): `--print` without a value → exit 2 + help; `--print --sandbox` → parsed (auth path), proving `--sandbox` is the print value.
- Isolated Electron CDP session of this worktree (`pnpm build:relay`, unique user-data, identity verified).
- Connected the SSH target, registered `/work/demo-project` (local git-bundle fallback after GitHub HTTPS clone needed auth), staged a real change, clicked **Generate commit message with AI**.
- Fake `agy` on the remote PATH captured argv/stdin before and after the fix.
- Relay: `linux-arm64`, already installed, reconnect succeeded. No commit-message spawn errors in app logs.
- Focused vitest: `commit-message-agent-spec`, `commit-message-plan`, `commit-message-text-generation`, `commit-message-generation`, `commit-message-prompt`.
- Those new tests fail if the old `--print --sandbox` + stdin contract is restored.
- `pnpm tc:node` and oxlint on the touched files.

Cleanup: stopped only the Electron/dev PIDs from this session, removed the Docker container, temp keys, and isolated user-data. Worktree `git status` was clean after the commit.

SSH merge verdict: **land**. Remaining risk: very large staged diffs now travel on argv like other argv-delivery agents (Kimi/Cursor/Copilot), not stdin.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)