### PR TITLE
fix(worktrees): keep failed local/WSL scans non-authoritative

### DIFF
--- a/src/main/git/worktree-list-failure-contract.test.ts
+++ b/src/main/git/worktree-list-failure-contract.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileSync: vi.fn(),
+  translateWslOutputPaths: (output: string) => output
+}))
+
+import { clearGitCapabilityStateForTests } from './git-capability-state'
+import { listWorktrees, listWorktreesStrict } from './worktree'
+
+function enoentError(message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code: 'ENOENT' })
+}
+
+describe('listWorktrees failure contract', () => {
+  beforeEach(() => {
+    clearGitCapabilityStateForTests()
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it.each([
+    ['timeout', new Error('wsl.exe timed out')],
+    ['missing path', enoentError('ENOENT: no such file or directory')],
+    [
+      'not a repository',
+      new Error('fatal: not a git repository (or any of the parent directories): .git')
+    ]
+  ])(
+    'swallows a %s failure in the forgiving list and rethrows it from the strict list',
+    async (_label, error) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        gitExecFileAsyncMock.mockRejectedValue(error)
+        await expect(listWorktrees('C:/repo')).resolves.toEqual([])
+        await expect(listWorktreesStrict('C:/repo')).rejects.toThrow(error)
+        await expect(listWorktreesStrict('C:/repo', { wslDistro: 'Ubuntu' })).rejects.toThrow(error)
+        expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+          ['worktree', 'list', '--porcelain', '-z'],
+          expect.objectContaining({ cwd: 'C:/repo', wslDistro: 'Ubuntu' })
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
+    }
+  )
+})

--- a/src/main/ipc/worktrees-detected-scan-failure.test.ts
+++ b/src/main/ipc/worktrees-detected-scan-failure.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GitUsernameModule from '../git/git-username'
+import type { DetectedWorktreeListResult, GitWorktreeInfo } from '../../shared/types'
+
+const {
+  handleMock,
+  removeHandlerMock,
+  listWorktreesMock,
+  listWorktreesStrictMock,
+  assertWorktreeCleanForRemovalMock,
+  addWorktreeMock,
+  removeWorktreeMock,
+  resolveLocalGitUsernameMock,
+  getDefaultBaseRefMock,
+  resolveDefaultBaseRefWithLocalGitMock,
+  resolveDefaultBaseRefViaExecMock,
+  getBranchConflictKindMock,
+  getPRForBranchMock,
+  createGitHubPullRequestMock,
+  getEffectiveHooksMock,
+  getEffectiveHooksFromConfigMock,
+  getDefaultTabsLaunchMock,
+  createIssueCommandRunnerScriptMock,
+  createSetupRunnerScriptMock,
+  resolveSetupRunnerShellMock,
+  shouldRunSetupForCreateMock,
+  runHookMock,
+  hasHooksFileMock,
+  loadHooksMock,
+  computeWorktreePathMock,
+  ensurePathWithinWorkspaceMock,
+  killAllProcessesForWorktreeMock,
+  clearProviderPtyStateMock,
+  getLocalPtyProviderMock,
+  deleteWorktreeHistoryDirMock
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  listWorktreesMock: vi.fn(),
+  listWorktreesStrictMock: vi.fn(),
+  assertWorktreeCleanForRemovalMock: vi.fn(),
+  addWorktreeMock: vi.fn(),
+  removeWorktreeMock: vi.fn(),
+  resolveLocalGitUsernameMock: vi.fn(),
+  getDefaultBaseRefMock: vi.fn(),
+  resolveDefaultBaseRefWithLocalGitMock: vi.fn(),
+  resolveDefaultBaseRefViaExecMock: vi.fn(),
+  getBranchConflictKindMock: vi.fn(),
+  getPRForBranchMock: vi.fn(),
+  createGitHubPullRequestMock: vi.fn(),
+  getEffectiveHooksMock: vi.fn(),
+  getEffectiveHooksFromConfigMock: vi.fn(),
+  getDefaultTabsLaunchMock: vi.fn(),
+  createIssueCommandRunnerScriptMock: vi.fn(),
+  createSetupRunnerScriptMock: vi.fn(),
+  resolveSetupRunnerShellMock: vi.fn(),
+  shouldRunSetupForCreateMock: vi.fn(),
+  runHookMock: vi.fn(),
+  hasHooksFileMock: vi.fn(),
+  loadHooksMock: vi.fn(),
+  computeWorktreePathMock: vi.fn(),
+  ensurePathWithinWorkspaceMock: vi.fn(),
+  killAllProcessesForWorktreeMock: vi.fn(),
+  clearProviderPtyStateMock: vi.fn(),
+  getLocalPtyProviderMock: vi.fn(),
+  deleteWorktreeHistoryDirMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}))
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: listWorktreesMock,
+  listWorktreesStrict: listWorktreesStrictMock,
+  assertWorktreeCleanForRemoval: assertWorktreeCleanForRemovalMock,
+  addWorktree: addWorktreeMock,
+  removeWorktree: removeWorktreeMock
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+  gitExecFileSync: vi.fn()
+}))
+
+vi.mock('../git/repo', () => ({
+  getDefaultBaseRef: getDefaultBaseRefMock,
+  resolveDefaultBaseRefWithLocalGit: resolveDefaultBaseRefWithLocalGitMock,
+  resolveDefaultBaseRefViaExec: resolveDefaultBaseRefViaExecMock,
+  getBranchConflictKind: getBranchConflictKindMock
+}))
+
+vi.mock('../git/git-username', async () => {
+  const actual = await vi.importActual<typeof GitUsernameModule>('../git/git-username')
+  return { ...actual, resolveLocalGitUsername: resolveLocalGitUsernameMock }
+})
+
+vi.mock('../github/client', () => ({
+  getPRForBranch: getPRForBranchMock,
+  createGitHubPullRequest: createGitHubPullRequestMock
+}))
+
+vi.mock('../hooks', () => ({
+  createIssueCommandRunnerScript: createIssueCommandRunnerScriptMock,
+  createSetupRunnerScript: createSetupRunnerScriptMock,
+  getEffectiveHooks: getEffectiveHooksMock,
+  getEffectiveHooksFromConfig: getEffectiveHooksFromConfigMock,
+  getDefaultTabsLaunch: getDefaultTabsLaunchMock,
+  loadHooks: loadHooksMock,
+  runHook: runHookMock,
+  hasHooksFile: hasHooksFileMock,
+  resolveSetupRunnerShell: resolveSetupRunnerShellMock,
+  shouldRunSetupForCreate: shouldRunSetupForCreateMock
+}))
+
+vi.mock('../runtime/worktree-teardown', () => ({
+  killAllProcessesForWorktree: killAllProcessesForWorktreeMock
+}))
+
+vi.mock('./pty', () => ({
+  clearProviderPtyState: clearProviderPtyStateMock,
+  getLocalPtyProvider: getLocalPtyProviderMock
+}))
+
+vi.mock('../terminal-history-deletion', () => ({
+  deleteWorktreeHistoryDir: deleteWorktreeHistoryDirMock
+}))
+
+vi.mock('./worktree-logic', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    computeWorktreePath: computeWorktreePathMock,
+    ensurePathWithinWorkspace: ensurePathWithinWorkspaceMock
+  }
+})
+
+import {
+  __getDetectedWorktreeScanCacheStatsForTests,
+  __resetDetectedWorktreeScanCacheForTests,
+  registerWorktreeHandlers
+} from './worktrees'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
+
+const MAIN_WORKTREE: GitWorktreeInfo = {
+  path: 'C:/repo',
+  head: 'abc123',
+  branch: 'refs/heads/main',
+  isBare: false,
+  isMainWorktree: true
+}
+
+const FEATURE_WORKTREE: GitWorktreeInfo = {
+  path: 'C:/workspaces/feature',
+  head: 'def456',
+  branch: 'refs/heads/feature',
+  isBare: false,
+  isMainWorktree: false
+}
+
+describe('listDetected local/WSL discovery failures', () => {
+  const handlers: HandlerMap = {}
+  const originalPlatform = process.platform
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  const mainWindow = {
+    isDestroyed: () => false,
+    webContents: {
+      send: vi.fn()
+    }
+  }
+  const store = {
+    getRepos: vi.fn(),
+    getRepo: vi.fn(),
+    getProjects: vi.fn(),
+    getProjectHostSetups: vi.fn(),
+    getSettings: vi.fn(),
+    getWorktreeMeta: vi.fn(),
+    getAllWorktreeMeta: vi.fn(),
+    setWorktreeMeta: vi.fn(),
+    removeWorktreeMeta: vi.fn(),
+    getAllWorktreeLineage: vi.fn(),
+    removeWorktreeLineage: vi.fn(),
+    getAllWorkspaceLineage: vi.fn(),
+    removeWorkspaceLineage: vi.fn()
+  }
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform
+    })
+  }
+
+  function localRepo(path = 'C:\\repo') {
+    return {
+      id: 'repo-1',
+      path,
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: null
+    }
+  }
+
+  function mockWslProjectRuntime(): void {
+    store.getProjects.mockReturnValue([
+      {
+        id: 'project-1',
+        displayName: 'repo',
+        badgeColor: '#000',
+        sourceRepoIds: ['repo-1'],
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' },
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+  }
+
+  async function listDetected(): Promise<DetectedWorktreeListResult> {
+    return (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1'
+    })) as DetectedWorktreeListResult
+  }
+
+  beforeEach(() => {
+    setPlatform('win32')
+    __resetDetectedWorktreeScanCacheForTests()
+    for (const mock of [
+      handleMock,
+      removeHandlerMock,
+      listWorktreesMock,
+      listWorktreesStrictMock,
+      assertWorktreeCleanForRemovalMock,
+      addWorktreeMock,
+      removeWorktreeMock,
+      resolveLocalGitUsernameMock,
+      getDefaultBaseRefMock,
+      resolveDefaultBaseRefWithLocalGitMock,
+      resolveDefaultBaseRefViaExecMock,
+      getBranchConflictKindMock,
+      getPRForBranchMock,
+      createGitHubPullRequestMock,
+      getEffectiveHooksMock,
+      getEffectiveHooksFromConfigMock,
+      getDefaultTabsLaunchMock,
+      createIssueCommandRunnerScriptMock,
+      createSetupRunnerScriptMock,
+      resolveSetupRunnerShellMock,
+      shouldRunSetupForCreateMock,
+      runHookMock,
+      hasHooksFileMock,
+      loadHooksMock,
+      computeWorktreePathMock,
+      ensurePathWithinWorkspaceMock,
+      killAllProcessesForWorktreeMock,
+      clearProviderPtyStateMock,
+      getLocalPtyProviderMock,
+      deleteWorktreeHistoryDirMock,
+      mainWindow.webContents.send,
+      store.getRepos,
+      store.getRepo,
+      store.getProjects,
+      store.getProjectHostSetups,
+      store.getSettings,
+      store.getWorktreeMeta,
+      store.getAllWorktreeMeta,
+      store.setWorktreeMeta,
+      store.removeWorktreeMeta,
+      store.getAllWorktreeLineage,
+      store.removeWorktreeLineage,
+      store.getAllWorkspaceLineage,
+      store.removeWorkspaceLineage
+    ]) {
+      mock.mockReset()
+    }
+
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+
+    const repo = localRepo()
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    store.getProjects.mockReturnValue([])
+    store.getProjectHostSetups.mockReturnValue([])
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'none',
+      nestWorkspaces: false,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      workspaceDir: 'C:\\workspaces'
+    })
+    store.getWorktreeMeta.mockReturnValue(undefined)
+    store.getAllWorktreeMeta.mockReturnValue({})
+    store.setWorktreeMeta.mockReturnValue({})
+    store.getAllWorktreeLineage.mockReturnValue({
+      'repo-1::C:/workspaces/feature': {
+        worktreeId: 'repo-1::C:/workspaces/feature',
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: 'repo-1::C:/repo',
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'agent',
+        capture: 'env-workspace',
+        createdAt: 1
+      }
+    })
+    store.getAllWorkspaceLineage.mockReturnValue({})
+    resolveSetupRunnerShellMock.mockReturnValue(undefined)
+    resolveLocalGitUsernameMock.mockResolvedValue('')
+    getDefaultBaseRefMock.mockReturnValue('origin/main')
+    resolveDefaultBaseRefWithLocalGitMock.mockResolvedValue('origin/main')
+    resolveDefaultBaseRefViaExecMock.mockResolvedValue('origin/main')
+    getBranchConflictKindMock.mockResolvedValue(null)
+    getPRForBranchMock.mockResolvedValue(null)
+    getEffectiveHooksMock.mockReturnValue(null)
+    getEffectiveHooksFromConfigMock.mockReturnValue(null)
+    getDefaultTabsLaunchMock.mockReturnValue(undefined)
+    shouldRunSetupForCreateMock.mockReturnValue(false)
+    listWorktreesMock.mockResolvedValue([])
+    killAllProcessesForWorktreeMock.mockResolvedValue({
+      runtimeStopped: 0,
+      providerStopped: 0,
+      registryStopped: 0
+    })
+    getLocalPtyProviderMock.mockReturnValue({})
+
+    const runtimeStub = {
+      resolveRemoteTrackingBase: vi.fn().mockResolvedValue(null),
+      hasRemoteTrackingRef: vi.fn().mockResolvedValue(false),
+      getOrStartRemoteTrackingBaseRefresh: vi.fn().mockResolvedValue({ ok: true }),
+      getOrStartRemoteFetch: vi.fn().mockResolvedValue({ ok: true }),
+      fetchRemoteWithCache: vi.fn().mockResolvedValue(undefined),
+      emitWorktreeBaseStatus: vi.fn(),
+      recordOptimisticReconcileToken: vi.fn().mockReturnValue('token-1'),
+      reconcileWorktreeBaseStatus: vi.fn(),
+      clearOptimisticReconcileToken: vi.fn(),
+      closeFileWatchersForRemoval: vi.fn().mockResolvedValue(undefined),
+      acquireFileWatcherRemoval: vi.fn().mockResolvedValue({
+        finish: vi.fn().mockResolvedValue(undefined)
+      })
+    }
+    registerWorktreeHandlers(mainWindow as never, store as never, runtimeStub as never)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    setPlatform(originalPlatform)
+  })
+
+  it.each([
+    ['wsl.exe timed out', new Error('wsl.exe timed out')],
+    [
+      'missing repo path',
+      Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+    ],
+    [
+      'not a git repository',
+      new Error('fatal: not a git repository (or any of the parent directories): .git')
+    ]
+  ])('keeps a %s local scan non-authoritative and uncached', async (_label, error) => {
+    listWorktreesStrictMock.mockRejectedValue(error)
+
+    const result = await listDetected()
+
+    expect(result).toMatchObject({
+      repoId: 'repo-1',
+      authoritative: false,
+      source: 'metadata-fallback',
+      worktrees: []
+    })
+    expect(listWorktreesStrictMock).toHaveBeenCalledWith('C:\\repo')
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(__getDetectedWorktreeScanCacheStatsForTests()).toEqual({
+      cacheSize: 0,
+      inFlightSize: 0
+    })
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+  })
+
+  it('keeps a WSL timeout non-authoritative and scoped to the selected distro', async () => {
+    mockWslProjectRuntime()
+    listWorktreesStrictMock.mockRejectedValue(new Error('wsl.exe timed out'))
+
+    const result = await listDetected()
+
+    expect(result).toMatchObject({
+      repoId: 'repo-1',
+      authoritative: false,
+      source: 'metadata-fallback',
+      worktrees: []
+    })
+    expect(listWorktreesStrictMock).toHaveBeenCalledWith('C:\\repo', { wslDistro: 'Ubuntu' })
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(__getDetectedWorktreeScanCacheStatsForTests()).toEqual({
+      cacheSize: 0,
+      inFlightSize: 0
+    })
+  })
+
+  it('republishes recovered worktrees after a failed local scan', async () => {
+    listWorktreesStrictMock
+      .mockRejectedValueOnce(new Error('wsl.exe timed out'))
+      .mockResolvedValueOnce([MAIN_WORKTREE, FEATURE_WORKTREE])
+
+    const failed = await listDetected()
+    const recovered = await listDetected()
+
+    expect(failed.authoritative).toBe(false)
+    expect(recovered).toMatchObject({
+      repoId: 'repo-1',
+      authoritative: true,
+      source: 'git',
+      worktrees: [
+        expect.objectContaining({ path: MAIN_WORKTREE.path }),
+        expect.objectContaining({ path: FEATURE_WORKTREE.path })
+      ]
+    })
+    expect(__getDetectedWorktreeScanCacheStatsForTests()).toEqual({
+      cacheSize: 1,
+      inFlightSize: 0
+    })
+  })
+
+  it('does not let a later success reuse a failed scan as a cached empty catalog', async () => {
+    listWorktreesStrictMock.mockRejectedValue(new Error('spawn git EAGAIN'))
+    await listDetected()
+    expect(__getDetectedWorktreeScanCacheStatsForTests().cacheSize).toBe(0)
+
+    listWorktreesStrictMock.mockResolvedValue([MAIN_WORKTREE])
+    const recovered = await listDetected()
+
+    expect(recovered.authoritative).toBe(true)
+    expect(recovered.worktrees).toEqual([
+      expect.objectContaining({ path: MAIN_WORKTREE.path, isMainWorktree: true })
+    ])
+    expect(listWorktreesStrictMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -689,7 +689,11 @@ async function listDetectedGitWorktrees(
 
   const scan: DetectedWorktreeScan = {
     invalidated: false,
-    promise: listRepoWorktrees(repo, localWorktreeGitOptions)
+    // Why: the forgiving `listWorktrees` path converts Git/WSL failures into `[]`,
+    // which this cache then publishes as a fresh authoritative empty catalog.
+    promise: localWorktreeGitOptions.wslDistro
+      ? listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
+      : listGitWorktreesStrict(repo.path)
   }
   detectedWorktreeScanInFlight.set(cacheKey, scan)
   try {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -796,6 +796,38 @@ describe('fetchWorktrees', () => {
     expect(result).toBe(false)
   })
 
+  it('keeps renderer tabs and skips teardown when a failed local/WSL scan is non-authoritative', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    const tab = { id: 'tab-1', worktreeId: existing.id }
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/path/repo1', displayName: 'R', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [existing] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [existing]) },
+      tabsByWorktree: { [existing.id]: [tab] },
+      sortEpoch: 7
+    } as unknown as Partial<AppState>)
+
+    const result = await store.getState().fetchWorktrees('repo1')
+
+    expect(result).toBe(false)
+    expect(store.getState().worktreesByRepo.repo1).toEqual([existing])
+    expect(store.getState().tabsByWorktree[existing.id]).toEqual([tab])
+    expect(store.getState().sortEpoch).toBe(7)
+    expect(mockApi.runtime.call).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.teardownMissingTerminals' })
+    )
+  })
+
   it('reports unchanged non-authoritative refreshes as not fully refreshed', async () => {
     const store = createTestStore()
     const existing = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })


### PR DESCRIPTION
## ELI5

If Git or WSL fails while Orca is listing worktrees, Orca used to treat that as "this repo has no worktrees" and wipe the sidebar. Now a failed scan is treated as "I don't know," so the last known worktrees, tabs, and terminals stay put until a later scan succeeds.

## What Changed

- `listDetectedGitWorktrees` now uses the existing strict `git worktree list` path for local/WSL repos instead of the forgiving lister that converts failures into `[]`.
- A failed scan stays uncached and is published as `authoritative: false` / `metadata-fallback`.
- A later successful scan still republishes recovered worktrees and refreshes the success cache.
- Renderer tests assert tabs survive and `worktree.teardownMissingTerminals` is not emitted for a non-authoritative empty result.

The forgiving `listWorktrees` contract is unchanged for unrelated callers.

## Why

On current `main`, a local/WSL `git worktree list` timeout, missing path, or not-a-repository error is swallowed to `[]`. `listDetectedGitWorktrees` then caches that empty list and publishes it as an authoritative git catalog. #13556's destructive teardown is already prevented on latest `main`, but the empty-catalog publish remains.

This keeps the fix at the detected-scan boundary instead of globally rethrowing from `listWorktrees`.

## Linked Issue

Fixes #14003
Linear: STA-3986

Related: #13556

## Visual Proof

N/A — main-process catalog authority and renderer store preservation. No layout, color, or sidebar chrome change. The renderer already kept last-known rows for `authoritative: false`; this PR stops the main process from labeling a failed scan as authoritative empty.

## Testing

- [x] Reproduced on origin/main: injected Git failures published `{ authoritative: true, source: 'git', worktrees: [] }` and populated the success cache. The new IPC tests were red on that code.
- [x] Same tests green with the fix; they fail again if `listDetectedGitWorktrees` is switched back to the forgiving lister.
- [x] Deterministic Git failure contract: timeout, ENOENT, and not-a-repository are swallowed by `listWorktrees` and rethrown by `listWorktreesStrict`, including `{ wslDistro: 'Ubuntu' }`.
- [x] Renderer store: last-known worktrees/tabs preserved; no `worktree.teardownMissingTerminals` on a non-authoritative empty scan.
- [x] Existing listDetected cache/coalesce tests still pass.
- [x] Real-binary injection on this Windows host (not committed): native Git 2.55 missing path / not-a-repo / 1ms timeout, and WSL Ubuntu Git 2.53 missing path, all matched the forgiving-vs-strict contract.
- [x] oxlint on changed files; `tsc --noEmit -p config/tsconfig.node.json`.
- [ ] Electron CDP of a worktree-built app was not launched: the host hit 0 bytes free mid-run and only ~0.9 GB remained after cleanup, which is not enough for electron-vite. The running production app is 1.4.181 and does not include this patch.

- [x] Automated tests added/updated, or explained why not below

## Review

Local Windows and WSL scans now fail closed at the detected-scan cache. Folder workspaces and SSH still use their existing listing paths. Git 2.25 remains on the existing `--porcelain` fallback inside `listWorktreesStrict`. No remote-wire change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter:
