### PR TITLE
fix(terminal): keep bold distinct when font weight is 600+

### DIFF
--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
@@ -41,6 +41,12 @@ describe('buildPreviewAppearanceOptions', () => {
     expect(options.fontSize).toBe(14)
     expect(options.cursorBlink).toBe(true)
   })
+
+  it('does not assign the same face to regular and bold at weight 700', () => {
+    const options = buildPreviewAppearanceOptions({ ...SETTINGS, terminalFontWeight: 700 }, false)
+    expect(options.fontWeight).toBe(400)
+    expect(options.fontWeightBold).toBe(700)
+  })
 })
 
 describe('buildPreviewTerminalOptions', () => {

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
@@ -2,6 +2,7 @@ import type { ITerminalInitOnlyOptions, ITerminalOptions, ITheme } from '@xterm/
 import type { GlobalSettings } from '../../../../shared/types'
 import type { DashboardCardTerminalInput } from '../../../../shared/dashboard-snapshot'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
+import { probeTerminalFontFaces } from '@/lib/terminal-font-face-probe'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import {
   buildDefaultTerminalOptions,
@@ -19,10 +20,14 @@ export function buildPreviewAppearanceOptions(
   macOptionIsMeta: boolean
 ): Partial<ITerminalOptions> {
   const cursorStyle = settings?.terminalCursorStyle ?? 'block'
-  const fontWeights = resolveTerminalFontWeights(settings?.terminalFontWeight)
+  const fontFamily = buildFontFamily(settings?.terminalFontFamily ?? '')
+  const fontWeights = resolveTerminalFontWeights(
+    settings?.terminalFontWeight,
+    probeTerminalFontFaces(fontFamily)
+  )
   return {
     fontSize: settings?.terminalFontSize ?? 14,
-    fontFamily: buildFontFamily(settings?.terminalFontFamily ?? ''),
+    fontFamily,
     fontWeight: fontWeights.fontWeight,
     fontWeightBold: fontWeights.fontWeightBold,
     cursorStyle,

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -134,9 +134,13 @@ vi.mock('@/lib/terminal-theme', () => ({
   })
 }))
 
-vi.mock('../../../../shared/terminal-fonts', () => ({
-  resolveTerminalFontWeights: () => ({ fontWeight: 500, fontWeightBold: 700 })
-}))
+vi.mock('../../../../shared/terminal-fonts', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    resolveTerminalFontWeights: () => ({ fontWeight: 500, fontWeightBold: 700 })
+  }
+})
 
 vi.mock('../../../../shared/terminal-ligatures', () => ({
   resolveTerminalLigaturesEnabled: () => mockLigaturesAddon.enabled

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -10,6 +10,7 @@ import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-
 import { clampNumber, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
+import { probeTerminalFontFaces } from '@/lib/terminal-font-face-probe'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { PREVIEW_BUFFER } from './terminal-preview-content'
@@ -117,7 +118,10 @@ export function TerminalSettingsPreview({
     if (!container) {
       return
     }
-    const weights = resolveTerminalFontWeights(settings.terminalFontWeight)
+    const weights = resolveTerminalFontWeights(
+      settings.terminalFontWeight,
+      probeTerminalFontFaces(buildFontFamily(effectiveFontFamily))
+    )
     skipInitialOptionMutationRef.current = true
     skipInitialThemeRewriteRef.current = true
     // Why: DOM renderer only — WebGL contexts are scarce and multiple previews can mount at once.
@@ -171,7 +175,10 @@ export function TerminalSettingsPreview({
       skipInitialOptionMutationRef.current = false
       return
     }
-    const weights = resolveTerminalFontWeights(settings.terminalFontWeight)
+    const weights = resolveTerminalFontWeights(
+      settings.terminalFontWeight,
+      probeTerminalFontFaces(buildFontFamily(effectiveFontFamily))
+    )
     terminal.options.fontSize = settings.terminalFontSize
     terminal.options.fontFamily = buildFontFamily(effectiveFontFamily)
     terminal.options.fontWeight = weights.fontWeight

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -2,6 +2,7 @@ import type { ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
+import { probeTerminalFontFaces } from '@/lib/terminal-font-face-probe'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import {
   getBuiltinTheme,
@@ -150,7 +151,11 @@ export function applyTerminalAppearance(
   publishTerminalViewAttributes(theme, appearance.mode, settings)
   const paneBackground = theme?.background ?? '#000000'
 
-  const terminalFontWeights = resolveTerminalFontWeights(settings.terminalFontWeight)
+  const fontFamily = buildFontFamily(settings.terminalFontFamily)
+  const terminalFontWeights = resolveTerminalFontWeights(
+    settings.terminalFontWeight,
+    probeTerminalFontFaces(fontFamily)
+  )
   const ligaturesEnabled = resolveTerminalLigaturesEnabled(
     settings.terminalLigatures,
     settings.terminalFontFamily
@@ -181,7 +186,7 @@ export function applyTerminalAppearance(
     const paneSize = paneFontSizes.get(pane.id)
     const metricOptions = {
       fontSize: paneSize ?? settings.terminalFontSize,
-      fontFamily: buildFontFamily(settings.terminalFontFamily),
+      fontFamily,
       fontWeight: terminalFontWeights.fontWeight,
       fontWeightBold: terminalFontWeights.fontWeightBold,
       lineHeight: normalizeTerminalLineHeight(settings.terminalLineHeight)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -72,6 +72,7 @@ import type {
   SleepingAgentLaunchConfig
 } from '../../../../shared/agent-session-resume'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
+import { probeTerminalFontFaces } from '@/lib/terminal-font-face-probe'
 import {
   buildFontFamily,
   normalizeTerminalLayoutSnapshot,
@@ -1505,7 +1506,11 @@ export function useTerminalPaneLifecycle({
       onExternalPaneDrop,
       terminalOptions: () => {
         const currentSettings = settingsRef.current
-        const terminalFontWeights = resolveTerminalFontWeights(currentSettings?.terminalFontWeight)
+        const fontFamily = buildFontFamily(currentSettings?.terminalFontFamily ?? '')
+        const terminalFontWeights = resolveTerminalFontWeights(
+          currentSettings?.terminalFontWeight,
+          probeTerminalFontFaces(fontFamily)
+        )
         const cursorStyle = currentSettings?.terminalCursorStyle ?? 'block'
         const storeState = useAppStore.getState()
         const currentTab = storeState.tabsByWorktree[worktreeId]?.find(
@@ -1534,7 +1539,7 @@ export function useTerminalPaneLifecycle({
           ...windowsPtyCompatibilityOptions,
           ...keyboardProtocolOptions,
           fontSize: currentSettings?.terminalFontSize ?? 14,
-          fontFamily: buildFontFamily(currentSettings?.terminalFontFamily ?? ''),
+          fontFamily,
           fontWeight: terminalFontWeights.fontWeight,
           fontWeightBold: terminalFontWeights.fontWeightBold,
           scrollback: normalizeDesktopTerminalScrollbackRows(

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -96,6 +96,12 @@ describe('buildDefaultTerminalOptions', () => {
     expect(buildDefaultTerminalOptions().scrollback).toBe(5_000)
   })
 
+  it('keeps default regular and bold weights on distinct faces', () => {
+    const options = buildDefaultTerminalOptions()
+    expect(options.fontWeight).toBe(500)
+    expect(options.fontWeightBold).toBe(700)
+  })
+
   it('slightly increases default terminal wheel scrolling while preserving fast scroll', () => {
     const options = buildDefaultTerminalOptions()
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -1,6 +1,10 @@
 import type { ITerminalOptions } from '@xterm/xterm'
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../../../shared/terminal-scrollback-policy'
 import { LIGHT_BG_MIN_CONTRAST } from '@/lib/terminal-contrast-correction'
+import {
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  resolveTerminalFontWeights
+} from '../../../../shared/terminal-fonts'
 
 type TerminalCursorStyle = NonNullable<ITerminalOptions['cursorStyle']>
 type TerminalCursorInactiveStyle = NonNullable<ITerminalOptions['cursorInactiveStyle']>
@@ -30,6 +34,7 @@ export function resolveTerminalCursorInactiveStyle(
 
 export function buildDefaultTerminalOptions(): ITerminalOptions {
   const cursorStyle: TerminalCursorStyle = 'block'
+  const defaultFontWeights = resolveTerminalFontWeights(DEFAULT_TERMINAL_FONT_WEIGHT)
 
   return {
     allowProposedApi: true,
@@ -40,8 +45,8 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     // Cross-platform fallback chain; keep in sync with FALLBACK_FONTS in layout-serialization.ts.
     fontFamily:
       '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace',
-    fontWeight: '300',
-    fontWeightBold: '500',
+    fontWeight: defaultFontWeights.fontWeight,
+    fontWeightBold: defaultFontWeights.fontWeightBold,
     scrollback: DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,
     // Why: Orca's default terminal cells are taller than many users' baseline
     // terminal, so a small multiplier keeps row-per-wheel movement familiar.

--- a/src/renderer/src/lib/terminal-font-face-probe.test.ts
+++ b/src/renderer/src/lib/terminal-font-face-probe.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { clearTerminalFontFaceProbeCache, probeTerminalFontFaces } from './terminal-font-face-probe'
+
+afterEach(() => {
+  clearTerminalFontFaceProbeCache()
+  vi.unstubAllGlobals()
+})
+
+describe('probeTerminalFontFaces', () => {
+  it('returns no faces when canvas rasters are empty', () => {
+    expect(probeTerminalFontFaces('Menlo')).toEqual([])
+  })
+
+  it('clusters two-state canvas rasters into regular and bold faces', () => {
+    vi.stubGlobal('document', {
+      createElement: () => {
+        let currentWeight = 400
+        return {
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            fillStyle: '',
+            textBaseline: '',
+            set font(value: string) {
+              currentWeight = Number(String(value).split(' ')[0])
+            },
+            fillRect: () => undefined,
+            fillText: () => undefined,
+            measureText: () => ({ width: 354.0059 }),
+            getImageData: () => {
+              const ink = currentWeight < 600 ? 10 : 20
+              const data = new Uint8ClampedArray(ink * 4)
+              for (let index = 0; index < data.length; index += 4) {
+                data[index] = 255
+              }
+              return { data }
+            }
+          })
+        }
+      }
+    })
+
+    expect(probeTerminalFontFaces('"SF Mono", "Menlo", monospace')).toEqual([400, 700])
+  })
+})

--- a/src/renderer/src/lib/terminal-font-face-probe.ts
+++ b/src/renderer/src/lib/terminal-font-face-probe.ts
@@ -1,0 +1,79 @@
+import {
+  TERMINAL_FONT_WEIGHT_MAX,
+  TERMINAL_FONT_WEIGHT_MIN,
+  TERMINAL_FONT_WEIGHT_STEP,
+  clusterTerminalFontFaces,
+  type TerminalFontWeightRaster
+} from '../../../shared/terminal-fonts'
+
+const SAMPLE = '0123456789 abcdefghij'
+const SAMPLE_SIZE_PX = 28
+const faceCache = new Map<string, number[]>()
+
+function rasterizeTerminalFontWeight(
+  fontFamily: string,
+  weight: number
+): TerminalFontWeightRaster | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = 800
+  canvas.height = 80
+  const context = canvas.getContext('2d', { willReadFrequently: true })
+  if (!context) {
+    return null
+  }
+
+  context.fillStyle = '#000'
+  context.fillRect(0, 0, canvas.width, canvas.height)
+  context.fillStyle = '#fff'
+  context.font = `${weight} ${SAMPLE_SIZE_PX}px ${fontFamily}`
+  context.textBaseline = 'top'
+  context.fillText(SAMPLE, 8, 8)
+  const advance = context.measureText(SAMPLE).width
+  const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
+  let ink = 0
+  let sum = 0
+  for (let index = 0; index < pixels.length; index += 4) {
+    const value = pixels[index] ?? 0
+    if (value > 0) {
+      ink += 1
+      sum += value
+    }
+  }
+
+  return { weight, ink, sum, advance }
+}
+
+/** Distinct CSS weights the family can actually rasterize. Empty when unknown. */
+export function probeTerminalFontFaces(fontFamily: string): number[] {
+  const cached = faceCache.get(fontFamily)
+  if (cached) {
+    return cached
+  }
+
+  const rasters: TerminalFontWeightRaster[] = []
+  for (
+    let weight = TERMINAL_FONT_WEIGHT_MIN;
+    weight <= TERMINAL_FONT_WEIGHT_MAX;
+    weight += TERMINAL_FONT_WEIGHT_STEP
+  ) {
+    const raster = rasterizeTerminalFontWeight(fontFamily, weight)
+    if (raster) {
+      rasters.push(raster)
+    }
+  }
+
+  // Why: document.fonts.check() is a fallback oracle, not a presence test.
+  // One all-zero cluster (jsdom/happy-dom) is not a real face table.
+  const faces = rasters.some((raster) => raster.ink > 0) ? clusterTerminalFontFaces(rasters) : []
+  const usableFaces = faces.length >= 2 ? faces : []
+  faceCache.set(fontFamily, usableFaces)
+  return usableFaces
+}
+
+export function clearTerminalFontFaceProbeCache(): void {
+  faceCache.clear()
+}

--- a/src/shared/terminal-fonts.test.ts
+++ b/src/shared/terminal-fonts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_TERMINAL_FONT_WEIGHT,
+  clusterTerminalFontFaces,
   resolveTerminalFontWeights,
   normalizeTerminalFontWeight
 } from './terminal-fonts'
@@ -20,9 +21,77 @@ describe('terminal font weights', () => {
       fontWeight: 500,
       fontWeightBold: 700
     })
-    expect(resolveTerminalFontWeights(800)).toEqual({
-      fontWeight: 800,
-      fontWeightBold: 900
+  })
+
+  it('does not collapse regular and bold when the slider is already 600+', () => {
+    expect(resolveTerminalFontWeights(600)).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
     })
+    expect(resolveTerminalFontWeights(700)).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+    expect(resolveTerminalFontWeights(800)).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+    expect(resolveTerminalFontWeights(900)).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+  })
+
+  it('maps a two-face family so a requested bold weight still has a lighter regular', () => {
+    expect(resolveTerminalFontWeights(600, [400, 700])).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+    expect(resolveTerminalFontWeights(700, [400, 700])).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+    expect(resolveTerminalFontWeights(900, [400, 700])).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+  })
+
+  it('keeps a multi-face family at the requested weight when a heavier bold exists', () => {
+    const jetbrainsFaces = [100, 200, 300, 400, 500, 600, 700, 800]
+    expect(resolveTerminalFontWeights(500, jetbrainsFaces)).toEqual({
+      fontWeight: 500,
+      fontWeightBold: 700
+    })
+    expect(resolveTerminalFontWeights(600, jetbrainsFaces)).toEqual({
+      fontWeight: 600,
+      fontWeightBold: 800
+    })
+    expect(resolveTerminalFontWeights(800, jetbrainsFaces)).toEqual({
+      fontWeight: 700,
+      fontWeightBold: 800
+    })
+  })
+})
+
+describe('clusterTerminalFontFaces', () => {
+  it('reduces the measured two-state Menlo raster to regular and bold anchors', () => {
+    const regular = { ink: 3023, sum: 684988, advance: 354.0059 }
+    const bold = { ink: 3855, sum: 903760, advance: 354.0059 }
+    const faces = clusterTerminalFontFaces(
+      [300, 400, 500, 600, 700, 800, 900].map((weight) => ({
+        weight,
+        ...(weight < 600 ? regular : bold)
+      }))
+    )
+
+    expect(faces).toEqual([400, 700])
+    expect(resolveTerminalFontWeights(600, faces)).toEqual({
+      fontWeight: 400,
+      fontWeightBold: 700
+    })
+    expect(resolveTerminalFontWeights(700, faces).fontWeight).not.toBe(
+      resolveTerminalFontWeights(700, faces).fontWeightBold
+    )
   })
 })

--- a/src/shared/terminal-fonts.ts
+++ b/src/shared/terminal-fonts.ts
@@ -3,6 +3,14 @@ export const TERMINAL_FONT_WEIGHT_MIN = 100
 export const TERMINAL_FONT_WEIGHT_MAX = 900
 export const TERMINAL_FONT_WEIGHT_STEP = 100
 const DEFAULT_TERMINAL_FONT_WEIGHT_BOLD = 700
+const FALLBACK_REGULAR_FACE = 400
+
+export type TerminalFontWeightRaster = {
+  weight: number
+  ink: number
+  sum: number
+  advance: number
+}
 
 export function normalizeTerminalFontWeight(fontWeight: number | null | undefined): number {
   const numericFontWeight = typeof fontWeight === 'number' ? fontWeight : Number.NaN
@@ -17,17 +25,99 @@ export function normalizeTerminalFontWeight(fontWeight: number | null | undefine
   )
 }
 
-export function resolveTerminalFontWeights(fontWeight: number | null | undefined): {
+function uniqueSortedFaces(faces: readonly number[]): number[] {
+  return [
+    ...new Set(
+      faces.map((face) => normalizeTerminalFontWeight(face)).filter((face) => Number.isFinite(face))
+    )
+  ].sort((left, right) => left - right)
+}
+
+function nearestFace(target: number, faces: readonly number[]): number {
+  return faces.reduce((best, face) =>
+    Math.abs(face - target) < Math.abs(best - target) ? face : best
+  )
+}
+
+function pickClusterRepresentative(weights: readonly number[]): number {
+  if (weights.includes(FALLBACK_REGULAR_FACE)) {
+    return FALLBACK_REGULAR_FACE
+  }
+  if (weights.includes(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD)) {
+    return DEFAULT_TERMINAL_FONT_WEIGHT_BOLD
+  }
+  return Math.min(...weights)
+}
+
+/** Collapse identical rasters into the CSS weights that first produce each face. */
+export function clusterTerminalFontFaces(rasters: readonly TerminalFontWeightRaster[]): number[] {
+  const groups = new Map<string, number[]>()
+  for (const raster of rasters) {
+    if (!Number.isFinite(raster.weight) || !Number.isFinite(raster.ink)) {
+      continue
+    }
+    const key = `${raster.ink}:${raster.sum}:${raster.advance}`
+    const group = groups.get(key)
+    if (group) {
+      group.push(raster.weight)
+    } else {
+      groups.set(key, [raster.weight])
+    }
+  }
+
+  return [...groups.values()]
+    .map(pickClusterRepresentative)
+    .filter((weight) => Number.isFinite(weight))
+    .sort((left, right) => left - right)
+}
+
+function resolveAgainstAvailableFaces(
+  requested: number,
+  faces: readonly number[]
+): { fontWeight: number; fontWeightBold: number } {
+  const sorted = uniqueSortedFaces(faces)
+  if (sorted.length === 0) {
+    // Why: two-face families (Menlo, Consolas, Cascadia Mono) raster 600–900
+    // identically. Arithmetic +200 would pick a pair inside that one face.
+    if (requested >= DEFAULT_TERMINAL_FONT_WEIGHT_BOLD - 100) {
+      return {
+        fontWeight: FALLBACK_REGULAR_FACE,
+        fontWeightBold: DEFAULT_TERMINAL_FONT_WEIGHT_BOLD
+      }
+    }
+    return {
+      fontWeight: requested,
+      fontWeightBold: Math.min(
+        TERMINAL_FONT_WEIGHT_MAX,
+        Math.max(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD, requested + 200)
+      )
+    }
+  }
+
+  const onlyFace = sorted[0]
+  if (sorted.length === 1 && onlyFace !== undefined) {
+    return { fontWeight: onlyFace, fontWeightBold: onlyFace }
+  }
+
+  const regularCandidates = sorted.slice(0, -1)
+  const regular = nearestFace(requested, regularCandidates)
+  const heavier = sorted.filter((face) => face > regular)
+  const desiredBold = Math.min(
+    TERMINAL_FONT_WEIGHT_MAX,
+    Math.max(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD, requested + 200)
+  )
+  return {
+    fontWeight: regular,
+    fontWeightBold: nearestFace(desiredBold, heavier)
+  }
+}
+
+export function resolveTerminalFontWeights(
+  fontWeight: number | null | undefined,
+  availableFaces?: readonly number[]
+): {
   fontWeight: number
   fontWeightBold: number
 } {
-  const normalizedFontWeight = normalizeTerminalFontWeight(fontWeight)
-
-  return {
-    fontWeight: normalizedFontWeight,
-    fontWeightBold: Math.min(
-      TERMINAL_FONT_WEIGHT_MAX,
-      Math.max(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD, normalizedFontWeight + 200)
-    )
-  }
+  return resolveAgainstAvailableFaces(normalizeTerminalFontWeight(fontWeight), availableFaces ?? [])
 }


### PR DESCRIPTION
## ELI5

Turning the terminal Font Weight slider up used to make bold and regular text look the same on the default Mac font. Bold is now kept as a separate face whenever the font can still show one.

## What Changed

`resolveTerminalFontWeights` no longer derives bold as `max(700, weight + 200)`. It maps the requested weight onto the family's actual rasterized faces and, when the slider is already on the heavy face, steps regular down so bold stays distinct.

The renderer probes those faces by drawing sample glyphs (not `document.fonts.check()`, which reports fallbacks as present). Live panes, the settings preview, dashboard preview, and default xterm options all go through the same resolver.

## Why

On macOS the default family chain rasterizes as Menlo. Menlo only has two faces: regular (100–500) and bold (600–900). A configured weight of 600+ produced pairs like `{600, 800}` or `{700, 900}`, both of which paint as the same bold face. Four of the nine slider positions silently destroyed ANSI bold.

Multi-weight families still keep the requested regular weight when a heavier bold exists (for example 600 → `{600, 800}`).

## Linked Issue

Fixes https://linear.app/stably/issue/STA-4071/terminal-font-weight-600-silently-destroys-boldregular-distinction-on

## Visual Proof

Before (slider 700 → `{700, 900}`): regular and bold are the same heavy face.

After (slider 700 → `{400, 700}`): regular and bold stay distinct on the default family.

![sta-4071-default-family-before-after.png](https://github.com/user-attachments/assets/6d021cb8-d734-4f91-9887-406fc4aae846)

Settings surface with Font Weight at 700:

![sta-4071-settings-font-weight-700.png](https://github.com/user-attachments/assets/7a5aaf75-5a10-4866-9c84-dfbbdb948467)

## Testing

- Rasterized the default `"SF Mono", "Menlo", …` chain in a real Orca renderer on macOS. The chain matched Menlo; 100–500 were one face and 600–900 another. Old `{600, 800}` / `{700, 900}` pairs were byte-identical; new `{400, 700}` is distinct (ink 3375 vs 4205).
- New unit tests fail on the old arithmetic (`600` → `{600, 800}`) and pass on the face-aware resolver. Restored the old implementation temporarily to confirm the 4 failing tests.
- Exercised Appearance → Terminal Typography → Advanced with Font Weight 700 in the isolated Electron app via Playwright CDP.
- Not retested on Linux/Windows hardware this pass. Consolas / Cascadia Mono are two-face like Menlo, so the no-probe fallback (`600+` → `{400, 700}`) covers them. Multi-face families use the live probe.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter:
