### PR TITLE
Fix remote server browser tab fallback behavior

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.remote-link-routing.test.ts
+++ b/src/renderer/src/components/browser-pane/BrowserPane.remote-link-routing.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+describe('remote browser link routing', () => {
+  it('pins context-menu opens to the runtime that owns the pane', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./BrowserPane.tsx', import.meta.url)),
+      'utf8'
+    )
+    const paneStart = source.indexOf('function RemoteBrowserPagePane')
+    const actionStart = source.indexOf('void openWorkspaceBrowserTab({', paneStart)
+    const actionEnd = source.indexOf('}).catch((error) => {', actionStart)
+    const openRequest = source.slice(actionStart, actionEnd)
+
+    expect(openRequest).toContain('workspaceId: worktreeId')
+    expect(openRequest).toContain('expectedRuntimeEnvironmentId: runtimeEnvironmentId')
+  })
+})

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2042,7 +2042,8 @@ function RemoteBrowserPagePane({
                         void openWorkspaceBrowserTab({
                           workspaceId: worktreeId,
                           url: linkUrl,
-                          intent: { kind: 'url' }
+                          intent: { kind: 'url' },
+                          expectedRuntimeEnvironmentId: runtimeEnvironmentId
                         }).catch((error) => {
                           setPaneNotice({
                             kind: 'direct',

--- a/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
@@ -319,7 +319,7 @@ describe('PortsPanel runtime routing', () => {
     ).toEqual(['runtime-repo::/srv/app', 'repo::/workspace/app'])
   })
 
-  it('opens remote workspace ports in the server-side browser and binds the local page handle', async () => {
+  it('reuses the capability verdict across remote port opens', async () => {
     runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
       Promise.resolve({
         id: method,
@@ -340,10 +340,20 @@ describe('PortsPanel runtime routing', () => {
         setRemoteBrowserPageHandle: setRemoteBrowserPageHandle as never
       })
     ).resolves.toEqual({ ok: true })
+    await expect(
+      openWorkspacePortInBrowser({
+        port: workspacePort,
+        runtimeTarget: { kind: 'environment', environmentId: 'env-1' },
+        createBrowserTab: createBrowserTab as never,
+        setRemoteBrowserPageHandle: setRemoteBrowserPageHandle as never
+      })
+    ).resolves.toEqual({ ok: true })
 
+    expect(activateAndRevealWorktreeMock).toHaveBeenCalledTimes(2)
     expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith('repo::/workspace/app')
     expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
       'status.get',
+      'browser.tabCreate',
       'browser.tabCreate'
     ])
     expect(runtimeEnvironmentCall.mock.calls[1][0].params).toEqual({

--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -131,7 +131,16 @@ describe('openWorkspaceBrowserTab', () => {
     expect(createBrowserTab).not.toHaveBeenCalled()
   })
 
-  it('fails closed instead of opening on a runtime other than the asserted owner', async () => {
+  it('fails closed when the workspace route swaps away from the pane runtime before opening', async () => {
+    mocks.state = {
+      ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+    const paneRuntimeEnvironmentId = 'hub-a'
+
     mocks.state = {
       ...ownerState(toRuntimeExecutionHostId('hub-b')),
       ...browserCapableRuntime('hub-b'),
@@ -145,10 +154,54 @@ describe('openWorkspaceBrowserTab', () => {
         workspaceId: WORKSPACE_ID,
         url: 'https://example.com/',
         intent: { kind: 'url' },
-        expectedRuntimeEnvironmentId: 'hub-a'
+        expectedRuntimeEnvironmentId: paneRuntimeEnvironmentId
       })
     ).rejects.toThrow('Unable to open URL.')
     expect(mocks.createRemote).not.toHaveBeenCalled()
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('fails closed for a blank asserted runtime owner', async () => {
+    mocks.state = {
+      ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+
+    await expect(
+      openWorkspaceBrowserTab({
+        workspaceId: WORKSPACE_ID,
+        url: 'https://example.com/',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: '   '
+      })
+    ).rejects.toThrow('Unable to open URL.')
+    expect(mocks.createRemote).not.toHaveBeenCalled()
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('routes an asserted paired-HUB SSH owner through that runtime', async () => {
+    const sshHost = toSshExecutionHostId('ssh-target')
+    mocks.state = {
+      ...ownerState(sshHost, 'hub-a'),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+
+    await openWorkspaceBrowserTab({
+      workspaceId: WORKSPACE_ID,
+      url: 'http://localhost:3000/',
+      intent: { kind: 'url' },
+      expectedRuntimeEnvironmentId: 'hub-a'
+    })
+
+    expect(mocks.createRemote).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentId: 'hub-a', worktreeId: WORKSPACE_ID })
+    )
     expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -4,6 +4,7 @@ import {
   toRuntimeExecutionHostId,
   toSshExecutionHostId
 } from '../../../shared/execution-host'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import {
   canOpenWorkspaceBrowserTabOnRuntime,
@@ -13,6 +14,7 @@ import {
 const mocks = vi.hoisted(() => ({
   createRemote: vi.fn(),
   getState: vi.fn(),
+  pairedWeb: false,
   state: {} as Record<string, unknown>
 }))
 
@@ -22,6 +24,10 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/runtime/web-runtime-session', () => ({
   createWebRuntimeSessionBrowserTab: (...args: unknown[]) => mocks.createRemote(...args)
+}))
+
+vi.mock('./desktop-window-chrome', () => ({
+  isPairedWebClientWindow: () => mocks.pairedWeb
 }))
 
 const WORKSPACE_ID = 'repo-1::/repo/worktree'
@@ -55,6 +61,7 @@ function browserCapableRuntime(environmentId: string): Record<string, unknown> {
 beforeEach(() => {
   mocks.createRemote.mockReset().mockResolvedValue(true)
   mocks.getState.mockReset().mockImplementation(() => mocks.state)
+  mocks.pairedWeb = false
   mocks.state = {}
 })
 
@@ -186,6 +193,70 @@ describe('openWorkspaceBrowserTab', () => {
         expectedRuntimeEnvironmentId: 'hub-a'
       })
     ).rejects.toThrow('Unable to open URL.')
+    expect(mocks.createRemote).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentId: 'hub-a' })
+    )
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('does not route an asserted floating-terminal source to either runtime or local browser', async () => {
+    const createBrowserTab = vi.fn()
+    mocks.state = {
+      activeWorktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      activeWorkspaceExecutionHostId: toRuntimeExecutionHostId('hub-a'),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab,
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+
+    expect(
+      canOpenWorkspaceBrowserTabOnRuntime(
+        mocks.state as never,
+        FLOATING_TERMINAL_WORKTREE_ID,
+        'hub-a'
+      )
+    ).toBe(false)
+
+    await expect(
+      openWorkspaceBrowserTab({
+        workspaceId: FLOATING_TERMINAL_WORKTREE_ID,
+        url: 'http://localhost:3000/',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: 'hub-a'
+      })
+    ).rejects.toThrow('Unable to open URL.')
+    expect(mocks.createRemote).not.toHaveBeenCalled()
+    expect(createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps runtime browser actions unavailable in a paired-web floating workspace', async () => {
+    mocks.pairedWeb = true
+    mocks.state = {
+      activeWorktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      activeWorkspaceExecutionHostId: toRuntimeExecutionHostId('hub-a'),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+
+    expect(
+      canOpenWorkspaceBrowserTabOnRuntime(
+        mocks.state as never,
+        FLOATING_TERMINAL_WORKTREE_ID,
+        'hub-a'
+      )
+    ).toBe(false)
+    await expect(
+      openWorkspaceBrowserTab({
+        workspaceId: FLOATING_TERMINAL_WORKTREE_ID,
+        url: 'http://localhost:3000/',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: 'hub-a'
+      })
+    ).rejects.toThrow('Unable to open URL.')
+    expect(mocks.createRemote).not.toHaveBeenCalled()
     expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -4,6 +4,7 @@ import {
   toRuntimeExecutionHostId,
   toSshExecutionHostId
 } from '../../../shared/execution-host'
+import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import {
   canOpenWorkspaceBrowserTabOnRuntime,
   openWorkspaceBrowserTab
@@ -43,7 +44,10 @@ function ownerState(hostId?: string, runtimeOwnerEnvironmentId?: string): Record
 function browserCapableRuntime(environmentId: string): Record<string, unknown> {
   return {
     runtimeStatusByEnvironmentId: new Map([
-      [environmentId, { status: { capabilities: ['browser.screencast.v1'] }, checkedAt: 1 }]
+      [
+        environmentId,
+        { status: { capabilities: [BROWSER_SCREENCAST_RUNTIME_CAPABILITY] }, checkedAt: 1 }
+      ]
     ])
   }
 }
@@ -161,6 +165,27 @@ describe('openWorkspaceBrowserTab', () => {
       })
     ).rejects.toThrow('Unable to open URL.')
     expect(mocks.createRemote).not.toHaveBeenCalled()
+    expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to a client browser when asserted runtime creation fails', async () => {
+    mocks.state = {
+      ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab: vi.fn(),
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+    mocks.createRemote.mockResolvedValue(false)
+
+    await expect(
+      openWorkspaceBrowserTab({
+        workspaceId: WORKSPACE_ID,
+        url: 'https://example.com/',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: 'hub-a'
+      })
+    ).rejects.toThrow('Unable to open URL.')
     expect(mocks.state.createBrowserTab).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -179,9 +179,12 @@ export async function openWorkspaceBrowserTab(
     throw openFailure(presentation.error, 'no active worktree route')
   }
   const environmentId = route.runtimeEnvironmentId?.trim() || null
-  const expectedEnvironmentId = request.expectedRuntimeEnvironmentId?.trim() || null
+  const expectedEnvironmentId =
+    request.expectedRuntimeEnvironmentId === undefined
+      ? null
+      : request.expectedRuntimeEnvironmentId.trim()
   if (
-    expectedEnvironmentId &&
+    expectedEnvironmentId !== null &&
     !isExpectedRuntimeBrowserRoute(
       state,
       availability,

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -8,6 +8,7 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { SEARCH_ENGINE_LABELS, type SearchEngine } from '../../../shared/browser-url'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import {
   getClientCreationActionPolicy,
@@ -27,10 +28,12 @@ export type OpenWorkspaceBrowserTabRequest = {
 
 function isExpectedRuntimeBrowserRoute(
   state: AppState,
+  availability: ClientCreationActionAvailability,
   route: ReturnType<typeof resolveWorktreeOperationRoute>,
+  workspaceId: string,
   expectedRuntimeEnvironmentId: string
 ): boolean {
-  if (!route) {
+  if (availability.state !== 'enabled' || workspaceId === FLOATING_TERMINAL_WORKTREE_ID || !route) {
     return false
   }
   const expectedEnvironmentId = expectedRuntimeEnvironmentId.trim()
@@ -55,8 +58,15 @@ export function canOpenWorkspaceBrowserTabOnRuntime(
   workspaceId: string,
   expectedRuntimeEnvironmentId: string
 ): boolean {
+  const availability = getClientCreationActionPolicy(state, workspaceId)['managed-browser']
   const route = resolveWorktreeOperationRoute(state, workspaceId)
-  return isExpectedRuntimeBrowserRoute(state, route, expectedRuntimeEnvironmentId)
+  return isExpectedRuntimeBrowserRoute(
+    state,
+    availability,
+    route,
+    workspaceId,
+    expectedRuntimeEnvironmentId
+  )
 }
 
 // Why: concurrent URL tabs are indistinguishable under a shared "Open URL"
@@ -172,7 +182,13 @@ export async function openWorkspaceBrowserTab(
   const expectedEnvironmentId = request.expectedRuntimeEnvironmentId?.trim() || null
   if (
     expectedEnvironmentId &&
-    !isExpectedRuntimeBrowserRoute(state, route, expectedEnvironmentId)
+    !isExpectedRuntimeBrowserRoute(
+      state,
+      availability,
+      route,
+      request.workspaceId,
+      expectedEnvironmentId
+    )
   ) {
     throw openFailure(presentation.error, 'asserted runtime cannot provide this managed browser')
   }

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -8,6 +8,7 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { SEARCH_ENGINE_LABELS, type SearchEngine } from '../../../shared/browser-url'
+import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import {
   getClientCreationActionPolicy,
   type ClientCreationActionAvailability
@@ -25,15 +26,21 @@ export type OpenWorkspaceBrowserTabRequest = {
 }
 
 function isExpectedRuntimeBrowserRoute(
-  availability: ClientCreationActionAvailability,
+  state: AppState,
   route: ReturnType<typeof resolveWorktreeOperationRoute>,
   expectedRuntimeEnvironmentId: string
 ): boolean {
-  if (availability.state !== 'enabled' || availability.provider !== 'paired-runtime' || !route) {
+  if (!route) {
     return false
   }
+  const expectedEnvironmentId = expectedRuntimeEnvironmentId.trim()
   const environmentId = route.runtimeEnvironmentId?.trim() || null
-  if (environmentId !== expectedRuntimeEnvironmentId.trim()) {
+  const capabilities =
+    state.runtimeStatusByEnvironmentId?.get(expectedEnvironmentId)?.status?.capabilities
+  if (
+    environmentId !== expectedEnvironmentId ||
+    !capabilities?.includes(BROWSER_SCREENCAST_RUNTIME_CAPABILITY)
+  ) {
     return false
   }
   const host = parseExecutionHostId(route.executionHostId)
@@ -48,9 +55,8 @@ export function canOpenWorkspaceBrowserTabOnRuntime(
   workspaceId: string,
   expectedRuntimeEnvironmentId: string
 ): boolean {
-  const availability = getClientCreationActionPolicy(state, workspaceId)['managed-browser']
   const route = resolveWorktreeOperationRoute(state, workspaceId)
-  return isExpectedRuntimeBrowserRoute(availability, route, expectedRuntimeEnvironmentId)
+  return isExpectedRuntimeBrowserRoute(state, route, expectedRuntimeEnvironmentId)
 }
 
 // Why: concurrent URL tabs are indistinguishable under a shared "Open URL"
@@ -166,7 +172,7 @@ export async function openWorkspaceBrowserTab(
   const expectedEnvironmentId = request.expectedRuntimeEnvironmentId?.trim() || null
   if (
     expectedEnvironmentId &&
-    !isExpectedRuntimeBrowserRoute(availability, route, expectedEnvironmentId)
+    !isExpectedRuntimeBrowserRoute(state, route, expectedEnvironmentId)
   ) {
     throw openFailure(presentation.error, 'asserted runtime cannot provide this managed browser')
   }

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -325,8 +325,7 @@ export async function assertRuntimeEnvironmentCapability(
   message: string,
   timeoutMs?: number
 ): Promise<void> {
-  const status = await getRuntimeEnvironmentStatus(environmentId, timeoutMs)
-  if (!status.capabilities?.includes(capability)) {
+  if (!(await runtimeEnvironmentSupportsCapability(environmentId, capability, timeoutMs))) {
     throw new Error(message)
   }
 }

--- a/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
+++ b/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
@@ -1,0 +1,326 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { Page } from '@stablyai/playwright-test'
+import { LOCAL_EXECUTION_HOST_ID } from '../../src/shared/execution-host'
+import {
+  launchHeadlessPairedRuntimeHost,
+  type HeadlessPairedRuntimeHost
+} from './helpers/headless-paired-runtime-host'
+import { expect, test } from './helpers/orca-app'
+import {
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+
+// What this proves: "Open Link In Orca Browser" inside a remote browser pane opens the link on the
+// runtime that owns the pane — never on the client machine. The URL is a dev-server URL, so a
+// client-local fallback would silently load a *different machine's* server while looking
+// successful. The second act puts the workspace on this machine (the execution-host switch a user
+// makes) while the pane still shows the runtime's page: the open must fail visibly in the pane
+// instead of quietly landing here. Every verdict comes from outside the client under test — the
+// host's own RPC connection, the DOM the user sees, and the fixture server's request log.
+
+const PANE_PATH = '/remote-pane'
+const LINK_PATH = '/remote-link-target'
+const LINK_MARKER = 'remote link target'
+
+type LinkFixtureServer = {
+  close: () => Promise<void>
+  linkLoadCount: () => number
+  linkUrl: string
+  paneUrl: string
+}
+
+async function startLinkFixtureServer(): Promise<LinkFixtureServer> {
+  let linkLoadCount = 0
+  const server: Server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    const requestPath = request.url ?? '/'
+    if (requestPath.startsWith(LINK_PATH)) {
+      linkLoadCount += 1
+      response.writeHead(200, {
+        'cache-control': 'no-store',
+        'content-type': 'text/html; charset=utf-8'
+      })
+      response.end(`<!doctype html><html><body><h1>${LINK_MARKER}</h1></body></html>`)
+      return
+    }
+    if (requestPath.startsWith(PANE_PATH)) {
+      response.writeHead(200, {
+        'cache-control': 'no-store',
+        'content-type': 'text/html; charset=utf-8'
+      })
+      // Why the viewport-filling anchor: the context menu reads the link with
+      // elementFromPoint over the screencast, so covering the viewport keeps the test off
+      // screencast coordinate mapping — any right-click lands on the link.
+      response.end(
+        `<!doctype html><html><body style="margin:0"><a href="${LINK_PATH}" style="position:fixed;inset:0;display:block;background:#fff;color:#000;font:24px sans-serif">open me</a></body></html>`
+      )
+      return
+    }
+    response.writeHead(404, { 'content-type': 'text/plain' })
+    response.end('not found')
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const { port } = server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${port}`
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        // Keep-alive sockets from either browser would otherwise hold the close open.
+        server.closeAllConnections()
+        server.close((error) => (error ? reject(error) : resolve()))
+      }),
+    linkLoadCount: () => linkLoadCount,
+    linkUrl: `${origin}${LINK_PATH}`,
+    paneUrl: `${origin}${PANE_PATH}`
+  }
+}
+
+/**
+ * What the host itself says it owns, asked over the host's own connection rather than proxied
+ * through the client under test — the client cannot talk its way out of this one.
+ */
+async function readHostBrowserUrls(
+  host: HeadlessPairedRuntimeHost,
+  worktreeId: string
+): Promise<string[]> {
+  const response = await host.client.call<{ tabs: { type: string; url?: string }[] }>(
+    'session.tabs.list',
+    { worktree: `id:${worktreeId}` },
+    { timeoutMs: 15_000 }
+  )
+  return response.result.tabs.filter((tab) => tab.type === 'browser').map((tab) => tab.url ?? '')
+}
+
+/**
+ * Browser pages this machine renders itself. A remote pane is a screencast image; a client-local
+ * tab is an Electron <webview> with the page really loaded here, so the URLs below are exactly the
+ * pages the client machine's own browser is showing.
+ */
+async function readLocalBrowserViewUrls(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll('webview')).map(
+      (view) => (view as HTMLElement & { src?: string }).src || view.getAttribute('src') || ''
+    )
+  )
+}
+
+async function readRemotePaneUrls(page: Page, worktreeId: string): Promise<string[]> {
+  return page.evaluate((worktreeId) => {
+    const state = window.__store?.getState()
+    const workspaces = state?.browserTabsByWorktree[worktreeId] ?? []
+    return workspaces
+      .flatMap((workspace) => state?.browserPagesByWorkspace[workspace.id] ?? [])
+      .filter(
+        (browserPage) => state?.remoteBrowserPageHandlesByPageId[browserPage.id]?.environmentId
+      )
+      .map((browserPage) => browserPage.url)
+  }, worktreeId)
+}
+
+/** The client mirrors host browser tabs on its own; this finds the mirrored page for one URL. */
+async function findMirroredPage(
+  page: Page,
+  worktreeId: string,
+  url: string
+): Promise<{ handleEnvironmentId: string | null; pageId: string } | null> {
+  return page.evaluate(
+    ({ url, worktreeId }) => {
+      const state = window.__store?.getState()
+      for (const workspace of state?.browserTabsByWorktree[worktreeId] ?? []) {
+        for (const browserPage of state?.browserPagesByWorkspace[workspace.id] ?? []) {
+          if (browserPage.url.startsWith(url)) {
+            return {
+              handleEnvironmentId:
+                state?.remoteBrowserPageHandlesByPageId[browserPage.id]?.environmentId ?? null,
+              pageId: browserPage.id
+            }
+          }
+        }
+      }
+      return null
+    },
+    { url, worktreeId }
+  )
+}
+
+async function focusMirroredPage(page: Page, worktreeId: string, pageId: string): Promise<void> {
+  await page.evaluate(
+    ({ pageId, worktreeId }) => {
+      window.__store?.getState().focusBrowserTabInWorktree(worktreeId, pageId, {
+        surfacePane: true
+      })
+    },
+    { pageId, worktreeId }
+  )
+}
+
+type LinkOpenOutcome = 'opened on this machine' | 'pending' | 'refused'
+
+/**
+ * Collapses the click's aftermath into the one distinction that matters, using only what a user
+ * could see: did the pane refuse the open, or is this machine's browser now showing the URL?
+ */
+async function readLinkOpenOutcome(page: Page, linkUrl: string): Promise<LinkOpenOutcome> {
+  if ((await readLocalBrowserViewUrls(page)).some((url) => url.startsWith(linkUrl))) {
+    return 'opened on this machine'
+  }
+  const notice = page.getByTestId('remote-browser-stream-error')
+  const text = (await notice.count()) > 0 ? ((await notice.first().textContent()) ?? '') : ''
+  return text.includes('Unable to open URL.') ? 'refused' : 'pending'
+}
+
+async function openLinkFromRemotePaneContextMenu(page: Page): Promise<void> {
+  const remoteFrame = page.locator('[data-testid="remote-browser-frame"]:visible').first()
+  await expect(remoteFrame).toBeVisible({ timeout: 60_000 })
+  await remoteFrame.click({ button: 'right', position: { x: 60, y: 60 }, force: true })
+  await expect(page.getByTestId('remote-browser-context-menu')).toBeVisible({ timeout: 30_000 })
+  // The item only renders once the remote hit-test resolves an anchor, so this wait is the
+  // wait for the link lookup itself.
+  const openInOrca = page.getByRole('menuitem', { name: 'Open Link In Orca Browser' })
+  await expect(openInOrca).toBeVisible({ timeout: 30_000 })
+  await openInOrca.click()
+}
+
+test('opens a remote pane link on the pane runtime and refuses to fall back to the client', async ({
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(300_000)
+  const fixture = await startLinkFixtureServer()
+  const host: HeadlessPairedRuntimeHost = await launchHeadlessPairedRuntimeHost()
+  let client: PairedElectronClient | null = null
+
+  try {
+    await host.client.call('repo.add', { path: testRepoPath, kind: 'git' })
+    client = await launchPairedElectronClient(host.offer, testInfo, 'Remote browser link routing')
+    const page = client.page
+    const environmentId = client.environmentId
+
+    await expect
+      .poll(() => page.evaluate(() => window.__store?.getState().allWorktrees().length ?? 0), {
+        timeout: 60_000,
+        message: 'paired client never saw a host worktree'
+      })
+      .toBeGreaterThan(0)
+    const worktreeId = await page.evaluate(
+      () => window.__store?.getState().allWorktrees()[0]?.id ?? null
+    )
+    if (!worktreeId) {
+      throw new Error('paired client did not receive the host worktree')
+    }
+
+    // The workspace runs on the paired runtime, the way it does when the user picks that host.
+    await page.evaluate(
+      ({ environmentId, worktreeId }) => {
+        window.__store?.getState().setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+      },
+      { environmentId, worktreeId }
+    )
+
+    // The host opens the page on itself: this is the "remote server" whose links must stay remote.
+    await host.client.call(
+      'browser.tabCreate',
+      { worktree: `id:${worktreeId}`, url: fixture.paneUrl, activate: true },
+      { timeoutMs: 30_000 }
+    )
+    await expect
+      .poll(() => findMirroredPage(page, worktreeId, fixture.paneUrl), {
+        timeout: 60_000,
+        message: 'the client never mirrored the host browser page'
+      })
+      .not.toBeNull()
+    const pane = await findMirroredPage(page, worktreeId, fixture.paneUrl)
+    if (!pane) {
+      throw new Error('mirrored host browser page disappeared')
+    }
+    expect(pane.handleEnvironmentId).toBe(environmentId)
+    await focusMirroredPage(page, worktreeId, pane.pageId)
+    const paneCountBeforeOpen = await page.getByTestId('remote-browser-pane').count()
+
+    // Act 1: the healthy path must land on the runtime, end to end.
+    await openLinkFromRemotePaneContextMenu(page)
+
+    await expect
+      .poll(
+        async () =>
+          (await readHostBrowserUrls(host, worktreeId)).filter((url) =>
+            url.startsWith(fixture.linkUrl)
+          ).length,
+        { timeout: 60_000, message: 'the link never opened as a browser tab on the host runtime' }
+      )
+      .toBe(1)
+    // The host's browser really fetched it; a tab record alone would not prove a load.
+    expect(fixture.linkLoadCount()).toBeGreaterThan(0)
+    // One more remote pane, and still nothing rendered by this machine's own browser.
+    await expect(page.getByTestId('remote-browser-pane')).toHaveCount(paneCountBeforeOpen + 1, {
+      timeout: 60_000
+    })
+    expect(await readRemotePaneUrls(page, worktreeId)).toContainEqual(
+      expect.stringContaining(fixture.linkUrl)
+    )
+    expect(await readLocalBrowserViewUrls(page)).toHaveLength(0)
+
+    // Drop every tab except the pane's, so the second act drives the pane it started with.
+    await page.evaluate(
+      ({ paneUrl, worktreeId }) => {
+        const state = window.__store?.getState()
+        for (const workspace of state?.browserTabsByWorktree[worktreeId] ?? []) {
+          const pages = state?.browserPagesByWorkspace[workspace.id] ?? []
+          if (!pages.some((browserPage) => browserPage.url.startsWith(paneUrl))) {
+            state?.closeBrowserTab(workspace.id)
+          }
+        }
+      },
+      { paneUrl: fixture.paneUrl, worktreeId }
+    )
+    await expect(page.getByTestId('remote-browser-pane')).toHaveCount(paneCountBeforeOpen, {
+      timeout: 60_000
+    })
+
+    // Act 2: the user moves this workspace onto their own machine while the runtime's page is
+    // still on screen. Opening the link must fail in the pane, not load the runtime's dev server
+    // here — the client has no business serving a page for a workspace it does not run.
+    await page.evaluate(
+      ({ localHostId, worktreeId }) => {
+        window.__store?.getState().setActiveWorktree(worktreeId, localHostId)
+      },
+      { localHostId: LOCAL_EXECUTION_HOST_ID, worktreeId }
+    )
+    await focusMirroredPage(page, worktreeId, pane.pageId)
+    const hostUrlsBefore = await readHostBrowserUrls(host, worktreeId)
+    const linkLoadsBefore = fixture.linkLoadCount()
+
+    await openLinkFromRemotePaneContextMenu(page)
+
+    // Wait for the click to produce an outcome — refusal or a local page — so the assertion below
+    // reports which one happened instead of racing past a fallback that lands a moment later.
+    await expect
+      .poll(() => readLinkOpenOutcome(page, fixture.linkUrl), {
+        timeout: 30_000,
+        message: 'the link open produced neither a refusal nor a page'
+      })
+      .not.toBe('pending')
+    expect(await readLinkOpenOutcome(page, fixture.linkUrl)).toBe('refused')
+
+    // The workspace must still be the local one, or the refusal above proved nothing.
+    expect(
+      await page.evaluate(() => window.__store?.getState().activeWorkspaceExecutionHostId ?? null)
+    ).toBe(LOCAL_EXECUTION_HOST_ID)
+    // Nothing rendered here, nothing new on the host, and nobody fetched the link anywhere.
+    expect(await readLocalBrowserViewUrls(page)).toHaveLength(0)
+    expect(await readHostBrowserUrls(host, worktreeId)).toEqual(hostUrlsBefore)
+    expect(fixture.linkLoadCount()).toBe(linkLoadsBefore)
+  } finally {
+    if (client) {
+      await client.dispose()
+    }
+    await host.dispose()
+    await fixture.close()
+  }
+})

--- a/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
+++ b/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
@@ -12,13 +12,8 @@ import {
   type PairedElectronClient
 } from './helpers/paired-electron-client'
 
-// What this proves: "Open Link In Orca Browser" inside a remote browser pane opens the link on the
-// runtime that owns the pane — never on the client machine. The URL is a dev-server URL, so a
-// client-local fallback would silently load a *different machine's* server while looking
-// successful. The second act puts the workspace on this machine (the execution-host switch a user
-// makes) while the pane still shows the runtime's page: the open must fail visibly in the pane
-// instead of quietly landing here. Every verdict comes from outside the client under test — the
-// host's own RPC connection, the DOM the user sees, and the fixture server's request log.
+// The link is a dev-server URL, so a client-local fallback would silently load a *different
+// machine's* server while looking successful.
 
 const PANE_PATH = '/remote-pane'
 const LINK_PATH = '/remote-link-target'
@@ -82,10 +77,7 @@ async function startLinkFixtureServer(): Promise<LinkFixtureServer> {
   }
 }
 
-/**
- * What the host itself says it owns, asked over the host's own connection rather than proxied
- * through the client under test — the client cannot talk its way out of this one.
- */
+/** Asked over the host's own connection, not proxied through the client under test. */
 async function readHostBrowserUrls(
   host: HeadlessPairedRuntimeHost,
   worktreeId: string
@@ -98,11 +90,7 @@ async function readHostBrowserUrls(
   return response.result.tabs.filter((tab) => tab.type === 'browser').map((tab) => tab.url ?? '')
 }
 
-/**
- * Browser pages this machine renders itself. A remote pane is a screencast image; a client-local
- * tab is an Electron <webview> with the page really loaded here, so the URLs below are exactly the
- * pages the client machine's own browser is showing.
- */
+/** A remote pane is a screencast image; a <webview> means the page really loaded on this machine. */
 async function readLocalBrowserViewUrls(page: Page): Promise<string[]> {
   return page.evaluate(() =>
     Array.from(document.querySelectorAll('webview')).map(
@@ -163,10 +151,6 @@ async function focusMirroredPage(page: Page, worktreeId: string, pageId: string)
 
 type LinkOpenOutcome = 'opened on this machine' | 'pending' | 'refused'
 
-/**
- * Collapses the click's aftermath into the one distinction that matters, using only what a user
- * could see: did the pane refuse the open, or is this machine's browser now showing the URL?
- */
 async function readLinkOpenOutcome(page: Page, linkUrl: string): Promise<LinkOpenOutcome> {
   if ((await readLocalBrowserViewUrls(page)).some((url) => url.startsWith(linkUrl))) {
     return 'opened on this machine'


### PR DESCRIPTION
## Problem

When opening URLs in a remote server's browser, the app was falling back to the client browser instead of respecting the user's explicit choice to open on the remote server.

## Solution

Changed the browser tab opening logic to directly validate that the target runtime has the browser screencast capability before proceeding. If a specific runtime is requested but lacks the capability or creation fails, the operation now fails cleanly instead of silently falling back to the client browser.

## What Changed

- Imported `BROWSER_SCREENCAST_RUNTIME_CAPABILITY` constant to replace hardcoded capability strings
- Refactored `isExpectedRuntimeBrowserRoute()` to check capabilities directly from runtime state instead of availability policies
- Added test case ensuring runtime creation failure doesn't trigger client browser fallback
- Updated function signatures to pass state for direct capability inspection

## Why

This approach ensures the browser opens where explicitly requested on the remote server, improving reliability of the remote execution flow.

## Visual Proof

N/A — behavioral fix with no UI changes

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below
  - Added: "does not fall back to a client browser when asserted runtime creation fails"

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)