### PR TITLE
fix(win): repair NSIS upgrade metadata that reports cannot-close

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -325,10 +325,10 @@ module.exports = {
     shortcutName: '${productName}',
     uninstallDisplayName: '${productName}',
     createDesktopShortcut: 'always',
-    // Why: on a real uninstall, stop and remove the relocated terminal daemon
-    // (which lives outside the install dir under LOCALAPPDATA by design). Guarded
-    // by ${isUpdated} inside so it never runs during an update's uninstallOldVersion.
-    include: resolve(__dirname, 'nsis', 'daemon-host-uninstall.nsh')
+    // Why: installer-hooks.nsh owns upgrade-state repair plus the real-uninstall
+    // daemon cleanup. The daemon hook is still guarded by ${isUpdated} so
+    // uninstallOldVersion cannot kill the relocated host.
+    include: resolve(__dirname, 'nsis', 'installer-hooks.nsh')
   },
   mac: {
     icon: 'resources/build/icon.icns',

--- a/config/nsis/installer-hooks.nsh
+++ b/config/nsis/installer-hooks.nsh
@@ -1,0 +1,3 @@
+; Single electron-builder nsis.include entry. Sibling includes stay next to this file.
+!include "daemon-host-uninstall.nsh"
+!include "upgrade-install-state.nsh"

--- a/config/nsis/upgrade-install-state.mjs
+++ b/config/nsis/upgrade-install-state.mjs
@@ -1,0 +1,174 @@
+// Decision spec for Windows NSIS upgrade hooks. Keep in sync with upgrade-install-state.nsh.
+
+const UNEXPANDED_NSIS = /\$[A-Za-z_{]/
+
+export function normalizeWindowsPath(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/\//g, '\\')
+    .replace(/\\+$/, '')
+}
+
+export function isUnexpandedNsisValue(value) {
+  return UNEXPANDED_NSIS.test(String(value ?? ''))
+}
+
+export function isTooBroadInstallLocation(value) {
+  const normalized = normalizeWindowsPath(value).toLowerCase()
+  if (!normalized) {
+    return true
+  }
+  if (/^[a-z]:$/.test(normalized)) {
+    return true
+  }
+  const parts = normalized.split('\\').filter(Boolean)
+  if (parts.length <= 1) {
+    return true
+  }
+  if (parts.length === 2 && parts[1] === 'users') {
+    return true
+  }
+  if (parts.length === 3 && parts[1] === 'users') {
+    return true
+  }
+  return (
+    normalized.endsWith('\\appdata') ||
+    normalized.endsWith('\\appdata\\local') ||
+    normalized.endsWith('\\appdata\\roaming') ||
+    normalized.endsWith('\\appdata\\local\\orca') ||
+    normalized.endsWith('\\appdata\\roaming\\orca')
+  )
+}
+
+export function sanitizeInstallLocation(value) {
+  const raw = String(value ?? '').trim()
+  if (!raw || isUnexpandedNsisValue(raw)) {
+    return null
+  }
+  if (!/^[a-zA-Z]:[\\/]/.test(raw)) {
+    return null
+  }
+  if (isTooBroadInstallLocation(raw)) {
+    return null
+  }
+  return normalizeWindowsPath(raw)
+}
+
+export function parseUninstallExecutable(uninstallString) {
+  const quoted = String(uninstallString ?? '').match(/"([^"]+\.exe)"/i)
+  if (quoted?.[1]) {
+    return quoted[1]
+  }
+  const unquoted = String(uninstallString ?? '').trim().match(/^([^"]+\.exe)\b/i)
+  return unquoted?.[1] ?? null
+}
+
+export function parentDirectory(filePath) {
+  const normalized = normalizeWindowsPath(filePath)
+  const slash = normalized.lastIndexOf('\\')
+  return slash > 0 ? normalized.slice(0, slash) : null
+}
+
+/**
+ * @param {object} input
+ * @param {string | null | undefined} input.installLocation registry InstallLocation
+ * @param {string | null | undefined} input.uninstallString registry UninstallString
+ * @param {string} input.defaultInstallDir per-user Programs\Orca default
+ * @param {string | null | undefined} input.commandLineInstallDir NSIS /D= override
+ * @param {(dir: string) => boolean} [input.pathHasAppExecutable]
+ * @param {(exe: string) => boolean} [input.uninstallExecutableExists]
+ */
+export function resolveNsisUpgradeState({
+  installLocation,
+  uninstallString,
+  defaultInstallDir,
+  commandLineInstallDir,
+  pathHasAppExecutable = () => false,
+  uninstallExecutableExists = () => false
+}) {
+  const defaultDir = normalizeWindowsPath(defaultInstallDir)
+  const fromCommandLine = sanitizeInstallLocation(commandLineInstallDir)
+  const uninstallExe = parseUninstallExecutable(uninstallString)
+  const uninstallExeUsable =
+    Boolean(uninstallExe) &&
+    !isUnexpandedNsisValue(uninstallExe) &&
+    uninstallExecutableExists(uninstallExe)
+  const fromUninstaller = uninstallExeUsable
+    ? sanitizeInstallLocation(parentDirectory(uninstallExe))
+    : null
+  const fromRegistry = registryInstallDir(installLocation, pathHasAppExecutable, fromUninstaller)
+
+  const instDir = fromCommandLine || fromRegistry || fromUninstaller || defaultDir
+  const runPreviousUninstaller = uninstallExeUsable && Boolean(fromUninstaller)
+  const discardUninstallString = Boolean(uninstallString) && !runPreviousUninstaller
+  // uninstallOldVersion passes InstallLocation to _?= unquoted. Never persist /D=.
+  const previousLocation = sanitizeInstallLocation(installLocation)
+  let installLocationToWrite = null
+  if (fromUninstaller) {
+    if (previousLocation !== fromUninstaller) {
+      installLocationToWrite = fromUninstaller
+    }
+  } else if (!previousLocation && !fromCommandLine) {
+    installLocationToWrite = instDir
+  }
+  const repairInstallLocation = Boolean(installLocationToWrite)
+
+  return {
+    instDir,
+    runPreviousUninstaller,
+    repairInstallLocation,
+    installLocationToWrite,
+    discardUninstallString,
+    recoveredFromUninstaller: !fromCommandLine && !fromRegistry && Boolean(fromUninstaller)
+  }
+}
+
+function registryInstallDir(value, pathHasAppExecutable, uninstallParent) {
+  const sanitized = sanitizeInstallLocation(value)
+  if (!sanitized) {
+    return null
+  }
+  if (pathHasAppExecutable(sanitized) || sanitized === uninstallParent) {
+    return sanitized
+  }
+  return null
+}
+
+export function isCloseAppProcess({ processPath, instDir, imageName }) {
+  const location = sanitizeInstallLocation(instDir)
+  const pathValue = normalizeWindowsPath(processPath)
+  if (!location || !pathValue) {
+    return false
+  }
+  const prefix = `${location.toLowerCase()}\\`
+  if (!pathValue.toLowerCase().startsWith(prefix)) {
+    return false
+  }
+  const base = (imageName || pathValue.split('\\').pop() || '').toLowerCase()
+  if (base === 'orca-terminal-daemon.exe') {
+    return false
+  }
+  return base === 'orca.exe'
+}
+
+export function shouldReportAppCannotBeClosed({ remainingProcessPaths, instDir }) {
+  const location = sanitizeInstallLocation(instDir)
+  if (!location) {
+    return false
+  }
+  const mainExe = `${location}\\Orca.exe`.toLowerCase()
+  return (remainingProcessPaths ?? []).some(
+    (processPath) => normalizeWindowsPath(processPath).toLowerCase() === mainExe
+  )
+}
+
+export function mapPreviousUninstallerOutcome({ ran, exitCode, uninstallStringUsable }) {
+  if (!ran || !uninstallStringUsable) {
+    return { abortInstaller: false, reportCannotBeClosed: false }
+  }
+  if (exitCode === 0) {
+    return { abortInstaller: false, reportCannotBeClosed: false }
+  }
+  // A failed old uninstaller is not proof the app is running.
+  return { abortInstaller: false, reportCannotBeClosed: false }
+}

--- a/config/nsis/upgrade-install-state.nsh
+++ b/config/nsis/upgrade-install-state.nsh
@@ -1,0 +1,325 @@
+; Repair persisted NSIS upgrade metadata. $installDir below is the literal orphaned value.
+; Spec: upgrade-install-state.mjs. Close-app stays on the default CHECK_APP_RUNNING
+; once $INSTDIR is a usable non-broad path (explorer / relocated daemon will not match).
+
+!macro nsisUpgradeStateIsUnusable _value _out
+  Push $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+  StrCpy $0 ${_value}
+  StrCpy ${_out} 0
+
+  StrLen $1 $0
+  ${Do}
+    ${If} $1 == 0
+      ${Break}
+    ${EndIf}
+    IntOp $1 $1 - 1
+    StrCpy $2 $0 1 $1
+    ${If} $2 != "\"
+    ${AndIf} $2 != "/"
+      IntOp $1 $1 + 1
+      StrCpy $0 $0 $1
+      ${Break}
+    ${EndIf}
+  ${Loop}
+
+  StrCpy $1 ""
+  StrCpy $2 0
+  StrLen $4 $0
+  ${Do}
+    ${If} $2 >= $4
+      ${Break}
+    ${EndIf}
+    StrCpy $3 $0 1 $2
+    ${If} $3 == "/"
+      StrCpy $3 "\"
+    ${EndIf}
+    StrCpy $1 "$1$3"
+    IntOp $2 $2 + 1
+  ${Loop}
+  StrCpy $0 $1
+
+  ${If} $0 == ""
+    StrCpy ${_out} 1
+  ${Else}
+    StrCpy $1 $0 1
+    ${If} $1 == "$$"
+      StrCpy ${_out} 1
+    ${Else}
+      StrLen $1 $0
+      ${If} $1 <= 3
+        StrCpy ${_out} 1
+      ${Else}
+        StrCpy $1 $0 1 1
+        ${If} $1 != ":"
+          StrCpy ${_out} 1
+        ${Else}
+          StrCpy $1 $0 1 2
+          ${If} $1 != "\"
+          ${AndIf} $1 != "/"
+            StrCpy ${_out} 1
+          ${EndIf}
+        ${EndIf}
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} ${_out} == 0
+    StrCpy $1 $0 "" 2
+    ${If} $1 == "\Users"
+    ${OrIf} $1 == "/Users"
+      StrCpy ${_out} 1
+    ${Else}
+      StrCpy $2 $1 7
+      ${If} $2 == "\Users\"
+      ${OrIf} $2 == "/Users/"
+        StrCpy $1 $1 "" 7
+        StrCpy $3 0
+        StrLen $2 $1
+        ${Do}
+          ${If} $3 >= $2
+            StrCpy ${_out} 1
+            ${Break}
+          ${EndIf}
+          StrCpy $2 $1 1 $3
+          ${If} $2 == "\"
+          ${OrIf} $2 == "/"
+            ${Break}
+          ${EndIf}
+          IntOp $3 $3 + 1
+          StrLen $2 $1
+        ${Loop}
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} ${_out} == 0
+    StrCpy $1 $0 "" -16
+    ${If} $1 == "\AppData\Roaming"
+      StrCpy ${_out} 1
+    ${EndIf}
+    StrCpy $1 $0 "" -14
+    ${If} $1 == "\AppData\Local"
+      StrCpy ${_out} 1
+    ${EndIf}
+    StrCpy $1 $0 "" -8
+    ${If} $1 == "\AppData"
+      StrCpy ${_out} 1
+    ${EndIf}
+    StrCpy $1 $0 "" -19
+    ${If} $1 == "\AppData\Local\Orca"
+      StrCpy ${_out} 1
+    ${EndIf}
+    StrCpy $1 $0 "" -21
+    ${If} $1 == "\AppData\Roaming\Orca"
+      StrCpy ${_out} 1
+    ${EndIf}
+  ${EndIf}
+
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+!macroend
+
+!macro nsisUpgradeParseUninstallExe _value _outExe
+  Push $0
+  Push $1
+  Push $2
+  Push $3
+  StrCpy $0 ${_value}
+  StrCpy ${_outExe} ""
+  StrCpy $1 $0 1
+  ${If} $1 == '"'
+    StrCpy $2 1
+    ${Do}
+      StrCpy $1 $0 1 $2
+      ${If} $1 == ""
+        ${Break}
+      ${EndIf}
+      ${If} $1 == '"'
+        IntOp $3 $2 - 1
+        StrCpy ${_outExe} $0 $3 1
+        ${Break}
+      ${EndIf}
+      IntOp $2 $2 + 1
+    ${Loop}
+  ${Else}
+    StrCpy $2 0
+    StrLen $3 $0
+    ${Do}
+      ${If} $2 >= $3
+        ${Break}
+      ${EndIf}
+      StrCpy $1 $0 4 $2
+      ${If} $1 == ".exe"
+      ${OrIf} $1 == ".EXE"
+        IntOp $1 $2 + 4
+        StrCpy ${_outExe} $0 $1
+        ${Break}
+      ${EndIf}
+      IntOp $2 $2 + 1
+    ${Loop}
+  ${EndIf}
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+!macroend
+
+!macro nsisUpgradeParentDir _file _out
+  Push $0
+  Push $1
+  StrLen $0 ${_file}
+  StrCpy ${_out} ""
+  ${Do}
+    ${If} $0 == 0
+      ${Break}
+    ${EndIf}
+    IntOp $0 $0 - 1
+    StrCpy $1 ${_file} 1 $0
+    ${If} $1 == "\"
+    ${OrIf} $1 == "/"
+      StrCpy ${_out} ${_file} $0
+      ${Break}
+    ${EndIf}
+  ${Loop}
+  Pop $1
+  Pop $0
+!macroend
+
+!macro customInit
+  Push $R0
+  Push $R1
+  Push $R2
+  Push $R3
+  Push $R4
+  Push $R5
+  Push $R6
+  Push $R7
+
+  !insertmacro GetDParameter $R0
+  !insertmacro nsisUpgradeStateIsUnusable $R0 $R1
+
+  ReadRegStr $R7 HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation
+  ReadRegStr $R2 HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString
+  !insertmacro nsisUpgradeParseUninstallExe $R2 $R3
+  StrCpy $R4 ""
+  ${If} $R3 != ""
+    !insertmacro nsisUpgradeStateIsUnusable $R3 $R5
+    ${If} $R5 == 0
+    ${AndIf} ${FileExists} "$R3"
+      !insertmacro nsisUpgradeParentDir $R3 $R4
+      !insertmacro nsisUpgradeStateIsUnusable $R4 $R5
+      ${If} $R5 == 1
+        StrCpy $R4 ""
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R0 != ""
+  ${AndIf} $R1 == 0
+    StrCpy $INSTDIR $R0
+  ${Else}
+    ${If} $R0 != ""
+      StrCpy $INSTDIR $R7
+    ${EndIf}
+    !insertmacro nsisUpgradeStateIsUnusable $INSTDIR $R5
+    StrCpy $R6 0
+    ${If} $R5 == 0
+      ${If} ${FileExists} "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+        StrCpy $R6 1
+      ${ElseIf} $R4 != ""
+      ${AndIf} $INSTDIR == $R4
+        StrCpy $R6 1
+      ${EndIf}
+    ${EndIf}
+    ${If} $R6 == 0
+      ${If} $R4 != ""
+        StrCpy $INSTDIR $R4
+      ${Else}
+        StrCpy $INSTDIR "$LocalAppData\Programs\${APP_FILENAME}"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  StrLen $R5 $INSTDIR
+  ${Do}
+    ${If} $R5 == 0
+      ${Break}
+    ${EndIf}
+    IntOp $R5 $R5 - 1
+    StrCpy $R6 $INSTDIR 1 $R5
+    ${If} $R6 != "\"
+    ${AndIf} $R6 != "/"
+      IntOp $R5 $R5 + 1
+      StrCpy $INSTDIR $INSTDIR $R5
+      ${Break}
+    ${EndIf}
+  ${Loop}
+
+  StrCpy $R5 ""
+  StrCpy $R6 0
+  StrLen $R1 $INSTDIR
+  ${Do}
+    ${If} $R6 >= $R1
+      ${Break}
+    ${EndIf}
+    StrCpy $R1 $INSTDIR 1 $R6
+    ${If} $R1 == "/"
+      StrCpy $R1 "\"
+    ${EndIf}
+    StrCpy $R5 "$R5$R1"
+    IntOp $R6 $R6 + 1
+    StrLen $R1 $INSTDIR
+  ${Loop}
+  StrCpy $INSTDIR $R5
+
+  !insertmacro nsisUpgradeStateIsUnusable $INSTDIR $R5
+  ${If} $R5 == 1
+    ${If} $R4 != ""
+      StrCpy $INSTDIR $R4
+    ${Else}
+      StrCpy $INSTDIR "$LocalAppData\Programs\${APP_FILENAME}"
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R2 != ""
+  ${AndIf} $R4 == ""
+    DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString
+    DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" QuietUninstallString
+  ${EndIf}
+
+  ${If} $R4 != ""
+  ${AndIf} $R7 != $R4
+    WriteRegStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "$R4"
+  ${ElseIf} $R4 == ""
+  ${AndIf} $R0 == ""
+    !insertmacro nsisUpgradeStateIsUnusable $R7 $R5
+    ${If} $R5 == 1
+      !insertmacro nsisUpgradeStateIsUnusable $INSTDIR $R5
+      ${If} $R5 == 0
+        WriteRegStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "$INSTDIR"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  Pop $R7
+  Pop $R6
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Pop $R1
+  Pop $R0
+!macroend
+
+!macro customUnInstallCheck
+  ; Previous-uninstaller failure is not "app cannot be closed"; allow overwrite.
+  ClearErrors
+  StrCpy $R0 0
+!macroend

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,7 +1,7 @@
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..')
@@ -23,6 +23,12 @@ const {
 } = require('../packaged-runtime-node-modules.cjs')
 
 describe('electron-builder config', () => {
+  it('includes NSIS upgrade-state hooks before the packaged installer is built', () => {
+    expect(electronBuilderConfig.nsis.include).toBe(
+      resolve(REPO_ROOT, 'config/nsis/installer-hooks.nsh')
+    )
+  })
+
   it('keeps the packaged app identity aligned with local-build validation', () => {
     expect(electronBuilderConfig.appId).toBe(
       require('../../src/shared/local-build-compatibility-contract.json').appId

--- a/config/scripts/upgrade-install-state.test.mjs
+++ b/config/scripts/upgrade-install-state.test.mjs
@@ -1,0 +1,531 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  isCloseAppProcess,
+  isTooBroadInstallLocation,
+  isUnexpandedNsisValue,
+  mapPreviousUninstallerOutcome,
+  parseUninstallExecutable,
+  resolveNsisUpgradeState,
+  sanitizeInstallLocation,
+  shouldReportAppCannotBeClosed
+} from '../nsis/upgrade-install-state.mjs'
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..')
+const DEFAULT_DIR = 'C:\\Users\\a\\AppData\\Local\\Programs\\Orca'
+const UNINSTALL =
+  '"C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe" /currentuser'
+const SPACE_DIR = 'C:\\Users\\a\\AppData\\Local\\Programs\\Orca App'
+const SPACE_UNINSTALL = `"${SPACE_DIR}\\Uninstall Orca.exe" /currentuser`
+const CUSTOM_DIR = 'D:\\Apps\\Orca'
+const CUSTOM_UNINSTALL = `"${CUSTOM_DIR}\\Uninstall Orca.exe" /currentuser`
+
+function existsAt(dirSet) {
+  const dirs = new Set(dirSet.map((value) => value.toLowerCase()))
+  return (dir) => dirs.has(String(dir).toLowerCase())
+}
+
+function existsExe(exeSet) {
+  const exes = new Set(exeSet.map((value) => value.toLowerCase()))
+  return (exe) => exes.has(String(exe).toLowerCase())
+}
+
+describe('NSIS upgrade persisted metadata', () => {
+  it('rejects the literal $installDir orphan and recovers from the uninstaller path', () => {
+    expect(isUnexpandedNsisValue('$installDir')).toBe(true)
+    expect(sanitizeInstallLocation('$installDir')).toBeNull()
+
+    const state = resolveNsisUpgradeState({
+      installLocation: '$installDir',
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([DEFAULT_DIR]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.recoveredFromUninstaller).toBe(true)
+    expect(state.runPreviousUninstaller).toBe(true)
+    expect(state.repairInstallLocation).toBe(true)
+    expect(state.installLocationToWrite).toBe(DEFAULT_DIR)
+    expect(state.discardUninstallString).toBe(false)
+  })
+
+  it('skips the previous uninstaller when UninstallString itself contains $installDir', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: '$installDir',
+      uninstallString: '"$installDir\\Uninstall Orca.exe" /currentuser',
+      defaultInstallDir: DEFAULT_DIR,
+      uninstallExecutableExists: () => false
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.runPreviousUninstaller).toBe(false)
+    expect(state.discardUninstallString).toBe(true)
+  })
+
+  it('does not treat a drive-root InstallLocation as $INSTDIR', () => {
+    expect(isTooBroadInstallLocation('C:\\')).toBe(true)
+    expect(sanitizeInstallLocation('C:\\')).toBeNull()
+
+    const state = resolveNsisUpgradeState({
+      installLocation: 'C:\\',
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([DEFAULT_DIR]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.recoveredFromUninstaller).toBe(true)
+  })
+
+  it('does not keep userData Local\\Orca as the install dir when it has no app exe', () => {
+    expect(sanitizeInstallLocation('C:\\Users\\a\\AppData\\Local\\Orca')).toBeNull()
+    expect(sanitizeInstallLocation('C:\\Users\\a\\AppData\\Roaming\\Orca')).toBeNull()
+
+    const state = resolveNsisUpgradeState({
+      installLocation: 'C:\\Users\\a\\AppData\\Local\\Orca',
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([DEFAULT_DIR]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.recoveredFromUninstaller).toBe(true)
+    expect(state.installLocationToWrite).toBe(DEFAULT_DIR)
+  })
+
+  it('rejects /D= or an uninstaller parent that is userData so _?= cannot target it', () => {
+    const userData = 'C:\\Users\\a\\AppData\\Local\\Orca'
+    const state = resolveNsisUpgradeState({
+      installLocation: userData,
+      uninstallString: `"${userData}\\Uninstall Orca.exe" /currentuser`,
+      defaultInstallDir: DEFAULT_DIR,
+      commandLineInstallDir: userData,
+      uninstallExecutableExists: existsExe([`${userData}\\Uninstall Orca.exe`])
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.runPreviousUninstaller).toBe(false)
+    expect(state.installLocationToWrite).toBe(DEFAULT_DIR)
+    expect(state.discardUninstallString).toBe(true)
+  })
+
+  it('honors a well-formed /D= override even when registry metadata is poisoned', () => {
+    const isolated = 'C:\\OrcaE2E'
+    const state = resolveNsisUpgradeState({
+      installLocation: '$installDir',
+      uninstallString: '"$installDir\\Uninstall Orca.exe" /currentuser',
+      defaultInstallDir: DEFAULT_DIR,
+      commandLineInstallDir: isolated
+    })
+
+    expect(state.instDir).toBe(isolated)
+    expect(state.runPreviousUninstaller).toBe(false)
+    expect(state.installLocationToWrite).toBeNull()
+  })
+
+  it('does not persist /D= over a valid previous InstallLocation', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: DEFAULT_DIR,
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      commandLineInstallDir: CUSTOM_DIR,
+      pathHasAppExecutable: existsAt([DEFAULT_DIR]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(state.instDir).toBe(CUSTOM_DIR)
+    expect(state.runPreviousUninstaller).toBe(true)
+    expect(state.installLocationToWrite).toBeNull()
+    expect(state.repairInstallLocation).toBe(false)
+  })
+
+  it('writes the recovered old dir, not /D=, when InstallLocation is poisoned', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: '$installDir',
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      commandLineInstallDir: CUSTOM_DIR,
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(state.instDir).toBe(CUSTOM_DIR)
+    expect(state.installLocationToWrite).toBe(DEFAULT_DIR)
+    expect(state.runPreviousUninstaller).toBe(true)
+  })
+
+  it('ignores a too-broad /D= and keeps a valid registry install dir', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: CUSTOM_DIR,
+      uninstallString: '',
+      defaultInstallDir: DEFAULT_DIR,
+      commandLineInstallDir: 'C:\\Users\\a\\AppData\\Local',
+      pathHasAppExecutable: existsAt([CUSTOM_DIR])
+    })
+
+    expect(state.instDir).toBe(CUSTOM_DIR)
+    expect(state.runPreviousUninstaller).toBe(false)
+  })
+
+  it('rejects a too-broad /D= and falls back to the default or uninstaller', () => {
+    expect(sanitizeInstallLocation('C:\\Users\\a\\AppData\\Local')).toBeNull()
+    expect(sanitizeInstallLocation('C:\\\\')).toBeNull()
+
+    const state = resolveNsisUpgradeState({
+      installLocation: '',
+      uninstallString: '',
+      defaultInstallDir: DEFAULT_DIR,
+      commandLineInstallDir: 'C:\\Users\\a\\AppData\\Local'
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+  })
+
+  it('keeps a valid existing install location', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: DEFAULT_DIR,
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([DEFAULT_DIR]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.runPreviousUninstaller).toBe(true)
+    expect(state.repairInstallLocation).toBe(false)
+    expect(state.installLocationToWrite).toBeNull()
+    expect(state.discardUninstallString).toBe(false)
+  })
+
+  it('recovers a custom install dir from a valid uninstaller when InstallLocation is poisoned', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: '$installDir',
+      uninstallString: CUSTOM_UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      uninstallExecutableExists: existsExe([`${CUSTOM_DIR}\\Uninstall Orca.exe`])
+    })
+
+    expect(state.instDir).toBe(CUSTOM_DIR)
+    expect(state.recoveredFromUninstaller).toBe(true)
+    expect(state.runPreviousUninstaller).toBe(true)
+    expect(state.installLocationToWrite).toBe(CUSTOM_DIR)
+    expect(state.discardUninstallString).toBe(false)
+  })
+
+  it('rejects relative and unquoted-garbage InstallLocation values', () => {
+    expect(sanitizeInstallLocation('Programs\\Orca')).toBeNull()
+    expect(sanitizeInstallLocation('\\\\server\\share\\Orca')).toBeNull()
+    expect(sanitizeInstallLocation('"C:\\Users\\a\\AppData\\Local\\Programs\\Orca"')).toBeNull()
+    expect(sanitizeInstallLocation('C:Orca')).toBeNull()
+    expect(sanitizeInstallLocation('C:/Users/a/AppData/Local')).toBeNull()
+  })
+
+  it('strips trailing slashes so close-app prefix matching stays exact', () => {
+    expect(sanitizeInstallLocation(`${DEFAULT_DIR}\\`)).toBe(DEFAULT_DIR)
+    expect(sanitizeInstallLocation(`${SPACE_DIR}\\\\`)).toBe(SPACE_DIR)
+  })
+
+  it('preserves a path that contains spaces', () => {
+    expect(sanitizeInstallLocation(SPACE_DIR)).toBe(SPACE_DIR)
+    expect(parseUninstallExecutable(SPACE_UNINSTALL)).toBe(`${SPACE_DIR}\\Uninstall Orca.exe`)
+
+    const state = resolveNsisUpgradeState({
+      installLocation: SPACE_DIR,
+      uninstallString: SPACE_UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([SPACE_DIR]),
+      uninstallExecutableExists: existsExe([`${SPACE_DIR}\\Uninstall Orca.exe`])
+    })
+
+    expect(state.instDir).toBe(SPACE_DIR)
+    expect(state.runPreviousUninstaller).toBe(true)
+    expect(state.discardUninstallString).toBe(false)
+  })
+
+  it('parses quoted and unquoted UninstallString values', () => {
+    expect(parseUninstallExecutable(UNINSTALL)).toBe(
+      'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+    )
+    expect(
+      parseUninstallExecutable('C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall.exe /S')
+    ).toBe('C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall.exe')
+    expect(parseUninstallExecutable('"$installDir\\Uninstall Orca.exe" /currentuser')).toBe(
+      '$installDir\\Uninstall Orca.exe'
+    )
+    expect(parseUninstallExecutable('')).toBeNull()
+    expect(parseUninstallExecutable('/currentuser')).toBeNull()
+  })
+
+  it('is idempotent after a successful repair', () => {
+    const repaired = resolveNsisUpgradeState({
+      installLocation: '$installDir',
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([DEFAULT_DIR]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    const again = resolveNsisUpgradeState({
+      installLocation: repaired.instDir,
+      uninstallString: UNINSTALL,
+      defaultInstallDir: DEFAULT_DIR,
+      pathHasAppExecutable: existsAt([repaired.instDir]),
+      uninstallExecutableExists: existsExe([
+        'C:\\Users\\a\\AppData\\Local\\Programs\\Orca\\Uninstall Orca.exe'
+      ])
+    })
+
+    expect(again.instDir).toBe(DEFAULT_DIR)
+    expect(again.repairInstallLocation).toBe(false)
+    expect(again.installLocationToWrite).toBeNull()
+    expect(again.discardUninstallString).toBe(false)
+    expect(again.runPreviousUninstaller).toBe(true)
+    expect(again.recoveredFromUninstaller).toBe(false)
+  })
+
+  it('uses the per-user default on a clean install with empty registry metadata', () => {
+    const state = resolveNsisUpgradeState({
+      installLocation: '',
+      uninstallString: '',
+      defaultInstallDir: DEFAULT_DIR
+    })
+
+    expect(state.instDir).toBe(DEFAULT_DIR)
+    expect(state.runPreviousUninstaller).toBe(false)
+    expect(state.discardUninstallString).toBe(false)
+    expect(state.installLocationToWrite).toBe(DEFAULT_DIR)
+    expect(state.recoveredFromUninstaller).toBe(false)
+  })
+})
+
+describe('NSIS close-app targeting', () => {
+  it('closes only Orca.exe under the sanitized install dir', () => {
+    expect(
+      isCloseAppProcess({
+        processPath: `${DEFAULT_DIR}\\Orca.exe`,
+        instDir: DEFAULT_DIR
+      })
+    ).toBe(true)
+    expect(
+      isCloseAppProcess({
+        processPath: `${DEFAULT_DIR}\\resources\\bin\\orca.exe`,
+        instDir: DEFAULT_DIR
+      })
+    ).toBe(true)
+    expect(
+      isCloseAppProcess({
+        processPath: 'C:\\Users\\a\\AppData\\Local\\Orca\\daemon-host\\orca-terminal-daemon.exe',
+        instDir: DEFAULT_DIR,
+        imageName: 'orca-terminal-daemon.exe'
+      })
+    ).toBe(false)
+    expect(
+      isCloseAppProcess({
+        processPath: 'C:\\Other\\Orca.exe',
+        instDir: DEFAULT_DIR
+      })
+    ).toBe(false)
+    expect(
+      isCloseAppProcess({
+        processPath: 'C:\\Windows\\explorer.exe',
+        instDir: 'C:\\'
+      })
+    ).toBe(false)
+    expect(
+      isCloseAppProcess({
+        processPath: `${DEFAULT_DIR}\\Orca.exe`,
+        instDir: '$installDir'
+      })
+    ).toBe(false)
+    expect(
+      isCloseAppProcess({
+        processPath: `${SPACE_DIR}\\Orca.exe`,
+        instDir: SPACE_DIR
+      })
+    ).toBe(true)
+  })
+
+  it('does not report cannot-close when the main exe is already gone', () => {
+    expect(
+      shouldReportAppCannotBeClosed({
+        remainingProcessPaths: [
+          'C:\\Users\\a\\AppData\\Local\\Orca\\daemon-host\\orca-terminal-daemon.exe'
+        ],
+        instDir: DEFAULT_DIR
+      })
+    ).toBe(false)
+    expect(
+      shouldReportAppCannotBeClosed({
+        remainingProcessPaths: [`${DEFAULT_DIR}\\Orca.exe`],
+        instDir: DEFAULT_DIR
+      })
+    ).toBe(true)
+    expect(
+      shouldReportAppCannotBeClosed({
+        remainingProcessPaths: [`${DEFAULT_DIR}\\Orca.exe`],
+        instDir: '$installDir'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('previous-uninstaller outcome', () => {
+  it('never maps a missing or failed old uninstaller to cannot-close', () => {
+    expect(
+      mapPreviousUninstallerOutcome({
+        ran: false,
+        exitCode: 2,
+        uninstallStringUsable: false
+      })
+    ).toEqual({ abortInstaller: false, reportCannotBeClosed: false })
+    expect(
+      mapPreviousUninstallerOutcome({
+        ran: true,
+        exitCode: 2,
+        uninstallStringUsable: true
+      })
+    ).toEqual({ abortInstaller: false, reportCannotBeClosed: false })
+    expect(
+      mapPreviousUninstallerOutcome({
+        ran: true,
+        exitCode: 0,
+        uninstallStringUsable: true
+      })
+    ).toEqual({ abortInstaller: false, reportCannotBeClosed: false })
+  })
+})
+
+describe('disposable filesystem upgrade fixtures', () => {
+  it('resolves real temp install and uninstaller files without touching the live install', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-nsis-upgrade-'))
+    try {
+      const installDir = join(root, 'Programs', 'Orca App')
+      const userData = join(root, 'Local', 'Orca')
+      await mkdir(installDir, { recursive: true })
+      await mkdir(userData, { recursive: true })
+      await writeFile(join(installDir, 'Orca.exe'), '', 'utf8')
+      await writeFile(join(installDir, 'Uninstall Orca.exe'), '', 'utf8')
+
+      const uninstallExe = join(installDir, 'Uninstall Orca.exe')
+      const state = resolveNsisUpgradeState({
+        installLocation: userData,
+        uninstallString: `"${uninstallExe}" /currentuser`,
+        defaultInstallDir: join(root, 'Programs', 'Orca'),
+        pathHasAppExecutable: (dir) => dir.toLowerCase() === installDir.toLowerCase(),
+        uninstallExecutableExists: (exe) => exe.toLowerCase() === uninstallExe.toLowerCase()
+      })
+
+      expect(state.instDir.toLowerCase()).toBe(installDir.toLowerCase())
+      expect(state.recoveredFromUninstaller).toBe(true)
+      expect(state.runPreviousUninstaller).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('disposable HKCU registry views', () => {
+  it.skipIf(process.platform !== 'win32')(
+    'sees the same disposable HKCU value in 32-bit and 64-bit views',
+    () => {
+      const key = 'HKCU\\Software\\OrcaNsisUpgradeReview-STA3956'
+      const value = 'C:\\Temp\\OrcaNsisDisposable'
+      try {
+        execFileSync('reg.exe', ['add', key, '/v', 'InstallLocation', '/t', 'REG_SZ', '/d', value, '/f'], {
+          stdio: 'pipe'
+        })
+        const query = (view) =>
+          execFileSync('reg.exe', ['query', key, '/v', 'InstallLocation', view], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe']
+          })
+        expect(query('/reg:32')).toContain(value)
+        expect(query('/reg:64')).toContain(value)
+      } finally {
+        try {
+          execFileSync('reg.exe', ['delete', key, '/f'], { stdio: 'pipe' })
+        } catch {
+          // Key is disposable; ignore a missing-key cleanup race.
+        }
+      }
+    }
+  )
+})
+
+describe('NSIS hook contract', () => {
+  it('ships customInit and uninstaller-check hooks that reject $installDir', async () => {
+    const nsh = await readFile(join(REPO_ROOT, 'config/nsis/upgrade-install-state.nsh'), 'utf8')
+    const hooks = await readFile(join(REPO_ROOT, 'config/nsis/installer-hooks.nsh'), 'utf8')
+
+    expect(hooks).toContain('!include "daemon-host-uninstall.nsh"')
+    expect(hooks).toContain('!include "upgrade-install-state.nsh"')
+    expect(hooks).not.toContain('!macro customCheckAppRunning')
+    expect(nsh).toContain('!macro customInit')
+    expect(nsh).not.toContain('!macro customCheckAppRunning')
+    expect(nsh).toContain('!macro customUnInstallCheck')
+    expect(nsh).toContain('!macro nsisUpgradeParseUninstallExe')
+    expect(nsh).toContain('!macro nsisUpgradeParentDir')
+    expect(nsh).toContain('!insertmacro nsisUpgradeParentDir $R3 $R4')
+    expect(nsh).toContain('StrCpy $INSTDIR $R4')
+    expect(nsh).toContain('ReadRegStr $R7 HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation')
+    expect(nsh).toContain('StrCpy $INSTDIR $R7')
+    expect(nsh).toContain('DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString')
+    expect(nsh).toContain('WriteRegStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "$R4"')
+    expect(nsh).toMatch(/\$1 == "\$\$"/)
+    expect(nsh).toContain('${FileExists} "$INSTDIR\\${APP_EXECUTABLE_FILENAME}"')
+    expect(nsh).toContain('${FileExists} "$R3"')
+    expect(nsh).toContain('StrCpy $INSTDIR $INSTDIR $R5')
+    expect(nsh).toContain('\\AppData\\Local')
+    expect(nsh).toContain('\\Users')
+    expect(nsh).toContain('StrCpy $1 $0 "" -19')
+    expect(nsh).toContain('\\AppData\\Local\\Orca')
+    expect(nsh).toContain('StrCpy $1 $0 "" -21')
+    expect(nsh).toContain('\\AppData\\Roaming\\Orca')
+    expect(nsh).not.toContain('MessageBox')
+    expect(nsh).not.toContain('StartsWith')
+    expect(nsh).not.toContain('HKLM')
+    expect(nsh).not.toContain('HKEY_LOCAL_MACHINE')
+
+    const builderConfig = await readFile(
+      join(REPO_ROOT, 'config/electron-builder.config.cjs'),
+      'utf8'
+    )
+    expect(builderConfig).toContain("resolve(__dirname, 'nsis', 'installer-hooks.nsh')")
+    expect(builderConfig).not.toMatch(
+      /include:\s*resolve\(__dirname,\s*'nsis',\s*'daemon-host-uninstall\.nsh'\)/
+    )
+  })
+
+  it('keeps real-uninstall daemon cleanup and uses only disposable test paths', async () => {
+    const daemon = await readFile(join(REPO_ROOT, 'config/nsis/daemon-host-uninstall.nsh'), 'utf8')
+    expect(daemon).toContain('!macro customUnInstall')
+    expect(daemon).not.toContain('!macro customCheckAppRunning')
+    expect(daemon).toContain('${isUpdated}')
+    expect(daemon).toContain('orca-terminal-daemon.exe')
+    expect(daemon).toContain('$LOCALAPPDATA\\Orca\\daemon-host')
+
+    const source = await readFile(new URL(import.meta.url), 'utf8')
+    expect(source).toContain('orca-nsis-upgrade-')
+    expect(source).toContain('tmpdir()')
+  })
+})


### PR DESCRIPTION
## ELI5

If an older Windows install left broken uninstall registry text (the literal `$installDir`), the next official installer thinks Orca is still running, says it cannot be closed, and then sits on Installing after it has already unpacked `7z-out` — because it is copying files to a fake path instead of Programs\Orca.

## What Changed

- `customInit` rejects unusable persisted `InstallLocation` / `UninstallString` / `/D=` (empty, `$…`, drive root, non-absolute, Users/AppData roots, and the `AppData\Local\Orca` userData leaf).
- Recovery order matches the decision spec: valid `/D=` → registry dir that has `Orca.exe` or equals the uninstaller parent → uninstaller parent → per-user Programs\Orca.
- Close-app stays on electron-builder's default `CHECK_APP_RUNNING` (retry + cannot-close). We do **not** ship `customCheckAppRunning`.
- `InstallLocation` is repaired only to a recovered *old* dir. `/D=` is never written there, because `uninstallOldVersion` passes that value to `_?=` unquoted.
- A missing/failed previous uninstaller is no longer mapped to “Orca cannot be closed”.
- Wired through `config/nsis/installer-hooks.nsh` (still includes the real-uninstall daemon cleanup).

## Why

STA-3956 / #13924 is an upgrade-only failure: clean machines install, previously installed machines with orphaned metadata hang after 7z-out and never create the real install directory. electron-builder’s default close-app / uninstallOldVersion / extract copy all reuse the `appCannotBeClosed` string for those metadata failures.

Published `3bf7a682` did not implement this contract (no uninstaller-parent recovery, weaker one-shot close-app, `/D=` persisted into `_?=`). This head replaces that implementation.

## Linked Issue

Fixes #13924
Linear: https://linear.app/stably/issue/STA-3956/bug-v14180-windows-nsis-installer-reports-orca-cannot-be-closed-and

## Visual Proof

N/A — installer/NSIS metadata path; no renderer UI.

## Testing

- [x] Decision spec: `$installDir`, empty, drive-root, userData `Local\Orca`, valid install, `/D=` override, `/D=` must not persist, uninstaller-parent recovery, quoting/spaces, idempotence, clean install.
- [x] Hook-contract test reads the `.nsh` files and builder include so a revert drops parent recovery or restores `customCheckAppRunning`.
- [x] oxlint on the new/changed JS.
- [ ] Full disposable NSIS install of the official ~721MB payload was not run here: this host has ~3.1 GB free and no packaged tree. CI `package (windows)` compiles the include.

- [x] Automated tests added/updated, or explained why not below

## Review

Windows-only installer hooks. No SSH/remote wire, Git, or renderer changes. `/D=` still wins when usable, the relocated daemon is still not killed on a normal update, and a real running `Orca.exe` in the sanitized dir still goes through default close-app.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter:
