### PR TITLE
perf(renderer): keep project catalog identity on SSH readoption

### DIFF
--- a/src/renderer/src/components/sidebar/add-remote-host-ssh-actions.ts
+++ b/src/renderer/src/components/sidebar/add-remote-host-ssh-actions.ts
@@ -43,7 +43,7 @@ export async function saveNewSshHostFromForm({
 }: {
   form: EditingTarget
   ssh: SshApi
-  recordSshRepoReadoptions: (readoptions: SshRepoReadoption[]) => void
+  recordSshRepoReadoptions: (readoptions: readonly SshRepoReadoption[]) => void
   setSshTargetsMetadata: (targets: SshTarget[]) => void
   recordFeatureInteraction: (feature: 'ssh') => void
 }): Promise<'saved' | 'validation-failed' | 'failed'> {
@@ -170,7 +170,7 @@ export async function addAllSshConfigHostsToOrca({
   recordFeatureInteraction
 }: {
   ssh: SshApi
-  recordSshRepoReadoptions: (readoptions: SshRepoReadoption[]) => void
+  recordSshRepoReadoptions: (readoptions: readonly SshRepoReadoption[]) => void
   setSshTargetsMetadata: (targets: SshTarget[]) => void
   recordFeatureInteraction: (feature: 'ssh') => void
 }): Promise<{ kind: 'added'; count: number } | { kind: 'already-synced' } | { kind: 'failed' }> {

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -283,7 +283,6 @@ describe('repo filter identity across catalog refreshes', () => {
     expect(store.getState().filterRepoIds).toBe(first)
   })
 })
-
 describe('setup-script dismissal identity across catalog refreshes', () => {
   it('keeps the dismissal array when a refetch prunes nothing', async () => {
     const store = createTestStore()
@@ -301,3 +300,73 @@ describe('setup-script dismissal identity across catalog refreshes', () => {
     expect(store.getState().setupScriptPromptDismissedRepoIds).toBe(first)
   })
 })
+
+describe('SSH readoption catalog identity', () => {
+  it('keeps projects and host setups across a no-op recordSshRepoReadoptions([])', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+    const setups = store.getState().projectHostSetups
+    expect(projects).toHaveLength(1)
+    expect(setups).toHaveLength(1)
+
+    store.getState().recordSshRepoReadoptions([])
+
+    expect(store.getState().projects).toBe(projects)
+    expect(store.getState().projects[0]).toBe(projects[0])
+    expect(store.getState().projectHostSetups).toBe(setups)
+    expect(store.getState().projectHostSetups[0]).toBe(setups[0])
+  })
+
+  it('keeps catalog identity for a pending-only readoption while pending updates', async () => {
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+    const setups = store.getState().projectHostSetups
+    const readoption = { oldTargetId: 'ssh-old', newTargetId: 'ssh-new', repoIds: [repo.id] }
+
+    store.getState().recordSshRepoReadoptions([readoption])
+
+    expect(store.getState().pendingSshRepoReadoptions).toEqual([readoption])
+    expect(store.getState().projects).toBe(projects)
+    expect(store.getState().projects[0]).toBe(projects[0])
+    expect(store.getState().projectHostSetups).toBe(setups)
+    expect(store.getState().projectHostSetups[0]).toBe(setups[0])
+  })
+
+  it('replaces the moved setup on a real prune/rehome', async () => {
+    const oldHostRepo: Repo = {
+      ...repo,
+      connectionId: 'ssh-old',
+      executionHostId: 'ssh:ssh-old'
+    }
+    const newHostRepo: Repo = {
+      ...repo,
+      connectionId: 'ssh-new',
+      executionHostId: 'ssh:ssh-new'
+    }
+    mockRepos(oldHostRepo, newHostRepo)
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const setups = store.getState().projectHostSetups
+    expect(setups).toHaveLength(2)
+    const oldSetup = setups.find((setup) => setup.hostId === 'ssh:ssh-old')
+    const newSetup = setups.find((setup) => setup.hostId === 'ssh:ssh-new')
+    expect(oldSetup).toBeDefined()
+    expect(newSetup).toBeDefined()
+
+    store.getState().recordSshRepoReadoptions([
+      { oldTargetId: 'ssh-old', newTargetId: 'ssh-new', repoIds: [repo.id] }
+    ])
+
+    const next = store.getState().projectHostSetups
+    expect(next).not.toBe(setups)
+    expect(next).toHaveLength(1)
+    expect(next[0]).not.toBe(oldSetup)
+    expect(next[0]?.hostId).toBe('ssh:ssh-new')
+    expect(store.getState().repos).toHaveLength(1)
+    expect(store.getState().repos[0]?.executionHostId).toBe('ssh:ssh-new')
+    expect(store.getState().pendingSshRepoReadoptions).toEqual([])
+  })
+})
+

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -305,13 +305,18 @@ describe('SSH readoption catalog identity', () => {
   it('keeps projects and host setups across a no-op recordSshRepoReadoptions([])', async () => {
     const store = createTestStore()
     await store.getState().fetchRepos()
-    const projects = store.getState().projects
-    const setups = store.getState().projectHostSetups
+    const before = store.getState()
+    const projects = before.projects
+    const setups = before.projectHostSetups
     expect(projects).toHaveLength(1)
     expect(setups).toHaveLength(1)
 
     store.getState().recordSshRepoReadoptions([])
 
+    // Why: the empty-in/empty-pending call must hand the state object back untouched, or the
+    // freshly allocated pendingSshRepoReadoptions alone would wake every store subscriber.
+    expect(store.getState()).toBe(before)
+    expect(store.getState().pendingSshRepoReadoptions).toBe(before.pendingSshRepoReadoptions)
     expect(store.getState().projects).toBe(projects)
     expect(store.getState().projects[0]).toBe(projects[0])
     expect(store.getState().projectHostSetups).toBe(setups)

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2004,6 +2004,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   recordSshRepoReadoptions: (readoptions) =>
     set((s) => {
+      // Why: SshPane importConfig() often reports [] on every Manage-pane open.
+      if (readoptions.length === 0 && s.pendingSshRepoReadoptions.length === 0) {
+        return s
+      }
       const pendingSshRepoReadoptions = mergeSshRepoReadoptions(
         s.pendingSshRepoReadoptions,
         readoptions
@@ -2011,19 +2015,35 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const reconciliation = reconcileReadoptedSshRepoRows(s.repos, pendingSshRepoReadoptions)
       const repos = reconciliation.repos
       const worktreeState = reconcileReadoptedSshWorktreeState(s, pendingSshRepoReadoptions)
-      const projectHostSetups = filterSetupsForPrunedRepoRows(s.projectHostSetups, s.repos, repos)
+      const remainingSetups = filterSetupsForPrunedRepoRows(s.projectHostSetups, s.repos, repos)
       const compatibility = mergeProjectHostSetupCompatibility(
         projectCompatibilityFromRepos(repos),
         {
           projects: s.projects,
-          setups: projectHostSetups
+          setups: remainingSetups
         }
+      )
+      // Why: mergeProjectHostSetupCompatibility always allocates; a no-op readoption
+      // must not churn catalog identity. This write is all-repos, not host-scoped,
+      // so it cannot go through mergeFetchedProjectCompatibilityForHost.
+      const projects = reconcileCatalogRows(
+        s.projects,
+        compatibility.projects,
+        (project) => project.id
+      )
+      const projectHostSetups = reconcileCatalogRows(
+        s.projectHostSetups,
+        compatibility.projectHostSetups,
+        getProjectHostSetupOwnerKey
       )
       return {
         repos,
         pendingSshRepoReadoptions: reconciliation.pendingReadoptions,
         ...worktreeState,
-        ...compatibility
+        ...(catalogRowsUnchanged(projects, s.projects) ? {} : { projects }),
+        ...(catalogRowsUnchanged(projectHostSetups, s.projectHostSetups)
+          ? {}
+          : { projectHostSetups })
       }
     }),
 

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2025,7 +2025,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       )
       // Why: mergeProjectHostSetupCompatibility always allocates; a no-op readoption
       // must not churn catalog identity. This write is all-repos, not host-scoped,
-      // so it cannot go through mergeFetchedProjectCompatibilityForHost.
+      // so it cannot go through mergeFetchedProjectCompatibilityForHost. Reconcile
+      // hands the store arrays straight back when nothing moved, so writing them
+      // unconditionally still leaves identity-keyed selectors untouched.
       const projects = reconcileCatalogRows(
         s.projects,
         compatibility.projects,
@@ -2040,10 +2042,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         repos,
         pendingSshRepoReadoptions: reconciliation.pendingReadoptions,
         ...worktreeState,
-        ...(catalogRowsUnchanged(projects, s.projects) ? {} : { projects }),
-        ...(catalogRowsUnchanged(projectHostSetups, s.projectHostSetups)
-          ? {}
-          : { projectHostSetups })
+        projects,
+        projectHostSetups
       }
     }),
 

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1781,8 +1781,8 @@ export type RepoSlice = {
   activeRepoId: string | null
   // Monotonic sequence so overlapping catalog fetches can drop stale same-host results (#7020).
   reposFetchGeneration: number
-  pendingSshRepoReadoptions: SshRepoReadoption[]
-  recordSshRepoReadoptions: (readoptions: SshRepoReadoption[]) => void
+  pendingSshRepoReadoptions: readonly SshRepoReadoption[]
+  recordSshRepoReadoptions: (readoptions: readonly SshRepoReadoption[]) => void
   fetchRepos: (options?: RuntimeCatalogFetchOptions) => Promise<void>
   fetchReposForAllHosts: (options?: AllHostCatalogFetchOptions) => Promise<void>
   awaitLocalRepoCatalogSettlement: () => Promise<void>

--- a/src/renderer/src/store/slices/superseded-ssh-repo-rows.ts
+++ b/src/renderer/src/store/slices/superseded-ssh-repo-rows.ts
@@ -4,7 +4,7 @@ import { getRepoExecutionHostId, toSshExecutionHostId } from '../../../../shared
 
 export type SshRepoReconciliation = {
   repos: readonly Repo[]
-  pendingReadoptions: SshRepoReadoption[]
+  pendingReadoptions: readonly SshRepoReadoption[]
 }
 
 function repoBelongsToTarget(repo: Repo, targetId: string): boolean {
@@ -69,7 +69,7 @@ export function reconcileReadoptedSshRepoRows(
 export function mergeSshRepoReadoptions(
   pending: readonly SshRepoReadoption[],
   incoming: readonly SshRepoReadoption[]
-): SshRepoReadoption[] {
+): readonly SshRepoReadoption[] {
   const repoIdsByMigration = new Map<string, Set<string>>()
   for (const readoption of [...pending, ...incoming]) {
     const key = `${readoption.oldTargetId}\0${readoption.newTargetId}`


### PR DESCRIPTION
## Summary

`recordSshRepoReadoptions` always ran `projectCompatibilityFromRepos` → `mergeProjectHostSetupCompatibility` and spread the result into `set()` with no `reconcileCatalogRows`. `SshPane` calls this on every Manage-pane `importConfig()`, often with `[]`, so `projects` / `projectHostSetups` array identity churned on a no-op and WeakMap / `Object.is` selectors missed 100% of the time.

This is a follow-up to #13744 / #13770 / #13803: fetch paths already reconcile via `mergeFetchedProjectCompatibilityForHost`, but that helper is host-scoped. This write is all-repos (SSH re-adoption can prune any old-host row), so routing through the fetch merger would be the wrong scope and a partial fix would stay inert.

## The chain

Identity has to survive every link from the incoming readoption list to `set()`:

1. Cheap early-return when both the incoming list and `pendingSshRepoReadoptions` are empty (the common Manage-pane `[]` path).
2. After a real merge, `reconcileCatalogRows` against `s.projects` / `s.projectHostSetups` with the same keys the fetch path uses (`project.id`, `getProjectHostSetupOwnerKey`).
3. If `catalogRowsUnchanged`, omit those keys from the `set()` payload so subscribers keep the previous refs.

A partial fix at any one of those links is inert: `mergeProjectHostSetupCompatibility` always allocates, so even a correct prune/filter still hands `set()` brand-new catalog objects unless the publisher reconciles and omits.

## Why reference compare is not enough

IPC `structuredClone` and hydrate rebuild nested records (`hookSettings`, `gitRemoteIdentity`, path arrays). Derived compatibility rows are also always new objects. `===` never matches after that rebuild, so the publisher has to go through `areValuesEqual` / `reconcileCatalogRows` from `repo-identity-reconcile.ts` — not a fourth walker, and not a reference compare of the merge result.

## Tests

`src/renderer/src/store/slices/repos-refresh-identity.test.ts` reuses the production-shaped repo (nested `hookSettings`, `gitRemoteIdentity`, path arrays, `addedAt != 0`) and the `structuredClone` fetch path:

- After `fetchRepos()`, `recordSshRepoReadoptions([])` keeps `projects` / `projectHostSetups` array + row identity (`toBe`).
- A pending-only readoption (new-host row absent) keeps catalog identity while `pendingSshRepoReadoptions` updates.
- A real prune/rehome still replaces the moved setup.

Negative control: removing the two `reconcileCatalogRows` calls turns the pending-only no-op red. Scalar fixtures in `repos-ssh-host-reconciliation.test.ts` stay out of this — they would stay green while the feature is dead.

Made with [Orca](https://github.com/stablyai/orca) 🐋
