### PR TITLE
fix(orchestration): mark late dependents ready when deps already completed

### DIFF
--- a/src/main/runtime/orchestration-cli-subprocess.test.ts
+++ b/src/main/runtime/orchestration-cli-subprocess.test.ts
@@ -310,3 +310,98 @@ describeIfBuilt('orca orchestration reset subprocess', () => {
     }
   }, 30_000)
 })
+
+describeIfBuilt('orca orchestration task readiness subprocess', () => {
+  it('creates a late dependent as ready through the built CLI and runtime', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-cli-task-readiness-'))
+    const dbPath = join(userDataPath, 'orchestration.db')
+    const runtime = new OrcaRuntimeService()
+    const db = new OrchestrationDb(dbPath)
+    runtime.setOrchestrationDb(db)
+    const coordinatorPaneKey = 'tab_cli:22222222-2222-4222-8222-222222222222'
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_cli' ? coordinatorPaneKey : null
+    )
+    db.createRun({
+      objective: 'CLI late dependency readiness fixture',
+      coordinatorHandle: 'term_cli',
+      coordinatorPaneKey
+    })
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+    await server.start()
+
+    try {
+      const dependencyCreate = await runBuiltCli(userDataPath, [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'dependency',
+        '--from',
+        'term_cli',
+        '--json'
+      ])
+      expect(dependencyCreate.exitCode, dependencyCreate.stderr).toBe(0)
+      const dependencyPayload = JSON.parse(dependencyCreate.stdout) as {
+        result: { task: { id: string; status: string } }
+      }
+      const dependencyId = dependencyPayload.result.task.id
+
+      const dependencyComplete = await runBuiltCli(userDataPath, [
+        'orchestration',
+        'task-update',
+        '--id',
+        dependencyId,
+        '--status',
+        'completed',
+        '--from',
+        'term_cli',
+        '--json'
+      ])
+      expect(dependencyComplete.exitCode, dependencyComplete.stderr).toBe(0)
+
+      const childCreate = await runBuiltCli(userDataPath, [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'late dependent',
+        '--deps',
+        JSON.stringify([dependencyId]),
+        '--from',
+        'term_cli',
+        '--json'
+      ])
+      expect(childCreate.exitCode, childCreate.stderr).toBe(0)
+      const childPayload = JSON.parse(childCreate.stdout) as {
+        result: { task: { id: string; status: string } }
+      }
+      const child = childPayload.result.task
+      expect(child.status).toBe('ready')
+
+      const taskList = await runBuiltCli(userDataPath, [
+        'orchestration',
+        'task-list',
+        '--from',
+        'term_cli',
+        '--json'
+      ])
+      expect(taskList.exitCode, taskList.stderr).toBe(0)
+      const taskListPayload = JSON.parse(taskList.stdout) as {
+        result: { tasks: { id: string; status: string }[] }
+      }
+      expect(taskListPayload.result.tasks).toContainEqual(
+        expect.objectContaining({ id: child.id, status: 'ready' })
+      )
+
+      const persisted = new OrchestrationDb(dbPath)
+      try {
+        expect(persisted.getTask(child.id)?.status).toBe('ready')
+      } finally {
+        persisted.close()
+      }
+    } finally {
+      db.close()
+      await server.stop()
+      rmSync(userDataPath, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/src/main/runtime/orchestration/db-task-create-readiness.test.ts
+++ b/src/main/runtime/orchestration/db-task-create-readiness.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+
+type OrchestrationDbAccess = {
+  db: Database.Database
+}
+
+describe('task creation dependency readiness', () => {
+  const databases: OrchestrationDb[] = []
+  const directories: string[] = []
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const database of databases) {
+      database.close()
+    }
+    for (const directory of directories) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+    databases.length = 0
+    directories.length = 0
+  })
+
+  function createDb(path: string = ':memory:'): OrchestrationDb {
+    const database = new OrchestrationDb(path)
+    databases.push(database)
+    return database
+  }
+
+  it('creates a late dependent as ready when every dependency is completed', () => {
+    const db = createDb()
+    const first = db.createTask({ spec: 'first' })
+    const second = db.createTask({ spec: 'second' })
+    db.updateTaskStatus(first.id, 'completed')
+    db.updateTaskStatus(second.id, 'completed')
+
+    const child = db.createTask({ spec: 'child', deps: [first.id, second.id] })
+
+    expect(child.status).toBe('ready')
+  })
+
+  it('observes a dependency completion forced between readiness evaluation and insertion', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-task-readiness-race-'))
+    directories.push(directory)
+    const path = join(directory, 'orchestration.db')
+    const db = createDb(path)
+    const concurrent = createDb(path)
+    const dependency = db.createTask({ spec: 'dependency' })
+    const sqlite = (db as unknown as OrchestrationDbAccess).db
+    const prepare = sqlite.prepare.bind(sqlite)
+    let injected = false
+    vi.spyOn(sqlite, 'prepare').mockImplementation((sql) => {
+      if (!injected && sql.includes('INSERT INTO tasks')) {
+        injected = true
+        concurrent.updateTaskStatus(dependency.id, 'completed')
+      }
+      return prepare(sql)
+    })
+
+    const child = db.createTask({ spec: 'child', deps: [dependency.id] })
+
+    expect(injected).toBe(true)
+    expect(child.status).toBe('ready')
+  })
+
+  it('promotes only after every dependency completes', () => {
+    const db = createDb()
+    const first = db.createTask({ spec: 'first' })
+    const second = db.createTask({ spec: 'second' })
+    db.updateTaskStatus(first.id, 'completed')
+    const child = db.createTask({ spec: 'child', deps: [first.id, second.id] })
+
+    expect(child.status).toBe('pending')
+    db.updateTaskStatus(second.id, 'completed')
+    expect(db.getTask(child.id)?.status).toBe('ready')
+  })
+
+  it.each(['failed', 'blocked'] as const)(
+    'does not unlock a dependent whose dependency is %s',
+    (status) => {
+      const db = createDb()
+      const terminal = db.createTask({ spec: 'terminal dependency' })
+      const completing = db.createTask({ spec: 'completing dependency' })
+      db.updateTaskStatus(terminal.id, status)
+
+      const child = db.createTask({ spec: 'child', deps: [terminal.id, completing.id] })
+
+      expect(child.status).toBe('pending')
+      db.updateTaskStatus(completing.id, 'completed')
+      expect(db.getTask(child.id)?.status).toBe('pending')
+    }
+  )
+
+  it('rejects missing dependencies without inserting a task', () => {
+    const db = createDb()
+
+    expect(() => db.createTask({ spec: 'child', deps: ['task_missing'] })).toThrow(
+      'Dependency task task_missing must belong to run'
+    )
+    expect(db.listTasks()).toEqual([])
+  })
+
+  it('preserves a caller-owned transaction', () => {
+    const db = createDb()
+    const sqlite = (db as unknown as OrchestrationDbAccess).db
+    sqlite.exec('BEGIN IMMEDIATE')
+
+    const task = db.createTask({ spec: 'transactional child' })
+    sqlite.exec('ROLLBACK')
+
+    expect(db.getTask(task.id)).toBeUndefined()
+  })
+
+  it('preserves readiness and later promotion across reload', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-task-readiness-'))
+    directories.push(directory)
+    const path = join(directory, 'orchestration.db')
+    const before = createDb(path)
+    const completed = before.createTask({ spec: 'completed' })
+    const open = before.createTask({ spec: 'open' })
+    before.updateTaskStatus(completed.id, 'completed')
+    const ready = before.createTask({ spec: 'ready', deps: [completed.id] })
+    const pending = before.createTask({ spec: 'pending', deps: [completed.id, open.id] })
+    before.close()
+    databases.splice(databases.indexOf(before), 1)
+
+    const after = createDb(path)
+
+    expect(after.getTask(ready.id)?.status).toBe('ready')
+    expect(after.getTask(pending.id)?.status).toBe('pending')
+    after.updateTaskStatus(open.id, 'completed')
+    expect(after.getTask(pending.id)?.status).toBe('ready')
+  })
+})

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -219,6 +219,23 @@ describe('OrchestrationDb', () => {
       expect(JSON.parse(child.deps)).toEqual([parent.id])
     })
 
+    it('creates a late dependent as ready when every dep is already completed', () => {
+      const d = createDb()
+      const parent = d.createTask({ spec: 'parent' })
+      d.updateTaskStatus(parent.id, 'completed')
+      const child = d.createTask({ spec: 'child', deps: [parent.id] })
+      expect(child.status).toBe('ready')
+    })
+
+    it('keeps a late dependent pending until every dep is completed', () => {
+      const d = createDb()
+      const first = d.createTask({ spec: 'first' })
+      const second = d.createTask({ spec: 'second' })
+      d.updateTaskStatus(first.id, 'completed')
+      const child = d.createTask({ spec: 'child', deps: [first.id, second.id] })
+      expect(child.status).toBe('pending')
+    })
+
     it('promotes pending tasks when deps complete', () => {
       const d = createDb()
       const t1 = d.createTask({ spec: 'first' })

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -219,23 +219,6 @@ describe('OrchestrationDb', () => {
       expect(JSON.parse(child.deps)).toEqual([parent.id])
     })
 
-    it('creates a late dependent as ready when every dep is already completed', () => {
-      const d = createDb()
-      const parent = d.createTask({ spec: 'parent' })
-      d.updateTaskStatus(parent.id, 'completed')
-      const child = d.createTask({ spec: 'child', deps: [parent.id] })
-      expect(child.status).toBe('ready')
-    })
-
-    it('keeps a late dependent pending until every dep is completed', () => {
-      const d = createDb()
-      const first = d.createTask({ spec: 'first' })
-      const second = d.createTask({ spec: 'second' })
-      d.updateTaskStatus(first.id, 'completed')
-      const child = d.createTask({ spec: 'child', deps: [first.id, second.id] })
-      expect(child.status).toBe('pending')
-    })
-
     it('promotes pending tasks when deps complete', () => {
       const d = createDb()
       const t1 = d.createTask({ spec: 'first' })

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -3780,9 +3780,11 @@ export class OrchestrationDb {
       }
     }
     const id = generateId('task')
-    const depsJson = JSON.stringify(task.deps ?? [])
-    const hasDeps = (task.deps ?? []).length > 0
-    const status: TaskStatus = hasDeps ? 'pending' : 'ready'
+    const deps = task.deps ?? []
+    const depsJson = JSON.stringify(deps)
+    // Why: late-created dependents never see a completion event; reuse the all-completed rule.
+    const status: TaskStatus =
+      deps.length > 0 && !this.areTaskDependenciesSatisfied(deps) ? 'pending' : 'ready'
     const display = buildOrchestrationTaskDisplayMetadata({
       spec: task.spec,
       taskTitle: task.taskTitle,
@@ -3925,6 +3927,10 @@ export class OrchestrationDb {
     return this.getTask(id)
   }
 
+  private areTaskDependenciesSatisfied(deps: string[]): boolean {
+    return deps.every((depId) => this.getTask(depId)?.status === 'completed')
+  }
+
   // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.
   private promoteReadyTasks(completedTaskId: string): void {
     const candidates = this.db
@@ -3936,12 +3942,7 @@ export class OrchestrationDb {
       if (!deps.includes(completedTaskId)) {
         continue
       }
-
-      const allDepsCompleted = deps.every((depId) => {
-        const dep = this.getTask(depId)
-        return dep?.status === 'completed'
-      })
-      if (allDepsCompleted) {
+      if (this.areTaskDependenciesSatisfied(deps)) {
         this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(task.id)
       }
     }

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -3780,11 +3780,7 @@ export class OrchestrationDb {
       }
     }
     const id = generateId('task')
-    const deps = task.deps ?? []
-    const depsJson = JSON.stringify(deps)
-    // Why: late-created dependents never see a completion event; reuse the all-completed rule.
-    const status: TaskStatus =
-      deps.length > 0 && !this.areTaskDependenciesSatisfied(deps) ? 'pending' : 'ready'
+    const depsJson = JSON.stringify(task.deps ?? [])
     const display = buildOrchestrationTaskDisplayMetadata({
       spec: task.spec,
       taskTitle: task.taskTitle,
@@ -3796,7 +3792,18 @@ export class OrchestrationDb {
            id, run_id, parent_id, created_by_terminal_handle, created_by_pane_key,
            created_by_process_incarnation, created_by_run_generation,
            task_title, display_name, spec, status, deps
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         ) VALUES (
+           ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+           CASE WHEN EXISTS (
+             SELECT 1
+             FROM json_each(?) requested
+             LEFT JOIN tasks dependency ON dependency.id = requested.value
+             WHERE dependency.id IS NULL
+                OR dependency.run_id <> ?
+                OR dependency.status <> 'completed'
+           ) THEN 'pending' ELSE 'ready' END,
+           ?
+         )`
       )
       .run(
         id,
@@ -3809,7 +3816,8 @@ export class OrchestrationDb {
         display.taskTitle || null,
         display.displayName || null,
         task.spec,
-        status,
+        depsJson,
+        runId,
         depsJson
       )
     return this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow
@@ -3927,10 +3935,6 @@ export class OrchestrationDb {
     return this.getTask(id)
   }
 
-  private areTaskDependenciesSatisfied(deps: string[]): boolean {
-    return deps.every((depId) => this.getTask(depId)?.status === 'completed')
-  }
-
   // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.
   private promoteReadyTasks(completedTaskId: string): void {
     const candidates = this.db
@@ -3942,7 +3946,12 @@ export class OrchestrationDb {
       if (!deps.includes(completedTaskId)) {
         continue
       }
-      if (this.areTaskDependenciesSatisfied(deps)) {
+
+      const allDepsCompleted = deps.every((depId) => {
+        const dep = this.getTask(depId)
+        return dep?.status === 'completed'
+      })
+      if (allDepsCompleted) {
         this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(task.id)
       }
     }


### PR DESCRIPTION
## Summary

`task-create --deps` after the parent is already `completed` left the new Task in `pending` forever. Coordinators then had to `task-update --status ready` by hand, which is the usual review/rework path.

`createTask` treated any non-empty dep list as `pending`. `promoteReadyTasks` only runs when a dependency later transitions to `completed`, so a late-created child never gets evaluated.

- Compute initial status with the same all-completed rule used on promotion
- Still `pending` if any dep is not `completed` (including a mixed already-done + still-open set)
- Tests: late child is `ready` when every dep is already completed; mixed deps stay `pending`

Fixes #14143

## Test plan

- [x] `pnpm exec vitest run src/main/runtime/orchestration/db.test.ts` (63 passed)
- [ ] Community PR: Approve and run workflows when convenient