### PR TITLE
feat(workspaces): make workspace board shortcut a toggle

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -85,7 +85,7 @@ import {
 } from '@/lib/floating-workspace-terminal-actions'
 import { createFloatingWorkspaceTourInteractionSnapshot } from '@/lib/floating-workspace-tour-interaction-snapshot'
 import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-current-workspace-status'
-import { OPEN_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
+import { TOGGLE_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
 import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
@@ -1710,7 +1710,7 @@ function App(): React.JSX.Element {
             }
             return claim('workspace.openBoard', () => {
               useAppStore.getState().setSidebarOpen(true)
-              window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
+              window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
             })
           }
         ],

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  OPEN_WORKSPACE_BOARD_EVENT,
+  TOGGLE_WORKSPACE_BOARD_EVENT,
   useWorkspaceBoardPanel,
   type WorkspaceBoardPanelState
 } from './useWorkspaceBoardPanel'
@@ -99,16 +99,24 @@ describe('useWorkspaceBoardPanel', () => {
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledOnce()
   })
 
-  it('opens the board from the shortcut bridge event', async () => {
+  it('toggles the board from the shortcut bridge event', async () => {
     await renderHookProbe()
 
     await act(async () => {
-      window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
+      window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
     })
 
     expect(panelState().workspaceBoardOpen).toBe(true)
     expect(panelState().workspaceBoardRenderedOpen).toBe(true)
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledExactlyOnceWith('workspace-board')
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
+    })
+
+    expect(panelState().workspaceBoardOpen).toBe(false)
+    expect(panelState().workspaceBoardRenderedOpen).toBe(false)
+    expect(mocks.recordFeatureInteraction).toHaveBeenCalledOnce()
   })
 
   it('renders a drag preview without recording an open interaction', async () => {

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
@@ -26,7 +26,7 @@ const WORKSPACE_BOARD_ESCAPE_BLOCKING_OVERLAY_SELECTOR = [
   '[role="listbox"][data-state="open"]'
 ].join(', ')
 
-export const OPEN_WORKSPACE_BOARD_EVENT = 'orca:open-workspace-board'
+export const TOGGLE_WORKSPACE_BOARD_EVENT = 'orca:toggle-workspace-board'
 
 export type WorkspaceBoardPanelState = {
   workspaceBoardOpen: boolean
@@ -158,9 +158,9 @@ export function useWorkspaceBoardPanel(): WorkspaceBoardPanelState {
   }, [closeWorkspaceBoard, workspaceBoardMenuOpen, workspaceBoardOpen])
 
   useEffect(() => {
-    window.addEventListener(OPEN_WORKSPACE_BOARD_EVENT, openWorkspaceBoard)
-    return () => window.removeEventListener(OPEN_WORKSPACE_BOARD_EVENT, openWorkspaceBoard)
-  }, [openWorkspaceBoard])
+    window.addEventListener(TOGGLE_WORKSPACE_BOARD_EVENT, toggleWorkspaceBoard)
+    return () => window.removeEventListener(TOGGLE_WORKSPACE_BOARD_EVENT, toggleWorkspaceBoard)
+  }, [toggleWorkspaceBoard])
 
   return {
     workspaceBoardOpen,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -11,7 +11,7 @@ import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
 import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
 import { runSleepWorktree } from '@/components/sidebar/sleep-worktree-flow'
 import { createBackgroundSleepingAgentWakeDispatcher } from '@/lib/wake-sleeping-agents-in-background'
-import { OPEN_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoardPanel'
+import { TOGGLE_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoardPanel'
 import { SPLIT_TERMINAL_PANE_EVENT, CLOSE_TERMINAL_PANE_EVENT } from '@/constants/terminal'
 import { requestBackgroundTerminalWorktreeMount } from '@/components/terminal/background-terminal-worktree-mount'
 import { planMobileTerminalTabMount } from '@/lib/mobile-terminal-tab-mount'
@@ -1370,7 +1370,7 @@ export function useIpcEvents(): void {
             return
           }
           store.setSidebarOpen(true)
-          window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
+          window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
         })
       )
     }

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -777,7 +777,7 @@ describe('keybindings', () => {
     const definition = getKeybindingDefinition('workspace.openBoard')
     expect(definition?.title).toBe('Toggle Workspace Board')
     expect(definition?.searchKeywords).toEqual(
-      expect.arrayContaining(['workspace', 'board', 'kanban'])
+      expect.arrayContaining(['workspace', 'board', 'kanban', 'toggle', 'open', 'close'])
     )
   })
 

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -775,7 +775,7 @@ describe('keybindings', () => {
     ).toBe(true)
 
     const definition = getKeybindingDefinition('workspace.openBoard')
-    expect(definition?.title).toBe('Open Workspace Board')
+    expect(definition?.title).toBe('Toggle Workspace Board')
     expect(definition?.searchKeywords).toEqual(
       expect.arrayContaining(['workspace', 'board', 'kanban'])
     )

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -298,10 +298,10 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
   },
   {
     id: 'workspace.openBoard',
-    title: 'Open Workspace Board',
+    title: 'Toggle Workspace Board',
     group: 'Global',
     scope: 'global',
-    searchKeywords: ['shortcut', 'global', 'workspace', 'board', 'kanban', 'worktree'],
+    searchKeywords: ['shortcut', 'global', 'workspace', 'board', 'kanban', 'worktree', 'toggle', 'open', 'close'],
     // Why: configurable but unbound by default, to not take a global chord from terminal/browser/editor users.
     defaultBindings: platformBindings([]),
     allowInTerminal: true

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -301,7 +301,17 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     title: 'Toggle Workspace Board',
     group: 'Global',
     scope: 'global',
-    searchKeywords: ['shortcut', 'global', 'workspace', 'board', 'kanban', 'worktree', 'toggle', 'open', 'close'],
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'workspace',
+      'board',
+      'kanban',
+      'worktree',
+      'toggle',
+      'open',
+      'close'
+    ],
     // Why: configurable but unbound by default, to not take a global chord from terminal/browser/editor users.
     defaultBindings: platformBindings([]),
     allowInTerminal: true


### PR DESCRIPTION
## ELI5

The keyboard shortcut for the Workspace Board used to only *open* it. Now the same shortcut opens it if it's closed and closes it if it's open.

## What Changed

- Bound the workspace-board shortcut bridge event to the existing `toggleWorkspaceBoard()` instead of an open-only handler.
- Renamed the bridge event `OPEN_WORKSPACE_BOARD_EVENT` → `TOGGLE_WORKSPACE_BOARD_EVENT` (dispatched from both the renderer shortcut handler in `App.tsx` and the main-process IPC path in `useIpcEvents.ts`).
- Retitled the command `Open Workspace Board` → `Toggle Workspace Board` and added `toggle`/`open`/`close` search keywords.
- Kept the action id `workspace.openBoard` unchanged so existing user keybinding overrides keep working.
- Updated unit tests.

## Why

The `workspace.openBoard` command was open-only: pressing the bound shortcut while the board was open did nothing, so dismissing it required Escape, the toolbar button, or collapsing the sidebar. Toggling is the natural behavior for a single shortcut and the hook already exposed `toggleWorkspaceBoard()`. Renaming the id was avoided deliberately to preserve stored keybindings.

## Linked Issue

Fixes #14239

## Visual Proof

N/A — this changes the behavior of a shortcut that has **no default binding** (users must assign one in Settings → Shortcuts). There is no default-state visual change; the board panel UI itself is unchanged. The open path is unchanged and the new close path reuses the same `closeWorkspaceBoard()` already used by Escape and the toolbar toggle.

## Testing

- [x] Automated tests added/updated: `useWorkspaceBoardPanel.test.tsx` now asserts the bridge event toggles (open then close); `keybindings.test.ts` asserts the new title.
- [ ] I manually tested these changes locally

Ran locally on macOS:
- `vitest run` for `useWorkspaceBoardPanel.test.tsx`, `keybindings.test.ts`, `window-shortcut-policy.test.ts` → 118 passed
- `oxlint` on the touched files → clean
- `tsc --noEmit -p config/tsconfig.tc.web.json` → clean

## AI Disclosure

Implemented with Claude Opus 4.8 (1M context) via Claude Code.

## Review

- **Cross-platform**: no platform-specific code touched; shortcut resolution and the IPC bridge are unchanged in structure. The main-process path (`window-shortcut-policy.ts` → `createMainWindow.ts`/`browser-guest-ui.ts` → IPC) still resolves `workspace.openBoard`; only the renderer-side event it ultimately dispatches now toggles.
- **Remote/SSH & mobile**: purely renderer/UI behavior; no wire or RPC change.
- **Backwards compatibility**: action id preserved, so stored keybindings and plugin command aliases keep resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)