### PR TITLE
fix(terminal): clear the SGR pen on hidden-output restore and abandon

### DIFF
--- a/src/main/daemon/AGENTS.md
+++ b/src/main/daemon/AGENTS.md
@@ -35,7 +35,7 @@ hands → probe once more → `rename` in one syscall → verify we kept it.
 - **Do not identify an entry by `birthtimeMs`.** Node documents it as sometimes holding the ctime,
   filesystems without a birth time report the epoch, and its granularity is often coarser than the
   events it must separate. Three attempts to patch around this produced three more defects; inode
-  recycling is now settled by asking whether anything is *serving*.
+  recycling is now settled by asking whether anything is _serving_.
 - **Do not add a sweeper.** Deciding whether someone else's leftover is safe to delete is the
   question this design retired; the last one produced five defects, including deleting a live
   listener's only pathname. Every actor removes its own scratch name on each non-crash path.

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -10210,7 +10210,7 @@ describe('connectPanePty', () => {
       claim: true
     })
     expect(written).toContain(viewportClear)
-    expect(written).not.toContain('\x1b[2J\x1b[3J\x1b[H')
+    expect(written).not.toContain('\x1b[0m\x1b[2J\x1b[3J\x1b[H')
     expect(written).toEqual(
       expect.arrayContaining([coldScrollback, POST_REPLAY_MODE_RESET, blankViewport])
     )
@@ -15465,7 +15465,10 @@ describe('connectPanePty', () => {
 
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.resize).toHaveBeenCalledWith(100, 30)
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
+      expect.any(Function)
+    )
     expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
     disposable.dispose()
@@ -15516,7 +15519,7 @@ describe('connectPanePty', () => {
 
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
@@ -15811,6 +15814,63 @@ describe('connectPanePty', () => {
       'late-snapshot-state\r\n',
       expect.any(Function)
     )
+    disposable.dispose()
+  })
+
+  // STA-4042: the hidden-delivery gate drops renderer-bound bytes, so the span it
+  // ate can contain the `ESC[22m` closing a bold run. Abandoning the restore means
+  // no snapshot will rebuild the buffer, so unless the pen is cleared here every
+  // drained and subsequent cell inherits bold — the "regular text renders bold"
+  // field report.
+  it('clears the SGR pen before draining abandoned foreground chunks', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const snapshot = createDeferred<{ data: string; cols: number; rows: number; seq: number }>()
+    getMainBufferSnapshot.mockReturnValue(snapshot.promise)
+    // The dropped span is where `ESC[22m` would have been; the pen is left bold.
+    const hidden = '\x1b[1mbold-run-opened-while-hidden\r\n'
+    const live = 'live-after-reveal\r\n'
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false },
+      startup: { command: 'codex' }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    vi.useFakeTimers()
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(4)
+
+    // Let the foreground deadline expire so the restore is abandoned.
+    vi.advanceTimersByTime(750)
+    vi.advanceTimersByTime(0)
+    await flushAsyncTicks(10)
+
+    const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
+    const resetIndex = written.indexOf('\x1b[0m')
+    const liveIndex = written.findIndex((data) => data.includes('live-after-reveal'))
+    expect(resetIndex).toBeGreaterThanOrEqual(0)
+    expect(liveIndex).toBeGreaterThanOrEqual(0)
+    expect(resetIndex).toBeLessThan(liveIndex)
     disposable.dispose()
   })
 
@@ -16330,7 +16390,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.clear).toHaveBeenCalled()
     expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     disposable.dispose()
@@ -17228,7 +17288,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -12122,8 +12122,6 @@ describe('connectPanePty', () => {
       const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
       const gapReset = written.find((data) => data === RESET_AFTER_BYTE_GAP)
       expect(gapReset).toBeDefined()
-      // charset too: a dropped ESC(B otherwise renders text as box characters
-      expect(gapReset).toContain('\x1b(B')
     })
 
     it('marks the PTY hidden on hidden output and clears it before requesting restore on reveal', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -12103,6 +12103,28 @@ describe('connectPanePty', () => {
       return { transport, pane, dataCallback: capturedDataCallback.current!, binding }
     }
 
+    // STA-4042 root: the restore-needed marker is the ONE point where "bytes
+    // were dropped" is known. The emulator carries state across chunks just like
+    // the cross-chunk parser the handler already resets, so the gap is closed
+    // here rather than left to each recovery path to remember.
+    it('closes the emulator state gap when a drop is announced', async () => {
+      enableMainAuthority()
+      const deps = createDeps({ isVisibleRef: { current: false } })
+      const { pane, dataCallback } = await connectHiddenPane(deps)
+      dataCallback('hidden output\r\n', { seq: 16, rawLength: 16 })
+      pane.terminal.write.mockClear()
+
+      const { _dispatchPtyModelRestoreNeededForTest } = await import('./pty-model-restore-channel')
+      _dispatchPtyModelRestoreNeededForTest({ id: 'pty-id', reason: 'hidden-drop', markerSeq: 64 })
+      await flushAsyncTicks(4)
+
+      const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
+      const gapReset = written.find((data) => data.startsWith('\x1b[0m'))
+      expect(gapReset).toBeDefined()
+      // charset too: a dropped ESC(B otherwise renders text as box characters
+      expect(gapReset).toContain('\x1b(B')
+    })
+
     it('marks the PTY hidden on hidden output and clears it before requesting restore on reveal', async () => {
       enableMainAuthority()
       const deps = createDeps({ isVisibleRef: { current: false } })

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -9,6 +9,7 @@ import {
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
   POST_REPLAY_REATTACH_RESET_KEEP_MOUSE,
+  RESET_AFTER_BYTE_GAP,
   RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from '../../../../shared/terminal-mode-reset-profiles'
@@ -10210,7 +10211,7 @@ describe('connectPanePty', () => {
       claim: true
     })
     expect(written).toContain(viewportClear)
-    expect(written).not.toContain('\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H')
+    expect(written).not.toContain(`${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`)
     expect(written).toEqual(
       expect.arrayContaining([coldScrollback, POST_REPLAY_MODE_RESET, blankViewport])
     )
@@ -12119,7 +12120,7 @@ describe('connectPanePty', () => {
       await flushAsyncTicks(4)
 
       const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
-      const gapReset = written.find((data) => data.startsWith('\x1b[0m'))
+      const gapReset = written.find((data) => data === RESET_AFTER_BYTE_GAP)
       expect(gapReset).toBeDefined()
       // charset too: a dropped ESC(B otherwise renders text as box characters
       expect(gapReset).toContain('\x1b(B')
@@ -15488,7 +15489,7 @@ describe('connectPanePty', () => {
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.resize).toHaveBeenCalledWith(100, 30)
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
@@ -15541,7 +15542,7 @@ describe('connectPanePty', () => {
 
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[0m\x1b(B\x0f\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
@@ -15549,16 +15550,16 @@ describe('connectPanePty', () => {
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
       expect.any(Function)
     )
     const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
       (call) => call[0]
     )
     expect(writes.indexOf('preserved-shell-history\r\n')).toBeLessThan(
-      writes.indexOf('\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H')
+      writes.indexOf(`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`)
     )
-    expect(writes.indexOf('\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H')).toBeLessThan(
+    expect(writes.indexOf(`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`)).toBeLessThan(
       writes.indexOf('altscreen-snapshot\r\n')
     )
     expect(pane.terminal.write).toHaveBeenCalledWith('altscreen-snapshot\r\n', expect.any(Function))
@@ -15760,7 +15761,7 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
-  it('abandons a stalled hidden restore and drains pending foreground chunks warning-first', async () => {
+  it('abandons a stalled hidden restore with reset, warning, then pending foreground', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: {
@@ -15822,6 +15823,7 @@ describe('connectPanePty', () => {
     const warningIndex = written.findIndex((data) => data.includes('main recovery was unavailable'))
     const combinedLiveIndex = written.indexOf(firstLive + secondLive)
     expect(warningIndex).toBeGreaterThanOrEqual(0)
+    expect(written[warningIndex - 1]).toBe(RESET_AFTER_BYTE_GAP)
     expect(combinedLiveIndex).toBeGreaterThan(warningIndex)
 
     snapshot.resolve({
@@ -15888,7 +15890,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(10)
 
     const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
-    const resetIndex = written.findIndex((data) => data.startsWith('\x1b[0m'))
+    const resetIndex = written.indexOf(RESET_AFTER_BYTE_GAP)
     const liveIndex = written.findIndex((data) => data.includes('live-after-reveal'))
     expect(resetIndex).toBeGreaterThanOrEqual(0)
     expect(liveIndex).toBeGreaterThanOrEqual(0)
@@ -16412,7 +16414,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.clear).toHaveBeenCalled()
     expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
       expect.any(Function)
     )
     disposable.dispose()
@@ -17310,7 +17312,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -15898,6 +15898,50 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('grounds byte-gap state before a remote restore re-arms', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const remotePtyId = 'remote:env-1@@terminal-rearm'
+    const transport = createMockTransport(remotePtyId)
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return remotePtyId
+    })
+    const snapshot = createDeferred<{ data: string; cols: number; rows: number; seq: number }>()
+    transport.serializeBuffer = vi.fn().mockReturnValue(snapshot.promise)
+    transportFactoryQueue.push(transport)
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'remote-live-after-rearm\r\n'
+
+    const pane = createPane(1)
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+
+    vi.useFakeTimers()
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(4)
+
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks(10)
+
+    const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
+    const resetIndex = written.indexOf(RESET_AFTER_BYTE_GAP)
+    const liveIndex = written.indexOf(live)
+    expect(resetIndex).toBeGreaterThanOrEqual(0)
+    expect(liveIndex).toBeGreaterThan(resetIndex)
+    expect(written.join('')).not.toContain('main recovery was unavailable')
+
+    disposable.dispose()
+  })
+
   it('falls back after repeated null hidden restore retries and drains blocked foreground', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -10210,7 +10210,7 @@ describe('connectPanePty', () => {
       claim: true
     })
     expect(written).toContain(viewportClear)
-    expect(written).not.toContain('\x1b[0m\x1b[2J\x1b[3J\x1b[H')
+    expect(written).not.toContain('\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H')
     expect(written).toEqual(
       expect.arrayContaining([coldScrollback, POST_REPLAY_MODE_RESET, blankViewport])
     )
@@ -15466,7 +15466,7 @@ describe('connectPanePty', () => {
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.resize).toHaveBeenCalledWith(100, 30)
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
@@ -15519,7 +15519,7 @@ describe('connectPanePty', () => {
 
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
@@ -15527,16 +15527,16 @@ describe('connectPanePty', () => {
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H',
       expect.any(Function)
     )
     const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
       (call) => call[0]
     )
     expect(writes.indexOf('preserved-shell-history\r\n')).toBeLessThan(
-      writes.indexOf('\x1b[0m\x1b[?1049h\x1b[2J\x1b[H')
+      writes.indexOf('\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H')
     )
-    expect(writes.indexOf('\x1b[0m\x1b[?1049h\x1b[2J\x1b[H')).toBeLessThan(
+    expect(writes.indexOf('\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H')).toBeLessThan(
       writes.indexOf('altscreen-snapshot\r\n')
     )
     expect(pane.terminal.write).toHaveBeenCalledWith('altscreen-snapshot\r\n', expect.any(Function))
@@ -15866,7 +15866,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(10)
 
     const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
-    const resetIndex = written.indexOf('\x1b[0m')
+    const resetIndex = written.findIndex((data) => data.startsWith('\x1b[0m'))
     const liveIndex = written.findIndex((data) => data.includes('live-after-reveal'))
     expect(resetIndex).toBeGreaterThanOrEqual(0)
     expect(liveIndex).toBeGreaterThanOrEqual(0)
@@ -16390,7 +16390,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.clear).toHaveBeenCalled()
     expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     disposable.dispose()
@@ -17288,7 +17288,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -124,6 +124,7 @@ import {
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
   POST_REPLAY_REATTACH_RESET_KEEP_MOUSE,
+  RESET_GRAPHIC_RENDITION,
   RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from '../../../../shared/terminal-mode-reset-profiles'
@@ -7058,6 +7059,14 @@ export function connectPanePty(
         clearHiddenOutputRestoreFloodRepaintTimer()
         writeRestoreUnavailableWarning()
       }
+      // Why before both exits: the gate dropped renderer-bound bytes, so the pen
+      // that was live when it started dropping is unknown — if the dropped span
+      // held the `ESC[22m`/`ESC[0m` closing a run, xterm still has bold (or any
+      // other attribute) latched. Abandoning means no snapshot will rebuild the
+      // buffer, so nothing else ever clears it and every later cell inherits it
+      // (STA-4042). Cheap and idempotent; a live TUI re-arms its own attributes
+      // on the next write.
+      writePtyOutputToXterm(RESET_GRAPHIC_RENDITION, true)
       if (hadPendingOverflow) {
         return
       }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7067,7 +7067,12 @@ export function connectPanePty(
         // backpressure must not outlive it — it would re-open recovery and banner a second time.
         clearHiddenOutputRestoreFloodRepaintTimer()
         writeRestoreUnavailableWarning()
-      } else if (!rearmedRemoteRestore) {
+      }
+      // Why not an else: the unavailable warning is plain text and carries no SGR
+      // of its own, so folding the reset into the other branch skipped it on the
+      // primary abandon path — the one that declares the bytes unrecoverable.
+      // Guarded only against the remote re-arm, which writes its own reset.
+      if (!rearmedRemoteRestore) {
         writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       }
       if (hadPendingOverflow) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -124,7 +124,7 @@ import {
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
   POST_REPLAY_REATTACH_RESET_KEEP_MOUSE,
-  RESET_GRAPHIC_RENDITION,
+  RESET_AFTER_BYTE_GAP,
   RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from '../../../../shared/terminal-mode-reset-profiles'
@@ -7064,9 +7064,10 @@ export function connectPanePty(
       // held the `ESC[22m`/`ESC[0m` closing a run, xterm still has bold (or any
       // other attribute) latched. Abandoning means no snapshot will rebuild the
       // buffer, so nothing else ever clears it and every later cell inherits it
-      // (STA-4042). Cheap and idempotent; a live TUI re-arms its own attributes
-      // on the next write.
-      writePtyOutputToXterm(RESET_GRAPHIC_RENDITION, true)
+      // (STA-4042). Same for the charset designation, whose loss renders text as
+      // box characters. Cheap and idempotent; a live TUI re-asserts both on its
+      // next write.
+      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       if (hadPendingOverflow) {
         return
       }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -6101,19 +6101,22 @@ export function connectPanePty(
       })
       // Why: dropped bytes invalidate cross-chunk carry — a partial OSC-9999 prefix spanning the gap would corrupt the next live chunk.
       transport.resetCrossChunkParserState?.()
-      // Why the emulator too: it carries state across chunks exactly like the
-      // parser does. If the gap swallowed the `ESC[22m` closing a bold run (or
-      // the `ESC(B` leaving line-drawing), every cell written afterwards
-      // inherits it. This marker is the one point where "bytes were dropped" is
-      // known, so close the state gap here instead of relying on each recovery
-      // path to remember — restore, abandon and overflow then all start from a
-      // known pen (STA-4042).
-      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       // Why gated (rc.7.perf loop): on a visible pane these markers come from our own restore starving ACKs; re-arming per marker kept the fetch loop alive all flood, so defer to one post-flood repaint.
       if (isForegroundRestoreBackpressureContext()) {
         noteHiddenOutputRestoreFloodBackpressure()
         return
       }
+      // Why the emulator too: it carries state across chunks exactly like the
+      // parser does. If the gap swallowed the `ESC[22m` closing a bold run,
+      // every cell written afterwards inherits it. This marker is the one point
+      // where "bytes were dropped" is known, so ground the pen here rather than
+      // relying on each recovery path to remember (STA-4042).
+      // Why after the backpressure return and not before: under flood these
+      // markers arrive continuously, and writing per marker would add work in
+      // exactly the case that guard exists to damp. The flood path repaints via
+      // buildMainModelSnapshotReplayWrites, which grounds the pen itself, so
+      // nothing is lost by skipping it here.
+      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       // Why: a marker during an in-flight restore means that snapshot may predate the drop, so a fresh one must follow; capture BEFORE the mark, which starts a restore synchronously on a visible pane.
       const restoreWasInFlight = hiddenOutputRestoreInFlight !== null
       markHiddenOutputRestoreNeeded()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7014,6 +7014,7 @@ export function connectPanePty(
         cycle: hiddenOutputRestoreRemoteAbandonCycles
       })
       noteHiddenOutputRestoreFloodBackpressure()
+      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       return true
     }
 
@@ -7066,7 +7067,7 @@ export function connectPanePty(
         // backpressure must not outlive it — it would re-open recovery and banner a second time.
         clearHiddenOutputRestoreFloodRepaintTimer()
         writeRestoreUnavailableWarning()
-      } else {
+      } else if (!rearmedRemoteRestore) {
         writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       }
       if (hadPendingOverflow) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -6101,6 +6101,14 @@ export function connectPanePty(
       })
       // Why: dropped bytes invalidate cross-chunk carry — a partial OSC-9999 prefix spanning the gap would corrupt the next live chunk.
       transport.resetCrossChunkParserState?.()
+      // Why the emulator too: it carries state across chunks exactly like the
+      // parser does. If the gap swallowed the `ESC[22m` closing a bold run (or
+      // the `ESC(B` leaving line-drawing), every cell written afterwards
+      // inherits it. This marker is the one point where "bytes were dropped" is
+      // known, so close the state gap here instead of relying on each recovery
+      // path to remember — restore, abandon and overflow then all start from a
+      // known pen (STA-4042).
+      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       // Why gated (rc.7.perf loop): on a visible pane these markers come from our own restore starving ACKs; re-arming per marker kept the fetch loop alive all flood, so defer to one post-flood repaint.
       if (isForegroundRestoreBackpressureContext()) {
         noteHiddenOutputRestoreFloodBackpressure()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -413,7 +413,7 @@ const FOREGROUND_GRID_DRIFT_CHECK_MIN_MS = 250
 // Why: this is only shown if hidden renderer output was skipped and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
-  '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because main recovery was unavailable.]\r\n'
+  '\r\n[Orca skipped hidden terminal output because main recovery was unavailable.]\r\n'
 type E2eTerminalPtyDataInjectionApi = {
   inject: (paneKey: string, data: string, meta?: PtyDataMeta) => boolean
   keys: () => string[]
@@ -7066,16 +7066,9 @@ export function connectPanePty(
         // backpressure must not outlive it — it would re-open recovery and banner a second time.
         clearHiddenOutputRestoreFloodRepaintTimer()
         writeRestoreUnavailableWarning()
+      } else {
+        writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       }
-      // Why before both exits: the gate dropped renderer-bound bytes, so the pen
-      // that was live when it started dropping is unknown — if the dropped span
-      // held the `ESC[22m`/`ESC[0m` closing a run, xterm still has bold (or any
-      // other attribute) latched. Abandoning means no snapshot will rebuild the
-      // buffer, so nothing else ever clears it and every later cell inherits it
-      // (STA-4042). Same for the charset designation, whose loss renders text as
-      // box characters. Cheap and idempotent; a live TUI re-asserts both on its
-      // next write.
-      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       if (hadPendingOverflow) {
         return
       }
@@ -7216,6 +7209,8 @@ export function connectPanePty(
     }
 
     function writeRestoreUnavailableWarning(): void {
+      // The reset must parse before both the warning and any foreground drain.
+      writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       if (!shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
         return
       }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -12,26 +12,23 @@ function writeTerminal(terminal: Terminal, data: string): Promise<void> {
   return new Promise((resolve) => terminal.write(data, resolve))
 }
 
-type CellWithOscLink = {
-  extended?: { urlId?: number }
-  isBold: () => number
-}
-
 describe('RESET_AFTER_BYTE_GAP', () => {
-  it('grounds incomplete escapes, SGR, OSC 8, and every charset register', async () => {
+  // Real emulator rather than a mock: the guarantee is that a cell written after
+  // the gap reset carries none of the pen the gap stranded (STA-4042). Scoped to
+  // SGR — see RESET_AFTER_BYTE_GAP for why the wider grounding was dropped.
+  it('grounds the SGR pen so post-gap cells are not bold', async () => {
     const terminal = new Terminal({ cols: 40, rows: 2, allowProposedApi: true })
     try {
-      await writeTerminal(
-        terminal,
-        '\x1b[1m\x1b(0\x1b)0\x1b*0\x1b+0\x0e\x1b]8;;https://example.test\x1b\\q\x1b['
-      )
-      await writeTerminal(terminal, `${RESET_AFTER_BYTE_GAP}A\x0eq\x1bnq\x1boq`)
+      // Bold opened and never closed — exactly what a dropped `ESC[22m` leaves.
+      await writeTerminal(terminal, '\x1b[1mBOLD')
+      await writeTerminal(terminal, `${RESET_AFTER_BYTE_GAP}after`)
 
       const line = terminal.buffer.active.getLine(0)
-      const plainCell = line?.getCell(1) as CellWithOscLink | undefined
-      expect(line?.translateToString(true)).toBe('─Aqqq')
-      expect(plainCell?.isBold()).toBe(0)
-      expect(plainCell?.extended?.urlId ?? 0).toBe(0)
+      expect(line?.translateToString(true)).toBe('BOLDafter')
+      // The pre-gap run keeps its bold; only what follows the reset is grounded.
+      expect(line?.getCell(0)?.isBold()).not.toBe(0)
+      expect(line?.getCell(4)?.isBold()).toBe(0)
+      expect(line?.getCell(8)?.isBold()).toBe(0)
     } finally {
       terminal.dispose()
     }
@@ -233,8 +230,6 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     ]
     for (const writes of branches) {
       expect(writes[0].startsWith(RESET_AFTER_BYTE_GAP)).toBe(true)
-      // charset too: a dropped ESC(B renders text as box characters
-      expect(writes[0].includes('\x1b(B')).toBe(true)
       // Nothing may be replayed ahead of the first reset.
       expect(writes.indexOf('scrollback')).not.toBe(0)
     }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@xterm/headless'
+import { RESET_AFTER_BYTE_GAP } from '../../../../shared/terminal-mode-reset-profiles'
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
@@ -10,6 +11,32 @@ import {
 function writeTerminal(terminal: Terminal, data: string): Promise<void> {
   return new Promise((resolve) => terminal.write(data, resolve))
 }
+
+type CellWithOscLink = {
+  extended?: { urlId?: number }
+  isBold: () => number
+}
+
+describe('RESET_AFTER_BYTE_GAP', () => {
+  it('grounds incomplete escapes, SGR, OSC 8, and every charset register', async () => {
+    const terminal = new Terminal({ cols: 40, rows: 2, allowProposedApi: true })
+    try {
+      await writeTerminal(
+        terminal,
+        '\x1b[1m\x1b(0\x1b)0\x1b*0\x1b+0\x0e\x1b]8;;https://example.test\x1b\\q\x1b['
+      )
+      await writeTerminal(terminal, `${RESET_AFTER_BYTE_GAP}A\x0eq\x1bnq\x1boq`)
+
+      const line = terminal.buffer.active.getLine(0)
+      const plainCell = line?.getCell(1) as CellWithOscLink | undefined
+      expect(line?.translateToString(true)).toBe('─Aqqq')
+      expect(plainCell?.isBold()).toBe(0)
+      expect(plainCell?.extended?.urlId ?? 0).toBe(0)
+    } finally {
+      terminal.dispose()
+    }
+  })
+})
 
 describe('hasPositiveTerminalDimensions', () => {
   it('accepts only finite positive numeric pairs', () => {
@@ -42,7 +69,7 @@ describe('resolvePositiveTerminalDimensions', () => {
 describe('buildMainModelSnapshotReplayWrites', () => {
   it('clears normal buffer + scrollback before a normal-buffer snapshot', () => {
     expect(buildMainModelSnapshotReplayWrites({ data: 'shell-output' })).toEqual([
-      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
       'shell-output'
     ])
   })
@@ -59,9 +86,9 @@ describe('buildMainModelSnapshotReplayWrites', () => {
         scrollbackAnsi: 'normal-history'
       })
     ).toEqual([
-      '\x1b[0m\x1b(B\x0f\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
       'normal-history',
-      '\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
       'alt-frame'
     ])
   })
@@ -69,7 +96,7 @@ describe('buildMainModelSnapshotReplayWrites', () => {
   it('enters a cleared alt screen when no split scrollback is available', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
-    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
+    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, 'alt-frame'])
   })
 })
 
@@ -153,9 +180,9 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         { skipAltFrame: true }
       )
     ).toEqual([
-      '\x1b[0m\x1b(B\x0f\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
       'normal-history',
-      '\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H',
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
       'complete-live-state'
     ])
   })
@@ -172,7 +199,7 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         },
         { skipAltFrame: true }
       )
-    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H', 'complete-live-state'])
+    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, 'complete-live-state'])
   })
 
   it('keeps composed data when an older producer omits the mode boundary', () => {
@@ -181,13 +208,13 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         { data: 'legacy-modes-and-frame', alternateScreen: true },
         { skipAltFrame: true }
       )
-    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H', 'legacy-modes-and-frame'])
+    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, 'legacy-modes-and-frame'])
   })
 
   it('never drops a normal-buffer snapshot, whose rows reflow correctly', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
-    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
+    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`, 'shell-output'])
   })
 
   // STA-4042: a replay only runs because renderer-bound bytes were dropped, so
@@ -205,7 +232,7 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
       buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
     ]
     for (const writes of branches) {
-      expect(writes[0].startsWith('\x1b[0m')).toBe(true)
+      expect(writes[0].startsWith(RESET_AFTER_BYTE_GAP)).toBe(true)
       // charset too: a dropped ESC(B renders text as box characters
       expect(writes[0].includes('\x1b(B')).toBe(true)
       // Nothing may be replayed ahead of the first reset.

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -42,7 +42,7 @@ describe('resolvePositiveTerminalDimensions', () => {
 describe('buildMainModelSnapshotReplayWrites', () => {
   it('clears normal buffer + scrollback before a normal-buffer snapshot', () => {
     expect(buildMainModelSnapshotReplayWrites({ data: 'shell-output' })).toEqual([
-      '\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
       'shell-output'
     ])
   })
@@ -59,7 +59,7 @@ describe('buildMainModelSnapshotReplayWrites', () => {
         scrollbackAnsi: 'normal-history'
       })
     ).toEqual([
-      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       'normal-history',
       '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
       'alt-frame'
@@ -153,7 +153,7 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         { skipAltFrame: true }
       )
     ).toEqual([
-      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       'normal-history',
       '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
       'complete-live-state'
@@ -187,6 +187,27 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
   it('never drops a normal-buffer snapshot, whose rows reflow correctly', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
-    ).toEqual(['\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
+    ).toEqual(['\x1b[0m\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
+  })
+
+  // STA-4042: a replay only runs because renderer-bound bytes were dropped, so
+  // the pen that the drop interrupted is unknown. Every branch must clear it
+  // BEFORE replaying content, or the whole restored buffer inherits it — the
+  // "regular text renders bold" field report.
+  it('clears the SGR pen before any replayed content in every branch', () => {
+    const branches = [
+      buildMainModelSnapshotReplayWrites({ data: 'normal-buffer' }),
+      buildMainModelSnapshotReplayWrites({
+        data: 'alt-frame',
+        alternateScreen: true,
+        scrollbackAnsi: 'scrollback'
+      }),
+      buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
+    ]
+    for (const writes of branches) {
+      expect(writes[0].startsWith('\x1b[0m')).toBe(true)
+      // Nothing may be replayed ahead of the first reset.
+      expect(writes.indexOf('scrollback')).not.toBe(0)
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -42,7 +42,7 @@ describe('resolvePositiveTerminalDimensions', () => {
 describe('buildMainModelSnapshotReplayWrites', () => {
   it('clears normal buffer + scrollback before a normal-buffer snapshot', () => {
     expect(buildMainModelSnapshotReplayWrites({ data: 'shell-output' })).toEqual([
-      '\x1b[0m\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H',
       'shell-output'
     ])
   })
@@ -59,9 +59,9 @@ describe('buildMainModelSnapshotReplayWrites', () => {
         scrollbackAnsi: 'normal-history'
       })
     ).toEqual([
-      '\x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       'normal-history',
-      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H',
       'alt-frame'
     ])
   })
@@ -69,7 +69,7 @@ describe('buildMainModelSnapshotReplayWrites', () => {
   it('enters a cleared alt screen when no split scrollback is available', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
-    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
+    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
   })
 })
 
@@ -153,9 +153,9 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         { skipAltFrame: true }
       )
     ).toEqual([
-      '\x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       'normal-history',
-      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      '\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H',
       'complete-live-state'
     ])
   })
@@ -172,7 +172,7 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         },
         { skipAltFrame: true }
       )
-    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'complete-live-state'])
+    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H', 'complete-live-state'])
   })
 
   it('keeps composed data when an older producer omits the mode boundary', () => {
@@ -181,13 +181,13 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
         { data: 'legacy-modes-and-frame', alternateScreen: true },
         { skipAltFrame: true }
       )
-    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'legacy-modes-and-frame'])
+    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[?1049h\x1b[2J\x1b[H', 'legacy-modes-and-frame'])
   })
 
   it('never drops a normal-buffer snapshot, whose rows reflow correctly', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
-    ).toEqual(['\x1b[0m\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
+    ).toEqual(['\x1b[0m\x1b(B\x0f\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
   })
 
   // STA-4042: a replay only runs because renderer-bound bytes were dropped, so
@@ -206,6 +206,8 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     ]
     for (const writes of branches) {
       expect(writes[0].startsWith('\x1b[0m')).toBe(true)
+      // charset too: a dropped ESC(B renders text as box characters
+      expect(writes[0].includes('\x1b(B')).toBe(true)
       // Nothing may be replayed ahead of the first reset.
       expect(writes.indexOf('scrollback')).not.toBe(0)
     }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,5 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
+import { RESET_GRAPHIC_RENDITION } from '../../../../shared/terminal-mode-reset-profiles'
 
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
@@ -81,7 +82,11 @@ export function buildMainModelSnapshotReplayWrites(
   if (!snapshot.alternateScreen) {
     // Why: \x1b[3J wipes xterm scrollback; safe here because a normal-buffer
     // snapshot carries its own history in data (mirrors pty-transport.ts).
-    return ['\x1b[2J\x1b[3J\x1b[H', snapshot.data]
+    // Why the leading SGR reset: a replay only happens because renderer-bound
+    // bytes were dropped, so the pen the drop interrupted is unknown — without
+    // clearing it the whole replayed buffer inherits it (STA-4042). The
+    // alt-screen branches below already reset; this one did not.
+    return [`${RESET_GRAPHIC_RENDITION}\x1b[2J\x1b[3J\x1b[H`, snapshot.data]
   }
   // Older snapshot producers do not expose the mode/frame boundary. Keep their
   // composed data rather than dropping terminal modes together with the frame.
@@ -92,10 +97,13 @@ export function buildMainModelSnapshotReplayWrites(
   if (snapshot.scrollbackAnsi !== undefined) {
     // Why: main serializes normal + alt buffers separately; rebuild normal
     // while active, then return to a clean alt frame.
+    // Why the reset moved to the front too: scrollbackAnsi was replayed BEFORE
+    // the existing \x1b[0m, so the normal-buffer history inherited the stale pen
+    // even though the alt frame after it did not (STA-4042).
     return [
-      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      `${RESET_GRAPHIC_RENDITION}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
       snapshot.scrollbackAnsi,
-      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      `${RESET_GRAPHIC_RENDITION}\x1b[?1049h\x1b[2J\x1b[H`,
       ...altFrame
     ]
   }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,6 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
-import { RESET_GRAPHIC_RENDITION } from '../../../../shared/terminal-mode-reset-profiles'
+import { RESET_AFTER_BYTE_GAP } from '../../../../shared/terminal-mode-reset-profiles'
 
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
@@ -86,7 +86,7 @@ export function buildMainModelSnapshotReplayWrites(
     // bytes were dropped, so the pen the drop interrupted is unknown — without
     // clearing it the whole replayed buffer inherits it (STA-4042). The
     // alt-screen branches below already reset; this one did not.
-    return [`${RESET_GRAPHIC_RENDITION}\x1b[2J\x1b[3J\x1b[H`, snapshot.data]
+    return [`${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`, snapshot.data]
   }
   // Older snapshot producers do not expose the mode/frame boundary. Keep their
   // composed data rather than dropping terminal modes together with the frame.
@@ -101,14 +101,14 @@ export function buildMainModelSnapshotReplayWrites(
     // the existing \x1b[0m, so the normal-buffer history inherited the stale pen
     // even though the alt frame after it did not (STA-4042).
     return [
-      `${RESET_GRAPHIC_RENDITION}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
       snapshot.scrollbackAnsi,
-      `${RESET_GRAPHIC_RENDITION}\x1b[?1049h\x1b[2J\x1b[H`,
+      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
       ...altFrame
     ]
   }
   // Why: the snapshot's ?1049h no-ops when already on alt screen and skips
   // blank cells; clear the alt buffer so the pre-hide frame can't bleed
   // through blank cells (spares normal-buffer scrollback).
-  return ['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', ...altFrame]
+  return [`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, ...altFrame]
 }

--- a/src/renderer/src/lib/setup-script-prompt.test.ts
+++ b/src/renderer/src/lib/setup-script-prompt.test.ts
@@ -220,10 +220,7 @@ describe('setup script prompt inspection', () => {
       getSetupScriptPromptDismissalKey(remoteIdentity)
     ]
     expect(
-      filterSetupScriptPromptDismissalsToValidRepos(
-        input,
-        new Set([localIdentity, remoteIdentity])
-      )
+      filterSetupScriptPromptDismissalsToValidRepos(input, new Set([localIdentity, remoteIdentity]))
     ).toBe(input)
   })
 

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -2787,9 +2787,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               ...(errorForCache
                 ? {
                     error:
-                      errorUnchanged && previousError !== undefined
-                        ? previousError
-                        : errorForCache
+                      errorUnchanged && previousError !== undefined ? previousError : errorForCache
                   }
                 : {}),
               ...(nextFellBack ? { issueSourceFellBack: true } : {})

--- a/src/renderer/src/store/slices/repos-refresh-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-refresh-identity.test.ts
@@ -421,9 +421,11 @@ describe('SSH readoption catalog identity', () => {
     expect(oldSetup).toBeDefined()
     expect(newSetup).toBeDefined()
 
-    store.getState().recordSshRepoReadoptions([
-      { oldTargetId: 'ssh-old', newTargetId: 'ssh-new', repoIds: [repo.id] }
-    ])
+    store
+      .getState()
+      .recordSshRepoReadoptions([
+        { oldTargetId: 'ssh-old', newTargetId: 'ssh-new', repoIds: [repo.id] }
+      ])
 
     const next = store.getState().projectHostSetups
     expect(next).not.toBe(setups)
@@ -435,4 +437,3 @@ describe('SSH readoption catalog identity', () => {
     expect(store.getState().pendingSshRepoReadoptions).toEqual([])
   })
 })
-

--- a/src/shared/terminal-mode-reset-profiles.ts
+++ b/src/shared/terminal-mode-reset-profiles.ts
@@ -40,6 +40,21 @@ export const COLD_RESTORE_SEED_MODE_RESET = RESET_MOUSE_REPORTING
 // drains queued foreground chunks under the stale pen).
 export const RESET_GRAPHIC_RENDITION = '\x1b[0m'
 
+// Designate ASCII into G0 and shift back to it. Same failure as the pen but a
+// louder symptom: a dropped `ESC(B` leaves line-drawing selected and ordinary
+// text renders as box characters.
+const RESET_CHARSET_TO_ASCII = '\x1b(B\x0f'
+
+/**
+ * State to re-establish when renderer-bound bytes were dropped and the gap
+ * cannot be replayed away. Deliberately NOT a soft reset (DECSTR): xterm's
+ * DECSTR wipes kitty flags and stacks (see terminal-kitty-keyboard-mode-tracker
+ * applySoftReset), which would silence Option chords for a live agent that only
+ * negotiates them at startup. So reset the state a gap can strand and that no
+ * running TUI re-asserts on its own, and leave the rest to its next repaint.
+ */
+export const RESET_AFTER_BYTE_GAP = `${RESET_GRAPHIC_RENDITION}${RESET_CHARSET_TO_ASCII}`
+
 // Why: DECTCEM applies in emission order, so the payload's last ?25l/?25h is the cursor state the TUI left.
 export function replayPayloadEndsWithCursorHidden(payload: string): boolean {
   const hideIndex = payload.lastIndexOf('\x1b[?25l')

--- a/src/shared/terminal-mode-reset-profiles.ts
+++ b/src/shared/terminal-mode-reset-profiles.ts
@@ -32,6 +32,14 @@ export const POST_REPLAY_LIVE_AGENT_SNAPSHOT_RESET = RESET_TERMINAL_CURSOR_STYLE
 /** Dead-TUI bytes feed a fresh shell; clear mouse modes here and renderer-owned modes later. */
 export const COLD_RESTORE_SEED_MODE_RESET = RESET_MOUSE_REPORTING
 
+// Why separate from every profile above: those clear DEC *mode* bits and none of
+// them touches SGR. A recovery path that declares bytes unrecoverable has by
+// definition lost whatever turned the pen on, so the pen must be cleared too —
+// otherwise a dropped `ESC[22m` leaves bold applied to everything written after
+// (STA-4042: hidden-delivery gate drops the reset, the abandoned restore then
+// drains queued foreground chunks under the stale pen).
+export const RESET_GRAPHIC_RENDITION = '\x1b[0m'
+
 // Why: DECTCEM applies in emission order, so the payload's last ?25l/?25h is the cursor state the TUI left.
 export function replayPayloadEndsWithCursorHidden(payload: string): boolean {
   const hideIndex = payload.lastIndexOf('\x1b[?25l')

--- a/src/shared/terminal-mode-reset-profiles.ts
+++ b/src/shared/terminal-mode-reset-profiles.ts
@@ -40,10 +40,10 @@ export const COLD_RESTORE_SEED_MODE_RESET = RESET_MOUSE_REPORTING
 // drains queued foreground chunks under the stale pen).
 export const RESET_GRAPHIC_RENDITION = '\x1b[0m'
 
-// Designate ASCII into G0 and shift back to it. Same failure as the pen but a
-// louder symptom: a dropped `ESC(B` leaves line-drawing selected and ordinary
-// text renders as box characters.
-const RESET_CHARSET_TO_ASCII = '\x1b(B\x0f'
+// Cancel any partial escape, close OSC 8, restore every ISO 2022 register, and select G0.
+const RESET_INCOMPLETE_ESCAPE = '\x18'
+const RESET_OSC_HYPERLINK = '\x1b]8;;\x1b\\'
+const RESET_CHARSETS_TO_ASCII = '\x1b(B\x1b)B\x1b*B\x1b+B\x0f'
 
 /**
  * State to re-establish when renderer-bound bytes were dropped and the gap
@@ -53,7 +53,7 @@ const RESET_CHARSET_TO_ASCII = '\x1b(B\x0f'
  * negotiates them at startup. So reset the state a gap can strand and that no
  * running TUI re-asserts on its own, and leave the rest to its next repaint.
  */
-export const RESET_AFTER_BYTE_GAP = `${RESET_GRAPHIC_RENDITION}${RESET_CHARSET_TO_ASCII}`
+export const RESET_AFTER_BYTE_GAP = `${RESET_INCOMPLETE_ESCAPE}${RESET_OSC_HYPERLINK}${RESET_GRAPHIC_RENDITION}${RESET_CHARSETS_TO_ASCII}`
 
 // Why: DECTCEM applies in emission order, so the payload's last ?25l/?25h is the cursor state the TUI left.
 export function replayPayloadEndsWithCursorHidden(payload: string): boolean {

--- a/src/shared/terminal-mode-reset-profiles.ts
+++ b/src/shared/terminal-mode-reset-profiles.ts
@@ -40,20 +40,24 @@ export const COLD_RESTORE_SEED_MODE_RESET = RESET_MOUSE_REPORTING
 // drains queued foreground chunks under the stale pen).
 export const RESET_GRAPHIC_RENDITION = '\x1b[0m'
 
-// Cancel any partial escape, close OSC 8, restore every ISO 2022 register, and select G0.
-const RESET_INCOMPLETE_ESCAPE = '\x18'
-const RESET_OSC_HYPERLINK = '\x1b]8;;\x1b\\'
-const RESET_CHARSETS_TO_ASCII = '\x1b(B\x1b)B\x1b*B\x1b+B\x0f'
-
 /**
  * State to re-establish when renderer-bound bytes were dropped and the gap
- * cannot be replayed away. Deliberately NOT a soft reset (DECSTR): xterm's
- * DECSTR wipes kitty flags and stacks (see terminal-kitty-keyboard-mode-tracker
- * applySoftReset), which would silence Option chords for a live agent that only
- * negotiates them at startup. So reset the state a gap can strand and that no
- * running TUI re-asserts on its own, and leave the rest to its next repaint.
+ * cannot be replayed away.
+ *
+ * Scoped to the pen on purpose. A gap can in principle strand other carried
+ * state — an ISO 2022 charset designation, an open OSC 8 hyperlink, a partial
+ * escape — and earlier revisions of this reset covered those too. They are
+ * dropped here because each one changes what a live TUI sees on a path that
+ * runs in production, none of them has a reported symptom behind it, and the
+ * pen is what the field reports actually show (STA-4042). Widen this only with
+ * a symptom to point at.
+ *
+ * Deliberately NOT a soft reset (DECSTR) either: xterm's DECSTR wipes kitty
+ * flags and stacks (see terminal-kitty-keyboard-mode-tracker applySoftReset),
+ * which would silence Option chords for a live agent that negotiates them only
+ * at startup.
  */
-export const RESET_AFTER_BYTE_GAP = `${RESET_INCOMPLETE_ESCAPE}${RESET_OSC_HYPERLINK}${RESET_GRAPHIC_RENDITION}${RESET_CHARSETS_TO_ASCII}`
+export const RESET_AFTER_BYTE_GAP = RESET_GRAPHIC_RENDITION
 
 // Why: DECTCEM applies in emission order, so the payload's last ?25l/?25h is the cursor state the TUI left.
 export function replayPayloadEndsWithCursorHidden(payload: string): boolean {


### PR DESCRIPTION
## ELI5

When you switch away from a terminal, Orca stops sending it output to save work. If it stops mid-way through a piece of styled text — after "start bold" but before "stop bold" — the terminal is left holding the bold pen. When you come back, neither recovery path put the pen down, so everything painted afterwards came out bold. This puts the pen down.

## What Changed

Added a `RESET_AFTER_BYTE_GAP` profile (an SGR reset) and emitted it wherever the renderer recovers from dropped bytes:

1. **`buildMainModelSnapshotReplayWrites`** — the two alt-screen branches already reset the pen; the **normal-buffer branch did not**, and the scrollback branch replayed `scrollbackAnsi` *ahead of* the `\x1b[0m` it did emit. Both now clear the pen before any replayed content.
2. **`abandonHiddenOutputRestoreAndDrainPendingForeground`** — this path declares the dropped bytes unrecoverable (it writes a user-visible "recovery was unavailable" warning) and then drained the queued foreground chunks into xterm under that same unknown pen. Now clears it before both exits, including the pending-overflow early return.

3. **The restore-needed marker handler** — the single point where "bytes were dropped" is known. It already resets the transport's cross-chunk parser state there for exactly this reason; the emulator carries state the same way. Placed after the flood-backpressure guard so a flood does not write one reset per marker — the flood path repaints through the replay builder, which grounds the pen itself.
4. **The remote re-arm path**, which abandons without writing the warning.

Every existing profile in `terminal-mode-reset-profiles.ts` clears DEC *mode* bits (cursor style, kitty keyboard, mouse reporting, bracketed paste). None touched SGR — the pen was never in scope for a recovery path.

**Deliberately scoped to the pen.** A gap can in principle strand other carried state — charset designations, an open OSC 8 hyperlink, a partial escape — and an earlier revision of this PR reset those too. They are dropped: each changes what a live TUI sees on a path that runs in production (a legitimately line-drawing TUI that does not re-designate would render box characters as ASCII), and none has a reported symptom behind it. Widen only with a symptom to point at. It is also **not** a soft reset (DECSTR) — xterm's DECSTR wipes kitty flags and stacks (`terminal-kitty-keyboard-mode-tracker` `applySoftReset`), silencing Option chords for agents that negotiate them only at startup.

## Why

`src/main/ipc/pty-hidden-delivery-gate.ts` drops renderer-bound PTY bytes while a pane has no visible view. The renderer's xterm is a **separate emulator** from the daemon model, which is why a pane can render wrong while the daemon's serialized buffer reads clean — I verified that against a real occurrence (`checkpoint.json`: 6.1% bold, all runs terminated) and against the raw PTY log (246 bold runs, **zero** unterminated).

If the dropped span contains the sequence closing an attribute run, the renderer's pen stays latched. A recovery path that knows bytes were lost cannot assume the terminal's attribute state is still coherent.

## Linked Issue

Related: STA-4042 / STA-4060 (bold and regular text becoming visually identical in terminal panes).

**Deliberately not marked as fixing them.** The layer is now confirmed against a live occurrence (below), but I have not proven that this specific abandon/replay path is the one users hit.

## Visual Proof

N/A for a static screenshot — the defect is a transient render state. Behavioural before/after is the A/B below, measured from the renderer's buffer rather than pixels.

## Testing

Live Electron A/B, isolated profile, 50 000-line scrollback, probing `cell.isBold()` on plain text written with no SGR codes at all after a hide → drop → reveal cycle:

| variant | before | after |
| -- | -- | -- |
| `deep-natural` (plain reveal, no forced hold) | **8/8 cells bold** | **0/8** |
| `hold-overflow` (overflow abandon after held snapshot) | **8/8 cells bold** | **0/8** |
| `hold-deadline` | 0/8 | 0/8 |

Each fix closes a different arm: the replay fix closes `deep-natural`, the abandon fix closes `hold-overflow`. Neither alone closes both.

Automated: 594 pass across `pty-connection.test.ts` and `terminal-snapshot-replay-paint.test.ts`; 7872 pass across the whole of `terminal-pane` + `shared`. Coverage **verified non-vacuous**: blanking `RESET_AFTER_BYTE_GAP` fails 5 tests spanning all four paths (replay branches, marker, abandon-with-warning, remote re-arm), including one that drives a real headless emulator and asserts post-gap cells are not bold. Several existing tests pinned the exact replay write arrays and were updated; the reattach/SSH replay assertions were deliberately left alone since that clear comes from a different code path.

`pnpm typecheck`, `oxlint`, `oxfmt --check` all clean.

**Field capture, live occurrence.** A pane was caught mid-symptom in a fresh session. Its raw PTY log — the daemon's record of the full byte stream — was clean: 9 SGR bold-on events, 31 resets, longest bold run 13 chars, **zero unterminated**, and none of the bolded spans corresponded to the affected text. The affected text was the user's own typed input line, showing bold on sub-word fragments (`shoud`+`l`, `spac`+`ed`, `al`+`w`+`ays`) — the signature of per-cell corruption applied as the TUI incrementally repaints. So the byte stream says that text is not bold and the screen rendered it bold: the divergence is renderer-side, on a real occurrence, which is the layer this PR addresses. It then healed on a hide/reveal — the restore path succeeding, which is the same path hardened here.

**What I did not verify:** that this is the cause of the field reports. The repro arms above are normal-buffer shells; the field reports are on alt-screen TUIs (Claude Code), whose branch already emitted a reset — for those, only the abandon path and the scrollback-ordering fix apply. I never observed `abandonWarning=true` on a natural (unforced) snapshot, so the field attribution remains unproven. Treat this as a real correctness fix on the recovery paths, not a confirmed closure of STA-4042.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform / SSH / mobile:** the change is renderer-side and protocol-level (an SGR reset in the replay/abandon byte stream), identical on every platform and transport. The SSH reattach replay path emits its own clear from `pty-transport.ts` and is untouched.
- **Backwards compatibility:** `\x1b[0m` prepended to writes that already cleared the screen in the same chunk. A live TUI re-arms its own attributes on its next write; a shell inherits a defined pen instead of an undefined one.
- **Performance:** four bytes per recovery event, and not emitted per-marker under flood.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
