### PR TITLE
fix(daemon): restore previously recoverable scrollback from durable history

### DIFF
--- a/src/main/daemon/daemon-checkpoint-file.ts
+++ b/src/main/daemon/daemon-checkpoint-file.ts
@@ -20,5 +20,7 @@ export type TerminalCheckpointFile = {
   /** Ties this checkpoint to the output.log whose header carries the same
    *  generation. Absent on checkpoints written before incremental logs. */
   generation?: number
+  /** Last daemon pending-output batch included in this checkpoint. */
+  pendingOutputSeq?: number
   checkpointedAt: string
 }

--- a/src/main/daemon/daemon-durable-history-snapshot.ts
+++ b/src/main/daemon/daemon-durable-history-snapshot.ts
@@ -32,7 +32,8 @@ export function terminalSnapshotFromColdRestore(
     modes: info.modes,
     cols: info.cols,
     rows: info.rows,
-    scrollbackLines: countAnsiRows(info.scrollbackAnsi),
+    scrollbackLines:
+      info.scrollbackLines ?? Math.max(0, countAnsiRows(info.scrollbackAnsi) - info.rows),
     ...(info.lastTitle ? { lastTitle: info.lastTitle } : {}),
     ...(opts?.outputSequence !== undefined ? { outputSequence: opts.outputSequence } : {})
   }
@@ -103,7 +104,8 @@ export async function buildDurableCheckpointSnapshot(opts: {
         ? { frameRestoreAnsi: opts.liveSnapshot.frameRestoreAnsi }
         : {})
     }
-  } catch {
+  } catch (error) {
+    console.warn('[history] durable snapshot rebuild failed:', error)
     return opts.liveSnapshot
   } finally {
     emulator.dispose()

--- a/src/main/daemon/daemon-durable-history-snapshot.ts
+++ b/src/main/daemon/daemon-durable-history-snapshot.ts
@@ -23,7 +23,7 @@ export function terminalSnapshotFromColdRestore(
 ): TerminalSnapshot {
   return {
     snapshotAnsi: info.snapshotAnsi,
-    scrollbackAnsi: info.scrollbackAnsi,
+    scrollbackAnsi: info.modes.alternateScreen ? info.scrollbackAnsi : '',
     oscLinks: info.oscLinks,
     rehydrateSequences: info.rehydrateSequences,
     ...(info.pendingEscapeTailAnsi ? { pendingEscapeTailAnsi: info.pendingEscapeTailAnsi } : {}),
@@ -42,12 +42,17 @@ export async function buildDurableCheckpointSnapshot(opts: {
   liveSnapshot: TerminalSnapshot
   restoreInfo: ColdRestoreInfo | null
   pendingRecords?: readonly PendingOutputRecord[]
+  scrollbackRows?: number
 }): Promise<TerminalSnapshot> {
   const pendingRecords = opts.pendingRecords ?? []
   if (!opts.restoreInfo && pendingRecords.length === 0) {
     return opts.liveSnapshot
   }
-  if (opts.restoreInfo && pendingRecords.length === 0) {
+  if (
+    opts.restoreInfo &&
+    pendingRecords.length === 0 &&
+    (opts.scrollbackRows === undefined || opts.scrollbackRows >= DAEMON_RESTORE_SCROLLBACK_ROWS)
+  ) {
     return terminalSnapshotFromColdRestore(opts.restoreInfo, {
       outputSequence: opts.liveSnapshot.outputSequence,
       frameRestoreAnsi: opts.liveSnapshot.frameRestoreAnsi
@@ -57,7 +62,10 @@ export async function buildDurableCheckpointSnapshot(opts: {
   const emulator = new HeadlessEmulator({
     cols: opts.restoreInfo?.cols ?? opts.liveSnapshot.cols,
     rows: opts.restoreInfo?.rows ?? opts.liveSnapshot.rows,
-    scrollback: DAEMON_RESTORE_SCROLLBACK_ROWS
+    scrollback: Math.min(
+      opts.scrollbackRows ?? DAEMON_RESTORE_SCROLLBACK_ROWS,
+      DAEMON_RESTORE_SCROLLBACK_ROWS
+    )
   })
   const replay = new ColdRestoreReplayWriter(emulator)
   try {
@@ -104,7 +112,7 @@ export async function buildDurableCheckpointSnapshot(opts: {
 
 function restoreBaseFrom(restoreInfo: ColdRestoreInfo): RestoreBase {
   return {
-    scrollbackAnsi: restoreInfo.scrollbackAnsi,
+    scrollbackAnsi: restoreInfo.modes.alternateScreen ? restoreInfo.scrollbackAnsi : '',
     rehydrateSequences: restoreInfo.rehydrateSequences,
     snapshotAnsi: restoreInfo.snapshotAnsi,
     ...(restoreInfo.pendingEscapeTailAnsi

--- a/src/main/daemon/daemon-durable-history-snapshot.ts
+++ b/src/main/daemon/daemon-durable-history-snapshot.ts
@@ -1,0 +1,149 @@
+import { ColdRestoreReplayWriter } from './cold-restore-replay-writer'
+import { DAEMON_RESTORE_SCROLLBACK_ROWS } from './daemon-restore-scrollback-depth'
+import { HeadlessEmulator } from './headless-emulator'
+import { isValidTerminalHistorySize } from './terminal-history-dimensions'
+import type { ColdRestoreInfo } from './terminal-history-cold-restore-info'
+import type { PendingOutputRecord, TerminalSnapshot } from './types'
+
+type RestoreBase = {
+  scrollbackAnsi: string
+  rehydrateSequences: string
+  snapshotAnsi: string
+  pendingEscapeTailAnsi?: string
+  oscLinks?: TerminalSnapshot['oscLinks']
+  lastTitle?: string
+  cwd: string | null
+  cols: number
+  rows: number
+}
+
+export function terminalSnapshotFromColdRestore(
+  info: ColdRestoreInfo,
+  opts?: { outputSequence?: number; frameRestoreAnsi?: string }
+): TerminalSnapshot {
+  return {
+    snapshotAnsi: info.snapshotAnsi,
+    scrollbackAnsi: info.scrollbackAnsi,
+    oscLinks: info.oscLinks,
+    rehydrateSequences: info.rehydrateSequences,
+    ...(info.pendingEscapeTailAnsi ? { pendingEscapeTailAnsi: info.pendingEscapeTailAnsi } : {}),
+    ...(opts?.frameRestoreAnsi ? { frameRestoreAnsi: opts.frameRestoreAnsi } : {}),
+    cwd: info.cwd,
+    modes: info.modes,
+    cols: info.cols,
+    rows: info.rows,
+    scrollbackLines: countAnsiRows(info.scrollbackAnsi),
+    ...(info.lastTitle ? { lastTitle: info.lastTitle } : {}),
+    ...(opts?.outputSequence !== undefined ? { outputSequence: opts.outputSequence } : {})
+  }
+}
+
+export async function buildDurableCheckpointSnapshot(opts: {
+  liveSnapshot: TerminalSnapshot
+  restoreInfo: ColdRestoreInfo | null
+  pendingRecords?: readonly PendingOutputRecord[]
+}): Promise<TerminalSnapshot> {
+  const pendingRecords = opts.pendingRecords ?? []
+  if (!opts.restoreInfo && pendingRecords.length === 0) {
+    return opts.liveSnapshot
+  }
+  if (opts.restoreInfo && pendingRecords.length === 0) {
+    return terminalSnapshotFromColdRestore(opts.restoreInfo, {
+      outputSequence: opts.liveSnapshot.outputSequence,
+      frameRestoreAnsi: opts.liveSnapshot.frameRestoreAnsi
+    })
+  }
+
+  const emulator = new HeadlessEmulator({
+    cols: opts.restoreInfo?.cols ?? opts.liveSnapshot.cols,
+    rows: opts.restoreInfo?.rows ?? opts.liveSnapshot.rows,
+    scrollback: DAEMON_RESTORE_SCROLLBACK_ROWS
+  })
+  const replay = new ColdRestoreReplayWriter(emulator)
+  try {
+    // Why not seed the live window when there is no disk history: pending records
+    // are the raw stream. Replaying them on top of the already-truncated live
+    // snapshot would duplicate the newest rows and evict the older recoverable ones.
+    if (opts.restoreInfo) {
+      const base = restoreBaseFrom(opts.restoreInfo)
+      for (const segment of [
+        base.scrollbackAnsi,
+        base.rehydrateSequences,
+        base.snapshotAnsi,
+        base.pendingEscapeTailAnsi ?? ''
+      ]) {
+        if (!(await replay.write(segment))) {
+          return opts.liveSnapshot
+        }
+      }
+      emulator.setRestoredOscLinks(base.oscLinks)
+      if (base.lastTitle) {
+        emulator.setLastTitle(base.lastTitle)
+      }
+      emulator.setCwd(base.cwd)
+    }
+    if (!(await replayPendingRecords(replay, pendingRecords))) {
+      return opts.liveSnapshot
+    }
+    const snapshot = emulator.getSnapshot()
+    return {
+      ...snapshot,
+      ...(opts.liveSnapshot.outputSequence !== undefined
+        ? { outputSequence: opts.liveSnapshot.outputSequence }
+        : {}),
+      ...(opts.liveSnapshot.frameRestoreAnsi && !snapshot.frameRestoreAnsi
+        ? { frameRestoreAnsi: opts.liveSnapshot.frameRestoreAnsi }
+        : {})
+    }
+  } catch {
+    return opts.liveSnapshot
+  } finally {
+    emulator.dispose()
+  }
+}
+
+function restoreBaseFrom(restoreInfo: ColdRestoreInfo): RestoreBase {
+  return {
+    scrollbackAnsi: restoreInfo.scrollbackAnsi,
+    rehydrateSequences: restoreInfo.rehydrateSequences,
+    snapshotAnsi: restoreInfo.snapshotAnsi,
+    ...(restoreInfo.pendingEscapeTailAnsi
+      ? { pendingEscapeTailAnsi: restoreInfo.pendingEscapeTailAnsi }
+      : {}),
+    oscLinks: restoreInfo.oscLinks,
+    lastTitle: restoreInfo.lastTitle,
+    cwd: restoreInfo.cwd,
+    cols: restoreInfo.cols,
+    rows: restoreInfo.rows
+  }
+}
+
+async function replayPendingRecords(
+  replay: ColdRestoreReplayWriter,
+  records: readonly PendingOutputRecord[]
+): Promise<boolean> {
+  for (const record of records) {
+    if (record.kind === 'output') {
+      if (!(await replay.write(record.data))) {
+        return false
+      }
+      continue
+    }
+    if (record.kind === 'resize') {
+      if (!isValidTerminalHistorySize(record.cols, record.rows)) {
+        return false
+      }
+      await replay.resize(record.cols, record.rows)
+      continue
+    }
+    await replay.clearScrollback()
+  }
+  return true
+}
+
+function countAnsiRows(ansi: string): number {
+  if (ansi.length === 0) {
+    return 0
+  }
+  return ansi.split(/\r\n|\n|\r/).filter((row) => row.length > 0).length
+}

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2717,7 +2717,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
         expect(checkpointSpy).toHaveBeenCalledWith(
           id,
-          expect.objectContaining({ snapshotAnsi: expect.stringContaining('latest before sleep') })
+          expect.objectContaining({ snapshotAnsi: expect.stringContaining('latest before sleep') }),
+          { pendingOutputSeq: expect.any(Number) }
         )
         expect(existsSync(join(historyDir, getHistorySessionDirName(id)))).toBe(true)
 
@@ -2850,7 +2851,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       expect(checkpointSpy).toHaveBeenCalledWith(
         id,
-        expect.objectContaining({ snapshotAnsi: expect.stringContaining('fresh output') })
+        expect.objectContaining({ snapshotAnsi: expect.stringContaining('fresh output') }),
+        { pendingOutputSeq: expect.any(Number) }
       )
       expect(existsSync(join(historyDir, getHistorySessionDirName(id)))).toBe(true)
     })
@@ -2875,7 +2877,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         id,
         expect.objectContaining({
           pendingEscapeTailAnsi: expect.stringContaining('\x1b]777;orca-shell-ready')
-        })
+        }),
+        { pendingOutputSeq: expect.any(Number) }
       )
     })
 
@@ -3264,7 +3267,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         expect(appendSpy).not.toHaveBeenCalled()
         expect(checkpointSpy).toHaveBeenCalledWith(
           sessionId,
-          expect.objectContaining({ snapshotAnsi: expect.stringContaining('revived session') })
+          expect.objectContaining({ snapshotAnsi: expect.stringContaining('revived session') }),
+          { pendingOutputSeq: expect.any(Number) }
         )
 
         // Subsequent ticks return to incremental appends.

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2866,14 +2866,17 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         env: { SHELL: '/bin/zsh' },
         sessionId: 'sleep-checkpoint-tail'
       })
-      const appendSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'appendIncrements')
+      const checkpointSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'checkpoint')
 
       lastSubprocess._simulateData('\x1b]777;orca-shell-ready')
       await historyAdapter.shutdown(id, { immediate: true, keepHistory: true })
 
-      expect(appendSpy).toHaveBeenCalledWith(id, expect.any(Number), [
-        { kind: 'output', data: '\x1b]777;orca-shell-ready' }
-      ])
+      expect(checkpointSpy).toHaveBeenCalledWith(
+        id,
+        expect.objectContaining({
+          pendingEscapeTailAnsi: expect.stringContaining('\x1b]777;orca-shell-ready')
+        })
+      )
     })
 
     it('returns cold restore data when disk history has unclean shutdown', async () => {
@@ -3320,8 +3323,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
       const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
       expect(result.isReattach).toBe(true)
-      expect(internals.sessionsNeedingFullCheckpoint.has(sessionId)).toBe(true)
-      expect(internals.lastFullCheckpointAt.has(sessionId)).toBe(false)
+      expect(internals.sessionsNeedingFullCheckpoint.has(sessionId)).toBe(false)
+      expect(internals.lastFullCheckpointAt.has(sessionId)).toBe(true)
     })
 
     it('skips the cold-restore replay when the daemon session is still alive', async () => {
@@ -3332,20 +3335,17 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await first.disconnectOnly()
 
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
-      const reader = (historyAdapter as unknown as { historyReader: HistoryReader }).historyReader
-      const detectSpy = vi.spyOn(reader, 'detectColdRestore')
       const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
 
       expect(result.isReattach).toBe(true)
       expect(result.coldRestore).toBeUndefined()
-      expect(detectSpy).not.toHaveBeenCalled()
-      // The unmanaged-reattach re-anchor must survive the skipped detect.
+      // The unmanaged-reattach re-anchor must survive a live remount overlay.
       const internals = historyAdapter as unknown as {
         sessionsNeedingFullCheckpoint: Set<string>
         lastFullCheckpointAt: Map<string, number>
       }
-      expect(internals.sessionsNeedingFullCheckpoint.has(sessionId)).toBe(true)
-      expect(internals.lastFullCheckpointAt.has(sessionId)).toBe(false)
+      expect(internals.sessionsNeedingFullCheckpoint.has(sessionId)).toBe(false)
+      expect(internals.lastFullCheckpointAt.has(sessionId)).toBe(true)
     })
 
     it('does not probe session aliveness when there is no restorable history', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -2273,6 +2273,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         opts?.requiredPreviousPendingOutputSeq !== undefined &&
         restoreInfo?.pendingOutputSeq !== opts.requiredPreviousPendingOutputSeq
       ) {
+        console.warn('[history] durable continuity unproven; using live snapshot:', sessionId)
         return liveSnapshot
       }
       return await buildDurableCheckpointSnapshot({

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -69,6 +69,7 @@ import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 import { resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { ColdRestorePayloadCache, type ColdRestorePayload } from './cold-restore-payload-cache'
+import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
 import { PtyProcessListAdmission } from '../providers/pty-process-list-admission'
 import {
   iterateTerminalHistorySeedChunks,
@@ -831,15 +832,16 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
     }
 
-    const isAltScreen = result.snapshot.modes.alternateScreen
-    const snapshotPrefix = result.snapshot.scrollbackAnsi + result.snapshot.rehydrateSequences
-    const snapshotFrame = result.snapshot.snapshotAnsi
+    const reattachSnapshot = await this.overlayDurableRestoreSnapshot(sessionId, result.snapshot)
+    const isAltScreen = reattachSnapshot.modes.alternateScreen
+    const snapshotPrefix = reattachSnapshot.scrollbackAnsi + reattachSnapshot.rehydrateSequences
+    const snapshotFrame = reattachSnapshot.snapshotAnsi
     const snapshotPayload = snapshotPrefix + snapshotFrame
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).
     // Why known `0` is no longer dropped: the pane tracker must be able to tell
     // "the app negotiated nothing" from "this reattach proved nothing".
     const kittyKeyboardFlags = parseTerminalKittyKeyboardFlags(
-      result.snapshot.modes.kittyKeyboardFlags
+      reattachSnapshot.modes.kittyKeyboardFlags
     )
     return {
       id: sessionId,
@@ -849,14 +851,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
       ...launchIdentity(),
       ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
       snapshot: snapshotPayload,
-      snapshotCols: result.snapshot.cols,
-      snapshotRows: result.snapshot.rows,
+      snapshotCols: reattachSnapshot.cols,
+      snapshotRows: reattachSnapshot.rows,
       // Why only for an alt frame: normal history remains safe to replay at its capture grid.
-      ...(isAltScreen && snapshotFrame && result.snapshot.frameRestoreAnsi
+      ...(isAltScreen && snapshotFrame && reattachSnapshot.frameRestoreAnsi
         ? {
             snapshotPrefixAnsi: snapshotPrefix,
             snapshotFrameAnsi: snapshotFrame,
-            snapshotFrameRestoreAnsi: result.snapshot.frameRestoreAnsi
+            snapshotFrameRestoreAnsi: reattachSnapshot.frameRestoreAnsi
           }
         : {}),
       ...(providerSequence ? { providerSequence } : {}),
@@ -866,10 +868,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
       isReattach: true,
       isAlternateScreen: isAltScreen,
       // Why: the snapshot ANSI has no title frame; carry lastTitle beside it so main can seed title records after a relaunch.
-      ...(result.snapshot.lastTitle ? { lastTitle: result.snapshot.lastTitle } : {}),
+      ...(reattachSnapshot.lastTitle ? { lastTitle: reattachSnapshot.lastTitle } : {}),
       // Why: carry the mid-escape tail so the renderer writes it after the reattach reset, else a split escape renders literally (#7329).
-      ...(result.snapshot.pendingEscapeTailAnsi
-        ? { pendingEscapeTailAnsi: result.snapshot.pendingEscapeTailAnsi }
+      ...(reattachSnapshot.pendingEscapeTailAnsi
+        ? { pendingEscapeTailAnsi: reattachSnapshot.pendingEscapeTailAnsi }
         : {})
     }
   }
@@ -1226,28 +1228,73 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (!snapshot || typeof snapshot.outputSequence !== 'number') {
         return null
       }
-      const kittyKeyboardFlags = parseTerminalKittyKeyboardFlags(snapshot.modes.kittyKeyboardFlags)
-      return {
-        data: snapshot.rehydrateSequences + snapshot.snapshotAnsi,
-        frameRestoreAnsi: snapshot.frameRestoreAnsi,
-        scrollbackAnsi: snapshot.scrollbackAnsi,
-        cols: snapshot.cols,
-        rows: snapshot.rows,
-        cwd: snapshot.cwd,
-        lastTitle: snapshot.lastTitle,
-        seq: snapshot.outputSequence,
-        source: 'headless',
-        oscLinks: snapshot.oscLinks,
-        alternateScreen: snapshot.modes.alternateScreen,
-        // Why known `0` is carried too: it proves the app negotiated nothing at
-        // this boundary, which is a different fact from a source that cannot say.
-        ...(kittyKeyboardFlags !== undefined ? { kittyKeyboardFlags } : {}),
-        ...(snapshot.pendingEscapeTailAnsi
-          ? { pendingEscapeTailAnsi: snapshot.pendingEscapeTailAnsi }
-          : {})
-      }
+      const restored =
+        this.historyManager && this.historyReader && opts.scrollbackRows !== 0
+          ? await this.overlayDurableRestoreSnapshot(id, snapshot)
+          : snapshot
+      return this.toProviderBufferSnapshot(restored)
     } catch {
       return null
+    }
+  }
+
+  private toProviderBufferSnapshot(
+    snapshot: NonNullable<GetSnapshotResult['snapshot']>
+  ): PtyProviderBufferSnapshot | null {
+    if (typeof snapshot.outputSequence !== 'number') {
+      return null
+    }
+    const kittyKeyboardFlags = parseTerminalKittyKeyboardFlags(snapshot.modes.kittyKeyboardFlags)
+    return {
+      data: snapshot.rehydrateSequences + snapshot.snapshotAnsi,
+      frameRestoreAnsi: snapshot.frameRestoreAnsi,
+      scrollbackAnsi: snapshot.scrollbackAnsi,
+      cols: snapshot.cols,
+      rows: snapshot.rows,
+      cwd: snapshot.cwd,
+      lastTitle: snapshot.lastTitle,
+      seq: snapshot.outputSequence,
+      source: 'headless',
+      oscLinks: snapshot.oscLinks,
+      alternateScreen: snapshot.modes.alternateScreen,
+      // Why known `0` is carried too: it proves the app negotiated nothing at
+      // this boundary, which is a different fact from a source that cannot say.
+      ...(kittyKeyboardFlags !== undefined ? { kittyKeyboardFlags } : {}),
+      ...(snapshot.pendingEscapeTailAnsi
+        ? { pendingEscapeTailAnsi: snapshot.pendingEscapeTailAnsi }
+        : {})
+    }
+  }
+
+  private async overlayDurableRestoreSnapshot(
+    sessionId: string,
+    liveSnapshot: NonNullable<GetSnapshotResult['snapshot']>
+  ): Promise<NonNullable<GetSnapshotResult['snapshot']>> {
+    if (!this.historyManager || !this.historyReader) {
+      return liveSnapshot
+    }
+    try {
+      // Why exclusive compact: an independent take/append races the 5s tick, can
+      // seq-gap the log, and would remount a stale checkpoint over the live window.
+      await this.runExclusiveCheckpoint(async () => {
+        const result = await this.takeSnapshotAndCheckpoint(sessionId, { teardown: false })
+        if (result === 'committed') {
+          this.sessionsNeedingFullCheckpoint.delete(sessionId)
+        }
+      })
+      const restoreInfo = await this.historyReader.detectColdRestore(sessionId, {
+        ignoreCleanEnd: true,
+        wslDistro: this.wslDistrosBySessionId.get(sessionId)
+      })
+      if (!restoreInfo) {
+        return liveSnapshot
+      }
+      return await buildDurableCheckpointSnapshot({
+        liveSnapshot,
+        restoreInfo
+      })
+    } catch {
+      return liveSnapshot
     }
   }
 
@@ -2102,7 +2149,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
       teardownSnapshot: opts.teardown
     })
     if (take?.snapshot && this.historyManager) {
-      const checkpoint = await this.historyManager.checkpoint(sessionId, take.snapshot)
+      // Why require drainedRecords: an older daemon still empties the pending
+      // queue on includeSnapshot but omits the field. Treating absence as []
+      // would compact stale disk history and reset the log.
+      const snapshot =
+        take.drainedRecords === undefined
+          ? take.snapshot
+          : await this.buildDurableHistorySnapshot(sessionId, take.snapshot, [
+              ...take.drainedRecords,
+              ...take.records
+            ])
+      const checkpoint = await this.historyManager.checkpoint(sessionId, snapshot)
       if (checkpoint !== 'committed') {
         // Why take.records is dropped, not appended: the pending output this take drained went into the snapshot that
         // failed to land, so appending the held tail at the next contiguous seq would splice it over that hole and
@@ -2110,13 +2167,36 @@ export class DaemonPtyAdapter implements IPtyProvider {
         return checkpoint
       }
       this.lastFullCheckpointAt.set(sessionId, Date.now())
-      if (take.records.length > 0) {
-        // Why: held parser-state bytes (an incomplete shell-ready marker) aren't in the snapshot; keep them as a post-checkpoint log tail.
+      if (take.records.length > 0 && snapshot === take.snapshot) {
+        // Why: live-window fallback still lacks held parser-state bytes; keep them as a post-checkpoint log tail.
         await this.historyManager.appendIncrements(sessionId, take.seq, take.records)
       }
       return 'committed'
     }
     return 'unavailable'
+  }
+
+  private async buildDurableHistorySnapshot(
+    sessionId: string,
+    liveSnapshot: NonNullable<TakePendingOutputResult['snapshot']>,
+    pendingRecords: TakePendingOutputResult['records']
+  ): Promise<NonNullable<TakePendingOutputResult['snapshot']>> {
+    if (!this.historyReader) {
+      return liveSnapshot
+    }
+    try {
+      const restoreInfo = await this.historyReader.detectColdRestore(sessionId, {
+        ignoreCleanEnd: true,
+        wslDistro: this.wslDistrosBySessionId.get(sessionId)
+      })
+      return await buildDurableCheckpointSnapshot({
+        liveSnapshot,
+        restoreInfo,
+        pendingRecords
+      })
+    } catch {
+      return liveSnapshot
+    }
   }
 
   // Why: the token read no longer throws, so audit its absence directly after an authenticated drop.

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -70,6 +70,7 @@ import { resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { ColdRestorePayloadCache, type ColdRestorePayload } from './cold-restore-payload-cache'
 import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
+import { DAEMON_SESSION_SCROLLBACK_ROWS } from './daemon-session-scrollback-window'
 import { PtyProcessListAdmission } from '../providers/pty-process-list-admission'
 import {
   iterateTerminalHistorySeedChunks,
@@ -87,6 +88,7 @@ import {
 } from './daemon-audit-classifier'
 import type { DaemonEvidenceSource, ExactDaemonIncarnation } from './daemon-incarnation-evidence'
 import { createDaemonAuditEligibilityTracker } from './daemon-audit-eligibility-event'
+import { normalizeDesktopTerminalSnapshotRows } from '../../shared/terminal-scrollback-policy'
 
 type PendingDaemonSpawnOperation = {
   exitsBySessionId: Map<string, { incarnationId?: string }[]>
@@ -1219,9 +1221,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return null
     }
     try {
+      const scrollbackRows = normalizeDesktopTerminalSnapshotRows(opts.scrollbackRows)
       const result = await this.client.request<GetSnapshotResult>('getSnapshot', {
         sessionId: id,
-        ...(typeof opts.scrollbackRows === 'number' ? { scrollbackRows: opts.scrollbackRows } : {})
+        ...(scrollbackRows !== undefined ? { scrollbackRows } : {})
       })
       const snapshot = result.snapshot
       // Why: older v19 daemons lack an absolute output sequence, so their snapshot can't reconcile bytes queued on the other socket.
@@ -1229,8 +1232,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
         return null
       }
       const restored =
-        this.historyManager && this.historyReader && opts.scrollbackRows !== 0
-          ? await this.overlayDurableRestoreSnapshot(id, snapshot)
+        this.historyManager &&
+        this.historyReader &&
+        (scrollbackRows === undefined || scrollbackRows > DAEMON_SESSION_SCROLLBACK_ROWS)
+          ? await this.overlayDurableRestoreSnapshot(id, snapshot, scrollbackRows)
           : snapshot
       return this.toProviderBufferSnapshot(restored)
     } catch {
@@ -1268,7 +1273,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   private async overlayDurableRestoreSnapshot(
     sessionId: string,
-    liveSnapshot: NonNullable<GetSnapshotResult['snapshot']>
+    liveSnapshot: NonNullable<GetSnapshotResult['snapshot']>,
+    scrollbackRows?: number
   ): Promise<NonNullable<GetSnapshotResult['snapshot']>> {
     if (!this.historyManager || !this.historyReader) {
       return liveSnapshot
@@ -1291,7 +1297,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
       return await buildDurableCheckpointSnapshot({
         liveSnapshot,
-        restoreInfo
+        restoreInfo,
+        scrollbackRows
       })
     } catch {
       return liveSnapshot

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -234,6 +234,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private sessionsNeedingFullCheckpoint = new Set<string>()
   // Why: overflow or an unpersisted drain breaks disk-to-queue continuity, so only the daemon emulator can safely re-anchor the next checkpoint.
   private sessionsNeedingLiveCheckpoint = new Set<string>()
+  // Why: a fresh adapter may reuse deep disk history only when the checkpoint proves it ends at the daemon's preceding pending-output batch.
+  private sessionsNeedingContinuityCheckpoint = new Set<string>()
   private checkpointTimer: ReturnType<typeof setTimeout> | null = null
   private checkpointInFlight: Promise<void> | null = null
   private keepHistoryShutdowns = new Set<Promise<void>>()
@@ -823,9 +825,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // Why: on warm reattach after relaunch the HistoryManager is fresh; registerWriter adds a writer without deleting the still-only-valid checkpoint.
       this.historyManager.registerWriter(sessionId, takeRecoveryFreeze(historyRecovery, sessionId))
       if (!wasAlreadyManaged) {
-        // Why: a previous adapter may have drained records it never persisted, so appending would leave a seq gap the reader rejects; force a full snapshot to re-anchor.
+        // Why: a previous adapter may have drained records it never persisted, so the first compact must prove disk-to-daemon continuity.
         this.sessionsNeedingFullCheckpoint.add(sessionId)
-        this.sessionsNeedingLiveCheckpoint.add(sessionId)
+        this.sessionsNeedingContinuityCheckpoint.add(sessionId)
         this.lastFullCheckpointAt.delete(sessionId)
       }
     }
@@ -845,6 +847,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const reattachSnapshot = await this.overlayDurableRestoreSnapshot(sessionId, result.snapshot)
+    const reattachProviderSequence =
+      typeof reattachSnapshot.outputSequence === 'number'
+        ? { value: reattachSnapshot.outputSequence, generation: 'continued' as const }
+        : providerSequence
     const isAltScreen = reattachSnapshot.modes.alternateScreen
     const snapshotPrefix = reattachSnapshot.scrollbackAnsi + reattachSnapshot.rehydrateSequences
     const snapshotFrame = reattachSnapshot.snapshotAnsi
@@ -873,7 +879,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
             snapshotFrameRestoreAnsi: reattachSnapshot.frameRestoreAnsi
           }
         : {}),
-      ...(providerSequence ? { providerSequence } : {}),
+      ...(reattachProviderSequence ? { providerSequence: reattachProviderSequence } : {}),
       ...(kittyKeyboardFlags !== undefined
         ? { snapshotKittyKeyboardFlags: kittyKeyboardFlags }
         : {}),
@@ -1141,6 +1147,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // Why: the !keepHistory path takes no final checkpoint, so clear sessionsNeedingFullCheckpoint here or it stays stranded (no-op under keepHistory).
     this.sessionsNeedingFullCheckpoint.delete(id)
     this.sessionsNeedingLiveCheckpoint.delete(id)
+    this.sessionsNeedingContinuityCheckpoint.delete(id)
     this.lastFullCheckpointAt.delete(id)
     this.stopCheckpointTimerIfIdle()
     this.initialCwds.delete(id)
@@ -1297,7 +1304,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
       await this.runExclusiveCheckpoint(async () => {
         checkpointResult.value = await this.takeSnapshotAndCheckpoint(sessionId, {
           teardown: false,
-          forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId)
+          forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId),
+          requireContinuityProof: this.sessionsNeedingContinuityCheckpoint.has(sessionId)
         })
         if (checkpointResult.value.checkpoint === 'committed') {
           this.sessionsNeedingFullCheckpoint.delete(sessionId)
@@ -1495,7 +1503,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
       if (historyManager.hasWriter(session.sessionId)) {
         this.sessionsNeedingFullCheckpoint.add(session.sessionId)
-        this.sessionsNeedingLiveCheckpoint.add(session.sessionId)
+        this.sessionsNeedingContinuityCheckpoint.add(session.sessionId)
         this.lastFullCheckpointAt.delete(session.sessionId)
         this.markSessionDirty(session.sessionId)
       }
@@ -1616,6 +1624,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.lastFullCheckpointAt.clear()
     this.sessionsNeedingFullCheckpoint.clear()
     this.sessionsNeedingLiveCheckpoint.clear()
+    this.sessionsNeedingContinuityCheckpoint.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
     this.stopCheckpointTimer()
@@ -1725,6 +1734,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.lastFullCheckpointAt.clear()
     this.sessionsNeedingFullCheckpoint.clear()
     this.sessionsNeedingLiveCheckpoint.clear()
+    this.sessionsNeedingContinuityCheckpoint.clear()
     this.coldRestoreCache.clear()
     this.wslDistrosBySessionId.clear()
     this.pausedProducerSessionIds.clear()
@@ -2120,14 +2130,16 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // so a warm reattach won't re-append records the checkpoint already contains (double-replay on cold restore).
       const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, {
         teardown: opts.teardown,
-        forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId)
+        forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId),
+        requireContinuityProof: this.sessionsNeedingContinuityCheckpoint.has(sessionId)
       })
-      if (checkpoint.checkpoint !== 'committed') {
+      if (checkpoint.checkpoint === 'retryable') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
       this.sessionsNeedingFullCheckpoint.delete(sessionId)
       this.sessionsNeedingLiveCheckpoint.delete(sessionId)
+      this.sessionsNeedingContinuityCheckpoint.delete(sessionId)
       return 'done'
     }
     const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
@@ -2146,7 +2158,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         teardown: false,
         forceLiveSnapshot: true
       })
-      if (checkpoint.checkpoint !== 'committed') {
+      if (checkpoint.checkpoint === 'retryable') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
@@ -2173,7 +2185,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         teardown: false,
         forceLiveSnapshot: true
       })
-      if (checkpoint.checkpoint !== 'committed') {
+      if (checkpoint.checkpoint === 'retryable') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
@@ -2183,7 +2195,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   private async takeSnapshotAndCheckpoint(
     sessionId: string,
-    opts: { teardown: boolean; forceLiveSnapshot?: boolean }
+    opts: {
+      teardown: boolean
+      forceLiveSnapshot?: boolean
+      requireContinuityProof?: boolean
+    }
   ): Promise<SnapshotCheckpointResult> {
     const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
       sessionId,
@@ -2197,18 +2213,31 @@ export class DaemonPtyAdapter implements IPtyProvider {
       const snapshot =
         take.drainedRecords === undefined || opts.forceLiveSnapshot === true || take.overflowed
           ? take.snapshot
-          : await this.buildDurableHistorySnapshot(sessionId, take.snapshot, [
-              ...take.drainedRecords,
-              ...take.records
-            ])
-      const checkpoint = await this.historyManager.checkpoint(sessionId, snapshot)
-      if (checkpoint !== 'committed') {
+          : await this.buildDurableHistorySnapshot(
+              sessionId,
+              take.snapshot,
+              [...take.drainedRecords, ...take.records],
+              opts.requireContinuityProof === true
+                ? { requiredPreviousPendingOutputSeq: take.seq - 1 }
+                : undefined
+            )
+      const checkpoint = await this.historyManager.checkpoint(sessionId, snapshot, {
+        pendingOutputSeq: take.seq
+      })
+      if (checkpoint === 'retryable') {
         // Why take.records is dropped, not appended: the pending output this take drained went into the snapshot that
         // failed to land, so appending the held tail at the next contiguous seq would splice it over that hole and
         // defeat the log's seq-gap detection. A stale prefix beats an undetectable hole.
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         this.sessionsNeedingLiveCheckpoint.add(sessionId)
+        this.sessionsNeedingContinuityCheckpoint.delete(sessionId)
         this.markSessionDirty(sessionId)
+        return { checkpoint, snapshot: take.snapshot }
+      }
+      if (checkpoint === 'unavailable') {
+        this.sessionsNeedingFullCheckpoint.delete(sessionId)
+        this.sessionsNeedingLiveCheckpoint.delete(sessionId)
+        this.sessionsNeedingContinuityCheckpoint.delete(sessionId)
         return { checkpoint, snapshot: take.snapshot }
       }
       this.lastFullCheckpointAt.set(sessionId, Date.now())
@@ -2217,15 +2246,20 @@ export class DaemonPtyAdapter implements IPtyProvider {
         await this.historyManager.appendIncrements(sessionId, take.seq, take.records)
       }
       this.sessionsNeedingLiveCheckpoint.delete(sessionId)
+      this.sessionsNeedingContinuityCheckpoint.delete(sessionId)
       return { checkpoint: 'committed', snapshot }
     }
+    this.sessionsNeedingFullCheckpoint.delete(sessionId)
+    this.sessionsNeedingLiveCheckpoint.delete(sessionId)
+    this.sessionsNeedingContinuityCheckpoint.delete(sessionId)
     return { checkpoint: 'unavailable', snapshot: take?.snapshot ?? null }
   }
 
   private async buildDurableHistorySnapshot(
     sessionId: string,
     liveSnapshot: NonNullable<TakePendingOutputResult['snapshot']>,
-    pendingRecords: TakePendingOutputResult['records']
+    pendingRecords: TakePendingOutputResult['records'],
+    opts?: { requiredPreviousPendingOutputSeq?: number }
   ): Promise<NonNullable<TakePendingOutputResult['snapshot']>> {
     if (!this.historyReader) {
       return liveSnapshot
@@ -2235,6 +2269,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ignoreCleanEnd: true,
         wslDistro: this.wslDistrosBySessionId.get(sessionId)
       })
+      if (
+        opts?.requiredPreviousPendingOutputSeq !== undefined &&
+        restoreInfo?.pendingOutputSeq !== opts.requiredPreviousPendingOutputSeq
+      ) {
+        return liveSnapshot
+      }
       return await buildDurableCheckpointSnapshot({
         liveSnapshot,
         restoreInfo,
@@ -2532,6 +2572,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         // Why: an exited session can't be checkpointed again; clearing its pending-full flag prevents a permanent leak.
         this.sessionsNeedingFullCheckpoint.delete(event.sessionId)
         this.sessionsNeedingLiveCheckpoint.delete(event.sessionId)
+        this.sessionsNeedingContinuityCheckpoint.delete(event.sessionId)
         // Why: a reused sessionId (renderer respawns a persisted ptyId) must not inherit the dead session's snapshot cooldown.
         this.lastFullCheckpointAt.delete(event.sessionId)
         this.stopCheckpointTimerIfIdle()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -2217,9 +2217,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
               sessionId,
               take.snapshot,
               [...take.drainedRecords, ...take.records],
-              opts.requireContinuityProof === true
-                ? { requiredPreviousPendingOutputSeq: take.seq - 1 }
-                : undefined
+              {
+                pendingRecordsAreComplete: take.seq === 1,
+                ...(opts.requireContinuityProof === true
+                  ? { requiredPreviousPendingOutputSeq: take.seq - 1 }
+                  : {})
+              }
             )
       const checkpoint = await this.historyManager.checkpoint(sessionId, snapshot, {
         pendingOutputSeq: take.seq
@@ -2259,7 +2262,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
     sessionId: string,
     liveSnapshot: NonNullable<TakePendingOutputResult['snapshot']>,
     pendingRecords: TakePendingOutputResult['records'],
-    opts?: { requiredPreviousPendingOutputSeq?: number }
+    opts: {
+      pendingRecordsAreComplete: boolean
+      requiredPreviousPendingOutputSeq?: number
+    }
   ): Promise<NonNullable<TakePendingOutputResult['snapshot']>> {
     if (!this.historyReader) {
       return liveSnapshot
@@ -2270,8 +2276,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
         wslDistro: this.wslDistrosBySessionId.get(sessionId)
       })
       if (
-        opts?.requiredPreviousPendingOutputSeq !== undefined &&
-        restoreInfo?.pendingOutputSeq !== opts.requiredPreviousPendingOutputSeq
+        (!restoreInfo && !opts.pendingRecordsAreComplete) ||
+        (opts.requiredPreviousPendingOutputSeq !== undefined &&
+          restoreInfo?.pendingOutputSeq !== opts.requiredPreviousPendingOutputSeq)
       ) {
         console.warn('[history] durable continuity unproven; using live snapshot:', sessionId)
         return liveSnapshot

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -70,6 +70,7 @@ import { resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { ColdRestorePayloadCache, type ColdRestorePayload } from './cold-restore-payload-cache'
 import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
+import { DAEMON_RESTORE_SCROLLBACK_ROWS } from './daemon-restore-scrollback-depth'
 import { DAEMON_SESSION_SCROLLBACK_ROWS } from './daemon-session-scrollback-window'
 import { PtyProcessListAdmission } from '../providers/pty-process-list-admission'
 import {
@@ -100,6 +101,11 @@ type HistoryRecoveryContext = {
   freeze: HistoryRecoveryFreeze | null
   unreadableSessionId: string | null
   identityChanged: boolean
+}
+
+type SnapshotCheckpointResult = {
+  checkpoint: HistoryCheckpointResult
+  snapshot: NonNullable<TakePendingOutputResult['snapshot']> | null
 }
 
 // Why take-and-clear together: every consuming branch must reset the field, so pairing them stops one from forgetting.
@@ -226,6 +232,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private dirtySessionVersions = new Map<string, number>()
   // Why: a cold-restored session is a fresh shell atop a pre-crash log; incremental appends would be rejected on restore, so the first tick re-anchors with a full snapshot.
   private sessionsNeedingFullCheckpoint = new Set<string>()
+  // Why: overflow or an unpersisted drain breaks disk-to-queue continuity, so only the daemon emulator can safely re-anchor the next checkpoint.
+  private sessionsNeedingLiveCheckpoint = new Set<string>()
   private checkpointTimer: ReturnType<typeof setTimeout> | null = null
   private checkpointInFlight: Promise<void> | null = null
   private keepHistoryShutdowns = new Set<Promise<void>>()
@@ -755,6 +763,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
           })
           if (this.historyManager.hasWriter(sessionId)) {
             this.sessionsNeedingFullCheckpoint.add(sessionId)
+            this.sessionsNeedingLiveCheckpoint.add(sessionId)
             this.lastFullCheckpointAt.delete(sessionId)
           }
         } else if (canReanchorHistory) {
@@ -816,6 +825,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (!wasAlreadyManaged) {
         // Why: a previous adapter may have drained records it never persisted, so appending would leave a seq gap the reader rejects; force a full snapshot to re-anchor.
         this.sessionsNeedingFullCheckpoint.add(sessionId)
+        this.sessionsNeedingLiveCheckpoint.add(sessionId)
         this.lastFullCheckpointAt.delete(sessionId)
       }
     }
@@ -1130,6 +1140,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     // Why: the !keepHistory path takes no final checkpoint, so clear sessionsNeedingFullCheckpoint here or it stays stranded (no-op under keepHistory).
     this.sessionsNeedingFullCheckpoint.delete(id)
+    this.sessionsNeedingLiveCheckpoint.delete(id)
     this.lastFullCheckpointAt.delete(id)
     this.stopCheckpointTimerIfIdle()
     this.initialCwds.delete(id)
@@ -1282,12 +1293,23 @@ export class DaemonPtyAdapter implements IPtyProvider {
     try {
       // Why exclusive compact: an independent take/append races the 5s tick, can
       // seq-gap the log, and would remount a stale checkpoint over the live window.
+      const checkpointResult: { value?: SnapshotCheckpointResult } = {}
       await this.runExclusiveCheckpoint(async () => {
-        const result = await this.takeSnapshotAndCheckpoint(sessionId, { teardown: false })
-        if (result === 'committed') {
+        checkpointResult.value = await this.takeSnapshotAndCheckpoint(sessionId, {
+          teardown: false,
+          forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId)
+        })
+        if (checkpointResult.value.checkpoint === 'committed') {
           this.sessionsNeedingFullCheckpoint.delete(sessionId)
         }
       })
+      const checkpoint = checkpointResult.value
+      if (checkpoint?.checkpoint !== 'committed' || !checkpoint.snapshot) {
+        return checkpoint?.snapshot ?? liveSnapshot
+      }
+      if (scrollbackRows === undefined || scrollbackRows >= DAEMON_RESTORE_SCROLLBACK_ROWS) {
+        return checkpoint.snapshot
+      }
       const restoreInfo = await this.historyReader.detectColdRestore(sessionId, {
         ignoreCleanEnd: true,
         wslDistro: this.wslDistrosBySessionId.get(sessionId)
@@ -1296,11 +1318,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
         return liveSnapshot
       }
       return await buildDurableCheckpointSnapshot({
-        liveSnapshot,
+        liveSnapshot: checkpoint.snapshot,
         restoreInfo,
         scrollbackRows
       })
-    } catch {
+    } catch (error) {
+      console.warn('[history] durable snapshot overlay failed:', sessionId, error)
       return liveSnapshot
     }
   }
@@ -1472,6 +1495,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
       if (historyManager.hasWriter(session.sessionId)) {
         this.sessionsNeedingFullCheckpoint.add(session.sessionId)
+        this.sessionsNeedingLiveCheckpoint.add(session.sessionId)
         this.lastFullCheckpointAt.delete(session.sessionId)
         this.markSessionDirty(session.sessionId)
       }
@@ -1591,6 +1615,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.dirtySessionVersions.clear()
     this.lastFullCheckpointAt.clear()
     this.sessionsNeedingFullCheckpoint.clear()
+    this.sessionsNeedingLiveCheckpoint.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
     this.stopCheckpointTimer()
@@ -1698,6 +1723,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.stopCheckpointTimer()
     this.dirtySessionVersions.clear()
     this.lastFullCheckpointAt.clear()
+    this.sessionsNeedingFullCheckpoint.clear()
+    this.sessionsNeedingLiveCheckpoint.clear()
     this.coldRestoreCache.clear()
     this.wslDistrosBySessionId.clear()
     this.pausedProducerSessionIds.clear()
@@ -2092,13 +2119,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // Why take-with-snapshot not plain getSnapshot: it clears pending records in the same turn as the serialize,
       // so a warm reattach won't re-append records the checkpoint already contains (double-replay on cold restore).
       const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, {
-        teardown: opts.teardown
+        teardown: opts.teardown,
+        forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId)
       })
-      if (checkpoint === 'retryable') {
+      if (checkpoint.checkpoint !== 'committed') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
       this.sessionsNeedingFullCheckpoint.delete(sessionId)
+      this.sessionsNeedingLiveCheckpoint.delete(sessionId)
       return 'done'
     }
     const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
@@ -2113,8 +2142,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
-      const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, { teardown: false })
-      if (checkpoint === 'retryable') {
+      const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, {
+        teardown: false,
+        forceLiveSnapshot: true
+      })
+      if (checkpoint.checkpoint !== 'committed') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
@@ -2137,8 +2169,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
-      const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, { teardown: false })
-      if (checkpoint === 'retryable') {
+      const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, {
+        teardown: false,
+        forceLiveSnapshot: true
+      })
+      if (checkpoint.checkpoint !== 'committed') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
@@ -2148,8 +2183,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   private async takeSnapshotAndCheckpoint(
     sessionId: string,
-    opts: { teardown: boolean }
-  ): Promise<HistoryCheckpointResult> {
+    opts: { teardown: boolean; forceLiveSnapshot?: boolean }
+  ): Promise<SnapshotCheckpointResult> {
     const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
       sessionId,
       includeSnapshot: true,
@@ -2160,7 +2195,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // queue on includeSnapshot but omits the field. Treating absence as []
       // would compact stale disk history and reset the log.
       const snapshot =
-        take.drainedRecords === undefined
+        take.drainedRecords === undefined || opts.forceLiveSnapshot === true || take.overflowed
           ? take.snapshot
           : await this.buildDurableHistorySnapshot(sessionId, take.snapshot, [
               ...take.drainedRecords,
@@ -2171,16 +2206,20 @@ export class DaemonPtyAdapter implements IPtyProvider {
         // Why take.records is dropped, not appended: the pending output this take drained went into the snapshot that
         // failed to land, so appending the held tail at the next contiguous seq would splice it over that hole and
         // defeat the log's seq-gap detection. A stale prefix beats an undetectable hole.
-        return checkpoint
+        this.sessionsNeedingFullCheckpoint.add(sessionId)
+        this.sessionsNeedingLiveCheckpoint.add(sessionId)
+        this.markSessionDirty(sessionId)
+        return { checkpoint, snapshot: take.snapshot }
       }
       this.lastFullCheckpointAt.set(sessionId, Date.now())
       if (take.records.length > 0 && snapshot === take.snapshot) {
         // Why: live-window fallback still lacks held parser-state bytes; keep them as a post-checkpoint log tail.
         await this.historyManager.appendIncrements(sessionId, take.seq, take.records)
       }
-      return 'committed'
+      this.sessionsNeedingLiveCheckpoint.delete(sessionId)
+      return { checkpoint: 'committed', snapshot }
     }
-    return 'unavailable'
+    return { checkpoint: 'unavailable', snapshot: take?.snapshot ?? null }
   }
 
   private async buildDurableHistorySnapshot(
@@ -2201,7 +2240,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
         restoreInfo,
         pendingRecords
       })
-    } catch {
+    } catch (error) {
+      console.warn('[history] durable history rebuild failed:', sessionId, error)
       return liveSnapshot
     }
   }
@@ -2491,6 +2531,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         }
         // Why: an exited session can't be checkpointed again; clearing its pending-full flag prevents a permanent leak.
         this.sessionsNeedingFullCheckpoint.delete(event.sessionId)
+        this.sessionsNeedingLiveCheckpoint.delete(event.sessionId)
         // Why: a reused sessionId (renderer respawns a persisted ptyId) must not inherit the dead session's snapshot cooldown.
         this.lastFullCheckpointAt.delete(event.sessionId)
         this.stopCheckpointTimerIfIdle()

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -20,6 +20,7 @@ import type { SubprocessHandle } from './session'
 const PREVIOUSLY_RECOVERABLE_LINE = 'LINE_01000'
 const OLDEST_WRITTEN_LINE = 'LINE_00001'
 const NEWEST_WRITTEN_LINE = `LINE_${String(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT).padStart(5, '0')}`
+const FRESH_AFTER_CHECKPOINT = 'FRESH_AFTER_CHECKPOINT'
 
 function numberedOutput(lineCount: number): string {
   let output = ''
@@ -192,6 +193,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
         })
         expect(durable.outputSequence).toBe(9)
         expect(durable.scrollbackAnsi).toBe('')
+        expect(durable.scrollbackLines).toBe(restoreInfo?.scrollbackLines)
         expect(snapshotText(durable)).toContain(PREVIOUSLY_RECOVERABLE_LINE)
       } finally {
         live.dispose()
@@ -350,6 +352,115 @@ describe('STA-4091 previously recoverable restore depth', () => {
       const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
       expect(text).toContain(NEWEST_WRITTEN_LINE)
       expect(text).not.toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('reanchors from the live window after pending output overflows', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'overflow-reanchor',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+
+      const overflowLine = `BULK_${'x'.repeat(100)}\r\n`
+      lastSubprocess.emitData(overflowLine.repeat(20_000))
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+      const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+      expect(text).toContain(FRESH_AFTER_CHECKPOINT)
+      const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(restore ?? {})).toContain(FRESH_AFTER_CHECKPOINT)
+    })
+
+    it.each(['retryable', 'unavailable'] as const)(
+      'returns the current live snapshot when a durable checkpoint is %s',
+      async (checkpointResult) => {
+        const { id } = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: `checkpoint-${checkpointResult}`,
+          cwd: '/tmp'
+        })
+        lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+        await adapter.getBufferSnapshot(id)
+        lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+        const internals = adapter as unknown as {
+          historyManager: HistoryManager
+          sessionsNeedingLiveCheckpoint: Set<string>
+        }
+        const checkpoint = vi
+          .spyOn(internals.historyManager, 'checkpoint')
+          .mockResolvedValueOnce(checkpointResult)
+
+        const snapshot = await adapter.getBufferSnapshot(id)
+        const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+        expect(text).toContain(FRESH_AFTER_CHECKPOINT)
+        expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(true)
+
+        const recovered = await adapter.getBufferSnapshot(id)
+        expect(`${recovered?.scrollbackAnsi ?? ''}${recovered?.data ?? ''}`).toContain(
+          FRESH_AFTER_CHECKPOINT
+        )
+        const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+          ignoreCleanEnd: true
+        })
+        expect(snapshotText(restore ?? {})).toContain(FRESH_AFTER_CHECKPOINT)
+        expect(checkpoint.mock.calls.at(-1)?.[1].scrollbackLines).toBe(
+          DAEMON_SESSION_SCROLLBACK_ROWS
+        )
+        expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(false)
+
+        checkpoint.mockResolvedValueOnce(checkpointResult)
+        const reattach = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: id,
+          cwd: '/tmp'
+        })
+        expect(reattach.isReattach).toBe(true)
+        expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+      }
+    )
+
+    it('uses the post-drain sequence for output produced during an overlay', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'overlay-sequence',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+
+      const internals = adapter as unknown as {
+        client: { request: (method: string, params?: unknown) => Promise<unknown> }
+      }
+      const request = internals.client.request.bind(internals.client)
+      let injected = false
+      vi.spyOn(internals.client, 'request').mockImplementation(async (method, params) => {
+        if (
+          method === 'takePendingOutput' &&
+          (params as { includeSnapshot?: boolean } | undefined)?.includeSnapshot &&
+          !injected
+        ) {
+          injected = true
+          lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+        }
+        return request(method, params)
+      })
+
+      const overlaid = await adapter.getBufferSnapshot(id)
+      const current = await adapter.getBufferSnapshot(id, { scrollbackRows: 24 })
+      expect(`${overlaid?.scrollbackAnsi ?? ''}${overlaid?.data ?? ''}`).toContain(
+        FRESH_AFTER_CHECKPOINT
+      )
+      expect(overlaid?.seq).toBe(current?.seq)
     })
   })
 })

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -8,6 +8,7 @@ import { DaemonServer } from './daemon-server'
 import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
 import { DAEMON_RESTORE_SCROLLBACK_ROWS } from './daemon-restore-scrollback-depth'
 import { DAEMON_SESSION_SCROLLBACK_ROWS } from './daemon-session-scrollback-window'
+import { getHistorySessionDirName } from './history-paths'
 import { getDaemonSocketPath } from './daemon-spawner'
 import { HeadlessEmulator } from './headless-emulator'
 import { HistoryManager } from './history-manager'
@@ -370,6 +371,44 @@ describe('STA-4091 previously recoverable restore depth', () => {
         ignoreCleanEnd: true
       })
       expect(snapshotText(restore ?? {})).toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('uses the live window when durable history disappears after a prior drain', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'missing-history-after-drain',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const internals = adapter as unknown as { checkpointDirtySessions: () => Promise<void> }
+      await internals.checkpointDirtySessions()
+      rmSync(join(historyDir, getHistorySessionDirName(id), 'checkpoint.json'))
+      lastSubprocess.emitData('TAIL_AFTER_HISTORY_LOSS\r\n')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        const snapshot = await adapter.getBufferSnapshot(id)
+        const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+        expect(text).toContain(NEWEST_WRITTEN_LINE)
+        expect(text).toContain('TAIL_AFTER_HISTORY_LOSS')
+        expect(text).not.toContain(OLDEST_WRITTEN_LINE)
+        const restored = await new HistoryReader(historyDir).detectColdRestore(id, {
+          ignoreCleanEnd: true
+        })
+        expect(snapshotText(restored ?? {})).toContain(NEWEST_WRITTEN_LINE)
+        expect(snapshotText(restored ?? {})).toContain('TAIL_AFTER_HISTORY_LOSS')
+        expect(restored?.scrollbackLines).toBe(DAEMON_SESSION_SCROLLBACK_ROWS)
+        expect(warn).toHaveBeenCalledWith(
+          '[history] durable continuity unproven; using live snapshot:',
+          id
+        )
+      } finally {
+        warn.mockRestore()
+      }
     })
 
     it('preserves durable depth after an incremental append and adapter crash', async () => {

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../shared/terminal-scrollback-policy'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonServer } from './daemon-server'
+import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
+import { DAEMON_RESTORE_SCROLLBACK_ROWS } from './daemon-restore-scrollback-depth'
+import { DAEMON_SESSION_SCROLLBACK_ROWS } from './daemon-session-scrollback-window'
+import { getDaemonSocketPath } from './daemon-spawner'
+import { HeadlessEmulator } from './headless-emulator'
+import { HistoryManager } from './history-manager'
+import { HistoryReader } from './history-reader'
+import { TerminalHost } from './terminal-host'
+import type { DaemonFileLog } from './daemon-file-log'
+import type { PendingOutputRecord, TerminalSnapshot } from './types'
+import type { SubprocessHandle } from './session'
+
+const PREVIOUSLY_RECOVERABLE_LINE = 'LINE_01000'
+const OLDEST_WRITTEN_LINE = 'LINE_00001'
+const NEWEST_WRITTEN_LINE = `LINE_${String(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT).padStart(5, '0')}`
+
+function numberedOutput(lineCount: number): string {
+  let output = ''
+  for (let index = 1; index <= lineCount; index += 1) {
+    output += `LINE_${String(index).padStart(5, '0')}\r\n`
+  }
+  return output
+}
+
+function snapshotText(snapshot: { scrollbackAnsi?: string; snapshotAnsi?: string }): string {
+  return `${snapshot.scrollbackAnsi ?? ''}${snapshot.snapshotAnsi ?? ''}`
+}
+
+function createMockSubprocess(): SubprocessHandle & {
+  emitData: (data: string) => void
+} {
+  let onData: ((data: string) => void) | undefined
+  let onExit: ((code: number) => void) | undefined
+  return {
+    pid: 4242,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => setTimeout(() => onExit?.(0), 1)),
+    forceKill: vi.fn(() => onExit?.(137)),
+    signal: vi.fn(),
+    onData(callback) {
+      onData = callback
+    },
+    onExit(callback) {
+      onExit = callback
+    },
+    dispose: vi.fn(),
+    emitData(data) {
+      onData?.(data)
+    }
+  }
+}
+
+describe('STA-4091 previously recoverable restore depth', () => {
+  it('live daemon memory still drops older rows so session count cannot grow unbounded', async () => {
+    const subprocess = createMockSubprocess()
+    const host = new TerminalHost({ spawnSubprocess: () => subprocess })
+    try {
+      await host.createOrAttach({
+        sessionId: 'live-window',
+        cols: 80,
+        rows: 24,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+      subprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await vi.waitFor(() => {
+        const snapshot = host.getSnapshot('live-window')
+        const text = snapshotText(snapshot ?? {})
+        expect(text).toContain(NEWEST_WRITTEN_LINE)
+        expect(text).not.toContain(OLDEST_WRITTEN_LINE)
+        expect(text).not.toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(DAEMON_SESSION_SCROLLBACK_ROWS).toBeLessThan(
+          DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT
+        )
+      })
+    } finally {
+      await host.dispose()
+    }
+  })
+
+  describe('durable history', () => {
+    let dir: string
+    let manager: HistoryManager
+    let reader: HistoryReader
+
+    beforeEach(async () => {
+      dir = mkdtempSync(join(tmpdir(), 'orca-restore-depth-'))
+      manager = new HistoryManager(dir)
+      reader = new HistoryReader(dir)
+      await manager.openSession('restore-depth', { cwd: '/tmp', cols: 80, rows: 24 })
+    })
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('reconstructs the previously recoverable desktop depth from incremental history', async () => {
+      const records: PendingOutputRecord[] = [
+        { kind: 'output', data: numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT) }
+      ]
+      expect(await manager.appendIncrements('restore-depth', 1, records)).toBe('ok')
+
+      const restore = await reader.detectColdRestore('restore-depth')
+      const text = snapshotText(restore ?? {})
+      expect(text).toContain(OLDEST_WRITTEN_LINE)
+      expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(text).toContain(NEWEST_WRITTEN_LINE)
+    })
+
+    it('keeps that depth after a production compact of the live daemon window', async () => {
+      const live = new HeadlessEmulator({
+        cols: 80,
+        rows: 24,
+        scrollback: DAEMON_SESSION_SCROLLBACK_ROWS
+      })
+      try {
+        live.writeSync(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+        const liveSnapshot = live.getSnapshot()
+        expect(snapshotText(liveSnapshot)).not.toContain(PREVIOUSLY_RECOVERABLE_LINE)
+
+        expect(
+          await manager.appendIncrements('restore-depth', 1, [
+            { kind: 'output', data: numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT) }
+          ])
+        ).toBe('ok')
+        const restoreInfo = await reader.detectColdRestore('restore-depth')
+        const durable = await buildDurableCheckpointSnapshot({
+          liveSnapshot,
+          restoreInfo
+        })
+        expect(await manager.checkpoint('restore-depth', durable)).toBe('committed')
+
+        const restore = await reader.detectColdRestore('restore-depth')
+        const text = snapshotText(restore ?? {})
+        expect(text).toContain(NEWEST_WRITTEN_LINE)
+        expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(text).toContain(OLDEST_WRITTEN_LINE)
+        expect(DAEMON_RESTORE_SCROLLBACK_ROWS).toBe(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT)
+      } finally {
+        live.dispose()
+      }
+    })
+
+    it('replays pending records into restore depth when disk history is empty', async () => {
+      const live = new HeadlessEmulator({
+        cols: 80,
+        rows: 24,
+        scrollback: DAEMON_SESSION_SCROLLBACK_ROWS
+      })
+      try {
+        live.writeSync(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+        const durable = await buildDurableCheckpointSnapshot({
+          liveSnapshot: live.getSnapshot(),
+          restoreInfo: null,
+          pendingRecords: [
+            { kind: 'output', data: numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT) }
+          ]
+        })
+        expect(snapshotText(durable)).toContain(OLDEST_WRITTEN_LINE)
+        expect(snapshotText(durable)).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(snapshotText(durable)).toContain(NEWEST_WRITTEN_LINE)
+      } finally {
+        live.dispose()
+      }
+    })
+
+    it('reuses restore info when there are no pending records to replay', async () => {
+      const live = new HeadlessEmulator({
+        cols: 80,
+        rows: 24,
+        scrollback: DAEMON_SESSION_SCROLLBACK_ROWS
+      })
+      try {
+        expect(
+          await manager.appendIncrements('restore-depth', 1, [
+            { kind: 'output', data: numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT) }
+          ])
+        ).toBe('ok')
+        const restoreInfo = await reader.detectColdRestore('restore-depth')
+        live.writeSync(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+        const durable = await buildDurableCheckpointSnapshot({
+          liveSnapshot: { ...live.getSnapshot(), outputSequence: 9 },
+          restoreInfo
+        })
+        expect(durable.outputSequence).toBe(9)
+        expect(snapshotText(durable)).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      } finally {
+        live.dispose()
+      }
+    })
+
+    it('falls back to the live window when pending resize records are invalid', async () => {
+      const liveSnapshot = {
+        snapshotAnsi: 'live-only',
+        scrollbackAnsi: '',
+        rehydrateSequences: '',
+        cwd: '/tmp',
+        cols: 80,
+        rows: 24,
+        scrollbackLines: 0,
+        modes: {
+          bracketedPaste: false,
+          alternateScreen: false,
+          applicationCursor: false,
+          mouseTracking: false
+        },
+        outputSequence: 4
+      } as TerminalSnapshot
+
+      const durable = await buildDurableCheckpointSnapshot({
+        liveSnapshot,
+        restoreInfo: null,
+        pendingRecords: [{ kind: 'resize', cols: 0, rows: 24 }]
+      })
+      expect(durable).toBe(liveSnapshot)
+    })
+  })
+
+  describe('adapter remount and restart', () => {
+    let dir: string
+    let historyDir: string
+    let server: DaemonServer
+    let adapter: DaemonPtyAdapter
+    let lastSubprocess: ReturnType<typeof createMockSubprocess>
+
+    beforeEach(async () => {
+      dir = mkdtempSync(join(tmpdir(), 'orca-restore-depth-adapter-'))
+      historyDir = join(dir, 'history')
+      const log: DaemonFileLog = { log: () => {}, close: () => {} }
+      server = new DaemonServer({
+        socketPath: getDaemonSocketPath(dir),
+        tokenPath: join(dir, 'test.token'),
+        log,
+        spawnSubprocess: () => {
+          lastSubprocess = createMockSubprocess()
+          return lastSubprocess
+        }
+      })
+      await server.start()
+      adapter = new DaemonPtyAdapter({
+        socketPath: getDaemonSocketPath(dir),
+        tokenPath: join(dir, 'test.token'),
+        historyPath: historyDir
+      })
+    })
+
+    afterEach(async () => {
+      adapter?.dispose()
+      await server?.shutdown()
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('restores the previously recoverable depth on remount snapshot', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'remount-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+      const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+      expect(text).toContain(NEWEST_WRITTEN_LINE)
+      expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(text).toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('restores that depth after a keepHistory restart compact', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'restart-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+
+      await adapter.shutdown(id, { immediate: true, keepHistory: true })
+
+      const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      const text = snapshotText(restore ?? {})
+      expect(text).toContain(NEWEST_WRITTEN_LINE)
+      expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(text).toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('restores that depth on warm reattach', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'reattach-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+
+      const reattach = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: id,
+        cwd: '/tmp'
+      })
+      expect(reattach.isReattach).toBe(true)
+      expect(reattach.snapshot).toContain(NEWEST_WRITTEN_LINE)
+      expect(reattach.snapshot).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('falls back to the live window when durable history cannot be read', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'error-fallback',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      const internals = adapter as unknown as { historyReader: HistoryReader }
+      vi.spyOn(internals.historyReader, 'detectColdRestore').mockRejectedValue(
+        new Error('history unreadable')
+      )
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+      const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+      expect(text).toContain(NEWEST_WRITTEN_LINE)
+      expect(text).not.toContain(OLDEST_WRITTEN_LINE)
+    })
+  })
+})

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -123,7 +123,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
         scrollback: DAEMON_SESSION_SCROLLBACK_ROWS
       })
       try {
-        live.writeSync(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+        expect(live.writeSync(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))).toBe(true)
         const liveSnapshot = live.getSnapshot()
         expect(snapshotText(liveSnapshot)).not.toContain(PREVIOUSLY_RECOVERABLE_LINE)
 

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -191,6 +191,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
           restoreInfo
         })
         expect(durable.outputSequence).toBe(9)
+        expect(durable.scrollbackAnsi).toBe('')
         expect(snapshotText(durable)).toContain(PREVIOUSLY_RECOVERABLE_LINE)
       } finally {
         live.dispose()
@@ -272,6 +273,23 @@ describe('STA-4091 previously recoverable restore depth', () => {
       expect(text).toContain(NEWEST_WRITTEN_LINE)
       expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
       expect(text).toContain(OLDEST_WRITTEN_LINE)
+      expect(text.split(OLDEST_WRITTEN_LINE)).toHaveLength(2)
+    })
+
+    it('honors a bounded remount snapshot depth', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'bounded-remount-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+
+      const snapshot = await adapter.getBufferSnapshot(id, { scrollbackRows: 24 })
+      const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+      expect(text).toContain(NEWEST_WRITTEN_LINE)
+      expect(text).not.toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(text).not.toContain(OLDEST_WRITTEN_LINE)
     })
 
     it('restores that depth after a keepHistory restart compact', async () => {

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -60,6 +60,15 @@ function createMockSubprocess(): SubprocessHandle & {
   }
 }
 
+function simulateAdapterCrash(adapter: DaemonPtyAdapter): void {
+  const internals = adapter as unknown as {
+    client: { disconnect: () => void }
+    stopCheckpointTimer: () => void
+  }
+  internals.stopCheckpointTimer()
+  internals.client.disconnect()
+}
+
 describe('STA-4091 previously recoverable restore depth', () => {
   it('live daemon memory still drops older rows so session count cannot grow unbounded', async () => {
     const subprocess = createMockSubprocess()
@@ -361,6 +370,81 @@ describe('STA-4091 previously recoverable restore depth', () => {
         ignoreCleanEnd: true
       })
       expect(snapshotText(restore ?? {})).toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('preserves durable depth after an incremental append and adapter crash', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'incremental-crash-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const oldInternals = adapter as unknown as { checkpointDirtySessions: () => Promise<void> }
+      await oldInternals.checkpointDirtySessions()
+      const beforeCrash = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(beforeCrash?.pendingOutputSeq).toBe(2)
+      expect(snapshotText(beforeCrash ?? {})).toContain(OLDEST_WRITTEN_LINE)
+
+      simulateAdapterCrash(adapter)
+      adapter = new DaemonPtyAdapter({
+        socketPath: getDaemonSocketPath(dir),
+        tokenPath: join(dir, 'test.token'),
+        historyPath: historyDir
+      })
+
+      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
+      expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+      expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
+      const restored = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(restored ?? {})).toContain(OLDEST_WRITTEN_LINE)
+    })
+
+    it('uses the live window when a crashed adapter left a pending-output gap', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'incremental-gap-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const oldInternals = adapter as unknown as {
+        client: { request: (method: string, params: unknown) => Promise<unknown> }
+      }
+      await oldInternals.client.request('takePendingOutput', {
+        sessionId: id,
+        includeSnapshot: false
+      })
+      simulateAdapterCrash(adapter)
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      adapter = new DaemonPtyAdapter({
+        socketPath: getDaemonSocketPath(dir),
+        tokenPath: join(dir, 'test.token'),
+        historyPath: historyDir
+      })
+
+      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
+      expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+      expect(reattach.snapshot).not.toContain(OLDEST_WRITTEN_LINE)
+      const restored = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(restored ?? {})).not.toContain(OLDEST_WRITTEN_LINE)
+      expect(restored?.scrollbackLines).toBe(DAEMON_SESSION_SCROLLBACK_ROWS)
+      expect(warn).toHaveBeenCalledWith(
+        '[history] durable continuity unproven; using live snapshot:',
+        id
+      )
     })
 
     it('falls back to the live window when durable history cannot be read', async () => {

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -335,6 +335,34 @@ describe('STA-4091 previously recoverable restore depth', () => {
       expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
     })
 
+    it('preserves durable depth across an adapter reconnect', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'adapter-reconnect-depth',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+
+      await adapter.disconnectOnly()
+      adapter = new DaemonPtyAdapter({
+        socketPath: getDaemonSocketPath(dir),
+        tokenPath: join(dir, 'test.token'),
+        historyPath: historyDir
+      })
+
+      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
+      expect(reattach.isReattach).toBe(true)
+      expect(reattach.snapshot).toContain(NEWEST_WRITTEN_LINE)
+      expect(reattach.snapshot).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+      expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
+
+      const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(restore ?? {})).toContain(OLDEST_WRITTEN_LINE)
+    })
+
     it('falls back to the live window when durable history cannot be read', async () => {
       const { id } = await adapter.spawn({
         cols: 80,
@@ -377,56 +405,129 @@ describe('STA-4091 previously recoverable restore depth', () => {
       expect(snapshotText(restore ?? {})).toContain(FRESH_AFTER_CHECKPOINT)
     })
 
-    it.each(['retryable', 'unavailable'] as const)(
-      'returns the current live snapshot when a durable checkpoint is %s',
-      async (checkpointResult) => {
-        const { id } = await adapter.spawn({
-          cols: 80,
-          rows: 24,
-          sessionId: `checkpoint-${checkpointResult}`,
-          cwd: '/tmp'
-        })
-        lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
-        await adapter.getBufferSnapshot(id)
-        lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+    it('reanchors after a retryable durable checkpoint', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'checkpoint-retryable',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
 
-        const internals = adapter as unknown as {
-          historyManager: HistoryManager
-          sessionsNeedingLiveCheckpoint: Set<string>
-        }
-        const checkpoint = vi
-          .spyOn(internals.historyManager, 'checkpoint')
-          .mockResolvedValueOnce(checkpointResult)
-
-        const snapshot = await adapter.getBufferSnapshot(id)
-        const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
-        expect(text).toContain(FRESH_AFTER_CHECKPOINT)
-        expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(true)
-
-        const recovered = await adapter.getBufferSnapshot(id)
-        expect(`${recovered?.scrollbackAnsi ?? ''}${recovered?.data ?? ''}`).toContain(
-          FRESH_AFTER_CHECKPOINT
-        )
-        const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
-          ignoreCleanEnd: true
-        })
-        expect(snapshotText(restore ?? {})).toContain(FRESH_AFTER_CHECKPOINT)
-        expect(checkpoint.mock.calls.at(-1)?.[1].scrollbackLines).toBe(
-          DAEMON_SESSION_SCROLLBACK_ROWS
-        )
-        expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(false)
-
-        checkpoint.mockResolvedValueOnce(checkpointResult)
-        const reattach = await adapter.spawn({
-          cols: 80,
-          rows: 24,
-          sessionId: id,
-          cwd: '/tmp'
-        })
-        expect(reattach.isReattach).toBe(true)
-        expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+      const internals = adapter as unknown as {
+        historyManager: HistoryManager
+        sessionsNeedingLiveCheckpoint: Set<string>
       }
-    )
+      const checkpoint = vi
+        .spyOn(internals.historyManager, 'checkpoint')
+        .mockResolvedValueOnce('retryable')
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+      const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+      expect(text).toContain(FRESH_AFTER_CHECKPOINT)
+      expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(true)
+
+      const recovered = await adapter.getBufferSnapshot(id)
+      expect(`${recovered?.scrollbackAnsi ?? ''}${recovered?.data ?? ''}`).toContain(
+        FRESH_AFTER_CHECKPOINT
+      )
+      const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+        ignoreCleanEnd: true
+      })
+      expect(snapshotText(restore ?? {})).toContain(FRESH_AFTER_CHECKPOINT)
+      expect(checkpoint.mock.calls.at(-1)?.[1].scrollbackLines).toBe(DAEMON_SESSION_SCROLLBACK_ROWS)
+      expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(false)
+
+      checkpoint.mockResolvedValueOnce('retryable')
+      const reattach = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: id,
+        cwd: '/tmp'
+      })
+      expect(reattach.isReattach).toBe(true)
+      expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+    })
+
+    it('stops retrying when durable history is unavailable', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'checkpoint-unavailable',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const internals = adapter as unknown as {
+        client: { request: (method: string, params?: unknown) => Promise<unknown> }
+        historyManager: HistoryManager
+        sessionsNeedingFullCheckpoint: Set<string>
+        sessionsNeedingLiveCheckpoint: Set<string>
+        checkpointDirtySessions: () => Promise<void>
+      }
+      const requests = vi.spyOn(internals.client, 'request')
+      const checkpoint = vi
+        .spyOn(internals.historyManager, 'checkpoint')
+        .mockResolvedValue('unavailable')
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+      expect(`${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`).toContain(
+        FRESH_AFTER_CHECKPOINT
+      )
+      expect(internals.sessionsNeedingFullCheckpoint.has(id)).toBe(false)
+      expect(internals.sessionsNeedingLiveCheckpoint.has(id)).toBe(false)
+
+      await internals.checkpointDirtySessions()
+      await internals.checkpointDirtySessions()
+      const snapshotTakes = requests.mock.calls.filter(
+        ([method, params]) =>
+          method === 'takePendingOutput' &&
+          (params as { includeSnapshot?: boolean } | undefined)?.includeSnapshot === true
+      )
+      expect(snapshotTakes).toHaveLength(1)
+      expect(checkpoint).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses the live window when an older daemon omits drained records', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'missing-drained-records',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+      lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+
+      const internals = adapter as unknown as {
+        client: { request: (method: string, params?: unknown) => Promise<unknown> }
+        historyManager: HistoryManager
+      }
+      const request = internals.client.request.bind(internals.client)
+      vi.spyOn(internals.client, 'request').mockImplementation(async (method, params) => {
+        const result = await request(method, params)
+        if (
+          method === 'takePendingOutput' &&
+          (params as { includeSnapshot?: boolean } | undefined)?.includeSnapshot &&
+          result &&
+          typeof result === 'object'
+        ) {
+          delete (result as { drainedRecords?: PendingOutputRecord[] }).drainedRecords
+        }
+        return result
+      })
+      const checkpoint = vi.spyOn(internals.historyManager, 'checkpoint')
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+      expect(`${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`).toContain(
+        FRESH_AFTER_CHECKPOINT
+      )
+      expect(checkpoint.mock.calls.at(-1)?.[1].scrollbackLines).toBe(DAEMON_SESSION_SCROLLBACK_ROWS)
+    })
 
     it('uses the post-drain sequence for output produced during an overlay', async () => {
       const { id } = await adapter.spawn({
@@ -461,6 +562,39 @@ describe('STA-4091 previously recoverable restore depth', () => {
         FRESH_AFTER_CHECKPOINT
       )
       expect(overlaid?.seq).toBe(current?.seq)
+    })
+
+    it('uses the post-drain sequence for output produced during warm reattach', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'reattach-overlay-sequence',
+        cwd: '/tmp'
+      })
+      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+      await adapter.getBufferSnapshot(id)
+
+      const internals = adapter as unknown as {
+        client: { request: (method: string, params?: unknown) => Promise<unknown> }
+      }
+      const request = internals.client.request.bind(internals.client)
+      let injected = false
+      vi.spyOn(internals.client, 'request').mockImplementation(async (method, params) => {
+        if (
+          method === 'takePendingOutput' &&
+          (params as { includeSnapshot?: boolean } | undefined)?.includeSnapshot &&
+          !injected
+        ) {
+          injected = true
+          lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+        }
+        return request(method, params)
+      })
+
+      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
+      const current = await adapter.getBufferSnapshot(id, { scrollbackRows: 24 })
+      expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
+      expect(reattach.providerSequence?.value).toBe(current?.seq)
     })
   })
 })

--- a/src/main/daemon/daemon-restore-scrollback-depth.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.ts
@@ -1,0 +1,5 @@
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../shared/terminal-scrollback-policy'
+
+// Why this number: it is the desktop default that rebuilds restored before the live
+// daemon window was flattened. Durable history keeps this depth; live RAM stays smaller.
+export const DAEMON_RESTORE_SCROLLBACK_ROWS = DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT

--- a/src/main/daemon/daemon-session-scrollback-window.ts
+++ b/src/main/daemon/daemon-session-scrollback-window.ts
@@ -1,10 +1,10 @@
 const DAEMON_SESSION_SCROLLBACK_ENV_VAR = 'ORCA_DAEMON_SESSION_SCROLLBACK_ROWS'
 
-// Why a flat window and not full renderer depth: retained grid is the daemon's dominant heap term and
-// session count is unbounded — a host owning 100+ terminals at full depth retained ~1 GB of grid and
-// was OOM-killed, taking every session it owned with it. A terminal the user has open scrolls its full
-// live renderer buffer; the daemon window is only what a REBUILD (reload, remount, restart, remote
-// attach) restores, and 1000 rows is the generous end of what terminal products restore there.
+// Why a flat live window and not full renderer depth: retained grid is the daemon's dominant heap
+// term and session count is unbounded — a host owning 100+ terminals at full depth retained ~1 GB
+// of grid and was OOM-killed, taking every session it owned with it. A terminal the user has open
+// scrolls its full live renderer buffer. Rebuilds (reload, remount, restart, remote attach) restore
+// from durable history at DAEMON_RESTORE_SCROLLBACK_ROWS, not this live RAM window.
 export const DAEMON_SESSION_SCROLLBACK_ROWS = 1000
 // Why: keep any override within sane terminal bounds — 0 would lose the visible screen's context and
 // huge values silently reintroduce the unbounded-retention failure this window exists to prevent.

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -225,13 +225,18 @@ export class HistoryManager {
   }
 
   // Full checkpoints are rare (clean disconnect, pending-buffer overflow, log cap); the 5s tick appends increments instead.
-  checkpoint(sessionId: string, snapshot: TerminalSnapshot): Promise<HistoryCheckpointResult> {
-    return this.mutations.track(sessionId, this.checkpointUntracked(sessionId, snapshot))
+  checkpoint(
+    sessionId: string,
+    snapshot: TerminalSnapshot,
+    opts?: { pendingOutputSeq?: number }
+  ): Promise<HistoryCheckpointResult> {
+    return this.mutations.track(sessionId, this.checkpointUntracked(sessionId, snapshot, opts))
   }
 
   private async checkpointUntracked(
     sessionId: string,
-    snapshot: TerminalSnapshot
+    snapshot: TerminalSnapshot,
+    opts?: { pendingOutputSeq?: number }
   ): Promise<HistoryCheckpointResult> {
     if (this.disabledSessions.has(sessionId)) {
       return 'unavailable'
@@ -244,7 +249,7 @@ export class HistoryManager {
     try {
       // Why: tmp+rename is atomic (corrupt checkpoint > stale); async so a sync ~MB write can't stall IPC (worse under Windows AV).
       // The adapter's checkpointInFlight guard serializes checkpoints, so concurrent async writes can't collide on the fixed .tmp path.
-      const checkpoint = await writer.checkpoint(snapshot)
+      const checkpoint = await writer.checkpoint(snapshot, opts)
       if (checkpoint.result === 'retryable') {
         this.onWriteError?.(sessionId, checkpoint.error)
       }

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -4,6 +4,7 @@ import { stat } from 'node:fs/promises'
 import type { TerminalCheckpointFile } from './types'
 import { getHistorySessionDirName } from './history-paths'
 import { decodeTerminalHistoryLog, LOG_HEADER_BYTES } from './terminal-history-log'
+import { DAEMON_RESTORE_SCROLLBACK_ROWS } from './daemon-restore-scrollback-depth'
 import { HeadlessEmulator } from './headless-emulator'
 import { PrioritySemaphore } from './priority-semaphore'
 import { ColdRestoreReplayWriter } from './cold-restore-replay-writer'
@@ -280,6 +281,7 @@ export class HistoryReader {
       const emulator = new HeadlessEmulator({
         cols: checkpoint?.cols ?? meta.cols,
         rows: checkpoint?.rows ?? meta.rows,
+        scrollback: DAEMON_RESTORE_SCROLLBACK_ROWS,
         wslDistro
       })
       const replay = new ColdRestoreReplayWriter(emulator)

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -317,9 +317,10 @@ export class HistoryReader {
           }
         }
         const snapshot = emulator.getSnapshot()
+        const lastBatch = log.batches.at(-1)!
         return {
           restoreInfo: coldRestoreInfoFromSnapshot(
-            snapshot,
+            { ...snapshot, pendingOutputSeq: lastBatch.seq },
             snapshot.cwd ?? checkpoint?.cwd ?? meta.cwd,
             meta
           ),

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -476,6 +476,19 @@ describe('Session', () => {
       ])
     })
 
+    it('exposes drained output beside an includeSnapshot take without changing records', () => {
+      createSession()
+      subprocess.simulateData('kept-for-durable-history\r\n')
+
+      const taken = session.takePendingOutput(true)
+
+      expect(taken?.records).toEqual([])
+      expect(taken?.drainedRecords).toEqual([
+        { kind: 'output', data: 'kept-for-durable-history\r\n' }
+      ])
+      expect(taken?.snapshot).toBeTruthy()
+    })
+
     it('keeps held marker-prefix bytes during live take-with-snapshot', () => {
       createSession({ shellReadySupported: true, shellReadyTimeoutMs: 100 })
       session.write('codex\n')
@@ -486,6 +499,7 @@ describe('Session', () => {
       vi.advanceTimersByTime(30)
 
       expect(taken?.records).toEqual([])
+      expect(taken?.drainedRecords).toEqual([])
       expect(taken?.snapshot).toBeTruthy()
       expect(session.shellState).toBe('ready' satisfies ShellReadyState)
       expect(subprocess.written).toEqual(['codex\n'])

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -509,6 +509,7 @@ export class Session {
           ? [{ kind: 'output', data: releasedHeldBytes }]
           : []
         : records,
+      ...(includeSnapshot ? { drainedRecords: records } : {}),
       seq: this.pendingOutputSeq,
       overflowed,
       snapshot: includeSnapshot ? this.getSnapshot() : null

--- a/src/main/daemon/terminal-checkpoint-serializer.ts
+++ b/src/main/daemon/terminal-checkpoint-serializer.ts
@@ -5,6 +5,7 @@ import { HeadlessEmulator } from './headless-emulator'
 type CheckpointMetadata = {
   cwd: string | null
   generation: number
+  pendingOutputSeq?: number
   checkpointedAt: string
 }
 
@@ -27,6 +28,9 @@ function checkpointFile(
     scrollbackLines: snapshot.scrollbackLines,
     ...(snapshot.lastTitle ? { lastTitle: snapshot.lastTitle } : {}),
     generation: metadata.generation,
+    ...(metadata.pendingOutputSeq !== undefined
+      ? { pendingOutputSeq: metadata.pendingOutputSeq }
+      : {}),
     checkpointedAt: metadata.checkpointedAt
   }
 }

--- a/src/main/daemon/terminal-history-checkpoint-reader.ts
+++ b/src/main/daemon/terminal-history-checkpoint-reader.ts
@@ -43,6 +43,8 @@ function isTerminalCheckpointFile(value: unknown): value is TerminalCheckpointFi
     isTerminalModes(checkpoint.modes) &&
     isNonNegativeSafeInteger(checkpoint.scrollbackLines) &&
     (checkpoint.generation === undefined || isNonNegativeSafeInteger(checkpoint.generation)) &&
+    (checkpoint.pendingOutputSeq === undefined ||
+      isNonNegativeSafeInteger(checkpoint.pendingOutputSeq)) &&
     typeof checkpoint.checkpointedAt === 'string' &&
     (checkpoint.oscLinks === undefined || isTerminalOscLinkRanges(checkpoint.oscLinks)) &&
     (checkpoint.pendingEscapeTailAnsi === undefined ||

--- a/src/main/daemon/terminal-history-cold-restore-info.ts
+++ b/src/main/daemon/terminal-history-cold-restore-info.ts
@@ -10,6 +10,7 @@ export type ColdRestoreInfo = {
   cwd: string
   cols: number
   rows: number
+  scrollbackLines?: number
   modes: TerminalModes
   pendingEscapeTailAnsi?: string
   lastTitle?: string
@@ -22,6 +23,7 @@ type RestoredSnapshot = {
   rehydrateSequences: string
   cols: number
   rows: number
+  scrollbackLines?: number
   modes: TerminalModes
   pendingEscapeTailAnsi?: string
   lastTitle?: string
@@ -43,6 +45,7 @@ export function coldRestoreInfoFromSnapshot(
     cwd: cwd ?? meta.cwd,
     cols: snapshot.cols,
     rows: snapshot.rows,
+    scrollbackLines: snapshot.scrollbackLines,
     modes: snapshot.modes,
     ...(snapshot.pendingEscapeTailAnsi
       ? { pendingEscapeTailAnsi: snapshot.pendingEscapeTailAnsi }

--- a/src/main/daemon/terminal-history-cold-restore-info.ts
+++ b/src/main/daemon/terminal-history-cold-restore-info.ts
@@ -11,6 +11,7 @@ export type ColdRestoreInfo = {
   cols: number
   rows: number
   scrollbackLines?: number
+  pendingOutputSeq?: number
   modes: TerminalModes
   pendingEscapeTailAnsi?: string
   lastTitle?: string
@@ -24,6 +25,7 @@ type RestoredSnapshot = {
   cols: number
   rows: number
   scrollbackLines?: number
+  pendingOutputSeq?: number
   modes: TerminalModes
   pendingEscapeTailAnsi?: string
   lastTitle?: string
@@ -46,6 +48,7 @@ export function coldRestoreInfoFromSnapshot(
     cols: snapshot.cols,
     rows: snapshot.rows,
     scrollbackLines: snapshot.scrollbackLines,
+    pendingOutputSeq: snapshot.pendingOutputSeq,
     modes: snapshot.modes,
     ...(snapshot.pendingEscapeTailAnsi
       ? { pendingEscapeTailAnsi: snapshot.pendingEscapeTailAnsi }

--- a/src/main/daemon/terminal-history-session-writer.ts
+++ b/src/main/daemon/terminal-history-session-writer.ts
@@ -59,7 +59,8 @@ export class TerminalHistorySessionWriter {
   }
 
   async checkpoint(
-    snapshot: TerminalSnapshot
+    snapshot: TerminalSnapshot,
+    opts?: { pendingOutputSeq?: number }
   ): Promise<{ result: 'committed' } | { result: 'retryable'; error: Error }> {
     // Why: snapshot.cwd is null until OSC-7; preserve meta.json's usable cwd for cold restore.
     const effectiveCwd = snapshot.cwd ?? this.readMeta()?.cwd ?? null
@@ -72,6 +73,9 @@ export class TerminalHistorySessionWriter {
         {
           cwd: effectiveCwd,
           generation,
+          ...(opts?.pendingOutputSeq !== undefined
+            ? { pendingOutputSeq: opts.pendingOutputSeq }
+            : {}),
           checkpointedAt: new Date().toISOString()
         },
         this.checkpointMaxBytes

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -282,6 +282,9 @@ export type TakePendingOutputRequest = {
 
 export type TakePendingOutputResult = {
   records: PendingOutputRecord[]
+  /** Drained pending queue. Absent on older daemons. includeSnapshot still
+   *  keeps `records` as held-only so mixed-version adapters do not double-replay. */
+  drainedRecords?: PendingOutputRecord[]
   /** Monotonic per-session batch sequence. The history log stores it so the
    *  cold-restore reader can detect a lost batch (gap) and discard the log
    *  instead of replaying a stream with missing bytes. */


### PR DESCRIPTION
## Summary

STA-4091. After #13061, daemon rebuild / remount / restart / remote reattach restored only the 1000-row live window. Earlier builds restored 5000 rows.

This keeps the 1000-row live RAM window so an unbounded session count cannot grow the grid without bound. Rebuilds reconstruct the desktop 5000-row depth from durable history (checkpoint + incremental log + drained pending records).

Live emulator = bounded RAM. Disk history = rebuild source. No attention heuristics or heap-pressure trimming.

`takePendingOutput.drainedRecords` is optional. Older daemons omit it and compact keeps the live snapshot. No new stream opcodes.

Fixes STA-4091. Follow-up to #13061.

## Reproduction on origin/main

Writing 5000 numbered lines then compacting the live snapshot restored from about `LINE_03978`. Incremental history without that compact already reconstructed `LINE_00001` / `LINE_01000`. Red test: `daemon-restore-scrollback-depth.test.ts`.

## Testing

- [x] `pnpm lint` (oxlint + type-aware oxlint on touched files; max-lines ratchet OK)
- [x] `pnpm typecheck:node`
- [ ] `pnpm test` (focused daemon suites, not full repo)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests

Focused: restore-depth, adapter, session, history recovery, incremental restore — 263 passed.

## SSH

Throwaway Linux Docker SSH target (not localhost). Relay built (`linux-arm64`). Isolated Electron identity: `Orca: brennanb2025/sta-4091-restored-scrollback`. SSH connected, relay deployed (`relay.js`, linux-arm64), `/work/demo-project` registered from a local git bundle after GitHub clone was blocked. Remote PTY spawned; warm reattach `isReattach: true`; relay process and bash PTYs observed on the container. Cleanup removed the containers.

Follow-up exhausted the remaining routes. The SSH product path never constructs `DaemonPtyAdapter`:

- `getProvider(connectionId)` returns the registered `SshPtyProvider`; `getProviderForPty` refuses to fall through to the hub-local provider for `ssh:` IDs.
- IPC spawn waits for the desktop daemon only when `connectionId` is absent (`SSH/headless don't use the desktop daemon`).
- The deployed `relay.js` talks to `node-pty` via `pty-handler.ts`. Grep of the live remote relay found no `DaemonPtyAdapter` / `daemon-entry` strings.
- `SshPtyProvider.canProvideAuthoritativeBufferSnapshot` is `false`; remount uses the Mac headless/renderer buffer, not durable daemon history.
- A remote `orca serve` *would* install `DaemonPtyAdapter` for that host's local PTYs, but pairing to this PR's Linux serve requires a Linux Electron binary of this worktree. Starting this PR's `daemon-entry.js` on the Linux target (using the relay's linux `node-pty`) bound a unix socket; no SSH runtime RPC or relay client connects to it.

The 1000-vs-5000 contract is therefore out of scope for `SshPtyProvider` / relay replay (100KB). It is proven on the daemon path in unit tests. Residual from the first SSH lane: a 5000-line `cat` did not appear in SSH `getMainBufferSnapshot` (61-char prompt; shell-ready / visible-vs-headless buffer race). That residual does not exercise the changed adapter.

## Residual risk

- Remount pays an exclusive durable compact.
- User presets above 5000 remain STA-3566.
- Mixed-version compact without `drainedRecords` keeps the previous live snapshot.

## Visual proof (Grok Electron / Playwright CDP)

Isolated local daemon-backed terminal on this PR HEAD. Wrote 5000 uniquely numbered `STA4091_L#####` lines, parked the worktree (xterm destroyed), then revealed it so remount used the authoritative snapshot path.

- Before remount, newest tail visible (`STA4091_L05000`).
- After remount, newest tail still present and scrolling to the top shows the older restored marker (`STA4091_L00001`), not a 1000-row live-window flatten.
- After remount the same PTY accepted a fresh `STA4091_FRESH_AFTER_RESTORE` write.

![Before remount — newest numbered tail](https://github.com/user-attachments/assets/d12f5e12-8851-40c8-941f-91a77e312342)

![After remount — newest tail retained](https://github.com/user-attachments/assets/0d3aae65-e631-489f-8894-b2a581737d77)

![After remount — older restored marker STA4091_L00001](https://github.com/user-attachments/assets/49ca85b0-c2ba-4303-b3de-4f24fe17b509)

![After remount — fresh marker, session still usable](https://github.com/user-attachments/assets/83c2e41d-8eb3-41af-9561-dea817fcf81d)
