### PR TITLE
perf(github): reuse workItemsCache identity on no-op refetch

### DIFF
--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -43,7 +43,7 @@ export type TaskPageWorkItemsFetchOptions = {
   noCache: boolean
 }
 
-type WorkItemsCache = Record<string, CacheEntry<GitHubWorkItem[]>>
+type WorkItemsCache = Record<string, CacheEntry<readonly GitHubWorkItem[]>>
 export type TaskPageWorkItemPages = readonly (GitHubWorkItem[] | null)[]
 
 export function deriveTaskPageGitHubWorkItemsFetchOptions(
@@ -61,7 +61,7 @@ export function selectTaskPageWorkItemsCacheEntries(
   repos: readonly TaskPageRepoCacheInput[],
   limit: number,
   query: string
-): (CacheEntry<GitHubWorkItem[]> | undefined)[] {
+): (CacheEntry<readonly GitHubWorkItem[]> | undefined)[] {
   return repos.map(
     (repo) =>
       workItemsCache[
@@ -72,7 +72,7 @@ export function selectTaskPageWorkItemsCacheEntries(
 
 export function buildTaskPageRepoSourceState(
   repos: readonly TaskPageRepoCacheInput[],
-  entries: readonly (CacheEntry<GitHubWorkItem[]> | undefined)[]
+  entries: readonly (CacheEntry<readonly GitHubWorkItem[]> | undefined)[]
 ): TaskPageRepoSourceState[] {
   return repos.map((repo, index) => {
     const entry = entries[index]
@@ -126,7 +126,7 @@ function taskPageWorkItemCacheKey(item: GitHubWorkItem): string {
 
 export function reconcileTaskPagePagesWithWorkItemsCache(
   pages: TaskPageWorkItemPages,
-  entries: readonly (CacheEntry<GitHubWorkItem[]> | undefined)[]
+  entries: readonly (CacheEntry<readonly GitHubWorkItem[]> | undefined)[]
 ): (GitHubWorkItem[] | null)[] {
   const cachedItems = new Map<string, GitHubWorkItem>()
   for (const entry of entries) {

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6300,6 +6300,151 @@ describe('createGitHubSlice.refreshGitHubForWorktree', () => {
   })
 })
 
+describe('createGitHubSlice.fetchWorkItems cache identity', () => {
+  const nestedSources = {
+    issues: { owner: 'acme', repo: 'widgets' },
+    prs: { owner: 'acme', repo: 'widgets' },
+    originCandidate: { owner: 'acme', repo: 'widgets' },
+    upstreamCandidate: { owner: 'acme-upstream', repo: 'widgets' }
+  }
+
+  function makeNestedWorkItem(
+    overrides: Partial<GitHubWorkItem> & Pick<GitHubWorkItem, 'id' | 'number' | 'title'>
+  ): Omit<GitHubWorkItem, 'repoId'> {
+    return {
+      type: 'pr',
+      state: 'open',
+      url: `https://github.com/acme/widgets/pull/${overrides.number}`,
+      labels: ['bug', 'needs-review'],
+      updatedAt: '2026-05-22T00:00:00Z',
+      author: 'octocat',
+      authorAvatarUrl: 'https://avatars.example/octocat.png',
+      branchName: 'feature/nested',
+      baseRefName: 'main',
+      headSha: 'abc123def456',
+      prRepo: { owner: 'acme', repo: 'widgets', host: 'github.com' },
+      additions: 12,
+      deletions: 3,
+      changedFiles: 2,
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviewRequests: [
+        { login: 'reviewer', name: 'Reviewer', avatarUrl: 'https://avatars.example/reviewer.png' }
+      ],
+      latestReviews: [
+        { login: 'reviewer', state: 'COMMENTED', avatarUrl: 'https://avatars.example/reviewer.png' }
+      ],
+      assignees: [
+        { login: 'assignee', name: 'Assignee', avatarUrl: 'https://avatars.example/assignee.png' }
+      ],
+      checksSummary: {
+        state: 'pending',
+        total: 4,
+        passed: 1,
+        failed: 0,
+        pending: 3,
+        neutral: 0
+      },
+      mergeable: 'MERGEABLE',
+      ...overrides
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRemoteRuntimeMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reuses the cache map, entry, and nested rows on a no-op force refetch', async () => {
+    const store = createTestStore()
+    const items = [
+      makeNestedWorkItem({ id: 'pr:42', number: 42, title: 'First nested PR' }),
+      makeNestedWorkItem({ id: 'pr:43', number: 43, title: 'Second nested PR' })
+    ]
+    mockApi.gh.listWorkItems.mockImplementation(() =>
+      Promise.resolve({
+        items: structuredClone(items),
+        sources: structuredClone(nestedSources)
+      })
+    )
+
+    let now = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    await store.getState().fetchWorkItems('repo-id', '/repo', 24, '')
+    const cacheKey = workItemsCacheKey('repo-id', 24, '')
+    const previousCache = store.getState().workItemsCache
+    const previousEntry = previousCache[cacheKey]
+    const previousRows = previousEntry?.data
+    expect(previousRows).toHaveLength(2)
+    expect(previousRows?.[0]?.labels).toEqual(['bug', 'needs-review'])
+    expect(previousRows?.[0]?.assignees?.[0]?.login).toBe('assignee')
+    expect(previousRows?.[0]?.reviewRequests?.[0]?.login).toBe('reviewer')
+    expect(previousRows?.[0]?.prRepo).toEqual({
+      owner: 'acme',
+      repo: 'widgets',
+      host: 'github.com'
+    })
+    expect(previousRows?.[0]?.checksSummary?.state).toBe('pending')
+
+    now += 5_000
+    await store.getState().fetchWorkItems('repo-id', '/repo', 24, '', { force: true })
+
+    const nextCache = store.getState().workItemsCache
+    const nextEntry = nextCache[cacheKey]
+    expect(nextCache).toBe(previousCache)
+    expect(nextEntry).toBe(previousEntry)
+    expect(nextEntry?.data).toBe(previousRows)
+    expect(nextEntry?.data?.[0]).toBe(previousRows?.[0])
+    expect(nextEntry?.data?.[1]).toBe(previousRows?.[1])
+    expect(nextEntry?.sources).toBe(previousEntry?.sources)
+    expect(nextEntry?.fetchedAt).toBe(now)
+    expect(nextEntry?.fetchedAt).toBeGreaterThan(1_700_000_000_000)
+  })
+
+  it('writes a new entry when a nested reviewRequests login changes but reuses the sibling row', async () => {
+    const store = createTestStore()
+    const first = makeNestedWorkItem({ id: 'pr:42', number: 42, title: 'First nested PR' })
+    const second = makeNestedWorkItem({ id: 'pr:43', number: 43, title: 'Second nested PR' })
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: structuredClone([first, second]),
+      sources: structuredClone(nestedSources)
+    })
+
+    await store.getState().fetchWorkItems('repo-id', '/repo', 24, '')
+    const cacheKey = workItemsCacheKey('repo-id', 24, '')
+    const previousCache = store.getState().workItemsCache
+    const previousEntry = previousCache[cacheKey]
+    const previousRows = previousEntry?.data
+    expect(previousRows).toHaveLength(2)
+
+    const changedFirst = structuredClone(first)
+    const nextReviewer = changedFirst.reviewRequests?.[0]
+    if (nextReviewer) {
+      nextReviewer.login = 'reviewer-updated'
+    }
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: [changedFirst, structuredClone(second)],
+      sources: structuredClone(nestedSources)
+    })
+
+    await store.getState().fetchWorkItems('repo-id', '/repo', 24, '', { force: true })
+
+    const nextCache = store.getState().workItemsCache
+    const nextEntry = nextCache[cacheKey]
+    expect(nextCache).not.toBe(previousCache)
+    expect(nextEntry).not.toBe(previousEntry)
+    expect(nextEntry?.data).not.toBe(previousRows)
+    expect(nextEntry?.data?.[0]).not.toBe(previousRows?.[0])
+    expect(nextEntry?.data?.[0]?.reviewRequests?.[0]?.login).toBe('reviewer-updated')
+    expect(nextEntry?.data?.[1]).toBe(previousRows?.[1])
+    expect(nextEntry?.sources).toBe(previousEntry?.sources)
+  })
+})
+
 describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -78,6 +78,7 @@ import { normalizeGitHubPRForBranchOutcome } from '../../../../shared/github-pr-
 import { restoreReactionOnSubject, setReactionOnSubject } from '@/lib/pr-comment-reactions'
 import { withGitHubCheckDetailsTimeout } from '@/runtime/github-check-details-timeout'
 import { getGitHubRepoLookupIndex } from './github-repo-lookup-index'
+import { areValuesEqual, reconcileCatalogRows } from './repo-identity-reconcile'
 
 // ─── ProjectV2 cache types ────────────────────────────────────────────
 // Why: separate from CacheEntry<T> — project-view has a single GraphQL source (no issue/PR fallback) and a distinct error union.
@@ -2739,15 +2740,57 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         if (get().workItemsInvalidationNonce !== requestInvalidationNonce) {
           return items
         }
-        set((s) => ({
-          workItemsCache: withBoundedCacheEntry(s.workItemsCache, key, {
-            data: items,
-            fetchedAt: Date.now(),
-            sources: envelope.sources,
-            ...(errorForCache ? { error: errorForCache } : {}),
-            ...(envelope.issueSourceFellBack ? { issueSourceFellBack: true } : {})
-          })
-        }))
+        // Why: TaskPage useShallow-selects cache entry refs. A new { ...entry, fetchedAt }
+        // still remaps every visible row. IPC structuredClone rebuilds nested records, so
+        // data === previous.data never holds — reconcile structurally, then either mutate
+        // fetchedAt in place or write one entry that keeps unchanged row/meta refs.
+        set((s) => {
+          const previousEntry = s.workItemsCache[key]
+          const previousData = previousEntry?.data ?? []
+          const reconciled = reconcileCatalogRows(
+            previousData,
+            items,
+            (row) => `${row.repoId}\0${row.id}`
+          )
+          const nextFellBack = envelope.issueSourceFellBack ? true : undefined
+          const sourcesUnchanged = areValuesEqual(previousEntry?.sources, envelope.sources)
+          const errorUnchanged = areValuesEqual(previousEntry?.error, errorForCache)
+          const fellBackUnchanged = previousEntry?.issueSourceFellBack === nextFellBack
+          if (
+            previousEntry &&
+            reconciled === previousData &&
+            sourcesUnchanged &&
+            errorUnchanged &&
+            fellBackUnchanged
+          ) {
+            previousEntry.fetchedAt = Date.now()
+            return {}
+          }
+          const previousSources = previousEntry?.sources
+          const previousError = previousEntry?.error
+          return {
+            workItemsCache: withBoundedCacheEntry(s.workItemsCache, key, {
+              data:
+                previousEntry?.data != null && reconciled === previousEntry.data
+                  ? previousEntry.data
+                  : reconciled.slice(),
+              fetchedAt: Date.now(),
+              sources:
+                sourcesUnchanged && previousSources !== undefined
+                  ? previousSources
+                  : envelope.sources,
+              ...(errorForCache
+                ? {
+                    error:
+                      errorUnchanged && previousError !== undefined
+                        ? previousError
+                        : errorForCache
+                  }
+                : {}),
+              ...(nextFellBack ? { issueSourceFellBack: true } : {})
+            })
+          }
+        })
         return items
       } catch (err) {
         // Why: rethrow but keep the stale cache entry so the UI still renders while the user retries.

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -685,7 +685,7 @@ type InflightChecks = {
 const inflightChecksRequests = new Map<string, InflightChecks>()
 const inflightCommentsRequests = new Map<string, Promise<PRComment[]>>()
 type InflightWorkItems = {
-  promise: Promise<GitHubWorkItem[]>
+  promise: Promise<readonly GitHubWorkItem[]>
   force: boolean
   noCache: boolean
   requireComplete: boolean
@@ -1974,7 +1974,7 @@ export type GitHubSlice = {
     limit: number,
     query: string,
     options?: FetchOptions
-  ) => Promise<GitHubWorkItem[]>
+  ) => Promise<readonly GitHubWorkItem[]>
   /**
    * Fan out one work-item query across repos; partial failures don't reject — a repo with no cached fallback increments `failedCount`, but one served stale cache on rejection isn't counted.
    * `githubUnavailable`: every selected GitHub source refresh failed because GitHub was unreachable (5xx/network/rate-limit), even if stale cache remains — lets the caller attribute the stale/empty list.
@@ -2658,7 +2658,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     return null
   },
 
-  fetchWorkItems: async (repoId, repoPath, limit, query, options): Promise<GitHubWorkItem[]> => {
+  fetchWorkItems: async (
+    repoId,
+    repoPath,
+    limit,
+    query,
+    options
+  ): Promise<readonly GitHubWorkItem[]> => {
     if (isGitHubWorkItemsQueryTooLarge(query)) {
       return []
     }

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -2776,10 +2776,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           const previousError = previousEntry?.error
           return {
             workItemsCache: withBoundedCacheEntry(s.workItemsCache, key, {
-              data:
-                previousEntry?.data != null && reconciled === previousEntry.data
-                  ? previousEntry.data
-                  : reconciled,
+              // Why: `reconciled` already is `previousEntry.data` when nothing changed —
+              // reconcileCatalogRows returns the previous array on a structural match.
+              data: reconciled,
               fetchedAt: Date.now(),
               sources:
                 sourcesUnchanged && previousSources !== undefined

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1853,7 +1853,7 @@ export type GitHubSlice = {
   prRefreshStates: Record<string, PRRefreshState>
   prVisibleRefreshGeneration: number
   // Why: keyed by repoId + limit + query so same-path repos on different SSH targets don't share results.
-  workItemsCache: Record<string, CacheEntry<GitHubWorkItem[]>>
+  workItemsCache: Record<string, CacheEntry<readonly GitHubWorkItem[]>>
   fetchPRForBranch: (
     repoPath: string,
     branch: string,
@@ -1951,7 +1951,7 @@ export type GitHubSlice = {
     query: string,
     repoPath?: string,
     sourceContext?: TaskSourceContext | null
-  ) => GitHubWorkItem[] | null
+  ) => readonly GitHubWorkItem[] | null
   /** Returns a thin view (sources + error, never items) so it stays a cheap selector without dragging the whole work-item array through the equality check. */
   getWorkItemsSourcesAndError: (
     repoId: string,
@@ -2773,7 +2773,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               data:
                 previousEntry?.data != null && reconciled === previousEntry.data
                   ? previousEntry.data
-                  : reconciled.slice(),
+                  : reconciled,
               fetchedAt: Date.now(),
               sources:
                 sourcesUnchanged && previousSources !== undefined
@@ -4749,7 +4749,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     set((s) => {
       const prefix = `${repoId}::`
       const legacyPrefix = `${repoPath}::`
-      const next: Record<string, CacheEntry<GitHubWorkItem[]>> = {}
+      const next: Record<string, CacheEntry<readonly GitHubWorkItem[]>> = {}
       for (const [key, entry] of Object.entries(s.workItemsCache)) {
         if (!key.startsWith(prefix) && !key.startsWith(legacyPrefix)) {
           next[key] = entry


### PR DESCRIPTION
## Summary

`fetchWorkItems` stamped every IPC row with `{ ...item, repoId }` and then wrote a brand-new `workItemsCache` entry (`{ data, fetchedAt: Date.now(), sources, ... }`) on every force refetch. TaskPage `useShallow`-selects those entry refs; a new entry fires the cache-sync effect, which remaps every visible row even when GitHub returned the same nested work items.

This keeps the existing `workItemsCache` map and entry objects when a refetch is a no-op, mutates `fetchedAt` in place so TTL still advances, and only allocates a new entry when a row or envelope field actually changes. Unchanged sibling rows and unchanged `sources`/`error` objects keep their previous refs.

Follow-up to the store-catalog identity work in #13744 / #13770 / #13803.

## Why a partial fix is inert

Identity has to survive every link from fetch to `set()`:

1. IPC `listWorkItems` always returns freshly cloned nested records (`labels`, `assignees`, `reviewRequests`, `prRepo`, `checksSummary`).
2. The fetch boundary then remaps each row with `{ ...item, repoId }`.
3. `withBoundedCacheEntry` always writes `{ ...cache, [key]: { data, fetchedAt: Date.now(), ... } }`.

Fixing only (3) still leaves new row objects, so `useShallow` and any `===` row compare miss. Reusing `data` on a *new* entry still changes the entry ref TaskPage selects, so the cache-sync effect still remaps every visible row. The no-op path has to keep **both** the cache map and the entry object.

This change is scoped to the `fetchWorkItems` `set()` write. `withBoundedCacheEntry` stays shared and unchanged for PR / issue / checks caches.

## Reference compare fails on IPC clones

`GitHubWorkItem` is deeply nested. After `structuredClone` (and the renderer stamp), `data === previous.data` and `row === previousRow` never hold even when every field is unchanged. The write path uses `reconcileCatalogRows` / `areValuesEqual` from `repo-identity-reconcile.ts` with key `` `${row.repoId}\0${row.id}` ``, then structurally compares `sources` / `error` / `issueSourceFellBack`.

If data + meta are unchanged: mutate `previousEntry.fetchedAt = Date.now()` and `return {}` so Zustand subscribers see the same refs. Skipping the `fetchedAt` bump would leave TTL stale and hot-loop force refetches.

If some rows or meta changed: write one new entry whose `data` is the reconciled array and whose unchanged `sources`/`error` objects are the previous refs.

## Tests

`src/renderer/src/store/slices/github.test.ts` (`createGitHubSlice.fetchWorkItems cache identity`):

- Force-refetch production-shaped nested fixtures (`labels[]`, `assignees`, `reviewRequests`, `prRepo`, `checksSummary`) cloned as distinct objects via `structuredClone`.
- Assert `workItemsCache === previous` map, `entry === previous` entry, `entry.data[i] === previous` rows, and `fetchedAt` advanced.
- A real nested change (`reviewRequests[].login`) produces a new entry/data array but reuses the unchanged sibling row and the previous `sources` object.

Scalar `{id, repoId, title}` fixtures are not the only coverage. Reverting the reuse write makes these assertions go red.

Made with [Orca](https://github.com/stablyai/orca) 🐋
