### PR TITLE
fix: opening tmp files read-only breaks fsync on Windows

### DIFF
--- a/src/shared/secure-file.ts
+++ b/src/shared/secure-file.ts
@@ -134,7 +134,8 @@ export function writeSecureFile(
 }
 
 export function fsyncFileSync(path: string): void {
-  const descriptor = openSync(path, 'r')
+  // Why: FlushFileBuffers needs write access on Windows, or fsyncSync throws EPERM.
+  const descriptor = openSync(path, process.platform === 'win32' ? 'r+' : 'r')
   try {
     fsyncSync(descriptor)
   } finally {


### PR DESCRIPTION
fsyncFileSync opened the target with openSync(path, 'r') before calling fsyncSync. On Windows, FlushFileBuffers requires a write-access handle, so the read-only descriptor throws EPERM every time. This makes writeProfileIndex crash as an unhandled rejection on first launch, since ensureActiveOrcaProfile calls it durably — every fresh Windows install fails to ever open a window.

Open with 'r+' on win32 only; POSIX keeps 'r' since this function also fsyncs directories there (never reached on win32, since bestEffortFsyncDirectorySync already skips win32 before calling in).

Verified directly on Windows: openSync(path, 'r') + fsyncSync throws EPERM; openSync(path, 'r+') + fsyncSync succeeds.

## ELI5

<!-- Simple high-level explanation -->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- What problem does this solve, and why is this approach right? -->

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #

## Visual Proof
<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->
<!-- If there is truly no visual or interaction change, write exactly: `N/A` and briefly say why. -->
<!-- For attachments NEVER add directly to the PR files (do not commit to files), use `gh image` extension or drag + drop (works for any attachment) -->

## Testing

<!-- How did you verify this? Steps a reviewer can follow. Which platforms did you actually test (macOS / Linux / Windows / SSH)? -->

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below


## AI Disclosure
<!-- For all external contributors only: Which AI model if anyone was used, please state the details -->

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @your_handle
  <!-- Optional but appreciated -->
