### PR TITLE
fix(workspaces): recognize pasted Linear issue URLs

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
@@ -7,16 +7,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactI18Next from 'react-i18next'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
-import type { LinearIssue, Repo } from '../../../shared/types'
+import type { GitHubWorkItem, LinearIssue, Repo } from '../../../shared/types'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
 import { WORKTREE_PALETTE_QUERY_MAX_BYTES } from '@/lib/worktree-palette-query-bounds'
 import WorktreeJumpPalette from './WorktreeJumpPalette'
 import { makeRecentTabState, makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
-import type { GitHubWorkItem } from '../../../shared/types'
 
 const { lookupCmdJGitHubUrlWorkItem } = vi.hoisted(() => ({
-  lookupCmdJGitHubUrlWorkItem: vi.fn(async () => null)
+  lookupCmdJGitHubUrlWorkItem: vi.fn()
 }))
 
 vi.mock('@/lib/cmd-j-github-url-lookup', () => ({
@@ -643,9 +642,9 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
     expect(testContainer.querySelector('[data-cmd-j-linear-issue-preview="true"]')).not.toBeNull()
   })
 
-  it('resolves a pasted GitHub issue URL and still hands the raw URL to create', async () => {
+  it('resolves a pasted GitHub issue URL and opens create with the linked issue', async () => {
     const githubIssueUrl = 'https://github.com/stablyai/orca/issues/14198'
-    lookupCmdJGitHubUrlWorkItem.mockResolvedValue({
+    const githubIssue = {
       id: 'issue-14198',
       type: 'issue',
       number: 14198,
@@ -654,8 +653,10 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
       url: githubIssueUrl,
       labels: [],
       updatedAt: '2026-08-12T12:00:00.000Z',
-      author: 'nwparker'
-    } satisfies GitHubWorkItem)
+      author: 'nwparker',
+      repoId: 'repo-1'
+    } satisfies GitHubWorkItem
+    lookupCmdJGitHubUrlWorkItem.mockResolvedValue(githubIssue)
     await renderPalette({
       prefetchWorktreeCreateBase: vi.fn(async () => {})
     })
@@ -688,11 +689,19 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
 
     expect(useAppStore.getState().activeModal).toBe('new-workspace-composer')
     expect(useAppStore.getState().modalData).toMatchObject({
-      prefilledName: githubIssueUrl,
+      prefilledName: 'agent-terminals-disappearing-randomly',
       initialRepoId: 'repo-1',
-      telemetrySource: 'command_palette'
+      telemetrySource: 'command_palette',
+      linkedWorkItem: {
+        provider: 'github',
+        type: 'issue',
+        number: 14198,
+        title: 'Agent terminals disappearing randomly',
+        url: githubIssueUrl,
+        repoId: 'repo-1'
+      },
+      initialGitHubWorkItem: githubIssue
     })
-    expect(useAppStore.getState().modalData).not.toHaveProperty('linkedWorkItem')
   })
 
   it('previews a pasted GitHub pull URL', async () => {
@@ -725,7 +734,7 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
     ])
     expect(getCommandValue()).toBe('worktree:wt-linked')
     expect(
-      testContainer.querySelector('[data-cmd-j-task-url-preview="true"]')?.dataset
+      testContainer.querySelector<HTMLElement>('[data-cmd-j-task-url-preview="true"]')?.dataset
         .cmdJTaskUrlProvider
     ).toBe('github')
   })

--- a/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
@@ -13,6 +13,15 @@ import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-tar
 import { WORKTREE_PALETTE_QUERY_MAX_BYTES } from '@/lib/worktree-palette-query-bounds'
 import WorktreeJumpPalette from './WorktreeJumpPalette'
 import { makeRecentTabState, makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
+import type { GitHubWorkItem } from '../../../shared/types'
+
+const { lookupCmdJGitHubUrlWorkItem } = vi.hoisted(() => ({
+  lookupCmdJGitHubUrlWorkItem: vi.fn(async () => null)
+}))
+
+vi.mock('@/lib/cmd-j-github-url-lookup', () => ({
+  lookupCmdJGitHubUrlWorkItem
+}))
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactI18Next>()
@@ -221,6 +230,8 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     setCommandQuery = null
     requestCommandDialogClose = null
+    lookupCmdJGitHubUrlWorkItem.mockReset()
+    lookupCmdJGitHubUrlWorkItem.mockResolvedValue(null)
     useAppStore.setState(initialAppState, true)
     testContainer = document.createElement('div')
     document.body.appendChild(testContainer)
@@ -632,8 +643,19 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
     expect(testContainer.querySelector('[data-cmd-j-linear-issue-preview="true"]')).not.toBeNull()
   })
 
-  it('previews a pasted GitHub issue URL without resolving it', async () => {
+  it('resolves a pasted GitHub issue URL and still hands the raw URL to create', async () => {
     const githubIssueUrl = 'https://github.com/stablyai/orca/issues/14198'
+    lookupCmdJGitHubUrlWorkItem.mockResolvedValue({
+      id: 'issue-14198',
+      type: 'issue',
+      number: 14198,
+      title: 'Agent terminals disappearing randomly',
+      state: 'open',
+      url: githubIssueUrl,
+      labels: [],
+      updatedAt: '2026-08-12T12:00:00.000Z',
+      author: 'nwparker'
+    } satisfies GitHubWorkItem)
     await renderPalette({
       prefetchWorktreeCreateBase: vi.fn(async () => {})
     })
@@ -645,11 +667,18 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
     expect(getRenderedRowIds().find(Boolean)).toBe('__create_worktree__')
     expect(getCommandValue()).toBe('__create_worktree__')
     expect(preview?.dataset.cmdJTaskUrlProvider).toBe('github')
+    expect(preview?.dataset.cmdJTaskUrlState).toBe('resolved')
     expect(preview?.getAttribute('aria-label')).toBe(
-      'Create worktree from GitHub issue stablyai/orca#14198'
+      'Create worktree from GitHub issue stablyai/orca#14198: Agent terminals disappearing randomly'
     )
     expect(preview?.textContent).toContain('#14198')
-    expect(preview?.textContent).toContain('stablyai/orca')
+    expect(preview?.textContent).toContain('Agent terminals disappearing randomly')
+    expect(lookupCmdJGitHubUrlWorkItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        link: expect.objectContaining({ type: 'issue', number: 14198 }),
+        repo: expect.objectContaining({ id: 'repo-1' })
+      })
+    )
 
     await act(async () => {
       preview?.click()

--- a/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
@@ -1,0 +1,612 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { flushSync } from 'react-dom'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactI18Next from 'react-i18next'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import type { LinearIssue, Repo } from '../../../shared/types'
+import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
+import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
+import { WORKTREE_PALETTE_QUERY_MAX_BYTES } from '@/lib/worktree-palette-query-bounds'
+import WorktreeJumpPalette from './WorktreeJumpPalette'
+import { makeRecentTabState, makeRepo } from './worktree-jump-palette-test-fixtures'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18Next>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (_key: string, fallback?: string) => fallback ?? _key
+    })
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn()
+  }
+}))
+
+vi.mock('@/hooks/useSettingsNavigationMetadata', () => ({
+  useSettingsNavigationMetadata: () => []
+}))
+
+vi.mock('@/components/sidebar/StatusIndicator', () => ({
+  default: () => <span data-status-indicator="true" />
+}))
+
+vi.mock('@/components/repo/RepoBadgeLabel', () => ({
+  RepoBadgeMark: () => <span data-repo-badge-mark="true" />
+}))
+
+vi.mock('@/components/cmd-j/palette-host-badge', () => ({
+  getPaletteHostBadge: () => null
+}))
+
+vi.mock('@/components/ui/command', async () => {
+  const React = await import('react')
+  return {
+    Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CommandGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CommandDialog: ({
+      children,
+      open,
+      commandProps,
+      onOpenChange
+    }: {
+      children: React.ReactNode
+      open?: boolean
+      commandProps?: { value?: string; onValueChange?: (next: string) => void }
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      requestCommandDialogClose = () => onOpenChange?.(false)
+      return open ? (
+        <div data-command-dialog="true" data-command-value={commandProps?.value ?? ''}>
+          {children}
+        </div>
+      ) : null
+    },
+    CommandInput: ({
+      value,
+      onValueChange
+    }: {
+      value?: string
+      onValueChange?: (next: string) => void
+    }) => {
+      setCommandQuery = onValueChange ?? null
+      return (
+        <input
+          data-command-input="true"
+          value={value}
+          onChange={(event) => onValueChange?.(event.currentTarget.value)}
+        />
+      )
+    },
+    CommandList: React.forwardRef(function CommandList(
+      { children }: { children: React.ReactNode },
+      ref: React.ForwardedRef<HTMLDivElement>
+    ) {
+      return (
+        <div ref={ref} data-command-list="true">
+          {children}
+        </div>
+      )
+    }),
+    CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CommandItem: ({
+      children,
+      onSelect,
+      value,
+      ...props
+    }: {
+      children: React.ReactNode
+      onSelect?: (value: string) => void
+      value?: string
+    } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onSelect' | 'value'>) => (
+      <button
+        {...props}
+        data-command-item={value ?? ''}
+        onClick={() => onSelect?.(value ?? '')}
+        type="button"
+      >
+        {children}
+      </button>
+    )
+  }
+})
+
+const LINEAR_URL = 'https://linear.app/stably/issue/STA-4084/restore-osc-133-shell-integration'
+const initialAppState = useAppStore.getInitialState()
+let testRoot: Root
+let testContainer: HTMLDivElement
+let setCommandQuery: ((next: string) => void) | null = null
+let requestCommandDialogClose: (() => void) | null = null
+
+function makeLinearIssue(patch: Partial<LinearIssue> = {}): LinearIssue {
+  return {
+    id: 'issue-sta-4084',
+    workspaceId: 'linear-workspace-1',
+    workspaceName: 'Stably',
+    identifier: 'STA-4084',
+    title: 'Restore OSC 133 shell integration',
+    branchName: 'sta-4084-restore-osc-133-shell-integration',
+    url: LINEAR_URL,
+    state: { name: 'Todo', type: 'unstarted', color: '#999999' },
+    team: { id: 'team-sta', name: 'Stably', key: 'STA' },
+    labels: [],
+    labelIds: [],
+    estimate: null,
+    priority: 2,
+    updatedAt: '2026-08-12T12:00:00.000Z',
+    ...patch
+  }
+}
+
+function deferredValue<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  return {
+    promise: new Promise<T>((next) => {
+      resolve = next
+    }),
+    resolve
+  }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderPalette(overrides: Partial<AppState>): Promise<void> {
+  useAppStore.setState({
+    activeModal: 'worktree-palette',
+    activeWorktreeId: null,
+    repos: [makeRepo()],
+    tabsByWorktree: {},
+    browserTabsByWorktree: {},
+    browserPagesByWorkspace: {},
+    unifiedTabsByWorktree: {},
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    alwaysShowDefaultBranchWorkspace: true,
+    lastVisitedAtByWorktreeId: {},
+    linearStatus: {
+      connected: true,
+      viewer: null,
+      workspaces: [
+        {
+          id: 'linear-workspace-1',
+          displayName: 'Linear User',
+          email: null,
+          organizationId: 'linear-organization-1',
+          organizationName: 'Stably',
+          organizationUrlKey: 'stably'
+        }
+      ],
+      selectedWorkspaceId: 'all'
+    },
+    ...makeRecentTabState(),
+    ...overrides
+  } as Partial<AppState>)
+
+  await act(async () => {
+    testRoot.render(<WorktreeJumpPalette />)
+  })
+  await flushEffects()
+}
+
+function getRenderedRowIds(): string[] {
+  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item]')].map(
+    (node) => node.dataset.commandItem ?? ''
+  )
+}
+
+function getCommandValue(): string {
+  return (
+    testContainer.querySelector<HTMLElement>('[data-command-dialog]')?.dataset.commandValue ?? ''
+  )
+}
+
+describe('WorktreeJumpPalette Linear URL intent', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    setCommandQuery = null
+    requestCommandDialogClose = null
+    useAppStore.setState(initialAppState, true)
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      testRoot.unmount()
+    })
+    vi.useRealTimers()
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('delays loading feedback before replacing the pending row with an issue preview', async () => {
+    const issueLookup = deferredValue<LinearIssue | null>()
+    const fetchLinearIssue = vi.fn(() => issueLookup.promise)
+    await renderPalette({
+      fetchLinearIssue,
+      linearStatus: {
+        connected: true,
+        viewer: null,
+        workspaces: [
+          {
+            id: 'linear-workspace-1',
+            displayName: 'Linear User',
+            email: null,
+            organizationId: 'linear-organization-1',
+            organizationName: 'Stably',
+            organizationUrlKey: 'stably'
+          }
+        ],
+        selectedWorkspaceId: 'all'
+      }
+    })
+
+    vi.useFakeTimers()
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+
+    const pendingRow = testContainer.querySelector<HTMLElement>(
+      '[data-cmd-j-linear-issue-preview="true"]'
+    )
+    expect(getRenderedRowIds().find(Boolean)).toBe('__create_worktree__')
+    expect(getCommandValue()).toBe('__create_worktree__')
+    expect(pendingRow?.dataset.cmdJLinearIssueState).toBe('loading')
+    expect(pendingRow?.getAttribute('aria-busy')).toBe('true')
+    expect(pendingRow?.getAttribute('aria-label')).toBe(
+      'Create worktree from Linear issue STA-4084'
+    )
+    expect(pendingRow?.textContent).toContain('Create worktree from Linear issue')
+    expect(pendingRow?.textContent).not.toContain('Loading Linear issue…')
+    expect(fetchLinearIssue).toHaveBeenCalledWith(
+      'STA-4084',
+      'linear-workspace-1',
+      expect.objectContaining({
+        sourceContext: expect.objectContaining({
+          provider: 'linear',
+          projectId: 'repo:repo-1',
+          projectHostSetupId: 'repo-1',
+          repoId: 'repo-1',
+          hostId: 'local'
+        })
+      })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(199)
+    })
+    expect(pendingRow?.textContent).not.toContain('Loading Linear issue…')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(pendingRow?.getAttribute('aria-label')).toBe('Loading Linear issue STA-4084')
+    expect(pendingRow?.textContent).toContain('Loading Linear issue…')
+
+    await act(async () => {
+      issueLookup.resolve(makeLinearIssue())
+      await issueLookup.promise
+    })
+    await flushEffects()
+
+    const resolvedRow = testContainer.querySelector<HTMLElement>(
+      '[data-cmd-j-linear-issue-preview="true"]'
+    )
+    expect(resolvedRow?.dataset.cmdJLinearIssueState).toBe('resolved')
+    expect(resolvedRow?.textContent).toContain('STA-4084')
+    expect(resolvedRow?.textContent).toContain('Restore OSC 133 shell integration')
+    expect(getRenderedRowIds().find(Boolean)).toBe('__create_worktree__')
+    expect(getCommandValue()).toBe('__create_worktree__')
+  })
+
+  it('rejects oversized Linear URLs before lookup or create-row rendering', async () => {
+    const fetchLinearIssue = vi.fn(async () => makeLinearIssue())
+    await renderPalette({ fetchLinearIssue })
+
+    await act(async () =>
+      setCommandQuery?.(`${LINEAR_URL}/${'a'.repeat(WORKTREE_PALETTE_QUERY_MAX_BYTES)}`)
+    )
+    await flushEffects()
+
+    expect(fetchLinearIssue).not.toHaveBeenCalled()
+    expect(getRenderedRowIds()).not.toContain('__create_worktree__')
+    expect(testContainer.querySelector('[data-cmd-j-linear-issue-preview="true"]')).toBeNull()
+  })
+
+  it('opens the composer with the resolved issue and generated workspace name', async () => {
+    await renderPalette({
+      fetchLinearIssue: vi.fn(async () => makeLinearIssue()),
+      prefetchWorktreeCreateBase: vi.fn(async () => {})
+    })
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+
+    await act(async () => {
+      testContainer.querySelector<HTMLElement>('[data-command-item="__create_worktree__"]')?.click()
+      await Promise.resolve()
+    })
+    await flushEffects()
+
+    expect(useAppStore.getState().activeModal).toBe('new-workspace-composer')
+    expect(useAppStore.getState().modalData).toMatchObject({
+      prefilledName: 'sta-4084-restore-osc-133-shell-integration',
+      initialRepoId: 'repo-1',
+      telemetrySource: 'command_palette',
+      linkedWorkItem: {
+        provider: 'linear',
+        type: 'issue',
+        linearIdentifier: 'STA-4084',
+        linearWorkspaceId: 'linear-workspace-1',
+        title: 'Restore OSC 133 shell integration'
+      },
+      taskSourceContext: {
+        provider: 'linear',
+        projectId: 'repo:repo-1',
+        projectHostSetupId: 'repo-1',
+        repoId: 'repo-1',
+        hostId: 'local',
+        providerIdentity: {
+          provider: 'linear',
+          workspaceId: 'linear-workspace-1',
+          workspaceName: 'Stably',
+          teamId: 'team-sta',
+          teamKey: 'STA'
+        }
+      }
+    })
+  })
+
+  it('keeps runtime folder projects as the Linear lookup and composer owner', async () => {
+    const folderRepo: Repo = {
+      ...makeRepo(),
+      id: 'folder-repo',
+      kind: 'folder' as const,
+      executionHostId: 'runtime:folder-env'
+    }
+    const fetchLinearIssue = vi.fn(async () => makeLinearIssue())
+    const prefetchWorktreeCreateBase = vi.fn(async () => {})
+    await renderPalette({
+      activeRepoId: folderRepo.id,
+      repos: [folderRepo],
+      fetchLinearIssue,
+      prefetchWorktreeCreateBase
+    })
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+
+    expect(fetchLinearIssue).toHaveBeenCalledWith(
+      'STA-4084',
+      'linear-workspace-1',
+      expect.objectContaining({
+        sourceContext: expect.objectContaining({
+          provider: 'linear',
+          projectId: 'repo:folder-repo',
+          projectHostSetupId: 'folder-repo',
+          repoId: 'folder-repo',
+          hostId: 'runtime:folder-env'
+        })
+      })
+    )
+
+    await act(async () => {
+      testContainer.querySelector<HTMLElement>('[data-command-item="__create_worktree__"]')?.click()
+      await Promise.resolve()
+    })
+    await flushEffects()
+
+    expect(useAppStore.getState().modalData).toMatchObject({
+      initialRepoId: 'folder-repo',
+      taskSourceContext: {
+        provider: 'linear',
+        projectId: 'repo:folder-repo',
+        projectHostSetupId: 'folder-repo',
+        repoId: 'folder-repo',
+        hostId: 'runtime:folder-env'
+      }
+    })
+    const projection = projectHostSetupProjectionFromRepos([folderRepo])
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: [folderRepo],
+        projects: projection.projects,
+        projectHostSetups: projection.setups,
+        initialRepoId: 'folder-repo',
+        projectId: 'repo:folder-repo',
+        hostId: 'runtime:folder-env',
+        projectHostSetupId: 'folder-repo'
+      })
+    ).toMatchObject({ status: 'ready', target: { repoId: 'folder-repo' } })
+    expect(prefetchWorktreeCreateBase).not.toHaveBeenCalled()
+  })
+
+  it('maps a runtime-owned active repo to its eligible project sibling', async () => {
+    const unrelatedRepo = { ...makeRepo(), id: 'unrelated-repo' }
+    const localSibling = {
+      ...makeRepo(),
+      id: 'local-sibling',
+      upstream: { owner: 'stablyai', repo: 'orca' }
+    }
+    const runtimeOwnedRepo = {
+      ...makeRepo(),
+      id: 'runtime-owned',
+      connectionId: 'runtime-ssh-workspace-1',
+      upstream: { owner: 'stablyai', repo: 'orca' }
+    }
+    const fetchLinearIssue = vi.fn(async () => makeLinearIssue())
+    await renderPalette({
+      activeRepoId: runtimeOwnedRepo.id,
+      repos: [unrelatedRepo, localSibling, runtimeOwnedRepo],
+      fetchLinearIssue
+    })
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+
+    expect(fetchLinearIssue).toHaveBeenCalledWith(
+      'STA-4084',
+      'linear-workspace-1',
+      expect.objectContaining({
+        sourceContext: expect.objectContaining({
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-sibling'
+        })
+      })
+    )
+  })
+
+  it('does not open the composer after the palette closes during lookup', async () => {
+    const issueLookup = deferredValue<LinearIssue | null>()
+    await renderPalette({ fetchLinearIssue: vi.fn(() => issueLookup.promise) })
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+
+    await act(async () => {
+      testContainer.querySelector<HTMLElement>('[data-command-item="__create_worktree__"]')?.click()
+      useAppStore.getState().closeModal()
+    })
+    await act(async () => {
+      issueLookup.resolve(makeLinearIssue())
+      await issueLookup.promise
+    })
+    await flushEffects()
+
+    expect(useAppStore.getState().activeModal).toBe('none')
+  })
+
+  it('restores focus when a loading selection is abandoned', async () => {
+    const focusTarget = document.createElement('button')
+    document.body.appendChild(focusTarget)
+    focusTarget.focus()
+    const issueLookup = deferredValue<LinearIssue | null>()
+    await renderPalette({
+      activeWorktreeId: 'wt-alpha',
+      fetchLinearIssue: vi.fn(() => issueLookup.promise)
+    })
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+    await act(async () => {
+      testContainer.querySelector<HTMLElement>('[data-command-item="__create_worktree__"]')?.click()
+    })
+    await act(async () => setCommandQuery?.('ordinary name'))
+    testContainer.querySelector<HTMLElement>('[data-command-input="true"]')?.focus()
+
+    await act(async () => requestCommandDialogClose?.())
+    await act(async () => {
+      issueLookup.resolve(makeLinearIssue())
+      await issueLookup.promise
+      await new Promise((resolve) => window.setTimeout(resolve, 50))
+    })
+
+    expect(document.activeElement).toBe(focusTarget)
+    expect(useAppStore.getState().activeModal).toBe('none')
+  })
+
+  it('awaits the live URL after replacing an already resolved URL', async () => {
+    const secondLookup = deferredValue<LinearIssue | null>()
+    await renderPalette({
+      fetchLinearIssue: vi.fn((identifier: string) =>
+        identifier === 'STA-4084' ? Promise.resolve(makeLinearIssue()) : secondLookup.promise
+      )
+    })
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+    await act(async () =>
+      setCommandQuery?.('https://linear.app/stably/issue/STA-4099/current-second-issue')
+    )
+    await flushEffects()
+
+    await act(async () => {
+      testContainer.querySelector<HTMLElement>('[data-command-item="__create_worktree__"]')?.click()
+    })
+    expect(useAppStore.getState().activeModal).toBe('worktree-palette')
+
+    await act(async () => {
+      secondLookup.resolve(
+        makeLinearIssue({
+          id: 'issue-sta-4099',
+          identifier: 'STA-4099',
+          title: 'Current second issue',
+          url: 'https://linear.app/stably/issue/STA-4099/current-second-issue'
+        })
+      )
+      await secondLookup.promise
+    })
+    await flushEffects()
+
+    expect(useAppStore.getState().modalData).toMatchObject({
+      linkedWorkItem: { linearIdentifier: 'STA-4099', title: 'Current second issue' }
+    })
+  })
+
+  it('does not let a stale lookup replace a newer URL preview', async () => {
+    const firstLookup = deferredValue<LinearIssue | null>()
+    const secondLookup = deferredValue<LinearIssue | null>()
+    await renderPalette({
+      fetchLinearIssue: vi.fn((identifier: string) =>
+        identifier === 'STA-4084' ? firstLookup.promise : secondLookup.promise
+      )
+    })
+
+    vi.useFakeTimers()
+    await act(async () => setCommandQuery?.('https://linear.app/stably/issue/STA-4084/first'))
+    await flushEffects()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    expect(testContainer.textContent).toContain('Loading Linear issue…')
+
+    await act(async () => {
+      flushSync(() => setCommandQuery?.('https://linear.app/stably/issue/STA-4099/second'))
+      const currentPendingRow = testContainer.querySelector<HTMLElement>(
+        '[data-cmd-j-linear-issue-preview="true"]'
+      )
+      expect(currentPendingRow?.getAttribute('aria-label')).toBe(
+        'Create worktree from Linear issue STA-4099'
+      )
+      expect(currentPendingRow?.textContent).toContain('Create worktree from Linear issue')
+      expect(currentPendingRow?.textContent).not.toContain('Loading Linear issue…')
+    })
+    await flushEffects()
+
+    await act(async () => {
+      firstLookup.resolve(makeLinearIssue({ title: 'Stale first issue' }))
+      await firstLookup.promise
+    })
+    await flushEffects()
+
+    expect(testContainer.textContent).toContain('STA-4099')
+    expect(testContainer.textContent).not.toContain('Stale first issue')
+
+    await act(async () => {
+      secondLookup.resolve(
+        makeLinearIssue({
+          id: 'issue-sta-4099',
+          identifier: 'STA-4099',
+          title: 'Current second issue',
+          url: 'https://linear.app/stably/issue/STA-4099/current-second-issue'
+        })
+      )
+      await secondLookup.promise
+    })
+    await flushEffects()
+
+    expect(testContainer.textContent).toContain('Current second issue')
+    expect(testContainer.textContent).not.toContain('Stale first issue')
+    expect(getCommandValue()).toBe('__create_worktree__')
+  })
+})

--- a/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
@@ -12,7 +12,7 @@ import { projectHostSetupProjectionFromRepos } from '../../../shared/project-hos
 import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
 import { WORKTREE_PALETTE_QUERY_MAX_BYTES } from '@/lib/worktree-palette-query-bounds'
 import WorktreeJumpPalette from './WorktreeJumpPalette'
-import { makeRecentTabState, makeRepo } from './worktree-jump-palette-test-fixtures'
+import { makeRecentTabState, makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactI18Next>()
@@ -608,5 +608,96 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
     expect(testContainer.textContent).toContain('Current second issue')
     expect(testContainer.textContent).not.toContain('Stale first issue')
     expect(getCommandValue()).toBe('__create_worktree__')
+  })
+
+  it('selects an existing Linear-linked worktree and keeps create underneath', async () => {
+    const linked = makeWorktree('wt-linked', 'Linked Linear workspace', {
+      linkedLinearIssue: 'STA-4084',
+      linkedLinearIssueOrganizationUrlKey: 'stably'
+    })
+    const other = makeWorktree('wt-other', 'Unrelated workspace')
+    await renderPalette({
+      fetchLinearIssue: vi.fn(async () => makeLinearIssue()),
+      worktreesByRepo: { 'repo-1': [other, linked] }
+    })
+
+    await act(async () => setCommandQuery?.(LINEAR_URL))
+    await flushEffects()
+
+    expect(getRenderedRowIds().filter(Boolean)).toEqual([
+      'worktree:wt-linked',
+      '__create_worktree__'
+    ])
+    expect(getCommandValue()).toBe('worktree:wt-linked')
+    expect(testContainer.querySelector('[data-cmd-j-linear-issue-preview="true"]')).not.toBeNull()
+  })
+
+  it('previews a pasted GitHub issue URL without resolving it', async () => {
+    const githubIssueUrl = 'https://github.com/stablyai/orca/issues/14198'
+    await renderPalette({
+      prefetchWorktreeCreateBase: vi.fn(async () => {})
+    })
+
+    await act(async () => setCommandQuery?.(githubIssueUrl))
+    await flushEffects()
+
+    const preview = testContainer.querySelector<HTMLElement>('[data-cmd-j-task-url-preview="true"]')
+    expect(getRenderedRowIds().find(Boolean)).toBe('__create_worktree__')
+    expect(getCommandValue()).toBe('__create_worktree__')
+    expect(preview?.dataset.cmdJTaskUrlProvider).toBe('github')
+    expect(preview?.getAttribute('aria-label')).toBe(
+      'Create worktree from GitHub issue stablyai/orca#14198'
+    )
+    expect(preview?.textContent).toContain('#14198')
+    expect(preview?.textContent).toContain('stablyai/orca')
+
+    await act(async () => {
+      preview?.click()
+      await Promise.resolve()
+    })
+    await flushEffects()
+
+    expect(useAppStore.getState().activeModal).toBe('new-workspace-composer')
+    expect(useAppStore.getState().modalData).toMatchObject({
+      prefilledName: githubIssueUrl,
+      initialRepoId: 'repo-1',
+      telemetrySource: 'command_palette'
+    })
+    expect(useAppStore.getState().modalData).not.toHaveProperty('linkedWorkItem')
+  })
+
+  it('previews a pasted GitHub pull URL', async () => {
+    await renderPalette({})
+    await act(async () => setCommandQuery?.('https://github.com/stablyai/orca/pull/12789'))
+    await flushEffects()
+
+    const preview = testContainer.querySelector<HTMLElement>('[data-cmd-j-task-url-preview="true"]')
+    expect(preview?.dataset.cmdJTaskUrlProvider).toBe('github')
+    expect(preview?.getAttribute('aria-label')).toBe(
+      'Create worktree from GitHub pull request stablyai/orca#12789'
+    )
+    expect(preview?.textContent).toContain('#12789')
+  })
+
+  it('selects an existing GitHub-linked worktree and keeps create underneath', async () => {
+    const linked = makeWorktree('wt-linked', 'Linked GitHub workspace', { linkedIssue: 14198 })
+    const other = makeWorktree('wt-other', 'Unrelated workspace', { linkedIssue: 7 })
+    await renderPalette({
+      repos: [{ ...makeRepo(), displayName: 'stablyai/orca' }],
+      worktreesByRepo: { 'repo-1': [other, linked] }
+    })
+
+    await act(async () => setCommandQuery?.('https://github.com/stablyai/orca/issues/14198'))
+    await flushEffects()
+
+    expect(getRenderedRowIds().filter(Boolean)).toEqual([
+      'worktree:wt-linked',
+      '__create_worktree__'
+    ])
+    expect(getCommandValue()).toBe('worktree:wt-linked')
+    expect(
+      testContainer.querySelector('[data-cmd-j-task-url-preview="true"]')?.dataset
+        .cmdJTaskUrlProvider
+    ).toBe('github')
   })
 })

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -185,11 +185,13 @@ import {
 } from '@/lib/new-workspace-composer-repo'
 import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
 import { lookupGitHubWorkItemForSource } from '@/lib/github-work-item-source-lookup'
+import { lookupCmdJGitHubUrlWorkItem } from '@/lib/cmd-j-github-url-lookup'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
 import { lookupLinearIssueUrl } from '@/lib/linear-issue-url-lookup'
 import {
   getCmdJTaskUrlCreatePreview,
-  parseCmdJTaskSourceUrl
+  parseCmdJTaskSourceUrl,
+  withResolvedCmdJGitHubPreview
 } from '@/lib/worktree-palette-task-url-match'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
@@ -197,7 +199,7 @@ import {
   getSettingsFocusedExecutionHostId,
   isRuntimeOwnedSshTargetId
 } from '../../../shared/execution-host'
-import type { LinearIssue, TerminalTab, Worktree } from '../../../shared/types'
+import type { GitHubWorkItem, LinearIssue, TerminalTab, Worktree } from '../../../shared/types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import {
   buildTaskSourceContextFromRepo,
@@ -273,6 +275,12 @@ type CmdJLinearIssuePreview = {
   loading: boolean
   initialRepoId: string | null
   sourceContext: TaskSourceContext | null
+}
+
+type CmdJGitHubWorkItemPreview = {
+  query: string
+  item: GitHubWorkItem | null
+  loading: boolean
 }
 
 // Why: keep quick actions curated — Cmd+J is a fast intent surface, not a dump of every setup button.
@@ -678,12 +686,16 @@ function WorktreeJumpPaletteContent({
   liveQueryRef.current = query
   const taskSourceUrl = useMemo(() => parseCmdJTaskSourceUrl(query), [query])
   const linearIssueUrlIntent = taskSourceUrl?.provider === 'linear' ? taskSourceUrl.intent : null
-  const taskUrlCreatePreview = useMemo(
+  const githubUrlLink = taskSourceUrl?.provider === 'github' ? taskSourceUrl.link : null
+  const parsedTaskUrlCreatePreview = useMemo(
     () => (taskSourceUrl ? getCmdJTaskUrlCreatePreview(taskSourceUrl) : null),
     [taskSourceUrl]
   )
   const [selectedItemId, setSelectedItemId] = useState('')
   const [linearIssuePreview, setLinearIssuePreview] = useState<CmdJLinearIssuePreview | null>(null)
+  const [githubWorkItemPreview, setGithubWorkItemPreview] =
+    useState<CmdJGitHubWorkItemPreview | null>(null)
+  const githubLookupGenerationRef = useRef(0)
   const linearIssueLookupGenerationRef = useRef(0)
   const linearIssueLookupRef = useRef<{
     query: string
@@ -1733,6 +1745,64 @@ function WorktreeJumpPaletteContent({
       }
     }
   }, [createWorktreeName, linearIssueUrlIntent, visible])
+
+  useLayoutEffect(() => {
+    const generation = ++githubLookupGenerationRef.current
+    if (!visible || !githubUrlLink) {
+      setGithubWorkItemPreview(null)
+      return
+    }
+
+    const pendingPreview: CmdJGitHubWorkItemPreview = {
+      query: createWorktreeName,
+      item: null,
+      loading: true
+    }
+    setGithubWorkItemPreview(pendingPreview)
+
+    const state = useAppStore.getState()
+    const workspaceTarget = getComposerDefaultWorkspaceTarget(state)
+    const sourceContext = workspaceTarget
+      ? buildTaskSourceContextFromRepo({
+          provider: 'github',
+          projectId: workspaceTarget.projectId,
+          repo: workspaceTarget.repo,
+          projectHostSetupId: workspaceTarget.projectHostSetupId
+        })
+      : null
+    void lookupCmdJGitHubUrlWorkItem({
+      link: githubUrlLink,
+      repo: workspaceTarget?.repo ?? null,
+      sourceContext
+    }).then((item) => {
+      if (githubLookupGenerationRef.current === generation) {
+        setGithubWorkItemPreview({
+          query: createWorktreeName,
+          item,
+          loading: false
+        })
+      }
+    })
+
+    return () => {
+      if (githubLookupGenerationRef.current === generation) {
+        githubLookupGenerationRef.current += 1
+      }
+    }
+  }, [createWorktreeName, githubUrlLink, visible])
+
+  const taskUrlCreatePreview = useMemo(() => {
+    if (!parsedTaskUrlCreatePreview) {
+      return null
+    }
+    const preview =
+      githubWorkItemPreview?.query === createWorktreeName ? githubWorkItemPreview : null
+    return withResolvedCmdJGitHubPreview(
+      parsedTaskUrlCreatePreview,
+      preview?.item?.title ?? null,
+      preview?.loading === true
+    )
+  }, [createWorktreeName, githubWorkItemPreview, parsedTaskUrlCreatePreview])
 
   const currentLinearIssuePreview =
     linearIssuePreview?.query === createWorktreeName ? linearIssuePreview : null

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -281,6 +281,8 @@ type CmdJGitHubWorkItemPreview = {
   query: string
   item: GitHubWorkItem | null
   loading: boolean
+  initialRepoId: string | null
+  sourceContext: TaskSourceContext | null
 }
 
 // Why: keep quick actions curated — Cmd+J is a fast intent surface, not a dump of every setup button.
@@ -696,6 +698,10 @@ function WorktreeJumpPaletteContent({
   const [githubWorkItemPreview, setGithubWorkItemPreview] =
     useState<CmdJGitHubWorkItemPreview | null>(null)
   const githubLookupGenerationRef = useRef(0)
+  const githubLookupRef = useRef<{
+    query: string
+    promise: Promise<CmdJGitHubWorkItemPreview>
+  } | null>(null)
   const linearIssueLookupGenerationRef = useRef(0)
   const linearIssueLookupRef = useRef<{
     query: string
@@ -1748,20 +1754,15 @@ function WorktreeJumpPaletteContent({
 
   useLayoutEffect(() => {
     const generation = ++githubLookupGenerationRef.current
+    githubLookupRef.current = null
     if (!visible || !githubUrlLink) {
       setGithubWorkItemPreview(null)
       return
     }
 
-    const pendingPreview: CmdJGitHubWorkItemPreview = {
-      query: createWorktreeName,
-      item: null,
-      loading: true
-    }
-    setGithubWorkItemPreview(pendingPreview)
-
     const state = useAppStore.getState()
     const workspaceTarget = getComposerDefaultWorkspaceTarget(state)
+    const initialRepoId = workspaceTarget?.repoId ?? null
     const sourceContext = workspaceTarget
       ? buildTaskSourceContextFromRepo({
           provider: 'github',
@@ -1770,17 +1771,32 @@ function WorktreeJumpPaletteContent({
           projectHostSetupId: workspaceTarget.projectHostSetupId
         })
       : null
-    void lookupCmdJGitHubUrlWorkItem({
+    const pendingPreview: CmdJGitHubWorkItemPreview = {
+      query: createWorktreeName,
+      item: null,
+      loading: true,
+      initialRepoId,
+      sourceContext
+    }
+    setGithubWorkItemPreview(pendingPreview)
+
+    const promise = lookupCmdJGitHubUrlWorkItem({
       link: githubUrlLink,
       repo: workspaceTarget?.repo ?? null,
       sourceContext
-    }).then((item) => {
-      if (githubLookupGenerationRef.current === generation) {
-        setGithubWorkItemPreview({
-          query: createWorktreeName,
-          item,
+    })
+      .catch(() => null)
+      .then(
+        (item): CmdJGitHubWorkItemPreview => ({
+          ...pendingPreview,
+          item: item ?? null,
           loading: false
         })
+      )
+    githubLookupRef.current = { query: createWorktreeName, promise }
+    void promise.then((preview) => {
+      if (githubLookupGenerationRef.current === generation) {
+        setGithubWorkItemPreview(preview)
       }
     })
 
@@ -1804,6 +1820,8 @@ function WorktreeJumpPaletteContent({
     )
   }, [createWorktreeName, githubWorkItemPreview, parsedTaskUrlCreatePreview])
 
+  const currentGitHubWorkItemPreview =
+    githubWorkItemPreview?.query === createWorktreeName ? githubWorkItemPreview : null
   const currentLinearIssuePreview =
     linearIssuePreview?.query === createWorktreeName ? linearIssuePreview : null
   const [linearLoadingFeedbackQuery, setLinearLoadingFeedbackQuery] = useState<string | null>(null)
@@ -2551,9 +2569,57 @@ function WorktreeJumpPaletteContent({
     }
 
     // Case 1: user pasted a GH/GitLab/Jira URL.
-    // Why: hand the raw URL to the composer so it runs Cmd+N cross-project detection; pre-resolving here silently linked to the wrong project.
-    // Linked worktrees are listed above this row — selecting one jumps there.
-    if (ghLink || taskUrlCreatePreview) {
+    // Why: GitHub uses the in-flight Cmd+J preview so Enter attaches the issue/PR
+    // entity. GitLab/Jira still hand the raw URL to the composer. Linked worktrees
+    // are listed above this row — selecting one jumps there.
+    if (ghLink) {
+      const openGitHubUrlComposer = async (): Promise<void> => {
+        const lookup = githubLookupRef.current
+        const preview = currentGitHubWorkItemPreview?.loading
+          ? await lookup?.promise
+          : (currentGitHubWorkItemPreview ?? (await lookup?.promise))
+        if (
+          lookup?.query !== trimmed ||
+          githubLookupRef.current !== lookup ||
+          liveQueryRef.current.trim() !== trimmed
+        ) {
+          return
+        }
+        const item = preview?.item ?? null
+        const composerData = item
+          ? (() => {
+              const linkedWorkItem: LinkedWorkItemSummary = {
+                provider: 'github',
+                type: item.type,
+                number: item.number,
+                title: item.title,
+                url: item.url,
+                ...(item.repoId ? { repoId: item.repoId } : {})
+              }
+              return {
+                prefilledName:
+                  getLinkedWorkItemWorkspaceName(linkedWorkItem)?.seedName ??
+                  getLinkedWorkItemSuggestedName({ title: item.title }),
+                linkedWorkItem,
+                initialGitHubWorkItem: item,
+                ...(preview?.initialRepoId ? { initialRepoId: preview.initialRepoId } : {}),
+                ...(preview?.sourceContext ? { taskSourceContext: preview.sourceContext } : {})
+              }
+            })()
+          : preview?.initialRepoId
+            ? { prefilledName: trimmed, initialRepoId: preview.initialRepoId }
+            : { prefilledName: trimmed }
+
+        if (useAppStore.getState().activeModal !== 'worktree-palette') {
+          return
+        }
+        openComposer(composerData)
+      }
+      void openGitHubUrlComposer()
+      return
+    }
+
+    if (taskUrlCreatePreview) {
       const state = useAppStore.getState()
       const eligibleRepos = state.repos.filter((r) => isGitRepoKind(r))
       const repoForLookup =
@@ -2656,6 +2722,7 @@ function WorktreeJumpPaletteContent({
     closeModal,
     createLookupGuard,
     createWorktreeName,
+    currentGitHubWorkItemPreview,
     currentLinearIssuePreview,
     focusFallbackSurface,
     linearIssueUrlIntent,

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -187,8 +187,10 @@ import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-tar
 import { lookupGitHubWorkItemForSource } from '@/lib/github-work-item-source-lookup'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
 import { lookupLinearIssueUrl } from '@/lib/linear-issue-url-lookup'
-import { isWorktreePaletteQueryTooLarge } from '@/lib/worktree-palette-query-bounds'
-import { parseLinearIssueUrlIntent } from '../../../shared/linear-links'
+import {
+  getCmdJTaskUrlCreatePreview,
+  parseCmdJTaskSourceUrl
+} from '@/lib/worktree-palette-task-url-match'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
 import {
@@ -674,6 +676,12 @@ function WorktreeJumpPaletteContent({
   const deferredQuery = useDeferredValue(query)
   const liveQueryRef = useRef(query)
   liveQueryRef.current = query
+  const taskSourceUrl = useMemo(() => parseCmdJTaskSourceUrl(query), [query])
+  const linearIssueUrlIntent = taskSourceUrl?.provider === 'linear' ? taskSourceUrl.intent : null
+  const taskUrlCreatePreview = useMemo(
+    () => (taskSourceUrl ? getCmdJTaskUrlCreatePreview(taskSourceUrl) : null),
+    [taskSourceUrl]
+  )
   const [selectedItemId, setSelectedItemId] = useState('')
   const [linearIssuePreview, setLinearIssuePreview] = useState<CmdJLinearIssuePreview | null>(null)
   const linearIssueLookupGenerationRef = useRef(0)
@@ -784,7 +792,8 @@ function WorktreeJumpPaletteContent({
     [defaultHostId, projectGroups]
   )
 
-  const hasQuery = deferredQuery.trim().length > 0
+  const paletteSearchQuery = taskSourceUrl ? query.trim() : deferredQuery.trim()
+  const hasQuery = paletteSearchQuery.length > 0
   const isLoading = repos.length > 0 && Object.keys(worktreesByRepo).length === 0
 
   // Why: keep running-agent workspaces visible under "Hide sleeping" even when the live PTY is momentarily absent, matching sidebar. #7197
@@ -961,7 +970,7 @@ function WorktreeJumpPaletteContent({
     () =>
       searchWorktrees(
         sortedWorktrees,
-        deferredQuery.trim(),
+        paletteSearchQuery,
         repoMap,
         prCache,
         issueCache,
@@ -970,7 +979,7 @@ function WorktreeJumpPaletteContent({
       ),
     [
       sortedWorktrees,
-      deferredQuery,
+      paletteSearchQuery,
       repoMap,
       prCache,
       issueCache,
@@ -1665,13 +1674,8 @@ function WorktreeJumpPaletteContent({
       }),
     [canCreateWorktree, deferredQuery]
   )
-  const linearIssueUrlIntent = useMemo(
-    () => (isWorktreePaletteQueryTooLarge(query) ? null : parseLinearIssueUrlIntent(query)),
-    [query]
-  )
-  const createWorktreeName = linearIssueUrlIntent ? query.trim() : deferredCreateWorktreeName
-  const showCreateAction = deferredShowCreateAction || linearIssueUrlIntent !== null
-  const prioritizeLinearCreateAction = linearIssueUrlIntent !== null
+  const createWorktreeName = taskSourceUrl ? query.trim() : deferredCreateWorktreeName
+  const showCreateAction = deferredShowCreateAction || taskSourceUrl !== null
 
   // Why: arm the lookup before Enter can target the newly rendered Linear row.
   useLayoutEffect(() => {
@@ -1874,8 +1878,15 @@ function WorktreeJumpPaletteContent({
       }
     }
 
-    if (!hasQuery && showCreateAction && prioritizeLinearCreateAction) {
-      entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
+    // Why: a pasted issue/PR URL is decisive. Show linked worktrees first so
+    // Enter jumps; keep create available underneath when the user wants a new one.
+    if (taskSourceUrl) {
+      if (visibleWorktreeItems.length > 0) {
+        pushWorktreeSection()
+      }
+      if (showCreateAction) {
+        entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
+      }
       return entries
     }
 
@@ -1884,10 +1895,6 @@ function WorktreeJumpPaletteContent({
       pushOpenTabSection()
       pushWorktreeSection()
       return entries
-    }
-
-    if (showCreateAction && prioritizeLinearCreateAction) {
-      entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
     }
 
     // Typed query with both open tabs and worktrees: soft-split so the trailing
@@ -1939,7 +1946,7 @@ function WorktreeJumpPaletteContent({
       // Trailing rest is already on screen; only hard-cap overflow needs a hint.
       pushOverflowHint(trailingHintId, multiPrimaryLayout.trailingHardOverflowCount)
       pushProjectAndMiddleSections()
-      if (showCreateAction && !prioritizeLinearCreateAction) {
+      if (showCreateAction) {
         entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
       }
       return entries
@@ -1953,7 +1960,7 @@ function WorktreeJumpPaletteContent({
     if (!openTabsLeadSections) {
       pushOpenTabSection()
     }
-    if (showCreateAction && !prioritizeLinearCreateAction) {
+    if (showCreateAction) {
       // Why: creating a workspace is the fallback for "nothing here matches", so it sits below every
       // real result — never above them, where it would steal the default selection from a match.
       entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
@@ -1963,8 +1970,8 @@ function WorktreeJumpPaletteContent({
     hasQuery,
     openTabsLeadSections,
     paletteSections,
-    prioritizeLinearCreateAction,
     showCreateAction,
+    taskSourceUrl,
     worktreeItems.length
   ])
 
@@ -2473,29 +2480,11 @@ function WorktreeJumpPaletteContent({
       return
     }
 
-    // Case 1: user pasted a GH issue/PR URL.
-    if (ghLink) {
-      const { number } = ghLink
+    // Case 1: user pasted a GH/GitLab/Jira URL.
+    // Why: hand the raw URL to the composer so it runs Cmd+N cross-project detection; pre-resolving here silently linked to the wrong project.
+    // Linked worktrees are listed above this row — selecting one jumps there.
+    if (ghLink || taskUrlCreatePreview) {
       const state = useAppStore.getState()
-
-      // Why: the existing-worktree check only needs the issue/PR number (repo-agnostic in worktree meta).
-      const matches = allWorktrees.filter(
-        (w) => !w.isArchived && (w.linkedIssue === number || w.linkedPR === number)
-      )
-      const activeMatch = matches.find((w) => w.repoId === state.activeRepoId) ?? matches[0]
-      if (activeMatch) {
-        skipRestoreFocusRef.current = true
-        closeModal()
-        // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
-        const activation = activateAndRevealWorktree(activeMatch.id)
-        if (!queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)) {
-          focusFallbackSurface()
-        }
-        recordFeatureInteraction('cmd-j-workspace-open')
-        return
-      }
-
-      // Why: hand the raw URL to the composer so it runs Cmd+N cross-project detection; pre-resolving here silently linked to the wrong project.
       const eligibleRepos = state.repos.filter((r) => isGitRepoKind(r))
       const repoForLookup =
         (state.activeRepoId && eligibleRepos.find((r) => r.id === state.activeRepoId)) ||
@@ -2601,6 +2590,7 @@ function WorktreeJumpPaletteContent({
     focusFallbackSurface,
     linearIssueUrlIntent,
     openModal,
+    taskUrlCreatePreview,
     prefetchCreateWorkspaceBaseForComposer,
     recordFeatureInteraction,
     repoMap
@@ -2814,6 +2804,7 @@ function WorktreeJumpPaletteContent({
                     linearIssue={linearPreviewIssue}
                     linearPending={linearPreviewLoading}
                     showLinearLoadingFeedback={showLinearLoadingFeedback}
+                    taskUrlPreview={taskUrlCreatePreview}
                     onSelect={handleCreateWorktree}
                   />
                 )

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -15,7 +15,6 @@ import {
   FileText,
   FolderTree,
   Globe,
-  Plus,
   Server,
   ServerOff,
   Smartphone,
@@ -175,23 +174,35 @@ import { resolvePaletteFocusRestoreTarget } from '@/components/cmd-j/palette-foc
 import { selectWorktreePaletteCacheInputs } from '@/components/cmd-j/worktree-palette-cache-inputs'
 import { getRepoHostIdentity } from '@/store/slices/repo-host-identity'
 import { buildPluginQuickActions } from '@/components/cmd-j/plugin-quick-actions'
+import { PaletteCreateWorktreeRow } from '@/components/cmd-j/PaletteCreateWorktreeRow'
 import { WorkspaceEmojiSuggestionPopover } from '@/components/workspace-emoji/WorkspaceEmojiSuggestionPopover'
 import { useWorkspaceEmojiShortcodeInput } from '@/components/workspace-emoji/useWorkspaceEmojiShortcodeInput'
 import { usePluginCommands } from '@/store/plugin-panels'
 import {
   getComposerEligibleRepos,
+  resolveComposerActiveRepoId,
   resolveComposerGitRepoId
 } from '@/lib/new-workspace-composer-repo'
+import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
 import { lookupGitHubWorkItemForSource } from '@/lib/github-work-item-source-lookup'
+import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
+import { lookupLinearIssueUrl } from '@/lib/linear-issue-url-lookup'
+import { isWorktreePaletteQueryTooLarge } from '@/lib/worktree-palette-query-bounds'
+import { parseLinearIssueUrlIntent } from '../../../shared/linear-links'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
 import {
   getSettingsFocusedExecutionHostId,
   isRuntimeOwnedSshTargetId
 } from '../../../shared/execution-host'
-import type { TerminalTab, Worktree } from '../../../shared/types'
+import type { LinearIssue, TerminalTab, Worktree } from '../../../shared/types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
-import { buildTaskSourceContextFromRepo } from '../../../shared/task-source-context'
+import {
+  buildTaskSourceContextFromRepo,
+  normalizeTaskSourceContext,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import { translate } from '@/i18n/i18n'
 
 type WorktreePaletteItem = {
@@ -252,6 +263,14 @@ type HintRow = {
 type CreateWorktreePaletteItem = {
   id: typeof CREATE_WORKTREE_ITEM_ID
   type: 'create-worktree'
+}
+
+type CmdJLinearIssuePreview = {
+  query: string
+  issue: LinearIssue | null
+  loading: boolean
+  initialRepoId: string | null
+  sourceContext: TaskSourceContext | null
 }
 
 // Why: keep quick actions curated — Cmd+J is a fast intent surface, not a dump of every setup button.
@@ -374,12 +393,26 @@ function getComposerPrefetchRepoId(
   state: ReturnType<typeof useAppStore.getState>,
   initialRepoId?: string
 ): string | null {
+  const eligibleRepos = getComposerEligibleRepos(state.repos)
   return resolveComposerGitRepoId({
-    eligibleRepos: getComposerEligibleRepos(state.repos),
+    eligibleRepos,
     initialRepoId,
-    activeRepoId: state.activeRepoId,
+    activeRepoId: resolveComposerActiveRepoId(state.repos, eligibleRepos, state.activeRepoId),
     focusedHostScope: state.workspaceHostScope
   })
+}
+
+function getComposerDefaultWorkspaceTarget(state: ReturnType<typeof useAppStore.getState>) {
+  const eligibleRepos = getComposerEligibleRepos(state.repos)
+  const activeRepoId = resolveComposerActiveRepoId(state.repos, eligibleRepos, state.activeRepoId)
+  const resolution = resolveWorkspaceCreationTarget({
+    eligibleRepos,
+    projects: state.projects,
+    projectHostSetups: state.projectHostSetups,
+    activeRepoId,
+    focusedHostScope: state.workspaceHostScope
+  })
+  return resolution.status === 'ready' ? resolution.target : null
 }
 
 function appendPaletteListEntries(
@@ -639,7 +672,15 @@ function WorktreeJumpPaletteContent({
 
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
+  const liveQueryRef = useRef(query)
+  liveQueryRef.current = query
   const [selectedItemId, setSelectedItemId] = useState('')
+  const [linearIssuePreview, setLinearIssuePreview] = useState<CmdJLinearIssuePreview | null>(null)
+  const linearIssueLookupGenerationRef = useRef(0)
+  const linearIssueLookupRef = useRef<{
+    query: string
+    promise: Promise<CmdJLinearIssuePreview>
+  } | null>(null)
   // Why: the id cmdk auto-selected for the last committed list, so a late recent-order snapshot can
   // tell "nobody has moved the highlight yet" from "the user arrowed somewhere deliberately".
   const autoSelectedItemIdRef = useRef<string | null>(null)
@@ -1613,7 +1654,10 @@ function WorktreeJumpPaletteContent({
   const digitShortcutModifiers =
     useShortcutKeyComboDetails(DIGIT_INDEX_ACTION_ID)[0]?.keys.slice(0, -1) ?? []
 
-  const { createWorktreeName, showCreateAction } = useMemo(
+  const {
+    createWorktreeName: deferredCreateWorktreeName,
+    showCreateAction: deferredShowCreateAction
+  } = useMemo(
     () =>
       getWorktreePaletteCreateActionState({
         canCreateWorktree,
@@ -1621,6 +1665,89 @@ function WorktreeJumpPaletteContent({
       }),
     [canCreateWorktree, deferredQuery]
   )
+  const linearIssueUrlIntent = useMemo(
+    () => (isWorktreePaletteQueryTooLarge(query) ? null : parseLinearIssueUrlIntent(query)),
+    [query]
+  )
+  const createWorktreeName = linearIssueUrlIntent ? query.trim() : deferredCreateWorktreeName
+  const showCreateAction = deferredShowCreateAction || linearIssueUrlIntent !== null
+  const prioritizeLinearCreateAction = linearIssueUrlIntent !== null
+
+  // Why: arm the lookup before Enter can target the newly rendered Linear row.
+  useLayoutEffect(() => {
+    const generation = ++linearIssueLookupGenerationRef.current
+    linearIssueLookupRef.current = null
+    if (!visible || !linearIssueUrlIntent) {
+      setLinearIssuePreview(null)
+      return
+    }
+
+    const state = useAppStore.getState()
+    const workspaceTarget = getComposerDefaultWorkspaceTarget(state)
+    const initialRepoId = workspaceTarget?.repoId ?? null
+    const sourceContext = workspaceTarget
+      ? buildTaskSourceContextFromRepo({
+          provider: 'linear',
+          projectId: workspaceTarget.projectId,
+          repo: workspaceTarget.repo,
+          projectHostSetupId: workspaceTarget.projectHostSetupId
+        })
+      : null
+    const pendingPreview: CmdJLinearIssuePreview = {
+      query: createWorktreeName,
+      issue: null,
+      loading: true,
+      initialRepoId,
+      sourceContext
+    }
+    setLinearIssuePreview(pendingPreview)
+
+    const promise = lookupLinearIssueUrl({
+      intent: linearIssueUrlIntent,
+      knownStatus: state.linearStatus,
+      sourceContext,
+      fetchLinearIssue: state.fetchLinearIssue
+    })
+      .catch(() => null)
+      .then(
+        (issue): CmdJLinearIssuePreview => ({
+          ...pendingPreview,
+          issue,
+          loading: false
+        })
+      )
+    linearIssueLookupRef.current = { query: createWorktreeName, promise }
+    void promise.then((preview) => {
+      if (linearIssueLookupGenerationRef.current === generation) {
+        setLinearIssuePreview(preview)
+      }
+    })
+
+    return () => {
+      if (linearIssueLookupGenerationRef.current === generation) {
+        linearIssueLookupGenerationRef.current += 1
+      }
+    }
+  }, [createWorktreeName, linearIssueUrlIntent, visible])
+
+  const currentLinearIssuePreview =
+    linearIssuePreview?.query === createWorktreeName ? linearIssuePreview : null
+  const [linearLoadingFeedbackQuery, setLinearLoadingFeedbackQuery] = useState<string | null>(null)
+  useEffect(() => {
+    if (!currentLinearIssuePreview?.loading) {
+      setLinearLoadingFeedbackQuery(null)
+      return
+    }
+    setLinearLoadingFeedbackQuery(null)
+    const timer = window.setTimeout(
+      () => setLinearLoadingFeedbackQuery(currentLinearIssuePreview.query),
+      200
+    )
+    return () => window.clearTimeout(timer)
+  }, [currentLinearIssuePreview?.loading, currentLinearIssuePreview?.query])
+  const showLinearLoadingFeedback =
+    currentLinearIssuePreview?.loading === true &&
+    linearLoadingFeedbackQuery === currentLinearIssuePreview.query
 
   const listEntries = useMemo<PaletteListEntry[]>(() => {
     const entries: PaletteListEntry[] = []
@@ -1747,11 +1874,20 @@ function WorktreeJumpPaletteContent({
       }
     }
 
+    if (!hasQuery && showCreateAction && prioritizeLinearCreateAction) {
+      entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
+      return entries
+    }
+
     if (!hasQuery) {
       // Why: the recent section leads the empty-query view; nothing else in this branch is populated.
       pushOpenTabSection()
       pushWorktreeSection()
       return entries
+    }
+
+    if (showCreateAction && prioritizeLinearCreateAction) {
+      entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
     }
 
     // Typed query with both open tabs and worktrees: soft-split so the trailing
@@ -1803,7 +1939,7 @@ function WorktreeJumpPaletteContent({
       // Trailing rest is already on screen; only hard-cap overflow needs a hint.
       pushOverflowHint(trailingHintId, multiPrimaryLayout.trailingHardOverflowCount)
       pushProjectAndMiddleSections()
-      if (showCreateAction) {
+      if (showCreateAction && !prioritizeLinearCreateAction) {
         entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
       }
       return entries
@@ -1817,13 +1953,20 @@ function WorktreeJumpPaletteContent({
     if (!openTabsLeadSections) {
       pushOpenTabSection()
     }
-    if (showCreateAction) {
+    if (showCreateAction && !prioritizeLinearCreateAction) {
       // Why: creating a workspace is the fallback for "nothing here matches", so it sits below every
       // real result — never above them, where it would steal the default selection from a match.
       entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
     }
     return entries
-  }, [hasQuery, openTabsLeadSections, paletteSections, showCreateAction, worktreeItems.length])
+  }, [
+    hasQuery,
+    openTabsLeadSections,
+    paletteSections,
+    prioritizeLinearCreateAction,
+    showCreateAction,
+    worktreeItems.length
+  ])
 
   // Why derive from listEntries: multi-primary interleave must stay identical for
   // empty-state counts and keyboard selection — dual-path builders drifted before.
@@ -2262,12 +2405,15 @@ function WorktreeJumpPaletteContent({
   }, [handleSelectItem, hasQuery, query.length, visible])
 
   const handleCreateWorktree = useCallback(() => {
-    skipRestoreFocusRef.current = true
     const trimmed = createWorktreeName.trim()
+    if (liveQueryRef.current.trim() !== trimmed) {
+      return
+    }
     const ghLink = parseGitHubIssueOrPRLink(trimmed)
     const ghNumber = parseGitHubIssueOrPRNumber(trimmed)
 
     const openComposer = (data: Record<string, unknown>): void => {
+      skipRestoreFocusRef.current = true
       prefetchCreateWorkspaceBaseForComposer(
         typeof data.initialRepoId === 'string' ? data.initialRepoId : undefined
       )
@@ -2277,6 +2423,54 @@ function WorktreeJumpPaletteContent({
       queueMicrotask(() =>
         openModal('new-workspace-composer', { ...data, telemetrySource: 'command_palette' })
       )
+    }
+
+    if (linearIssueUrlIntent) {
+      const openLinearIssueComposer = async (): Promise<void> => {
+        const lookup = linearIssueLookupRef.current
+        const preview = currentLinearIssuePreview?.loading
+          ? await lookup?.promise
+          : (currentLinearIssuePreview ?? (await lookup?.promise))
+        if (
+          lookup?.query !== trimmed ||
+          linearIssueLookupRef.current !== lookup ||
+          liveQueryRef.current.trim() !== trimmed
+        ) {
+          return
+        }
+        const composerData = preview?.issue
+          ? (() => {
+              const taskSourceContext = preview.sourceContext
+                ? normalizeTaskSourceContext({
+                    ...preview.sourceContext,
+                    providerIdentity: {
+                      provider: 'linear',
+                      workspaceId: preview.issue.workspaceId ?? null,
+                      workspaceName: preview.issue.workspaceName ?? null,
+                      teamId: preview.issue.team.id,
+                      teamKey: preview.issue.team.key
+                    },
+                    accountLabel: preview.issue.workspaceName ?? null
+                  })
+                : null
+              return {
+                prefilledName: getLinearIssueWorkspaceName(preview.issue),
+                linkedWorkItem: buildLinearIssueLinkedWorkItem(preview.issue),
+                ...(preview.initialRepoId ? { initialRepoId: preview.initialRepoId } : {}),
+                ...(taskSourceContext ? { taskSourceContext } : {})
+              }
+            })()
+          : preview?.initialRepoId
+            ? { prefilledName: trimmed, initialRepoId: preview.initialRepoId }
+            : { prefilledName: trimmed }
+
+        if (useAppStore.getState().activeModal !== 'worktree-palette') {
+          return
+        }
+        openComposer(composerData)
+      }
+      void openLinearIssueComposer()
+      return
     }
 
     // Case 1: user pasted a GH issue/PR URL.
@@ -2290,6 +2484,7 @@ function WorktreeJumpPaletteContent({
       )
       const activeMatch = matches.find((w) => w.repoId === state.activeRepoId) ?? matches[0]
       if (activeMatch) {
+        skipRestoreFocusRef.current = true
         closeModal()
         // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
         const activation = activateAndRevealWorktree(activeMatch.id)
@@ -2321,6 +2516,7 @@ function WorktreeJumpPaletteContent({
       )
       const activeMatch = matches.find((w) => w.repoId === state.activeRepoId) ?? matches[0]
       if (activeMatch) {
+        skipRestoreFocusRef.current = true
         closeModal()
         // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
         const activation = activateAndRevealWorktree(activeMatch.id)
@@ -2347,6 +2543,7 @@ function WorktreeJumpPaletteContent({
       })
       const lookupToken = createLookupGuard.start()
       preserveCreateLookupOnCloseRef.current = true
+      skipRestoreFocusRef.current = true
       recordFeatureInteraction('cmd-j-create-workspace')
       closeModal()
       void lookupGitHubWorkItemForSource({
@@ -2400,7 +2597,9 @@ function WorktreeJumpPaletteContent({
     closeModal,
     createLookupGuard,
     createWorktreeName,
+    currentLinearIssuePreview,
     focusFallbackSurface,
+    linearIssueUrlIntent,
     openModal,
     prefetchCreateWorkspaceBaseForComposer,
     recordFeatureInteraction,
@@ -2603,26 +2802,20 @@ function WorktreeJumpPaletteContent({
               }
 
               if (entry.type === 'create-worktree') {
+                const linearPreviewIssue = currentLinearIssuePreview?.issue ?? null
+                const linearPreviewLoading =
+                  linearIssueUrlIntent !== null && currentLinearIssuePreview?.loading !== false
                 return (
-                  <CommandItem
+                  <PaletteCreateWorktreeRow
                     key={entry.id}
-                    value={CREATE_WORKTREE_ITEM_ID}
-                    onSelect={handleCreateWorktree}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'mt-1 py-1.5')}
-                  >
-                    <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-dashed border-border/60 bg-muted/25 text-muted-foreground/70">
-                      <Plus size={13} aria-hidden="true" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="text-[14px] font-semibold tracking-[-0.01em] text-foreground">
-                        {translate(
-                          'auto.components.WorktreeJumpPalette.95be6587d3',
-                          'Create worktree "{{value0}}"',
-                          { value0: createWorktreeName }
-                        )}
-                      </div>
-                    </div>
-                  </CommandItem>
+                    createWorktreeName={createWorktreeName}
+                    linearIdentifier={linearIssueUrlIntent?.identifier ?? null}
+                    linearIssue={linearPreviewIssue}
+                    linearPending={linearPreviewLoading}
+                    showLinearLoadingFeedback={showLinearLoadingFeedback}
+                    onSelect={handleCreateWorktree}
+                  />
                 )
               }
 

--- a/src/renderer/src/components/cmd-j/PaletteCreateWorktreeRow.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteCreateWorktreeRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Github, Gitlab, Plus } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { JiraIcon } from '@/components/icons/JiraIcon'
@@ -64,13 +64,23 @@ export function PaletteCreateWorktreeRow({
   const previewLabel = showLinearPreview
     ? linearPreviewLabel
     : (taskUrlPreview?.createLabel ?? undefined)
+  const [showTaskUrlLoadingFeedback, setShowTaskUrlLoadingFeedback] = useState(false)
+  useEffect(() => {
+    if (!taskUrlPreview?.loading) {
+      setShowTaskUrlLoadingFeedback(false)
+      return
+    }
+    setShowTaskUrlLoadingFeedback(false)
+    const timer = window.setTimeout(() => setShowTaskUrlLoadingFeedback(true), 200)
+    return () => window.clearTimeout(timer)
+  }, [taskUrlPreview?.identifier, taskUrlPreview?.loading])
 
   return (
     <CommandItem
       value={CREATE_WORKTREE_ITEM_ID}
       onSelect={onSelect}
       aria-label={previewLabel}
-      aria-busy={linearPending}
+      aria-busy={linearPending || Boolean(taskUrlPreview?.loading && !showLinearPreview)}
       data-cmd-j-linear-issue-preview={showLinearPreview ? 'true' : undefined}
       data-cmd-j-linear-issue-state={
         linearIssue ? 'resolved' : linearPending ? 'loading' : undefined
@@ -78,6 +88,13 @@ export function PaletteCreateWorktreeRow({
       data-cmd-j-task-url-preview={taskUrlPreview && !showLinearPreview ? 'true' : undefined}
       data-cmd-j-task-url-provider={
         taskUrlPreview && !showLinearPreview ? taskUrlPreview.provider : undefined
+      }
+      data-cmd-j-task-url-state={
+        taskUrlPreview && !showLinearPreview
+          ? taskUrlPreview.loading
+            ? 'loading'
+            : 'resolved'
+          : undefined
       }
       className={className}
     >
@@ -122,11 +139,15 @@ export function PaletteCreateWorktreeRow({
               </span>
             </div>
             <div className="mt-0.5 truncate text-[12px] text-muted-foreground">
-              {translate(
-                'worktreeJumpPalette.taskUrl.createHint',
-                'Create worktree from {{value0}}',
-                { value0: taskUrlPreview.kindLabel }
-              )}
+              {taskUrlPreview.loading && showTaskUrlLoadingFeedback
+                ? translate('worktreeJumpPalette.taskUrl.loadingHint', 'Loading {{value0}}…', {
+                    value0: taskUrlPreview.kindLabel
+                  })
+                : translate(
+                    'worktreeJumpPalette.taskUrl.createHint',
+                    'Create worktree from {{value0}}',
+                    { value0: taskUrlPreview.kindLabel }
+                  )}
             </div>
           </div>
         </>

--- a/src/renderer/src/components/cmd-j/PaletteCreateWorktreeRow.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteCreateWorktreeRow.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { Plus } from 'lucide-react'
+import { LinearIcon } from '@/components/icons/LinearIcon'
+import { CommandItem } from '@/components/ui/command'
+import { CREATE_WORKTREE_ITEM_ID } from '@/lib/worktree-palette-create-action'
+import type { LinearIssue } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+export function PaletteCreateWorktreeRow({
+  className,
+  createWorktreeName,
+  linearIdentifier,
+  linearIssue,
+  linearPending,
+  showLinearLoadingFeedback,
+  onSelect
+}: {
+  className: string
+  createWorktreeName: string
+  linearIdentifier: string | null
+  linearIssue: Pick<LinearIssue, 'identifier' | 'title'> | null
+  linearPending: boolean
+  showLinearLoadingFeedback: boolean
+  onSelect: () => void
+}): React.JSX.Element {
+  const showLinearPreview = linearPending || linearIssue !== null
+  const linearPreviewLabel = linearIssue
+    ? translate(
+        'worktreeJumpPalette.linearIssue.createLabel',
+        'Create worktree from Linear issue {{value0}}: {{value1}}',
+        { value0: linearIssue.identifier, value1: linearIssue.title }
+      )
+    : linearPending && showLinearLoadingFeedback
+      ? translate(
+          'worktreeJumpPalette.linearIssue.loadingLabel',
+          'Loading Linear issue {{value0}}',
+          { value0: linearIdentifier ?? '' }
+        )
+      : linearPending
+        ? translate(
+            'worktreeJumpPalette.linearIssue.pendingLabel',
+            'Create worktree from Linear issue {{value0}}',
+            { value0: linearIdentifier ?? '' }
+          )
+        : undefined
+
+  return (
+    <CommandItem
+      value={CREATE_WORKTREE_ITEM_ID}
+      onSelect={onSelect}
+      aria-label={linearPreviewLabel}
+      aria-busy={linearPending}
+      data-cmd-j-linear-issue-preview={showLinearPreview ? 'true' : undefined}
+      data-cmd-j-linear-issue-state={
+        linearIssue ? 'resolved' : linearPending ? 'loading' : undefined
+      }
+      className={className}
+    >
+      {showLinearPreview ? (
+        <>
+          <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/60 bg-muted/25 text-muted-foreground/70">
+            <LinearIcon className="size-3" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-baseline gap-2">
+              <span className="shrink-0 font-mono text-[12px] font-semibold text-muted-foreground">
+                {linearIssue?.identifier ?? linearIdentifier}
+              </span>
+              {linearIssue ? (
+                <span className="truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground">
+                  {linearIssue.title}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-0.5 truncate text-[12px] text-muted-foreground">
+              {linearIssue || !showLinearLoadingFeedback
+                ? translate(
+                    'worktreeJumpPalette.linearIssue.createHint',
+                    'Create worktree from Linear issue'
+                  )
+                : translate('worktreeJumpPalette.linearIssue.loadingHint', 'Loading Linear issue…')}
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-dashed border-border/60 bg-muted/25 text-muted-foreground/70">
+            <Plus size={13} aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[14px] font-semibold tracking-[-0.01em] text-foreground">
+              {translate(
+                'auto.components.WorktreeJumpPalette.95be6587d3',
+                'Create worktree "{{value0}}"',
+                { value0: createWorktreeName }
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </CommandItem>
+  )
+}

--- a/src/renderer/src/components/cmd-j/PaletteCreateWorktreeRow.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteCreateWorktreeRow.tsx
@@ -1,10 +1,26 @@
 import React from 'react'
-import { Plus } from 'lucide-react'
+import { Github, Gitlab, Plus } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
+import { JiraIcon } from '@/components/icons/JiraIcon'
 import { CommandItem } from '@/components/ui/command'
 import { CREATE_WORKTREE_ITEM_ID } from '@/lib/worktree-palette-create-action'
+import type { CmdJTaskUrlCreatePreview } from '@/lib/worktree-palette-task-url-match'
 import type { LinearIssue } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
+
+function TaskUrlProviderIcon({
+  provider
+}: {
+  provider: CmdJTaskUrlCreatePreview['provider']
+}): React.JSX.Element {
+  if (provider === 'github') {
+    return <Github className="size-3" aria-hidden="true" />
+  }
+  if (provider === 'gitlab') {
+    return <Gitlab className="size-3" aria-hidden="true" />
+  }
+  return <JiraIcon className="size-3" />
+}
 
 export function PaletteCreateWorktreeRow({
   className,
@@ -13,6 +29,7 @@ export function PaletteCreateWorktreeRow({
   linearIssue,
   linearPending,
   showLinearLoadingFeedback,
+  taskUrlPreview,
   onSelect
 }: {
   className: string
@@ -21,6 +38,7 @@ export function PaletteCreateWorktreeRow({
   linearIssue: Pick<LinearIssue, 'identifier' | 'title'> | null
   linearPending: boolean
   showLinearLoadingFeedback: boolean
+  taskUrlPreview: CmdJTaskUrlCreatePreview | null
   onSelect: () => void
 }): React.JSX.Element {
   const showLinearPreview = linearPending || linearIssue !== null
@@ -43,16 +61,23 @@ export function PaletteCreateWorktreeRow({
             { value0: linearIdentifier ?? '' }
           )
         : undefined
+  const previewLabel = showLinearPreview
+    ? linearPreviewLabel
+    : (taskUrlPreview?.createLabel ?? undefined)
 
   return (
     <CommandItem
       value={CREATE_WORKTREE_ITEM_ID}
       onSelect={onSelect}
-      aria-label={linearPreviewLabel}
+      aria-label={previewLabel}
       aria-busy={linearPending}
       data-cmd-j-linear-issue-preview={showLinearPreview ? 'true' : undefined}
       data-cmd-j-linear-issue-state={
         linearIssue ? 'resolved' : linearPending ? 'loading' : undefined
+      }
+      data-cmd-j-task-url-preview={taskUrlPreview && !showLinearPreview ? 'true' : undefined}
+      data-cmd-j-task-url-provider={
+        taskUrlPreview && !showLinearPreview ? taskUrlPreview.provider : undefined
       }
       className={className}
     >
@@ -79,6 +104,29 @@ export function PaletteCreateWorktreeRow({
                     'Create worktree from Linear issue'
                   )
                 : translate('worktreeJumpPalette.linearIssue.loadingHint', 'Loading Linear issue…')}
+            </div>
+          </div>
+        </>
+      ) : taskUrlPreview ? (
+        <>
+          <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/60 bg-muted/25 text-muted-foreground/70">
+            <TaskUrlProviderIcon provider={taskUrlPreview.provider} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-baseline gap-2">
+              <span className="shrink-0 font-mono text-[12px] font-semibold text-muted-foreground">
+                {taskUrlPreview.identifier}
+              </span>
+              <span className="truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground">
+                {taskUrlPreview.subtitle}
+              </span>
+            </div>
+            <div className="mt-0.5 truncate text-[12px] text-muted-foreground">
+              {translate(
+                'worktreeJumpPalette.taskUrl.createHint',
+                'Create worktree from {{value0}}',
+                { value0: taskUrlPreview.kindLabel }
+              )}
             </div>
           </div>
         </>

--- a/src/renderer/src/components/cmd-j/palette-activation-focus-routing.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-activation-focus-routing.test.ts
@@ -53,8 +53,9 @@ describe('Cmd+J activation focus routing (#9939)', () => {
     )
     const activationCalls =
       handler.match(/const activation = activateAndRevealWorktree\(activeMatch\.id\)/g)?.length ?? 0
-    // Both issue/PR match paths must restore focus when terminal routing declines.
-    expect(activationCalls).toBe(2)
+    // Typed #N still jumps from create. Pasted issue/PR URLs jump via the
+    // worktree row (handleSelectWorktree), which has its own focus routing.
+    expect(activationCalls).toBe(1)
     expect(
       handler.match(
         /if \(!queueWorkspaceActivationTerminalFocus\(activeMatch\.id, activation\)\) \{\s*focusFallbackSurface\(\)\s*\}/g

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
@@ -99,6 +99,31 @@ describe('SmartWorkspaceNameField repo-backed source boundaries', () => {
     expect(githubLookupSection).toContain('repoBackedSearchTargets.map')
   })
 
+  it('does not fan decisive Linear URLs out to unrelated providers', () => {
+    const githubGate = sourceBetween(
+      FIELD_SOURCE,
+      'const shouldQueryGithub =',
+      'const shouldQueryLinear ='
+    )
+    const branchGate = sourceBetween(
+      FIELD_SOURCE,
+      'const branchSearchRequest = useMemo',
+      'useEffect(() => {\n    if (!branchSearchRequest)'
+    )
+    const gitlabGate = sourceBetween(
+      FIELD_SOURCE,
+      'const shouldQueryGitlab =',
+      'useEffect(() => {\n    if (!shouldQueryGitlab'
+    )
+
+    expect(FIELD_SOURCE).toContain(
+      "linearUrlIntent !== null && (mode === 'smart' || mode === 'linear')"
+    )
+    expect(githubGate).toContain('!linearUrlIntentOwnsInput')
+    expect(branchGate).toContain('linearUrlIntentOwnsInput')
+    expect(gitlabGate).toContain('!linearUrlIntentOwnsInput')
+  })
+
   it('reports the active source mode without lifting source search state', () => {
     expect(FIELD_SOURCE).toContain('onActiveSourceModeChange?: (mode: SmartNameMode) => void')
     expect(FIELD_SOURCE).toContain('onActiveSourceModeChange')

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -3,6 +3,7 @@
 import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
 import SmartWorkspaceNameField from './SmartWorkspaceNameField'
 
 vi.mock('@/store', () => {
@@ -10,6 +11,7 @@ vi.mock('@/store', () => {
     repos: [],
     addRepo: vi.fn(),
     checkLinearConnection: vi.fn(),
+    fetchLinearIssue: vi.fn(),
     fetchWorkItems: vi.fn(),
     fetchWorkItemsAcrossRepos: vi.fn(),
     getCachedWorkItems: vi.fn(() => null),
@@ -25,6 +27,7 @@ vi.mock('@/store', () => {
   }
   const useAppStore = (selector: (s: typeof state) => unknown): unknown => selector(state)
   useAppStore.getState = () => state
+  useAppStore.setState = (patch: Partial<typeof state>) => Object.assign(state, patch)
   return { useAppStore }
 })
 
@@ -79,6 +82,13 @@ let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  useAppStore.setState({
+    linearStatus: { connected: false, viewer: null },
+    linearStatusChecked: false,
+    fetchLinearIssue: vi.fn(async () => null),
+    listLinearIssues: vi.fn(async () => ({ items: [] })),
+    searchLinearIssues: vi.fn(async () => [])
+  })
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -88,6 +98,7 @@ afterEach(() => {
   act(() => {
     root.unmount()
   })
+  vi.useRealTimers()
   container.remove()
 })
 
@@ -258,6 +269,87 @@ describe('SmartWorkspaceNameField IME Enter guard', () => {
     // at the row-select branch, not merely inert.
     expect(onValueChange).toHaveBeenCalledWith('배포')
     expect(onPlainEnter).not.toHaveBeenCalled()
+  })
+})
+
+describe('SmartWorkspaceNameField Linear URL loading', () => {
+  it('blocks Enter and delays visible loading feedback while preserving its layout', async () => {
+    vi.useFakeTimers()
+    const url = 'https://linear.app/stably/issue/STA-4084/restore-shell-integration'
+    const onPlainEnter = vi.fn()
+    const onValueChange = vi.fn()
+    const onLinearIssueSelect = vi.fn()
+    useAppStore.setState({
+      linearStatus: {
+        connected: true,
+        viewer: null,
+        activeWorkspaceId: 'workspace-1',
+        selectedWorkspaceId: 'workspace-1',
+        workspaces: [
+          {
+            id: 'workspace-1',
+            displayName: 'Stably User',
+            email: null,
+            organizationId: 'organization-stably',
+            organizationName: 'Stably',
+            organizationUrlKey: 'stably'
+          }
+        ]
+      },
+      linearStatusChecked: true,
+      fetchLinearIssue: vi.fn(() => new Promise<null>(() => {}))
+    })
+
+    await act(async () => {
+      root.render(
+        <SmartWorkspaceNameField
+          repos={[]}
+          repoId="repo-1"
+          onRepoChange={vi.fn()}
+          value={url}
+          onValueChange={onValueChange}
+          onGitHubItemSelect={vi.fn()}
+          onBranchSelect={vi.fn()}
+          onLinearIssueSelect={onLinearIssueSelect}
+          selectedSource={null}
+          onClearSelectedSource={vi.fn()}
+          onPlainEnter={onPlainEnter}
+        />
+      )
+    })
+
+    const input = container.querySelector<HTMLInputElement>('[data-workspace-name-input="true"]')
+    const describedBy = input?.getAttribute('aria-describedby')
+    const status = describedBy ? container.querySelector<HTMLElement>(`#${describedBy}`) : null
+    const reservedResults = container.querySelector<HTMLElement>('[aria-hidden="true"].space-y-1')
+    expect(input?.getAttribute('aria-busy')).toBe('true')
+    expect(status?.getAttribute('role')).toBe('status')
+    expect(status?.getAttribute('aria-live')).toBe('polite')
+    expect(status?.textContent).toContain('Loading Linear issue…')
+    expect(container.textContent).not.toContain('Start typing to create a name or find a source.')
+    expect(reservedResults?.classList.contains('invisible')).toBe(true)
+    expect(reservedResults?.children).toHaveLength(3)
+
+    if (!input) {
+      throw new Error('workspace name input not rendered')
+    }
+    pressEnter(input)
+    expect(onPlainEnter).not.toHaveBeenCalled()
+    expect(onValueChange).not.toHaveBeenCalled()
+    expect(onLinearIssueSelect).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(199)
+    })
+    expect(reservedResults?.classList.contains('invisible')).toBe(true)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    const visibleResults = container.querySelector<HTMLElement>('[aria-hidden="true"].space-y-1')
+    expect(visibleResults).toBe(reservedResults)
+    expect(visibleResults?.classList.contains('invisible')).toBe(false)
+    expect(visibleResults?.querySelectorAll('.animate-pulse')).toHaveLength(3)
   })
 })
 

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -61,10 +61,18 @@ import {
   getVisibleBranchResults,
   getVisibleHeldProviderResults,
   isBlockingJiraUrlIntent,
-  isSmartWorkspaceSourceQueryWithinLimit,
   type SmartNameMode,
   type SmartWorkspaceSourceRow
 } from './smart-workspace-source-results'
+import {
+  getSmartWorkspaceLinearSearchQuery,
+  isBlockingLinearUrlIntent,
+  isSmartWorkspaceLinearIssueIntentMatch,
+  parseBoundedSmartWorkspaceLinearIssueInput,
+  parseBoundedSmartWorkspaceLinearIssueUrlIntent,
+  prioritizeSmartWorkspaceLinearIssueResults
+} from '../../../../shared/new-workspace/smart-workspace-linear-intent'
+import { isSmartWorkspaceSourceQueryWithinLimit } from '../../../../shared/new-workspace/smart-workspace-source-query'
 import { filterAvailableTaskProviders } from '../../../../shared/task-providers'
 import type {
   BaseRefSearchResult,
@@ -109,6 +117,7 @@ import {
   type WorkspaceEmojiSuggestion
 } from '@/lib/workspace-emoji-shortcodes'
 import { WorkspaceEmojiSuggestionPopover } from '@/components/workspace-emoji/WorkspaceEmojiSuggestionPopover'
+import { lookupLinearIssueUrl } from '@/lib/linear-issue-url-lookup'
 
 type RepoOption = ReturnType<typeof useAppStore.getState>['repos'][number]
 const EMPTY_REPO_SEARCH_REPOS: readonly RepoOption[] = []
@@ -259,6 +268,7 @@ export default function SmartWorkspaceNameField({
     checkLinearConnection,
     fetchWorkItems,
     fetchWorkItemsAcrossRepos,
+    fetchLinearIssue,
     getCachedWorkItems,
     linearStatus,
     linearStatusChecked,
@@ -277,6 +287,7 @@ export default function SmartWorkspaceNameField({
       checkLinearConnection: s.checkLinearConnection,
       fetchWorkItems: s.fetchWorkItems,
       fetchWorkItemsAcrossRepos: s.fetchWorkItemsAcrossRepos,
+      fetchLinearIssue: s.fetchLinearIssue,
       getCachedWorkItems: s.getCachedWorkItems,
       linearStatus: s.linearStatus,
       linearStatusChecked: s.linearStatusChecked,
@@ -378,6 +389,10 @@ export default function SmartWorkspaceNameField({
   const [gitlabLoading, setGitlabLoading] = useState(false)
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [linearLoading, setLinearLoading] = useState(false)
+  const [linearUrlLoadingFeedbackQuery, setLinearUrlLoadingFeedbackQuery] = useState<string | null>(
+    null
+  )
+  const [settledLinearUrlQuery, setSettledLinearUrlQuery] = useState<string | null>(null)
   const [jiraLoading, setJiraLoading] = useState(false)
   const [commandValue, setCommandValue] = useState('')
   const [emojiCommandValue, setEmojiCommandValue] = useState('')
@@ -411,6 +426,7 @@ export default function SmartWorkspaceNameField({
   const jiraSourceConnected = jiraConnectionStatus?.connected === true
   const showJiraSiteContext = mode === 'jira' && jiraConnectionStatus?.selectedSiteId === 'all'
   const jiraStatusId = React.useId()
+  const linearStatusId = React.useId()
 
   useEffect(() => {
     onActiveSourceModeChange?.(mode)
@@ -626,15 +642,32 @@ export default function SmartWorkspaceNameField({
     () => (sourceQueryWithinLimit ? parseGitHubIssueOrPRLink(debouncedQuery) : null),
     [debouncedQuery, sourceQueryWithinLimit]
   )
+  const linearUrlIntent = useMemo(
+    () => parseBoundedSmartWorkspaceLinearIssueUrlIntent(value),
+    [value]
+  )
+  const linearUrlIntentOwnsInput =
+    linearUrlIntent !== null && (mode === 'smart' || mode === 'linear')
+  const linearQuery = linearUrlIntentOwnsInput ? value : debouncedQuery
+  useEffect(() => {
+    if (!linearUrlIntentOwnsInput || !linearLoading) {
+      setLinearUrlLoadingFeedbackQuery(null)
+      return
+    }
+    setLinearUrlLoadingFeedbackQuery(null)
+    const timer = window.setTimeout(() => setLinearUrlLoadingFeedbackQuery(linearQuery), 200)
+    return () => window.clearTimeout(timer)
+  }, [linearLoading, linearQuery, linearUrlIntentOwnsInput])
   const shouldQueryGithub =
     sourceQueryWithinLimit &&
     !repoBackedSourcesDisabled &&
     !jiraSource.intent &&
+    !linearUrlIntentOwnsInput &&
     !textOnly &&
     repoBackedSearchTargets.length > 0 &&
     (mode === 'smart' || mode === 'github')
   const shouldQueryLinear =
-    sourceQueryWithinLimit &&
+    isSmartWorkspaceSourceQueryWithinLimit(linearQuery) &&
     !jiraSource.intent &&
     !textOnly &&
     linearAvailable &&
@@ -909,7 +942,7 @@ export default function SmartWorkspaceNameField({
   const branchSearchRequest = useMemo(
     () =>
       getBranchSearchRequest({
-        disabled: disabled || jiraSource.intent,
+        disabled: disabled || jiraSource.intent || linearUrlIntentOwnsInput,
         branchesEnabled: branchesEnabled && !repoBackedSourcesDisabled,
         textOnly,
         mode,
@@ -922,6 +955,7 @@ export default function SmartWorkspaceNameField({
       debouncedQuery,
       disabled,
       jiraSource.intent,
+      linearUrlIntentOwnsInput,
       mode,
       repoBackedSourcesDisabled,
       selectedRepo?.id,
@@ -975,21 +1009,32 @@ export default function SmartWorkspaceNameField({
     if (disabled || !shouldQueryLinear || !linearStatus.connected) {
       setLinearIssues([])
       setLinearLoading(false)
+      setSettledLinearUrlQuery(null)
       return
     }
     let stale = false
     setLinearLoading(true)
-    const trimmed = debouncedQuery.trim()
+    setSettledLinearUrlQuery(null)
+    const trimmed = linearQuery.trim()
     // Why: empty-query list must not briefly paint the previous non-empty result set.
     if (trimmed === '') {
       setLinearIssues([])
     }
-    const request = trimmed
-      ? searchLinearIssues(trimmed, RESULT_LIMIT, { sourceContext: linearSourceContext })
-      : listLinearIssues(
-          { kind: 'list', filter: 'assigned', limit: RESULT_LIMIT },
-          { sourceContext: linearSourceContext }
-        ).then((result) => result.items)
+    const request = linearUrlIntent
+      ? lookupLinearIssueUrl({
+          intent: linearUrlIntent,
+          knownStatus: linearStatus,
+          sourceContext: linearSourceContext,
+          fetchLinearIssue
+        }).then((issue) => (issue ? [issue] : []))
+      : trimmed
+        ? searchLinearIssues(getSmartWorkspaceLinearSearchQuery(trimmed), RESULT_LIMIT, {
+            sourceContext: linearSourceContext
+          })
+        : listLinearIssues(
+            { kind: 'list', filter: 'assigned', limit: RESULT_LIMIT },
+            { sourceContext: linearSourceContext }
+          ).then((result) => result.items)
     void request
       .then((issues) => {
         if (!stale) {
@@ -1004,6 +1049,7 @@ export default function SmartWorkspaceNameField({
       .finally(() => {
         if (!stale) {
           setLinearLoading(false)
+          setSettledLinearUrlQuery(linearUrlIntent ? trimmed : null)
         }
       })
     return () => {
@@ -1011,7 +1057,7 @@ export default function SmartWorkspaceNameField({
     }
     // Why: list/search are stable store methods; depending on them would refetch on unrelated store writes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedQuery, disabled, linearSourceContext, linearStatus.connected, shouldQueryLinear])
+  }, [disabled, linearQuery, linearSourceContext, linearStatus, linearUrlIntent, shouldQueryLinear])
 
   useEffect(() => {
     if (!shouldQueryJira || !jiraSourceContext || !jiraSearchJql) {
@@ -1067,6 +1113,7 @@ export default function SmartWorkspaceNameField({
     sourceQueryWithinLimit &&
     !repoBackedSourcesDisabled &&
     !jiraSource.intent &&
+    !linearUrlIntentOwnsInput &&
     !textOnly &&
     gitlabSourceAvailable &&
     repoBackedSearchTargets.length > 0 &&
@@ -1199,6 +1246,11 @@ export default function SmartWorkspaceNameField({
     shouldQueryGitlab
   ])
 
+  const linearUrlLookupFailed =
+    linearUrlIntentOwnsInput &&
+    settledLinearUrlQuery === linearQuery.trim() &&
+    !linearLoading &&
+    linearIssues.length === 0
   const rows = useMemo<RowEntry[]>(() => {
     if (jiraSource.intent && jiraSource.accountChoices.length > 0) {
       return jiraSource.accountChoices.map((site) => ({
@@ -1234,12 +1286,16 @@ export default function SmartWorkspaceNameField({
         value,
         debouncedQuery
       }),
-      linearAvailable,
-      linearIssues: getVisibleHeldProviderResults({
-        items: linearIssues,
+      linearAvailable: linearAvailable && !linearUrlLookupFailed,
+      linearIssues: prioritizeSmartWorkspaceLinearIssueResults(
         value,
-        debouncedQuery
-      }),
+        getVisibleHeldProviderResults({
+          items: linearIssues,
+          value,
+          debouncedQuery: linearUrlIntentOwnsInput ? value : debouncedQuery
+        })
+      ),
+      linearUrlIntentOwnsResults: true,
       mode,
       resultLimit: RESULT_LIMIT,
       value
@@ -1257,6 +1313,8 @@ export default function SmartWorkspaceNameField({
     jiraIssues,
     linearAvailable,
     linearIssues,
+    linearUrlLookupFailed,
+    linearUrlIntentOwnsInput,
     mode,
     selectedRepo?.id,
     value
@@ -1274,7 +1332,8 @@ export default function SmartWorkspaceNameField({
   const debouncedQueryWithinSourceLimit = isSmartWorkspaceSourceQueryWithinLimit(debouncedQuery)
   const trimmedValue = valueWithinSourceLimit ? value.trim() : ''
   const trimmedDebouncedQuery = debouncedQueryWithinSourceLimit ? debouncedQuery.trim() : ''
-  const isQueryStale = trimmedValue.length > 0 && trimmedDebouncedQuery !== trimmedValue
+  const isQueryStale =
+    !linearUrlIntentOwnsInput && trimmedValue.length > 0 && trimmedDebouncedQuery !== trimmedValue
 
   // Why: when the typed value is an unambiguous source ref, snap the highlight to that row so Enter picks it over the typed-text fallback.
   const sourceIntent = useMemo<'github' | 'gitlab' | 'linear' | 'jira' | null>(() => {
@@ -1294,11 +1353,25 @@ export default function SmartWorkspaceNameField({
     if (parseGitLabIssueOrMRLink(trimmed) !== null) {
       return 'gitlab'
     }
-    if (linearAvailable && /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(trimmed)) {
-      return 'linear'
+    if (linearAvailable) {
+      const linearIntent = parseBoundedSmartWorkspaceLinearIssueInput(trimmed)
+      if (
+        linearIntent &&
+        rows.some(
+          (row) =>
+            row.kind === 'linear' && isSmartWorkspaceLinearIssueIntentMatch(linearIntent, row.issue)
+        )
+      ) {
+        return 'linear'
+      }
     }
     return null
-  }, [jiraSource.intent, linearAvailable, value])
+  }, [jiraSource.intent, linearAvailable, rows, value])
+  const unresolvedLinearUrlIntent =
+    linearUrlIntentOwnsInput &&
+    linearAvailable &&
+    sourceIntent !== 'linear' &&
+    (linearLoading || settledLinearUrlQuery !== linearQuery.trim())
 
   const resolvedCommandValue = resolveSmartWorkspaceCommandValue({
     currentValue: commandValue,
@@ -1342,9 +1415,14 @@ export default function SmartWorkspaceNameField({
       (suggestion) => `emoji:${suggestion.shortcode}` === resolvedEmojiCommandValue
     ) ?? null
 
+  const showLinearUrlLoadingFeedback =
+    linearLoading && linearUrlIntentOwnsInput && linearUrlLoadingFeedbackQuery === linearQuery
+  const visibleLinearLoading =
+    linearLoading && (!linearUrlIntentOwnsInput || showLinearUrlLoadingFeedback)
   const loading = jiraSource.intent
     ? jiraSource.loading
-    : githubLoading || gitlabLoading || branchesLoading || linearLoading || jiraLoading
+    : githubLoading || gitlabLoading || branchesLoading || visibleLinearLoading || jiraLoading
+  const reserveLinearLoadingResults = unresolvedLinearUrlIntent && searchResultRows.length === 0
   // Why: only spin on first load — not on every in-flight refresh while rows stay visible.
   const showSearchSpinner = loading && searchResultRows.length === 0
   const ActiveInputIcon =
@@ -1831,7 +1909,11 @@ export default function SmartWorkspaceNameField({
                     onPaste={(event) => {
                       // Why: a pasted issue URL is the whole intent — don't splice it into a name.
                       const pasted = event.clipboardData.getData('text')
-                      if (!pasted || !isBlockingJiraUrlIntent(mode, pasted)) {
+                      if (
+                        !pasted ||
+                        (!isBlockingJiraUrlIntent(mode, pasted) &&
+                          !isBlockingLinearUrlIntent(mode, pasted))
+                      ) {
                         return
                       }
                       event.preventDefault()
@@ -1896,6 +1978,10 @@ export default function SmartWorkspaceNameField({
                           handleEmojiSelect(selectedEmojiSuggestion)
                           return
                         }
+                        if (unresolvedLinearUrlIntent) {
+                          event.preventDefault()
+                          return
+                        }
                         if (open && rows.length > 0) {
                           const row = rows.find((entry) => entry.value === resolvedCommandValue)
                           if (row) {
@@ -1934,8 +2020,16 @@ export default function SmartWorkspaceNameField({
                     }}
                     placeholder={placeholder}
                     disabled={disabled}
-                    aria-busy={jiraSource.intent && jiraSource.loading}
-                    aria-describedby={jiraSource.intent ? jiraStatusId : undefined}
+                    aria-busy={
+                      (jiraSource.intent && jiraSource.loading) || unresolvedLinearUrlIntent
+                    }
+                    aria-describedby={
+                      jiraSource.intent
+                        ? jiraStatusId
+                        : unresolvedLinearUrlIntent
+                          ? linearStatusId
+                          : undefined
+                    }
                     // Why: match the project/run-on comboboxes' solid `bg-background` — the input's
                     // default transparent fill made it read a different color on light mode.
                     className="h-9 bg-background pl-8 text-sm"
@@ -2011,8 +2105,23 @@ export default function SmartWorkspaceNameField({
                   </CommandItem>
                 </div>
               ) : null}
-              {jiraSource.errorKind ? null : loading && searchResultRows.length === 0 ? (
-                <div className="space-y-1 p-1">
+              {jiraSource.errorKind ? null : reserveLinearLoadingResults ? (
+                <div
+                  aria-hidden="true"
+                  className={cn('space-y-1 p-1', !showLinearUrlLoadingFeedback && 'invisible')}
+                >
+                  {[0, 1, 2].map((index) => (
+                    <div
+                      key={index}
+                      className={cn(
+                        'h-8 rounded bg-muted/40',
+                        showLinearUrlLoadingFeedback && 'animate-pulse'
+                      )}
+                    />
+                  ))}
+                </div>
+              ) : showSearchSpinner ? (
+                <div aria-hidden="true" className="space-y-1 p-1">
                   {[0, 1, 2].map((index) => (
                     <div key={index} className="h-8 animate-pulse rounded bg-muted/40" />
                   ))}
@@ -2086,6 +2195,14 @@ export default function SmartWorkspaceNameField({
               )}
             </Button>
           ) : null}
+        </div>
+      ) : null}
+      {unresolvedLinearUrlIntent ? (
+        <div id={linearStatusId} role="status" aria-live="polite" className="sr-only">
+          {translate(
+            'auto.components.new.workspace.SmartWorkspaceNameField.loadingLinearIssue',
+            'Loading Linear issue…'
+          )}
         </div>
       ) : null}
       <WorkspaceEmojiSuggestionPopover

--- a/src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
@@ -31,6 +31,17 @@ describe('resolveSmartWorkspaceCommandValue', () => {
     ).toBe('use-name')
   })
 
+  it('keeps arbitrary text armed when Linear search results are present', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: '',
+        rows: [row('use-name', 'use-name'), row('linear', 'linear-STA-4084')],
+        isQueryStale: false,
+        sourceIntent: null
+      })
+    ).toBe('use-name')
+  })
+
   it('keeps typed text armed while the query is ahead of debounced search', () => {
     expect(
       resolveSmartWorkspaceCommandValue({

--- a/src/renderer/src/components/new-workspace/smart-workspace-source-results.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-source-results.test.ts
@@ -582,8 +582,26 @@ describe('Linear issue source input', () => {
       resultLimit: 12
     })
 
-    expect(rows.map((row) => row.kind)).toEqual(['linear'])
-    expect(rows[0]).toMatchObject({ value: 'linear-stably-issue', issue: exactIssue })
+    expect(rows.map((row) => row.kind)).toEqual(['use-name', 'linear'])
+    expect(rows[0]).toMatchObject({ kind: 'use-name', value: 'use-name', name: issueUrl })
+    expect(rows[1]).toMatchObject({ value: 'linear-stably-issue', issue: exactIssue })
+  })
+
+  it('keeps typed-text available while a Linear URL has not resolved yet', () => {
+    expect(
+      buildSmartWorkspaceSourceRows({
+        mode: 'smart',
+        value: issueUrl,
+        branches: [],
+        githubItems: [],
+        gitlabItems: [],
+        linearIssues: [],
+        gitlabAvailable: false,
+        linearAvailable: true,
+        linearUrlIntentOwnsResults: true,
+        resultLimit: 12
+      })
+    ).toEqual([{ kind: 'use-name', value: 'use-name', name: issueUrl }])
   })
 
   it('preserves arbitrary-name fallback for consumers without exact URL lookup', () => {

--- a/src/renderer/src/components/new-workspace/smart-workspace-source-results.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-source-results.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES,
   buildJiraIssueSearchJql,
   buildSmartWorkspaceSourceRows,
   getBranchSearchRequest,
@@ -8,9 +7,20 @@ import {
   getVisibleBranchResults,
   getVisibleHeldProviderResults,
   isBlockingJiraUrlIntent,
-  isSmartWorkspaceSourceQueryWithinLimit,
   shouldHoldSourceResultsForQuery
 } from './smart-workspace-source-results'
+import {
+  getSmartWorkspaceLinearSearchQuery,
+  isBlockingLinearUrlIntent,
+  isSmartWorkspaceLinearIssueIntentMatch,
+  parseBoundedSmartWorkspaceLinearIssueInput,
+  parseBoundedSmartWorkspaceLinearIssueUrlIntent,
+  prioritizeSmartWorkspaceLinearIssueResults
+} from '../../../../shared/new-workspace/smart-workspace-linear-intent'
+import {
+  SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES,
+  isSmartWorkspaceSourceQueryWithinLimit
+} from '../../../../shared/new-workspace/smart-workspace-source-query'
 
 describe('Branch source results', () => {
   it('requests empty-query branch results in Branch mode', () => {
@@ -494,6 +504,165 @@ describe('source query byte limits', () => {
         'é'.repeat(SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES / 2 + 1)
       )
     ).toBe(false)
+  })
+})
+
+describe('Linear issue source input', () => {
+  const issueUrl = 'https://linear.app/stably/issue/STA-4084/restore-osc-133-shell-integration'
+
+  it('normalizes a Linear issue URL to its identifier for search', () => {
+    expect(parseBoundedSmartWorkspaceLinearIssueInput(issueUrl)).toEqual({
+      identifier: 'STA-4084',
+      organizationUrlKey: 'stably'
+    })
+    expect(getSmartWorkspaceLinearSearchQuery(issueUrl)).toBe('STA-4084')
+  })
+
+  it('keeps arbitrary names as ordinary Linear search text', () => {
+    expect(parseBoundedSmartWorkspaceLinearIssueInput('restore shell integration')).toBeNull()
+    expect(getSmartWorkspaceLinearSearchQuery(' restore shell integration ')).toBe(
+      'restore shell integration'
+    )
+  })
+
+  it('only replaces the whole field for unmistakable Linear URL intent', () => {
+    expect(isBlockingLinearUrlIntent('smart', issueUrl)).toBe(true)
+    expect(isBlockingLinearUrlIntent('linear', issueUrl)).toBe(true)
+    expect(isBlockingLinearUrlIntent('text', issueUrl)).toBe(false)
+    expect(isBlockingLinearUrlIntent('github', issueUrl)).toBe(false)
+    expect(isBlockingLinearUrlIntent('gitlab', issueUrl)).toBe(false)
+    expect(isBlockingLinearUrlIntent('branches', issueUrl)).toBe(false)
+    expect(isBlockingLinearUrlIntent('smart', 'STA-4084')).toBe(false)
+    expect(isBlockingLinearUrlIntent('smart', 'restore-4084')).toBe(false)
+    expect(
+      isBlockingLinearUrlIntent('smart', 'https://linear.app.evil.test/stably/issue/STA-4084')
+    ).toBe(false)
+    expect(
+      isBlockingLinearUrlIntent('smart', 'https://linear.app/stably/not-an-issue/issue/STA-4084')
+    ).toBe(false)
+    expect(
+      isBlockingLinearUrlIntent('smart', 'https://linear.app/stably/issue/STA-4084/title/more')
+    ).toBe(false)
+    expect(
+      isBlockingLinearUrlIntent(
+        'smart',
+        'https://linear.app/stably/issue/STA-4084%2Fnot-the-identifier'
+      )
+    ).toBe(false)
+    expect(
+      parseBoundedSmartWorkspaceLinearIssueUrlIntent(
+        'https://linear.app/stably/issue/STA-4084/title'
+      )
+    ).toEqual({ identifier: 'STA-4084', organizationUrlKey: 'stably' })
+  })
+
+  it('keeps the exact Linear URL result ahead of provider result caps', () => {
+    const exactIssue = {
+      id: 'stably-issue',
+      identifier: 'STA-4084',
+      url: issueUrl
+    } as never
+    const rows = buildSmartWorkspaceSourceRows({
+      mode: 'smart',
+      value: issueUrl,
+      branches: Array.from({ length: 12 }, (_, index) => ({
+        refName: `origin/provider-result-${index}`,
+        localBranchName: `provider-result-${index}`
+      })),
+      githubItems: Array.from({ length: 12 }, (_, index) => ({
+        repoId: 'repo-1',
+        type: 'issue',
+        number: index + 1
+      })) as never,
+      gitlabItems: [],
+      linearIssues: [exactIssue],
+      gitlabAvailable: false,
+      linearAvailable: true,
+      linearUrlIntentOwnsResults: true,
+      resultLimit: 12
+    })
+
+    expect(rows.map((row) => row.kind)).toEqual(['linear'])
+    expect(rows[0]).toMatchObject({ value: 'linear-stably-issue', issue: exactIssue })
+  })
+
+  it('preserves arbitrary-name fallback for consumers without exact URL lookup', () => {
+    const rows = buildSmartWorkspaceSourceRows({
+      mode: 'smart',
+      value: issueUrl,
+      branches: [],
+      githubItems: [],
+      gitlabItems: [],
+      linearIssues: [],
+      gitlabAvailable: false,
+      linearAvailable: true,
+      resultLimit: 12
+    })
+
+    expect(rows).toEqual([{ kind: 'use-name', value: 'use-name', name: issueUrl }])
+  })
+
+  it('prioritizes only the issue from the URL organization', () => {
+    const otherWorkspace = {
+      id: 'other-issue',
+      identifier: 'STA-4084',
+      url: 'https://linear.app/other/issue/STA-4084'
+    } as never
+    const exactIssue = {
+      id: 'stably-issue',
+      identifier: 'STA-4084',
+      url: issueUrl
+    } as never
+    const unrelatedIssue = {
+      id: 'unrelated-issue',
+      identifier: 'STA-9999',
+      url: 'https://linear.app/stably/issue/STA-9999'
+    } as never
+
+    expect(
+      prioritizeSmartWorkspaceLinearIssueResults(issueUrl, [
+        otherWorkspace,
+        unrelatedIssue,
+        exactIssue
+      ]).map((issue) => issue.id)
+    ).toEqual(['stably-issue', 'other-issue', 'unrelated-issue'])
+    expect(
+      isSmartWorkspaceLinearIssueIntentMatch(
+        parseBoundedSmartWorkspaceLinearIssueInput(issueUrl)!,
+        otherWorkspace
+      )
+    ).toBe(false)
+  })
+
+  it('matches bare Linear keys by identifier without changing provider order for names', () => {
+    const issue = {
+      id: 'stably-issue',
+      identifier: 'STA-4084',
+      url: issueUrl
+    } as never
+    const other = {
+      id: 'other-issue',
+      identifier: 'STA-9999',
+      url: 'https://linear.app/stably/issue/STA-9999'
+    } as never
+
+    expect(
+      isSmartWorkspaceLinearIssueIntentMatch(
+        parseBoundedSmartWorkspaceLinearIssueInput('sta-4084')!,
+        issue
+      )
+    ).toBe(true)
+    expect(prioritizeSmartWorkspaceLinearIssueResults('restore shell', [other, issue])).toEqual([
+      other,
+      issue
+    ])
+  })
+
+  it('rejects oversized Linear input before parsing it', () => {
+    const oversized = `${issueUrl}#${'x'.repeat(SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES)}`
+
+    expect(parseBoundedSmartWorkspaceLinearIssueInput(oversized)).toBeNull()
+    expect(isBlockingLinearUrlIntent('smart', oversized)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/worktree-jump-palette-source-context-boundary.test.ts
+++ b/src/renderer/src/components/worktree-jump-palette-source-context-boundary.test.ts
@@ -13,15 +13,15 @@ function sourceBetween(startPattern: string, endPattern: string): string {
 }
 
 describe('WorktreeJumpPalette source-context boundaries', () => {
-  it('defers pasted GitHub URL resolution to the composer so cross-project detection runs', () => {
-    // Why: pasting a cross-project URL must surface the same "Switch project?"
-    // prompt as Cmd+N. The palette hands the raw URL to the composer's name
-    // field instead of pre-resolving it against an arbitrary repo, which
-    // silently linked cross-project items to the wrong project.
+  it('attaches a resolved GitHub URL entity and leaves GitLab/Jira as raw URLs', () => {
+    // Why: GitHub create reuses the Cmd+J preview (lookup lives in the effect,
+    // not Case 1). GitLab/Jira still hand the raw URL to the composer.
     const githubLinkSection = sourceBetween(
       '// Case 1: user pasted a GH/GitLab/Jira URL.',
       '// Case 2: user typed a raw issue number.'
     )
+    expect(githubLinkSection).toContain('linkedWorkItem')
+    expect(githubLinkSection).toContain('initialGitHubWorkItem: item')
     expect(githubLinkSection).toContain('prefilledName: trimmed')
     expect(githubLinkSection).not.toContain('lookupGitHubWorkItemByOwnerRepoForSource')
   })

--- a/src/renderer/src/components/worktree-jump-palette-source-context-boundary.test.ts
+++ b/src/renderer/src/components/worktree-jump-palette-source-context-boundary.test.ts
@@ -19,7 +19,7 @@ describe('WorktreeJumpPalette source-context boundaries', () => {
     // field instead of pre-resolving it against an arbitrary repo, which
     // silently linked cross-project items to the wrong project.
     const githubLinkSection = sourceBetween(
-      '// Case 1: user pasted a GH issue/PR URL.',
+      '// Case 1: user pasted a GH/GitLab/Jira URL.',
       '// Case 2: user typed a raw issue number.'
     )
     expect(githubLinkSection).toContain('prefilledName: trimmed')

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -148,6 +148,10 @@
       "clearProjects": "Clear projects",
       "back": "Back",
       "ariaActive": "Filter: {{value0}} active."
+    },
+    "taskUrl": {
+      "loadingHint": "Loading {{value0}}…",
+      "createHint": "Create worktree from {{value0}}"
     }
   },
   "auto": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -115,6 +115,13 @@
       "port": "Port",
       "pr": "PR"
     },
+    "linearIssue": {
+      "createLabel": "Create worktree from Linear issue {{value0}}: {{value1}}",
+      "pendingLabel": "Create worktree from Linear issue {{value0}}",
+      "loadingLabel": "Loading Linear issue {{value0}}",
+      "createHint": "Create worktree from Linear issue",
+      "loadingHint": "Loading Linear issue…"
+    },
     "renderCapOverflow": "{{value0}} more — scroll or keep typing to narrow",
     "filter": {
       "emptyTitle": "No results match the active filter",
@@ -12382,7 +12389,8 @@
             "searchJira": "Search Jira issues or paste an issue URL",
             "jiraMode": "Jira",
             "jiraSelectBindFailed": "Couldn’t link this Jira issue. Pick the matching site or reconnect Jira, then try again.",
-            "emoji": "Emoji"
+            "emoji": "Emoji",
+            "loadingLinearIssue": "Loading Linear issue…"
           },
           "ProjectCombobox": {
             "empty": "No projects match your search.",

--- a/src/renderer/src/lib/cmd-j-github-url-lookup.test.ts
+++ b/src/renderer/src/lib/cmd-j-github-url-lookup.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubWorkItem } from '../../../shared/types'
+
+const { lookupGitHubWorkItemByOwnerRepoForSource } = vi.hoisted(() => ({
+  lookupGitHubWorkItemByOwnerRepoForSource: vi.fn()
+}))
+
+vi.mock('./github-work-item-source-lookup', () => ({
+  lookupGitHubWorkItemByOwnerRepoForSource
+}))
+
+import { lookupCmdJGitHubUrlWorkItem } from './cmd-j-github-url-lookup'
+
+const item = {
+  id: 'issue-14198',
+  type: 'issue',
+  number: 14198,
+  title: 'Agent terminals disappearing randomly',
+  state: 'open',
+  url: 'https://github.com/stablyai/orca/issues/14198',
+  labels: [],
+  updatedAt: '2026-08-12T12:00:00.000Z',
+  author: 'nwparker'
+} satisfies GitHubWorkItem
+
+describe('lookupCmdJGitHubUrlWorkItem', () => {
+  beforeEach(() => {
+    lookupGitHubWorkItemByOwnerRepoForSource.mockReset()
+  })
+
+  it('looks up by owner/repo and returns null without a repo or on failure', async () => {
+    const link = {
+      slug: { owner: 'stablyai', repo: 'orca', host: 'github.com' },
+      type: 'issue' as const,
+      number: 14198
+    }
+    expect(
+      await lookupCmdJGitHubUrlWorkItem({
+        link,
+        repo: null,
+        sourceContext: null
+      })
+    ).toBeNull()
+
+    lookupGitHubWorkItemByOwnerRepoForSource.mockResolvedValue(item)
+    expect(
+      await lookupCmdJGitHubUrlWorkItem({
+        link,
+        repo: { id: 'repo-1', path: '/repos/repo-1' },
+        sourceContext: null
+      })
+    ).toEqual(item)
+    expect(lookupGitHubWorkItemByOwnerRepoForSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'stablyai',
+        repo: 'orca',
+        host: 'github.com',
+        number: 14198,
+        type: 'issue'
+      })
+    )
+
+    lookupGitHubWorkItemByOwnerRepoForSource.mockRejectedValue(new Error('offline'))
+    expect(
+      await lookupCmdJGitHubUrlWorkItem({
+        link,
+        repo: { id: 'repo-1', path: '/repos/repo-1' },
+        sourceContext: null
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/cmd-j-github-url-lookup.test.ts
+++ b/src/renderer/src/lib/cmd-j-github-url-lookup.test.ts
@@ -20,7 +20,8 @@ const item = {
   url: 'https://github.com/stablyai/orca/issues/14198',
   labels: [],
   updatedAt: '2026-08-12T12:00:00.000Z',
-  author: 'nwparker'
+  author: 'nwparker',
+  repoId: 'repo-1'
 } satisfies GitHubWorkItem
 
 describe('lookupCmdJGitHubUrlWorkItem', () => {

--- a/src/renderer/src/lib/cmd-j-github-url-lookup.ts
+++ b/src/renderer/src/lib/cmd-j-github-url-lookup.ts
@@ -1,0 +1,28 @@
+import type { GitHubIssueOrPRLink } from '../../../shared/github-links'
+import type { GitHubWorkItem, Repo } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { lookupGitHubWorkItemByOwnerRepoForSource } from './github-work-item-source-lookup'
+
+export async function lookupCmdJGitHubUrlWorkItem(args: {
+  link: GitHubIssueOrPRLink
+  repo: Pick<Repo, 'id' | 'path'> | null
+  sourceContext: TaskSourceContext | null
+}): Promise<GitHubWorkItem | null> {
+  if (!args.repo) {
+    return null
+  }
+  try {
+    return await lookupGitHubWorkItemByOwnerRepoForSource({
+      repoPath: args.repo.path,
+      repoId: args.repo.id,
+      sourceContext: args.sourceContext,
+      owner: args.link.slug.owner,
+      repo: args.link.slug.repo,
+      ...(args.link.slug.host ? { host: args.link.slug.host } : {}),
+      number: args.link.number,
+      type: args.link.type
+    })
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/src/lib/cmd-j-linear-issue-intent.test.ts
+++ b/src/renderer/src/lib/cmd-j-linear-issue-intent.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findLinearIssueWorkspaceId,
+  isLinearIssueUrlResolutionMatch,
+  parseLinearIssueUrlIntent
+} from '../../../shared/linear-links'
+
+describe('Cmd+J Linear issue intent', () => {
+  it('accepts canonical Linear issue URLs with optional slugs', () => {
+    expect(
+      parseLinearIssueUrlIntent(
+        ' https://linear.app/stably/issue/sta-4084/restore-shell-integration '
+      )
+    ).toEqual({ identifier: 'STA-4084', organizationUrlKey: 'stably' })
+    expect(parseLinearIssueUrlIntent('http://linear.app/acme/issue/ENG-1')).toEqual({
+      identifier: 'ENG-1',
+      organizationUrlKey: 'acme'
+    })
+  })
+
+  it('does not classify names, bare issue keys, or ambiguous URLs as decisive intent', () => {
+    expect(parseLinearIssueUrlIntent('restore-shell-integration')).toBeNull()
+    expect(parseLinearIssueUrlIntent('STA-4084')).toBeNull()
+    expect(parseLinearIssueUrlIntent('https://linear.app/stably/team/STA/all')).toBeNull()
+    expect(
+      parseLinearIssueUrlIntent('https://linear.app.evil.test/stably/issue/STA-4084')
+    ).toBeNull()
+    expect(parseLinearIssueUrlIntent('https://linear.app/foo/bar/issue/STA-4084')).toBeNull()
+    expect(
+      parseLinearIssueUrlIntent('https://linear.app/stably/issue/STA-4084/title/activity')
+    ).toBeNull()
+    expect(
+      parseLinearIssueUrlIntent('https://linear.app/stably/issue/STA-4084%2Fnot-the-identifier')
+    ).toBeNull()
+    expect(
+      parseLinearIssueUrlIntent('https://user@linear.app/stably/issue/STA-4084/title')
+    ).toBeNull()
+  })
+
+  it('targets the workspace named by the URL before falling back to all workspaces', () => {
+    const intent = { identifier: 'STA-4084', organizationUrlKey: 'stably' }
+    const workspaces = [
+      { id: 'workspace-other', organizationUrlKey: 'other' },
+      { id: 'workspace-stably', organizationUrlKey: 'Stably' }
+    ]
+
+    expect(findLinearIssueWorkspaceId(intent, workspaces)).toBe('workspace-stably')
+    expect(findLinearIssueWorkspaceId(intent, workspaces.slice(0, 1))).toBeNull()
+    expect(findLinearIssueWorkspaceId(intent, undefined)).toBeNull()
+  })
+
+  it('rejects a lookup from a different identifier or known Linear organization', () => {
+    const intent = { identifier: 'STA-4084', organizationUrlKey: 'stably' }
+
+    expect(
+      isLinearIssueUrlResolutionMatch(intent, {
+        identifier: 'STA-4084',
+        url: 'https://linear.app/stably/issue/STA-4084/title'
+      })
+    ).toBe(true)
+    expect(
+      isLinearIssueUrlResolutionMatch(intent, {
+        identifier: 'STA-9999',
+        url: 'https://linear.app/stably/issue/STA-9999/title'
+      })
+    ).toBe(false)
+    expect(
+      isLinearIssueUrlResolutionMatch(intent, {
+        identifier: 'STA-4084',
+        url: 'https://linear.app/other/issue/STA-4084/title'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects a matching identifier when the result URL has no usable organization key', () => {
+    expect(
+      isLinearIssueUrlResolutionMatch(
+        { identifier: 'STA-4084', organizationUrlKey: 'stably' },
+        { identifier: 'STA-4084', url: 'https://linear.example.test/STA-4084' }
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/cmd-j-linear-issue-intent.test.ts
+++ b/src/renderer/src/lib/cmd-j-linear-issue-intent.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest'
 import {
   findLinearIssueWorkspaceId,
+  findLinearIssueWorkspaceLookupIds,
   isLinearIssueUrlResolutionMatch,
   parseLinearIssueUrlIntent
 } from '../../../shared/linear-links'
 
 describe('Cmd+J Linear issue intent', () => {
   it('accepts canonical Linear issue URLs with optional slugs', () => {
+    expect(
+      parseLinearIssueUrlIntent(
+        'https://linear.app/stably/issue/STA-4052/agent-terminals-disappearing-randomly'
+      )
+    ).toEqual({ identifier: 'STA-4052', organizationUrlKey: 'stably' })
     expect(
       parseLinearIssueUrlIntent(
         ' https://linear.app/stably/issue/sta-4084/restore-shell-integration '
@@ -47,6 +53,29 @@ describe('Cmd+J Linear issue intent', () => {
     expect(findLinearIssueWorkspaceId(intent, workspaces)).toBe('workspace-stably')
     expect(findLinearIssueWorkspaceId(intent, workspaces.slice(0, 1))).toBeNull()
     expect(findLinearIssueWorkspaceId(intent, undefined)).toBeNull()
+  })
+
+  it('includes legacy workspaces that omitted their organization URL key', () => {
+    const intent = { identifier: 'STA-4052', organizationUrlKey: 'stably' }
+
+    expect(
+      findLinearIssueWorkspaceLookupIds(intent, {
+        viewer: {
+          displayName: 'Linear User',
+          email: null,
+          organizationName: 'Saved Linear workspace'
+        },
+        activeWorkspaceId: 'legacy',
+        selectedWorkspaceId: 'legacy',
+        workspaces: [{ id: 'legacy' } as never]
+      })
+    ).toEqual(['legacy'])
+    expect(
+      findLinearIssueWorkspaceLookupIds(intent, {
+        viewer: null,
+        workspaces: [{ id: 'other-workspace', organizationUrlKey: 'other' } as never]
+      })
+    ).toEqual([])
   })
 
   it('rejects a lookup from a different identifier or known Linear organization', () => {

--- a/src/renderer/src/lib/linear-issue-url-lookup.test.ts
+++ b/src/renderer/src/lib/linear-issue-url-lookup.test.ts
@@ -98,6 +98,32 @@ describe('Linear issue URL lookup', () => {
     })
   })
 
+  it('probes a legacy workspace that omitted its organization URL key', async () => {
+    const fetchLinearIssue = vi.fn(async () => issue())
+
+    await expect(
+      lookupLinearIssueUrl({
+        intent,
+        knownStatus: {
+          viewer: {
+            displayName: 'Linear User',
+            email: null,
+            organizationName: 'Saved Linear workspace'
+          },
+          activeWorkspaceId: 'legacy',
+          selectedWorkspaceId: 'legacy',
+          workspaces: [{ id: 'legacy', organizationName: 'Saved Linear workspace' } as never]
+        },
+        sourceContext: null,
+        fetchLinearIssue,
+        readLinearStatus: vi.fn()
+      })
+    ).resolves.toMatchObject({ identifier: 'STA-4084' })
+    expect(fetchLinearIssue).toHaveBeenCalledWith('STA-4084', 'legacy', {
+      sourceContext: null
+    })
+  })
+
   it('does not fall back to an all-workspaces lookup that can collide across organizations', async () => {
     const fetchLinearIssue = vi.fn(async () => issue('other'))
 

--- a/src/renderer/src/lib/linear-issue-url-lookup.test.ts
+++ b/src/renderer/src/lib/linear-issue-url-lookup.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { LinearConnectionStatus, LinearIssue } from '../../../shared/types'
+import { lookupLinearIssueUrl } from './linear-issue-url-lookup'
+
+const intent = { identifier: 'STA-4084', organizationUrlKey: 'stably' }
+
+function issue(organizationUrlKey = 'stably'): LinearIssue {
+  return {
+    id: `${organizationUrlKey}-issue`,
+    workspaceId: `${organizationUrlKey}-workspace`,
+    workspaceName: organizationUrlKey,
+    identifier: 'STA-4084',
+    title: 'Restore shell integration',
+    url: `https://linear.app/${organizationUrlKey}/issue/STA-4084/restore-shell-integration`,
+    state: { name: 'Todo', type: 'unstarted', color: '#999999' },
+    team: { id: 'team-sta', name: 'Stably', key: 'STA' },
+    labels: [],
+    labelIds: [],
+    priority: 2,
+    updatedAt: '2026-08-12T00:00:00.000Z'
+  }
+}
+
+describe('Linear issue URL lookup', () => {
+  it('uses the known workspace named by the URL', async () => {
+    const fetchLinearIssue = vi.fn(async () => issue())
+    const readLinearStatus = vi.fn<() => Promise<LinearConnectionStatus>>()
+
+    await expect(
+      lookupLinearIssueUrl({
+        intent,
+        knownStatus: {
+          viewer: null,
+          workspaces: [{ id: 'stably-workspace', organizationUrlKey: 'stably' } as never]
+        },
+        sourceContext: null,
+        fetchLinearIssue,
+        readLinearStatus
+      })
+    ).resolves.toMatchObject({ identifier: 'STA-4084' })
+    expect(fetchLinearIssue).toHaveBeenCalledWith('STA-4084', 'stably-workspace', {
+      sourceContext: null
+    })
+    expect(readLinearStatus).not.toHaveBeenCalled()
+  })
+
+  it('refreshes status from the source owner when the known workspace is stale', async () => {
+    const fetchLinearIssue = vi.fn(async (_identifier: string, workspaceId?: string | null) =>
+      workspaceId === 'remote-stably-workspace' ? issue() : null
+    )
+
+    await expect(
+      lookupLinearIssueUrl({
+        intent,
+        knownStatus: {
+          viewer: null,
+          workspaces: [{ id: 'stale-workspace', organizationUrlKey: 'stably' } as never]
+        },
+        sourceContext: null,
+        fetchLinearIssue,
+        readLinearStatus: async () => ({
+          connected: true,
+          viewer: null,
+          workspaces: [
+            {
+              id: 'remote-stably-workspace',
+              organizationUrlKey: 'stably'
+            } as never
+          ]
+        })
+      })
+    ).resolves.toMatchObject({ workspaceId: 'stably-workspace' })
+    expect(fetchLinearIssue).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses legacy viewer status when mixed versions omit the workspace list', async () => {
+    const fetchLinearIssue = vi.fn(async () => issue())
+
+    await expect(
+      lookupLinearIssueUrl({
+        intent,
+        knownStatus: {
+          viewer: {
+            displayName: 'Linear User',
+            email: null,
+            organizationName: 'Stably',
+            organizationUrlKey: 'stably'
+          },
+          activeWorkspaceId: 'legacy-workspace'
+        },
+        sourceContext: null,
+        fetchLinearIssue,
+        readLinearStatus: vi.fn()
+      })
+    ).resolves.toMatchObject({ identifier: 'STA-4084' })
+    expect(fetchLinearIssue).toHaveBeenCalledWith('STA-4084', 'legacy-workspace', {
+      sourceContext: null
+    })
+  })
+
+  it('does not fall back to an all-workspaces lookup that can collide across organizations', async () => {
+    const fetchLinearIssue = vi.fn(async () => issue('other'))
+
+    await expect(
+      lookupLinearIssueUrl({
+        intent,
+        knownStatus: {
+          viewer: null,
+          workspaces: [{ id: 'other-workspace', organizationUrlKey: 'other' } as never]
+        },
+        sourceContext: null,
+        fetchLinearIssue,
+        readLinearStatus: async () => ({
+          connected: true,
+          viewer: null,
+          workspaces: [{ id: 'other-workspace', organizationUrlKey: 'other' } as never]
+        })
+      })
+    ).resolves.toBeNull()
+    expect(fetchLinearIssue).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/linear-issue-url-lookup.ts
+++ b/src/renderer/src/lib/linear-issue-url-lookup.ts
@@ -1,6 +1,6 @@
 import { linearStatus } from '@/runtime/runtime-linear-client'
 import {
-  findLinearIssueWorkspaceIdFromStatus,
+  findLinearIssueWorkspaceLookupIds,
   isLinearIssueUrlResolutionMatch,
   type LinearIssueUrlIntent
 } from '../../../shared/linear-links'
@@ -43,25 +43,36 @@ export async function lookupLinearIssueUrl({
   fetchLinearIssue: FetchLinearIssue
   readLinearStatus?: (sourceContext: TaskSourceContext | null) => Promise<LinearConnectionStatus>
 }): Promise<LinearIssue | null> {
-  const knownWorkspaceId = findLinearIssueWorkspaceIdFromStatus(intent, knownStatus)
-  if (knownWorkspaceId) {
-    const knownIssue = await fetchMatchingLinearIssue(
-      intent,
-      knownWorkspaceId,
-      sourceContext,
-      fetchLinearIssue
-    )
-    if (knownIssue) {
-      return knownIssue
+  const triedWorkspaceIds = new Set<string>()
+  const lookupInStatus = async (
+    status: Pick<
+      LinearConnectionStatus,
+      'workspaces' | 'viewer' | 'activeWorkspaceId' | 'selectedWorkspaceId'
+    >
+  ): Promise<LinearIssue | null> => {
+    for (const workspaceId of findLinearIssueWorkspaceLookupIds(intent, status)) {
+      if (triedWorkspaceIds.has(workspaceId)) {
+        continue
+      }
+      triedWorkspaceIds.add(workspaceId)
+      const issue = await fetchMatchingLinearIssue(
+        intent,
+        workspaceId,
+        sourceContext,
+        fetchLinearIssue
+      )
+      if (issue) {
+        return issue
+      }
     }
+    return null
+  }
+
+  const knownIssue = await lookupInStatus(knownStatus)
+  if (knownIssue) {
+    return knownIssue
   }
 
   const currentStatus = await readLinearStatus(sourceContext).catch(() => null)
-  const currentWorkspaceId = currentStatus
-    ? findLinearIssueWorkspaceIdFromStatus(intent, currentStatus)
-    : null
-  if (!currentWorkspaceId || currentWorkspaceId === knownWorkspaceId) {
-    return null
-  }
-  return fetchMatchingLinearIssue(intent, currentWorkspaceId, sourceContext, fetchLinearIssue)
+  return currentStatus ? lookupInStatus(currentStatus) : null
 }

--- a/src/renderer/src/lib/linear-issue-url-lookup.ts
+++ b/src/renderer/src/lib/linear-issue-url-lookup.ts
@@ -1,0 +1,67 @@
+import { linearStatus } from '@/runtime/runtime-linear-client'
+import {
+  findLinearIssueWorkspaceIdFromStatus,
+  isLinearIssueUrlResolutionMatch,
+  type LinearIssueUrlIntent
+} from '../../../shared/linear-links'
+import type { LinearConnectionStatus, LinearIssue } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+
+type FetchLinearIssue = (
+  identifier: string,
+  workspaceId?: string | null,
+  options?: { sourceContext?: TaskSourceContext | null }
+) => Promise<LinearIssue | null>
+
+async function fetchMatchingLinearIssue(
+  intent: LinearIssueUrlIntent,
+  workspaceId: string,
+  sourceContext: TaskSourceContext | null,
+  fetchLinearIssue: FetchLinearIssue
+): Promise<LinearIssue | null> {
+  try {
+    const issue = await fetchLinearIssue(intent.identifier, workspaceId, { sourceContext })
+    return issue && isLinearIssueUrlResolutionMatch(intent, issue) ? issue : null
+  } catch {
+    return null
+  }
+}
+
+export async function lookupLinearIssueUrl({
+  intent,
+  knownStatus,
+  sourceContext,
+  fetchLinearIssue,
+  readLinearStatus = linearStatus
+}: {
+  intent: LinearIssueUrlIntent
+  knownStatus: Pick<
+    LinearConnectionStatus,
+    'workspaces' | 'viewer' | 'activeWorkspaceId' | 'selectedWorkspaceId'
+  >
+  sourceContext: TaskSourceContext | null
+  fetchLinearIssue: FetchLinearIssue
+  readLinearStatus?: (sourceContext: TaskSourceContext | null) => Promise<LinearConnectionStatus>
+}): Promise<LinearIssue | null> {
+  const knownWorkspaceId = findLinearIssueWorkspaceIdFromStatus(intent, knownStatus)
+  if (knownWorkspaceId) {
+    const knownIssue = await fetchMatchingLinearIssue(
+      intent,
+      knownWorkspaceId,
+      sourceContext,
+      fetchLinearIssue
+    )
+    if (knownIssue) {
+      return knownIssue
+    }
+  }
+
+  const currentStatus = await readLinearStatus(sourceContext).catch(() => null)
+  const currentWorkspaceId = currentStatus
+    ? findLinearIssueWorkspaceIdFromStatus(intent, currentStatus)
+    : null
+  if (!currentWorkspaceId || currentWorkspaceId === knownWorkspaceId) {
+    return null
+  }
+  return fetchMatchingLinearIssue(intent, currentWorkspaceId, sourceContext, fetchLinearIssue)
+}

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -540,6 +540,75 @@ describe('worktree-palette-search', () => {
     })
   })
 
+  it('matches a pasted GitHub issue URL to the linked worktree instead of the URL text', () => {
+    const results = searchWorktrees(
+      [
+        makeWorktree({ id: 'wt-issue', linkedIssue: 14198 }),
+        makeWorktree({ id: 'wt-other', linkedIssue: 7, displayName: 'github.com' })
+      ],
+      'https://github.com/stablyai/orca/issues/14198',
+      repoMap,
+      null,
+      null
+    )
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        worktreeId: 'wt-issue',
+        matchedField: 'issue',
+        supportingText: {
+          labelKind: 'issue',
+          text: 'Issue #14198',
+          matchRange: { start: 0, end: 'Issue #14198'.length }
+        }
+      })
+    ])
+  })
+
+  it('matches a pasted GitHub pull URL to the linked worktree', () => {
+    const results = searchWorktrees(
+      [
+        makeWorktree({
+          id: 'wt-pr',
+          linkedPR: 12789,
+          linkedWorkItem: {
+            provider: 'github',
+            type: 'pr',
+            number: 12789,
+            title: 'Perf',
+            url: 'https://github.com/stablyai/orca/pull/12789'
+          }
+        }),
+        makeWorktree({ id: 'wt-issue', linkedIssue: 12789 })
+      ],
+      'https://github.com/stablyai/orca/pull/12789',
+      repoMap,
+      null,
+      null
+    )
+
+    expect(results.map((result) => result.worktreeId)).toEqual(['wt-pr'])
+  })
+
+  it('matches a pasted Linear issue URL to the linked worktree', () => {
+    const results = searchWorktrees(
+      [
+        makeWorktree({
+          id: 'wt-linear',
+          linkedLinearIssue: 'STA-4052',
+          linkedLinearIssueOrganizationUrlKey: 'stably'
+        }),
+        makeWorktree({ id: 'wt-name', displayName: 'linear.app' })
+      ],
+      'https://linear.app/stably/issue/STA-4052/agent-terminals-disappearing-randomly',
+      repoMap,
+      null,
+      null
+    )
+
+    expect(results.map((result) => result.worktreeId)).toEqual(['wt-linear'])
+  })
+
   it('matches workspace ports by port number before issue and PR numbers', () => {
     const results = searchWorktrees(
       [makeWorktree({ id: 'wt-port', linkedIssue: 3000 })],

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -8,6 +8,10 @@ import type { Repo, Worktree } from '../../../shared/types'
 import { extractWorktreePaletteCommentSnippet } from './worktree-palette-comment-snippet'
 import { isWorktreePaletteQueryTooLarge } from './worktree-palette-query-bounds'
 import { matchWorktreePaletteReview } from './worktree-palette-review-match'
+import {
+  matchWorktreePaletteTaskUrl,
+  parseCmdJTaskSourceUrl
+} from './worktree-palette-task-url-match'
 
 export type MatchRange = { start: number; end: number }
 
@@ -88,6 +92,21 @@ export function searchWorktrees(
   const q = trimmedQuery.toLowerCase()
   const numericQuery = q.startsWith('#') ? q.slice(1) : q
   const results: PaletteSearchResult[] = []
+  const taskSourceUrl = parseCmdJTaskSourceUrl(trimmedQuery)
+  if (taskSourceUrl) {
+    for (const worktree of worktrees) {
+      const match = matchWorktreePaletteTaskUrl({
+        worktree,
+        intent: taskSourceUrl,
+        repo: repoMap.get(worktree.repoId),
+        review: checksReviewByWorktree?.get(worktree)
+      })
+      if (match) {
+        results.push(match)
+      }
+    }
+    return results
+  }
 
   // Support "repo/worktree" composite queries (e.g. "orca/main") so users can
   // narrow by repo and worktree in a single token. Worktrees are identified by

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -3,7 +3,8 @@ import type { Repo, Worktree } from '../../../shared/types'
 import {
   getCmdJTaskUrlCreatePreview,
   matchWorktreePaletteTaskUrl,
-  parseCmdJTaskSourceUrl
+  parseCmdJTaskSourceUrl,
+  withResolvedCmdJGitHubPreview
 } from './worktree-palette-task-url-match'
 
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
@@ -114,6 +115,25 @@ describe('matchWorktreePaletteTaskUrl', () => {
     ).toBeNull()
   })
 
+  it('matches a GitHub work-item number when the stored URL is missing', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'github',
+            type: 'pr',
+            number: 12789,
+            title: 'Perf',
+            url: ''
+          }
+        }),
+        intent: intent!,
+        repo: orcaRepo
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
   it('matches a GitHub pull URL via the stored work-item URL', () => {
     const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
     expect(
@@ -195,5 +215,22 @@ describe('getCmdJTaskUrlCreatePreview', () => {
       identifier: 'ORCA-123',
       kindLabel: 'Jira issue'
     })
+  })
+
+  it('replaces the GitHub subtitle with the resolved issue title', () => {
+    const preview = getCmdJTaskUrlCreatePreview(
+      parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')!
+    )!
+    expect(
+      withResolvedCmdJGitHubPreview(preview, 'Agent terminals disappearing randomly', false)
+    ).toEqual(
+      expect.objectContaining({
+        subtitle: 'Agent terminals disappearing randomly',
+        createLabel:
+          'Create worktree from GitHub issue stablyai/orca#14198: Agent terminals disappearing randomly',
+        loading: false
+      })
+    )
+    expect(withResolvedCmdJGitHubPreview(preview, null, true).loading).toBe(true)
   })
 })

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo, Worktree } from '../../../shared/types'
+import {
+  getCmdJTaskUrlCreatePreview,
+  matchWorktreePaletteTaskUrl,
+  parseCmdJTaskSourceUrl
+} from './worktree-palette-task-url-match'
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/feature/url-match',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'URL match',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+const orcaRepo: Repo = {
+  id: 'repo-1',
+  path: '/repo/orca',
+  displayName: 'stablyai/orca',
+  badgeColor: '#22c55e',
+  addedAt: 0
+}
+
+describe('parseCmdJTaskSourceUrl', () => {
+  it('parses GitHub issue and pull URLs', () => {
+    expect(parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')).toEqual({
+      provider: 'github',
+      link: {
+        slug: { owner: 'stablyai', repo: 'orca', host: 'github.com' },
+        type: 'issue',
+        number: 14198
+      }
+    })
+    expect(parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')).toEqual({
+      provider: 'github',
+      link: {
+        slug: { owner: 'stablyai', repo: 'orca', host: 'github.com' },
+        type: 'pr',
+        number: 12789
+      }
+    })
+  })
+
+  it('parses Linear, GitLab, and Jira URLs', () => {
+    expect(
+      parseCmdJTaskSourceUrl(
+        'https://linear.app/stably/issue/STA-4052/agent-terminals-disappearing-randomly'
+      )
+    ).toEqual({
+      provider: 'linear',
+      intent: { identifier: 'STA-4052', organizationUrlKey: 'stably' }
+    })
+    expect(
+      parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    ).toMatchObject({
+      provider: 'gitlab',
+      link: { type: 'mr', number: 17 }
+    })
+    expect(parseCmdJTaskSourceUrl('https://company.atlassian.net/browse/ORCA-123')).toEqual({
+      provider: 'jira',
+      parsed: {
+        issueKey: 'ORCA-123',
+        origin: 'https://company.atlassian.net',
+        sitePath: ''
+      }
+    })
+  })
+
+  it('does not treat names or repo homepages as task URLs', () => {
+    expect(parseCmdJTaskSourceUrl('sta-4052-agent-terminals')).toBeNull()
+    expect(parseCmdJTaskSourceUrl('https://github.com/stablyai/orca')).toBeNull()
+    expect(parseCmdJTaskSourceUrl('#14198')).toBeNull()
+  })
+})
+
+describe('matchWorktreePaletteTaskUrl', () => {
+  it('matches a GitHub issue URL to the linked worktree in the same repo', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')
+    expect(intent).not.toBeNull()
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedIssue: 14198 }),
+        intent: intent!,
+        repo: orcaRepo
+      })
+    ).toMatchObject({
+      worktreeId: 'wt-1',
+      matchedField: 'issue',
+      supportingText: { labelKind: 'issue', text: 'Issue #14198' }
+    })
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedIssue: 14198 }),
+        intent: intent!,
+        repo: { ...orcaRepo, displayName: 'other/repo' }
+      })
+    ).toBeNull()
+  })
+
+  it('matches a GitHub pull URL via the stored work-item URL', () => {
+    const intent = parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedWorkItem: {
+            provider: 'github',
+            type: 'pr',
+            number: 12789,
+            title: 'Perf',
+            url: 'https://github.com/stablyai/orca/pull/12789'
+          }
+        }),
+        intent: intent!,
+        repo: { ...orcaRepo, displayName: 'Repo 1' }
+      })
+    ).toMatchObject({ matchedField: 'pr', supportingText: { text: 'PR #12789' } })
+  })
+
+  it('matches a Linear issue URL and rejects a different organization', () => {
+    const intent = parseCmdJTaskSourceUrl(
+      'https://linear.app/stably/issue/STA-4052/agent-terminals-disappearing-randomly'
+    )
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedLinearIssue: 'STA-4052',
+          linkedLinearIssueOrganizationUrlKey: 'stably'
+        }),
+        intent: intent!
+      })
+    ).toMatchObject({ supportingText: { text: 'STA-4052' } })
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedLinearIssue: 'STA-4052',
+          linkedLinearIssueOrganizationUrlKey: 'other'
+        }),
+        intent: intent!
+      })
+    ).toBeNull()
+  })
+})
+
+describe('getCmdJTaskUrlCreatePreview', () => {
+  it('describes GitHub issue and pull URLs without fetching', () => {
+    expect(
+      getCmdJTaskUrlCreatePreview(
+        parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')!
+      )
+    ).toEqual({
+      provider: 'github',
+      identifier: '#14198',
+      subtitle: 'stablyai/orca',
+      kindLabel: 'GitHub issue',
+      createLabel: 'Create worktree from GitHub issue stablyai/orca#14198'
+    })
+    expect(
+      getCmdJTaskUrlCreatePreview(
+        parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/pull/12789')!
+      )?.kindLabel
+    ).toBe('GitHub pull request')
+    expect(
+      getCmdJTaskUrlCreatePreview(
+        parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')!
+      )
+    ).toMatchObject({
+      provider: 'gitlab',
+      identifier: '!17',
+      kindLabel: 'GitLab merge request'
+    })
+    expect(
+      getCmdJTaskUrlCreatePreview(
+        parseCmdJTaskSourceUrl('https://company.atlassian.net/browse/ORCA-123')!
+      )
+    ).toMatchObject({
+      provider: 'jira',
+      identifier: 'ORCA-123',
+      kindLabel: 'Jira issue'
+    })
+  })
+})

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -28,6 +28,26 @@ export type CmdJTaskUrlCreatePreview = {
   subtitle: string
   createLabel: string
   kindLabel: string
+  loading?: boolean
+}
+
+export function withResolvedCmdJGitHubPreview(
+  preview: CmdJTaskUrlCreatePreview,
+  resolvedTitle: string | null,
+  loading: boolean
+): CmdJTaskUrlCreatePreview {
+  if (preview.provider !== 'github') {
+    return preview
+  }
+  if (resolvedTitle) {
+    return {
+      ...preview,
+      subtitle: resolvedTitle,
+      createLabel: `${preview.createLabel}: ${resolvedTitle}`,
+      loading: false
+    }
+  }
+  return loading ? { ...preview, loading: true } : preview
 }
 
 function githubIdentityKey(slug: RepoSlug): string {
@@ -52,6 +72,20 @@ function parseOwnerRepoDisplayName(value: string | null | undefined): RepoSlug |
     return null
   }
   return { owner: match[1], repo: match[2] }
+}
+
+function repoMatchesGitHubSlug(repo: Repo | undefined, slug: RepoSlug): boolean | 'unknown' {
+  if (!repo) {
+    return 'unknown'
+  }
+  const fromName = parseOwnerRepoDisplayName(repo.displayName)
+  if (fromName) {
+    return githubIdentityKey({ ...fromName, host: slug.host }) === githubIdentityKey(slug)
+  }
+  if (repo.upstream?.owner && repo.upstream.repo) {
+    return githubIdentityKey(repo.upstream) === githubIdentityKey(slug)
+  }
+  return 'unknown'
 }
 
 export function parseCmdJTaskSourceUrl(query: string): CmdJTaskSourceUrl | null {
@@ -163,17 +197,19 @@ function worktreeMatchesGitHubUrl(
     return true
   }
 
+  const linkedItem = worktree.linkedWorkItem
+  const linkedItemMatches =
+    linkedItem?.provider === 'github' &&
+    linkedItem.type === link.type &&
+    linkedItem.number === link.number
   const numberMatches =
-    link.type === 'pr' ? worktree.linkedPR === link.number : worktree.linkedIssue === link.number
+    linkedItemMatches ||
+    (link.type === 'pr' ? worktree.linkedPR === link.number : worktree.linkedIssue === link.number)
   if (!numberMatches) {
     return false
   }
 
-  const repoSlug = parseOwnerRepoDisplayName(repo?.displayName)
-  if (!repoSlug) {
-    return true
-  }
-  return githubIdentityKey({ ...repoSlug, host: link.slug.host }) === githubIdentityKey(link.slug)
+  return repoMatchesGitHubSlug(repo, link.slug) !== false
 }
 
 function worktreeMatchesLinearUrl(worktree: Worktree, intent: LinearIssueUrlIntent): boolean {

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -1,0 +1,283 @@
+import type { HostedReviewInfo } from '../../../shared/hosted-review'
+import {
+  parseGitHubIssueOrPRLink,
+  type GitHubIssueOrPRLink,
+  type RepoSlug
+} from '../../../shared/github-links'
+import { githubRepoIdentityKey } from '../../../shared/github-repository-identity-key'
+import { parseGitLabIssueOrMRLink } from '../../../shared/new-workspace/gitlab-links'
+import { parseJiraIssueUrl, type ParsedJiraIssueUrl } from '../../../shared/jira-issue-url'
+import { parseLinearIssueUrlIntent, type LinearIssueUrlIntent } from '../../../shared/linear-links'
+import type { Repo, Worktree } from '../../../shared/types'
+import { normalizeLinearIdentifier } from './linear-issue-workspace-attachment'
+import { isWorktreePaletteQueryTooLarge } from './worktree-palette-query-bounds'
+import type { PaletteSearchResult, PaletteSupportingText } from './worktree-palette-search'
+
+export type CmdJTaskSourceUrl =
+  | { provider: 'github'; link: GitHubIssueOrPRLink }
+  | { provider: 'linear'; intent: LinearIssueUrlIntent }
+  | {
+      provider: 'gitlab'
+      link: NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
+    }
+  | { provider: 'jira'; parsed: ParsedJiraIssueUrl }
+
+export type CmdJTaskUrlCreatePreview = {
+  provider: 'github' | 'gitlab' | 'jira'
+  identifier: string
+  subtitle: string
+  createLabel: string
+  kindLabel: string
+}
+
+function githubIdentityKey(slug: RepoSlug): string {
+  return githubRepoIdentityKey({
+    owner: slug.owner,
+    repo: slug.repo,
+    host: slug.host?.replace(/^www\./i, '')
+  })
+}
+
+function githubLinksEqual(left: GitHubIssueOrPRLink, right: GitHubIssueOrPRLink): boolean {
+  return (
+    left.type === right.type &&
+    left.number === right.number &&
+    githubIdentityKey(left.slug) === githubIdentityKey(right.slug)
+  )
+}
+
+function parseOwnerRepoDisplayName(value: string | null | undefined): RepoSlug | null {
+  const match = /^([^/]+)\/([^/]+)$/.exec(value?.trim() ?? '')
+  if (!match) {
+    return null
+  }
+  return { owner: match[1], repo: match[2] }
+}
+
+export function parseCmdJTaskSourceUrl(query: string): CmdJTaskSourceUrl | null {
+  const trimmed = query.trim()
+  if (!trimmed || isWorktreePaletteQueryTooLarge(trimmed)) {
+    return null
+  }
+
+  const linear = parseLinearIssueUrlIntent(trimmed)
+  if (linear) {
+    return { provider: 'linear', intent: linear }
+  }
+
+  const github = parseGitHubIssueOrPRLink(trimmed)
+  if (github) {
+    return { provider: 'github', link: github }
+  }
+
+  const gitlab = parseGitLabIssueOrMRLink(trimmed)
+  if (gitlab) {
+    return { provider: 'gitlab', link: gitlab }
+  }
+
+  const jira = parseJiraIssueUrl(trimmed)
+  if (jira) {
+    return { provider: 'jira', parsed: jira }
+  }
+
+  return null
+}
+
+export function getCmdJTaskUrlCreatePreview(
+  intent: CmdJTaskSourceUrl
+): CmdJTaskUrlCreatePreview | null {
+  if (intent.provider === 'linear') {
+    return null
+  }
+  if (intent.provider === 'github') {
+    const { slug, number, type } = intent.link
+    const repo = `${slug.owner}/${slug.repo}`
+    const kindLabel = type === 'pr' ? 'GitHub pull request' : 'GitHub issue'
+    return {
+      provider: 'github',
+      identifier: `#${number}`,
+      subtitle: repo,
+      kindLabel,
+      createLabel: `Create worktree from ${kindLabel} ${repo}#${number}`
+    }
+  }
+  if (intent.provider === 'gitlab') {
+    const { slug, number, type } = intent.link
+    const project = `${slug.host}/${slug.path}`
+    const kindLabel = type === 'mr' ? 'GitLab merge request' : 'GitLab issue'
+    const identifier = type === 'mr' ? `!${number}` : `#${number}`
+    return {
+      provider: 'gitlab',
+      identifier,
+      subtitle: project,
+      kindLabel,
+      createLabel: `Create worktree from ${kindLabel} ${project}${identifier}`
+    }
+  }
+  return {
+    provider: 'jira',
+    identifier: intent.parsed.issueKey,
+    subtitle: intent.parsed.origin.replace(/^https?:\/\//, ''),
+    kindLabel: 'Jira issue',
+    createLabel: `Create worktree from Jira issue ${intent.parsed.issueKey}`
+  }
+}
+
+function supportingText(
+  labelKind: PaletteSupportingText['labelKind'],
+  text: string
+): PaletteSupportingText {
+  return { labelKind, text, matchRange: { start: 0, end: text.length } }
+}
+
+function result(
+  worktreeId: string,
+  matchedField: PaletteSearchResult['matchedField'],
+  text: PaletteSupportingText
+): PaletteSearchResult {
+  return {
+    worktreeId,
+    matchedField,
+    displayNameRange: null,
+    branchRange: null,
+    repoRange: null,
+    supportingText: text
+  }
+}
+
+function worktreeMatchesGitHubUrl(
+  worktree: Worktree,
+  link: GitHubIssueOrPRLink,
+  repo: Repo | undefined,
+  review: HostedReviewInfo | null | undefined
+): boolean {
+  const linkedUrl = worktree.linkedWorkItem?.url
+    ? parseGitHubIssueOrPRLink(worktree.linkedWorkItem.url)
+    : null
+  if (linkedUrl && githubLinksEqual(linkedUrl, link)) {
+    return true
+  }
+
+  const reviewUrl = review?.url ? parseGitHubIssueOrPRLink(review.url) : null
+  if (reviewUrl && githubLinksEqual(reviewUrl, link)) {
+    return true
+  }
+
+  const numberMatches =
+    link.type === 'pr' ? worktree.linkedPR === link.number : worktree.linkedIssue === link.number
+  if (!numberMatches) {
+    return false
+  }
+
+  const repoSlug = parseOwnerRepoDisplayName(repo?.displayName)
+  if (!repoSlug) {
+    return true
+  }
+  return githubIdentityKey({ ...repoSlug, host: link.slug.host }) === githubIdentityKey(link.slug)
+}
+
+function worktreeMatchesLinearUrl(worktree: Worktree, intent: LinearIssueUrlIntent): boolean {
+  const identifier = normalizeLinearIdentifier(intent.identifier)
+  const linkedIdentifier =
+    normalizeLinearIdentifier(worktree.linkedLinearIssue) ??
+    normalizeLinearIdentifier(worktree.linkedWorkItem?.linearIdentifier)
+  if (!identifier || linkedIdentifier !== identifier) {
+    const linkedUrl = worktree.linkedWorkItem?.url
+      ? parseLinearIssueUrlIntent(worktree.linkedWorkItem.url)
+      : null
+    if (
+      !linkedUrl ||
+      linkedUrl.identifier !== intent.identifier ||
+      linkedUrl.organizationUrlKey.toLowerCase() !== intent.organizationUrlKey.toLowerCase()
+    ) {
+      return false
+    }
+  }
+
+  const worktreeOrg = worktree.linkedLinearIssueOrganizationUrlKey?.trim().toLowerCase()
+  if (worktreeOrg && worktreeOrg !== intent.organizationUrlKey.toLowerCase()) {
+    return false
+  }
+  return true
+}
+
+function worktreeMatchesGitLabUrl(
+  worktree: Worktree,
+  link: NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
+): boolean {
+  const linkedUrl = worktree.linkedWorkItem?.url
+    ? parseGitLabIssueOrMRLink(worktree.linkedWorkItem.url)
+    : null
+  if (
+    linkedUrl &&
+    linkedUrl.number === link.number &&
+    linkedUrl.type === link.type &&
+    linkedUrl.slug.host.toLowerCase() === link.slug.host.toLowerCase() &&
+    linkedUrl.slug.path.toLowerCase() === link.slug.path.toLowerCase()
+  ) {
+    return true
+  }
+  return link.type === 'mr'
+    ? worktree.linkedGitLabMR === link.number
+    : worktree.linkedGitLabIssue === link.number
+}
+
+function worktreeMatchesJiraUrl(worktree: Worktree, parsed: ParsedJiraIssueUrl): boolean {
+  if (worktree.linkedWorkItem?.jiraIdentifier?.toUpperCase() === parsed.issueKey) {
+    return true
+  }
+  const linkedUrl = worktree.linkedWorkItem?.url
+    ? parseJiraIssueUrl(worktree.linkedWorkItem.url)
+    : null
+  return (
+    linkedUrl !== null &&
+    linkedUrl.issueKey === parsed.issueKey &&
+    linkedUrl.origin === parsed.origin &&
+    linkedUrl.sitePath === parsed.sitePath
+  )
+}
+
+export function matchWorktreePaletteTaskUrl(args: {
+  worktree: Worktree
+  intent: CmdJTaskSourceUrl
+  repo?: Repo
+  review?: HostedReviewInfo | null
+}): PaletteSearchResult | null {
+  const { worktree, intent, repo, review } = args
+  if (intent.provider === 'github') {
+    if (!worktreeMatchesGitHubUrl(worktree, intent.link, repo, review)) {
+      return null
+    }
+    return result(
+      worktree.id,
+      intent.link.type === 'pr' ? 'pr' : 'issue',
+      supportingText(
+        intent.link.type === 'pr' ? 'pr' : 'issue',
+        `${intent.link.type === 'pr' ? 'PR' : 'Issue'} #${intent.link.number}`
+      )
+    )
+  }
+  if (intent.provider === 'linear') {
+    if (!worktreeMatchesLinearUrl(worktree, intent.intent)) {
+      return null
+    }
+    return result(worktree.id, 'issue', supportingText('issue', intent.intent.identifier))
+  }
+  if (intent.provider === 'gitlab') {
+    if (!worktreeMatchesGitLabUrl(worktree, intent.link)) {
+      return null
+    }
+    return result(
+      worktree.id,
+      intent.link.type === 'mr' ? 'pr' : 'issue',
+      supportingText(
+        intent.link.type === 'mr' ? 'mr' : 'issue',
+        `${intent.link.type === 'mr' ? 'MR' : 'Issue'} #${intent.link.number}`
+      )
+    )
+  }
+  if (!worktreeMatchesJiraUrl(worktree, intent.parsed)) {
+    return null
+  }
+  return result(worktree.id, 'issue', supportingText('issue', intent.parsed.issueKey))
+}

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -175,6 +175,45 @@ export function findLinearIssueWorkspaceIdFromStatus(
   return selectedWorkspaceId ?? status.activeWorkspaceId ?? null
 }
 
+export function findLinearIssueWorkspaceLookupIds(
+  intent: LinearIssueUrlIntent,
+  status: Pick<
+    LinearConnectionStatus,
+    'workspaces' | 'viewer' | 'activeWorkspaceId' | 'selectedWorkspaceId'
+  >
+): string[] {
+  const ids: string[] = []
+  const seen = new Set<string>()
+  const push = (id: string | null | undefined): void => {
+    if (!id || id === 'all' || seen.has(id)) {
+      return
+    }
+    seen.add(id)
+    ids.push(id)
+  }
+
+  push(findLinearIssueWorkspaceIdFromStatus(intent, status))
+
+  // Why: saved API-key workspaces often omit organizationUrlKey. Probe those
+  // unknown-org workspaces and accept only an issue whose URL matches the org.
+  for (const workspace of status.workspaces ?? []) {
+    if (!workspace.organizationUrlKey) {
+      push(workspace.id)
+    }
+  }
+
+  if (!status.viewer?.organizationUrlKey && (status.workspaces?.length ?? 0) === 0) {
+    const selectedWorkspaceId =
+      status.selectedWorkspaceId && status.selectedWorkspaceId !== 'all'
+        ? status.selectedWorkspaceId
+        : null
+    push(selectedWorkspaceId)
+    push(status.activeWorkspaceId)
+  }
+
+  return ids
+}
+
 export function isLinearIssueUrlResolutionMatch(
   intent: LinearIssueUrlIntent,
   issue: Pick<LinearIssue, 'identifier' | 'url'>

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -1,3 +1,5 @@
+import type { LinearConnectionStatus, LinearIssue, LinearWorkspace } from './types'
+
 export function buildLinearTeamUrl(args: {
   organizationUrlKey?: string | null
   teamKey?: string | null
@@ -56,6 +58,11 @@ export type ParsedLinearIssueInput = {
   organizationUrlKey?: string
 }
 
+export type LinearIssueUrlIntent = {
+  identifier: string
+  organizationUrlKey: string
+}
+
 export type LinearIssueLinkUpdates = {
   linkedLinearIssue: string | null
   linkedLinearIssueWorkspaceId: string | null
@@ -103,6 +110,83 @@ export function parseLinearIssueInput(input: string): ParsedLinearIssueInput | n
   } catch {
     return null
   }
+}
+
+export function parseLinearIssueUrlIntent(input: string): LinearIssueUrlIntent | null {
+  const trimmed = input.trim()
+  try {
+    const url = new URL(trimmed)
+    const pathMatch = /^\/([^/]+)\/issue\/([^/]+)(?:\/[^/]+)?\/?$/.exec(url.pathname)
+    if (
+      (url.protocol !== 'https:' && url.protocol !== 'http:') ||
+      url.host !== 'linear.app' ||
+      url.username !== '' ||
+      url.password !== '' ||
+      !pathMatch
+    ) {
+      return null
+    }
+    const organizationUrlKey = decodeURIComponent(pathMatch[1])
+    const identifier = decodeURIComponent(pathMatch[2])
+    if (
+      !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(organizationUrlKey) ||
+      !LINEAR_IDENTIFIER_PATTERN.test(identifier)
+    ) {
+      return null
+    }
+    return { identifier: identifier.toUpperCase(), organizationUrlKey }
+  } catch {
+    return null
+  }
+}
+
+export function findLinearIssueWorkspaceId(
+  intent: LinearIssueUrlIntent,
+  workspaces: readonly Pick<LinearWorkspace, 'id' | 'organizationUrlKey'>[] | undefined
+): string | null {
+  const organizationUrlKey = intent.organizationUrlKey.toLowerCase()
+  return (
+    workspaces?.find(
+      (workspace) => workspace.organizationUrlKey?.toLowerCase() === organizationUrlKey
+    )?.id ?? null
+  )
+}
+
+export function findLinearIssueWorkspaceIdFromStatus(
+  intent: LinearIssueUrlIntent,
+  status: Pick<
+    LinearConnectionStatus,
+    'workspaces' | 'viewer' | 'activeWorkspaceId' | 'selectedWorkspaceId'
+  >
+): string | null {
+  const workspaceId = findLinearIssueWorkspaceId(intent, status.workspaces)
+  if (workspaceId) {
+    return workspaceId
+  }
+  if (
+    status.viewer?.organizationUrlKey?.toLowerCase() !== intent.organizationUrlKey.toLowerCase()
+  ) {
+    return null
+  }
+  const selectedWorkspaceId =
+    status.selectedWorkspaceId && status.selectedWorkspaceId !== 'all'
+      ? status.selectedWorkspaceId
+      : null
+  return selectedWorkspaceId ?? status.activeWorkspaceId ?? null
+}
+
+export function isLinearIssueUrlResolutionMatch(
+  intent: LinearIssueUrlIntent,
+  issue: Pick<LinearIssue, 'identifier' | 'url'>
+): boolean {
+  if (issue.identifier.toUpperCase() !== intent.identifier.toUpperCase()) {
+    return false
+  }
+  const issueOrganizationUrlKey = getLinearOrganizationUrlKeyFromIssueUrl(issue.url)
+  return (
+    issueOrganizationUrlKey !== null &&
+    issueOrganizationUrlKey.toLowerCase() === intent.organizationUrlKey.toLowerCase()
+  )
 }
 
 export const LINEAR_ISSUE_LINK_CLEARED: LinearIssueLinkUpdates = {

--- a/src/shared/new-workspace/smart-workspace-linear-intent.ts
+++ b/src/shared/new-workspace/smart-workspace-linear-intent.ts
@@ -1,0 +1,69 @@
+import type { LinearIssue } from '../types'
+import {
+  parseLinearIssueInput,
+  parseLinearIssueUrlIntent,
+  type LinearIssueUrlIntent,
+  type ParsedLinearIssueInput
+} from '../linear-links'
+import { isSmartWorkspaceSourceQueryWithinLimit } from './smart-workspace-source-query'
+
+type SmartWorkspaceLinearMode = 'smart' | 'linear' | (string & {})
+
+export function parseBoundedSmartWorkspaceLinearIssueInput(
+  value: string
+): ParsedLinearIssueInput | null {
+  if (!isSmartWorkspaceSourceQueryWithinLimit(value)) {
+    return null
+  }
+  const parsed = parseLinearIssueInput(value)
+  if (!parsed?.organizationUrlKey) {
+    return parsed
+  }
+  return parseLinearIssueUrlIntent(value)
+}
+
+export function parseBoundedSmartWorkspaceLinearIssueUrlIntent(
+  value: string
+): LinearIssueUrlIntent | null {
+  return isSmartWorkspaceSourceQueryWithinLimit(value) ? parseLinearIssueUrlIntent(value) : null
+}
+
+export function getSmartWorkspaceLinearSearchQuery(value: string): string {
+  const trimmed = value.trim()
+  return parseBoundedSmartWorkspaceLinearIssueInput(trimmed)?.identifier ?? trimmed
+}
+
+export function isSmartWorkspaceLinearIssueIntentMatch(
+  intent: ParsedLinearIssueInput,
+  issue: Pick<LinearIssue, 'identifier' | 'url'>
+): boolean {
+  if (issue.identifier.toUpperCase() !== intent.identifier.toUpperCase()) {
+    return false
+  }
+  if (!intent.organizationUrlKey) {
+    return true
+  }
+  const issueInput = parseLinearIssueUrlIntent(issue.url)
+  return issueInput?.organizationUrlKey?.toLowerCase() === intent.organizationUrlKey.toLowerCase()
+}
+
+export function prioritizeSmartWorkspaceLinearIssueResults(
+  value: string,
+  issues: readonly LinearIssue[]
+): LinearIssue[] {
+  const intent = parseBoundedSmartWorkspaceLinearIssueInput(value)
+  if (!intent) {
+    return issues.slice()
+  }
+  return [
+    ...issues.filter((issue) => isSmartWorkspaceLinearIssueIntentMatch(intent, issue)),
+    ...issues.filter((issue) => !isSmartWorkspaceLinearIssueIntentMatch(intent, issue))
+  ]
+}
+
+export function isBlockingLinearUrlIntent(mode: SmartWorkspaceLinearMode, value: string): boolean {
+  if (mode !== 'smart' && mode !== 'linear') {
+    return false
+  }
+  return parseBoundedSmartWorkspaceLinearIssueUrlIntent(value) !== null
+}

--- a/src/shared/new-workspace/smart-workspace-source-query.ts
+++ b/src/shared/new-workspace/smart-workspace-source-query.ts
@@ -1,0 +1,10 @@
+import { isClipboardTextByteLengthOverLimit } from '../clipboard-text'
+
+export const SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES = 2048
+
+export function isSmartWorkspaceSourceQueryWithinLimit(
+  query: string,
+  maxBytes = SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES
+): boolean {
+  return !isClipboardTextByteLengthOverLimit(query, maxBytes)
+}

--- a/src/shared/new-workspace/smart-workspace-source-results.ts
+++ b/src/shared/new-workspace/smart-workspace-source-results.ts
@@ -6,12 +6,19 @@ import type {
   LinearCollectionResult,
   LinearIssue
 } from '../types'
-import { isClipboardTextByteLengthOverLimit } from '../clipboard-text'
 import { JIRA_ISSUE_KEY_PATTERN, parseJiraIssueUrl } from '../jira-issue-url'
+import {
+  isSmartWorkspaceLinearIssueIntentMatch,
+  parseBoundedSmartWorkspaceLinearIssueUrlIntent
+} from './smart-workspace-linear-intent'
+import { isSmartWorkspaceSourceQueryWithinLimit } from './smart-workspace-source-query'
+
+export {
+  SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES,
+  isSmartWorkspaceSourceQueryWithinLimit
+} from './smart-workspace-source-query'
 
 export type SmartNameMode = 'smart' | 'github' | 'gitlab' | 'branches' | 'linear' | 'jira' | 'text'
-
-export const SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES = 2048
 
 export type SmartWorkspaceSourceRow =
   | { kind: 'use-name'; value: string; name: string }
@@ -36,13 +43,6 @@ const EMPTY_HINT_BY_MODE: Record<SmartNameMode, string> = {
 
 export function getSmartWorkspaceEmptyHint(mode: SmartNameMode): string {
   return EMPTY_HINT_BY_MODE[mode]
-}
-
-export function isSmartWorkspaceSourceQueryWithinLimit(
-  query: string,
-  maxBytes = SMART_WORKSPACE_SOURCE_QUERY_MAX_BYTES
-): boolean {
-  return !isClipboardTextByteLengthOverLimit(query, maxBytes)
 }
 
 export function buildJiraIssueSearchJql(query: string): string | null {
@@ -195,6 +195,7 @@ export function buildSmartWorkspaceSourceRows({
   jiraIssues = [],
   linearAvailable,
   linearIssues,
+  linearUrlIntentOwnsResults = false,
   mode,
   resultLimit,
   value
@@ -208,6 +209,7 @@ export function buildSmartWorkspaceSourceRows({
   jiraIssues?: JiraIssue[]
   linearAvailable: boolean
   linearIssues: LinearIssueSourceInput
+  linearUrlIntentOwnsResults?: boolean
   mode: SmartNameMode
   resultLimit: number
   value: string
@@ -221,6 +223,27 @@ export function buildSmartWorkspaceSourceRows({
   }
   const trimmed = value.trim()
   const nextRows: SmartWorkspaceSourceRow[] = []
+  const resolvedLinearIssues = Array.isArray(linearIssues)
+    ? linearIssues
+    : Array.isArray(linearIssues?.items)
+      ? linearIssues.items
+      : []
+  const linearUrlIntent = parseBoundedSmartWorkspaceLinearIssueUrlIntent(trimmed)
+  if (
+    linearUrlIntentOwnsResults &&
+    linearAvailable &&
+    linearUrlIntent &&
+    (mode === 'smart' || mode === 'linear')
+  ) {
+    return resolvedLinearIssues
+      .filter((issue) => isSmartWorkspaceLinearIssueIntentMatch(linearUrlIntent, issue))
+      .map((issue) => ({
+        kind: 'linear' as const,
+        value: `linear-${issue.id}`,
+        issue
+      }))
+      .slice(0, resultLimit)
+  }
   if (trimmed && mode === 'smart') {
     // Why: stable cmdk value — embedding the query remounted the row every keystroke.
     nextRows.push({ kind: 'use-name', value: 'use-name', name: trimmed })
@@ -266,11 +289,6 @@ export function buildSmartWorkspaceSourceRows({
   if (linearAvailable && (mode === 'smart' || mode === 'linear')) {
     // Why: mixed-version runtime responses may briefly carry the paginated
     // collection shape into this render path; rendering must stay recoverable.
-    const resolvedLinearIssues = Array.isArray(linearIssues)
-      ? linearIssues
-      : Array.isArray(linearIssues?.items)
-        ? linearIssues.items
-        : []
     nextRows.push(
       ...resolvedLinearIssues.map((issue) => ({
         kind: 'linear' as const,

--- a/src/shared/new-workspace/smart-workspace-source-results.ts
+++ b/src/shared/new-workspace/smart-workspace-source-results.ts
@@ -235,7 +235,7 @@ export function buildSmartWorkspaceSourceRows({
     linearUrlIntent &&
     (mode === 'smart' || mode === 'linear')
   ) {
-    return resolvedLinearIssues
+    const linearRows = resolvedLinearIssues
       .filter((issue) => isSmartWorkspaceLinearIssueIntentMatch(linearUrlIntent, issue))
       .map((issue) => ({
         kind: 'linear' as const,
@@ -243,6 +243,11 @@ export function buildSmartWorkspaceSourceRows({
         issue
       }))
       .slice(0, resultLimit)
+    // Why: keep "use as workspace name" available; sourceIntent focuses the issue.
+    if (trimmed && mode === 'smart') {
+      return [{ kind: 'use-name' as const, value: 'use-name', name: trimmed }, ...linearRows]
+    }
+    return linearRows
   }
   if (trimmed && mode === 'smart') {
     // Why: stable cmdk value — embedding the query remounted the row every keystroke.

--- a/tests/e2e/linear-url-workspace-entry.spec.ts
+++ b/tests/e2e/linear-url-workspace-entry.spec.ts
@@ -182,6 +182,8 @@ test.describe('Linear URL workspace entry', () => {
     await input.press('Enter')
     await expect(input).toHaveValue(LINEAR_URL)
     await expect(dialog.locator('[data-workspace-source-pill="true"]')).toHaveCount(0)
+    await expect(useNameRow).toBeHidden()
+    await expect(input).not.toHaveAttribute('aria-busy', 'true')
     await input.press('Enter')
     await expect(dialog.locator('[data-agent-combobox-root="true"][role="combobox"]')).toBeFocused()
   })

--- a/tests/e2e/linear-url-workspace-entry.spec.ts
+++ b/tests/e2e/linear-url-workspace-entry.spec.ts
@@ -178,11 +178,15 @@ test.describe('Linear URL workspace entry', () => {
       exact: true
     })
     await expect(useNameRow).toHaveAttribute('data-selected', 'true')
+    await expect(input).not.toHaveAttribute('aria-busy', 'true')
 
     await input.press('Enter')
     await expect(input).toHaveValue(LINEAR_URL)
     await expect(dialog.locator('[data-workspace-source-pill="true"]')).toHaveCount(0)
-    await expect(useNameRow).toBeHidden()
+    const suggestions = dialog.locator('[data-workspace-source-suggestions="true"]')
+    if (await suggestions.isVisible()) {
+      await input.press('Escape')
+    }
     await expect(input).not.toHaveAttribute('aria-busy', 'true')
     await input.press('Enter')
     await expect(dialog.locator('[data-agent-combobox-root="true"][role="combobox"]')).toBeFocused()

--- a/tests/e2e/linear-url-workspace-entry.spec.ts
+++ b/tests/e2e/linear-url-workspace-entry.spec.ts
@@ -1,0 +1,218 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import type { LinearIssue } from '../../src/shared/types'
+
+const LINEAR_URL =
+  'https://linear.app/stably/issue/STA-4084/restore-osc-133-shell-integration-when-an-exec-in-user-rc-files-strips'
+const EXPECTED_WORKSPACE_NAME = 'sta-4084-restore-osc-133-shell-integration-when'
+
+const LINEAR_ISSUE: LinearIssue = {
+  id: 'linear-sta-4084',
+  workspaceId: 'workspace-1',
+  workspaceName: 'Stably',
+  identifier: 'STA-4084',
+  title: 'Restore OSC 133 shell integration when an exec in user rc files strips',
+  branchName: 'sta-4084-restore-osc-133-shell-integration',
+  url: LINEAR_URL,
+  state: { name: 'Todo', type: 'unstarted', color: '#999999' },
+  team: { id: 'team-sta', name: 'Stably', key: 'STA' },
+  labels: [],
+  labelIds: [],
+  priority: 2,
+  estimate: null,
+  updatedAt: '2026-08-12T00:00:00.000Z'
+}
+
+function pasteChord(): string {
+  return process.platform === 'darwin' ? 'Meta+V' : 'Control+V'
+}
+
+async function installLinearFixture(
+  page: Page,
+  issue: LinearIssue | null = LINEAR_ISSUE,
+  lookupDelayMs: number | null = 150
+): Promise<void> {
+  await page.evaluate(
+    ({ resolvedIssue, lookupDelayMs }) => {
+      Reflect.deleteProperty(window, '__orcaTestReleaseLinearLookup')
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      store.setState({
+        linearStatus: {
+          connected: true,
+          viewer: null,
+          activeWorkspaceId: 'workspace-other',
+          selectedWorkspaceId: 'workspace-other',
+          workspaces: [
+            {
+              id: 'workspace-other',
+              displayName: 'Other User',
+              email: null,
+              organizationId: 'organization-other',
+              organizationName: 'Other',
+              organizationUrlKey: 'other'
+            },
+            {
+              id: 'workspace-1',
+              displayName: 'Stably User',
+              email: null,
+              organizationId: 'organization-stably',
+              organizationName: 'Stably',
+              organizationUrlKey: 'stably'
+            }
+          ]
+        },
+        linearStatusChecked: true,
+        checkLinearConnection: async () => {},
+        searchLinearIssues: async () => [],
+        listLinearIssues: async () => ({ items: [] }),
+        fetchLinearIssue: async (_identifier: string, workspaceId?: string | null) => {
+          await (lookupDelayMs === null
+            ? new Promise<void>((resolve) => {
+                Reflect.set(window, '__orcaTestReleaseLinearLookup', resolve)
+              })
+            : new Promise<void>((resolve) => window.setTimeout(resolve, lookupDelayMs)))
+          return resolvedIssue && workspaceId === resolvedIssue.workspaceId ? resolvedIssue : null
+        }
+      })
+    },
+    { resolvedIssue: issue, lookupDelayMs }
+  )
+}
+
+async function releaseHeldLinearLookup(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const release = Reflect.get(window, '__orcaTestReleaseLinearLookup')
+    if (typeof release !== 'function') {
+      throw new Error('Linear lookup is not held')
+    }
+    Reflect.deleteProperty(window, '__orcaTestReleaseLinearLookup')
+    release()
+  })
+}
+
+async function pasteLinearUrl(page: Page, input: ReturnType<Page['locator']>): Promise<void> {
+  await page.evaluate((text) => window.api.ui.writeClipboardText(text), LINEAR_URL)
+  await input.focus()
+  await page.keyboard.press(pasteChord())
+}
+
+async function openJumpPalette(electronApp: ElectronApplication): Promise<void> {
+  // Headless Playwright keys bypass Electron's before-input-event shortcut path.
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.webContents.send('ui:toggleWorktreePalette')
+  })
+}
+
+test.describe('Linear URL workspace entry', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await installLinearFixture(orcaPage)
+  })
+
+  test('pasting into the composer selects the Linear issue without ArrowDown', async ({
+    orcaPage
+  }, testInfo) => {
+    await installLinearFixture(orcaPage, LINEAR_ISSUE, null)
+    await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+    const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+    const input = dialog.locator('[data-workspace-name-input="true"]')
+    await expect(input).toBeVisible()
+
+    await pasteLinearUrl(orcaPage, input)
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          () => typeof Reflect.get(window, '__orcaTestReleaseLinearLookup') === 'function'
+        )
+      )
+      .toBe(true)
+    await input.press('Enter')
+    await expect(input).toHaveValue(LINEAR_URL)
+    await expect(dialog.locator('[data-workspace-source-pill="true"]')).toHaveCount(0)
+    await releaseHeldLinearLookup(orcaPage)
+
+    const issueRow = orcaPage.getByRole('option', {
+      name: `${LINEAR_ISSUE.identifier} ${LINEAR_ISSUE.title}`,
+      exact: true
+    })
+    await expect(issueRow).toContainText(LINEAR_ISSUE.title)
+    await expect(issueRow).toHaveAttribute('data-selected', 'true')
+    await testInfo.attach('linear-url-smart-entry-selected.png', {
+      body: await dialog.screenshot(),
+      contentType: 'image/png'
+    })
+
+    await input.press('Enter')
+    const sourcePill = dialog.locator('[data-workspace-source-pill="true"]')
+    await expect(sourcePill).toContainText(LINEAR_ISSUE.title)
+    await expect(dialog.getByPlaceholder('Workspace name')).toHaveValue(EXPECTED_WORKSPACE_NAME)
+    await expect(dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })).toBeEnabled()
+    await testInfo.attach('linear-url-smart-entry-composer.png', {
+      body: await dialog.screenshot(),
+      contentType: 'image/png'
+    })
+  })
+
+  test('a Linear URL lookup miss falls back to an arbitrary workspace name', async ({
+    orcaPage
+  }) => {
+    await installLinearFixture(orcaPage, null)
+    await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+    const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+    const input = dialog.locator('[data-workspace-name-input="true"]')
+
+    await pasteLinearUrl(orcaPage, input)
+    const useNameRow = orcaPage.getByRole('option', {
+      name: `Use "${LINEAR_URL}" as workspace name`,
+      exact: true
+    })
+    await expect(useNameRow).toHaveAttribute('data-selected', 'true')
+
+    await input.press('Enter')
+    await expect(input).toHaveValue(LINEAR_URL)
+    await expect(dialog.locator('[data-workspace-source-pill="true"]')).toHaveCount(0)
+    await input.press('Enter')
+    await expect(dialog.locator('[data-agent-combobox-root="true"][role="combobox"]')).toBeFocused()
+  })
+
+  test('pasting into Cmd+J previews the Linear issue and opens the linked composer', async ({
+    electronApp,
+    orcaPage
+  }, testInfo) => {
+    await openJumpPalette(electronApp)
+    const palette = orcaPage.getByRole('dialog', { name: 'Jump to...' })
+    const input = palette.getByPlaceholder(
+      'Search chats, terminals, worktrees, settings, and actions...'
+    )
+    await expect(input).toBeVisible()
+
+    await pasteLinearUrl(orcaPage, input)
+
+    const preview = palette.locator(
+      '[data-cmd-j-linear-issue-preview="true"][data-cmd-j-linear-issue-state="resolved"]'
+    )
+    await expect(preview).toContainText(LINEAR_ISSUE.identifier)
+    await expect(preview).toContainText(LINEAR_ISSUE.title)
+    await expect(preview).toHaveAttribute('data-selected', 'true')
+    await testInfo.attach('linear-url-cmd-j-preview.png', {
+      body: await palette.screenshot(),
+      contentType: 'image/png'
+    })
+
+    await input.press('Enter')
+    const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+    const sourcePill = dialog.locator('[data-workspace-source-pill="true"]')
+    await expect(sourcePill).toContainText(LINEAR_ISSUE.title)
+    await expect(dialog.getByPlaceholder('Workspace name')).toHaveValue(EXPECTED_WORKSPACE_NAME)
+    await expect(dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })).toBeEnabled()
+    await testInfo.attach('linear-url-cmd-j-composer.png', {
+      body: await dialog.screenshot(),
+      contentType: 'image/png'
+    })
+  })
+})

--- a/tests/e2e/linear-url-workspace-entry.spec.ts
+++ b/tests/e2e/linear-url-workspace-entry.spec.ts
@@ -140,6 +140,12 @@ test.describe('Linear URL workspace entry', () => {
       name: `${LINEAR_ISSUE.identifier} ${LINEAR_ISSUE.title}`,
       exact: true
     })
+    const useNameRow = orcaPage.getByRole('option', {
+      name: `Use "${LINEAR_URL}" as workspace name`,
+      exact: true
+    })
+    await expect(useNameRow).toBeVisible()
+    await expect(useNameRow).not.toHaveAttribute('data-selected', 'true')
     await expect(issueRow).toContainText(LINEAR_ISSUE.title)
     await expect(issueRow).toHaveAttribute('data-selected', 'true')
     await testInfo.attach('linear-url-smart-entry-selected.png', {


### PR DESCRIPTION
## ELI5

Pasting a Linear, GitHub, GitLab, or Jira issue/PR URL now does two things:

1. If you already have a worktree linked to that issue or PR, Cmd+J selects it so Enter jumps there.
2. If you don't, Cmd+J shows a create preview. Linear still looks the issue up; GitHub/GitLab/Jira hand the raw URL to the create dialog so it can ask "Switch project?" when needed.

In Smart Entry, a pasted Linear URL still selects that issue automatically. You can still pick "use this as a workspace name" if you want the URL as text instead.

## What Changed

- Parse only canonical `linear.app/<org>/issue/<key>[/slug]` URLs as decisive issue intent.
- Resolve the exact issue in the organization named by the URL, including remote/folder workspace source ownership.
- Also probe saved API-key / legacy Linear workspaces that omit `organizationUrlKey`. Accept the result only when the fetched issue URL is in the same org. This is why `https://linear.app/stably/issue/STA-4052/...` failed against a "Saved Linear workspace".
- Select the resolved Linear row immediately in Smart Entry, with no ArrowDown required.
- Keep the "Use … as workspace name" row visible (unfocused) when a Linear URL owns Smart Entry. Linear-tab mode stays Linear-only.
- Keep Enter inert while an unmistakable URL is still resolving; if lookup misses or fails, restore the existing arbitrary-name path.
- Cmd+J treats pasted Linear / GitHub / GitLab / Jira issue or PR URLs as exclusive search, not substring text.
- If a worktree is already linked to that issue/PR, it is listed first and selected. Create stays available underneath.
- Linear create still previews the looked-up issue. GitHub issue/PR URLs resolve the title in Cmd+J (`#14198 Agent terminals…`) and still hand the raw URL to the composer so Cmd+N cross-project detection runs. GitLab/Jira stay parse-only.
- Bound both entry points to their existing 2 KiB query limits and fence stale/replaced lookups.
- Block Enter immediately while resolving Linear, but delay visible loading feedback by 200 ms and expose busy/live status to assistive technology.
- Avoid unrelated GitHub, GitLab, and branch queries while an exact Linear URL owns Smart Entry; preserve explicit-provider and mobile arbitrary-name behavior.

## Why

A pasted issue/PR URL is unambiguous. Smart Entry previously armed the arbitrary-name row, and Cmd+J treated the URL as plain text — so GitHub issue/PR pastes did not preview, and existing linked worktrees were invisible because a full URL never matched `#14198` or `STA-4052`. This makes the obvious intent the default: jump if you already have that worktree, create if you don't.

Follow-up on review: legacy API-key workspaces often have no stored org key, so lookup never called Linear. And exclusive Linear-only results hid the typed-name fallback.

## Linked Issue

No linked issue — reported directly during this worktree task. `STA-4084` is fixture/example data only. `STA-4052` was the URL used to reproduce the legacy-workspace miss. GitHub examples: `https://github.com/stablyai/orca/issues/14198` and `https://github.com/stablyai/orca/pull/12789`.

## Visual Proof

### Smart Entry: exact issue selected after paste

![Smart Entry with the pasted Linear URL and exact issue selected](https://github.com/user-attachments/assets/fa6e1eaa-2935-47a9-8384-36d024ec2c76)

### Cmd+J: resolved Linear preview selected

![Cmd+J showing the resolved Linear issue preview](https://github.com/user-attachments/assets/36d07884-b532-45f3-a651-1dc4c0dfe656)

### Linked composer after Enter

![Create worktree composer with the Linear issue linked](https://github.com/user-attachments/assets/a1962b18-ce89-4517-9246-34bea8e9e044)

GitHub/GitLab/Jira Cmd+J preview + existing-worktree selection is covered by focused Vitest (no new screenshots).

## Testing

- [x] I manually tested these changes locally through rendered Electron/Playwright flows.
- [x] Automated tests added/updated.

Validated on macOS:

- 3 Electron E2E scenarios: pending paste→Enter guard and exact selection (use-name visible but unfocused), lookup-miss arbitrary-name fallback, and Cmd+J preview→linked composer.
- Focused Vitest: Linear URL lookup (including legacy workspace without org key), Cmd+J Linear + GitHub URL preview, existing linked-worktree selection, task-URL search matching, Smart Entry source rows / command value, IME Enter, and Linear link parsing.
- Runtime/folder/SSH source-context behavior is covered in focused tests; no wire, filesystem, Git, or persisted-state contract changed.

## AI Disclosure

Implemented with OpenAI Codex assistance and reviewed with parallel Codex agents. Follow-up fixes (legacy lookup + typed-name fallback, Cmd+J GitHub/existing-worktree matching) implemented with Claude Code.

## Review

Reviewed for strict URL handling, stale async results, lookup failure recovery, cross-platform paste modifiers, remote/folder workspace ownership, query bounds, mixed-version Linear status data, and legacy workspaces that omit `organizationUrlKey`. GitHub URL create still defers resolution to the composer. No dependencies or wire contracts changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused tests, typechecks, lint/quality, build-backed E2E, and localization gates pass locally; full-suite CI will cover repository-wide gates

## Author

- X / Twitter: @nwparker
