### PR TITLE
fix(terminal): restore remote replay grid on reveal

### DIFF
--- a/src/main/daemon/terminal-history-dimensions.ts
+++ b/src/main/daemon/terminal-history-dimensions.ts
@@ -1,14 +1,1 @@
-// Why separate from live admission: existing recovery was written through a 1,000-column viewport contract.
-const MAX_TERMINAL_HISTORY_COLS = 1_000
-const MAX_TERMINAL_HISTORY_ROWS = 500
-
-export function isValidTerminalHistorySize(cols: unknown, rows: unknown): boolean {
-  return (
-    Number.isSafeInteger(cols) &&
-    (cols as number) >= 1 &&
-    (cols as number) <= MAX_TERMINAL_HISTORY_COLS &&
-    Number.isSafeInteger(rows) &&
-    (rows as number) >= 1 &&
-    (rows as number) <= MAX_TERMINAL_HISTORY_ROWS
-  )
-}
+export { isValidTerminalHistorySize } from '../../shared/terminal-history-dimensions'

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -309,7 +309,10 @@ type ConnectCallbacks = {
     data: string,
     meta?: { seq?: number; rawLength?: number; background?: boolean; droppedOutput?: boolean }
   ) => void
-  onReplayData?: (data: string, meta?: { clearBeforeReplay?: boolean }) => void
+  onReplayData?: (
+    data: string,
+    meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+  ) => void
   onError?: (msg: string) => void
   onWriteUnavailable?: () => void
   onOutputPauseChanged?: (paused: boolean, supported: boolean) => void
@@ -9524,7 +9527,12 @@ describe('connectPanePty', () => {
       current:
         | ((
             data: string,
-            meta?: { clearBeforeReplay?: boolean; pendingEscapeTailAnsi?: string }
+            meta?: {
+              clearBeforeReplay?: boolean
+              pendingEscapeTailAnsi?: string
+              snapshotCols?: number
+              snapshotRows?: number
+            }
           ) => void)
         | null
     } = { current: null }
@@ -17304,7 +17312,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17342,7 +17355,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17381,7 +17399,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17415,7 +17438,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17457,7 +17485,12 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17492,7 +17525,12 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17256,13 +17256,20 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
-  it('paints remote replay at its snapshot grid before returning to the live pane grid', async () => {
+  it('paints remote replay at its snapshot grid and reports the live grid from a measurable hidden pane', async () => {
     const { connectPanePty } = await import('./pty-connection')
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-grid')
     const capturedReplayCallback: {
       current:
-        | ((data: string, meta?: { snapshotCols?: number; snapshotRows?: number }) => void)
+        | ((
+            data: string,
+            meta?: {
+              snapshotCols?: number
+              snapshotRows?: number
+              pendingEscapeTailAnsi?: string
+            }
+          ) => void)
         | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
@@ -17285,9 +17292,10 @@ describe('connectPanePty', () => {
       callback?.()
     }) as typeof pane.terminal.write
     const manager = createManager(1)
-    const deps = createDeps()
+    const deps = createDeps({ isVisibleRef: { current: false } })
     const disposable = connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(6)
+    transport.resize.mockClear()
 
     capturedReplayCallback.current?.('snapshot payload', {
       snapshotCols: 60,
@@ -17304,6 +17312,40 @@ describe('connectPanePty', () => {
     )
     expect(pane.terminal.cols).toBe(180)
     expect(pane.terminal.rows).toBe(50)
+    expect(transport.resize).toHaveBeenCalledWith(180, 50)
+
+    vi.mocked(pane.terminal.resize).mockClear()
+    capturedReplayCallback.current?.('unknown-size payload', {
+      snapshotCols: 0,
+      snapshotRows: 0
+    })
+    await flushAsyncTicks(12)
+    expect(pane.terminal.resize).not.toHaveBeenCalledWith(0, 0)
+
+    vi.mocked(pane.terminal.resize).mockClear()
+    capturedReplayCallback.current?.('', {
+      snapshotCols: 30,
+      snapshotRows: 10,
+      pendingEscapeTailAnsi: '\x1b[3'
+    })
+    await flushAsyncTicks(12)
+    expect(pane.terminal.resize).not.toHaveBeenCalledWith(30, 10)
+
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    setDriverForPty('remote:env-1@@terminal-grid', { kind: 'mobile', clientId: 'phone-1' })
+    transport.resize.mockClear()
+    try {
+      capturedReplayCallback.current?.('mobile-owned payload', {
+        snapshotCols: 60,
+        snapshotRows: 20
+      })
+      await flushAsyncTicks(12)
+      expect(pane.terminal.cols).toBe(180)
+      expect(pane.terminal.rows).toBe(50)
+      expect(transport.resize).not.toHaveBeenCalled()
+    } finally {
+      setDriverForPty('remote:env-1@@terminal-grid', { kind: 'idle' })
+    }
     disposable.dispose()
   })
 
@@ -25807,6 +25849,7 @@ describe('connectPanePty', () => {
 
       expect(getSize).not.toHaveBeenCalled()
       expect(pane.fitAddon.proposeDimensions).toHaveBeenCalled()
+      expect(pane.fitAddon.fit).not.toHaveBeenCalled()
       expect(transport.resize).toHaveBeenCalledWith(120, 40)
     })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17330,10 +17330,8 @@ describe('connectPanePty', () => {
       vi.mocked(pane.terminal.write).mockClear()
       const payload = `invalid-grid ${snapshotCols}x${snapshotRows}`
       capturedReplayCallback.current?.(payload, { snapshotCols, snapshotRows })
-      await vi.waitFor(() =>
-        expect(pane.terminal.write).toHaveBeenCalledWith(payload, expect.any(Function))
-      )
-      await flushAsyncTicks(4)
+      await flushAsyncTicks(24)
+      expect(pane.terminal.write).toHaveBeenCalledWith(payload, expect.any(Function))
       expect(pane.terminal.resize).not.toHaveBeenCalled()
     }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -495,6 +495,10 @@ function createPaneContainer(): HTMLElement {
     configurable: true,
     value: {}
   })
+  Object.defineProperties(container, {
+    clientWidth: { configurable: true, value: 1200 },
+    clientHeight: { configurable: true, value: 800 }
+  })
   return container
 }
 
@@ -17244,6 +17248,57 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('paints remote replay at its snapshot grid before returning to the live pane grid', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    enableActiveRuntimeEnvironment()
+    const transport = createMockTransport('remote:env-1@@terminal-grid')
+    const capturedReplayCallback: {
+      current:
+        | ((data: string, meta?: { snapshotCols?: number; snapshotRows?: number }) => void)
+        | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return { id: 'remote:env-1@@terminal-grid', replay: '' }
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const operations: string[] = []
+    pane.terminal.resize = vi.fn((cols: number, rows: number) => {
+      operations.push(`resize:${cols}x${rows}`)
+      pane.terminal.cols = cols
+      pane.terminal.rows = rows
+    })
+    pane.fitAddon.fit = vi.fn(() => pane.terminal.resize(180, 50))
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 180, rows: 50 }))
+    pane.terminal.write = vi.fn((data: string, callback?: () => void) => {
+      operations.push(`write:${data}`)
+      callback?.()
+    }) as typeof pane.terminal.write
+    const manager = createManager(1)
+    const deps = createDeps()
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedReplayCallback.current?.('snapshot payload', {
+      snapshotCols: 60,
+      snapshotRows: 20
+    })
+    await flushAsyncTicks(12)
+
+    expect(operations).toContain('resize:60x20')
+    expect(operations.indexOf('resize:60x20')).toBeLessThan(
+      operations.indexOf('write:snapshot payload')
+    )
+    expect(operations.lastIndexOf('resize:180x50')).toBeGreaterThan(
+      operations.indexOf('write:snapshot payload')
+    )
+    expect(pane.terminal.cols).toBe(180)
+    expect(pane.terminal.rows).toBe(50)
+    disposable.dispose()
+  })
+
   it('preserves live agent modes when queued replay data carries the Cursor Agent screen', async () => {
     const { connectPanePty } = await import('./pty-connection')
     enableActiveRuntimeEnvironment()
@@ -25689,7 +25744,7 @@ describe('connectPanePty', () => {
       }
     })
 
-    it('skips remote-runtime PTYs (their size lives outside the local ptySizes map)', async () => {
+    it('re-fits and re-reports a remote viewport on reveal even when its grid is unchanged', async () => {
       const getSize = vi.mocked(window.api.pty.getSize)
       getSize.mockClear()
       const { connectPanePty } = await import('./pty-connection')
@@ -25702,17 +25757,68 @@ describe('connectPanePty', () => {
         paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
       })
       const pane = createPane(2)
+      pane.fitAddon.fit = vi.fn()
       const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
         noteVisibilityResume: () => void
       }
       transport.resize.mockClear()
+      pane.fitAddon.proposeDimensions.mockClear()
 
       binding.noteVisibilityResume()
       await flushAsyncTicks()
 
-      // Never even queries size for a remote pane, and never re-asserts.
       expect(getSize).not.toHaveBeenCalled()
+      expect(pane.fitAddon.proposeDimensions).toHaveBeenCalled()
+      expect(transport.resize).toHaveBeenCalledWith(120, 40)
+    })
+
+    it('does not fit or report a remote viewport from a zero-sized reveal box', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('remote:env-1@@terminal-zero-box')
+      const capturedReplayCallback: {
+        current:
+          | ((data: string, meta?: { snapshotCols?: number; snapshotRows?: number }) => void)
+          | null
+      } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedReplayCallback.current = callbacks.onReplayData ?? null
+          return { id: 'remote:env-1@@terminal-zero-box', replay: '' }
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const pane = createPane(2)
+      Object.defineProperties(pane.container, {
+        clientWidth: { configurable: true, value: 0 },
+        clientHeight: { configurable: true, value: 0 }
+      })
+      pane.fitAddon.fit = vi.fn()
+      const manager = createManager(2)
+      const deps = createDeps({
+        restoredLeafId: LEAF_2,
+        paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
+      })
+      const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+        noteVisibilityResume: () => void
+      }
+      transport.resize.mockClear()
+      pane.fitAddon.proposeDimensions.mockClear()
+      pane.terminal.write.mockClear()
+
+      capturedReplayCallback.current?.('must wait for a box', {
+        snapshotCols: 60,
+        snapshotRows: 20
+      })
+      binding.noteVisibilityResume()
+      await flushAsyncTicks()
+
+      expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        'must wait for a box',
+        expect.any(Function)
+      )
       expect(transport.resize).not.toHaveBeenCalled()
+      expect(transport.claimViewport).not.toHaveBeenCalled()
     })
 
     it('claims a focused visible remote mirror once when its passive fit hold arrives', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17322,6 +17322,21 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(12)
     expect(pane.terminal.resize).not.toHaveBeenCalledWith(0, 0)
 
+    for (const [snapshotCols, snapshotRows] of [
+      [60.5, 20],
+      [1_001, 501]
+    ]) {
+      vi.mocked(pane.terminal.resize).mockClear()
+      vi.mocked(pane.terminal.write).mockClear()
+      const payload = `invalid-grid ${snapshotCols}x${snapshotRows}`
+      capturedReplayCallback.current?.(payload, { snapshotCols, snapshotRows })
+      await vi.waitFor(() =>
+        expect(pane.terminal.write).toHaveBeenCalledWith(payload, expect.any(Function))
+      )
+      await flushAsyncTicks(4)
+      expect(pane.terminal.resize).not.toHaveBeenCalled()
+    }
+
     vi.mocked(pane.terminal.resize).mockClear()
     capturedReplayCallback.current?.('', {
       snapshotCols: 30,

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -302,7 +302,10 @@ type ConnectCallbacks = {
     data: string,
     meta?: { seq?: number; rawLength?: number; background?: boolean; droppedOutput?: boolean }
   ) => void
-  onReplayData?: (data: string, meta?: { clearBeforeReplay?: boolean }) => void
+  onReplayData?: (
+    data: string,
+    meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+  ) => void
   onError?: (msg: string) => void
   onWriteUnavailable?: () => void
   onOutputPauseChanged?: (paused: boolean, supported: boolean) => void
@@ -9503,7 +9506,12 @@ describe('connectPanePty', () => {
       current:
         | ((
             data: string,
-            meta?: { clearBeforeReplay?: boolean; pendingEscapeTailAnsi?: string }
+            meta?: {
+              clearBeforeReplay?: boolean
+              pendingEscapeTailAnsi?: string
+              snapshotCols?: number
+              snapshotRows?: number
+            }
           ) => void)
         | null
     } = { current: null }
@@ -17096,7 +17104,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17134,7 +17147,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17173,7 +17191,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17207,7 +17230,12 @@ describe('connectPanePty', () => {
     enableActiveRuntimeEnvironment()
     const transport = createMockTransport('remote:env-1@@terminal-1')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17249,7 +17277,12 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null
@@ -17284,7 +17317,12 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedReplayCallback: {
-      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+      current:
+        | ((
+            data: string,
+            meta?: { clearBeforeReplay?: boolean; snapshotCols?: number; snapshotRows?: number }
+          ) => void)
+        | null
     } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedReplayCallback.current = callbacks.onReplayData ?? null

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -488,6 +488,10 @@ function createPaneContainer(): HTMLElement {
     configurable: true,
     value: {}
   })
+  Object.defineProperties(container, {
+    clientWidth: { configurable: true, value: 1200 },
+    clientHeight: { configurable: true, value: 800 }
+  })
   return container
 }
 
@@ -17036,6 +17040,57 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('paints remote replay at its snapshot grid before returning to the live pane grid', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    enableActiveRuntimeEnvironment()
+    const transport = createMockTransport('remote:env-1@@terminal-grid')
+    const capturedReplayCallback: {
+      current:
+        | ((data: string, meta?: { snapshotCols?: number; snapshotRows?: number }) => void)
+        | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return { id: 'remote:env-1@@terminal-grid', replay: '' }
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const operations: string[] = []
+    pane.terminal.resize = vi.fn((cols: number, rows: number) => {
+      operations.push(`resize:${cols}x${rows}`)
+      pane.terminal.cols = cols
+      pane.terminal.rows = rows
+    })
+    pane.fitAddon.fit = vi.fn(() => pane.terminal.resize(180, 50))
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 180, rows: 50 }))
+    pane.terminal.write = vi.fn((data: string, callback?: () => void) => {
+      operations.push(`write:${data}`)
+      callback?.()
+    }) as typeof pane.terminal.write
+    const manager = createManager(1)
+    const deps = createDeps()
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedReplayCallback.current?.('snapshot payload', {
+      snapshotCols: 60,
+      snapshotRows: 20
+    })
+    await flushAsyncTicks(12)
+
+    expect(operations).toContain('resize:60x20')
+    expect(operations.indexOf('resize:60x20')).toBeLessThan(
+      operations.indexOf('write:snapshot payload')
+    )
+    expect(operations.lastIndexOf('resize:180x50')).toBeGreaterThan(
+      operations.indexOf('write:snapshot payload')
+    )
+    expect(pane.terminal.cols).toBe(180)
+    expect(pane.terminal.rows).toBe(50)
+    disposable.dispose()
+  })
+
   it('preserves live agent modes when queued replay data carries the Cursor Agent screen', async () => {
     const { connectPanePty } = await import('./pty-connection')
     enableActiveRuntimeEnvironment()
@@ -25481,7 +25536,7 @@ describe('connectPanePty', () => {
       }
     })
 
-    it('skips remote-runtime PTYs (their size lives outside the local ptySizes map)', async () => {
+    it('re-fits and re-reports a remote viewport on reveal even when its grid is unchanged', async () => {
       const getSize = vi.mocked(window.api.pty.getSize)
       getSize.mockClear()
       const { connectPanePty } = await import('./pty-connection')
@@ -25494,17 +25549,68 @@ describe('connectPanePty', () => {
         paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
       })
       const pane = createPane(2)
+      pane.fitAddon.fit = vi.fn()
       const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
         noteVisibilityResume: () => void
       }
       transport.resize.mockClear()
+      pane.fitAddon.proposeDimensions.mockClear()
 
       binding.noteVisibilityResume()
       await flushAsyncTicks()
 
-      // Never even queries size for a remote pane, and never re-asserts.
       expect(getSize).not.toHaveBeenCalled()
+      expect(pane.fitAddon.proposeDimensions).toHaveBeenCalled()
+      expect(transport.resize).toHaveBeenCalledWith(120, 40)
+    })
+
+    it('does not fit or report a remote viewport from a zero-sized reveal box', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('remote:env-1@@terminal-zero-box')
+      const capturedReplayCallback: {
+        current:
+          | ((data: string, meta?: { snapshotCols?: number; snapshotRows?: number }) => void)
+          | null
+      } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedReplayCallback.current = callbacks.onReplayData ?? null
+          return { id: 'remote:env-1@@terminal-zero-box', replay: '' }
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const pane = createPane(2)
+      Object.defineProperties(pane.container, {
+        clientWidth: { configurable: true, value: 0 },
+        clientHeight: { configurable: true, value: 0 }
+      })
+      pane.fitAddon.fit = vi.fn()
+      const manager = createManager(2)
+      const deps = createDeps({
+        restoredLeafId: LEAF_2,
+        paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
+      })
+      const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+        noteVisibilityResume: () => void
+      }
+      transport.resize.mockClear()
+      pane.fitAddon.proposeDimensions.mockClear()
+      pane.terminal.write.mockClear()
+
+      capturedReplayCallback.current?.('must wait for a box', {
+        snapshotCols: 60,
+        snapshotRows: 20
+      })
+      binding.noteVisibilityResume()
+      await flushAsyncTicks()
+
+      expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        'must wait for a box',
+        expect.any(Function)
+      )
       expect(transport.resize).not.toHaveBeenCalled()
+      expect(transport.claimViewport).not.toHaveBeenCalled()
     })
 
     it('claims a focused visible remote mirror once when its passive fit hold arrives', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1136,6 +1136,7 @@ export function connectPanePty(
   let resetRendererOrderedSeqForPtyExit: (exitedPtyId: string) => void = () => {}
   let cleanupStartupDraftPasteTimers = (): void => {}
   let unregisterE2ePtyDataInjection = (): void => {}
+  let resumePendingReplayDataDrain = (): void => {}
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteNotificationGraceTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteNotificationMaxTimer: ReturnType<typeof setTimeout> | null = null
@@ -4349,6 +4350,28 @@ export function connectPanePty(
       }
     }
   }
+  const reportRemoteViewportOnReveal = (): void => {
+    const revealedPtyId = transport.getPtyId()
+    if (
+      !revealedPtyId ||
+      !isRemoteRuntimePtyId(revealedPtyId) ||
+      pane.container.clientWidth <= 0 ||
+      pane.container.clientHeight <= 0 ||
+      shouldSuppressDesktopPtyResize()
+    ) {
+      return
+    }
+    safeFitAndThen(pane, 'remote-reveal-viewport', () => {
+      if (disposed || transport.getPtyId() !== revealedPtyId || shouldSuppressDesktopPtyResize()) {
+        return
+      }
+      const cols = pane.terminal.cols
+      const rows = pane.terminal.rows
+      if (Number.isFinite(cols) && Number.isFinite(rows) && cols > 0 && rows > 0) {
+        transport.resize(cols, rows)
+      }
+    })
+  }
   let pendingForegroundGridDriftCheckRaf: number | null = null
   let lastForegroundGridDriftCheckAt = Number.NEGATIVE_INFINITY
   const readProposedTerminalGrid = (): { cols: number; rows: number } | null => {
@@ -4421,6 +4444,9 @@ export function connectPanePty(
     pendingGeometryReportRaf = null
     if (disposed) {
       return
+    }
+    if (pane.container.clientWidth > 0 && pane.container.clientHeight > 0) {
+      resumePendingReplayDataDrain()
     }
     if (
       deferTerminalGeometryMutationDuringRebuild(
@@ -5608,6 +5634,8 @@ export function connectPanePty(
     type PendingReplayData = {
       data: string
       clearBeforeReplay: boolean
+      snapshotCols?: number
+      snapshotRows?: number
       ptyId: string | null
       generation: number
       streamGeneration: number
@@ -5658,6 +5686,22 @@ export function connectPanePty(
             continue
           }
         }
+        const snapshotDimensions = resolvePositiveTerminalDimensions(
+          payload.snapshotCols,
+          payload.snapshotRows
+        )
+        if (
+          snapshotDimensions &&
+          (pane.terminal.cols !== snapshotDimensions.cols ||
+            pane.terminal.rows !== snapshotDimensions.rows)
+        ) {
+          suppressStructuralReplayPtyResize = true
+          try {
+            pane.terminal.resize(snapshotDimensions.cols, snapshotDimensions.rows)
+          } finally {
+            suppressStructuralReplayPtyResize = false
+          }
+        }
         if (clearBeforeReplay || data.length > 0) {
           // Why: an empty clearing frame is still an authoritative repaint and
           // must clear a stale agent signal from an earlier payload.
@@ -5699,7 +5743,13 @@ export function connectPanePty(
       return appliedCurrentPayload
     }
     const scheduleReplayDataDrain = (): void => {
-      if (replayDrainQueued) {
+      if (
+        replayDrainQueued ||
+        pendingReplayData === null ||
+        pane.container.clientWidth <= 0 ||
+        pane.container.clientHeight <= 0 ||
+        !safeFit(pane)
+      ) {
         return
       }
       const scheduledPtyId = pendingReplayData?.ptyId ?? null
@@ -5724,7 +5774,12 @@ export function connectPanePty(
               shouldRestore: () =>
                 !disposed &&
                 transport.getPtyId() === scheduledPtyId &&
-                transportStreamGeneration === scheduledStreamGeneration
+                transportStreamGeneration === scheduledStreamGeneration,
+              afterRestore: () => {
+                if (replayCompleted) {
+                  safeFit(pane)
+                }
+              }
             }
           )
         )
@@ -5741,6 +5796,7 @@ export function connectPanePty(
           finishReattachLiveDataDeferral(replayCompleted, scheduledStreamGeneration)
         })
     }
+    resumePendingReplayDataDrain = scheduleReplayDataDrain
     const replayDataCallback = (
       data: string,
       meta: PtyReplayDataMeta = {},
@@ -5749,6 +5805,8 @@ export function connectPanePty(
       pendingReplayData = {
         data,
         clearBeforeReplay: meta.clearBeforeReplay !== false,
+        ...(meta.snapshotCols !== undefined ? { snapshotCols: meta.snapshotCols } : {}),
+        ...(meta.snapshotRows !== undefined ? { snapshotRows: meta.snapshotRows } : {}),
         ptyId: transport.getPtyId(),
         generation: (replayPayloadGeneration += 1),
         streamGeneration,
@@ -9283,6 +9341,8 @@ export function connectPanePty(
     noteVisibilityResume() {
       armVisibleRemoteViewportClaim()
       claimPendingVisibleRemoteViewport()
+      reportRemoteViewportOnReveal()
+      resumePendingReplayDataDrain()
       ptySizeReassertion.request({ fit: false })
       consumeHibernatedAgentWake()
       requestKnownWindowsShiftEnterReconfirmation()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4350,8 +4350,29 @@ export function connectPanePty(
       }
     }
   }
+  const reportRemoteViewportAfterFit = (
+    ptyId: string | null,
+    expectedStreamGeneration: number
+  ): void => {
+    if (
+      !ptyId ||
+      !isRemoteRuntimePtyId(ptyId) ||
+      disposed ||
+      transport.getPtyId() !== ptyId ||
+      transportStreamGeneration !== expectedStreamGeneration ||
+      shouldSuppressDesktopPtyResize()
+    ) {
+      return
+    }
+    const cols = pane.terminal.cols
+    const rows = pane.terminal.rows
+    if (Number.isFinite(cols) && Number.isFinite(rows) && cols > 0 && rows > 0) {
+      transport.resize(cols, rows)
+    }
+  }
   const reportRemoteViewportOnReveal = (): void => {
     const revealedPtyId = transport.getPtyId()
+    const revealedStreamGeneration = transportStreamGeneration
     if (
       !revealedPtyId ||
       !isRemoteRuntimePtyId(revealedPtyId) ||
@@ -4362,14 +4383,7 @@ export function connectPanePty(
       return
     }
     safeFitAndThen(pane, 'remote-reveal-viewport', () => {
-      if (disposed || transport.getPtyId() !== revealedPtyId || shouldSuppressDesktopPtyResize()) {
-        return
-      }
-      const cols = pane.terminal.cols
-      const rows = pane.terminal.rows
-      if (Number.isFinite(cols) && Number.isFinite(rows) && cols > 0 && rows > 0) {
-        transport.resize(cols, rows)
-      }
+      reportRemoteViewportAfterFit(revealedPtyId, revealedStreamGeneration)
     })
   }
   let pendingForegroundGridDriftCheckRaf: number | null = null
@@ -5649,7 +5663,8 @@ export function connectPanePty(
     let replayDrainQueued = false
     const drainReplayDataQueue = async (
       expectedPtyId: string | null,
-      expectedStreamGeneration: number
+      expectedStreamGeneration: number,
+      noteSnapshotGridReplay: () => void
     ): Promise<boolean> => {
       let appliedCurrentPayload = false
       while (pendingReplayData !== null) {
@@ -5692,9 +5707,11 @@ export function connectPanePty(
         )
         if (
           snapshotDimensions &&
+          data.length > 0 &&
           (pane.terminal.cols !== snapshotDimensions.cols ||
             pane.terminal.rows !== snapshotDimensions.rows)
         ) {
+          noteSnapshotGridReplay()
           suppressStructuralReplayPtyResize = true
           try {
             pane.terminal.resize(snapshotDimensions.cols, snapshotDimensions.rows)
@@ -5760,6 +5777,7 @@ export function connectPanePty(
         pendingReplayData?.streamGeneration ?? transportStreamGeneration
       beginReattachLiveDataDeferral(scheduledStreamGeneration)
       let replayCompleted = false
+      let replayUsedSnapshotGrid = false
       replayWriteQueue = replayWriteQueue
         .catch(() => undefined)
         .then(() =>
@@ -5767,7 +5785,10 @@ export function connectPanePty(
             async () => {
               replayCompleted = await drainReplayDataQueue(
                 scheduledPtyId,
-                scheduledStreamGeneration
+                scheduledStreamGeneration,
+                () => {
+                  replayUsedSnapshotGrid = true
+                }
               )
             },
             {
@@ -5776,8 +5797,9 @@ export function connectPanePty(
                 transport.getPtyId() === scheduledPtyId &&
                 transportStreamGeneration === scheduledStreamGeneration,
               afterRestore: () => {
-                if (replayCompleted) {
-                  safeFit(pane)
+                if (replayCompleted && replayUsedSnapshotGrid && safeFit(pane)) {
+                  // Why: a measurable hidden pane is authoritative; only presence ownership gates this report (#12768).
+                  reportRemoteViewportAfterFit(scheduledPtyId, scheduledStreamGeneration)
                 }
               }
             }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1136,6 +1136,7 @@ export function connectPanePty(
   let resetRendererOrderedSeqForPtyExit: (exitedPtyId: string) => void = () => {}
   let cleanupStartupDraftPasteTimers = (): void => {}
   let unregisterE2ePtyDataInjection = (): void => {}
+  let resumePendingReplayDataDrain = (): void => {}
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   let sshShellReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteNotificationGraceTimer: ReturnType<typeof setTimeout> | null = null
@@ -4343,6 +4344,28 @@ export function connectPanePty(
       }
     }
   }
+  const reportRemoteViewportOnReveal = (): void => {
+    const revealedPtyId = transport.getPtyId()
+    if (
+      !revealedPtyId ||
+      !isRemoteRuntimePtyId(revealedPtyId) ||
+      pane.container.clientWidth <= 0 ||
+      pane.container.clientHeight <= 0 ||
+      shouldSuppressDesktopPtyResize()
+    ) {
+      return
+    }
+    safeFitAndThen(pane, 'remote-reveal-viewport', () => {
+      if (disposed || transport.getPtyId() !== revealedPtyId || shouldSuppressDesktopPtyResize()) {
+        return
+      }
+      const cols = pane.terminal.cols
+      const rows = pane.terminal.rows
+      if (Number.isFinite(cols) && Number.isFinite(rows) && cols > 0 && rows > 0) {
+        transport.resize(cols, rows)
+      }
+    })
+  }
   let pendingForegroundGridDriftCheckRaf: number | null = null
   let lastForegroundGridDriftCheckAt = Number.NEGATIVE_INFINITY
   const readProposedTerminalGrid = (): { cols: number; rows: number } | null => {
@@ -4415,6 +4438,9 @@ export function connectPanePty(
     pendingGeometryReportRaf = null
     if (disposed) {
       return
+    }
+    if (pane.container.clientWidth > 0 && pane.container.clientHeight > 0) {
+      resumePendingReplayDataDrain()
     }
     if (
       deferTerminalGeometryMutationDuringRebuild(
@@ -5649,6 +5675,8 @@ export function connectPanePty(
     type PendingReplayData = {
       data: string
       clearBeforeReplay: boolean
+      snapshotCols?: number
+      snapshotRows?: number
       ptyId: string | null
       generation: number
       streamGeneration: number
@@ -5699,6 +5727,22 @@ export function connectPanePty(
             continue
           }
         }
+        const snapshotDimensions = resolvePositiveTerminalDimensions(
+          payload.snapshotCols,
+          payload.snapshotRows
+        )
+        if (
+          snapshotDimensions &&
+          (pane.terminal.cols !== snapshotDimensions.cols ||
+            pane.terminal.rows !== snapshotDimensions.rows)
+        ) {
+          suppressStructuralReplayPtyResize = true
+          try {
+            pane.terminal.resize(snapshotDimensions.cols, snapshotDimensions.rows)
+          } finally {
+            suppressStructuralReplayPtyResize = false
+          }
+        }
         if (clearBeforeReplay || data.length > 0) {
           // Why: an empty clearing frame is still an authoritative repaint and
           // must clear a stale agent signal from an earlier payload.
@@ -5740,7 +5784,13 @@ export function connectPanePty(
       return appliedCurrentPayload
     }
     const scheduleReplayDataDrain = (): void => {
-      if (replayDrainQueued) {
+      if (
+        replayDrainQueued ||
+        pendingReplayData === null ||
+        pane.container.clientWidth <= 0 ||
+        pane.container.clientHeight <= 0 ||
+        !safeFit(pane)
+      ) {
         return
       }
       const scheduledPtyId = pendingReplayData?.ptyId ?? null
@@ -5765,7 +5815,12 @@ export function connectPanePty(
               shouldRestore: () =>
                 !disposed &&
                 transport.getPtyId() === scheduledPtyId &&
-                transportStreamGeneration === scheduledStreamGeneration
+                transportStreamGeneration === scheduledStreamGeneration,
+              afterRestore: () => {
+                if (replayCompleted) {
+                  safeFit(pane)
+                }
+              }
             }
           )
         )
@@ -5782,6 +5837,7 @@ export function connectPanePty(
           finishReattachLiveDataDeferral(replayCompleted, scheduledStreamGeneration)
         })
     }
+    resumePendingReplayDataDrain = scheduleReplayDataDrain
     const replayDataCallback = (
       data: string,
       meta: PtyReplayDataMeta = {},
@@ -5790,6 +5846,8 @@ export function connectPanePty(
       pendingReplayData = {
         data,
         clearBeforeReplay: meta.clearBeforeReplay !== false,
+        ...(meta.snapshotCols !== undefined ? { snapshotCols: meta.snapshotCols } : {}),
+        ...(meta.snapshotRows !== undefined ? { snapshotRows: meta.snapshotRows } : {}),
         ptyId: transport.getPtyId(),
         generation: (replayPayloadGeneration += 1),
         streamGeneration,
@@ -9286,6 +9344,8 @@ export function connectPanePty(
     noteVisibilityResume() {
       armVisibleRemoteViewportClaim()
       claimPendingVisibleRemoteViewport()
+      reportRemoteViewportOnReveal()
+      resumePendingReplayDataDrain()
       ptySizeReassertion.request({ fit: false })
       consumeHibernatedAgentWake()
       requestKnownWindowsShiftEnterReconfirmation()

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -49,6 +49,10 @@ export type PtyBufferSnapshot = {
 /** Metadata for one authoritative replay payload. */
 export type PtyReplayDataMeta = {
   clearBeforeReplay?: boolean
+  /** Source grid for this replay payload. Zero means the producer could not
+   *  determine a size and must never reach xterm.resize(). */
+  snapshotCols?: number
+  snapshotRows?: number
   pendingEscapeTailAnsi?: string
   /** Kitty flags the snapshot's owner PROVED at `snapshotSeq`. Absent means
    *  unknown; the pane tracker must stay unproven rather than assume zero. */

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -103,6 +103,8 @@ type ProcessPtyOutputOptions = {
   replayingBufferedData?: boolean
   suppressAttentionEvents?: boolean
   clearBeforeReplay?: boolean
+  snapshotCols?: number
+  snapshotRows?: number
   // Why: a mid-escape tail; the replay consumer writes it LAST (after the post-replay reset) so the next live chunk completes it, not renders it literally (#7329).
   pendingEscapeTailAnsi?: string
   /** Kitty flags the snapshot owner proved at `snapshotSeq`. */
@@ -498,6 +500,8 @@ export function createPtyOutputProcessor({
     if (options.replayingBufferedData && callbacks.onReplayData) {
       const replayMeta = {
         ...(options.clearBeforeReplay === false ? { clearBeforeReplay: false } : {}),
+        ...(options.snapshotCols !== undefined ? { snapshotCols: options.snapshotCols } : {}),
+        ...(options.snapshotRows !== undefined ? { snapshotRows: options.snapshotRows } : {}),
         ...(options.pendingEscapeTailAnsi
           ? { pendingEscapeTailAnsi: options.pendingEscapeTailAnsi }
           : {}),

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -6099,6 +6099,32 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onConnect).toHaveBeenCalled()
   })
 
+  it('forwards the source grid with an initial replay payload', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onReplayData = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', { worktreeId: 'wt-1' })
+
+    await transport.connect({ url: '', callbacks: { onReplayData } })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const { streamId } = latestSubscribePayload()
+    emitSnapshotFrame(
+      streamId,
+      TerminalStreamOpcode.SnapshotStart,
+      encodeTerminalStreamJson({ kind: 'scrollback', cols: 60, rows: 20 })
+    )
+    emitSnapshotFrame(
+      streamId,
+      TerminalStreamOpcode.SnapshotChunk,
+      encodeTerminalStreamText('source-grid replay')
+    )
+    emitSnapshotFrame(streamId, TerminalStreamOpcode.SnapshotEnd, new Uint8Array())
+
+    expect(onReplayData).toHaveBeenCalledWith('source-grid replay', {
+      snapshotCols: 60,
+      snapshotRows: 20
+    })
+  })
+
   it('resolves explicit binary snapshot requests without replaying into xterm', async () => {
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const onReplayData = vi.fn()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1768,6 +1768,8 @@ export function createRemoteRuntimePtyTransport(
             outputProcessor.processData(data, storedCallbacks, {
               replayingBufferedData: true,
               suppressAttentionEvents: true,
+              ...(meta?.cols !== undefined ? { snapshotCols: meta.cols } : {}),
+              ...(meta?.rows !== undefined ? { snapshotRows: meta.rows } : {}),
               ...(meta?.pendingEscapeTailAnsi
                 ? { pendingEscapeTailAnsi: meta.pendingEscapeTailAnsi }
                 : {}),

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -618,12 +618,15 @@ describe('hasPositiveTerminalDimensions', () => {
     expect(hasPositiveTerminalDimensions(1, 1)).toBe(true)
   })
 
-  // Why: Infinity passes `> 0` — the exact drift that let a malformed SSH
-  // model snapshot reach terminal.resize(Infinity, …).
-  it('rejects non-finite, non-positive, and non-numeric values', () => {
+  // Why: xterm throws on fractional grids and can allocate excessively for oversized grids.
+  it('rejects unsafe, out-of-contract, non-positive, and non-numeric values', () => {
     expect(hasPositiveTerminalDimensions(Infinity, 24)).toBe(false)
     expect(hasPositiveTerminalDimensions(80, Infinity)).toBe(false)
     expect(hasPositiveTerminalDimensions(Number.NaN, 24)).toBe(false)
+    expect(hasPositiveTerminalDimensions(80.5, 24)).toBe(false)
+    expect(hasPositiveTerminalDimensions(80, 24.5)).toBe(false)
+    expect(hasPositiveTerminalDimensions(1_001, 24)).toBe(false)
+    expect(hasPositiveTerminalDimensions(80, 501)).toBe(false)
     expect(hasPositiveTerminalDimensions(0, 24)).toBe(false)
     expect(hasPositiveTerminalDimensions(80, -1)).toBe(false)
     expect(hasPositiveTerminalDimensions(undefined, 24)).toBe(false)

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -4,6 +4,7 @@ import {
   ABORT_TRUNCATED_CONTROL_STRING,
   buildSnapshotReplayPrologue
 } from '../../../../shared/terminal-mode-reset-profiles'
+import { isValidTerminalHistorySize } from '../../../../shared/terminal-history-dimensions'
 
 // Once only: CAN must precede the first ESC of the replay, but the split branch
 // builds two prologues and later writes follow well-formed payloads.
@@ -17,18 +18,9 @@ function abortGapBeforeFirstWrite(writes: string[]): string[] {
  * paths so their dimension guards and alt-screen branches cannot drift.
  */
 
-/** True only for finite positive numeric cols/rows — Infinity/NaN/undefined
- *  from a malformed snapshot must degrade to "no resize", never reach
- *  terminal.resize(). */
+/** True only for dimensions safe to restore into xterm. */
 export function hasPositiveTerminalDimensions(cols: unknown, rows: unknown): boolean {
-  return (
-    typeof cols === 'number' &&
-    typeof rows === 'number' &&
-    Number.isFinite(cols) &&
-    Number.isFinite(rows) &&
-    cols > 0 &&
-    rows > 0
-  )
+  return isValidTerminalHistorySize(cols, rows)
 }
 
 /** Narrowing form of hasPositiveTerminalDimensions for optional-typed payloads. */

--- a/src/renderer/src/runtime/remote-runtime-snapshot-outcome.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-snapshot-outcome.test.ts
@@ -38,6 +38,7 @@ class ScriptedSnapshotServer {
   private cursorUnits = 0
   requestIds: (number | undefined)[] = []
   nextRequestedReply: RequestedReply = { kind: 'buffer', data: 'MANUAL' }
+  omitNextSize = false
   dropNextOutput = false
   holdResyncReplies = false
   private heldRequestId: number | null = null
@@ -112,11 +113,12 @@ class ScriptedSnapshotServer {
   }
 
   private sendStart(meta: { requestId?: number; truncated?: boolean; unavailable?: string }): void {
+    const size = this.omitNextSize ? {} : { cols: 80, rows: 24 }
+    this.omitNextSize = false
     this.send(
       TerminalStreamOpcode.SnapshotStart,
       encodeTerminalStreamJson({
-        cols: 80,
-        rows: 24,
+        ...size,
         seq: meta.truncated ? undefined : this.cursorUnits,
         ...meta
       })
@@ -194,6 +196,16 @@ describe('remote terminal snapshot outcome reasons', () => {
     })
     await expect(stream.serializeBuffer({ scrollbackRows: 100 })).resolves.toMatchObject({
       data: 'RESTORED'
+    })
+  })
+
+  it('uses 0x0 as the unknown-size sentinel for an older snapshot producer', async () => {
+    const stream = await subscribeClient()
+    server.nextRequestedReply = { kind: 'buffer', data: 'LEGACY' }
+    server.omitNextSize = true
+
+    await expect(stream.serializeBufferOutcome({ scrollbackRows: 100 })).resolves.toMatchObject({
+      snapshot: { data: 'LEGACY', cols: 0, rows: 0 }
     })
   })
 

--- a/src/renderer/src/runtime/remote-runtime-snapshot-outcome.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-snapshot-outcome.test.ts
@@ -39,6 +39,7 @@ class ScriptedSnapshotServer {
   requestIds: (number | undefined)[] = []
   nextRequestedReply: RequestedReply = { kind: 'buffer', data: 'MANUAL' }
   omitNextSize = false
+  nextSizeOverride: { cols: unknown; rows: unknown } | null = null
   dropNextOutput = false
   holdResyncReplies = false
   private heldRequestId: number | null = null
@@ -113,8 +114,9 @@ class ScriptedSnapshotServer {
   }
 
   private sendStart(meta: { requestId?: number; truncated?: boolean; unavailable?: string }): void {
-    const size = this.omitNextSize ? {} : { cols: 80, rows: 24 }
+    const size = this.omitNextSize ? {} : (this.nextSizeOverride ?? { cols: 80, rows: 24 })
     this.omitNextSize = false
+    this.nextSizeOverride = null
     this.send(
       TerminalStreamOpcode.SnapshotStart,
       encodeTerminalStreamJson({
@@ -206,6 +208,19 @@ describe('remote terminal snapshot outcome reasons', () => {
 
     await expect(stream.serializeBufferOutcome({ scrollbackRows: 100 })).resolves.toMatchObject({
       snapshot: { data: 'LEGACY', cols: 0, rows: 0 }
+    })
+  })
+
+  it.each([
+    ['fractional', { cols: 80.5, rows: 24 }],
+    ['oversized', { cols: 1_001, rows: 501 }]
+  ])('uses 0x0 when SnapshotStart carries a %s grid', async (_label, dimensions) => {
+    const stream = await subscribeClient()
+    server.nextRequestedReply = { kind: 'buffer', data: 'UNTRUSTED' }
+    server.nextSizeOverride = dimensions
+
+    await expect(stream.serializeBufferOutcome({ scrollbackRows: 100 })).resolves.toMatchObject({
+      snapshot: { data: 'UNTRUSTED', cols: 0, rows: 0 }
     })
   })
 

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: the remote terminal multiplexer owns one bridged subscription, stream lifecycle, binary frame parsing, and remote lock events as a single transport contract. */
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import { isRecoverableRemoteRuntimeConnectionError } from '../../../shared/remote-runtime-client-error-classification'
+import { isValidTerminalHistorySize } from '../../../shared/terminal-history-dimensions'
 import {
   TerminalStreamOpcode,
   decodeTerminalStreamFrame,
@@ -1558,9 +1559,10 @@ function decodeSnapshotInfo(
   if (!raw) {
     return null
   }
+  const hasSnapshotDimensions = isValidTerminalHistorySize(raw.cols, raw.rows)
   return {
-    cols: typeof raw.cols === 'number' ? raw.cols : undefined,
-    rows: typeof raw.rows === 'number' ? raw.rows : undefined,
+    cols: hasSnapshotDimensions ? (raw.cols as number) : undefined,
+    rows: hasSnapshotDimensions ? (raw.rows as number) : undefined,
     seq: typeof raw.seq === 'number' ? raw.seq : undefined,
     source: raw.source === 'headless' || raw.source === 'renderer' ? raw.source : undefined,
     // Negative, fractional, and unsafe values are treated as absent, never clamped.

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -64,6 +64,8 @@ export type RemoteRuntimeMultiplexedTerminalCallbacks = {
   onSnapshot: (
     data: string,
     meta?: {
+      cols?: number
+      rows?: number
       pendingEscapeTailAnsi?: string
       seq?: number
       kittyKeyboardFlags?: number
@@ -888,8 +890,8 @@ class RemoteRuntimeTerminalMultiplexer {
             availability: classifySnapshotAvailability(stream.snapshotOverflowed, info),
             snapshot: {
               data: data ?? '',
-              cols: info?.cols ?? 80,
-              rows: info?.rows ?? 24,
+              cols: info?.cols ?? 0,
+              rows: info?.rows ?? 0,
               seq: info?.seq,
               source: info?.source,
               kittyKeyboardFlags: info?.kittyKeyboardFlags,
@@ -899,6 +901,8 @@ class RemoteRuntimeTerminalMultiplexer {
           clearPendingSnapshotRequest(stream)
         } else if (target === 'initial') {
           stream.callbacks.onSnapshot(data ?? '', {
+            cols: info?.cols,
+            rows: info?.rows,
             pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
             seq: info?.seq,
             kittyKeyboardFlags: info?.kittyKeyboardFlags
@@ -909,6 +913,8 @@ class RemoteRuntimeTerminalMultiplexer {
           // An empty snapshot is still applied so stale dropped output does
           // not linger on a terminal the model says is blank.
           stream.callbacks.onSnapshot(`\x1b[2J\x1b[3J\x1b[H${data ?? ''}`, {
+            cols: info?.cols,
+            rows: info?.rows,
             pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
             seq: info?.seq,
             kittyKeyboardFlags: info?.kittyKeyboardFlags

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -572,6 +572,8 @@ describe('remote runtime terminal multiplex ACK gate', () => {
 
     injectSnapshot({ kind: 'scrollback', cols: 120, rows: 40, truncated: false }, 'initial state')
     expect(onSnapshot).toHaveBeenCalledWith('initial state', {
+      cols: 120,
+      rows: 40,
       pendingEscapeTailAnsi: undefined
     })
     expect(onSubscribed).toHaveBeenCalledTimes(1)
@@ -590,6 +592,8 @@ describe('remote runtime terminal multiplex ACK gate', () => {
     // clears screen and scrollback first and must not replay the subscribe
     // lifecycle.
     expect(onSnapshot).toHaveBeenCalledWith(`\x1b[2J\x1b[3J\x1b[H${'recovered state'}`, {
+      cols: 120,
+      rows: 40,
       pendingEscapeTailAnsi: undefined
     })
     expect(onSubscribed).toHaveBeenCalledTimes(1)
@@ -607,6 +611,8 @@ describe('remote runtime terminal multiplex ACK gate', () => {
       ''
     )
     expect(onSnapshot).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', {
+      cols: 120,
+      rows: 40,
       pendingEscapeTailAnsi: undefined
     })
     expect(onSubscribed).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -581,6 +581,44 @@ describe('remote runtime terminal multiplex ACK gate', () => {
     injectSnapshot(
       {
         kind: 'scrollback',
+        cols: 120.5,
+        rows: 40,
+        reason: 'ack-pending-overflow',
+        truncated: false
+      },
+      'fractional-grid recovery'
+    )
+    expect(onSnapshot).toHaveBeenLastCalledWith(
+      `\x1b[2J\x1b[3J\x1b[H${'fractional-grid recovery'}`,
+      {
+        cols: undefined,
+        rows: undefined,
+        pendingEscapeTailAnsi: undefined
+      }
+    )
+
+    injectSnapshot(
+      {
+        kind: 'scrollback',
+        cols: 1_001,
+        rows: 501,
+        reason: 'ack-pending-overflow',
+        truncated: false
+      },
+      'oversized-grid recovery'
+    )
+    expect(onSnapshot).toHaveBeenLastCalledWith(
+      `\x1b[2J\x1b[3J\x1b[H${'oversized-grid recovery'}`,
+      {
+        cols: undefined,
+        rows: undefined,
+        pendingEscapeTailAnsi: undefined
+      }
+    )
+
+    injectSnapshot(
+      {
+        kind: 'scrollback',
         cols: 120,
         rows: 40,
         reason: 'ack-pending-overflow',

--- a/src/renderer/src/runtime/runtime-terminal-stream.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.ts
@@ -13,7 +13,10 @@ export type RemoteRuntimePtyIdParts = {
 
 export type RuntimeTerminalDataSubscriptionOptions = {
   startAtLiveTail?: boolean
-  onSnapshot?: (data: string, meta?: { pendingEscapeTailAnsi?: string }) => void
+  onSnapshot?: (
+    data: string,
+    meta?: { cols?: number; rows?: number; pendingEscapeTailAnsi?: string }
+  ) => void
   onEnd?: () => void
   onError?: (message: string) => void
   onTransportClose?: (event: { recoverable: boolean; retryWithBackoff?: boolean }) => void

--- a/src/shared/terminal-history-dimensions.ts
+++ b/src/shared/terminal-history-dimensions.ts
@@ -1,0 +1,14 @@
+// Why separate from live admission: existing recovery was written through a 1,000-column viewport contract.
+export const MAX_TERMINAL_HISTORY_COLS = 1_000
+export const MAX_TERMINAL_HISTORY_ROWS = 500
+
+export function isValidTerminalHistorySize(cols: unknown, rows: unknown): boolean {
+  return (
+    Number.isSafeInteger(cols) &&
+    (cols as number) >= 1 &&
+    (cols as number) <= MAX_TERMINAL_HISTORY_COLS &&
+    Number.isSafeInteger(rows) &&
+    (rows as number) >= 1 &&
+    (rows as number) <= MAX_TERMINAL_HISTORY_ROWS
+  )
+}


### PR DESCRIPTION
## ELI5

A remote terminal could reopen in a wide pane while its host still believed it was narrow. Orca now replays the saved screen at the grid that produced it, returns the pane to its live grid, and tells the host that live size again immediately on reveal.

## What Changed

- carry optional snapshot columns and rows through pushed remote replay metadata
- validate snapshot grids through the shared history contract: safe integers, 1–1,000 columns and 1–500 rows
- degrade malformed or unknown dimensions to the 0x0 sentinel and guard every xterm resize site
- paint non-empty replay data at its positive source grid, then fit and report the live destination grid
- re-fit and report a revealed remote viewport even when the client grid did not change
- preserve the established presence-lock-only reveal report rule; renderer resize-authority does not suppress it
- generation-guard replay completion so stale payloads cannot report or release deferred live data

## Why

A hidden-but-measurable pane can already fit to its destination grid before reveal. That makes a later client-side fit look unchanged even though the remote host PTY is still at the stale snapshot grid, leaving replay wrapped at the old width until an unrelated layout change.

## Linked Issue

N/A — dispatched regression fix from a user recording; no public issue was provided.

## Visual Proof

Rendered Electron QA used this exact branch in isolated host and client apps, paired the client through the host to a throwaway Linux Docker SSH runtime, and reproduced a 61-column source grid inside a 173-column destination grid.

Before — source grid wrapped at 61 columns:

![source grid](https://github.com/user-attachments/assets/d87c420b-fe90-4a15-a109-ac4410c13ac7)

After — immediate reveal at the destination width, without a later layout change:

![immediate reveal](https://github.com/user-attachments/assets/b7f83626-01ff-4fea-9efc-86e31d34d8a3)

Live input then painted immediately and the host PTY reported 56×173:

![live input and paint](https://github.com/user-attachments/assets/d899d662-9cb5-4275-b7ad-3227c1ff70c6)

Full topology, identity, and cleanup evidence: https://github.com/stablyai/orca/pull/14206#issuecomment-5299732991

## Testing

- [x] full affected directories: 343 test files / 4,235 tests
- [x] `config/tsconfig.tc.web.json`
- [x] `config/tsconfig.node.json`
- [x] cross-version terminal wire suite: 5 tests
- [x] mutation-tested replay/reveal reporting and invalid-grid guards; weakening or removing each behavior makes its focused assertion fail
- [x] paired Electron hidden, cold-parked, reconnect-parked, and nested Linux Docker SSH reveal validation
- [x] focused lint, formatting, max-lines ratchet, and `git diff --check`
- [x] packaging and macOS/Linux/Windows smoke checks
- [ ] required Node 26 CI shard rerun is queued after the first attempt completed 303 files / 3,298 tests with no assertion failure but one unexpected Vitest worker exit

## AI Disclosure

Codex (GPT-5) assisted with implementation, tests, and review. A Grok worker performed the final rendered Electron and Linux Docker SSH proof.

## Review

- Security: no new command execution, credentials, dependencies, or trust boundaries
- Cross-platform: renderer geometry uses DOM/xterm APIs and the shared bounded grid validator; packaging and native smoke passed on macOS, Linux, and Windows
- Remote/SSH: optional metadata is mixed-version-safe; the Linux Docker SSH paired-runtime journey passed with immediate host-grid convergence and live paint
- Mobile: reveal reporting keeps the established presence-lock guard and does not add a renderer-visibility authority gate
- Performance: work is limited to snapshot/reveal boundaries; live output remains unchanged
- Scope: focused on replay and reveal geometry; no sibling snapshot-recovery behavior was pulled in

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after evidence is attached
- [x] Self-reviewed for correctness, security, performance, and mixed-version compatibility
- [x] Cross-platform, SSH/remote, folder-workspace, and provider impact considered
- [x] Full affected-directory tests, both required typechecks, wire checks, and rendered QA pass
- [ ] Required CI rerun is green

## Author

- X / Twitter: @BrennanKB5
