### PR TITLE
fix(terminal): restore shell integration after startup exec

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -247,6 +247,7 @@ jobs:
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            src/relay/pty-shell-launch.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
   test:
@@ -283,6 +284,7 @@ jobs:
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
+            --exclude=src/relay/pty-shell-launch.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -181,6 +181,7 @@
           "assertions": [
             "local zsh and bash wrappers survive Fig-shaped exec replacements",
             "bash prompt rewrites are re-pinned before exec and temporary hooks are removed after normal startup",
+            "bash nounset, redirection-only exec, and failed-exec prompt-array paths preserve user shell state",
             "zsh exec targets and redirections expand against the user ZDOTDIR before wrapper re-entry",
             "zsh bare exec redirections and user exec functions retain native behavior"
           ]
@@ -199,8 +200,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.test.ts",
           "result": "passed",
-          "durationSeconds": 4.65,
-          "summary": "All 107 focused local, daemon, and relay assertions passed, including real zsh/bash exec restoration, command modifiers, ZDOTDIR expansion ordering, and DEBUG trap invocation preservation when the user enables functrace during startup."
+          "durationSeconds": 6.19,
+          "summary": "All 110 focused local, daemon, and relay assertions passed, including real zsh/bash exec restoration, command modifiers, ZDOTDIR expansion ordering, nounset and prompt-array cleanup, redirection-only exec behavior, and DEBUG trap invocation preservation when the user enables functrace during startup."
         }
       ],
       "runtimeBudget": {
@@ -213,7 +214,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "PR head 05c0ac91dd1 failed the exact exec \"$ZDOTDIR/zsh-replacement\" oracle with status 127 after expanding the target inside Orca's wrapper directory. The just-in-time shim candidate passed that oracle plus all 107 focused assertions. The pre-fix Bash guard reported USER_DEBUG_NESTED=0 after a profile enabled functrace; the reviewed guard reports USER_DEBUG_NESTED=1 while keeping the ordinary non-functrace trap unmultiplied. The existing #13767 red/green evidence independently proves the original replacement-shell readiness failure."
+        "evidence": "PR head 05c0ac91dd1 failed the exact exec \"$ZDOTDIR/zsh-replacement\" oracle with status 127 after expanding the target inside Orca's wrapper directory. The just-in-time shim candidate passed that oracle. The pre-fix Bash guard reported USER_DEBUG_NESTED=0 after a profile enabled functrace; the reviewed guard reports USER_DEBUG_NESTED=1 while keeping the ordinary non-functrace trap unmultiplied. Exact head 205e63e4338 armed prompt hooks for redirection-only exec, failed with an unbound PROMPT_COMMAND under nounset, and ran a trailing prompt-array element five times; the reviewed candidate keeps the bridge unarmed, restores the replacement hooks, and runs each array element once. All 110 focused assertions pass. The existing #13767 red/green evidence independently proves the original replacement-shell readiness failure."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -142,6 +142,97 @@
       "demotionRule": "Keep experimental or demote if prompt fallback enters a normal, child, or line-init read; a non-shell executable triggers prompt fallback; the identified shell PID is not foreground; delivery duplicates; ordinary startup output spawns probes; probe attempts exceed four; or the focused gate flakes without an identified harness defect."
     },
     {
+      "id": "terminal-session.shell-ready-exec-integration-restoration",
+      "title": "Exec-replaced shells retain Orca prompt instrumentation",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-session-readiness",
+      "layer": "posix-shell-startup",
+      "surfaces": ["OSC 133 command lifecycle", "queued terminal startup commands"],
+      "platforms": ["macos", "linux"],
+      "providers": ["local", "local-daemon", "ssh-daemon", "ssh-relay", "paired-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "local-daemon", "ssh-relay"],
+      "coverageNotes": "Real macOS zsh and bash subprocesses execute Fig/Kiro-shaped replacements from .zshenv, .zprofile, and .bash_profile. Local, daemon, and relay wrappers prove re-entry, readiness, OSC 133 where that wrapper already provides it, leading environment assignments, exec -a, noglob/time modifiers, prompt rewrites, ZDOTDIR-dependent target/redirection expansion, user exec functions, and temporary-hook cleanup. Existing WSL and non-ASCII ZDOTDIR contracts exercise the shared zsh templates; live Linux, WSL, SSH-daemon, and paired-runtime evidence remains uncollected.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4084/restore-osc-133-shell-integration-when-an-exec-in-user-rc-files-strips",
+        "https://github.com/stablyai/orca/issues/13767"
+      ],
+      "invariant": "When a supported startup file replaces zsh or bash with exec, the replacement shell re-enters Orca's established prompt instrumentation before its first usable prompt, preserving shell readiness, exactly-once startup-command delivery, and the wrapper's OSC 133 lifecycle contract.",
+      "oracle": "Launch real generated wrappers with disposable HOME directories whose startup files execute Fig/Kiro-shaped replacement shells. Require the queued command exactly once, an authoritative ready state, restored zsh precmd or bash PROMPT_COMMAND hooks, OSC 133 C output where supported, preserved leading environment assignments, user-ZDOTDIR expansion for exec targets/redirections, and no leaked temporary startup trap after non-replacing startup.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.test.ts"
+      ],
+      "testFiles": [
+        "src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts",
+        "src/main/providers/local-pty-shell-ready.test.ts",
+        "src/relay/pty-shell-launch.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts",
+          "assertions": [
+            "real zsh and bash replacement shells restore instrumentation and receive the queued command exactly once",
+            "same-shell and child-process silent reads still retain queued input"
+          ]
+        },
+        {
+          "file": "src/main/providers/local-pty-shell-ready.test.ts",
+          "assertions": [
+            "local zsh and bash wrappers survive Fig-shaped exec replacements",
+            "bash prompt rewrites are re-pinned before exec and temporary hooks are removed after normal startup",
+            "zsh exec targets and redirections expand against the user ZDOTDIR before wrapper re-entry",
+            "zsh bare exec redirections and user exec functions retain native behavior"
+          ]
+        },
+        {
+          "file": "src/relay/pty-shell-launch.test.ts",
+          "assertions": [
+            "persistent relay zsh and bash wrappers restore their established readiness and prompt hooks after exec"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-12",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.test.ts",
+          "result": "passed",
+          "durationSeconds": 4.65,
+          "summary": "All 107 focused local, daemon, and relay assertions passed, including real zsh/bash exec restoration, command modifiers, ZDOTDIR expansion ordering, and DEBUG trap invocation preservation."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 10,
+        "scope": "focused real zsh/bash local, daemon, and relay wrapper contracts"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "Deterministic local macOS runs pass; CI and soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "PR head 05c0ac91dd1 failed the exact exec \"$ZDOTDIR/zsh-replacement\" oracle with status 127 after expanding the target inside Orca's wrapper directory. The just-in-time shim candidate passed that oracle plus all 107 focused assertions; the existing #13767 red/green evidence independently proves the original replacement-shell readiness failure."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The zsh DEBUG trap and just-in-time exec shim, plus the bash exported prompt bridge, exist only while startup files are sourced or until the replacement shell takes ownership. The change adds no polling, timers, subprocesses, listeners, network work, or unbounded state."
+      },
+      "promotionCriteria": [
+        "Collect live Linux, WSL, SSH-daemon, and paired-runtime evidence.",
+        "Collect 100 consecutive CI passes or 14 days of soak history without unexplained flakes.",
+        "Retain native exec redirection, user function authority, prompt-hook cleanup, and exactly-once delivery assertions."
+      ],
+      "knownGaps": [
+        "A third-party launcher that sanitizes exported shell state or bypasses supported shell startup and prompt hooks cannot inherit the restoration bridge.",
+        "A bash profile that replaces Orca's temporary DEBUG trap and later overwrites PROMPT_COMMAND before exec can still fall through to the existing safe prompt-readiness fallback.",
+        "Zsh startup code that explicitly bypasses functions with builtin exec retains the existing safe prompt-readiness fallback but cannot inherit restored OSC 133.",
+        "Native Windows PowerShell and cmd do not use these POSIX wrapper paths."
+      ],
+      "demotionRule": "Keep experimental or demote if an exec-replaced supported shell reaches its first usable prompt without the established Orca lifecycle, startup delivery duplicates, native exec behavior changes, temporary startup hooks leak after normal startup, or the focused oracle flakes without an identified harness defect."
+    },
+    {
       "id": "editor.restored-sibling-owner-reparent",
       "title": "Restored sibling tabs migrate filesystem authority before becoming editable",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -200,7 +200,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.test.ts",
           "result": "passed",
           "durationSeconds": 4.65,
-          "summary": "All 107 focused local, daemon, and relay assertions passed, including real zsh/bash exec restoration, command modifiers, ZDOTDIR expansion ordering, and DEBUG trap invocation preservation."
+          "summary": "All 107 focused local, daemon, and relay assertions passed, including real zsh/bash exec restoration, command modifiers, ZDOTDIR expansion ordering, and DEBUG trap invocation preservation when the user enables functrace during startup."
         }
       ],
       "runtimeBudget": {
@@ -213,7 +213,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "PR head 05c0ac91dd1 failed the exact exec \"$ZDOTDIR/zsh-replacement\" oracle with status 127 after expanding the target inside Orca's wrapper directory. The just-in-time shim candidate passed that oracle plus all 107 focused assertions; the existing #13767 red/green evidence independently proves the original replacement-shell readiness failure."
+        "evidence": "PR head 05c0ac91dd1 failed the exact exec \"$ZDOTDIR/zsh-replacement\" oracle with status 127 after expanding the target inside Orca's wrapper directory. The just-in-time shim candidate passed that oracle plus all 107 focused assertions. The pre-fix Bash guard reported USER_DEBUG_NESTED=0 after a profile enabled functrace; the reviewed guard reports USER_DEBUG_NESTED=1 while keeping the ordinary non-functrace trap unmultiplied. The existing #13767 red/green evidence independently proves the original replacement-shell readiness failure."
       },
       "performanceBudget": {
         "required": true,

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -12,6 +12,7 @@ const shellContractFiles = [
   'src/main/daemon/shell-ready.test.ts',
   'src/main/providers/local-pty-shell-ready.test.ts',
   'src/main/providers/__tests__/shell-ready-framework-example.test.ts',
+  'src/relay/pty-shell-launch.test.ts',
   'src/shared/posix-command-path-lookup.test.ts'
 ]
 const patchedNodePtyContractFiles = [

--- a/src/main/bash-startup-exec-preservation.ts
+++ b/src/main/bash-startup-exec-preservation.ts
@@ -63,6 +63,7 @@ __orca_install_exec_prompt_hooks() {
     unset PROMPT_COMMAND
     PROMPT_COMMAND="$_orca_exec_joined"
   fi
+  PROMPT_COMMAND="\${PROMPT_COMMAND:-}"
   PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_precmd;/}"
   PROMPT_COMMAND="\${PROMPT_COMMAND//;__orca_exec_osc133_precmd/}"
   PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_prompt_done;/}"
@@ -90,7 +91,10 @@ __orca_startup_command_is_exec() {
   local _orca_exec_command="$1" _orca_exec_char _orca_exec_previous
   local _orca_exec_word="" _orca_exec_quote="" _orca_exec_name=""
   local _orca_exec_index=0 _orca_exec_nested_parens=0 _orca_exec_nested_braces=0
-  local _orca_exec_modifier=0 _orca_exec_escaped=0
+  local _orca_exec_modifier=0 _orca_exec_escaped=0 _orca_exec_found=0
+  local _orca_exec_has_redirection=0 _orca_exec_skip_option_value=0
+  local _orca_exec_skip_redirection_target=0 _orca_exec_options_done=0
+  local _orca_exec_redirection_prefix=""
   while (( _orca_exec_index <= \${#_orca_exec_command} )); do
     if (( _orca_exec_index == \${#_orca_exec_command} )); then
       _orca_exec_char=" "
@@ -126,23 +130,62 @@ __orca_startup_command_is_exec() {
     elif [[ "$_orca_exec_char" == "{" && "$_orca_exec_previous" == "$" ]]; then
       _orca_exec_nested_braces=1
       _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    elif [[ "$_orca_exec_char" == "<" || "$_orca_exec_char" == ">" ]]; then
+      if (( !_orca_exec_has_redirection )); then
+        _orca_exec_redirection_prefix="$_orca_exec_word"
+        _orca_exec_has_redirection=1
+      fi
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
     elif [[ "$_orca_exec_char" == [[:space:]] ]]; then
       if [[ -n "$_orca_exec_word" ]]; then
-        if [[ "$_orca_exec_word" == "exec" ]]; then
-          return 0
+        if (( !_orca_exec_found && _orca_exec_has_redirection )) &&
+          [[ "$_orca_exec_redirection_prefix" == "exec" ]]; then
+          _orca_exec_found=1
+          _orca_exec_redirection_prefix=""
         fi
-        _orca_exec_name="\${_orca_exec_word%%=*}"
-        if (( !_orca_exec_modifier )) && [[ "$_orca_exec_word" == *=* &&
-          "$_orca_exec_name" == [a-zA-Z_]* && "$_orca_exec_name" != *[!a-zA-Z0-9_]* ]]; then
-          :
-        elif (( !_orca_exec_modifier )) && [[ "$_orca_exec_word" == "builtin" || "$_orca_exec_word" == "command" ]]; then
-          _orca_exec_modifier=1
-        elif (( _orca_exec_modifier )) && [[ "$_orca_exec_word" == -* ]]; then
-          :
+        if (( _orca_exec_found )); then
+          if (( _orca_exec_skip_redirection_target )); then
+            _orca_exec_skip_redirection_target=0
+          elif (( _orca_exec_has_redirection )); then
+            if [[ -n "$_orca_exec_redirection_prefix" &&
+              "$_orca_exec_redirection_prefix" == *[!0-9]* &&
+              ! "$_orca_exec_redirection_prefix" =~ ^[{][a-zA-Z_][a-zA-Z0-9_]*[}]$ ]]; then
+              return 0
+            fi
+            case "$_orca_exec_word" in
+              *">"|*"<"|*">&"|*"<&"|*"<<-"|*">|") _orca_exec_skip_redirection_target=1 ;;
+            esac
+          elif (( _orca_exec_skip_option_value )); then
+            _orca_exec_skip_option_value=0
+          elif (( _orca_exec_options_done )); then
+            return 0
+          else
+            case "$_orca_exec_word" in
+              -a) _orca_exec_skip_option_value=1 ;;
+              -c|-l|-cl|-lc) ;;
+              --) _orca_exec_options_done=1 ;;
+              -*) return 1 ;;
+              *) return 0 ;;
+            esac
+          fi
+        elif [[ "$_orca_exec_word" == "exec" ]]; then
+          _orca_exec_found=1
         else
-          return 1
+          _orca_exec_name="\${_orca_exec_word%%=*}"
+          if (( !_orca_exec_modifier )) && [[ "$_orca_exec_word" == *=* &&
+            "$_orca_exec_name" == [a-zA-Z_]* && "$_orca_exec_name" != *[!a-zA-Z0-9_]* ]]; then
+            :
+          elif (( !_orca_exec_modifier )) && [[ "$_orca_exec_word" == "builtin" || "$_orca_exec_word" == "command" ]]; then
+            _orca_exec_modifier=1
+          elif (( _orca_exec_modifier )) && [[ "$_orca_exec_word" == -* ]]; then
+            :
+          else
+            return 1
+          fi
         fi
         _orca_exec_word=""
+        _orca_exec_has_redirection=0
+        _orca_exec_redirection_prefix=""
       fi
     else
       _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
@@ -203,8 +246,10 @@ __orca_remove_exec_prompt_hooks() {
       [[ -n "$_orca_exec_prompt_part" ]] || continue
       _orca_exec_joined="\${_orca_exec_joined}\${_orca_exec_joined:+;}$_orca_exec_prompt_part"
     done
+    unset PROMPT_COMMAND
     PROMPT_COMMAND="$_orca_exec_joined"
   fi
+  PROMPT_COMMAND="\${PROMPT_COMMAND:-}"
   PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_precmd;/}"
   PROMPT_COMMAND="\${PROMPT_COMMAND//;__orca_exec_osc133_precmd/}"
   PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_prompt_done;/}"

--- a/src/main/bash-startup-exec-preservation.ts
+++ b/src/main/bash-startup-exec-preservation.ts
@@ -1,0 +1,254 @@
+// Preserves Bash prompt instrumentation when startup files replace the shell with exec.
+
+export function getBashStartupExecPreservationStart(escapedReadyMarker: string): string {
+  return `_orca_exec_prompt_hooks_installed=0
+__orca_exec_osc133_precmd() {
+  local exit_code=$?
+  __orca_exec_in_prompt_command=1
+  if [[ -n "\${__orca_exec_in_command:-}" ]]; then
+    printf "\\033]133;D;%s\\007" "$exit_code"
+    unset __orca_exec_in_command
+  fi
+  printf "\\033]133;A\\007"
+  [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]] && printf "${escapedReadyMarker}"
+}
+__orca_exec_osc133_preexec() {
+  if [[ -n "\${__orca_exec_chained_debug_trap:-}" ]]; then
+    eval "$__orca_exec_chained_debug_trap" || true
+  fi
+  [[ -z "\${__orca_exec_in_prompt_command:-}" ]] || return
+  [[ -z "\${__orca_exec_in_command:-}" ]] || return
+  case "$BASH_COMMAND" in *__orca_exec_osc133_*) return ;; esac
+  printf "\\033]133;C\\007"
+  __orca_exec_in_command=1
+}
+__orca_exec_osc133_prompt_done() {
+  local _orca_exec_debug_spec="$(trap -p DEBUG)"
+  case "$_orca_exec_debug_spec" in
+    ""|*__orca_exec_osc133_preexec*) __orca_exec_chained_debug_trap="" ;;
+    *)
+      _orca_exec_debug_spec="\${_orca_exec_debug_spec#trap -- }"
+      _orca_exec_debug_spec="\${_orca_exec_debug_spec% DEBUG}"
+      eval "__orca_exec_chained_debug_trap=$_orca_exec_debug_spec"
+      ;;
+  esac
+  trap '__orca_exec_osc133_preexec' DEBUG
+  unset __orca_exec_in_prompt_command
+  if [[ "\${_orca_exec_prompt_command_was_exported:-0}" != "1" ]]; then
+    export -nf __orca_exec_osc133_precmd __orca_exec_osc133_preexec __orca_exec_osc133_prompt_done
+    export -n PROMPT_COMMAND
+    unset _orca_exec_prompt_command_was_exported
+  fi
+}
+_orca_exec_precmd_body="$(declare -f __orca_exec_osc133_precmd)"
+_orca_exec_preexec_body="$(declare -f __orca_exec_osc133_preexec)"
+_orca_exec_prompt_done_body="$(declare -f __orca_exec_osc133_prompt_done)"
+export -f __orca_exec_osc133_precmd __orca_exec_osc133_preexec __orca_exec_osc133_prompt_done
+__orca_install_exec_prompt_hooks() {
+  local _orca_exec_joined="" _orca_exec_prompt_part
+  if [[ "\${_orca_exec_prompt_hooks_installed:-0}" != "1" ]]; then
+    _orca_exec_prompt_command_was_exported=0
+    _orca_exec_prompt_declaration="$(declare -p PROMPT_COMMAND 2>/dev/null)"
+    case "\${_orca_exec_prompt_declaration%% PROMPT_COMMAND=*}" in
+      *x*) _orca_exec_prompt_command_was_exported=1 ;;
+    esac
+    export _orca_exec_prompt_command_was_exported
+    _orca_exec_prompt_hooks_installed=1
+  fi
+  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+    for _orca_exec_prompt_part in "\${PROMPT_COMMAND[@]}"; do
+      [[ -n "$_orca_exec_prompt_part" ]] || continue
+      _orca_exec_joined="\${_orca_exec_joined}\${_orca_exec_joined:+;}$_orca_exec_prompt_part"
+    done
+    unset PROMPT_COMMAND
+    PROMPT_COMMAND="$_orca_exec_joined"
+  fi
+  PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_precmd;/}"
+  PROMPT_COMMAND="\${PROMPT_COMMAND//;__orca_exec_osc133_precmd/}"
+  PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_prompt_done;/}"
+  PROMPT_COMMAND="\${PROMPT_COMMAND//;__orca_exec_osc133_prompt_done/}"
+  [[ "$PROMPT_COMMAND" != "__orca_exec_osc133_precmd" ]] || PROMPT_COMMAND=""
+  [[ "$PROMPT_COMMAND" != "__orca_exec_osc133_prompt_done" ]] || PROMPT_COMMAND=""
+  PROMPT_COMMAND="__orca_exec_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}};__orca_exec_osc133_prompt_done"
+  export PROMPT_COMMAND
+}
+_orca_exec_install_body="$(declare -f __orca_install_exec_prompt_hooks)"
+_orca_exec_functrace_was_set=0
+shopt -qo functrace && _orca_exec_functrace_was_set=1
+_orca_exec_startup_debug_spec="$(builtin trap -p DEBUG)"
+_orca_exec_startup_debug_had_trap=0
+_orca_exec_startup_chained_debug_trap=""
+_orca_exec_user_enabled_functrace=0
+if [[ -n "$_orca_exec_startup_debug_spec" ]]; then
+  _orca_exec_startup_debug_had_trap=1
+  _orca_exec_startup_debug_spec="\${_orca_exec_startup_debug_spec#trap -- }"
+  _orca_exec_startup_debug_spec="\${_orca_exec_startup_debug_spec% DEBUG}"
+  eval "_orca_exec_startup_chained_debug_trap=$_orca_exec_startup_debug_spec"
+fi
+# Why: BASH_COMMAND is source text, so only a lexical command-prefix match may arm the bridge.
+__orca_startup_command_is_exec() {
+  local _orca_exec_command="$1" _orca_exec_char _orca_exec_previous
+  local _orca_exec_word="" _orca_exec_quote="" _orca_exec_name=""
+  local _orca_exec_index=0 _orca_exec_nested_parens=0 _orca_exec_nested_braces=0
+  local _orca_exec_modifier=0 _orca_exec_escaped=0
+  while (( _orca_exec_index <= \${#_orca_exec_command} )); do
+    if (( _orca_exec_index == \${#_orca_exec_command} )); then
+      _orca_exec_char=" "
+    else
+      _orca_exec_char="\${_orca_exec_command:_orca_exec_index:1}"
+    fi
+    if (( _orca_exec_escaped )); then
+      _orca_exec_escaped=0
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    elif [[ "$_orca_exec_char" == "\\\\" && "$_orca_exec_quote" != "'" ]]; then
+      _orca_exec_escaped=1
+    elif [[ -n "$_orca_exec_quote" ]]; then
+      if [[ "$_orca_exec_char" == "$_orca_exec_quote" ]]; then
+        _orca_exec_quote=""
+      else
+        _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+      fi
+    elif [[ "$_orca_exec_char" == "'" || "$_orca_exec_char" == '"' ||
+      "$_orca_exec_char" == $'\\x60' ]]; then
+      _orca_exec_quote="$_orca_exec_char"
+    elif (( _orca_exec_nested_parens > 0 )); then
+      [[ "$_orca_exec_char" != "(" ]] || (( _orca_exec_nested_parens++ ))
+      [[ "$_orca_exec_char" != ")" ]] || (( _orca_exec_nested_parens-- ))
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    elif (( _orca_exec_nested_braces > 0 )); then
+      [[ "$_orca_exec_char" != "{" ]] || (( _orca_exec_nested_braces++ ))
+      [[ "$_orca_exec_char" != "}" ]] || (( _orca_exec_nested_braces-- ))
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    elif [[ "$_orca_exec_char" == "(" &&
+      ( "$_orca_exec_previous" == "$" || "$_orca_exec_previous" == "<" || "$_orca_exec_previous" == ">" ) ]]; then
+      _orca_exec_nested_parens=1
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    elif [[ "$_orca_exec_char" == "{" && "$_orca_exec_previous" == "$" ]]; then
+      _orca_exec_nested_braces=1
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    elif [[ "$_orca_exec_char" == [[:space:]] ]]; then
+      if [[ -n "$_orca_exec_word" ]]; then
+        if [[ "$_orca_exec_word" == "exec" ]]; then
+          return 0
+        fi
+        _orca_exec_name="\${_orca_exec_word%%=*}"
+        if (( !_orca_exec_modifier )) && [[ "$_orca_exec_word" == *=* &&
+          "$_orca_exec_name" == [a-zA-Z_]* && "$_orca_exec_name" != *[!a-zA-Z0-9_]* ]]; then
+          :
+        elif (( !_orca_exec_modifier )) && [[ "$_orca_exec_word" == "builtin" || "$_orca_exec_word" == "command" ]]; then
+          _orca_exec_modifier=1
+        elif (( _orca_exec_modifier )) && [[ "$_orca_exec_word" == -* ]]; then
+          :
+        else
+          return 1
+        fi
+        _orca_exec_word=""
+      fi
+    else
+      _orca_exec_word="\${_orca_exec_word}$_orca_exec_char"
+    fi
+    _orca_exec_previous="$_orca_exec_char"
+    (( _orca_exec_index++ ))
+  done
+  return 1
+}
+_orca_exec_command_check_body="$(declare -f __orca_startup_command_is_exec)"
+__orca_preserve_startup_exec() {
+  local _orca_exec_command="$BASH_COMMAND"
+  if [[ -n "\${_orca_exec_startup_chained_debug_trap:-}" ]] &&
+    { [[ "\${_orca_exec_functrace_was_set:-0}" == "1" ]] || (( \${#FUNCNAME[@]} <= 1 )); }; then
+    eval "$_orca_exec_startup_chained_debug_trap" || true
+  fi
+  case "$_orca_exec_command" in
+    set[[:space:]]-T|set[[:space:]]-o[[:space:]]functrace) _orca_exec_user_enabled_functrace=1 ;;
+  esac
+  case "$_orca_exec_command" in
+    *exec*)
+      if __orca_startup_command_is_exec "$_orca_exec_command" && [[ "$(type -t exec)" == "builtin" ]]; then
+        __orca_install_exec_prompt_hooks
+      fi
+      ;;
+  esac
+}
+_orca_exec_startup_debug_body="$(declare -f __orca_preserve_startup_exec)"
+set -T
+builtin trap '__orca_preserve_startup_exec' DEBUG
+_orca_exec_startup_debug_installed=1`
+}
+
+export const BASH_STARTUP_EXEC_PRESERVATION_END = `if [[ "\${_orca_exec_startup_debug_installed:-0}" == "1" ]] &&
+  [[ "$(declare -f __orca_preserve_startup_exec)" == "\${_orca_exec_startup_debug_body-}" ]] &&
+  [[ "$(builtin trap -p DEBUG)" == *"__orca_preserve_startup_exec"* ]]; then
+  if [[ "\${_orca_exec_startup_debug_had_trap:-0}" == "1" ]]; then
+    builtin trap -- "\${_orca_exec_startup_chained_debug_trap-}" DEBUG
+  else
+    builtin trap - DEBUG
+  fi
+fi
+if [[ "\${_orca_exec_functrace_was_set:-0}" != "1" ]] &&
+  [[ "\${_orca_exec_user_enabled_functrace:-0}" != "1" ]]; then
+  set +T
+fi
+if [[ "$(declare -f __orca_preserve_startup_exec)" == "\${_orca_exec_startup_debug_body-}" ]]; then
+  unset -f __orca_preserve_startup_exec
+fi
+if [[ "$(declare -f __orca_startup_command_is_exec)" == "\${_orca_exec_command_check_body-}" ]]; then
+  unset -f __orca_startup_command_is_exec
+fi
+__orca_remove_exec_prompt_hooks() {
+  local _orca_exec_joined="" _orca_exec_prompt_part
+  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+    for _orca_exec_prompt_part in "\${PROMPT_COMMAND[@]}"; do
+      [[ -n "$_orca_exec_prompt_part" ]] || continue
+      _orca_exec_joined="\${_orca_exec_joined}\${_orca_exec_joined:+;}$_orca_exec_prompt_part"
+    done
+    PROMPT_COMMAND="$_orca_exec_joined"
+  fi
+  PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_precmd;/}"
+  PROMPT_COMMAND="\${PROMPT_COMMAND//;__orca_exec_osc133_precmd/}"
+  PROMPT_COMMAND="\${PROMPT_COMMAND//__orca_exec_osc133_prompt_done;/}"
+  PROMPT_COMMAND="\${PROMPT_COMMAND//;__orca_exec_osc133_prompt_done/}"
+  [[ "$PROMPT_COMMAND" != "__orca_exec_osc133_precmd" ]] || PROMPT_COMMAND=""
+  [[ "$PROMPT_COMMAND" != "__orca_exec_osc133_prompt_done" ]] || PROMPT_COMMAND=""
+}
+if [[ "\${_orca_exec_prompt_hooks_installed:-0}" == "1" ]]; then
+  __orca_remove_exec_prompt_hooks
+fi
+unset -f __orca_remove_exec_prompt_hooks
+if [[ "$(declare -f __orca_exec_osc133_precmd)" == "\${_orca_exec_precmd_body-}" ]]; then
+  export -nf __orca_exec_osc133_precmd
+  unset -f __orca_exec_osc133_precmd
+fi
+if [[ "$(declare -f __orca_exec_osc133_preexec)" == "\${_orca_exec_preexec_body-}" ]]; then
+  export -nf __orca_exec_osc133_preexec
+  unset -f __orca_exec_osc133_preexec
+fi
+if [[ "$(declare -f __orca_exec_osc133_prompt_done)" == "\${_orca_exec_prompt_done_body-}" ]]; then
+  export -nf __orca_exec_osc133_prompt_done
+  unset -f __orca_exec_osc133_prompt_done
+fi
+if [[ "$(declare -f __orca_install_exec_prompt_hooks)" == "\${_orca_exec_install_body-}" ]]; then
+  unset -f __orca_install_exec_prompt_hooks
+fi
+if [[ "\${_orca_exec_prompt_hooks_installed:-0}" == "1" ]] &&
+  [[ "\${_orca_exec_prompt_command_was_exported:-0}" != "1" ]]; then
+  export -n PROMPT_COMMAND
+fi
+unset _orca_exec_prompt_hooks_installed _orca_exec_prompt_command_was_exported _orca_exec_prompt_declaration
+unset _orca_exec_precmd_body _orca_exec_preexec_body _orca_exec_prompt_done_body _orca_exec_install_body
+unset _orca_exec_functrace_was_set _orca_exec_startup_debug_spec _orca_exec_startup_debug_had_trap
+unset _orca_exec_startup_chained_debug_trap _orca_exec_command_check_body _orca_exec_startup_debug_body _orca_exec_startup_debug_installed
+unset _orca_exec_user_enabled_functrace`
+
+export function getBashStartupProfileSourceBlock(escapedReadyMarker: string): string {
+  return `${getBashStartupExecPreservationStart(escapedReadyMarker)}
+[[ -f /etc/profile ]] && source /etc/profile
+if [[ -f "$HOME/.bash_profile" ]]; then
+  source "$HOME/.bash_profile"
+elif [[ -f "$HOME/.bash_login" ]]; then
+  source "$HOME/.bash_login"
+elif [[ -f "$HOME/.profile" ]]; then
+  source "$HOME/.profile"
+fi
+${BASH_STARTUP_EXEC_PRESERVATION_END}`
+}

--- a/src/main/bash-startup-exec-preservation.ts
+++ b/src/main/bash-startup-exec-preservation.ts
@@ -156,7 +156,8 @@ _orca_exec_command_check_body="$(declare -f __orca_startup_command_is_exec)"
 __orca_preserve_startup_exec() {
   local _orca_exec_command="$BASH_COMMAND"
   if [[ -n "\${_orca_exec_startup_chained_debug_trap:-}" ]] &&
-    { [[ "\${_orca_exec_functrace_was_set:-0}" == "1" ]] || (( \${#FUNCNAME[@]} <= 1 )); }; then
+    { [[ "\${_orca_exec_functrace_was_set:-0}" == "1" ||
+      "\${_orca_exec_user_enabled_functrace:-0}" == "1" ]] || (( \${#FUNCNAME[@]} <= 1 )); }; then
     eval "$_orca_exec_startup_chained_debug_trap" || true
   fi
   case "$_orca_exec_command" in

--- a/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
+++ b/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
@@ -19,6 +19,8 @@ type ShellFixture = {
   replacement: string
   command: string
   instrumentationOutput: string
+  restoresOsc133: boolean
+  preservesStartupText: boolean
   secretRead: string
   childRead: string
 }
@@ -28,9 +30,12 @@ const FIXTURES: ShellFixture[] = [
     name: 'zsh profile',
     shellPath: '/bin/zsh',
     startupFile: '.zprofile',
-    replacement: 'exec -a kiro-cli-term /bin/zsh -o noglobalrcs -l -i',
-    command: `printf 'ORCA_STARTUP_%s:PF=%s\\n' COMMAND_RAN "\${(j:,:)precmd_functions}"\r`,
-    instrumentationOutput: `${COMMAND_OUTPUT}:PF=`,
+    replacement:
+      'Q_START_TEXT=seed exec -a kiro-cli-term 3>/dev/null env /bin/zsh -o noglobalrcs -l -i',
+    command: `printf 'ORCA_STARTUP_%s:PF=%s:DEBUG_TRAP=%s:Q_START_TEXT=%s\\n' COMMAND_RAN "\${(j:,:)precmd_functions}" "\${+functions[TRAPDEBUG]}" "$Q_START_TEXT"\r`,
+    instrumentationOutput: `${COMMAND_OUTPUT}:PF=__orca_osc133_precmd`,
+    restoresOsc133: true,
+    preservesStartupText: true,
     secretRead: `: > "$HOME/${READ_STARTED_FILE}"; read -sk 1\n`,
     childRead: `/bin/zsh -fc ': > "$HOME/${READ_STARTED_FILE}"; read -sk 1'\n`
   },
@@ -39,8 +44,10 @@ const FIXTURES: ShellFixture[] = [
     shellPath: '/bin/zsh',
     startupFile: '.zshenv',
     replacement: 'exec /bin/zsh -o noglobalrcs -l -i',
-    command: `printf 'ORCA_STARTUP_%s:PF=%s\\n' COMMAND_RAN "\${(j:,:)precmd_functions}"\r`,
-    instrumentationOutput: `${COMMAND_OUTPUT}:PF=`,
+    command: `printf 'ORCA_STARTUP_%s:PF=%s:DEBUG_TRAP=%s\\n' COMMAND_RAN "\${(j:,:)precmd_functions}" "\${+functions[TRAPDEBUG]}"\r`,
+    instrumentationOutput: `${COMMAND_OUTPUT}:PF=__orca_osc133_precmd`,
+    restoresOsc133: true,
+    preservesStartupText: false,
     secretRead: `: > "$HOME/${READ_STARTED_FILE}"; read -sk 1\n`,
     childRead: `/bin/zsh -fc ': > "$HOME/${READ_STARTED_FILE}"; read -sk 1'\n`
   },
@@ -48,9 +55,11 @@ const FIXTURES: ShellFixture[] = [
     name: 'bash profile',
     shellPath: '/bin/bash',
     startupFile: '.bash_profile',
-    replacement: 'exec -a figterm-test /bin/bash --noprofile --norc -l -i',
-    command: `printf 'ORCA_STARTUP_%s:PC=%s\\n' COMMAND_RAN "$PROMPT_COMMAND"\r`,
-    instrumentationOutput: `${COMMAND_OUTPUT}:PC=`,
+    replacement: 'Q_START_TEXT=seed exec -a figterm-test /bin/bash --noprofile --norc -l -i',
+    command: `printf 'ORCA_STARTUP_%s:PC=%s:Q_START_TEXT=%s\\n' COMMAND_RAN "$PROMPT_COMMAND" "$Q_START_TEXT"\r`,
+    instrumentationOutput: `${COMMAND_OUTPUT}:PC=__orca_exec_osc133_precmd`,
+    restoresOsc133: true,
+    preservesStartupText: true,
     secretRead: `: > "$HOME/${READ_STARTED_FILE}"; read -s -n 1\n`,
     childRead: `/bin/bash --noprofile --norc -c ': > "$HOME/${READ_STARTED_FILE}"; read -s -n 1'\n`
   }
@@ -237,6 +246,7 @@ async function runExecOracle(fixture: ShellFixture): Promise<void> {
     fixture,
     `if [[ -z "\${ORCA_EXEC_REPRO_DONE:-}" ]]; then
   export ORCA_EXEC_REPRO_DONE=1
+  ${fixture.shellPath.endsWith('bash') ? `PROMPT_COMMAND='printf "USER_EXEC_PROMPT\\n"'` : ''}
   ${fixture.replacement}
 fi
 `
@@ -246,6 +256,18 @@ fi
     expect(running.session.shellState).toBe('ready')
     expect(count(running.output(), COMMAND_OUTPUT)).toBe(1)
     expect(running.output()).toContain(fixture.instrumentationOutput)
+    if (fixture.restoresOsc133) {
+      expect(running.output()).toContain('\x1b]133;C\x07')
+      if (fixture.shellPath.endsWith('zsh')) {
+        expect(running.output()).toContain('DEBUG_TRAP=0')
+      }
+    }
+    if (fixture.preservesStartupText) {
+      expect(running.output()).toContain('Q_START_TEXT=seed')
+    }
+    if (fixture.shellPath.endsWith('bash')) {
+      expect(running.output()).toContain('USER_EXEC_PROMPT')
+    }
     expect(running.output()).not.toContain('orca-shell-start')
   } finally {
     await running.cleanup()

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -11,6 +11,7 @@ import {
   isPowerShellExecutableName
 } from '../powershell-osc133-bootstrap'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
+import { getBashStartupProfileSourceBlock } from '../bash-startup-exec-preservation'
 import {
   getFishShellReadyInitCommand,
   getZshEnvTemplate,
@@ -90,14 +91,7 @@ function shellReadyWrappersExist(): boolean {
 export function getDaemonBashShellReadyRcfileContent(): string {
   return `# Orca daemon bash shell-ready wrapper
 ${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
-[[ -f /etc/profile ]] && source /etc/profile
-if [[ -f "$HOME/.bash_profile" ]]; then
-  source "$HOME/.bash_profile"
-elif [[ -f "$HOME/.bash_login" ]]; then
-  source "$HOME/.bash_login"
-elif [[ -f "$HOME/.profile" ]]; then
-  source "$HOME/.profile"
-fi
+${getBashStartupProfileSourceBlock(SHELL_READY_MARKER)}
 # Why: enable bracketed paste so Orca can deliver a multiline startup prompt as
 # a single literal paste (ESC[200~…ESC[201~); without it, older readline builds
 # treat each embedded newline as Enter and mangle the prompt into PS2

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -606,7 +606,7 @@ describePosix('local PTY shell-ready launch config', () => {
         'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
         '  export ORCA_EXEC_REPRO_DONE=1',
         '  PROMPT_COMMAND=\'printf "USER_EXEC_PROMPT\\n"\'',
-        '  Q_START_TEXT="local seed" exec -a figterm-test bash --noprofile --norc -l -i',
+        '  Q_START_TEXT="local seed" exec -a 3> /dev/null figterm-test bash --noprofile --norc -l -i',
         'fi',
         ''
       ].join('\n')
@@ -639,6 +639,73 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(output).not.toContain('LEAKprompt_done')
     expect(output).toContain('FUNCTRACE_OFF')
     expect(output).toContain('CHILD_TEMP_PC=unset')
+  })
+
+  itWithBash('does not arm bash exec hooks for redirection-only commands', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      [
+        'unset PROMPT_COMMAND',
+        'exec 3>"$HOME/startup-redirection"',
+        'printf "REDIRECTION_PC=%s:ARMED=%s\\n" "${PROMPT_COMMAND+set}" "$_orca_exec_prompt_hooks_installed"',
+        'exec 3>&-',
+        ''
+      ].join('\n')
+    )
+
+    const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
+
+    expect(output).toContain('REDIRECTION_PC=:ARMED=0')
+  })
+
+  itWithBash('survives nounset before an exec replacement without PROMPT_COMMAND', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      [
+        'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
+        '  export ORCA_EXEC_REPRO_DONE=1',
+        '  unset PROMPT_COMMAND',
+        '  set -u',
+        '  exec -a figterm-test bash --noprofile --norc -l -i',
+        'fi',
+        ''
+      ].join('\n')
+    )
+
+    const output = runInteractiveBashRcfile(
+      getBashShellReadyRcfileContent(),
+      userDataPath,
+      'printf \'NOUNSET_EXEC_PC=%s\\n\' "$PROMPT_COMMAND"\nexit 0\n'
+    )
+
+    expect(output).toContain('NOUNSET_EXEC_PC=__orca_exec_osc133_precmd')
+    expect(output).not.toContain('unbound variable')
+  })
+
+  itWithBash('flattens a prompt array replaced after a failed exec', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      [
+        'PROMPT_COMMAND=(\'printf "ARRAY_ZERO\\n"\' \'printf "ARRAY_ONE\\n"\')',
+        'shopt -s execfail',
+        'exec /orca-missing-replacement 2>/dev/null',
+        'PROMPT_COMMAND=(\'printf "ARRAY_ZERO\\n"\' \'printf "ARRAY_ONE\\n"\')',
+        ''
+      ].join('\n')
+    )
+
+    const output = runInteractiveBashRcfile(
+      getBashShellReadyRcfileContent(),
+      userDataPath,
+      'exit 0\n'
+    )
+
+    expect(output.split('ARRAY_ZERO')).toHaveLength(2)
+    expect(output.split('ARRAY_ONE')).toHaveLength(2)
+    expect(output).not.toContain('__orca_exec_osc133_precmd: command not found')
   })
 
   itWithBash('preserves user-enabled functrace and nested DEBUG trap behavior', async () => {

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -3,7 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
-import { mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync
+} from 'node:fs'
 import type * as pty from 'node-pty'
 import type * as LocalPtyShellReadyModule from './local-pty-shell-ready'
 import {
@@ -291,15 +299,19 @@ const describePosix = process.platform === 'win32' ? describe.skip : describe
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
 
-function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
+function runInteractiveBashRcfile(
+  rcfileContent: string,
+  tempDir: string,
+  input = 'true\nfalse\nexit 0\n'
+): string {
   const rcfile = join(tempDir, 'bash-osc133-rcfile')
   writeFileSync(rcfile, rcfileContent)
 
   const result = spawnSync(
     'bash',
-    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
+    ['--noprofile', '--norc', '-c', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
     {
-      input: 'true\nfalse\nexit 0\n',
+      input,
       encoding: 'utf8',
       env: {
         ...process.env,
@@ -586,6 +598,77 @@ describePosix('local PTY shell-ready launch config', () => {
     expectBashOsc133Lifecycle(output)
   })
 
+  itWithBash('restores bash OSC 133 after a startup file execs a replacement shell', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      [
+        'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
+        '  export ORCA_EXEC_REPRO_DONE=1',
+        '  PROMPT_COMMAND=\'printf "USER_EXEC_PROMPT\\n"\'',
+        '  Q_START_TEXT="local seed" exec -a figterm-test bash --noprofile --norc -l -i',
+        'fi',
+        ''
+      ].join('\n')
+    )
+
+    const output = runInteractiveBashRcfile(
+      getBashShellReadyRcfileContent(),
+      userDataPath,
+      'printf \'LOCAL_EXEC_PC=%s:Q_START_TEXT=%s\\n\' "$PROMPT_COMMAND" "$Q_START_TEXT"\nbash --noprofile --norc -c \'printf "REPLACEMENT_CHILD_PC=%s\\n" "${PROMPT_COMMAND-unset}"\'\nexit 0\n'
+    )
+
+    expect(output).toContain('LOCAL_EXEC_PC=__orca_exec_osc133_precmd')
+    expect(output).toContain('Q_START_TEXT=local seed')
+    expect(output).toContain('USER_EXEC_PROMPT')
+    expect(output).toContain('REPLACEMENT_CHILD_PC=unset')
+    expect(output).toContain('\x1b]777;orca-shell-ready\x07')
+    expect(output).toContain('\x1b]133;C\x07')
+  })
+
+  itWithBash('removes temporary bash exec hooks when startup returns', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    const output = runInteractiveBashRcfile(
+      getBashShellReadyRcfileContent(),
+      userDataPath,
+      'declare -F __orca_exec_osc133_precmd >/dev/null; printf \'TEMP_FUNC=%s:TEMP_PC=%s\\n\' "$?" "${PROMPT_COMMAND//__orca_exec_osc133_/LEAK}"\nif shopt -qo functrace; then printf \'FUNCTRACE_ON\\n\'; else printf \'FUNCTRACE_OFF\\n\'; fi\nbash --noprofile --norc -c \'printf "CHILD_TEMP_PC=%s\\n" "${PROMPT_COMMAND-unset}"\'\nexit 0\n'
+    )
+
+    expect(output).toContain('TEMP_FUNC=1:')
+    expect(output).not.toContain('LEAKprecmd')
+    expect(output).not.toContain('LEAKprompt_done')
+    expect(output).toContain('FUNCTRACE_OFF')
+    expect(output).toContain('CHILD_TEMP_PC=unset')
+  })
+
+  itWithBash('preserves functrace enabled by a user profile', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(join(userDataPath, '.bash_profile'), 'set -T\n')
+
+    const output = runInteractiveBashRcfile(
+      getBashShellReadyRcfileContent(),
+      userDataPath,
+      "shopt -qo functrace && printf 'USER_FUNCTRACE_ON\\n'\nexit 0\n"
+    )
+
+    expect(output).toContain('USER_FUNCTRACE_ON')
+  })
+
+  itWithBash('does not multiply a pre-existing DEBUG trap inside startup functions', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'profile_nested() { printf "NESTED_PROFILE_BODY\\n"; }\nprofile_nested\n'
+    )
+    const wrapper = `trap 'printf "PREEXISTING_DEBUG=%s\\\\n" "$BASH_COMMAND"' DEBUG
+${getBashShellReadyRcfileContent()}`
+
+    const output = runInteractiveBashRcfile(wrapper, userDataPath)
+
+    expect(output).toContain('NESTED_PROFILE_BODY')
+    expect(output).not.toContain('PREEXISTING_DEBUG=printf "NESTED_PROFILE_BODY')
+  })
+
   itWithBash(
     'preserves prompt hooks and existing DEBUG traps without fake command markers',
     async () => {
@@ -593,7 +676,9 @@ describePosix('local PTY shell-ready launch config', () => {
       writeFileSync(
         join(userDataPath, '.bash_profile'),
         [
-          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+          'printf "STARTUP_LITERAL=before exec after\\n"',
+          'STARTUP_ASSIGNMENT=$(printf "before exec after")',
+          'export PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"; _orca_test_prompt_declaration="$(declare -p PROMPT_COMMAND)"; case "${_orca_test_prompt_declaration%% PROMPT_COMMAND=*}" in *x*) printf "PROMPT_EXPORTED\\n" ;; esac; unset _orca_test_prompt_declaration\'',
           'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
         ].join('\n')
       )
@@ -601,6 +686,7 @@ describePosix('local PTY shell-ready launch config', () => {
       const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
 
       expect(output).toContain('PROMPT_HOOK')
+      expect(output).toContain('PROMPT_EXPORTED')
       expect(output).toContain('USER_DEBUG_AFTER')
       expectBashOsc133Lifecycle(output)
     }
@@ -750,11 +836,12 @@ describePosix('local PTY shell-ready launch config', () => {
     // Trust the runtime path only when it still holds a wrapper .zshenv; else fall back to the generation-time literal.
     expect(zshenv).toContain(
       'if [[ -n "${_orca_wrapper_zdotdir_self:-}" && -f "${_orca_wrapper_zdotdir_self:-}/.zshenv" ]]; then\n' +
-        '  export ZDOTDIR="${_orca_wrapper_zdotdir_self:-}"\n' +
+        '  _orca_effective_wrapper_zdotdir="${_orca_wrapper_zdotdir_self:-}"\n' +
         'else\n' +
-        `  export ZDOTDIR='${join(userDataPath, 'shell-ready', 'zsh')}'\n` +
+        `  _orca_effective_wrapper_zdotdir='${join(userDataPath, 'shell-ready', 'zsh')}'\n` +
         'fi'
     )
+    expect(zshenv).toContain('export ZDOTDIR="$_orca_effective_wrapper_zdotdir"')
     // Capture must happen before the wrapper unsets ZDOTDIR to source user files.
     expect(zshenv.indexOf('_orca_wrapper_zdotdir_self="${${(%):-%x}:h}"')).toBeLessThan(
       zshenv.indexOf('unset ZDOTDIR')
@@ -784,6 +871,130 @@ describePosix('live zsh subprocess tests', () => {
     afterEach(() => {
       rmSync(testHome, { recursive: true, force: true })
       rmSync(userDataPath, { recursive: true, force: true })
+    })
+
+    it('restores local zsh OSC 133 after a startup file execs a wrapper', async () => {
+      writeFileSync(
+        join(testHome, '.zprofile'),
+        [
+          'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
+          '  export ORCA_EXEC_REPRO_DONE=1',
+          '  Q_START_TEXT=local-seed exec -a kiro-cli-term env zsh -o noglobalrcs -l -i',
+          'fi',
+          ''
+        ].join('\n')
+      )
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      const cleanEnv: Record<string, string | undefined> = {
+        ...process.env,
+        ...config.env,
+        HOME: testHome,
+        PATH: '/usr/bin:/bin',
+        TERM: process.env.TERM || 'xterm'
+      }
+      delete cleanEnv.ORCA_ORIG_ZDOTDIR
+      cleanEnv.ORCA_ZSHENV_SOURCE_DIR = testHome
+
+      const result = spawnSync('zsh', [...(config.args ?? []), '-i'], {
+        input:
+          `printf 'LOCAL_EXEC_PF=%s:Q_START_TEXT=%s\\n' "\${(j:,:)precmd_functions}" "$Q_START_TEXT"\n` +
+          'exit 0\n',
+        encoding: 'utf8',
+        env: cleanEnv as NodeJS.ProcessEnv,
+        timeout: 5_000
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toContain('LOCAL_EXEC_PF=__orca_osc133_precmd')
+      expect(result.stdout).toContain('Q_START_TEXT=local-seed')
+    })
+
+    it.each([
+      { label: 'plain', modifier: '' },
+      { label: 'noglob', modifier: 'noglob ' },
+      { label: 'timed', modifier: 'time ' }
+    ])(
+      'expands a $label exec target against the user ZDOTDIR before wrapper re-entry',
+      async ({ modifier }) => {
+        const replacement = join(testHome, 'zsh-replacement')
+        writeFileSync(
+          replacement,
+          '#!/bin/sh\nexport ORCA_ZDOTDIR_TARGET_RAN=1\nexec /bin/zsh -o noglobalrcs -l -i\n'
+        )
+        chmodSync(replacement, 0o755)
+        writeFileSync(
+          join(testHome, '.zprofile'),
+          [
+            'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
+            '  export ORCA_EXEC_REPRO_DONE=1',
+            `  ${modifier}exec "$ZDOTDIR/zsh-replacement"`,
+            'fi',
+            ''
+          ].join('\n')
+        )
+        const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+        const config = getShellReadyLaunchConfig('/bin/zsh')
+        const cleanEnv: Record<string, string | undefined> = {
+          ...process.env,
+          ...config.env,
+          HOME: testHome,
+          PATH: '/usr/bin:/bin',
+          TERM: process.env.TERM || 'xterm'
+        }
+        delete cleanEnv.ORCA_ORIG_ZDOTDIR
+        cleanEnv.ORCA_ZSHENV_SOURCE_DIR = testHome
+
+        const result = spawnSync('zsh', [...(config.args ?? []), '-i'], {
+          input:
+            `printf 'ZDOTDIR_TARGET=%s:PF=%s\\n' "$ORCA_ZDOTDIR_TARGET_RAN" "\${(j:,:)precmd_functions}"\n` +
+            'exit 0\n',
+          encoding: 'utf8',
+          env: cleanEnv as NodeJS.ProcessEnv,
+          timeout: 5_000
+        })
+
+        expect(result.error).toBeUndefined()
+        expect(result.status, result.stderr).toBe(0)
+        expect(result.stdout).toContain('ZDOTDIR_TARGET=1:PF=__orca_osc133_precmd')
+      }
+    )
+
+    it('preserves non-replacing exec redirections and user exec functions', async () => {
+      const execLog = join(testHome, 'exec-startup.log')
+      writeFileSync(
+        join(testHome, '.zprofile'),
+        [
+          'exec 3> "$ZDOTDIR/exec-startup.log"',
+          'printf "REDIRECT_ZDOTDIR=%s\\n" "$ZDOTDIR" >&3',
+          'exec 3>&-',
+          'exec() { printf "USER_EXEC_FUNCTION\\n"; }',
+          'exec',
+          ''
+        ].join('\n')
+      )
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      const cleanEnv: Record<string, string | undefined> = {
+        ...process.env,
+        ...config.env,
+        HOME: testHome,
+        PATH: '/usr/bin:/bin'
+      }
+      delete cleanEnv.ORCA_ORIG_ZDOTDIR
+      cleanEnv.ORCA_ZSHENV_SOURCE_DIR = testHome
+
+      const result = spawnSync('zsh', ['-l', '-c', 'exit 0'], {
+        encoding: 'utf8',
+        env: cleanEnv as NodeJS.ProcessEnv,
+        timeout: 5_000
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stderr).toBe(0)
+      expect(readFileSync(execLog, 'utf8')).toContain(`REDIRECT_ZDOTDIR=${testHome}`)
+      expect(result.stdout).toContain('USER_EXEC_FUNCTION')
     })
 
     it('preserves typeset -U path scoping when user .zshrc uses it', async () => {

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -641,17 +641,23 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(output).toContain('CHILD_TEMP_PC=unset')
   })
 
-  itWithBash('preserves functrace enabled by a user profile', async () => {
+  itWithBash('preserves user-enabled functrace and nested DEBUG trap behavior', async () => {
     const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
-    writeFileSync(join(userDataPath, '.bash_profile'), 'set -T\n')
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'set -T\nprofile_nested() { :; }\nprofile_nested\nprintf "USER_DEBUG_NESTED=%s\\n" "${USER_DEBUG_NESTED:-0}"\n'
+    )
+    const wrapper = `trap '[[ " \${FUNCNAME[*]} " != *" profile_nested "* ]] || USER_DEBUG_NESTED=1' DEBUG
+${getBashShellReadyRcfileContent()}`
 
     const output = runInteractiveBashRcfile(
-      getBashShellReadyRcfileContent(),
+      wrapper,
       userDataPath,
       "shopt -qo functrace && printf 'USER_FUNCTRACE_ON\\n'\nexit 0\n"
     )
 
     expect(output).toContain('USER_FUNCTRACE_ON')
+    expect(output).toContain('USER_DEBUG_NESTED=1')
   })
 
   itWithBash('does not multiply a pre-existing DEBUG trap inside startup functions', async () => {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -16,6 +16,7 @@ import {
 } from '../powershell-osc133-bootstrap'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
+import { getBashStartupProfileSourceBlock } from '../bash-startup-exec-preservation'
 import {
   getFishShellReadyInitCommand,
   getZshEnvTemplate,
@@ -94,14 +95,7 @@ function resolveOriginalZshenvSourceDir(): string {
 export function getBashShellReadyRcfileContent(): string {
   return `# Orca bash shell-ready wrapper
 ${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
-[[ -f /etc/profile ]] && source /etc/profile
-if [[ -f "$HOME/.bash_profile" ]]; then
-  source "$HOME/.bash_profile"
-elif [[ -f "$HOME/.bash_login" ]]; then
-  source "$HOME/.bash_login"
-elif [[ -f "$HOME/.profile" ]]; then
-  source "$HOME/.profile"
-fi
+${getBashStartupProfileSourceBlock(SHELL_READY_MARKER_ESCAPED)}
 # Why: enable bracketed paste so Orca can deliver a multiline startup prompt as
 # a single literal paste (ESC[200~…ESC[201~). Without it, older readline builds
 # treat each embedded newline as Enter and mangle the prompt into PS2

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -10,6 +10,78 @@ export const SHELL_STARTUP_IDENTITY_MARKER_BLOCK = `if [[ "\${ORCA_SHELL_STARTUP
   printf "\\033]777;orca-shell-start:%s\\007" "$$"
 fi`
 
+export function getZshStartupExecPreservationStart(wrapperZdotdirExpression: string): string {
+  return `_orca_exec_wrapper_zdotdir=${wrapperZdotdirExpression}
+_orca_exec_debug_installed=0
+# Why: route through a just-in-time function so argument/redirection expansion
+# uses the user's ZDOTDIR before the replacement inherits Orca's wrapper.
+if (( ! \${+functions[TRAPDEBUG]} && ! \${+aliases[exec]} && ! \${+functions[exec]} )); then
+  TRAPDEBUG() {
+    [[ -z "\${_orca_exec_shim_active:-}" ]] || return 0
+    local -a _orca_exec_words
+    _orca_exec_words=("\${(z)ZSH_DEBUG_CMD}")
+    local _orca_exec_index=1
+    while (( _orca_exec_index <= \${#_orca_exec_words} )) && [[ "\${(Q)_orca_exec_words[_orca_exec_index]}" == *=* ]]; do
+      (( _orca_exec_index++ ))
+    done
+    while (( _orca_exec_index <= \${#_orca_exec_words} )) && [[ "\${(Q)_orca_exec_words[_orca_exec_index]}" == noglob || "\${(Q)_orca_exec_words[_orca_exec_index]}" == time ]]; do
+      (( _orca_exec_index++ ))
+    done
+    if [[ "\${(Q)_orca_exec_words[_orca_exec_index]-}" == exec && \${+functions[exec]} -eq 0 ]]; then
+      (( _orca_exec_index++ ))
+      while (( _orca_exec_index <= \${#_orca_exec_words} )); do
+        case "\${(Q)_orca_exec_words[_orca_exec_index]}" in
+          -a) (( _orca_exec_index += 2 )) ;;
+          -c|-l|-cl|-lc) (( _orca_exec_index++ )) ;;
+          --) (( _orca_exec_index++ )); break ;;
+          *) break ;;
+        esac
+      done
+      while (( _orca_exec_index <= \${#_orca_exec_words} )); do
+        case "\${(Q)_orca_exec_words[_orca_exec_index]-}" in
+          *"<"*|*">"*) (( _orca_exec_index += 2 )) ;;
+          "") break ;;
+          *)
+            exec() {
+              local _orca_exec_status
+              local _orca_exec_had_zdotdir=\${+ZDOTDIR}
+              local _orca_exec_previous_zdotdir="\${ZDOTDIR-}"
+              _orca_exec_shim_active=1
+              unfunction exec
+              export ZDOTDIR="$_orca_exec_wrapper_zdotdir"
+              builtin exec "$@"
+              _orca_exec_status=$?
+              if (( _orca_exec_had_zdotdir )); then
+                export ZDOTDIR="$_orca_exec_previous_zdotdir"
+              else
+                unset ZDOTDIR
+              fi
+              unset _orca_exec_shim_active
+              return $_orca_exec_status
+            }
+            _orca_exec_shim_body="\${functions[exec]}"
+            break
+            ;;
+        esac
+      done
+    fi
+  }
+  _orca_exec_debug_body="\${functions[TRAPDEBUG]}"
+  _orca_exec_debug_installed=1
+fi`
+}
+
+export const ZSH_STARTUP_EXEC_PRESERVATION_END = `if (( \${_orca_exec_debug_installed:-0} )); then
+  if [[ "\${functions[TRAPDEBUG]-}" == "\${_orca_exec_debug_body-}" ]]; then
+    unfunction TRAPDEBUG
+  fi
+fi
+if [[ -n "\${_orca_exec_shim_body:-}" && "\${functions[exec]-}" == "$_orca_exec_shim_body" ]]; then
+  unfunction exec
+fi
+unset _orca_exec_wrapper_zdotdir _orca_exec_debug_installed _orca_exec_debug_body
+unset _orca_exec_shim_active _orca_exec_shim_body`
+
 export function getZshEnvTemplate(zshDir: string, headerPrefix = ''): string {
   const header = headerPrefix
     ? `Orca ${headerPrefix} zsh shell-ready wrapper`
@@ -54,6 +126,12 @@ case "\${_orca_zshenv_source_dir}" in
   ""|*/shell-ready/zsh) _orca_zshenv_source_dir="$HOME" ;;
 esac
 
+if [[ -n "\${_orca_wrapper_zdotdir_self:-}" && -f "\${_orca_wrapper_zdotdir_self:-}/.zshenv" ]]; then
+  _orca_effective_wrapper_zdotdir="\${_orca_wrapper_zdotdir_self:-}"
+else
+  _orca_effective_wrapper_zdotdir=${quotePosixSingle(zshDir)}
+fi
+
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
 # exports, functions, path/fpath typesets, and zsh options keep normal scope.
 unset ZDOTDIR
@@ -61,7 +139,9 @@ if [[ -n "\${_orca_zshenv_source_dir:-}" && -f "\${_orca_zshenv_source_dir}/.zsh
   _orca_zshenv_path="\${_orca_zshenv_source_dir}/.zshenv"
 fi
 if [[ -n "\${_orca_zshenv_path:-}" ]]; then
+${getZshStartupExecPreservationStart('"$_orca_effective_wrapper_zdotdir"')}
   source "\${_orca_zshenv_path}"
+${ZSH_STARTUP_EXEC_PRESERVATION_END}
 fi
 
 _orca_discovered_zdotdir="\${ZDOTDIR:-}"
@@ -90,14 +170,8 @@ case "\${ORCA_ORIG_ZDOTDIR}" in
   ""|*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
 esac
 
-# Why: use :- after user .zshenv — a pathological unset under set -u must not
-# abort the wrapper; empty falls through to the baked-literal branch.
-if [[ -n "\${_orca_wrapper_zdotdir_self:-}" && -f "\${_orca_wrapper_zdotdir_self:-}/.zshenv" ]]; then
-  export ZDOTDIR="\${_orca_wrapper_zdotdir_self:-}"
-else
-  export ZDOTDIR=${quotePosixSingle(zshDir)}
-fi
-unset _orca_spawn_orig_zdotdir _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+export ZDOTDIR="$_orca_effective_wrapper_zdotdir"
+unset _orca_spawn_orig_zdotdir _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self _orca_effective_wrapper_zdotdir
 `
 }
 
@@ -123,7 +197,9 @@ if [[ ${checks.join(' && ')} ]]; then
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
   # Orca restores its wrapper dir afterward so zsh still loads wrapper files.
   export ZDOTDIR="$_orca_home"
+${getZshStartupExecPreservationStart('"$_orca_wrapper_zdotdir"')}
   source "$_orca_home/${options.fileName}"
+${ZSH_STARTUP_EXEC_PRESERVATION_END}
   export ZDOTDIR="$_orca_wrapper_zdotdir"
   unset _orca_wrapper_zdotdir
 fi

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -7,16 +7,24 @@ import { getRelayShellLaunchConfig } from './pty-shell-launch'
 
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const itWithZsh = hasZsh ? it : it.skip
 
-function runInteractiveBashRcfile(rcfile: string, homeDir: string): string {
+function runInteractiveBashRcfile(
+  rcfile: string,
+  homeDir: string,
+  input = 'true\nfalse\nexit 0\n',
+  extraEnv: Record<string, string> = {}
+): string {
   const result = spawnSync(
     'bash',
-    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
+    ['--noprofile', '--norc', '-c', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
     {
-      input: 'true\nfalse\nexit 0\n',
+      input,
       encoding: 'utf8',
       env: {
         ...process.env,
+        ...extraEnv,
         HOME: homeDir,
         TERM: process.env.TERM || 'xterm'
       },
@@ -191,6 +199,74 @@ describe('getRelayShellLaunchConfig', () => {
       expect(zlogin).toContain('printf "\\033]777;orca-shell-ready\\007"')
     }
   )
+
+  itWithZsh('re-enters the relay zsh wrapper after a startup file exec', () => {
+    const replacement = join(homeDir, 'zsh-replacement')
+    writeFileSync(replacement, '#!/bin/sh\nexec zsh -o noglobalrcs -l -i\n')
+    chmodSync(replacement, 0o755)
+    writeFileSync(
+      join(homeDir, '.zprofile'),
+      [
+        'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
+        '  export ORCA_EXEC_REPRO_DONE=1',
+        '  Q_START_TEXT=relay-seed exec "$ZDOTDIR/zsh-replacement"',
+        'fi',
+        ''
+      ].join('\n')
+    )
+    const config = getRelayShellLaunchConfig(
+      'zsh',
+      { HOME: homeDir, PATH: process.env.PATH ?? '/usr/bin:/bin' },
+      process.platform,
+      { emitReadyMarker: true }
+    )
+    const result = spawnSync('zsh', [...config.args, '-i'], {
+      input:
+        `printf 'RELAY_EXEC_WIDGET=%s:Q_START_TEXT=%s\\n' "\${widgets[zle-line-init]-}" "$Q_START_TEXT"\n` +
+        'exit 0\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        TERM: process.env.TERM || 'xterm',
+        ...config.env
+      },
+      timeout: 5_000
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('RELAY_EXEC_WIDGET=user:__orca_prompt_mark')
+    expect(result.stdout).toContain('Q_START_TEXT=relay-seed')
+  })
+
+  itWithBash('restores relay bash OSC 133 after a startup file exec', () => {
+    writeFileSync(
+      join(homeDir, '.bash_profile'),
+      [
+        'if [[ -z "${ORCA_EXEC_REPRO_DONE:-}" ]]; then',
+        '  export ORCA_EXEC_REPRO_DONE=1',
+        '  Q_START_TEXT=relay-seed exec -a figterm-test bash --noprofile --norc -l -i',
+        'fi',
+        ''
+      ].join('\n')
+    )
+    const config = getRelayShellLaunchConfig('/bin/bash', { HOME: homeDir }, 'linux', {
+      emitReadyMarker: true
+    })
+    const output = runInteractiveBashRcfile(
+      config.args[1] as string,
+      homeDir,
+      'printf \'RELAY_EXEC_PC=%s:Q_START_TEXT=%s\\n\' "$PROMPT_COMMAND" "$Q_START_TEXT"\nexit 0\n',
+      config.env
+    )
+
+    expect(output).toContain('RELAY_EXEC_PC=__orca_exec_osc133_precmd')
+    expect(output).toContain('Q_START_TEXT=relay-seed')
+    expect(output).toContain('\x1b]777;orca-shell-ready\x07')
+    expect(output).toContain('\x1b]133;C\x07')
+  })
 
   it.skipIf(process.platform === 'win32')(
     'enables the shell-ready marker for requested bash startup delivery',

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -2,10 +2,13 @@ import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { getPosixOmpShellWrapper } from '../main/pty/omp-shell-wrapper'
+import { getBashStartupProfileSourceBlock } from '../main/bash-startup-exec-preservation'
 import {
+  getZshStartupExecPreservationStart,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
   SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
+  ZSH_STARTUP_EXEC_PRESERVATION_END,
   getZshStartupFileSourceBlock
 } from '../main/shell-templates'
 
@@ -90,7 +93,11 @@ export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
 case "\${ORCA_ORIG_ZDOTDIR%/}" in
   */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
 esac
-[[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
+if [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]]; then
+${getZshStartupExecPreservationStart(quotePosixSingle(zshDir))}
+  source "$ORCA_ORIG_ZDOTDIR/.zshenv"
+${ZSH_STARTUP_EXEC_PRESERVATION_END}
+fi
 export ORCA_USER_ZDOTDIR="\${ZDOTDIR:-\${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 case "\${ORCA_USER_ZDOTDIR%/}" in
   */shell-ready/zsh) export ORCA_USER_ZDOTDIR="$HOME" ;;
@@ -136,14 +143,7 @@ ${getZshShellReadyMarkerRegistrationBlock(SHELL_READY_MARKER_ESCAPED)}
 `
   const bashRc = `# Orca relay bash overlay wrapper
 ${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
-[[ -f /etc/profile ]] && source /etc/profile
-if [[ -f "$HOME/.bash_profile" ]]; then
-  source "$HOME/.bash_profile"
-elif [[ -f "$HOME/.bash_login" ]]; then
-  source "$HOME/.bash_login"
-elif [[ -f "$HOME/.profile" ]]; then
-  source "$HOME/.profile"
-fi
+${getBashStartupProfileSourceBlock(SHELL_READY_MARKER_ESCAPED)}
 # Why: enable bracketed paste so Orca can deliver a multiline startup prompt as
 # a single literal paste (ESC[200~…ESC[201~); without it, older readline builds
 # treat each embedded newline as Enter and mangle the prompt into PS2


### PR DESCRIPTION
## Summary

- Route zsh startup-file replacements through a just-in-time `exec` shim, so command arguments and redirections expand against the user's `ZDOTDIR` before only the replacement process inherits Orca's wrapper.
- Export a temporary Bash prompt bridge while login profiles run, then reattach it immediately before a builtin `exec` so replacement shells retain readiness and OSC 133 lifecycle hooks.
- Clean up temporary traps, functions, export state, and `functrace` after normal startup; persist the same restoration behavior across local, daemon, and SSH relay wrappers.
- Add real zsh/bash replacement-shell coverage and an experimental reliability gate.

## Reliability contract

- **Invariant:** `terminal-session.shell-ready-exec-integration-restoration` — an exec-replaced supported shell re-enters Orca's established prompt instrumentation before its first usable prompt, preserving shell readiness, exactly-once startup-command delivery, and the wrapper's OSC 133 lifecycle contract.
- **Failure source:** STA-4084 / #13767. The prompt-readiness fallback restored command delivery but could not recreate OSC 133 hooks stripped by startup-file `exec`.
- **Oracle:** real zsh and bash subprocesses with disposable HOME directories run Fig/Kiro-shaped replacements, then prove readiness, restored prompt hooks/OSC bytes, leading environment assignments, `exec -a`, `noglob`/`time` modifiers, user-`ZDOTDIR` target/redirection expansion, and exactly-once command delivery.
- **Gate:** new experimental `terminal-session.shell-ready-exec-integration-restoration` entry in `config/reliability-gates.jsonc`.
- **Coverage:** local PTY and local daemon are covered by live subprocess tests; relay wrapper generation and re-entry are covered. Shared templates retain existing WSL/non-ASCII ZDOTDIR coverage, but live WSL, SSH-daemon, and paired-runtime evidence remains a gap. Native Windows PowerShell/cmd paths are unaffected. No mobile-facing protocol, RPC, persistence, or pairing surface changed.
- **Performance budget:** startup-local shell traps/functions only. No polling, timers, subprocesses, network work, listeners, or unbounded state were added; temporary state is removed after normal startup or relinquishes export state at the replacement shell's first prompt.
- **Diagnostics:** the existing shell prompt-readiness fallback and warning remain available if a third-party launcher prevents restoration.
- **Residual gaps:** launchers that sanitize exported shell state or bypass supported startup/prompt hooks cannot inherit the bridge. Bash profiles that replace the temporary DEBUG trap and subsequently overwrite `PROMPT_COMMAND` before `exec`, and zsh code that explicitly uses `builtin exec`, retain the existing safe prompt fallback without restored OSC 133.

## Red/green evidence

- Prior PR head `05c0ac91dd1` failed the ticket's exact `exec "$ZDOTDIR/zsh-replacement"` constraint with status 127 after expanding the target inside Orca's wrapper directory.
- The just-in-time shim passes that oracle, `exec 3>"$ZDOTDIR/out"`, plain/`noglob`/`time` replacement forms, and the full focused gate.
- The pre-fix Bash guard suppressed a user DEBUG trap inside nested startup functions after the profile enabled functrace; the reviewed guard preserves that behavior, while the ordinary non-functrace regression remains unmultiplied.
- Pre-fix exact head `205e63e4338` armed the bridge for redirection-only `exec`, failed on an unset `PROMPT_COMMAND` under nounset, and retained trailing prompt-array elements; the reviewed paths now remain unarmed or cleanly restore user state.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.test.ts` — 110 passed
- Exact CI real-shell lane — 176 passed, 1 platform skip
- Existing shell-readiness reliability gate — 478 passed
- `pnpm run typecheck`
- `pnpm run lint`

## Review

The completion audit reproduced and fixed the P1 ZDOTDIR expansion-order regression documented on STA-4084 and closed PR #13869. The final readiness and repository-review scans found no remaining P0, P1, or P2 issues after checking cleanup/authority, failure behavior, macOS/Linux/Windows/WSL and relay assumptions, mobile/wire compatibility, security/supply chain, crash/cast/retry/growth risks, and startup performance.

Related to #13767
Linear: https://linear.app/stably/issue/STA-4084/restore-osc-133-shell-integration-when-an-exec-in-user-rc-files-strips



