### PR TITLE
fix(codex): seed spawn-window agent status from launch metadata

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -8808,3 +8808,200 @@ describe('AgentHookServer closed-tab suppression bound', () => {
     expect(internals.closedAgentStatusTabIds.has(`closed-tab-${total - 1}`)).toBe(true)
   })
 })
+
+describe('seedCodexLaunchStatus', () => {
+  const SEED = { paneKey: PANE, tabId: 'tab-1', worktreeId: 'wt-1' }
+
+  it('seeds a working row with the injected prompt during the spawn window', () => {
+    const server = new AgentHookServer()
+
+    server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'working',
+        prompt: 'say hi',
+        agentType: 'codex'
+      })
+    ])
+  })
+
+  it('seeds an idle session-boundary done row for a promptless spawn', () => {
+    const server = new AgentHookServer()
+
+    server.seedCodexLaunchStatus(SEED)
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'done',
+        prompt: '',
+        agentType: 'codex',
+        sessionBoundary: true
+      })
+    ])
+  })
+
+  it('is idempotent under duplicate seeds', () => {
+    const server = new AgentHookServer()
+    const changeListener = vi.fn()
+    server.subscribeStatusChanges(changeListener)
+
+    server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+    const afterFirst = server.getStatusSnapshot()
+    server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+
+    expect(server.getStatusSnapshot()).toEqual(afterFirst)
+    expect(changeListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('never clobbers an existing pane status such as a real PermissionRequest waiting', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postCodexHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+      await postCodexHook({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' })
+
+      server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'waiting', agentType: 'codex' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not seed a retired pane', () => {
+    const server = new AgentHookServer()
+    server.retirePaneAuthority(PANE)
+
+    server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+
+    expect(server.getStatusSnapshot()).toEqual([])
+  })
+
+  it('lets the real first-turn hooks replace the seed and cache the provider session', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postCodexHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+      server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+
+      // Codex fires SessionStart only alongside the first UserPromptSubmit,
+      // and stamps session_id on every event of the turn.
+      await postCodexHook({ hook_event_name: 'SessionStart', session_id: 'codex-session-1' })
+      await postCodexHook({
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'codex-session-1',
+        prompt: 'say hi'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'say hi',
+          agentType: 'codex',
+          providerSession: expect.objectContaining({ key: 'session_id', id: 'codex-session-1' })
+        })
+      ])
+
+      await postCodexHook({ hook_event_name: 'Stop', last_assistant_message: 'Hi! 👋' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          lastAssistantMessage: 'Hi! 👋'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('recovers waiting → working when the first turn starts after a spawn approval', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postCodexHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+      server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+      await postCodexHook({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'waiting', agentType: 'codex' })
+      ])
+
+      await postCodexHook({ hook_event_name: 'SessionStart', session_id: 'codex-session-2' })
+      await postCodexHook({ hook_event_name: 'UserPromptSubmit', prompt: 'say hi' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'working', prompt: 'say hi', agentType: 'codex' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('stays a single working row under duplicate identical UserPromptSubmit delivery', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postCodexHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+      server.seedCodexLaunchStatus({ ...SEED, prompt: 'say hi' })
+
+      // Two managed hook brands can both deliver the same event on this machine.
+      await postCodexHook({ hook_event_name: 'UserPromptSubmit', prompt: 'say hi' })
+      await postCodexHook({ hook_event_name: 'UserPromptSubmit', prompt: 'say hi' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'working', prompt: 'say hi', agentType: 'codex' })
+      ])
+
+      await postCodexHook({ hook_event_name: 'Stop', last_assistant_message: 'Hi! 👋' })
+      await postCodexHook({ hook_event_name: 'Stop', last_assistant_message: 'Hi! 👋' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ state: 'done', agentType: 'codex' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1859,6 +1859,51 @@ export class AgentHookServer {
     })
   }
 
+  /** Seed a status row for a freshly spawned local Codex pane. Codex emits no hook
+   *  until the first prompt submission (SessionStart only fires alongside the first
+   *  UserPromptSubmit), so a spawned pane otherwise has no status row during the
+   *  spawn window (#6643). An existing row always wins — a real PermissionRequest
+   *  waiting is never overwritten — and any later hook/OSC status replaces the seed. */
+  seedCodexLaunchStatus(seed: {
+    paneKey: string
+    tabId?: string
+    worktreeId?: string
+    prompt?: string
+    launchToken?: string
+  }): void {
+    const paneKey = seed.paneKey.trim()
+    if (paneKey.length === 0 || paneKey.length > MAX_PANE_KEY_LEN || !parsePaneKey(paneKey)) {
+      return
+    }
+    if (
+      this.state.lastStatusByPaneKey.has(paneKey) ||
+      this.getAgentStatusDisposition(paneKey) !== 'accept'
+    ) {
+      return
+    }
+    const prompt = seed.prompt?.trim() ?? ''
+    // Why: an idle spawn mirrors Claude's SessionStart row — 'working' would show a
+    // phantom spinner on an idle TUI, and sessionBoundary keeps completion-reactive
+    // consumers (notifications, automation runs) out of it (STA-3386).
+    const payload = normalizeAgentStatusPayload(
+      prompt
+        ? { state: 'working', prompt, agentType: 'codex' }
+        : { state: 'done', prompt: '', agentType: 'codex', sessionBoundary: true }
+    )
+    if (!payload) {
+      return
+    }
+    this.applyNormalizedStatus({
+      paneKey,
+      source: 'codex',
+      ...(seed.launchToken ? { launchToken: seed.launchToken } : {}),
+      ...(seed.tabId ? { tabId: seed.tabId } : {}),
+      ...(seed.worktreeId ? { worktreeId: seed.worktreeId } : {}),
+      connectionId: null,
+      payload
+    })
+  }
+
   /** Ingest a payload from the relay JSON-RPC channel (not the local HTTP server); connectionId is stamped here. Main is still the SSH trust boundary, so re-run the canonical normalizer before caching. */
   ingestRemote(
     envelope: {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -42998,6 +42998,87 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('keeps the startup-terminal success when Codex status seeding throws', async () => {
+    // Why: seeding is best-effort UI state — a failure after the terminal
+    // spawned must not surface as a startup-terminal failure warning.
+    const seedSpy = vi.spyOn(agentHookServer, 'seedCodexLaunchStatus').mockImplementation(() => {
+      throw new Error('seed boom')
+    })
+    seedSpy.mockClear()
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        agentCmdOverrides: {}
+      }),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-cli-codex-seed-throw' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-cli-codex-seed-throw' }),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term-cli-codex-seed-throw',
+      tabId: 'tab-cli-codex-seed-throw',
+      paneKey: 'tab-cli-codex-seed-throw:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      ptyId: 'pty-cli-codex-seed-throw',
+      worktreeId: 'unused',
+      title: null,
+      surface: 'background'
+    } as never)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed-throw')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed-throw')
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-cli-codex-seed-throw',
+        head: 'def',
+        branch: 'runtime-cli-codex-seed-throw',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: TEST_REPO_ID,
+      name: 'runtime-cli-codex-seed-throw',
+      startupAgent: 'codex',
+      startupPrompt: 'hi'
+    })
+
+    expect(seedSpy).toHaveBeenCalledTimes(1)
+    expect(result.warning).toBeUndefined()
+    expect(result.startupTerminal).toMatchObject({
+      spawned: true,
+      handle: 'term-cli-codex-seed-throw'
+    })
+  })
+
   it('sends follow-up prompts for CLI-created stdin-after-start startup agents', async () => {
     const metaById: Record<string, WorktreeMeta> = {}
     const runtimeStore = {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: runtime behavior is stateful and cross-cutting, so these tests stay in one file to preserve the end-to-end invariants around handles, waits, and graph sync. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { agentHookServer } from '../agent-hooks/server'
 import type * as GitUsernameModule from '../git/git-username'
 import { performance } from 'node:perf_hooks'
 import { EventEmitter } from 'node:events'
@@ -42915,6 +42916,86 @@ describe('OrcaRuntimeService', () => {
       })
     )
     expect(metaById[result.worktree.id]).toMatchObject({ createdWithAgent: 'codex' })
+  })
+
+  it('seeds the Codex spawn-window status for a CLI-created local worktree', async () => {
+    // Why: Codex emits no hook until its first prompt, so the runtime must seed
+    // the card status from launch metadata at spawn (#6643).
+    const seedSpy = vi.spyOn(agentHookServer, 'seedCodexLaunchStatus').mockImplementation(() => {})
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        agentCmdOverrides: {}
+      }),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-cli-codex-seed' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-cli-codex-seed' }),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term-cli-codex-seed',
+      tabId: 'tab-cli-codex-seed',
+      paneKey: 'tab-cli-codex-seed:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      ptyId: 'pty-cli-codex-seed',
+      worktreeId: 'unused',
+      title: null,
+      surface: 'background'
+    } as never)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-cli-codex-seed')
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-cli-codex-seed',
+        head: 'def',
+        branch: 'runtime-cli-codex-seed',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: TEST_REPO_ID,
+      name: 'runtime-cli-codex-seed',
+      startupAgent: 'codex',
+      startupPrompt: 'hi'
+    })
+
+    expect(seedSpy).toHaveBeenCalledTimes(1)
+    expect(seedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paneKey: 'tab-cli-codex-seed:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        worktreeId: result.worktree.id,
+        prompt: 'hi'
+      })
+    )
   })
 
   it('sends follow-up prompts for CLI-created stdin-after-start startup agents', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -21680,6 +21680,45 @@ export class OrcaRuntimeService {
     })
   }
 
+  // Why: Codex fires no hook until its first prompt submission, so a
+  // runtime-built spawn (CLI/automation — no renderer pane to seed) shows no
+  // card status until the first turn (#6643). UI-built startups
+  // (startupProvided) seed through the renderer's initialAgentStatus path.
+  // Local only: remote pane status arrives relay-stamped with a connectionId,
+  // which a local-connection seed row would contradict. Best-effort: the
+  // startup terminal already spawned, so a seeding failure is logged instead
+  // of thrown — it must not surface as a startup-terminal failure.
+  private seedCodexLaunchStatusIfEligible(options: {
+    startupProvided: boolean
+    repo: { connectionId?: string | null }
+    createdWithAgent: TuiAgent | undefined
+    terminal: { paneKey?: string | null; tabId?: string | null }
+    worktreeId: string
+    prompt: string | undefined
+  }): void {
+    if (
+      options.startupProvided ||
+      repoIsRemote(options.repo) ||
+      options.createdWithAgent !== 'codex' ||
+      !options.terminal.paneKey
+    ) {
+      return
+    }
+    try {
+      agentHookServer.seedCodexLaunchStatus({
+        paneKey: options.terminal.paneKey,
+        ...(options.terminal.tabId ? { tabId: options.terminal.tabId } : {}),
+        worktreeId: options.worktreeId,
+        ...(options.prompt ? { prompt: options.prompt } : {})
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(
+        `[worktree-create] Failed to seed the Codex launch status for ${options.worktreeId}: ${message}`
+      )
+    }
+  }
+
   async createManagedWorktree(args: {
     repoSelector: string
     name: string
@@ -21862,25 +21901,14 @@ export class OrcaRuntimeService {
             ...(terminal.ptyId ? { ptyId: terminal.ptyId } : {}),
             surface: 'background'
           }
-          // Why: Codex fires no hook until its first prompt submission, so a
-          // runtime-built spawn (CLI/automation — no renderer pane to seed) shows
-          // no card status until the first turn (#6643). UI-built startups
-          // (args.startup) seed through the renderer's initialAgentStatus path.
-          // Local only: remote pane status arrives relay-stamped with a
-          // connectionId, which a local-connection seed row would contradict.
-          if (
-            !args.startup &&
-            !repoIsRemote(repo) &&
-            effectiveCreatedWithAgent === 'codex' &&
-            terminal.paneKey
-          ) {
-            agentHookServer.seedCodexLaunchStatus({
-              paneKey: terminal.paneKey,
-              ...(terminal.tabId ? { tabId: terminal.tabId } : {}),
-              worktreeId: worktree.id,
-              ...(agentStartup && args.startupPrompt ? { prompt: args.startupPrompt } : {})
-            })
-          }
+          this.seedCodexLaunchStatusIfEligible({
+            startupProvided: Boolean(args.startup),
+            repo,
+            createdWithAgent: effectiveCreatedWithAgent,
+            terminal,
+            worktreeId: worktree.id,
+            prompt: agentStartup && args.startupPrompt ? args.startupPrompt : undefined
+          })
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           warning = `Failed to create the startup terminal for ${worktree.path}: ${message}`
@@ -22631,25 +22659,14 @@ export class OrcaRuntimeService {
         startupTerminalTabId = terminal.tabId ?? null
         startupTerminalPaneKey = terminal.paneKey ?? null
         startupTerminalPtyId = terminal.ptyId ?? null
-        // Why: Codex fires no hook until its first prompt submission, so a
-        // runtime-built spawn (CLI/automation — no renderer pane to seed) shows
-        // no card status until the first turn (#6643). UI-built startups
-        // (args.startup) seed through the renderer's initialAgentStatus path.
-        // Local only: remote pane status arrives relay-stamped with a
-        // connectionId, which a local-connection seed row would contradict.
-        if (
-          !args.startup &&
-          !repoIsRemote(repo) &&
-          effectiveCreatedWithAgent === 'codex' &&
-          terminal.paneKey
-        ) {
-          agentHookServer.seedCodexLaunchStatus({
-            paneKey: terminal.paneKey,
-            ...(terminal.tabId ? { tabId: terminal.tabId } : {}),
-            worktreeId: worktree.id,
-            ...(agentStartup && args.startupPrompt ? { prompt: args.startupPrompt } : {})
-          })
-        }
+        this.seedCodexLaunchStatusIfEligible({
+          startupProvided: Boolean(args.startup),
+          repo,
+          createdWithAgent: effectiveCreatedWithAgent,
+          terminal,
+          worktreeId: worktree.id,
+          prompt: agentStartup && args.startupPrompt ? args.startupPrompt : undefined
+        })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         warning = warning

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -49,7 +49,7 @@ import {
   type AgentStatusEntry
 } from '../../shared/agent-status-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
-import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
+import { agentHookServer, type AgentHookAuthorityAttestation } from '../agent-hooks/server'
 import type {
   AgentSessionClaimedSpawnResult,
   AgentSessionExecutionClaim,
@@ -21862,6 +21862,25 @@ export class OrcaRuntimeService {
             ...(terminal.ptyId ? { ptyId: terminal.ptyId } : {}),
             surface: 'background'
           }
+          // Why: Codex fires no hook until its first prompt submission, so a
+          // runtime-built spawn (CLI/automation — no renderer pane to seed) shows
+          // no card status until the first turn (#6643). UI-built startups
+          // (args.startup) seed through the renderer's initialAgentStatus path.
+          // Local only: remote pane status arrives relay-stamped with a
+          // connectionId, which a local-connection seed row would contradict.
+          if (
+            !args.startup &&
+            !repoIsRemote(repo) &&
+            effectiveCreatedWithAgent === 'codex' &&
+            terminal.paneKey
+          ) {
+            agentHookServer.seedCodexLaunchStatus({
+              paneKey: terminal.paneKey,
+              ...(terminal.tabId ? { tabId: terminal.tabId } : {}),
+              worktreeId: worktree.id,
+              ...(agentStartup && args.startupPrompt ? { prompt: args.startupPrompt } : {})
+            })
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           warning = `Failed to create the startup terminal for ${worktree.path}: ${message}`
@@ -22612,6 +22631,25 @@ export class OrcaRuntimeService {
         startupTerminalTabId = terminal.tabId ?? null
         startupTerminalPaneKey = terminal.paneKey ?? null
         startupTerminalPtyId = terminal.ptyId ?? null
+        // Why: Codex fires no hook until its first prompt submission, so a
+        // runtime-built spawn (CLI/automation — no renderer pane to seed) shows
+        // no card status until the first turn (#6643). UI-built startups
+        // (args.startup) seed through the renderer's initialAgentStatus path.
+        // Local only: remote pane status arrives relay-stamped with a
+        // connectionId, which a local-connection seed row would contradict.
+        if (
+          !args.startup &&
+          !repoIsRemote(repo) &&
+          effectiveCreatedWithAgent === 'codex' &&
+          terminal.paneKey
+        ) {
+          agentHookServer.seedCodexLaunchStatus({
+            paneKey: terminal.paneKey,
+            ...(terminal.tabId ? { tabId: terminal.tabId } : {}),
+            worktreeId: worktree.id,
+            ...(agentStartup && args.startupPrompt ? { prompt: args.startupPrompt } : {})
+          })
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         warning = warning


### PR DESCRIPTION
## Summary

Fixes the #6643 symptom for runtime-built spawns: a Codex agent launched by Orca now appears in the agent status surface at spawn, using launch metadata, instead of staying absent until the first user message.

## Root cause (measured)

Codex emits **no hook at TUI startup**. Captured with a captive HTTP listener replacing the managed hook endpoint (codex current, macOS):

- Idle TUI open: zero hook posts while the TUI sits at the prompt.
- First prompt submit: `SessionStart` at 05:40:22.597Z, `UserPromptSubmit` at 05:40:22.616Z — **19 ms apart**, ~50 s after the TUI opened. `session_id` is stamped on every event of the turn.

Claude has no such gap because its `SessionStart` fires at TUI open. Orca's Codex status surface is hook-driven, and the renderer's `paneStartup.initialAgentStatus` seeding only covers UI-created panes. Runtime-built spawns (CLI `worktree create --agent codex`, automations) mount no renderer pane, so nothing seeds:

- create with `--prompt`: no status row from create (05:36:16Z) until the first turn's hooks (05:36:24Z), while the TUI was already Working at 05:36:19Z
- plain spawn: no status row indefinitely while the TUI idles

## Fix

`AgentHookServer.seedCodexLaunchStatus` + a call in `createManagedWorktree` after the startup terminal spawns (git and folder-workspace branches):

- injected prompt → `working` row carrying the prompt
- plain spawn → idle `done` + `sessionBoundary` row (mirrors Claude's SessionStart row: no phantom spinner, completion-reactive consumers skip it)
- an existing pane status always wins (a real `PermissionRequest` waiting is never overwritten), retired panes are not resurrected, duplicate seeds are idempotent, and any later hook/OSC status replaces the seed
- local repos only: remote pane status arrives relay-stamped with a `connectionId` that a local seed row would contradict (the SSH app-server-reuse gap is #11941, out of scope here)
- no wire/payload shape changes — existing optional fields only

## Relationship to #8292

Builds on, does not duplicate: #8292 makes `SessionStart` metadata-only (identity cache + stale-row clear) and explicitly excludes startup delivery. This PR touches none of #8292's normalizer/relay/hook-service lines, and the seed behaves correctly under #8292's semantics — the first turn's `SessionStart` clears the seed row and `UserPromptSubmit` recreates it 19 ms later. Since Codex fires `SessionStart` only alongside the first prompt, spawn-window presence has to come from launch metadata, which #6643's notes also suggest.

## Testing

- [x] `src/main/agent-hooks/server.test.ts`: 8 new state-machine tests (seed shapes, idempotence, PermissionRequest-at-spawn precedence, waiting→working recovery on first turn, first-turn replacement with providerSession caching, duplicate identical UserPromptSubmit/Stop delivery, retired-pane no-op) — 276 file tests green
- [x] `src/main/runtime/orca-runtime.test.ts`: CLI-created local worktree seeds with the injected prompt — 1082 file tests green
- [x] Node typecheck, targeted `oxlint`, `oxfmt --check`
- [ ] Electron/E2E

Refs #6643

🤖 Generated with [Claude Code](https://claude.com/claude-code)