### PR TITLE
Add filter and sorting to automations page

### DIFF
--- a/src/renderer/src/components/automations/AutomationListExternalRows.tsx
+++ b/src/renderer/src/components/automations/AutomationListExternalRows.tsx
@@ -36,6 +36,8 @@ import {
   AUTOMATIONS_TABLE_ROW_SELECTED_CLASS
 } from './automations-table-layout'
 import { isPortaledRowMenuClick, isRowActivationKey } from './automation-list-row-interaction'
+import { getExternalAutomationLastRunSnapshot } from './automation-list-last-run'
+import { AutomationListLastRunCell } from './AutomationListLastRunCell'
 import { AutomationListStatusCell } from './AutomationListStatusCell'
 import { translate } from '@/i18n/i18n'
 
@@ -85,6 +87,7 @@ export function AutomationListExternalRows({
         const nextRunLabel = entry.job.enabled
           ? formatExternalDate(entry.job.nextRunAt, relativeNow)
           : translate('auto.components.automations.AutomationsPage.paused', 'Paused')
+        const lastRunSnapshot = getExternalAutomationLastRunSnapshot(entry.job)
 
         return (
           <ContextMenu key={entry.key}>
@@ -124,6 +127,7 @@ export function AutomationListExternalRows({
                 <span className="min-w-0 truncate text-muted-foreground" title={nextRunLabel}>
                   {nextRunLabel}
                 </span>
+                <AutomationListLastRunCell snapshot={lastRunSnapshot} now={relativeNow} />
                 <AutomationListStatusCell enabled={entry.job.enabled} />
                 <span className="truncate text-center text-xs text-muted-foreground">
                   {providerLabel}

--- a/src/renderer/src/components/automations/AutomationListFilterMenu.tsx
+++ b/src/renderer/src/components/automations/AutomationListFilterMenu.tsx
@@ -119,10 +119,6 @@ export function AutomationListFilterMenu({
           type="button"
           variant="ghost"
           size="sm"
-          aria-label={translate(
-            'auto.components.automations.AutomationListFilterMenu.filters',
-            'Filters'
-          )}
           className="h-8 shrink-0 gap-1.5 border border-border bg-background px-2.5 text-xs shadow-none hover:bg-muted/50 focus-visible:border-ring/70 focus-visible:ring-0"
         >
           <ListFilter className="size-3.5" />

--- a/src/renderer/src/components/automations/AutomationListFilterMenu.tsx
+++ b/src/renderer/src/components/automations/AutomationListFilterMenu.tsx
@@ -1,0 +1,196 @@
+import React from 'react'
+import { ListFilter, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { translate } from '@/i18n/i18n'
+import {
+  countAutomationListFilters,
+  EMPTY_AUTOMATION_LIST_FILTER,
+  type AutomationListFilter,
+  type AutomationListLastRunFilter,
+  type AutomationListStatusFilter
+} from './automation-list-view'
+
+function FilterPill({
+  label,
+  value,
+  onClear
+}: {
+  label: string
+  value: string
+  onClear: () => void
+}): React.JSX.Element {
+  return (
+    <span className="inline-flex h-6 items-center gap-1 rounded-full border border-border/60 bg-muted/50 pl-2 pr-1 text-[11px] text-foreground">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="max-w-[140px] truncate font-medium">{value}</span>
+      <button
+        type="button"
+        aria-label={translate(
+          'auto.components.automations.AutomationListFilterMenu.removeFilter',
+          'Remove {{value0}} filter',
+          { value0: label }
+        )}
+        onClick={onClear}
+        className="rounded-full p-0.5 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+      >
+        <X className="size-3" />
+      </button>
+    </span>
+  )
+}
+
+export function AutomationListFilterPills({
+  filter,
+  onChange
+}: {
+  filter: AutomationListFilter
+  onChange: (next: AutomationListFilter) => void
+}): React.JSX.Element | null {
+  const statusLabel = translate('auto.components.automations.AutomationsPage.tableStatus', 'Status')
+  const lastRunLabel = translate(
+    'auto.components.automations.AutomationsPage.tableLastRun',
+    'Last run'
+  )
+  const statusValueLabel =
+    filter.status === 'enabled'
+      ? translate('auto.components.automations.AutomationDetail.eaa02014f8', 'Enabled')
+      : filter.status === 'paused'
+        ? translate('auto.components.automations.AutomationDetail.b09b2384fd', 'Paused')
+        : null
+  const lastRunValueLabel =
+    filter.lastRun === 'failed'
+      ? translate('auto.components.automations.AutomationListFilterMenu.failed', 'Failed')
+      : filter.lastRun === 'succeeded'
+        ? translate('auto.components.automations.AutomationListFilterMenu.succeeded', 'Succeeded')
+        : filter.lastRun === 'never'
+          ? translate('auto.components.automations.AutomationListFilterMenu.neverRan', 'Never ran')
+          : null
+  if (!statusValueLabel && !lastRunValueLabel) {
+    return null
+  }
+  return (
+    <>
+      {statusValueLabel ? (
+        <FilterPill
+          label={statusLabel}
+          value={statusValueLabel}
+          onClear={() => onChange({ ...filter, status: 'all' })}
+        />
+      ) : null}
+      {lastRunValueLabel ? (
+        <FilterPill
+          label={lastRunLabel}
+          value={lastRunValueLabel}
+          onClear={() => onChange({ ...filter, lastRun: 'all' })}
+        />
+      ) : null}
+    </>
+  )
+}
+
+export function AutomationListFilterMenu({
+  filter,
+  onChange
+}: {
+  filter: AutomationListFilter
+  onChange: (next: AutomationListFilter) => void
+}): React.JSX.Element {
+  const activeCount = countAutomationListFilters(filter)
+  const statusLabel = translate('auto.components.automations.AutomationsPage.tableStatus', 'Status')
+  const lastRunLabel = translate(
+    'auto.components.automations.AutomationsPage.tableLastRun',
+    'Last run'
+  )
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={translate(
+            'auto.components.automations.AutomationListFilterMenu.filters',
+            'Filters'
+          )}
+          className="h-8 shrink-0 gap-1.5 border border-border bg-background px-2.5 text-xs shadow-none hover:bg-muted/50 focus-visible:border-ring/70 focus-visible:ring-0"
+        >
+          <ListFilter className="size-3.5" />
+          {translate('auto.components.automations.AutomationListFilterMenu.filters', 'Filters')}
+          {activeCount > 0 ? (
+            <span className="rounded-full bg-foreground px-1.5 text-[10px] font-semibold leading-4 text-background">
+              {activeCount}
+            </span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        <DropdownMenuLabel>{statusLabel}</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={filter.status}
+          onValueChange={(value) =>
+            onChange({ ...filter, status: value as AutomationListStatusFilter })
+          }
+        >
+          <DropdownMenuRadioItem value="all">
+            {translate('auto.components.automations.AutomationListFilterMenu.all', 'All')}
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="enabled">
+            {translate('auto.components.automations.AutomationDetail.eaa02014f8', 'Enabled')}
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="paused">
+            {translate('auto.components.automations.AutomationDetail.b09b2384fd', 'Paused')}
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>{lastRunLabel}</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={filter.lastRun}
+          onValueChange={(value) =>
+            onChange({ ...filter, lastRun: value as AutomationListLastRunFilter })
+          }
+        >
+          <DropdownMenuRadioItem value="all">
+            {translate('auto.components.automations.AutomationListFilterMenu.all', 'All')}
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="failed">
+            {translate('auto.components.automations.AutomationListFilterMenu.failed', 'Failed')}
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="succeeded">
+            {translate(
+              'auto.components.automations.AutomationListFilterMenu.succeeded',
+              'Succeeded'
+            )}
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="never">
+            {translate(
+              'auto.components.automations.AutomationListFilterMenu.neverRan',
+              'Never ran'
+            )}
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        {activeCount > 0 ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => onChange(EMPTY_AUTOMATION_LIST_FILTER)}>
+              {translate(
+                'auto.components.automations.AutomationListFilterMenu.clear',
+                'Clear filters'
+              )}
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationListLastRunCell.tsx
+++ b/src/renderer/src/components/automations/AutomationListLastRunCell.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+import {
+  formatAutomationLastRunCell,
+  type AutomationLastRunSnapshot
+} from './automation-list-last-run'
+
+export function AutomationListLastRunCell({
+  snapshot,
+  now
+}: {
+  snapshot: AutomationLastRunSnapshot
+  now: number
+}): React.JSX.Element {
+  const cell = formatAutomationLastRunCell(snapshot, now)
+  const failed = cell.tone === 'failed'
+  return (
+    <span
+      className={cn(
+        'inline-flex min-w-0 items-center gap-1.5 truncate',
+        failed ? 'text-destructive' : 'text-muted-foreground'
+      )}
+      title={cell.title}
+    >
+      {cell.tone !== 'never' ? (
+        <span
+          className={cn(
+            'size-1.5 shrink-0 rounded-full',
+            failed ? 'bg-destructive' : 'bg-muted-foreground/70'
+          )}
+          aria-hidden="true"
+        />
+      ) : null}
+      <span className="truncate">{cell.text}</span>
+    </span>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationListLocalRows.test.tsx
+++ b/src/renderer/src/components/automations/AutomationListLocalRows.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type {
   Automation,
+  AutomationRun,
   ExternalAutomationJob,
   ExternalAutomationManager
 } from '../../../../shared/automations-types'
@@ -84,16 +85,42 @@ function makeExternalManager(): ExternalAutomationManager {
   }
 }
 
+function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: 'run-1',
+    automationId: 'automation-1',
+    title: 'test',
+    scheduledFor: 1,
+    status: 'dispatch_failed',
+    trigger: 'scheduled',
+    workspaceId: 'worktree-1',
+    sessionKind: 'terminal',
+    chatSessionId: null,
+    terminalSessionId: null,
+    terminalPaneKey: null,
+    terminalPtyId: null,
+    outputSnapshot: null,
+    precheckResult: null,
+    usage: null,
+    error: 'boom',
+    startedAt: Date.now() - 8 * 60 * 60 * 1000,
+    dispatchedAt: Date.now() - 8 * 60 * 60 * 1000,
+    createdAt: Date.now() - 8 * 60 * 60 * 1000,
+    ...overrides
+  }
+}
+
 function renderLocalRows(handlers: {
   onSelect: (automationId: string) => void
   onDelete?: (automation: Automation) => void
+  runs?: AutomationRun[]
 }) {
   return render(
     <AutomationListLocalRows
       automations={[makeAutomation()]}
       selectedId={null}
       isSelectedLocal={true}
-      runs={[]}
+      runs={handlers.runs ?? []}
       relativeNow={Date.now()}
       repoMap={new Map()}
       worktreeMap={new Map()}
@@ -160,6 +187,11 @@ describe('Automation list row selection', () => {
 
     expect(onDelete).toHaveBeenCalledTimes(1)
     expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('shows last-run status and relative time', () => {
+    renderLocalRows({ onSelect: vi.fn(), runs: [makeRun()] })
+    expect(screen.getByText('Failed 8h ago')).toBeTruthy()
   })
 
   it('still selects when the local row itself is clicked', async () => {

--- a/src/renderer/src/components/automations/AutomationListLocalRows.test.tsx
+++ b/src/renderer/src/components/automations/AutomationListLocalRows.test.tsx
@@ -12,6 +12,7 @@ import type {
 } from '../../../../shared/automations-types'
 import { AutomationListLocalRows } from './AutomationListLocalRows'
 import { AutomationListExternalRows } from './AutomationListExternalRows'
+import { indexLatestAutomationRuns } from './automation-list-last-run'
 
 // Why: Tooltip needs a provider in the app; stub so rows render standalone.
 vi.mock('@/components/ui/tooltip', () => ({
@@ -120,7 +121,7 @@ function renderLocalRows(handlers: {
       automations={[makeAutomation()]}
       selectedId={null}
       isSelectedLocal={true}
-      runs={handlers.runs ?? []}
+      lastRunByAutomationId={indexLatestAutomationRuns(handlers.runs ?? [])}
       relativeNow={Date.now()}
       repoMap={new Map()}
       worktreeMap={new Map()}

--- a/src/renderer/src/components/automations/AutomationListLocalRows.tsx
+++ b/src/renderer/src/components/automations/AutomationListLocalRows.tsx
@@ -31,6 +31,11 @@ import type { ProjectHostSetup, Repo, Worktree } from '../../../../shared/types'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import type { TaskSourceHostAvailability } from '../task-source-context-summary'
 import type { AutomationHostTarget } from './automation-host-client'
+import {
+  getLocalAutomationLastRunSnapshot,
+  indexLatestAutomationRuns
+} from './automation-list-last-run'
+import { AutomationListLastRunCell } from './AutomationListLastRunCell'
 import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
 import { getAutomationTargetAvailability } from './automation-target-availability'
 import { getAgentLabel } from './automation-draft-model'
@@ -88,16 +93,7 @@ export function AutomationListLocalRows({
 }): React.JSX.Element {
   // Why: one pass over runs instead of a full scan per rendered automation —
   // this list re-renders on the relativeNow timer.
-  const lastRunByAutomationId = React.useMemo(() => {
-    const latest = new Map<string, AutomationRun>()
-    for (const run of runs) {
-      const existing = latest.get(run.automationId)
-      if (!existing || run.createdAt > existing.createdAt) {
-        latest.set(run.automationId, run)
-      }
-    }
-    return latest
-  }, [runs])
+  const lastRunByAutomationId = React.useMemo(() => indexLatestAutomationRuns(runs), [runs])
 
   return (
     <>
@@ -132,6 +128,7 @@ export function AutomationListLocalRows({
           ? (hostLabelById.get(hostId) ?? getExecutionHostLabel(hostId))
           : getLocalExecutionHostLabel()
         const lastRun = lastRunByAutomationId.get(automation.id)
+        const lastRunSnapshot = getLocalAutomationLastRunSnapshot(automation, lastRun)
         const lastRunCost =
           lastRun?.usage?.status === 'known'
             ? formatAutomationCost(lastRun.usage.estimatedCostUsd)
@@ -213,6 +210,7 @@ export function AutomationListLocalRows({
                 <span className="min-w-0 truncate text-muted-foreground" title={nextRunLabel}>
                   {nextRunLabel}
                 </span>
+                <AutomationListLastRunCell snapshot={lastRunSnapshot} now={relativeNow} />
                 <AutomationListStatusCell enabled={automation.enabled} />
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/src/renderer/src/components/automations/AutomationListLocalRows.tsx
+++ b/src/renderer/src/components/automations/AutomationListLocalRows.tsx
@@ -31,10 +31,7 @@ import type { ProjectHostSetup, Repo, Worktree } from '../../../../shared/types'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import type { TaskSourceHostAvailability } from '../task-source-context-summary'
 import type { AutomationHostTarget } from './automation-host-client'
-import {
-  getLocalAutomationLastRunSnapshot,
-  indexLatestAutomationRuns
-} from './automation-list-last-run'
+import { getLocalAutomationLastRunSnapshot } from './automation-list-last-run'
 import { AutomationListLastRunCell } from './AutomationListLastRunCell'
 import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
 import { getAutomationTargetAvailability } from './automation-target-availability'
@@ -53,7 +50,7 @@ export function AutomationListLocalRows({
   automations,
   selectedId,
   isSelectedLocal,
-  runs,
+  lastRunByAutomationId,
   relativeNow,
   repoMap,
   worktreeMap,
@@ -72,7 +69,7 @@ export function AutomationListLocalRows({
   automations: readonly Automation[]
   selectedId: string | null | undefined
   isSelectedLocal: boolean
-  runs: readonly AutomationRun[]
+  lastRunByAutomationId: ReadonlyMap<string, AutomationRun>
   relativeNow: number
   repoMap: ReadonlyMap<string, Repo>
   worktreeMap: ReadonlyMap<string, Worktree>
@@ -91,10 +88,6 @@ export function AutomationListLocalRows({
   onToggle: (automation: Automation) => void
   onDelete: (automation: Automation) => void
 }): React.JSX.Element {
-  // Why: one pass over runs instead of a full scan per rendered automation —
-  // this list re-renders on the relativeNow timer.
-  const lastRunByAutomationId = React.useMemo(() => indexLatestAutomationRuns(runs), [runs])
-
   return (
     <>
       {automations.map((automation) => {

--- a/src/renderer/src/components/automations/AutomationListSortHeader.tsx
+++ b/src/renderer/src/components/automations/AutomationListSortHeader.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { ArrowDown, ArrowUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { AutomationListSort, AutomationListSortField } from './automation-list-view'
+
+export function AutomationListSortHeader({
+  field,
+  label,
+  sort,
+  onSort
+}: {
+  field: AutomationListSortField
+  label: string
+  sort: AutomationListSort | null
+  onSort: (field: AutomationListSortField) => void
+}): React.JSX.Element {
+  const active = sort?.field === field
+  const direction = active ? sort.direction : null
+  const directionLabel =
+    direction === 'asc'
+      ? translate('auto.components.automations.AutomationListSortHeader.ascending', 'ascending')
+      : direction === 'desc'
+        ? translate('auto.components.automations.AutomationListSortHeader.descending', 'descending')
+        : null
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(field)}
+      aria-label={directionLabel ? `${label}, ${directionLabel}` : label}
+      aria-pressed={active}
+      className={cn(
+        'flex min-w-0 items-center gap-1 rounded-sm text-left text-[11px] font-medium tracking-[0.08em] uppercase select-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
+        active && 'text-foreground'
+      )}
+    >
+      <span className="truncate">{label}</span>
+      {direction === 'asc' ? <ArrowUp aria-hidden="true" className="size-3 shrink-0" /> : null}
+      {direction === 'desc' ? <ArrowDown aria-hidden="true" className="size-3 shrink-0" /> : null}
+    </button>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationListSortHeader.tsx
+++ b/src/renderer/src/components/automations/AutomationListSortHeader.tsx
@@ -17,18 +17,27 @@ export function AutomationListSortHeader({
 }): React.JSX.Element {
   const active = sort?.field === field
   const direction = active ? sort.direction : null
-  const directionLabel =
+  // Why: one interpolated key per direction — word order and punctuation around
+  // the column name differ per language.
+  const sortedLabel =
     direction === 'asc'
-      ? translate('auto.components.automations.AutomationListSortHeader.ascending', 'ascending')
+      ? translate(
+          'auto.components.automations.AutomationListSortHeader.sortedAscending',
+          '{{value0}}, sorted ascending',
+          { value0: label }
+        )
       : direction === 'desc'
-        ? translate('auto.components.automations.AutomationListSortHeader.descending', 'descending')
+        ? translate(
+            'auto.components.automations.AutomationListSortHeader.sortedDescending',
+            '{{value0}}, sorted descending',
+            { value0: label }
+          )
         : null
   return (
     <button
       type="button"
       onClick={() => onSort(field)}
-      aria-label={directionLabel ? `${label}, ${directionLabel}` : label}
-      aria-pressed={active}
+      aria-label={sortedLabel ?? label}
       className={cn(
         'flex min-w-0 items-center gap-1 rounded-sm text-left text-[11px] font-medium tracking-[0.08em] uppercase select-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
         active && 'text-foreground'

--- a/src/renderer/src/components/automations/AutomationListTableHeader.tsx
+++ b/src/renderer/src/components/automations/AutomationListTableHeader.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import {
+  AUTOMATIONS_TABLE_GRID_CLASS,
+  AUTOMATIONS_TABLE_HEADER_CLASS
+} from './automations-table-layout'
+import { AutomationListSortHeader } from './AutomationListSortHeader'
+import type { AutomationListSort, AutomationListSortField } from './automation-list-view'
+
+export function AutomationListTableHeader({
+  sort,
+  onSort
+}: {
+  sort: AutomationListSort | null
+  onSort: (field: AutomationListSortField) => void
+}): React.JSX.Element {
+  return (
+    <div className={cn(AUTOMATIONS_TABLE_GRID_CLASS, AUTOMATIONS_TABLE_HEADER_CLASS)}>
+      <AutomationListSortHeader
+        field="name"
+        label={translate('auto.components.automations.AutomationsPage.tableName', 'Name')}
+        sort={sort}
+        onSort={onSort}
+      />
+      <span>
+        {translate('auto.components.automations.AutomationDetail.18763ded26', 'Schedule')}
+      </span>
+      <span>
+        {translate('auto.components.automations.AutomationsPage.tableProject', 'Project')}
+      </span>
+      <span>
+        {translate('auto.components.automations.AutomationDetail.578ff46987', 'Next run')}
+      </span>
+      <AutomationListSortHeader
+        field="lastRun"
+        label={translate('auto.components.automations.AutomationsPage.tableLastRun', 'Last run')}
+        sort={sort}
+        onSort={onSort}
+      />
+      <span>{translate('auto.components.automations.AutomationsPage.tableStatus', 'Status')}</span>
+      <span className="text-center">
+        {translate('auto.components.automations.AutomationDetail.2df8970cd5', 'Agent')}
+      </span>
+      <span className="sr-only">
+        {translate('auto.components.automations.AutomationsPage.tableActions', 'Actions')}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationListToolbar.tsx
+++ b/src/renderer/src/components/automations/AutomationListToolbar.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { Plus, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { clampAutomationListSearchQueryInput } from './automation-list-search'
+import type { AutomationListFilter } from './automation-list-view'
+import { AutomationListFilterMenu, AutomationListFilterPills } from './AutomationListFilterMenu'
+import { AutomationListSearchField } from './AutomationListSearchField'
+import type { AutomationTemplate } from './automation-templates'
+
+export function AutomationListToolbar({
+  listSearchQuery,
+  isListSearchQueryTooLarge,
+  onListSearchQueryChange,
+  filter,
+  onFilterChange,
+  onRefresh,
+  isRefreshing,
+  openCreateDialog
+}: {
+  listSearchQuery: string
+  isListSearchQueryTooLarge: boolean
+  onListSearchQueryChange: (query: string) => void
+  filter: AutomationListFilter
+  onFilterChange: (filter: AutomationListFilter) => void
+  onRefresh: () => void
+  isRefreshing: boolean
+  openCreateDialog: (template?: AutomationTemplate) => void
+}): React.JSX.Element {
+  return (
+    <div className="flex shrink-0 items-start justify-between gap-3">
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
+          <AutomationListSearchField
+            query={listSearchQuery}
+            isTooLarge={isListSearchQueryTooLarge}
+            className="w-56"
+            onQueryChange={(query) =>
+              onListSearchQueryChange(clampAutomationListSearchQueryInput(query))
+            }
+            onClear={() => onListSearchQueryChange('')}
+          />
+          <AutomationListFilterMenu filter={filter} onChange={onFilterChange} />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={translate(
+                  'auto.components.automations.AutomationsPage.19a6e30eae',
+                  'Refresh automations'
+                )}
+                onClick={onRefresh}
+                disabled={isRefreshing}
+                className="shrink-0 border border-border bg-background shadow-none hover:bg-muted/50"
+              >
+                <RefreshCw className={cn('size-4', isRefreshing && 'animate-spin')} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              {translate(
+                'auto.components.automations.AutomationsPage.19a6e30eae',
+                'Refresh automations'
+              )}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <AutomationListFilterPills filter={filter} onChange={onFilterChange} />
+      </div>
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        className="shrink-0"
+        onClick={() => openCreateDialog()}
+        data-contextual-tour-target="automations-create"
+      >
+        <Plus className="size-4" />
+        {translate('auto.components.automations.AutomationsPage.newAutomation', 'New Automation')}
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationsListPanel.tsx
+++ b/src/renderer/src/components/automations/AutomationsListPanel.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { Plus, RefreshCw } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type {
   Automation,
@@ -15,29 +14,34 @@ import type { ProjectHostSetup, Repo, Worktree } from '../../../../shared/types'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import type { TaskSourceHostAvailability } from '../task-source-context-summary'
 import type { AutomationHostTarget } from './automation-host-client'
-import { clampAutomationListSearchQueryInput } from './automation-list-search'
 import type { AutomationPaneTab } from './automation-page-state'
-import { AutomationListSearchField } from './AutomationListSearchField'
 import { getAutomationTemplates, type AutomationTemplate } from './automation-templates'
-import type { ExternalAutomationListEntry } from './external-automation-list-entries'
 import { AutomationListLocalRows } from './AutomationListLocalRows'
 import { AutomationListExternalRows } from './AutomationListExternalRows'
-import {
-  AUTOMATIONS_TABLE_CONTAINER_CLASS,
-  AUTOMATIONS_TABLE_GRID_CLASS,
-  AUTOMATIONS_TABLE_HEADER_CLASS
-} from './automations-table-layout'
+import { AUTOMATIONS_TABLE_CONTAINER_CLASS } from './automations-table-layout'
 import { translate } from '@/i18n/i18n'
+import type {
+  AutomationListFilter,
+  AutomationListSort,
+  AutomationListSortField,
+  AutomationListViewItem
+} from './automation-list-view'
+import { AutomationListTableHeader } from './AutomationListTableHeader'
+import { AutomationListToolbar } from './AutomationListToolbar'
 
 type AutomationsListPanelProps = {
   hasListItems: boolean
   hasFilteredListItems: boolean
   isListSearchActive: boolean
+  isListFilterActive: boolean
   listSearchQuery: string
   isListSearchQueryTooLarge: boolean
   onListSearchQueryChange: (query: string) => void
-  filteredAutomations: readonly Automation[]
-  filteredExternalAutomationEntries: readonly ExternalAutomationListEntry[]
+  visibleItems: readonly AutomationListViewItem[]
+  listFilter: AutomationListFilter
+  onListFilterChange: (filter: AutomationListFilter) => void
+  listSort: AutomationListSort | null
+  onListSort: (field: AutomationListSortField) => void
   // Why: use explicit ids, not resolved detail selection (which falls back to the
   // first row) — list highlight should only mark a user-chosen row.
   selectedId: string | null
@@ -79,11 +83,15 @@ export function AutomationsListPanel({
   hasListItems,
   hasFilteredListItems,
   isListSearchActive,
+  isListFilterActive,
   listSearchQuery,
   isListSearchQueryTooLarge,
   onListSearchQueryChange,
-  filteredAutomations,
-  filteredExternalAutomationEntries,
+  visibleItems,
+  listFilter,
+  onListFilterChange,
+  listSort,
+  onListSort,
   selectedId,
   selectedExternalKey,
   runs,
@@ -154,57 +162,16 @@ export function AutomationsListPanel({
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-4">
-          <div className="flex shrink-0 items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-2">
-              <AutomationListSearchField
-                query={listSearchQuery}
-                isTooLarge={isListSearchQueryTooLarge}
-                className="w-full max-w-xs"
-                onQueryChange={(query) =>
-                  onListSearchQueryChange(clampAutomationListSearchQueryInput(query))
-                }
-                onClear={() => onListSearchQueryChange('')}
-              />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={translate(
-                      'auto.components.automations.AutomationsPage.19a6e30eae',
-                      'Refresh automations'
-                    )}
-                    onClick={onRefresh}
-                    disabled={isRefreshing}
-                    className="shrink-0 border border-border bg-background shadow-none hover:bg-muted/50"
-                  >
-                    <RefreshCw className={cn('size-4', isRefreshing && 'animate-spin')} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate(
-                    'auto.components.automations.AutomationsPage.19a6e30eae',
-                    'Refresh automations'
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </div>
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              className="shrink-0"
-              onClick={() => openCreateDialog()}
-              data-contextual-tour-target="automations-create"
-            >
-              <Plus className="size-4" />
-              {translate(
-                'auto.components.automations.AutomationsPage.newAutomation',
-                'New Automation'
-              )}
-            </Button>
-          </div>
+          <AutomationListToolbar
+            listSearchQuery={listSearchQuery}
+            isListSearchQueryTooLarge={isListSearchQueryTooLarge}
+            onListSearchQueryChange={onListSearchQueryChange}
+            filter={listFilter}
+            onFilterChange={onListFilterChange}
+            onRefresh={onRefresh}
+            isRefreshing={isRefreshing}
+            openCreateDialog={openCreateDialog}
+          />
 
           <div
             className={cn(
@@ -214,88 +181,61 @@ export function AutomationsListPanel({
           >
             {hasFilteredListItems ? (
               <>
-                <div className={cn(AUTOMATIONS_TABLE_GRID_CLASS, AUTOMATIONS_TABLE_HEADER_CLASS)}>
-                  <span>
-                    {translate('auto.components.automations.AutomationsPage.tableName', 'Name')}
-                  </span>
-                  <span>
-                    {translate(
-                      'auto.components.automations.AutomationDetail.18763ded26',
-                      'Schedule'
-                    )}
-                  </span>
-                  <span>
-                    {translate(
-                      'auto.components.automations.AutomationsPage.tableProject',
-                      'Project'
-                    )}
-                  </span>
-                  <span>
-                    {translate(
-                      'auto.components.automations.AutomationDetail.578ff46987',
-                      'Next run'
-                    )}
-                  </span>
-                  <span>
-                    {translate('auto.components.automations.AutomationsPage.tableStatus', 'Status')}
-                  </span>
-                  <span className="text-center">
-                    {translate('auto.components.automations.AutomationDetail.2df8970cd5', 'Agent')}
-                  </span>
-                  <span className="sr-only">
-                    {translate(
-                      'auto.components.automations.AutomationsPage.tableActions',
-                      'Actions'
-                    )}
-                  </span>
-                </div>
+                <AutomationListTableHeader sort={listSort} onSort={onListSort} />
                 <div className="divide-y divide-border/50">
-                  <AutomationListLocalRows
-                    automations={filteredAutomations}
-                    selectedId={selectedId}
-                    isSelectedLocal={selectedExternalKey === null}
-                    runs={runs}
-                    relativeNow={relativeNow}
-                    repoMap={repoMap}
-                    worktreeMap={worktreeMap}
-                    projectHostSetups={projectHostSetups}
-                    sshConnectionStates={sshConnectionStates}
-                    runtimeStatusByEnvironmentId={runtimeStatusByEnvironmentId}
-                    automationHostTarget={automationHostTarget}
-                    automationSourceHostAvailabilityById={automationSourceHostAvailabilityById}
-                    hostLabelById={hostLabelById}
-                    onSelect={(automationId) => {
-                      selectExternalKey(null)
-                      selectAutomationId(automationId)
-                      onOpenDetail()
-                    }}
-                    onRunNow={runNow}
-                    onEdit={openEditDialog}
-                    onToggle={toggleAutomation}
-                    onDelete={requestDeleteAutomation}
-                  />
-                  <AutomationListExternalRows
-                    entries={filteredExternalAutomationEntries}
-                    selectedExternalKey={selectedExternalKey}
-                    relativeNow={relativeNow}
-                    sshConnectionStates={sshConnectionStates}
-                    externalActionKey={externalActionKey}
-                    onSelect={(entryKey) => {
-                      selectAutomationId(null)
-                      selectExternalKey(entryKey)
-                      setActivePaneTab('overview')
-                      onOpenDetail()
-                    }}
-                    onRequestAction={requestExternalAction}
-                    onEdit={openEditExternalDialog}
-                  />
+                  {visibleItems.map((item) =>
+                    item.kind === 'local' ? (
+                      <AutomationListLocalRows
+                        key={item.id}
+                        automations={[item.automation]}
+                        selectedId={selectedId}
+                        isSelectedLocal={selectedExternalKey === null}
+                        runs={runs}
+                        relativeNow={relativeNow}
+                        repoMap={repoMap}
+                        worktreeMap={worktreeMap}
+                        projectHostSetups={projectHostSetups}
+                        sshConnectionStates={sshConnectionStates}
+                        runtimeStatusByEnvironmentId={runtimeStatusByEnvironmentId}
+                        automationHostTarget={automationHostTarget}
+                        automationSourceHostAvailabilityById={automationSourceHostAvailabilityById}
+                        hostLabelById={hostLabelById}
+                        onSelect={(automationId) => {
+                          selectExternalKey(null)
+                          selectAutomationId(automationId)
+                          onOpenDetail()
+                        }}
+                        onRunNow={runNow}
+                        onEdit={openEditDialog}
+                        onToggle={toggleAutomation}
+                        onDelete={requestDeleteAutomation}
+                      />
+                    ) : (
+                      <AutomationListExternalRows
+                        key={item.id}
+                        entries={[item.entry]}
+                        selectedExternalKey={selectedExternalKey}
+                        relativeNow={relativeNow}
+                        sshConnectionStates={sshConnectionStates}
+                        externalActionKey={externalActionKey}
+                        onSelect={(entryKey) => {
+                          selectAutomationId(null)
+                          selectExternalKey(entryKey)
+                          setActivePaneTab('overview')
+                          onOpenDetail()
+                        }}
+                        onRequestAction={requestExternalAction}
+                        onEdit={openEditExternalDialog}
+                      />
+                    )
+                  )}
                 </div>
               </>
-            ) : isListSearchActive ? (
+            ) : isListSearchActive || isListFilterActive ? (
               <div className="px-3 py-6 text-center text-sm text-muted-foreground">
                 {translate(
-                  'auto.components.automations.AutomationsPage.noSearchMatches',
-                  'No automations match your search.'
+                  'auto.components.automations.AutomationsPage.noListMatches',
+                  'No automations match.'
                 )}
               </div>
             ) : null}

--- a/src/renderer/src/components/automations/AutomationsListPanel.tsx
+++ b/src/renderer/src/components/automations/AutomationsListPanel.tsx
@@ -28,6 +28,7 @@ import type {
 } from './automation-list-view'
 import { AutomationListTableHeader } from './AutomationListTableHeader'
 import { AutomationListToolbar } from './AutomationListToolbar'
+import { indexLatestAutomationRuns } from './automation-list-last-run'
 
 type AutomationsListPanelProps = {
   hasListItems: boolean
@@ -119,6 +120,10 @@ export function AutomationsListPanel({
   onRefresh,
   isRefreshing
 }: AutomationsListPanelProps): React.JSX.Element {
+  // Why: one pass over runs for the whole list — each row renders its own
+  // component, so indexing per row would be O(rows × runs) on every re-render.
+  const lastRunByAutomationId = React.useMemo(() => indexLatestAutomationRuns(runs), [runs])
+
   return (
     <section
       className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-4 md:px-5"
@@ -190,7 +195,7 @@ export function AutomationsListPanel({
                         automations={[item.automation]}
                         selectedId={selectedId}
                         isSelectedLocal={selectedExternalKey === null}
-                        runs={runs}
+                        lastRunByAutomationId={lastRunByAutomationId}
                         relativeNow={relativeNow}
                         repoMap={repoMap}
                         worktreeMap={worktreeMap}

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -106,6 +106,13 @@ import {
 import { buildExternalAutomationListEntries } from './external-automation-list-entries'
 import { shouldCloseDetailForLostSelection } from './automation-detail-selection'
 import { useAutomationListSearch } from './use-automation-list-search'
+import { useAutomationListView } from './use-automation-list-view'
+import {
+  EMPTY_AUTOMATION_LIST_FILTER,
+  nextAutomationListSort,
+  type AutomationListFilter,
+  type AutomationListSort
+} from './automation-list-view'
 import { AutomationDeleteDialog, ExternalAutomationDeleteDialog } from './AutomationDeleteDialogs'
 import { AutomationsListPanel } from './AutomationsListPanel'
 import { AutomationsDetailPane } from './AutomationsDetailPane'
@@ -173,6 +180,8 @@ export default function AutomationsPage(): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [listSearchQuery, setListSearchQuery] = useState('')
+  const [listFilter, setListFilter] = useState<AutomationListFilter>(EMPTY_AUTOMATION_LIST_FILTER)
+  const [listSort, setListSort] = useState<AutomationListSort | null>(null)
   const [createOpen, setCreateOpen] = useState(false)
   const [createTarget, setCreateTarget] = useState<AutomationCreateTarget>('orca')
   const [editingAutomationId, setEditingAutomationId] = useState<string | null>(null)
@@ -273,13 +282,27 @@ export default function AutomationsPage(): React.JSX.Element {
     isListSearchActive,
     filteredAutomations,
     filteredExternalAutomationEntries,
-    hasListItems,
-    hasFilteredListItems
+    hasListItems
   } = useAutomationListSearch({
     listSearchQuery,
     automations,
     externalAutomationEntries,
     repoMap,
+    selectedId,
+    selectedExternalKey,
+    selectAutomationId,
+    selectExternalKey
+  })
+  const {
+    visibleItems,
+    isListFilterActive,
+    hasVisibleListItems: hasFilteredListItems
+  } = useAutomationListView({
+    automations: filteredAutomations,
+    externalEntries: filteredExternalAutomationEntries,
+    runs,
+    filter: listFilter,
+    sort: listSort,
     selectedId,
     selectedExternalKey,
     selectAutomationId,
@@ -2015,11 +2038,15 @@ export default function AutomationsPage(): React.JSX.Element {
           hasListItems={hasListItems}
           hasFilteredListItems={hasFilteredListItems}
           isListSearchActive={isListSearchActive}
+          isListFilterActive={isListFilterActive}
           listSearchQuery={listSearchQuery}
           isListSearchQueryTooLarge={isListSearchQueryTooLarge}
           onListSearchQueryChange={setListSearchQuery}
-          filteredAutomations={filteredAutomations}
-          filteredExternalAutomationEntries={filteredExternalAutomationEntries}
+          visibleItems={visibleItems}
+          listFilter={listFilter}
+          onListFilterChange={setListFilter}
+          listSort={listSort}
+          onListSort={(field) => setListSort((current) => nextAutomationListSort(current, field))}
           selectedId={selectedId}
           selectedExternalKey={selectedExternalKey}
           runs={runs}

--- a/src/renderer/src/components/automations/AutomationsPageSkeleton.tsx
+++ b/src/renderer/src/components/automations/AutomationsPageSkeleton.tsx
@@ -16,12 +16,14 @@ function TableRowSkeleton({
   scheduleWidthClass,
   projectWidthClass,
   nextWidthClass,
+  lastRunWidthClass,
   statusWidthClass
 }: {
   nameWidthClass: string
   scheduleWidthClass: string
   projectWidthClass: string
   nextWidthClass: string
+  lastRunWidthClass: string
   statusWidthClass: string
 }): React.JSX.Element {
   return (
@@ -30,6 +32,7 @@ function TableRowSkeleton({
       <SkeletonBar className={cn('h-3.5', scheduleWidthClass)} />
       <SkeletonBar className={cn('h-3.5', projectWidthClass)} />
       <SkeletonBar className={cn('h-3.5', nextWidthClass)} />
+      <SkeletonBar className={cn('h-3.5', lastRunWidthClass)} />
       <SkeletonBar className={cn('h-3.5', statusWidthClass)} />
       <SkeletonBar className="mx-auto size-4 rounded" />
       <SkeletonBar className="size-6 rounded-md" />
@@ -44,6 +47,7 @@ const TABLE_ROW_SKELETONS = [
     scheduleWidthClass: 'w-36',
     projectWidthClass: 'w-28',
     nextWidthClass: 'w-24',
+    lastRunWidthClass: 'w-20',
     statusWidthClass: 'w-16'
   },
   {
@@ -52,6 +56,7 @@ const TABLE_ROW_SKELETONS = [
     scheduleWidthClass: 'w-28',
     projectWidthClass: 'w-32',
     nextWidthClass: 'w-20',
+    lastRunWidthClass: 'w-24',
     statusWidthClass: 'w-14'
   },
   {
@@ -60,6 +65,7 @@ const TABLE_ROW_SKELETONS = [
     scheduleWidthClass: 'w-40',
     projectWidthClass: 'w-24',
     nextWidthClass: 'w-28',
+    lastRunWidthClass: 'w-16',
     statusWidthClass: 'w-16'
   },
   {
@@ -68,6 +74,7 @@ const TABLE_ROW_SKELETONS = [
     scheduleWidthClass: 'w-32',
     projectWidthClass: 'w-36',
     nextWidthClass: 'w-24',
+    lastRunWidthClass: 'w-20',
     statusWidthClass: 'w-14'
   },
   {
@@ -76,6 +83,7 @@ const TABLE_ROW_SKELETONS = [
     scheduleWidthClass: 'w-24',
     projectWidthClass: 'w-28',
     nextWidthClass: 'w-20',
+    lastRunWidthClass: 'w-24',
     statusWidthClass: 'w-16'
   },
   {
@@ -84,6 +92,7 @@ const TABLE_ROW_SKELETONS = [
     scheduleWidthClass: 'w-36',
     projectWidthClass: 'w-20',
     nextWidthClass: 'w-24',
+    lastRunWidthClass: 'w-16',
     statusWidthClass: 'w-14'
   }
 ] as const
@@ -100,7 +109,8 @@ export function AutomationsPageSkeleton(): React.JSX.Element {
     >
       <div className="flex shrink-0 items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
-          <SkeletonBar className="h-8 w-full max-w-xs rounded-md" />
+          <SkeletonBar className="h-8 w-56 shrink-0 rounded-md" />
+          <SkeletonBar className="h-8 w-20 shrink-0 rounded-md" />
           <SkeletonBar className="size-8 shrink-0 rounded-md" />
         </div>
         <SkeletonBar className="h-8 w-32 shrink-0 rounded-md" />
@@ -113,6 +123,7 @@ export function AutomationsPageSkeleton(): React.JSX.Element {
           <SkeletonBar className="h-2.5 w-12" />
           <SkeletonBar className="h-2.5 w-14" />
           <SkeletonBar className="h-2.5 w-14" />
+          <SkeletonBar className="h-2.5 w-16" />
           <SkeletonBar className="h-2.5 w-16" />
           <SkeletonBar className="h-2.5 w-12" />
           <SkeletonBar className="mx-auto h-2.5 w-10" />

--- a/src/renderer/src/components/automations/automation-list-last-run.test.ts
+++ b/src/renderer/src/components/automations/automation-list-last-run.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Automation,
+  AutomationRun,
+  ExternalAutomationJob
+} from '../../../../shared/automations-types'
+import {
+  formatAutomationLastRunCell,
+  getExternalAutomationLastRunSnapshot,
+  getLocalAutomationLastRunSnapshot,
+  getToneForAutomationRunStatus,
+  indexLatestAutomationRuns
+} from './automation-list-last-run'
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: 'automation-1',
+    name: 'Nightly',
+    prompt: 'run',
+    precheck: null,
+    agentId: 'codex',
+    projectId: 'repo-1',
+    executionTargetType: 'local',
+    executionTargetId: 'local',
+    schedulerOwner: 'local_host_service',
+    workspaceMode: 'existing',
+    workspaceId: 'worktree-1',
+    baseBranch: null,
+    reuseSession: false,
+    timezone: 'UTC',
+    rrule: 'FREQ=DAILY',
+    dtstart: 1,
+    enabled: true,
+    nextRunAt: 2,
+    missedRunPolicy: 'run_once_within_grace',
+    missedRunGraceMinutes: 720,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: 'run-1',
+    automationId: 'automation-1',
+    title: 'Nightly',
+    scheduledFor: 10,
+    status: 'completed',
+    trigger: 'scheduled',
+    workspaceId: 'worktree-1',
+    sessionKind: 'terminal',
+    chatSessionId: null,
+    terminalSessionId: null,
+    terminalPaneKey: null,
+    terminalPtyId: null,
+    outputSnapshot: null,
+    precheckResult: null,
+    usage: null,
+    error: null,
+    startedAt: 20,
+    dispatchedAt: 30,
+    createdAt: 10,
+    ...overrides
+  }
+}
+
+function makeJob(overrides: Partial<ExternalAutomationJob> = {}): ExternalAutomationJob {
+  return {
+    id: 'job-1',
+    managerId: 'manager-1',
+    provider: 'hermes',
+    name: 'Digest',
+    schedule: '0 9 * * 1-5',
+    rawSchedule: null,
+    enabled: true,
+    state: 'enabled',
+    prompt: null,
+    promptPreview: '',
+    nextRunAt: null,
+    lastRunAt: null,
+    lastStatus: null,
+    lastError: null,
+    workdir: null,
+    runCount: 0,
+    runs: [],
+    ...overrides
+  }
+}
+
+describe('automation-list-last-run', () => {
+  it('indexes the newest run per automation', () => {
+    const latest = indexLatestAutomationRuns([
+      makeRun({ id: 'old', createdAt: 10, dispatchedAt: 10 }),
+      makeRun({ id: 'new', createdAt: 50, dispatchedAt: 50, status: 'dispatch_failed' }),
+      makeRun({ id: 'other', automationId: 'automation-2', createdAt: 20 })
+    ])
+    expect(latest.get('automation-1')?.id).toBe('new')
+    expect(latest.get('automation-2')?.id).toBe('other')
+  })
+
+  it('classifies local run statuses', () => {
+    expect(getToneForAutomationRunStatus('dispatch_failed')).toBe('failed')
+    expect(getToneForAutomationRunStatus('completed')).toBe('succeeded')
+    expect(getToneForAutomationRunStatus('dispatched')).toBe('running')
+    expect(getToneForAutomationRunStatus('skipped_precheck')).toBe('skipped')
+  })
+
+  it('prefers the latest run over lastRunAt-only metadata', () => {
+    const snapshot = getLocalAutomationLastRunSnapshot(
+      makeAutomation({ lastRunAt: 5 }),
+      makeRun({ status: 'dispatch_failed', dispatchedAt: 40, createdAt: 40 })
+    )
+    expect(snapshot.tone).toBe('failed')
+    expect(snapshot.at).toBe(40)
+    expect(snapshot.statusLabel).toBe('Failed')
+  })
+
+  it('falls back to lastRunAt when no run history exists', () => {
+    const snapshot = getLocalAutomationLastRunSnapshot(makeAutomation({ lastRunAt: 99 }), undefined)
+    expect(snapshot).toEqual({ at: 99, tone: 'unknown', statusLabel: '' })
+  })
+
+  it('treats missing local history as never run', () => {
+    expect(getLocalAutomationLastRunSnapshot(makeAutomation(), undefined).tone).toBe('never')
+  })
+
+  it('classifies external last-run status and errors', () => {
+    expect(
+      getExternalAutomationLastRunSnapshot(
+        makeJob({ lastRunAt: '2026-08-12T01:00:00Z', lastStatus: 'failed' })
+      )
+    ).toMatchObject({ tone: 'failed', statusLabel: 'Failed' })
+    expect(
+      getExternalAutomationLastRunSnapshot(
+        makeJob({ lastRunAt: '2026-08-12T01:00:00Z', lastStatus: 'ok' })
+      )
+    ).toMatchObject({ tone: 'succeeded', statusLabel: 'Done' })
+    expect(
+      getExternalAutomationLastRunSnapshot(makeJob({ lastError: 'boom', lastStatus: null }))
+    ).toMatchObject({ tone: 'failed', statusLabel: 'Failed' })
+    expect(
+      getExternalAutomationLastRunSnapshot(
+        makeJob({ lastRunAt: '2026-08-12T01:00:00Z', lastStatus: 'ok', lastError: 'stale' })
+      )
+    ).toMatchObject({ tone: 'succeeded', statusLabel: 'Done' })
+    expect(getExternalAutomationLastRunSnapshot(makeJob()).tone).toBe('never')
+  })
+
+  it('formats last-run cells as status plus relative time', () => {
+    const now = Date.parse('2026-08-12T10:00:00Z')
+    const failed = formatAutomationLastRunCell(
+      { at: now - 8 * 60 * 60 * 1000, tone: 'failed', statusLabel: 'Failed' },
+      now
+    )
+    expect(failed.text).toBe('Failed 8h ago')
+    expect(failed.tone).toBe('failed')
+    expect(
+      formatAutomationLastRunCell({ at: null, tone: 'never', statusLabel: '' }, now).text
+    ).toBe('Never')
+    const failedNoTime = formatAutomationLastRunCell(
+      { at: null, tone: 'failed', statusLabel: 'Failed' },
+      now
+    )
+    expect(failedNoTime.text).toBe('Failed')
+    expect(failedNoTime.tone).toBe('failed')
+  })
+})

--- a/src/renderer/src/components/automations/automation-list-last-run.ts
+++ b/src/renderer/src/components/automations/automation-list-last-run.ts
@@ -1,0 +1,140 @@
+import type {
+  Automation,
+  AutomationRun,
+  AutomationRunStatus,
+  ExternalAutomationJob
+} from '../../../../shared/automations-types'
+import {
+  formatAutomationDateTime,
+  formatAutomationRelativeTime,
+  getAutomationRunStatusLabel
+} from './automation-page-parts'
+
+export type AutomationLastRunTone =
+  | 'failed'
+  | 'succeeded'
+  | 'running'
+  | 'skipped'
+  | 'never'
+  | 'unknown'
+
+export type AutomationLastRunSnapshot = {
+  at: number | null
+  tone: AutomationLastRunTone
+  statusLabel: string
+}
+
+const EXTERNAL_FAILED_STATUSES = new Set(['failed', 'fail', 'error', 'dispatch_failed'])
+const EXTERNAL_SUCCEEDED_STATUSES = new Set([
+  'ok',
+  'completed',
+  'success',
+  'succeeded',
+  'done',
+  'healthy'
+])
+
+export function indexLatestAutomationRuns(
+  runs: readonly AutomationRun[]
+): ReadonlyMap<string, AutomationRun> {
+  const latest = new Map<string, AutomationRun>()
+  for (const run of runs) {
+    const existing = latest.get(run.automationId)
+    if (!existing || run.createdAt > existing.createdAt) {
+      latest.set(run.automationId, run)
+    }
+  }
+  return latest
+}
+
+export function getAutomationRunLastRunAt(run: AutomationRun): number {
+  return run.dispatchedAt ?? run.startedAt ?? run.createdAt
+}
+
+export function getToneForAutomationRunStatus(status: AutomationRunStatus): AutomationLastRunTone {
+  if (status === 'dispatch_failed') {
+    return 'failed'
+  }
+  if (status === 'completed') {
+    return 'succeeded'
+  }
+  if (status === 'pending' || status === 'dispatching' || status === 'dispatched') {
+    return 'running'
+  }
+  if (status.startsWith('skipped')) {
+    return 'skipped'
+  }
+  return 'unknown'
+}
+
+export function getLocalAutomationLastRunSnapshot(
+  automation: Automation,
+  lastRun: AutomationRun | undefined
+): AutomationLastRunSnapshot {
+  if (lastRun) {
+    return {
+      at: getAutomationRunLastRunAt(lastRun),
+      tone: getToneForAutomationRunStatus(lastRun.status),
+      statusLabel: getAutomationRunStatusLabel(lastRun.status)
+    }
+  }
+  if (automation.lastRunAt) {
+    return {
+      at: automation.lastRunAt,
+      tone: 'unknown',
+      statusLabel: ''
+    }
+  }
+  return { at: null, tone: 'never', statusLabel: '' }
+}
+
+function parseExternalLastRunAt(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function getExternalAutomationLastRunSnapshot(
+  job: ExternalAutomationJob
+): AutomationLastRunSnapshot {
+  const at = parseExternalLastRunAt(job.lastRunAt)
+  const raw = job.lastStatus?.trim() ?? ''
+  const normalized = raw.toLowerCase()
+  if (!at && !raw && !job.lastError) {
+    return { at: null, tone: 'never', statusLabel: '' }
+  }
+  if (EXTERNAL_SUCCEEDED_STATUSES.has(normalized)) {
+    return { at, tone: 'succeeded', statusLabel: 'Done' }
+  }
+  if (EXTERNAL_FAILED_STATUSES.has(normalized) || Boolean(job.lastError)) {
+    return { at, tone: 'failed', statusLabel: 'Failed' }
+  }
+  if (raw) {
+    return { at, tone: 'unknown', statusLabel: raw }
+  }
+  return { at, tone: 'unknown', statusLabel: '' }
+}
+
+export function formatAutomationLastRunCell(
+  snapshot: AutomationLastRunSnapshot,
+  now: number
+): { text: string; title: string; tone: AutomationLastRunTone } {
+  const status = snapshot.statusLabel.trim()
+  if (snapshot.tone === 'never') {
+    const never = formatAutomationDateTime(null)
+    return { text: never, title: never, tone: 'never' }
+  }
+  if (snapshot.at == null) {
+    return { text: status || formatAutomationDateTime(null), title: status, tone: snapshot.tone }
+  }
+  const relative = formatAutomationRelativeTime(snapshot.at, now)
+  const absolute = formatAutomationDateTime(snapshot.at)
+  const text = status && relative ? `${status} ${relative}` : status || relative || absolute
+  return {
+    text,
+    title: status ? `${status} · ${absolute}` : absolute,
+    tone: snapshot.tone
+  }
+}

--- a/src/renderer/src/components/automations/automation-list-last-run.ts
+++ b/src/renderer/src/components/automations/automation-list-last-run.ts
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n/i18n'
 import type {
   Automation,
   AutomationRun,
@@ -106,10 +107,21 @@ export function getExternalAutomationLastRunSnapshot(
     return { at: null, tone: 'never', statusLabel: '' }
   }
   if (EXTERNAL_SUCCEEDED_STATUSES.has(normalized)) {
-    return { at, tone: 'succeeded', statusLabel: 'Done' }
+    return {
+      at,
+      tone: 'succeeded',
+      statusLabel: translate('auto.components.automations.automation.list.last.run.done', 'Done')
+    }
   }
   if (EXTERNAL_FAILED_STATUSES.has(normalized) || Boolean(job.lastError)) {
-    return { at, tone: 'failed', statusLabel: 'Failed' }
+    return {
+      at,
+      tone: 'failed',
+      statusLabel: translate(
+        'auto.components.automations.automation.list.last.run.failed',
+        'Failed'
+      )
+    }
   }
   if (raw) {
     return { at, tone: 'unknown', statusLabel: raw }

--- a/src/renderer/src/components/automations/automation-list-view.test.ts
+++ b/src/renderer/src/components/automations/automation-list-view.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Automation,
+  AutomationRun,
+  ExternalAutomationJob,
+  ExternalAutomationManager
+} from '../../../../shared/automations-types'
+import {
+  applyAutomationListView,
+  countAutomationListFilters,
+  isAutomationListFilterActive,
+  nextAutomationListSort
+} from './automation-list-view'
+import type { ExternalAutomationListEntry } from './external-automation-list-entries'
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: 'automation-1',
+    name: 'Zebra job',
+    prompt: 'run',
+    precheck: null,
+    agentId: 'codex',
+    projectId: 'repo-1',
+    executionTargetType: 'local',
+    executionTargetId: 'local',
+    schedulerOwner: 'local_host_service',
+    workspaceMode: 'existing',
+    workspaceId: 'worktree-1',
+    baseBranch: null,
+    reuseSession: false,
+    timezone: 'UTC',
+    rrule: 'FREQ=DAILY',
+    dtstart: 1,
+    enabled: true,
+    nextRunAt: 2,
+    missedRunPolicy: 'run_once_within_grace',
+    missedRunGraceMinutes: 720,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: 'run-1',
+    automationId: 'automation-1',
+    title: 'Zebra job',
+    scheduledFor: 10,
+    status: 'completed',
+    trigger: 'scheduled',
+    workspaceId: 'worktree-1',
+    sessionKind: 'terminal',
+    chatSessionId: null,
+    terminalSessionId: null,
+    terminalPaneKey: null,
+    terminalPtyId: null,
+    outputSnapshot: null,
+    precheckResult: null,
+    usage: null,
+    error: null,
+    startedAt: 20,
+    dispatchedAt: 30,
+    createdAt: 10,
+    ...overrides
+  }
+}
+
+function makeExternalEntry(
+  overrides: Partial<ExternalAutomationJob> = {}
+): ExternalAutomationListEntry {
+  const manager: ExternalAutomationManager = {
+    id: 'manager-1',
+    provider: 'hermes',
+    label: 'Local Hermes',
+    targetLabel: 'Local',
+    target: { type: 'local' },
+    status: 'available',
+    error: null,
+    canManage: true,
+    jobs: []
+  }
+  const job: ExternalAutomationJob = {
+    id: 'job-1',
+    managerId: manager.id,
+    provider: 'hermes',
+    name: 'Alpha digest',
+    schedule: '0 9 * * 1-5',
+    rawSchedule: null,
+    enabled: true,
+    state: 'enabled',
+    prompt: null,
+    promptPreview: '',
+    nextRunAt: null,
+    lastRunAt: '2026-08-12T01:00:00Z',
+    lastStatus: 'failed',
+    lastError: null,
+    workdir: null,
+    runCount: 1,
+    runs: [],
+    ...overrides
+  }
+  return { key: `${manager.id}:${job.id}`, manager, job }
+}
+
+describe('automation-list-view', () => {
+  it('counts and detects active filters', () => {
+    expect(isAutomationListFilterActive({ status: 'all', lastRun: 'all' })).toBe(false)
+    expect(isAutomationListFilterActive({ status: 'paused', lastRun: 'all' })).toBe(true)
+    expect(countAutomationListFilters({ status: 'paused', lastRun: 'failed' })).toBe(2)
+  })
+
+  it('toggles sort direction and defaults last run to newest first', () => {
+    expect(nextAutomationListSort(null, 'name')).toEqual({ field: 'name', direction: 'asc' })
+    expect(nextAutomationListSort(null, 'lastRun')).toEqual({ field: 'lastRun', direction: 'desc' })
+    expect(nextAutomationListSort({ field: 'name', direction: 'asc' }, 'name')).toEqual({
+      field: 'name',
+      direction: 'desc'
+    })
+    expect(nextAutomationListSort({ field: 'name', direction: 'asc' }, 'lastRun')).toEqual({
+      field: 'lastRun',
+      direction: 'desc'
+    })
+  })
+
+  it('filters by enabled state and last-run outcome', () => {
+    const items = applyAutomationListView({
+      automations: [
+        makeAutomation({ id: 'paused', name: 'Paused', enabled: false }),
+        makeAutomation({ id: 'ok', name: 'Healthy' })
+      ],
+      externalEntries: [makeExternalEntry()],
+      runs: [
+        makeRun({ automationId: 'paused', status: 'completed' }),
+        makeRun({ automationId: 'ok', status: 'dispatch_failed' })
+      ],
+      filter: { status: 'enabled', lastRun: 'failed' },
+      sort: null
+    })
+    expect(items.map((item) => item.id)).toEqual(['ok', 'manager-1:job-1'])
+  })
+
+  it('sorts by name across local and external rows', () => {
+    const items = applyAutomationListView({
+      automations: [makeAutomation({ name: 'Zebra job' })],
+      externalEntries: [makeExternalEntry({ name: 'Alpha digest' })],
+      runs: [],
+      filter: { status: 'all', lastRun: 'all' },
+      sort: { field: 'name', direction: 'asc' }
+    })
+    expect(items.map((item) => item.name)).toEqual(['Alpha digest', 'Zebra job'])
+  })
+
+  it('sorts by last run newest first and keeps never-run rows last', () => {
+    const items = applyAutomationListView({
+      automations: [
+        makeAutomation({ id: 'old', name: 'Old' }),
+        makeAutomation({ id: 'never', name: 'Never' })
+      ],
+      externalEntries: [makeExternalEntry({ lastRunAt: '2026-08-12T09:00:00Z' })],
+      runs: [makeRun({ automationId: 'old', dispatchedAt: Date.parse('2026-08-11T09:00:00Z') })],
+      filter: { status: 'all', lastRun: 'all' },
+      sort: { field: 'lastRun', direction: 'desc' }
+    })
+    expect(items.map((item) => item.id)).toEqual(['manager-1:job-1', 'old', 'never'])
+  })
+})

--- a/src/renderer/src/components/automations/automation-list-view.ts
+++ b/src/renderer/src/components/automations/automation-list-view.ts
@@ -1,0 +1,189 @@
+import type { Automation, AutomationRun } from '../../../../shared/automations-types'
+import type { ExternalAutomationListEntry } from './external-automation-list-entries'
+import {
+  getExternalAutomationLastRunSnapshot,
+  getLocalAutomationLastRunSnapshot,
+  indexLatestAutomationRuns,
+  type AutomationLastRunSnapshot
+} from './automation-list-last-run'
+
+export type AutomationListStatusFilter = 'all' | 'enabled' | 'paused'
+export type AutomationListLastRunFilter = 'all' | 'failed' | 'succeeded' | 'never'
+export type AutomationListSortField = 'name' | 'lastRun'
+export type AutomationListSortDirection = 'asc' | 'desc'
+
+export type AutomationListSort = {
+  field: AutomationListSortField
+  direction: AutomationListSortDirection
+}
+
+export type AutomationListViewItem =
+  | {
+      kind: 'local'
+      id: string
+      name: string
+      enabled: boolean
+      lastRunAt: number | null
+      lastRun: AutomationLastRunSnapshot
+      automation: Automation
+    }
+  | {
+      kind: 'external'
+      id: string
+      name: string
+      enabled: boolean
+      lastRunAt: number | null
+      lastRun: AutomationLastRunSnapshot
+      entry: ExternalAutomationListEntry
+    }
+
+export type AutomationListFilter = {
+  status: AutomationListStatusFilter
+  lastRun: AutomationListLastRunFilter
+}
+
+export const EMPTY_AUTOMATION_LIST_FILTER: AutomationListFilter = {
+  status: 'all',
+  lastRun: 'all'
+}
+
+export function isAutomationListFilterActive(filter: AutomationListFilter): boolean {
+  return filter.status !== 'all' || filter.lastRun !== 'all'
+}
+
+export function countAutomationListFilters(filter: AutomationListFilter): number {
+  return (filter.status !== 'all' ? 1 : 0) + (filter.lastRun !== 'all' ? 1 : 0)
+}
+
+export function defaultAutomationListSortDirection(
+  field: AutomationListSortField
+): AutomationListSortDirection {
+  return field === 'lastRun' ? 'desc' : 'asc'
+}
+
+export function nextAutomationListSort(
+  current: AutomationListSort | null,
+  field: AutomationListSortField
+): AutomationListSort {
+  if (current?.field !== field) {
+    return { field, direction: defaultAutomationListSortDirection(field) }
+  }
+  return {
+    field,
+    direction: current.direction === 'asc' ? 'desc' : 'asc'
+  }
+}
+
+function matchesStatusFilter(enabled: boolean, filter: AutomationListStatusFilter): boolean {
+  if (filter === 'all') {
+    return true
+  }
+  return filter === 'enabled' ? enabled : !enabled
+}
+
+function matchesLastRunFilter(
+  snapshot: AutomationLastRunSnapshot,
+  filter: AutomationListLastRunFilter
+): boolean {
+  if (filter === 'all') {
+    return true
+  }
+  return snapshot.tone === filter
+}
+
+export function buildAutomationListViewItems({
+  automations,
+  externalEntries,
+  runs
+}: {
+  automations: readonly Automation[]
+  externalEntries: readonly ExternalAutomationListEntry[]
+  runs: readonly AutomationRun[]
+}): AutomationListViewItem[] {
+  const lastRunByAutomationId = indexLatestAutomationRuns(runs)
+  const locals: AutomationListViewItem[] = automations.map((automation) => {
+    const lastRun = getLocalAutomationLastRunSnapshot(
+      automation,
+      lastRunByAutomationId.get(automation.id)
+    )
+    return {
+      kind: 'local',
+      id: automation.id,
+      name: automation.name,
+      enabled: automation.enabled,
+      lastRunAt: lastRun.at,
+      lastRun,
+      automation
+    }
+  })
+  const externals: AutomationListViewItem[] = externalEntries.map((entry) => {
+    const lastRun = getExternalAutomationLastRunSnapshot(entry.job)
+    return {
+      kind: 'external',
+      id: entry.key,
+      name: entry.job.name,
+      enabled: entry.job.enabled,
+      lastRunAt: lastRun.at,
+      lastRun,
+      entry
+    }
+  })
+  return [...locals, ...externals]
+}
+
+export function filterAutomationListViewItems(
+  items: readonly AutomationListViewItem[],
+  filter: AutomationListFilter
+): AutomationListViewItem[] {
+  if (!isAutomationListFilterActive(filter)) {
+    return [...items]
+  }
+  return items.filter(
+    (item) =>
+      matchesStatusFilter(item.enabled, filter.status) &&
+      matchesLastRunFilter(item.lastRun, filter.lastRun)
+  )
+}
+
+export function sortAutomationListViewItems(
+  items: readonly AutomationListViewItem[],
+  sort: AutomationListSort | null
+): AutomationListViewItem[] {
+  if (!sort) {
+    return [...items]
+  }
+  const next = [...items]
+  next.sort((left, right) => {
+    const compared =
+      sort.field === 'name'
+        ? left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+        : (left.lastRunAt ?? 0) - (right.lastRunAt ?? 0)
+    if (compared !== 0) {
+      return sort.direction === 'asc' ? compared : -compared
+    }
+    return left.id.localeCompare(right.id)
+  })
+  return next
+}
+
+export function applyAutomationListView({
+  automations,
+  externalEntries,
+  runs,
+  filter,
+  sort
+}: {
+  automations: readonly Automation[]
+  externalEntries: readonly ExternalAutomationListEntry[]
+  runs: readonly AutomationRun[]
+  filter: AutomationListFilter
+  sort: AutomationListSort | null
+}): AutomationListViewItem[] {
+  return sortAutomationListViewItems(
+    filterAutomationListViewItems(
+      buildAutomationListViewItems({ automations, externalEntries, runs }),
+      filter
+    ),
+    sort
+  )
+}

--- a/src/renderer/src/components/automations/automation-list-view.ts
+++ b/src/renderer/src/components/automations/automation-list-view.ts
@@ -1,3 +1,4 @@
+import { getIntlLocale } from '@/i18n/i18n'
 import type { Automation, AutomationRun } from '../../../../shared/automations-types'
 import type { ExternalAutomationListEntry } from './external-automation-list-entries'
 import {
@@ -153,10 +154,11 @@ export function sortAutomationListViewItems(
     return [...items]
   }
   const next = [...items]
+  const locale = getIntlLocale()
   next.sort((left, right) => {
     const compared =
       sort.field === 'name'
-        ? left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+        ? left.name.localeCompare(right.name, locale, { sensitivity: 'base' })
         : (left.lastRunAt ?? 0) - (right.lastRunAt ?? 0)
     if (compared !== 0) {
       return sort.direction === 'asc' ? compared : -compared

--- a/src/renderer/src/components/automations/automations-table-layout.ts
+++ b/src/renderer/src/components/automations/automations-table-layout.ts
@@ -1,8 +1,8 @@
 /** Shared layout classes for the automations list table.
  * Matches AutomationRunHistory / ExternalAutomationRunTable / Tasks list tables. */
-// Name | Schedule | Project | Next run | Status | Agent | Actions
+// Name | Schedule | Project | Next run | Last run | Status | Agent | Actions
 export const AUTOMATIONS_TABLE_GRID_CLASS =
-  'grid grid-cols-[minmax(0,1.5fr)_minmax(7rem,10rem)_minmax(5rem,9rem)_minmax(10rem,1.2fr)_minmax(4.5rem,6rem)_2.5rem_2.5rem]'
+  'grid grid-cols-[minmax(0,1.4fr)_minmax(7.5rem,10rem)_minmax(4.5rem,8rem)_minmax(8.5rem,1fr)_minmax(8rem,11rem)_minmax(4.5rem,6rem)_2.5rem_2.5rem]'
 
 export const AUTOMATIONS_TABLE_CONTAINER_CLASS = 'rounded-md border border-border/50 bg-muted/20'
 

--- a/src/renderer/src/components/automations/use-automation-list-view.ts
+++ b/src/renderer/src/components/automations/use-automation-list-view.ts
@@ -1,0 +1,98 @@
+import { useEffect, useMemo } from 'react'
+import type { Automation, AutomationRun } from '../../../../shared/automations-types'
+import type { ExternalAutomationListEntry } from './external-automation-list-entries'
+import {
+  applyAutomationListView,
+  isAutomationListFilterActive,
+  type AutomationListFilter,
+  type AutomationListSort,
+  type AutomationListViewItem
+} from './automation-list-view'
+
+export function useAutomationListView({
+  automations,
+  externalEntries,
+  runs,
+  filter,
+  sort,
+  selectedId,
+  selectedExternalKey,
+  selectAutomationId,
+  selectExternalKey
+}: {
+  automations: readonly Automation[]
+  externalEntries: readonly ExternalAutomationListEntry[]
+  runs: readonly AutomationRun[]
+  filter: AutomationListFilter
+  sort: AutomationListSort | null
+  selectedId: string | null
+  selectedExternalKey: string | null
+  selectAutomationId: (automationId: string | null) => void
+  selectExternalKey: (externalKey: string | null) => void
+}): {
+  visibleItems: readonly AutomationListViewItem[]
+  isListFilterActive: boolean
+  hasVisibleListItems: boolean
+} {
+  const isListFilterActive = isAutomationListFilterActive(filter)
+  const visibleItems = useMemo(
+    () =>
+      applyAutomationListView({
+        automations,
+        externalEntries,
+        runs,
+        filter,
+        sort
+      }),
+    [automations, externalEntries, filter, runs, sort]
+  )
+  const hasVisibleListItems = visibleItems.length > 0
+
+  // Why: search already hides rows; filter/sort must keep highlight + detail on a
+  // still-visible row so the list never points at something the user cannot see.
+  useEffect(() => {
+    if (!isListFilterActive && !sort) {
+      return
+    }
+    const localVisible =
+      selectedExternalKey === null &&
+      selectedId != null &&
+      visibleItems.some((item) => item.kind === 'local' && item.id === selectedId)
+    const externalVisible =
+      selectedExternalKey != null &&
+      visibleItems.some((item) => item.kind === 'external' && item.id === selectedExternalKey)
+    if (localVisible || externalVisible) {
+      return
+    }
+    const first = visibleItems[0]
+    if (!first) {
+      return
+    }
+    if (first.kind === 'local') {
+      if (selectedExternalKey !== null) {
+        selectExternalKey(null)
+      }
+      if (selectedId !== first.id) {
+        selectAutomationId(first.id)
+      }
+      return
+    }
+    if (selectedExternalKey !== first.id) {
+      selectExternalKey(first.id)
+    }
+  }, [
+    isListFilterActive,
+    selectAutomationId,
+    selectExternalKey,
+    selectedExternalKey,
+    selectedId,
+    sort,
+    visibleItems
+  ])
+
+  return {
+    visibleItems,
+    isListFilterActive,
+    hasVisibleListItems
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14569,6 +14569,14 @@
               "name": "Hourly maintenance check",
               "prompt": "Check for stuck work, stale generated files, failing validation, and anything that needs human attention. Report only actionable issues."
             }
+          },
+          "list": {
+            "last": {
+              "run": {
+                "done": "Done",
+                "failed": "Failed"
+              }
+            }
           }
         },
         "external": {
@@ -14612,8 +14620,8 @@
           "clear": "Clear filters"
         },
         "AutomationListSortHeader": {
-          "ascending": "ascending",
-          "descending": "descending"
+          "sortedAscending": "{{value0}}, sorted ascending",
+          "sortedDescending": "{{value0}}, sorted descending"
         }
       },
       "agent": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14473,7 +14473,9 @@
           "tableStatus": "Status",
           "tableActions": "Actions",
           "newAutomation": "New Automation",
-          "rowActions": "Automation actions"
+          "rowActions": "Automation actions",
+          "tableLastRun": "Last run",
+          "noListMatches": "No automations match."
         },
         "AutomationsPageSkeleton": {
           "55527b7bcf": "Loading automations"
@@ -14599,6 +14601,19 @@
         },
         "AutomationListLocalRows": {
           "c92c9463c6": "Automation actions"
+        },
+        "AutomationListFilterMenu": {
+          "removeFilter": "Remove {{value0}} filter",
+          "failed": "Failed",
+          "succeeded": "Succeeded",
+          "neverRan": "Never ran",
+          "filters": "Filters",
+          "all": "All",
+          "clear": "Clear filters"
+        },
+        "AutomationListSortHeader": {
+          "ascending": "ascending",
+          "descending": "descending"
         }
       },
       "agent": {


### PR DESCRIPTION
## Problem

The automations list lacked filtering and sorting capabilities, making it hard to find specific automations or quickly assess their run history.

## Solution

Added a filter menu (status + last-run filters), sortable table columns (Name, Last Run), and a view model to manage filtering/sorting state across local and external automations.

## What Changed

- **Filter UI**: `AutomationListFilterMenu` with enabled/paused/last-run outcome filters and active filter pills
- **Sort UI**: `AutomationListSortHeader` with visual direction indicators; Name sorts A→Z, Last Run defaults newest-first
- **Last-run display**: `AutomationListLastRunCell` + `automation-list-last-run.ts` utilities to capture and format run status (Failed/Succeeded/Never) with relative time
- **View model**: Core logic in `automation-list-view.ts` for filtering, sorting, and unified item presentation across local + external automations
- **Toolbar refactor**: Extracted search/filter/refresh/create into `AutomationListToolbar` component
- **Table header**: New `AutomationListTableHeader` with sortable columns
- **Grid layout**: Updated column widths in `automations-table-layout.ts` to fit Last Run column

## Why

Enables users to filter by automation state and last-run outcome, sort for discovery, and see status + timing at a glance.

## Testing

- Unit tests for `automation-list-last-run.ts`: status classification, snapshot building, relative time formatting
- Unit tests for `automation-list-view.ts`: filtering, sorting, cross-type behavior (local + external)
- Integration test in `AutomationListLocalRows.test.tsx` verifies last-run cell display
- Skeleton loader updated for new column

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below