### PR TITLE
fix(windows): restore fresh-profile startup after durable fsync

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -426,8 +426,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test Windows PowerShell CLI boundary
-        run: pnpm exec vitest run --config config/vitest.config.ts src/main/cli/wsl-cli-powershell-boundary.test.ts
+      - name: Test Windows-specific boundaries
+        run: >-
+          pnpm exec vitest run --config config/vitest.config.ts
+          src/main/cli/wsl-cli-powershell-boundary.test.ts
+          src/main/orca-profiles/profile-index-store.test.ts
+          src/shared/secure-file-fsync-flags.test.ts
 
       - name: Build package inputs
         run: pnpm run build:release

--- a/src/shared/secure-file-fsync-flags.test.ts
+++ b/src/shared/secure-file-fsync-flags.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const openedPaths = vi.hoisted(() => [] as { path: string; flags: string | number }[])
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    openSync: (path: NodeFs.PathLike, flags: string | number, mode?: NodeFs.Mode) => {
+      openedPaths.push({ path: String(path), flags })
+      return actual.openSync(path, flags, mode)
+    }
+  }
+})
+
+import { bestEffortFsyncDirectorySync, fsyncFileSync } from './secure-file'
+
+const createdPaths: string[] = []
+
+afterEach(() => {
+  openedPaths.length = 0
+  for (const path of createdPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true })
+  }
+})
+
+describe('secure file fsync flags', () => {
+  it('opens files read/write before fsync', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-file-fsync-'))
+    createdPaths.push(directory)
+    const path = join(directory, 'record.json')
+    writeFileSync(path, '{}')
+
+    fsyncFileSync(path)
+
+    expect(openedPaths).toEqual([{ path, flags: 'r+' }])
+  })
+
+  const posixIt = process.platform === 'win32' ? it.skip : it
+  posixIt('opens directories read-only before fsync', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-directory-fsync-'))
+    createdPaths.push(directory)
+
+    bestEffortFsyncDirectorySync(directory)
+
+    expect(openedPaths).toEqual([{ path: directory, flags: 'r' }])
+  })
+})

--- a/src/shared/secure-file.ts
+++ b/src/shared/secure-file.ts
@@ -133,8 +133,8 @@ export function writeSecureFile(
   }
 }
 
-export function fsyncFileSync(path: string): void {
-  const descriptor = openSync(path, 'r')
+function fsyncPathSync(path: string, flags: 'r' | 'r+'): void {
+  const descriptor = openSync(path, flags)
   try {
     fsyncSync(descriptor)
   } finally {
@@ -142,12 +142,17 @@ export function fsyncFileSync(path: string): void {
   }
 }
 
+export function fsyncFileSync(path: string): void {
+  // FlushFileBuffers requires a write-capable handle on Windows.
+  fsyncPathSync(path, 'r+')
+}
+
 export function bestEffortFsyncDirectorySync(directory: string): void {
   if (process.platform === 'win32') {
     return
   }
   try {
-    fsyncFileSync(directory)
+    fsyncPathSync(directory, 'r')
   } catch (error) {
     if (
       error instanceof Error &&


### PR DESCRIPTION
## Summary

- Open files with a write-capable handle before `fsync`, as required by Windows `FlushFileBuffers`.
- Keep directory fsync read-only on POSIX instead of applying the tempting but incorrect global `r` → `r+` replacement.
- Record the actual `openSync` flags while passing through to real syscalls, covering both file and directory invariants.
- Run fresh profile-index creation and the flag proof in Windows PR CI.

Fixes #14108.
Fixes #14130.

Introduced by #13796 and first shipped in v1.4.181.

## Root cause and impact

`writeProfileIndex` writes `orca-profile-index.json.tmp`, calls `fsyncFileSync`, and then renames it. The helper opened the file with `r`. Windows rejects `FlushFileBuffers` on that read-only handle, surfaced by Node as `EPERM`, so a missing or invalid profile index stopped startup before Orca created a window.

Existing profiles with a valid unchanged index skip the write, explaining why upgrades could appear healthy while first-time installs failed. The in-app updater initializes after this startup point, so affected users need a working full installer rather than an in-app recovery.

## Reproduction

Confirmed against the packaged v1.4.181 build on a Windows 11 Orca host using an isolated disposable user-data directory:

- `MainWindowHandle` remained `0`.
- `orca-profile-index.json` was absent.
- `orca-profile-index.json.tmp` remained.
- stderr reported `EPERM: operation not permitted, fsync` through `fsyncFileSync` → `writeProfileIndex` → `ensureActiveOrcaProfile`.
- Direct syscall probe: file opened with `r` → `EPERM`; file opened with `r+` → success.

The production profile and installed package were not modified during reproduction.

## Cross-platform guard

The helper is also used for directory fsync. A global `r+` change fixes Windows files but produces `EISDIR` when opening POSIX directories. The implementation therefore encodes the actual invariant:

- files: `r+`
- directories: `r`

The new regression test records these flags and delegates to the real filesystem calls, unlike the existing directory-fsync test whose directory descriptor is mocked.

## Community credit

This fix incorporates independent diagnosis and validation from:

- @OrcaWin — reported the complete Windows `FlushFileBuffers` diagnosis and fresh-profile reproduction in #14108.
- @DHTheOne — published and validated a working packaged-ASAR `r+` recovery in [#14130](https://github.com/stablyai/orca/issues/14130#issuecomment-5275076106).
- @PLUTONYY — reported the original clean-install failure and independently validated the source-level `r+` correction in [#14130](https://github.com/stablyai/orca/issues/14130#issuecomment-5275271311).
- @7loop — independently confirmed both the affected behavior and successful recovery in [#14130](https://github.com/stablyai/orca/issues/14130#issuecomment-5275283104).
- @brennanb2025 — caught the POSIX `EISDIR` trap in the naive global replacement and designed the real-syscall flag guard.

They are credited as co-authors on the commit using their verified GitHub identities.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/secure-file-fsync-flags.test.ts src/shared/secure-file.test.ts src/main/orca-profiles/profile-index-store.test.ts src/main/artifacts/artifact-recovery-directory-fsync.test.ts` — 28 passed
- `pnpm run typecheck:node`
- focused oxlint
- oxfmt check
- max-lines ratchet
- `git diff --check`

No UI, RPC, remote-wire, SSH, folder-workspace, or Git behavior changes.
