### PR TITLE
fix(shell): keep OMP wrapper parse-safe under zsh global aliases

### DIFF
--- a/src/main/pty/omp-shell-wrapper.test.ts
+++ b/src/main/pty/omp-shell-wrapper.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { getPosixOmpShellWrapper } from './omp-shell-wrapper'
+
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const itWithZsh = hasZsh ? it : it.skip
+
+describe('getPosixOmpShellWrapper', () => {
+  it('does not embed alias-expandable --help/--version tokens', () => {
+    const code = getPosixOmpShellWrapper()
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n')
+    expect(code).not.toMatch(/(?:^|[\s|])--help(?:[\s)|]|$)/)
+    expect(code).not.toMatch(/(?:^|[\s|])--version(?:[\s)|]|$)/)
+  })
+
+  itWithZsh('parses under zsh global aliases that rewrite --help and --version', () => {
+    const script = `
+alias -g -- --help='--help 2>&1 | cat'
+alias -g -- --version='--version 2>&1 | cat'
+${getPosixOmpShellWrapper()}
+arg='--help'
+__orca_omp_should_skip_extension "$arg"
+print skip_help:$?
+arg='--version'
+__orca_omp_should_skip_extension "$arg"
+print skip_version:$?
+arg='config'
+__orca_omp_should_skip_extension "$arg"
+print skip_config:$?
+arg='ask'
+__orca_omp_should_skip_extension "$arg"
+print skip_ask:$?
+`
+    const result = spawnSync('zsh', ['-c', script], { encoding: 'utf8' })
+    expect(result.stderr, result.stderr).not.toMatch(/parse error/)
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('skip_help:0')
+    expect(result.stdout).toContain('skip_version:0')
+    expect(result.stdout).toContain('skip_config:0')
+    expect(result.stdout).toContain('skip_ask:1')
+  })
+})

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -45,9 +45,14 @@ export function getPosixOmpShellWrapper(): string {
 # interactive launch invocations so subcommands such as \`omp config\` keep
 # their normal argv shape.
 __orca_omp_should_skip_extension() {
+  # Why: zsh global aliases rewrite tokens such as double-dash help during
+  # interactive parse (HyDE bat.zsh). Strip a leading -- before matching so
+  # the pattern list never contains those alias names.
   case "\${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    ${subcommands}) return 0 ;;
+    help|-h|-v) return 0 ;;
+  esac
+  case "\${1#--}" in
+    help|version|${subcommands}) return 0 ;;
   esac
   return 1
 }


### PR DESCRIPTION
## Summary

User zsh global aliases whose name is a literal token in Orca's generated `shell-ready/zsh` wrapper (`--help`, `--version`) expand during interactive parse. HyDE's `alias -g -- --help='--help 2>&1 | bat …'` turns the `case` pattern into a `>&` list and every Orca-managed zsh terminal starts with:

```
.zshrc: parse error near `>&'
.zlogin: parse error near `>&'
```

`zsh -n` does not catch this (aliases are not expanded in a syntax-only check).

`__orca_omp_should_skip_extension` now matches help/version after stripping a leading `--`, so the generated `.zshrc` / `.zlogin` / bash rc never contain those alias names in a `case` pattern. Subcommand skip (`config`, `launch`, …) is unchanged.

Fixes #14208

## Test plan

- [x] `vitest run src/main/pty/omp-shell-wrapper.test.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts` (18 passed)
- [ ] Community PR: Approve and run workflows when convenient