### PR TITLE
fix(store): keep project catalog identity when repo.addedAt is 0

### DIFF
--- a/src/renderer/src/store/slices/repos-project-runtime.test.ts
+++ b/src/renderer/src/store/slices/repos-project-runtime.test.ts
@@ -281,12 +281,15 @@ describe('repo slice project runtime updates', () => {
       ...project,
       sourceRepoIds: ['local-repo'],
       createdAt: 100,
-      updatedAt: 100
+      updatedAt: 100,
+      localWindowsRuntimePreference: { kind: 'windows-host' }
     })
     const store = createTestStore()
     store.setState({ projects: [project] })
 
-    await store.getState().updateProject(project.id, { displayName: 'Orca' })
+    await store.getState().updateProject(project.id, {
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
 
     expect(store.getState().projects[0]?.createdAt).toBe(100)
     expect(store.getState().projects[0]?.updatedAt).toBe(100)

--- a/src/renderer/src/store/slices/repos-project-runtime.test.ts
+++ b/src/renderer/src/store/slices/repos-project-runtime.test.ts
@@ -266,6 +266,32 @@ describe('repo slice project runtime updates', () => {
     expect(projectsUpdate).not.toHaveBeenCalled()
   })
 
+  // Why: a host whose repos carry no `addedAt` projects createdAt 0, which means unknown, not
+  // epoch. Merging it with the host that does know the timestamp must keep the real one.
+  it('prefers a known createdAt over an unknown 0 when merging the same project id', async () => {
+    const project: Project = {
+      id: 'github:stablyai/orca',
+      displayName: 'Orca',
+      badgeColor: '#000',
+      sourceRepoIds: ['remote-repo'],
+      createdAt: 0,
+      updatedAt: 0
+    }
+    projectsUpdate.mockResolvedValue({
+      ...project,
+      sourceRepoIds: ['local-repo'],
+      createdAt: 100,
+      updatedAt: 100
+    })
+    const store = createTestStore()
+    store.setState({ projects: [project] })
+
+    await store.getState().updateProject(project.id, { displayName: 'Orca' })
+
+    expect(store.getState().projects[0]?.createdAt).toBe(100)
+    expect(store.getState().projects[0]?.updatedAt).toBe(100)
+  })
+
   it('preserves shared project source repos when updating local runtime preferences', async () => {
     const project: Project = {
       id: 'github:stablyai/orca',

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -52,8 +52,13 @@ function clone<T>(value: T): T {
   return structuredClone(value)
 }
 
-function mockRepos(...rows: readonly Repo[]): void {
+function mockRepos(...rows: readonly (Repo | Omit<Repo, 'addedAt'>)[]): void {
   reposList.mockImplementation(async () => rows.map(clone))
+}
+
+function omitAddedAt(row: Repo): Omit<Repo, 'addedAt'> {
+  const { addedAt: _addedAt, ...rest } = row
+  return rest
 }
 
 beforeEach(() => {
@@ -235,6 +240,62 @@ describe('repo catalog refresh identity', () => {
     expect(store.getState().projects).not.toBe(projects)
     expect(store.getState().projects).toHaveLength(2)
     expect(store.getState().projectHostSetups).toHaveLength(2)
+  })
+
+  it('keeps catalog identity when repo.addedAt is 0', async () => {
+    mockRepos({ ...repo, addedAt: 0 })
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+    const setups = store.getState().projectHostSetups
+    expect(projects).toHaveLength(1)
+    expect(setups).toHaveLength(1)
+    expect(projects[0]?.createdAt).toBe(0)
+    expect(setups[0]?.createdAt).toBe(0)
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).toBe(projects)
+    expect(store.getState().projects[0]).toBe(projects[0])
+    expect(store.getState().projectHostSetups).toBe(setups)
+    expect(store.getState().projectHostSetups[0]).toBe(setups[0])
+  })
+
+  it('keeps catalog identity when repo.addedAt is omitted', async () => {
+    mockRepos(omitAddedAt(repo))
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const projects = store.getState().projects
+    const setups = store.getState().projectHostSetups
+    expect(projects).toHaveLength(1)
+    expect(setups).toHaveLength(1)
+    expect(projects[0]?.createdAt).toBe(0)
+    expect(setups[0]?.createdAt).toBe(0)
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).toBe(projects)
+    expect(store.getState().projects[0]).toBe(projects[0])
+    expect(store.getState().projectHostSetups).toBe(setups)
+    expect(store.getState().projectHostSetups[0]).toBe(setups[0])
+  })
+
+  it('lets a nested hookSettings change through when repo.addedAt is 0', async () => {
+    mockRepos({ ...repo, addedAt: 0 })
+    const store = createTestStore()
+    await store.getState().fetchRepos()
+    const setups = store.getState().projectHostSetups
+
+    mockRepos({
+      ...repo,
+      addedAt: 0,
+      hookSettings: { mode: 'override', scripts: { setup: '', archive: '' } }
+    })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projectHostSetups).not.toBe(setups)
+    expect(store.getState().projectHostSetups[0]).not.toBe(setups[0])
+    expect(store.getState().projectHostSetups[0]?.hookSettings?.mode).toBe('override')
   })
 })
 

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -6,8 +6,8 @@ import { createTestStore } from './store-test-helpers'
 
 // Why: every field here is load-bearing. A scalar-only repo reconciles even when the structural
 // compare is broken, which is exactly how an earlier version of this work shipped green and inert.
-// addedAt must stay non-zero: project-host-setup-projection falls back to `repo.addedAt || now`,
-// so a zero timestamp stamps Date.now() into every projection and nothing ever reconciles.
+// addedAt is non-zero on this fixture so the default case still exercises a real timestamp;
+// dedicated tests below cover addedAt 0 / omitted without restamping Date.now().
 const repo: Repo = {
   id: 'repo-1',
   path: '/repo-1',

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -25,6 +25,8 @@ import type {
 } from '../../../../shared/types'
 import {
   getProjectIdentityKey,
+  mergeCatalogCreatedAt,
+  mergeCatalogUpdatedAt,
   projectHostSetupProjectionFromRepos,
   type ProjectHostSetupProjection
 } from '../../../../shared/project-host-setup-projection'
@@ -561,8 +563,10 @@ function mergeProjectCompatibilityProject(base: Project, overlay: Project): Proj
     ...overlay,
     // Why: all-host startup fetches hosts separately; one host's record must not erase repo ownership learned from another host with the same id.
     sourceRepoIds: [...new Set([...base.sourceRepoIds, ...overlay.sourceRepoIds])],
-    createdAt: Math.min(base.createdAt, overlay.createdAt),
-    updatedAt: Math.max(base.updatedAt, overlay.updatedAt)
+    // Why not plain min/max: a host whose repos carry no `addedAt` projects 0, and 0 means
+    // unknown, not epoch — it must not win over the real timestamp the other host knows.
+    createdAt: mergeCatalogCreatedAt(base.createdAt, overlay.createdAt),
+    updatedAt: mergeCatalogUpdatedAt(base.updatedAt, overlay.updatedAt)
   }
   if (localWindowsRuntimePreference === undefined) {
     delete project.localWindowsRuntimePreference

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -38,28 +38,54 @@ describe('project host setup projection', () => {
     expect(second.setups[0]?.updatedAt).toBe(first.setups[0]?.updatedAt)
   })
 
+  // Why both orders: repo order comes from disk/host enumeration, so it must not decide the
+  // project's timestamps. The accumulator carries 0 when the *first* sibling is the unknown one.
+  const timestampedSibling = repo({
+    id: 'local-repo',
+    path: '/Users/alice/orca',
+    displayName: 'Orca',
+    addedAt: 100,
+    upstream: { owner: 'StablyAI', repo: 'Orca' }
+  })
+  const unknownSibling = repo({
+    id: 'remote-repo',
+    path: '/home/alice/orca',
+    displayName: 'orca',
+    addedAt: 0,
+    connectionId: 'gpu-vm',
+    upstream: { owner: 'stablyai', repo: 'orca' }
+  })
+
   it('does not wipe a persisted createdAt when a sibling repo has addedAt 0', () => {
-    const projection = projectHostSetupProjectionFromRepos([
-      repo({
-        id: 'local-repo',
-        path: '/Users/alice/orca',
-        displayName: 'Orca',
-        addedAt: 100,
-        upstream: { owner: 'StablyAI', repo: 'Orca' }
-      }),
-      repo({
-        id: 'remote-repo',
-        path: '/home/alice/orca',
-        displayName: 'orca',
-        addedAt: 0,
-        connectionId: 'gpu-vm',
-        upstream: { owner: 'stablyai', repo: 'orca' }
-      })
-    ])
+    const projection = projectHostSetupProjectionFromRepos([timestampedSibling, unknownSibling])
 
     expect(projection.projects).toHaveLength(1)
     expect(projection.projects[0]?.createdAt).toBe(100)
     expect(projection.projects[0]?.updatedAt).toBe(100)
+  })
+
+  it('does not wipe a persisted createdAt when the addedAt 0 sibling comes first', () => {
+    const projection = projectHostSetupProjectionFromRepos([unknownSibling, timestampedSibling])
+
+    expect(projection.projects).toHaveLength(1)
+    expect(projection.projects[0]?.createdAt).toBe(100)
+    expect(projection.projects[0]?.updatedAt).toBe(100)
+  })
+
+  it('keeps per-repo setup timestamps independent of sibling order', () => {
+    for (const repos of [
+      [timestampedSibling, unknownSibling],
+      [unknownSibling, timestampedSibling]
+    ]) {
+      const { setups } = projectHostSetupProjectionFromRepos(repos)
+      const timestamped = setups.find((setup) => setup.repoId === 'local-repo')
+      const unknown = setups.find((setup) => setup.repoId === 'remote-repo')
+      expect(timestamped?.createdAt).toBe(100)
+      expect(timestamped?.updatedAt).toBe(100)
+      // Setups are per repo and never merged, so the unknown one keeps its own 0 either way.
+      expect(unknown?.createdAt).toBe(0)
+      expect(unknown?.updatedAt).toBe(0)
+    }
   })
 
   it('projects a legacy local repo into one project and one ready local setup', () => {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -20,7 +20,12 @@ function repo(overrides: Partial<Repo> & Pick<Repo, 'id' | 'path' | 'displayName
 
 describe('project host setup projection', () => {
   it('keeps timestamps stable when addedAt is 0 across different now values', () => {
-    const target = repo({ id: 'repo-1', path: '/Users/alice/orca', displayName: 'orca', addedAt: 0 })
+    const target = repo({
+      id: 'repo-1',
+      path: '/Users/alice/orca',
+      displayName: 'orca',
+      addedAt: 0
+    })
     const first = projectHostSetupProjectionFromRepos([target], 1_000)
     const second = projectHostSetupProjectionFromRepos([target], 9_999)
 

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -19,6 +19,44 @@ function repo(overrides: Partial<Repo> & Pick<Repo, 'id' | 'path' | 'displayName
 }
 
 describe('project host setup projection', () => {
+  it('keeps timestamps stable when addedAt is 0 across different now values', () => {
+    const target = repo({ id: 'repo-1', path: '/Users/alice/orca', displayName: 'orca', addedAt: 0 })
+    const first = projectHostSetupProjectionFromRepos([target], 1_000)
+    const second = projectHostSetupProjectionFromRepos([target], 9_999)
+
+    expect(first.projects[0]?.createdAt).toBe(0)
+    expect(first.projects[0]?.updatedAt).toBe(0)
+    expect(first.setups[0]?.createdAt).toBe(0)
+    expect(second.projects[0]?.createdAt).toBe(first.projects[0]?.createdAt)
+    expect(second.projects[0]?.updatedAt).toBe(first.projects[0]?.updatedAt)
+    expect(second.setups[0]?.createdAt).toBe(first.setups[0]?.createdAt)
+    expect(second.setups[0]?.updatedAt).toBe(first.setups[0]?.updatedAt)
+  })
+
+  it('does not wipe a persisted createdAt when a sibling repo has addedAt 0', () => {
+    const projection = projectHostSetupProjectionFromRepos([
+      repo({
+        id: 'local-repo',
+        path: '/Users/alice/orca',
+        displayName: 'Orca',
+        addedAt: 100,
+        upstream: { owner: 'StablyAI', repo: 'Orca' }
+      }),
+      repo({
+        id: 'remote-repo',
+        path: '/home/alice/orca',
+        displayName: 'orca',
+        addedAt: 0,
+        connectionId: 'gpu-vm',
+        upstream: { owner: 'stablyai', repo: 'orca' }
+      })
+    ])
+
+    expect(projection.projects).toHaveLength(1)
+    expect(projection.projects[0]?.createdAt).toBe(100)
+    expect(projection.projects[0]?.updatedAt).toBe(100)
+  })
+
   it('projects a legacy local repo into one project and one ready local setup', () => {
     const projection = projectHostSetupProjectionFromRepos(
       [repo({ id: 'repo-1', path: '/Users/alice/orca', displayName: 'orca' })],

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -205,9 +205,16 @@ function parseGitHubRemoteUrl(remoteUrl: string | undefined): ProjectProviderIde
   }
 }
 
-function createProjectFromRepo(repo: Repo, now: number): Project {
+// Why: `addedAt || now` restamps Date.now() when addedAt is 0 / absent / NaN, so every
+// projection looks dirty and reconcileCatalogRows never reuses the project or setup.
+function catalogTimestampFromAddedAt(addedAt: number): number {
+  return Number.isFinite(addedAt) ? addedAt : 0
+}
+
+function createProjectFromRepo(repo: Repo): Project {
   const identity = getProjectProviderIdentity(repo)
   const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
+  const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
   return {
     id: getProjectId(repo),
     displayName: repo.displayName,
@@ -217,8 +224,8 @@ function createProjectFromRepo(repo: Repo, now: number): Project {
     ...(identity ? { providerIdentity: identity } : {}),
     ...(gitRemoteIdentity ? { gitRemoteIdentity } : {}),
     sourceRepoIds: [repo.id],
-    createdAt: repo.addedAt || now,
-    updatedAt: repo.addedAt || now
+    createdAt: addedAt,
+    updatedAt: addedAt
   }
 }
 
@@ -226,17 +233,20 @@ function mergeProjectRepo(project: Project, repo: Repo): Project {
   const sourceRepoIds = project.sourceRepoIds.includes(repo.id)
     ? project.sourceRepoIds
     : [...project.sourceRepoIds, repo.id]
+  // Why: 0 / absent / NaN means "unknown", not epoch — min() would wipe a persisted createdAt.
+  const addedAt =
+    Number.isFinite(repo.addedAt) && repo.addedAt !== 0 ? repo.addedAt : undefined
   return {
     ...project,
     sourceRepoIds,
-    createdAt: Math.min(project.createdAt, repo.addedAt || project.createdAt),
-    updatedAt: Math.max(project.updatedAt, repo.addedAt || project.updatedAt)
+    createdAt: Math.min(project.createdAt, addedAt ?? project.createdAt),
+    updatedAt: Math.max(project.updatedAt, addedAt ?? project.updatedAt)
   }
 }
 
-function createSetupFromRepo(repo: Repo, projectId: string, now: number): ProjectHostSetup {
+function createSetupFromRepo(repo: Repo, projectId: string): ProjectHostSetup {
   const hostId = getRepoExecutionHostId(repo)
-  const createdAt = repo.addedAt || now
+  const createdAt = catalogTimestampFromAddedAt(repo.addedAt)
   const setupMethod = repo.projectHostSetupMethod ?? 'legacy-repo'
   return {
     id: repo.id,
@@ -261,7 +271,7 @@ function createSetupFromRepo(repo: Repo, projectId: string, now: number): Projec
 
 export function projectHostSetupProjectionFromRepos(
   repos: readonly Repo[],
-  now = Date.now()
+  _now?: number
 ): ProjectHostSetupProjection {
   const projectById = new Map<string, ProjectAccumulator>()
   const setups: ProjectHostSetup[] = []
@@ -271,8 +281,8 @@ export function projectHostSetupProjectionFromRepos(
     const existing = projectById.get(projectId)
     const project = existing
       ? mergeProjectRepo(existing.project, repo)
-      : createProjectFromRepo(repo, now)
-    const setup = createSetupFromRepo(repo, projectId, now)
+      : createProjectFromRepo(repo)
+    const setup = createSetupFromRepo(repo, projectId)
     projectById.set(projectId, {
       project
     })

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -211,6 +211,33 @@ function catalogTimestampFromAddedAt(addedAt: number): number {
   return Number.isFinite(addedAt) ? addedAt : 0
 }
 
+// Why: 0 / absent / NaN means "the repo predates timestamped catalog rows", not epoch. Keeping
+// it out of min()/max() stops one unknown sibling from wiping a real timestamp — and unlike the
+// old `|| now` fallback it stays order-independent, so both merge orders agree.
+function knownCatalogTimestamp(value: number): number | undefined {
+  return Number.isFinite(value) && value !== 0 ? value : undefined
+}
+
+/** Oldest of two catalog `createdAt` values, treating 0/NaN on either side as unknown. */
+export function mergeCatalogCreatedAt(left: number, right: number): number {
+  const known = knownCatalogTimestamp(left)
+  const other = knownCatalogTimestamp(right)
+  if (known === undefined || other === undefined) {
+    return known ?? other ?? 0
+  }
+  return Math.min(known, other)
+}
+
+/** Newest of two catalog `updatedAt` values, treating 0/NaN on either side as unknown. */
+export function mergeCatalogUpdatedAt(left: number, right: number): number {
+  const known = knownCatalogTimestamp(left)
+  const other = knownCatalogTimestamp(right)
+  if (known === undefined || other === undefined) {
+    return known ?? other ?? 0
+  }
+  return Math.max(known, other)
+}
+
 function createProjectFromRepo(repo: Repo): Project {
   const identity = getProjectProviderIdentity(repo)
   const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
@@ -233,13 +260,14 @@ function mergeProjectRepo(project: Project, repo: Repo): Project {
   const sourceRepoIds = project.sourceRepoIds.includes(repo.id)
     ? project.sourceRepoIds
     : [...project.sourceRepoIds, repo.id]
-  // Why: 0 / absent / NaN means "unknown", not epoch — min() would wipe a persisted createdAt.
-  const addedAt = Number.isFinite(repo.addedAt) && repo.addedAt !== 0 ? repo.addedAt : undefined
+  // Why unknown-aware on both sides: the accumulator itself carries 0 when the first repo of the
+  // project had no addedAt, so a plain min() would let repo order decide the project's createdAt.
+  const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
   return {
     ...project,
     sourceRepoIds,
-    createdAt: Math.min(project.createdAt, addedAt ?? project.createdAt),
-    updatedAt: Math.max(project.updatedAt, addedAt ?? project.updatedAt)
+    createdAt: mergeCatalogCreatedAt(project.createdAt, addedAt),
+    updatedAt: mergeCatalogUpdatedAt(project.updatedAt, addedAt)
   }
 }
 

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -234,8 +234,7 @@ function mergeProjectRepo(project: Project, repo: Repo): Project {
     ? project.sourceRepoIds
     : [...project.sourceRepoIds, repo.id]
   // Why: 0 / absent / NaN means "unknown", not epoch — min() would wipe a persisted createdAt.
-  const addedAt =
-    Number.isFinite(repo.addedAt) && repo.addedAt !== 0 ? repo.addedAt : undefined
+  const addedAt = Number.isFinite(repo.addedAt) && repo.addedAt !== 0 ? repo.addedAt : undefined
   return {
     ...project,
     sourceRepoIds,

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -298,7 +298,7 @@ export function projectHostSetupProjectionFromRepos(
 export function getProjectHostSetupsForProject(
   setups: readonly ProjectHostSetup[],
   projectId: string
-): ProjectHostSetup[] {
+): readonly ProjectHostSetup[] {
   return setups.filter((setup) => setup.projectId === projectId)
 }
 


### PR DESCRIPTION
## Summary

`projectHostSetupProjectionFromRepos` used `repo.addedAt || now` (and `now` defaulted to `Date.now()`). Repos with `addedAt === 0`, an omitted `addedAt`, or `NaN` therefore stamped a new wall-clock into `createdAt` / `updatedAt` on every projection.

`#13803` already reconciles `projects` / `projectHostSetups` with `areValuesEqual` / `reconcileCatalogRows`. That only works when the projected timestamps already match. This is the leftover it documented: the reconcile is inert for degraded `addedAt` because the projection itself is never stable.

## The chain / why a partial fix is inert

Identity has to survive every link from fetch to `set()`:

1. `fetchRepos()` lists repos (IPC `structuredClone` rebuilds nested records).
2. `projectCompatibilityFromRepos()` always re-projects via `createProjectFromRepo` / `createSetupFromRepo` / `mergeProjectRepo`.
3. `mergeFetchedProjectCompatibilityForHost` then reconciles against the previous catalog.

If step 2 restamps timestamps, step 3 sees a real field change and allocates new project/setup objects. WeakMap / `Object.is` selectors miss 100% of the time even though the user-visible catalog did not change. Fixing only the reconcile (or only `?? now`, which still restamps absent/`NaN`) leaves this path dead.

## Reference compare fails on IPC clones

Nested `hookSettings` / `gitRemoteIdentity` / path arrays are rebuilt on every fetch. A `===` compare never matches after `structuredClone`. The existing `#13803` structural compare is the right tool once timestamps stop moving; this PR does not add another walker.

## Tests

- `src/renderer/src/store/slices/repos-refresh-identity.test.ts` adds production-shaped cases for `addedAt: 0` and omitted `addedAt` (nested hook settings, git remote identity, path arrays, `structuredClone` on every mock list).
- Asserts `projects` / `projectHostSetups` array **and** element identity across two `fetchRepos()` calls, and that a real nested `hookSettings` change still flows through.
- Existing non-zero `addedAt` fixtures stay as they are so other cases do not hide this path.
- Optional unit coverage in `project-host-setup-projection.test.ts`: two projections of `addedAt: 0` with different `now` values produce identical timestamps; merging a sibling with `addedAt: 0` does not wipe a persisted `createdAt`.
- Reverting the projection fallback to `repo.addedAt || now` goes red (stable `createdAt: 0` and the `now`-independence assertion).

Follow-up to #13744 / #13770 / #13803.

Made with [Orca](https://github.com/stablyai/orca) 🐋
