### PR TITLE
fix(terminal): keep gh auth prompts from dying on OSC 11 replies

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -8999,52 +8999,111 @@
     },
     {
       "id": "terminal-capability.startup-color-query",
-      "title": "Startup color capability queries do not leak into shell or terminal streams",
+      "title": "OSC color capability queries are answered without leaking into terminal streams",
       "maturity": "experimental",
-      "protection": "none",
+      "protection": "partial",
       "owner": "terminal-rendering",
-      "layer": "renderer-provider-contract",
+      "layer": "pty-owner-provider-contract",
       "surfaces": [
         "OSC 10/11",
         "startup capability query",
+        "runtime capability query",
         "shell stream",
         "renderer stream",
         "terminal colors"
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
-      "coveredPlatforms": [],
-      "coveredProviders": [],
-      "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
-      "motivatingLinks": ["https://github.com/stablyai/orca/pull/6949"],
-      "invariant": "Startup OSC 10/11 color queries are answered out of band at startup only, never leak into shell/provider output streams, and ordinary runtime OSC color queries remain renderer-handled.",
-      "oracle": "A provider-contract fixture records startup query replies, shell-visible bytes, renderer-visible bytes, and later runtime OSC behavior to prove no query leakage or color deadlock.",
-      "commands": [],
-      "testFiles": [],
-      "assertionRefs": [],
-      "evidenceRuns": [],
+      "coveredPlatforms": ["macos", "linux"],
+      "coveredProviders": ["local", "daemon", "ssh"],
+      "coverageNotes": "Deterministic ingress, IPC, daemon-chain, SSH request, and relay tests prove immediate POSIX-host replies, torn-query retention, query stripping, and unchanged Windows fallbacks. A real throwaway Linux SSH gh-auth run covers the reported failure path; mixed old hosts safely retain renderer handling.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/6949",
+        "https://github.com/stablyai/orca/issues/14020",
+        "https://github.com/stablyai/orca/pull/14170"
+      ],
+      "invariant": "Valid OSC 10/11 queries are answered immediately by a configured POSIX PTY owner for the session lifetime and stripped from forwarded output, including when split across startup handoff; Windows ConPTY remains consume-only while Windows WSL and peers without the optional host field retain renderer handling.",
+      "oracle": "Provider-contract fixtures record provider writes and forwarded bytes, proving the OSC reply lands before a following CPR, the query never reaches the renderer, torn queries survive startup handoff, ordinary output is unchanged, and old-host fallback remains decodable.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/pty-startup-ingress.test.ts src/shared/pty-startup-ingress-live-osc.test.ts src/shared/terminal-osc-color-reply.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/providers/ssh-pty-spawn-request.test.ts src/relay/pty-handler.test.ts src/main/ipc/pty.test.ts"
+      ],
+      "testFiles": [
+        "src/shared/pty-startup-ingress.test.ts",
+        "src/shared/pty-startup-ingress-live-osc.test.ts",
+        "src/shared/terminal-osc-color-reply.test.ts",
+        "src/main/daemon/daemon-pty-adapter.test.ts",
+        "src/main/providers/ssh-pty-spawn-request.test.ts",
+        "src/relay/pty-handler.test.ts",
+        "src/main/ipc/pty.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/shared/pty-startup-ingress-live-osc.test.ts",
+          "assertions": [
+            "a live OSC 11 reply is written before ingress accept returns and before a following CPR is forwarded",
+            "a torn live OSC 11 query remains held and is answered after startup query authority closes",
+            "OSC color sets and CSI-dense output remain unchanged"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-pty-adapter.test.ts",
+          "assertions": [
+            "daemon adapter, RPC server, terminal host, and Session preserve live reply colors and answer OSC 11 before forwarding CPR"
+          ]
+        },
+        {
+          "file": "src/main/providers/ssh-pty-spawn-request.test.ts",
+          "assertions": [
+            "the SSH spawn request forwards configured live reply colors and omits the optional field when absent"
+          ]
+        },
+        {
+          "file": "src/relay/pty-handler.test.ts",
+          "assertions": [
+            "a POSIX SSH relay owner answers OSC 11 and strips the query",
+            "a relay without configured reply colors forwards the query unchanged"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-14",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/pty-startup-ingress.test.ts src/shared/pty-startup-ingress-live-osc.test.ts src/shared/terminal-osc-color-reply.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/providers/ssh-pty-spawn-request.test.ts src/relay/pty-handler.test.ts src/main/ipc/pty.test.ts",
+          "result": "passed",
+          "durationSeconds": 14.51,
+          "summary": "7 test files and 858 tests passed on the latest-main PR integration branch."
+        }
+      ],
       "runtimeBudget": {
         "p95Seconds": 30,
-        "scope": "renderer provider-contract gate"
+        "scope": "PTY owner provider-contract gate"
       },
       "flakeHistory": {
         "status": "not-started",
-        "evidence": "Gate is registered as a capability/startup gap; no command is wired."
+        "evidence": "Focused deterministic coverage is wired; soak history is not yet recorded."
       },
       "redGreenEvidence": {
-        "status": "missing",
-        "evidence": "Needs intentional-break proof for leaked startup OSC replies or disabled runtime OSC handling."
+        "status": "partial",
+        "evidence": "Focused tests fail when immediate live answering, query stripping, or torn-query retention is reverted; the real gh-auth failure was reproduced on origin/main and cleared by the host fix."
       },
       "performanceBudget": {
-        "required": false,
-        "evidence": "Required if capability probing adds retry loops or startup polling."
+        "required": true,
+        "evidence": "Session-lived parsing adds no polling; scanning is bounded to OSC 10/11 candidates and reply/echo tracking remains capped at 64 entries."
       },
       "promotionCriteria": [
         "Assert shell/provider byte streams directly.",
         "Cover startup-only and runtime OSC paths separately.",
+        "Register physical Windows/ConPTY and mixed-version runs.",
         "Keep screenshot evidence diagnostic only."
       ],
-      "knownGaps": ["No manifest command yet.", "No startup color-query contract is wired."],
+      "knownGaps": [
+        "No physical Windows/ConPTY or WSL run is registered; WSL retains renderer handling because its host echo shape is unverified.",
+        "An old daemon or relay host ignores the optional field and retains the pre-fix renderer reply race.",
+        "Live host replies use the colors captured when the PTY is created; a later theme or TUI color change is not synchronized to the host.",
+        "No long-running terminal-output flood soak is registered."
+      ],
       "demotionRule": "Cannot promote if success is based only on absence of visible artifacts."
     },
     {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -194,6 +194,31 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       })
     })
 
+    it('carries live OSC color replies through the daemon host', async () => {
+      const onData = vi.fn()
+      adapter.onData(onData)
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        oscColorQueryReplies: { foreground: '#2e3434', background: '#ffffff' }
+      })
+      const query = '\x1b]11;?\x1b\\'
+      const cpr = '\x1b[6n'
+
+      lastSubprocess._simulateData(`${query}${cpr}`)
+      await waitFor(() => onData.mock.calls.length > 0)
+
+      expect(lastSubprocess.write).toHaveBeenCalledWith('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+      expect(onData).toHaveBeenNthCalledWith(1, {
+        id,
+        data: '',
+        sequenceChars: query.length,
+        seq: query.length,
+        transformed: true
+      })
+      expect(onData).toHaveBeenNthCalledWith(2, { id, data: cpr })
+    })
+
     it('omits startup intent and close control for the preserved v23 protocol', async () => {
       const ensureConnectedSpy = vi
         .spyOn(DaemonClient.prototype, 'ensureConnected')

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -533,6 +533,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ...(this.supportsStartupIngress && !attachOnly && opts.startupIngress
           ? { startupIngress: opts.startupIngress }
           : {}),
+        ...(!attachOnly && opts.oscColorQueryReplies
+          ? { oscColorQueryReplies: opts.oscColorQueryReplies }
+          : {}),
         ...(!attachOnly && opts.agentSessionEnsure
           ? { agentSessionEnsure: opts.agentSessionEnsure }
           : {})

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -22,6 +22,7 @@ import { checkPtySpawnHealth } from './pty-subprocess'
 import { createNoopDaemonFileLog, type DaemonFileLog } from './daemon-file-log'
 import { isTuiAgent } from '../../shared/tui-agent-config'
 import { parsePtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
+import { parseTerminalOscColorQueryReplyColors } from '../../shared/terminal-osc-color-reply'
 import { unlinkOwnedDaemonPidFile, unlinkOwnedDaemonTokenFile } from './daemon-spawner'
 import {
   DAEMON_ENDPOINT_LOST_MESSAGE,
@@ -1028,6 +1029,7 @@ export class DaemonServer {
             shellReadySupported: p.shellReadySupported,
             historySeedChunks,
             startupIngress: parsePtyStartupIngressIntent(p.startupIngress),
+            oscColorQueryReplies: parseTerminalOscColorQueryReplyColors(p.oscColorQueryReplies),
             ...(p.shellReadyTimeoutMs !== undefined
               ? { shellReadyTimeoutMs: p.shellReadyTimeoutMs }
               : {}),

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -34,6 +34,7 @@ import {
   type PtyStartupIngressIntent
 } from '../../shared/pty-startup-ingress'
 import { extractOnlyCookedEchoSafeQueryReplies } from '../../shared/terminal-query-reply'
+import type { TerminalOscColorQueryReplyColors } from '../../shared/terminal-osc-color-reply'
 import type {
   PendingOutputRecord,
   SessionState,
@@ -109,6 +110,7 @@ export type SessionOptions = {
   // a reaper, dead sessions and their scrollback emulators accumulate for the daemon's lifetime.
   onExit?: (code: number) => void
   startupIngress?: PtyStartupIngressIntent
+  oscColorQueryReplies?: TerminalOscColorQueryReplyColors
   ownerBackend?: PtyOwnerBackend
 }
 
@@ -206,6 +208,7 @@ export class Session {
     const echoProbe = createPtySlaveEchoProbe(this.subprocess.slavePath)
     this.startupIngress = new PtyStartupIngress({
       ...(opts.startupIngress ? { intent: opts.startupIngress } : {}),
+      ...(opts.oscColorQueryReplies ? { liveOscColors: opts.oscColorQueryReplies } : {}),
       ...(opts.ownerBackend ? { ownerBackend: opts.ownerBackend } : {}),
       write: (data) => this.subprocess.write(data),
       onEmission: (emission) => this.emitSubprocessOutput(emission),

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -2,6 +2,7 @@ import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery
 import type { TuiAgent } from '../../shared/types'
 import type { ShellReadyState, TerminalSnapshot } from './types'
 import type { PtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
+import type { TerminalOscColorQueryReplyColors } from '../../shared/terminal-osc-color-reply'
 import type {
   AgentSessionClaimedSpawnResult,
   AgentSessionExecutionClaim,
@@ -29,6 +30,7 @@ export type CreateOrAttachOptions = {
   shellReadyTimeoutMs?: number
   historySeedChunks?: readonly string[]
   startupIngress?: PtyStartupIngressIntent
+  oscColorQueryReplies?: TerminalOscColorQueryReplyColors
   agentSessionEnsure?: {
     claim: AgentSessionExecutionClaim
     surface: AgentSessionSurfaceBinding

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -109,6 +109,7 @@ export async function createOrAttachTerminalSession(
     shellReadySupported,
     historySeedChunks: opts.historySeedChunks,
     ...(opts.startupIngress ? { startupIngress: opts.startupIngress } : {}),
+    ...(opts.oscColorQueryReplies ? { oscColorQueryReplies: opts.oscColorQueryReplies } : {}),
     wslDistro,
     onExit: () => deps.onSessionExit(opts.sessionId, opts.agentSessionGeneration),
     ...(opts.shellReadyTimeoutMs !== undefined

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -86,6 +86,10 @@ export type CreateOrAttachRequest = {
     shellReadySupported?: boolean
     shellReadyTimeoutMs?: number
     startupIngress?: PtyStartupIngressIntent
+    oscColorQueryReplies?: {
+      foreground?: string
+      background?: string
+    }
     agentSessionEnsure?: {
       claim: AgentSessionExecutionClaim
       surface: AgentSessionSurfaceBinding

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -13805,7 +13805,7 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  it('does not answer ordinary terminal OSC color queries in main', async () => {
+  it('answers ordinary terminal OSC color queries on the POSIX PTY host', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()
     spawnMock.mockReturnValue(mockProc.proc)
@@ -13821,16 +13821,20 @@ describe('registerPtyHandlers', () => {
           background: '#111111'
         }
       })) as { id: string }
+      mockProc.proc.write.mockClear()
       mainWindow.webContents.send.mockClear()
 
       const query = '\x1b]10;?\x1b\\\x1b]11;?\x1b\\'
       mockProc.emitData(`${query}ready`)
 
-      expect(mockProc.proc.write).not.toHaveBeenCalled()
-      vi.advanceTimersByTime(2)
+      expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+      await vi.advanceTimersByTimeAsync(2)
       expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
         id: spawnResult.id,
-        data: `${query}ready`
+        data: 'ready',
+        rawLength: query.length + 'ready'.length,
+        transformed: true
       })
     } finally {
       vi.useRealTimers()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -226,7 +226,10 @@ import {
 } from '../../shared/setup-agent-sequencing'
 import { dropAgentResumeArgvFromCommand } from '../../shared/agent-resume-argv-drop'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
-import { getStartupTerminalColorQueryReplyColors } from './terminal-startup-color-query-replies'
+import {
+  getLiveTerminalOscColorQueryReplyColors,
+  getStartupTerminalColorQueryReplyColors
+} from './terminal-startup-color-query-replies'
 import {
   assertFolderWorkspacePathUsable,
   getFolderWorkspacePathStatus
@@ -4704,6 +4707,10 @@ export function registerPtyHandlers(
           deadlineMs: 5_000
         }
       }
+      const liveOscColorQueryReplyColors = getLiveTerminalOscColorQueryReplyColors(args)
+      if (liveOscColorQueryReplyColors) {
+        spawnOptions.oscColorQueryReplies = liveOscColorQueryReplyColors
+      }
       let ptySpawnCommitReported = false
       const reportPtySpawnCommitted = (): void => {
         if (ptySpawnCommitReported) {
@@ -6431,6 +6438,10 @@ export function registerPtyHandlers(
             colors: startupTerminalColorQueryReplyColors,
             deadlineMs: 5_000
           }
+        }
+        const liveOscColorQueryReplyColors = getLiveTerminalOscColorQueryReplyColors(args)
+        if (liveOscColorQueryReplyColors) {
+          spawnOptions.oscColorQueryReplies = liveOscColorQueryReplyColors
         }
         const resolvedPaneSpawnReservationKey = makePaneSpawnReservationKey(
           args.worktreeId,

--- a/src/main/ipc/terminal-startup-color-query-replies.ts
+++ b/src/main/ipc/terminal-startup-color-query-replies.ts
@@ -4,26 +4,8 @@ import { agentKindSchema } from '../../shared/telemetry-events'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
 import {
   parseTerminalOscColorQueryReplyColors,
-  terminalOscColorQueryReply,
   type TerminalOscColorQueryReplyColors
 } from '../../shared/terminal-osc-color-reply'
-
-function normalizeTerminalColorQueryReplyColors(
-  value: unknown
-): TerminalOscColorQueryReplyColors | null {
-  if (!value || typeof value !== 'object') {
-    return null
-  }
-  const record = value as { foreground?: unknown; background?: unknown }
-  const colors = {
-    ...(typeof record.foreground === 'string' ? { foreground: record.foreground } : {}),
-    ...(typeof record.background === 'string' ? { background: record.background } : {})
-  }
-  if (!terminalOscColorQueryReply(colors, 10) || !terminalOscColorQueryReply(colors, 11)) {
-    return null
-  }
-  return colors
-}
 
 function shouldReplyToStartupTerminalColorQueries(args: {
   launchAgent?: unknown
@@ -55,7 +37,7 @@ export function getStartupTerminalColorQueryReplyColors(args: {
   if (!shouldReplyToStartupTerminalColorQueries(args)) {
     return null
   }
-  return normalizeTerminalColorQueryReplyColors(args.terminalColorQueryReplies)
+  return parseTerminalOscColorQueryReplyColors(args.terminalColorQueryReplies) ?? null
 }
 
 export function getLiveTerminalOscColorQueryReplyColors(args: {

--- a/src/main/ipc/terminal-startup-color-query-replies.ts
+++ b/src/main/ipc/terminal-startup-color-query-replies.ts
@@ -3,6 +3,7 @@ import { isTuiAgent } from '../../shared/tui-agent-config'
 import { agentKindSchema } from '../../shared/telemetry-events'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
 import {
+  parseTerminalOscColorQueryReplyColors,
   terminalOscColorQueryReply,
   type TerminalOscColorQueryReplyColors
 } from '../../shared/terminal-osc-color-reply'
@@ -55,4 +56,10 @@ export function getStartupTerminalColorQueryReplyColors(args: {
     return null
   }
   return normalizeTerminalColorQueryReplyColors(args.terminalColorQueryReplies)
+}
+
+export function getLiveTerminalOscColorQueryReplyColors(args: {
+  terminalColorQueryReplies?: unknown
+}): TerminalOscColorQueryReplyColors | null {
+  return parseTerminalOscColorQueryReplyColors(args.terminalColorQueryReplies) ?? null
 }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -945,6 +945,7 @@ export class LocalPtyProvider implements IPtyProvider {
     const startupEchoProbe = createPtySlaveEchoProbe(readPtySlavePath(proc))
     const startupIngress = new PtyStartupIngress({
       ...(args.startupIngress ? { intent: args.startupIngress } : {}),
+      ...(args.oscColorQueryReplies ? { liveOscColors: args.oscColorQueryReplies } : {}),
       ownerBackend: resolvePtyOwnerBackend({
         platform: process.platform,
         shellPath,

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -1,5 +1,6 @@
 import type { TuiAgent } from '../../shared/types'
 import type { PtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
+import type { TerminalOscColorQueryReplyColors } from '../../shared/terminal-osc-color-reply'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import type { PtyBackgroundStreamEvent, PtyDataEvent } from './pty-provider-events'
@@ -92,6 +93,8 @@ export type PtySpawnOptions = {
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   /** Fresh-spawn-only source authority installed before any PTY output is released. */
   startupIngress?: PtyStartupIngressIntent
+  /** Theme colors for live OSC 10/11 answers after startup query authority closes. */
+  oscColorQueryReplies?: TerminalOscColorQueryReplyColors
   agentSessionEnsure?: {
     claim: AgentSessionExecutionClaim
     surface: AgentSessionSurfaceBinding

--- a/src/main/providers/ssh-pty-spawn-request.test.ts
+++ b/src/main/providers/ssh-pty-spawn-request.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { buildSshPtySpawnRequest } from './ssh-pty-spawn-request'
+
+describe('buildSshPtySpawnRequest', () => {
+  it('forwards live OSC color replies to the relay host', () => {
+    const oscColorQueryReplies = { foreground: '#2e3434', background: '#ffffff' }
+
+    expect(
+      buildSshPtySpawnRequest({
+        options: { cols: 80, rows: 24, oscColorQueryReplies },
+        supportsCreateOperation: false
+      })
+    ).toMatchObject({ oscColorQueryReplies })
+  })
+
+  it('omits live OSC color replies when the client has none', () => {
+    expect(
+      buildSshPtySpawnRequest({
+        options: { cols: 80, rows: 24 },
+        supportsCreateOperation: false
+      })
+    ).not.toHaveProperty('oscColorQueryReplies')
+  })
+})

--- a/src/main/providers/ssh-pty-spawn-request.ts
+++ b/src/main/providers/ssh-pty-spawn-request.ts
@@ -39,6 +39,7 @@ export function buildSshPtySpawnRequest(args: {
           startupIngress: options.startupIngress
         }
       : {}),
+    ...(options.oscColorQueryReplies ? { oscColorQueryReplies: options.oscColorQueryReplies } : {}),
     ...(options.agentSessionEnsure ? { agentSessionEnsure: options.agentSessionEnsure } : {}),
     ...(args.supportsCreateOperation
       ? { agentSessionCreateOperationId: options.agentSessionCreateOperationId }

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -1866,6 +1866,40 @@ describe('PtyHandler', () => {
     }
   })
 
+  it('answers live OSC 11 on a POSIX SSH relay and strips the query', async () => {
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    try {
+      let dataCallback: ((data: string) => void) | undefined
+      const term = {
+        ...mockPtyInstance,
+        onData: vi.fn((cb: (data: string) => void) => {
+          dataCallback = cb
+        }),
+        onExit: vi.fn()
+      }
+      mockPtySpawn.mockReturnValue(term)
+      await dispatcher.callRequest('pty.spawn', {
+        shellOverride: '/bin/bash',
+        oscColorQueryReplies: { foreground: '#2e3434', background: '#ffffff' }
+      })
+
+      dataCallback!('\x1b]11;?\x1b\\\x1b[6n')
+      await vi.advanceTimersByTimeAsync(8)
+
+      expect(term.write).toHaveBeenCalledWith('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+      const dataNotifies = dispatcher.notify.mock.calls
+        .filter((call) => call[0] === 'pty.data')
+        .map((call) => call[1] as { data: string })
+      expect(dataNotifies.map((frame) => frame.data).join('')).toBe('\x1b[6n')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
   it('forwards color queries from a POSIX SSH relay owner', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -59,6 +59,10 @@ import {
   parsePtyStartupIngressIntent,
   type PtyIngressEmission
 } from '../shared/pty-startup-ingress'
+import {
+  parseTerminalOscColorQueryReplyColors,
+  type TerminalOscColorQueryReplyColors
+} from '../shared/terminal-osc-color-reply'
 import { extractOnlyCookedEchoSafeQueryReplies } from '../shared/terminal-query-reply'
 import { resolvePtyOwnerBackend, type PtyOwnerBackend } from '../shared/pty-owner-backend'
 import { RecentPtyOutputBuffer } from '../main/runtime/recent-pty-output-buffer'
@@ -169,6 +173,7 @@ type ManagedPty = {
   gracefulKillSent?: boolean
   startupIngress?: PtyStartupIngress
   startupIngressIntent?: ReturnType<typeof parsePtyStartupIngressIntent>
+  liveOscColors?: TerminalOscColorQueryReplyColors
   ownerBackend: PtyOwnerBackend
   agentSessionOwners?: AgentSessionOwnerBinding[]
 }
@@ -743,6 +748,7 @@ export class PtyHandler {
     const echoProbe = createPtySlaveEchoProbe(readPtySlavePath(managed.pty))
     managed.startupIngress ??= new PtyStartupIngress({
       ...(managed.startupIngressIntent ? { intent: managed.startupIngressIntent } : {}),
+      ...(managed.liveOscColors ? { liveOscColors: managed.liveOscColors } : {}),
       ownerBackend: managed.ownerBackend,
       write: (data) => managed.pty.write(data),
       onEmission: emitIngressData,
@@ -1611,6 +1617,7 @@ export class PtyHandler {
       params.startupIngressVersion === PTY_STARTUP_INGRESS_VERSION
         ? parsePtyStartupIngressIntent(params.startupIngress)
         : undefined
+    const liveOscColors = parseTerminalOscColorQueryReplyColors(params.oscColorQueryReplies)
     const managed: ManagedPty = {
       id,
       incarnationId: randomUUID(),
@@ -1636,6 +1643,7 @@ export class PtyHandler {
         wslDistro: terminalWindowsWslDistro
       }),
       ...(startupIngressIntent ? { startupIngressIntent } : {}),
+      ...(liveOscColors ? { liveOscColors } : {}),
       ...(terminalHandle ? { terminalHandle } : {}),
       ...(managedStartupCommand && (shouldProviderDeliverCommand || rendererShellReadySupported)
         ? {

--- a/src/shared/pty-startup-ingress-color-answer.ts
+++ b/src/shared/pty-startup-ingress-color-answer.ts
@@ -8,6 +8,7 @@ import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
 
 type ColorReplyDelivery = {
   answer: (reply: string, onFailed?: () => void) => boolean
+  answerImmediately: (reply: string, onFailed?: () => void) => boolean
 }
 
 export function answerLiveOscColorQuery(args: {
@@ -24,7 +25,7 @@ export function answerLiveOscColorQuery(args: {
     return false
   }
   for (const reply of replies) {
-    args.delivery.answer(reply)
+    args.delivery.answerImmediately(reply)
   }
   return true
 }

--- a/src/shared/pty-startup-ingress-color-answer.ts
+++ b/src/shared/pty-startup-ingress-color-answer.ts
@@ -1,0 +1,69 @@
+import {
+  terminalOscColorQueryReplies,
+  type TerminalOscColorQueryReplyColors,
+  type TerminalOscColorQuerySlot
+} from './terminal-osc-color-reply'
+import type { PtyOwnerBackend } from './pty-owner-backend'
+import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
+
+type ColorReplyDelivery = {
+  answer: (reply: string, onFailed?: () => void) => boolean
+}
+
+export function answerLiveOscColorQuery(args: {
+  slots: readonly TerminalOscColorQuerySlot[]
+  colors: TerminalOscColorQueryReplyColors | undefined
+  ownerBackend: PtyOwnerBackend
+  delivery: ColorReplyDelivery
+}): boolean {
+  if (!args.colors || args.ownerBackend === 'windows-conpty') {
+    return false
+  }
+  const replies = terminalOscColorQueryReplies(args.colors, args.slots)
+  if (!replies) {
+    return false
+  }
+  for (const reply of replies) {
+    args.delivery.answer(reply)
+  }
+  return true
+}
+
+export function answerStartupOscColorQuery(args: {
+  slots: readonly TerminalOscColorQuerySlot[]
+  intent: PtyStartupIngressIntent | undefined
+  answeredSlots: Set<TerminalOscColorQuerySlot>
+  delivery: ColorReplyDelivery
+  onBothSlotsAnswered: () => void
+}): boolean {
+  if (args.slots.some((slot) => args.answeredSlots.has(slot)) || !args.intent) {
+    return false
+  }
+  const replies = terminalOscColorQueryReplies(args.intent.colors, args.slots)
+  if (!replies) {
+    return false
+  }
+
+  let wroteAny = false
+  for (const [index, reply] of replies.entries()) {
+    const slot = args.slots[index]
+    if (slot === undefined) {
+      return wroteAny
+    }
+    args.answeredSlots.add(slot)
+    // Why per slot: the replies to one query are written independently, so a
+    // deferred write that fails after reporting success invalidates only its own
+    // claim. Dropping every claim would let a slot that did land be answered a
+    // second time, and a duplicate reply corrupts a parser already mid-read.
+    if (!args.delivery.answer(reply, () => args.answeredSlots.delete(slot))) {
+      args.answeredSlots.delete(slot)
+      return wroteAny
+    }
+    wroteAny = true
+  }
+
+  if (args.answeredSlots.has(10) && args.answeredSlots.has(11)) {
+    args.onBothSlotsAnswered()
+  }
+  return wroteAny
+}

--- a/src/shared/pty-startup-ingress-color-answer.ts
+++ b/src/shared/pty-startup-ingress-color-answer.ts
@@ -17,7 +17,7 @@ export function answerLiveOscColorQuery(args: {
   ownerBackend: PtyOwnerBackend
   delivery: ColorReplyDelivery
 }): boolean {
-  if (!args.colors || args.ownerBackend === 'windows-conpty') {
+  if (!args.colors || args.ownerBackend !== 'posix-pty') {
     return false
   }
   const replies = terminalOscColorQueryReplies(args.colors, args.slots)

--- a/src/shared/pty-startup-ingress-contract.ts
+++ b/src/shared/pty-startup-ingress-contract.ts
@@ -1,6 +1,7 @@
 import type { PtyOwnerBackend } from './pty-owner-backend'
 import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
 import type { PtySlaveEchoProbe } from './pty-slave-line-discipline-echo'
+import type { TerminalOscColorQueryReplyColors } from './terminal-osc-color-reply'
 
 export type PtyIngressEmission = {
   data: string
@@ -11,6 +12,13 @@ export type PtyIngressEmission = {
 
 export type PtyStartupIngressOptions = {
   intent?: PtyStartupIngressIntent
+  /**
+   * Live OSC 10/11 answers for the whole PTY lifetime. Distinct from startup
+   * `intent`: that path is once-per-slot and expires. Survey-style readers
+   * (gh auth login) query after that window; a late renderer reply is `\x1b]`
+   * on stdin.
+   */
+  liveOscColors?: TerminalOscColorQueryReplyColors
   ownerBackend?: PtyOwnerBackend
   write: (data: string) => void
   onEmission: (emission: PtyIngressEmission) => void

--- a/src/shared/pty-startup-ingress-live-osc.test.ts
+++ b/src/shared/pty-startup-ingress-live-osc.test.ts
@@ -12,6 +12,20 @@ function visible(emissions: readonly PtyIngressEmission[]): string {
 describe('PtyStartupIngress live OSC 10/11 answers', () => {
   afterEach(() => vi.useRealTimers())
 
+  it('writes a live OSC 11 reply before accept returns', () => {
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    ingress.accept('\x1b]11;?\x1b\\\x1b[6n')
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('\x1b[6n')
+    ingress.drainAndClose()
+  })
+
   it('answers a post-startup OSC 11 query and strips it from forwarded output', async () => {
     vi.useFakeTimers()
     const emissions: PtyIngressEmission[] = []
@@ -52,6 +66,106 @@ describe('PtyStartupIngress live OSC 10/11 answers', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(writes).toEqual([BACKGROUND_REPLY])
     expect(visible(emissions)).toBe('')
+    ingress.drainAndClose()
+  })
+
+  it('answers a second OSC 11 during the startup window after that slot is claimed', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      intent: { colors: COLORS, deadlineMs: 5_000 },
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    ingress.accept('\x1b]11;?\x07')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    writes.length = 0
+    // gh auth login can query after an earlier startup OSC 11, while slot 10
+    // is still open so startup authority has not handed off.
+    ingress.accept('\x1b]11;?\x1b\\\x1b[6n')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('\x1b[6n')
+    ingress.drainAndClose()
+  })
+
+  it('does not strip an OSC 11 color set or other application output', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    const setAndTitle = '\x1b]11;#ffffff\x07\x1b]0;title\x07prompt'
+    ingress.accept(setAndTitle)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([])
+    expect(visible(emissions)).toBe(setAndTitle)
+    ingress.drainAndClose()
+  })
+
+  it('forwards CSI-dense output without holding or answering', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    const frame = '\x1b[31mred\x1b[0m\x1b[2J\x1b[Hprompt'
+    ingress.accept(frame)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([])
+    expect(visible(emissions)).toBe(frame)
+    ingress.drainAndClose()
+  })
+
+  it('keeps a torn live OSC 11 held across query-authority close', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      intent: { colors: COLORS, deadlineMs: 5_000 },
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    ingress.accept('\x1b]11;?')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([])
+    expect(visible(emissions)).toBe('')
+    ingress.closeQueryAuthority()
+    expect(visible(emissions)).toBe('')
+    ingress.accept('\x1b\\prompt')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('prompt')
+    ingress.drainAndClose()
+  })
+
+  it('reassembles a fragmented OSC 11 query and still strips it', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    ingress.accept('\x1b]11;?')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([])
+    expect(visible(emissions)).toBe('')
+    ingress.accept('\x1b\\\x1b[6n')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('\x1b[6n')
     ingress.drainAndClose()
   })
 })

--- a/src/shared/pty-startup-ingress-live-osc.test.ts
+++ b/src/shared/pty-startup-ingress-live-osc.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PtyStartupIngress, type PtyIngressEmission } from './pty-startup-ingress'
+
+const COLORS = { foreground: '#2e3434', background: '#ffffff' }
+const FOREGROUND_REPLY = '\x1b]10;rgb:2e2e/3434/3434\x1b\\'
+const BACKGROUND_REPLY = '\x1b]11;rgb:ffff/ffff/ffff\x1b\\'
+
+function visible(emissions: readonly PtyIngressEmission[]): string {
+  return emissions.map((emission) => emission.data).join('')
+}
+
+describe('PtyStartupIngress live OSC 10/11 answers', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('answers a post-startup OSC 11 query and strips it from forwarded output', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    // gh auth login writes OSC 11 (ST) plus CPR, then survey-reads stdin.
+    ingress.accept('\x1b]11;?\x1b\\\x1b[6n')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('\x1b[6n')
+    ingress.accept('\x1b]11;?\x07prompt')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY, BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('\x1b[6nprompt')
+    ingress.drainAndClose()
+  })
+
+  it('still answers live OSC 11 after startup query authority expires', async () => {
+    vi.useFakeTimers()
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      intent: { colors: COLORS, deadlineMs: 5_000 },
+      liveOscColors: COLORS,
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    ingress.accept('\x1b]10;?\x07\x1b]11;?\x07')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([FOREGROUND_REPLY, BACKGROUND_REPLY])
+    await vi.advanceTimersByTimeAsync(5_000)
+    writes.length = 0
+    ingress.accept('\x1b]11;?\x1b\\')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([BACKGROUND_REPLY])
+    expect(visible(emissions)).toBe('')
+    ingress.drainAndClose()
+  })
+})

--- a/src/shared/pty-startup-ingress-live-osc.test.ts
+++ b/src/shared/pty-startup-ingress-live-osc.test.ts
@@ -126,6 +126,24 @@ describe('PtyStartupIngress live OSC 10/11 answers', () => {
     ingress.drainAndClose()
   })
 
+  it('leaves Windows WSL color queries renderer-handled', () => {
+    const emissions: PtyIngressEmission[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      liveOscColors: COLORS,
+      ownerBackend: 'windows-wsl',
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emissions.push(emission)
+    })
+    const tornQuery = '\x1b]11;?'
+    ingress.accept(tornQuery)
+    expect(writes).toEqual([])
+    expect(visible(emissions)).toBe(tornQuery)
+    ingress.accept('\x1b\\\x1b[6n')
+    expect(visible(emissions)).toBe(`${tornQuery}\x1b\\\x1b[6n`)
+    ingress.drainAndClose()
+  })
+
   it('keeps a torn live OSC 11 held across query-authority close', async () => {
     vi.useFakeTimers()
     const emissions: PtyIngressEmission[] = []

--- a/src/shared/pty-startup-ingress-operations.ts
+++ b/src/shared/pty-startup-ingress-operations.ts
@@ -1,0 +1,70 @@
+import type { PtyOwnerBackend } from './pty-owner-backend'
+import type {
+  PtyStartupIngressOperation,
+  PtyIngressSourceSpan
+} from './pty-startup-ingress-contract'
+
+export type PtyStartupIngressOperationHost = {
+  ownerBackend: PtyOwnerBackend
+  keepLiveQueryHold: boolean
+  processEchoSpan: (span: PtyIngressSourceSpan) => void
+  endQueryAuthority: () => void
+  releaseQueryPending: () => void
+  releaseEchoPendingOnly: () => void
+  releasePendingInSourceOrder: (includeConptyQuery: boolean) => void
+  resetDelivery: () => void
+  closeDelivery: () => void
+  clearDeadline: () => void
+  markClosed: () => void
+}
+
+export function applyPtyStartupIngressOperation(
+  host: PtyStartupIngressOperationHost,
+  operation: PtyStartupIngressOperation
+): void {
+  switch (operation.kind) {
+    case 'data':
+      host.processEchoSpan(operation.chunk)
+      return
+    case 'close-query':
+      if (host.ownerBackend !== 'windows-conpty') {
+        host.endQueryAuthority()
+        // Why the echo hold deliberately survives this, unlike `snapshot`: the
+        // handoff ends query *authority*, but a reply already on the wire is still
+        // Orca's to swallow. Releasing here would show the first half of an echo
+        // split across the boundary and orphan the second.
+        // Live OSC 10/11 still owns torn queries after this handoff.
+        if (!host.keepLiveQueryHold) {
+          host.releaseQueryPending()
+        }
+      }
+      // Why: ConPTY cannot safely transfer color-query authority to a downstream view.
+      return
+    case 'expire':
+      host.endQueryAuthority()
+      if (host.keepLiveQueryHold) {
+        host.releaseEchoPendingOnly()
+      } else {
+        host.releasePendingInSourceOrder(false)
+      }
+      host.resetDelivery()
+      host.clearDeadline()
+      return
+    case 'snapshot':
+      if (host.keepLiveQueryHold) {
+        host.releaseEchoPendingOnly()
+        return
+      }
+      host.releasePendingInSourceOrder(false)
+      return
+    case 'release-echo':
+      host.releasePendingInSourceOrder(false)
+      return
+    case 'teardown':
+      host.endQueryAuthority()
+      host.releasePendingInSourceOrder(true)
+      host.closeDelivery()
+      host.clearDeadline()
+      host.markClosed()
+  }
+}

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -70,7 +70,7 @@ export class PtyStartupIngress {
     this.onEmission = options.onEmission
     this.operationHost = {
       ownerBackend: this.ownerBackend,
-      keepLiveQueryHold: Boolean(this.liveOscColors),
+      keepLiveQueryHold: Boolean(this.liveOscColors) && this.ownerBackend === 'posix-pty',
       processEchoSpan: (span) => this.processEchoSpan(span),
       endQueryAuthority: () => {
         this.queryOpen = false
@@ -238,9 +238,10 @@ export class PtyStartupIngress {
   private processQuerySpan(span: PtyIngressSourceSpan): void {
     const input = combinePtyIngressSourceSpans(this.queryPending, span)
     this.queryPending = null
-    const suppressConptyQuery = this.ownerBackend === 'windows-conpty'
-    const canAnswerColorQuery = Boolean(this.liveOscColors || (this.queryOpen && this.intent))
-    if (!canAnswerColorQuery && !suppressConptyQuery) {
+    const canAnswerColorQuery =
+      (Boolean(this.liveOscColors) && this.ownerBackend === 'posix-pty') ||
+      Boolean(this.queryOpen && this.intent)
+    if (!canAnswerColorQuery && this.ownerBackend !== 'windows-conpty') {
       this.emit(input, false)
       return
     }
@@ -296,11 +297,8 @@ export class PtyStartupIngress {
           ownerBackend: this.ownerBackend,
           delivery: this.delivery
         })
-      if (answered || suppressConptyQuery) {
-        this.emit(querySpan, true, '')
-      } else {
-        this.emit(querySpan, false)
-      }
+      const suppressQuery = answered || this.ownerBackend === 'windows-conpty'
+      this.emit(querySpan, suppressQuery, suppressQuery ? '' : querySpan.data)
       scanOffset = query.endIndex
       emittedOffset = query.endIndex
     }

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -1,8 +1,12 @@
 import {
   parseTerminalOscColorQuery,
-  terminalOscColorQueryReplies,
+  type TerminalOscColorQueryReplyColors,
   type TerminalOscColorQuerySlot
 } from './terminal-osc-color-reply'
+import {
+  answerLiveOscColorQuery,
+  answerStartupOscColorQuery
+} from './pty-startup-ingress-color-answer'
 import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
 import type { PtyOwnerBackend } from './pty-owner-backend'
 import { PtyStartupReplyDelivery } from './pty-startup-reply-delivery'
@@ -38,6 +42,7 @@ const ECHO_CONTINUATION_HOLD_MS = 500
  */
 export class PtyStartupIngress {
   private readonly intent: PtyStartupIngressIntent | undefined
+  private readonly liveOscColors: TerminalOscColorQueryReplyColors | undefined
   private readonly ownerBackend: PtyOwnerBackend
   private readonly delivery: PtyStartupReplyDelivery
   private readonly onEmission: (emission: PtyIngressEmission) => void
@@ -54,6 +59,7 @@ export class PtyStartupIngress {
 
   constructor(options: PtyStartupIngressOptions) {
     this.intent = options.intent
+    this.liveOscColors = options.liveOscColors
     this.ownerBackend = options.ownerBackend ?? 'posix-pty'
     this.delivery = new PtyStartupReplyDelivery(this.ownerBackend, options.write, options.echoProbe)
     this.onEmission = options.onEmission
@@ -242,7 +248,8 @@ export class PtyStartupIngress {
     const input = combinePtyIngressSourceSpans(this.queryPending, span)
     this.queryPending = null
     const suppressConptyQuery = this.ownerBackend === 'windows-conpty'
-    if ((!this.queryOpen || !this.intent) && !suppressConptyQuery) {
+    const canAnswerColorQuery = Boolean(this.liveOscColors || (this.queryOpen && this.intent))
+    if (!canAnswerColorQuery && !suppressConptyQuery) {
       this.emit(input, false)
       return
     }
@@ -277,7 +284,23 @@ export class PtyStartupIngress {
         this.emit(slicePtyIngressSourceSpan(input, emittedOffset, candidateIndex), false)
       }
       const querySpan = slicePtyIngressSourceSpan(input, candidateIndex, query.endIndex)
-      const answered = this.queryOpen && this.intent && this.answerQuery(query.slots)
+      const answered =
+        this.queryOpen && this.intent
+          ? answerStartupOscColorQuery({
+              slots: query.slots,
+              intent: this.intent,
+              answeredSlots: this.answeredSlots,
+              delivery: this.delivery,
+              onBothSlotsAnswered: () => {
+                this.queryOpen = false
+              }
+            })
+          : answerLiveOscColorQuery({
+              slots: query.slots,
+              colors: this.liveOscColors,
+              ownerBackend: this.ownerBackend,
+              delivery: this.delivery
+            })
       if (answered || suppressConptyQuery) {
         this.emit(querySpan, true, '')
       } else {
@@ -286,39 +309,6 @@ export class PtyStartupIngress {
       scanOffset = query.endIndex
       emittedOffset = query.endIndex
     }
-  }
-
-  private answerQuery(slots: readonly TerminalOscColorQuerySlot[]): boolean {
-    if (slots.some((slot) => this.answeredSlots.has(slot)) || !this.intent) {
-      return false
-    }
-    const replies = terminalOscColorQueryReplies(this.intent.colors, slots)
-    if (!replies) {
-      return false
-    }
-
-    let wroteAny = false
-    for (const [index, reply] of replies.entries()) {
-      const slot = slots[index]
-      if (slot === undefined) {
-        return wroteAny
-      }
-      this.answeredSlots.add(slot)
-      // Why per slot: the replies to one query are written independently, so a
-      // deferred write that fails after reporting success invalidates only its own
-      // claim. Dropping every claim would let a slot that did land be answered a
-      // second time, and a duplicate reply corrupts a parser already mid-read.
-      if (!this.delivery.answer(reply, () => this.answeredSlots.delete(slot))) {
-        this.answeredSlots.delete(slot)
-        return wroteAny
-      }
-      wroteAny = true
-    }
-
-    if (this.answeredSlots.has(10) && this.answeredSlots.has(11)) {
-      this.queryOpen = false
-    }
-    return wroteAny
   }
 
   private releaseQueryPending(): void {

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -7,6 +7,10 @@ import {
   answerLiveOscColorQuery,
   answerStartupOscColorQuery
 } from './pty-startup-ingress-color-answer'
+import {
+  applyPtyStartupIngressOperation,
+  type PtyStartupIngressOperationHost
+} from './pty-startup-ingress-operations'
 import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
 import type { PtyOwnerBackend } from './pty-owner-backend'
 import { PtyStartupReplyDelivery } from './pty-startup-reply-delivery'
@@ -56,6 +60,7 @@ export class PtyStartupIngress {
   private echoPending: PtyIngressSourceSpan | null = null
   private echoHoldTimer: ReturnType<typeof setTimeout> | null = null
   private deadlineTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly operationHost: PtyStartupIngressOperationHost
 
   constructor(options: PtyStartupIngressOptions) {
     this.intent = options.intent
@@ -63,6 +68,23 @@ export class PtyStartupIngress {
     this.ownerBackend = options.ownerBackend ?? 'posix-pty'
     this.delivery = new PtyStartupReplyDelivery(this.ownerBackend, options.write, options.echoProbe)
     this.onEmission = options.onEmission
+    this.operationHost = {
+      ownerBackend: this.ownerBackend,
+      keepLiveQueryHold: Boolean(this.liveOscColors),
+      processEchoSpan: (span) => this.processEchoSpan(span),
+      endQueryAuthority: () => {
+        this.queryOpen = false
+      },
+      releaseQueryPending: () => this.releaseQueryPending(),
+      releaseEchoPendingOnly: () => this.releaseEchoPendingOnly(),
+      releasePendingInSourceOrder: (include) => this.releasePendingInSourceOrder(include),
+      resetDelivery: () => this.delivery.reset(),
+      closeDelivery: () => this.delivery.close(),
+      clearDeadline: () => this.clearDeadline(),
+      markClosed: () => {
+        this.closed = true
+      }
+    }
     this.queryOpen = options.intent !== undefined
     if (options.intent) {
       this.deadlineTimer = setTimeout(
@@ -131,38 +153,7 @@ export class PtyStartupIngress {
   }
 
   private applyOperation(operation: PtyStartupIngressOperation): void {
-    switch (operation.kind) {
-      case 'data':
-        this.processEchoSpan(operation.chunk)
-        return
-      case 'close-query':
-        if (this.ownerBackend !== 'windows-conpty') {
-          this.queryOpen = false
-          // Why the echo hold deliberately survives this, unlike `snapshot`: the
-          // handoff ends query *authority*, but a reply already on the wire is still
-          // Orca's to swallow. Releasing here would show the first half of an echo
-          // split across the boundary and orphan the second.
-          this.releaseQueryPending()
-        }
-        // Why: ConPTY cannot safely transfer color-query authority to a downstream view.
-        return
-      case 'expire':
-        this.queryOpen = false
-        this.releasePendingInSourceOrder(false)
-        this.delivery.reset()
-        this.clearDeadline()
-        return
-      case 'snapshot':
-      case 'release-echo':
-        this.releasePendingInSourceOrder(false)
-        return
-      case 'teardown':
-        this.queryOpen = false
-        this.releasePendingInSourceOrder(true)
-        this.delivery.close()
-        this.clearDeadline()
-        this.closed = true
-    }
+    applyPtyStartupIngressOperation(this.operationHost, operation)
   }
 
   /**
@@ -284,8 +275,11 @@ export class PtyStartupIngress {
         this.emit(slicePtyIngressSourceSpan(input, emittedOffset, candidateIndex), false)
       }
       const querySpan = slicePtyIngressSourceSpan(input, candidateIndex, query.endIndex)
+      // Startup is once-per-slot. A later genuine query of the same slot
+      // must still be host-answered, or the renderer sees it and can send a
+      // late `\x1b]` reply into a survey reader.
       const answered =
-        this.queryOpen && this.intent
+        (this.queryOpen && this.intent
           ? answerStartupOscColorQuery({
               slots: query.slots,
               intent: this.intent,
@@ -295,12 +289,13 @@ export class PtyStartupIngress {
                 this.queryOpen = false
               }
             })
-          : answerLiveOscColorQuery({
-              slots: query.slots,
-              colors: this.liveOscColors,
-              ownerBackend: this.ownerBackend,
-              delivery: this.delivery
-            })
+          : false) ||
+        answerLiveOscColorQuery({
+          slots: query.slots,
+          colors: this.liveOscColors,
+          ownerBackend: this.ownerBackend,
+          delivery: this.delivery
+        })
       if (answered || suppressConptyQuery) {
         this.emit(querySpan, true, '')
       } else {
@@ -308,6 +303,13 @@ export class PtyStartupIngress {
       }
       scanOffset = query.endIndex
       emittedOffset = query.endIndex
+    }
+  }
+
+  private releaseEchoPendingOnly(): void {
+    const pending = this.takeEchoPending()
+    if (pending) {
+      this.emit(pending, false)
     }
   }
 

--- a/src/shared/pty-startup-reply-delivery.ts
+++ b/src/shared/pty-startup-reply-delivery.ts
@@ -189,14 +189,6 @@ export class PtyStartupReplyDelivery {
   }
 
   /**
-   * True once the reply has been written or accepted for a later write.
-   *
-   * `onFailed` fires only for the second case: a deferred write reports success
-   * before it happens, so the caller's bookkeeping for THIS reply is a lie if the
-   * write later throws. Scoped per reply because the replies to one query are
-   * written independently — one failing says nothing about the ones that landed.
-   */
-  /**
    * Write now. Live OSC 10/11 answers cannot wait for the cooked-echo probe:
    * gh auth starts its survey reader in the next syscall, and a deferred
    * `\x1b]` is the same late stdin the renderer used to send.
@@ -205,6 +197,10 @@ export class PtyStartupReplyDelivery {
     return this.writeReply(reply, onFailed)
   }
 
+  /**
+   * True once the reply has been written or accepted for a later write.
+   * `onFailed` retracts only a deferred reply whose eventual write throws.
+   */
   answer(reply: string, onFailed?: () => void): boolean {
     if (this.closed) {
       return false

--- a/src/shared/pty-startup-reply-delivery.ts
+++ b/src/shared/pty-startup-reply-delivery.ts
@@ -196,6 +196,15 @@ export class PtyStartupReplyDelivery {
    * write later throws. Scoped per reply because the replies to one query are
    * written independently — one failing says nothing about the ones that landed.
    */
+  /**
+   * Write now. Live OSC 10/11 answers cannot wait for the cooked-echo probe:
+   * gh auth starts its survey reader in the next syscall, and a deferred
+   * `\x1b]` is the same late stdin the renderer used to send.
+   */
+  answerImmediately(reply: string, onFailed?: () => void): boolean {
+    return this.writeReply(reply, onFailed)
+  }
+
   answer(reply: string, onFailed?: () => void): boolean {
     if (this.closed) {
       return false

--- a/src/shared/terminal-osc-color-reply.test.ts
+++ b/src/shared/terminal-osc-color-reply.test.ts
@@ -55,6 +55,18 @@ describe('parseTerminalOscColorQuery', () => {
     ).toEqual({ foreground: '#2e3434', background: '#ffffff' })
     expect(parseTerminalOscColorQueryReplyColors({ foreground: '#2e3434' })).toBeUndefined()
     expect(parseTerminalOscColorQueryReplyColors(null)).toBeUndefined()
+    expect(
+      parseTerminalOscColorQueryReplyColors({
+        foreground: 'not-a-color',
+        background: '#ffffff'
+      })
+    ).toBeUndefined()
+    expect(
+      parseTerminalOscColorQueryReplyColors({
+        foreground: 42,
+        background: '#ffffff'
+      })
+    ).toBeUndefined()
   })
 
   it('rejects unsupported query-shaped bodies without waiting for a terminator', () => {

--- a/src/shared/terminal-osc-color-reply.test.ts
+++ b/src/shared/terminal-osc-color-reply.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { parseTerminalOscColorQuery } from './terminal-osc-color-reply'
+import {
+  parseTerminalOscColorQuery,
+  parseTerminalOscColorQueryReplyColors
+} from './terminal-osc-color-reply'
 
 describe('parseTerminalOscColorQuery', () => {
   it('matches exact OSC color queries terminated by ST or BEL', () => {
@@ -41,6 +44,17 @@ describe('parseTerminalOscColorQuery', () => {
     expect(parseTerminalOscColorQuery('\x1b]10;?;#123456\x1b\\', 0)).toEqual({ kind: 'none' })
     expect(parseTerminalOscColorQuery('\x1b]10;?;?;?\x1b\\', 0)).toEqual({ kind: 'none' })
     expect(parseTerminalOscColorQuery('\x1b]11;?;?\x1b\\', 0)).toEqual({ kind: 'none' })
+  })
+
+  it('accepts theme colors that can produce OSC 10 and OSC 11 replies', () => {
+    expect(
+      parseTerminalOscColorQueryReplyColors({
+        foreground: '#2e3434',
+        background: '#ffffff'
+      })
+    ).toEqual({ foreground: '#2e3434', background: '#ffffff' })
+    expect(parseTerminalOscColorQueryReplyColors({ foreground: '#2e3434' })).toBeUndefined()
+    expect(parseTerminalOscColorQueryReplyColors(null)).toBeUndefined()
   })
 
   it('rejects unsupported query-shaped bodies without waiting for a terminator', () => {

--- a/src/shared/terminal-osc-color-reply.ts
+++ b/src/shared/terminal-osc-color-reply.ts
@@ -100,6 +100,23 @@ function clampByte(value: number): number {
   return Math.min(255, Math.max(0, Math.round(value)))
 }
 
+export function parseTerminalOscColorQueryReplyColors(
+  value: unknown
+): TerminalOscColorQueryReplyColors | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const record = value as { foreground?: unknown; background?: unknown }
+  const colors: TerminalOscColorQueryReplyColors = {
+    ...(typeof record.foreground === 'string' ? { foreground: record.foreground } : {}),
+    ...(typeof record.background === 'string' ? { background: record.background } : {})
+  }
+  if (!terminalOscColorQueryReply(colors, 10) || !terminalOscColorQueryReply(colors, 11)) {
+    return undefined
+  }
+  return colors
+}
+
 export function terminalOscColorQueryReply(
   colors: TerminalOscColorQueryReplyColors,
   slot: TerminalOscColorQuerySlot

--- a/src/shared/terminal-osc-color-reply.ts
+++ b/src/shared/terminal-osc-color-reply.ts
@@ -215,6 +215,11 @@ export function parseTerminalOscColorQuery(
     data.startsWith(prefix, offset)
   )
   if (!entry) {
+    // CSI and other ESC sequences are not OSC 10/11. Avoid slicing the rest
+    // of a TUI chunk just to prove that.
+    if (offset + 1 < data.length && data[offset + 1] !== ']') {
+      return { kind: 'none' }
+    }
     const fragment = data.slice(offset)
     return TERMINAL_OSC_COLOR_QUERY_PREFIXES.some(({ prefix }) => prefix.startsWith(fragment))
       ? { kind: 'partial' }


### PR DESCRIPTION
## Summary

`gh auth login` on Linux writes an OSC 11 background-color query, then immediately starts a survey key reader. Orca answered that query from the renderer, so over SSH (and any path with a similar RTT) the `\x1b]11;rgb:…` reply landed after survey was already reading stdin. Survey treats `\x1b]` as an unexpected escape and aborts with:

```
could not prompt: unexpected escape sequence from terminal: ['\x1b' ']']
```

This change answers OSC 10/11 on the POSIX PTY host for the life of the session and strips those queries from forwarded output so the renderer cannot send a late duplicate. Windows ConPTY stays on its existing consume-only path.

Fixes #14020
Fixes STA-3994

## Reliability

- **Invariant:** after a program emits OSC 10/11, a later survey-style stdin reader must not see a late `\x1b]` color reply. Class: terminal input / PTY query replies.
- **Failure source:** STA-3994 / #14020 (`gh auth login` on Linux).
- **Oracle:** `gh auth login` stays on the GitHub host prompt until cancelled; unit tests fail if live host answering or query stripping is reverted.
- **Gate:** no new blocking gate. Covered by unit tests in `pty-startup-ingress-live-osc.test.ts` and `pty-handler.test.ts`.
- **Provider / platform:** local POSIX and SSH/relay Linux covered. Windows ConPTY unchanged (accepted existing consume-only behavior). WSL-on-Windows host path unchanged.
- **Performance:** no new polling or wake loops. One extra parse of OSC 10/11 on existing PTY `onData`.
- **Diagnostics:** existing PTY/relay logs; test failure names the query/reply bytes.
- **Residual gaps:** mixed old-host/new-client still uses the renderer reply path. Arrow-key encoding was not the failure mode.

## Tests

- [x] Reproduced on `origin/main` with real `gh auth login` (v2.96.0) through Orca’s SSH PTY to a throwaway Linux Docker target. Prompt died immediately with the reported `\x1b]` error. Raw `ssh -tt` to the same target did not crash (no emulator reply).
- [x] After the fix, the same `gh auth login` stayed on `Where do you use GitHub?` until `timeout` exited 124. No `could not prompt` line. No credentials used.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/pty-startup-ingress.test.ts src/shared/pty-startup-ingress-live-osc.test.ts src/shared/terminal-osc-color-reply.test.ts src/relay/pty-handler.test.ts -t "answers live OSC 11"`
- [x] `pnpm tc`
- [x] `oxlint` on the changed files (pre-commit)
- [x] Throwaway Linux SSH target used `demo-project` from a local git bundle (GitHub clone was auth-blocked). Relay rebuilt; identity verified against this worktree. Container, temp keys, and isolated Electron profile removed after the run.

## Remote wire

New optional spawn field `oscColorQueryReplies`. Older relays ignore it. A new host strips answered OSC 10/11 queries from the output stream (invisible sequences) so an older renderer does not double-answer.