### PR TITLE
fix(mobile): trade a lease-only stream for output when leaving a chat tab

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -917,6 +917,9 @@ export default function SessionScreen() {
   } | null>(null)
   const terminalUnsubsRef = useRef<Map<string, () => void>>(new Map())
   const subscribingHandlesRef = useRef<Set<string>>(new Set())
+  // Why: a lease-only subscribe never renders, so the reconciler needs to tell it apart
+  // from a stream that does — an uncovered handle holding one is a blank terminal.
+  const leaseOnlyHandlesRef = useRef<Set<string>>(new Set())
   const initializedHandlesRef = useRef<Set<string>>(new Set())
   const terminalDiagnosticsRef = useRef(new MobileTerminalDiagnostics())
   // Why: bounds the scrollback→resubscribe fit loop per handle (STA-3337).
@@ -1233,6 +1236,7 @@ export default function SessionScreen() {
       terminalUnsubsRef.current.get(handle)?.()
       terminalUnsubsRef.current.delete(handle)
       subscribingHandlesRef.current.delete(handle)
+      leaseOnlyHandlesRef.current.delete(handle)
       terminalDiagnosticsRef.current.terminalUnsubscribed(handle)
       subscribeSeqRef.current.set(handle, (subscribeSeqRef.current.get(handle) ?? 0) + 1)
       // Why: reset the high-water mark so a fresh subscription's first scrollback isn't dropped as stale.
@@ -1265,6 +1269,7 @@ export default function SessionScreen() {
     clearNativeChatInputLease()
     terminalUnsubsRef.current.clear()
     subscribingHandlesRef.current.clear()
+    leaseOnlyHandlesRef.current.clear()
     initializedHandlesRef.current.clear()
     terminalDiagnosticsRef.current.clearTerminalCache()
     viewportResubscribeBudgetRef.current.clear()
@@ -1331,6 +1336,11 @@ export default function SessionScreen() {
       }
 
       subscribingHandlesRef.current.add(handle)
+      if (covered) {
+        leaseOnlyHandlesRef.current.add(handle)
+      } else {
+        leaseOnlyHandlesRef.current.delete(handle)
+      }
       const seq = (subscribeSeqRef.current.get(handle) ?? 0) + 1
       subscribeSeqRef.current.set(handle, seq)
       diagnostics.streamArmed(handle, seq, viewportRef.current)
@@ -1519,6 +1529,7 @@ export default function SessionScreen() {
     streamRevision: coveredStreamRevision,
     subscriptionsRef: terminalUnsubsRef,
     subscribingRef: subscribingHandlesRef,
+    leaseOnlyRef: leaseOnlyHandlesRef,
     webReadyRef: webReadyHandlesRef,
     initializedRef: initializedHandlesRef,
     subscribe: subscribeToTerminal,

--- a/mobile/src/session/mobile-native-chat-terminal-stream.test.ts
+++ b/mobile/src/session/mobile-native-chat-terminal-stream.test.ts
@@ -12,6 +12,7 @@ const base = {
   activeTabType: 'terminal',
   streamActive: true,
   streamCovered: false,
+  streamIsLeaseOnly: false,
   webViewReady: true
 }
 
@@ -93,8 +94,40 @@ describe('mobile native-chat terminal stream lifecycle', () => {
     ).toBe('rearm')
   })
 
+  it('resumes an uncovered handle still holding a lease-only stream', () => {
+    // Leaving a chat tab for a terminal tab subscribes the incoming handle before the
+    // route learns chat is gone, so the terminal streams nothing but its input lease.
+    expect(resolveMobileNativeChatTerminalStreamAction({ ...base, streamIsLeaseOnly: true })).toBe(
+      'resume'
+    )
+    // Same wait the other resume paths take — never init a WebView that cannot receive it.
+    expect(
+      resolveMobileNativeChatTerminalStreamAction({
+        ...base,
+        streamIsLeaseOnly: true,
+        webViewReady: false
+      })
+    ).toBe('none')
+  })
+
+  it('leaves a lease-only stream alone while chat still covers it (#10681)', () => {
+    // Lease-only is the correct shape under chat; trading it for output here would
+    // drop the input floor the composer depends on.
+    expect(
+      resolveMobileNativeChatTerminalStreamAction({
+        ...base,
+        showNativeChat: true,
+        streamCovered: true,
+        streamIsLeaseOnly: true
+      })
+    ).toBe('none')
+  })
+
   it('does nothing for non-terminal tabs, missing handles, or settled states', () => {
-    expect(resolveMobileNativeChatTerminalStreamAction(base)).toBe('none')
+    // A full stream on an uncovered handle is the one genuinely settled shape.
+    expect(resolveMobileNativeChatTerminalStreamAction({ ...base, streamIsLeaseOnly: false })).toBe(
+      'none'
+    )
     expect(
       resolveMobileNativeChatTerminalStreamAction({
         ...base,

--- a/mobile/src/session/mobile-native-chat-terminal-stream.ts
+++ b/mobile/src/session/mobile-native-chat-terminal-stream.ts
@@ -8,6 +8,10 @@ export function resolveMobileNativeChatTerminalStreamAction(args: {
   activeTabType: string | null
   streamActive: boolean
   streamCovered: boolean
+  /** The active stream was opened as an input lease, so the host sends `subscribed`
+   *  and nothing else — no scrollback, no data. Distinguishes a stream that renders
+   *  from one that only holds the input floor. */
+  streamIsLeaseOnly: boolean
   webViewReady: boolean
 }): MobileNativeChatTerminalStreamAction {
   if (!args.activeHandle || args.activeTabType !== 'terminal') {
@@ -22,7 +26,13 @@ export function resolveMobileNativeChatTerminalStreamAction(args: {
     // the composer locked forever — nothing else re-subscribes a covered handle.
     return args.streamActive ? 'none' : 'rearm'
   }
-  return (args.streamCovered || !args.streamActive) && args.webViewReady ? 'resume' : 'none'
+  // Why `streamIsLeaseOnly`: switching from a chat tab to a terminal tab subscribes the
+  // incoming handle before the route learns chat is gone, so it lands a lease-only stream
+  // on an uncovered handle. Without this input that is indistinguishable from a healthy
+  // stream and the terminal renders blank until restart.
+  return (args.streamCovered || args.streamIsLeaseOnly || !args.streamActive) && args.webViewReady
+    ? 'resume'
+    : 'none'
 }
 
 export function isTerminalCoveredByNativeChat(

--- a/mobile/src/session/use-mobile-native-chat-terminal-stream.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-terminal-stream.test.ts
@@ -8,10 +8,25 @@ describe('useMobileNativeChatTerminalStream', () => {
   let harnessRenderCount = 0
   const subscriptionsRef = { current: new Map<string, () => void>() }
   const subscribingRef = { current: new Set<string>() }
+  const leaseOnlyRef = { current: new Set<string>() }
   const webReadyRef = { current: new Set(['terminal-1']) }
   const initializedRef = { current: new Set(['terminal-1']) }
-  const subscribe = vi.fn((handle: string) => subscriptionsRef.current.set(handle, () => {}))
-  const unsubscribe = vi.fn((handle: string) => subscriptionsRef.current.delete(handle))
+  /** Mirrors the route's subscribe-time coverage guess, which is what decides whether
+   *  the host opens a lease-only stream or a streaming one. */
+  let subscribeOpensLeaseOnly = false
+  const registerSubscription = (handle: string): void => {
+    subscriptionsRef.current.set(handle, () => {})
+    if (subscribeOpensLeaseOnly) {
+      leaseOnlyRef.current.add(handle)
+    } else {
+      leaseOnlyRef.current.delete(handle)
+    }
+  }
+  const subscribe = vi.fn(registerSubscription)
+  const unsubscribe = vi.fn((handle: string) => {
+    subscriptionsRef.current.delete(handle)
+    leaseOnlyRef.current.delete(handle)
+  })
   const notifyWebReadyRef = { current: (_handle: string, _wasAlreadyReady: boolean): void => {} }
   const notifyListedHandlesRef = { current: (_liveHandles: ReadonlySet<string>): void => {} }
   const hasTabsRecoveryNeedRef = { current: (): boolean => false }
@@ -19,6 +34,8 @@ describe('useMobileNativeChatTerminalStream', () => {
   beforeEach(() => {
     subscriptionsRef.current = new Map([['terminal-1', () => {}]])
     subscribingRef.current = new Set()
+    leaseOnlyRef.current = new Set()
+    subscribeOpensLeaseOnly = false
     webReadyRef.current = new Set(['terminal-1'])
     initializedRef.current = new Set(['terminal-1'])
     harnessRenderCount = 0
@@ -51,6 +68,7 @@ describe('useMobileNativeChatTerminalStream', () => {
       streamRevision,
       subscriptionsRef,
       subscribingRef,
+      leaseOnlyRef,
       webReadyRef,
       initializedRef,
       subscribe,
@@ -105,6 +123,111 @@ describe('useMobileNativeChatTerminalStream', () => {
 
     expect(unsubscribe).toHaveBeenNthCalledWith(2, 'terminal-1')
     expect(subscribe).toHaveBeenNthCalledWith(2, 'terminal-1')
+  })
+
+  /** What switchTab does synchronously on the tap, before the route re-renders: the
+   *  coverage it reads still describes the chat tab being left, so the incoming
+   *  terminal gets a lease-only subscribe — the shape that renders nothing. */
+  function handOffToTerminalTwo(): void {
+    subscribeOpensLeaseOnly = true
+    subscribe('terminal-2')
+    subscribeOpensLeaseOnly = false
+    subscribe.mockClear()
+    unsubscribe.mockClear()
+  }
+
+  it('trades a lease-only stream for output when a chat tab hands off to a terminal tab', async () => {
+    webReadyRef.current.add('terminal-2')
+    initializedRef.current.add('terminal-2')
+    await act(async () => {
+      renderer = create(createElement(Harness, { showNativeChat: true }))
+    })
+    handOffToTerminalTwo()
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, { showNativeChat: false, activeHandle: 'terminal-2' })
+      )
+    })
+
+    expect(unsubscribe).toHaveBeenCalledWith('terminal-2')
+    expect(subscribe).toHaveBeenCalledWith('terminal-2')
+    expect(leaseOnlyRef.current.has('terminal-2')).toBe(false)
+    // The lease-only stream carried no scrollback, so xterm is empty — a stale
+    // initialized mark would drop the replacement snapshot and keep the tab blank.
+    expect(initializedRef.current.has('terminal-2')).toBe(false)
+  })
+
+  it('settles once a lease-only stream has been replaced by a full one', async () => {
+    webReadyRef.current.add('terminal-2')
+    await act(async () => {
+      renderer = create(createElement(Harness, { showNativeChat: true }))
+    })
+    handOffToTerminalTwo()
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, { showNativeChat: false, activeHandle: 'terminal-2' })
+      )
+    })
+    subscribe.mockClear()
+    unsubscribe.mockClear()
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          showNativeChat: false,
+          activeHandle: 'terminal-2',
+          streamRevision: 1
+        })
+      )
+    })
+
+    // A stream that renders is settled — resubscribing it again would be a loop.
+    expect(subscribe).not.toHaveBeenCalled()
+    expect(unsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('repairs a lease-only stream once its WebView reports ready', async () => {
+    await act(async () => {
+      renderer = create(createElement(Harness, { showNativeChat: true }))
+    })
+    handOffToTerminalTwo()
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, { showNativeChat: false, activeHandle: 'terminal-2' })
+      )
+    })
+
+    // Cold WebView: the resume must wait, and the route's own web-ready path bails
+    // because the lease-only subscription already counts as live.
+    expect(subscribe).not.toHaveBeenCalled()
+
+    await act(async () => {
+      webReadyRef.current.add('terminal-2')
+      notifyWebReadyRef.current('terminal-2', false)
+    })
+
+    expect(unsubscribe).toHaveBeenCalledWith('terminal-2')
+    expect(subscribe).toHaveBeenCalledWith('terminal-2')
+  })
+
+  it('keeps a covered lease-only stream instead of trading it for output (#10681)', async () => {
+    subscribeOpensLeaseOnly = true
+    await act(async () => {
+      renderer = create(createElement(Harness, { showNativeChat: true }))
+    })
+    subscribe.mockClear()
+    unsubscribe.mockClear()
+
+    await act(async () => {
+      renderer?.update(createElement(Harness, { showNativeChat: true, streamRevision: 1 }))
+    })
+
+    // Lease-only is the correct shape under chat; swapping it for output would drop
+    // the input floor the composer holds.
+    expect(subscribe).not.toHaveBeenCalled()
+    expect(unsubscribe).not.toHaveBeenCalled()
+    expect(leaseOnlyRef.current.has('terminal-1')).toBe(true)
   })
 
   it('re-subscribes a covered stream torn down under chat (#10681)', async () => {
@@ -174,9 +297,7 @@ describe('useMobileNativeChatTerminalStream', () => {
 
       expect(subscribe).toHaveBeenCalledTimes(5)
     } finally {
-      subscribe.mockImplementation((handle: string) =>
-        subscriptionsRef.current.set(handle, () => {})
-      )
+      subscribe.mockImplementation(registerSubscription)
     }
   })
 

--- a/mobile/src/session/use-mobile-native-chat-terminal-stream.ts
+++ b/mobile/src/session/use-mobile-native-chat-terminal-stream.ts
@@ -23,6 +23,8 @@ export function useMobileNativeChatTerminalStream(args: {
   streamRevision: number
   subscriptionsRef: MutableRefObject<Map<string, () => void>>
   subscribingRef: MutableRefObject<Set<string>>
+  /** Handles whose current subscribe went out as an input lease only. */
+  leaseOnlyRef: MutableRefObject<Set<string>>
   webReadyRef: MutableRefObject<Set<string>>
   initializedRef: MutableRefObject<Set<string>>
   subscribe: (handle: string) => void
@@ -55,13 +57,21 @@ export function useMobileNativeChatTerminalStream(args: {
       healthyStreamProofRef.current = null
     }
   }, [])
-  const notifyWebReady = useCallback((handle: string, wasAlreadyReady: boolean) => {
-    // Why: ordinary WebView startups must not rerender the large session route;
-    // only readiness that can release a native-chat lease needs reconciliation.
-    if (!wasAlreadyReady && coveredHandleRef.current === handle) {
-      setWebReadyRevision((revision) => revision + 1)
-    }
-  }, [])
+  const notifyWebReady = useCallback(
+    (handle: string, wasAlreadyReady: boolean) => {
+      // Why: ordinary WebView startups must not rerender the large session route;
+      // only readiness that can release a native-chat lease needs reconciliation.
+      // A lease-only stream counts: the route's own web-ready path bails on any live
+      // subscription, so nothing else would ever trade that lease for output.
+      if (
+        !wasAlreadyReady &&
+        (coveredHandleRef.current === handle || args.leaseOnlyRef.current.has(handle))
+      ) {
+        setWebReadyRevision((revision) => revision + 1)
+      }
+    },
+    [args.leaseOnlyRef]
+  )
   const notifyListedHandles = useCallback(
     (liveHandles: ReadonlySet<string>) => {
       // Why: the rearm budget bounds one teardown, not the handle's lifetime. A covered
@@ -115,12 +125,15 @@ export function useMobileNativeChatTerminalStream(args: {
     const streamActive =
       handle != null &&
       (args.subscriptionsRef.current.has(handle) || args.subscribingRef.current.has(handle))
+    const streamIsLeaseOnly =
+      streamActive && handle != null && args.leaseOnlyRef.current.has(handle)
     const action = resolveMobileNativeChatTerminalStreamAction({
       showNativeChat: args.showNativeChat,
       activeHandle: handle,
       activeTabType: args.activeTabType,
       streamActive,
       streamCovered: coveredHandleRef.current === handle,
+      streamIsLeaseOnly,
       webViewReady: handle != null && args.webReadyRef.current.has(handle)
     })
     const streamHolding = action === 'none' && streamActive && coveredHandleRef.current === handle
@@ -181,7 +194,11 @@ export function useMobileNativeChatTerminalStream(args: {
       args.subscribe(handle)
       return
     }
-    if (coveredHandleRef.current === handle) {
+    if (coveredHandleRef.current === handle || streamIsLeaseOnly) {
+      // Why clear `initialized`: a lease-only stream delivered no scrollback, so xterm
+      // holds nothing — a stale mark would drop the replacement snapshot and the
+      // terminal would stay blank through the resubscribe.
+      args.initializedRef.current.delete(handle)
       args.unsubscribe(handle)
       coveredHandleRef.current = null
     }
@@ -190,6 +207,7 @@ export function useMobileNativeChatTerminalStream(args: {
     args.activeHandle,
     args.activeTabType,
     args.initializedRef,
+    args.leaseOnlyRef,
     args.leaseReady,
     args.showNativeChat,
     args.streamRevision,

--- a/mobile/src/session/use-mobile-native-chat-terminal-stream.ts
+++ b/mobile/src/session/use-mobile-native-chat-terminal-stream.ts
@@ -116,8 +116,7 @@ export function useMobileNativeChatTerminalStream(args: {
       (rearmAttemptsRef.current.get(handle) ?? 0) >= MAX_REARM_ATTEMPTS
     )
   }, [])
-  // oxlint-disable-next-line react-doctor/effect-needs-cleanup -- The route owns streams; the hook cancels its proof timer on unmount.
-  useEffect(() => {
+  const reconcileStream = useCallback(() => {
     const handle = args.activeHandle
     if (coveredHandleRef.current && coveredHandleRef.current !== handle) {
       forgetRearmState(coveredHandleRef.current)
@@ -222,6 +221,7 @@ export function useMobileNativeChatTerminalStream(args: {
     rearmBudgetRevision,
     webReadyRevision
   ])
+  useEffect(() => reconcileStream(), [reconcileStream])
   useEffect(() => cancelHealthyStreamProof, [cancelHealthyStreamProof])
   // Why memoized: the session route keeps this object in callback dep arrays, and a
   // fresh literal per render would rebuild them on every keystroke. All three members

--- a/mobile/src/session/use-mobile-native-chat-terminal-stream.ts
+++ b/mobile/src/session/use-mobile-native-chat-terminal-stream.ts
@@ -116,6 +116,7 @@ export function useMobileNativeChatTerminalStream(args: {
       (rearmAttemptsRef.current.get(handle) ?? 0) >= MAX_REARM_ATTEMPTS
     )
   }, [])
+  // oxlint-disable-next-line react-doctor/effect-needs-cleanup -- The route owns streams; the hook cancels its proof timer on unmount.
   useEffect(() => {
     const handle = args.activeHandle
     if (coveredHandleRef.current && coveredHandleRef.current !== handle) {


### PR DESCRIPTION
## ELI5

When you're looking at a native chat tab and tap over to a terminal tab, the phone was opening the wrong kind of connection to that terminal — one that carries your keystrokes but never carries any output back. So the terminal looked empty even though it was alive and listening. This teaches the app to notice "this connection can't show anything" and swap it for a real one.

## What Changed

- `resolveMobileNativeChatTerminalStreamAction` gains a `streamIsLeaseOnly` input. An uncovered handle still holding a lease-only stream now resolves to `resume` instead of `none`.
- The session route tracks which handles hold a lease-only subscribe (`leaseOnlyHandlesRef`), set at subscribe time from the same `covered` flag that already decides the `mobileInputLeaseOnly` capability, and cleared on unsubscribe / cache clear.
- The reconciler's resume branch now also fires for a lease-only stream, and clears the handle's `initialized` mark before resubscribing — a lease-only stream delivered no scrollback, so a stale mark would drop the replacement snapshot and keep the tab blank anyway.
- `notifyWebReady` now reconciles for a lease-only handle too, so the repair still happens when the WebView reports ready after the switch.

The covered branch of the state machine is deliberately untouched.

## Why

When native chat covers a terminal, mobile subscribes lease-only. That subscribe exists only to hold the input floor, so the host emits a single `subscribed` frame and then waits — no scrollback frame, no data frames (`src/main/runtime/rpc/methods/terminal.ts`). Input keeps working because it rides a separate `terminal.send` RPC, which is exactly the blank-content-with-working-chrome symptom.

`switchTab` subscribes the incoming handle synchronously, and the coverage it reads at that moment still describes the chat tab being left — so tapping a terminal tab from a chat tab opens a **lease-only** stream on that terminal. The reconciler then clears its covered marker because the active handle changed, leaving a stream that is active and uncovered. `streamActive` conflated a full stream with a lease-only one, so that state was indistinguishable from a healthy stream and resolved to `none`. Nothing repaired it afterwards: the route's web-ready path bails whenever a subscription is already live. The tab stayed blank until app restart.

That missing input is the actual defect, so the fix adds it rather than patching the caller. Two consequences worth calling out:

- **It cannot regress the covered input lease (#10681).** The `showNativeChat` branch is unchanged; lease-only remains the correct, preserved shape while chat covers the terminal. A new test pins that directly.
- **It repairs the state regardless of origin.** Any future path that lands a lease-only stream on an uncovered handle self-heals, rather than depending on one call site guessing coverage correctly. This mirrors how the existing design already works in the other direction — `switchTab`'s coverage guess is provisional and the reconciler is the authority, which is why switching *to* a chat tab already converts a full stream to a lease-only one.

Note: reading the live `showNativeChat` instead of the ref in `switchTab` would *not* have fixed this. During the tap, the live value is also `true` — it describes the tab being left, not the target — so the ref lag is incidental here, not causal.

**Remote wire compatibility:** no wire change. The client sends the same `terminal.subscribe` capabilities and the host emits the same frames. The only new behavior on the wire is an extra unsubscribe + resubscribe after a chat→terminal switch, which is byte-identical to the covered→uncovered toggle old hosts already serve. Old client + new host and new client + old host both behave as before.

**SSH / remote / folder workspaces:** the lease-only shape is transport-agnostic client stream state — nothing here touches paths, worktree layout, or host-specific behavior — so the fix applies identically to local worktrees, folder workspaces, SSH, and remote Orca servers.

## Linked Issue

Fixes #14178

## Visual Proof

Not captured — I do not have the iOS device/simulator rig attached in this session, so I would rather not present a staged capture as device proof.

The change is visible as: terminal tab goes from an **empty black content area** (chrome, dock, and Paste/Esc/Tab/Enter all rendering normally) to **normal scrollback and live output**, immediately on tapping the tab. Repro on device: open a native chat tab (Codex or Claude) in a workspace, then tap a terminal tab.

Behavior is pinned deterministically by the regression tests below instead, including the exact failure state.

## Testing

Verified the trace against the code first rather than trusting the report — the lease-only host emit, the synchronous `switchTab` subscribe, the reconciler nulling its covered marker, and the web-ready path bailing on a live subscription.

**Regression tests — confirmed red before the fix, green after.** With only the three source files stashed and the new tests in place:

```
× resumes an uncovered handle still holding a lease-only stream
× trades a lease-only stream for output when a chat tab hands off to a terminal tab
× repairs a lease-only stream once its WebView reports ready
Tests  3 failed | 20 passed (23)
```

With the fix applied: `Tests 23 passed (23)`.

Coverage added:
- **chat tab → terminal tab** (`trades a lease-only stream for output…`) — the reported repro, asserting the resubscribe *and* that the stale `initialized` mark is cleared so the replacement snapshot lands.
- **lease-only replaced by a full stream** (`settles once a lease-only stream has been replaced by a full one`) — re-runs the reconciler after the repair and asserts no further churn, pinning that this cannot become a resubscribe loop.
- **covered lease survives (#10681)** — two tests, one on the resolver and one on the hook, asserting a lease-only stream under chat is left strictly alone. These pass both before and after, which is the point: they are the guard, not the demonstration.

A test that enshrined the bug had to change. `mobile-native-chat-terminal-stream.test.ts` used a base fixture that *was* the broken state and asserted `none`, calling it settled. The fixture now carries `streamIsLeaseOnly: false` explicitly, which makes that assertion mean "a full stream on an uncovered handle is settled" — true — while the lease-only variant is asserted as `resume` in its own test. Nothing that previously passed was silently reinterpreted.

Commands run, from `mobile/`:
- `pnpm vitest run --config vitest.config.ts src/session/mobile-native-chat-terminal-stream.test.ts src/session/use-mobile-native-chat-terminal-stream.test.ts` → 23 passed
- `pnpm vitest run --config vitest.config.ts src/session/` → 126 files, 1108 passed
- `pnpm run lint` → clean
- `pnpm run typecheck` → clean
- Root `pnpm run check:max-lines-ratchet` → OK, no new bypasses (no `max-lines` disable or per-file bump added)
- Root `pnpm run lint:react-doctor:changed` → passes; remaining warnings are pre-existing lines, none introduced here

Not run: full repo build, and no on-device iOS verification (see Visual Proof).

- [ ] I manually tested these changes locally — **no**, not on device; verified by trace + red/green regression tests
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

N/A — internal contribution.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security:** none — no new data crosses the wire, no new authorization surface.
- **Cross-platform:** mobile-only client state; no paths, shortcuts, or platform branches touched.
- **Remote SSH:** covered above; transport-agnostic, no wire change.
- **Backwards compatibility:** no wire change; mixed client/host versions behave as before.
- **Performance:** one `Set` membership check per reconciler pass. The repair costs one unsubscribe + resubscribe per chat→terminal switch — the same round trip the covered→uncovered toggle already pays — and the added `notifyWebReady` re-render is gated on a lease-only handle, so ordinary WebView startups still do not re-render the session route.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — reason given under Visual Proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — mobile lint/typecheck/tests pass locally; build left to CI
