### PR TITLE
perf(store): keep runtimeEnvironments identity across no-op catalog lists

### DIFF
--- a/src/renderer/src/hooks/use-terminal-quick-command-hosts.ts
+++ b/src/renderer/src/hooks/use-terminal-quick-command-hosts.ts
@@ -43,11 +43,11 @@ type TerminalQuickCommandHostState = {
   remoteEnvironmentId: string | null
   remoteHostId: ExecutionHostId | null
   remoteState: RuntimeTerminalQuickCommands | undefined
-  runtimeEnvironments: PublicKnownRuntimeEnvironment[]
+  runtimeEnvironments: readonly PublicKnownRuntimeEnvironment[]
   settings: GlobalSettings | null
 }
 
-const EMPTY_RUNTIME_ENVIRONMENTS: PublicKnownRuntimeEnvironment[] = []
+const EMPTY_RUNTIME_ENVIRONMENTS: readonly PublicKnownRuntimeEnvironment[] = []
 const DISABLED_TERMINAL_QUICK_COMMAND_HOSTS: TerminalQuickCommandHost[] = []
 const DISABLED_TERMINAL_QUICK_COMMAND_HOST_STATE: TerminalQuickCommandHostState = {
   executionHostId: LOCAL_EXECUTION_HOST_ID,

--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/runtime-session-mirror-targets', async (importOriginal) => {
 })
 
 import { useAppStore } from '@/store'
+import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
 import type { AppState } from '@/store/types'
 import {
   selectRuntimeSessionMirrorTargetInputs,
@@ -71,7 +72,7 @@ function seedMirrorState(): void {
       runtimeEnvironments: [
         { id: 'env-a', createdAt: 100, pairingRevision: 101 },
         { id: 'env-b', createdAt: 200, pairingRevision: 201 }
-      ] as AppState['runtimeEnvironments'],
+      ] as PublicKnownRuntimeEnvironment[],
       runtimeStatusByEnvironmentId: new Map([
         [
           'env-a',
@@ -260,7 +261,7 @@ describe('useRuntimeSessionMirrorEnvironmentKey', () => {
       useAppStore.setState({
         runtimeEnvironments: [
           { id: 'env-a', createdAt: 100, pairingRevision: 102 }
-        ] as AppState['runtimeEnvironments']
+        ] as PublicKnownRuntimeEnvironment[]
       })
     })
     expect(hook.result.current).toBe('env-a\u0001runtime-a\u00012\u0001102')

--- a/src/renderer/src/runtime/web-session-tabs-sync-visibility-collision.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-visibility-collision.test.tsx
@@ -38,6 +38,7 @@ vi.mock('./web-runtime-session', async (importOriginal) => {
 })
 
 import { useAppStore } from '@/store'
+import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
 import type { AppState } from '@/store/types'
 import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
 import { toRemoteRuntimePtyId } from './runtime-terminal-stream'
@@ -221,7 +222,7 @@ function seedRemoteMirrorState(): void {
   const runtimeEnvironments = [
     { id: ENV_A, createdAt: 100, pairingRevision: REVISION_A },
     { id: ENV_B, createdAt: 200, pairingRevision: REVISION_B }
-  ] as AppState['runtimeEnvironments']
+  ] as PublicKnownRuntimeEnvironment[]
   replaceRuntimeEnvironmentRevisions(runtimeEnvironments)
   useAppStore.setState(
     {

--- a/src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx
@@ -37,6 +37,7 @@ vi.mock('./web-runtime-session', async (importOriginal) => {
 })
 
 import { useAppStore } from '@/store'
+import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
 import type { AppState } from '@/store/types'
 import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
 import {
@@ -179,7 +180,7 @@ function seedRemoteMirrorState(): void {
   const runtimeEnvironments = [
     { id: ENV_A, createdAt: 100, pairingRevision: REVISION_A },
     { id: ENV_B, createdAt: 200, pairingRevision: REVISION_B }
-  ] as AppState['runtimeEnvironments']
+  ] as PublicKnownRuntimeEnvironment[]
   replaceRuntimeEnvironmentRevisions(runtimeEnvironments)
   useAppStore.setState(
     {

--- a/src/renderer/src/store/slices/runtime-status-catalog-identity.test.ts
+++ b/src/renderer/src/store/slices/runtime-status-catalog-identity.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  redactRuntimeEnvironment,
+  type KnownRuntimeEnvironment
+} from '../../../../shared/runtime-environments'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import {
+  clearRuntimeEnvironmentConnectionGenerationsForTests,
+  getRuntimeEnvironmentConnectionGeneration
+} from './runtime-status'
+import { createTestStore } from './store-test-helpers'
+
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn(), dismiss: vi.fn() }
+}))
+
+// Why: production rows carry nested endpoints. A scalar-only fixture reconciles even
+// when the walker is broken, which is how a redact-only or Object.is fix stays green.
+const pairingRevision = 1_700_000_000_000
+const knownEndpoint: KnownRuntimeEnvironment['endpoints'][number] = {
+  id: 'ws-a',
+  kind: 'websocket',
+  label: 'WebSocket',
+  endpoint: 'wss://box.example:8787',
+  deviceToken: 'device-token-a',
+  publicKeyB64: 'public-key-a'
+}
+const knownEnvironment: KnownRuntimeEnvironment = {
+  id: 'env-a',
+  name: 'Dev Box',
+  createdAt: pairingRevision,
+  updatedAt: pairingRevision,
+  pairingRevision,
+  lastUsedAt: 1_700_000_100_000,
+  runtimeId: 'runtime-a',
+  source: 'manual',
+  endpoints: [knownEndpoint],
+  preferredEndpointId: 'ws-a'
+}
+
+function cloneRedactedCatalog(
+  environment: KnownRuntimeEnvironment = knownEnvironment
+): ReturnType<typeof redactRuntimeEnvironment>[] {
+  return structuredClone([redactRuntimeEnvironment(environment)])
+}
+
+function makeStatus(): RuntimeStatus {
+  return {
+    runtimeId: 'rt',
+    rendererGraphEpoch: 0,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    runtimeProtocolVersion: 3,
+    minCompatibleRuntimeClientVersion: 3
+  }
+}
+
+beforeEach(() => {
+  clearRuntimeEnvironmentConnectionGenerationsForTests()
+  vi.stubGlobal('window', { api: {}, dispatchEvent: vi.fn() })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('setRuntimeEnvironments catalog identity', () => {
+  it('keeps the array, row, and endpoints across independently cloned no-op lists', () => {
+    const store = createTestStore()
+    store.getState().setRuntimeEnvironments(cloneRedactedCatalog())
+    const previous = store.getState().runtimeEnvironments
+    const second = cloneRedactedCatalog()
+    expect(second).not.toBe(previous)
+    expect(second[0]).not.toBe(previous[0])
+    expect(second[0]?.endpoints).not.toBe(previous[0]?.endpoints)
+
+    store.getState().setRuntimeEnvironments(second)
+    const next = store.getState().runtimeEnvironments
+
+    expect(next).toBe(previous)
+    expect(next[0]).toBe(previous[0])
+    expect(next[0]?.endpoints).toBe(previous[0]?.endpoints)
+  })
+
+  it('keeps the same empty array across two empty lists', () => {
+    const store = createTestStore()
+    store.getState().setRuntimeEnvironments([])
+    const empty = store.getState().runtimeEnvironments
+
+    store.getState().setRuntimeEnvironments([])
+
+    expect(store.getState().runtimeEnvironments).toBe(empty)
+    expect(empty).toEqual([])
+  })
+
+  it('flips catalog hydrated and settled on the first write', () => {
+    const store = createTestStore()
+    expect(store.getState().runtimeEnvironmentCatalogHydrated).toBe(false)
+    expect(store.getState().runtimeEnvironmentCatalogSettled).toBe(false)
+
+    store.getState().setRuntimeEnvironments(cloneRedactedCatalog())
+
+    expect(store.getState().runtimeEnvironmentCatalogHydrated).toBe(true)
+    expect(store.getState().runtimeEnvironmentCatalogSettled).toBe(true)
+  })
+
+  it('allocates a new row when a public name changes', () => {
+    const store = createTestStore()
+    store.getState().setRuntimeEnvironments(cloneRedactedCatalog())
+    const previous = store.getState().runtimeEnvironments
+
+    store
+      .getState()
+      .setRuntimeEnvironments(cloneRedactedCatalog({ ...knownEnvironment, name: 'Lab' }))
+
+    const next = store.getState().runtimeEnvironments
+    expect(next).not.toBe(previous)
+    expect(next[0]).not.toBe(previous[0])
+    expect(next[0]?.name).toBe('Lab')
+  })
+
+  it('allocates a new row when an endpoint URL changes', () => {
+    const store = createTestStore()
+    store.getState().setRuntimeEnvironments(cloneRedactedCatalog())
+    const previous = store.getState().runtimeEnvironments
+
+    store.getState().setRuntimeEnvironments(
+      cloneRedactedCatalog({
+        ...knownEnvironment,
+        endpoints: [{ ...knownEndpoint, endpoint: 'wss://box.example:9999' }]
+      })
+    )
+
+    const next = store.getState().runtimeEnvironments
+    expect(next).not.toBe(previous)
+    expect(next[0]).not.toBe(previous[0])
+    expect(next[0]?.endpoints).not.toBe(previous[0]?.endpoints)
+    expect(next[0]?.endpoints[0]?.endpoint).toBe('wss://box.example:9999')
+  })
+
+  it('allocates a new row when lastUsedAt or updatedAt changes', () => {
+    const store = createTestStore()
+    store.getState().setRuntimeEnvironments(cloneRedactedCatalog())
+    const previous = store.getState().runtimeEnvironments
+
+    store.getState().setRuntimeEnvironments(
+      cloneRedactedCatalog({
+        ...knownEnvironment,
+        lastUsedAt: 1_700_000_200_000,
+        updatedAt: 1_700_000_200_000
+      })
+    )
+
+    const next = store.getState().runtimeEnvironments
+    expect(next).not.toBe(previous)
+    expect(next[0]).not.toBe(previous[0])
+    expect(next[0]?.lastUsedAt).toBe(1_700_000_200_000)
+    expect(next[0]?.updatedAt).toBe(1_700_000_200_000)
+  })
+
+  it('still drops status and advances generation on a pairingRevision change', () => {
+    const store = createTestStore()
+    store.getState().setRuntimeEnvironments(cloneRedactedCatalog())
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+    const before = getRuntimeEnvironmentConnectionGeneration('env-a')
+
+    store
+      .getState()
+      .setRuntimeEnvironments(
+        cloneRedactedCatalog({ ...knownEnvironment, pairingRevision: pairingRevision + 1 })
+      )
+
+    expect(store.getState().runtimeStatusByEnvironmentId.has('env-a')).toBe(false)
+    expect(getRuntimeEnvironmentConnectionGeneration('env-a')).toBe(before + 1)
+    expect(store.getState().runtimeEnvironments[0]?.pairingRevision).toBe(pairingRevision + 1)
+  })
+})

--- a/src/renderer/src/store/slices/runtime-status-hydration.ts
+++ b/src/renderer/src/store/slices/runtime-status-hydration.ts
@@ -19,14 +19,14 @@ export function resetRuntimeCatalogListingForTests(): void {
 
 type RuntimeStatusHydrationDependencies = {
   listEnvironments: () => Promise<PublicKnownRuntimeEnvironment[]>
-  getCurrentEnvironments: () => PublicKnownRuntimeEnvironment[]
-  publishEnvironments: (environments: PublicKnownRuntimeEnvironment[]) => void
+  getCurrentEnvironments: () => readonly PublicKnownRuntimeEnvironment[]
+  publishEnvironments: (environments: readonly PublicKnownRuntimeEnvironment[]) => void
   refreshEnvironmentStatus: (environmentId: string) => Promise<boolean>
   markCatalogSettled: () => void
 }
 
 function environmentRevisions(
-  environments: PublicKnownRuntimeEnvironment[]
+  environments: readonly PublicKnownRuntimeEnvironment[]
 ): ReadonlyMap<string, number> {
   return new Map(
     environments.map((environment) => [
@@ -37,7 +37,7 @@ function environmentRevisions(
 }
 
 function revisionsMatch(
-  environments: PublicKnownRuntimeEnvironment[],
+  environments: readonly PublicKnownRuntimeEnvironment[],
   expected: ReadonlyMap<string, number>
 ): boolean {
   const current = environmentRevisions(environments)

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -799,7 +799,7 @@ describe('runtime-status slice', () => {
 
     expect(list).toHaveBeenCalledTimes(2)
     expect(getStatus).toHaveBeenCalledTimes(2)
-    expect(publications).toBe(4)
+    expect(publications).toBe(3)
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status?.runtimeId).toBe(
       'runtime-2'
     )

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -32,7 +32,7 @@ export type RuntimeEnvironmentStatus = {
 export type RuntimeStatusSlice = {
   /** Saved remote Orca servers. Host pickers use this to show user-chosen names
    * instead of opaque runtime ids. */
-  runtimeEnvironments: PublicKnownRuntimeEnvironment[]
+  runtimeEnvironments: readonly PublicKnownRuntimeEnvironment[]
   /** True only after the saved-runtime catalog has loaded successfully. Gates
    * fail-closed host routing, so a failed read must NOT flip it. */
   runtimeEnvironmentCatalogHydrated: boolean
@@ -52,7 +52,7 @@ export type RuntimeStatusSlice = {
   removedRuntimeEnvironmentIds: ReadonlySet<string>
   /** Replaces the saved-environment list, trims stale status entries, and
    * retires state owned by any environment that just left the saved list. */
-  setRuntimeEnvironments: (environments: PublicKnownRuntimeEnvironment[]) => void
+  setRuntimeEnvironments: (environments: readonly PublicKnownRuntimeEnvironment[]) => void
   /** Merges one environment's status. Replaces the prior entry for that id. */
   setRuntimeEnvironmentStatus: (
     environmentId: string,
@@ -170,7 +170,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         return s
       }
       return {
-        runtimeEnvironments: catalogUnchanged ? s.runtimeEnvironments : reconciled.slice(),
+        runtimeEnvironments: catalogUnchanged ? s.runtimeEnvironments : reconciled,
         runtimeEnvironmentCatalogHydrated: true,
         runtimeEnvironmentCatalogSettled: true,
         ...(statusesChanged ? { runtimeStatusByEnvironmentId: nextStatuses } : {}),

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -13,6 +13,7 @@ import {
   dismissRuntimeDisconnectedToast,
   showRuntimeDisconnectedToast
 } from './runtime-environment-disconnect-toast'
+import { reconcileCatalogRows } from './repo-identity-reconcile'
 import { createRuntimeStatusHydration } from './runtime-status-hydration'
 import { refreshRuntimeEnvironmentStatus } from './runtime-status-refresh'
 
@@ -151,8 +152,25 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
           removedChanged = true
         }
       }
+      // Why: list()/hydrate always allocate (IPC structuredClone + redact remaps
+      // endpoints[]). Reuse equal rows so Object.is subscribers don't miss 100%.
+      const reconciled = reconcileCatalogRows(
+        s.runtimeEnvironments,
+        environments,
+        (environment) => environment.id
+      )
+      const catalogUnchanged = reconciled === s.runtimeEnvironments
+      if (
+        catalogUnchanged &&
+        s.runtimeEnvironmentCatalogHydrated &&
+        s.runtimeEnvironmentCatalogSettled &&
+        !statusesChanged &&
+        !removedChanged
+      ) {
+        return s
+      }
       return {
-        runtimeEnvironments: environments,
+        runtimeEnvironments: catalogUnchanged ? s.runtimeEnvironments : reconciled.slice(),
         runtimeEnvironmentCatalogHydrated: true,
         runtimeEnvironmentCatalogSettled: true,
         ...(statusesChanged ? { runtimeStatusByEnvironmentId: nextStatuses } : {}),


### PR DESCRIPTION
## Summary

`setRuntimeEnvironments` always wrote `runtimeEnvironments: environments`, so a no-op catalog list allocated a new array and new rows. `useAppStore((s) => s.runtimeEnvironments)` is an `Object.is` selector in `useComposerState`, `WorktreeList`, sidebar host scope, and several settings/status-bar panes — those subscribers missed on every write.

This is a follow-up to #13744 / #13770 / #13803 for the runtime-environment catalog.

## The chain / why a partial fix is inert

Identity has to survive every link from fetch to `set()`:

1. `createRuntimeStatusHydration` always `publishEnvironments` after `list()`.
2. `fetchSettings` re-hydrates when the 60s catalog TTL expires, even if status coverage looks complete.
3. `window.api.runtimeEnvironments.list()` crosses IPC, so every row and `endpoints[]` is a `structuredClone` rebuild.
4. `redactRuntimeEnvironment` remaps `endpoints[]` to drop `deviceToken` / `publicKeyB64` — a new nested array even before IPC.

A redact-only change is inert: IPC still clones, and the unconditional `set()` still replaces the store array. An `Object.is` row compare is also inert: cloned nested records never match by reference. The fix has to structurally reconcile **and** skip the write when nothing else changed.

## The fix

Inside the `set()` updater, `reconcileCatalogRows(s.runtimeEnvironments, environments, (e) => e.id)` (uses `areValuesEqual` from `repo-identity-reconcile.ts`; no fourth walker). If the reconciled array is the previous array **and** the catalog is already hydrated/settled **and** statuses / removed-id tombstones are unchanged, return `s` — the same pattern as `setRuntimeEnvironmentStatus`.

Real catalog diffs still run pairingRevision status-drop / generation advance, removed-id tombstones, and status trim. `lastUsedAt` / `updatedAt` stay in the compare so a real write still updates.

## Tests

New `runtime-status-catalog-identity.test.ts` (sibling file: `runtime-status.test.ts` is already at 779/800 counted lines). Fixtures are production-shaped `KnownRuntimeEnvironment` rows whose endpoints include `deviceToken` + `publicKeyB64`, independently `redactRuntimeEnvironment()`'d and `structuredClone()`'d — not the same array twice, not scalar-only.

- Two cloned no-op lists keep the same array, row, and `endpoints[]`.
- Two empty lists keep the same `[]`.
- A public `name` or `endpoint.endpoint` change allocates a new row.
- `lastUsedAt` / `updatedAt` changes allocate a new row.
- First write still flips `catalogHydrated` / `catalogSettled`.
- `pairingRevision` change still drops status and advances generation.

Verified red against a reverted reconcile (unconditional `runtimeEnvironments: environments`), then restored. The existing overlapping-hydration publication count dropped from 4 to 3 because the second catalog publish is now a no-op.

Made with [Orca](https://github.com/stablyai/orca) 🐋
