### PR TITLE
feat(dashboard): give the agent question state its own color and glyph

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -60,6 +60,8 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-agent-question: var(--agent-question);
+  --color-agent-question-text: var(--agent-question-text);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
@@ -169,6 +171,12 @@
   --ring: #a1a1a1;
   --terminal-pane-locate: var(--color-blue-600);
   --ai-action-accent: var(--color-violet-500);
+  /* "An agent is asking you something" — one hue for every surface that shows
+     it (sidebar, tabs, dashboard, agent map). Orange, not amber: on the map it
+     has to stay separable from working-yellow at a glance. */
+  --agent-question: var(--color-orange-500);
+  /* Legible weight for text/glyphs on a tinted --agent-question surface. */
+  --agent-question-text: var(--color-orange-700);
   --status-success: #15803d;
   --status-success-background: color-mix(in srgb, var(--status-success) 10%, transparent);
   --status-success-border: color-mix(in srgb, var(--status-success) 25%, transparent);
@@ -272,6 +280,8 @@
   --ring: #737373;
   --terminal-pane-locate: var(--color-blue-400);
   --ai-action-accent: var(--color-violet-400);
+  --agent-question: var(--color-orange-500);
+  --agent-question-text: var(--color-orange-300);
   --status-success: #86efac;
   --status-success-background: color-mix(in srgb, var(--status-success) 10%, transparent);
   --status-success-border: color-mix(in srgb, var(--status-success) 25%, transparent);

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -174,7 +174,7 @@
   /* "An agent is asking you something" — one hue for every surface that shows
      it (sidebar, tabs, dashboard, agent map). Orange, not amber: on the map it
      has to stay separable from working-yellow at a glance. */
-  --agent-question: var(--color-orange-500);
+  --agent-question: var(--color-orange-600);
   /* Legible weight for text/glyphs on a tinted --agent-question surface. */
   --agent-question-text: var(--color-orange-700);
   --status-success: #15803d;

--- a/src/renderer/src/components/AgentQuestionIcon.tsx
+++ b/src/renderer/src/components/AgentQuestionIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { MessageCircleQuestion } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+// Why: "the agent is asking you something" shows up in the sidebar, terminal
+// tabs, the dashboard, the kanban and the agent map. One icon + one token
+// (--agent-question) so the four never drift apart; the map paints the same
+// token from agent-map.css. Callers pass sizing via className.
+
+export function AgentQuestionIcon({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <MessageCircleQuestion className={cn('text-agent-question', className)} aria-hidden="true" />
+  )
+}

--- a/src/renderer/src/components/AgentQuestionIcon.tsx
+++ b/src/renderer/src/components/AgentQuestionIcon.tsx
@@ -7,8 +7,17 @@ import { cn } from '@/lib/utils'
 // (--agent-question) so the four never drift apart; the map paints the same
 // token from agent-map.css. Callers pass sizing via className.
 
-export function AgentQuestionIcon({ className }: { className?: string }): React.JSX.Element {
+type AgentQuestionIconProps = React.ComponentProps<typeof MessageCircleQuestion>
+
+export function AgentQuestionIcon({
+  className,
+  ...props
+}: AgentQuestionIconProps): React.JSX.Element {
   return (
-    <MessageCircleQuestion className={cn('text-agent-question', className)} aria-hidden="true" />
+    <MessageCircleQuestion
+      {...props}
+      className={cn('text-agent-question', className)}
+      aria-hidden="true"
+    />
   )
 }

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -45,13 +45,14 @@ describe('AgentStateDot', () => {
   })
 
   it.each(['permission', 'waiting'] satisfies AgentDotState[])(
-    'renders %s as an amber question glyph',
+    'renders %s as the shared question glyph',
     (state) => {
       const markup = renderMarkup(state)
 
       expect(markup).toContain('lucide-message-circle-question-mark')
-      expect(markup).toContain('text-amber-500')
-      expect(markup).not.toContain('bg-amber-500')
+      // One token across sidebar, tabs, dashboard and map — never a raw hue.
+      expect(markup).toContain('text-agent-question')
+      expect(markup).not.toContain('text-amber-500')
       expect(markup).not.toContain('data-agent-spinner')
     }
   )

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -1,4 +1,6 @@
 import React from 'react'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { AgentStateDot, type AgentDotState } from './AgentStateDot'
@@ -17,6 +19,15 @@ function renderDotClassNames(state: AgentDotState): string[] {
 }
 
 describe('AgentStateDot', () => {
+  it('keeps the question glyph above the light-theme non-text contrast floor', () => {
+    const css = readFileSync(join(__dirname, '../assets/main.css'), 'utf8')
+    const lightTheme = css.match(/:root\s*\{(?<body>[\s\S]*?)\n\}/)?.groups?.body
+    const darkTheme = css.match(/\.dark\s*\{(?<body>[\s\S]*?)\n\}/)?.groups?.body
+
+    expect(lightTheme).toContain('--agent-question: var(--color-orange-600)')
+    expect(darkTheme).toContain('--agent-question: var(--color-orange-500)')
+  })
+
   it('renders working as a yellow spinner', () => {
     const markup = renderMarkup('working')
 

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { CircleCheck, MessageCircleQuestion } from 'lucide-react'
+import { CircleCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 
 // Why: shared state-indicator primitive so the dashboard and the sidebar's
@@ -27,8 +28,8 @@ export type AgentDotState =
   // Why: the sidebar's title-based status flow (StatusIndicator/WorktreeCard)
   // collapses blocked + waiting into a single "needs attention" state. Keep
   // this as a distinct member so that flow can render without inventing a new
-  // vocabulary, while rendering it with the same amber attention color as the
-  // worktree-level permission dot.
+  // vocabulary, while rendering it with the same question glyph and
+  // --agent-question color as the worktree-level permission indicator.
   | 'permission'
 
 /** Return the accessible label shared by every visual agent-state marker. */
@@ -101,7 +102,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
       >
-        <MessageCircleQuestion className={cn('text-amber-500', icon)} aria-hidden="true" />
+        <AgentQuestionIcon className={icon} />
       </span>
     )
   }

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -181,7 +181,7 @@ describe('AgentKanbanCard', () => {
       card: card({ bucket: 'attention', dotState: 'waiting' }),
       now: 2_000
     })
-    expect(attention.firstElementChild?.className).toContain('border-amber-500/40')
+    expect(attention.firstElementChild?.className).toContain('border-agent-question/40')
 
     cleanup()
     const { container: done } = renderCard({
@@ -198,7 +198,7 @@ describe('AgentKanbanCard', () => {
     const idleClassName = idle.firstElementChild?.className ?? ''
     expect(idleClassName).toContain('border-border/60')
     expect(idleClassName).not.toContain('emerald')
-    expect(idleClassName).not.toContain('amber')
+    expect(idleClassName).not.toContain('agent-question')
   })
 
   it('heads the card with the conversation name and drops the worktree to the footer', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -5,11 +5,11 @@ import {
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
-  GitPullRequestDraft,
-  MessageCircleQuestion
+  GitPullRequestDraft
 } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
+import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentStateDot } from '@/components/AgentStateDot'
 import { RepoIconGlyph } from '@/components/repo/repo-icon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -203,9 +203,9 @@ export const AgentKanbanCard = memo(
   }: AgentKanbanCardProps): React.JSX.Element {
     useTranslation()
     const [subagentsOpen, setSubagentsOpen] = useState(false)
-    // Why: the two outcomes worth scanning for get a tinted card — amber for
-    // "answer me", green for "finished, look at it". Everything else stays
-    // neutral so the tint keeps meaning something.
+    // Why: the two outcomes worth scanning for get a tinted card — the
+    // --agent-question accent for "answer me", green for "finished, look at
+    // it". Everything else stays neutral so the tint keeps meaning something.
     const needsYou = card.bucket === 'attention'
     const displayState = dashboardCardDisplayState(card)
     const isDone = displayState === 'done'
@@ -224,7 +224,7 @@ export const AgentKanbanCard = memo(
         className={cn(
           'group flex w-full flex-col gap-1.5 rounded-lg border p-2.5 text-left transition-colors',
           needsYou
-            ? 'border-amber-500/40 bg-amber-500/[0.06] hover:border-amber-500/60 hover:bg-amber-500/10'
+            ? 'border-agent-question/40 bg-agent-question/[0.06] hover:border-agent-question/60 hover:bg-agent-question/10'
             : isDone
               ? 'border-emerald-500/40 bg-emerald-500/[0.06] hover:border-emerald-500/60 hover:bg-emerald-500/10'
               : 'border-border/60 bg-card hover:border-border hover:bg-accent/40'
@@ -277,8 +277,8 @@ export const AgentKanbanCard = memo(
           ) : null}
 
           {card.askSummary ? (
-            <div className="flex w-full items-start gap-1 rounded-md bg-amber-500/15 px-1.5 py-1 text-[11px] text-amber-600 ring-1 ring-inset ring-amber-500/25 dark:text-amber-400">
-              <MessageCircleQuestion className="mt-px size-3 shrink-0" aria-hidden />
+            <div className="flex w-full items-start gap-1 rounded-md bg-agent-question/15 px-1.5 py-1 text-[11px] text-agent-question-text ring-1 ring-inset ring-agent-question/25">
+              <AgentQuestionIcon className="mt-px size-3 shrink-0" />
               <span className="line-clamp-2">{card.askSummary}</span>
             </div>
           ) : null}

--- a/src/renderer/src/components/dashboard-popout/AgentMapQuestionMarker.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapQuestionMarker.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
+
+// Why: hue alone can't carry 'waiting' on the map — it sits one step from
+// blocked-red, and nodes shrink as you zoom out. The badge repeats the same
+// question glyph every other surface uses, so the state is readable by shape.
+
+/** Question badge marking an agent that is waiting on the user. */
+export function AgentMapQuestionMarker({
+  radius,
+  markerScale
+}: {
+  radius: number
+  markerScale: number
+}): React.JSX.Element {
+  const iconSize = radius * 0.74 * markerScale
+  // Mirrors the unread dot across the node so the two never stack.
+  const offset = radius * Math.SQRT1_2
+  return (
+    <g transform={`translate(${offset} ${-offset})`} aria-hidden="true">
+      {/* Cuts the node ring out from behind the glyph. */}
+      <circle
+        className="agent-map-agent-question-backdrop"
+        data-agent-question-marker=""
+        r={iconSize * 0.62}
+        vectorEffect="none"
+      />
+      <foreignObject
+        className="agent-map-agent-question-icon"
+        x={-iconSize / 2}
+        y={-iconSize / 2}
+        width={iconSize}
+        height={iconSize}
+      >
+        <div>
+          <AgentQuestionIcon />
+        </div>
+      </foreignObject>
+    </g>
+  )
+}

--- a/src/renderer/src/components/dashboard-popout/AgentMapQuestionMarker.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapQuestionMarker.tsx
@@ -25,17 +25,13 @@ export function AgentMapQuestionMarker({
         r={iconSize * 0.62}
         vectorEffect="none"
       />
-      <foreignObject
+      <AgentQuestionIcon
         className="agent-map-agent-question-icon"
         x={-iconSize / 2}
         y={-iconSize / 2}
         width={iconSize}
         height={iconSize}
-      >
-        <div>
-          <AgentQuestionIcon />
-        </div>
-      </foreignObject>
+      />
     </g>
   )
 }

--- a/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
@@ -52,4 +52,33 @@ describe('AgentMap status glow', () => {
     expect(container.querySelectorAll('.fleet-status-done .agent-map-agent-mark')).toHaveLength(200)
     expect(container.querySelectorAll('[data-agent-unread-marker]')).toHaveLength(200)
   })
+
+  it.each([
+    { dotState: 'waiting', marked: true },
+    { dotState: 'working', marked: false },
+    { dotState: 'blocked', marked: false }
+  ] as const)('marks $dotState agents with a question badge: $marked', (state) => {
+    const { container } = renderMap([card({ bucket: 'attention', dotState: state.dotState })])
+    const marker = container.querySelector('[data-agent-question-marker]')
+
+    if (!state.marked) {
+      expect(marker).not.toBeInTheDocument()
+      return
+    }
+    expect(marker).toBeInTheDocument()
+    // Same glyph the sidebar and tabs use, not a map-local invention.
+    expect(container.querySelector('.agent-map-agent-question-icon svg')).toBeInTheDocument()
+  })
+
+  it('keeps the question badge clear of the unread dot', () => {
+    const { container } = renderMap([
+      card({ bucket: 'attention', dotState: 'waiting', unseen: true })
+    ])
+    const question = container.querySelector('[data-agent-question-marker]')!.parentElement!
+    const unread = container.querySelector('[data-agent-unread-marker]')!
+
+    // Unread sits top-left, the badge top-right — opposite signs on x.
+    expect(question.getAttribute('transform')).toMatch(/translate\(\d/)
+    expect(Number(unread.getAttribute('cx'))).toBeLessThan(0)
+  })
 })

--- a/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
@@ -67,7 +67,8 @@ describe('AgentMap status glow', () => {
     }
     expect(marker).toBeInTheDocument()
     // Same glyph the sidebar and tabs use, not a map-local invention.
-    expect(container.querySelector('.agent-map-agent-question-icon svg')).toBeInTheDocument()
+    expect(container.querySelector('svg.agent-map-agent-question-icon')).toBeInTheDocument()
+    expect(marker!.parentElement!.querySelector('foreignObject')).not.toBeInTheDocument()
   })
 
   it('keeps the question badge clear of the unread dot', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
@@ -14,6 +14,7 @@ import type {
   AgentMapWorktreeRing
 } from './agent-map-layout'
 import { AGENT_MAP_LINEAGE_RELATION, shouldAggregateAgentMapWorktree } from './agent-map-layout'
+import { AgentMapQuestionMarker } from './AgentMapQuestionMarker'
 import {
   agentMapAttentionMarkerScale,
   agentMapStatusLabel,
@@ -380,6 +381,12 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
                         r={agent.radius * 0.225 * agentMapAttentionMarkerScale(mapScale)}
                         vectorEffect="none"
                         aria-hidden="true"
+                      />
+                    ) : null}
+                    {agent.status === 'waiting' ? (
+                      <AgentMapQuestionMarker
+                        radius={agent.radius}
+                        markerScale={agentMapAttentionMarkerScale(mapScale)}
                       />
                     ) : null}
                   </g>

--- a/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
@@ -42,6 +42,19 @@ describe('Agent Map glow performance boundary', () => {
     expect(markRule).not.toMatch(/filter:|animation:|transition:/)
   })
 
+  it('keeps the waiting badge on the native SVG paint path', () => {
+    const marker = source('AgentMapQuestionMarker.tsx')
+    const css = source('agent-map.css')
+    const markerRules = css.match(/\.agent-map-agent-question-[^{}]*\{[^}]+\}/gs) ?? []
+
+    expect(marker).not.toContain('<foreignObject')
+    expect(marker).toContain('<AgentQuestionIcon')
+    expect(markerRules).toHaveLength(2)
+    for (const rule of markerRules) {
+      expect(rule).not.toMatch(/filter:|animation:|transition:/)
+    }
+  })
+
   it('confines the finish flare to nodes inside the recency window', () => {
     const component = source('AgentMapWorktreeRingNode.tsx')
     const metadata = source('agent-map-node-metadata.ts')

--- a/src/renderer/src/components/dashboard-popout/agent-map.css
+++ b/src/renderer/src/components/dashboard-popout/agent-map.css
@@ -458,19 +458,6 @@
   pointer-events: none;
 }
 
-.agent-map-agent-question-icon > div {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-}
-
-.agent-map-agent-question-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 .agent-map-aggregate-node circle {
   fill: color-mix(in srgb, var(--muted-foreground) 12%, var(--card));
   stroke: color-mix(in srgb, var(--muted-foreground) 46%, transparent);

--- a/src/renderer/src/components/dashboard-popout/agent-map.css
+++ b/src/renderer/src/components/dashboard-popout/agent-map.css
@@ -153,7 +153,7 @@
 }
 
 .agent-map-worktree-status-glow.fleet-status-waiting {
-  stroke: color-mix(in srgb, var(--color-amber-500) 28%, transparent);
+  stroke: color-mix(in srgb, var(--agent-question) 32%, transparent);
 }
 
 .agent-map-worktree-status-glow.fleet-status-working {
@@ -199,7 +199,7 @@
 }
 
 .agent-map-worktree-ring.is-waiting {
-  stroke: var(--color-amber-500);
+  stroke: var(--agent-question);
 }
 
 .agent-map-worktree-ring.is-blocked {
@@ -366,7 +366,7 @@
 }
 
 .agent-map-agent-status-glow.fleet-status-waiting {
-  stroke: color-mix(in srgb, var(--color-amber-500) 42%, transparent);
+  stroke: color-mix(in srgb, var(--agent-question) 48%, transparent);
 }
 
 .agent-map-agent-status-glow.fleet-status-blocked {
@@ -418,7 +418,7 @@
 }
 
 .fleet-status-waiting .agent-map-agent-mark {
-  stroke: var(--color-amber-500);
+  stroke: var(--agent-question);
 }
 
 /* Unread: filled core. Fill survives zoom-out further than a halo does, and it is the
@@ -443,6 +443,32 @@
   pointer-events: none;
   stroke: var(--background);
   stroke-width: 2;
+}
+
+/* Shape cue for 'waiting': hue alone can't carry it at low zoom or for
+   red-green CVD, where orange and blocked-red converge. */
+.agent-map-agent-question-backdrop {
+  fill: var(--background);
+  pointer-events: none;
+  stroke: none;
+}
+
+.agent-map-agent-question-icon {
+  overflow: visible;
+  pointer-events: none;
+}
+
+.agent-map-agent-question-icon > div {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.agent-map-agent-question-icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .agent-map-aggregate-node circle {
@@ -482,8 +508,8 @@
 }
 
 .agent-map-legend-dot.fleet-status-waiting {
-  background: var(--color-amber-500);
-  box-shadow: 0 0 4px color-mix(in srgb, var(--color-amber-500) 72%, transparent);
+  background: var(--agent-question);
+  box-shadow: 0 0 4px color-mix(in srgb, var(--agent-question) 72%, transparent);
   opacity: 1;
 }
 

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -247,13 +247,14 @@ describe('DashboardAgentRow', () => {
     expect(classes.every((className) => !/\bgroup-hover:/.test(className))).toBe(true)
   })
 
-  it('renders waiting rows with the amber question glyph', () => {
+  it('renders waiting rows with the shared question glyph', () => {
     const markup = renderRow(makeAgent({}, { state: 'waiting' }))
     const tokens = classTokens(markup)
 
     expect(markup).toContain('aria-label="Waiting for input"')
     expect(markup).toContain('lucide-message-circle-question-mark')
-    expect(tokens).toContain('text-amber-500')
+    expect(tokens).toContain('text-agent-question')
+    expect(tokens).not.toContain('text-amber-500')
     expect(tokens).not.toContain('bg-red-500')
   })
 

--- a/src/renderer/src/components/sidebar/AgentDashboardSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/AgentDashboardSidebarEntry.tsx
@@ -1,6 +1,7 @@
-import { LayoutDashboard, MessageCircleQuestion } from 'lucide-react'
+import { LayoutDashboard } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
+import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { DASHBOARD_BUCKET_ORDER, type DashboardBucket } from '../../../../shared/dashboard-snapshot'
 import { useAgentBucketCounts } from '@/components/dashboard/useAgentBucketCounts'
 import { translate } from '@/i18n/i18n'
@@ -46,7 +47,7 @@ function DashboardBucketCounts({
           className="inline-flex items-center gap-1 text-[10px] tabular-nums text-worktree-sidebar-foreground/55"
         >
           {bucket === 'attention' ? (
-            <MessageCircleQuestion className="size-2.5 text-amber-500" aria-hidden />
+            <AgentQuestionIcon className="size-2.5" />
           ) : (
             <span className={cn('size-1.5 rounded-full', DASHBOARD_BUCKET_DOT_CLASS[bucket])} />
           )}

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -31,12 +31,12 @@ describe('StatusIndicator', () => {
     expect(markup).toContain('motion-reduce:border-t-yellow-500')
   })
 
-  it('renders permission as an amber question glyph', () => {
+  it('renders permission as the shared question glyph', () => {
     const markup = renderMarkup('permission')
 
     expect(markup).toContain('lucide-message-circle-question-mark')
-    expect(markup).toContain('text-amber-500')
-    expect(markup).not.toContain('bg-amber-500')
+    expect(markup).toContain('text-agent-question')
+    expect(markup).not.toContain('text-amber-500')
     expect(markup).not.toContain('data-agent-spinner')
   })
 

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { MessageCircleQuestion } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { AgentQuestionIcon } from '@/components/AgentQuestionIcon'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
 
@@ -47,7 +47,7 @@ const StatusIndicator = React.memo(function StatusIndicator({
         title={resolvedTitle}
         {...rest}
       >
-        <MessageCircleQuestion className="size-3 text-amber-500" aria-hidden="true" />
+        <AgentQuestionIcon className="size-3" />
       </span>
     )
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -127,7 +127,7 @@ describe('WorktreeCardStatusSlot', () => {
 
     expect(markup).toContain('Needs permission · Unread')
     expect(markup).toContain('lucide-message-circle-question-mark')
-    expect(markup).toContain('text-amber-500')
+    expect(markup).toContain('text-agent-question')
     expect(markup).not.toContain('data-worktree-status-lane-unread=""')
     expect(markup).not.toContain('data-worktree-unread-alert=""')
     expect(markup).not.toContain('aria-label="Mark as read"')
@@ -380,7 +380,7 @@ describe('WorktreeCardStatusSlot', () => {
 
     expect(markup).toContain('Needs permission')
     expect(markup).toContain('lucide-message-circle-question-mark')
-    expect(markup).toContain('text-amber-500')
+    expect(markup).toContain('text-agent-question')
     expect(markup).not.toContain('PR checks: Failed')
   })
 

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
@@ -36,12 +36,12 @@ describe('TerminalTabLeadingIcon', () => {
     expect(markup).toContain('data-agent-icon="codex"')
   })
 
-  it('shows a needs-input (permission) state as an amber question glyph', () => {
+  it('shows a needs-input (permission) state as the shared question glyph', () => {
     const markup = renderStatus('permission')
 
     expect(markup).toContain('data-agent-activity-status="permission"')
     expect(markup).toContain('lucide-message-circle-question-mark')
-    expect(markup).toContain('text-amber-500')
+    expect(markup).toContain('text-agent-question')
     expect(markup).not.toContain('bg-red-500')
   })
 


### PR DESCRIPTION
## ELI5

When an agent is busy it glows yellow. When it stops and asks you a question it glowed amber — a colour so close to yellow that on the agent map you couldn't tell "leave it alone" from "it needs you". Questions are now orange with a `?` badge, and every part of the app that shows "this agent is asking you something" uses that same one colour and icon.

## What Changed

**The map (the reported problem)**

- `waiting` moves from `--color-amber-500` to orange on all four map surfaces: the agent halo (42% → 48%), the worktree halo (28% → 32%), the worktree ring stroke, and the agent mark stroke.
- Waiting agent nodes get a question badge — the same `MessageCircleQuestion` glyph used elsewhere — mirrored across the node from the unread pip so the two never stack. It scales on the existing `agentMapAttentionMarkerScale` curve, so it stays readable when you zoom out.
- `working` (yellow-500) and `blocked` (red-500) are unchanged.

**One vocabulary instead of four copies**

- New token `--agent-question` (orange-600 light / orange-500 dark) + `--agent-question-text` (orange-700 light / orange-300 dark, for glyphs and text on a tinted question surface), both exposed through `@theme inline` as `text-agent-question`, `bg-agent-question/15`, `ring-agent-question/25`.
- New `AgentQuestionIcon` — one icon, one token, callers pass only sizing.

| Surface | Before | After |
| --- | --- | --- |
| `AgentStateDot` — sidebar agent rows, terminal tabs, kanban, toolbar filter, cmd-J palette | hand-rolled amber icon | `AgentQuestionIcon` |
| `StatusIndicator` — left worktree sidebar card | hand-rolled amber icon | `AgentQuestionIcon` |
| `AgentDashboardSidebarEntry` — attention bucket count | hand-rolled amber icon | `AgentQuestionIcon` |
| `AgentKanbanCard` — ask callout + "needs you" card tint | `amber-500` tints, `text-amber-600 dark:text-amber-400` | question tokens (the dark-mode fork is no longer needed) |
| Agent map | amber, no glyph | same glyph, same token |

`AgentStateDot` was already the hub for most surfaces, so only three places were genuinely hand-rolled.

**Deliberately left amber:** the unread bell/pip in `WorktreeCardStatusSlot`, `TerminalTabLeadingIcon` and the map. "New output you haven't seen" is a different state from "needs an answer", and they now read as different colours instead of the same amber. `workspace-status.ts`'s amber is a user-pickable workspace label colour and is also untouched.

## Why

On the map both states rendered as identical solid halo rings, so hue was the *only* cue — and `yellow-500` (86°) and `amber-500` (70°) are 16° apart in OKLCH. Light mode uses orange-600 so the question glyph clears the 3:1 non-text contrast floor on white (3.58:1); dark mode keeps orange-500 (6.86:1). The orange state is darker and more saturated than the prior amber, so it separates from working-yellow on lightness and chroma too.

Hue alone isn't enough, though: pushing toward red means question and blocked converge under red–green CVD (yellow/amber collapse there today too, so this isn't a regression — but it's why the badge matters). Every other surface already distinguished the states by *shape* — spinner vs question glyph — and the map had simply dropped that cue. The badge restores it, so the state survives low zoom and CVD.

The token exists so this can't drift apart again: the map paints `--agent-question` from CSS and every React surface reads the same token through `AgentQuestionIcon`.

## Linked Issue

None — direct request from @brennanbenson in-session ("Agent map view in agent dashboard popout … the colors are too close", then "we should be using the same icon/color for all of them, also on regular left worktree sidebar").

Fixes #

## Visual Proof

Captured from the real app (Electron dev build on this branch, driven over CDP) with a simulated fleet of 10 agents across 4 workspaces. Before/after are the same window size, same simulated data — only the branch code differs.

### Agent map — the reported problem

Before, `working` and `waiting` are both yellow-ish and there is no way to tell "busy" from "asking you something". After, waiting is orange and carries the `?` glyph.

| Before | After |
| --- | --- |
| <img width="840" src="https://github.com/user-attachments/assets/d8ae9bde-4014-4926-bf1b-6ede7bcffd7b" /> | <img width="840" src="https://github.com/user-attachments/assets/0c8bb44e-f04b-4a42-8ed5-6a4b72cb9481" /> |

### Kanban board — card tint + ask callout

| Before | After |
| --- | --- |
| <img width="840" src="https://github.com/user-attachments/assets/3a9d8ebf-e3f8-4cf4-b613-1649838c440e" /> | <img width="840" src="https://github.com/user-attachments/assets/7db6824b-40aa-4882-9a5f-b91d669fbf5c" /> |

### Left worktree sidebar

Two workspaces are waiting on the user (`remote-wire-compat`, `agent-map-status-color`) and one is working (`mobile-ime`). Note the Agent Dashboard entry at the top too — its attention count glyph moves with the same token.

| Before | After |
| --- | --- |
| <img width="840" src="https://github.com/user-attachments/assets/fd0f2529-4396-4322-af18-c65739b744c6" /> | <img width="840" src="https://github.com/user-attachments/assets/19d80902-fe2b-4ec6-9da3-7c2cd7960622" /> |

**Honest caveat on the map:** the amber *unread* pip and the orange *question* badge sit on the same node and, at 100% map zoom, are closer in hue than I would like. They are semantically different states and the badge shape disambiguates, but if a reviewer prefers, the unread pip could move to a cooler hue in a follow-up.

## Testing

- [x] I manually tested these changes locally — real Electron dev build, macOS, simulated agent fleet; see Visual Proof.
- [x] Automated tests added/updated, or explained why not below

- `AgentMapStatusGlow.test.tsx`: new cases asserting the badge renders for `waiting` and not for `working`/`blocked`, that it uses the shared glyph rather than a map-local invention, and that it stays clear of the unread pip.
- Updated the six existing assertions that pinned the question glyph to `text-amber-500` (`AgentStateDot`, `StatusIndicator`, `TerminalTabLeadingIcon`, `WorktreeCardStatusSlot` ×2, `AgentKanbanCard`). Those six were the *only* failures after the change — the unread-amber assertions in those same files kept passing, which is decent evidence the split landed where intended.
- Verified the new utilities actually compile (`text-agent-question`, `text-agent-question-text`, `bg-agent-question/15`, `ring-agent-question/25`) by running Tailwind against the real `main.css` — a missing `@theme` entry would have silently left the icons inheriting their parent's colour instead of erroring.
- `AgentStateDot.test.ts` pins the accessible light/dark question-token shades.
- `agent-map-glow.performance.test.ts` still passes: 8 glow rules, no `filter:` / `animation:` / `transition:`. Everything added is static paint, so no new compositor work per node.
- Renderer suite: **311 files / 2775 tests pass**. `pnpm typecheck` (web project), `oxlint`, `oxfmt` and React Doctor changed-lines all clean. Platform tested: macOS.

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform:** CSS tokens and an SVG/lucide glyph only — no shortcuts, paths, shell or platform branches. Renders identically on macOS/Linux/Windows.
- **Remote SSH:** presentation-only; no wire format, RPC param, stream opcode or published host content changes, so mixed client/host versions are unaffected.
- **Mobile:** no mobile surface touched. `mobile/`'s amber references are transport-connection state, not agent question state — checked, nothing to unify there.
- **Performance:** the map's per-node glow boundary is preserved (no filters/animations/transitions). The badge adds one `<circle>` + one `foreignObject` per *waiting* agent only — the same pattern the node already uses for its provider icon, and waiting nodes are a small minority.
- **Backwards compatibility:** no persisted state, settings or snapshot schema touched.
- **Security:** no new input handling, IPC, network or filesystem access.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint/typecheck/renderer tests run locally; full `pnpm build` left to CI

## Author

- X / Twitter: @BrennanKB5
