### PR TITLE
fix(terminal): restore retained tail when host snapshot is empty

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2349,13 +2349,10 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             source: serializedContent?.source,
             kittyKeyboardFlags: serializedContent?.kittyKeyboardFlags,
             oscLinks: serializedContent?.oscLinks,
-            pendingEscapeTailAnsi: serializedContent?.pendingEscapeTailAnsi,
+            pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
             truncated: false,
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
-            // Why: `unavailable` means nobody answered, so the client retries and can
-            // eventually banner. A serializer that DID answer with an empty buffer has
-            // answered — reporting that as unavailable banners genuinely empty panes.
-            // Empty content still suppresses the seq/source metadata below.
+            // Why: only absence is retry-worthy; empty visual data still suppresses provenance.
             unavailable: serialized ? undefined : 'no-serializable-buffer',
             data: serializedContent?.data ?? ''
           })
@@ -2696,10 +2693,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               source: serializedContent?.source,
               kittyKeyboardFlags: serializedContent?.kittyKeyboardFlags,
               oscLinks: serializedContent?.oscLinks,
-              pendingEscapeTailAnsi: serializedContent?.pendingEscapeTailAnsi,
-              // Why: same rule as the tagged path — only an absent serializer answer is
-              // "unavailable". A serializer that answered empty, with an empty retained
-              // tail, is a genuinely empty pane and must not be reported as a failure.
+              pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
+              // Why: only absence without retained tail is retry-worthy; empty answers are valid.
               unavailable:
                 serialized || read.tail.length > 0 ? undefined : 'no-serializable-buffer',
               data:

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2682,7 +2682,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
                   'initial-snapshot'
                 )
               : null
-          const retainedTail = read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : ''
           const snapshotPublication = sendSnapshotFrames(
             (opcode, payload) => sendFrame(request.streamId, opcode, payload),
             {
@@ -2703,7 +2702,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               // tail, is a genuinely empty pane and must not be reported as a failure.
               unavailable:
                 serialized || read.tail.length > 0 ? undefined : 'no-serializable-buffer',
-              data: serializedContent?.data ?? retainedTail
+              data:
+                serializedContent?.data ??
+                (read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : '')
             }
           )
           const replacement = stream.sourceRangeReplacement

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2352,8 +2352,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             pendingEscapeTailAnsi: serializedContent?.pendingEscapeTailAnsi,
             truncated: false,
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
-            // Why: an absent or empty serializer answer is not proof the pane is empty.
-            unavailable: serializedContent ? undefined : 'no-serializable-buffer',
+            // Why: `unavailable` means nobody answered, so the client retries and can
+            // eventually banner. A serializer that DID answer with an empty buffer has
+            // answered — reporting that as unavailable banners genuinely empty panes.
+            // Empty content still suppresses the seq/source metadata below.
+            unavailable: serialized ? undefined : 'no-serializable-buffer',
             data: serializedContent?.data ?? ''
           })
         } catch (error) {
@@ -2695,8 +2698,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               kittyKeyboardFlags: serializedContent?.kittyKeyboardFlags,
               oscLinks: serializedContent?.oscLinks,
               pendingEscapeTailAnsi: serializedContent?.pendingEscapeTailAnsi,
+              // Why: same rule as the tagged path — only an absent serializer answer is
+              // "unavailable". A serializer that answered empty, with an empty retained
+              // tail, is a genuinely empty pane and must not be reported as a failure.
               unavailable:
-                serializedContent || read.tail.length > 0 ? undefined : 'no-serializable-buffer',
+                serialized || read.tail.length > 0 ? undefined : 'no-serializable-buffer',
               data: serializedContent?.data ?? retainedTail
             }
           )

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -118,6 +118,12 @@ type SerializedSnapshot = {
   kittyKeyboardFlags?: number
 } | null
 
+function hasSerializedSnapshotContent(
+  snapshot: SerializedSnapshot
+): snapshot is Exclude<SerializedSnapshot, null> {
+  return Boolean(snapshot && (snapshot.data.length > 0 || snapshot.scrollbackAnsi))
+}
+
 type TerminalViewportClient = {
   id: string
   type?: 'mobile' | 'desktop'
@@ -2330,24 +2336,25 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               return
             }
           }
-          sentSnapshotOutputSeq = serialized?.seq
+          const serializedContent = hasSerializedSnapshotContent(serialized) ? serialized : null
+          sentSnapshotOutputSeq = serializedContent?.seq
           sendSnapshotFrames((opcode, payload) => sendFrame(stream.streamId, opcode, payload), {
             kind: 'scrollback',
             cols: serialized?.cols ?? size?.cols ?? 80,
             rows: serialized?.rows ?? size?.rows ?? 24,
             requestId,
             displayMode,
-            seq: serialized?.seq,
-            cwd: serialized?.cwd,
-            source: serialized?.source,
-            kittyKeyboardFlags: serialized?.kittyKeyboardFlags,
-            oscLinks: serialized?.oscLinks,
-            pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
+            seq: serializedContent?.seq,
+            cwd: serializedContent?.cwd,
+            source: serializedContent?.source,
+            kittyKeyboardFlags: serializedContent?.kittyKeyboardFlags,
+            oscLinks: serializedContent?.oscLinks,
+            pendingEscapeTailAnsi: serializedContent?.pendingEscapeTailAnsi,
             truncated: false,
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
-            // Why: no serializer answered, which is not proof the pane is empty — say so instead of passing off '' as the buffer.
-            unavailable: serialized ? undefined : 'no-serializable-buffer',
-            data: serialized?.data ?? ''
+            // Why: an absent or empty serializer answer is not proof the pane is empty.
+            unavailable: serializedContent ? undefined : 'no-serializable-buffer',
+            data: serializedContent?.data ?? ''
           })
         } catch (error) {
           sendStreamError(
@@ -2637,8 +2644,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           const size = runtime.getTerminalSize(ptyId)
           const displayMode = runtime.getMobileDisplayMode(ptyId)
           const layoutSeq = runtime.getLayout(ptyId)?.seq
+          const serializedContent = hasSerializedSnapshotContent(serialized) ? serialized : null
           // Why: layout versions and output offsets are different sequence domains.
-          const snapshotOutputSeq = serialized?.seq
+          const snapshotOutputSeq = serializedContent?.seq
           emit({
             type: 'subscribed',
             streamId: request.streamId,
@@ -2659,18 +2667,19 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           })
           stream.sourceRangeReplacement =
             stream.ackOutputSourceRanges &&
-            serialized?.source !== undefined &&
-            typeof serialized.seq === 'number'
+            serializedContent?.source !== undefined &&
+            typeof serializedContent.seq === 'number'
               ? runtime.reserveRemoteTerminalSourceRangeReplacement(
                   {
                     ptyId,
                     consumerId: stream.remoteDesktopSubscriptionKey,
                     streamGeneration: stream.streamGeneration
                   },
-                  serialized.seq,
+                  serializedContent.seq,
                   'initial-snapshot'
                 )
               : null
+          const retainedTail = read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : ''
           const snapshotPublication = sendSnapshotFrames(
             (opcode, payload) => sendFrame(request.streamId, opcode, payload),
             {
@@ -2679,15 +2688,16 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               rows: serialized?.rows ?? size?.rows ?? 24,
               displayMode,
               seq: snapshotOutputSeq,
-              cwd: serialized?.cwd,
+              cwd: serializedContent?.cwd,
               truncated: initialOutputOverflowed,
               truncatedByByteBudget: serialized?.truncatedByByteBudget,
-              source: serialized?.source,
-              kittyKeyboardFlags: serialized?.kittyKeyboardFlags,
-              oscLinks: serialized?.oscLinks,
-              pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
-              data:
-                serialized?.data ?? (read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : '')
+              source: serializedContent?.source,
+              kittyKeyboardFlags: serializedContent?.kittyKeyboardFlags,
+              oscLinks: serializedContent?.oscLinks,
+              pendingEscapeTailAnsi: serializedContent?.pendingEscapeTailAnsi,
+              unavailable:
+                serializedContent || read.tail.length > 0 ? undefined : 'no-serializable-buffer',
+              data: serializedContent?.data ?? retainedTail
             }
           )
           const replacement = stream.sourceRangeReplacement
@@ -2695,11 +2705,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           if (replacement) {
             const committed =
               snapshotPublication.published &&
-              serialized?.source !== undefined &&
-              typeof serialized.seq === 'number' &&
+              serializedContent?.source !== undefined &&
+              typeof serializedContent.seq === 'number' &&
               runtime.commitRemoteTerminalSourceRangeReplacement(replacement, {
-                source: serialized.source,
-                seq: serialized.seq
+                source: serializedContent.source,
+                seq: serializedContent.seq
               })
             if (!committed) {
               runtime.rollbackRemoteTerminalSourceRangeReplacement(

--- a/src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts
@@ -20,6 +20,8 @@ type SerializedBuffer = {
   rows: number
   seq?: number
   source?: 'headless' | 'renderer'
+  cwd?: string
+  pendingEscapeTailAnsi?: string
 } | null
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
@@ -121,7 +123,14 @@ describe('terminal multiplex initial snapshot fallback', () => {
   it('serves the retained tail when serialization returns an empty snapshot object', async () => {
     const snapshot = await subscribeSnapshot({
       connectionId: 'conn-empty-snapshot-tail',
-      serialized: { data: '', cols: 120, rows: 40, seq: 42, source: 'renderer' },
+      serialized: {
+        data: '',
+        cols: 120,
+        rows: 40,
+        seq: 42,
+        source: 'renderer',
+        cwd: '/stale'
+      },
       tail: ['retained line 1', 'retained line 2']
     })
 
@@ -129,6 +138,7 @@ describe('terminal multiplex initial snapshot fallback', () => {
     expect(snapshot.start.unavailable).toBeUndefined()
     expect(snapshot.start.seq).toBeUndefined()
     expect(snapshot.start.source).toBeUndefined()
+    expect(snapshot.start.cwd).toBeUndefined()
   })
 
   it('keeps the retained-tail fallback when serialization returns null', async () => {
@@ -164,5 +174,38 @@ describe('terminal multiplex initial snapshot fallback', () => {
 
     expect(snapshot.data).toBe('')
     expect(snapshot.start.unavailable).toBe('no-serializable-buffer')
+  })
+
+  it('reports a successful empty snapshot when the serializer answered and no tail exists', async () => {
+    const snapshot = await subscribeSnapshot({
+      connectionId: 'conn-empty-snapshot-no-tail',
+      serialized: { data: '', cols: 120, rows: 40, seq: 42, source: 'renderer' },
+      tail: []
+    })
+
+    expect(snapshot.data).toBe('')
+    expect(snapshot.start.unavailable).toBeUndefined()
+    expect(snapshot.start.seq).toBeUndefined()
+    expect(snapshot.start.source).toBeUndefined()
+  })
+
+  it('preserves parser carry state when serialized visual data is empty', async () => {
+    const snapshot = await subscribeSnapshot({
+      connectionId: 'conn-empty-snapshot-parser-tail',
+      serialized: {
+        data: '',
+        cols: 120,
+        rows: 40,
+        seq: 42,
+        source: 'renderer',
+        pendingEscapeTailAnsi: '\x1b[38;2;255'
+      },
+      tail: []
+    })
+
+    expect(snapshot.data).toBe('')
+    expect(snapshot.start.pendingEscapeTailAnsi).toBe('\x1b[38;2;255')
+    expect(snapshot.start.seq).toBeUndefined()
+    expect(snapshot.start.source).toBeUndefined()
   })
 })

--- a/src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts
@@ -142,6 +142,19 @@ describe('terminal multiplex initial snapshot fallback', () => {
     expect(snapshot.start.unavailable).toBeUndefined()
   })
 
+  it('does not rebuild the retained tail when serialized content is available', async () => {
+    const tail = ['retained line']
+    const tailJoin = vi.spyOn(tail, 'join')
+    const snapshot = await subscribeSnapshot({
+      connectionId: 'conn-serialized-snapshot-tail',
+      serialized: { data: 'serialized screen', cols: 120, rows: 40 },
+      tail
+    })
+
+    expect(snapshot.data).toBe('serialized screen')
+    expect(tailJoin).not.toHaveBeenCalled()
+  })
+
   it('reports unavailable when neither serialized data nor a retained tail exists', async () => {
     const snapshot = await subscribeSnapshot({
       connectionId: 'conn-null-snapshot-no-tail',

--- a/src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamJson,
+  decodeTerminalStreamText,
+  encodeTerminalStreamFrame,
+  encodeTerminalStreamJson
+} from '../../../shared/terminal-stream-protocol'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+type SerializedBuffer = {
+  data: string
+  scrollbackAnsi?: string
+  cols: number
+  rows: number
+  seq?: number
+  source?: 'headless' | 'renderer'
+} | null
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+async function subscribeSnapshot(options: {
+  connectionId: string
+  serialized: SerializedBuffer
+  tail: string[]
+}): Promise<{ start: Record<string, unknown>; data: string }> {
+  const messages: string[] = []
+  const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+  const handlers = new Map<
+    number,
+    (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+  >()
+  const cleanups = new Map<string, () => void>()
+  const runtime = {
+    getRuntimeId: () => 'test-runtime',
+    registerRemoteTerminalViewSubscriber: () => () => {},
+    resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+    requestRendererTerminalTabMount: vi.fn().mockReturnValue(true),
+    updateRemoteDesktopViewer: vi.fn().mockResolvedValue(true),
+    unregisterRemoteDesktopViewer: vi.fn().mockResolvedValue(true),
+    unregisterRemoteDesktopViewers: vi.fn().mockResolvedValue(true),
+    isPtyResizeDrivenRemotely: vi.fn().mockReturnValue(false),
+    getRemoteDesktopFitHold: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 120, rows: 40 }),
+    isRemoteDesktopViewerOwner: vi.fn().mockReturnValue(false),
+    getPtyOutputSequence: vi.fn().mockReturnValue(0),
+    readTerminal: vi.fn().mockResolvedValue({ tail: options.tail, truncated: false }),
+    serializeTerminalBuffer: vi.fn().mockResolvedValue(options.serialized),
+    getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+    getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+    getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+    subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+    subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+    subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+    subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+    getTerminalFitOverride: vi.fn().mockReturnValue(null),
+    getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+    registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+      cleanups.set(id, cleanup)
+    }),
+    cleanupSubscription: vi.fn((id: string) => cleanups.get(id)?.()),
+    waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
+  } as unknown as OrcaRuntimeService
+  const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+  const dispatchPromise = dispatcher.dispatchStreaming(
+    makeRequest('terminal.multiplex', {}),
+    (message) => messages.push(message),
+    {
+      connectionId: options.connectionId,
+      sendBinary: (bytes) => {
+        binaryFrames.push(bytes)
+      },
+      registerBinaryStreamHandler: (streamId, handler) => {
+        handlers.set(streamId, handler)
+        return () => handlers.delete(streamId)
+      }
+    }
+  )
+
+  await vi.waitFor(() =>
+    expect(messages.some((message) => JSON.parse(message).result?.type === 'ready')).toBe(true)
+  )
+  handlers.get(0)?.(
+    decodeTerminalStreamFrame(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Subscribe,
+        streamId: 0,
+        seq: 1,
+        payload: encodeTerminalStreamJson({
+          streamId: 7,
+          terminal: 'terminal-1',
+          client: { id: 'desktop-1', type: 'desktop' }
+        })
+      })
+    )!
+  )
+  await vi.waitFor(() =>
+    expect(messages.some((message) => JSON.parse(message).result?.type === 'subscribed')).toBe(true)
+  )
+
+  const frames = binaryFrames
+    .map((bytes) => decodeTerminalStreamFrame(bytes))
+    .filter((frame) => frame?.streamId === 7)
+  const start = frames.find((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart)!
+  const data = frames
+    .filter((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotChunk)
+    .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+    .join('')
+  cleanups.get(`terminal-multiplex:${options.connectionId}`)?.()
+  await dispatchPromise
+  return { start: decodeTerminalStreamJson<Record<string, unknown>>(start.payload)!, data }
+}
+
+describe('terminal multiplex initial snapshot fallback', () => {
+  it('serves the retained tail when serialization returns an empty snapshot object', async () => {
+    const snapshot = await subscribeSnapshot({
+      connectionId: 'conn-empty-snapshot-tail',
+      serialized: { data: '', cols: 120, rows: 40, seq: 42, source: 'renderer' },
+      tail: ['retained line 1', 'retained line 2']
+    })
+
+    expect(snapshot.data).toBe('retained line 1\r\nretained line 2\r\n')
+    expect(snapshot.start.unavailable).toBeUndefined()
+    expect(snapshot.start.seq).toBeUndefined()
+    expect(snapshot.start.source).toBeUndefined()
+  })
+
+  it('keeps the retained-tail fallback when serialization returns null', async () => {
+    const snapshot = await subscribeSnapshot({
+      connectionId: 'conn-null-snapshot-tail',
+      serialized: null,
+      tail: ['retained line']
+    })
+
+    expect(snapshot.data).toBe('retained line\r\n')
+    expect(snapshot.start.unavailable).toBeUndefined()
+  })
+
+  it('reports unavailable when neither serialized data nor a retained tail exists', async () => {
+    const snapshot = await subscribeSnapshot({
+      connectionId: 'conn-null-snapshot-no-tail',
+      serialized: null,
+      tail: []
+    })
+
+    expect(snapshot.data).toBe('')
+    expect(snapshot.start.unavailable).toBe('no-serializable-buffer')
+  })
+})

--- a/src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts
+++ b/src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts
@@ -13,7 +13,16 @@ import {
   encodeTerminalStreamJson
 } from '../../../shared/terminal-stream-protocol'
 
-type SerializedBuffer = { data: string; scrollbackAnsi?: string; cols: number; rows: number } | null
+type SerializedBuffer = {
+  data: string
+  scrollbackAnsi?: string
+  cols: number
+  rows: number
+  seq?: number
+  cwd?: string
+  source?: 'headless' | 'renderer'
+  pendingEscapeTailAnsi?: string
+} | null
 type SnapshotStartPayload = Record<string, unknown>
 
 // Why: 256 KiB is the pending-output budget, so this many 1 KiB chunks always trips the overflow guard.
@@ -168,9 +177,7 @@ describe('requested terminal snapshot unavailability reasons', () => {
     expect(start.unavailable).toBeUndefined()
   })
 
-  // Why: `unavailable` drives client retries and eventually a loss banner. A serializer
-  // that answered with an empty buffer HAS answered; a genuinely empty pane must not be
-  // reported as a failure or every fresh pane banners. Only an absent answer is a failure.
+  // Why: unavailable answers retry and eventually banner; empty answers are valid.
   it('does not report a reason when the serializer answered with an empty buffer', async () => {
     const { start, chunks } = await requestSnapshotReply({
       connectionId: 'conn-reason-empty',
@@ -181,15 +188,37 @@ describe('requested terminal snapshot unavailability reasons', () => {
     expect(start.unavailable).toBeUndefined()
   })
 
-  // Why: an empty answer must still not publish seq/source metadata, or the client
-  // anchors its stream to a snapshot that carries no content.
-  it('omits seq and source metadata for an empty serialized answer', async () => {
+  // Why: empty visual data cannot anchor stream provenance.
+  it('omits seq, source, and cwd metadata for an empty serialized answer', async () => {
     const { start } = await requestSnapshotReply({
       connectionId: 'conn-reason-empty-metadata',
-      serializeRequested: async () => ({ data: '', cols: 120, rows: 40 })
+      serializeRequested: async () => ({
+        data: '',
+        cols: 120,
+        rows: 40,
+        seq: 42,
+        source: 'renderer',
+        cwd: '/stale'
+      })
     })
     expect(start.seq).toBeUndefined()
     expect(start.source).toBeUndefined()
+    expect(start.cwd).toBeUndefined()
+  })
+
+  it('preserves parser carry state when serialized visual data is empty', async () => {
+    const { start, chunks } = await requestSnapshotReply({
+      connectionId: 'conn-reason-empty-parser-tail',
+      serializeRequested: async () => ({
+        data: '',
+        cols: 120,
+        rows: 40,
+        pendingEscapeTailAnsi: '\x1b[38;2;255'
+      })
+    })
+    expect(chunks).toBe('')
+    expect(start.pendingEscapeTailAnsi).toBe('\x1b[38;2;255')
+    expect(start.unavailable).toBeUndefined()
   })
 
   it('accepts scrollback-only serialized content', async () => {

--- a/src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts
+++ b/src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts
@@ -13,7 +13,7 @@ import {
   encodeTerminalStreamJson
 } from '../../../shared/terminal-stream-protocol'
 
-type SerializedBuffer = { data: string; cols: number; rows: number } | null
+type SerializedBuffer = { data: string; scrollbackAnsi?: string; cols: number; rows: number } | null
 type SnapshotStartPayload = Record<string, unknown>
 
 // Why: 256 KiB is the pending-output budget, so this many 1 KiB chunks always trips the overflow guard.
@@ -168,13 +168,27 @@ describe('requested terminal snapshot unavailability reasons', () => {
     expect(start.unavailable).toBeUndefined()
   })
 
-  it('omits a reason for a proven-empty buffer so absence stays distinguishable from failure', async () => {
+  it('reports no-serializable-buffer for an empty snapshot object', async () => {
     const { start, chunks } = await requestSnapshotReply({
       connectionId: 'conn-reason-empty',
       serializeRequested: async () => ({ data: '', cols: 120, rows: 40 })
     })
     expect(chunks).toBe('')
     expect(start).toMatchObject({ requestId: 77, truncated: false })
+    expect(start.unavailable).toBe('no-serializable-buffer')
+  })
+
+  it('accepts scrollback-only serialized content', async () => {
+    const { start, chunks } = await requestSnapshotReply({
+      connectionId: 'conn-reason-scrollback',
+      serializeRequested: async () => ({
+        data: '',
+        scrollbackAnsi: 'restored scrollback',
+        cols: 120,
+        rows: 40
+      })
+    })
+    expect(chunks).toBe('restored scrollback')
     expect(start.unavailable).toBeUndefined()
   })
 

--- a/src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts
+++ b/src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts
@@ -168,14 +168,28 @@ describe('requested terminal snapshot unavailability reasons', () => {
     expect(start.unavailable).toBeUndefined()
   })
 
-  it('reports no-serializable-buffer for an empty snapshot object', async () => {
+  // Why: `unavailable` drives client retries and eventually a loss banner. A serializer
+  // that answered with an empty buffer HAS answered; a genuinely empty pane must not be
+  // reported as a failure or every fresh pane banners. Only an absent answer is a failure.
+  it('does not report a reason when the serializer answered with an empty buffer', async () => {
     const { start, chunks } = await requestSnapshotReply({
       connectionId: 'conn-reason-empty',
       serializeRequested: async () => ({ data: '', cols: 120, rows: 40 })
     })
     expect(chunks).toBe('')
     expect(start).toMatchObject({ requestId: 77, truncated: false })
-    expect(start.unavailable).toBe('no-serializable-buffer')
+    expect(start.unavailable).toBeUndefined()
+  })
+
+  // Why: an empty answer must still not publish seq/source metadata, or the client
+  // anchors its stream to a snapshot that carries no content.
+  it('omits seq and source metadata for an empty serialized answer', async () => {
+    const { start } = await requestSnapshotReply({
+      connectionId: 'conn-reason-empty-metadata',
+      serializeRequested: async () => ({ data: '', cols: 120, rows: 40 })
+    })
+    expect(start.seq).toBeUndefined()
+    expect(start.source).toBeUndefined()
   })
 
   it('accepts scrollback-only serialized content', async () => {


### PR DESCRIPTION
## ELI5

When a preserved terminal has exited, Orca can still retain its text even if the screen serializer answers with an empty object. The host now sends that retained text instead of authoritatively telling the client the terminal is blank.

## What Changed

- Treat a serialized snapshot as visually available only when it contains `data` or `scrollbackAnsi`.
- On initial multiplex subscribe, fall back to the already-read retained tail when serialization is empty or null.
- Keep tagged snapshot requests free of retained-tail reads; they only distinguish empty answers from absent answers.
- Suppress `seq`, `source`, and `cwd` provenance when visual serialization is empty.
- Preserve `pendingEscapeTailAnsi` on both initial and tagged paths because it is parser-continuity state, even when visual data is empty.
- Report `no-serializable-buffer` only when no serializer answered and no retained initial tail can answer; a genuinely empty serialized pane remains successful.

## Why

An exited-but-preserved PTY can retain its leaf transcript while its remaining renderer serializer returns `{ data: '' }`. The previous nullish fallback accepted that empty string, discarded the retained tail, and published an authoritative empty snapshot. Empty visual data also must not discard a pending escape-sequence fragment, or the next live chunk can render incorrectly.

This PR intentionally fixes only the reporting seam from #14182. Headless-emulator lifetime and dead-PTY renderer-readiness work remain out of scope.

## Remote wire compatibility

- Retained bytes use the existing snapshot chunk opcode; old clients render useful bytes where they previously rendered `''`.
- `unavailable` and `pendingEscapeTailAnsi` are optional fields on the existing `SnapshotStart` payload. Older decoders ignore unknown fields, while current clients already consume parser carry state.
- The released/current cross-version terminal journey passes in both directions; no opcode, required field, or capability changes.

## Reliability contract

- **Invariant:** initial paired-terminal restore uses retained host tail when visual serialization is empty, empty panes remain successful, empty visual answers publish no stream provenance, and parser carry survives both initial and requested snapshots.
- **Failure source:** #14182 and the existing pending-escape continuity contract from #7329.
- **Oracle:** binary-frame tests assert exact retained bytes, empty success, absence of `seq`/`source`/`cwd`, parser-carry preservation, and unavailable only for an absent answer without retained initial tail.
- **Gate:** `terminal-performance.remote-hidden-retention-budget`, plus the full runtime RPC directory and cross-version wire suites.
- **Coverage:** the shared runtime method covers paired desktop, mobile/relay, SSH-backed, and folder workspaces without platform-specific paths; deterministic coverage ran on macOS, with Linux/Windows live UI evidence unchanged as an existing gap.
- **Performance budget:** the initial path reuses its existing bounded read, tagged requests add no retained-tail read, and parser carry reuses the existing frame field. No polling, provider scan, subprocess, retry loop, or additional serializer call was added.
- **Diagnostics:** existing `unavailable` outcomes and snapshot frame metadata distinguish absent serializers from valid empty answers.
- **Residual gaps:** live exited-pane Electron reproduction and live Linux/Windows/SSH/mobile runs remain unproved; the deterministic host and client contracts cover the changed seam.

## Linked Issue

Fixes #14182

## Visual Proof

N/A — this is a host-only binary snapshot publication change; deterministic frame tests are the direct oracle.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc` — 137 files passed; 1,349 passed, 1 skipped.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex-initial-snapshot-fallback.test.ts src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts` — 78 passed after the final rebase.
- Cross-version wire plus current client consumers — 4 files, 140 passed.
- `pnpm exec tsc --noEmit -p config/tsconfig.tc.web.json`.
- `pnpm exec tsc --noEmit -p config/tsconfig.node.json`.
- Targeted `oxlint`, `git diff --check`, and `pnpm run check:max-lines-ratchet`.
- Mutation proof: initial empty-success, both parser-carry paths, and both `cwd`-suppression paths failed when each behavior was temporarily broken, then passed after restoration.
- The known unrelated fish color-scheme test was not encountered in these affected suites.

## AI Disclosure

N/A (internal contribution).

## Review

Reviewed for security, macOS/Linux/Windows behavior, SSH and folder workspaces, mobile/desktop consumers, backwards compatibility, and performance. The final diff adds no tagged-path retained-tail I/O and no new wire shape.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused/full affected tests, both typechecks, compatibility checks, and mutation controls pass

## Author

@BrennanKB5
