### PR TITLE
fix(store): keep setup-script dismissal array identity on no-op repo fetches

### DIFF
--- a/src/renderer/src/lib/setup-script-prompt.test.ts
+++ b/src/renderer/src/lib/setup-script-prompt.test.ts
@@ -202,6 +202,59 @@ describe('setup script prompt inspection', () => {
     ).toEqual([getSetupScriptPromptDismissalKey(localIdentity)])
   })
 
+  it('reuses the input array when it is empty', () => {
+    const input: string[] = []
+    expect(
+      filterSetupScriptPromptDismissalsToValidRepos(
+        input,
+        new Set([getRepoHostIdentityForParts('repo-1', 'local')])
+      )
+    ).toBe(input)
+  })
+
+  it('reuses the input array when every dismissal is already a valid host-identity key', () => {
+    const localIdentity = getRepoHostIdentityForParts('repo-1', 'local')
+    const remoteIdentity = getRepoHostIdentityForParts('repo-2', 'ssh:host-a')
+    const input = [
+      getSetupScriptPromptDismissalKey(localIdentity),
+      getSetupScriptPromptDismissalKey(remoteIdentity)
+    ]
+    expect(
+      filterSetupScriptPromptDismissalsToValidRepos(
+        input,
+        new Set([localIdentity, remoteIdentity])
+      )
+    ).toBe(input)
+  })
+
+  it('allocates when a legacy repo-id dismissal is rewritten to a host identity', () => {
+    const localIdentity = getRepoHostIdentityForParts('repo-1', 'local')
+    const input = [getSetupScriptPromptDismissalKey('repo-1')]
+    const result = filterSetupScriptPromptDismissalsToValidRepos(input, new Set([localIdentity]))
+    expect(result).not.toBe(input)
+    expect(result).toEqual([getSetupScriptPromptDismissalKey(localIdentity)])
+  })
+
+  it('allocates when a stale dismissal is dropped', () => {
+    const localIdentity = getRepoHostIdentityForParts('repo-1', 'local')
+    const input = [
+      getSetupScriptPromptDismissalKey(localIdentity),
+      getSetupScriptPromptDismissalKey(getRepoHostIdentityForParts('gone', 'local'))
+    ]
+    const result = filterSetupScriptPromptDismissalsToValidRepos(input, new Set([localIdentity]))
+    expect(result).not.toBe(input)
+    expect(result).toEqual([getSetupScriptPromptDismissalKey(localIdentity)])
+  })
+
+  it('allocates when a duplicate valid dismissal is deduped', () => {
+    const localIdentity = getRepoHostIdentityForParts('repo-1', 'local')
+    const key = getSetupScriptPromptDismissalKey(localIdentity)
+    const input = [key, key]
+    const result = filterSetupScriptPromptDismissalsToValidRepos(input, new Set([localIdentity]))
+    expect(result).not.toBe(input)
+    expect(result).toEqual([key])
+  })
+
   it('drops a legacy repo-id dismissal when that id exists on multiple hosts', () => {
     const localIdentity = getRepoHostIdentityForParts('repo-1', 'local')
     const remoteIdentity = getRepoHostIdentityForParts('repo-1', 'runtime:windows')

--- a/src/renderer/src/lib/setup-script-prompt.ts
+++ b/src/renderer/src/lib/setup-script-prompt.ts
@@ -90,10 +90,21 @@ export function isSetupScriptPromptDismissed(
   return dismissedEntries.includes(getSetupScriptPromptDismissalKey(repoHostIdentity))
 }
 
+function isUnchangedDismissalList(
+  value: unknown,
+  next: readonly string[]
+): value is readonly string[] {
+  return (
+    Array.isArray(value) &&
+    value.length === next.length &&
+    value.every((entry, index) => entry === next[index])
+  )
+}
+
 export function filterSetupScriptPromptDismissalsToValidRepos(
   value: unknown,
   validRepoHostIdentities: Set<string>
-): string[] {
+): readonly string[] {
   const unambiguousIdentityByRepoId = new Map<string, string | null>()
   for (const identity of validRepoHostIdentities) {
     const separatorIndex = identity.indexOf('\0')
@@ -122,17 +133,13 @@ export function filterSetupScriptPromptDismissalsToValidRepos(
   // subscribes to the array, so a fresh copy on a no-op prune is a guaranteed miss.
   // Compare against the original input, not the sanitize copy — sanitize always
   // allocates, including for [] and already-valid host-identity keys.
-  if (
-    Array.isArray(value) &&
-    value.length === next.length &&
-    value.every((entry, index) => entry === next[index])
-  ) {
+  if (isUnchangedDismissalList(value, next)) {
     return value
   }
   return next
 }
 
-export function sanitizeSetupScriptPromptDismissals(value: unknown): string[] {
+export function sanitizeSetupScriptPromptDismissals(value: unknown): readonly string[] {
   if (!Array.isArray(value)) {
     return []
   }

--- a/src/renderer/src/lib/setup-script-prompt.ts
+++ b/src/renderer/src/lib/setup-script-prompt.ts
@@ -117,6 +117,18 @@ export function filterSetupScriptPromptDismissalsToValidRepos(
       }
     }
   }
+  // Why: fetchRepos / fetchRuntimeEnvironmentRepos / validateRepoScopedUi assign
+  // this into set() on every catalog refresh. SetupScriptPromptCard Object.is-
+  // subscribes to the array, so a fresh copy on a no-op prune is a guaranteed miss.
+  // Compare against the original input, not the sanitize copy — sanitize always
+  // allocates, including for [] and already-valid host-identity keys.
+  if (
+    Array.isArray(value) &&
+    value.length === next.length &&
+    value.every((entry, index) => entry === next[index])
+  ) {
+    return value
+  }
   return next
 }
 

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Project, Repo } from '../../../../shared/types'
+import { getSetupScriptPromptDismissalKey } from '../../lib/setup-script-prompt'
+import { getRepoHostIdentityForParts } from './repo-host-identity'
 import { createTestStore } from './store-test-helpers'
 
 // Why: every field here is load-bearing. A scalar-only repo reconciles even when the structural
@@ -279,5 +281,23 @@ describe('repo filter identity across catalog refreshes', () => {
     await store.getState().fetchRepos()
 
     expect(store.getState().filterRepoIds).toBe(first)
+  })
+})
+
+describe('setup-script dismissal identity across catalog refreshes', () => {
+  it('keeps the dismissal array when a refetch prunes nothing', async () => {
+    const store = createTestStore()
+    store.setState({
+      setupScriptPromptDismissedRepoIds: [
+        getSetupScriptPromptDismissalKey(getRepoHostIdentityForParts(repo.id, 'local'))
+      ]
+    })
+    const first = store.getState().setupScriptPromptDismissedRepoIds
+
+    await store.getState().fetchRepos()
+
+    // Why: SetupScriptPromptCard Object.is-subscribes to this array. A no-op
+    // catalog refresh must not allocate just because the helper rebuilt next.
+    expect(store.getState().setupScriptPromptDismissedRepoIds).toBe(first)
   })
 })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -853,7 +853,7 @@ export type UISlice = {
   ) => void
   markOrcaHookRepoAlwaysTrusted: (repoId: string) => void
   clearOrcaHookTrustForRepo: (repoId: string) => void
-  setupScriptPromptDismissedRepoIds: string[]
+  setupScriptPromptDismissedRepoIds: readonly string[]
   dismissSetupScriptPrompt: (repoHostIdentity: string) => void
   setupGuideSidebarDismissed: boolean
   setSetupGuideSidebarDismissed: (dismissed: boolean) => void


### PR DESCRIPTION
## Summary

Follow-up to #13744 / #13770 / #13803. Those PRs made `repos` / `projects` / `projectHostSetups` / `filterRepoIds` referentially stable across a no-op catalog refresh. This sibling field still churned on every fetch: `filterSetupScriptPromptDismissalsToValidRepos` always did `const next: string[] = []` and returned it.

`fetchRepos`, `fetchRuntimeEnvironmentRepos`, and `validateRepoScopedUi` assign that helper result into `set()` even when the catalog is already identity-stable. `SetupScriptPromptCard` Object.is-subscribes to `setupScriptPromptDismissedRepoIds`, so a no-op refresh missed 100% of the time.

Return the original store array when the filtered result is element-wise identical to the **input** (not the sanitize copy). Allocate only when an entry is dropped, rewritten from a legacy `generation-v1:repoId` key to `generation-v1:host\0repoId`, or deduped. Call sites already assign the helper result — no second copy.

## The chain — why a partial fix is inert

Identity has to survive every link from fetch to `set()`:

1. Catalog rows arrive over IPC (`structuredClone` / hydrate rebuilds nested records).
2. `reconcileCatalogRows` / `areValuesEqual` keep `repos` / `projects` / `projectHostSetups` stable (#13744 / #13770 / #13803).
3. `retainValidFilterRepoIds` keeps `filterRepoIds` when nothing is pruned (#13803).
4. **This helper still allocated**, so `set({ setupScriptPromptDismissedRepoIds: next })` replaced the array even when every dismissal was already a valid host-identity key.

Fixing 1–3 without 4 leaves `SetupScriptPromptCard` re-rendering on every catalog echo. Fixing 4 without 1–3 would still see a new `validRepoHostIdentities` set each time, but the array contents would match and the helper can now return the original store array — the last link is what this PR closes.

## Reference compare fails on IPC clones

Dismissal **keys** are strings (`generation-v1:` + `getRepoHostIdentityForParts(repoId, hostId)`), so the element check is `===`. The array itself is what subscribers compare. A reference compare of the helper's newly built `next` against the store array never matches after a rebuild — same strings, new object. Nested catalog records still cannot be compared by reference after IPC `structuredClone` / hydrate; that is why the earlier PRs use `areValuesEqual` / `reconcileCatalogRows`. This helper does not invent a fourth walker: it compares string entries against the original input.

Sanitize always allocates (including for `[]` and already-valid keys). Comparing against that copy would still return a new array and the empty-array / no-op cases would stay dead.

SSH hosts are already in the key (`host\0repoId`). Folder workspaces are not in this array; no change there.

## Testing

- `setup-script-prompt.test.ts`: empty array and already-valid host-identity keys `toBe(input)`; rewrite / drop / dedupe allocate. Existing prune / migrate assertions kept.
- `repos-refresh-identity.test.ts`: `fetchRepos` no-op seeded with production-shaped `getSetupScriptPromptDismissalKey(getRepoHostIdentityForParts(...))` keys; asserts the store array is the same ref.

Verified red then restored: reverting the helper to `return next` fails those three identity assertions and leaves the prune / migrate / allocate tests green.

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/setup-script-prompt.test.ts \
  src/renderer/src/store/slices/repos-refresh-identity.test.ts
```

34 passed. Did not run the full suite or typecheck.

Made with [Orca](https://github.com/stablyai/orca)

Made with [Orca](https://github.com/stablyai/orca) 🐋
