### PR TITLE
feat(worktrees): create child worktrees from the composer

### DIFF
--- a/src/main/ipc/worktree-remote-lineage.test.ts
+++ b/src/main/ipc/worktree-remote-lineage.test.ts
@@ -1,0 +1,476 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type {
+  CreateWorktreeArgs,
+  Repo,
+  Worktree,
+  WorktreeLineage,
+  WorktreeMeta,
+  WorkspaceLineage
+} from '../../shared/types'
+import {
+  recordLineageForCreatedWorktree,
+  validateExplicitWorktreeParentBeforeCreate
+} from './worktree-remote'
+
+const LOCAL_REPO: Repo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'Repo',
+  badgeColor: 'blue',
+  addedAt: 1
+}
+const LOCAL_PROJECT_ID = 'repo:repo-1'
+
+afterEach(() => vi.restoreAllMocks())
+
+function makeMeta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: '',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  } as WorktreeMeta
+}
+
+function makeWorktree(
+  id: string,
+  instanceId: string,
+  projectId = LOCAL_PROJECT_ID,
+  hostId: Worktree['hostId'] = 'local'
+): Worktree {
+  const path = id.slice(id.indexOf('::') + 2)
+  return {
+    id,
+    instanceId,
+    repoId: id.slice(0, id.indexOf('::')),
+    projectId,
+    hostId,
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+function makeStore(args: {
+  metaById: Record<string, WorktreeMeta>
+  lineageById?: Record<string, WorktreeLineage>
+  repo?: Repo
+  folderWorkspaceIds?: string[]
+}) {
+  const repo = args.repo ?? LOCAL_REPO
+  const lineageById = args.lineageById ?? {}
+  const setWorktreeLineage = vi.fn((_worktreeId: string, lineage: WorktreeLineage) => lineage)
+  const setWorkspaceLineage = vi.fn((lineage: WorkspaceLineage) => lineage)
+  const store = {
+    getWorktreeMeta: (worktreeId: string) => args.metaById[worktreeId],
+    getWorktreeLineage: (worktreeId: string) => lineageById[worktreeId],
+    getProjectHostSetups: () => [
+      {
+        id: repo.id,
+        projectId: LOCAL_PROJECT_ID,
+        hostId: repo.connectionId ? `ssh:${repo.connectionId}` : 'local',
+        repoId: repo.id,
+        path: repo.path,
+        displayName: repo.displayName,
+        setupState: 'ready',
+        setupMethod: 'legacy-repo',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    getFolderWorkspace: (id: string) =>
+      args.folderWorkspaceIds?.includes(id) ? { id } : undefined,
+    setWorktreeLineage,
+    setWorkspaceLineage
+  } as unknown as Store
+  return { store, setWorktreeLineage, setWorkspaceLineage }
+}
+
+type ParentRaceState = {
+  metaById: Record<string, WorktreeMeta>
+  lineageById: Record<string, WorktreeLineage>
+}
+
+const POST_CREATE_PARENT_RACES: {
+  name: string
+  activePaths: string[]
+  mutate: (state: ParentRaceState, parentId: string, childId: string) => void
+}[] = [
+  {
+    name: 'same-path replacement',
+    activePaths: ['/workspace/parent', '/workspace/child'],
+    mutate: (state, parentId) => {
+      state.metaById[parentId] = makeMeta({
+        instanceId: 'replacement-instance',
+        projectId: LOCAL_PROJECT_ID,
+        hostId: 'local'
+      })
+    }
+  },
+  {
+    name: 'archival',
+    activePaths: ['/workspace/parent', '/workspace/child'],
+    mutate: (state, parentId) => {
+      state.metaById[parentId] = makeMeta({
+        instanceId: 'parent-instance',
+        projectId: LOCAL_PROJECT_ID,
+        hostId: 'local',
+        isArchived: true
+      })
+    }
+  },
+  {
+    name: 'project boundary change',
+    activePaths: ['/workspace/parent', '/workspace/child'],
+    mutate: (state, parentId) => {
+      state.metaById[parentId] = makeMeta({
+        instanceId: 'parent-instance',
+        projectId: 'repo:other',
+        hostId: 'local'
+      })
+    }
+  },
+  {
+    name: 'lineage cycle insertion',
+    activePaths: ['/workspace/parent', '/workspace/child'],
+    mutate: (state, parentId, childId) => {
+      state.metaById[childId] = makeMeta({
+        instanceId: 'child-instance',
+        projectId: LOCAL_PROJECT_ID,
+        hostId: 'local'
+      })
+      state.lineageById[parentId] = {
+        worktreeId: parentId,
+        worktreeInstanceId: 'parent-instance',
+        parentWorktreeId: childId,
+        parentWorktreeInstanceId: 'child-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 1
+      }
+    }
+  },
+  {
+    name: 'removal from the Git worktree listing',
+    activePaths: ['/workspace/child'],
+    mutate: () => undefined
+  }
+]
+
+describe('explicit worktree parent creation lineage', () => {
+  it('validates and records both local lineage projections', () => {
+    const parentId = 'repo-1::/workspace/parent'
+    const childId = 'repo-1::/workspace/child'
+    const { store, setWorktreeLineage, setWorkspaceLineage } = makeStore({
+      metaById: {
+        [parentId]: makeMeta({
+          instanceId: 'parent-instance',
+          projectId: LOCAL_PROJECT_ID,
+          hostId: 'local'
+        })
+      }
+    })
+
+    const parent = validateExplicitWorktreeParentBeforeCreate(
+      store,
+      LOCAL_REPO,
+      parentId,
+      childId,
+      ['/workspace/repo', '/workspace/parent']
+    )
+    const result = recordLineageForCreatedWorktree(
+      store,
+      { repoId: LOCAL_REPO.id, name: 'child', parentWorktreeId: parentId },
+      makeWorktree(childId, 'child-instance'),
+      123,
+      parent,
+      LOCAL_REPO,
+      ['/workspace/repo', '/workspace/parent', '/workspace/child']
+    )
+
+    expect(setWorktreeLineage).toHaveBeenCalledWith(
+      childId,
+      expect.objectContaining({
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: 'parent-instance',
+        capture: { source: 'manual-action', confidence: 'explicit' }
+      })
+    )
+    expect(setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childWorkspaceKey: `worktree:${childId}`,
+        childInstanceId: 'child-instance',
+        parentWorkspaceKey: `worktree:${parentId}`,
+        parentInstanceId: 'parent-instance'
+      })
+    )
+    expect(result).toEqual({
+      lineage: setWorktreeLineage.mock.results[0]?.value,
+      workspaceLineage: setWorkspaceLineage.mock.results[0]?.value
+    })
+  })
+
+  it.each(POST_CREATE_PARENT_RACES)(
+    'leaves the created worktree at root after a parent $name race',
+    ({ activePaths, mutate }) => {
+      const parentId = 'repo-1::/workspace/parent'
+      const childId = 'repo-1::/workspace/child'
+      const state: ParentRaceState = {
+        metaById: {
+          [parentId]: makeMeta({
+            instanceId: 'parent-instance',
+            projectId: LOCAL_PROJECT_ID,
+            hostId: 'local'
+          })
+        },
+        lineageById: {}
+      }
+      const { store, setWorktreeLineage, setWorkspaceLineage } = makeStore(state)
+      const parent = validateExplicitWorktreeParentBeforeCreate(
+        store,
+        LOCAL_REPO,
+        parentId,
+        childId,
+        ['/workspace/parent']
+      )
+      mutate(state, parentId, childId)
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+      const result = recordLineageForCreatedWorktree(
+        store,
+        { repoId: LOCAL_REPO.id, name: 'child', parentWorktreeId: parentId },
+        makeWorktree(childId, 'child-instance'),
+        123,
+        parent,
+        LOCAL_REPO,
+        activePaths
+      )
+
+      expect(setWorktreeLineage).not.toHaveBeenCalled()
+      expect(setWorkspaceLineage).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        lineage: null,
+        workspaceLineage: null,
+        warning: expect.stringContaining('left at the root')
+      })
+    }
+  )
+
+  it('accepts a parent on the same direct SSH host and project', () => {
+    const repo: Repo = { ...LOCAL_REPO, connectionId: 'conn-1' }
+    const parentId = 'repo-1::/remote/parent'
+    const childId = 'repo-1::/remote/child'
+    const { store } = makeStore({
+      repo,
+      metaById: {
+        [parentId]: makeMeta({
+          instanceId: 'parent-instance',
+          projectId: LOCAL_PROJECT_ID,
+          hostId: 'ssh:conn-1'
+        })
+      }
+    })
+
+    expect(
+      validateExplicitWorktreeParentBeforeCreate(store, repo, parentId, childId, ['/remote/parent'])
+    ).toEqual({ worktreeId: parentId, instanceId: 'parent-instance' })
+  })
+
+  it('accepts legacy parent metadata without projected ownership', () => {
+    const parentId = 'repo-1::/workspace/parent'
+    const { store } = makeStore({
+      metaById: {
+        [parentId]: makeMeta({ instanceId: 'parent-instance' })
+      }
+    })
+
+    expect(
+      validateExplicitWorktreeParentBeforeCreate(store, LOCAL_REPO, parentId, 'child', [
+        '/workspace/parent'
+      ])
+    ).toEqual({ worktreeId: parentId, instanceId: 'parent-instance' })
+  })
+
+  it.each([
+    {
+      name: 'missing instance identity',
+      meta: makeMeta({ projectId: LOCAL_PROJECT_ID, hostId: 'local' }),
+      activePaths: ['/workspace/parent'],
+      error: 'Parent worktree instance identity was unavailable.'
+    },
+    {
+      name: 'archived parent',
+      meta: makeMeta({
+        instanceId: 'parent-instance',
+        projectId: LOCAL_PROJECT_ID,
+        hostId: 'local',
+        isArchived: true
+      }),
+      activePaths: ['/workspace/parent'],
+      error: 'Archived worktrees cannot be used as parents.'
+    },
+    {
+      name: 'inactive parent',
+      meta: makeMeta({
+        instanceId: 'parent-instance',
+        projectId: LOCAL_PROJECT_ID,
+        hostId: 'local'
+      }),
+      activePaths: ['/workspace/repo'],
+      error: 'Parent worktree is no longer active.'
+    },
+    {
+      name: 'different project',
+      meta: makeMeta({
+        instanceId: 'parent-instance',
+        projectId: 'repo:other',
+        hostId: 'local'
+      }),
+      activePaths: ['/workspace/parent'],
+      error: 'same repository, execution host, and project'
+    },
+    {
+      name: 'different execution host',
+      meta: makeMeta({
+        instanceId: 'parent-instance',
+        projectId: LOCAL_PROJECT_ID,
+        hostId: 'ssh:other'
+      }),
+      activePaths: ['/workspace/parent'],
+      error: 'same repository, execution host, and project'
+    }
+  ])('rejects a $name before creation', ({ meta, activePaths, error }) => {
+    const parentId = 'repo-1::/workspace/parent'
+    const { store } = makeStore({ metaById: { [parentId]: meta } })
+
+    expect(() =>
+      validateExplicitWorktreeParentBeforeCreate(
+        store,
+        LOCAL_REPO,
+        parentId,
+        'repo-1::/workspace/child',
+        activePaths
+      )
+    ).toThrow(error)
+  })
+
+  it('rejects a parent whose valid lineage would create a cycle', () => {
+    const parentId = 'repo-1::/workspace/parent'
+    const childId = 'repo-1::/workspace/child'
+    const { store } = makeStore({
+      metaById: {
+        [parentId]: makeMeta({
+          instanceId: 'parent-instance',
+          projectId: LOCAL_PROJECT_ID,
+          hostId: 'local'
+        }),
+        [childId]: makeMeta({
+          instanceId: 'stale-child-instance',
+          projectId: LOCAL_PROJECT_ID,
+          hostId: 'local'
+        })
+      },
+      lineageById: {
+        [parentId]: {
+          worktreeId: parentId,
+          worktreeInstanceId: 'parent-instance',
+          parentWorktreeId: childId,
+          parentWorktreeInstanceId: 'stale-child-instance',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 1
+        }
+      }
+    })
+
+    expect(() =>
+      validateExplicitWorktreeParentBeforeCreate(store, LOCAL_REPO, parentId, childId, [
+        '/workspace/parent'
+      ])
+    ).toThrow('Parent worktree would create a lineage cycle.')
+  })
+
+  it('keeps folder-parent workspace lineage when no explicit worktree parent is selected', () => {
+    const childId = 'repo-1::/workspace/child'
+    const { store, setWorktreeLineage, setWorkspaceLineage } = makeStore({
+      metaById: {},
+      folderWorkspaceIds: ['folder-parent']
+    })
+    const args: CreateWorktreeArgs = {
+      repoId: LOCAL_REPO.id,
+      name: 'child',
+      parentWorkspace: 'folder:folder-parent'
+    }
+
+    const result = recordLineageForCreatedWorktree(
+      store,
+      args,
+      makeWorktree(childId, 'child-instance'),
+      123,
+      null,
+      LOCAL_REPO,
+      []
+    )
+
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspaceKey: 'folder:folder-parent' })
+    )
+    expect(result.lineage).toBeNull()
+  })
+
+  it('lets an explicit worktree parent override inherited folder-parent context', () => {
+    const parentId = 'repo-1::/workspace/parent'
+    const childId = 'repo-1::/workspace/child'
+    const { store, setWorkspaceLineage } = makeStore({
+      metaById: {
+        [parentId]: makeMeta({
+          instanceId: 'parent-instance',
+          projectId: LOCAL_PROJECT_ID,
+          hostId: 'local'
+        })
+      },
+      folderWorkspaceIds: ['folder-parent']
+    })
+
+    recordLineageForCreatedWorktree(
+      store,
+      {
+        repoId: LOCAL_REPO.id,
+        name: 'child',
+        parentWorktreeId: parentId,
+        parentWorkspace: 'folder:folder-parent'
+      },
+      makeWorktree(childId, 'child-instance'),
+      123,
+      { worktreeId: parentId, instanceId: 'parent-instance' },
+      LOCAL_REPO,
+      ['/workspace/parent', '/workspace/child']
+    )
+
+    expect(setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspaceKey: `worktree:${parentId}` })
+    )
+  })
+})

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -19,6 +19,7 @@ import type {
   Worktree,
   WorktreeCreateBaseFallback,
   WorktreeHeadIdentity,
+  WorktreeLineage,
   WorktreeMeta
 } from '../../shared/types'
 import { getPRForBranch } from '../github/client'
@@ -61,7 +62,10 @@ import { requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
 import { TUI_AGENT_CONFIG, isTuiAgent } from '../../shared/tui-agent-config'
-import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
+import {
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathForComparison
+} from '../../shared/cross-platform-path'
 import { runWorktreeChangeInvalidators } from './worktree-change-invalidators'
 import {
   registerOptionalSshWorktreeCreateRoots,
@@ -88,7 +92,7 @@ import {
 } from './worktree-logic'
 import { findCreatedWorktree } from './created-worktree-reconciliation'
 import type { BranchPrefixSettings } from '../../shared/branch-prefix'
-import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import {
   cleanupUnusedWorktreePushTargetRemoteWithExec,
@@ -209,6 +213,124 @@ function validateWorkspaceLineageParentBeforeCreate(
   }
 }
 
+type ValidatedCreateParent = {
+  worktreeId: string
+  instanceId: string
+}
+
+const STALE_CREATE_PARENT_WARNING =
+  'Worktree created, but Orca could not safely attach it to the selected parent because the parent changed during creation. It was left at the root.'
+
+function wouldCreateWorktreeLineageCycle(
+  store: Store,
+  parentWorktreeId: string,
+  childWorktreeId: string
+): boolean {
+  let cursor = parentWorktreeId
+  const visited = new Set<string>([childWorktreeId])
+  while (cursor) {
+    if (visited.has(cursor)) {
+      return true
+    }
+    visited.add(cursor)
+    const lineage = store.getWorktreeLineage(cursor)
+    if (!lineage) {
+      return false
+    }
+    const cursorInstanceId = store.getWorktreeMeta(cursor)?.instanceId
+    const ancestorInstanceId = store.getWorktreeMeta(lineage.parentWorktreeId)?.instanceId
+    if (
+      cursorInstanceId !== lineage.worktreeInstanceId ||
+      ancestorInstanceId !== lineage.parentWorktreeInstanceId
+    ) {
+      return false
+    }
+    cursor = lineage.parentWorktreeId
+  }
+  return false
+}
+
+export function validateExplicitWorktreeParentBeforeCreate(
+  store: Store,
+  repo: Repo,
+  parentWorktreeId: string | undefined,
+  childWorktreeId: string,
+  activeWorktreePaths: readonly string[]
+): ValidatedCreateParent | null {
+  if (parentWorktreeId === undefined) {
+    return null
+  }
+  const parsedParent = splitWorktreeId(parentWorktreeId)
+  if (!parsedParent?.repoId || !parsedParent.worktreePath) {
+    throw new Error(`Invalid parent worktree: ${parentWorktreeId}`)
+  }
+  if (parentWorktreeId === childWorktreeId) {
+    throw new Error('A worktree cannot parent itself.')
+  }
+  if (parsedParent.repoId !== repo.id) {
+    throw new Error('Parent worktree must belong to the same repository.')
+  }
+
+  const parentMeta = store.getWorktreeMeta(parentWorktreeId)
+  if (!parentMeta) {
+    throw new Error(`Parent worktree not found: ${parentWorktreeId}`)
+  }
+  if (!parentMeta.instanceId) {
+    throw new Error('Parent worktree instance identity was unavailable.')
+  }
+  if (parentMeta.isArchived) {
+    throw new Error('Archived worktrees cannot be used as parents.')
+  }
+  const parentPathKey = normalizeRuntimePathForComparison(parsedParent.worktreePath)
+  if (
+    !activeWorktreePaths.some(
+      (pathValue) => normalizeRuntimePathForComparison(pathValue) === parentPathKey
+    )
+  ) {
+    throw new Error('Parent worktree is no longer active.')
+  }
+
+  const boundary = getProjectHostSetupWorktreeMeta(store.getProjectHostSetups(), repo)
+  if (
+    (parentMeta.projectId !== undefined && parentMeta.projectId !== boundary.projectId) ||
+    (parentMeta.hostId !== undefined && parentMeta.hostId !== boundary.hostId)
+  ) {
+    throw new Error(
+      'Parent worktree must belong to the same repository, execution host, and project.'
+    )
+  }
+
+  if (wouldCreateWorktreeLineageCycle(store, parentWorktreeId, childWorktreeId)) {
+    throw new Error('Parent worktree would create a lineage cycle.')
+  }
+
+  return { worktreeId: parentWorktreeId, instanceId: parentMeta.instanceId }
+}
+
+function getPostCreateParentValidationError(
+  store: Store,
+  worktree: Worktree,
+  explicitParent: ValidatedCreateParent,
+  repo: Repo,
+  activeWorktreePaths: readonly string[]
+): string | null {
+  try {
+    const currentParent = validateExplicitWorktreeParentBeforeCreate(
+      store,
+      repo,
+      explicitParent.worktreeId,
+      worktree.id,
+      activeWorktreePaths
+    )
+    if (!currentParent || currentParent.instanceId !== explicitParent.instanceId) {
+      return 'Parent worktree instance changed during creation.'
+    }
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Parent worktree validation failed.'
+  }
+  return null
+}
+
 function recordWorkspaceLineageForCreatedWorktree(
   store: Store,
   args: CreateWorktreeArgs,
@@ -247,6 +369,58 @@ function recordWorkspaceLineageForCreatedWorktree(
     capture: { source: 'active-workspace', confidence: 'explicit' },
     createdAt
   })
+}
+
+export function recordLineageForCreatedWorktree(
+  store: Store,
+  args: CreateWorktreeArgs,
+  worktree: Worktree,
+  createdAt: number,
+  explicitParent: ValidatedCreateParent | null,
+  repo: Repo,
+  activeWorktreePaths: readonly string[]
+): {
+  lineage: WorktreeLineage | null
+  workspaceLineage: CreateWorktreeResult['workspaceLineage']
+  warning?: string
+} {
+  if (!explicitParent || !worktree.instanceId) {
+    return {
+      lineage: null,
+      workspaceLineage: recordWorkspaceLineageForCreatedWorktree(store, args, worktree, createdAt)
+    }
+  }
+  const validationError = getPostCreateParentValidationError(
+    store,
+    worktree,
+    explicitParent,
+    repo,
+    activeWorktreePaths
+  )
+  if (validationError) {
+    console.warn(`[worktree-create] ${STALE_CREATE_PARENT_WARNING} (${validationError})`)
+    return { lineage: null, workspaceLineage: null, warning: STALE_CREATE_PARENT_WARNING }
+  }
+  const capture = { source: 'manual-action', confidence: 'explicit' } as const
+  const lineage = store.setWorktreeLineage(worktree.id, {
+    worktreeId: worktree.id,
+    worktreeInstanceId: worktree.instanceId,
+    parentWorktreeId: explicitParent.worktreeId,
+    parentWorktreeInstanceId: explicitParent.instanceId,
+    origin: 'manual',
+    capture,
+    createdAt
+  })
+  const workspaceLineage = store.setWorkspaceLineage({
+    childWorkspaceKey: worktreeWorkspaceKey(worktree.id),
+    childInstanceId: worktree.instanceId,
+    parentWorkspaceKey: worktreeWorkspaceKey(explicitParent.worktreeId),
+    parentInstanceId: explicitParent.instanceId,
+    origin: 'manual',
+    capture,
+    createdAt
+  })
+  return { lineage, workspaceLineage }
 }
 
 function countNonEmptyGitOutputLines(output: string): number {
@@ -1615,9 +1789,20 @@ export async function createRemoteWorktree(
     )
   }
 
+  const explicitParent = validateExplicitWorktreeParentBeforeCreate(
+    store,
+    repo,
+    args.parentWorktreeId,
+    `${repo.id}::${remotePath}`,
+    args.parentWorktreeId
+      ? (await provider.listWorktrees(repo.path))
+          .filter((worktree) => !worktree.prunable)
+          .map((worktree) => worktree.path)
+      : []
+  )
   validateWorkspaceLineageParentBeforeCreate(
     store,
-    args.parentWorkspace,
+    explicitParent ? undefined : args.parentWorkspace,
     worktreeWorkspaceKey(`${repo.id}::${remotePath}`)
   )
 
@@ -1834,7 +2019,19 @@ export async function createRemoteWorktree(
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
     return { worktree: mergeWorktree(repo.id, created, meta) }
   })
-  const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
+  const {
+    lineage,
+    workspaceLineage,
+    warning: lineageWarning
+  } = recordLineageForCreatedWorktree(
+    store,
+    args,
+    worktree,
+    now,
+    explicitParent,
+    repo,
+    gitWorktrees.filter((worktree) => !worktree.prunable).map((worktree) => worktree.path)
+  )
 
   // Why: shared/symlink paths, `orca.yaml` shared directories, and `.worktreeinclude` copies are local-only; remote (SSH) support needs a new relay method + auth surface, so all are skipped here.
 
@@ -1881,13 +2078,25 @@ export async function createRemoteWorktree(
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
-    worktree: { ...worktree, workspaceLineage },
+    worktree: {
+      ...worktree,
+      ...(lineage
+        ? {
+            parentWorktreeId: lineage.parentWorktreeId,
+            childWorktreeIds: [],
+            lineage
+          }
+        : {}),
+      workspaceLineage
+    },
+    ...(lineage ? { lineage } : {}),
     ...(workspaceLineage ? { workspaceLineage } : {}),
     ...(setup ? { setup } : {}),
     ...(defaultTabs ? { defaultTabs } : {}),
     ...(localBaseRefRefresh ? { localBaseRefRefresh } : {}),
     ...(localBaseRefUpdateSuggestion ? { localBaseRefUpdateSuggestion } : {}),
     ...(baseFallback ? { baseFallback } : {}),
+    ...(lineageWarning ? { warning: lineageWarning } : {}),
     timing: timing.finish()
   }
 }
@@ -2209,9 +2418,24 @@ export async function createLocalWorktree(
     )
   }
 
+  const explicitParent = validateExplicitWorktreeParentBeforeCreate(
+    store,
+    repo,
+    args.parentWorktreeId,
+    `${repo.id}::${worktreePath}`,
+    args.parentWorktreeId
+      ? (
+          await (hasLocalWorktreeGitOptions
+            ? listWorktrees(repo.path, localWorktreeGitOptions)
+            : listWorktrees(repo.path))
+        )
+          .filter((worktree) => !worktree.prunable)
+          .map((worktree) => worktree.path)
+      : []
+  )
   validateWorkspaceLineageParentBeforeCreate(
     store,
-    args.parentWorkspace,
+    explicitParent ? undefined : args.parentWorkspace,
     worktreeWorkspaceKey(`${repo.id}::${worktreePath}`)
   )
 
@@ -2443,7 +2667,19 @@ export async function createLocalWorktree(
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
     return { worktree: mergeWorktree(repo.id, created, meta) }
   })
-  const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
+  const {
+    lineage,
+    workspaceLineage,
+    warning: lineageWarning
+  } = recordLineageForCreatedWorktree(
+    store,
+    args,
+    worktree,
+    now,
+    explicitParent,
+    repo,
+    gitWorktrees.filter((worktree) => !worktree.prunable).map((worktree) => worktree.path)
+  )
   // Why: reuse the roots creation already paid for via `git worktree list` so later IPC doesn't lazily rescan and trip macOS privacy prompts.
   registerWorktreeRootsForRepo(store, repo.id, [
     repo.path,
@@ -2543,10 +2779,27 @@ export async function createLocalWorktree(
       createdWithAgent: args.createdWithAgent
     })
   )
+  const lineageAndCopyWarning = lineageWarning
+    ? appendWorktreeCreateWarning(includeCopyWarning, lineageWarning)
+    : includeCopyWarning
+  const creationWarning = stagedStartup.warning
+    ? appendWorktreeCreateWarning(lineageAndCopyWarning, stagedStartup.warning)
+    : lineageAndCopyWarning
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
-    worktree: { ...worktree, workspaceLineage },
+    worktree: {
+      ...worktree,
+      ...(lineage
+        ? {
+            parentWorktreeId: lineage.parentWorktreeId,
+            childWorktreeIds: [],
+            lineage
+          }
+        : {}),
+      workspaceLineage
+    },
+    ...(lineage ? { lineage } : {}),
     ...(workspaceLineage ? { workspaceLineage } : {}),
     ...(stagedStartup.activationSetup
       ? { setup: stagedStartup.activationSetup }
@@ -2562,11 +2815,7 @@ export async function createLocalWorktree(
       : {}),
     ...(stagedStartup.startupTerminal ? { startupTerminal: stagedStartup.startupTerminal } : {}),
     ...(baseFallback ? { baseFallback } : {}),
-    ...(stagedStartup.warning
-      ? { warning: appendWorktreeCreateWarning(includeCopyWarning, stagedStartup.warning) }
-      : includeCopyWarning
-        ? { warning: includeCopyWarning }
-        : {}),
+    ...(creationWarning ? { warning: creationWarning } : {}),
     timing: timing.finish()
   }
 }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -280,7 +280,8 @@ import {
   LINEAGE_HYDRATION_TIMEOUT_MS,
   __getDetectedWorktreeScanCacheStatsForTests,
   __resetDetectedWorktreeScanCacheForTests,
-  registerWorktreeHandlers
+  registerWorktreeHandlers,
+  resolveSelectedWorktreeCreateRepo
 } from './worktrees'
 import { clearConfiguredWorktreeSharedDirectoriesCacheForTests } from '../git/worktree-shared-directories'
 import {
@@ -290,6 +291,80 @@ import {
 } from '../ssh/ssh-provider-authority'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
+
+describe('selected worktree create repository', () => {
+  const localRepo: Repo = {
+    id: 'duplicate',
+    path: '/local/repo',
+    displayName: 'Local',
+    badgeColor: 'blue',
+    addedAt: 1
+  }
+  const sshRepo: Repo = {
+    ...localRepo,
+    path: '/remote/repo',
+    displayName: 'SSH',
+    connectionId: 'ssh-1'
+  }
+
+  it.each([
+    {
+      name: 'local repository after an SSH sibling',
+      repos: [sshRepo, localRepo],
+      authority: { path: localRepo.path, connectionId: null },
+      expected: localRepo
+    },
+    {
+      name: 'SSH repository after a local sibling',
+      repos: [localRepo, sshRepo],
+      authority: { path: sshRepo.path, connectionId: 'ssh-1' },
+      expected: sshRepo
+    }
+  ])('resolves the exact $name', ({ repos, authority, expected }) => {
+    const selectionStore = {
+      getRepos: () => repos,
+      getRepo: () => repos[0]
+    }
+
+    expect(
+      resolveSelectedWorktreeCreateRepo(selectionStore as never, {
+        repoId: 'duplicate',
+        repoAuthority: authority
+      })
+    ).toBe(expected)
+  })
+
+  it('fails closed for stale or duplicate authority', () => {
+    const selectionStore = {
+      getRepos: () => [localRepo, { ...localRepo }],
+      getRepo: () => localRepo
+    }
+
+    expect(() =>
+      resolveSelectedWorktreeCreateRepo(selectionStore as never, {
+        repoId: 'duplicate',
+        repoAuthority: { path: localRepo.path, connectionId: null }
+      })
+    ).toThrow('ambiguous')
+    expect(() =>
+      resolveSelectedWorktreeCreateRepo(selectionStore as never, {
+        repoId: 'duplicate',
+        repoAuthority: { path: '/stale/repo', connectionId: null }
+      })
+    ).toThrow('no longer available')
+  })
+
+  it('preserves the legacy store selection without authority', () => {
+    const selectionStore = {
+      getRepos: () => [localRepo, sshRepo],
+      getRepo: () => sshRepo
+    }
+
+    expect(
+      resolveSelectedWorktreeCreateRepo(selectionStore as never, { repoId: 'duplicate' })
+    ).toBe(sshRepo)
+  })
+})
 
 describe('registerWorktreeHandlers', () => {
   const handlers: HandlerMap = {}

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -13,6 +13,7 @@ import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup
 import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
 import { WorkspaceLinkedItemSchema } from '../../shared/workspace-linked-item-schema'
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-linked-item-source-context'
+import { resolveSelectedRepositoryAuthority } from '../../shared/selected-repository-authority'
 import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
 import { isPathInsideOrEqual, isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
@@ -1801,6 +1802,27 @@ async function listHostQualifiedDetectedWorktrees(
   }
 }
 
+export function resolveSelectedWorktreeCreateRepo(
+  store: Pick<Store, 'getRepo' | 'getRepos'>,
+  args: Pick<CreateWorktreeArgs, 'repoId' | 'repoAuthority'>
+): Repo | undefined {
+  if (!args.repoAuthority) {
+    return store.getRepo(args.repoId)
+  }
+  const resolution = resolveSelectedRepositoryAuthority(
+    store.getRepos().filter((repo) => repo.id === args.repoId),
+    args.repoAuthority
+  )
+  if (resolution.status === 'resolved') {
+    return resolution.candidate
+  }
+  throw new Error(
+    resolution.status === 'rejected' && resolution.reason === 'ambiguous'
+      ? `Repository selection is ambiguous: ${args.repoId}`
+      : `Selected repository is no longer available: ${args.repoId}`
+  )
+}
+
 export function registerWorktreeHandlers(
   mainWindow: BrowserWindow,
   store: Store,
@@ -2189,7 +2211,7 @@ export function registerWorktreeHandlers(
       const args = normalizeLinkedWorkItemFields(rawArgs)
       // Why span here: parent the child git spans for the trace tree; don't attach branch name/remote URL (user content) — repo ID is the safer correlator.
       return withWorktreeSpan({ stage: 'create' }, async () => {
-        const repo = store.getRepo(args.repoId)
+        const repo = resolveSelectedWorktreeCreateRepo(store, args)
         if (!repo) {
           throw new Error(`Repo not found: ${args.repoId}`)
         }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1656,6 +1656,77 @@ describe('OrcaRuntimeService.dedupeWorktreeCreate', () => {
 })
 
 describe('OrcaRuntimeService', () => {
+  it.each([
+    {
+      name: 'host-local repository',
+      selected: {
+        id: TEST_REPO_ID,
+        path: '/local/repo',
+        displayName: 'Local',
+        badgeColor: 'blue',
+        addedAt: 1
+      },
+      sibling: {
+        id: TEST_REPO_ID,
+        path: '/remote/repo',
+        displayName: 'SSH',
+        badgeColor: 'blue',
+        addedAt: 1,
+        connectionId: 'ssh-1'
+      },
+      authority: { path: '/local/repo', connectionId: null }
+    },
+    {
+      name: 'nested SSH repository',
+      selected: {
+        id: TEST_REPO_ID,
+        path: '/remote/repo',
+        displayName: 'SSH',
+        badgeColor: 'blue',
+        addedAt: 1,
+        connectionId: 'ssh-1'
+      },
+      sibling: {
+        id: TEST_REPO_ID,
+        path: '/local/repo',
+        displayName: 'Local',
+        badgeColor: 'blue',
+        addedAt: 1
+      },
+      authority: { path: '/remote/repo', connectionId: 'ssh-1' }
+    }
+  ])('resolves selected $name authority among duplicate ids', async (scenario) => {
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => [scenario.sibling, scenario.selected]
+    } as never)
+
+    await expect(runtime.showRepo(TEST_REPO_ID, scenario.authority)).resolves.toBe(
+      scenario.selected
+    )
+  })
+
+  it('fails selected repository authority closed before creation', async () => {
+    const duplicate = {
+      id: TEST_REPO_ID,
+      path: '/local/repo',
+      displayName: 'Local',
+      badgeColor: 'blue',
+      addedAt: 1
+    }
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => [duplicate, { ...duplicate }]
+    } as never)
+
+    await expect(
+      runtime.showRepo(TEST_REPO_ID, { path: duplicate.path, connectionId: null })
+    ).rejects.toThrow('selector_ambiguous')
+    await expect(
+      runtime.showRepo(TEST_REPO_ID, { path: '/stale/repo', connectionId: null })
+    ).rejects.toThrow('repo_not_found')
+  })
+
   it('projects runtime-backed settings to paired clients', () => {
     const terminalQuickCommands = [
       {
@@ -5303,7 +5374,21 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).not.toHaveBeenCalled()
   })
 
-  it('records lineage for SSH-backed CLI-created worktrees', async () => {
+  it.each([
+    { name: 'records paired-runtime lineage on nested SSH', postCreateState: 'present' },
+    {
+      name: 'keeps nested SSH creation at root when its parent disappears',
+      postCreateState: 'missing'
+    },
+    {
+      name: 'keeps nested SSH creation at root when its parent becomes prunable',
+      postCreateState: 'prunable'
+    },
+    {
+      name: 'keeps nested SSH creation at root when its parent scan fails',
+      postCreateState: 'scan-failed'
+    }
+  ])('$name', async ({ postCreateState }) => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(addWorktree).mockClear()
     const remoteRepo = {
@@ -5337,7 +5422,11 @@ describe('OrcaRuntimeService', () => {
     const parentId = `${TEST_REPO_ID}::${parent.path}`
     const childId = `${TEST_REPO_ID}::${created.path}`
     const metaById: Record<string, WorktreeMeta> = {
-      [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
+      [parentId]: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        projectId: `repo:${TEST_REPO_ID}`,
+        hostId: 'ssh:ssh-1'
+      })
     }
     const lineageById: Record<string, WorktreeLineage> = {}
     const remoteStore = {
@@ -5356,6 +5445,7 @@ describe('OrcaRuntimeService', () => {
         return lineage
       })
     }
+    let worktreeScanCount = 0
     const provider = {
       exec: vi.fn(async (args: string[]) => {
         if (args[0] === 'config') {
@@ -5376,7 +5466,19 @@ describe('OrcaRuntimeService', () => {
         throw new Error(`unexpected git call: ${args.join(' ')}`)
       }),
       addWorktree: vi.fn().mockResolvedValue(undefined),
-      listWorktrees: vi.fn().mockResolvedValueOnce([parent]).mockResolvedValue([parent, created])
+      listWorktrees: vi.fn(async () => {
+        worktreeScanCount += 1
+        if (worktreeScanCount <= 2) {
+          return [parent]
+        }
+        if (worktreeScanCount === 3 || postCreateState === 'present') {
+          return [parent, created]
+        }
+        if (postCreateState === 'scan-failed') {
+          throw new Error('post-create scan failed')
+        }
+        return postCreateState === 'prunable' ? [{ ...parent, prunable: true }, created] : [created]
+      })
     }
     registerSshGitProvider('ssh-1', provider as never)
     getActiveMultiplexerMock.mockReturnValue({ request: muxRequestMock, notify: vi.fn() })
@@ -5386,28 +5488,526 @@ describe('OrcaRuntimeService', () => {
       const result = await runtime.createManagedWorktree({
         repoSelector: TEST_REPO_ID,
         name: 'child-feature',
-        lineage: { parentWorktree: `id:${parentId}` }
+        lineage: {
+          parentWorkspace: `worktree:${parentId}`,
+          parentWorkspaceCaptureSource: 'manual-action'
+        }
       })
 
-      expect(result.worktree).toMatchObject({
-        id: childId,
-        parentWorktreeId: parentId,
-        lineage: expect.objectContaining({
-          worktreeId: childId,
+      if (postCreateState === 'present') {
+        expect(result.worktree).toMatchObject({
+          id: childId,
           parentWorktreeId: parentId,
-          worktreeInstanceId: metaById[childId].instanceId,
-          parentWorktreeInstanceId: 'parent-instance',
-          origin: 'cli'
+          lineage: expect.objectContaining({
+            worktreeId: childId,
+            parentWorktreeId: parentId,
+            worktreeInstanceId: metaById[childId].instanceId,
+            parentWorktreeInstanceId: 'parent-instance',
+            origin: 'manual',
+            capture: { source: 'manual-action', confidence: 'explicit' }
+          })
         })
-      })
-      expect(result.lineage).toBe(result.worktree.lineage)
-      expect(result.warnings).toEqual([])
-      expect(remoteStore.setWorktreeLineage).toHaveBeenCalledWith(childId, expect.any(Object))
+        expect(result.lineage).toBe(result.worktree.lineage)
+        expect(result.warnings).toEqual([])
+        expect(remoteStore.setWorktreeLineage).toHaveBeenCalledWith(childId, expect.any(Object))
+      } else {
+        const scanFailed = postCreateState === 'scan-failed'
+        expect(result.worktree).toMatchObject({
+          id: childId,
+          parentWorktreeId: null,
+          lineage: null,
+          workspaceLineage: null
+        })
+        expect(result.lineage).toBeNull()
+        expect(result.workspaceLineage).toBeNull()
+        expect(result.warnings).toEqual([
+          expect.objectContaining({
+            code: scanFailed ? 'LINEAGE_PARENT_CONTEXT_MISSING' : 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+            details: expect.objectContaining({
+              reason: scanFailed ? 'LINEAGE_PARENT_CONTEXT_MISSING' : 'LINEAGE_PARENT_NOT_FOUND',
+              parentWorktreeId: parentId
+            })
+          })
+        ])
+        expect(remoteStore.setWorktreeLineage).not.toHaveBeenCalled()
+      }
+      expect(provider.addWorktree).toHaveBeenCalled()
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(4)
       expect(addWorktree).not.toHaveBeenCalled()
       expect(listWorktrees).not.toHaveBeenCalled()
     } finally {
       unregisterSshGitProvider('ssh-1')
     }
+  })
+
+  it('keeps local creation at root when its parent disappears after Git mutation', async () => {
+    const parent = MOCK_GIT_WORKTREES[0]
+    const created = {
+      path: '/tmp/workspaces/local-child',
+      head: 'def',
+      branch: 'refs/heads/local-child',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const parentId = `${TEST_REPO_ID}::${parent.path}`
+    const childId = `${TEST_REPO_ID}::${created.path}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
+    }
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      },
+      getWorktreeLineage: () => undefined,
+      setWorktreeLineage,
+      setWorkspaceLineage
+    }
+    computeWorktreePathMock.mockReturnValue(created.path)
+    ensurePathWithinWorkspaceMock.mockImplementation((pathValue: string) => pathValue)
+    let worktreeScanCount = 0
+    vi.mocked(listWorktrees).mockImplementation(async () => {
+      worktreeScanCount += 1
+      if (worktreeScanCount <= 2) {
+        return [parent]
+      }
+      return worktreeScanCount === 3 ? [parent, created] : [created]
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: TEST_REPO_ID,
+      name: 'local-child',
+      baseBranch: 'origin/main',
+      lineage: {
+        parentWorkspace: `worktree:${parentId}`,
+        parentWorkspaceCaptureSource: 'manual-action'
+      }
+    })
+
+    expect(addWorktree).toHaveBeenCalled()
+    expect(listWorktrees).toHaveBeenCalledTimes(4)
+    expect(result.worktree).toMatchObject({
+      id: childId,
+      parentWorktreeId: null,
+      lineage: null,
+      workspaceLineage: null
+    })
+    expect(result.lineage).toBeNull()
+    expect(result.workspaceLineage).toBeNull()
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+        details: expect.objectContaining({
+          reason: 'LINEAGE_PARENT_NOT_FOUND',
+          parentWorktreeId: parentId
+        })
+      })
+    ])
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      name: 'archived parent',
+      snapshotMeta: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        projectId: `repo:${TEST_REPO_ID}`,
+        hostId: 'ssh:ssh-1',
+        isArchived: true
+      }),
+      code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      error: 'Archived worktrees cannot be used as parents.'
+    },
+    {
+      name: 'parent from another project',
+      snapshotMeta: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        projectId: 'repo:other',
+        hostId: 'ssh:ssh-1'
+      }),
+      code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      error: 'same repository, execution host, and project'
+    },
+    {
+      name: 'parent from another nested SSH host',
+      snapshotMeta: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        projectId: `repo:${TEST_REPO_ID}`,
+        hostId: 'ssh:ssh-2'
+      }),
+      code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      error: 'same repository, execution host, and project'
+    },
+    {
+      name: 'stale parent identity',
+      snapshotMeta: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        projectId: `repo:${TEST_REPO_ID}`,
+        hostId: 'ssh:ssh-1'
+      }),
+      currentMeta: makeWorktreeMeta({
+        instanceId: 'replacement-instance',
+        projectId: `repo:${TEST_REPO_ID}`,
+        hostId: 'ssh:ssh-1'
+      }),
+      code: 'LINEAGE_PARENT_NOT_FOUND',
+      error: 'Parent worktree identity is stale.'
+    },
+    {
+      name: 'parent removed after selection',
+      snapshotMeta: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        projectId: `repo:${TEST_REPO_ID}`,
+        hostId: 'ssh:ssh-1'
+      }),
+      activeOnRecheck: false,
+      code: 'LINEAGE_PARENT_NOT_FOUND',
+      error: 'Parent worktree is no longer active.'
+    }
+  ])('rejects a $name before nested SSH Git mutation', async (scenario) => {
+    const remoteRepo = {
+      id: TEST_REPO_ID,
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const parent = {
+      path: '/remote/repo-parent',
+      head: 'abc',
+      branch: 'refs/heads/repo-parent',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const parentId = `${TEST_REPO_ID}::${parent.path}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [parentId]: scenario.snapshotMeta
+    }
+    const currentParentMeta = scenario.currentMeta ?? scenario.snapshotMeta
+    const remoteStore = {
+      ...store,
+      getRepos: () => [remoteRepo],
+      getRepo: (id: string) => (id === TEST_REPO_ID ? remoteRepo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === parentId ? currentParentMeta : metaById[worktreeId]
+    }
+    const listRemoteWorktrees = vi
+      .fn()
+      .mockResolvedValueOnce([parent])
+      .mockResolvedValue(scenario.activeOnRecheck === false ? [] : [parent])
+    const provider = {
+      exec: vi.fn(),
+      addWorktree: vi.fn(),
+      listWorktrees: listRemoteWorktrees
+    }
+    registerSshGitProvider('ssh-1', provider as never)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    try {
+      await expect(
+        runtime.createManagedWorktree({
+          repoSelector: TEST_REPO_ID,
+          name: 'child-feature',
+          lineage: { parentWorkspace: `worktree:${parentId}` }
+        })
+      ).rejects.toMatchObject({
+        code: scenario.code,
+        message: expect.stringContaining(scenario.error)
+      })
+      expect(provider.addWorktree).not.toHaveBeenCalled()
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+  })
+
+  it('returns created success without lineage when the parent boundary changes after creation', () => {
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorktreeLineage: () => undefined,
+      setWorktreeLineage,
+      setWorkspaceLineage
+    } as never)
+    const parentId = `${TEST_REPO_ID}::/remote/parent`
+    const childId = `${TEST_REPO_ID}::/remote/child`
+    const parent = {
+      id: parentId,
+      repoId: TEST_REPO_ID,
+      path: '/remote/parent',
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'ssh:ssh-1',
+      instanceId: 'parent-instance'
+    }
+    const child = {
+      id: childId,
+      repoId: TEST_REPO_ID,
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'ssh:ssh-2',
+      instanceId: 'child-instance'
+    }
+
+    const result = runtime['recordCreatedWorktreeLineage'](
+      child as never,
+      {
+        kind: 'lineage',
+        parent: {
+          type: 'worktree',
+          workspaceKey: `worktree:${parentId}`,
+          worktree: parent as never,
+          instanceId: parent.instanceId
+        },
+        origin: 'cli',
+        capture: { source: 'explicit-cli-flag', confidence: 'explicit' }
+      },
+      [parent.path]
+    )
+
+    expect(result).toEqual({
+      lineage: null,
+      workspaceLineage: null,
+      warnings: [
+        expect.objectContaining({
+          code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          details: expect.objectContaining({
+            reason: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+            parentWorktreeId: parentId
+          })
+        })
+      ]
+    })
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it('returns created success without lineage when a parent cycle appears after creation', () => {
+    const parentId = `${TEST_REPO_ID}::/tmp/worktree-parent`
+    const childId = `${TEST_REPO_ID}::/tmp/workspaces/child`
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const lineageById: Record<string, WorktreeLineage> = {
+      [parentId]: {
+        worktreeId: parentId,
+        worktreeInstanceId: 'parent-instance',
+        parentWorktreeId: childId,
+        parentWorktreeInstanceId: 'child-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 1
+      }
+    }
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === parentId ? makeWorktreeMeta({ instanceId: 'parent-instance' }) : undefined,
+      getWorktreeLineage: (worktreeId: string) => lineageById[worktreeId],
+      setWorktreeLineage,
+      setWorkspaceLineage
+    } as never)
+    const parent = {
+      id: parentId,
+      repoId: TEST_REPO_ID,
+      path: '/tmp/worktree-parent',
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'local',
+      instanceId: 'parent-instance'
+    }
+    const child = {
+      id: childId,
+      repoId: TEST_REPO_ID,
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'local',
+      instanceId: 'child-instance'
+    }
+    runtime['resolvedWorktreeCache'] = {
+      worktrees: [parent as never],
+      platformByRepoId: new Map(),
+      expiresAt: Date.now() + 1_000
+    }
+
+    const result = runtime['recordCreatedWorktreeLineage'](
+      child as never,
+      {
+        kind: 'lineage',
+        parent: {
+          type: 'worktree',
+          workspaceKey: `worktree:${parentId}`,
+          worktree: parent as never,
+          instanceId: parent.instanceId
+        },
+        origin: 'cli',
+        capture: { source: 'explicit-cli-flag', confidence: 'explicit' }
+      },
+      [parent.path]
+    )
+
+    expect(result).toEqual({
+      lineage: null,
+      workspaceLineage: null,
+      warnings: [
+        expect.objectContaining({
+          code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          details: expect.objectContaining({
+            reason: 'LINEAGE_PARENT_CYCLE',
+            parentWorktreeId: parentId
+          })
+        })
+      ]
+    })
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it('returns created success without lineage when the parent disappears after creation', () => {
+    const parentPath = '/tmp/worktree-parent'
+    const parentId = `${TEST_REPO_ID}::${parentPath}`
+    const childId = `${TEST_REPO_ID}::/tmp/workspaces/child`
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === parentId ? makeWorktreeMeta({ instanceId: 'parent-instance' }) : undefined,
+      getWorktreeLineage: () => undefined,
+      setWorktreeLineage,
+      setWorkspaceLineage
+    } as never)
+    const parent = {
+      id: parentId,
+      repoId: TEST_REPO_ID,
+      path: parentPath,
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'local',
+      instanceId: 'parent-instance'
+    }
+    const child = {
+      id: childId,
+      repoId: TEST_REPO_ID,
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'local',
+      instanceId: 'child-instance'
+    }
+
+    const result = runtime['recordCreatedWorktreeLineage'](
+      child as never,
+      {
+        kind: 'lineage',
+        parent: {
+          type: 'worktree',
+          workspaceKey: `worktree:${parentId}`,
+          worktree: parent as never,
+          instanceId: parent.instanceId
+        },
+        origin: 'cli',
+        capture: { source: 'explicit-cli-flag', confidence: 'explicit' }
+      },
+      []
+    )
+
+    expect(result).toEqual({
+      lineage: null,
+      workspaceLineage: null,
+      warnings: [
+        expect.objectContaining({
+          code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          details: expect.objectContaining({
+            reason: 'LINEAGE_PARENT_NOT_FOUND',
+            parentWorktreeId: parentId,
+            validationMessage: 'Parent worktree is no longer active.'
+          })
+        })
+      ]
+    })
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      name: 'archived',
+      currentMeta: makeWorktreeMeta({
+        instanceId: 'parent-instance',
+        isArchived: true
+      }),
+      warningCode: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+      reason: 'LINEAGE_PARENT_CONTEXT_CONFLICT'
+    },
+    {
+      name: 'identity-replaced',
+      currentMeta: makeWorktreeMeta({ instanceId: 'replacement-instance' }),
+      warningCode: 'LINEAGE_PARENT_INSTANCE_STALE',
+      reason: 'LINEAGE_PARENT_INSTANCE_STALE'
+    }
+  ])('returns created success without lineage when the parent becomes $name', (scenario) => {
+    const parentId = `${TEST_REPO_ID}::/tmp/worktree-parent`
+    const childId = `${TEST_REPO_ID}::/tmp/workspaces/child`
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === parentId ? scenario.currentMeta : undefined,
+      getWorktreeLineage: () => undefined,
+      setWorktreeLineage,
+      setWorkspaceLineage
+    } as never)
+    const parent = {
+      id: parentId,
+      repoId: TEST_REPO_ID,
+      path: '/tmp/worktree-parent',
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'local',
+      instanceId: 'parent-instance',
+      isArchived: false
+    }
+    const child = {
+      id: childId,
+      repoId: TEST_REPO_ID,
+      projectId: `repo:${TEST_REPO_ID}`,
+      hostId: 'local',
+      instanceId: 'child-instance'
+    }
+
+    const result = runtime['recordCreatedWorktreeLineage'](
+      child as never,
+      {
+        kind: 'lineage',
+        parent: {
+          type: 'worktree',
+          workspaceKey: `worktree:${parentId}`,
+          worktree: parent as never,
+          instanceId: parent.instanceId
+        },
+        origin: 'cli',
+        capture: { source: 'explicit-cli-flag', confidence: 'explicit' }
+      },
+      [parent.path]
+    )
+
+    expect(result).toEqual({
+      lineage: null,
+      workspaceLineage: null,
+      warnings: [
+        expect.objectContaining({
+          code: scenario.warningCode,
+          details: expect.objectContaining({
+            reason: scenario.reason,
+            parentWorktreeId: parentId
+          })
+        })
+      ]
+    })
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(setWorkspaceLineage).not.toHaveBeenCalled()
   })
 
   it('records folder workspace lineage inferred from environment context', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -463,6 +463,10 @@ import {
   isPathInsideOrEqual,
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
+import {
+  resolveSelectedRepositoryAuthority,
+  type SelectedRepositoryAuthority
+} from '../../shared/selected-repository-authority'
 import { findRuntimeWorkspaceFileOwner } from '../../shared/runtime-workspace-file-owner'
 import { resolveTerminalStartupCwd } from '../../shared/terminal-startup-cwd'
 import { isWslUncPath, parseWslUncPath } from '../../shared/wsl-paths'
@@ -2482,6 +2486,7 @@ type TerminalWorkspaceLaunchScope = {
 
 type WorktreeLineageInput = {
   parentWorkspace?: string
+  parentWorkspaceCaptureSource?: 'manual-action'
   envParentWorkspace?: string
   parentWorktree?: string
   cwdParentWorktree?: string
@@ -19109,8 +19114,8 @@ export class OrcaRuntimeService {
     return this.store.getRepo(repo.id) ?? repo
   }
 
-  async showRepo(repoSelector: string): Promise<Repo> {
-    return await this.resolveRepoSelector(repoSelector)
+  async showRepo(repoSelector: string, repoAuthority?: SelectedRepositoryAuthority): Promise<Repo> {
+    return await this.resolveRepoSelector(repoSelector, repoAuthority)
   }
 
   async setRepoBaseRef(repoSelector: string, baseRef: string): Promise<Repo> {
@@ -21450,8 +21455,9 @@ export class OrcaRuntimeService {
   }
 
   private recordCreatedWorktreeLineage(
-    worktree: Pick<Worktree, 'id' | 'instanceId'>,
-    lineageResolution: WorktreeLineageResolution
+    worktree: Worktree,
+    lineageResolution: WorktreeLineageResolution,
+    activeWorktreePaths: readonly string[] | null
   ): {
     lineage: WorktreeLineage | null
     workspaceLineage: WorkspaceLineage | null
@@ -21462,6 +21468,43 @@ export class OrcaRuntimeService {
     let workspaceLineage: WorkspaceLineage | null = null
     if (lineageResolution.kind !== 'lineage') {
       return { lineage, workspaceLineage, warnings }
+    }
+
+    if (
+      lineageResolution.parent.type === 'worktree' &&
+      lineageResolution.capture.confidence === 'explicit'
+    ) {
+      try {
+        this.validateCreatedWorktreeLineageParent(
+          worktree,
+          lineageResolution.parent.worktree,
+          lineageResolution.parent.instanceId,
+          activeWorktreePaths
+        )
+      } catch (error) {
+        if (!(error instanceof RuntimeLineageError)) {
+          throw error
+        }
+        warnings.push({
+          code:
+            error.code === 'LINEAGE_PARENT_INSTANCE_STALE'
+              ? 'LINEAGE_PARENT_INSTANCE_STALE'
+              : error.code === 'LINEAGE_PARENT_CONTEXT_MISSING'
+                ? 'LINEAGE_PARENT_CONTEXT_MISSING'
+                : 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          message:
+            error.code === 'LINEAGE_PARENT_CONTEXT_MISSING'
+              ? 'Worktree created, but Orca could not verify the selected parent after creation. It was left at the root.'
+              : 'Worktree created, but Orca could not record lineage because the selected parent changed during creation.',
+          details: {
+            reason: error.code,
+            parentWorkspaceKey: lineageResolution.parent.workspaceKey,
+            parentWorktreeId: lineageResolution.parent.worktree.id,
+            validationMessage: error.message
+          }
+        })
+        return { lineage, workspaceLineage, warnings }
+      }
     }
 
     const childInstanceId = worktree.instanceId
@@ -21794,6 +21837,7 @@ export class OrcaRuntimeService {
 
   async createManagedWorktree(args: {
     repoSelector: string
+    repoAuthority?: SelectedRepositoryAuthority
     name: string
     baseBranch?: string
     compareBaseRef?: string
@@ -21839,7 +21883,7 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
 
-    const repo = await this.resolveRepoSelector(args.repoSelector)
+    const repo = await this.resolveRepoSelector(args.repoSelector, args.repoAuthority)
     const createSettings = this.store.getSettings()
     const requestedAgent = args.startupAgent ?? args.createdWithAgent
     const requestedAgentEnabled =
@@ -22018,6 +22062,7 @@ export class OrcaRuntimeService {
     const lineageInput =
       args.lineage || args.comment ? { ...args.lineage, comment: args.comment } : undefined
     const lineageResolution = await this.resolveLineageForWorktreeCreate(lineageInput)
+    await this.validateWorktreeCreateLineageAuthority(repo, lineageResolution)
     if (repo.connectionId) {
       const result = await this.createManagedRemoteWorktree(repo, {
         ...args,
@@ -22027,7 +22072,25 @@ export class OrcaRuntimeService {
         ...(effectiveCreatedWithAgent ? { createdWithAgent: effectiveCreatedWithAgent } : {}),
         ...(effectiveDraftPaste ? { startupDraftPaste: effectiveDraftPaste } : {})
       })
-      const recordedLineage = this.recordCreatedWorktreeLineage(result.worktree, lineageResolution)
+      let postCreateScan: RuntimeWorktreeScanResult | undefined
+      if (
+        lineageResolution.kind === 'lineage' &&
+        lineageResolution.parent.type === 'worktree' &&
+        lineageResolution.capture.confidence === 'explicit'
+      ) {
+        postCreateScan = await this.listRepoWorktreesForResolutionUncached(repo, undefined)
+      }
+      const recordedLineage = this.recordCreatedWorktreeLineage(
+        result.worktree,
+        lineageResolution,
+        postCreateScan === undefined
+          ? []
+          : postCreateScan.ok
+            ? postCreateScan.worktrees
+                .filter((worktree) => !worktree.prunable)
+                .map((worktree) => worktree.path)
+            : null
+      )
       this.emitWorktreeLifecycle({
         kind: 'created',
         worktreeId: result.worktree.id,
@@ -22534,11 +22597,32 @@ export class OrcaRuntimeService {
       ...mergeWorktree(repo.id, created, meta),
       hostId: meta.hostId ?? getRepoExecutionHostId(repo)
     }
+    let postCreateLineageScan: RuntimeWorktreeScanResult | undefined
+    if (
+      lineageResolution.kind === 'lineage' &&
+      lineageResolution.parent.type === 'worktree' &&
+      lineageResolution.capture.confidence === 'explicit'
+    ) {
+      postCreateLineageScan = await this.listRepoWorktreesForResolutionUncached(
+        repo,
+        resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
+      )
+    }
     const {
       lineage,
       workspaceLineage,
       warnings: lineageWarnings
-    } = this.recordCreatedWorktreeLineage(worktree, lineageResolution)
+    } = this.recordCreatedWorktreeLineage(
+      worktree,
+      lineageResolution,
+      postCreateLineageScan === undefined
+        ? []
+        : postCreateLineageScan.ok
+          ? postCreateLineageScan.worktrees
+              .filter((candidate) => !candidate.prunable)
+              .map((candidate) => candidate.path)
+          : null
+    )
 
     const symlinkPaths = repo.symlinkPaths ?? []
     if (symlinkPaths.length > 0) {
@@ -28612,7 +28696,7 @@ export class OrcaRuntimeService {
     }
   }
 
-  private validateLineageParent(child: ResolvedWorktree, parent: ResolvedWorktree): void {
+  private validateLineageParent(child: Worktree, parent: Worktree): void {
     const childWorktreeId = child.id
     const parentWorktreeId = parent.id
     if (childWorktreeId === parentWorktreeId) {
@@ -28625,14 +28709,12 @@ export class OrcaRuntimeService {
       )
     }
     const instanceByWorktreeId = new Map(
-      this.resolvedWorktreeCache?.worktrees.map((worktree) => [
-        worktree.id,
-        worktree.instanceId
-      ]) ?? [
-        [child.id, child.instanceId],
-        [parent.id, parent.instanceId]
-      ]
+      this.resolvedWorktreeCache?.worktrees.map(
+        (worktree) => [worktree.id, worktree.instanceId] as const
+      ) ?? []
     )
+    instanceByWorktreeId.set(child.id, child.instanceId)
+    instanceByWorktreeId.set(parent.id, parent.instanceId)
     let cursor: string | undefined = parentWorktreeId
     const visited = new Set<string>([childWorktreeId])
     while (cursor) {
@@ -28656,6 +28738,123 @@ export class OrcaRuntimeService {
         break
       }
       cursor = lineage.parentWorktreeId
+    }
+  }
+
+  private validateCreatedWorktreeLineageParent(
+    child: Worktree,
+    parent: ResolvedWorktree,
+    parentInstanceId: string | null,
+    activeWorktreePaths: readonly string[] | null
+  ): void {
+    const parentMeta = this.store?.getWorktreeMeta(parent.id)
+    const currentParent: Worktree = {
+      ...parent,
+      ...(parentMeta?.projectId !== undefined ? { projectId: parentMeta.projectId } : {}),
+      ...(parentMeta?.hostId !== undefined ? { hostId: parentMeta.hostId } : {}),
+      ...(parentMeta?.instanceId !== undefined ? { instanceId: parentMeta.instanceId } : {}),
+      isArchived: parentMeta?.isArchived ?? parent.isArchived
+    }
+    if (currentParent.isArchived) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_CONTEXT_CONFLICT',
+        'Archived worktrees cannot be used as parents.'
+      )
+    }
+    if (activeWorktreePaths === null) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_CONTEXT_MISSING',
+        'The authoritative worktree scan failed after creation.'
+      )
+    }
+    if (!activeWorktreePaths.some((pathValue) => runtimePathsEqual(pathValue, parent.path))) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_NOT_FOUND',
+        'Parent worktree is no longer active.'
+      )
+    }
+    this.validateLineageParent(child, currentParent)
+    if (parentInstanceId && parentMeta?.instanceId !== parentInstanceId) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_INSTANCE_STALE',
+        'Parent worktree identity changed during creation.'
+      )
+    }
+  }
+
+  private validateWorktreeCreateParentBoundary(repo: Repo, parent: ResolvedWorktree): void {
+    const parentMeta = this.store?.getWorktreeMeta(parent.id)
+    if (parent.isArchived || parentMeta?.isArchived) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_CONTEXT_CONFLICT',
+        'Archived worktrees cannot be used as parents.'
+      )
+    }
+
+    const targetBoundary = getProjectHostSetupWorktreeMeta(
+      this.store?.getProjectHostSetups?.() ?? [],
+      repo
+    )
+    const parentProjectId = parentMeta?.projectId ?? parent.projectId ?? targetBoundary.projectId
+    const parentHostId = parentMeta?.hostId ?? parent.hostId ?? targetBoundary.hostId
+    if (
+      parent.repoId !== repo.id ||
+      parentProjectId !== targetBoundary.projectId ||
+      parentHostId !== targetBoundary.hostId
+    ) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_CONTEXT_CONFLICT',
+        'Parent worktree must belong to the same repository, execution host, and project.'
+      )
+    }
+  }
+
+  private validateExplicitWorktreeCreateParentIdentity(parent: ResolvedWorktree): void {
+    const parentMeta = this.store?.getWorktreeMeta(parent.id)
+    if (!parentMeta) {
+      throw new RuntimeLineageError('LINEAGE_PARENT_NOT_FOUND', 'Parent worktree was not found.')
+    }
+    if (
+      !parent.instanceId ||
+      !parentMeta.instanceId ||
+      parent.instanceId !== parentMeta.instanceId
+    ) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_NOT_FOUND',
+        'Parent worktree identity is stale.'
+      )
+    }
+  }
+
+  private async validateWorktreeCreateLineageAuthority(
+    repo: Repo,
+    lineageResolution: WorktreeLineageResolution
+  ): Promise<void> {
+    if (lineageResolution.kind !== 'lineage' || lineageResolution.parent.type !== 'worktree') {
+      return
+    }
+
+    const parent = lineageResolution.parent.worktree
+    this.validateWorktreeCreateParentBoundary(repo, parent)
+    if (lineageResolution.capture.confidence !== 'explicit') {
+      return
+    }
+
+    this.validateExplicitWorktreeCreateParentIdentity(parent)
+    const projectRuntime = repo.connectionId
+      ? undefined
+      : resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
+    const scan = await this.listRepoWorktreesForResolutionUncached(repo, projectRuntime)
+    const parentIsActive =
+      scan.ok &&
+      scan.worktrees.some(
+        (worktree) => !worktree.prunable && runtimePathsEqual(worktree.path, parent.path)
+      )
+    if (!parentIsActive) {
+      throw new RuntimeLineageError(
+        'LINEAGE_PARENT_NOT_FOUND',
+        'Parent worktree is no longer active.'
+      )
     }
   }
 
@@ -28694,11 +28893,15 @@ export class OrcaRuntimeService {
 
     if (input.parentWorkspace) {
       try {
+        const fromManualAction = input.parentWorkspaceCaptureSource === 'manual-action'
         return {
           kind: 'lineage',
           parent: await this.resolveWorkspaceParentSelector(input.parentWorkspace),
-          origin: 'cli',
-          capture: { source: 'explicit-cli-flag', confidence: 'explicit' }
+          origin: fromManualAction ? 'manual' : 'cli',
+          capture: {
+            source: fromManualAction ? 'manual-action' : 'explicit-cli-flag',
+            confidence: 'explicit'
+          }
         }
       } catch (err) {
         throw new RuntimeLineageError(
@@ -29015,11 +29218,24 @@ export class OrcaRuntimeService {
     )
   }
 
-  private async resolveRepoSelector(selector: string): Promise<Repo> {
+  private async resolveRepoSelector(
+    selector: string,
+    authority?: SelectedRepositoryAuthority
+  ): Promise<Repo> {
     if (!this.store) {
       throw new Error('repo_not_found')
     }
     const candidates = this.selectReposBySelector(selector)
+
+    const authorityResolution = resolveSelectedRepositoryAuthority(candidates, authority)
+    if (authorityResolution.status === 'resolved') {
+      return authorityResolution.candidate
+    }
+    if (authorityResolution.status === 'rejected') {
+      throw new Error(
+        authorityResolution.reason === 'ambiguous' ? 'selector_ambiguous' : 'repo_not_found'
+      )
+    }
 
     if (candidates.length === 1) {
       return candidates[0]

--- a/src/main/runtime/rpc/methods/worktree-create-method.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-method.ts
@@ -1,0 +1,106 @@
+import {
+  finishAutomationWorkspaceProvenanceRequest,
+  releaseAutomationWorkspaceProvenanceRequest,
+  resolveAutomationWorkspaceProvenance
+} from '../../../automations/workspace-provenance'
+import { buildCliWorkspaceProvenance } from '../../../../shared/cli-workspace-provenance'
+import { defineMethod, type RpcMethod } from '../core'
+import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
+import { WorktreeCreate } from './worktree-schemas'
+
+export const WORKTREE_CREATE_METHOD: RpcMethod = defineMethod({
+  name: 'worktree.create',
+  params: WorktreeCreate,
+  handler: async (params, context) =>
+    context.runtime.dedupeWorktreeCreate(
+      params.repoAuthority
+        ? JSON.stringify([
+            params.repo,
+            params.repoAuthority.path,
+            params.repoAuthority.connectionId
+          ])
+        : params.repo,
+      params.clientMutationId,
+      async () => {
+        const { runtime } = context
+        const repo = await runtime.showRepo(params.repo, params.repoAuthority)
+        const automationProvenance = resolveAutomationWorkspaceProvenance({
+          authority: runtime,
+          repoSelector: params.repo,
+          repo,
+          request: params.automationProvenanceRequest
+        })
+        try {
+          const result = await runtime.createManagedWorktree({
+            repoSelector: params.repo,
+            ...(params.repoAuthority ? { repoAuthority: params.repoAuthority } : {}),
+            name: params.name ?? '',
+            baseBranch: params.baseBranch,
+            compareBaseRef: params.compareBaseRef,
+            branchNameOverride: params.branchNameOverride,
+            linkedIssue: params.linkedIssue,
+            linkedPR: params.linkedPR,
+            linkedLinearIssue: params.linkedLinearIssue,
+            linkedLinearIssueWorkspaceId: params.linkedLinearIssueWorkspaceId,
+            linkedLinearIssueOrganizationUrlKey: params.linkedLinearIssueOrganizationUrlKey,
+            linkedGitLabMR: params.linkedGitLabMR,
+            linkedGitLabIssue: params.linkedGitLabIssue,
+            linkedBitbucketPR: params.linkedBitbucketPR,
+            linkedAzureDevOpsPR: params.linkedAzureDevOpsPR,
+            linkedGiteaPR: params.linkedGiteaPR,
+            linkedWorkItem: params.linkedWorkItem,
+            linkedTaskSourceContext: params.linkedTaskSourceContext,
+            comment: params.comment,
+            displayName: params.displayName,
+            telemetrySource: params.telemetrySource,
+            workspaceStatus: params.workspaceStatus,
+            manualOrder: params.manualOrder,
+            sparseCheckout: params.sparseCheckout,
+            pushTarget: params.pushTarget,
+            runHooks: params.runHooks === true,
+            activate: params.activate === true,
+            setupDecision: params.setupDecision,
+            createdWithAgent: params.createdWithAgent ?? params.startupAgent,
+            automationProvenance,
+            cliProvenance: buildCliWorkspaceProvenance(params.cliProvenanceRequest, {
+              startupAgent: params.startupAgent ?? params.createdWithAgent,
+              createdAt: Date.now()
+            }),
+            creatorProvenance: resolveRpcWorkspaceCreatorProvenance(context),
+            startup: params.startupCommand
+              ? {
+                  command: params.startupCommand,
+                  ...(params.startupEnv ? { env: params.startupEnv } : {}),
+                  ...(params.startupLaunchConfig
+                    ? { launchConfig: params.startupLaunchConfig }
+                    : {}),
+                  ...(params.startupCommandDelivery
+                    ? { startupCommandDelivery: params.startupCommandDelivery }
+                    : {})
+                }
+              : undefined,
+            ...(params.startupAgent ? { startupAgent: params.startupAgent } : {}),
+            ...(params.startupPrompt !== undefined ? { startupPrompt: params.startupPrompt } : {}),
+            startupDraft: params.startupDraft,
+            lineage: {
+              parentWorkspace: params.parentWorkspace,
+              parentWorkspaceCaptureSource: params.parentWorkspaceCaptureSource,
+              envParentWorkspace: params.envParentWorkspace,
+              parentWorktree: params.parentWorktree,
+              ...(params.cwdParentWorktree ? { cwdParentWorktree: params.cwdParentWorktree } : {}),
+              noParent: params.noParent === true,
+              callerTerminalHandle: params.callerTerminalHandle,
+              orchestrationContext: params.orchestrationContext
+            }
+          })
+          finishAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
+          return params.startupAgent && result.startupTerminal?.handle
+            ? { ...result, agentTerminalHandle: result.startupTerminal.handle }
+            : result
+        } catch (error) {
+          releaseAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
+          throw error
+        }
+      }
+    )
+})

--- a/src/main/runtime/rpc/methods/worktree-create-parent-provenance.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-parent-provenance.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcRequest } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { WORKTREE_METHODS } from './worktree'
+
+const repo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 1,
+  kind: 'git' as const,
+  executionHostId: 'ssh:ssh-target-1' as const
+}
+
+const makeRequest = (params: unknown): RpcRequest => ({
+  id: 'req-1',
+  authToken: 'tok',
+  method: 'worktree.create',
+  params
+})
+
+describe('worktree create parent provenance', () => {
+  it('routes manual parent-workspace provenance to the runtime server', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      dedupeWorktreeCreate: <T>(
+        _repoSelector: string,
+        _clientMutationId: string | undefined,
+        run: () => Promise<T>
+      ) => run(),
+      showRepo: vi.fn().mockResolvedValue(repo),
+      createManagedWorktree: vi.fn().mockResolvedValue({ worktree: { id: 'wt-1' } })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest({
+        repo: 'repo-1',
+        name: 'feature',
+        parentWorkspace: 'worktree:repo-1::/parent',
+        parentWorkspaceCaptureSource: 'manual-action'
+      })
+    )
+
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lineage: expect.objectContaining({
+          parentWorkspace: 'worktree:repo-1::/parent',
+          parentWorkspaceCaptureSource: 'manual-action'
+        })
+      })
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -103,6 +103,12 @@ export const WorktreeCreate = z
       .unknown()
       .transform((v) => (typeof v === 'string' ? v : ''))
       .pipe(z.string().min(1, 'Missing repo selector')),
+    repoAuthority: z
+      .object({
+        path: z.string().min(1).max(32_768),
+        connectionId: z.string().max(1_024).nullable()
+      })
+      .optional(),
     name: OptionalString,
     baseBranch: OptionalString,
     compareBaseRef: OptionalString,
@@ -146,6 +152,7 @@ export const WorktreeCreate = z
     runHooks: OptionalBoolean,
     activate: OptionalBoolean,
     parentWorkspace: OptionalString,
+    parentWorkspaceCaptureSource: z.literal('manual-action').optional(),
     envParentWorkspace: OptionalString,
     parentWorktree: OptionalString,
     cwdParentWorktree: OptionalString,

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -1,15 +1,7 @@
-import {
-  finishAutomationWorkspaceProvenanceRequest,
-  releaseAutomationWorkspaceProvenanceRequest,
-  resolveAutomationWorkspaceProvenance
-} from '../../../automations/workspace-provenance'
-import { buildCliWorkspaceProvenance } from '../../../../shared/cli-workspace-provenance'
 import { defineMethod, type RpcMethod } from '../core'
 import { resolveWorktreeCatalogSnapshot } from '../worktree-catalog-snapshot'
 import { resolveRuntimeNavigationTarget } from '../../../../shared/runtime-navigation'
-import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
 import {
-  WorktreeCreate,
   WorktreeDetectedListParams,
   WorktreeActivate,
   WorktreeForceDeleteBranch,
@@ -24,6 +16,7 @@ import {
   WorktreeSortOrder,
   WorktreeTeardownMissingTerminalsParams
 } from './worktree-schemas'
+import { WORKTREE_CREATE_METHOD } from './worktree-create-method'
 
 export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
@@ -94,97 +87,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         })
       })
   }),
-  defineMethod({
-    name: 'worktree.create',
-    params: WorktreeCreate,
-    handler: async (params, context) =>
-      // Why: a mobile create interrupted by a connection migration is retried with
-      // the same clientMutationId; dedupe so the host returns the in-flight/created
-      // worktree instead of spawning a duplicate. No key (desktop/CLI) runs plainly.
-      context.runtime.dedupeWorktreeCreate(params.repo, params.clientMutationId, async () => {
-        const { runtime } = context
-        const repo = await runtime.showRepo(params.repo)
-        const automationProvenance = resolveAutomationWorkspaceProvenance({
-          authority: runtime,
-          repoSelector: params.repo,
-          repo,
-          request: params.automationProvenanceRequest
-        })
-        // Why: provenance tokens are reserved before creation so retries can recover,
-        // but failed create attempts must release the reservation for a safe retry.
-        try {
-          const result = await runtime.createManagedWorktree({
-            repoSelector: params.repo,
-            name: params.name ?? '',
-            baseBranch: params.baseBranch,
-            compareBaseRef: params.compareBaseRef,
-            branchNameOverride: params.branchNameOverride,
-            linkedIssue: params.linkedIssue,
-            linkedPR: params.linkedPR,
-            linkedLinearIssue: params.linkedLinearIssue,
-            linkedLinearIssueWorkspaceId: params.linkedLinearIssueWorkspaceId,
-            linkedLinearIssueOrganizationUrlKey: params.linkedLinearIssueOrganizationUrlKey,
-            linkedGitLabMR: params.linkedGitLabMR,
-            linkedGitLabIssue: params.linkedGitLabIssue,
-            linkedBitbucketPR: params.linkedBitbucketPR,
-            linkedAzureDevOpsPR: params.linkedAzureDevOpsPR,
-            linkedGiteaPR: params.linkedGiteaPR,
-            linkedWorkItem: params.linkedWorkItem,
-            linkedTaskSourceContext: params.linkedTaskSourceContext,
-            comment: params.comment,
-            displayName: params.displayName,
-            telemetrySource: params.telemetrySource,
-            workspaceStatus: params.workspaceStatus,
-            manualOrder: params.manualOrder,
-            sparseCheckout: params.sparseCheckout,
-            pushTarget: params.pushTarget,
-            runHooks: params.runHooks === true,
-            activate: params.activate === true,
-            setupDecision: params.setupDecision,
-            createdWithAgent: params.createdWithAgent ?? params.startupAgent,
-            automationProvenance,
-            cliProvenance: buildCliWorkspaceProvenance(params.cliProvenanceRequest, {
-              startupAgent: params.startupAgent ?? params.createdWithAgent,
-              createdAt: Date.now()
-            }),
-            creatorProvenance: resolveRpcWorkspaceCreatorProvenance(context),
-            startup: params.startupCommand
-              ? {
-                  command: params.startupCommand,
-                  ...(params.startupEnv ? { env: params.startupEnv } : {}),
-                  ...(params.startupLaunchConfig
-                    ? { launchConfig: params.startupLaunchConfig }
-                    : {}),
-                  ...(params.startupCommandDelivery
-                    ? { startupCommandDelivery: params.startupCommandDelivery }
-                    : {})
-                }
-              : undefined,
-            ...(params.startupAgent ? { startupAgent: params.startupAgent } : {}),
-            ...(params.startupPrompt !== undefined ? { startupPrompt: params.startupPrompt } : {}),
-            startupDraft: params.startupDraft,
-            lineage: {
-              parentWorkspace: params.parentWorkspace,
-              envParentWorkspace: params.envParentWorkspace,
-              parentWorktree: params.parentWorktree,
-              ...(params.cwdParentWorktree ? { cwdParentWorktree: params.cwdParentWorktree } : {}),
-              noParent: params.noParent === true,
-              callerTerminalHandle: params.callerTerminalHandle,
-              orchestrationContext: params.orchestrationContext
-            }
-          })
-          finishAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
-          // Why: agent callers need a stable dispatch target without traversing
-          // terminal-list layout duplicates after creating the worktree.
-          return params.startupAgent && result.startupTerminal?.handle
-            ? { ...result, agentTerminalHandle: result.startupTerminal.handle }
-            : result
-        } catch (error) {
-          releaseAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
-          throw error
-        }
-      })
-  }),
+  WORKTREE_CREATE_METHOD,
   defineMethod({
     name: 'worktree.prefetchCreateBase',
     params: WorktreePrefetchCreateBase,

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -42,7 +42,8 @@ import type {
   SetupAgentStartupPolicy,
   OrcaHooks,
   SparsePreset,
-  TuiAgent
+  TuiAgent,
+  Worktree
 } from '../../../shared/types'
 import SparseCheckoutPresetSelect from '@/components/sparse/SparseCheckoutPresetSelect'
 import SmartWorkspaceNameField, {
@@ -51,6 +52,7 @@ import SmartWorkspaceNameField, {
 import type { SmartNameMode } from '@/components/new-workspace/smart-workspace-source-results'
 import ProjectCombobox from '@/components/new-workspace/ProjectCombobox'
 import RunTargetCombobox from '@/components/new-workspace/RunTargetCombobox'
+import ChildWorktreeParentField from '@/components/new-workspace/ChildWorktreeParentField'
 import {
   AddRemoteHostDialog,
   type AddRemoteHostMode
@@ -75,6 +77,10 @@ type EphemeralVmRecipeOption = NonNullable<OrcaHooks['environmentRecipes']>[numb
 const EMPTY_PROJECT_OPTIONS: NewWorkspaceProjectOption[] = []
 const EMPTY_PROJECT_HOST_SETUP_OPTIONS: ProjectHostSetupOption[] = []
 const EMPTY_EPHEMERAL_VM_RECIPES: EphemeralVmRecipeOption[] = []
+const EMPTY_PARENT_WORKTREES: Worktree[] = []
+const EMPTY_WORKTREE_VISITS: Record<string, number> = {}
+const NOOP_BOOLEAN_CHANGE = (): void => {}
+const NOOP_PARENT_WORKTREE_CHANGE = (): void => {}
 
 type NewWorkspaceComposerCardProps = {
   contextualTourSource?: string
@@ -124,6 +130,15 @@ type NewWorkspaceComposerCardProps = {
   canReuseSelectedBranch: boolean
   reuseSelectedBranch: boolean
   onReuseSelectedBranchChange: (next: boolean) => void
+  showChildWorktreeParent?: boolean
+  childWorktreeParentSelectionSupported?: boolean
+  parentWorktreeCandidates?: readonly Worktree[]
+  makeChildWorktree?: boolean
+  parentWorktreeId?: string | null
+  activeWorktreeId?: string | null
+  lastVisitedAtByWorktreeId?: Readonly<Record<string, number>>
+  onMakeChildWorktreeChange?: (next: boolean) => void
+  onParentWorktreeIdChange?: (worktreeId: string) => void
   /** Shows the footer "Create more" switch — worktree targets only. */
   showCreateMultiple?: boolean
   createMultiple?: boolean
@@ -337,6 +352,15 @@ export default function NewWorkspaceComposerCard({
   canReuseSelectedBranch,
   reuseSelectedBranch,
   onReuseSelectedBranchChange,
+  showChildWorktreeParent = false,
+  childWorktreeParentSelectionSupported = true,
+  parentWorktreeCandidates = EMPTY_PARENT_WORKTREES,
+  makeChildWorktree = false,
+  parentWorktreeId = null,
+  activeWorktreeId = null,
+  lastVisitedAtByWorktreeId = EMPTY_WORKTREE_VISITS,
+  onMakeChildWorktreeChange = NOOP_BOOLEAN_CHANGE,
+  onParentWorktreeIdChange = NOOP_PARENT_WORKTREE_CHANGE,
   showCreateMultiple = false,
   createMultiple = false,
   onCreateMultipleChange,
@@ -863,6 +887,19 @@ export default function NewWorkspaceComposerCard({
             </div>
           </div>
         </div>
+
+        {showChildWorktreeParent ? (
+          <ChildWorktreeParentField
+            candidates={parentWorktreeCandidates}
+            enabled={makeChildWorktree}
+            selectionSupported={childWorktreeParentSelectionSupported}
+            value={parentWorktreeId}
+            activeWorktreeId={activeWorktreeId}
+            lastVisitedAtByWorktreeId={lastVisitedAtByWorktreeId}
+            onEnabledChange={onMakeChildWorktreeChange}
+            onValueChange={onParentWorktreeIdChange}
+          />
+        ) : null}
 
         <div className="min-w-0 space-y-1" data-contextual-tour-target="workspace-creation-agent">
           <div className="flex items-center justify-between gap-2">

--- a/src/renderer/src/components/new-workspace/ChildWorktreeParentField.test.tsx
+++ b/src/renderer/src/components/new-workspace/ChildWorktreeParentField.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import ChildWorktreeParentField from './ChildWorktreeParentField'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverAnchor: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+function worktree(id: string, displayName: string): Worktree {
+  return {
+    id,
+    repoId: 'repo-1',
+    projectId: 'project-1',
+    hostId: 'local',
+    displayName,
+    path: `/worktrees/${id}`,
+    branch: `refs/heads/${id}`,
+    head: id,
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function renderField(
+  overrides: Partial<React.ComponentProps<typeof ChildWorktreeParentField>> = {}
+): void {
+  const candidates = Array.from({ length: 6 }, (_, index) =>
+    worktree(`wt-${index}`, index === 5 ? 'Payments workspace' : `Worktree ${index}`)
+  )
+  act(() => {
+    root.render(
+      <ChildWorktreeParentField
+        candidates={candidates}
+        enabled
+        selectionSupported
+        value="wt-0"
+        activeWorktreeId="wt-0"
+        lastVisitedAtByWorktreeId={{ 'wt-0': 60, 'wt-1': 50, 'wt-2': 40, 'wt-3': 30 }}
+        onEnabledChange={vi.fn()}
+        onValueChange={vi.fn()}
+        {...overrides}
+      />
+    )
+  })
+}
+
+function combobox(): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>('[role="combobox"]')
+  if (!input) {
+    throw new Error('parent combobox not found')
+  }
+  return input
+}
+
+function typeQuery(value: string): void {
+  const input = combobox()
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+describe('ChildWorktreeParentField', () => {
+  it('renders a checked switch and the selected current parent', () => {
+    renderField()
+
+    const toggle = container.querySelector<HTMLButtonElement>('[role="switch"]')
+    expect(container.textContent).toContain('Make this a child worktree')
+    expect(container.textContent).toContain('Group this worktree under a parent.')
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+    const descriptionId = toggle?.getAttribute('aria-describedby')
+    expect(descriptionId).toBeTruthy()
+    expect(container.querySelector(`#${descriptionId}`)?.textContent).toBe(
+      'Group this worktree under a parent.'
+    )
+    expect(container.textContent).toContain('Worktree 0')
+    expect(container.textContent).toContain('Current')
+  })
+
+  it('shows Recent before All worktrees in a blank-query list', () => {
+    renderField()
+
+    const text = container.textContent ?? ''
+    expect(text.indexOf('Recent')).toBeGreaterThanOrEqual(0)
+    expect(text.indexOf('All worktrees')).toBeGreaterThan(text.indexOf('Recent'))
+  })
+
+  it('exposes the committed parent as selected independently of keyboard focus', () => {
+    renderField({ value: 'wt-5' })
+
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[role="option"]'))
+    const committed = rows.find((row) => row.textContent?.includes('Payments workspace'))
+    const first = rows.find((row) => row.textContent?.includes('Worktree 0'))
+    expect(committed?.getAttribute('aria-selected')).toBe('true')
+    expect(first?.getAttribute('aria-selected')).toBe('false')
+    const input = combobox()
+    const label = container.querySelector<HTMLLabelElement>(`label[for="${input.id}"]`)
+    expect(label?.htmlFor).toBe(input.id)
+    expect(container.querySelector(`#${input.getAttribute('aria-describedby')}`)?.textContent).toBe(
+      'Selected parent: Payments workspace on wt-5'
+    )
+    expect(input.hasAttribute('aria-valuetext')).toBe(false)
+  })
+
+  it('filters the field itself and commits a matching parent', () => {
+    const onValueChange = vi.fn()
+    renderField({ onValueChange })
+
+    typeQuery('payments')
+    expect(container.textContent).toContain('Payments workspace')
+    expect(container.textContent).not.toContain('Worktree 1')
+
+    const row = Array.from(container.querySelectorAll<HTMLElement>('[role="option"]')).find(
+      (candidate) => candidate.textContent?.includes('Payments workspace')
+    )
+    act(() => row?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onValueChange).toHaveBeenCalledWith('wt-5')
+  })
+
+  it('does not commit a parent while an IME owns Enter', () => {
+    const onValueChange = vi.fn()
+    renderField({ onValueChange })
+
+    const input = combobox()
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, isComposing: true })
+      )
+    })
+
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('reports switch changes and hides the picker while off', () => {
+    const onEnabledChange = vi.fn()
+    renderField({ enabled: false, value: null, onEnabledChange })
+
+    expect(container.querySelector('[role="combobox"]')).toBeNull()
+    const toggle = container.querySelector<HTMLButtonElement>('[role="switch"]')
+    act(() => toggle?.click())
+    expect(onEnabledChange).toHaveBeenCalledWith(true)
+  })
+
+  it('disables the switch when this project and host have no eligible parents', () => {
+    renderField({ candidates: [], enabled: false, value: null })
+
+    const toggle = container.querySelector<HTMLButtonElement>('[role="switch"]')
+    expect(toggle?.disabled).toBe(true)
+    expect(container.textContent).toContain(
+      'No eligible parent worktrees on this project and host.'
+    )
+  })
+
+  it('keeps the field visible but disabled when the connected server needs an update', () => {
+    renderField({ enabled: false, selectionSupported: false })
+
+    const toggle = container.querySelector<HTMLButtonElement>('[role="switch"]')
+    expect(toggle?.disabled).toBe(true)
+    expect(container.textContent).toContain(
+      'Update the connected Orca server to choose a child worktree parent.'
+    )
+  })
+})

--- a/src/renderer/src/components/new-workspace/ChildWorktreeParentField.tsx
+++ b/src/renderer/src/components/new-workspace/ChildWorktreeParentField.tsx
@@ -1,0 +1,370 @@
+import React, { useCallback, useMemo } from 'react'
+import { ChevronDown, GitFork } from 'lucide-react'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { Switch } from '@/components/ui/switch'
+import { translate } from '@/i18n/i18n'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
+import { cn } from '@/lib/utils'
+import type { Worktree } from '../../../../shared/types'
+import {
+  rankChildWorktreeParentCandidates,
+  sectionChildWorktreeParentCandidates
+} from './child-worktree-parent-options'
+import { COMBOBOX_FIELD_SHELL, COMBOBOX_POPOVER_SURFACE } from './type-ahead-combobox-styles'
+import { isWithinComboboxRoot, useTypeAheadCombobox } from './use-type-ahead-combobox'
+import { ChildWorktreeParentRow, childWorktreeParentBranchLabel } from './ChildWorktreeParentRow'
+
+type ChildWorktreeParentFieldProps = {
+  candidates: readonly Worktree[]
+  enabled: boolean
+  selectionSupported: boolean
+  value: string | null
+  activeWorktreeId: string | null
+  lastVisitedAtByWorktreeId: Readonly<Record<string, number>>
+  onEnabledChange: (enabled: boolean) => void
+  onValueChange: (worktreeId: string) => void
+}
+
+type ParentWorktreeComboboxProps = Pick<
+  ChildWorktreeParentFieldProps,
+  'activeWorktreeId' | 'candidates' | 'lastVisitedAtByWorktreeId' | 'onValueChange' | 'value'
+> & {
+  inputId: string
+  selectedDescriptionId: string
+}
+
+const ROOT_ATTRIBUTE = 'data-child-worktree-parent-combobox-root'
+
+function ParentWorktreeCombobox({
+  candidates,
+  value,
+  activeWorktreeId,
+  lastVisitedAtByWorktreeId,
+  onValueChange,
+  inputId,
+  selectedDescriptionId
+}: ParentWorktreeComboboxProps): React.JSX.Element {
+  const deriveRowKeys = useCallback(
+    (query: string): string[] =>
+      rankChildWorktreeParentCandidates(candidates, query, lastVisitedAtByWorktreeId).map(
+        (candidate) => candidate.id
+      ),
+    [candidates, lastVisitedAtByWorktreeId]
+  )
+  const {
+    query,
+    setQuery,
+    open,
+    setOpen,
+    close,
+    handleOpenChange,
+    armedKey,
+    arm,
+    moveArm,
+    inputRef,
+    listId,
+    setListNode
+  } = useTypeAheadCombobox(deriveRowKeys)
+  const ranked = useMemo(
+    () => rankChildWorktreeParentCandidates(candidates, query, lastVisitedAtByWorktreeId),
+    [candidates, lastVisitedAtByWorktreeId, query]
+  )
+  const sections = useMemo(
+    () => sectionChildWorktreeParentCandidates(ranked, query),
+    [query, ranked]
+  )
+  const selected = candidates.find((candidate) => candidate.id === value) ?? null
+  const committed = selected !== null && query.length === 0
+
+  const commit = useCallback(
+    (worktreeId: string | null): void => {
+      if (!worktreeId) {
+        return
+      }
+      close()
+      onValueChange(worktreeId)
+    },
+    [close, onValueChange]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void => {
+      if (isImeCompositionKeyDown(event)) {
+        return
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setOpen(true)
+        moveArm(event.key === 'ArrowDown' ? 1 : -1)
+      } else if (event.key === 'Enter' && open) {
+        event.preventDefault()
+        commit(armedKey)
+      } else if (event.key === 'Escape' && (open || query.length > 0)) {
+        event.preventDefault()
+        event.stopPropagation()
+        close()
+      } else if (event.key === 'Backspace' && committed && selected) {
+        event.preventDefault()
+        setQuery(selected.displayName)
+        setOpen(true)
+      }
+    },
+    [armedKey, close, commit, committed, moveArm, open, query, selected, setOpen, setQuery]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverAnchor asChild>
+        <div
+          data-child-worktree-parent-combobox-root="true"
+          onClick={() => {
+            inputRef.current?.focus()
+            setOpen(true)
+          }}
+          className={COMBOBOX_FIELD_SHELL}
+        >
+          <GitFork className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="relative min-w-0 flex-1 overflow-hidden">
+            <input
+              id={inputId}
+              ref={inputRef}
+              type="text"
+              role="combobox"
+              data-child-worktree-parent-combobox-root="true"
+              aria-expanded={open}
+              aria-controls={listId}
+              aria-autocomplete="list"
+              aria-activedescendant={open && armedKey ? `${listId}-armed` : undefined}
+              aria-describedby={committed && selected ? selectedDescriptionId : undefined}
+              value={query}
+              placeholder={
+                committed
+                  ? ''
+                  : translate(
+                      'auto.components.new.workspace.ChildWorktreeParentField.placeholder',
+                      'Choose a parent worktree'
+                    )
+              }
+              onChange={(event) => {
+                setQuery(event.target.value)
+                setOpen(true)
+              }}
+              onFocus={() => setOpen(true)}
+              onKeyDown={handleKeyDown}
+              className={cn(
+                'w-full min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground',
+                committed && 'text-transparent caret-foreground'
+              )}
+            />
+            {committed && selected ? (
+              <>
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-0 flex min-w-0 items-baseline gap-2 text-sm"
+                >
+                  <span className="min-w-0 flex-1 truncate">{selected.displayName}</span>
+                  <span className="max-w-[45%] shrink truncate text-xs text-muted-foreground">
+                    {childWorktreeParentBranchLabel(selected)}
+                  </span>
+                </div>
+                <span id={selectedDescriptionId} className="sr-only">
+                  {translate(
+                    'auto.components.new.workspace.ChildWorktreeParentField.selectedParent',
+                    'Selected parent: {{value0}} on {{value1}}',
+                    {
+                      value0: selected.displayName,
+                      value1: childWorktreeParentBranchLabel(selected)
+                    }
+                  )}
+                </span>
+              </>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label={translate(
+              'auto.components.new.workspace.ChildWorktreeParentField.browse',
+              'Browse parent worktrees'
+            )}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={(event) => {
+              event.stopPropagation()
+              inputRef.current?.focus()
+              setOpen(!open)
+            }}
+            className="-mr-1 flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <ChevronDown className={cn('size-3.5 transition-transform', open && 'rotate-180')} />
+          </button>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className={cn(
+          'flex w-[var(--radix-popover-trigger-width)] min-w-[19rem] flex-col p-0',
+          COMBOBOX_POPOVER_SURFACE
+        )}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        onFocusOutside={(event) => {
+          if (isWithinComboboxRoot(event.target, ROOT_ATTRIBUTE)) {
+            event.preventDefault()
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (isWithinComboboxRoot(event.target, ROOT_ATTRIBUTE)) {
+            event.preventDefault()
+          }
+        }}
+      >
+        <div
+          id={listId}
+          role="listbox"
+          aria-label={translate(
+            'auto.components.new.workspace.ChildWorktreeParentField.listLabel',
+            'Parent worktrees'
+          )}
+          ref={setListNode}
+          className="max-h-72 overflow-y-auto p-1 scrollbar-sleek"
+        >
+          {ranked.length === 0 ? (
+            <p className="flex h-10 items-center justify-center px-2 text-sm text-muted-foreground">
+              {translate(
+                'auto.components.new.workspace.ChildWorktreeParentField.empty',
+                'No worktrees match your search.'
+              )}
+            </p>
+          ) : null}
+          {sections.map((section) => {
+            const heading =
+              section.key === 'recent'
+                ? translate(
+                    'auto.components.new.workspace.ChildWorktreeParentField.recent',
+                    'Recent'
+                  )
+                : section.key === 'all'
+                  ? translate(
+                      'auto.components.new.workspace.ChildWorktreeParentField.all',
+                      'All worktrees'
+                    )
+                  : null
+            return (
+              <div key={section.key} role="group" aria-label={heading ?? undefined}>
+                {heading ? (
+                  <div
+                    aria-hidden="true"
+                    className="px-2 pt-2.5 pb-1 text-[11px] font-semibold tracking-[0.05em] text-muted-foreground uppercase"
+                  >
+                    {heading}
+                  </div>
+                ) : null}
+                {section.items.map((worktree) => (
+                  <ChildWorktreeParentRow
+                    key={worktree.id}
+                    worktree={worktree}
+                    armed={armedKey === worktree.id}
+                    selected={value === worktree.id}
+                    current={activeWorktreeId === worktree.id}
+                    optionId={armedKey === worktree.id ? `${listId}-armed` : undefined}
+                    onArm={() => arm(worktree.id)}
+                    onCommit={() => commit(worktree.id)}
+                  />
+                ))}
+              </div>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default function ChildWorktreeParentField({
+  candidates,
+  enabled,
+  selectionSupported,
+  value,
+  activeWorktreeId,
+  lastVisitedAtByWorktreeId,
+  onEnabledChange,
+  onValueChange
+}: ChildWorktreeParentFieldProps): React.JSX.Element {
+  const switchId = React.useId()
+  const labelId = React.useId()
+  const descriptionId = React.useId()
+  const parentInputId = React.useId()
+  const selectedDescriptionId = React.useId()
+  const unavailable = !selectionSupported || candidates.length === 0
+
+  return (
+    <section className="rounded-lg border border-border bg-muted/20 px-3 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <label id={labelId} htmlFor={switchId} className="block text-xs font-medium">
+            {translate(
+              'auto.components.new.workspace.ChildWorktreeParentField.toggleLabel',
+              'Make this a child worktree'
+            )}
+          </label>
+          <p id={descriptionId} className="text-[11px] text-muted-foreground">
+            {!selectionSupported
+              ? translate(
+                  'auto.components.new.workspace.ChildWorktreeParentField.updateRequired',
+                  'Update the connected Orca server to choose a child worktree parent.'
+                )
+              : unavailable
+                ? translate(
+                    'auto.components.new.workspace.ChildWorktreeParentField.unavailable',
+                    'No eligible parent worktrees on this project and host.'
+                  )
+                : translate(
+                    'auto.components.new.workspace.ChildWorktreeParentField.description',
+                    'Group this worktree under a parent.'
+                  )}
+          </p>
+        </div>
+        <Switch
+          id={switchId}
+          checked={enabled}
+          disabled={unavailable}
+          aria-labelledby={labelId}
+          aria-describedby={descriptionId}
+          onCheckedChange={onEnabledChange}
+        />
+      </div>
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none',
+          enabled ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          {enabled ? (
+            <div className="space-y-1 pt-3">
+              <label
+                htmlFor={parentInputId}
+                className="block text-xs font-medium text-muted-foreground"
+              >
+                {translate(
+                  'auto.components.new.workspace.ChildWorktreeParentField.parentLabel',
+                  'Parent worktree'
+                )}
+              </label>
+              <ParentWorktreeCombobox
+                candidates={candidates}
+                value={value}
+                inputId={parentInputId}
+                selectedDescriptionId={selectedDescriptionId}
+                activeWorktreeId={activeWorktreeId}
+                lastVisitedAtByWorktreeId={lastVisitedAtByWorktreeId}
+                onValueChange={onValueChange}
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/new-workspace/ChildWorktreeParentRow.tsx
+++ b/src/renderer/src/components/new-workspace/ChildWorktreeParentRow.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { Check, GitBranch, GitFork } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import type { Worktree } from '../../../../shared/types'
+
+export function childWorktreeParentBranchLabel(worktree: Worktree): string {
+  return worktree.branch.replace(/^refs\/heads\//, '') || 'Detached HEAD'
+}
+
+export function ChildWorktreeParentRow({
+  worktree,
+  armed,
+  selected,
+  current,
+  optionId,
+  onArm,
+  onCommit
+}: {
+  worktree: Worktree
+  armed: boolean
+  selected: boolean
+  current: boolean
+  optionId: string | undefined
+  onArm: () => void
+  onCommit: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      role="option"
+      id={optionId}
+      aria-selected={selected}
+      data-armed={armed || undefined}
+      data-current={current ? 'true' : undefined}
+      onMouseDown={(event) => event.preventDefault()}
+      onMouseMove={onArm}
+      onClick={onCommit}
+      className={cn(
+        'flex min-h-12 cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
+        armed &&
+          'bg-[color-mix(in_srgb,var(--foreground)_12%,var(--popover))] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--foreground)_18%,transparent)]',
+        selected && !armed && 'bg-accent/60'
+      )}
+    >
+      <GitFork className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className={cn('truncate text-[13px]', selected && 'font-medium')}>
+            {worktree.displayName}
+          </span>
+          {current ? (
+            <span className="shrink-0 rounded border border-border bg-muted px-1.5 py-px text-[9px] font-medium leading-none text-muted-foreground">
+              {translate(
+                'auto.components.new.workspace.ChildWorktreeParentField.current',
+                'Current'
+              )}
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground">
+          <GitBranch className="size-3 shrink-0" aria-hidden="true" />
+          <span className="max-w-[45%] shrink-0 truncate">
+            {childWorktreeParentBranchLabel(worktree)}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span className="min-w-0 truncate font-mono" title={worktree.path}>
+            {worktree.path}
+          </span>
+        </div>
+      </div>
+      <Check
+        className={cn('size-3.5 shrink-0', selected ? 'opacity-100' : 'opacity-0')}
+        aria-hidden="true"
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/new-workspace/child-worktree-parent-options.test.ts
+++ b/src/renderer/src/components/new-workspace/child-worktree-parent-options.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import { WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import {
+  getChildWorktreeParentCandidates,
+  getDefaultChildWorktreeParentId,
+  rankChildWorktreeParentCandidates,
+  resolveChildWorktreeCreateParentId,
+  resolvePreferredChildWorktreeParentId,
+  sectionChildWorktreeParentCandidates,
+  shouldShowChildWorktreeParentField,
+  supportsChildWorktreeParentSelection
+} from './child-worktree-parent-options'
+
+function worktree(
+  id: string,
+  overrides: Partial<Worktree> & Pick<Worktree, 'displayName'>
+): Worktree {
+  const { displayName, ...rest } = overrides
+  return {
+    id,
+    repoId: 'repo-1',
+    projectId: 'project-1',
+    hostId: 'local',
+    displayName,
+    path: `/worktrees/${id}`,
+    branch: `refs/heads/${id}`,
+    head: id,
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...rest
+  }
+}
+
+describe('getChildWorktreeParentCandidates', () => {
+  it('keeps only eligible worktrees on the selected project and execution host', () => {
+    const current = worktree('current', { displayName: 'Current' })
+    const legacy = worktree('legacy', { displayName: 'Legacy', projectId: undefined })
+    const candidates = getChildWorktreeParentCandidates({
+      worktrees: [
+        current,
+        legacy,
+        worktree('other-project', { displayName: 'Other project', projectId: 'project-2' }),
+        worktree('other-host', { displayName: 'Other host', hostId: 'ssh:server' }),
+        worktree('archived', { displayName: 'Archived', isArchived: true }),
+        worktree('other-repo', { displayName: 'Other repo', repoId: 'repo-2' })
+      ],
+      repoId: 'repo-1',
+      projectId: 'project-1',
+      executionHostId: 'local',
+      repo: { connectionId: null, executionHostId: 'local' }
+    })
+
+    expect(candidates.map(({ id }) => id)).toEqual(['current', 'legacy'])
+  })
+
+  it('matches nested SSH worktrees through their paired runtime owner', () => {
+    const nested = worktree('nested', {
+      displayName: 'Nested',
+      hostId: 'ssh:private-target',
+      runtimeOwnerEnvironmentId: 'hub-1'
+    })
+    const foreign = worktree('foreign', {
+      displayName: 'Foreign',
+      hostId: 'ssh:private-target',
+      runtimeOwnerEnvironmentId: 'hub-2'
+    })
+
+    const candidates = getChildWorktreeParentCandidates({
+      worktrees: [nested, foreign],
+      repoId: 'repo-1',
+      projectId: 'project-1',
+      executionHostId: 'runtime:hub-1',
+      repo: { connectionId: 'private-target', executionHostId: 'runtime:hub-1' }
+    })
+
+    expect(candidates).toEqual([nested])
+  })
+
+  it('separates physical SSH targets transported through the same paired runtime', () => {
+    const selectedTarget = worktree('selected-target', {
+      displayName: 'Selected target',
+      hostId: 'ssh:private-target',
+      runtimeOwnerEnvironmentId: 'hub-1'
+    })
+    const siblingTarget = worktree('sibling-target', {
+      displayName: 'Sibling target',
+      hostId: 'ssh:other-target',
+      runtimeOwnerEnvironmentId: 'hub-1'
+    })
+
+    const candidates = getChildWorktreeParentCandidates({
+      worktrees: [selectedTarget, siblingTarget],
+      repoId: 'repo-1',
+      projectId: 'project-1',
+      executionHostId: 'runtime:hub-1',
+      repo: { connectionId: 'private-target', executionHostId: 'runtime:hub-1' }
+    })
+
+    expect(candidates).toEqual([selectedTarget])
+  })
+
+  it('does not leak paired-runtime worktrees into their physical client host', () => {
+    const nested = worktree('nested', {
+      displayName: 'Nested',
+      hostId: 'ssh:private-target',
+      runtimeOwnerEnvironmentId: 'hub-1'
+    })
+
+    expect(
+      getChildWorktreeParentCandidates({
+        worktrees: [nested],
+        repoId: 'repo-1',
+        projectId: 'project-1',
+        executionHostId: 'ssh:private-target',
+        repo: { connectionId: 'private-target', executionHostId: 'ssh:private-target' }
+      })
+    ).toEqual([])
+  })
+})
+
+describe('shouldShowChildWorktreeParentField', () => {
+  it('shows only for Git worktree targets', () => {
+    expect(shouldShowChildWorktreeParentField(false, true, false)).toBe(true)
+    expect(shouldShowChildWorktreeParentField(false, false, false)).toBe(false)
+    expect(shouldShowChildWorktreeParentField(true, true, false)).toBe(false)
+    expect(shouldShowChildWorktreeParentField(false, true, true)).toBe(false)
+  })
+})
+
+describe('supportsChildWorktreeParentSelection', () => {
+  it('allows local and direct SSH hosts without a runtime capability', () => {
+    expect(supportsChildWorktreeParentSelection('local', undefined)).toBe(true)
+    expect(supportsChildWorktreeParentSelection('ssh:server', undefined)).toBe(true)
+  })
+
+  it('fails closed for paired runtimes until the parent authority is advertised', () => {
+    expect(supportsChildWorktreeParentSelection('runtime:hub', undefined)).toBe(false)
+    expect(supportsChildWorktreeParentSelection('runtime:hub', [])).toBe(false)
+    expect(
+      supportsChildWorktreeParentSelection('runtime:hub', [
+        WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY
+      ])
+    ).toBe(true)
+  })
+})
+
+describe('rankChildWorktreeParentCandidates', () => {
+  it('orders visited worktrees first, then falls back to activity and name', () => {
+    const oldestVisited = worktree('visited-old', {
+      displayName: 'Visited old',
+      lastActivityAt: 10_000
+    })
+    const newestVisited = worktree('visited-new', {
+      displayName: 'Visited new',
+      lastActivityAt: 1
+    })
+    const active = worktree('active', { displayName: 'Active', lastActivityAt: 500 })
+    const inactive = worktree('inactive', { displayName: 'Inactive', lastActivityAt: 100 })
+
+    const ranked = rankChildWorktreeParentCandidates(
+      [inactive, oldestVisited, active, newestVisited],
+      '',
+      { 'visited-old': 20, 'visited-new': 40 }
+    )
+
+    expect(ranked.map(({ id }) => id)).toEqual(['visited-new', 'visited-old', 'active', 'inactive'])
+  })
+
+  it('searches worktree names, branches, and paths', () => {
+    const branchMatch = worktree('branch', {
+      displayName: 'Checkout',
+      branch: 'refs/heads/feature/payments'
+    })
+    const pathMatch = worktree('path', {
+      displayName: 'API',
+      path: '/worktrees/customer-portal'
+    })
+
+    expect(
+      rankChildWorktreeParentCandidates([branchMatch, pathMatch], 'payments', {}).map(
+        ({ id }) => id
+      )
+    ).toEqual(['branch'])
+    expect(
+      rankChildWorktreeParentCandidates([branchMatch, pathMatch], 'customer', {}).map(
+        ({ id }) => id
+      )
+    ).toEqual(['path'])
+  })
+})
+
+describe('sectionChildWorktreeParentCandidates', () => {
+  it('puts the first four blank-query options in Recent', () => {
+    const ranked = Array.from({ length: 6 }, (_, index) =>
+      worktree(`wt-${index}`, { displayName: `Worktree ${index}` })
+    )
+    const sections = sectionChildWorktreeParentCandidates(ranked, '')
+
+    expect(sections.map(({ key }) => key)).toEqual(['recent', 'all'])
+    expect(sections[0]?.items.map(({ id }) => id)).toEqual(['wt-0', 'wt-1', 'wt-2', 'wt-3'])
+    expect(sections[1]?.items.map(({ id }) => id)).toEqual(['wt-4', 'wt-5'])
+  })
+
+  it('uses one unsectioned result list while searching', () => {
+    const candidate = worktree('wt-1', { displayName: 'Worktree' })
+    expect(sectionChildWorktreeParentCandidates([candidate], 'work').map(({ key }) => key)).toEqual(
+      ['results']
+    )
+  })
+})
+
+describe('child worktree parent defaults', () => {
+  const recent = worktree('recent', { displayName: 'Recent' })
+  const active = worktree('active', { displayName: 'Active' })
+
+  it('defaults only when the active worktree is eligible', () => {
+    const repo = { connectionId: null, executionHostId: 'local' as const }
+    expect(getDefaultChildWorktreeParentId([recent, active], 'active', 'local', repo)).toBe(
+      'active'
+    )
+    expect(getDefaultChildWorktreeParentId([recent, active], 'elsewhere', 'local', repo)).toBeNull()
+    expect(getDefaultChildWorktreeParentId([recent, active], 'active', null, repo)).toBeNull()
+  })
+
+  it('uses physical and paired-runtime ownership to disambiguate an active id', () => {
+    const nested = worktree('active', {
+      displayName: 'Nested active',
+      hostId: 'ssh:private-target',
+      runtimeOwnerEnvironmentId: 'hub-1'
+    })
+    const repo = { connectionId: null, executionHostId: 'runtime:hub-1' as const }
+
+    expect(getDefaultChildWorktreeParentId([nested], 'active', 'ssh:private-target', repo)).toBe(
+      'active'
+    )
+    expect(getDefaultChildWorktreeParentId([nested], 'active', 'runtime:hub-1', repo)).toBe(
+      'active'
+    )
+    expect(
+      getDefaultChildWorktreeParentId([nested], 'active', 'ssh:different-target', repo)
+    ).toBeNull()
+  })
+
+  it('preserves a valid choice and repairs an invalid choice to active or recent', () => {
+    expect(resolvePreferredChildWorktreeParentId('recent', [recent, active], 'active')).toBe(
+      'recent'
+    )
+    expect(resolvePreferredChildWorktreeParentId('gone', [recent, active], 'active')).toBe('active')
+    expect(resolvePreferredChildWorktreeParentId('gone', [recent], null)).toBe('recent')
+    expect(resolvePreferredChildWorktreeParentId('gone', [], null)).toBeNull()
+  })
+
+  it('preserves legacy inference until the child setting is explicitly changed', () => {
+    expect(resolveChildWorktreeCreateParentId(false, false, null)).toBeUndefined()
+    expect(resolveChildWorktreeCreateParentId(true, false, null)).toBeNull()
+    expect(resolveChildWorktreeCreateParentId(true, true, 'parent')).toBe('parent')
+  })
+})

--- a/src/renderer/src/components/new-workspace/child-worktree-parent-options.ts
+++ b/src/renderer/src/components/new-workspace/child-worktree-parent-options.ts
@@ -1,0 +1,210 @@
+import { defaultFilter } from 'cmdk'
+import {
+  getWorktreeExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  toRuntimeExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import { WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import type { Repo, Worktree } from '../../../../shared/types'
+
+type ChildWorktreeParentCandidateArgs = {
+  worktrees: readonly Worktree[]
+  repoId: string
+  projectId: string | null
+  executionHostId: ExecutionHostId
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+}
+
+export type ChildWorktreeParentSection = {
+  key: 'recent' | 'all' | 'results'
+  items: Worktree[]
+}
+
+const RECENT_LIMIT = 4
+const MAX_QUERY_LENGTH = 2_048
+
+export function shouldShowChildWorktreeParentField(
+  isProjectGroupTarget: boolean,
+  selectedRepoIsGit: boolean,
+  hasEphemeralVmTarget: boolean
+): boolean {
+  return !isProjectGroupTarget && selectedRepoIsGit && !hasEphemeralVmTarget
+}
+
+export function supportsChildWorktreeParentSelection(
+  executionHostId: ExecutionHostId | null,
+  runtimeCapabilities: readonly string[] | null | undefined
+): boolean {
+  const host = parseExecutionHostId(executionHostId)
+  return (
+    host?.kind !== 'runtime' ||
+    runtimeCapabilities?.includes(WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY) === true
+  )
+}
+
+function getCandidateRuntimeHostId(candidate: Worktree): ExecutionHostId | null {
+  const environmentId = candidate.runtimeOwnerEnvironmentId?.trim()
+  return environmentId ? toRuntimeExecutionHostId(environmentId) : null
+}
+
+function candidateBelongsToTargetHost(
+  candidate: Worktree,
+  executionHostId: ExecutionHostId,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): boolean {
+  const runtimeHostId = getCandidateRuntimeHostId(candidate)
+  if (parseExecutionHostId(executionHostId)?.kind === 'runtime') {
+    const connectionId = repo.connectionId?.trim()
+    const physicalHostId = connectionId
+      ? toSshExecutionHostId(connectionId)
+      : LOCAL_EXECUTION_HOST_ID
+    return (
+      runtimeHostId === executionHostId &&
+      getWorktreeExecutionHostId(candidate, undefined) === physicalHostId
+    )
+  }
+  return runtimeHostId === null && getWorktreeExecutionHostId(candidate, repo) === executionHostId
+}
+
+function candidateMatchesActiveHost(
+  candidate: Worktree,
+  activeExecutionHostId: ExecutionHostId,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): boolean {
+  return (
+    getWorktreeExecutionHostId(candidate, repo) === activeExecutionHostId ||
+    getCandidateRuntimeHostId(candidate) === activeExecutionHostId
+  )
+}
+
+export function getChildWorktreeParentCandidates({
+  worktrees,
+  repoId,
+  projectId,
+  executionHostId,
+  repo
+}: ChildWorktreeParentCandidateArgs): Worktree[] {
+  return worktrees.filter(
+    (candidate) =>
+      candidate.repoId === repoId &&
+      !candidate.isArchived &&
+      candidateBelongsToTargetHost(candidate, executionHostId, repo) &&
+      (projectId === null || candidate.projectId === undefined || candidate.projectId === projectId)
+  )
+}
+
+function compareParentRecency(
+  a: Worktree,
+  b: Worktree,
+  lastVisitedAtByWorktreeId: Readonly<Record<string, number>>
+): number {
+  const aVisited = lastVisitedAtByWorktreeId[a.id]
+  const bVisited = lastVisitedAtByWorktreeId[b.id]
+  if (aVisited !== undefined && bVisited !== undefined && aVisited !== bVisited) {
+    return bVisited - aVisited
+  }
+  if (aVisited !== undefined) {
+    return -1
+  }
+  if (bVisited !== undefined) {
+    return 1
+  }
+  return (
+    b.lastActivityAt - a.lastActivityAt ||
+    (a.displayName ?? '').localeCompare(b.displayName ?? '') ||
+    a.path.localeCompare(b.path)
+  )
+}
+
+function searchableParentText(candidate: Worktree): string {
+  return `${candidate.displayName ?? ''} ${candidate.branch.replace(/^refs\/heads\//, '')} ${candidate.path}`
+}
+
+export function rankChildWorktreeParentCandidates(
+  candidates: readonly Worktree[],
+  rawQuery: string,
+  lastVisitedAtByWorktreeId: Readonly<Record<string, number>>
+): Worktree[] {
+  if (rawQuery.length > MAX_QUERY_LENGTH) {
+    return []
+  }
+  const query = rawQuery.trim()
+  if (!query) {
+    return [...candidates].sort((a, b) => compareParentRecency(a, b, lastVisitedAtByWorktreeId))
+  }
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      score: defaultFilter(searchableParentText(candidate), query, [])
+    }))
+    .filter(({ score }) => score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        compareParentRecency(a.candidate, b.candidate, lastVisitedAtByWorktreeId)
+    )
+    .map(({ candidate }) => candidate)
+}
+
+export function sectionChildWorktreeParentCandidates(
+  ranked: readonly Worktree[],
+  query: string
+): ChildWorktreeParentSection[] {
+  if (query.trim()) {
+    return [{ key: 'results', items: [...ranked] }]
+  }
+  const recent = ranked.slice(0, RECENT_LIMIT)
+  const remaining = ranked.slice(RECENT_LIMIT)
+  return [
+    ...(recent.length > 0 ? [{ key: 'recent' as const, items: recent }] : []),
+    ...(remaining.length > 0 ? [{ key: 'all' as const, items: remaining }] : [])
+  ]
+}
+
+export function resolvePreferredChildWorktreeParentId(
+  currentId: string | null,
+  orderedCandidates: readonly Worktree[],
+  activeWorktreeId: string | null
+): string | null {
+  if (currentId && orderedCandidates.some((candidate) => candidate.id === currentId)) {
+    return currentId
+  }
+  if (
+    activeWorktreeId &&
+    orderedCandidates.some((candidate) => candidate.id === activeWorktreeId)
+  ) {
+    return activeWorktreeId
+  }
+  return orderedCandidates[0]?.id ?? null
+}
+
+export function getDefaultChildWorktreeParentId(
+  candidates: readonly Worktree[],
+  activeWorktreeId: string | null,
+  activeExecutionHostId: ExecutionHostId | null,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): string | null {
+  return activeWorktreeId &&
+    activeExecutionHostId &&
+    candidates.some(
+      (candidate) =>
+        candidate.id === activeWorktreeId &&
+        candidateMatchesActiveHost(candidate, activeExecutionHostId, repo)
+    )
+    ? activeWorktreeId
+    : null
+}
+
+export function resolveChildWorktreeCreateParentId(
+  touched: boolean,
+  enabled: boolean,
+  selectedParentId: string | null
+): string | null | undefined {
+  if (enabled && selectedParentId) {
+    return selectedParentId
+  }
+  return touched ? null : undefined
+}

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -54,6 +54,7 @@ import type {
   SetupRunPolicy,
   SparsePreset,
   TuiAgent,
+  Worktree,
   WorktreeMeta,
   WorkspaceStatus,
   WorkspaceCreateTelemetrySource,
@@ -212,6 +213,15 @@ import { isWorkspaceLinkedItemSourceContextMatch } from '../../../shared/workspa
 import { resolveJiraSourceHostId } from '@/lib/jira-source-host'
 import { buildTrustedComposerIssueCommand } from '@/lib/composer-issue-command'
 import { settleComposerSubmit } from '@/lib/composer-submit-cancellation'
+import {
+  getChildWorktreeParentCandidates,
+  getDefaultChildWorktreeParentId,
+  rankChildWorktreeParentCandidates,
+  resolveChildWorktreeCreateParentId,
+  resolvePreferredChildWorktreeParentId,
+  shouldShowChildWorktreeParentField,
+  supportsChildWorktreeParentSelection
+} from '@/components/new-workspace/child-worktree-parent-options'
 
 const NEVER_CANCEL_COMPOSER_SUBMIT = (): boolean => false
 
@@ -313,6 +323,15 @@ export type ComposerCardProps = {
   /** Whether the selected existing local branch is reused (checked out) rather than branched from. */
   reuseSelectedBranch: boolean
   onReuseSelectedBranchChange: (next: boolean) => void
+  showChildWorktreeParent: boolean
+  childWorktreeParentSelectionSupported: boolean
+  parentWorktreeCandidates: readonly Worktree[]
+  makeChildWorktree: boolean
+  parentWorktreeId: string | null
+  activeWorktreeId: string | null
+  lastVisitedAtByWorktreeId: Readonly<Record<string, number>>
+  onMakeChildWorktreeChange: (next: boolean) => void
+  onParentWorktreeIdChange: (worktreeId: string) => void
   /** Whether the "create multiple" toggle shows — worktree (git) targets only; folder workspaces create-and-close. */
   showCreateMultiple: boolean
   /** When on, the modal stays open after each create and resets identity fields to allow creating several in a row. */
@@ -659,6 +678,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const settings = useAppStore((s) => s.settings)
   const newWorkspaceDraft = useAppStore((s) => s.newWorkspaceDraft)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeWorkspaceExecutionHostId = useAppStore((s) => s.activeWorkspaceExecutionHostId)
+  const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
   const sparsePresetsByRepo = useAppStore((s) => s.sparsePresetsByRepo)
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
@@ -947,6 +969,114 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     projectGroupTarget: isProjectGroupTarget,
     initialRecipeId: initialEphemeralVmRecipeId
   })
+  const showChildWorktreeParent = shouldShowChildWorktreeParentField(
+    isProjectGroupTarget,
+    selectedRepoIsGit,
+    selectedEphemeralVmRecipeId !== null
+  )
+  const selectedRepoHost = parseExecutionHostId(selectedRepoExecutionHostId)
+  const selectedRuntimeCapabilities =
+    selectedRepoHost?.kind === 'runtime'
+      ? runtimeStatusByEnvironmentId.get(selectedRepoHost.environmentId)?.status?.capabilities
+      : undefined
+  const childWorktreeParentSelectionSupported = supportsChildWorktreeParentSelection(
+    selectedRepoExecutionHostId,
+    selectedRuntimeCapabilities
+  )
+  const parentWorktreeCandidates = useMemo(() => {
+    if (!showChildWorktreeParent || !selectedRepo || !selectedRepoExecutionHostId) {
+      return []
+    }
+    const eligible = getChildWorktreeParentCandidates({
+      worktrees: worktreesByRepo[repoId] ?? [],
+      repoId,
+      projectId: selectedRepoProjectId,
+      executionHostId: selectedRepoExecutionHostId,
+      repo: selectedRepo
+    })
+    return rankChildWorktreeParentCandidates(eligible, '', lastVisitedAtByWorktreeId)
+  }, [
+    lastVisitedAtByWorktreeId,
+    repoId,
+    selectedRepo,
+    selectedRepoExecutionHostId,
+    selectedRepoProjectId,
+    showChildWorktreeParent,
+    worktreesByRepo
+  ])
+  const activeParentWorktreeId = selectedRepo
+    ? getDefaultChildWorktreeParentId(
+        parentWorktreeCandidates,
+        activeWorktreeId,
+        activeWorkspaceExecutionHostId,
+        selectedRepo
+      )
+    : null
+  const initialParentWorktreeId = childWorktreeParentSelectionSupported
+    ? activeParentWorktreeId
+    : null
+  const [wantsChildWorktree, setWantsChildWorktree] = useState(initialParentWorktreeId !== null)
+  const [preferredParentWorktreeId, setPreferredParentWorktreeId] = useState<string | null>(
+    initialParentWorktreeId ?? parentWorktreeCandidates[0]?.id ?? null
+  )
+  const [childWorktreeParentTouched, setChildWorktreeParentTouched] = useState(false)
+
+  useEffect(() => {
+    const defaultId = activeParentWorktreeId
+    if (!childWorktreeParentTouched) {
+      setWantsChildWorktree(defaultId !== null)
+      setPreferredParentWorktreeId(defaultId ?? parentWorktreeCandidates[0]?.id ?? null)
+      return
+    }
+    setPreferredParentWorktreeId((currentId) =>
+      resolvePreferredChildWorktreeParentId(
+        currentId,
+        parentWorktreeCandidates,
+        activeParentWorktreeId
+      )
+    )
+  }, [activeParentWorktreeId, childWorktreeParentTouched, parentWorktreeCandidates])
+
+  const handleMakeChildWorktreeChange = useCallback(
+    (next: boolean): void => {
+      setChildWorktreeParentTouched(true)
+      setWantsChildWorktree(next)
+      if (next) {
+        setPreferredParentWorktreeId((currentId) =>
+          resolvePreferredChildWorktreeParentId(
+            currentId,
+            parentWorktreeCandidates,
+            activeParentWorktreeId
+          )
+        )
+      }
+    },
+    [activeParentWorktreeId, parentWorktreeCandidates]
+  )
+  const handleParentWorktreeIdChange = useCallback((worktreeId: string): void => {
+    setChildWorktreeParentTouched(true)
+    setPreferredParentWorktreeId(worktreeId)
+    setWantsChildWorktree(true)
+  }, [])
+  const reconciledParentWorktreeId = resolvePreferredChildWorktreeParentId(
+    preferredParentWorktreeId,
+    parentWorktreeCandidates,
+    activeParentWorktreeId
+  )
+  const effectiveWantsChildWorktree = childWorktreeParentTouched
+    ? wantsChildWorktree
+    : initialParentWorktreeId !== null
+  const makeChildWorktree =
+    showChildWorktreeParent &&
+    childWorktreeParentSelectionSupported &&
+    effectiveWantsChildWorktree &&
+    reconciledParentWorktreeId !== null
+  const parentWorktreeId = makeChildWorktree ? reconciledParentWorktreeId : null
+  const creationParentWorktreeId = resolveChildWorktreeCreateParentId(
+    childWorktreeParentTouched,
+    makeChildWorktree,
+    parentWorktreeId
+  )
   const selectedRepoConnectionId = selectedRepo?.connectionId ?? null
   const selectedRepoSshState = selectedRepoConnectionId
     ? (sshConnectionStates.get(selectedRepoConnectionId) ?? null)
@@ -3883,6 +4013,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         undefined,
         submitCompareBaseRef,
         {
+          ...(selectedRepo
+            ? {
+                repoAuthority: {
+                  path: selectedRepo.path,
+                  connectionId: selectedRepo.connectionId ?? null
+                },
+                repoExecutionHostId: selectedRepoExecutionHostId ?? undefined
+              }
+            : {}),
+          parentWorktreeId: creationParentWorktreeId,
           linkedWorkItem: toFolderWorkspaceLinkedTask(submitLinkedWorkItem),
           linkedTaskSourceContext: taskSourceContext,
           ...(!backendStartup && startupPlan?.draftPrompt
@@ -3994,6 +4134,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     normalizedSparseDirectories,
     note,
     onCreated,
+    creationParentWorktreeId,
     parsedLinkedIssueNumber,
     persistSetupAgentStartupPolicy,
     persistDraft,
@@ -4486,6 +4627,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
         const request: WorktreeCreationRequest = {
           repoId,
+          ...(selectedRepo
+            ? {
+                repoAuthority: {
+                  path: selectedRepo.path,
+                  connectionId: selectedRepo.connectionId ?? null
+                },
+                repoExecutionHostId: selectedRepoExecutionHostId ?? undefined
+              }
+            : {}),
+          parentWorktreeId: creationParentWorktreeId,
           ...(ephemeralVmRecipe ? { ephemeralVmRecipe } : {}),
           worktreeCreateProgressMode:
             activeEphemeralVmRecipeId ||
@@ -4587,6 +4738,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       normalizedSparseDirectories,
       note,
       onCreated,
+      creationParentWorktreeId,
       parsedLinkedIssueNumber,
       persistSetupAgentStartupPolicy,
       persistDraft,
@@ -4696,6 +4848,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       smartNameSelection?.kind === 'branch',
     reuseSelectedBranch,
     onReuseSelectedBranchChange: handleReuseSelectedBranchChange,
+    showChildWorktreeParent,
+    childWorktreeParentSelectionSupported,
+    parentWorktreeCandidates,
+    makeChildWorktree,
+    parentWorktreeId,
+    activeWorktreeId: activeParentWorktreeId,
+    lastVisitedAtByWorktreeId,
+    onMakeChildWorktreeChange: handleMakeChildWorktreeChange,
+    onParentWorktreeIdChange: handleParentWorktreeIdChange,
     // Why: "create multiple" applies only to worktree (git) targets; folder-workspace keeps create-and-close.
     showCreateMultiple: !isProjectGroupTarget,
     createMultiple,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -308,6 +308,7 @@
           "localBaseRefRefreshFailedDetailDirty": "The worktree where local {{value0}} is checked out has uncommitted changes. Commit, stash, or discard those changes, then update local {{value0}} manually.",
           "localBaseRefRefreshFailedDetailNotFastForward": "Local {{value0}} does not exist or cannot be fast-forwarded cleanly from the remote base. Check for local-only commits before updating it manually.",
           "localBaseRefRefreshFailedDetailError": "Git returned an error while updating local {{value0}}. Check the repo for locked refs or unusual worktree state, then update local {{value0}} manually.",
+          "worktreeCreatedWithWarning": "Worktree created with a warning",
           "0216895fb5": "Failed to delete branch",
           "c6cf133786": "This workspace is no longer available.",
           "19db0085fb": "Local branch deleted",
@@ -12391,6 +12392,21 @@
             "browse": "Browse projects",
             "listLabel": "Projects",
             "noProjects": "No projects yet."
+          },
+          "ChildWorktreeParentField": {
+            "all": "All worktrees",
+            "browse": "Browse parent worktrees",
+            "current": "Current",
+            "description": "Group this worktree under a parent.",
+            "empty": "No worktrees match your search.",
+            "listLabel": "Parent worktrees",
+            "parentLabel": "Parent worktree",
+            "placeholder": "Choose a parent worktree",
+            "recent": "Recent",
+            "selectedParent": "Selected parent: {{value0}} on {{value1}}",
+            "toggleLabel": "Make this a child worktree",
+            "unavailable": "No eligible parent worktrees on this project and host.",
+            "updateRequired": "Update the connected Orca server to choose a child worktree parent."
           },
           "RunTargetCombobox": {
             "listLabel": "Run targets",

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateWorktreeArgs,
   CreateSparseCheckoutRequest,
   GitPushTarget,
   SetupDecision,
@@ -11,6 +12,7 @@ import type {
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import type { AgentStartedTelemetry } from '@/lib/worktree-activation'
 import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
+import type { ExecutionHostId } from '../../../shared/execution-host'
 
 /** Two-phase status reported by the main process while a worktree is created.
  *  `preparing` covers renderer-side preflight before `createWorktree` starts;
@@ -30,6 +32,10 @@ export type WorktreeCreationProgressMode = 'stepped' | 'indeterminate'
  */
 export type WorktreeCreationRequest = {
   repoId: string
+  repoAuthority?: CreateWorktreeArgs['repoAuthority']
+  repoExecutionHostId?: ExecutionHostId
+  /** Worktree parent selected by the create surface. Null explicitly creates a root workspace. */
+  parentWorktreeId?: string | null
   /** Source host/account that produced the linked task. Kept separate from the
    *  run context so Retry does not infer provider ownership from the run host. */
   taskSourceContext?: TaskSourceContext | null

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -470,8 +470,8 @@ describe('staged background worktree creation', () => {
       },
       accountLabel: 'dev@company.test'
     }
-    const request = makeRequest({ linkedWorkItem, linkedTaskSourceContext })
-    const expectedOptions = { linkedWorkItem, linkedTaskSourceContext }
+    const request = makeRequest({ linkedWorkItem, linkedTaskSourceContext, parentWorktreeId: 'p' })
+    const expectedOptions = { linkedWorkItem, linkedTaskSourceContext, parentWorktreeId: 'p' }
 
     expect(continueBackgroundWorktreeCreation('creation-1', request)).toBe(true)
     await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalledTimes(1))

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -135,11 +135,20 @@ async function executeWorktreeCreation(
         preparedRequest.linkedGiteaPR,
         preparedRequest.compareBaseRef,
         {
+          ...(preparedRequest.repoAuthority
+            ? { repoAuthority: preparedRequest.repoAuthority }
+            : {}),
+          ...(preparedRequest.repoExecutionHostId
+            ? { repoExecutionHostId: preparedRequest.repoExecutionHostId }
+            : {}),
           ...(preparedRequest.linkedWorkItem !== undefined
             ? { linkedWorkItem: preparedRequest.linkedWorkItem }
             : {}),
           ...(preparedRequest.linkedTaskSourceContext !== undefined
             ? { linkedTaskSourceContext: preparedRequest.linkedTaskSourceContext }
+            : {}),
+          ...(preparedRequest.parentWorktreeId !== undefined
+            ? { parentWorktreeId: preparedRequest.parentWorktreeId }
             : {}),
           // Why: the remote host must own task-draft startup so its initial terminal is the agent, not an idle fallback shell.
           ...(!backendStartup && preparedRequest.agent && preparedRequest.launchDraftPrompt

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -233,7 +233,8 @@ export function markRuntimeEnvironmentCompatible(environmentId: string): void {
 
 export async function getRuntimeEnvironmentStatus(
   environmentId: string,
-  timeoutMs?: number
+  timeoutMs?: number,
+  expectedEnvironmentPairingRevision?: number
 ): Promise<RuntimeStatus> {
   const trimmed = environmentId.trim()
   const entry: RuntimeCompatibilityCacheEntry = {
@@ -250,7 +251,8 @@ export async function getRuntimeEnvironmentStatus(
     const response = await window.api.runtimeEnvironments.call({
       selector: trimmed,
       method: 'status.get',
-      timeoutMs
+      timeoutMs,
+      expectedEnvironmentPairingRevision
     })
     const status = unwrapRuntimeRpcResult<RuntimeStatus>(
       response as RuntimeRpcResponse<RuntimeStatus>
@@ -323,14 +325,17 @@ export async function assertRuntimeEnvironmentCapability(
   environmentId: string,
   capability: RuntimeCapability,
   message: string,
-  timeoutMs?: number
+  timeoutMs?: number,
+  expectedEnvironmentPairingRevision?: number
 ): Promise<void> {
-  const status = await getRuntimeEnvironmentStatus(environmentId, timeoutMs)
+  const status = await getRuntimeEnvironmentStatus(
+    environmentId,
+    timeoutMs,
+    expectedEnvironmentPairingRevision
+  )
   if (!status.capabilities?.includes(capability)) {
     throw new Error(message)
   }
 }
 
-export function clearRuntimeCompatibilityCacheForTests(): void {
-  clearRuntimeCompatibilityCache()
-}
+export const clearRuntimeCompatibilityCacheForTests = (): void => clearRuntimeCompatibilityCache()

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -205,8 +205,12 @@ export type WorktreeSlice = {
     compareBaseRef?: string,
     options?: {
       automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+      repoAuthority?: CreateWorktreeArgs['repoAuthority']
+      repoExecutionHostId?: ExecutionHostId
       linkedWorkItem?: WorkspaceLinkedItem | null
       linkedTaskSourceContext?: TaskSourceContext | null
+      /** Null explicitly suppresses active-folder parenting; undefined preserves legacy inference. */
+      parentWorktreeId?: string | null
       /** Lets the owning runtime launch and prefill a task agent without first creating an idle shell. */
       startupDraft?: string
     }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -17,7 +17,12 @@ import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
 } from '../../runtime/runtime-compatibility-test-fixture'
+import {
+  RUNTIME_CAPABILITIES,
+  WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY
+} from '../../../../shared/protocol-version'
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { replaceRuntimeEnvironmentRevisions } from '../../runtime/runtime-environment-revision'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import type {
   ForgetRemovedWorktreesForExecutionHostArgs,
@@ -185,6 +190,7 @@ import { useAppStore } from '@/store'
 
 function resetRemoteRuntimeMocks() {
   clearRuntimeCompatibilityCacheForTests()
+  replaceRuntimeEnvironmentRevisions([])
   resetHostedReviewLinkMutationGenerationForTests()
   runtimeEnvironmentCall.mockReset()
   runtimeEnvironmentTransportCall.mockReset()
@@ -4806,6 +4812,405 @@ describe('createWorktree base status merge', () => {
     })
   })
 
+  it('uses an explicit worktree parent over the active folder and ingests create lineage', async () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/path/parent',
+      repoId: 'repo1',
+      path: '/path/parent',
+      instanceId: 'parent-instance'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      path: '/path/child',
+      instanceId: 'child-instance'
+    })
+    const lineage = makeLineage({
+      worktreeId: child.id,
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: parent.id,
+      parentWorktreeInstanceId: 'parent-instance',
+      capture: { source: 'active-workspace', confidence: 'explicit' }
+    })
+    const workspaceLineage = makeWorkspaceLineage({
+      childWorkspaceKey: worktreeWorkspaceKey(child.id),
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: worktreeWorkspaceKey(parent.id),
+      parentInstanceId: 'parent-instance',
+      capture: { source: 'active-workspace', confidence: 'explicit' }
+    })
+    store.setState({
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      worktreesByRepo: { repo1: [parent] }
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child, lineage, workspaceLineage })
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'feature', 'origin/main']
+    args[25] = { parentWorktreeId: parent.id }
+
+    await createWorktree(...args)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentWorktreeId: parent.id
+      })
+    )
+    expect(store.getState().worktreeLineageById).toEqual({ [child.id]: lineage })
+    expect(store.getState().workspaceLineageByChildKey).toEqual({
+      [workspaceLineage.childWorkspaceKey]: workspaceLineage
+    })
+    expect(store.getState().worktreesByRepo.repo1[1]).toMatchObject({
+      id: child.id,
+      parentWorktreeId: parent.id,
+      lineage
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      id: parent.id,
+      childWorktreeIds: [child.id]
+    })
+  })
+
+  it('merges created child lineage only into the selected host rows', async () => {
+    const store = createTestStore()
+    const parentId = 'repo-shared::/same/parent'
+    const childId = 'repo-shared::/same/child'
+    const localParent = makeWorktree({
+      id: parentId,
+      repoId: 'repo-shared',
+      hostId: 'local',
+      instanceId: 'local-parent-instance',
+      displayName: 'Local parent'
+    })
+    const sshParent = makeWorktree({
+      id: parentId,
+      repoId: 'repo-shared',
+      hostId: 'ssh:ssh-1',
+      instanceId: 'ssh-parent-instance',
+      displayName: 'SSH parent'
+    })
+    const localChild = makeWorktree({
+      id: childId,
+      repoId: 'repo-shared',
+      hostId: 'local',
+      instanceId: 'local-child-instance',
+      displayName: 'Local child'
+    })
+    const createdChild = makeWorktree({
+      id: childId,
+      repoId: 'repo-shared',
+      instanceId: 'ssh-child-instance',
+      displayName: 'SSH child'
+    })
+    const lineage = makeLineage({
+      worktreeId: childId,
+      worktreeInstanceId: 'ssh-child-instance',
+      parentWorktreeId: parentId,
+      parentWorktreeInstanceId: 'ssh-parent-instance'
+    })
+    store.setState({
+      repos: [
+        {
+          id: 'repo-shared',
+          path: '/local/repo',
+          displayName: 'Local repo',
+          badgeColor: '#000',
+          addedAt: 0
+        },
+        {
+          id: 'repo-shared',
+          path: '/remote/repo',
+          displayName: 'SSH repo',
+          badgeColor: '#111',
+          addedAt: 1,
+          connectionId: 'ssh-1'
+        }
+      ],
+      worktreesByRepo: { 'repo-shared': [localParent, sshParent, localChild] }
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: createdChild, lineage })
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo-shared', 'feature']
+    args[25] = {
+      repoAuthority: { path: '/remote/repo', connectionId: 'ssh-1' },
+      repoExecutionHostId: 'ssh:ssh-1',
+      parentWorktreeId: parentId
+    }
+
+    await createWorktree(...args)
+
+    const rows = store.getState().worktreesByRepo['repo-shared']
+    expect(rows[0]).toBe(localParent)
+    expect(rows[1]).toMatchObject({ id: parentId, childWorktreeIds: [childId] })
+    expect(rows[2]).toBe(localChild)
+    expect(rows[3]).toMatchObject({
+      id: childId,
+      hostId: 'ssh:ssh-1',
+      displayName: 'SSH child',
+      parentWorktreeId: parentId,
+      lineage
+    })
+  })
+
+  it('suppresses active-folder parenting for an explicit root selection', async () => {
+    const store = createTestStore()
+    const child = makeWorktree({ id: 'repo1::/path/child', repoId: 'repo1' })
+    store.setState({
+      activeWorkspaceKey: folderWorkspaceKey('folder-1')
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child })
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'feature']
+    args[25] = { parentWorktreeId: null }
+
+    await createWorktree(...args)
+
+    const createArgs = mockApi.worktrees.create.mock.calls[0]?.[0]
+    expect(createArgs).not.toHaveProperty('parentWorkspace')
+    expect(createArgs).not.toHaveProperty('parentWorktreeId')
+  })
+
+  it('surfaces create warnings after keeping the created worktree', async () => {
+    const store = createTestStore()
+    const child = makeWorktree({ id: 'repo1::/path/child', repoId: 'repo1' })
+    mockApi.worktrees.create.mockResolvedValue({
+      worktree: child,
+      warning: 'The selected parent changed during creation.',
+      warnings: [
+        {
+          code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          message: 'The worktree was left at the root.'
+        }
+      ]
+    })
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().worktreesByRepo.repo1).toContainEqual(
+      expect.objectContaining({ id: child.id })
+    )
+    expect(toast.warning).toHaveBeenCalledWith('Worktree created with a warning', {
+      id: `worktree-create-warning:${child.id}`,
+      description:
+        'The selected parent changed during creation. The worktree was left at the root.',
+      duration: Infinity,
+      dismissible: true
+    })
+  })
+
+  it('forwards an explicit parent through direct SSH creation', async () => {
+    const store = createTestStore()
+    const parentWorktreeId = 'repo-ssh::/remote/parent'
+    const child = makeWorktree({
+      id: 'repo-ssh::/remote/child',
+      repoId: 'repo-ssh',
+      path: '/remote/child'
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [
+        {
+          id: 'repo-ssh',
+          path: '/remote/repo',
+          displayName: 'repo',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-1'
+        }
+      ]
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child })
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo-ssh', 'feature']
+    args[25] = { parentWorktreeId }
+
+    await createWorktree(...args)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentWorktreeId
+      })
+    )
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  it('ingests inline worktree and workspace lineage from create results', async () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/path/parent',
+      repoId: 'repo1',
+      instanceId: 'parent-instance'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      instanceId: 'child-instance'
+    })
+    const lineage = makeLineage({ worktreeId: child.id })
+    const workspaceLineage = makeWorkspaceLineage({
+      childWorkspaceKey: worktreeWorkspaceKey(child.id),
+      parentWorkspaceKey: worktreeWorkspaceKey(parent.id),
+      parentInstanceId: 'parent-instance'
+    })
+    mockApi.worktrees.create.mockResolvedValue({
+      worktree: { ...child, lineage, workspaceLineage }
+    })
+    store.setState({ worktreesByRepo: { repo1: [parent] } } as Partial<AppState>)
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().worktreeLineageById).toEqual({ [child.id]: lineage })
+    expect(store.getState().workspaceLineageByChildKey).toEqual({
+      [workspaceLineage.childWorkspaceKey]: workspaceLineage
+    })
+  })
+
+  it('rejects instance-stale lineage returned by an older create host', async () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/path/parent',
+      repoId: 'repo1',
+      instanceId: 'current-parent-instance'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      instanceId: 'child-instance'
+    })
+    const lineage = makeLineage({
+      worktreeId: child.id,
+      parentWorktreeId: parent.id,
+      parentWorktreeInstanceId: 'stale-parent-instance'
+    })
+    const workspaceLineage = makeWorkspaceLineage({
+      childWorkspaceKey: worktreeWorkspaceKey(child.id),
+      parentWorkspaceKey: worktreeWorkspaceKey(parent.id)
+    })
+    store.setState({ worktreesByRepo: { repo1: [parent] } } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child, lineage, workspaceLineage })
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().worktreeLineageById).toEqual({})
+    expect(store.getState().workspaceLineageByChildKey).toEqual({})
+    expect(store.getState().worktreesByRepo.repo1[1]).toMatchObject({
+      id: child.id,
+      parentWorktreeId: null,
+      lineage: null
+    })
+  })
+
+  it('rejects workspace lineage that disagrees with an accepted worktree edge', async () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/path/parent',
+      repoId: 'repo1',
+      instanceId: 'parent-instance'
+    })
+    const otherParent = makeWorktree({
+      id: 'repo1::/path/other-parent',
+      repoId: 'repo1',
+      instanceId: 'other-parent-instance'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      instanceId: 'child-instance'
+    })
+    const lineage = makeLineage({ worktreeId: child.id, parentWorktreeId: parent.id })
+    const workspaceLineage = makeWorkspaceLineage({
+      childWorkspaceKey: worktreeWorkspaceKey(child.id),
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: worktreeWorkspaceKey(otherParent.id),
+      parentInstanceId: 'other-parent-instance'
+    })
+    store.setState({ worktreesByRepo: { repo1: [parent, otherParent] } } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child, lineage, workspaceLineage })
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().worktreeLineageById).toEqual({ [child.id]: lineage })
+    expect(store.getState().workspaceLineageByChildKey).toEqual({})
+    expect(store.getState().worktreesByRepo.repo1[2]).toMatchObject({
+      id: child.id,
+      parentWorktreeId: parent.id,
+      lineage,
+      workspaceLineage: null
+    })
+  })
+
+  it('rejects worktree workspace lineage without a valid returned worktree edge', async () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/path/parent',
+      repoId: 'repo1',
+      instanceId: 'current-parent-instance'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      instanceId: 'child-instance'
+    })
+    const workspaceLineage = makeWorkspaceLineage({
+      childWorkspaceKey: worktreeWorkspaceKey(child.id),
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: worktreeWorkspaceKey(parent.id),
+      parentInstanceId: 'stale-parent-instance'
+    })
+    store.setState({
+      worktreesByRepo: { repo1: [parent] },
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey(child.id)]: makeWorkspaceLineage({
+          childWorkspaceKey: worktreeWorkspaceKey(child.id)
+        })
+      }
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child, workspaceLineage })
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().workspaceLineageByChildKey).toEqual({})
+    const created = store.getState().worktreesByRepo.repo1[1]
+    expect(created).toMatchObject({ id: child.id })
+    expect(created).not.toHaveProperty('parentWorktreeId')
+    expect(created).not.toHaveProperty('lineage')
+  })
+
+  it('rejects cyclic lineage returned by an older create host', async () => {
+    const store = createTestStore()
+    const parent = makeWorktree({
+      id: 'repo1::/path/parent',
+      repoId: 'repo1',
+      instanceId: 'parent-instance'
+    })
+    const child = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      instanceId: 'child-instance'
+    })
+    const parentLineage = makeLineage({
+      worktreeId: parent.id,
+      worktreeInstanceId: 'parent-instance',
+      parentWorktreeId: child.id,
+      parentWorktreeInstanceId: 'child-instance'
+    })
+    const childLineage = makeLineage({ worktreeId: child.id, parentWorktreeId: parent.id })
+    store.setState({
+      worktreesByRepo: { repo1: [parent] },
+      worktreeLineageById: { [parent.id]: parentLineage }
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: child, lineage: childLineage })
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().worktreeLineageById).toEqual({ [parent.id]: parentLineage })
+    expect(store.getState().worktreesByRepo.repo1[1]).toMatchObject({
+      id: child.id,
+      parentWorktreeId: null,
+      lineage: null
+    })
+  })
+
   it('merges create result metadata into a worktree inserted by the watcher race', async () => {
     const store = createTestStore()
     const watcherWorktree = makeWorktree({
@@ -5902,6 +6307,187 @@ describe('worktree remote runtime mutations', () => {
     })
     expect(mockApi.worktrees.create).not.toHaveBeenCalled()
     expect(store.getState().worktreesByRepo.repo1).toEqual([wt])
+  })
+
+  it('routes duplicate repo ids through the selected repository owner and authority', async () => {
+    const store = createTestStore()
+    const authority = { path: '/runtime/repo', connectionId: null }
+    const wt = makeWorktree({
+      id: 'repo1::/runtime/worktrees/feature',
+      repoId: 'repo1',
+      path: '/runtime/worktrees/feature'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-selected' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/local/repo',
+          displayName: 'Local',
+          badgeColor: 'blue',
+          addedAt: 1,
+          executionHostId: 'local'
+        },
+        {
+          id: 'repo1',
+          path: authority.path,
+          displayName: 'Runtime',
+          badgeColor: 'blue',
+          addedAt: 1,
+          executionHostId: 'runtime:env-selected'
+        }
+      ],
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'feature']
+    args[25] = {
+      repoAuthority: authority,
+      repoExecutionHostId: 'runtime:env-selected'
+    }
+
+    await createWorktree(...args)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'env-selected',
+        method: 'worktree.create',
+        params: expect.objectContaining({ repo: 'repo1', repoAuthority: authority })
+      })
+    )
+    expect(mockApi.worktrees.create).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      id: wt.id,
+      hostId: 'runtime:env-selected',
+      runtimeOwnerEnvironmentId: 'env-selected'
+    })
+  })
+
+  it('uses the compatible workspace-parent field for paired-runtime creation', async () => {
+    const store = createTestStore()
+    const parentWorktreeId = 'repo1::/path/parent'
+    const wt = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      path: '/path/child'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'feature']
+    args[25] = { parentWorktreeId }
+
+    await createWorktree(...args)
+
+    const request = runtimeEnvironmentCall.mock.calls[0]?.[0]
+    expect(request).toEqual(
+      expect.objectContaining({
+        method: 'worktree.create',
+        params: expect.objectContaining({
+          parentWorkspace: worktreeWorkspaceKey(parentWorktreeId),
+          parentWorkspaceCaptureSource: 'manual-action'
+        })
+      })
+    )
+    expect(request?.params).not.toHaveProperty('parentWorktreeId')
+  })
+
+  it('binds the parent capability probe and create to one pairing revision', async () => {
+    const store = createTestStore()
+    const parentWorktreeId = 'repo1::/path/parent'
+    const wt = makeWorktree({
+      id: 'repo1::/path/child',
+      repoId: 'repo1',
+      path: '/path/child'
+    })
+    replaceRuntimeEnvironmentRevisions([{ id: 'env-1', createdAt: 1, pairingRevision: 41 }])
+    runtimeEnvironmentTransportCall.mockImplementation(
+      (
+        request: RuntimeEnvironmentCallRequest & { expectedEnvironmentPairingRevision?: number }
+      ) => {
+        if (request.method === 'status.get') {
+          replaceRuntimeEnvironmentRevisions([{ id: 'env-1', createdAt: 1, pairingRevision: 42 }])
+          return createCompatibleRuntimeStatusResponse()
+        }
+        return {
+          id: 'rpc-create',
+          ok: true,
+          result: { worktree: wt },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+    )
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'feature']
+    args[25] = { parentWorktreeId }
+
+    await createWorktree(...args)
+
+    const requests = runtimeEnvironmentTransportCall.mock.calls.map(([request]) => request)
+    expect(requests).toHaveLength(2)
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: 'status.get',
+        expectedEnvironmentPairingRevision: 41
+      }),
+      expect.objectContaining({
+        method: 'worktree.create',
+        expectedEnvironmentPairingRevision: 41
+      })
+    ])
+  })
+
+  it('rejects an explicit parent before calling an older paired runtime', async () => {
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    runtimeEnvironmentTransportCall.mockImplementation((request: RuntimeEnvironmentCallRequest) =>
+      request.method === 'status.get'
+        ? (() => {
+            const status = createCompatibleRuntimeStatusResponse()
+            if (!status.ok) {
+              return status
+            }
+            return {
+              ...status,
+              result: {
+                ...status.result,
+                capabilities: RUNTIME_CAPABILITIES.filter(
+                  (capability) => capability !== WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY
+                )
+              }
+            }
+          })()
+        : runtimeEnvironmentCall(request)
+    )
+    const createWorktree = store.getState().createWorktree
+    const args: Parameters<typeof createWorktree> = ['repo1', 'feature']
+    args[25] = { parentWorktreeId: 'repo1::/path/parent' }
+
+    await expect(createWorktree(...args)).rejects.toThrow(
+      'Child worktree creation requires a newer Orca server'
+    )
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
   it('persists Jira item and source context through paired-runtime create', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2,6 +2,7 @@
 import type { StateCreator, StoreApi } from 'zustand'
 import type { AppState } from '../types'
 import type {
+  CreateWorktreeResult,
   DetectedWorktreeListResult,
   LocalBaseRefRefreshResult,
   ForceDeleteWorktreeBranchResult,
@@ -52,6 +53,8 @@ import {
 } from '../../runtime/runtime-rpc-client'
 import {
   TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY,
+  WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY,
+  WORKTREE_CREATE_PARENT_AUTHORITY_UPDATE_REQUIRED_MESSAGE,
   WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY
 } from '../../../../shared/protocol-version'
 import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
@@ -95,6 +98,7 @@ import {
 import { captureWorktreeOperationGenerationGuard } from '@/lib/worktree-operation-generation'
 import { getEnvironmentSshStateGeneration } from './runtime-environment-ssh'
 import { getRuntimeEnvironmentConnectionGeneration } from './runtime-status'
+import { captureRuntimeEnvironmentRequestRevision } from '../../runtime/runtime-environment-revision'
 import {
   folderWorkspaceKey,
   getActiveSidebarWorkspaceId,
@@ -103,6 +107,10 @@ import {
   worktreeWorkspaceKey
 } from '../../../../shared/workspace-scope'
 import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import {
+  projectResolvedWorktreeLineage,
+  sharesResolvedWorktreeLineageBoundary
+} from '../../../../shared/resolved-worktree-lineage'
 import {
   CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS,
   getClientWorktreeCreateCandidate,
@@ -318,6 +326,94 @@ function showLocalBaseRefRefreshToast(
       dismissible: true
     }
   )
+}
+
+function showWorktreeCreateWarningToast(
+  result: Pick<CreateWorktreeResult, 'warning' | 'warnings'>,
+  worktreeId: string
+): void {
+  const messages = [
+    result.warning,
+    ...(result.warnings ?? []).map(({ message }) => message)
+  ].filter(
+    (message, index, all): message is string => Boolean(message) && all.indexOf(message) === index
+  )
+  if (messages.length === 0) {
+    return
+  }
+  toast.warning(
+    translate(
+      'auto.store.slices.worktrees.worktreeCreatedWithWarning',
+      'Worktree created with a warning'
+    ),
+    {
+      id: `worktree-create-warning:${worktreeId}`,
+      description: messages.join(' '),
+      duration: Infinity,
+      dismissible: true
+    }
+  )
+}
+
+function getValidatedCreatedWorktreeLineage(
+  worktrees: readonly Worktree[],
+  lineageById: Readonly<Record<string, WorktreeLineage>>,
+  createdWorktree: Worktree,
+  returnedLineage: WorktreeLineage | null | undefined
+): WorktreeLineage | null {
+  if (!returnedLineage) {
+    return null
+  }
+  const candidateLineageById = {
+    ...lineageById,
+    [createdWorktree.id]: returnedLineage
+  }
+  return (
+    projectResolvedWorktreeLineage(worktrees, candidateLineageById).find(
+      (worktree) => worktree.id === createdWorktree.id
+    )?.lineage ?? null
+  )
+}
+
+function getValidatedReturnedWorkspaceLineage(
+  worktrees: readonly Worktree[],
+  createdWorktree: Worktree,
+  returnedWorkspaceLineage: WorkspaceLineage | null | undefined,
+  validatedWorktreeLineage: WorktreeLineage | null
+): WorkspaceLineage | null {
+  if (!returnedWorkspaceLineage) {
+    return null
+  }
+  const childScope = parseWorkspaceKey(returnedWorkspaceLineage.childWorkspaceKey)
+  const parentScope = parseWorkspaceKey(returnedWorkspaceLineage.parentWorkspaceKey)
+  if (
+    childScope?.type !== 'worktree' ||
+    childScope.worktreeId !== createdWorktree.id ||
+    returnedWorkspaceLineage.childInstanceId !== createdWorktree.instanceId
+  ) {
+    return null
+  }
+  if (validatedWorktreeLineage) {
+    return parentScope?.type === 'worktree' &&
+      parentScope.worktreeId === validatedWorktreeLineage.parentWorktreeId &&
+      returnedWorkspaceLineage.parentInstanceId ===
+        validatedWorktreeLineage.parentWorktreeInstanceId
+      ? returnedWorkspaceLineage
+      : null
+  }
+  if (parentScope?.type !== 'worktree') {
+    return returnedWorkspaceLineage
+  }
+  const child = worktrees.find((worktree) => worktree.id === createdWorktree.id)
+  const parent = worktrees.find((worktree) => worktree.id === parentScope.worktreeId)
+  return child &&
+    parent &&
+    child.id !== parent.id &&
+    sharesResolvedWorktreeLineageBoundary(child, parent) &&
+    child.instanceId === returnedWorkspaceLineage.childInstanceId &&
+    parent.instanceId === returnedWorkspaceLineage.parentInstanceId
+    ? returnedWorkspaceLineage
+    : null
 }
 
 function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): boolean {
@@ -3908,8 +4004,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     options
   ) => {
     const automationProvenanceRequest = options?.automationProvenanceRequest
+    const repoAuthority = options?.repoAuthority
+    const repoExecutionHostId = options?.repoExecutionHostId
     const linkedWorkItem = options?.linkedWorkItem
     const linkedTaskSourceContext = options?.linkedTaskSourceContext
+    const parentWorktreeId = options?.parentWorktreeId
     const startupDraft = options?.startupDraft
     try {
       for (let attempt = 0; attempt < CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS; attempt += 1) {
@@ -3923,11 +4022,18 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           const manualOrder = get().sortBy === 'manual' ? Date.now() : undefined
           const activeScope = parseWorkspaceKey(get().activeWorkspaceKey ?? '')
           const parentWorkspace =
-            activeScope?.type === 'folder'
-              ? folderWorkspaceKey(activeScope.folderWorkspaceId)
-              : undefined
+            parentWorktreeId !== undefined
+              ? undefined
+              : activeScope?.type === 'folder'
+                ? folderWorkspaceKey(activeScope.folderWorkspaceId)
+                : undefined
+          const runtimeParentWorkspace =
+            typeof parentWorktreeId === 'string'
+              ? worktreeWorkspaceKey(parentWorktreeId)
+              : parentWorkspace
           const createArgs = {
             repoId,
+            ...(repoAuthority ? { repoAuthority } : {}),
             name: candidateName,
             baseBranch,
             ...(compareBaseRef ? { compareBaseRef } : {}),
@@ -3951,6 +4057,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
               ? { linkedLinearIssueOrganizationUrlKey }
               : {}),
             ...(manualOrder !== undefined ? { manualOrder } : {}),
+            ...(typeof parentWorktreeId === 'string' ? { parentWorktreeId } : {}),
             ...(parentWorkspace ? { parentWorkspace } : {}),
             ...(workspaceStatus !== undefined ? { workspaceStatus } : {}),
             ...(linkedGitLabMR !== undefined ? { linkedGitLabMR } : {}),
@@ -3964,7 +4071,13 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(creationId ? { creationId } : {}),
             ...(automationProvenanceRequest ? { automationProvenanceRequest } : {})
           }
-          const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
+          const target = getActiveRuntimeTarget(
+            settingsForRepoOwner(get(), repoId, repoExecutionHostId, true)
+          )
+          const expectedEnvironmentPairingRevision =
+            target.kind === 'environment'
+              ? captureRuntimeEnvironmentRequestRevision(target.environmentId)
+              : undefined
           if (
             target.kind === 'environment' &&
             (linkedWorkItem?.provider === 'jira' || linkedTaskSourceContext?.provider === 'jira')
@@ -3972,7 +4085,18 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             await assertRuntimeEnvironmentCapability(
               target.environmentId,
               WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY,
-              'Update the remote runtime to link Jira'
+              'Update the remote runtime to link Jira',
+              undefined,
+              expectedEnvironmentPairingRevision
+            )
+          }
+          if (target.kind === 'environment' && typeof parentWorktreeId === 'string') {
+            await assertRuntimeEnvironmentCapability(
+              target.environmentId,
+              WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY,
+              WORKTREE_CREATE_PARENT_AUTHORITY_UPDATE_REQUIRED_MESSAGE,
+              undefined,
+              expectedEnvironmentPairingRevision
             )
           }
           const result =
@@ -3983,6 +4107,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                   'worktree.create',
                   {
                     repo: repoId,
+                    ...(repoAuthority ? { repoAuthority } : {}),
                     name: candidateName,
                     baseBranch,
                     ...(compareBaseRef ? { compareBaseRef } : {}),
@@ -4008,7 +4133,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                       ? { linkedLinearIssueOrganizationUrlKey }
                       : {}),
                     ...(manualOrder !== undefined ? { manualOrder } : {}),
-                    ...(parentWorkspace ? { parentWorkspace } : {}),
+                    ...(runtimeParentWorkspace
+                      ? {
+                          parentWorkspace: runtimeParentWorkspace,
+                          ...(typeof parentWorktreeId === 'string'
+                            ? { parentWorkspaceCaptureSource: 'manual-action' as const }
+                            : {})
+                        }
+                      : {}),
                     ...(workspaceStatus !== undefined ? { workspaceStatus } : {}),
                     ...(linkedGitLabMR !== undefined ? { linkedGitLabMR } : {}),
                     ...(linkedGitLabIssue !== undefined ? { linkedGitLabIssue } : {}),
@@ -4033,38 +4165,120 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                         }
                       : {})
                   },
-                  { timeoutMs: 10 * 60_000 }
+                  { timeoutMs: 10 * 60_000, expectedEnvironmentPairingRevision }
                 )
           // Why: worktrees.onChanged can add this worktree before this callback runs; appending blindly would duplicate it (React key clash).
           set((s) => {
-            const hostId = repoHostId(s, repoId)
-            const createdWorktree = withRepoHostOwnership(
-              result.worktree,
+            const hostId = repoHostId(s, repoId, repoExecutionHostId)
+            const returnedLineage = result.lineage ?? result.worktree.lineage
+            const returnedWorkspaceLineage =
+              result.workspaceLineage ?? result.worktree.workspaceLineage
+            const unparentedCreatedWorktree = withRepoHostOwnership(
+              returnedLineage || returnedWorkspaceLineage
+                ? {
+                    ...result.worktree,
+                    ...(returnedLineage
+                      ? {
+                          parentWorktreeId: null,
+                          childWorktreeIds: [],
+                          lineage: null
+                        }
+                      : {}),
+                    ...(returnedWorkspaceLineage ? { workspaceLineage: null } : {})
+                  }
+                : result.worktree,
               hostId,
               getProjectHostSetupForRepoHost(s, repoId, hostId)
             )
             const current = s.worktreesByRepo[repoId] ?? []
-            const alreadyPresent = current.some((w) => w.id === createdWorktree.id)
-            const nextWorktrees = alreadyPresent
+            const hostMatchOptions = worktreeHostMatchOptions(s, repoId, hostId)
+            const matchesCreateHost = (worktree: Worktree): boolean =>
+              worktreeMatchesHost(worktree, hostId, hostMatchOptions)
+            const alreadyPresent = current.some(
+              (worktree) =>
+                worktree.id === unparentedCreatedWorktree.id && matchesCreateHost(worktree)
+            )
+            const unparentedWorktrees = alreadyPresent
               ? current.map((worktree) =>
-                  worktree.id === createdWorktree.id
-                    ? { ...worktree, ...createdWorktree }
+                  worktree.id === unparentedCreatedWorktree.id && matchesCreateHost(worktree)
+                    ? { ...worktree, ...unparentedCreatedWorktree }
                     : worktree
                 )
-              : [...current, createdWorktree]
+              : [...current, unparentedCreatedWorktree]
+            const createHostWorktrees = unparentedWorktrees.filter(matchesCreateHost)
+            const validatedLineage = getValidatedCreatedWorktreeLineage(
+              createHostWorktrees,
+              s.worktreeLineageById,
+              unparentedCreatedWorktree,
+              returnedLineage
+            )
+            const validatedWorkspaceLineage = returnedLineage
+              ? validatedLineage
+                ? getValidatedReturnedWorkspaceLineage(
+                    createHostWorktrees,
+                    unparentedCreatedWorktree,
+                    returnedWorkspaceLineage,
+                    validatedLineage
+                  )
+                : null
+              : getValidatedReturnedWorkspaceLineage(
+                  createHostWorktrees,
+                  unparentedCreatedWorktree,
+                  returnedWorkspaceLineage,
+                  null
+                )
+            const createdWorktree = {
+              ...unparentedCreatedWorktree,
+              ...(validatedLineage
+                ? {
+                    parentWorktreeId: validatedLineage.parentWorktreeId,
+                    lineage: validatedLineage
+                  }
+                : {}),
+              ...(returnedWorkspaceLineage ? { workspaceLineage: validatedWorkspaceLineage } : {})
+            }
+            const nextWorktrees = unparentedWorktrees.map((worktree) => {
+              if (worktree.id === createdWorktree.id && matchesCreateHost(worktree)) {
+                return createdWorktree
+              }
+              if (
+                validatedLineage?.parentWorktreeId !== worktree.id ||
+                !matchesCreateHost(worktree)
+              ) {
+                return worktree
+              }
+              return {
+                ...worktree,
+                childWorktreeIds: Array.from(
+                  new Set([
+                    ...((worktree as WorktreeWithLineage).childWorktreeIds ?? []),
+                    createdWorktree.id
+                  ])
+                )
+              }
+            })
+            const nextWorktreeLineageById = { ...s.worktreeLineageById }
+            if (validatedLineage) {
+              nextWorktreeLineageById[validatedLineage.worktreeId] = validatedLineage
+            } else if (returnedLineage) {
+              delete nextWorktreeLineageById[unparentedCreatedWorktree.id]
+            }
+            const nextWorkspaceLineageByChildKey = { ...s.workspaceLineageByChildKey }
+            if (validatedWorkspaceLineage) {
+              nextWorkspaceLineageByChildKey[validatedWorkspaceLineage.childWorkspaceKey] =
+                validatedWorkspaceLineage
+            } else if (returnedLineage || returnedWorkspaceLineage) {
+              delete nextWorkspaceLineageByChildKey[
+                worktreeWorkspaceKey(unparentedCreatedWorktree.id)
+              ]
+            }
             return {
               worktreesByRepo: {
                 ...s.worktreesByRepo,
                 [repoId]: nextWorktrees
               },
-              ...(result.workspaceLineage
-                ? {
-                    workspaceLineageByChildKey: {
-                      ...s.workspaceLineageByChildKey,
-                      [result.workspaceLineage.childWorkspaceKey]: result.workspaceLineage
-                    }
-                  }
-                : {}),
+              worktreeLineageById: nextWorktreeLineageById,
+              workspaceLineageByChildKey: nextWorkspaceLineageByChildKey,
               ...(result.initialBaseStatus
                 ? {
                     baseStatusByWorktreeId: {
@@ -4077,6 +4291,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
               sortEpoch: s.sortEpoch + 1
             }
           })
+          showWorktreeCreateWarningToast(result, result.worktree.id)
           showLocalBaseRefRefreshToast(result.localBaseRefRefresh, result.worktree)
           if (result.baseFallback) {
             requestWorktreeBaseFallbackNotice(result.baseFallback)

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -5,7 +5,10 @@ import type { PreloadApi } from '../../../preload/api-types'
 import type { FeatureInteractionState } from '../../../shared/feature-interactions'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
-import { MIN_COMPATIBLE_RUNTIME_SERVER_VERSION } from '../../../shared/protocol-version'
+import {
+  MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
+  WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY
+} from '../../../shared/protocol-version'
 
 const TEST_COMMIT_OID = '0123456789abcdef0123456789abcdef01234567'
 
@@ -3296,6 +3299,14 @@ describe('web worktree preload API', () => {
       WebRuntimeClient: class {
         call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
           runtimeCalls.push({ method, params })
+          if (method === 'status.get') {
+            return Promise.resolve({
+              id: `call-${runtimeCalls.length}`,
+              ok: true,
+              result: { capabilities: [WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY] },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
           if (method === 'worktree.resolvePrBase') {
             return Promise.resolve({
               id: `call-${runtimeCalls.length}`,
@@ -3341,6 +3352,7 @@ describe('web worktree preload API', () => {
       compareBaseRef: 'refs/remotes/origin/main',
       setupDecision: 'inherit',
       createdWithAgent: 'codex',
+      parentWorktreeId: 'repo-1::/workspace/parent',
       startup: {
         command: "codex 'summarize repo'",
         env: { ORCA_AGENT_MODE: 'direct' },
@@ -3369,12 +3381,18 @@ describe('web worktree preload API', () => {
 
     expect(runtimeCalls).toEqual([
       {
+        method: 'status.get',
+        params: undefined
+      },
+      {
         method: 'worktree.create',
         params: expect.objectContaining({
           repo: 'repo-1',
           baseBranch: TEST_COMMIT_OID,
           compareBaseRef: 'refs/remotes/origin/main',
           createdWithAgent: 'codex',
+          parentWorkspace: 'worktree:repo-1::/workspace/parent',
+          parentWorkspaceCaptureSource: 'manual-action',
           startupCommand: "codex 'summarize repo'",
           startupEnv: { ORCA_AGENT_MODE: 'direct' },
           startupLaunchConfig: {
@@ -3407,6 +3425,124 @@ describe('web worktree preload API', () => {
         }
       }
     ])
+  })
+
+  it('rejects an explicit child parent before calling an older runtime', async () => {
+    const runtimeCalls: string[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push(method)
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: { capabilities: [] },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      globals.window.api.worktrees.create({
+        repoId: 'repo-1',
+        name: 'child',
+        parentWorktreeId: 'repo-1::/workspace/parent'
+      })
+    ).rejects.toThrow('Child worktree creation requires a newer Orca server')
+    expect(runtimeCalls).toEqual(['status.get'])
+  })
+
+  it('does not create an explicit child against a newly paired server', async () => {
+    const runtimeCalls: { method: string; server: string }[] = []
+    let resolveServerAStatus: ((response: RuntimeRpcResponse<unknown>) => void) | undefined
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        constructor(private readonly offer: { publicKeyB64: string }) {}
+
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, server: this.offer.publicKeyB64 })
+          if (this.offer.publicKeyB64 === 'public-key' && method === 'status.get') {
+            return new Promise((resolve) => {
+              resolveServerAStatus = resolve
+            })
+          }
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result:
+              method === 'status.get'
+                ? { capabilities: [WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY] }
+                : { worktree: { id: 'repo-1::/workspace/child', path: '/workspace/child' } },
+            _meta: { runtimeId: 'runtime-b' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const create = globals.window.api.worktrees.create({
+      repoId: 'repo-1',
+      name: 'child',
+      parentWorktreeId: 'repo-1::/workspace/parent'
+    })
+    await vi.waitFor(() => expect(resolveServerAStatus).toBeTypeOf('function'))
+    await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server B',
+      pairingCode: encodePairingCode({ publicKeyB64: 'server-b-key' })
+    })
+    resolveServerAStatus?.({
+      id: 'server-a-status',
+      ok: true,
+      result: { capabilities: [WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY] },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(create).rejects.toThrow(
+      'The paired Orca server changed while the request was in progress.'
+    )
+    expect(runtimeCalls).toEqual([{ method: 'status.get', server: 'public-key' }])
+  })
+
+  it('keeps root worktree creation compatible with an older runtime', async () => {
+    const runtimeCalls: string[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push(method)
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: { worktree: { id: 'repo-1::/workspace/root', path: '/workspace/root' } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await globals.window.api.worktrees.create({ repoId: 'repo-1', name: 'root' })
+
+    expect(runtimeCalls).toEqual(['worktree.create'])
   })
 
   it('encodes explicit push target clears for runtime worktree updates', async () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -100,6 +100,10 @@ import type { RateLimitState } from '../../../shared/rate-limit-types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../../../shared/runtime-types'
 import { assertFileMutationOwnershipCapability } from '../../../shared/file-mutation-ownership'
 import {
+  WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY,
+  WORKTREE_CREATE_PARENT_AUTHORITY_UPDATE_REQUIRED_MESSAGE
+} from '../../../shared/protocol-version'
+import {
   findKeybindingConflicts,
   formatKeybindingList,
   getKeybindingPlatform,
@@ -154,6 +158,7 @@ import {
   parseRuntimeNativeChatTurnLifecycle
 } from '@/components/native-chat/native-chat-runtime-contract'
 import { createWebFileMutationMethods } from './web-file-mutation-methods'
+import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
 
 const SETTINGS_STORAGE_KEY = 'orca.web.settings.v1'
 const UI_STORAGE_KEY = 'orca.web.ui.v1'
@@ -1775,50 +1780,70 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
     listDetected: async ({ repoId }) => callRuntimeDetectedWorktrees(repoId),
     listAll: () => listAllRuntimeWorktrees(),
     create: async (args) => {
+      const runtimeSession = captureWebWorktreeCreateRuntimeSession()
+      if (args.parentWorktreeId) {
+        const status = await runtimeSession.callRuntimeResult<RuntimeStatus>(
+          'status.get',
+          undefined,
+          15_000
+        )
+        if (!status.capabilities?.includes(WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY)) {
+          throw new Error(WORKTREE_CREATE_PARENT_AUTHORITY_UPDATE_REQUIRED_MESSAGE)
+        }
+      }
       invalidateRuntimeWorktreeCaches()
-      const owned = await callRuntimeResultWithOwner<{ worktree: Worktree }>('worktree.create', {
-        repo: args.repoId,
-        name: args.name,
-        baseBranch: args.baseBranch,
-        compareBaseRef: args.compareBaseRef,
-        branchNameOverride: args.branchNameOverride,
-        linkedIssue: args.linkedIssue,
-        linkedPR: args.linkedPR,
-        linkedLinearIssue: args.linkedLinearIssue,
-        linkedLinearIssueWorkspaceId: args.linkedLinearIssueWorkspaceId,
-        linkedLinearIssueOrganizationUrlKey: args.linkedLinearIssueOrganizationUrlKey,
-        linkedGitLabIssue: args.linkedGitLabIssue,
-        linkedGitLabMR: args.linkedGitLabMR,
-        linkedBitbucketPR: args.linkedBitbucketPR,
-        linkedAzureDevOpsPR: args.linkedAzureDevOpsPR,
-        linkedGiteaPR: args.linkedGiteaPR,
-        displayName: args.displayName,
-        sparseCheckout: args.sparseCheckout,
-        pushTarget: args.pushTarget,
-        setupDecision: args.setupDecision,
-        createdWithAgent: args.createdWithAgent,
-        pendingFirstAgentMessageRename: args.pendingFirstAgentMessageRename,
-        ...(args.startup
-          ? {
-              startupCommand: args.startup.command,
-              ...(args.startup.env ? { startupEnv: args.startup.env } : {}),
-              ...(args.startup.launchConfig
-                ? { startupLaunchConfig: args.startup.launchConfig }
-                : {}),
-              ...(args.startup.startupCommandDelivery
-                ? { startupCommandDelivery: args.startup.startupCommandDelivery }
-                : {}),
-              activate: true
-            }
-          : {}),
-        parentWorkspace: args.parentWorkspace,
-        workspaceStatus: args.workspaceStatus,
-        manualOrder: args.manualOrder,
-        automationProvenanceRequest: args.automationProvenanceRequest
-      })
+      const result = await runtimeSession.callRuntimeResult<{ worktree: Worktree }>(
+        'worktree.create',
+        {
+          repo: args.repoId,
+          ...(args.repoAuthority ? { repoAuthority: args.repoAuthority } : {}),
+          name: args.name,
+          baseBranch: args.baseBranch,
+          compareBaseRef: args.compareBaseRef,
+          branchNameOverride: args.branchNameOverride,
+          linkedIssue: args.linkedIssue,
+          linkedPR: args.linkedPR,
+          linkedLinearIssue: args.linkedLinearIssue,
+          linkedLinearIssueWorkspaceId: args.linkedLinearIssueWorkspaceId,
+          linkedLinearIssueOrganizationUrlKey: args.linkedLinearIssueOrganizationUrlKey,
+          linkedGitLabIssue: args.linkedGitLabIssue,
+          linkedGitLabMR: args.linkedGitLabMR,
+          linkedBitbucketPR: args.linkedBitbucketPR,
+          linkedAzureDevOpsPR: args.linkedAzureDevOpsPR,
+          linkedGiteaPR: args.linkedGiteaPR,
+          displayName: args.displayName,
+          sparseCheckout: args.sparseCheckout,
+          pushTarget: args.pushTarget,
+          setupDecision: args.setupDecision,
+          createdWithAgent: args.createdWithAgent,
+          pendingFirstAgentMessageRename: args.pendingFirstAgentMessageRename,
+          ...(args.startup
+            ? {
+                startupCommand: args.startup.command,
+                ...(args.startup.env ? { startupEnv: args.startup.env } : {}),
+                ...(args.startup.launchConfig
+                  ? { startupLaunchConfig: args.startup.launchConfig }
+                  : {}),
+                ...(args.startup.startupCommandDelivery
+                  ? { startupCommandDelivery: args.startup.startupCommandDelivery }
+                  : {}),
+                activate: true
+              }
+            : {}),
+          parentWorkspace: args.parentWorktreeId
+            ? worktreeWorkspaceKey(args.parentWorktreeId)
+            : args.parentWorkspace,
+          ...(args.parentWorktreeId
+            ? { parentWorkspaceCaptureSource: 'manual-action' as const }
+            : {}),
+          workspaceStatus: args.workspaceStatus,
+          manualOrder: args.manualOrder,
+          automationProvenanceRequest: args.automationProvenanceRequest
+        }
+      )
       return {
-        ...owned.result,
-        worktree: withRuntimeWorktreeOwner(owned.result.worktree, owned.hostId)
+        ...result,
+        worktree: withRuntimeWorktreeOwner(result.worktree, runtimeSession.hostId)
       }
     },
     // Why: the runtime create path emits no two-phase progress, so the panel falls back to an indeterminate spinner.
@@ -3494,6 +3519,40 @@ function withRuntimeWorktreeOwner<T extends Worktree>(worktree: T, hostId: Execu
     return worktree
   }
   return { ...worktree, runtimeOwnerEnvironmentId: runtimeOwner.environmentId }
+}
+
+function captureWebWorktreeCreateRuntimeSession(): {
+  callRuntimeResult: WebRuntimeResultCaller
+  hostId: ExecutionHostId
+} {
+  const environment = requireActiveEnvironment()
+  const client = getClientForEnvironment(environment)
+  const assertCurrent = (): void => {
+    if (activeClient !== client || requireActiveEnvironmentOrNull()?.id !== environment.id) {
+      throw new Error('The paired Orca server changed while the request was in progress.')
+    }
+  }
+  const callBoundRuntimeResult: WebRuntimeResultCaller = async <TResult>(
+    method: string,
+    params?: unknown,
+    timeoutMs?: number
+  ): Promise<TResult> => {
+    assertCurrent()
+    const response = await runtimeCallQueuePool.enqueue(environment.id, method, () => {
+      assertCurrent()
+      return client.call(method, params, { timeoutMs })
+    })
+    assertCurrent()
+    updateEnvironmentFromResponse(environment, response)
+    if (!response.ok) {
+      throw new Error(response.error.message)
+    }
+    return response.result as TResult
+  }
+  return {
+    callRuntimeResult: callBoundRuntimeResult,
+    hostId: toRuntimeExecutionHostId(environment.id)
+  }
 }
 
 function captureWebFileMutationSession(): {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -468,6 +468,33 @@ describe('project host setup projection', () => {
       projectHostSetupId: 'remote-repo'
     })
   })
+
+  it('selects setup metadata by execution host when repo ids overlap', () => {
+    const targetRepo = repo({
+      id: 'shared-repo-id',
+      path: '/srv/orca',
+      displayName: 'orca',
+      connectionId: 'builder'
+    })
+    const targetSetup = {
+      ...projectHostSetupProjectionFromRepos([targetRepo]).setups[0],
+      id: 'ssh-setup',
+      projectId: 'ssh-project'
+    }
+    const siblingSetup = {
+      ...targetSetup,
+      id: 'local-setup',
+      projectId: 'local-project',
+      hostId: 'local' as const,
+      path: '/Users/alice/orca'
+    }
+
+    expect(getProjectHostSetupWorktreeMeta([siblingSetup, targetSetup], targetRepo)).toEqual({
+      projectId: 'ssh-project',
+      hostId: 'ssh:builder',
+      projectHostSetupId: 'ssh-setup'
+    })
+  })
 })
 
 describe('isGitHubBackedRepo', () => {

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -296,8 +296,12 @@ export function getProjectHostSetupForRepo(
   setups: readonly ProjectHostSetup[],
   repo: Repo
 ): ProjectHostSetup {
+  const hostId = getRepoExecutionHostId(repo)
   return (
-    setups.find((setup) => setup.repoId === repo.id) ??
+    setups.find(
+      (setup) => setup.repoId === repo.id && setup.hostId === hostId && setup.path === repo.path
+    ) ??
+    setups.find((setup) => setup.repoId === repo.id && setup.hostId === hostId) ??
     projectHostSetupProjectionFromRepos([repo]).setups[0]
   )
 }

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -71,6 +71,10 @@ export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-comman
 // replay ambiguous cutovers when the host advertises idempotent create support.
 export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
   'worktree.create-idempotency.v1' as const
+export const WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY =
+  'worktree.create-parent-authority.v1' as const
+export const WORKTREE_CREATE_PARENT_AUTHORITY_UPDATE_REQUIRED_MESSAGE =
+  'Child worktree creation requires a newer Orca server. Update the HUB and try again.'
 export const CODEX_RESET_CREDIT_RUNTIME_CAPABILITY = 'accounts.codex-reset-credit.v1' as const
 export const ACCOUNT_IMPORT_RUNTIME_CAPABILITY = 'accounts.import-host-credentials.v1' as const
 // Why: older hosts cannot reconcile terminal.create's mutation after losing the reply, so clients may only retry unknown outcomes when advertised.
@@ -115,6 +119,7 @@ export const RUNTIME_CAPABILITIES = [
   TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY,
   TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY,
   WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
+  WORKTREE_CREATE_PARENT_AUTHORITY_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,

--- a/src/shared/selected-repository-authority.test.ts
+++ b/src/shared/selected-repository-authority.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSelectedRepositoryAuthority } from './selected-repository-authority'
+
+type Candidate = {
+  id: string
+  path: string
+  connectionId?: string | null
+}
+
+describe('selected repository authority', () => {
+  it('leaves legacy selection unchanged when authority is omitted', () => {
+    const candidates: Candidate[] = [
+      { id: 'local', path: '/repo' },
+      { id: 'ssh', path: '/repo', connectionId: 'builder' }
+    ]
+
+    expect(resolveSelectedRepositoryAuthority(candidates)).toEqual({
+      status: 'legacy-selection'
+    })
+  })
+
+  it('returns the exact path and connection owner', () => {
+    const local = { id: 'local', path: '/repo' }
+    const ssh = { id: 'ssh', path: '/repo', connectionId: 'builder' }
+
+    const resolution = resolveSelectedRepositoryAuthority([local, ssh], {
+      path: '/repo',
+      connectionId: 'builder'
+    })
+
+    expect(resolution).toEqual({ status: 'resolved', candidate: ssh })
+    if (resolution.status === 'resolved') {
+      expect(resolution.candidate).toBe(ssh)
+    }
+  })
+
+  it('uses cross-platform path comparison and trims connection ids', () => {
+    const candidate = {
+      id: 'windows-ssh',
+      path: 'C:\\Repos\\Orca',
+      connectionId: ' builder '
+    }
+
+    expect(
+      resolveSelectedRepositoryAuthority([candidate], {
+        path: 'c:/repos/orca/',
+        connectionId: 'builder'
+      })
+    ).toEqual({ status: 'resolved', candidate })
+  })
+
+  it('normalizes missing and blank connection ids to the local owner', () => {
+    const candidate = { id: 'local', path: '/repo', connectionId: undefined }
+
+    expect(
+      resolveSelectedRepositoryAuthority([candidate], {
+        path: '/repo/',
+        connectionId: null
+      })
+    ).toEqual({ status: 'resolved', candidate })
+    expect(
+      resolveSelectedRepositoryAuthority([{ ...candidate, connectionId: '  ' }], {
+        path: '/repo',
+        connectionId: null
+      })
+    ).toMatchObject({ status: 'resolved' })
+  })
+
+  it('fails closed when no candidate has the selected authority', () => {
+    expect(
+      resolveSelectedRepositoryAuthority([{ id: 'local', path: '/repo' }], {
+        path: '/repo',
+        connectionId: 'builder'
+      })
+    ).toEqual({ status: 'rejected', reason: 'no-match', matchCount: 0 })
+  })
+
+  it('fails closed when multiple candidates have the selected authority', () => {
+    const authority = { path: '/repo', connectionId: 'builder' }
+    const candidates = [
+      { id: 'first', ...authority },
+      { id: 'second', path: '/repo/', connectionId: ' builder ' }
+    ]
+
+    expect(resolveSelectedRepositoryAuthority(candidates, authority)).toEqual({
+      status: 'rejected',
+      reason: 'ambiguous',
+      matchCount: 2
+    })
+  })
+
+  it('keeps POSIX paths case-sensitive', () => {
+    expect(
+      resolveSelectedRepositoryAuthority(
+        [{ id: 'case-distinct', path: '/srv/Orca', connectionId: 'builder' }],
+        { path: '/srv/orca', connectionId: 'builder' }
+      )
+    ).toEqual({ status: 'rejected', reason: 'no-match', matchCount: 0 })
+  })
+})

--- a/src/shared/selected-repository-authority.ts
+++ b/src/shared/selected-repository-authority.ts
@@ -1,0 +1,46 @@
+import { normalizeRuntimePathForComparison } from './cross-platform-path'
+
+export type SelectedRepositoryAuthority = Readonly<{
+  path: string
+  connectionId: string | null
+}>
+
+export type SelectedRepositoryAuthorityCandidate = Readonly<{
+  path: string
+  connectionId?: string | null
+}>
+
+export type SelectedRepositoryAuthorityResolution<T> =
+  | { status: 'legacy-selection' }
+  | { status: 'resolved'; candidate: T }
+  | { status: 'rejected'; reason: 'no-match' | 'ambiguous'; matchCount: number }
+
+function normalizeConnectionId(value: string | null | undefined): string | null {
+  return value?.trim() || null
+}
+
+export function resolveSelectedRepositoryAuthority<T extends SelectedRepositoryAuthorityCandidate>(
+  candidates: readonly T[],
+  authority?: SelectedRepositoryAuthority | null
+): SelectedRepositoryAuthorityResolution<T> {
+  if (authority == null) {
+    return { status: 'legacy-selection' }
+  }
+
+  const authorityPath = normalizeRuntimePathForComparison(authority.path)
+  const authorityConnectionId = normalizeConnectionId(authority.connectionId)
+  const matches = candidates.filter(
+    (candidate) =>
+      normalizeRuntimePathForComparison(candidate.path) === authorityPath &&
+      normalizeConnectionId(candidate.connectionId) === authorityConnectionId
+  )
+
+  if (matches.length === 1) {
+    return { status: 'resolved', candidate: matches[0] }
+  }
+  return {
+    status: 'rejected',
+    reason: matches.length === 0 ? 'no-match' : 'ambiguous',
+    matchCount: matches.length
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,6 +54,7 @@ import type { TaskSourceContext } from './task-source-context'
 import type { SetupRunnerShell } from './setup-runner-command'
 import type { AiVaultSessionTitle } from './ai-vault-session-title'
 import type { ComputerAwakeMode } from './computer-awake-mode'
+import type { SelectedRepositoryAuthority } from './selected-repository-authority'
 
 // Re-exported for backward compat with renderer call sites that import
 // `WorkspaceCreateTelemetrySource` from '../../../shared/types'.
@@ -2285,6 +2286,8 @@ export type SparsePreset = {
 
 export type CreateWorktreeArgs = {
   repoId: string
+  /** Exact physical repository selected by the create surface. Optional for older clients. */
+  repoAuthority?: SelectedRepositoryAuthority
   name: string
   /** Optional user-facing label to persist separately from the git-safe
    *  branch/path seed. Used when a workspace is created from a GitHub or
@@ -2316,6 +2319,8 @@ export type CreateWorktreeArgs = {
   manualOrder?: number
   /** Parent workspace for in-app creates launched from a folder workspace. */
   parentWorkspace?: WorkspaceKey
+  /** Explicit worktree parent selected in the desktop create dialog. */
+  parentWorktreeId?: string
   /** Agent selected in the create surface. Omitted for blank-shell creates. */
   createdWithAgent?: TuiAgent
   /** Set when the renderer knows this auto-generated branch should be renamed

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -28,6 +28,7 @@ import {
   ensureTerminalVisible,
   worktreeExists
 } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
 
 test.describe('Create Workspace', () => {
   test.beforeEach(async ({ orcaPage }) => {
@@ -475,6 +476,115 @@ test.describe('Create Workspace', () => {
         .evaluate(() => {
           window.__store?.getState().closeModal()
         })
+        .catch(() => {
+          /* page may already be torn down */
+        })
+    }
+  })
+
+  test('creates a child worktree under a selected recent parent', async ({
+    orcaPage
+  }, testInfo) => {
+    const workspaceName = `E2E child ${Date.now().toString().slice(-6)}`
+    const parents = await orcaPage.evaluate(async () => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const state = store.getState()
+      const active = state.activeWorktreeId
+        ? Object.values(state.worktreesByRepo)
+            .flat()
+            .find((worktree) => worktree.id === state.activeWorktreeId)
+        : null
+      const alternate = active
+        ? (state.worktreesByRepo[active.repoId] ?? []).find(
+            (worktree) => worktree.id !== active.id && !worktree.isArchived
+          )
+        : null
+      if (!active || !alternate) {
+        throw new Error('Child worktree E2E requires two eligible worktrees')
+      }
+
+      await Promise.all([
+        state.updateWorktreeMeta(active.id, { displayName: 'Atlas parent' }),
+        state.updateWorktreeMeta(alternate.id, { displayName: 'Beacon parent' })
+      ])
+      const next = store.getState()
+      next.setGroupBy('none')
+      next.setSortBy('recent')
+      next.setShowActiveOnly(false)
+      next.setShowSleepingWorkspaces(true)
+      next.setHideDefaultBranchWorkspace(false)
+      next.setFilterRepoIds([])
+      next.setSidebarOpen(true)
+      next.setActiveWorktree(active.id, active.hostId ?? 'local')
+      store.setState((current) => ({
+        lastVisitedAtByWorktreeId: {
+          ...current.lastVisitedAtByWorktreeId,
+          [active.id]: 100,
+          [alternate.id]: 200
+        }
+      }))
+      return { activeId: active.id, alternateId: alternate.id }
+    })
+
+    try {
+      await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+      const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+      await expect(dialog).toBeVisible()
+
+      const childSwitch = dialog.getByRole('switch', { name: 'Make this a child worktree' })
+      await expect(childSwitch).toBeChecked()
+      const parentField = dialog.getByRole('combobox', { name: 'Parent worktree' })
+      await expect(parentField.locator('..')).toContainText('Atlas parent')
+
+      await parentField.click()
+      const parentList = orcaPage.getByRole('listbox', { name: 'Parent worktrees' })
+      await expect(parentList).toBeVisible()
+      await expect(parentList.getByText('Recent', { exact: true })).toBeVisible()
+      const parentOptions = parentList.getByRole('option')
+      await expect.poll(() => parentOptions.count()).toBeGreaterThanOrEqual(2)
+      await expect(parentOptions.nth(0)).toContainText('Beacon parent')
+      await expect(parentOptions.nth(1)).toContainText('Atlas parent')
+      await parentOptions.filter({ hasText: 'Beacon parent' }).click()
+      await expect(parentField.locator('..')).toContainText('Beacon parent')
+
+      const nameInput = dialog.getByPlaceholder(/Type a name/i)
+      await nameInput.fill(workspaceName)
+      await orcaPage.screenshot({ path: testInfo.outputPath('child-worktree-dialog.png') })
+
+      const createButton = dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })
+      await expect(createButton).toBeEnabled()
+      await createButton.click()
+      await expect(dialog).toBeHidden({ timeout: 15_000 })
+
+      const parentRow = worktreeRow(orcaPage, parents.alternateId)
+      const childRow = orcaPage
+        .locator('[data-worktree-sidebar]')
+        .getByText(workspaceName, { exact: true })
+        .locator('xpath=ancestor::*[@data-worktree-id][1]')
+      const hideChild = parentRow.getByRole('button', { name: 'Hide 1 child workspace' })
+      await expect(hideChild).toBeVisible({ timeout: 10_000 })
+      await expect(childRow).toBeVisible()
+      await hideChild.click()
+      await expect(childRow).toBeHidden()
+      await parentRow.getByRole('button', { name: 'Show 1 child workspace' }).click()
+      await expect(childRow).toBeVisible()
+      await expect
+        .poll(async () => {
+          const [parentBox, childBox] = await Promise.all([
+            parentRow.boundingBox(),
+            childRow.boundingBox()
+          ])
+          return parentBox && childBox ? childBox.y > parentBox.y : false
+        })
+        .toBe(true)
+      await orcaPage.screenshot({ path: testInfo.outputPath('child-worktree-created.png') })
+      await orcaPage.waitForTimeout(750)
+    } finally {
+      await orcaPage
+        .evaluate(() => window.__store?.getState().closeModal())
         .catch(() => {
           /* page may already be torn down */
         })


### PR DESCRIPTION
## ELI5

Creating a workspace can now optionally place it beneath another Orca worktree. The active eligible worktree is selected by default, and the picker puts recently used parents first.

## What Changed

- Added a “Make this a child worktree” toggle and searchable recent-parent picker to the create dialog.
- Made explicit parent selection and explicit root creation work across local, WSL, direct/nested SSH, web, and paired-runtime creation paths.
- Rendered newly created children immediately beneath their selected parent.
- Added mixed-version capability gating, exact host/repository authority, and post-create lineage validation with safe root fallback warnings.
- Added unit, integration, compatibility, accessibility, and Electron E2E coverage.

## Why

Related worktrees should be visually grouped without forcing users to reorganize them after creation. This keeps the common case one-click while still allowing a different recent parent or a root worktree.

## Linked Issue

No linked issue was supplied for this request.

## Visual Proof

### Recent parent picker

![Child worktree dialog with recent parent picker](https://github.com/user-attachments/assets/90264104-5c44-4154-ac2a-897cf39f1c47)

### Created child nested under the selected parent

![Created child worktree nested under its parent](https://github.com/user-attachments/assets/58469e0b-f337-4652-b119-6a348c5442a7)

### Recorded create flow

The visual-proof recording passed three consecutive Electron runs; this is one representative run.

https://github.com/user-attachments/assets/c82830eb-e60b-400e-bb9f-8544c5d5ae8b

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- pnpm run typecheck
- pnpm run lint
- 322 post-rebase targeted store/RPC tests
- Electron E2E child-create flow: 1 validation run plus 3/3 recorded proof runs
- pnpm exec electron-vite build --mode e2e
- Additional pre-rebase matrices: 1,429 main/authority tests and 474 renderer/web tests

Validated on macOS through Electron Playwright/CDP. CI will cover the full cross-platform matrix.

## AI Disclosure

OpenAI Codex (GPT-5) was used to implement, test, and review this change.

## Review

Reviewed for host authority, mixed client/server versions, SSH and folder-workspace behavior, stale parent cleanup, accessibility, and duplicate IDs across hosts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)

## Author

- X / Twitter: not provided
