### PR TITLE
Fix mobile HTML report rendering

### DIFF
--- a/mobile/src/browser/MobileBrowserAddressField.tsx
+++ b/mobile/src/browser/MobileBrowserAddressField.tsx
@@ -1,0 +1,91 @@
+import { Platform, StyleSheet, Text, TextInput, View } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+import { compactMobileBrowserFileAddress } from './browser-url'
+
+type Props = {
+  disabled: boolean
+  focused: boolean
+  onBlur: () => void
+  onChangeText: (value: string) => void
+  onFocus: () => void
+  onSubmit: () => void
+  value: string
+}
+
+export function MobileBrowserAddressField({
+  disabled,
+  focused,
+  onBlur,
+  onChangeText,
+  onFocus,
+  onSubmit,
+  value
+}: Props): React.JSX.Element {
+  const fileLabel = focused ? null : compactMobileBrowserFileAddress(value)
+  const selection = focused ? undefined : { start: 0, end: 0 }
+
+  return (
+    <View style={styles.field}>
+      <TextInput
+        style={styles.input}
+        value={value}
+        onChangeText={onChangeText}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onSubmitEditing={onSubmit}
+        selectTextOnFocus
+        selection={selection}
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType={Platform.OS === 'ios' ? 'url' : 'default'}
+        numberOfLines={1}
+        returnKeyType="go"
+        placeholder="URL"
+        placeholderTextColor={colors.textMuted}
+        editable={!disabled}
+      />
+      {fileLabel ? (
+        <View pointerEvents="none" style={styles.fileLabelHost}>
+          <Text style={styles.fileLabel} numberOfLines={1} ellipsizeMode="middle">
+            {fileLabel}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  field: {
+    flex: 1,
+    minWidth: 0,
+    height: 28
+  },
+  input: {
+    flex: 1,
+    minWidth: 0,
+    borderRadius: radii.input,
+    backgroundColor: colors.bgRaised,
+    color: colors.textPrimary,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 0,
+    fontSize: 12,
+    lineHeight: 16,
+    includeFontPadding: false,
+    textAlignVertical: 'center',
+    fontFamily: typography.monoFamily
+  },
+  fileLabelHost: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.input,
+    backgroundColor: colors.bgRaised
+  },
+  fileLabel: {
+    color: colors.textPrimary,
+    fontSize: 12,
+    lineHeight: 16,
+    fontFamily: typography.monoFamily
+  }
+})

--- a/mobile/src/browser/MobileBrowserPane.tsx
+++ b/mobile/src/browser/MobileBrowserPane.tsx
@@ -9,7 +9,6 @@ import {
   Image,
   PanResponder,
   PixelRatio,
-  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -54,6 +53,7 @@ import {
   type BrowserZoomState
 } from './browser-touch-geometry'
 import { displayBrowserUrl, normalizeBrowserUrl } from './browser-url'
+import { MobileBrowserAddressField } from './MobileBrowserAddressField'
 import { resolveMobileBrowserAddressSync } from './mobile-browser-address-sync'
 
 export type MobileBrowserTab = {
@@ -140,7 +140,7 @@ export function MobileBrowserPane({
   onToast
 }: MobileBrowserPaneProps) {
   const [browserViewMode, setBrowserViewMode] = useState<MobileBrowserViewMode>(() =>
-    getInitialMobileBrowserViewMode(worktreeId, tab.browserPageId)
+    getInitialMobileBrowserViewMode(worktreeId, tab.browserPageId, tab.url)
   )
   const cacheKey = makeBrowserFrameCacheKey(worktreeId, tab.browserPageId, browserViewMode)
   const cachedInitialFrame = peekCachedBrowserFrame(cacheKey)
@@ -264,6 +264,10 @@ export function MobileBrowserPane({
     lastZoomResetUrlRef.current = tab.url || 'about:blank'
     resetBrowserZoomState()
   }, [resetBrowserZoomState, tab.browserPageId, tab.url])
+
+  useEffect(() => {
+    setBrowserViewMode(getInitialMobileBrowserViewMode(worktreeId, tab.browserPageId, tab.url))
+  }, [tab.browserPageId, tab.url, worktreeId])
 
   const pageParams = useCallback(() => {
     if (!tab.browserPageId) {
@@ -1018,10 +1022,6 @@ export function MobileBrowserPane({
   )
 
   const controlsDisabled = !client || !tab.browserPageId || screencastSupported !== true
-  const addressSelection = useMemo(
-    () => (addressFocused ? undefined : { start: 0, end: 0 }),
-    [addressFocused]
-  )
   const goBack = useCallback(() => {
     if (controlsDisabled || !tab.canGoBack) {
       return
@@ -1045,8 +1045,7 @@ export function MobileBrowserPane({
       if (browserViewMode === mode) {
         return
       }
-      // Why: browser panes can remount during normal tab/workspace navigation;
-      // keep a page-scoped choice while new browser pages still default to Web.
+      // Why: preserve explicit page-scoped choices across normal browser pane remounts.
       saveMobileBrowserViewMode(worktreeId, tab.browserPageId, mode)
       setBrowserViewMode(mode)
       resetBrowserZoomState()
@@ -1104,23 +1103,14 @@ export function MobileBrowserPane({
         >
           <RefreshCw size={15} color={buttonColor(!controlsDisabled)} />
         </MobileBrowserToolbarIconButton>
-        <TextInput
-          style={styles.addressInput}
+        <MobileBrowserAddressField
           value={addressValue}
           onChangeText={setAddressValue}
           onFocus={() => setAddressFocused(true)}
           onBlur={() => setAddressFocused(false)}
-          onSubmitEditing={() => void navigateToAddress()}
-          selectTextOnFocus
-          selection={addressSelection}
-          autoCapitalize="none"
-          autoCorrect={false}
-          keyboardType={Platform.OS === 'ios' ? 'url' : 'default'}
-          numberOfLines={1}
-          returnKeyType="go"
-          placeholder="URL"
-          placeholderTextColor={colors.textMuted}
-          editable={!controlsDisabled}
+          onSubmit={() => void navigateToAddress()}
+          focused={addressFocused}
+          disabled={controlsDisabled}
         />
         <MobileBrowserViewModeSwitch
           disabled={controlsDisabled}
@@ -1493,21 +1483,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: colors.borderSubtle,
     backgroundColor: colors.bgPanel
-  },
-  addressInput: {
-    flex: 1,
-    minWidth: 0,
-    height: 28,
-    borderRadius: radii.input,
-    backgroundColor: colors.bgRaised,
-    color: colors.textPrimary,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 0,
-    fontSize: 12,
-    lineHeight: 16,
-    includeFontPadding: false,
-    textAlignVertical: 'center',
-    fontFamily: typography.monoFamily
   },
   viewport: {
     flex: 1,

--- a/mobile/src/browser/MobileBrowserViewModeSwitch.tsx
+++ b/mobile/src/browser/MobileBrowserViewModeSwitch.tsx
@@ -1,5 +1,6 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native'
-import { colors, radii, spacing } from '../theme/mobile-theme'
+import { Pressable, StyleSheet, View } from 'react-native'
+import { Monitor, Smartphone, type LucideIcon } from 'lucide-react-native'
+import { colors, radii } from '../theme/mobile-theme'
 import type { MobileBrowserViewMode } from './browser-screencast-request'
 
 type Props = {
@@ -8,9 +9,9 @@ type Props = {
   onChange: (mode: MobileBrowserViewMode) => void
 }
 
-const VIEW_MODES: { id: MobileBrowserViewMode; label: string }[] = [
-  { id: 'web', label: 'Web' },
-  { id: 'mobile', label: 'Mobile' }
+const VIEW_MODES: { id: MobileBrowserViewMode; label: string; icon: LucideIcon }[] = [
+  { id: 'web', label: 'Web', icon: Monitor },
+  { id: 'mobile', label: 'Mobile', icon: Smartphone }
 ]
 
 export function MobileBrowserViewModeSwitch({
@@ -23,6 +24,7 @@ export function MobileBrowserViewModeSwitch({
       {VIEW_MODES.map((mode) => (
         <ViewModeButton
           key={mode.id}
+          Icon={mode.icon}
           label={mode.label}
           selected={value === mode.id}
           disabled={disabled}
@@ -34,11 +36,13 @@ export function MobileBrowserViewModeSwitch({
 }
 
 function ViewModeButton({
+  Icon,
   disabled,
   label,
   onPress,
   selected
 }: {
+  Icon: LucideIcon
   disabled?: boolean
   label: string
   onPress: () => void
@@ -58,7 +62,7 @@ function ViewModeButton({
       accessibilityState={{ selected, disabled }}
       accessibilityLabel={`Show ${label.toLowerCase()} website view`}
     >
-      <Text style={[styles.buttonText, selected && styles.buttonTextSelected]}>{label}</Text>
+      <Icon size={14} color={selected ? colors.bgBase : colors.textSecondary} />
     </Pressable>
   )
 }
@@ -74,25 +78,16 @@ const styles = StyleSheet.create({
   },
   button: {
     minHeight: 24,
-    minWidth: 52,
+    width: 32,
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: radii.button,
-    paddingHorizontal: spacing.sm
+    borderRadius: radii.button
   },
   buttonPressed: {
     backgroundColor: colors.borderSubtle
   },
   buttonSelected: {
     backgroundColor: colors.textPrimary
-  },
-  buttonText: {
-    color: colors.textSecondary,
-    fontSize: 12,
-    fontWeight: '600'
-  },
-  buttonTextSelected: {
-    color: colors.bgBase
   },
   disabled: {
     opacity: 0.35

--- a/mobile/src/browser/browser-url.test.ts
+++ b/mobile/src/browser/browser-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeBrowserUrl } from './browser-url'
+import { compactMobileBrowserFileAddress, normalizeBrowserUrl } from './browser-url'
 
 describe('normalizeBrowserUrl', () => {
   it('keeps localhost-style addresses as http URLs', () => {
@@ -12,5 +12,21 @@ describe('normalizeBrowserUrl', () => {
 
   it('adds https for regular domains without a scheme', () => {
     expect(normalizeBrowserUrl('github.com/stablyai/orca')).toBe('https://github.com/stablyai/orca')
+  })
+})
+
+describe('compactMobileBrowserFileAddress', () => {
+  it('shows the decoded filename for local and Windows-style file URLs', () => {
+    expect(compactMobileBrowserFileAddress('file:///Users/me/reports/status%20report.html')).toBe(
+      'file: …/status report.html'
+    )
+    expect(compactMobileBrowserFileAddress('file:///C:/Users/me/report.htm')).toBe(
+      'file: …/report.htm'
+    )
+  })
+
+  it('does not compact ordinary or malformed URLs', () => {
+    expect(compactMobileBrowserFileAddress('https://example.com/report.html')).toBeNull()
+    expect(compactMobileBrowserFileAddress('not a url')).toBeNull()
   })
 })

--- a/mobile/src/browser/browser-url.ts
+++ b/mobile/src/browser/browser-url.ts
@@ -38,7 +38,7 @@ export function compactMobileBrowserFileAddress(value: string): string | null {
       return null
     }
     const segments = url.pathname.split('/').filter(Boolean)
-    const encodedFilename = segments[segments.length - 1]
+    const encodedFilename = segments.at(-1)
     if (!encodedFilename) {
       return 'file:'
     }

--- a/mobile/src/browser/browser-url.ts
+++ b/mobile/src/browser/browser-url.ts
@@ -31,6 +31,27 @@ export function displayBrowserUrl(value: string | null | undefined): string {
   return isBlankBrowserUrl(trimmed) ? 'about:blank' : trimmed
 }
 
+export function compactMobileBrowserFileAddress(value: string): string | null {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'file:') {
+      return null
+    }
+    const segments = url.pathname.split('/').filter(Boolean)
+    const encodedFilename = segments[segments.length - 1]
+    if (!encodedFilename) {
+      return 'file:'
+    }
+    try {
+      return `file: …/${decodeURIComponent(encodedFilename)}`
+    } catch {
+      return `file: …/${encodedFilename}`
+    }
+  } catch {
+    return null
+  }
+}
+
 export function isBlankBrowserUrl(value: string | null | undefined): boolean {
   const trimmed = value?.trim() ?? ''
   return !trimmed || trimmed === 'about:blank' || trimmed.startsWith('data:text/html')

--- a/mobile/src/browser/mobile-browser-view-mode-state.test.ts
+++ b/mobile/src/browser/mobile-browser-view-mode-state.test.ts
@@ -15,11 +15,41 @@ describe('mobile browser view mode state', () => {
     expect(getInitialMobileBrowserViewMode('worktree-1', null)).toBe('web')
   })
 
+  it('defaults local HTML reports to mobile view', () => {
+    expect(
+      getInitialMobileBrowserViewMode(
+        'folder:workspace-1',
+        'page-1',
+        'file:///Users/me/report%20one.HTML?generated=1'
+      )
+    ).toBe('mobile')
+    expect(
+      getInitialMobileBrowserViewMode('worktree-1', 'page-2', 'file:///C:/Users/me/report.htm')
+    ).toBe('mobile')
+  })
+
+  it('keeps remote HTML URLs and non-HTML files in web view', () => {
+    expect(
+      getInitialMobileBrowserViewMode('worktree-1', 'page-1', 'https://example.com/report.html')
+    ).toBe('web')
+    expect(getInitialMobileBrowserViewMode('worktree-1', 'page-2', 'file:///repo/notes.txt')).toBe(
+      'web'
+    )
+  })
+
   it('restores the last mode for the same browser page after remount', () => {
     saveMobileBrowserViewMode('worktree-1', 'page-1', 'mobile')
 
     expect(getInitialMobileBrowserViewMode('worktree-1', 'page-1')).toBe('mobile')
     expect(getInitialMobileBrowserViewMode('worktree-1', 'page-2')).toBe('web')
     expect(getInitialMobileBrowserViewMode('worktree-2', 'page-1')).toBe('web')
+  })
+
+  it('preserves an explicit web choice for a local HTML report', () => {
+    saveMobileBrowserViewMode('worktree-1', 'page-1', 'web')
+
+    expect(
+      getInitialMobileBrowserViewMode('worktree-1', 'page-1', 'file:///repo/report.html')
+    ).toBe('web')
   })
 })

--- a/mobile/src/browser/mobile-browser-view-mode-state.ts
+++ b/mobile/src/browser/mobile-browser-view-mode-state.ts
@@ -5,13 +5,23 @@ const browserViewModeByPageKey = new Map<string, MobileBrowserViewMode>()
 
 export function getInitialMobileBrowserViewMode(
   worktreeId: string,
-  browserPageId: string | null
+  browserPageId: string | null,
+  url = 'about:blank'
 ): MobileBrowserViewMode {
   const pageKey = makeBrowserViewModePageKey(worktreeId, browserPageId)
   if (!pageKey) {
+    return defaultMobileBrowserViewMode(url)
+  }
+  return browserViewModeByPageKey.get(pageKey) ?? defaultMobileBrowserViewMode(url)
+}
+
+function defaultMobileBrowserViewMode(url: string): MobileBrowserViewMode {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'file:' && /\.html?$/i.test(parsed.pathname) ? 'mobile' : 'web'
+  } catch {
     return 'web'
   }
-  return browserViewModeByPageKey.get(pageKey) ?? 'web'
 }
 
 export function saveMobileBrowserViewMode(


### PR DESCRIPTION
## Problem

Local `file:` HTML reports inherited the desktop Web viewport in the mobile browser, leaving reports scaled down and letterboxed. Long local paths also hid the useful filename in the address field.

## Fix

- Default local `.html` and `.htm` pages to Mobile view while preserving explicit page-scoped choices.
- Show a compact `file: …/report.html` address when the field is unfocused.
- Replace the Web/Mobile text toggle with accessible viewport icons and keep remote HTML and non-HTML behavior unchanged.

## Tests

- `pnpm exec vitest run src/browser` — 6 files, 22 tests passed
- `pnpm run typecheck`
- Focused `oxlint`, `oxfmt --check`, and `git diff --check`
- Electron/CDP validation on an iPhone 17 Pro simulator

## Visual proof

The local report fills the phone-width canvas with Mobile mode selected and the report filename visible in the compact address field.

![Mobile HTML report rendered at phone width](https://github.com/user-attachments/assets/d7e45b87-1285-4172-b72c-28ad14a10ca8)
