### PR TITLE
fix(terminal): preserve panes on empty recovery snapshots

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -118,6 +118,12 @@ type SerializedSnapshot = {
   kittyKeyboardFlags?: number
 } | null
 
+function hasSerializedSnapshotContent(
+  snapshot: SerializedSnapshot
+): snapshot is Exclude<SerializedSnapshot, null> {
+  return Boolean(snapshot && (snapshot.data.length > 0 || snapshot.scrollbackAnsi))
+}
+
 type TerminalViewportClient = {
   id: string
   type?: 'mobile' | 'desktop'
@@ -1813,7 +1819,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           if (closed || streams.get(stream.streamId) !== stream || stream.outputPaused) {
             return
           }
-          if (!serialized) {
+          if (!hasSerializedSnapshotContent(serialized)) {
             throw new Error('Remote terminal recovery snapshot unavailable.')
           }
           if (
@@ -2329,6 +2335,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               })
               return
             }
+          }
+          if (typeof requestId !== 'number' && !hasSerializedSnapshotContent(serialized)) {
+            return
           }
           sentSnapshotOutputSeq = serialized?.seq
           sendSnapshotFrames((opcode, payload) => sendFrame(stream.streamId, opcode, payload), {

--- a/src/main/runtime/rpc/terminal-multiplex-resync-replay-trim.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-resync-replay-trim.test.ts
@@ -225,4 +225,28 @@ describe('terminal.multiplex requested-snapshot replay trim', () => {
       vi.useRealTimers()
     }
   })
+
+  it('suppresses an empty untagged resync reply', async () => {
+    vi.useFakeTimers()
+    try {
+      const harness = await setupMultiplexStream()
+      const frameCountBeforeRequest = harness.binaryFrames.length
+
+      harness.setSnapshot({ data: '', seq: 12 })
+      harness.deferNextSerialize()
+      harness.sendClientFrame(TerminalStreamOpcode.SnapshotRequest, encodeTerminalStreamJson({}))
+      await harness.releaseSerialize()
+
+      expect(
+        harness.binaryFrames
+          .slice(frameCountBeforeRequest)
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .some((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart)
+      ).toBe(false)
+
+      await harness.finish()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -2857,6 +2857,43 @@ describe('terminal multiplex RPC', () => {
     await harness.dispatchPromise
   })
 
+  it('does not publish an empty ACK overflow recovery snapshot', async () => {
+    const flooded = 'x'.repeat(3 * 1024 * 1024)
+    const harness = startSourceRangeOverflowHarness({
+      recover: async () => ({
+        data: '',
+        cols: 120,
+        rows: 40,
+        source: 'renderer',
+        seq: flooded.length
+      })
+    })
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+    sendDesktopSourceRangeSubscribe(harness.handlers)
+    await vi.waitFor(() => expect(harness.getDataListener()).toBeDefined())
+    const frameCount = harness.binaryFrames.length
+
+    await acknowledgeSourceRangeOverflow(harness, harness.getDataListener()!, flooded)
+    await vi.waitFor(() => expect(harness.cancel).toHaveBeenCalledOnce())
+
+    expect(
+      harness.binaryFrames
+        .slice(frameCount)
+        .map(decodeTerminalStreamFrame)
+        .some(
+          (frame) =>
+            frame?.opcode === TerminalStreamOpcode.SnapshotStart &&
+            decodeTerminalStreamJson<{ reason?: string }>(frame.payload)?.reason ===
+              'ack-pending-overflow'
+        )
+    ).toBe(false)
+    expect(harness.reserve.mock.calls.some((call) => call[2] === 'ack-pending-overflow')).toBe(
+      false
+    )
+    harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
+    await harness.dispatchPromise
+  })
+
   it('caps stalled ACK output and snapshots before resuming retained tail frames', async () => {
     const messages: string[] = []
     const binaryFrames: Uint8Array<ArrayBufferLike>[] = []

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -42,6 +42,7 @@ class FakeMultiplexServer {
   truncateNextRecoverySnapshot = false
   dropNextRecoverySnapshotEnd = false
   holdNextRecoverySnapshot = false
+  emptyNextRecoverySnapshot = false
   snapshotRequests: (number | undefined)[] = []
   private heldManualRequestId: number | null = null
   private snapshotData = 'INITIAL'
@@ -73,7 +74,8 @@ class FakeMultiplexServer {
       }
       // Resync request: the server serializes the *current* buffer, so recovery
       // includes everything the client missed.
-      this.snapshotData = 'RECOVERED'
+      this.snapshotData = this.emptyNextRecoverySnapshot ? '' : 'RECOVERED'
+      this.emptyNextRecoverySnapshot = false
       if (typeof payload?.requestId !== 'number' && this.holdNextRecoverySnapshot) {
         // The reply's binary frames were all dropped under backpressure.
         this.holdNextRecoverySnapshot = false
@@ -248,6 +250,21 @@ describe('remote terminal frame-drop resync', () => {
     server.replaySnapshotCoveredOutput('ccc')
     server.output('ddd')
     expect(data).toEqual(['aaa', 'ddd'])
+  })
+
+  it('keeps a painted pane when recovery has no content', async () => {
+    const { data, snapshots } = await subscribeClient()
+    server.emptyNextRecoverySnapshot = true
+
+    server.output('painted')
+    server.dropNextOutput = true
+    server.output('dropped')
+    server.output('gap')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(data).toEqual(['painted'])
+    expect(snapshots).toEqual(['INITIAL'])
   })
 
   it('retries a truncated recovery on a backoff without accepting output across the gap', async () => {

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -905,14 +905,14 @@ class RemoteRuntimeTerminalMultiplexer {
           })
         } else if (target === 'recovery') {
           // Why: a server-pushed recovery snapshot replaces terminal state
-          // mid-session; clear the screen and scrollback before applying it.
-          // An empty snapshot is still applied so stale dropped output does
-          // not linger on a terminal the model says is blank.
-          stream.callbacks.onSnapshot(`\x1b[2J\x1b[3J\x1b[H${data ?? ''}`, {
-            pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
-            seq: info?.seq,
-            kittyKeyboardFlags: info?.kittyKeyboardFlags
-          })
+          // mid-session; atomically clear and apply only when it has content.
+          if (data) {
+            stream.callbacks.onSnapshot(`\x1b[2J\x1b[3J\x1b[H${data}`, {
+              pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
+              seq: info?.seq,
+              kittyKeyboardFlags: info?.kittyKeyboardFlags
+            })
+          }
         }
       } else if (matchesPendingRequest) {
         pendingRequest.resolve({
@@ -994,7 +994,7 @@ class RemoteRuntimeTerminalMultiplexer {
 
   // Why: on a detected gap, discard the corrupt tail and pull a fresh
   // authoritative snapshot. The request carries no requestId so the server
-  // reply renders through the initial-snapshot path (full reset), self-healing
+  // reply renders through the recovery path (full reset), self-healing
   // without surfacing an error to the user.
   private requestResyncSnapshot(stream: RemoteRuntimeMultiplexedTerminalState): void {
     if (stream.resyncInFlight) {


### PR DESCRIPTION
## ELI5

An empty recovery reply can no longer erase a remote terminal that already has useful output painted. The client keeps the existing pane, and the host avoids sending recovery frames that contain nothing.

## What Changed

- Gate recovery rendering on non-empty snapshot data, keeping the clear sequence and replacement payload in one atomic callback.
- Suppress contentless host recovery snapshots for both ACK-overflow recovery and untagged resync requests.
- Keep tagged snapshot requests unchanged, including proven-empty tagged replies.
- Correct the resync comment to identify the recovery path.
- Add client and host regressions for empty and non-empty recovery behavior.

This branch is based on `main` and includes the minimal `hasSerializedSnapshotContent` helper required by the host invariant. If #14184 lands first, the duplicate helper definition is an expected trivial rebase conflict that should collapse to one copy.

## Why

Clients and remote hosts update independently, so both layers need the invariant: a new client must tolerate an old host's empty recovery, and a new host must not send a destructive no-content recovery to an old client.

The host implementation uses the existing serialized-content predicate because the current serializer result has no distinct typed “cannot answer” outcome. A typed suppression result paired with a repaint nudge is the stronger follow-up, but introducing that contract and lifecycle is broader than this targeted mixed-version fix.

## Linked Issue

Related to #14182

## Visual Proof

N/A — this is a binary terminal-stream recovery invariant verified deterministically at the multiplexer callback and host frame boundaries; there is no stable standalone Electron interaction that isolates the old-host/new-client pairing.

## Testing

RED before GREEN: before production edits, the three new regressions failed because the client emitted a clear-only callback, the untagged resync emitted a SnapshotStart frame, and ACK-overflow recovery published instead of suppressing.

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts src/main/runtime/rpc/terminal-multiplex-resync-replay-trim.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts src/main/runtime/rpc/terminal-requested-snapshot-unavailability.test.ts` — 87 passed
- `pnpm exec vitest run --config config/vitest.config.ts tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` — 4 passed
- `npx tsc --noEmit -p config/tsconfig.node.json`
- `pnpm run typecheck:web`
- `pnpm exec oxfmt --check <changed files>`
- `pnpm exec oxlint <changed files>`
- `pnpm run check:max-lines-ratchet`

The changed-code wrapper itself could not run under local Node 26 because it parsed the engine warning as JSON; direct lint of all changed files passed. macOS was the local host; the transport-only change is platform-neutral and applies equally to SSH and paired remote hosts.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI GPT-5 was used for implementation and test review.

## Review

Reviewed for mixed-version compatibility, remote SSH behavior, source-range replacement cleanup, performance, and platform neutrality. No protocol shape or opcode changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Full lint/typecheck/test/build delegated to CI; required focused validation passes locally
