### PR TITLE
fix(mobile): stop republishing stale launch agent identity

### DIFF
--- a/src/main/runtime/orca-runtime-mobile-agent-status-title-truthfulness.test.ts
+++ b/src/main/runtime/orca-runtime-mobile-agent-status-title-truthfulness.test.ts
@@ -113,6 +113,52 @@ function publishRendererWorkingPane(runtime: OrcaRuntimeService, paneTitle: stri
   })
 }
 
+function publishRendererReleasedPane(runtime: OrcaRuntimeService, title: string): void {
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        title,
+        activeLeafId: LEAF_ID,
+        layout: null
+      }
+    ],
+    leaves: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        leafId: LEAF_ID,
+        paneRuntimeId: 1,
+        ptyId: PTY_ID,
+        paneTitle: 'zsh'
+      }
+    ],
+    mobileSessionTabs: [
+      {
+        worktree: WORKTREE_ID,
+        publicationEpoch: 'epoch-released',
+        snapshotVersion: 1,
+        activeGroupId: null,
+        activeTabId: `${TAB_ID}::${LEAF_ID}`,
+        activeTabType: 'terminal',
+        tabs: [
+          {
+            type: 'terminal',
+            id: `${TAB_ID}::${LEAF_ID}`,
+            parentTabId: TAB_ID,
+            leafId: LEAF_ID,
+            ptyId: PTY_ID,
+            title,
+            isActive: true
+          }
+        ]
+      }
+    ]
+  })
+}
+
 async function projectAgentStatus(
   runtime: OrcaRuntimeService
 ): Promise<Record<string, unknown> | undefined> {
@@ -124,6 +170,15 @@ async function projectAgentStatus(
 }
 
 describe('mobile session tabs: live-title evidence vs published agent status', () => {
+  it('does not resurrect launch identity after the renderer clears it', async () => {
+    const runtime = await createRuntime()
+    publishRendererReleasedPane(runtime, '[Image #1] Inspect this')
+
+    const result = await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+    expect(result.tabs[0]).toEqual(expect.objectContaining({ type: 'terminal' }))
+    expect(result.tabs[0]).not.toHaveProperty('launchAgent')
+  })
+
   it('keeps renderer-published working under a neutral live title', async () => {
     const runtime = await createRuntime()
     publishRendererWorkingPane(runtime, 'Terminal')

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24556,7 +24556,7 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
-  it('derives remote OMP owner from live PTY metadata when the tab snapshot omits it', async () => {
+  it('normalizes a remote OMP title without republishing omitted launch identity', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-omp' })
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
@@ -24630,10 +24630,10 @@ describe('OrcaRuntimeService', () => {
     expect(result.tabs[0]).toEqual(
       expect.objectContaining({
         type: 'terminal',
-        title: '\u280b OMP',
-        launchAgent: 'omp'
+        title: '\u280b OMP'
       })
     )
+    expect(result.tabs[0]).not.toHaveProperty('launchAgent')
   })
 
   it('skips the foreground-process probe when the PTY launch agent is already known', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -30757,11 +30757,13 @@ export class OrcaRuntimeService {
             { title: pty.lastOscTitle, updatedAt: pty.lastOscTitleAt }
           )
         : null
-      const launchAgent = tab.launchAgent ?? liveLeafPty?.launchAgent ?? pty?.launchAgent ?? null
+      // Renderer omission is authoritative: PTY launch provenance outlives agent exit.
+      const launchAgent = tab.launchAgent ?? null
+      const launchOwnerAgent = launchAgent ?? liveLeafPty?.launchAgent ?? pty?.launchAgent ?? null
       // Why: a retained OMP hook stays stable while wrapper foreground reads can report Pi.
       const ownerAgent =
         resolvePaneAgentOwner({
-          launchAgent,
+          launchAgent: launchOwnerAgent,
           hookAgent:
             tab.agentStatus?.agentType ??
             hookAgentStatus?.agentType ??


### PR DESCRIPTION
## ELI5

The host remembered that a terminal was originally launched with an agent and later treated that historical fact as proof that the agent still owned the terminal. After the agent exited, mobile could therefore receive a stale Codex/Claude identity and render native chat over a plain shell.

## What Changed

- Make the renderer-published `launchAgent` authoritative for the client-facing mobile tab projection.
- Keep PTY launch provenance available only for internal owner/title normalization.
- Add a regression test proving that a renderer omission is not repopulated from the PTY record.
- Preserve the existing OMP title-normalization behavior without republishing omitted launch identity.

## Why

This is a scope and ownership fix, not a null-check fix.

PTY launch provenance is provenance, not identity. It records how a PTY was originally spawned and intentionally does not decay when the process returns to a shell. It must therefore never feed the current agent identity published to clients. The renderer owns the agent lifecycle; once it clears and omits `launchAgent`, that omission is authoritative.

Before this change, the host rebuilt the published field from `liveLeafPty.launchAgent` or `pty.launchAgent`. Mobile native-chat eligibility falls back to that field when live agent status is absent, so the historical spawn marker could turn a released terminal into an empty native-chat surface.

This changes session-tab projection content but not the wire shape. With a new host and old mobile client, the client stops receiving a false `launchAgent` after renderer lifecycle clearance. An old host with a new client retains the existing bug until the host updates, but there is no protocol or decoder failure. Runtime-owned/headless terminals still publish launch identity from their authoritative tab snapshots. The same ownership rule applies to local, SSH, remote-runtime, git-worktree, and folder-workspace tabs.

### Follow-ups intentionally not included

These are tracked separately to keep this PR to one ownership defect:

1. `src/renderer/src/runtime/sync-runtime-graph.ts:1900` currently stamps parent-tab `launchAgent`/`launchDraft`/title context onto every split leaf. Any container-scoped evidence retained as a compatibility fallback must be degenerate-only: it may apply when there is exactly one leaf, never when a tab has two or more leaves.
2. Native chat can become a per-device global default through the session-view preference and onboarding's “Use Chat UI” promotion, violating the strict opt-in invariant. This PR does not change mobile preferences or onboarding.

## Linked Issue

Internal tester report for Orca Mobile iOS 0.0.43 build 2; no public GitHub issue.

## Visual Proof

N/A

This is a host projection fix with no UI code change. It was verified with a regression that launches an agent-backed PTY, publishes the same pane after the renderer clears `launchAgent`, and asserts that the host does not resurrect the client-facing field.

## Testing

- macOS: `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-mobile-agent-status-title-truthfulness.test.ts` — 7 passed
- macOS: targeted `src/main/runtime/orca-runtime.test.ts` OMP projection case — 1 passed
- macOS: mobile native-chat eligibility/controller suites — 38 passed
- `oxfmt --check` on all changed files
- `oxlint` on all changed files
- `git diff --check`
- Full typecheck was intentionally not run for this focused investigation; CI will cover repository-wide checks.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI Codex was used for code tracing, implementation, tests, and PR drafting.

## Review

Reviewed for security, cross-platform behavior, SSH/remote and folder-workspace ownership, mobile behavior, mixed-version wire compatibility, and performance. No new paths, commands, protocol fields, or stream opcodes were introduced.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused lint/tests passed; CI will cover repository-wide checks)

## Author

- X / Twitter: @brennanb2025
