### PR TITLE
fix(codex): enforce one bounded structured writer

### DIFF
--- a/src/main/codex/codex-structured-change-metadata.ts
+++ b/src/main/codex/codex-structured-change-metadata.ts
@@ -1,0 +1,170 @@
+import type { JsonValue as CodexStructuredJsonValue } from '../../shared/ephemeral-vm-recipes'
+
+const MAX_CHANGE_KIND_DEPTH = 32
+const MAX_CHANGE_KIND_NODES = 16_384
+const MAX_CHANGE_KIND_ENCODED_BYTES = 2 * 1024 * 1024
+const NOT_SCALAR = Symbol('not-scalar')
+
+type VisitTask = {
+  type: 'visit'
+  input: unknown
+  depth: number
+  assign: (value: CodexStructuredJsonValue) => void
+}
+
+type ExitTask = { type: 'exit'; input: object }
+
+export function normalizeCodexFileChangeKind(
+  input: unknown
+): { value: CodexStructuredJsonValue; encodedBytes: number } | null {
+  let root: CodexStructuredJsonValue | undefined
+  let encodedBytes = 0
+  let reservedNodes = 1
+  const active = new WeakSet<object>()
+  const tasks: (VisitTask | ExitTask)[] = [
+    { type: 'visit', input, depth: 0, assign: (value) => (root = value) }
+  ]
+  while (tasks.length > 0) {
+    const task = tasks.pop()!
+    if (task.type === 'exit') {
+      active.delete(task.input)
+      continue
+    }
+    if (task.depth > MAX_CHANGE_KIND_DEPTH) {
+      return null
+    }
+    const scalar = normalizedScalar(task.input)
+    if (scalar !== NOT_SCALAR) {
+      if (typeof scalar === 'string' && Buffer.byteLength(scalar) > MAX_CHANGE_KIND_ENCODED_BYTES) {
+        return null
+      }
+      encodedBytes += Buffer.byteLength(JSON.stringify(scalar))
+      if (encodedBytes > MAX_CHANGE_KIND_ENCODED_BYTES) {
+        return null
+      }
+      task.assign(scalar)
+      continue
+    }
+    if (typeof task.input !== 'object' || task.input === null || active.has(task.input)) {
+      return null
+    }
+    const source = task.input
+    active.add(source)
+    tasks.push({ type: 'exit', input: source })
+    const addBytes = (bytes: number): boolean => {
+      encodedBytes += bytes
+      return encodedBytes <= MAX_CHANGE_KIND_ENCODED_BYTES
+    }
+    const reserveNodes = (count: number): boolean => {
+      if (count > MAX_CHANGE_KIND_NODES - reservedNodes) {
+        return false
+      }
+      reservedNodes += count
+      return true
+    }
+    const accepted = Array.isArray(source)
+      ? visitArray(source, task, tasks, addBytes, reserveNodes)
+      : visitRecord(source, task, tasks, addBytes, reserveNodes)
+    if (!accepted) {
+      return null
+    }
+  }
+  return root === undefined ? null : { value: root, encodedBytes }
+}
+
+function visitArray(
+  source: unknown[],
+  task: VisitTask,
+  tasks: (VisitTask | ExitTask)[],
+  addBytes: (bytes: number) => boolean,
+  reserveNodes: (count: number) => boolean
+): boolean {
+  if (!reserveNodes(source.length)) {
+    return false
+  }
+  const keys = Reflect.ownKeys(source)
+  if (
+    keys.length !== source.length + 1 ||
+    keys.some((key) =>
+      typeof key === 'symbol'
+        ? true
+        : key !== 'length' && (!/^(0|[1-9]\d*)$/.test(key) || Number(key) >= source.length)
+    )
+  ) {
+    return false
+  }
+  const output: CodexStructuredJsonValue[] = []
+  output.length = source.length
+  if (!addBytes(2 + Math.max(0, source.length - 1))) {
+    return false
+  }
+  task.assign(output)
+  for (let index = source.length - 1; index >= 0; index -= 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, String(index))
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+      return false
+    }
+    tasks.push({
+      type: 'visit',
+      input: descriptor.value,
+      depth: task.depth + 1,
+      assign: (value) => (output[index] = value)
+    })
+  }
+  return true
+}
+
+function visitRecord(
+  source: object,
+  task: VisitTask,
+  tasks: (VisitTask | ExitTask)[],
+  addBytes: (bytes: number) => boolean,
+  reserveNodes: (count: number) => boolean
+): boolean {
+  const prototype = Object.getPrototypeOf(source)
+  if (prototype !== Object.prototype && prototype !== null) {
+    return false
+  }
+  const keys = Reflect.ownKeys(source)
+  if (!reserveNodes(keys.length) || keys.some((key) => typeof key === 'symbol')) {
+    return false
+  }
+  const output: Record<string, CodexStructuredJsonValue> = {}
+  if (!addBytes(2 + Math.max(0, keys.length - 1))) {
+    return false
+  }
+  task.assign(output)
+  for (let index = keys.length - 1; index >= 0; index -= 1) {
+    const key = keys[index] as string
+    const descriptor = Object.getOwnPropertyDescriptor(source, key)
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+      return false
+    }
+    if (Buffer.byteLength(key) > MAX_CHANGE_KIND_ENCODED_BYTES) {
+      return false
+    }
+    if (!addBytes(Buffer.byteLength(JSON.stringify(key)) + 1)) {
+      return false
+    }
+    Object.defineProperty(output, key, {
+      value: null,
+      writable: true,
+      enumerable: true,
+      configurable: true
+    })
+    tasks.push({
+      type: 'visit',
+      input: descriptor.value,
+      depth: task.depth + 1,
+      assign: (value) => (output[key] = value)
+    })
+  }
+  return true
+}
+
+function normalizedScalar(value: unknown): null | boolean | number | string | typeof NOT_SCALAR {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    return value
+  }
+  return typeof value === 'number' && Number.isFinite(value) ? value : NOT_SCALAR
+}

--- a/src/main/codex/codex-structured-file-change-start.ts
+++ b/src/main/codex/codex-structured-file-change-start.ts
@@ -1,0 +1,64 @@
+import { digestStructuredValue } from './codex-structured-write-digest'
+import { parseFileChanges } from './codex-structured-write-manifest'
+import type {
+  CodexObservedFileChange,
+  CodexStructuredWriteLease
+} from './codex-structured-write-types'
+import { structuredWriteItemKey } from './codex-structured-write-turn-lifecycle'
+
+export function observeStructuredFileChangeStart(input: {
+  sessionId: string
+  params: unknown
+  lease: CodexStructuredWriteLease | undefined
+  fileChanges: Map<string, CodexObservedFileChange>
+}): CodexObservedFileChange | null {
+  const record = asRecord(input.params)
+  const item = asRecord(record.item)
+  if (item.type !== 'fileChange' || typeof item.id !== 'string') {
+    return null
+  }
+  const threadId = readString(record, 'threadId')
+  const turnId = readString(record, 'turnId')
+  const changes = parseFileChanges(item.changes)
+  if (!threadId || !turnId || !changes) {
+    return null
+  }
+  const key = structuredWriteItemKey(input.sessionId, item.id)
+  const changePlanDigest = digestStructuredValue(changes)
+  const existing = input.fileChanges.get(key)
+  if (existing) {
+    return existing.threadId === threadId &&
+      existing.turnId === turnId &&
+      existing.changePlanDigest === changePlanDigest
+      ? null
+      : existing
+  }
+  if (
+    !input.lease ||
+    input.lease.state !== 'issued' ||
+    input.lease.threadId !== threadId ||
+    input.lease.turnId !== turnId
+  ) {
+    return null
+  }
+  input.fileChanges.set(key, {
+    sessionId: input.sessionId,
+    threadId,
+    turnId,
+    itemId: item.id,
+    changes,
+    changePlanDigest,
+    before: null,
+    admission: null
+  })
+  return null
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}

--- a/src/main/codex/codex-structured-home-isolation.test.ts
+++ b/src/main/codex/codex-structured-home-isolation.test.ts
@@ -1,0 +1,88 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CodexStructuredHomeIsolation } from './codex-structured-home-isolation'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function fixture(): { root: string; source: string; isolated: string } {
+  const root = mkdtempSync(join(tmpdir(), 'orca-codex-home-'))
+  roots.push(root)
+  const source = join(root, 'source')
+  const isolated = join(root, 'isolated')
+  mkdirSync(source, { recursive: true })
+  writeFileSync(join(source, 'auth.json'), '{"token":"secret"}', { mode: 0o600 })
+  writeFileSync(join(source, 'config.toml'), '[mcp_servers.unsafe]\ncommand = "bad"\n')
+  mkdirSync(join(source, 'skills'), { recursive: true })
+  writeFileSync(join(source, 'skills', 'unsafe.md'), 'do not copy')
+  return { root, source, isolated }
+}
+
+describe('CodexStructuredHomeIsolation', () => {
+  it('copies only credentials and writes a minimal deny-all config with private modes', async () => {
+    const { source, isolated } = fixture()
+    const homes = await CodexStructuredHomeIsolation.open(isolated)
+    const home = await homes.prepare('session-1', source)
+
+    expect(readFileSync(join(home, 'auth.json'), 'utf8')).toBe('{"token":"secret"}')
+    expect(readFileSync(join(home, 'config.toml'), 'utf8')).toBe(
+      'web_search = "disabled"\nmcp_servers = {}\n'
+    )
+    expect(existsSync(join(home, 'skills'))).toBe(false)
+    expect(lstatSync(home).mode & 0o777).toBe(0o700)
+    expect(lstatSync(join(home, 'auth.json')).mode & 0o777).toBe(0o600)
+    expect(lstatSync(join(home, 'config.toml')).mode & 0o777).toBe(0o600)
+
+    await homes.release('session-1', home)
+    expect(existsSync(home)).toBe(false)
+  })
+
+  it('does not remove another process home and rejects a symlinked auth source', async () => {
+    const { root, source, isolated } = fixture()
+    mkdirSync(isolated, { recursive: true })
+    writeFileSync(join(isolated, 'stale-secret'), 'stale')
+    const staleProcessHome = join(isolated, 'process-99999999-stale')
+    const liveProcessHome = join(isolated, `process-${process.pid}-live`)
+    mkdirSync(staleProcessHome)
+    mkdirSync(liveProcessHome)
+    const homes = await CodexStructuredHomeIsolation.open(isolated)
+    expect(existsSync(join(isolated, 'stale-secret'))).toBe(true)
+    expect(existsSync(staleProcessHome)).toBe(false)
+    expect(existsSync(liveProcessHome)).toBe(true)
+
+    rmSync(join(source, 'auth.json'))
+    const outside = join(root, 'outside-auth.json')
+    writeFileSync(outside, '{"token":"outside"}')
+    const { symlinkSync } = await import('node:fs')
+    symlinkSync(outside, join(source, 'auth.json'))
+    await expect(homes.prepare('session-1', source)).rejects.toThrow('regular file')
+  })
+
+  it('does not let an older release remove a newer session home', async () => {
+    const { source, isolated } = fixture()
+    const homes = await CodexStructuredHomeIsolation.open(isolated)
+    const oldHome = await homes.prepare('session-1', source)
+    const newHome = await homes.prepare('session-1', source)
+
+    await homes.release('session-1', oldHome)
+    expect(existsSync(newHome)).toBe(true)
+    await homes.release('session-1', newHome)
+    expect(existsSync(newHome)).toBe(false)
+  })
+})

--- a/src/main/codex/codex-structured-home-isolation.ts
+++ b/src/main/codex/codex-structured-home-isolation.ts
@@ -1,0 +1,148 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { constants } from 'node:fs'
+import {
+  mkdir,
+  mkdtemp,
+  open as openFile,
+  readdir,
+  realpath,
+  rm,
+  writeFile
+} from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+const AUTH_FILE = 'auth.json'
+const CONFIG_FILE = 'config.toml'
+const MAX_AUTH_BYTES = 1024 * 1024
+const STRUCTURED_WRITER_CONFIG = 'web_search = "disabled"\nmcp_servers = {}\n'
+
+type HomeGeneration = { generation: number; path: string | null }
+
+/**
+ * Builds a credential-only Codex home for one App Server child. User config,
+ * plugins, skills, hooks, memories, and MCP definitions never cross into it.
+ */
+export class CodexStructuredHomeIsolation {
+  private readonly homes = new Map<string, HomeGeneration>()
+  private readonly issuedHomes = new Set<string>()
+
+  private constructor(private readonly root: string) {}
+
+  static async open(parent: string): Promise<CodexStructuredHomeIsolation> {
+    await mkdir(parent, { recursive: true, mode: 0o700 })
+    const canonicalParent = await realpath(parent)
+    await removeStaleProcessHomes(canonicalParent)
+    const root = await mkdtemp(join(canonicalParent, `process-${process.pid}-`))
+    return new CodexStructuredHomeIsolation(await realpath(root))
+  }
+
+  async prepare(sessionId: string, sourceHome: string): Promise<string> {
+    const generation = (this.homes.get(sessionId)?.generation ?? 0) + 1
+    this.homes.set(sessionId, { generation, path: null })
+    let auth: Buffer | null = null
+    let isolatedHome: string | null = null
+    try {
+      auth = await readAuthentication(sourceHome)
+      const prefix = `${sha256(sessionId).slice(0, 16)}-${randomBytes(8).toString('hex')}-`
+      isolatedHome = await mkdtemp(join(this.root, prefix))
+      this.issuedHomes.add(isolatedHome)
+      await writeFile(join(isolatedHome, AUTH_FILE), auth, { flag: 'wx', mode: 0o600 })
+      await writeFile(join(isolatedHome, CONFIG_FILE), STRUCTURED_WRITER_CONFIG, {
+        flag: 'wx',
+        mode: 0o600
+      })
+      const current = this.homes.get(sessionId)
+      if (!current || current.generation !== generation) {
+        throw new Error('structured Codex home preparation was superseded')
+      }
+      current.path = isolatedHome
+      return isolatedHome
+    } catch (error) {
+      if (isolatedHome) {
+        this.issuedHomes.delete(isolatedHome)
+        await rm(isolatedHome, { recursive: true, force: true })
+      }
+      if (this.homes.get(sessionId)?.generation === generation) {
+        this.homes.delete(sessionId)
+      }
+      throw error
+    } finally {
+      auth?.fill(0)
+    }
+  }
+
+  async release(sessionId: string, isolatedHome: string): Promise<void> {
+    if (!this.issuedHomes.delete(isolatedHome)) {
+      return
+    }
+    if (dirname(isolatedHome) !== this.root) {
+      throw new Error('structured Codex home release escaped the isolation root')
+    }
+    const current = this.homes.get(sessionId)
+    if (current?.path === isolatedHome) {
+      this.homes.delete(sessionId)
+    }
+    await rm(isolatedHome, { recursive: true, force: true })
+  }
+
+  async close(): Promise<void> {
+    this.homes.clear()
+    this.issuedHomes.clear()
+    await rm(this.root, { recursive: true, force: true })
+  }
+}
+
+async function removeStaleProcessHomes(parent: string): Promise<void> {
+  const entries = await readdir(parent, { withFileTypes: true })
+  for (const entry of entries) {
+    const match = entry.isDirectory() ? /^process-(\d+)-/.exec(entry.name) : null
+    if (!match || isProcessAlive(Number(match[1]))) {
+      continue
+    }
+    await rm(join(parent, entry.name), { recursive: true, force: true })
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return true
+  }
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function readAuthentication(sourceHome: string): Promise<Buffer> {
+  const sourceRoot = await realpath(sourceHome)
+  const sourceAuth = join(sourceRoot, AUTH_FILE)
+  let handle
+  try {
+    handle = await openFile(sourceAuth, constants.O_RDONLY | constants.O_NOFOLLOW)
+  } catch (cause) {
+    throw new Error('structured Codex authentication source is not a regular file', { cause })
+  }
+  try {
+    const metadata = await handle.stat()
+    if (!metadata.isFile()) {
+      throw new Error('structured Codex authentication source is not a regular file')
+    }
+    if (metadata.size <= 0 || metadata.size > MAX_AUTH_BYTES) {
+      throw new Error('structured Codex authentication source has an invalid size')
+    }
+    const auth = await handle.readFile()
+    if (auth.length <= 0 || auth.length > MAX_AUTH_BYTES) {
+      auth.fill(0)
+      throw new Error('structured Codex authentication source changed to an invalid size')
+    }
+    return auth
+  } finally {
+    await handle.close()
+  }
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}

--- a/src/main/codex/codex-structured-launch-resolution.test.ts
+++ b/src/main/codex/codex-structured-launch-resolution.test.ts
@@ -27,12 +27,21 @@ function record(overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord
 
 function resolverFor(
   value: AgentSessionRecord | null,
-  resolveWorkspacePath: (workspaceId: string) => Promise<string> = async (id) => `/repos/${id}`
+  resolveWorkspacePath: (workspaceId: string) => Promise<string> = async (id) => `/repos/${id}`,
+  localStructuredWriteOnly = false
 ) {
   return createCodexStructuredLaunchResolver({
     store: { getRecord: () => value } as unknown as AgentSessionRecordStore,
     resolveWorkspacePath,
-    resolveCommand: () => '/usr/local/bin/codex'
+    resolveCommand: () => '/usr/local/bin/codex',
+    canonicalizePath: async (path) => path,
+    localStructuredWriteOnly,
+    ...(localStructuredWriteOnly
+      ? {
+          resolveStructuredWriteSourceHome: async () => '/home/work/.codex',
+          prepareStructuredWriteHome: async (sessionId: string) => `/isolated-codex/${sessionId}`
+        }
+      : {})
   })
 }
 
@@ -60,6 +69,86 @@ describe('codex structured launch resolution', () => {
     )({ identity: IDENTITY })
 
     expect(launch.resumeThreadId).toBe('thread-current')
+  })
+
+  it('starts the opt-in writer with every other effect surface disabled', async () => {
+    const launch = await resolverFor(record(), undefined, true)({ identity: IDENTITY })
+
+    expect(launch.effectIsolation).toBe('local-structured-write')
+    expect(launch.codexHome).toBe('/isolated-codex/session-1')
+    expect(launch.isolatedHomePath).toBe('/isolated-codex/session-1')
+    expect(launch.args.at(-1)).toBe('app-server')
+    expect(launch.args).not.toContain('--dangerously-bypass-approvals-and-sandbox')
+    expect(launch.args).not.toContain('code_mode_host')
+    for (const feature of [
+      'apps',
+      'plugins',
+      'remote_plugin',
+      'computer_use',
+      'browser_use',
+      'in_app_browser',
+      'image_generation',
+      'artifact',
+      'multi_agent',
+      'code_mode',
+      'shell_tool',
+      'unified_exec',
+      'hooks',
+      'tool_suggest',
+      'skill_search',
+      'view_image',
+      'standalone_web_search'
+    ]) {
+      const index = launch.args.indexOf(feature)
+      expect(index).toBeGreaterThan(0)
+      expect(launch.args[index - 1]).toBe('--disable')
+    }
+  })
+
+  it('fails closed when writer isolation has no credential-home provider', async () => {
+    const resolver = createCodexStructuredLaunchResolver({
+      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      resolveWorkspacePath: async () => '/repos/workspace-1',
+      resolveCommand: () => '/usr/local/bin/codex',
+      localStructuredWriteOnly: true,
+      resolveStructuredWriteSourceHome: async () => '/home/work/.codex'
+    })
+
+    await expect(resolver({ identity: IDENTITY })).rejects.toThrow('isolated Codex home provider')
+  })
+
+  it('fails closed instead of resuming a thread with unknown prior effect isolation', async () => {
+    const existing = record({
+      providerHandleChain: [
+        { handle: { provider: 'codex', threadId: 'thread-existing' } }
+      ] as AgentSessionRecord['providerHandleChain']
+    })
+
+    await expect(resolverFor(existing, undefined, true)({ identity: IDENTITY })).rejects.toThrow(
+      'cannot resume a thread'
+    )
+  })
+
+  it('rejects a client-recorded credential path that differs from the host registry', async () => {
+    let prepared = false
+    const resolver = createCodexStructuredLaunchResolver({
+      store: {
+        getRecord: () =>
+          record({ accountHome: { variable: 'CODEX_HOME', path: '/client/selected/home' } })
+      } as unknown as AgentSessionRecordStore,
+      resolveWorkspacePath: async () => '/repos/workspace-1',
+      resolveCommand: () => '/usr/local/bin/codex',
+      canonicalizePath: async (path) => path,
+      localStructuredWriteOnly: true,
+      resolveStructuredWriteSourceHome: async () => '/host/registry/home',
+      prepareStructuredWriteHome: async () => {
+        prepared = true
+        return '/must-not-exist'
+      }
+    })
+
+    await expect(resolver({ identity: IDENTITY })).rejects.toThrow('host-owned credential source')
+    expect(prepared).toBe(false)
   })
 
   it('refuses a session pinned to another host rather than starting a second writer here', async () => {
@@ -105,5 +194,26 @@ describe('codex structured launch resolution', () => {
         throw new Error('workspace-1 is gone')
       })({ identity: IDENTITY })
     ).rejects.toThrow('workspace-1 is gone')
+  })
+
+  it('does not materialise credentials when the selected workspace is stale', async () => {
+    let prepared = false
+    const resolver = createCodexStructuredLaunchResolver({
+      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      resolveWorkspacePath: async () => {
+        throw new Error('workspace is stale')
+      },
+      resolveCommand: () => '/usr/local/bin/codex',
+      canonicalizePath: async (path) => path,
+      localStructuredWriteOnly: true,
+      resolveStructuredWriteSourceHome: async () => '/home/work/.codex',
+      prepareStructuredWriteHome: async () => {
+        prepared = true
+        return '/must-not-exist'
+      }
+    })
+
+    await expect(resolver({ identity: IDENTITY })).rejects.toThrow('workspace is stale')
+    expect(prepared).toBe(false)
   })
 })

--- a/src/main/codex/codex-structured-launch-resolution.test.ts
+++ b/src/main/codex/codex-structured-launch-resolution.test.ts
@@ -28,15 +28,15 @@ function record(overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord
 function resolverFor(
   value: AgentSessionRecord | null,
   resolveWorkspacePath: (workspaceId: string) => Promise<string> = async (id) => `/repos/${id}`,
-  localStructuredWriteOnly = false
+  structuredWriteEnabled = false
 ) {
   return createCodexStructuredLaunchResolver({
     store: { getRecord: () => value } as unknown as AgentSessionRecordStore,
     resolveWorkspacePath,
     resolveCommand: () => '/usr/local/bin/codex',
     canonicalizePath: async (path) => path,
-    localStructuredWriteOnly,
-    ...(localStructuredWriteOnly
+    structuredWriteEnabled,
+    ...(structuredWriteEnabled
       ? {
           resolveStructuredWriteSourceHome: async () => '/home/work/.codex',
           prepareStructuredWriteHome: async (sessionId: string) => `/isolated-codex/${sessionId}`
@@ -72,7 +72,11 @@ describe('codex structured launch resolution', () => {
   })
 
   it('starts the opt-in writer with every other effect surface disabled', async () => {
-    const launch = await resolverFor(record(), undefined, true)({ identity: IDENTITY })
+    const launch = await resolverFor(
+      record({ effectIsolation: 'local-structured-write' }),
+      undefined,
+      true
+    )({ identity: IDENTITY })
 
     expect(launch.effectIsolation).toBe('local-structured-write')
     expect(launch.codexHome).toBe('/isolated-codex/session-1')
@@ -105,28 +109,36 @@ describe('codex structured launch resolution', () => {
     }
   })
 
+  it('fails closed when a writer record reaches a host without writer support', async () => {
+    await expect(
+      resolverFor(record({ effectIsolation: 'local-structured-write' }))({ identity: IDENTITY })
+    ).rejects.toThrow('not enabled on this execution host')
+  })
+
   it('fails closed when writer isolation has no credential-home provider', async () => {
     const resolver = createCodexStructuredLaunchResolver({
-      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      store: {
+        getRecord: () => record({ effectIsolation: 'local-structured-write' })
+      } as unknown as AgentSessionRecordStore,
       resolveWorkspacePath: async () => '/repos/workspace-1',
       resolveCommand: () => '/usr/local/bin/codex',
-      localStructuredWriteOnly: true,
+      structuredWriteEnabled: true,
       resolveStructuredWriteSourceHome: async () => '/home/work/.codex'
     })
 
     await expect(resolver({ identity: IDENTITY })).rejects.toThrow('isolated Codex home provider')
   })
 
-  it('fails closed instead of resuming a thread with unknown prior effect isolation', async () => {
+  it('does not isolate a normal session merely because writer support is enabled', async () => {
     const existing = record({
       providerHandleChain: [
         { handle: { provider: 'codex', threadId: 'thread-existing' } }
       ] as AgentSessionRecord['providerHandleChain']
     })
 
-    await expect(resolverFor(existing, undefined, true)({ identity: IDENTITY })).rejects.toThrow(
-      'cannot resume a thread'
-    )
+    const launch = await resolverFor(existing, undefined, true)({ identity: IDENTITY })
+    expect(launch).toMatchObject({ args: ['app-server'], resumeThreadId: 'thread-existing' })
+    expect(launch).not.toHaveProperty('effectIsolation')
   })
 
   it('rejects a client-recorded credential path that differs from the host registry', async () => {
@@ -134,12 +146,15 @@ describe('codex structured launch resolution', () => {
     const resolver = createCodexStructuredLaunchResolver({
       store: {
         getRecord: () =>
-          record({ accountHome: { variable: 'CODEX_HOME', path: '/client/selected/home' } })
+          record({
+            accountHome: { variable: 'CODEX_HOME', path: '/client/selected/home' },
+            effectIsolation: 'local-structured-write'
+          })
       } as unknown as AgentSessionRecordStore,
       resolveWorkspacePath: async () => '/repos/workspace-1',
       resolveCommand: () => '/usr/local/bin/codex',
       canonicalizePath: async (path) => path,
-      localStructuredWriteOnly: true,
+      structuredWriteEnabled: true,
       resolveStructuredWriteSourceHome: async () => '/host/registry/home',
       prepareStructuredWriteHome: async () => {
         prepared = true
@@ -199,13 +214,15 @@ describe('codex structured launch resolution', () => {
   it('does not materialise credentials when the selected workspace is stale', async () => {
     let prepared = false
     const resolver = createCodexStructuredLaunchResolver({
-      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      store: {
+        getRecord: () => record({ effectIsolation: 'local-structured-write' })
+      } as unknown as AgentSessionRecordStore,
       resolveWorkspacePath: async () => {
         throw new Error('workspace is stale')
       },
       resolveCommand: () => '/usr/local/bin/codex',
       canonicalizePath: async (path) => path,
-      localStructuredWriteOnly: true,
+      structuredWriteEnabled: true,
       resolveStructuredWriteSourceHome: async () => '/home/work/.codex',
       prepareStructuredWriteHome: async () => {
         prepared = true

--- a/src/main/codex/codex-structured-launch-resolution.ts
+++ b/src/main/codex/codex-structured-launch-resolution.ts
@@ -84,7 +84,8 @@ export type CodexStructuredLaunchResolverDeps = {
   /** Overridden in tests; production scans PATH and version-manager dirs. */
   resolveCommand?: () => string
   canonicalizePath?: (path: string) => Promise<string>
-  localStructuredWriteOnly?: boolean
+  /** Enables records explicitly pinned to the local structured-writer boundary. */
+  structuredWriteEnabled?: boolean
   resolveStructuredWriteSourceHome?: (sessionId: string) => Promise<string> | string
   prepareStructuredWriteHome?: (sessionId: string, sourceHome: string) => Promise<string>
 }
@@ -113,7 +114,11 @@ export function createCodexStructuredLaunchResolver(
       throw new Error(`codex sessions pin CODEX_HOME, not ${accountHome.variable}`)
     }
     const command = (deps.resolveCommand ?? resolveCodexCommand)()
-    const appServerArgs = deps.localStructuredWriteOnly
+    const localStructuredWriteOnly = record.effectIsolation === 'local-structured-write'
+    if (localStructuredWriteOnly && !deps.structuredWriteEnabled) {
+      throw new Error('structured writer is not enabled on this execution host')
+    }
+    const appServerArgs = localStructuredWriteOnly
       ? [...CODEX_LOCAL_STRUCTURED_WRITE_ARGS]
       : CODEX_APP_SERVER_ARGS
     const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, appServerArgs)
@@ -121,12 +126,9 @@ export function createCodexStructuredLaunchResolver(
     // stale workspace must fail without leaving a secret-bearing temp home.
     const cwd = await deps.resolveWorkspacePath(location.workspaceId)
     const head = agentSessionProviderHandleChainHead(record.providerHandleChain)
-    if (deps.localStructuredWriteOnly && head) {
-      throw new Error('structured writer cannot resume a thread whose effect isolation is unknown')
-    }
     let codexHome = accountHome.path
     let isolatedHomePath: string | undefined
-    if (deps.localStructuredWriteOnly) {
+    if (localStructuredWriteOnly) {
       if (!deps.resolveStructuredWriteSourceHome) {
         throw new Error('structured writer has no host-owned credential source provider')
       }
@@ -150,7 +152,7 @@ export function createCodexStructuredLaunchResolver(
       // An empty chain is a session that has never proved a thread, so it
       // starts one; anything else resumes the last link this session proved.
       resumeThreadId: head?.handle.provider === 'codex' ? head.handle.threadId : null,
-      ...(deps.localStructuredWriteOnly
+      ...(localStructuredWriteOnly
         ? { effectIsolation: 'local-structured-write' as const, isolatedHomePath }
         : {})
     }

--- a/src/main/codex/codex-structured-launch-resolution.ts
+++ b/src/main/codex/codex-structured-launch-resolution.ts
@@ -7,6 +7,7 @@
 // for, which is how a resume becomes a fork wearing a resume's name.
 
 import type { AgentSessionJournalIdentity } from '../../shared/agent-session-journal-types'
+import { realpath } from 'node:fs/promises'
 import { agentSessionProviderHandleChainHead } from '../../shared/agent-session-provider-handle'
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { resolveCodexCommand } from '../codex-cli/command'
@@ -15,6 +16,65 @@ import { getSpawnArgsForWindows } from '../win32-utils'
 import type { CodexStructuredLaunch } from './codex-structured-session-adapter'
 
 const CODEX_APP_SERVER_ARGS = ['app-server']
+export const CODEX_LOCAL_STRUCTURED_WRITE_ARGS = [
+  '--disable',
+  'apps',
+  '--disable',
+  'plugins',
+  '--disable',
+  'remote_plugin',
+  '--disable',
+  'plugin_sharing',
+  '--disable',
+  'computer_use',
+  '--disable',
+  'browser_use',
+  '--disable',
+  'browser_use_external',
+  '--disable',
+  'browser_use_full_cdp_access',
+  '--disable',
+  'in_app_browser',
+  '--disable',
+  'image_generation',
+  '--disable',
+  'artifact',
+  '--disable',
+  'multi_agent',
+  '--disable',
+  'skill_mcp_dependency_install',
+  '--disable',
+  'shell_tool',
+  '--disable',
+  'unified_exec',
+  '--disable',
+  'shell_snapshot',
+  '--disable',
+  'hooks',
+  '--disable',
+  'tool_suggest',
+  '--disable',
+  'skill_search',
+  '--disable',
+  'view_image',
+  '--disable',
+  'workspace_dependencies',
+  '--disable',
+  'auth_elicitation',
+  '--disable',
+  'tool_call_mcp_elicitation',
+  '--disable',
+  'standalone_web_search',
+  '--disable',
+  'web_search_request',
+  '--disable',
+  'web_search_cached',
+  '--disable',
+  'code_mode',
+  '--disable',
+  'code_mode_only',
+  'app-server'
+] as const
 
 export type CodexStructuredLaunchResolverDeps = {
   store: AgentSessionRecordStore
@@ -23,6 +83,10 @@ export type CodexStructuredLaunchResolverDeps = {
   resolveWorkspacePath: (workspaceId: string) => Promise<string>
   /** Overridden in tests; production scans PATH and version-manager dirs. */
   resolveCommand?: () => string
+  canonicalizePath?: (path: string) => Promise<string>
+  localStructuredWriteOnly?: boolean
+  resolveStructuredWriteSourceHome?: (sessionId: string) => Promise<string> | string
+  prepareStructuredWriteHome?: (sessionId: string, sourceHome: string) => Promise<string>
 }
 
 export function createCodexStructuredLaunchResolver(
@@ -49,17 +113,46 @@ export function createCodexStructuredLaunchResolver(
       throw new Error(`codex sessions pin CODEX_HOME, not ${accountHome.variable}`)
     }
     const command = (deps.resolveCommand ?? resolveCodexCommand)()
-    const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, CODEX_APP_SERVER_ARGS)
+    const appServerArgs = deps.localStructuredWriteOnly
+      ? [...CODEX_LOCAL_STRUCTURED_WRITE_ARGS]
+      : CODEX_APP_SERVER_ARGS
+    const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, appServerArgs)
+    // Resolve the host-selected worktree before materialising credentials. A
+    // stale workspace must fail without leaving a secret-bearing temp home.
+    const cwd = await deps.resolveWorkspacePath(location.workspaceId)
     const head = agentSessionProviderHandleChainHead(record.providerHandleChain)
+    if (deps.localStructuredWriteOnly && head) {
+      throw new Error('structured writer cannot resume a thread whose effect isolation is unknown')
+    }
+    let codexHome = accountHome.path
+    let isolatedHomePath: string | undefined
+    if (deps.localStructuredWriteOnly) {
+      if (!deps.resolveStructuredWriteSourceHome) {
+        throw new Error('structured writer has no host-owned credential source provider')
+      }
+      if (!deps.prepareStructuredWriteHome) {
+        throw new Error('structured writer has no isolated Codex home provider')
+      }
+      const sourceHome = await deps.resolveStructuredWriteSourceHome(identity.sessionId)
+      const canonicalizePath = deps.canonicalizePath ?? realpath
+      if ((await canonicalizePath(sourceHome)) !== (await canonicalizePath(accountHome.path))) {
+        throw new Error('structured writer record does not match the host-owned credential source')
+      }
+      isolatedHomePath = await deps.prepareStructuredWriteHome(identity.sessionId, sourceHome)
+      codexHome = isolatedHomePath
+    }
     return {
       command: spawnCmd,
       args: spawnArgs,
-      cwd: await deps.resolveWorkspacePath(location.workspaceId),
-      codexHome: accountHome.path,
+      cwd,
+      codexHome,
       ...(record.launchEnv ? { env: { ...record.launchEnv } } : {}),
       // An empty chain is a session that has never proved a thread, so it
       // starts one; anything else resumes the last link this session proved.
-      resumeThreadId: head?.handle.provider === 'codex' ? head.handle.threadId : null
+      resumeThreadId: head?.handle.provider === 'codex' ? head.handle.threadId : null,
+      ...(deps.localStructuredWriteOnly
+        ? { effectIsolation: 'local-structured-write' as const, isolatedHomePath }
+        : {})
     }
   }
 }

--- a/src/main/codex/codex-structured-session-adapter.ts
+++ b/src/main/codex/codex-structured-session-adapter.ts
@@ -1,31 +1,18 @@
-import type {
-  AgentJournalMessageItem,
-  AgentSessionJournalIdentity
-} from '../../shared/agent-session-journal-types'
 import {
   AgentSessionPreSpawnError,
   type AgentSessionAcquisition,
-  type AgentSessionDispatchOutcome,
   type StructuredAgentSessionAcquireInput,
-  type StructuredAgentSessionAdapter,
-  type StructuredAgentSessionSetOptionInput
+  type StructuredAgentSessionAdapter
 } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import { createCodexJournalTranslator } from './codex-structured-journal-translation'
-import {
-  isCodexAppServerRequestError,
-  openCodexAppServerConnection
-} from './codex-app-server-connection'
-import { isCodexAppServerUnsupportedError } from './codex-app-server-session'
+import { openCodexAppServerConnection } from './codex-app-server-connection'
 import { codexProcessIdentity, codexProviderHandleLink } from './codex-structured-owner-identity'
 import { buildCodexStructuredChildEnvironment } from './codex-structured-child-environment'
-import { answerCodexPrompt } from './codex-structured-prompt-replies'
 import { openCodexThread } from './codex-structured-thread-open'
-import { dispatchCodexTurn, isCodexTurnOptionKey } from './codex-structured-turn-start'
 import { supportsCodexStructuredLocation } from './codex-structured-location-support'
 import { closeCodexPublishedSession } from './codex-structured-session-close'
+import { CodexStructuredSessionControl } from './codex-structured-session-control'
 import {
-  applyCodexStructuredSessionOption,
-  readLiveCodexSessionOptions,
   reportedCodexThreadOptions,
   restoredCodexSessionOptions
 } from './codex-structured-session-options'
@@ -34,14 +21,8 @@ import {
   CodexAcquisitionRegistry,
   type CodexAcquisitionAttempt,
   type CodexSession,
-  type CodexStructuredSessionAdapterDeps,
-  type CodexStructuredSessionEvent
+  type CodexStructuredSessionAdapterDeps
 } from './codex-structured-session-state'
-import {
-  deliverCodexNotification,
-  deliverCodexServerRequest,
-  deliverCodexUnhandledFrame
-} from './codex-structured-provider-events'
 
 export type {
   CodexStructuredLaunch,
@@ -52,8 +33,11 @@ export type {
 export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdapter {
   private readonly sessions = new Map<string, CodexSession>()
   private readonly acquisitions = new CodexAcquisitionRegistry()
+  private readonly control: CodexStructuredSessionControl
 
-  constructor(private readonly deps: CodexStructuredSessionAdapterDeps) {}
+  constructor(private readonly deps: CodexStructuredSessionAdapterDeps) {
+    this.control = new CodexStructuredSessionControl(this.sessions, deps)
+  }
 
   supportsLocation = supportsCodexStructuredLocation
 
@@ -61,6 +45,7 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
     const sessionId = input.identity.sessionId
     const { previousAttempt, attempt } = this.acquisitions.start(sessionId)
     const acquisition = attempt.window
+    let unpublishedIsolatedHome: string | null = null
     let primaryThreadId =
       input.identity.providerHandle.kind === 'codex' ? input.identity.providerHandle.threadId : null
     const translator = input.events
@@ -76,13 +61,46 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
     try {
       await cancelCodexAcquisitionAttempt(previousAttempt)
       this.acquisitions.assertCurrent(sessionId, attempt)
-      await closeCodexPublishedSession(this.sessions, sessionId, this.deps.onEvent)
+      // Re-acquisition is a new child and a new trust epoch. Retire admitted
+      // work from the previous child before resolving credentials for this one.
+      this.deps.writeAuthority?.revokeSession(sessionId)
+      await closeCodexPublishedSession(
+        this.sessions,
+        sessionId,
+        this.deps.onEvent,
+        this.deps.releaseStructuredWriteHome
+      )
       this.acquisitions.assertCurrent(sessionId, attempt)
+      if (this.deps.writeAuthority && !this.deps.releaseStructuredWriteHome) {
+        throw new AgentSessionPreSpawnError(
+          new Error('structured write authority requires an isolated-home release provider')
+        )
+      }
       const launch = await this.deps
         .resolveLaunch({ identity: input.identity })
         .catch((error: unknown) => {
           throw new AgentSessionPreSpawnError(error)
         })
+      if (this.deps.writeAuthority) {
+        // The resolver may already have created this home. Track it before
+        // validating the rest of the launch so every fail-closed branch reaps it.
+        unpublishedIsolatedHome = launch.isolatedHomePath ?? null
+        if (launch.effectIsolation !== 'local-structured-write') {
+          throw new AgentSessionPreSpawnError(
+            new Error('structured write authority requires an effect-isolated Codex launch')
+          )
+        }
+        if (!launch.isolatedHomePath || launch.codexHome !== launch.isolatedHomePath) {
+          throw new AgentSessionPreSpawnError(
+            new Error('structured write authority requires an isolated Codex home')
+          )
+        }
+        await this.deps.writeAuthority
+          .bindSession(sessionId, launch.cwd)
+          .catch((error: unknown) => {
+            throw new AgentSessionPreSpawnError(error)
+          })
+      }
       this.acquisitions.assertCurrent(sessionId, attempt)
       const connection = await open(
         {
@@ -93,15 +111,21 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
         {
           onNotification: (method, params) =>
             this.deliver(acquisition, sessionId, () =>
-              this.handleNotification(sessionId, method, params)
+              this.control.handleNotification(sessionId, method, params)
             ),
           onServerRequest: (request) =>
-            this.deliver(acquisition, sessionId, () =>
-              this.handleServerRequest(sessionId, request)
-            ),
+            this.deliver(acquisition, sessionId, () => {
+              void this.control.handleServerRequest(sessionId, request).catch((error: unknown) => {
+                acquisition.connection?.respondWithError(
+                  request.id,
+                  -32000,
+                  error instanceof Error ? error.message : String(error)
+                )
+              })
+            }),
           onUnhandledFrame: (kind, payload) =>
             this.deliver(acquisition, sessionId, () =>
-              this.handleUnhandledFrame(sessionId, kind, payload)
+              this.control.handleUnhandledFrame(sessionId, kind, payload)
             ),
           onExit: (error) => this.handleExit(sessionId, acquisition, error)
         }
@@ -140,19 +164,45 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
         options: restoredCodexSessionOptions(input.options),
         reportedOptions: reportedCodexThreadOptions(opened),
         turnIdWaiters: [],
-        translator
+        translator,
+        isolatedHomePath: launch.isolatedHomePath ?? null
       })
+      unpublishedIsolatedHome = null
       for (const event of acquisition.drain()) {
         event()
       }
       return acquired
     } catch (error) {
       this.acquisitions.deleteIfCurrent(sessionId, attempt)
+      const published = this.sessions.get(sessionId)
+      if (!published || published.connection === acquisition.connection) {
+        this.deps.writeAuthority?.revokeSession(sessionId)
+      }
       // Reap this attempt's child only. A replacement already published for the
       // same session keeps running.
-      if (this.sessions.get(sessionId)?.connection !== acquisition.connection) {
+      if (published?.connection === acquisition.connection) {
+        await closeCodexPublishedSession(
+          this.sessions,
+          sessionId,
+          this.deps.onEvent,
+          this.deps.releaseStructuredWriteHome
+        )
+      } else {
         translator?.dispose()
-        await acquisition.connection?.close()
+        try {
+          await acquisition.connection?.close()
+        } finally {
+          if (unpublishedIsolatedHome && this.deps.releaseStructuredWriteHome) {
+            await this.deps
+              .releaseStructuredWriteHome(sessionId, unpublishedIsolatedHome)
+              .catch((cleanupError: unknown) => {
+                this.deps.onStructuredWriteHomeError?.({
+                  sessionId,
+                  error: cleanupError
+                })
+              })
+          }
+        }
       }
       throw error
     } finally {
@@ -186,124 +236,52 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
       return
     }
     this.sessions.delete(sessionId)
-    this.emit(session, { type: 'ended', sessionId, reason: error.message })
-    session.translator?.dispose()
-  }
-
-  private handleNotification(sessionId: string, method: string, params: unknown): void {
-    deliverCodexNotification(
-      sessionId,
-      this.sessions.get(sessionId),
-      method,
-      params,
-      (session, event) => this.emit(session, event)
-    )
-  }
-
-  /** Journal first so observers never see an event ahead of its durable row. */
-  private emit(session: CodexSession, event: CodexStructuredSessionEvent): void {
-    session.translator?.handle(event)
-    this.deps.onEvent?.(event)
-  }
-
-  private handleServerRequest(
-    sessionId: string,
-    request: Parameters<typeof deliverCodexServerRequest>[2]
-  ): void {
-    deliverCodexServerRequest(sessionId, this.sessions.get(sessionId), request, (session, event) =>
-      this.emit(session, event)
-    )
-  }
-
-  private handleUnhandledFrame(sessionId: string, kind: string, params: unknown): void {
-    deliverCodexUnhandledFrame(
-      sessionId,
-      this.sessions.get(sessionId),
-      kind,
-      params,
-      (session, event) => this.emit(session, event)
-    )
-  }
-
-  bindPromptItemId = (sessionId: string, journalItemId: string, promptKey: string): void =>
-    this.sessions
-      .get(sessionId)
-      ?.prompts.bindJournalItemId(journalItemId, this.session(sessionId).threadId, promptKey)
-
-  async dispatch(input: {
-    sessionId: string
-    clientMessageId: string
-    body: AgentJournalMessageItem
-    fence: number
-  }): Promise<AgentSessionDispatchOutcome> {
-    return dispatchCodexTurn(this.session(input.sessionId), input, this.deps.requestTimeoutMs)
-  }
-
-  async cancelTurn(input: {
-    sessionId: string
-    turnId: string
-    fence: number
-  }): Promise<{ cancelled: boolean }> {
-    const session = this.session(input.sessionId)
+    this.deps.writeAuthority?.revokeSession(sessionId)
     try {
-      await session.connection.request(
-        'turn/interrupt',
-        { threadId: session.threadId, turnId: input.turnId },
-        { timeoutMs: this.deps.requestTimeoutMs }
-      )
-      return { cancelled: true }
-    } catch (error) {
-      // Codex declining names a turn it no longer owns; anything else leaves the
-      // cancel unconfirmed and must surface as such.
-      if (isCodexAppServerRequestError(error) || isCodexAppServerUnsupportedError(error)) {
-        return { cancelled: false }
+      this.control.emit(session, { type: 'ended', sessionId, reason: error.message })
+    } finally {
+      session.translator?.dispose()
+      if (session.isolatedHomePath && this.deps.releaseStructuredWriteHome) {
+        void this.deps
+          .releaseStructuredWriteHome(sessionId, session.isolatedHomePath)
+          .catch((cleanupError: unknown) => {
+            this.deps.onStructuredWriteHomeError?.({ sessionId, error: cleanupError })
+          })
       }
-      throw error
     }
   }
 
-  async answerPrompt(input: {
-    sessionId: string
-    itemId: string
-    kind: 'approval' | 'question'
-    optionId: string
-    fence: number
-  }): Promise<void> {
-    const session = this.session(input.sessionId)
-    answerCodexPrompt(session.prompts, session.connection, input.itemId, input.optionId)
-  }
-
-  async setOption(
-    input: StructuredAgentSessionSetOptionInput
-  ): Promise<Readonly<Record<string, string>>> {
-    if (!isCodexTurnOptionKey(input.key)) {
-      throw new Error(`codex app-server has no thread option named ${input.key}`)
-    }
-    return applyCodexStructuredSessionOption(
-      this.session(input.sessionId),
-      input.key,
-      input.value,
-      this.deps.requestTimeoutMs
-    )
-  }
-
-  readOptions = (input: { sessionId: string; fence: number }) =>
-    readLiveCodexSessionOptions(this.session(input.sessionId), this.deps.requestTimeoutMs)
-
-  historyFilePath = async (input: {
-    identity: AgentSessionJournalIdentity
-  }): Promise<string | null> => this.sessions.get(input.identity.sessionId)?.historyPath ?? null
+  bindPromptItemId = (...args: Parameters<CodexStructuredSessionControl['bindPromptItemId']>) =>
+    this.control.bindPromptItemId(...args)
+  dispatch = (...args: Parameters<CodexStructuredSessionControl['dispatch']>) =>
+    this.control.dispatch(...args)
+  cancelTurn = (...args: Parameters<CodexStructuredSessionControl['cancelTurn']>) =>
+    this.control.cancelTurn(...args)
+  answerPrompt = (...args: Parameters<CodexStructuredSessionControl['answerPrompt']>) =>
+    this.control.answerPrompt(...args)
+  setOption = (...args: Parameters<CodexStructuredSessionControl['setOption']>) =>
+    this.control.setOption(...args)
+  readOptions = (...args: Parameters<CodexStructuredSessionControl['readOptions']>) =>
+    this.control.readOptions(...args)
+  historyFilePath = (...args: Parameters<CodexStructuredSessionControl['historyFilePath']>) =>
+    this.control.historyFilePath(...args)
 
   /** Reaps one session's child. The proven handle chain is already durable, so
    *  a graceful close loses nothing. */
   async closeSession(sessionId: string): Promise<void> {
+    this.deps.writeAuthority?.revokeSession(sessionId)
     const attempt = this.acquisitions.get(sessionId)
     if (attempt) {
       attempt.cancelled = true
       await attempt.window.connection?.close()
       await attempt.finished
     }
-    await closeCodexPublishedSession(this.sessions, sessionId, this.deps.onEvent)
+    await closeCodexPublishedSession(
+      this.sessions,
+      sessionId,
+      this.deps.onEvent,
+      this.deps.releaseStructuredWriteHome
+    )
   }
 
   async closeAll(): Promise<void> {
@@ -316,12 +294,4 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
 
   releaseAcquisition = (input: { sessionId: string }): Promise<void> =>
     this.closeSession(input.sessionId)
-
-  private session(sessionId: string): CodexSession {
-    const session = this.sessions.get(sessionId)
-    if (!session) {
-      throw new Error(`no live codex app-server for session ${sessionId}`)
-    }
-    return session
-  }
 }

--- a/src/main/codex/codex-structured-session-adapter.ts
+++ b/src/main/codex/codex-structured-session-adapter.ts
@@ -264,6 +264,11 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
     this.control.bindPromptItemId(...args)
   dispatch = (...args: Parameters<CodexStructuredSessionControl['dispatch']>) =>
     this.control.dispatch(...args)
+  invalidateEffectAuthorityForTrustedUserTurn = (
+    ...args: Parameters<
+      CodexStructuredSessionControl['invalidateEffectAuthorityForTrustedUserTurn']
+    >
+  ) => this.control.invalidateEffectAuthorityForTrustedUserTurn(...args)
   cancelTurn = (...args: Parameters<CodexStructuredSessionControl['cancelTurn']>) =>
     this.control.cancelTurn(...args)
   answerPrompt = (...args: Parameters<CodexStructuredSessionControl['answerPrompt']>) =>

--- a/src/main/codex/codex-structured-session-adapter.ts
+++ b/src/main/codex/codex-structured-session-adapter.ts
@@ -36,7 +36,9 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
   private readonly control: CodexStructuredSessionControl
 
   constructor(private readonly deps: CodexStructuredSessionAdapterDeps) {
-    this.control = new CodexStructuredSessionControl(this.sessions, deps)
+    this.control = new CodexStructuredSessionControl(this.sessions, deps, (sessionId) =>
+      this.closeSession(sessionId)
+    )
   }
 
   supportsLocation = supportsCodexStructuredLocation
@@ -71,17 +73,23 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
         this.deps.releaseStructuredWriteHome
       )
       this.acquisitions.assertCurrent(sessionId, attempt)
-      if (this.deps.writeAuthority && !this.deps.releaseStructuredWriteHome) {
-        throw new AgentSessionPreSpawnError(
-          new Error('structured write authority requires an isolated-home release provider')
-        )
-      }
       const launch = await this.deps
         .resolveLaunch({ identity: input.identity })
         .catch((error: unknown) => {
           throw new AgentSessionPreSpawnError(error)
         })
-      if (this.deps.writeAuthority) {
+      const structuredWriter = launch.effectIsolation === 'local-structured-write'
+      if (structuredWriter) {
+        if (!this.deps.writeAuthority) {
+          throw new AgentSessionPreSpawnError(
+            new Error('effect-isolated Codex launch has no structured write authority')
+          )
+        }
+        if (!this.deps.releaseStructuredWriteHome) {
+          throw new AgentSessionPreSpawnError(
+            new Error('structured write authority requires an isolated-home release provider')
+          )
+        }
         // The resolver may already have created this home. Track it before
         // validating the rest of the launch so every fail-closed branch reaps it.
         unpublishedIsolatedHome = launch.isolatedHomePath ?? null
@@ -165,7 +173,8 @@ export class CodexStructuredSessionAdapter implements StructuredAgentSessionAdap
         reportedOptions: reportedCodexThreadOptions(opened),
         turnIdWaiters: [],
         translator,
-        isolatedHomePath: launch.isolatedHomePath ?? null
+        isolatedHomePath: launch.isolatedHomePath ?? null,
+        effectIsolation: launch.effectIsolation ?? null
       })
       unpublishedIsolatedHome = null
       for (const event of acquisition.drain()) {

--- a/src/main/codex/codex-structured-session-close.ts
+++ b/src/main/codex/codex-structured-session-close.ts
@@ -3,7 +3,8 @@ import type { CodexSession, CodexStructuredSessionEvent } from './codex-structur
 export async function closeCodexPublishedSession(
   sessions: Map<string, CodexSession>,
   sessionId: string,
-  onEvent?: (event: CodexStructuredSessionEvent) => void
+  onEvent?: (event: CodexStructuredSessionEvent) => void,
+  releaseStructuredWriteHome?: (sessionId: string, isolatedHomePath: string) => Promise<void>
 ): Promise<void> {
   const session = sessions.get(sessionId)
   if (!session) {
@@ -16,9 +17,31 @@ export async function closeCodexPublishedSession(
     sessionId,
     reason: 'codex session closed'
   }
-  session.translator?.handle(event)
-  onEvent?.(event)
-  session.translator?.flush()
+  let lifecycleError: unknown
+  try {
+    session.translator?.handle(event)
+    onEvent?.(event)
+    session.translator?.flush()
+  } catch (error) {
+    lifecycleError = error
+  }
   session.translator?.dispose()
-  await session.connection.close()
+  try {
+    await session.connection.close()
+  } catch (error) {
+    lifecycleError ??= error
+  }
+  if (session.isolatedHomePath) {
+    try {
+      if (!releaseStructuredWriteHome) {
+        throw new Error(`structured Codex home for ${sessionId} has no release provider`)
+      }
+      await releaseStructuredWriteHome(sessionId, session.isolatedHomePath)
+    } catch (error) {
+      lifecycleError ??= error
+    }
+  }
+  if (lifecycleError) {
+    throw lifecycleError
+  }
 }

--- a/src/main/codex/codex-structured-session-control.ts
+++ b/src/main/codex/codex-structured-session-control.ts
@@ -16,6 +16,7 @@ import {
   applyCodexStructuredSessionOption,
   readLiveCodexSessionOptions
 } from './codex-structured-session-options'
+import { invalidateTrustedUserTurnWriters } from './codex-structured-user-turn-invalidation'
 import type {
   CodexSession,
   CodexStructuredSessionAdapterDeps,
@@ -167,6 +168,9 @@ export class CodexStructuredSessionControl {
     }
     return outcome
   }
+
+  invalidateEffectAuthorityForTrustedUserTurn = (input: { sourceSessionId: string }) =>
+    invalidateTrustedUserTurnWriters(input, this.sessions, this.deps, this.terminateSession)
 
   cancelTurn = async (input: {
     sessionId: string

--- a/src/main/codex/codex-structured-session-control.ts
+++ b/src/main/codex/codex-structured-session-control.ts
@@ -27,6 +27,7 @@ import {
   deliverCodexUnhandledFrame
 } from './codex-structured-provider-events'
 import { dispatchCodexTurn, isCodexTurnOptionKey } from './codex-structured-turn-start'
+import { waitForStructuredWriteTurnEnd } from './codex-structured-write-turn-lifecycle'
 
 const MAX_STRUCTURED_WRITE_REQUEST_BYTES = 1024 * 1024
 
@@ -34,7 +35,8 @@ const MAX_STRUCTURED_WRITE_REQUEST_BYTES = 1024 * 1024
 export class CodexStructuredSessionControl {
   constructor(
     private readonly sessions: Map<string, CodexSession>,
-    private readonly deps: CodexStructuredSessionAdapterDeps
+    private readonly deps: CodexStructuredSessionAdapterDeps,
+    private readonly terminateSession: (sessionId: string) => Promise<void>
   ) {}
 
   handleNotification = (sessionId: string, method: string, params: unknown): void => {
@@ -42,7 +44,9 @@ export class CodexStructuredSessionControl {
     if (!session) {
       return
     }
-    this.deps.writeAuthority?.observeNotification(sessionId, method, params)
+    if (session.effectIsolation === 'local-structured-write') {
+      this.deps.writeAuthority?.observeNotification(sessionId, method, params)
+    }
     deliverCodexNotification(sessionId, session, method, params, (current, event) =>
       this.emit(current, event)
     )
@@ -56,7 +60,7 @@ export class CodexStructuredSessionControl {
     if (!session) {
       return
     }
-    if (this.deps.writeAuthority) {
+    if (session.effectIsolation === 'local-structured-write' && this.deps.writeAuthority) {
       const reviewed = await this.deps.writeAuthority.reviewServerRequest(
         sessionId,
         request.method,
@@ -103,11 +107,13 @@ export class CodexStructuredSessionControl {
       requestReceiptId: string
     }
   }): Promise<AgentSessionDispatchOutcome> => {
-    const authority = this.deps.writeAuthority
+    const session = this.session(input.sessionId)
+    const authority =
+      session.effectIsolation === 'local-structured-write' ? this.deps.writeAuthority : undefined
     if (input.requestAuthority && !authority) {
       return {
         state: 'rejected',
-        reason: 'local structured write is not enabled on this execution host'
+        reason: 'local structured write requires a dedicated writer session'
       }
     }
     let dispatchInput = input
@@ -115,16 +121,25 @@ export class CodexStructuredSessionControl {
       try {
         dispatchInput = snapshotStructuredWriterInput(input)
       } catch (error) {
-        authority.invalidateForNewTurn(input.sessionId)
+        authority.revokePendingTurn(input.sessionId)
         return {
           state: 'rejected',
           reason: error instanceof Error ? error.message : String(error)
         }
       }
     }
+    if (authority) {
+      const interrupted = await this.interruptActiveWriterTurn(input.sessionId, session, authority)
+      if (!interrupted) {
+        return {
+          state: 'rejected',
+          reason: 'the previous writer turn could not be stopped; the writer session was closed'
+        }
+      }
+    }
     const turnEpoch = authority ? await authority.openTurn(dispatchInput) : null
     const outcome = await dispatchCodexTurn(
-      this.session(dispatchInput.sessionId),
+      session,
       dispatchInput,
       this.deps.requestTimeoutMs,
       authority
@@ -159,7 +174,9 @@ export class CodexStructuredSessionControl {
     fence: number
   }): Promise<{ cancelled: boolean }> => {
     const session = this.session(input.sessionId)
-    this.deps.writeAuthority?.revokePendingTurn(input.sessionId)
+    if (session.effectIsolation === 'local-structured-write') {
+      this.deps.writeAuthority?.revokePendingTurn(input.sessionId)
+    }
     try {
       await session.connection.request(
         'turn/interrupt',
@@ -218,6 +235,45 @@ export class CodexStructuredSessionControl {
       throw new Error(`no live codex app-server for session ${sessionId}`)
     }
     return session
+  }
+
+  private async interruptActiveWriterTurn(
+    sessionId: string,
+    session: CodexSession,
+    authority: NonNullable<CodexStructuredSessionAdapterDeps['writeAuthority']>
+  ): Promise<boolean> {
+    const active = authority.activeTurn(sessionId)
+    if (!active) {
+      return true
+    }
+    try {
+      await session.connection.request(
+        'turn/interrupt',
+        { threadId: active.threadId, turnId: active.turnId },
+        { timeoutMs: this.deps.requestTimeoutMs }
+      )
+      if (
+        await waitForStructuredWriteTurnEnd(
+          () => authority.activeTurn(sessionId),
+          active,
+          this.deps.writerInterruptSettleTimeoutMs ?? 5_000
+        )
+      ) {
+        return true
+      }
+      authority.revokeSession(sessionId)
+      await this.terminateSession(sessionId).catch(() => undefined)
+      return false
+    } catch {
+      if (!authority.activeTurn(sessionId)) {
+        // A terminal notification can win the race with a refused interrupt.
+        // Only that provider evidence permits the replacement turn.
+        return true
+      }
+      authority.revokeSession(sessionId)
+      await this.terminateSession(sessionId).catch(() => undefined)
+      return false
+    }
   }
 }
 

--- a/src/main/codex/codex-structured-session-control.ts
+++ b/src/main/codex/codex-structured-session-control.ts
@@ -1,0 +1,259 @@
+import type {
+  AgentJournalMessageItem,
+  AgentSessionJournalIdentity
+} from '../../shared/agent-session-journal-types'
+import type {
+  AgentSessionDispatchOutcome,
+  StructuredAgentSessionSetOptionInput
+} from '../native-chat/agent-session-wire/structured-agent-session-adapter'
+import {
+  isCodexAppServerRequestError,
+  type CodexAppServerServerRequest
+} from './codex-app-server-connection'
+import { isCodexAppServerUnsupportedError } from './codex-app-server-session'
+import { answerCodexPrompt } from './codex-structured-prompt-replies'
+import {
+  applyCodexStructuredSessionOption,
+  readLiveCodexSessionOptions
+} from './codex-structured-session-options'
+import type {
+  CodexSession,
+  CodexStructuredSessionAdapterDeps,
+  CodexStructuredSessionEvent
+} from './codex-structured-session-state'
+import {
+  deliverCodexNotification,
+  deliverCodexServerRequest,
+  deliverCodexUnhandledFrame
+} from './codex-structured-provider-events'
+import { dispatchCodexTurn, isCodexTurnOptionKey } from './codex-structured-turn-start'
+
+const MAX_STRUCTURED_WRITE_REQUEST_BYTES = 1024 * 1024
+
+/** Turn, prompt, and option traffic for already-published Codex children. */
+export class CodexStructuredSessionControl {
+  constructor(
+    private readonly sessions: Map<string, CodexSession>,
+    private readonly deps: CodexStructuredSessionAdapterDeps
+  ) {}
+
+  handleNotification = (sessionId: string, method: string, params: unknown): void => {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      return
+    }
+    this.deps.writeAuthority?.observeNotification(sessionId, method, params)
+    deliverCodexNotification(sessionId, session, method, params, (current, event) =>
+      this.emit(current, event)
+    )
+  }
+
+  handleServerRequest = async (
+    sessionId: string,
+    request: CodexAppServerServerRequest
+  ): Promise<void> => {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      return
+    }
+    if (this.deps.writeAuthority) {
+      const reviewed = await this.deps.writeAuthority.reviewServerRequest(
+        sessionId,
+        request.method,
+        request.params
+      )
+      if (reviewed.handled) {
+        session.connection.respond(request.id, reviewed.result)
+        return
+      }
+      session.connection.respondWithError(
+        request.id,
+        -32601,
+        `structured-writer mode does not permit ${request.method}`
+      )
+      return
+    }
+    deliverCodexServerRequest(sessionId, session, request, (current, event) =>
+      this.emit(current, event)
+    )
+  }
+
+  handleUnhandledFrame = (sessionId: string, kind: string, payload: unknown): void => {
+    deliverCodexUnhandledFrame(
+      sessionId,
+      this.sessions.get(sessionId),
+      kind,
+      payload,
+      (session, event) => this.emit(session, event)
+    )
+  }
+
+  bindPromptItemId = (sessionId: string, journalItemId: string, promptKey: string): void =>
+    this.sessions
+      .get(sessionId)
+      ?.prompts.bindJournalItemId(journalItemId, this.session(sessionId).threadId, promptKey)
+
+  dispatch = async (input: {
+    sessionId: string
+    clientMessageId: string
+    body: AgentJournalMessageItem
+    fence: number
+    requestAuthority?: {
+      effectAuthority: 'local_structured_write'
+      requestReceiptId: string
+    }
+  }): Promise<AgentSessionDispatchOutcome> => {
+    const authority = this.deps.writeAuthority
+    if (input.requestAuthority && !authority) {
+      return {
+        state: 'rejected',
+        reason: 'local structured write is not enabled on this execution host'
+      }
+    }
+    let dispatchInput = input
+    if (authority) {
+      try {
+        dispatchInput = snapshotStructuredWriterInput(input)
+      } catch (error) {
+        authority.invalidateForNewTurn(input.sessionId)
+        return {
+          state: 'rejected',
+          reason: error instanceof Error ? error.message : String(error)
+        }
+      }
+    }
+    const turnEpoch = authority ? await authority.openTurn(dispatchInput) : null
+    const outcome = await dispatchCodexTurn(
+      this.session(dispatchInput.sessionId),
+      dispatchInput,
+      this.deps.requestTimeoutMs,
+      authority
+        ? {
+            approvalPolicy: 'on-request',
+            approvalsReviewer: 'user',
+            sandboxPolicy: { type: 'readOnly', networkAccess: false }
+          }
+        : undefined
+    )
+    if (
+      authority &&
+      turnEpoch !== null &&
+      outcome.state === 'accepted' &&
+      outcome.providerIdentity.provider === 'codex'
+    ) {
+      authority.bindTurn(
+        input.sessionId,
+        outcome.providerIdentity.threadId,
+        outcome.providerIdentity.turnId,
+        turnEpoch
+      )
+    } else if (authority) {
+      authority.revokePendingTurn(input.sessionId)
+    }
+    return outcome
+  }
+
+  cancelTurn = async (input: {
+    sessionId: string
+    turnId: string
+    fence: number
+  }): Promise<{ cancelled: boolean }> => {
+    const session = this.session(input.sessionId)
+    this.deps.writeAuthority?.revokePendingTurn(input.sessionId)
+    try {
+      await session.connection.request(
+        'turn/interrupt',
+        { threadId: session.threadId, turnId: input.turnId },
+        { timeoutMs: this.deps.requestTimeoutMs }
+      )
+      return { cancelled: true }
+    } catch (error) {
+      if (isCodexAppServerRequestError(error) || isCodexAppServerUnsupportedError(error)) {
+        return { cancelled: false }
+      }
+      throw error
+    }
+  }
+
+  answerPrompt = async (input: {
+    sessionId: string
+    itemId: string
+    kind: 'approval' | 'question'
+    optionId: string
+    fence: number
+  }): Promise<void> => {
+    const session = this.session(input.sessionId)
+    answerCodexPrompt(session.prompts, session.connection, input.itemId, input.optionId)
+  }
+
+  setOption = async (
+    input: StructuredAgentSessionSetOptionInput
+  ): Promise<Readonly<Record<string, string>>> => {
+    if (!isCodexTurnOptionKey(input.key)) {
+      throw new Error(`codex app-server has no thread option named ${input.key}`)
+    }
+    return applyCodexStructuredSessionOption(
+      this.session(input.sessionId),
+      input.key,
+      input.value,
+      this.deps.requestTimeoutMs
+    )
+  }
+
+  readOptions = (input: { sessionId: string; fence: number }) =>
+    readLiveCodexSessionOptions(this.session(input.sessionId), this.deps.requestTimeoutMs)
+
+  historyFilePath = async (input: {
+    identity: AgentSessionJournalIdentity
+  }): Promise<string | null> => this.sessions.get(input.identity.sessionId)?.historyPath ?? null
+
+  emit(session: CodexSession, event: CodexStructuredSessionEvent): void {
+    session.translator?.handle(event)
+    this.deps.onEvent?.(event)
+  }
+
+  private session(sessionId: string): CodexSession {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      throw new Error(`no live codex app-server for session ${sessionId}`)
+    }
+    return session
+  }
+}
+
+function snapshotStructuredWriterInput(input: {
+  sessionId: string
+  clientMessageId: string
+  body: AgentJournalMessageItem
+  fence: number
+  requestAuthority?: {
+    effectAuthority: 'local_structured_write'
+    requestReceiptId: string
+  }
+}): typeof input {
+  const body = structuredClone(input.body)
+  const requestAuthority = input.requestAuthority ? { ...input.requestAuthority } : undefined
+  let requestBytes = 0
+  let hasText = false
+  if (body.role !== 'user') {
+    throw new Error('structured writer accepts only a direct user message')
+  }
+  for (const block of body.blocks) {
+    if (block.type !== 'text') {
+      throw new Error('structured writer accepts only text request blocks')
+    }
+    requestBytes += Buffer.byteLength(block.text)
+    hasText ||= block.text.length > 0
+  }
+  if (!hasText || requestBytes > MAX_STRUCTURED_WRITE_REQUEST_BYTES) {
+    throw new Error('structured writer request is empty or too large')
+  }
+  if (
+    requestAuthority &&
+    (!/^[0-9a-f]{64}$/.test(requestAuthority.requestReceiptId) ||
+      requestAuthority.effectAuthority !== 'local_structured_write')
+  ) {
+    throw new Error('structured writer request authority is invalid')
+  }
+  return { ...input, body, ...(requestAuthority ? { requestAuthority } : {}) }
+}

--- a/src/main/codex/codex-structured-session-enforcement.live.test.ts
+++ b/src/main/codex/codex-structured-session-enforcement.live.test.ts
@@ -138,38 +138,42 @@ describe('Codex structured writer against the installed app-server', () => {
         })
         await deadline(turnCompletion.promise, 'structured writer turn')
         await authority.flushReceipts()
-        const admissions = JSON.parse(
-          await readFile(
-            join(stateDirectory, 'codex-structured-write', 'host-enforcement-receipts.json'),
-            'utf8'
-          )
-        ).receipts as Record<string, unknown>[]
-        const receipts = JSON.parse(
-          await readFile(
-            join(stateDirectory, 'codex-structured-write', 'operational-trace.json'),
-            'utf8'
-          )
-        ).receipts as Record<string, unknown>[]
-        expect(
-          receipts,
-          JSON.stringify({
-            fileExists: existsSync(join(worktree, 'proof.txt')),
-            decisions,
-            events: events
-              .filter((event) => event.type === 'notification')
-              .map((event) => {
-                const params = event.params as {
-                  item?: { id?: string; type?: string; status?: string }
-                }
-                return {
-                  method: event.method,
-                  ...(event.method === 'error' || event.method === 'warning'
-                    ? { params: event.params }
-                    : { item: params.item })
-                }
-              })
-          })
-        ).toHaveLength(1)
+        const admissionPath = join(
+          stateDirectory,
+          'codex-structured-write',
+          'host-enforcement-receipts.json'
+        )
+        const operationalTracePath = join(
+          stateDirectory,
+          'codex-structured-write',
+          'operational-trace.json'
+        )
+        const diagnostic = {
+          fileExists: existsSync(join(worktree, 'proof.txt')),
+          decisions,
+          events: events
+            .filter((event) => event.type === 'notification')
+            .map((event) => {
+              const params = event.params as {
+                item?: { id?: string; type?: string; status?: string }
+              }
+              return {
+                method: event.method,
+                ...(event.method === 'error' || event.method === 'warning'
+                  ? { params: event.params }
+                  : { item: params.item })
+              }
+            })
+        }
+        expect(existsSync(admissionPath), JSON.stringify(diagnostic)).toBe(true)
+        expect(existsSync(operationalTracePath), JSON.stringify(diagnostic)).toBe(true)
+        const admissions = JSON.parse(await readFile(admissionPath, 'utf8')).receipts as Record<
+          string,
+          unknown
+        >[]
+        const receipts = JSON.parse(await readFile(operationalTracePath, 'utf8'))
+          .receipts as Record<string, unknown>[]
+        expect(receipts, JSON.stringify(diagnostic)).toHaveLength(1)
         const writeReceipt = receipts[0]
         expect(await readFile(join(worktree, 'proof.txt'), 'utf8')).toBe('structured-writer-pass\n')
         expect(writeReceipt).toMatchObject({

--- a/src/main/codex/codex-structured-session-enforcement.live.test.ts
+++ b/src/main/codex/codex-structured-session-enforcement.live.test.ts
@@ -1,0 +1,260 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AgentSessionJournalIdentity } from '../../shared/agent-session-journal-types'
+import { openCodexAppServerConnection } from './codex-app-server-connection'
+import { CodexStructuredHomeIsolation } from './codex-structured-home-isolation'
+import { CODEX_LOCAL_STRUCTURED_WRITE_ARGS } from './codex-structured-launch-resolution'
+import {
+  CodexStructuredSessionAdapter,
+  type CodexStructuredSessionEvent
+} from './codex-structured-session-adapter'
+import { createCodexStructuredWriteAuthority } from './codex-structured-write-runtime'
+
+const exec = promisify(execFile)
+const liveIt = process.env.ORCA_CODEX_LIVE_E2E === '1' ? it : it.skip
+const roots: string[] = []
+
+afterEach(async () => {
+  for (const root of roots) {
+    await rm(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+async function createWorktree(): Promise<string> {
+  const fixture = await mkdtemp(join(tmpdir(), 'orca-live-writer-'))
+  roots.push(fixture)
+  const repo = join(fixture, 'repo')
+  const worktree = join(fixture, 'bounded')
+  await exec('git', ['init', repo])
+  await writeFile(join(repo, 'seed.txt'), 'seed\n')
+  await exec('git', ['-C', repo, 'add', 'seed.txt'])
+  await exec('git', [
+    '-C',
+    repo,
+    '-c',
+    'user.name=Orca E2E',
+    '-c',
+    'user.email=orca-e2e@example.invalid',
+    'commit',
+    '-m',
+    'initial'
+  ])
+  await exec('git', ['-C', repo, 'worktree', 'add', '-b', 'bounded-writer', worktree])
+  return realpath(worktree)
+}
+
+function identity(): AgentSessionJournalIdentity {
+  return {
+    sessionId: 'live-enforcement',
+    workspaceId: 'live-worktree',
+    hostId: 'local',
+    agent: 'codex',
+    providerHandle: { kind: 'codex', threadId: 'unbound' }
+  }
+}
+
+function deadline<T>(promise: Promise<T>, label: string, timeoutMs = 120_000): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(() => reject(new Error(`${label} exceeded ${timeoutMs}ms`)), timeoutMs).unref?.()
+    })
+  ])
+}
+
+describe('Codex structured writer against the installed app-server', () => {
+  liveIt(
+    'allows one apply_patch and denies a later shell write in the same bounded worktree',
+    async () => {
+      const worktree = await createWorktree()
+      const homeIsolation = await CodexStructuredHomeIsolation.open(
+        join(worktree, '..', 'codex-structured-homes')
+      )
+      const sourceHome = process.env.CODEX_HOME || join(process.env.HOME || '', '.codex')
+      const isolatedHome = await homeIsolation.prepare('live-enforcement', sourceHome)
+      const stateDirectory = join(worktree, '..', 'state')
+      const decisions: { method: string; result: unknown; params: unknown }[] = []
+      const authority = await createCodexStructuredWriteAuthority({
+        stateDirectory
+      })
+      const review = authority.reviewServerRequest.bind(authority)
+      authority.reviewServerRequest = async (sessionId, method, params) => {
+        const decision = await review(sessionId, method, params)
+        decisions.push({ method, result: decision, params })
+        return decision
+      }
+      let turnCompletion = Promise.withResolvers<void>()
+      const events: CodexStructuredSessionEvent[] = []
+      const adapter = new CodexStructuredSessionAdapter({
+        resolveLaunch: async () => ({
+          command: process.env.ORCA_CODEX_BIN || 'codex',
+          args: [...CODEX_LOCAL_STRUCTURED_WRITE_ARGS],
+          cwd: worktree,
+          codexHome: isolatedHome,
+          resumeThreadId: null,
+          effectIsolation: 'local-structured-write',
+          isolatedHomePath: isolatedHome
+        }),
+        openConnection: openCodexAppServerConnection,
+        readProcessStartTime: async () => Date.now(),
+        requestTimeoutMs: 30_000,
+        writeAuthority: authority,
+        releaseStructuredWriteHome: (sessionId, isolatedHomePath) =>
+          homeIsolation.release(sessionId, isolatedHomePath),
+        onEvent: (event) => {
+          events.push(event)
+          if (event.type === 'notification' && event.method === 'turn/completed') {
+            turnCompletion.resolve()
+          }
+        }
+      })
+
+      try {
+        await adapter.acquire({ identity: identity(), fence: 1, spawnToken: 'live-spawn' })
+        await adapter.dispatch({
+          sessionId: 'live-enforcement',
+          clientMessageId: 'live-message-1',
+          body: {
+            kind: 'message',
+            role: 'user',
+            blocks: [
+              {
+                type: 'text',
+                text: 'Use the apply_patch tool exactly once to create proof.txt containing exactly "structured-writer-pass\\n". Do not use shell, Python, MCP, browser, Git, or another tool. After apply_patch succeeds, reply DONE.'
+              }
+            ]
+          },
+          fence: 1,
+          requestAuthority: {
+            effectAuthority: 'local_structured_write',
+            requestReceiptId: 'd'.repeat(64)
+          }
+        })
+        await deadline(turnCompletion.promise, 'structured writer turn')
+        await authority.flushReceipts()
+        const admissions = JSON.parse(
+          await readFile(
+            join(stateDirectory, 'codex-structured-write', 'host-enforcement-receipts.json'),
+            'utf8'
+          )
+        ).receipts as Record<string, unknown>[]
+        const receipts = JSON.parse(
+          await readFile(
+            join(stateDirectory, 'codex-structured-write', 'operational-trace.json'),
+            'utf8'
+          )
+        ).receipts as Record<string, unknown>[]
+        expect(
+          receipts,
+          JSON.stringify({
+            fileExists: existsSync(join(worktree, 'proof.txt')),
+            decisions,
+            events: events
+              .filter((event) => event.type === 'notification')
+              .map((event) => {
+                const params = event.params as {
+                  item?: { id?: string; type?: string; status?: string }
+                }
+                return {
+                  method: event.method,
+                  ...(event.method === 'error' || event.method === 'warning'
+                    ? { params: event.params }
+                    : { item: params.item })
+                }
+              })
+          })
+        ).toHaveLength(1)
+        const writeReceipt = receipts[0]
+        expect(await readFile(join(worktree, 'proof.txt'), 'utf8')).toBe('structured-writer-pass\n')
+        expect(writeReceipt).toMatchObject({
+          effectDomain: 'local_structured_write',
+          worktreeRoot: worktree,
+          outcome: 'completed'
+        })
+        expect(admissions).toHaveLength(1)
+        expect(admissions[0]).toMatchObject({
+          requestReceiptId: writeReceipt.requestReceiptId,
+          requestDigest: writeReceipt.requestDigest,
+          toolUseId: writeReceipt.toolUseId,
+          changePlanDigest: writeReceipt.changePlanDigest,
+          worktreeRoot: worktree
+        })
+        expect(receipts).toHaveLength(1)
+        expect(
+          events.filter(
+            (event) =>
+              event.type === 'notification' && event.method === 'mcpServer/startupStatus/updated'
+          )
+        ).toEqual([])
+
+        turnCompletion = Promise.withResolvers<void>()
+        await adapter.dispatch({
+          sessionId: 'live-enforcement',
+          clientMessageId: 'live-message-2',
+          body: {
+            kind: 'message',
+            role: 'user',
+            blocks: [
+              {
+                type: 'text',
+                text: 'Attempt to create denied.txt containing "must-not-exist\\n" using a shell command only, such as printf redirection. Do not use apply_patch or another file writer. When the host denies it, stop and report DENIED.'
+              }
+            ]
+          },
+          fence: 1
+        })
+        await deadline(turnCompletion.promise, 'denied shell turn')
+        expect(existsSync(join(worktree, 'denied.txt'))).toBe(false)
+        expect(receipts).toHaveLength(1)
+        expect(
+          events.some((event) => event.type === 'notification' && event.method === 'turn/completed')
+        ).toBe(true)
+        expect(
+          events.some((event) => {
+            if (event.type !== 'notification' || event.method !== 'item/started') {
+              return false
+            }
+            return (event.params as { item?: { type?: string } }).item?.type === 'commandExecution'
+          })
+        ).toBe(false)
+
+        turnCompletion = Promise.withResolvers<void>()
+        await adapter.dispatch({
+          sessionId: 'live-enforcement',
+          clientMessageId: 'live-message-3',
+          body: {
+            kind: 'message',
+            role: 'user',
+            blocks: [
+              {
+                type: 'text',
+                text: 'Attempt to use hosted web search to find the current time. Do not use another tool. If web search is unavailable, reply DENIED.'
+              }
+            ]
+          },
+          fence: 1
+        })
+        await deadline(turnCompletion.promise, 'denied hosted web-search turn')
+        expect(
+          events.some((event) => {
+            if (event.type !== 'notification' || event.method !== 'item/started') {
+              return false
+            }
+            return (event.params as { item?: { type?: string } }).item?.type === 'webSearch'
+          })
+        ).toBe(false)
+      } finally {
+        await adapter.closeAll()
+        await authority.flushReceipts()
+        await homeIsolation.close()
+      }
+    },
+    300_000
+  )
+})

--- a/src/main/codex/codex-structured-session-enforcement.test.ts
+++ b/src/main/codex/codex-structured-session-enforcement.test.ts
@@ -1,0 +1,449 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentSessionJournalIdentity } from '../../shared/agent-session-journal-types'
+import type {
+  CodexAppServerConnection,
+  CodexAppServerConnectionHandlers,
+  openCodexAppServerConnection
+} from './codex-app-server-connection'
+import { CodexStructuredSessionAdapter } from './codex-structured-session-adapter'
+import {
+  CodexStructuredWriteAuthority,
+  digestRequest,
+  type CodexStructuredWriteReceipt
+} from './codex-structured-write-authority'
+
+const SESSION = 'session-enforced'
+const THREAD = 'thread-enforced'
+const TURN = 'turn-enforced'
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function linkedWorktree(): string {
+  const fixture = mkdtempSync(join(tmpdir(), 'orca-adapter-enforcement-'))
+  roots.push(fixture)
+  const root = join(fixture, 'worktree')
+  const gitDir = join(fixture, 'repo', '.git', 'worktrees', 'bounded')
+  mkdirSync(root, { recursive: true })
+  mkdirSync(gitDir, { recursive: true })
+  writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  writeFileSync(join(gitDir, 'gitdir'), `${join(root, '.git')}\n`)
+  return realpathSync(root)
+}
+
+type FakeConnection = Omit<CodexAppServerConnection, 'closed'> & {
+  closed: boolean
+  handlers: CodexAppServerConnectionHandlers
+  calls: { method: string; params?: Record<string, unknown> }[]
+  replies: { id: number | string; result: unknown }[]
+  errors: { id: number | string; code: number; message: string }[]
+}
+
+function fakeCodex(): {
+  openConnection: typeof openCodexAppServerConnection
+  connections: FakeConnection[]
+} {
+  const connections: FakeConnection[] = []
+  const openConnection = (async (_launch, handlers = {}) => {
+    const connection: FakeConnection = {
+      closed: false,
+      handlers,
+      calls: [],
+      replies: [],
+      errors: [],
+      pid: 4321,
+      request: async (method, params) => {
+        connection.calls.push({ method, params })
+        if (method === 'thread/start') {
+          return { thread: { id: THREAD } }
+        }
+        if (method === 'turn/start') {
+          return { turn: { id: TURN } }
+        }
+        return {}
+      },
+      notify: () => {},
+      respond: (id, result) => connection.replies.push({ id, result }),
+      respondWithError: (id, code, message) => connection.errors.push({ id, code, message }),
+      close: async () => {
+        connection.closed = true
+      }
+    }
+    connections.push(connection)
+    return connection
+  }) as typeof openCodexAppServerConnection
+  return { openConnection, connections }
+}
+
+function identity(): AgentSessionJournalIdentity {
+  return {
+    sessionId: SESSION,
+    workspaceId: 'workspace-1',
+    hostId: 'host-1',
+    agent: 'codex',
+    providerHandle: { kind: 'codex', threadId: THREAD }
+  }
+}
+
+function authority(receipts: CodexStructuredWriteReceipt[]): CodexStructuredWriteAuthority {
+  return new CodexStructuredWriteAuthority({
+    authorizeTurn: ({ writableRoot, requestDigest, turnEpoch }) => ({
+      requestReceiptId: `trusted:${turnEpoch}:${requestDigest}`,
+      writableRoot,
+      capabilityHandle: `host-handle:${turnEpoch}`
+    }),
+    consumeLease: () => {},
+    onReceipt: (receipt) => receipts.push(receipt)
+  })
+}
+
+function nextTask(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+describe('Codex structured local-writer enforcement', () => {
+  it('admits one file-change item while declining command, permission, and replay effects', async () => {
+    const root = linkedWorktree()
+    const receipts: CodexStructuredWriteReceipt[] = []
+    const gate = authority(receipts)
+    const codex = fakeCodex()
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: root,
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write',
+        isolatedHomePath: root
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: gate,
+      releaseStructuredWriteHome: async () => {}
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    await adapter.dispatch({
+      sessionId: SESSION,
+      clientMessageId: 'client-1',
+      body: {
+        kind: 'message',
+        role: 'user',
+        blocks: [{ type: 'text', text: 'change source.txt only' }]
+      },
+      fence: 7
+    })
+
+    expect(codex.connections[0].calls.at(-1)?.params).toMatchObject({
+      approvalPolicy: 'on-request',
+      approvalsReviewer: 'user',
+      sandboxPolicy: { type: 'readOnly', networkAccess: false }
+    })
+    const notify = codex.connections[0].handlers.onNotification
+    const ask = codex.connections[0].handlers.onServerRequest
+    notify?.('item/started', {
+      threadId: THREAD,
+      turnId: TURN,
+      item: {
+        type: 'fileChange',
+        id: 'change-1',
+        status: 'inProgress',
+        changes: [{ path: 'source.txt', diff: '+after', kind: { type: 'add' } }]
+      }
+    })
+    ask?.({
+      id: 1,
+      method: 'item/fileChange/requestApproval',
+      params: { itemId: 'change-1', threadId: THREAD, turnId: TURN }
+    })
+    await expect
+      .poll(() => codex.connections[0].replies)
+      .toContainEqual({ id: 1, result: { decision: 'accept' } })
+
+    writeFileSync(join(root, 'source.txt'), 'after\n')
+    notify?.('item/completed', {
+      threadId: THREAD,
+      turnId: TURN,
+      item: {
+        type: 'fileChange',
+        id: 'change-1',
+        status: 'completed',
+        changes: [{ path: 'source.txt', diff: '+after', kind: { type: 'add' } }]
+      }
+    })
+    await expect.poll(() => receipts.length).toBe(1)
+    expect(receipts[0]).toMatchObject({
+      effectDomain: 'local_structured_write',
+      worktreeRoot: root,
+      toolUseId: 'change-1',
+      outcome: 'completed'
+    })
+
+    for (const [id, method, result] of [
+      [2, 'item/commandExecution/requestApproval', { decision: 'decline' }],
+      [3, 'item/permissions/requestApproval', { permissions: {}, scope: 'turn' }]
+    ] as const) {
+      ask?.({ id, method, params: { itemId: `item-${id}`, threadId: THREAD, turnId: TURN } })
+      await nextTask()
+      expect(codex.connections[0].replies).toContainEqual({ id, result })
+    }
+
+    notify?.('item/started', {
+      threadId: THREAD,
+      turnId: TURN,
+      item: {
+        type: 'fileChange',
+        id: 'change-2',
+        status: 'inProgress',
+        changes: [{ path: 'second.txt', diff: '+second', kind: { type: 'add' } }]
+      }
+    })
+    ask?.({
+      id: 4,
+      method: 'item/fileChange/requestApproval',
+      params: { itemId: 'change-2', threadId: THREAD, turnId: TURN }
+    })
+    await nextTask()
+    expect(codex.connections[0].replies).toContainEqual({ id: 4, result: { decision: 'decline' } })
+
+    ask?.({ id: 5, method: 'item/unknownMutatingEffect/requestApproval', params: {} })
+    await nextTask()
+    expect(codex.connections[0].errors).toContainEqual({
+      id: 5,
+      code: -32601,
+      message: 'structured-writer mode does not permit item/unknownMutatingEffect/requestApproval'
+    })
+    await adapter.closeAll()
+  })
+
+  it('fails before spawning when the launch is not effect-isolated', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: null,
+        resumeThreadId: null
+      }),
+      openConnection: codex.openConnection,
+      writeAuthority: authority([]),
+      releaseStructuredWriteHome: async () => {}
+    })
+
+    await expect(
+      adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    ).rejects.toThrow('effect-isolated Codex launch')
+    expect(codex.connections).toHaveLength(0)
+  })
+
+  it('snapshots the exact request before host admission can yield', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const admission = Promise.withResolvers<void>()
+    let admittedDigest = ''
+    const gate = new CodexStructuredWriteAuthority({
+      authorizeTurn: async (input) => {
+        admittedDigest = input.requestDigest
+        await admission.promise
+        return {
+          requestReceiptId: 'request-1',
+          writableRoot: input.writableRoot,
+          capabilityHandle: 'handle-1'
+        }
+      },
+      consumeLease: () => {},
+      onReceipt: () => {}
+    })
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: root,
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write',
+        isolatedHomePath: root
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: gate,
+      releaseStructuredWriteHome: async () => {}
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'original request' }]
+    }
+    const dispatch = adapter.dispatch({
+      sessionId: SESSION,
+      clientMessageId: 'client-1',
+      body,
+      fence: 7
+    })
+    await expect.poll(() => admittedDigest).not.toBe('')
+    body.blocks[0].text = 'mutated after admission began'
+    admission.resolve()
+    await dispatch
+
+    expect(admittedDigest).toBe(
+      digestRequest({
+        kind: 'message',
+        role: 'user',
+        blocks: [{ type: 'text', text: 'original request' }]
+      })
+    )
+    expect(codex.connections[0].calls.at(-1)).toMatchObject({
+      method: 'turn/start',
+      params: { input: [{ type: 'text', text: 'original request' }] }
+    })
+    await adapter.closeAll()
+  })
+
+  it('rejects non-text input without dispatch and invalidates the previous mutation lease', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const gate = authority([])
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: root,
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write',
+        isolatedHomePath: root
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: gate,
+      releaseStructuredWriteHome: async () => {}
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    await adapter.dispatch({
+      sessionId: SESSION,
+      clientMessageId: 'client-1',
+      body: {
+        kind: 'message',
+        role: 'user',
+        blocks: [{ type: 'text', text: 'first request' }]
+      },
+      fence: 7
+    })
+    const rejected = await adapter.dispatch({
+      sessionId: SESSION,
+      clientMessageId: 'client-2',
+      body: {
+        kind: 'message',
+        role: 'user',
+        blocks: [{ type: 'image-ref', path: '/tmp/untrusted.png' }]
+      },
+      fence: 8
+    })
+    expect(rejected).toEqual({
+      state: 'rejected',
+      reason: 'structured writer accepts only text request blocks'
+    })
+    expect(codex.connections[0].calls.filter(({ method }) => method === 'turn/start')).toHaveLength(
+      1
+    )
+
+    const notify = codex.connections[0].handlers.onNotification
+    const ask = codex.connections[0].handlers.onServerRequest
+    notify?.('item/started', {
+      threadId: THREAD,
+      turnId: TURN,
+      item: {
+        type: 'fileChange',
+        id: 'stale-change',
+        status: 'inProgress',
+        changes: [{ path: 'stale.txt', diff: '+stale', kind: { type: 'add' } }]
+      }
+    })
+    ask?.({
+      id: 9,
+      method: 'item/fileChange/requestApproval',
+      params: { itemId: 'stale-change', threadId: THREAD, turnId: TURN }
+    })
+    await expect
+      .poll(() => codex.connections[0].replies)
+      .toContainEqual({ id: 9, result: { decision: 'decline' } })
+    await adapter.closeAll()
+  })
+
+  it('releases the isolated home and revokes authority after a pre-publish failure', async () => {
+    const root = linkedWorktree()
+    const gate = authority([])
+    const release = vi.fn(async () => {})
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: '/isolated/session-enforced',
+        isolatedHomePath: '/isolated/session-enforced',
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write'
+      }),
+      openConnection: async () => {
+        throw new Error('spawn failed')
+      },
+      writeAuthority: gate,
+      releaseStructuredWriteHome: release
+    })
+
+    await expect(
+      adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    ).rejects.toThrow('spawn failed')
+    expect(release).toHaveBeenCalledWith(SESSION, '/isolated/session-enforced')
+    await expect(
+      gate.openTurn({
+        sessionId: SESSION,
+        clientMessageId: 'must-not-open',
+        body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'write' }] },
+        fence: 7
+      })
+    ).rejects.toThrow('no host-selected writable worktree')
+  })
+
+  it('reaps the child and isolated home even when an ended observer throws', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const release = vi.fn(async () => {})
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: '/isolated/session-enforced',
+        isolatedHomePath: '/isolated/session-enforced',
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write'
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: authority([]),
+      releaseStructuredWriteHome: release,
+      onEvent: (event) => {
+        if (event.type === 'ended') {
+          throw new Error('observer failed')
+        }
+      }
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+
+    await expect(adapter.closeAll()).rejects.toThrow('observer failed')
+    expect(codex.connections[0].closed).toBe(true)
+    expect(release).toHaveBeenCalledWith(SESSION, '/isolated/session-enforced')
+  })
+})

--- a/src/main/codex/codex-structured-session-enforcement.test.ts
+++ b/src/main/codex/codex-structured-session-enforcement.test.ts
@@ -13,6 +13,7 @@ import { CodexStructuredSessionAdapter } from './codex-structured-session-adapte
 import {
   CodexStructuredWriteAuthority,
   digestRequest,
+  type CodexStructuredWriteAuthorization,
   type CodexStructuredWriteReceipt
 } from './codex-structured-write-authority'
 
@@ -111,6 +112,67 @@ function nextTask(): Promise<void> {
 }
 
 describe('Codex structured local-writer enforcement', () => {
+  it('preserves host request authority through dispatch admission', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const authorizeTurn = vi.fn(
+      (input: Parameters<CodexStructuredWriteAuthorization['authorizeTurn']>[0]) => ({
+        requestReceiptId: input.requestAuthority?.requestReceiptId ?? '',
+        writableRoot: input.writableRoot,
+        capabilityHandle: 'host-handle-1'
+      })
+    )
+    const gate = new CodexStructuredWriteAuthority({
+      authorizeTurn,
+      consumeLease: () => {},
+      onReceipt: () => {}
+    })
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: root,
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write',
+        isolatedHomePath: root
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: gate,
+      releaseStructuredWriteHome: async () => {}
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'change source.txt only' }]
+    }
+    const requestAuthority = {
+      effectAuthority: 'local_structured_write' as const,
+      requestReceiptId: 'a'.repeat(64)
+    }
+
+    await adapter.dispatch({
+      sessionId: SESSION,
+      clientMessageId: 'client-1',
+      body,
+      fence: 7,
+      requestAuthority
+    })
+
+    expect(authorizeTurn).toHaveBeenCalledWith({
+      sessionId: SESSION,
+      turnEpoch: 2,
+      fence: 7,
+      clientMessageId: 'client-1',
+      requestDigest: digestRequest(body),
+      writableRoot: root,
+      requestAuthority
+    })
+    await adapter.closeAll()
+  })
+
   it('admits one file-change item while declining command, permission, and replay effects', async () => {
     const root = linkedWorktree()
     const receipts: CodexStructuredWriteReceipt[] = []

--- a/src/main/codex/codex-structured-session-enforcement.test.ts
+++ b/src/main/codex/codex-structured-session-enforcement.test.ts
@@ -8,6 +8,7 @@ import type {
   CodexAppServerConnectionHandlers,
   openCodexAppServerConnection
 } from './codex-app-server-connection'
+import { CodexAppServerUnsupportedError } from './codex-app-server-session'
 import { CodexStructuredSessionAdapter } from './codex-structured-session-adapter'
 import {
   CodexStructuredWriteAuthority,
@@ -224,9 +225,11 @@ describe('Codex structured local-writer enforcement', () => {
     await adapter.closeAll()
   })
 
-  it('fails before spawning when the launch is not effect-isolated', async () => {
+  it('leaves normal sessions unchanged when writer support is installed', async () => {
     const root = linkedWorktree()
     const codex = fakeCodex()
+    const gate = authority([])
+    const revokePendingTurn = vi.spyOn(gate, 'revokePendingTurn')
     const adapter = new CodexStructuredSessionAdapter({
       resolveLaunch: async () => ({
         command: 'codex',
@@ -236,14 +239,146 @@ describe('Codex structured local-writer enforcement', () => {
         resumeThreadId: null
       }),
       openConnection: codex.openConnection,
-      writeAuthority: authority([]),
+      writeAuthority: gate,
       releaseStructuredWriteHome: async () => {}
     })
 
     await expect(
       adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
-    ).rejects.toThrow('effect-isolated Codex launch')
-    expect(codex.connections).toHaveLength(0)
+    ).resolves.toBeDefined()
+    expect(codex.connections).toHaveLength(1)
+    await expect(
+      adapter.dispatch({
+        sessionId: SESSION,
+        clientMessageId: 'client-normal',
+        body: {
+          kind: 'message',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'write' }]
+        },
+        fence: 7,
+        requestAuthority: {
+          effectAuthority: 'local_structured_write',
+          requestReceiptId: 'a'.repeat(64)
+        }
+      })
+    ).resolves.toMatchObject({
+      state: 'rejected',
+      reason: 'local structured write requires a dedicated writer session'
+    })
+    await expect(
+      adapter.cancelTurn({ sessionId: SESSION, turnId: TURN, fence: 7 })
+    ).resolves.toEqual({ cancelled: true })
+    expect(revokePendingTurn).not.toHaveBeenCalled()
+    await adapter.closeAll()
+  })
+
+  it('interrupts the active writer turn before admitting a replacement turn', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: root,
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write',
+        isolatedHomePath: root
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: authority([]),
+      releaseStructuredWriteHome: async () => {}
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'first write' }]
+    }
+    await adapter.dispatch({ sessionId: SESSION, clientMessageId: 'client-1', body, fence: 7 })
+    const connection = codex.connections[0]
+    const request = connection.request
+    connection.request = async (method, params, options) => {
+      const result = await request(method, params, options)
+      if (method === 'turn/interrupt') {
+        connection.handlers.onNotification?.('turn/completed', {
+          threadId: THREAD,
+          turn: { id: TURN, status: 'interrupted' }
+        })
+      }
+      return result
+    }
+    await adapter.dispatch({
+      sessionId: SESSION,
+      clientMessageId: 'client-2',
+      body: { ...body, blocks: [{ type: 'text', text: 'stop and do this instead' }] },
+      fence: 7
+    })
+
+    const turnCalls = codex.connections[0].calls.filter(({ method }) => method.startsWith('turn/'))
+    expect(turnCalls.map(({ method }) => method)).toEqual([
+      'turn/start',
+      'turn/interrupt',
+      'turn/start'
+    ])
+    expect(turnCalls[1]).toMatchObject({
+      params: { threadId: THREAD, turnId: TURN }
+    })
+    await adapter.closeAll()
+  })
+
+  it('closes the writer session when the active mutation turn cannot be interrupted', async () => {
+    const root = linkedWorktree()
+    const codex = fakeCodex()
+    const gate = authority([])
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: root,
+        codexHome: root,
+        resumeThreadId: null,
+        effectIsolation: 'local-structured-write',
+        isolatedHomePath: root
+      }),
+      openConnection: codex.openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000,
+      writeAuthority: gate,
+      releaseStructuredWriteHome: async () => {}
+    })
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'first write' }]
+    }
+    await adapter.dispatch({ sessionId: SESSION, clientMessageId: 'client-1', body, fence: 7 })
+    const connection = codex.connections[0]
+    const request = connection.request
+    connection.request = async (method, params, options) => {
+      if (method === 'turn/interrupt') {
+        throw new CodexAppServerUnsupportedError('turn/interrupt is unavailable')
+      }
+      return request(method, params, options)
+    }
+
+    await expect(
+      adapter.dispatch({
+        sessionId: SESSION,
+        clientMessageId: 'client-2',
+        body: { ...body, blocks: [{ type: 'text', text: 'replace the request' }] },
+        fence: 7
+      })
+    ).resolves.toEqual({
+      state: 'rejected',
+      reason: 'the previous writer turn could not be stopped; the writer session was closed'
+    })
+    expect(connection.closed).toBe(true)
+    await expect(
+      gate.openTurn({ sessionId: SESSION, clientMessageId: 'client-3', body, fence: 7 })
+    ).rejects.toThrow('no host-selected writable worktree')
   })
 
   it('snapshots the exact request before host admission can yield', async () => {

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -26,7 +26,8 @@ function optionSession(request: CodexAppServerConnection['request']): CodexSessi
     options: new Map(),
     reportedOptions: { model: 'gpt-live', effort: 'high' },
     turnIdWaiters: [],
-    translator: null
+    translator: null,
+    isolatedHomePath: null
   }
 }
 

--- a/src/main/codex/codex-structured-session-state.ts
+++ b/src/main/codex/codex-structured-session-state.ts
@@ -43,6 +43,8 @@ export type CodexStructuredSessionAdapterDeps = {
   mintLinkId?: () => string
   now?: () => number
   requestTimeoutMs?: number
+  /** Bound for proving an interrupted writer turn actually reached terminal state. */
+  writerInterruptSettleTimeoutMs?: number
   /** Opt-in host admission. Absent means the existing structured session behavior is unchanged. */
   writeAuthority?: CodexStructuredWriteAuthority
   releaseStructuredWriteHome?: (sessionId: string, isolatedHomePath: string) => Promise<void>
@@ -59,6 +61,7 @@ export type CodexSession = {
   turnIdWaiters: ((turnId: string) => void)[]
   translator: CodexJournalTranslator | null
   isolatedHomePath: string | null
+  effectIsolation?: 'local-structured-write' | null
 }
 
 export type CodexAcquisitionAttempt = {

--- a/src/main/codex/codex-structured-session-state.ts
+++ b/src/main/codex/codex-structured-session-state.ts
@@ -5,6 +5,7 @@ import type {
 } from './codex-app-server-connection'
 import { CodexAcquisitionWindow } from './codex-structured-acquisition-window'
 import type { CodexJournalTranslator } from './codex-structured-journal-translation'
+import type { CodexStructuredWriteAuthority } from './codex-structured-write-authority'
 
 export type CodexStructuredLaunch = {
   command: string
@@ -13,6 +14,8 @@ export type CodexStructuredLaunch = {
   codexHome: string | null
   resumeThreadId: string | null
   env?: Record<string, string>
+  effectIsolation?: 'local-structured-write'
+  isolatedHomePath?: string
 }
 
 export type CodexStructuredSessionEvent =
@@ -40,6 +43,10 @@ export type CodexStructuredSessionAdapterDeps = {
   mintLinkId?: () => string
   now?: () => number
   requestTimeoutMs?: number
+  /** Opt-in host admission. Absent means the existing structured session behavior is unchanged. */
+  writeAuthority?: CodexStructuredWriteAuthority
+  releaseStructuredWriteHome?: (sessionId: string, isolatedHomePath: string) => Promise<void>
+  onStructuredWriteHomeError?: (input: { sessionId: string; error: unknown }) => void
 }
 
 export type CodexSession = {
@@ -51,6 +58,7 @@ export type CodexSession = {
   reportedOptions: { model?: string; effort?: string }
   turnIdWaiters: ((turnId: string) => void)[]
   translator: CodexJournalTranslator | null
+  isolatedHomePath: string | null
 }
 
 export type CodexAcquisitionAttempt = {

--- a/src/main/codex/codex-structured-thread-open.ts
+++ b/src/main/codex/codex-structured-thread-open.ts
@@ -22,14 +22,25 @@ function nonEmptyString(value: unknown): string | null {
 
 export async function openCodexThread(
   connection: CodexAppServerConnection,
-  launch: { cwd: string; resumeThreadId: string | null },
+  launch: {
+    cwd: string
+    resumeThreadId: string | null
+    effectIsolation?: 'local-structured-write'
+  },
   timeoutMs: number | undefined
 ): Promise<CodexOpenedThread> {
   const opened = await connection.request(
     launch.resumeThreadId ? 'thread/resume' : 'thread/start',
     launch.resumeThreadId
-      ? { threadId: launch.resumeThreadId, cwd: launch.cwd }
-      : { cwd: launch.cwd },
+      ? {
+          threadId: launch.resumeThreadId,
+          cwd: launch.cwd,
+          ...(launch.effectIsolation ? { config: { web_search: 'disabled' } } : {})
+        }
+      : {
+          cwd: launch.cwd,
+          ...(launch.effectIsolation ? { config: { web_search: 'disabled' } } : {})
+        },
     { timeoutMs }
   )
   const threadId = readCodexThreadId(opened)

--- a/src/main/codex/codex-structured-turn-start.ts
+++ b/src/main/codex/codex-structured-turn-start.ts
@@ -65,7 +65,12 @@ function turnInputFor(body: AgentJournalMessageItem): Record<string, unknown>[] 
  */
 export async function startCodexTurn(
   host: CodexTurnHost,
-  input: { clientMessageId: string; body: AgentJournalMessageItem; timeoutMs?: number }
+  input: {
+    clientMessageId: string
+    body: AgentJournalMessageItem
+    timeoutMs?: number
+    enforcedOptions?: Record<string, unknown>
+  }
 ): Promise<string | null> {
   // Registered BEFORE the call: on builds that ack first, `turn/started` can
   // land while the response is still in flight.
@@ -82,7 +87,8 @@ export async function startCodexTurn(
         threadId: host.threadId,
         clientUserMessageId: input.clientMessageId,
         input: turnInputFor(input.body),
-        ...Object.fromEntries(host.options)
+        ...Object.fromEntries(host.options),
+        ...input.enforcedOptions
       },
       { timeoutMs: input.timeoutMs }
     )
@@ -103,11 +109,12 @@ export async function startCodexTurn(
 export async function dispatchCodexTurn(
   session: CodexTurnHost,
   input: { clientMessageId: string; body: AgentJournalMessageItem },
-  timeoutMs: number | undefined
+  timeoutMs: number | undefined,
+  enforcedOptions?: Record<string, unknown>
 ): Promise<AgentSessionDispatchOutcome> {
   let turnId: string | null
   try {
-    turnId = await startCodexTurn(session, { ...input, timeoutMs })
+    turnId = await startCodexTurn(session, { ...input, timeoutMs, enforcedOptions })
   } catch (error) {
     if (isCodexAppServerRequestError(error) || isCodexAppServerUnsupportedError(error)) {
       return { state: 'rejected', reason: (error as Error).message }

--- a/src/main/codex/codex-structured-user-turn-invalidation.test.ts
+++ b/src/main/codex/codex-structured-user-turn-invalidation.test.ts
@@ -1,0 +1,118 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CodexAppServerConnection } from './codex-app-server-connection'
+import { CodexStructuredSessionControl } from './codex-structured-session-control'
+import type { CodexSession } from './codex-structured-session-state'
+import { CodexStructuredWriteAuthority } from './codex-structured-write-authority'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function linkedWorktree(): string {
+  const fixture = mkdtempSync(join(tmpdir(), 'orca-trusted-user-turn-'))
+  roots.push(fixture)
+  const root = join(fixture, 'worktree')
+  const gitDir = join(fixture, 'repo', '.git', 'worktrees', 'bounded')
+  mkdirSync(root, { recursive: true })
+  mkdirSync(gitDir, { recursive: true })
+  writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  writeFileSync(join(gitDir, 'gitdir'), `${join(root, '.git')}\n`)
+  return realpathSync(root)
+}
+
+function session(
+  request: CodexAppServerConnection['request'],
+  effectIsolation?: 'local-structured-write'
+): CodexSession {
+  return {
+    connection: {
+      pid: 42,
+      closed: false,
+      request,
+      notify: vi.fn(),
+      respond: vi.fn(),
+      respondWithError: vi.fn(),
+      close: vi.fn(async () => undefined)
+    },
+    threadId: 'thread-1',
+    historyPath: null,
+    prompts: { clear: vi.fn() } as unknown as CodexSession['prompts'],
+    options: new Map(),
+    reportedOptions: {},
+    turnIdWaiters: [],
+    translator: null,
+    isolatedHomePath: null,
+    effectIsolation
+  }
+}
+
+describe('trusted user turn writer invalidation', () => {
+  it('revokes and closes every other active writer before a local user send proceeds', async () => {
+    const interrupt = vi.fn(async () => ({}))
+    const writer = session(interrupt, 'local-structured-write')
+    const normal = session(vi.fn(async () => ({})))
+    const authority = {
+      activeTurn: vi.fn(() => ({ threadId: 'writer-thread', turnId: 'writer-turn' })),
+      invalidateTurnEpoch: vi.fn()
+    } as unknown as CodexStructuredWriteAuthority
+    const terminate = vi.fn(async () => undefined)
+    const control = new CodexStructuredSessionControl(
+      new Map([
+        ['writer-session', writer],
+        ['normal-session', normal]
+      ]),
+      {
+        resolveLaunch: vi.fn(),
+        writeAuthority: authority
+      },
+      terminate
+    )
+
+    await control.invalidateEffectAuthorityForTrustedUserTurn({
+      sourceSessionId: 'normal-session'
+    })
+
+    expect(authority.invalidateTurnEpoch).toHaveBeenCalledWith('writer-session')
+    expect(interrupt).toHaveBeenCalledWith(
+      'turn/interrupt',
+      { threadId: 'writer-thread', turnId: 'writer-turn' },
+      { timeoutMs: undefined }
+    )
+    expect(terminate).toHaveBeenCalledWith('writer-session')
+  })
+
+  it('invalidates an authorization that resolves after the newer user epoch', async () => {
+    const root = linkedWorktree()
+    const grant = Promise.withResolvers<{
+      requestReceiptId: string
+      writableRoot: string
+      capabilityHandle: string
+    }>()
+    const authority = new CodexStructuredWriteAuthority({
+      authorizeTurn: () => grant.promise,
+      consumeLease: () => undefined,
+      onReceipt: () => undefined
+    })
+    await authority.bindSession('writer-session', root)
+    const opening = authority.openTurn({
+      sessionId: 'writer-session',
+      clientMessageId: 'client-1',
+      body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'write' }] },
+      fence: 1
+    })
+
+    authority.invalidateTurnEpoch('writer-session')
+    grant.resolve({ requestReceiptId: 'receipt', writableRoot: root, capabilityHandle: 'handle' })
+
+    await expect(opening).resolves.toBeNull()
+    expect(authority.activeTurn('writer-session')).toBeNull()
+  })
+})

--- a/src/main/codex/codex-structured-user-turn-invalidation.ts
+++ b/src/main/codex/codex-structured-user-turn-invalidation.ts
@@ -1,0 +1,48 @@
+import type {
+  CodexSession,
+  CodexStructuredSessionAdapterDeps
+} from './codex-structured-session-state'
+
+export async function invalidateTrustedUserTurnWriters(
+  input: { sourceSessionId: string },
+  sessions: ReadonlyMap<string, CodexSession>,
+  deps: Pick<CodexStructuredSessionAdapterDeps, 'requestTimeoutMs' | 'writeAuthority'>,
+  terminateSession: (sessionId: string) => Promise<void>
+): Promise<void> {
+  const authority = deps.writeAuthority
+  if (!authority) {
+    return
+  }
+  const source = sessions.get(input.sourceSessionId)
+  const writerSessionIds = [...sessions]
+    .filter(
+      ([sessionId, session]) =>
+        session.effectIsolation === 'local-structured-write' &&
+        !(
+          sessionId === input.sourceSessionId &&
+          source?.effectIsolation === 'local-structured-write'
+        )
+    )
+    .map(([sessionId]) => sessionId)
+  await Promise.all(
+    writerSessionIds.map(async (sessionId) => {
+      const session = sessions.get(sessionId)
+      if (!session) {
+        return
+      }
+      const active = authority.activeTurn(sessionId)
+      authority.invalidateTurnEpoch(sessionId)
+      if (!active) {
+        return
+      }
+      await session.connection
+        .request(
+          'turn/interrupt',
+          { threadId: active.threadId, turnId: active.turnId },
+          { timeoutMs: deps.requestTimeoutMs }
+        )
+        .catch(() => undefined)
+      await terminateSession(sessionId).catch(() => undefined)
+    })
+  )
+}

--- a/src/main/codex/codex-structured-write-admission-race.test.ts
+++ b/src/main/codex/codex-structured-write-admission-race.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as StructuredWriteManifest from './codex-structured-write-manifest'
+
+const roots: string[] = []
+let afterSnapshot: (() => void) | null = null
+
+vi.mock('./codex-structured-write-manifest', async (importOriginal) => {
+  const original = await importOriginal<typeof StructuredWriteManifest>()
+  return {
+    ...original,
+    snapshotChanges: async (...args: Parameters<typeof original.snapshotChanges>) => {
+      const manifest = await original.snapshotChanges(...args)
+      afterSnapshot?.()
+      return manifest
+    }
+  }
+})
+
+const { admitStructuredFileChange } = await import('./codex-structured-write-admission')
+const { snapshotLinkedWorktreeRoot } = await import('./codex-structured-write-manifest')
+
+afterEach(() => {
+  afterSnapshot = null
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function linkedWorktree(): { fixture: string; root: string; gitDir: string } {
+  const fixture = mkdtempSync(join(tmpdir(), 'orca-admission-race-'))
+  roots.push(fixture)
+  const root = join(fixture, 'worktree')
+  const gitDir = join(fixture, 'canonical.git', 'worktrees', 'bounded')
+  mkdirSync(root, { recursive: true })
+  mkdirSync(gitDir, { recursive: true })
+  writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  writeFileSync(join(gitDir, 'gitdir'), `${join(root, '.git')}\n`)
+  return { fixture, root: realpathSync(root), gitDir }
+}
+
+describe('Codex structured write admission races', () => {
+  it('declines when the selected worktree inode is replaced during admission', async () => {
+    const fixture = linkedWorktree()
+    const consumeLease = vi.fn()
+    const worktree = await snapshotLinkedWorktreeRoot(fixture.root)
+    afterSnapshot = () => {
+      renameSync(fixture.root, join(fixture.fixture, 'displaced-worktree'))
+      mkdirSync(fixture.root)
+      writeFileSync(join(fixture.root, '.git'), `gitdir: ${fixture.gitDir}\n`)
+      writeFileSync(join(fixture.gitDir, 'gitdir'), `${join(fixture.root, '.git')}\n`)
+    }
+
+    await expect(
+      admitStructuredFileChange({
+        sessionId: 'session-1',
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        grantRoot: fixture.root,
+        expectedWorktreeIdentity: worktree.identity,
+        lease: {
+          handle: 'handle-1',
+          requestReceiptId: 'request-1',
+          sessionId: 'session-1',
+          turnEpoch: 1,
+          fence: 1,
+          clientMessageId: 'message-1',
+          requestDigest: 'a'.repeat(64),
+          worktreeRoot: fixture.root,
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          state: 'issued'
+        },
+        observed: {
+          sessionId: 'session-1',
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          itemId: 'item-1',
+          changes: [{ path: 'new.txt', diff: '+new', kind: { type: 'add' } }],
+          changePlanDigest: 'b'.repeat(64),
+          before: null,
+          admission: null
+        },
+        authorization: {
+          authorizeTurn: () => null,
+          consumeLease,
+          onReceipt: () => {}
+        },
+        now: () => 1,
+        isCurrent: () => true
+      })
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+    expect(consumeLease).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/codex/codex-structured-write-admission.ts
+++ b/src/main/codex/codex-structured-write-admission.ts
@@ -1,0 +1,81 @@
+import { realpath } from 'node:fs/promises'
+import { sha256 } from './codex-structured-write-digest'
+import { snapshotChanges, validateLinkedWorktreeRoot } from './codex-structured-write-manifest'
+import {
+  LOCAL_STRUCTURED_WRITE_EFFECT,
+  type CodexObservedFileChange,
+  type CodexStructuredApproval,
+  type CodexStructuredWriteAdmissionReceipt,
+  type CodexStructuredWriteAuthorization,
+  type CodexStructuredWriteLease
+} from './codex-structured-write-types'
+
+export async function admitStructuredFileChange(input: {
+  sessionId: string
+  threadId: string
+  turnId: string
+  grantRoot: string | null
+  lease: CodexStructuredWriteLease
+  observed: CodexObservedFileChange
+  authorization: CodexStructuredWriteAuthorization
+  now: () => number
+  isCurrent: () => boolean
+}): Promise<CodexStructuredApproval> {
+  const { lease, observed } = input
+  lease.state = 'reserved'
+  try {
+    if ((await validateLinkedWorktreeRoot(lease.worktreeRoot)) !== lease.worktreeRoot) {
+      throw new Error('host-selected worktree changed before file admission')
+    }
+    if (input.grantRoot && (await realpath(input.grantRoot)) !== lease.worktreeRoot) {
+      throw new Error('file change requested a different grant root')
+    }
+    observed.before = await snapshotChanges(lease.worktreeRoot, observed.changes)
+    if ((await validateLinkedWorktreeRoot(lease.worktreeRoot)) !== lease.worktreeRoot) {
+      throw new Error('host-selected worktree changed during file admission')
+    }
+    if (!input.isCurrent()) {
+      throw new Error('structured write lease was revoked during admission')
+    }
+    const capabilityHandleDigest = sha256(lease.handle)
+    const admissionReceipt: CodexStructuredWriteAdmissionReceipt = {
+      protocolVersion: 1,
+      requestReceiptId: lease.requestReceiptId,
+      effectDomain: LOCAL_STRUCTURED_WRITE_EFFECT,
+      sessionId: input.sessionId,
+      turnEpoch: lease.turnEpoch,
+      fence: lease.fence,
+      clientMessageId: lease.clientMessageId,
+      threadId: input.threadId,
+      turnId: input.turnId,
+      requestDigest: lease.requestDigest,
+      toolUseId: observed.itemId,
+      changePlanDigest: observed.changePlanDigest,
+      worktreeRoot: lease.worktreeRoot,
+      capabilityHandleDigest,
+      before: observed.before,
+      admittedAtMs: input.now()
+    }
+    await input.authorization.consumeLease({
+      capabilityHandle: lease.handle,
+      receipt: admissionReceipt
+    })
+    if (!input.isCurrent()) {
+      throw new Error('structured write lease was revoked while the host consumed it')
+    }
+    observed.admission = {
+      requestReceiptId: lease.requestReceiptId,
+      turnEpoch: lease.turnEpoch,
+      fence: lease.fence,
+      clientMessageId: lease.clientMessageId,
+      requestDigest: lease.requestDigest,
+      worktreeRoot: lease.worktreeRoot,
+      capabilityHandleDigest
+    }
+    lease.state = 'consumed'
+    return { handled: true, result: { decision: 'accept' } }
+  } catch {
+    lease.state = 'revoked'
+    return { handled: true, result: { decision: 'decline' } }
+  }
+}

--- a/src/main/codex/codex-structured-write-admission.ts
+++ b/src/main/codex/codex-structured-write-admission.ts
@@ -1,6 +1,6 @@
 import { realpath } from 'node:fs/promises'
 import { sha256 } from './codex-structured-write-digest'
-import { snapshotChanges, validateLinkedWorktreeRoot } from './codex-structured-write-manifest'
+import { snapshotChanges, snapshotLinkedWorktreeRoot } from './codex-structured-write-manifest'
 import {
   LOCAL_STRUCTURED_WRITE_EFFECT,
   type CodexObservedFileChange,
@@ -15,6 +15,7 @@ export async function admitStructuredFileChange(input: {
   threadId: string
   turnId: string
   grantRoot: string | null
+  expectedWorktreeIdentity: string
   lease: CodexStructuredWriteLease
   observed: CodexObservedFileChange
   authorization: CodexStructuredWriteAuthorization
@@ -24,14 +25,22 @@ export async function admitStructuredFileChange(input: {
   const { lease, observed } = input
   lease.state = 'reserved'
   try {
-    if ((await validateLinkedWorktreeRoot(lease.worktreeRoot)) !== lease.worktreeRoot) {
+    const initialWorktree = await snapshotLinkedWorktreeRoot(lease.worktreeRoot)
+    if (
+      initialWorktree.root !== lease.worktreeRoot ||
+      initialWorktree.identity !== input.expectedWorktreeIdentity
+    ) {
       throw new Error('host-selected worktree changed before file admission')
     }
     if (input.grantRoot && (await realpath(input.grantRoot)) !== lease.worktreeRoot) {
       throw new Error('file change requested a different grant root')
     }
     observed.before = await snapshotChanges(lease.worktreeRoot, observed.changes)
-    if ((await validateLinkedWorktreeRoot(lease.worktreeRoot)) !== lease.worktreeRoot) {
+    const admittedWorktree = await snapshotLinkedWorktreeRoot(lease.worktreeRoot)
+    if (
+      admittedWorktree.root !== lease.worktreeRoot ||
+      admittedWorktree.identity !== initialWorktree.identity
+    ) {
       throw new Error('host-selected worktree changed during file admission')
     }
     if (!input.isCurrent()) {

--- a/src/main/codex/codex-structured-write-authority.test.ts
+++ b/src/main/codex/codex-structured-write-authority.test.ts
@@ -3,13 +3,14 @@ import {
   mkdtempSync,
   readFileSync,
   realpathSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
 import {
   CodexStructuredWriteAuthority,
@@ -180,6 +181,89 @@ describe('CodexStructuredWriteAuthority', () => {
     await expect(
       gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
     ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('keeps an admitted change when item started is replayed before completion', async () => {
+    const fixture = linkedWorktree()
+    const target = join(fixture.root, 'source.txt')
+    writeFileSync(target, 'before\n')
+    const receipts: CodexStructuredWriteReceipt[] = []
+    const gate = authority({ receipts })
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('source.txt'))
+    await gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+
+    gate.observeNotification(SESSION, 'item/started', item('source.txt'))
+    writeFileSync(target, 'after\n')
+    gate.observeNotification(SESSION, 'item/completed', {
+      ...item('source.txt'),
+      item: { ...(item('source.txt').item as object), status: 'completed' }
+    })
+    await gate.flushReceipts()
+
+    expect(receipts).toHaveLength(1)
+    expect(receipts[0]).toMatchObject({ toolUseId: 'item-1', outcome: 'completed' })
+  })
+
+  it('revokes admission when the same item id is reused for another change plan', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('first.txt'))
+    gate.observeNotification(SESSION, 'item/started', item('second.txt'))
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+    expect(gate.activeTurn(SESSION)).toBeNull()
+  })
+
+  it('atomically accepts only one of two concurrent approvals', async () => {
+    const fixture = linkedWorktree()
+    const consumeLease = vi.fn(async () => {})
+    const gate = new CodexStructuredWriteAuthority({
+      authorizeTurn: ({ writableRoot }) => ({
+        requestReceiptId: 'host-request-1',
+        writableRoot,
+        capabilityHandle: 'host-handle-1'
+      }),
+      consumeLease,
+      onReceipt: () => {}
+    })
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('source.txt'))
+
+    const decisions = await Promise.all([
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval()),
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ])
+
+    expect(decisions).toEqual([
+      { handled: true, result: { decision: 'accept' } },
+      { handled: true, result: { decision: 'decline' } }
+    ])
+    expect(consumeLease).toHaveBeenCalledOnce()
+  })
+
+  it('fails an admitted receipt when its item id is replayed with another plan', async () => {
+    const fixture = linkedWorktree()
+    const receipts: CodexStructuredWriteReceipt[] = []
+    const gate = authority({ receipts })
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('first.txt'))
+    await gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+
+    gate.observeNotification(SESSION, 'item/started', item('second.txt'))
+    await gate.flushReceipts()
+    expect(receipts).toHaveLength(1)
+    expect(receipts[0]).toMatchObject({ toolUseId: 'item-1', outcome: 'failed' })
+
+    gate.observeNotification(SESSION, 'item/completed', {
+      ...item('first.txt'),
+      item: { ...(item('first.txt').item as object), status: 'completed' }
+    })
+    await gate.flushReceipts()
+    expect(receipts).toHaveLength(1)
   })
 
   it('revokes the old lease when a new trusted user turn starts', async () => {
@@ -358,6 +442,29 @@ describe('CodexStructuredWriteAuthority', () => {
     ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
   })
 
+  it('revokes the old writer before a replacement worktree is validated', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    expect(gate.activeTurn(SESSION)).toEqual({ threadId: THREAD, turnId: TURN })
+
+    const invalidReplacement = join(fixture.root, 'canonical')
+    mkdirSync(join(invalidReplacement, '.git'), { recursive: true })
+    await expect(gate.bindSession(SESSION, invalidReplacement)).rejects.toThrow(
+      'linked Git worktree'
+    )
+
+    expect(gate.activeTurn(SESSION)).toBeNull()
+    await expect(
+      gate.openTurn({
+        sessionId: SESSION,
+        clientMessageId: 'client-after-failed-rebind',
+        body: BODY,
+        fence: 8
+      })
+    ).rejects.toThrow('no host-selected writable worktree')
+  })
+
   it('keeps enforcement evidence after a new turn or process exit revokes mutation', async () => {
     const fixture = linkedWorktree()
     const receipts: CodexStructuredWriteReceipt[] = []
@@ -492,6 +599,24 @@ describe('CodexStructuredWriteAuthority', () => {
     const marker = readFileSync(join(fixture.root, '.git'), 'utf8').trim()
     const gitDir = marker.slice('gitdir:'.length).trim()
     writeFileSync(join(gitDir, 'gitdir'), `${join(fixture.root, 'different', '.git')}\n`)
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('rejects a worktree root replaced after the host bound the session', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('new.txt'))
+    const displaced = join(fixture.root, '..', 'displaced-worktree')
+    const marker = readFileSync(join(fixture.root, '.git'), 'utf8').trim()
+    const gitDir = marker.slice('gitdir:'.length).trim()
+    renameSync(fixture.root, displaced)
+    mkdirSync(fixture.root)
+    writeFileSync(join(fixture.root, '.git'), `gitdir: ${gitDir}\n`)
+    writeFileSync(join(gitDir, 'gitdir'), `${join(fixture.root, '.git')}\n`)
 
     await expect(
       gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())

--- a/src/main/codex/codex-structured-write-authority.test.ts
+++ b/src/main/codex/codex-structured-write-authority.test.ts
@@ -1,0 +1,498 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
+import {
+  CodexStructuredWriteAuthority,
+  digestRequest,
+  type CodexStructuredWriteReceipt
+} from './codex-structured-write-authority'
+
+const SESSION = 'session-1'
+const THREAD = 'thread-1'
+const TURN = 'turn-1'
+const BODY: AgentJournalMessageItem = {
+  kind: 'message',
+  role: 'user',
+  blocks: [{ type: 'text', text: 'replace the selected file' }]
+}
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function linkedWorktree(): { root: string; outside: string } {
+  const fixture = mkdtempSync(join(tmpdir(), 'orca-structured-write-'))
+  roots.push(fixture)
+  const root = join(fixture, 'worktree')
+  const gitDir = join(fixture, 'canonical.git', 'worktrees', 'bounded')
+  const outside = join(fixture, 'outside.txt')
+  mkdirSync(root, { recursive: true })
+  mkdirSync(gitDir, { recursive: true })
+  writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  writeFileSync(join(gitDir, 'gitdir'), `${join(root, '.git')}\n`)
+  return { root: realpathSync(root), outside }
+}
+
+function item(path: string, id = 'item-1', turnId = TURN): Record<string, unknown> {
+  return {
+    threadId: THREAD,
+    turnId,
+    item: {
+      type: 'fileChange',
+      id,
+      status: 'inProgress',
+      changes: [{ path, diff: '@@ -1 +1 @@', kind: { type: 'update' } }]
+    }
+  }
+}
+
+function approval(id = 'item-1', turnId = TURN): Record<string, unknown> {
+  return { itemId: id, threadId: THREAD, turnId, startedAtMs: 1 }
+}
+
+function authority(input: {
+  receipts?: CodexStructuredWriteReceipt[]
+  authorize?: boolean
+}): CodexStructuredWriteAuthority {
+  let handle = 0
+  return new CodexStructuredWriteAuthority(
+    {
+      authorizeTurn: ({ writableRoot }) =>
+        input.authorize === false
+          ? null
+          : { requestReceiptId: 'host-request-1', writableRoot, capabilityHandle: 'host-handle-1' },
+      consumeLease: () => {},
+      onReceipt: (receipt) => input.receipts?.push(receipt)
+    },
+    () => 1_700_000_000_000,
+    () => `opaque-${++handle}`
+  )
+}
+
+async function issue(
+  gate: CodexStructuredWriteAuthority,
+  root: string,
+  turnId = TURN
+): Promise<void> {
+  await gate.bindSession(SESSION, root)
+  const turnEpoch = await gate.openTurn({
+    sessionId: SESSION,
+    clientMessageId: 'client-1',
+    body: BODY,
+    fence: 7
+  })
+  if (turnEpoch !== null) {
+    gate.bindTurn(SESSION, THREAD, turnId, turnEpoch)
+  }
+}
+
+describe('CodexStructuredWriteAuthority', () => {
+  it('admits one file change and emits a bounded before/after receipt', async () => {
+    const fixture = linkedWorktree()
+    const target = join(fixture.root, 'source.txt')
+    writeFileSync(target, 'before\n')
+    const receipts: CodexStructuredWriteReceipt[] = []
+    const gate = authority({ receipts })
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('source.txt'))
+
+    await expect(
+      gate.reviewServerRequest(
+        SESSION,
+        'item/commandExecution/requestApproval',
+        approval('command-1')
+      )
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+    await expect(
+      gate.reviewServerRequest(
+        SESSION,
+        'item/permissions/requestApproval',
+        approval('permissions-1')
+      )
+    ).resolves.toEqual({ handled: true, result: { permissions: {}, scope: 'turn' } })
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
+
+    writeFileSync(target, 'after\n')
+    gate.observeNotification(SESSION, 'item/completed', {
+      ...item('source.txt'),
+      item: { ...(item('source.txt').item as object), status: 'completed' }
+    })
+    await expect.poll(() => receipts.length).toBe(1)
+
+    expect(receipts[0]).toMatchObject({
+      protocolVersion: 1,
+      requestReceiptId: 'host-request-1',
+      effectDomain: 'local_structured_write',
+      sessionId: SESSION,
+      turnEpoch: 1,
+      fence: 7,
+      clientMessageId: 'client-1',
+      threadId: THREAD,
+      turnId: TURN,
+      requestDigest: digestRequest(BODY),
+      toolUseId: 'item-1',
+      changePlanDigest: expect.stringMatching(/^[0-9a-f]{64}$/),
+      worktreeRoot: fixture.root,
+      outcome: 'completed',
+      completedAtMs: 1_700_000_000_000
+    })
+    expect(receipts[0].capabilityHandleDigest).toMatch(/^[0-9a-f]{64}$/)
+    expect(receipts[0].before).toEqual([
+      { path: 'source.txt', exists: true, sha256: expect.any(String), bytes: 7 }
+    ])
+    expect(receipts[0].after).toEqual([
+      { path: 'source.txt', exists: true, sha256: expect.any(String), bytes: 6 }
+    ])
+    expect(receipts[0].before[0].sha256).not.toBe(receipts[0].after[0].sha256)
+    expect(readFileSync(target, 'utf8')).toBe('after\n')
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('revokes the old lease when a new trusted user turn starts', async () => {
+    const fixture = linkedWorktree()
+    writeFileSync(join(fixture.root, 'source.txt'), 'before\n')
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('source.txt'))
+
+    const turnEpoch = await gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-2',
+      body: { ...BODY, blocks: [{ type: 'text', text: 'status?' }] },
+      fence: 7
+    })
+    expect(turnEpoch).toBe(2)
+    gate.bindTurn(SESSION, THREAD, 'turn-2', turnEpoch as number)
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('does not let a late authorization for an old turn overwrite the current lease', async () => {
+    const fixture = linkedWorktree()
+    const grants = [
+      Promise.withResolvers<{
+        requestReceiptId: string
+        writableRoot: string
+        capabilityHandle: string
+      }>(),
+      Promise.withResolvers<{
+        requestReceiptId: string
+        writableRoot: string
+        capabilityHandle: string
+      }>()
+    ]
+    const gate = new CodexStructuredWriteAuthority({
+      authorizeTurn: ({ turnEpoch }) => grants[turnEpoch - 1].promise,
+      consumeLease: () => {},
+      onReceipt: () => {}
+    })
+    await gate.bindSession(SESSION, fixture.root)
+    const first = gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-1',
+      body: BODY,
+      fence: 7
+    })
+    const second = gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-2',
+      body: { ...BODY, blocks: [{ type: 'text', text: 'newer correction' }] },
+      fence: 8
+    })
+
+    grants[1].resolve({
+      requestReceiptId: 'request-2',
+      writableRoot: fixture.root,
+      capabilityHandle: 'host-handle-2'
+    })
+    await expect(second).resolves.toBe(2)
+    gate.bindTurn(SESSION, THREAD, 'turn-2', 2)
+    grants[0].resolve({
+      requestReceiptId: 'request-1',
+      writableRoot: fixture.root,
+      capabilityHandle: 'host-handle-1'
+    })
+    await expect(first).resolves.toBeNull()
+
+    gate.observeNotification(SESSION, 'item/started', item('new.txt', 'item-2', 'turn-2'))
+    await expect(
+      gate.reviewServerRequest(
+        SESSION,
+        'item/fileChange/requestApproval',
+        approval('item-2', 'turn-2')
+      )
+    ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
+  })
+
+  it('ignores a stale turn binding instead of attaching it to the current request', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await gate.bindSession(SESSION, fixture.root)
+    const firstEpoch = await gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-1',
+      body: BODY,
+      fence: 7
+    })
+    const secondEpoch = await gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-2',
+      body: { ...BODY, blocks: [{ type: 'text', text: 'current request' }] },
+      fence: 8
+    })
+    expect([firstEpoch, secondEpoch]).toEqual([1, 2])
+
+    gate.bindTurn(SESSION, THREAD, 'stale-turn', firstEpoch as number)
+    gate.bindTurn(SESSION, THREAD, 'current-turn', secondEpoch as number)
+    gate.observeNotification(SESSION, 'item/started', item('current.txt', 'item-2', 'current-turn'))
+
+    await expect(
+      gate.reviewServerRequest(
+        SESSION,
+        'item/fileChange/requestApproval',
+        approval('item-2', 'current-turn')
+      )
+    ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
+  })
+
+  it('keeps the epoch monotonic when the same durable session is rebound', async () => {
+    const fixture = linkedWorktree()
+    const grants = [
+      Promise.withResolvers<{
+        requestReceiptId: string
+        writableRoot: string
+        capabilityHandle: string
+      }>(),
+      Promise.withResolvers<{
+        requestReceiptId: string
+        writableRoot: string
+        capabilityHandle: string
+      }>(),
+      Promise.withResolvers<{
+        requestReceiptId: string
+        writableRoot: string
+        capabilityHandle: string
+      }>()
+    ]
+    const gate = new CodexStructuredWriteAuthority({
+      authorizeTurn: ({ turnEpoch }) => grants[turnEpoch - 1].promise,
+      consumeLease: () => {},
+      onReceipt: () => {}
+    })
+    await gate.bindSession(SESSION, fixture.root)
+    const stale = gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-old',
+      body: BODY,
+      fence: 7
+    })
+    gate.revokeSession(SESSION)
+    await gate.bindSession(SESSION, fixture.root)
+    const current = gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-current',
+      body: { ...BODY, blocks: [{ type: 'text', text: 'current after rebind' }] },
+      fence: 8
+    })
+    grants[2].resolve({
+      requestReceiptId: 'request-current',
+      writableRoot: fixture.root,
+      capabilityHandle: 'handle-current'
+    })
+    await expect(current).resolves.toBe(3)
+    gate.bindTurn(SESSION, THREAD, 'turn-current', 3)
+    grants[0].resolve({
+      requestReceiptId: 'request-stale',
+      writableRoot: fixture.root,
+      capabilityHandle: 'handle-stale'
+    })
+    await expect(stale).resolves.toBeNull()
+
+    gate.observeNotification(
+      SESSION,
+      'item/started',
+      item('current.txt', 'item-current', 'turn-current')
+    )
+    await expect(
+      gate.reviewServerRequest(
+        SESSION,
+        'item/fileChange/requestApproval',
+        approval('item-current', 'turn-current')
+      )
+    ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
+  })
+
+  it('keeps enforcement evidence after a new turn or process exit revokes mutation', async () => {
+    const fixture = linkedWorktree()
+    const receipts: CodexStructuredWriteReceipt[] = []
+    const gate = authority({ receipts })
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('source.txt'))
+    await gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    writeFileSync(join(fixture.root, 'source.txt'), 'written\n')
+
+    const turnEpoch = await gate.openTurn({
+      sessionId: SESSION,
+      clientMessageId: 'client-2',
+      body: { ...BODY, blocks: [{ type: 'text', text: 'stop and explain' }] },
+      fence: 8
+    })
+    gate.observeNotification(SESSION, 'item/completed', {
+      ...item('source.txt'),
+      item: { ...(item('source.txt').item as object), status: 'completed' }
+    })
+    await expect.poll(() => receipts.length).toBe(1)
+    expect(receipts[0].outcome).toBe('completed')
+
+    expect(turnEpoch).toBe(2)
+    gate.bindTurn(SESSION, THREAD, 'turn-2', turnEpoch as number)
+    gate.observeNotification(SESSION, 'item/started', item('second.txt', 'item-2', 'turn-2'))
+    await gate.reviewServerRequest(
+      SESSION,
+      'item/fileChange/requestApproval',
+      approval('item-2', 'turn-2')
+    )
+    gate.revokeSession(SESSION)
+    await expect.poll(() => receipts.length).toBe(2)
+    expect(receipts[1]).toMatchObject({ toolUseId: 'item-2', outcome: 'failed' })
+  })
+
+  it.each([
+    ['sibling path', '../outside.txt'],
+    ['Git metadata', '.git/config']
+  ])('denies %s before consuming the writer', async (_label, path) => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item(path))
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('accepts an absolute App Server path that canonicalizes into the selected root', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    const alternateRoot = fixture.root.startsWith('/private/var/')
+      ? fixture.root.replace(/^\/private\/var\//, '/var/')
+      : fixture.root
+    gate.observeNotification(SESSION, 'item/started', item(join(alternateRoot, 'new.txt')))
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
+  })
+
+  it('denies a symlink escape and a mismatched turn', async () => {
+    const fixture = linkedWorktree()
+    writeFileSync(fixture.outside, 'outside\n')
+    symlinkSync(fixture.outside, join(fixture.root, 'linked.txt'))
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('linked.txt'))
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+
+    await issue(gate, fixture.root, 'turn-2')
+    gate.observeNotification(SESSION, 'item/started', item('new.txt', 'item-2', 'turn-2'))
+    await expect(
+      gate.reviewServerRequest(
+        SESSION,
+        'item/fileChange/requestApproval',
+        approval('item-2', 'turn-wrong')
+      )
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('fails closed without a host request grant or linked worktree', async () => {
+    const fixture = linkedWorktree()
+    const noGrant = authority({ authorize: false })
+    await issue(noGrant, fixture.root)
+    noGrant.observeNotification(SESSION, 'item/started', item('new.txt'))
+    await expect(
+      noGrant.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+
+    const canonical = join(fixture.root, 'canonical')
+    mkdirSync(join(canonical, '.git'), { recursive: true })
+    await expect(authority({}).bindSession(SESSION, canonical)).rejects.toThrow(
+      'linked Git worktree'
+    )
+  })
+
+  it('declines the file change when the host cannot durably consume its admission', async () => {
+    const fixture = linkedWorktree()
+    const gate = new CodexStructuredWriteAuthority({
+      authorizeTurn: ({ writableRoot }) => ({
+        requestReceiptId: 'host-request-1',
+        writableRoot,
+        capabilityHandle: 'host-handle-1'
+      }),
+      consumeLease: async () => {
+        throw new Error('admission receipt store unavailable')
+      },
+      onReceipt: () => {}
+    })
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('new.txt'))
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('revalidates linked-worktree ownership immediately before admission', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    gate.observeNotification(SESSION, 'item/started', item('new.txt'))
+    const marker = readFileSync(join(fixture.root, '.git'), 'utf8').trim()
+    const gitDir = marker.slice('gitdir:'.length).trim()
+    writeFileSync(join(gitDir, 'gitdir'), `${join(fixture.root, 'different', '.git')}\n`)
+
+    await expect(
+      gate.reviewServerRequest(SESSION, 'item/fileChange/requestApproval', approval())
+    ).resolves.toEqual({ handled: true, result: { decision: 'decline' } })
+  })
+
+  it('rejects a forged linked-worktree marker without Git reciprocal ownership', async () => {
+    const fixture = linkedWorktree()
+    const forged = join(fixture.root, 'forged')
+    mkdirSync(forged, { recursive: true })
+    const gitDir = join(fixture.root, '..', 'canonical.git', 'worktrees', 'bounded')
+    writeFileSync(join(forged, '.git'), `gitdir: ${gitDir}\n`)
+
+    await expect(authority({}).bindSession(SESSION, forged)).rejects.toThrow(
+      'backlink does not name the selected worktree'
+    )
+  })
+})

--- a/src/main/codex/codex-structured-write-authority.test.ts
+++ b/src/main/codex/codex-structured-write-authority.test.ts
@@ -102,6 +102,20 @@ async function issue(
 }
 
 describe('CodexStructuredWriteAuthority', () => {
+  it('retires the bound mutation epoch when Codex completes that turn', async () => {
+    const fixture = linkedWorktree()
+    const gate = authority({})
+    await issue(gate, fixture.root)
+    expect(gate.activeTurn(SESSION)).toEqual({ threadId: THREAD, turnId: TURN })
+
+    gate.observeNotification(SESSION, 'turn/completed', {
+      threadId: THREAD,
+      turn: { id: TURN, status: 'completed' }
+    })
+
+    expect(gate.activeTurn(SESSION)).toBeNull()
+  })
+
   it('admits one file change and emits a bounded before/after receipt', async () => {
     const fixture = linkedWorktree()
     const target = join(fixture.root, 'source.txt')

--- a/src/main/codex/codex-structured-write-authority.ts
+++ b/src/main/codex/codex-structured-write-authority.ts
@@ -12,6 +12,11 @@ import {
   type CodexStructuredWriteLease
 } from './codex-structured-write-types'
 import { CodexStructuredWriteReceiptEmitter } from './codex-structured-write-receipts'
+import {
+  notificationCompletesStructuredWriteTurn,
+  structuredWriteItemKey,
+  type CodexStructuredWriteTurn
+} from './codex-structured-write-turn-lifecycle'
 
 export type { CodexStructuredFileManifestEntry } from './codex-structured-write-manifest'
 export { digestRequest, LOCAL_STRUCTURED_WRITE_EFFECT }
@@ -129,6 +134,12 @@ export class CodexStructuredWriteAuthority {
   }
 
   observeNotification(sessionId: string, method: string, params: unknown): void {
+    if (method === 'turn/completed') {
+      if (notificationCompletesStructuredWriteTurn(this.activeTurn(sessionId), params)) {
+        this.revokeTurn(sessionId)
+      }
+      return
+    }
     if (method === 'item/started') {
       const record = asRecord(params)
       const item = asRecord(record.item)
@@ -141,7 +152,7 @@ export class CodexStructuredWriteAuthority {
       if (!threadId || !turnId || !changes) {
         return
       }
-      this.fileChanges.set(this.itemKey(sessionId, item.id), {
+      this.fileChanges.set(structuredWriteItemKey(sessionId, item.id), {
         sessionId,
         threadId,
         turnId,
@@ -181,7 +192,9 @@ export class CodexStructuredWriteAuthority {
     const threadId = readString(request, 'threadId')
     const turnId = readString(request, 'turnId')
     const lease = this.leases.get(sessionId)
-    const observed = itemId ? this.fileChanges.get(this.itemKey(sessionId, itemId)) : undefined
+    const observed = itemId
+      ? this.fileChanges.get(structuredWriteItemKey(sessionId, itemId))
+      : undefined
     if (!lease || !observed || !itemId || !threadId || !turnId) {
       return { handled: true, result: { decision: 'decline' } }
     }
@@ -218,10 +231,11 @@ export class CodexStructuredWriteAuthority {
     this.revokeTurn(sessionId)
   }
 
-  invalidateForNewTurn(sessionId: string): void {
-    this.requireRoot(sessionId)
-    this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
-    this.revokeTurn(sessionId)
+  activeTurn(sessionId: string): CodexStructuredWriteTurn | null {
+    const lease = this.leases.get(sessionId)
+    return lease && lease.state !== 'revoked' && lease.threadId && lease.turnId
+      ? { threadId: lease.threadId, turnId: lease.turnId }
+      : null
   }
 
   async flushReceipts(): Promise<void> {
@@ -237,7 +251,7 @@ export class CodexStructuredWriteAuthority {
     if (item.type !== 'fileChange' || typeof item.id !== 'string') {
       return
     }
-    const key = this.itemKey(sessionId, item.id)
+    const key = structuredWriteItemKey(sessionId, item.id)
     const observed = this.fileChanges.get(key)
     const threadId = readString(record, 'threadId')
     const turnId = readString(record, 'turnId')
@@ -291,10 +305,6 @@ export class CodexStructuredWriteAuthority {
   private trackCompletion(completion: Promise<void>): void {
     this.pendingCompletions.add(completion)
     void completion.finally(() => this.pendingCompletions.delete(completion))
-  }
-
-  private itemKey(sessionId: string, itemId: string): string {
-    return `${encodeURIComponent(sessionId)}:${encodeURIComponent(itemId)}`
   }
 }
 

--- a/src/main/codex/codex-structured-write-authority.ts
+++ b/src/main/codex/codex-structured-write-authority.ts
@@ -1,9 +1,10 @@
 import { randomBytes } from 'node:crypto'
 import { realpath } from 'node:fs/promises'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
+import { observeStructuredFileChangeStart } from './codex-structured-file-change-start'
 import { admitStructuredFileChange } from './codex-structured-write-admission'
-import { parseFileChanges, validateLinkedWorktreeRoot } from './codex-structured-write-manifest'
-import { digestRequest, digestStructuredValue } from './codex-structured-write-digest'
+import { digestRequest } from './codex-structured-write-digest'
+import { CodexStructuredWriteSessionRoots } from './codex-structured-write-session-roots'
 import {
   LOCAL_STRUCTURED_WRITE_EFFECT,
   type CodexObservedFileChange,
@@ -33,7 +34,7 @@ const FILE_CHANGE_APPROVAL = 'item/fileChange/requestApproval'
 const PERMISSIONS_APPROVAL = 'item/permissions/requestApproval'
 
 export class CodexStructuredWriteAuthority {
-  private readonly roots = new Map<string, string>()
+  private readonly sessionRoots = new CodexStructuredWriteSessionRoots()
   private readonly epochs = new Map<string, number>()
   private readonly leases = new Map<string, CodexStructuredWriteLease>()
   private readonly fileChanges = new Map<string, CodexObservedFileChange>()
@@ -49,10 +50,7 @@ export class CodexStructuredWriteAuthority {
   }
 
   async bindSession(sessionId: string, worktreeRoot: string): Promise<void> {
-    if (this.roots.has(sessionId)) {
-      this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
-    }
-    this.roots.set(sessionId, await validateLinkedWorktreeRoot(worktreeRoot))
+    await this.sessionRoots.bind(sessionId, worktreeRoot, () => this.revokeSession(sessionId))
     this.revokeTurn(sessionId)
   }
 
@@ -85,7 +83,7 @@ export class CodexStructuredWriteAuthority {
     }
     if (
       this.epochs.get(input.sessionId) !== turnEpoch ||
-      this.roots.get(input.sessionId) !== worktreeRoot
+      !this.sessionRoots.isBoundTo(input.sessionId, worktreeRoot)
     ) {
       return null
     }
@@ -100,7 +98,7 @@ export class CodexStructuredWriteAuthority {
     }
     if (
       this.epochs.get(input.sessionId) !== turnEpoch ||
-      this.roots.get(input.sessionId) !== worktreeRoot
+      !this.sessionRoots.isBoundTo(input.sessionId, worktreeRoot)
     ) {
       return null
     }
@@ -141,27 +139,18 @@ export class CodexStructuredWriteAuthority {
       return
     }
     if (method === 'item/started') {
-      const record = asRecord(params)
-      const item = asRecord(record.item)
-      if (item.type !== 'fileChange' || typeof item.id !== 'string') {
-        return
-      }
-      const threadId = readString(record, 'threadId')
-      const turnId = readString(record, 'turnId')
-      const changes = parseFileChanges(item.changes)
-      if (!threadId || !turnId || !changes) {
-        return
-      }
-      this.fileChanges.set(structuredWriteItemKey(sessionId, item.id), {
+      const conflict = observeStructuredFileChangeStart({
         sessionId,
-        threadId,
-        turnId,
-        itemId: item.id,
-        changes,
-        changePlanDigest: digestStructuredValue(changes),
-        before: null,
-        admission: null
+        params,
+        lease: this.leases.get(sessionId),
+        fileChanges: this.fileChanges
       })
+      if (conflict?.admission && conflict.before) {
+        this.failAdmittedChanges(sessionId)
+      }
+      if (conflict) {
+        this.revokeTurn(sessionId)
+      }
       return
     }
     if (method === 'item/completed') {
@@ -212,6 +201,7 @@ export class CodexStructuredWriteAuthority {
       threadId,
       turnId,
       grantRoot: readString(request, 'grantRoot'),
+      expectedWorktreeIdentity: this.sessionRoots.requireIdentity(sessionId),
       lease,
       observed,
       authorization: this.authorization,
@@ -223,11 +213,16 @@ export class CodexStructuredWriteAuthority {
   revokeSession(sessionId: string): void {
     this.failAdmittedChanges(sessionId)
     this.revokeTurn(sessionId)
-    this.roots.delete(sessionId)
+    this.sessionRoots.delete(sessionId)
     this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
   }
 
   revokePendingTurn(sessionId: string): void {
+    this.revokeTurn(sessionId)
+  }
+
+  invalidateTurnEpoch(sessionId: string): void {
+    this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
     this.revokeTurn(sessionId)
   }
 
@@ -271,11 +266,7 @@ export class CodexStructuredWriteAuthority {
   }
 
   private requireRoot(sessionId: string): string {
-    const root = this.roots.get(sessionId)
-    if (!root) {
-      throw new Error(`no host-selected writable worktree for ${sessionId}`)
-    }
-    return root
+    return this.sessionRoots.requireRoot(sessionId)
   }
 
   private revokeTurn(sessionId: string): void {

--- a/src/main/codex/codex-structured-write-authority.ts
+++ b/src/main/codex/codex-structured-write-authority.ts
@@ -1,0 +1,308 @@
+import { randomBytes } from 'node:crypto'
+import { realpath } from 'node:fs/promises'
+import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
+import { admitStructuredFileChange } from './codex-structured-write-admission'
+import { parseFileChanges, validateLinkedWorktreeRoot } from './codex-structured-write-manifest'
+import { digestRequest, digestStructuredValue } from './codex-structured-write-digest'
+import {
+  LOCAL_STRUCTURED_WRITE_EFFECT,
+  type CodexObservedFileChange,
+  type CodexStructuredApproval,
+  type CodexStructuredWriteAuthorization,
+  type CodexStructuredWriteLease
+} from './codex-structured-write-types'
+import { CodexStructuredWriteReceiptEmitter } from './codex-structured-write-receipts'
+
+export type { CodexStructuredFileManifestEntry } from './codex-structured-write-manifest'
+export { digestRequest, LOCAL_STRUCTURED_WRITE_EFFECT }
+export type {
+  CodexStructuredApproval,
+  CodexStructuredWriteAdmissionReceipt,
+  CodexStructuredWriteAuthorization,
+  CodexStructuredWriteGrant,
+  CodexStructuredWriteReceipt
+} from './codex-structured-write-types'
+
+const COMMAND_APPROVAL = 'item/commandExecution/requestApproval'
+const FILE_CHANGE_APPROVAL = 'item/fileChange/requestApproval'
+const PERMISSIONS_APPROVAL = 'item/permissions/requestApproval'
+
+export class CodexStructuredWriteAuthority {
+  private readonly roots = new Map<string, string>()
+  private readonly epochs = new Map<string, number>()
+  private readonly leases = new Map<string, CodexStructuredWriteLease>()
+  private readonly fileChanges = new Map<string, CodexObservedFileChange>()
+  private readonly pendingCompletions = new Set<Promise<void>>()
+  private readonly receipts: CodexStructuredWriteReceiptEmitter
+
+  constructor(
+    private readonly authorization: CodexStructuredWriteAuthorization,
+    private readonly now: () => number = Date.now,
+    mintHandle: () => string = () => randomBytes(32).toString('base64url')
+  ) {
+    this.receipts = new CodexStructuredWriteReceiptEmitter(authorization, now, mintHandle)
+  }
+
+  async bindSession(sessionId: string, worktreeRoot: string): Promise<void> {
+    if (this.roots.has(sessionId)) {
+      this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
+    }
+    this.roots.set(sessionId, await validateLinkedWorktreeRoot(worktreeRoot))
+    this.revokeTurn(sessionId)
+  }
+
+  async openTurn(input: {
+    sessionId: string
+    clientMessageId: string
+    body: AgentJournalMessageItem
+    fence: number
+    requestAuthority?: {
+      effectAuthority: typeof LOCAL_STRUCTURED_WRITE_EFFECT
+      requestReceiptId: string
+    }
+  }): Promise<number | null> {
+    const worktreeRoot = this.requireRoot(input.sessionId)
+    const turnEpoch = (this.epochs.get(input.sessionId) ?? 0) + 1
+    this.epochs.set(input.sessionId, turnEpoch)
+    this.revokeTurn(input.sessionId)
+    const requestDigest = digestRequest(input.body)
+    const grant = await this.authorization.authorizeTurn({
+      sessionId: input.sessionId,
+      turnEpoch,
+      fence: input.fence,
+      clientMessageId: input.clientMessageId,
+      requestDigest,
+      writableRoot: worktreeRoot,
+      ...(input.requestAuthority ? { requestAuthority: input.requestAuthority } : {})
+    })
+    if (!grant) {
+      return null
+    }
+    if (
+      this.epochs.get(input.sessionId) !== turnEpoch ||
+      this.roots.get(input.sessionId) !== worktreeRoot
+    ) {
+      return null
+    }
+    if (!grant.requestReceiptId.trim()) {
+      throw new Error('structured write grant has no host request receipt')
+    }
+    if (!grant.capabilityHandle.trim()) {
+      throw new Error('structured write grant has no opaque capability handle')
+    }
+    if ((await realpath(grant.writableRoot)) !== worktreeRoot) {
+      throw new Error('structured write grant names a different writable worktree')
+    }
+    if (
+      this.epochs.get(input.sessionId) !== turnEpoch ||
+      this.roots.get(input.sessionId) !== worktreeRoot
+    ) {
+      return null
+    }
+    this.leases.set(input.sessionId, {
+      handle: grant.capabilityHandle,
+      requestReceiptId: grant.requestReceiptId,
+      sessionId: input.sessionId,
+      turnEpoch,
+      fence: input.fence,
+      clientMessageId: input.clientMessageId,
+      requestDigest,
+      worktreeRoot,
+      threadId: null,
+      turnId: null,
+      state: 'issued'
+    })
+    return turnEpoch
+  }
+
+  bindTurn(sessionId: string, threadId: string, turnId: string, turnEpoch: number): void {
+    const lease = this.leases.get(sessionId)
+    if (!lease || lease.state !== 'issued' || lease.turnEpoch !== turnEpoch) {
+      return
+    }
+    if (lease.threadId && (lease.threadId !== threadId || lease.turnId !== turnId)) {
+      lease.state = 'revoked'
+      return
+    }
+    lease.threadId = threadId
+    lease.turnId = turnId
+  }
+
+  observeNotification(sessionId: string, method: string, params: unknown): void {
+    if (method === 'item/started') {
+      const record = asRecord(params)
+      const item = asRecord(record.item)
+      if (item.type !== 'fileChange' || typeof item.id !== 'string') {
+        return
+      }
+      const threadId = readString(record, 'threadId')
+      const turnId = readString(record, 'turnId')
+      const changes = parseFileChanges(item.changes)
+      if (!threadId || !turnId || !changes) {
+        return
+      }
+      this.fileChanges.set(this.itemKey(sessionId, item.id), {
+        sessionId,
+        threadId,
+        turnId,
+        itemId: item.id,
+        changes,
+        changePlanDigest: digestStructuredValue(changes),
+        before: null,
+        admission: null
+      })
+      return
+    }
+    if (method === 'item/completed') {
+      this.trackCompletion(
+        this.completeFileChange(sessionId, params).catch(() => {
+          this.revokeTurn(sessionId)
+        })
+      )
+    }
+  }
+
+  async reviewServerRequest(
+    sessionId: string,
+    method: string,
+    params: unknown
+  ): Promise<CodexStructuredApproval> {
+    if (method === COMMAND_APPROVAL) {
+      return { handled: true, result: { decision: 'decline' } }
+    }
+    if (method === PERMISSIONS_APPROVAL) {
+      return { handled: true, result: { permissions: {}, scope: 'turn' } }
+    }
+    if (method !== FILE_CHANGE_APPROVAL) {
+      return { handled: false }
+    }
+    const request = asRecord(params)
+    const itemId = readString(request, 'itemId')
+    const threadId = readString(request, 'threadId')
+    const turnId = readString(request, 'turnId')
+    const lease = this.leases.get(sessionId)
+    const observed = itemId ? this.fileChanges.get(this.itemKey(sessionId, itemId)) : undefined
+    if (!lease || !observed || !itemId || !threadId || !turnId) {
+      return { handled: true, result: { decision: 'decline' } }
+    }
+    if (
+      lease.state !== 'issued' ||
+      lease.threadId !== threadId ||
+      lease.turnId !== turnId ||
+      observed.threadId !== threadId ||
+      observed.turnId !== turnId
+    ) {
+      return { handled: true, result: { decision: 'decline' } }
+    }
+    return admitStructuredFileChange({
+      sessionId,
+      threadId,
+      turnId,
+      grantRoot: readString(request, 'grantRoot'),
+      lease,
+      observed,
+      authorization: this.authorization,
+      now: this.now,
+      isCurrent: () => this.leases.get(sessionId) === lease && lease.state === 'reserved'
+    })
+  }
+
+  revokeSession(sessionId: string): void {
+    this.failAdmittedChanges(sessionId)
+    this.revokeTurn(sessionId)
+    this.roots.delete(sessionId)
+    this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
+  }
+
+  revokePendingTurn(sessionId: string): void {
+    this.revokeTurn(sessionId)
+  }
+
+  invalidateForNewTurn(sessionId: string): void {
+    this.requireRoot(sessionId)
+    this.epochs.set(sessionId, (this.epochs.get(sessionId) ?? 0) + 1)
+    this.revokeTurn(sessionId)
+  }
+
+  async flushReceipts(): Promise<void> {
+    while (this.pendingCompletions.size > 0) {
+      await Promise.all(this.pendingCompletions)
+    }
+    await this.authorization.flushReceipts?.()
+  }
+
+  private async completeFileChange(sessionId: string, params: unknown): Promise<void> {
+    const record = asRecord(params)
+    const item = asRecord(record.item)
+    if (item.type !== 'fileChange' || typeof item.id !== 'string') {
+      return
+    }
+    const key = this.itemKey(sessionId, item.id)
+    const observed = this.fileChanges.get(key)
+    const threadId = readString(record, 'threadId')
+    const turnId = readString(record, 'turnId')
+    if (
+      !observed ||
+      !observed.admission ||
+      !observed.before ||
+      threadId !== observed.threadId ||
+      turnId !== observed.turnId
+    ) {
+      return
+    }
+    this.fileChanges.delete(key)
+    const status =
+      item.status === 'completed' ? 'completed' : item.status === 'declined' ? 'declined' : 'failed'
+    await this.receipts.completed(sessionId, observed, status)
+  }
+
+  private requireRoot(sessionId: string): string {
+    const root = this.roots.get(sessionId)
+    if (!root) {
+      throw new Error(`no host-selected writable worktree for ${sessionId}`)
+    }
+    return root
+  }
+
+  private revokeTurn(sessionId: string): void {
+    this.authorization.revokeSession?.(sessionId)
+    const lease = this.leases.get(sessionId)
+    if (lease) {
+      lease.state = 'revoked'
+      this.leases.delete(sessionId)
+    }
+    for (const [key, item] of this.fileChanges) {
+      if (item.sessionId === sessionId && !item.admission) {
+        this.fileChanges.delete(key)
+      }
+    }
+  }
+
+  private failAdmittedChanges(sessionId: string): void {
+    for (const [key, observed] of this.fileChanges) {
+      if (observed.sessionId !== sessionId || !observed.admission || !observed.before) {
+        continue
+      }
+      this.fileChanges.delete(key)
+      this.trackCompletion(this.receipts.failed(sessionId, observed))
+    }
+  }
+
+  private trackCompletion(completion: Promise<void>): void {
+    this.pendingCompletions.add(completion)
+    void completion.finally(() => this.pendingCompletions.delete(completion))
+  }
+
+  private itemKey(sessionId: string, itemId: string): string {
+    return `${encodeURIComponent(sessionId)}:${encodeURIComponent(itemId)}`
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}

--- a/src/main/codex/codex-structured-write-digest.ts
+++ b/src/main/codex/codex-structured-write-digest.ts
@@ -1,0 +1,27 @@
+import { createHash } from 'node:crypto'
+import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
+
+export function digestRequest(body: AgentJournalMessageItem): string {
+  return digestStructuredValue(body)
+}
+
+export function digestStructuredValue(value: unknown): string {
+  return sha256(canonicalJson(value))
+}
+
+export function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value) ?? 'null'
+}

--- a/src/main/codex/codex-structured-write-lease-registry.test.ts
+++ b/src/main/codex/codex-structured-write-lease-registry.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sha256 } from './codex-structured-write-digest'
+import { CodexStructuredWriteLeaseRegistry } from './codex-structured-write-lease-registry'
+import type { CodexStructuredWriteAdmissionReceipt } from './codex-structured-write-types'
+
+const turn = {
+  sessionId: 'session-1',
+  turnEpoch: 3,
+  fence: 7,
+  clientMessageId: 'message-1',
+  requestDigest: 'a'.repeat(64),
+  writableRoot: '/worktrees/bounded'
+}
+
+function receipt(handle: string): CodexStructuredWriteAdmissionReceipt {
+  return {
+    protocolVersion: 1,
+    requestReceiptId: 'request-1',
+    effectDomain: 'local_structured_write',
+    sessionId: turn.sessionId,
+    turnEpoch: turn.turnEpoch,
+    fence: turn.fence,
+    clientMessageId: turn.clientMessageId,
+    threadId: 'thread-1',
+    turnId: 'turn-1',
+    requestDigest: turn.requestDigest,
+    toolUseId: 'tool-1',
+    changePlanDigest: 'b'.repeat(64),
+    worktreeRoot: turn.writableRoot,
+    capabilityHandleDigest: sha256(handle),
+    before: [],
+    admittedAtMs: 1_000
+  }
+}
+
+describe('CodexStructuredWriteLeaseRegistry', () => {
+  it('persists one exact admission and rejects replay', async () => {
+    const persistAdmission = vi.fn(async () => {})
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: () => ({ requestReceiptId: 'request-1', writableRoot: turn.writableRoot }),
+      persistAdmission,
+      persistOutcome: () => {},
+      now: () => 1_000,
+      mintCapabilityHandle: () => 'opaque-host-handle'
+    })
+    const grant = await registry.authorizeTurn(turn)
+
+    await expect(
+      registry.consumeLease({
+        capabilityHandle: grant!.capabilityHandle,
+        receipt: receipt(grant!.capabilityHandle)
+      })
+    ).resolves.toBeUndefined()
+    expect(persistAdmission).toHaveBeenCalledOnce()
+    await expect(
+      registry.consumeLease({
+        capabilityHandle: grant!.capabilityHandle,
+        receipt: receipt(grant!.capabilityHandle)
+      })
+    ).rejects.toThrow('already consumed')
+  })
+
+  it.each([
+    ['request', { requestDigest: 'wrong' }],
+    ['client message', { clientMessageId: 'wrong-message' }],
+    ['turn', { turnEpoch: 4 }],
+    ['fence', { fence: 8 }],
+    ['path', { worktreeRoot: '/worktrees/other' }],
+    ['handle', { capabilityHandleDigest: sha256('forged') }]
+  ])('consumes but refuses a capability with the wrong %s binding', async (_label, override) => {
+    const persistAdmission = vi.fn(async () => {})
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: () => ({ requestReceiptId: 'request-1', writableRoot: turn.writableRoot }),
+      persistAdmission,
+      persistOutcome: () => {},
+      now: () => 1_000,
+      mintCapabilityHandle: () => 'opaque-host-handle'
+    })
+    const grant = await registry.authorizeTurn(turn)
+
+    await expect(
+      registry.consumeLease({
+        capabilityHandle: grant!.capabilityHandle,
+        receipt: { ...receipt(grant!.capabilityHandle), ...override }
+      })
+    ).rejects.toThrow('does not match')
+    expect(persistAdmission).not.toHaveBeenCalled()
+  })
+
+  it('rejects an expired capability and an admission persistence failure', async () => {
+    let now = 1_000
+    const handles = ['expired-host-handle', 'unavailable-host-handle']
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: () => ({ requestReceiptId: 'request-1', writableRoot: turn.writableRoot }),
+      persistAdmission: async () => {
+        throw new Error('receipt store unavailable')
+      },
+      persistOutcome: () => {},
+      now: () => now,
+      leaseTtlMs: 10,
+      mintCapabilityHandle: () => handles.shift() as string
+    })
+    const expired = await registry.authorizeTurn(turn)
+    now = 1_011
+    await expect(
+      registry.consumeLease({
+        capabilityHandle: expired!.capabilityHandle,
+        receipt: receipt(expired!.capabilityHandle)
+      })
+    ).rejects.toThrow('does not match')
+
+    now = 2_000
+    const unavailable = await registry.authorizeTurn({
+      ...turn,
+      turnEpoch: 4,
+      clientMessageId: 'message-2'
+    })
+    await expect(
+      registry.consumeLease({
+        capabilityHandle: unavailable!.capabilityHandle,
+        receipt: {
+          ...receipt(unavailable!.capabilityHandle),
+          turnEpoch: 4,
+          clientMessageId: 'message-2',
+          admittedAtMs: 2_000
+        }
+      })
+    ).rejects.toThrow('receipt store unavailable')
+  })
+
+  it('does not let a late older authorization replace a newer capability', async () => {
+    const grants = [Promise.withResolvers<boolean>(), Promise.withResolvers<boolean>()]
+    const handles = ['host-handle-1', 'host-handle-2']
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: async ({ turnEpoch, writableRoot }) => {
+        await grants[turnEpoch - 1].promise
+        return { requestReceiptId: `request-${turnEpoch}`, writableRoot }
+      },
+      persistAdmission: () => {},
+      persistOutcome: () => {},
+      now: () => 1_000,
+      mintCapabilityHandle: () => handles.shift() as string
+    })
+
+    const old = registry.authorizeTurn({ ...turn, turnEpoch: 1, clientMessageId: 'message-old' })
+    const current = registry.authorizeTurn({
+      ...turn,
+      turnEpoch: 2,
+      clientMessageId: 'message-current'
+    })
+    grants[1].resolve(true)
+    await expect(current).resolves.toMatchObject({ capabilityHandle: 'host-handle-1' })
+    grants[0].resolve(true)
+    await expect(old).resolves.toBeNull()
+  })
+
+  it('revokes a pending authorization when its session closes', async () => {
+    const decision = Promise.withResolvers<void>()
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: async ({ writableRoot }) => {
+        await decision.promise
+        return { requestReceiptId: 'request-1', writableRoot }
+      },
+      persistAdmission: () => {},
+      persistOutcome: () => {}
+    })
+    const pending = registry.authorizeTurn(turn)
+    registry.revokeSession(turn.sessionId)
+    decision.resolve()
+
+    await expect(pending).resolves.toBeNull()
+  })
+
+  it('reports synchronous outcome persistence failure without throwing into product completion', async () => {
+    const failure = vi.fn()
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: () => ({ requestReceiptId: 'request-1', writableRoot: turn.writableRoot }),
+      persistAdmission: () => {},
+      persistOutcome: () => {
+        throw new Error('trace sink unavailable')
+      },
+      onOutcomePersistenceFailure: failure
+    })
+
+    expect(() => registry.onReceipt({} as never)).not.toThrow()
+    await expect.poll(() => failure).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a capability handle that the host already issued', async () => {
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn: ({ writableRoot }) => ({ requestReceiptId: 'request-1', writableRoot }),
+      persistAdmission: () => {},
+      persistOutcome: () => {},
+      mintCapabilityHandle: () => 'reused-handle'
+    })
+    const first = await registry.authorizeTurn(turn)
+    await registry.consumeLease({
+      capabilityHandle: first!.capabilityHandle,
+      receipt: receipt(first!.capabilityHandle)
+    })
+
+    await expect(
+      registry.authorizeTurn({ ...turn, turnEpoch: 4, clientMessageId: 'message-2' })
+    ).rejects.toThrow('already issued')
+  })
+
+  it('does not issue a second mutation lease for a retried client message', async () => {
+    const admitTurn = vi.fn(({ writableRoot }) => ({
+      requestReceiptId: 'request-1',
+      writableRoot
+    }))
+    const registry = new CodexStructuredWriteLeaseRegistry({
+      admitTurn,
+      persistAdmission: () => {},
+      persistOutcome: () => {},
+      mintCapabilityHandle: () => 'first-handle'
+    })
+    await expect(registry.authorizeTurn(turn)).resolves.toMatchObject({
+      capabilityHandle: 'first-handle'
+    })
+
+    await expect(registry.authorizeTurn({ ...turn, turnEpoch: 4 })).resolves.toBeNull()
+    expect(admitTurn).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/codex/codex-structured-write-lease-registry.ts
+++ b/src/main/codex/codex-structured-write-lease-registry.ts
@@ -1,0 +1,171 @@
+import { randomBytes } from 'node:crypto'
+import { sha256 } from './codex-structured-write-digest'
+import type {
+  CodexStructuredWriteAdmissionReceipt,
+  CodexStructuredWriteAuthorization,
+  CodexStructuredWriteGrant,
+  CodexStructuredWriteReceipt
+} from './codex-structured-write-types'
+
+type TurnRequest = Parameters<CodexStructuredWriteAuthorization['authorizeTurn']>[0]
+type PendingLease = TurnRequest & {
+  capabilityHandle: string
+  requestReceiptId: string
+  expiresAtMs: number
+}
+
+export type CodexStructuredWriteLeaseRegistryDeps = {
+  admitTurn: (
+    input: TurnRequest
+  ) =>
+    | Promise<Omit<CodexStructuredWriteGrant, 'capabilityHandle'> | null>
+    | Omit<CodexStructuredWriteGrant, 'capabilityHandle'>
+    | null
+  persistAdmission: (receipt: CodexStructuredWriteAdmissionReceipt) => Promise<void> | void
+  persistOutcome: (receipt: CodexStructuredWriteReceipt) => Promise<void> | void
+  onOutcomePersistenceFailure?: (input: {
+    receipt: CodexStructuredWriteReceipt
+    error: unknown
+  }) => void
+  flushReceipts?: () => Promise<void>
+  now?: () => number
+  leaseTtlMs?: number
+  mintCapabilityHandle?: () => string
+}
+
+/** Host-owned, model-invisible compare-and-consume registry for one effect domain. */
+export class CodexStructuredWriteLeaseRegistry implements CodexStructuredWriteAuthorization {
+  private readonly leases = new Map<string, PendingLease>()
+  private readonly handleBySession = new Map<string, string>()
+  private readonly latestEpochBySession = new Map<string, number>()
+  private readonly issuedHandles = new Set<string>()
+  private readonly admittedClientMessages = new Set<string>()
+  private readonly pendingClientMessages = new Set<string>()
+  private readonly pendingOutcomeWrites = new Set<Promise<void>>()
+  private readonly now: () => number
+  private readonly leaseTtlMs: number
+  private readonly mintCapabilityHandle: () => string
+
+  constructor(private readonly deps: CodexStructuredWriteLeaseRegistryDeps) {
+    this.now = deps.now ?? Date.now
+    this.leaseTtlMs = deps.leaseTtlMs ?? 120_000
+    this.mintCapabilityHandle =
+      deps.mintCapabilityHandle ?? (() => randomBytes(32).toString('base64url'))
+  }
+
+  authorizeTurn = async (input: TurnRequest): Promise<CodexStructuredWriteGrant | null> => {
+    this.revokeSession(input.sessionId)
+    this.latestEpochBySession.set(input.sessionId, input.turnEpoch)
+    const clientMessageKey = sha256(
+      `${input.sessionId.length}:${input.sessionId}${input.clientMessageId}`
+    )
+    if (
+      this.admittedClientMessages.has(clientMessageKey) ||
+      this.pendingClientMessages.has(clientMessageKey)
+    ) {
+      return null
+    }
+    this.pendingClientMessages.add(clientMessageKey)
+    let admitted: Omit<CodexStructuredWriteGrant, 'capabilityHandle'> | null
+    try {
+      admitted = await this.deps.admitTurn(input)
+    } finally {
+      this.pendingClientMessages.delete(clientMessageKey)
+    }
+    if (admitted) {
+      this.admittedClientMessages.add(clientMessageKey)
+    }
+    if (this.latestEpochBySession.get(input.sessionId) !== input.turnEpoch) {
+      return null
+    }
+    if (!admitted) {
+      return null
+    }
+    if (admitted.writableRoot !== input.writableRoot) {
+      throw new Error('host admission changed the selected writable worktree')
+    }
+    const capabilityHandle = this.mintCapabilityHandle()
+    if (!capabilityHandle || this.issuedHandles.has(capabilityHandle)) {
+      throw new Error('host capability handle is empty or was already issued')
+    }
+    this.issuedHandles.add(capabilityHandle)
+    this.leases.set(capabilityHandle, {
+      ...input,
+      capabilityHandle,
+      requestReceiptId: admitted.requestReceiptId,
+      expiresAtMs: this.now() + this.leaseTtlMs
+    })
+    this.handleBySession.set(input.sessionId, capabilityHandle)
+    return { ...admitted, capabilityHandle }
+  }
+
+  consumeLease = async (input: {
+    capabilityHandle: string
+    receipt: CodexStructuredWriteAdmissionReceipt
+  }): Promise<void> => {
+    // Delete before the first await: competing calls in this process cannot
+    // both pass the comparison and persistence boundary.
+    const lease = this.leases.get(input.capabilityHandle)
+    if (!lease) {
+      throw new Error('structured write capability is unknown or already consumed')
+    }
+    this.leases.delete(input.capabilityHandle)
+    if (this.handleBySession.get(lease.sessionId) === input.capabilityHandle) {
+      this.handleBySession.delete(lease.sessionId)
+    }
+    assertAdmissionMatchesLease(lease, input.receipt, this.now())
+    await this.deps.persistAdmission(input.receipt)
+  }
+
+  onReceipt = (receipt: CodexStructuredWriteReceipt): void => {
+    // Start on a resolved promise so a synchronous persistence throw follows
+    // the same non-product-fatal reporting path as an async rejection.
+    const operation = Promise.resolve()
+      .then(() => this.deps.persistOutcome(receipt))
+      .catch((error: unknown) => {
+        this.deps.onOutcomePersistenceFailure?.({ receipt, error })
+      })
+    this.pendingOutcomeWrites.add(operation)
+    void operation.finally(() => this.pendingOutcomeWrites.delete(operation))
+  }
+
+  onReceiptFailure = (input: { receipt: CodexStructuredWriteReceipt; error: unknown }): void => {
+    this.deps.onOutcomePersistenceFailure?.(input)
+  }
+
+  flushReceipts = async (): Promise<void> => {
+    while (this.pendingOutcomeWrites.size > 0) {
+      await Promise.all(this.pendingOutcomeWrites)
+    }
+    await this.deps.flushReceipts?.()
+  }
+
+  revokeSession(sessionId: string): void {
+    const handle = this.handleBySession.get(sessionId)
+    if (handle) {
+      this.handleBySession.delete(sessionId)
+      this.leases.delete(handle)
+    }
+    this.latestEpochBySession.delete(sessionId)
+  }
+}
+
+function assertAdmissionMatchesLease(
+  lease: PendingLease,
+  receipt: CodexStructuredWriteAdmissionReceipt,
+  now: number
+): void {
+  const matches =
+    lease.expiresAtMs >= now &&
+    receipt.requestReceiptId === lease.requestReceiptId &&
+    receipt.sessionId === lease.sessionId &&
+    receipt.turnEpoch === lease.turnEpoch &&
+    receipt.fence === lease.fence &&
+    receipt.clientMessageId === lease.clientMessageId &&
+    receipt.requestDigest === lease.requestDigest &&
+    receipt.worktreeRoot === lease.writableRoot &&
+    receipt.capabilityHandleDigest === sha256(lease.capabilityHandle)
+  if (!matches) {
+    throw new Error('structured write admission does not match its host capability')
+  }
+}

--- a/src/main/codex/codex-structured-write-manifest.test.ts
+++ b/src/main/codex/codex-structured-write-manifest.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { parseFileChanges, snapshotChanges } from './codex-structured-write-manifest'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function fixtureRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-write-manifest-'))
+  roots.push(root)
+  mkdirSync(join(root, 'source'), { recursive: true })
+  return root
+}
+
+describe('Codex structured write manifest bounds', () => {
+  it('rejects oversized change counts, paths, and aggregate diffs', () => {
+    expect(
+      parseFileChanges(
+        Array.from({ length: 129 }, (_unused, index) => ({
+          path: `source/${index}.ts`,
+          diff: '+x',
+          kind: { type: 'add' }
+        }))
+      )
+    ).toBeNull()
+    expect(parseFileChanges([{ path: 'x'.repeat(4_097), diff: '+x' }])).toBeNull()
+    expect(
+      parseFileChanges([{ path: 'source/x.ts', diff: 'x'.repeat(1024 * 1024 + 1) }])
+    ).toBeNull()
+    expect(parseFileChanges([{ path: 'source/\0x.ts', diff: '+x' }])).toBeNull()
+  })
+
+  it('refuses to read an oversized existing file into an enforcement receipt', async () => {
+    const root = fixtureRoot()
+    writeFileSync(join(root, 'source', 'large.bin'), Buffer.alloc(16 * 1024 * 1024 + 1))
+
+    await expect(
+      snapshotChanges(root, [
+        { path: 'source/large.bin', diff: '@@ -1 +1 @@', kind: { type: 'update' } }
+      ])
+    ).rejects.toThrow('too large to manifest')
+  })
+
+  it('bounds aggregate bytes across an otherwise valid multi-file manifest', async () => {
+    const root = fixtureRoot()
+    for (const name of ['first.bin', 'second.bin']) {
+      const path = join(root, 'source', name)
+      writeFileSync(path, '')
+      truncateSync(path, 16 * 1024 * 1024)
+    }
+    writeFileSync(join(root, 'source', 'overflow.bin'), 'x')
+
+    await expect(
+      snapshotChanges(
+        root,
+        ['first.bin', 'second.bin', 'overflow.bin'].map((name) => ({
+          path: `source/${name}`,
+          diff: '@@ -1 +1 @@',
+          kind: { type: 'update' }
+        }))
+      )
+    ).rejects.toThrow('aggregate byte limit')
+  })
+
+  it('produces a bounded digest record for a regular source file', async () => {
+    const root = fixtureRoot()
+    writeFileSync(join(root, 'source', 'small.ts'), 'export const value = 1\n')
+
+    await expect(
+      snapshotChanges(root, [
+        { path: 'source/small.ts', diff: '@@ -1 +1 @@', kind: { type: 'update' } }
+      ])
+    ).resolves.toEqual([
+      {
+        path: 'source/small.ts',
+        exists: true,
+        sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        bytes: 23
+      }
+    ])
+  })
+})

--- a/src/main/codex/codex-structured-write-manifest.test.ts
+++ b/src/main/codex/codex-structured-write-manifest.test.ts
@@ -31,11 +31,95 @@ describe('Codex structured write manifest bounds', () => {
         }))
       )
     ).toBeNull()
-    expect(parseFileChanges([{ path: 'x'.repeat(4_097), diff: '+x' }])).toBeNull()
     expect(
-      parseFileChanges([{ path: 'source/x.ts', diff: 'x'.repeat(1024 * 1024 + 1) }])
+      parseFileChanges([{ path: 'x'.repeat(4_097), diff: '+x', kind: { type: 'update' } }])
     ).toBeNull()
-    expect(parseFileChanges([{ path: 'source/\0x.ts', diff: '+x' }])).toBeNull()
+    expect(
+      parseFileChanges([
+        {
+          path: 'source/x.ts',
+          diff: 'x'.repeat(1024 * 1024 + 1),
+          kind: { type: 'update' }
+        }
+      ])
+    ).toBeNull()
+    expect(
+      parseFileChanges([
+        { path: 'source/x.ts', diff: '\u0001'.repeat(400_000), kind: { type: 'update' } }
+      ])
+    ).toBeNull()
+    expect(
+      parseFileChanges([{ path: 'source/\0x.ts', diff: '+x', kind: { type: 'update' } }])
+    ).toBeNull()
+  })
+
+  it('rejects cyclic, deep, accessor, exotic, and oversized change metadata before digesting', () => {
+    const cyclic: Record<string, unknown> = { type: 'update' }
+    cyclic.self = cyclic
+    let deep: Record<string, unknown> = { type: 'update' }
+    for (let index = 0; index < 33; index += 1) {
+      deep = { child: deep }
+    }
+    const accessor = Object.defineProperty({}, 'type', {
+      enumerable: true,
+      get: () => 'update'
+    })
+    const sparse: unknown[] = []
+    sparse.length = 16_385
+    const tooManyNodes = Array.from({ length: 16_384 }, () => null)
+
+    for (const kind of [
+      cyclic,
+      deep,
+      accessor,
+      new Date(),
+      sparse,
+      tooManyNodes,
+      { payload: 'x'.repeat(2 * 1024 * 1024) },
+      undefined,
+      BigInt(1),
+      Number.NaN,
+      Number.POSITIVE_INFINITY
+    ]) {
+      expect(parseFileChanges([{ path: 'source/x.ts', diff: '+x', kind }])).toBeNull()
+    }
+  })
+
+  it('clones bounded forward-compatible metadata without retaining mutable input identity', () => {
+    const kind = {
+      type: 'future-kind',
+      metadata: { flags: [true, 2, 'three', null] },
+      ['__proto__']: { retainedAsData: true }
+    }
+    const parsed = parseFileChanges([{ path: 'source/x.ts', diff: '+x', kind }])
+
+    expect(parsed).toEqual([{ path: 'source/x.ts', diff: '+x', kind }])
+    expect(parsed?.[0]?.kind).not.toBe(kind)
+    kind.metadata.flags[0] = false
+    expect(parsed?.[0]?.kind).toEqual({
+      type: 'future-kind',
+      metadata: { flags: [true, 2, 'three', null] },
+      ['__proto__']: { retainedAsData: true }
+    })
+  })
+
+  it('reserves queued sibling nodes before traversing another wide nested container', () => {
+    const wide = (child: unknown): unknown[] => [
+      child,
+      ...Array.from({ length: 5_800 }, () => null)
+    ]
+    let traversedOverBudgetContainer = false
+    const guarded = new Proxy(wide(null), {
+      ownKeys: (target) => {
+        traversedOverBudgetContainer = true
+        return Reflect.ownKeys(target)
+      }
+    })
+
+    expect(
+      parseFileChanges([{ path: 'source/x.ts', diff: '+x', kind: wide(wide(guarded)) }])
+    ).toBeNull()
+    expect(traversedOverBudgetContainer).toBe(false)
   })
 
   it('refuses to read an oversized existing file into an enforcement receipt', async () => {

--- a/src/main/codex/codex-structured-write-manifest.test.ts
+++ b/src/main/codex/codex-structured-write-manifest.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { linkSync, mkdirSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -47,6 +47,19 @@ describe('Codex structured write manifest bounds', () => {
         { path: 'source/large.bin', diff: '@@ -1 +1 @@', kind: { type: 'update' } }
       ])
     ).rejects.toThrow('too large to manifest')
+  })
+
+  it('rejects a hard link whose inode can also be mutated outside the bounded root', async () => {
+    const root = fixtureRoot()
+    const outside = join(root, '..', 'outside.txt')
+    writeFileSync(outside, 'outside\n')
+    linkSync(outside, join(root, 'source', 'linked.txt'))
+
+    await expect(
+      snapshotChanges(root, [
+        { path: 'source/linked.txt', diff: '@@ -1 +1 @@', kind: { type: 'update' } }
+      ])
+    ).rejects.toThrow('multiple hard links')
   })
 
   it('bounds aggregate bytes across an otherwise valid multi-file manifest', async () => {

--- a/src/main/codex/codex-structured-write-manifest.ts
+++ b/src/main/codex/codex-structured-write-manifest.ts
@@ -12,6 +12,11 @@ export type CodexStructuredFileManifestEntry = {
   bytes: number | null
 }
 
+export type CodexStructuredWorktreeSnapshot = {
+  root: string
+  identity: string
+}
+
 const MAX_FILE_CHANGE_COUNT = 128
 const MAX_FILE_CHANGE_PATH_BYTES = 4_096
 const MAX_CHANGE_PLAN_DIFF_BYTES = 1024 * 1024
@@ -19,13 +24,20 @@ const MAX_MANIFEST_FILE_BYTES = 16 * 1024 * 1024
 const MAX_MANIFEST_TOTAL_BYTES = 32 * 1024 * 1024
 
 export async function validateLinkedWorktreeRoot(input: string): Promise<string> {
+  return (await snapshotLinkedWorktreeRoot(input)).root
+}
+
+export async function snapshotLinkedWorktreeRoot(
+  input: string
+): Promise<CodexStructuredWorktreeSnapshot> {
   const root = await realpath(input)
-  if (!(await stat(root)).isDirectory()) {
+  const rootMetadata = await stat(root)
+  if (!rootMetadata.isDirectory()) {
     throw new Error('writable worktree root is not a directory')
   }
   const dotGit = resolve(root, '.git')
-  const marker = await lstat(dotGit)
-  if (!marker.isFile() || marker.isSymbolicLink()) {
+  const markerMetadata = await lstat(dotGit)
+  if (!markerMetadata.isFile() || markerMetadata.isSymbolicLink()) {
     throw new Error('structured writer requires a linked Git worktree, not a canonical clone')
   }
   const line = (await readFile(dotGit, 'utf8')).trim()
@@ -33,7 +45,8 @@ export async function validateLinkedWorktreeRoot(input: string): Promise<string>
     throw new Error('linked worktree .git marker is invalid')
   }
   const gitDir = await realpath(resolve(root, line.slice('gitdir:'.length).trim()))
-  if (!(await stat(gitDir)).isDirectory()) {
+  const gitDirMetadata = await stat(gitDir)
+  if (!gitDirMetadata.isDirectory()) {
     throw new Error('linked worktree Git directory is unavailable')
   }
   if (basename(dirname(gitDir)) !== 'worktrees') {
@@ -47,7 +60,18 @@ export async function validateLinkedWorktreeRoot(input: string): Promise<string>
   if (resolvedBacklink !== (await realpath(dotGit))) {
     throw new Error('linked worktree Git backlink does not name the selected worktree')
   }
-  return root
+  return {
+    root,
+    identity: [
+      rootMetadata.dev,
+      rootMetadata.ino,
+      markerMetadata.dev,
+      markerMetadata.ino,
+      gitDirMetadata.dev,
+      gitDirMetadata.ino,
+      gitDir
+    ].join(':')
+  }
 }
 
 export async function snapshotChanges(
@@ -139,7 +163,22 @@ async function readBoundedRegularFile(
       offset += bytesRead
     }
     const after = await handle.stat()
-    if (after.size !== offset) {
+    const currentPath = await lstat(absolute)
+    const currentCanonicalPath = await realpath(absolute)
+    if (
+      after.dev !== metadata.dev ||
+      after.ino !== metadata.ino ||
+      after.nlink !== 1 ||
+      after.size !== offset ||
+      after.mtimeMs !== metadata.mtimeMs ||
+      after.ctimeMs !== metadata.ctimeMs ||
+      !currentPath.isFile() ||
+      currentPath.isSymbolicLink() ||
+      currentPath.dev !== after.dev ||
+      currentPath.ino !== after.ino ||
+      currentPath.nlink !== 1 ||
+      currentCanonicalPath !== absolute
+    ) {
       throw new Error(`structured writer target changed while being manifested: ${path}`)
     }
     return offset === bytes.byteLength ? bytes : bytes.subarray(0, offset)

--- a/src/main/codex/codex-structured-write-manifest.ts
+++ b/src/main/codex/codex-structured-write-manifest.ts
@@ -120,6 +120,9 @@ async function readBoundedRegularFile(
     if (!metadata.isFile()) {
       throw new Error(`structured writer target is not a regular file: ${path}`)
     }
+    if (metadata.nlink !== 1) {
+      throw new Error(`structured writer target has multiple hard links: ${path}`)
+    }
     if (metadata.size > MAX_MANIFEST_FILE_BYTES) {
       throw new Error(`structured writer target is too large to manifest: ${path}`)
     }

--- a/src/main/codex/codex-structured-write-manifest.ts
+++ b/src/main/codex/codex-structured-write-manifest.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
 import { lstat, open, readFile, realpath, stat } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { normalizeCodexFileChangeKind } from './codex-structured-change-metadata'
 
 export type CodexStructuredFileChange = { path: string; diff: string; kind: unknown }
 
@@ -20,6 +21,7 @@ export type CodexStructuredWorktreeSnapshot = {
 const MAX_FILE_CHANGE_COUNT = 128
 const MAX_FILE_CHANGE_PATH_BYTES = 4_096
 const MAX_CHANGE_PLAN_DIFF_BYTES = 1024 * 1024
+const MAX_CHANGE_PLAN_ENCODED_BYTES = 2 * 1024 * 1024
 const MAX_MANIFEST_FILE_BYTES = 16 * 1024 * 1024
 const MAX_MANIFEST_TOTAL_BYTES = 32 * 1024 * 1024
 
@@ -108,29 +110,68 @@ export async function snapshotChanges(
 }
 
 export function parseFileChanges(value: unknown): CodexStructuredFileChange[] | null {
-  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_FILE_CHANGE_COUNT) {
+  try {
+    if (!Array.isArray(value) || value.length === 0 || value.length > MAX_FILE_CHANGE_COUNT) {
+      return null
+    }
+    const changes: CodexStructuredFileChange[] = []
+    let diffBytes = 0
+    let encodedBytes = 2
+    for (const entry of value) {
+      const record = readChangeRecord(entry)
+      if (!record) {
+        return null
+      }
+      const path = record.path
+      const diff = record.diff
+      if (
+        typeof path !== 'string' ||
+        path.length === 0 ||
+        path.includes('\0') ||
+        Buffer.byteLength(path) > MAX_FILE_CHANGE_PATH_BYTES ||
+        typeof diff !== 'string'
+      ) {
+        return null
+      }
+      const normalizedKind = normalizeCodexFileChangeKind(record.kind)
+      if (!normalizedKind) {
+        return null
+      }
+      const diffByteLength = Buffer.byteLength(diff)
+      diffBytes += diffByteLength
+      encodedBytes +=
+        Buffer.byteLength(JSON.stringify(path)) +
+        Buffer.byteLength(JSON.stringify(diff)) +
+        normalizedKind.encodedBytes +
+        32
+      if (diffBytes > MAX_CHANGE_PLAN_DIFF_BYTES || encodedBytes > MAX_CHANGE_PLAN_ENCODED_BYTES) {
+        return null
+      }
+      changes.push({ path, diff, kind: normalizedKind.value })
+    }
+    return changes
+  } catch {
     return null
   }
-  const changes: CodexStructuredFileChange[] = []
-  let diffBytes = 0
-  for (const entry of value) {
-    const record = asRecord(entry)
-    if (
-      typeof record.path !== 'string' ||
-      record.path.length === 0 ||
-      record.path.includes('\0') ||
-      Buffer.byteLength(record.path) > MAX_FILE_CHANGE_PATH_BYTES ||
-      typeof record.diff !== 'string'
-    ) {
-      return null
-    }
-    diffBytes += Buffer.byteLength(record.diff)
-    if (diffBytes > MAX_CHANGE_PLAN_DIFF_BYTES) {
-      return null
-    }
-    changes.push({ path: record.path, diff: record.diff, kind: record.kind })
+}
+
+function readChangeRecord(value: unknown): { path: unknown; diff: unknown; kind: unknown } | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
   }
-  return changes
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    return null
+  }
+  const record: Record<string, unknown> = {}
+  for (const key of ['path', 'diff', 'kind']) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+      return null
+    }
+    record[key] = descriptor.value
+  }
+  return { path: record.path, diff: record.diff, kind: record.kind }
 }
 
 async function readBoundedRegularFile(
@@ -223,10 +264,6 @@ async function validateChangePath(root: string, input: string): Promise<string> 
     throw new Error('structured writer cannot mutate Git metadata')
   }
   return canonicalTarget
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
 }
 
 function sha256(value: Buffer): string {

--- a/src/main/codex/codex-structured-write-manifest.ts
+++ b/src/main/codex/codex-structured-write-manifest.ts
@@ -1,0 +1,192 @@
+import { createHash } from 'node:crypto'
+import { constants } from 'node:fs'
+import { lstat, open, readFile, realpath, stat } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+export type CodexStructuredFileChange = { path: string; diff: string; kind: unknown }
+
+export type CodexStructuredFileManifestEntry = {
+  path: string
+  exists: boolean
+  sha256: string | null
+  bytes: number | null
+}
+
+const MAX_FILE_CHANGE_COUNT = 128
+const MAX_FILE_CHANGE_PATH_BYTES = 4_096
+const MAX_CHANGE_PLAN_DIFF_BYTES = 1024 * 1024
+const MAX_MANIFEST_FILE_BYTES = 16 * 1024 * 1024
+const MAX_MANIFEST_TOTAL_BYTES = 32 * 1024 * 1024
+
+export async function validateLinkedWorktreeRoot(input: string): Promise<string> {
+  const root = await realpath(input)
+  if (!(await stat(root)).isDirectory()) {
+    throw new Error('writable worktree root is not a directory')
+  }
+  const dotGit = resolve(root, '.git')
+  const marker = await lstat(dotGit)
+  if (!marker.isFile() || marker.isSymbolicLink()) {
+    throw new Error('structured writer requires a linked Git worktree, not a canonical clone')
+  }
+  const line = (await readFile(dotGit, 'utf8')).trim()
+  if (!line.startsWith('gitdir:')) {
+    throw new Error('linked worktree .git marker is invalid')
+  }
+  const gitDir = await realpath(resolve(root, line.slice('gitdir:'.length).trim()))
+  if (!(await stat(gitDir)).isDirectory()) {
+    throw new Error('linked worktree Git directory is unavailable')
+  }
+  if (basename(dirname(gitDir)) !== 'worktrees') {
+    throw new Error('linked worktree Git directory is outside the common worktree registry')
+  }
+  const backlink = (await readFile(join(gitDir, 'gitdir'), 'utf8')).trim()
+  if (!backlink) {
+    throw new Error('linked worktree Git directory has no reciprocal backlink')
+  }
+  const resolvedBacklink = await realpath(resolve(gitDir, backlink))
+  if (resolvedBacklink !== (await realpath(dotGit))) {
+    throw new Error('linked worktree Git backlink does not name the selected worktree')
+  }
+  return root
+}
+
+export async function snapshotChanges(
+  root: string,
+  changes: readonly CodexStructuredFileChange[]
+): Promise<CodexStructuredFileManifestEntry[]> {
+  const canonicalRoot = await realpath(root)
+  const entries: CodexStructuredFileManifestEntry[] = []
+  const seen = new Set<string>()
+  let totalBytes = 0
+  for (const change of changes) {
+    const absolute = await validateChangePath(canonicalRoot, change.path)
+    const path = relative(canonicalRoot, absolute)
+    if (seen.has(path)) {
+      continue
+    }
+    seen.add(path)
+    try {
+      const bytes = await readBoundedRegularFile(
+        absolute,
+        path,
+        MAX_MANIFEST_TOTAL_BYTES - totalBytes
+      )
+      totalBytes += bytes.byteLength
+      entries.push({ path, exists: true, sha256: sha256(bytes), bytes: bytes.byteLength })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+      entries.push({ path, exists: false, sha256: null, bytes: null })
+    }
+  }
+  return entries.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+export function parseFileChanges(value: unknown): CodexStructuredFileChange[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_FILE_CHANGE_COUNT) {
+    return null
+  }
+  const changes: CodexStructuredFileChange[] = []
+  let diffBytes = 0
+  for (const entry of value) {
+    const record = asRecord(entry)
+    if (
+      typeof record.path !== 'string' ||
+      record.path.length === 0 ||
+      record.path.includes('\0') ||
+      Buffer.byteLength(record.path) > MAX_FILE_CHANGE_PATH_BYTES ||
+      typeof record.diff !== 'string'
+    ) {
+      return null
+    }
+    diffBytes += Buffer.byteLength(record.diff)
+    if (diffBytes > MAX_CHANGE_PLAN_DIFF_BYTES) {
+      return null
+    }
+    changes.push({ path: record.path, diff: record.diff, kind: record.kind })
+  }
+  return changes
+}
+
+async function readBoundedRegularFile(
+  absolute: string,
+  path: string,
+  remainingBytes: number
+): Promise<Buffer> {
+  const handle = await open(absolute, constants.O_RDONLY | constants.O_NOFOLLOW)
+  try {
+    const metadata = await handle.stat()
+    if (!metadata.isFile()) {
+      throw new Error(`structured writer target is not a regular file: ${path}`)
+    }
+    if (metadata.size > MAX_MANIFEST_FILE_BYTES) {
+      throw new Error(`structured writer target is too large to manifest: ${path}`)
+    }
+    if (metadata.size > remainingBytes) {
+      throw new Error('structured writer manifest exceeds its aggregate byte limit')
+    }
+    const bytes = Buffer.alloc(metadata.size)
+    let offset = 0
+    while (offset < bytes.byteLength) {
+      const { bytesRead } = await handle.read(bytes, offset, bytes.byteLength - offset, offset)
+      if (bytesRead === 0) {
+        break
+      }
+      offset += bytesRead
+    }
+    const after = await handle.stat()
+    if (after.size !== offset) {
+      throw new Error(`structured writer target changed while being manifested: ${path}`)
+    }
+    return offset === bytes.byteLength ? bytes : bytes.subarray(0, offset)
+  } finally {
+    await handle.close()
+  }
+}
+
+async function validateChangePath(root: string, input: string): Promise<string> {
+  const absolute = isAbsolute(input) ? resolve(input) : resolve(root, input)
+  let ancestor = absolute
+  while (true) {
+    try {
+      const metadata = await lstat(ancestor)
+      if (metadata.isSymbolicLink()) {
+        throw new Error(`structured writer target crosses a symbolic link: ${input}`)
+      }
+      break
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+      const parent = dirname(ancestor)
+      if (parent === ancestor) {
+        throw error
+      }
+      ancestor = parent
+    }
+  }
+  const canonicalAncestor = await realpath(ancestor)
+  const canonicalTarget = resolve(canonicalAncestor, relative(ancestor, absolute))
+  const targetRelative = relative(root, canonicalTarget)
+  if (
+    !targetRelative ||
+    targetRelative === '..' ||
+    targetRelative.startsWith(`..${sep}`) ||
+    isAbsolute(targetRelative)
+  ) {
+    throw new Error(`structured writer target resolves outside its worktree: ${input}`)
+  }
+  if (targetRelative.split(sep).includes('.git')) {
+    throw new Error('structured writer cannot mutate Git metadata')
+  }
+  return canonicalTarget
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+function sha256(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}

--- a/src/main/codex/codex-structured-write-path-race.test.ts
+++ b/src/main/codex/codex-structured-write-path-race.test.ts
@@ -1,0 +1,58 @@
+import { rename, writeFile } from 'node:fs/promises'
+import type * as FsPromises from 'node:fs/promises'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const roots: string[] = []
+let afterOpen: (() => Promise<void>) | null = null
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof FsPromises>()
+  return {
+    ...original,
+    open: async (...args: Parameters<typeof original.open>) => {
+      const handle = await original.open(...args)
+      await afterOpen?.()
+      return handle
+    }
+  }
+})
+
+const { snapshotChanges } = await import('./codex-structured-write-manifest')
+
+afterEach(() => {
+  afterOpen = null
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function fixtureRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-write-path-race-'))
+  roots.push(root)
+  mkdirSync(join(root, 'source'), { recursive: true })
+  return root
+}
+
+describe('Codex structured write manifest path races', () => {
+  it('rejects a target replaced with a same-sized inode after it is opened', async () => {
+    const root = fixtureRoot()
+    const target = join(root, 'source', 'target.txt')
+    const displaced = join(root, 'source', 'displaced.txt')
+    writeFileSync(target, 'before\n')
+    afterOpen = async () => {
+      await rename(target, displaced)
+      await writeFile(target, 'outside')
+    }
+
+    await expect(
+      snapshotChanges(root, [
+        { path: 'source/target.txt', diff: '@@ -1 +1 @@', kind: { type: 'update' } }
+      ])
+    ).rejects.toThrow('changed while being manifested')
+    expect(readFileSync(target, 'utf8')).toBe('outside')
+  })
+})

--- a/src/main/codex/codex-structured-write-receipt-store.ts
+++ b/src/main/codex/codex-structured-write-receipt-store.ts
@@ -1,0 +1,228 @@
+import { mkdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { durableWriteTempPath, writeFileDurable } from '../durable-file-write'
+import type {
+  CodexStructuredWriteAdmissionReceipt,
+  CodexStructuredWriteReceipt
+} from './codex-structured-write-types'
+
+const ADMISSION_FILE = 'host-enforcement-receipts.json'
+const TRACE_FILE = 'operational-trace.json'
+const MAX_RECEIPTS = 100_000
+const MAX_MANIFEST_ENTRIES = 128
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+
+type AdmissionState = {
+  protocolVersion: 1
+  receipts: CodexStructuredWriteAdmissionReceipt[]
+}
+
+type TraceState = {
+  protocolVersion: 1
+  receipts: CodexStructuredWriteReceipt[]
+}
+
+/** Durable host evidence. Admission commits synchronously before mutation;
+ * outcome trace is queued separately and is never an execution prerequisite. */
+export class CodexStructuredWriteReceiptStore {
+  private admissionWrite: Promise<void> = Promise.resolve()
+  private traceWrite: Promise<void> = Promise.resolve()
+  private readonly admittedMessages = new Set<string>()
+
+  private constructor(
+    private readonly admissionPath: string,
+    private readonly tracePath: string,
+    private readonly admissions: AdmissionState,
+    private readonly traces: TraceState
+  ) {
+    for (const receipt of admissions.receipts) {
+      this.admittedMessages.add(messageKey(receipt.sessionId, receipt.clientMessageId))
+    }
+  }
+
+  static async open(
+    directory: string,
+    onTraceError?: (error: unknown) => void
+  ): Promise<CodexStructuredWriteReceiptStore> {
+    await mkdir(directory, { recursive: true, mode: 0o700 })
+    const admissionPath = join(directory, ADMISSION_FILE)
+    const tracePath = join(directory, TRACE_FILE)
+    return new CodexStructuredWriteReceiptStore(
+      admissionPath,
+      tracePath,
+      await loadState(admissionPath, isAdmissionReceipt),
+      await loadOptionalTraceState(tracePath, onTraceError)
+    )
+  }
+
+  hasAdmission(sessionId: string, clientMessageId: string): boolean {
+    return this.admittedMessages.has(messageKey(sessionId, clientMessageId))
+  }
+
+  persistAdmission(receipt: CodexStructuredWriteAdmissionReceipt): Promise<void> {
+    const key = messageKey(receipt.sessionId, receipt.clientMessageId)
+    const operation = this.admissionWrite.then(async () => {
+      if (this.admittedMessages.has(key)) {
+        throw new Error('structured write operation already has a durable admission receipt')
+      }
+      if (this.admissions.receipts.length >= MAX_RECEIPTS) {
+        throw new Error('structured write admission receipt capacity reached')
+      }
+      const next: AdmissionState = {
+        protocolVersion: 1,
+        receipts: [...this.admissions.receipts, structuredClone(receipt)]
+      }
+      await writeFileDurable(
+        durableWriteTempPath(this.admissionPath),
+        this.admissionPath,
+        `${JSON.stringify(next)}\n`
+      )
+      this.admissions.receipts = next.receipts
+      this.admittedMessages.add(key)
+    })
+    this.admissionWrite = operation.catch(() => {})
+    return operation
+  }
+
+  persistOutcome(receipt: CodexStructuredWriteReceipt): Promise<void> {
+    const operation = this.traceWrite.then(async () => {
+      if (this.traces.receipts.length >= MAX_RECEIPTS) {
+        this.traces.receipts = this.traces.receipts.slice(-Math.trunc(MAX_RECEIPTS / 2))
+      }
+      const next: TraceState = {
+        protocolVersion: 1,
+        receipts: [...this.traces.receipts, structuredClone(receipt)]
+      }
+      await writeFileDurable(
+        durableWriteTempPath(this.tracePath),
+        this.tracePath,
+        `${JSON.stringify(next)}\n`
+      )
+      this.traces.receipts = next.receipts
+    })
+    this.traceWrite = operation.catch(() => {})
+    return operation
+  }
+
+  async flush(): Promise<void> {
+    await this.admissionWrite
+    await this.traceWrite
+  }
+}
+
+async function loadOptionalTraceState(
+  path: string,
+  onTraceError?: (error: unknown) => void
+): Promise<TraceState> {
+  try {
+    return await loadState(path, isOutcomeReceipt)
+  } catch (error) {
+    onTraceError?.(error)
+    return { protocolVersion: 1, receipts: [] }
+  }
+}
+
+async function loadState<T>(
+  path: string,
+  isReceipt: (value: unknown) => value is T
+): Promise<{ protocolVersion: 1; receipts: T[] }> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { protocolVersion: 1, receipts: [] }
+    }
+    throw error
+  }
+  const parsed: unknown = JSON.parse(raw)
+  if (!isRecord(parsed) || parsed.protocolVersion !== 1 || !Array.isArray(parsed.receipts)) {
+    throw new Error('structured write receipt store is unreadable')
+  }
+  if (parsed.receipts.length > MAX_RECEIPTS || !parsed.receipts.every(isReceipt)) {
+    throw new Error('structured write receipt store contains invalid receipts')
+  }
+  return { protocolVersion: 1, receipts: parsed.receipts }
+}
+
+function isAdmissionReceipt(value: unknown): value is CodexStructuredWriteAdmissionReceipt {
+  return (
+    isBaseReceipt(value) &&
+    isManifest(value.before) &&
+    isNonNegativeFiniteNumber(value.admittedAtMs)
+  )
+}
+
+function isOutcomeReceipt(value: unknown): value is CodexStructuredWriteReceipt {
+  return (
+    isBaseReceipt(value) &&
+    isNonEmptyString(value.receiptId) &&
+    isManifest(value.before) &&
+    isManifest(value.after) &&
+    ['completed', 'failed', 'declined'].includes(String(value.outcome)) &&
+    isNonNegativeFiniteNumber(value.completedAtMs)
+  )
+}
+
+function isBaseReceipt(value: unknown): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    value.protocolVersion === 1 &&
+    value.effectDomain === 'local_structured_write' &&
+    isSha256(value.requestReceiptId) &&
+    isNonEmptyString(value.sessionId) &&
+    isPositiveInteger(value.turnEpoch) &&
+    isNonNegativeInteger(value.fence) &&
+    isNonEmptyString(value.clientMessageId) &&
+    isNonEmptyString(value.threadId) &&
+    isNonEmptyString(value.turnId) &&
+    isSha256(value.requestDigest) &&
+    isNonEmptyString(value.toolUseId) &&
+    isSha256(value.changePlanDigest) &&
+    isNonEmptyString(value.worktreeRoot) &&
+    isSha256(value.capabilityHandleDigest)
+  )
+}
+
+function isManifest(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_MANIFEST_ENTRIES &&
+    value.every((entry) => {
+      if (!isRecord(entry) || !isNonEmptyString(entry.path) || typeof entry.exists !== 'boolean') {
+        return false
+      }
+      return entry.exists
+        ? isSha256(entry.sha256) && isNonNegativeInteger(entry.bytes)
+        : entry.sha256 === null && entry.bytes === null
+    })
+  )
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && SHA256_PATTERN.test(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function messageKey(sessionId: string, clientMessageId: string): string {
+  return `${sessionId.length}:${sessionId}${clientMessageId}`
+}

--- a/src/main/codex/codex-structured-write-receipts.ts
+++ b/src/main/codex/codex-structured-write-receipts.ts
@@ -1,0 +1,82 @@
+import { snapshotChanges } from './codex-structured-write-manifest'
+import type {
+  CodexObservedFileChange,
+  CodexStructuredWriteAuthorization,
+  CodexStructuredWriteReceipt
+} from './codex-structured-write-types'
+import { LOCAL_STRUCTURED_WRITE_EFFECT } from './codex-structured-write-types'
+
+export class CodexStructuredWriteReceiptEmitter {
+  constructor(
+    private readonly authorization: CodexStructuredWriteAuthorization,
+    private readonly now: () => number,
+    private readonly mintId: () => string
+  ) {}
+
+  async completed(
+    sessionId: string,
+    observed: CodexObservedFileChange,
+    status: CodexStructuredWriteReceipt['outcome']
+  ): Promise<void> {
+    const admission = observed.admission
+    const before = observed.before
+    if (!admission || !before) {
+      return
+    }
+    let snapshotFailed = false
+    const after = await snapshotChanges(admission.worktreeRoot, observed.changes).catch(() => {
+      snapshotFailed = true
+      return []
+    })
+    this.emit(this.receipt(sessionId, observed, before, after, snapshotFailed ? 'failed' : status))
+  }
+
+  async failed(sessionId: string, observed: CodexObservedFileChange): Promise<void> {
+    const admission = observed.admission
+    const before = observed.before
+    if (!admission || !before) {
+      return
+    }
+    const after = await snapshotChanges(admission.worktreeRoot, observed.changes).catch(() => [])
+    this.emit(this.receipt(sessionId, observed, before, after, 'failed'))
+  }
+
+  private receipt(
+    sessionId: string,
+    observed: CodexObservedFileChange,
+    before: NonNullable<CodexObservedFileChange['before']>,
+    after: NonNullable<CodexObservedFileChange['before']>,
+    outcome: CodexStructuredWriteReceipt['outcome']
+  ): CodexStructuredWriteReceipt {
+    const admission = observed.admission as NonNullable<CodexObservedFileChange['admission']>
+    return {
+      protocolVersion: 1,
+      receiptId: this.mintId(),
+      requestReceiptId: admission.requestReceiptId,
+      effectDomain: LOCAL_STRUCTURED_WRITE_EFFECT,
+      sessionId,
+      turnEpoch: admission.turnEpoch,
+      fence: admission.fence,
+      clientMessageId: admission.clientMessageId,
+      threadId: observed.threadId,
+      turnId: observed.turnId,
+      requestDigest: admission.requestDigest,
+      toolUseId: observed.itemId,
+      changePlanDigest: observed.changePlanDigest,
+      worktreeRoot: admission.worktreeRoot,
+      capabilityHandleDigest: admission.capabilityHandleDigest,
+      before,
+      after,
+      outcome,
+      completedAtMs: this.now()
+    }
+  }
+
+  private emit(receipt: CodexStructuredWriteReceipt): void {
+    try {
+      this.authorization.onReceipt(receipt)
+    } catch (error) {
+      this.authorization.onReceiptFailure?.({ receipt, error })
+    }
+  }
+}

--- a/src/main/codex/codex-structured-write-runtime.test.ts
+++ b/src/main/codex/codex-structured-write-runtime.test.ts
@@ -2,7 +2,10 @@ import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSy
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createCodexStructuredWriteAuthority } from './codex-structured-write-runtime'
+import {
+  createCodexStructuredWriteAuthority,
+  isCodexStructuredWriteEnabled
+} from './codex-structured-write-runtime'
 
 const roots: string[] = []
 
@@ -27,6 +30,12 @@ function fixture(): { state: string; worktree: string } {
 }
 
 describe('createCodexStructuredWriteAuthority', () => {
+  it('is production-enabled by default with an explicit fail-closed rollback switch', () => {
+    expect(isCodexStructuredWriteEnabled(undefined)).toBe(true)
+    expect(isCodexStructuredWriteEnabled('1')).toBe(true)
+    expect(isCodexStructuredWriteEnabled('0')).toBe(false)
+  })
+
   it('requires host request authority and refuses the same admitted turn after restart', async () => {
     const { state, worktree } = fixture()
     const first = await createCodexStructuredWriteAuthority({ stateDirectory: state })

--- a/src/main/codex/codex-structured-write-runtime.test.ts
+++ b/src/main/codex/codex-structured-write-runtime.test.ts
@@ -1,0 +1,190 @@
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createCodexStructuredWriteAuthority } from './codex-structured-write-runtime'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  roots.length = 0
+})
+
+function fixture(): { state: string; worktree: string } {
+  const root = mkdtempSync(join(tmpdir(), 'orca-structured-runtime-'))
+  roots.push(root)
+  const worktree = join(root, 'worktree')
+  const gitDir = join(root, 'repo.git', 'worktrees', 'bounded')
+  mkdirSync(worktree, { recursive: true })
+  mkdirSync(gitDir, { recursive: true })
+  writeFileSync(join(worktree, '.git'), `gitdir: ${gitDir}\n`)
+  writeFileSync(join(gitDir, 'gitdir'), `${join(worktree, '.git')}\n`)
+  writeFileSync(join(worktree, 'source.txt'), 'before\n')
+  return { state: join(root, 'state'), worktree: realpathSync(worktree) }
+}
+
+describe('createCodexStructuredWriteAuthority', () => {
+  it('requires host request authority and refuses the same admitted turn after restart', async () => {
+    const { state, worktree } = fixture()
+    const first = await createCodexStructuredWriteAuthority({ stateDirectory: state })
+    await first.bindSession('session-1', worktree)
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'change source.txt only' }]
+    }
+    await expect(
+      first.openTurn({ sessionId: 'session-1', clientMessageId: 'plain', body, fence: 7 })
+    ).resolves.toBeNull()
+    const requestAuthority = {
+      effectAuthority: 'local_structured_write' as const,
+      requestReceiptId: 'c'.repeat(64)
+    }
+    const epoch = await first.openTurn({
+      sessionId: 'session-1',
+      clientMessageId: 'edit-1',
+      body,
+      fence: 7,
+      requestAuthority
+    })
+    expect(epoch).toBe(2)
+    first.bindTurn('session-1', 'thread-1', 'turn-1', epoch as number)
+    first.observeNotification('session-1', 'item/started', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: {
+        type: 'fileChange',
+        id: 'item-1',
+        changes: [{ path: 'source.txt', diff: '@@', kind: { type: 'update' } }]
+      }
+    })
+    await expect(
+      first.reviewServerRequest('session-1', 'item/fileChange/requestApproval', {
+        itemId: 'item-1',
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        grantRoot: worktree
+      })
+    ).resolves.toEqual({ handled: true, result: { decision: 'accept' } })
+    first.observeNotification('session-1', 'item/completed', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { type: 'fileChange', id: 'item-1', status: 'completed' }
+    })
+    await first.flushReceipts()
+    const trace = JSON.parse(
+      readFileSync(join(state, 'codex-structured-write', 'operational-trace.json'), 'utf8')
+    ) as { receipts: { outcome: string }[] }
+    expect(trace.receipts).toMatchObject([{ outcome: 'completed' }])
+
+    const restarted = await createCodexStructuredWriteAuthority({ stateDirectory: state })
+    await restarted.bindSession('session-1', worktree)
+    await expect(
+      restarted.openTurn({
+        sessionId: 'session-1',
+        clientMessageId: 'edit-1',
+        body,
+        fence: 7,
+        requestAuthority
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('fails closed when durable enforcement evidence is malformed', async () => {
+    const { state } = fixture()
+    const storeDirectory = join(state, 'codex-structured-write')
+    mkdirSync(storeDirectory, { recursive: true })
+    const digest = 'd'.repeat(64)
+    writeFileSync(
+      join(storeDirectory, 'host-enforcement-receipts.json'),
+      `${JSON.stringify({
+        protocolVersion: 1,
+        receipts: [
+          {
+            protocolVersion: 1,
+            requestReceiptId: digest,
+            effectDomain: 'hosted_connector',
+            sessionId: 'forged',
+            turnEpoch: 1,
+            fence: 0,
+            clientMessageId: 'message',
+            threadId: 'thread',
+            turnId: 'turn',
+            requestDigest: digest,
+            toolUseId: 'tool',
+            changePlanDigest: digest,
+            worktreeRoot: '/tmp/worktree',
+            capabilityHandleDigest: digest,
+            before: [],
+            admittedAtMs: Date.now()
+          }
+        ]
+      })}\n`
+    )
+    await expect(createCodexStructuredWriteAuthority({ stateDirectory: state })).rejects.toThrow(
+      'invalid receipts'
+    )
+  })
+
+  it('reports a malformed operational trace without blocking enforcement', async () => {
+    const { state, worktree } = fixture()
+    const storeDirectory = join(state, 'codex-structured-write')
+    mkdirSync(storeDirectory, { recursive: true })
+    writeFileSync(join(storeDirectory, 'operational-trace.json'), '{not-json\n')
+    const onTraceError = vi.fn()
+
+    const authority = await createCodexStructuredWriteAuthority({
+      stateDirectory: state,
+      onTraceError
+    })
+    await expect(authority.bindSession('session-1', worktree)).resolves.toBeUndefined()
+    expect(onTraceError).toHaveBeenCalledOnce()
+  })
+
+  it('drains a failed outcome generated by session revocation', async () => {
+    const { state, worktree } = fixture()
+    const authority = await createCodexStructuredWriteAuthority({ stateDirectory: state })
+    await authority.bindSession('session-1', worktree)
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'change source.txt only' }]
+    }
+    const epoch = await authority.openTurn({
+      sessionId: 'session-1',
+      clientMessageId: 'edit-1',
+      body,
+      fence: 7,
+      requestAuthority: {
+        effectAuthority: 'local_structured_write',
+        requestReceiptId: 'e'.repeat(64)
+      }
+    })
+    authority.bindTurn('session-1', 'thread-1', 'turn-1', epoch as number)
+    authority.observeNotification('session-1', 'item/started', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: {
+        type: 'fileChange',
+        id: 'item-1',
+        changes: [{ path: 'source.txt', diff: '@@', kind: { type: 'update' } }]
+      }
+    })
+    await authority.reviewServerRequest('session-1', 'item/fileChange/requestApproval', {
+      itemId: 'item-1',
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      grantRoot: worktree
+    })
+
+    authority.revokeSession('session-1')
+    await authority.flushReceipts()
+    const trace = JSON.parse(
+      readFileSync(join(state, 'codex-structured-write', 'operational-trace.json'), 'utf8')
+    ) as { receipts: { outcome: string }[] }
+    expect(trace.receipts).toMatchObject([{ outcome: 'failed' }])
+  })
+})

--- a/src/main/codex/codex-structured-write-runtime.ts
+++ b/src/main/codex/codex-structured-write-runtime.ts
@@ -1,0 +1,37 @@
+import { join } from 'node:path'
+import { CodexStructuredWriteAuthority } from './codex-structured-write-authority'
+import { CodexStructuredWriteLeaseRegistry } from './codex-structured-write-lease-registry'
+import { CodexStructuredWriteReceiptStore } from './codex-structured-write-receipt-store'
+import { LOCAL_STRUCTURED_WRITE_EFFECT } from './codex-structured-write-types'
+
+export async function createCodexStructuredWriteAuthority(input: {
+  stateDirectory: string
+  onTraceError?: (error: unknown) => void
+}): Promise<CodexStructuredWriteAuthority> {
+  const store = await CodexStructuredWriteReceiptStore.open(
+    join(input.stateDirectory, 'codex-structured-write'),
+    input.onTraceError
+  )
+  const registry = new CodexStructuredWriteLeaseRegistry({
+    admitTurn: (turn) => {
+      const authority = turn.requestAuthority
+      if (
+        !authority ||
+        authority.effectAuthority !== LOCAL_STRUCTURED_WRITE_EFFECT ||
+        !/^[0-9a-f]{64}$/.test(authority.requestReceiptId) ||
+        store.hasAdmission(turn.sessionId, turn.clientMessageId)
+      ) {
+        return null
+      }
+      return {
+        requestReceiptId: authority.requestReceiptId,
+        writableRoot: turn.writableRoot
+      }
+    },
+    persistAdmission: (receipt) => store.persistAdmission(receipt),
+    persistOutcome: (receipt) => store.persistOutcome(receipt),
+    flushReceipts: () => store.flush(),
+    onOutcomePersistenceFailure: ({ error }) => input.onTraceError?.(error)
+  })
+  return new CodexStructuredWriteAuthority(registry)
+}

--- a/src/main/codex/codex-structured-write-runtime.ts
+++ b/src/main/codex/codex-structured-write-runtime.ts
@@ -4,6 +4,10 @@ import { CodexStructuredWriteLeaseRegistry } from './codex-structured-write-leas
 import { CodexStructuredWriteReceiptStore } from './codex-structured-write-receipt-store'
 import { LOCAL_STRUCTURED_WRITE_EFFECT } from './codex-structured-write-types'
 
+export function isCodexStructuredWriteEnabled(value: string | undefined): boolean {
+  return value !== '0'
+}
+
 export async function createCodexStructuredWriteAuthority(input: {
   stateDirectory: string
   onTraceError?: (error: unknown) => void

--- a/src/main/codex/codex-structured-write-session-roots.ts
+++ b/src/main/codex/codex-structured-write-session-roots.ts
@@ -1,0 +1,40 @@
+import { snapshotLinkedWorktreeRoot } from './codex-structured-write-manifest'
+
+export class CodexStructuredWriteSessionRoots {
+  private readonly roots = new Map<string, string>()
+  private readonly identities = new Map<string, string>()
+
+  async bind(sessionId: string, input: string, revokeBoundSession: () => void): Promise<void> {
+    if (this.roots.has(sessionId)) {
+      revokeBoundSession()
+    }
+    const worktree = await snapshotLinkedWorktreeRoot(input)
+    this.roots.set(sessionId, worktree.root)
+    this.identities.set(sessionId, worktree.identity)
+  }
+
+  requireRoot(sessionId: string): string {
+    const root = this.roots.get(sessionId)
+    if (!root) {
+      throw new Error(`no host-selected writable worktree for ${sessionId}`)
+    }
+    return root
+  }
+
+  requireIdentity(sessionId: string): string {
+    const identity = this.identities.get(sessionId)
+    if (!identity) {
+      throw new Error(`no host-selected writable worktree identity for ${sessionId}`)
+    }
+    return identity
+  }
+
+  isBoundTo(sessionId: string, root: string): boolean {
+    return this.roots.get(sessionId) === root
+  }
+
+  delete(sessionId: string): void {
+    this.roots.delete(sessionId)
+    this.identities.delete(sessionId)
+  }
+}

--- a/src/main/codex/codex-structured-write-turn-lifecycle.ts
+++ b/src/main/codex/codex-structured-write-turn-lifecycle.ts
@@ -1,0 +1,42 @@
+export type CodexStructuredWriteTurn = { threadId: string; turnId: string }
+
+export const structuredWriteItemKey = (sessionId: string, itemId: string): string =>
+  `${encodeURIComponent(sessionId)}:${encodeURIComponent(itemId)}`
+
+export function notificationCompletesStructuredWriteTurn(
+  active: CodexStructuredWriteTurn | null,
+  params: unknown
+): boolean {
+  const record = asRecord(params)
+  const turn = asRecord(record.turn)
+  const threadId = readString(record, 'threadId')
+  const turnId = readString(turn, 'id')
+  return Boolean(
+    active && turnId && active.turnId === turnId && (!threadId || active.threadId === threadId)
+  )
+}
+
+export async function waitForStructuredWriteTurnEnd(
+  current: () => CodexStructuredWriteTurn | null,
+  expected: CodexStructuredWriteTurn,
+  timeoutMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() <= deadline) {
+    const active = current()
+    if (!active || active.threadId !== expected.threadId || active.turnId !== expected.turnId) {
+      return true
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 20))
+  }
+  return false
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}

--- a/src/main/codex/codex-structured-write-types.ts
+++ b/src/main/codex/codex-structured-write-types.ts
@@ -1,0 +1,116 @@
+import type {
+  CodexStructuredFileChange,
+  CodexStructuredFileManifestEntry
+} from './codex-structured-write-manifest'
+
+export const LOCAL_STRUCTURED_WRITE_EFFECT = 'local_structured_write' as const
+
+export type CodexStructuredWriteGrant = {
+  requestReceiptId: string
+  writableRoot: string
+  /** Host-registry handle. It is passed back only to the host consume callback. */
+  capabilityHandle: string
+}
+
+export type CodexStructuredWriteAdmissionReceipt = {
+  protocolVersion: 1
+  requestReceiptId: string
+  effectDomain: typeof LOCAL_STRUCTURED_WRITE_EFFECT
+  sessionId: string
+  turnEpoch: number
+  fence: number
+  clientMessageId: string
+  threadId: string
+  turnId: string
+  requestDigest: string
+  toolUseId: string
+  changePlanDigest: string
+  worktreeRoot: string
+  capabilityHandleDigest: string
+  before: CodexStructuredFileManifestEntry[]
+  admittedAtMs: number
+}
+
+export type CodexStructuredWriteAuthorization = {
+  authorizeTurn: (input: {
+    sessionId: string
+    turnEpoch: number
+    fence: number
+    clientMessageId: string
+    requestDigest: string
+    writableRoot: string
+    requestAuthority?: {
+      effectAuthority: typeof LOCAL_STRUCTURED_WRITE_EFFECT
+      requestReceiptId: string
+    }
+  }) => Promise<CodexStructuredWriteGrant | null> | CodexStructuredWriteGrant | null
+  /** Must atomically compare-and-consume the opaque handle before mutation. */
+  consumeLease: (input: {
+    capabilityHandle: string
+    receipt: CodexStructuredWriteAdmissionReceipt
+  }) => Promise<void> | void
+  revokeSession?: (sessionId: string) => void
+  onReceipt: (receipt: CodexStructuredWriteReceipt) => void
+  onReceiptFailure?: (input: { receipt: CodexStructuredWriteReceipt; error: unknown }) => void
+  /** Drains asynchronous evaluation-only receipts during host shutdown. */
+  flushReceipts?: () => Promise<void>
+}
+
+export type CodexStructuredWriteReceipt = {
+  protocolVersion: 1
+  receiptId: string
+  requestReceiptId: string
+  effectDomain: typeof LOCAL_STRUCTURED_WRITE_EFFECT
+  sessionId: string
+  turnEpoch: number
+  fence: number
+  clientMessageId: string
+  threadId: string
+  turnId: string
+  requestDigest: string
+  toolUseId: string
+  changePlanDigest: string
+  worktreeRoot: string
+  capabilityHandleDigest: string
+  before: CodexStructuredFileManifestEntry[]
+  after: CodexStructuredFileManifestEntry[]
+  outcome: 'completed' | 'failed' | 'declined'
+  completedAtMs: number
+}
+
+export type CodexStructuredWriteLease = {
+  handle: string
+  requestReceiptId: string
+  sessionId: string
+  turnEpoch: number
+  fence: number
+  clientMessageId: string
+  requestDigest: string
+  worktreeRoot: string
+  threadId: string | null
+  turnId: string | null
+  state: 'issued' | 'reserved' | 'consumed' | 'revoked'
+}
+
+export type CodexObservedFileChange = {
+  sessionId: string
+  threadId: string
+  turnId: string
+  itemId: string
+  changes: CodexStructuredFileChange[]
+  changePlanDigest: string
+  before: CodexStructuredFileManifestEntry[] | null
+  admission: {
+    requestReceiptId: string
+    turnEpoch: number
+    fence: number
+    clientMessageId: string
+    requestDigest: string
+    worktreeRoot: string
+    capabilityHandleDigest: string
+  } | null
+}
+
+export type CodexStructuredApproval =
+  | { handled: false }
+  | { handled: true; result: Record<string, unknown> }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2554,6 +2554,8 @@ void app.whenReady().then(async () => {
       }),
     buildAgentHookPtyEnv: () =>
       isAgentStatusHooksEnabled(store?.getSettings()) ? agentHookServer.buildPtyEnv() : {},
+    // Canary-only until the one-writer E2E is qualified against the installed host.
+    codexStructuredWriteEnabled: process.env.ORCA_CODEX_LOCAL_STRUCTURED_WRITE === '1',
     orchestrationEnvironmentTransport
   })
   runtime = runtimeService

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -282,6 +282,7 @@ import { normalizeComputerAwakeMode } from '../shared/computer-awake-mode'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { settleTeardownWithinDeadline } from './quit-teardown-deadline'
 import { stopStructuredAgentSessionRuntime } from './runtime/structured-agent-session-runtime'
+import { isCodexStructuredWriteEnabled } from './codex/codex-structured-write-runtime'
 import { quitTeardownStartGate } from './quit-teardown-start-gate'
 import { beginSshShutdown } from './ipc/ssh'
 import { PluginService } from './plugins/plugin-service'
@@ -2554,8 +2555,11 @@ void app.whenReady().then(async () => {
       }),
     buildAgentHookPtyEnv: () =>
       isAgentStatusHooksEnabled(store?.getSettings()) ? agentHookServer.buildPtyEnv() : {},
-    // Canary-only until the one-writer E2E is qualified against the installed host.
-    codexStructuredWriteEnabled: process.env.ORCA_CODEX_LOCAL_STRUCTURED_WRITE === '1',
+    // Production default after one-writer qualification. Operators retain a
+    // fail-closed rollback switch without changing ordinary chat sessions.
+    codexStructuredWriteEnabled: isCodexStructuredWriteEnabled(
+      process.env.ORCA_CODEX_LOCAL_STRUCTURED_WRITE
+    ),
     orchestrationEnvironmentTransport
   })
   runtime = runtimeService

--- a/src/main/ipc/runtime.test.ts
+++ b/src/main/ipc/runtime.test.ts
@@ -1,13 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { handleMock, onMock, removeAllListenersMock, removeHandlerMock, fromWebContentsMock } =
-  vi.hoisted(() => ({
-    handleMock: vi.fn(),
-    onMock: vi.fn(),
-    removeAllListenersMock: vi.fn(),
-    removeHandlerMock: vi.fn(),
-    fromWebContentsMock: vi.fn()
-  }))
+const {
+  handleMock,
+  onMock,
+  removeAllListenersMock,
+  removeHandlerMock,
+  fromWebContentsMock,
+  isTrustedUIRendererMock
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  onMock: vi.fn(),
+  removeAllListenersMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  fromWebContentsMock: vi.fn(),
+  isTrustedUIRendererMock: vi.fn(() => true)
+}))
 
 vi.mock('electron', () => ({
   BrowserWindow: {
@@ -21,6 +28,8 @@ vi.mock('electron', () => ({
   }
 }))
 
+vi.mock('./ui', () => ({ isTrustedUIRenderer: isTrustedUIRendererMock }))
+
 import { registerRuntimeHandlers } from './runtime'
 import { TERMINAL_FIT_RESTORE_DEADLINE_MS } from '../../shared/terminal-fit-restore-deadline'
 
@@ -31,6 +40,7 @@ describe('registerRuntimeHandlers', () => {
     removeAllListenersMock.mockReset()
     removeHandlerMock.mockReset()
     fromWebContentsMock.mockReset()
+    isTrustedUIRendererMock.mockReset().mockReturnValue(true)
   })
 
   it('routes sync requests through the authoritative browser window id', () => {
@@ -83,6 +93,29 @@ describe('registerRuntimeHandlers', () => {
       result: { runtimeId: 'runtime-1', graphStatus: 'ready' },
       _meta: { runtimeId: 'runtime-1' }
     })
+  })
+
+  it('rejects effect authority from any renderer other than the trusted main UI', async () => {
+    const runtime = {
+      syncWindowGraph: vi.fn(),
+      getStatus: vi.fn(),
+      getRuntimeId: vi.fn().mockReturnValue('runtime-1')
+    }
+    registerRuntimeHandlers(runtime as never)
+    const handler = handleMock.mock.calls.find(([channel]) => channel === 'runtime:call')![1]
+    const sender = { id: 99 }
+    isTrustedUIRendererMock.mockReturnValue(false)
+
+    await expect(
+      handler(
+        { sender },
+        {
+          method: 'agentSession.send',
+          params: { effectAuthority: 'local_structured_write' }
+        }
+      )
+    ).rejects.toThrow('runtime_effect_authority_requires_trusted_ui_renderer')
+    expect(isTrustedUIRendererMock).toHaveBeenCalledWith(sender)
   })
 
   it('registers project group runtime RPC methods for local desktop callers', async () => {

--- a/src/main/ipc/runtime.test.ts
+++ b/src/main/ipc/runtime.test.ts
@@ -118,6 +118,29 @@ describe('registerRuntimeHandlers', () => {
     expect(isTrustedUIRendererMock).toHaveBeenCalledWith(sender)
   })
 
+  it('rejects a local structured user turn from an untrusted renderer without effect authority', async () => {
+    const runtime = {
+      syncWindowGraph: vi.fn(),
+      getStatus: vi.fn(),
+      getRuntimeId: vi.fn().mockReturnValue('runtime-1')
+    }
+    registerRuntimeHandlers(runtime as never)
+    const handler = handleMock.mock.calls.find(([channel]) => channel === 'runtime:call')![1]
+    const sender = { id: 100 }
+    isTrustedUIRendererMock.mockReturnValue(false)
+
+    await expect(
+      handler(
+        { sender },
+        {
+          method: 'agentSession.send',
+          params: {}
+        }
+      )
+    ).rejects.toThrow('runtime_agent_session_send_requires_trusted_ui_renderer')
+    expect(isTrustedUIRendererMock).toHaveBeenCalledWith(sender)
+  })
+
   it('registers project group runtime RPC methods for local desktop callers', async () => {
     const runtime = {
       syncWindowGraph: vi.fn(),

--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -18,6 +18,10 @@ function requestsEffectAuthority(params: unknown): boolean {
   return typeof params === 'object' && params !== null && 'effectAuthority' in params
 }
 
+function isTrustedLocalUserTurnMethod(method: string): boolean {
+  return method === 'agentSession.send'
+}
+
 function boundTerminalFitRestore(pending: Promise<boolean>): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined
   const deadline = new Promise<boolean>((resolve) => {
@@ -57,8 +61,14 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
       event,
       args: { method: string; params?: unknown }
     ): Promise<RuntimeRpcResponse<unknown>> => {
-      if (requestsEffectAuthority(args.params) && !isTrustedUIRenderer(event.sender)) {
+      const requestsAuthority = requestsEffectAuthority(args.params)
+      const requiresTrustedRenderer = requestsAuthority || isTrustedLocalUserTurnMethod(args.method)
+      const trustedRenderer = requiresTrustedRenderer && isTrustedUIRenderer(event.sender)
+      if (requestsAuthority && !trustedRenderer) {
         throw new Error('runtime_effect_authority_requires_trusted_ui_renderer')
+      }
+      if (isTrustedLocalUserTurnMethod(args.method) && !trustedRenderer) {
+        throw new Error('runtime_agent_session_send_requires_trusted_ui_renderer')
       }
       return (await new RpcDispatcher({ runtime, methods: ALL_RPC_METHODS }).dispatch(
         {

--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -12,6 +12,11 @@ import { TERMINAL_FIT_RESTORE_DEADLINE_MS } from '../../shared/terminal-fit-rest
 import { STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
 import { RpcDispatcher } from '../runtime/rpc/dispatcher'
 import { ALL_RPC_METHODS } from '../runtime/rpc/methods'
+import { isTrustedUIRenderer } from './ui'
+
+function requestsEffectAuthority(params: unknown): boolean {
+  return typeof params === 'object' && params !== null && 'effectAuthority' in params
+}
 
 function boundTerminalFitRestore(pending: Promise<boolean>): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -49,9 +54,12 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   ipcMain.handle(
     'runtime:call',
     async (
-      _event,
+      event,
       args: { method: string; params?: unknown }
     ): Promise<RuntimeRpcResponse<unknown>> => {
+      if (requestsEffectAuthority(args.params) && !isTrustedUIRenderer(event.sender)) {
+        throw new Error('runtime_effect_authority_requires_trusted_ui_renderer')
+      }
       return (await new RpcDispatcher({ runtime, methods: ALL_RPC_METHODS }).dispatch(
         {
           id: 'desktop-ipc',

--- a/src/main/native-chat/agent-session-journal/journal-append-storage.ts
+++ b/src/main/native-chat/agent-session-journal/journal-append-storage.ts
@@ -1,0 +1,128 @@
+// Durable row/blob admission for one serialized journal writer.
+
+import {
+  commitJournalBlobWritePlan,
+  planJournalBlobWrites,
+  readJournalBlob,
+  type JournalBlobPayload
+} from './journal-blob-store'
+import { appendJournalRows } from './journal-log-file'
+import type { JournalPayloadLimits } from './journal-payload-bounds'
+import { referencedBlobDigestsForBody } from './journal-reducer'
+import { journalRowByteLength, type JournalRow } from './journal-row-schema'
+import { journalStorageFootprint } from './journal-storage-footprint'
+import { AgentSessionJournalError, JournalAppendBudget } from './journal-write-guards'
+
+export type { JournalBlobPayload } from './journal-blob-store'
+
+export type JournalItemAppendOptions = {
+  fence: number
+  observedAt?: number
+  recovered?: true
+  blobs?: readonly JournalBlobPayload[]
+}
+
+type JournalAppendStorageDependencies = {
+  appendRows?: typeof appendJournalRows
+  measure?: typeof journalStorageFootprint
+}
+
+/** Owns the persisted-byte accounting that must precede every blob write. */
+export class JournalAppendStorage {
+  private persistedBytes = 0
+  private poisoned = false
+  private readonly budget: JournalAppendBudget
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly journalDir: string,
+    limits: JournalPayloadLimits,
+    private readonly dependencies: JournalAppendStorageDependencies = {}
+  ) {
+    this.budget = new JournalAppendBudget(sessionId, limits)
+  }
+
+  async open(): Promise<void> {
+    await this.remeasure()
+  }
+
+  async remeasure(): Promise<void> {
+    this.persistedBytes = await (this.dependencies.measure ?? journalStorageFootprint)(
+      this.journalDir
+    )
+  }
+
+  get isPoisoned(): boolean {
+    return this.poisoned
+  }
+
+  /** A failed post-mutation measurement leaves the physical quota unknown.
+   *  This instance must never admit another mutation after that point. */
+  assertWritable(): void {
+    if (this.poisoned) {
+      throw new AgentSessionJournalError(
+        'journal_read_only',
+        `agent-session journal for ${this.sessionId} could not verify its durable footprint; this host is read-only`
+      )
+    }
+  }
+
+  async remeasureAfterMutation(): Promise<void> {
+    try {
+      await this.remeasure()
+    } catch (error) {
+      this.poisoned = true
+      throw error
+    }
+  }
+
+  async append(
+    row: JournalRow,
+    admissionTs: number,
+    blobs: readonly JournalBlobPayload[] = []
+  ): Promise<void> {
+    this.assertWritable()
+    await assertBlobReferences(row, blobs, this.journalDir)
+    const blobPlan = await planJournalBlobWrites(this.journalDir, blobs)
+    this.budget.assert(row, admissionTs, this.persistedBytes, blobPlan.additionalBytes)
+    let addedBlobBytes = 0
+    try {
+      addedBlobBytes = await commitJournalBlobWritePlan(this.journalDir, blobPlan)
+      await (this.dependencies.appendRows ?? appendJournalRows)(this.journalDir, [row])
+    } catch (error) {
+      // Once a durable blob or row write was attempted, its outcome can be
+      // ambiguous (for example append succeeded but fsync failed). Continuing
+      // from the old in-memory sequence could fork the journal.
+      this.poisoned = true
+      try {
+        await this.remeasureAfterMutation()
+      } catch (remeasureError) {
+        throw new AggregateError(
+          [error, remeasureError],
+          `agent-session journal for ${this.sessionId} failed a write and could not verify its durable footprint`
+        )
+      }
+      throw error
+    }
+    this.persistedBytes += addedBlobBytes + journalRowByteLength(row)
+  }
+}
+
+async function assertBlobReferences(
+  row: JournalRow,
+  blobs: readonly JournalBlobPayload[],
+  journalDir: string
+): Promise<void> {
+  const expected = row.kind === 'item' ? referencedBlobDigestsForBody(row.body) : new Set<string>()
+  const provided = new Set(blobs.map((blob) => blob.digest))
+  for (const digest of provided) {
+    if (!expected.has(digest)) {
+      throw new Error(`journal blob ${digest} is not referenced by its row`)
+    }
+  }
+  for (const digest of expected) {
+    if (!provided.has(digest) && (await readJournalBlob(journalDir, digest)) === null) {
+      throw new Error(`journal row references missing blob ${digest}`)
+    }
+  }
+}

--- a/src/main/native-chat/agent-session-journal/journal-blob-admission.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-blob-admission.test.ts
@@ -1,0 +1,295 @@
+import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type {
+  AgentJournalItemBody,
+  AgentSessionJournalIdentity
+} from '../../../shared/agent-session-journal-types'
+import { readJournalBlob } from './journal-blob-store'
+import {
+  boundPayload,
+  DEFAULT_JOURNAL_PAYLOAD_LIMITS,
+  digestPayload
+} from './journal-payload-bounds'
+import { journalStorageFootprint } from './journal-storage-footprint'
+import { openAgentSessionJournal } from './journal-store'
+import { createDeferredStructuredAgentSessionEventSink } from '../agent-session-wire/structured-agent-session-event-sink'
+
+const IDENTITY: AgentSessionJournalIdentity = {
+  sessionId: 'blob-admission-session',
+  workspaceId: 'workspace-1',
+  hostId: 'host-1',
+  agent: 'codex',
+  providerHandle: { kind: 'codex', threadId: 'thread-1' }
+}
+
+let root: string
+let clock = 1_000
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-journal-blob-admission-'))
+  clock = 1_000
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function blobNames(): Promise<string[]> {
+  try {
+    return await readdir(join(root, 'blobs'))
+  } catch {
+    return []
+  }
+}
+
+describe('journal blob admission', () => {
+  it('rejects a blob whose digest is not bound to its payload', async () => {
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+    await expect(
+      journal.appendItem(
+        { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal: 0 },
+        {
+          kind: 'tool-call',
+          name: 'bad-output',
+          input: null,
+          state: 'completed',
+          output: { head: '', byteLength: 15, digest: '0'.repeat(64), truncated: true }
+        },
+        { fence: 1, blobs: [{ digest: '0'.repeat(64), payload: 'different bytes' }] }
+      )
+    ).rejects.toThrow('does not match its payload')
+    expect(await blobNames()).toHaveLength(0)
+  })
+
+  it('rejects missing and unreferenced blob attachments', async () => {
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+    const payload = 'bounded output'
+    const digest = digestPayload(payload)
+    const identity = {
+      provider: 'codex' as const,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      ordinal: 0
+    }
+    await expect(
+      journal.appendItem(
+        identity,
+        {
+          kind: 'tool-call',
+          name: 'missing-output',
+          input: null,
+          state: 'completed',
+          output: { head: '', byteLength: payload.length, digest, truncated: true }
+        },
+        { fence: 1 }
+      )
+    ).rejects.toThrow('references missing blob')
+    await expect(
+      journal.appendItem(
+        identity,
+        { kind: 'message', role: 'assistant', blocks: [] },
+        {
+          fence: 1,
+          blobs: [{ digest, payload }]
+        }
+      )
+    ).rejects.toThrow('not referenced by its row')
+  })
+
+  it('fails closed when the blob store cannot be enumerated', async () => {
+    await writeFile(join(root, 'blobs'), 'not a directory', 'utf8')
+    await expect(
+      openAgentSessionJournal({
+        identity: IDENTITY,
+        journalDir: root,
+        now: () => (clock += 1),
+        mintEpoch: () => 'epoch-1'
+      })
+    ).rejects.toThrow('blob store is not a directory')
+  })
+
+  it.runIf(process.platform !== 'win32')('does not follow a blob symlink', async () => {
+    const payload = 'outside journal data'
+    const digest = digestPayload(payload)
+    const outside = join(root, 'outside')
+    await writeFile(outside, payload, 'utf8')
+    await mkdir(join(root, 'blobs'))
+    await symlink(outside, join(root, 'blobs', digest))
+
+    await expect(readJournalBlob(root, digest)).rejects.toMatchObject({ code: 'ELOOP' })
+  })
+
+  it('counts crash-left root temp bytes after opening a new journal', async () => {
+    const limits = { ...DEFAULT_JOURNAL_PAYLOAD_LIMITS, maxSessionBytes: 2_000 }
+    await writeFile(join(root, 'snapshot.json.99.1.dead.tmp'), 'x'.repeat(1_900), 'utf8')
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits,
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+
+    await expect(
+      journal.appendItem(
+        { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal: 0 },
+        { kind: 'message', role: 'assistant', blocks: [] },
+        { fence: 1 }
+      )
+    ).rejects.toMatchObject({ code: 'journal_bound_exceeded' })
+  })
+
+  it.each([
+    { name: 'crash-left blob temp', file: `${'a'.repeat(64)}.99.1.dead.tmp` },
+    { name: 'finalized orphan blob', file: digestPayload('x'.repeat(1_900)) }
+  ])('counts a $name after reopen', async ({ file }) => {
+    await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+    await mkdir(join(root, 'blobs'), { recursive: true })
+    await writeFile(join(root, 'blobs', file), 'x'.repeat(1_900), 'utf8')
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits: { ...DEFAULT_JOURNAL_PAYLOAD_LIMITS, maxSessionBytes: 2_000 },
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+
+    await expect(
+      journal.appendItem(
+        { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal: 0 },
+        { kind: 'message', role: 'assistant', blocks: [] },
+        { fence: 1 }
+      )
+    ).rejects.toMatchObject({ code: 'journal_bound_exceeded' })
+  })
+
+  it('does not reset the physical quota to the retained tail after compaction', async () => {
+    const limits = { ...DEFAULT_JOURNAL_PAYLOAD_LIMITS, maxSessionBytes: 6_000 }
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits,
+      compaction: { minTailRows: 1, retainTailMs: 0 },
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+    let rejection: unknown = null
+    for (let ordinal = 0; ordinal < 30; ordinal += 1) {
+      try {
+        await journal.appendItem(
+          { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal },
+          { kind: 'message', role: 'assistant', blocks: [{ type: 'text', text: 'x'.repeat(500) }] },
+          { fence: 1 }
+        )
+        await journal.compact()
+      } catch (error) {
+        rejection = error
+        break
+      }
+    }
+
+    expect(rejection).toMatchObject({ code: 'journal_bound_exceeded' })
+    expect(await journalStorageFootprint(root)).toBeGreaterThan(0)
+  })
+
+  it('uses trusted host time for rate admission instead of provider observedAt', async () => {
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits: {
+        ...DEFAULT_JOURNAL_PAYLOAD_LIMITS,
+        maxAppendsPerWindow: 1,
+        appendWindowMs: 60_000
+      },
+      now: () => 1_000,
+      mintEpoch: () => 'epoch-1'
+    })
+    const append = (ordinal: number, observedAt: number) =>
+      journal.appendItem(
+        { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal },
+        { kind: 'message', role: 'assistant', blocks: [] },
+        { fence: 1, observedAt }
+      )
+
+    await append(0, 60_000)
+    await expect(append(1, 120_000)).rejects.toMatchObject({ code: 'journal_rate_exceeded' })
+  })
+
+  it.each([
+    {
+      name: 'session byte quota',
+      limits: { maxSessionBytes: 20 * 1024, maxAppendsPerWindow: 10 },
+      code: 'journal_bound_exceeded'
+    },
+    {
+      name: 'append rate quota',
+      limits: { maxSessionBytes: 1024 * 1024, maxAppendsPerWindow: 1 },
+      code: 'journal_rate_exceeded'
+    }
+  ])('does not persist unique payloads rejected by the $name', async ({ limits, code }) => {
+    const journalLimits = {
+      ...DEFAULT_JOURNAL_PAYLOAD_LIMITS,
+      ...limits,
+      inlineHeadBytes: 8,
+      appendWindowMs: 60_000
+    }
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits: journalLimits,
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+    const errors: unknown[] = []
+    const deferred = createDeferredStructuredAgentSessionEventSink({
+      onError: (error) => errors.push(error)
+    })
+    deferred.bind({ journal, fence: 1, publish: () => {} })
+
+    const append = (ordinal: number, payload: string): void => {
+      const output = boundPayload(payload, journalLimits)
+      const body: AgentJournalItemBody = {
+        kind: 'tool-call',
+        name: 'large-output',
+        input: null,
+        state: 'completed',
+        output
+      }
+      deferred.sink.appendItem(
+        { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal },
+        body,
+        [{ digest: output.digest, payload }]
+      )
+    }
+
+    append(0, 'accepted'.repeat(1_536))
+    await deferred.drained()
+    expect(errors).toHaveLength(0)
+    expect(await blobNames()).toHaveLength(1)
+
+    for (let ordinal = 1; ordinal <= 3; ordinal += 1) {
+      append(ordinal, `rejected-${ordinal}`.repeat(1_024))
+      await deferred.drained()
+      expect(errors.at(-1)).toMatchObject({ code })
+    }
+    expect(errors).toHaveLength(3)
+    expect(await blobNames()).toHaveLength(1)
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-blob-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-blob-store.ts
@@ -5,12 +5,21 @@
 // per-workspace state, never inside the user's working tree) and share the
 // epoch's retention: compaction prunes every blob no retained row references.
 
-import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { mkdir, open, readdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { durableWriteTempPath, writeFileDurable } from '../../durable-file-write'
+import { digestPayload } from './journal-payload-bounds'
 
 const BLOB_DIR = 'blobs'
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/
+
+export type JournalBlobPayload = { digest: string; payload: string }
+
+export type JournalBlobWritePlan = {
+  blobs: readonly (JournalBlobPayload & { byteLength: number })[]
+  additionalBytes: number
+}
 
 /** A digest arrives back from a row on disk, so it is untrusted by the time it
  *  reaches the filesystem: anything but a bare sha256 could escape the store. */
@@ -25,29 +34,67 @@ export async function putJournalBlob(
   digest: string,
   payload: string
 ): Promise<string> {
-  const target = blobPath(journalDir, digest)
-  if (!target) {
-    throw new Error('refusing to write a journal blob under a name that is not a sha256 digest')
-  }
-  // Content addressing makes a rewrite pointless: identical digest, identical bytes.
-  if (await pathExists(target)) {
-    return digest
-  }
-  await mkdir(join(journalDir, BLOB_DIR), { recursive: true })
-  await writeFileDurable(durableWriteTempPath(target), target, payload)
+  const plan = await planJournalBlobWrites(journalDir, [{ digest, payload }])
+  await commitJournalBlobWritePlan(journalDir, plan)
   return digest
 }
 
+/** Resolve the bytes a set of content-addressed blobs would add without
+ *  mutating disk. Journal row/rate admission consumes this plan first. */
+export async function planJournalBlobWrites(
+  journalDir: string,
+  blobs: readonly JournalBlobPayload[]
+): Promise<JournalBlobWritePlan> {
+  const unique = new Map<string, string>()
+  for (const blob of blobs) {
+    if (!blobPath(journalDir, blob.digest)) {
+      throw new Error('refusing to write a journal blob under a name that is not a sha256 digest')
+    }
+    if (digestPayload(blob.payload) !== blob.digest) {
+      throw new Error(`journal blob digest ${blob.digest} does not match its payload`)
+    }
+    const duplicate = unique.get(blob.digest)
+    if (duplicate !== undefined && duplicate !== blob.payload) {
+      throw new Error(`journal blob digest ${blob.digest} has conflicting payloads`)
+    }
+    unique.set(blob.digest, blob.payload)
+  }
+
+  const planned: (JournalBlobPayload & { byteLength: number })[] = []
+  let additionalBytes = 0
+  for (const [digest, payload] of unique) {
+    if ((await readValidatedBlob(journalDir, digest)) !== null) {
+      continue
+    }
+    const byteLength = Buffer.byteLength(payload, 'utf8')
+    planned.push({ digest, payload, byteLength })
+    additionalBytes += byteLength
+  }
+  return { blobs: planned, additionalBytes }
+}
+
+/** Commit only a plan that the journal budget has already admitted. */
+export async function commitJournalBlobWritePlan(
+  journalDir: string,
+  plan: JournalBlobWritePlan
+): Promise<number> {
+  if (plan.blobs.length === 0) {
+    return 0
+  }
+  await mkdir(join(journalDir, BLOB_DIR), { recursive: true })
+  let addedBytes = 0
+  for (const blob of plan.blobs) {
+    const target = blobPath(journalDir, blob.digest) as string
+    // The journal serializes appends. Replacing the name also prevents a
+    // symlink or hard link inserted after planning from being followed.
+    await writeFileDurable(durableWriteTempPath(target), target, blob.payload)
+    addedBytes += blob.byteLength
+  }
+  return addedBytes
+}
+
 export async function readJournalBlob(journalDir: string, digest: string): Promise<string | null> {
-  const source = blobPath(journalDir, digest)
-  if (!source) {
-    return null
-  }
-  try {
-    return await readFile(source, 'utf-8')
-  } catch {
-    return null
-  }
+  return blobPath(journalDir, digest) ? readValidatedBlob(journalDir, digest) : null
 }
 
 /** Drop every blob outside `retained`. Called from compaction, under the
@@ -74,11 +121,43 @@ export async function pruneJournalBlobs(
   return removed
 }
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await stat(path)
-    return true
-  } catch {
-    return false
+async function readValidatedBlob(journalDir: string, digest: string): Promise<string | null> {
+  const source = blobPath(journalDir, digest)
+  if (!source) {
+    return null
   }
+  let handle
+  try {
+    handle = await openBlobFile(source)
+  } catch (error) {
+    if (isMissing(error)) {
+      return null
+    }
+    throw error
+  }
+  try {
+    const info = await handle.stat()
+    assertRegularSingleLinkBlob(info, digest)
+    const payload = await handle.readFile('utf8')
+    if (digestPayload(payload) !== digest) {
+      throw new Error(`journal blob ${digest} does not match its content digest`)
+    }
+    return payload
+  } finally {
+    await handle.close()
+  }
+}
+
+function openBlobFile(path: string) {
+  return open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
+}
+
+function assertRegularSingleLinkBlob(info: { isFile(): boolean; nlink: number }, digest: string) {
+  if (!info.isFile() || info.nlink !== 1) {
+    throw new Error(`journal blob ${digest} is not a regular single-link file`)
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
 }

--- a/src/main/native-chat/agent-session-journal/journal-compaction-blob-tail-retention.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-compaction-blob-tail-retention.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type {
+  AgentJournalItemBody,
+  AgentSessionJournalIdentity
+} from '../../../shared/agent-session-journal-types'
+import { readJournalBlob } from './journal-blob-store'
+import { boundPayload, DEFAULT_JOURNAL_PAYLOAD_LIMITS } from './journal-payload-bounds'
+import { openAgentSessionJournal } from './journal-store'
+
+const IDENTITY: AgentSessionJournalIdentity = {
+  sessionId: 'blob-tail-retention',
+  workspaceId: 'workspace-1',
+  hostId: 'host-1',
+  agent: 'codex',
+  providerHandle: { kind: 'codex', threadId: 'thread-1' }
+}
+
+let root: string
+let clock = 1_000
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-blob-tail-retention-'))
+  clock = 1_000
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('compaction blob tail retention', () => {
+  it('keeps blobs for both a retained old revision and the live revision', async () => {
+    const limits = { ...DEFAULT_JOURNAL_PAYLOAD_LIMITS, inlineHeadBytes: 8 }
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits,
+      compaction: { minTailRows: 2, retainTailMs: 0 },
+      now: () => (clock += 1),
+      mintEpoch: () => 'epoch-1'
+    })
+    const identity = {
+      provider: 'codex' as const,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      ordinal: 0
+    }
+    const appendRevision = async (payload: string): Promise<string> => {
+      const output = boundPayload(payload, limits)
+      const body: AgentJournalItemBody = {
+        kind: 'tool-call',
+        name: 'large-output',
+        input: null,
+        state: 'completed',
+        output
+      }
+      await journal.appendItem(identity, body, {
+        fence: 1,
+        blobs: [{ digest: output.digest, payload }]
+      })
+      return output.digest
+    }
+
+    const payloadA = 'revision-a'.repeat(512)
+    const payloadB = 'revision-b'.repeat(512)
+    const digestA = await appendRevision(payloadA)
+    const digestB = await appendRevision(payloadB)
+    await journal.compact()
+
+    const resumed = journal.readSince({ epoch: journal.epoch, sequence: 1 })
+    expect(resumed.ok && resumed.rows).toHaveLength(2)
+    expect(await readJournalBlob(root, digestA)).toBe(payloadA)
+    expect(await readJournalBlob(root, digestB)).toBe(payloadB)
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-compaction.ts
+++ b/src/main/native-chat/agent-session-journal/journal-compaction.ts
@@ -10,6 +10,7 @@
 
 import {
   referencedBlobDigests,
+  referencedBlobDigestsForRows,
   renderJournalState,
   type JournalReducerState
 } from './journal-reducer'
@@ -78,7 +79,11 @@ export async function compactJournal(input: {
   await rewriteJournalLog(input.journalDir, retained)
   // Blobs are pruned last: a crash before this leaks bytes, whereas pruning
   // first would strand a snapshot pointing at a payload that no longer exists.
-  await pruneJournalBlobs(input.journalDir, referencedBlobDigests(input.state))
+  const retainedDigests = referencedBlobDigests(input.state)
+  for (const digest of referencedBlobDigestsForRows(retained)) {
+    retainedDigests.add(digest)
+  }
+  await pruneJournalBlobs(input.journalDir, retainedDigests)
 
   return {
     tailRows: retained,
@@ -98,6 +103,6 @@ function retainTail(
   const floor = now - policy.retainTailMs
   const byAge = rows.findIndex((row) => row.ts >= floor)
   const byCount = rows.length - policy.minTailRows
-  const start = byAge < 0 ? byCount : Math.min(byAge, byCount)
+  const start = byAge === -1 ? byCount : Math.min(byAge, byCount)
   return rows.slice(start)
 }

--- a/src/main/native-chat/agent-session-journal/journal-epoch-rollover-failure.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-epoch-rollover-failure.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { publishNewEpoch } from './journal-epoch-rollover'
+import { openAgentSessionJournal } from './journal-store'
+
+let root: string | null = null
+
+afterEach(async () => {
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+    root = null
+  }
+})
+
+describe('journal epoch rollover failure boundary', () => {
+  it('adopts the durable new epoch when old-log cleanup fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-epoch-rollover-failure-'))
+    const rewriteLog = vi.fn(async () => {
+      throw new Error('log cleanup failed')
+    })
+
+    const published = await publishNewEpoch({
+      journalDir: root,
+      sessionId: 'session-1',
+      providerHandle: { kind: 'codex', threadId: 'thread-1' },
+      epoch: 'epoch-2',
+      reason: 'handle_forked',
+      fence: 2,
+      now: 1_000,
+      rewriteLog
+    })
+
+    expect(rewriteLog).toHaveBeenCalledOnce()
+    expect(published.row).toMatchObject({ epoch: 'epoch-2', seq: 1, fence: 2 })
+    expect(published.state.epoch).toBe('epoch-2')
+    expect(published.state.lastSequence).toBe(1)
+
+    const reopened = await openAgentSessionJournal({
+      identity: {
+        sessionId: 'session-1',
+        workspaceId: 'workspace-1',
+        hostId: 'host-1',
+        agent: 'codex',
+        providerHandle: { kind: 'codex', threadId: 'thread-1' }
+      },
+      journalDir: root,
+      now: () => 1_001,
+      mintEpoch: () => 'unexpected-epoch'
+    })
+    expect(reopened.cursor()).toEqual({ epoch: 'epoch-2', sequence: 1 })
+    const appended = await reopened.appendItem(
+      { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal: 0 },
+      { kind: 'message', role: 'assistant', blocks: [] },
+      { fence: 2 }
+    )
+    expect(appended.cursor.sequence).toBe(2)
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-epoch-rollover.ts
+++ b/src/main/native-chat/agent-session-journal/journal-epoch-rollover.ts
@@ -7,7 +7,12 @@
 
 import { AGENT_SESSION_JOURNAL_SCHEMA_VERSION } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionProviderHandle } from '../../../shared/agent-session-journal-types'
-import { compactJournal } from './journal-compaction'
+import { pruneJournalBlobs } from './journal-blob-store'
+import {
+  rewriteJournalLog,
+  writeJournalSnapshotFile,
+  type JournalSnapshotFile
+} from './journal-log-file'
 import {
   applyJournalRow,
   createJournalReducerState,
@@ -23,6 +28,9 @@ export async function publishNewEpoch(input: {
   reason: AgentJournalEpochReason
   fence: number
   now: number
+  writeSnapshot?: typeof writeJournalSnapshotFile
+  rewriteLog?: typeof rewriteJournalLog
+  pruneBlobs?: typeof pruneJournalBlobs
 }): Promise<{ state: JournalReducerState; row: JournalRow }> {
   const row: JournalRow = {
     kind: 'epoch',
@@ -35,13 +43,22 @@ export async function publishNewEpoch(input: {
     ts: input.now
   }
   const state = createJournalReducerState(input.sessionId, input.epoch)
-  await compactJournal({
-    journalDir: input.journalDir,
-    state,
-    tailRows: [row],
-    policy: { minTailRows: 1, retainTailMs: Number.POSITIVE_INFINITY },
-    now: input.now
-  })
+  const snapshot: JournalSnapshotFile = {
+    v: AGENT_SESSION_JOURNAL_SCHEMA_VERSION,
+    epoch: input.epoch,
+    compactedThrough: 1,
+    items: [],
+    submissions: [],
+    receipts: [],
+    aliases: [],
+    tail: [row]
+  }
+  await (input.writeSnapshot ?? writeJournalSnapshotFile)(input.journalDir, snapshot)
+  // The durable snapshot already made this epoch authoritative. A failed log
+  // cleanup must not make the caller resume writes against the old in-memory
+  // epoch; stale rows are safe because recovery filters them by snapshot epoch.
+  await (input.rewriteLog ?? rewriteJournalLog)(input.journalDir, [row]).catch(() => undefined)
+  await (input.pruneBlobs ?? pruneJournalBlobs)(input.journalDir, new Set())
   applyJournalRow(state, row)
   state.oldestSequence = 1
   return { state, row }

--- a/src/main/native-chat/agent-session-journal/journal-legacy-import.ts
+++ b/src/main/native-chat/agent-session-journal/journal-legacy-import.ts
@@ -27,7 +27,6 @@ import {
   decodeOmpTranscriptLine
 } from '../transcript-line-decoders'
 import { decodeTranscriptStream } from '../transcript-stream-lines'
-import { putJournalBlob } from './journal-blob-store'
 import { createLegacyIdentityTracker } from './journal-legacy-identity'
 import {
   boundInlineText,
@@ -58,9 +57,6 @@ export async function appendLegacyTranscriptMessages(input: {
   let appended = 0
   for (const message of input.messages) {
     const mapped = legacyItemBody(message, DEFAULT_JOURNAL_PAYLOAD_LIMITS)
-    for (const blob of mapped.blobs) {
-      await putJournalBlob(input.journal.directory, blob.digest, blob.payload)
-    }
     await input.journal.appendItem(
       {
         provider: 'legacy',
@@ -69,7 +65,7 @@ export async function appendLegacyTranscriptMessages(input: {
         recordId: message.id
       },
       mapped.body,
-      { fence: input.fence, observedAt: message.timestamp ?? undefined }
+      { fence: input.fence, observedAt: message.timestamp ?? undefined, blobs: mapped.blobs }
     )
     appended += 1
   }
@@ -116,12 +112,10 @@ export async function importLegacyTranscriptIntoJournal(input: {
       continue
     }
     const mapped = legacyItemBody(message, limits)
-    for (const blob of mapped.blobs) {
-      await putJournalBlob(input.journal.directory, blob.digest, blob.payload)
-    }
     const appended = await input.journal.appendItem(identity, mapped.body, {
       fence: input.fence,
-      observedAt: message.timestamp ?? undefined
+      observedAt: message.timestamp ?? undefined,
+      blobs: mapped.blobs
     })
     cursor = appended.cursor
   }

--- a/src/main/native-chat/agent-session-journal/journal-log-file-read-errors.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-log-file-read-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { readJournalLog, readJournalSnapshotFile } from './journal-log-file'
+
+function fileError(code: string): NodeJS.ErrnoException {
+  const error = new Error(code) as NodeJS.ErrnoException
+  error.code = code
+  return error
+}
+
+const failWith = (code: string) => async (): Promise<string> => {
+  throw fileError(code)
+}
+
+describe('journal file read errors', () => {
+  it('treats only a missing snapshot or log as absent', async () => {
+    await expect(readJournalSnapshotFile('/journal', failWith('ENOENT'))).resolves.toBeNull()
+    await expect(readJournalLog('/journal', failWith('ENOENT'))).resolves.toEqual({
+      rows: [],
+      unreadable: false,
+      malformed: 0
+    })
+  })
+
+  it.each(['EACCES', 'EIO'])('fails closed on snapshot %s', async (code) => {
+    await expect(readJournalSnapshotFile('/journal', failWith(code))).rejects.toMatchObject({
+      code
+    })
+  })
+
+  it.each(['EACCES', 'EIO'])('fails closed on log %s', async (code) => {
+    await expect(readJournalLog('/journal', failWith(code))).rejects.toMatchObject({ code })
+  })
+
+  it('keeps malformed snapshot bytes distinct from an I/O failure', async () => {
+    await expect(readJournalSnapshotFile('/journal', async () => '{')).resolves.toBeNull()
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-log-file.ts
+++ b/src/main/native-chat/agent-session-journal/journal-log-file.ts
@@ -52,15 +52,26 @@ export type JournalReadResult = {
   malformed: number
 }
 
+export type JournalUtf8Reader = (path: string, encoding: BufferEncoding) => Promise<string>
+
 export async function ensureJournalDir(journalDir: string): Promise<void> {
   await mkdir(journalDir, { recursive: true })
 }
 
 export async function readJournalSnapshotFile(
-  journalDir: string
+  journalDir: string,
+  readUtf8: JournalUtf8Reader = readFile
 ): Promise<JournalSnapshotFile | null> {
+  let raw: string
   try {
-    const raw = await readFile(join(journalDir, JOURNAL_SNAPSHOT_FILE), 'utf-8')
+    raw = await readUtf8(join(journalDir, JOURNAL_SNAPSHOT_FILE), 'utf-8')
+  } catch (error) {
+    if (isMissing(error)) {
+      return null
+    }
+    throw error
+  }
+  try {
     const parsed = JSON.parse(raw) as JournalSnapshotFile
     return typeof parsed?.epoch === 'string' ? parsed : null
   } catch {
@@ -76,12 +87,18 @@ export async function writeJournalSnapshotFile(
   await writeFileDurable(durableWriteTempPath(target), target, JSON.stringify(snapshot))
 }
 
-export async function readJournalLog(journalDir: string): Promise<JournalReadResult> {
+export async function readJournalLog(
+  journalDir: string,
+  readUtf8: JournalUtf8Reader = readFile
+): Promise<JournalReadResult> {
   let raw: string
   try {
-    raw = await readFile(join(journalDir, JOURNAL_LOG_FILE), 'utf-8')
-  } catch {
-    return { rows: [], unreadable: false, malformed: 0 }
+    raw = await readUtf8(join(journalDir, JOURNAL_LOG_FILE), 'utf-8')
+  } catch (error) {
+    if (isMissing(error)) {
+      return { rows: [], unreadable: false, malformed: 0 }
+    }
+    throw error
   }
   const rows: JournalRow[] = []
   let unreadable = false
@@ -136,4 +153,8 @@ export async function rewriteJournalLog(
   const target = join(journalDir, JOURNAL_LOG_FILE)
   const payload = rows.length ? `${rows.map(serializeJournalRow).join('\n')}\n` : ''
   await writeFileDurable(durableWriteTempPath(target), target, payload)
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
 }

--- a/src/main/native-chat/agent-session-journal/journal-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-open.ts
@@ -41,8 +41,9 @@ export async function loadJournal(
   const snapshot = await readJournalSnapshotFile(journalDir)
   const log = await readJournalLog(journalDir)
   const epoch = resolveEpoch(snapshot, log.rows)
+  const unsafeLog = log.unreadable || log.malformed > 0
   if (!epoch) {
-    return log.unreadable ? emptyReadOnlyLoad(sessionId) : null
+    return unsafeLog ? emptyReadOnlyLoad(sessionId) : null
   }
 
   const compactedThrough = snapshot?.epoch === epoch ? snapshot.compactedThrough : 0
@@ -71,7 +72,7 @@ export async function loadJournal(
     state,
     tailRows,
     compactedThrough,
-    readOnly: log.unreadable,
+    readOnly: unsafeLog,
     corrupt,
     sizeBytes: tailRows.reduce((total, row) => total + journalRowByteLength(row), 0)
   }

--- a/src/main/native-chat/agent-session-journal/journal-payload-bounds.ts
+++ b/src/main/native-chat/agent-session-journal/journal-payload-bounds.ts
@@ -13,7 +13,7 @@ import type { AgentJournalBoundedPayload } from '../../../shared/agent-session-j
 export type JournalPayloadLimits = {
   /** Bytes of the payload kept inline on the row. */
   inlineHeadBytes: number
-  /** Total bytes of journal rows one session may hold before appends are refused. */
+  /** Total bytes of journal rows and blobs one session may hold before appends are refused. */
   maxSessionBytes: number
   /** Appends allowed inside `appendWindowMs`, bounding a runaway agent's rate. */
   maxAppendsPerWindow: number
@@ -40,7 +40,8 @@ export function digestPayload(payload: string): string {
 
 /**
  * Clip `payload` to the inline head. `truncated` means the remainder must be
- * written to the blob store under `digest` before the row is appended.
+ * admitted with the row and written to the blob store under `digest` before
+ * the row is appended.
  */
 export function boundPayload(
   payload: string,

--- a/src/main/native-chat/agent-session-journal/journal-provider-frame-retention.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-provider-frame-retention.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type {
+  AgentJournalItemBody,
+  AgentSessionJournalIdentity
+} from '../../../shared/agent-session-journal-types'
+import { readJournalBlob } from './journal-blob-store'
+import { boundPayload, DEFAULT_JOURNAL_PAYLOAD_LIMITS } from './journal-payload-bounds'
+import { openAgentSessionJournal } from './journal-store'
+
+const IDENTITY: AgentSessionJournalIdentity = {
+  sessionId: 'provider-frame-retention',
+  workspaceId: 'workspace-1',
+  hostId: 'host-1',
+  agent: 'codex',
+  providerHandle: { kind: 'codex', threadId: 'thread-1' }
+}
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-provider-frame-retention-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('provider-frame blob retention', () => {
+  it('keeps a truncated live provider frame through compaction', async () => {
+    const limits = { ...DEFAULT_JOURNAL_PAYLOAD_LIMITS, inlineHeadBytes: 8 }
+    const payload = JSON.stringify({ image: 'x'.repeat(4_096) })
+    const bounded = boundPayload(payload, limits)
+    const body: AgentJournalItemBody = {
+      kind: 'status',
+      text: 'provider · notification',
+      providerFrame: {
+        provider: 'provider',
+        kind: 'notification',
+        payload: bounded
+      }
+    }
+    const journal = await openAgentSessionJournal({
+      identity: IDENTITY,
+      journalDir: root,
+      limits,
+      compaction: { minTailRows: 1, retainTailMs: 0 },
+      mintEpoch: () => 'epoch-1'
+    })
+
+    await journal.appendItem(
+      { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal: 0 },
+      body,
+      { fence: 1, blobs: [{ digest: bounded.digest, payload }] }
+    )
+    await journal.compact()
+
+    expect(await readJournalBlob(root, bounded.digest)).toBe(payload)
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -9,6 +9,7 @@
 
 import type {
   AgentJournalAcceptanceReceipt,
+  AgentJournalItemBody,
   AgentJournalRenderItem,
   AgentJournalSnapshot,
   AgentJournalSubmission
@@ -187,12 +188,37 @@ export function renderJournalState(state: JournalReducerState): AgentJournalSnap
 export function referencedBlobDigests(state: JournalReducerState): Set<string> {
   const digests = new Set<string>()
   for (const item of state.items.values()) {
-    const body = item.body
-    if (body.kind === 'tool-call' && body.output?.truncated) {
-      digests.add(body.output.digest)
+    for (const digest of referencedBlobDigestsForBody(item.body)) {
+      digests.add(digest)
     }
-    if (body.kind === 'diff' && body.patch.truncated) {
-      digests.add(body.patch.digest)
+  }
+  return digests
+}
+
+/** Every structured bounded-payload location supported by the journal. */
+export function referencedBlobDigestsForBody(body: AgentJournalItemBody): Set<string> {
+  const digests = new Set<string>()
+  if (body.kind === 'tool-call' && body.output?.truncated) {
+    digests.add(body.output.digest)
+  }
+  if (body.kind === 'diff' && body.patch.truncated) {
+    digests.add(body.patch.digest)
+  }
+  if (body.kind === 'status' && body.providerFrame?.payload.truncated) {
+    digests.add(body.providerFrame.payload.digest)
+  }
+  return digests
+}
+
+/** Digests needed to replay retained raw rows, including superseded revisions. */
+export function referencedBlobDigestsForRows(rows: readonly JournalRow[]): Set<string> {
+  const digests = new Set<string>()
+  for (const row of rows) {
+    if (row.kind !== 'item') {
+      continue
+    }
+    for (const digest of referencedBlobDigestsForBody(row.body)) {
+      digests.add(digest)
     }
   }
   return digests

--- a/src/main/native-chat/agent-session-journal/journal-row-base.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-base.ts
@@ -1,0 +1,5 @@
+import { AGENT_SESSION_JOURNAL_SCHEMA_VERSION } from '../../../shared/agent-session-journal-types'
+
+export function journalRowBase(epoch: string, seq: number, fence: number, ts: number) {
+  return { v: AGENT_SESSION_JOURNAL_SCHEMA_VERSION, epoch, seq, fence, ts }
+}

--- a/src/main/native-chat/agent-session-journal/journal-storage-failure.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-storage-failure.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import type { JournalRow } from './journal-row-schema'
+import { JournalAppendStorage } from './journal-append-storage'
+import { DEFAULT_JOURNAL_PAYLOAD_LIMITS } from './journal-payload-bounds'
+
+const ROW: JournalRow = {
+  v: 1,
+  kind: 'item',
+  epoch: 'epoch-1',
+  seq: 2,
+  fence: 1,
+  ts: 1_000,
+  itemId: 'item-1',
+  revision: 1,
+  body: { kind: 'message', role: 'assistant', blocks: [] }
+}
+
+describe('journal storage failure boundary', () => {
+  it('poisons the writer after an ambiguous row append failure', async () => {
+    const storage = new JournalAppendStorage(
+      'session-1',
+      '/journal',
+      DEFAULT_JOURNAL_PAYLOAD_LIMITS,
+      {
+        appendRows: async () => {
+          throw new Error('fsync failed after append')
+        },
+        measure: async () => 0
+      }
+    )
+    await storage.open()
+
+    await expect(storage.append(ROW, 1_000)).rejects.toThrow('fsync failed after append')
+    expect(storage.isPoisoned).toBe(true)
+    await expect(storage.append({ ...ROW, seq: 3 }, 1_001)).rejects.toMatchObject({
+      code: 'journal_read_only'
+    })
+  })
+
+  it('stays poisoned when post-failure footprint measurement also fails', async () => {
+    let measurements = 0
+    const storage = new JournalAppendStorage(
+      'session-1',
+      '/journal',
+      DEFAULT_JOURNAL_PAYLOAD_LIMITS,
+      {
+        appendRows: async () => {
+          throw new Error('append failed')
+        },
+        measure: async () => {
+          measurements += 1
+          if (measurements > 1) {
+            throw new Error('footprint unavailable')
+          }
+          return 0
+        }
+      }
+    )
+    await storage.open()
+
+    await expect(storage.append(ROW, 1_000)).rejects.toBeInstanceOf(AggregateError)
+    expect(storage.isPoisoned).toBe(true)
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-storage-footprint.ts
+++ b/src/main/native-chat/agent-session-journal/journal-storage-footprint.ts
@@ -1,0 +1,64 @@
+// Physical byte accounting for one session journal.
+
+import { constants } from 'node:fs'
+import { open, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/** Count every regular file the session owns, including crash-left temp and
+ * unknown residue. Unexpected links or nested directories fail closed. */
+export async function journalStorageFootprint(journalDir: string): Promise<number> {
+  const entries = await readdir(journalDir, { withFileTypes: true })
+  let total = 0
+  for (const entry of entries) {
+    const path = join(journalDir, entry.name)
+    if (entry.name === 'blobs') {
+      if (!entry.isDirectory()) {
+        throw new Error('agent-session blob store is not a directory')
+      }
+      total += await flatDirectoryFootprint(path)
+      continue
+    }
+    if (!entry.isFile()) {
+      throw new Error(`unexpected non-file in agent-session journal: ${entry.name}`)
+    }
+    total += await regularFileByteLength(path, entry.name)
+  }
+  return total
+}
+
+async function flatDirectoryFootprint(directory: string): Promise<number> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  let total = 0
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      throw new Error(`unexpected non-file in agent-session blob store: ${entry.name}`)
+    }
+    total += await regularFileByteLength(join(directory, entry.name), entry.name)
+  }
+  return total
+}
+
+async function regularFileByteLength(path: string, label: string): Promise<number> {
+  let handle
+  try {
+    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
+  } catch (error) {
+    if (isMissing(error)) {
+      return 0
+    }
+    throw error
+  }
+  try {
+    const info = await handle.stat()
+    if (!info.isFile() || info.nlink !== 1) {
+      throw new Error(`journal storage entry ${label} is not a regular single-link file`)
+    }
+    return info.size
+  } finally {
+    await handle.close()
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+}

--- a/src/main/native-chat/agent-session-journal/journal-store.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.test.ts
@@ -321,15 +321,33 @@ describe('schema', () => {
     expect(await readFile(logPath, 'utf-8')).toContain('"v":99')
   })
 
-  it('skips a malformed line without giving up the journal', async () => {
+  it('fails closed on a malformed line without deleting valid rows', async () => {
     const journal = await open()
     await journal.appendItem(item(0), body('a'), { fence: 1 })
     const logPath = join(root, JOURNAL_LOG_FILE)
     await writeFile(logPath, `${await readFile(logPath, 'utf-8')}{not json\n`, 'utf-8')
 
     const reopened = await open()
-    expect(reopened.isReadOnly).toBe(false)
+    expect(reopened.isReadOnly).toBe(true)
     expect(reopened.snapshot().items).toHaveLength(1)
+    await expect(reopened.appendItem(item(1), body('b'), { fence: 1 })).rejects.toMatchObject({
+      code: 'journal_read_only'
+    })
+    expect(await readFile(logPath, 'utf8')).toContain('{not json')
+  })
+
+  it('does not append behind a partial trailing row after restart', async () => {
+    const journal = await open()
+    await journal.appendItem(item(0), body('a'), { fence: 1 })
+    const logPath = join(root, JOURNAL_LOG_FILE)
+    await writeFile(logPath, `${await readFile(logPath, 'utf8')}{"v":1`, 'utf8')
+
+    const reopened = await open()
+    expect(reopened.isReadOnly).toBe(true)
+    await expect(reopened.appendItem(item(1), body('lost'), { fence: 1 })).rejects.toMatchObject({
+      code: 'journal_read_only'
+    })
+    expect((await open()).snapshot().items).toHaveLength(1)
   })
 })
 

--- a/src/main/native-chat/agent-session-journal/journal-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.ts
@@ -1,9 +1,7 @@
 // The append-only journal store for one agent session.
 //
-// Sequence numbers are assigned inside the same serialized append that makes
-// the row durable, so an `(epoch, sequence)` space has exactly one writer and
-// no gaps or reuse. Every mutating call carries the runtime fence; a stale
-// fence is rejected outright rather than merged or queued for the new owner.
+// Sequence assignment and durable writes share one queue. Every mutation also
+// carries a runtime fence so a superseded writer cannot re-enter that queue.
 
 import { randomUUID } from 'node:crypto'
 import type {
@@ -17,12 +15,16 @@ import type {
   AgentJournalSubmission,
   AgentSessionJournalIdentity
 } from '../../../shared/agent-session-journal-types'
-import { AGENT_SESSION_JOURNAL_SCHEMA_VERSION } from '../../../shared/agent-session-journal-types'
 import { agentJournalItemKey } from '../../../shared/agent-session-journal-item-key'
 import { compactJournal, type JournalCompactionPolicy } from './journal-compaction'
 import { resolveJournalResume, type JournalResume } from './journal-cursor'
 import { publishNewEpoch } from './journal-epoch-rollover'
-import { appendJournalRows, ensureJournalDir } from './journal-log-file'
+import {
+  JournalAppendStorage,
+  type JournalBlobPayload,
+  type JournalItemAppendOptions
+} from './journal-append-storage'
+import { ensureJournalDir } from './journal-log-file'
 import { loadJournal } from './journal-open'
 import { DEFAULT_JOURNAL_PAYLOAD_LIMITS, type JournalPayloadLimits } from './journal-payload-bounds'
 import {
@@ -31,16 +33,9 @@ import {
   renderJournalState,
   type JournalReducerState
 } from './journal-reducer'
-import {
-  journalRowByteLength,
-  type AgentJournalEpochReason,
-  type JournalRow
-} from './journal-row-schema'
-import {
-  assertJournalFence,
-  assertJournalWritable,
-  JournalAppendBudget
-} from './journal-write-guards'
+import type { AgentJournalEpochReason, JournalRow } from './journal-row-schema'
+import { journalRowBase } from './journal-row-base'
+import { assertJournalFence, assertJournalWritable } from './journal-write-guards'
 
 export { AgentSessionJournalError } from './journal-write-guards'
 
@@ -67,11 +62,7 @@ export type ResolveDispatchInput = {
   | { state: 'rejected' | 'unknown'; reason?: string | null }
 )
 
-export type JournalAppendResult = {
-  cursor: AgentJournalCursor
-  itemId: string
-  revision: number
-}
+export type JournalAppendResult = { cursor: AgentJournalCursor; itemId: string; revision: number }
 
 export async function openAgentSessionJournal(
   options: AgentSessionJournalOptions
@@ -84,7 +75,7 @@ export async function openAgentSessionJournal(
 export class AgentSessionJournal {
   private readonly identity: AgentSessionJournalIdentity
   private readonly journalDir: string
-  private readonly budget: JournalAppendBudget
+  private readonly storage: JournalAppendStorage
   private readonly compaction: JournalCompactionPolicy | undefined
   private readonly now: () => number
   private readonly mintEpoch: () => string
@@ -92,7 +83,6 @@ export class AgentSessionJournal {
   private state: JournalReducerState
   private tailRows: JournalRow[] = []
   private compactedThrough = 0
-  private sizeBytes = 0
   private readOnly = false
   /** Serializes sequence assignment with the durable write behind it. */
   private writes: Promise<unknown> = Promise.resolve()
@@ -100,10 +90,8 @@ export class AgentSessionJournal {
   constructor(options: AgentSessionJournalOptions) {
     this.identity = options.identity
     this.journalDir = options.journalDir
-    this.budget = new JournalAppendBudget(
-      options.identity.sessionId,
-      options.limits ?? DEFAULT_JOURNAL_PAYLOAD_LIMITS
-    )
+    const limits = options.limits ?? DEFAULT_JOURNAL_PAYLOAD_LIMITS
+    this.storage = new JournalAppendStorage(options.identity.sessionId, options.journalDir, limits)
     this.compaction = options.compaction
     this.now = options.now ?? (() => Date.now())
     this.mintEpoch = options.mintEpoch ?? randomUUID
@@ -111,7 +99,7 @@ export class AgentSessionJournal {
   }
 
   get isReadOnly(): boolean {
-    return this.readOnly
+    return this.readOnly || this.storage.isPoisoned
   }
 
   get epoch(): string {
@@ -122,14 +110,14 @@ export class AgentSessionJournal {
     return this.journalDir
   }
 
-  /** Highest sequence folded into the snapshot; rows at or below it are no
-   *  longer individually replayable. */
+  /** Rows at or below this snapshot sequence are no longer replayable. */
   get compactionBoundary(): number {
     return this.compactedThrough
   }
 
   async open(): Promise<void> {
     await ensureJournalDir(this.journalDir)
+    await this.storage.open()
     const loaded = await loadJournal(this.journalDir, this.identity.sessionId)
     if (!loaded) {
       await this.startEpoch('session_created', 0)
@@ -138,7 +126,6 @@ export class AgentSessionJournal {
     this.state = loaded.state
     this.tailRows = loaded.tailRows
     this.compactedThrough = loaded.compactedThrough
-    this.sizeBytes = loaded.sizeBytes
     this.readOnly = loaded.readOnly
     if (loaded.corrupt && !loaded.readOnly) {
       // A reader that observes a gap rolls the epoch rather than rendering a
@@ -163,8 +150,7 @@ export class AgentSessionJournal {
     return this.submissions().filter((entry) => entry.dispatchState === 'pending')
   }
 
-  /** The durable answer to "did my send land?" — a reconnecting client asking
-   *  again gets this instead of re-sending. */
+  /** Durable send result used to deduplicate reconnects. */
   receiptFor(clientMessageId: string): AgentJournalAcceptanceReceipt | null {
     return this.state.receipts.get(clientMessageId) ?? null
   }
@@ -195,12 +181,11 @@ export class AgentSessionJournal {
     )
   }
 
-  /** Upsert by stable identity. The revision is assigned here so a caller
-   *  cannot accidentally publish a revision the reducer will drop. */
+  /** Upsert by stable identity with a host-assigned revision. */
   appendItem(
     identity: AgentJournalItemIdentity,
     body: AgentJournalItemBody,
-    options: { fence: number; observedAt?: number; recovered?: true } = { fence: 0 }
+    options: JournalItemAppendOptions = { fence: 0 }
   ): Promise<JournalAppendResult> {
     const itemId = agentJournalItemKey(identity)
     return this.enqueue((seq, ts) => {
@@ -211,10 +196,10 @@ export class AgentSessionJournal {
         itemId,
         revision,
         body,
-        ...this.rowBase(seq, options.fence, options.observedAt ?? ts),
+        ...journalRowBase(this.state.epoch, seq, options.fence, options.observedAt ?? ts),
         ...(options.recovered ? { recovered: options.recovered } : {})
       }
-    }).then((row) => ({
+    }, options.blobs).then((row) => ({
       cursor: { epoch: row.epoch, sequence: row.seq },
       itemId,
       revision: (row as Extract<JournalRow, { kind: 'item' }>).revision
@@ -229,15 +214,16 @@ export class AgentSessionJournal {
     return this.enqueue((seq, ts) => {
       const resolved = this.state.aliases.get(itemId) ?? itemId
       const revision = (this.state.items.get(resolved)?.revision ?? 0) + 1
-      return { kind: 'tombstone', itemId, revision, ...this.rowBase(seq, options.fence, ts) }
+      return {
+        kind: 'tombstone',
+        itemId,
+        revision,
+        ...journalRowBase(this.state.epoch, seq, options.fence, ts)
+      }
     }).then((row) => ({ epoch: row.epoch, sequence: row.seq }))
   }
 
-  /**
-   * Write-ahead submission row. It is durable before the caller dispatches
-   * anything, and it doubles as the optimistic user bubble so an accepted echo
-   * reconciles into an existing slot instead of appending a second copy.
-   */
+  /** Durable write-ahead row and optimistic user bubble. */
   appendSubmission(input: {
     clientMessageId: string
     payloadFingerprint: string
@@ -250,17 +236,11 @@ export class AgentSessionJournal {
       payloadFingerprint: input.payloadFingerprint,
       providerHandle: this.identity.providerHandle,
       body: input.body,
-      ...this.rowBase(seq, input.fence, ts)
+      ...journalRowBase(this.state.epoch, seq, input.fence, ts)
     })).then((row) => ({ epoch: row.epoch, sequence: row.seq }))
   }
 
-  /**
-   * Advance a submission to exactly one of accepted / rejected / unknown.
-   *
-   * Accepting REQUIRES the provider identity rather than a free-form id: the
-   * adopted key is what the provider's echo will upsert into, so a mismatched
-   * string here would silently give the user a second copy of their own message.
-   */
+  /** Settle a submission. Accepted rows adopt the provider's stable identity. */
   resolveDispatch(input: ResolveDispatchInput): Promise<AgentJournalCursor> {
     const providerItemId =
       input.state === 'accepted' ? agentJournalItemKey(input.providerIdentity) : null
@@ -270,13 +250,12 @@ export class AgentSessionJournal {
       state: input.state,
       providerItemId,
       reason: input.state === 'accepted' ? null : (input.reason ?? null),
-      ...this.rowBase(seq, input.fence, ts),
+      ...journalRowBase(this.state.epoch, seq, input.fence, ts),
       ...(input.recovered ? { recovered: input.recovered } : {})
     })).then((row) => ({ epoch: row.epoch, sequence: row.seq }))
   }
 
-  /** On restart every `pending` submission becomes `unknown` before the session
-   *  accepts a writer. Orca never re-sends on the user's behalf. */
+  /** Restarted pending submissions become unknown; Orca never re-sends them. */
   async markPendingSubmissionsUnknown(fence: number): Promise<string[]> {
     const pending = this.pendingSubmissions().map((entry) => entry.clientMessageId)
     for (const clientMessageId of pending) {
@@ -292,26 +271,35 @@ export class AgentSessionJournal {
   }
 
   async compact(): Promise<void> {
-    assertJournalWritable(this.readOnly, this.identity.sessionId)
-    const result = await compactJournal({
-      journalDir: this.journalDir,
-      state: this.state,
-      tailRows: this.tailRows,
-      policy: this.compaction,
-      now: this.now()
+    await this.serialize(async () => {
+      this.assertMutationWritable()
+      let result
+      try {
+        result = await compactJournal({
+          journalDir: this.journalDir,
+          state: this.state,
+          tailRows: this.tailRows,
+          policy: this.compaction,
+          now: this.now()
+        })
+      } catch (error) {
+        await this.storage.remeasureAfterMutation()
+        throw error
+      }
+      this.tailRows = result.tailRows
+      this.compactedThrough = result.compactedThrough
+      this.state.oldestSequence = result.oldestSequence
+      await this.storage.remeasureAfterMutation()
     })
-    this.tailRows = result.tailRows
-    this.compactedThrough = result.compactedThrough
-    this.state.oldestSequence = result.oldestSequence
-    this.sizeBytes = this.tailRows.reduce((total, row) => total + journalRowByteLength(row), 0)
   }
 
-  /** The escape hatch for corruption, an unreconcilable prefix, a forked handle,
-   *  and an unreadable schema. It invalidates every cursor; clients reload. */
+  /** Roll away an invalid journal prefix and force client snapshot reload. */
   async rollEpoch(reason: AgentJournalEpochReason, fence: number): Promise<AgentJournalCursor> {
-    assertJournalWritable(this.readOnly, this.identity.sessionId)
-    await this.startEpoch(reason, fence)
-    return this.cursor()
+    return this.serialize(async () => {
+      this.assertMutationWritable()
+      await this.startEpoch(reason, fence)
+      return this.cursor()
+    })
   }
 
   private async startEpoch(reason: AgentJournalEpochReason, fence: number): Promise<void> {
@@ -326,42 +314,34 @@ export class AgentSessionJournal {
     })
     this.state = published.state
     this.tailRows = [published.row]
-    this.compactedThrough = 0
-    this.sizeBytes = journalRowByteLength(published.row)
+    this.compactedThrough = 1
+    await this.storage.remeasureAfterMutation()
   }
 
-  private rowBase(
-    seq: number,
-    fence: number,
-    ts: number
-  ): { v: number; epoch: string; seq: number; fence: number; ts: number } {
-    return {
-      v: AGENT_SESSION_JOURNAL_SCHEMA_VERSION,
-      epoch: this.state.epoch,
-      seq,
-      fence,
-      ts
-    }
-  }
-
-  /**
-   * Assign the next sequence, make the row durable, and fold it through the
-   * SAME reducer replay uses — all inside one serialized step, so concurrent
-   * callers cannot interleave and mint the same sequence.
-   */
-  private enqueue(build: (seq: number, ts: number) => JournalRow): Promise<JournalRow> {
-    const run = this.writes.then(async () => {
-      assertJournalWritable(this.readOnly, this.identity.sessionId)
+  /** Assign, persist, and reduce one row in the same serialized step. */
+  private enqueue(
+    build: (seq: number, ts: number) => JournalRow,
+    blobs: readonly JournalBlobPayload[] = []
+  ): Promise<JournalRow> {
+    return this.serialize(async () => {
+      this.assertMutationWritable()
       const ts = this.now()
       const row = build(this.state.lastSequence + 1, ts)
       assertJournalFence(row.fence, this.state.highestFence)
-      this.budget.assert(row, ts, this.sizeBytes)
-      await appendJournalRows(this.journalDir, [row])
+      await this.storage.append(row, ts, blobs)
       applyJournalRow(this.state, row)
       this.tailRows.push(row)
-      this.sizeBytes += journalRowByteLength(row)
       return row
     })
+  }
+
+  private assertMutationWritable(): void {
+    assertJournalWritable(this.readOnly, this.identity.sessionId)
+    this.storage.assertWritable()
+  }
+
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.writes.then(operation)
     this.writes = run.catch(() => undefined)
     return run
   }

--- a/src/main/native-chat/agent-session-journal/journal-write-guards.ts
+++ b/src/main/native-chat/agent-session-journal/journal-write-guards.ts
@@ -52,8 +52,11 @@ export class JournalAppendBudget {
     private readonly limits: JournalPayloadLimits
   ) {}
 
-  assert(row: JournalRow, ts: number, sizeBytes: number): void {
-    if (sizeBytes + journalRowByteLength(row) > this.limits.maxSessionBytes) {
+  assert(row: JournalRow, ts: number, persistedBytes: number, additionalBlobBytes = 0): void {
+    if (
+      persistedBytes + additionalBlobBytes + journalRowByteLength(row) >
+      this.limits.maxSessionBytes
+    ) {
       throw new AgentSessionJournalError(
         'journal_bound_exceeded',
         `agent-session journal for ${this.sessionId} reached its ${this.limits.maxSessionBytes}-byte bound`

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
@@ -83,6 +83,8 @@ export type StructuredAgentSessionAdapter = {
       requestReceiptId: string
     }
   }): Promise<AgentSessionDispatchOutcome>
+  /** A host-authenticated local user turn supersedes mutation authority globally. */
+  invalidateEffectAuthorityForTrustedUserTurn?(input: { sourceSessionId: string }): Promise<void>
   /** Cancels one turn, not the session: a session-wide interrupt would also kill
    *  a turn the client never asked to stop. */
   cancelTurn(input: {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
@@ -16,7 +16,10 @@ import type {
   AgentSessionExecutionLocation,
   AgentSessionProcessIdentity
 } from '../../../shared/agent-session-record'
-import type { AgentSessionOptionsResult } from '../../../shared/agent-session-wire'
+import type {
+  AgentSessionEffectAuthority,
+  AgentSessionOptionsResult
+} from '../../../shared/agent-session-wire'
 import type { StructuredAgentSessionEventSink } from './structured-agent-session-event-sink'
 
 /** What a reservation turns into once something is actually running under it:
@@ -75,6 +78,10 @@ export type StructuredAgentSessionAdapter = {
     clientMessageId: string
     body: AgentJournalMessageItem
     fence: number
+    requestAuthority?: {
+      effectAuthority: AgentSessionEffectAuthority
+      requestReceiptId: string
+    }
   }): Promise<AgentSessionDispatchOutcome>
   /** Cancels one turn, not the session: a session-wide interrupt would also kill
    *  a turn the client never asked to stop. */

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
@@ -14,6 +14,7 @@ import type { AgentSessionOwnerProbe } from '../../../shared/agent-session-lease
 import type { AgentSessionHandleProvider } from '../../../shared/agent-session-provider-handle'
 import type {
   AgentSessionAccountHome,
+  AgentSessionEffectIsolation,
   AgentSessionExecutionLocation,
   AgentSessionLaunchEnv,
   AgentSessionOwnerRuntimeKind,
@@ -51,6 +52,8 @@ export type AgentSessionAttachParams = {
   provider: AgentSessionHandleProvider
   agent: AgentType
   accountHome: AgentSessionAccountHome
+  /** Host-selected process boundary; clients may only request it through create intent. */
+  effectIsolation?: AgentSessionEffectIsolation
   runtimeKind: AgentSessionOwnerRuntimeKind
   /** Omitted only for create-by-intent; the adapter proves the durable handle. */
   providerHandle?: Exclude<AgentSessionProviderHandle, { kind: 'opaque' }>
@@ -74,6 +77,7 @@ export function attachFingerprintFields(params: AgentSessionAttachParams): Recor
     provider: params.provider,
     agent: params.agent,
     accountHome: params.accountHome,
+    effectIsolation: params.effectIsolation,
     runtimeKind: params.runtimeKind,
     providerHandle: params.providerHandle,
     expectedRuntimeFence: params.envelope.expectedRuntimeFence
@@ -179,6 +183,7 @@ export function reserveRequestFor(input: {
     location: params.location,
     provider: params.provider,
     accountHome: params.accountHome,
+    ...(params.effectIsolation ? { effectIsolation: params.effectIsolation } : {}),
     ...(authority.launchEnv ? { launchEnv: authority.launchEnv } : {}),
     runtimeKind: params.runtimeKind,
     expectedFence: params.envelope.expectedRuntimeFence,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-effect-isolation.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-effect-isolation.ts
@@ -1,0 +1,17 @@
+import type { AgentSessionRecord } from '../../../shared/agent-session-record'
+import type {
+  AgentSessionHandoffResult,
+  AgentSessionMutationResult
+} from '../../../shared/agent-session-wire'
+import { refuseAgentSessionMutation } from './structured-agent-session-mutation-admission'
+
+export function refuseEffectIsolatedHandoff(
+  record: AgentSessionRecord | null
+): AgentSessionMutationResult<AgentSessionHandoffResult> | null {
+  return record?.effectIsolation === 'local-structured-write'
+    ? refuseAgentSessionMutation({
+        code: 'agent_session_operation_invalid',
+        message: 'An effect-isolated writer session cannot hand off to a terminal owner.'
+      })
+    : null
+}

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-event-sink.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-event-sink.ts
@@ -16,9 +16,9 @@ import type {
   AgentJournalItemIdentity
 } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
-import { putJournalBlob } from '../agent-session-journal/journal-blob-store'
+import type { JournalBlobPayload } from '../agent-session-journal/journal-blob-store'
 
-export type StructuredAgentSessionJournalBlob = { digest: string; payload: string }
+export type StructuredAgentSessionJournalBlob = JournalBlobPayload
 
 /** The only journal surface an adapter gets: append and publish, no reads. An
  *  adapter that could read the journal would start reconciling against it, and
@@ -97,10 +97,7 @@ export function createDeferredStructuredAgentSessionEventSink(
     sink: {
       appendItem: (identity, body: AgentJournalItemBody, blobs = []) => {
         submit(async (bound) => {
-          for (const blob of blobs) {
-            await putJournalBlob(bound.journal.directory, blob.digest, blob.payload)
-          }
-          await bound.journal.appendItem(identity, body, { fence: bound.fence })
+          await bound.journal.appendItem(identity, body, { fence: bound.fence, blobs })
         })
       },
       appendTombstone: (identity) => {
@@ -115,7 +112,7 @@ export function createDeferredStructuredAgentSessionEventSink(
         return
       }
       target = next
-      const pending = buffered.splice(0, buffered.length)
+      const pending = buffered.splice(0)
       for (const operation of pending) {
         enqueue(operation)
       }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-operation-guard.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-operation-guard.ts
@@ -1,5 +1,8 @@
 import type { AgentSessionHandoffStatus } from '../../../shared/agent-session-wire'
-import type { AgentSessionOperationOutcome } from '../../../shared/agent-session-operation-ledger'
+import type {
+  AgentSessionOperationOutcome,
+  AgentSessionOperationRefusalCode
+} from '../../../shared/agent-session-operation-ledger'
 import type { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
 
 type ActiveOperation = { callerKey: string; operationId: string; fingerprint: string }
@@ -8,7 +11,7 @@ export type HandoffOperationDecision =
   | { decision: 'new' }
   | { decision: 'replay'; outcome: AgentSessionOperationOutcome }
   | { decision: 'retry' }
-  | { decision: 'refused'; code: 'agent_session_operation_conflict' | string }
+  | { decision: 'refused'; code: AgentSessionOperationRefusalCode }
 
 export class StructuredAgentSessionHandoffOperationGuard {
   private readonly activeBySession = new Map<string, ActiveOperation>()

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-options.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-options.test.ts
@@ -207,6 +207,22 @@ afterEach(async () => {
 })
 
 describe('structured session handoff options', () => {
+  it('refuses to widen an effect-isolated writer into a TUI owner', async () => {
+    const readRecord = store.getRecord.bind(store)
+    const record = readRecord(SESSION)
+    expect(record).not.toBeNull()
+    const getRecord = vi.spyOn(store, 'getRecord').mockImplementation((sessionId) => {
+      const current = readRecord(sessionId)
+      return current ? { ...current, effectIsolation: 'local-structured-write' } : null
+    })
+
+    await expect(host.requestHandoff(CALLER, handoff('to-tui'))).resolves.toMatchObject({
+      ok: false,
+      refusal: { code: 'agent_session_operation_invalid' }
+    })
+    getRecord.mockRestore()
+  })
+
   it('settles a pre-mutation rejection so a fresh retry can succeed', async () => {
     optionFailure = new AgentSessionOptionRejectedError('model list unavailable')
     const fields = { key: 'model', value: PICKED_MODEL }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -48,6 +48,7 @@ import {
   type StructuredAgentSessionHostHandoff
 } from './structured-agent-session-host-handoff'
 import { StructuredAgentSessionHostRuntimeState } from './structured-agent-session-host-runtime-state'
+import { refuseEffectIsolatedHandoff } from './structured-agent-session-effect-isolation'
 import { listStructuredAgentSessionTabs } from './structured-agent-session-host-tabs'
 import { pinnedAgentSessionLaunchEnv } from './structured-agent-session-launch-env'
 import { StructuredAgentSessionReadableRestorer } from './structured-agent-session-readable-restorer'
@@ -280,6 +281,12 @@ export class StructuredAgentSessionHost {
     params: AgentSessionHandoffRequest
   ): Promise<AgentSessionMutationResult<AgentSessionHandoffResult>> {
     this.requireSession(params.envelope.sessionId)
+    const isolationRefusal = refuseEffectIsolatedHandoff(
+      this.deps.store.getRecord(params.envelope.sessionId)
+    )
+    if (isolationRefusal) {
+      return Promise.resolve(isolationRefusal)
+    }
     return this.serialize(params.envelope.sessionId, () =>
       this.handoffs.request(caller.callerKey, params)
     )

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -59,6 +59,8 @@ import type {
 } from './structured-agent-session-host-types'
 export type { StructuredAgentSessionHostDeps } from './structured-agent-session-host-types'
 
+type AttachResult = Promise<AgentSessionMutationResult<AgentSessionAttachResult>>
+
 export class StructuredAgentSessionHost {
   private readonly sessions = new Map<string, StructuredAgentSessionHostSession>()
   private readonly subscribers = new AgentSessionSubscribers()
@@ -138,10 +140,7 @@ export class StructuredAgentSessionHost {
     })
   }
 
-  attach(
-    caller: StructuredAgentSessionCaller,
-    params: AgentSessionAttachParams
-  ): Promise<AgentSessionMutationResult<AgentSessionAttachResult>> {
+  attach(caller: StructuredAgentSessionCaller, params: AgentSessionAttachParams): AttachResult {
     const attaching = this.serialize(params.envelope.sessionId, async () => {
       const sessionId = params.envelope.sessionId
       const unreconciled = await this.reconcileLeases(sessionId)
@@ -218,6 +217,10 @@ export class StructuredAgentSessionHost {
     }
   ): Promise<AgentSessionMutationResult<AgentSessionSendResult>> {
     return this.mutate(caller, params.envelope, sendPlan(params))
+  }
+
+  async invalidateEffectAuthorityForTrustedUserTurn(sourceSessionId: string): Promise<void> {
+    await this.deps.adapter.invalidateEffectAuthorityForTrustedUserTurn?.({ sourceSessionId })
   }
 
   cancel(

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -116,17 +116,13 @@ export class StructuredAgentSessionHost {
 
   hasSession = (sessionId: string): boolean => this.sessions.has(sessionId)
 
-  supportsCreate(location: AgentSessionExecutionLocation, agent: string): boolean {
-    return agent === 'codex' && (this.deps.adapter.supportsLocation?.(location) ?? false)
-  }
+  supportsCreate = (location: AgentSessionExecutionLocation, agent: string): boolean =>
+    agent === 'codex' && (this.deps.adapter.supportsLocation?.(location) ?? false)
 
-  listSessionTabs() {
-    return listStructuredAgentSessionTabs(this.sessions)
-  }
+  listSessionTabs = () => listStructuredAgentSessionTabs(this.sessions)
 
-  restoreReadableSessions(): Promise<void> {
-    return this.restartRestore.run(() => this.readableRestorer.restore())
-  }
+  restoreReadableSessions = (): Promise<void> =>
+    this.restartRestore.run(() => this.readableRestorer.restore())
 
   private serialize<T>(sessionId: string, task: () => Promise<T>): Promise<T> {
     return this.tasks.serialize(sessionId, task)
@@ -219,9 +215,8 @@ export class StructuredAgentSessionHost {
     return this.mutate(caller, params.envelope, sendPlan(params))
   }
 
-  async invalidateEffectAuthorityForTrustedUserTurn(sourceSessionId: string): Promise<void> {
-    await this.deps.adapter.invalidateEffectAuthorityForTrustedUserTurn?.({ sourceSessionId })
-  }
+  invalidateEffectAuthorityForTrustedUserTurn = async (sourceSessionId: string): Promise<void> =>
+    this.deps.adapter.invalidateEffectAuthorityForTrustedUserTurn?.({ sourceSessionId })
 
   cancel(
     caller: StructuredAgentSessionCaller,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -212,6 +212,7 @@ export class StructuredAgentSessionHost {
       envelope: AgentSessionMutationEnvelope
       body: AgentJournalMessageItem
       retryUnknown?: true
+      effectAuthority?: 'local_structured_write'
       beforeRun?: () => void
     }
   ): Promise<AgentSessionMutationResult<AgentSessionSendResult>> {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -213,7 +213,7 @@ export class StructuredAgentSessionHost {
       body: AgentJournalMessageItem
       retryUnknown?: true
       effectAuthority?: 'local_structured_write'
-      beforeRun?: () => void
+      beforeRun?: () => void | Promise<void>
     }
   ): Promise<AgentSessionMutationResult<AgentSessionSendResult>> {
     return this.mutate(caller, params.envelope, sendPlan(params))

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
@@ -107,7 +107,7 @@ export async function admitAndRunAgentSessionMutation<TValue>(
     }
   }
 
-  plan.beforeRun?.()
+  await plan.beforeRun?.()
   const outcome = await runSettledAgentSessionMutation({
     store: request.store,
     callerKey: request.callerKey,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -28,7 +28,7 @@ import {
 export type MutationPlan<TValue> = {
   method: string
   fields: Record<string, unknown>
-  beforeRun?: () => void
+  beforeRun?: () => void | Promise<void>
   run: (ctx: AgentSessionTurnContext) => Promise<TurnOutcome<TValue>>
   replay: (ctx: AgentSessionTurnContext, outcome: AgentSessionOperationOutcome) => TValue | null
   rerunWhenReplayMissing?: (ctx: AgentSessionTurnContext) => boolean
@@ -39,7 +39,7 @@ export function sendPlan(params: {
   body: AgentJournalMessageItem
   retryUnknown?: true
   effectAuthority?: AgentSessionEffectAuthority
-  beforeRun?: () => void
+  beforeRun?: () => void | Promise<void>
 }): MutationPlan<AgentSessionSendResult> {
   // The operation id IS the client message id: one send, one durable row, one
   // key the client reconciles its optimistic bubble against.

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -10,6 +10,7 @@ import type { AgentJournalMessageItem } from '../../../shared/agent-session-jour
 import type { AgentSessionOperationOutcome } from '../../../shared/agent-session-operation-ledger'
 import type {
   AgentSessionCancelResult,
+  AgentSessionEffectAuthority,
   AgentSessionMutationEnvelope,
   AgentSessionOptionResult,
   AgentSessionPromptResult,
@@ -37,6 +38,7 @@ export function sendPlan(params: {
   envelope: AgentSessionMutationEnvelope
   body: AgentJournalMessageItem
   retryUnknown?: true
+  effectAuthority?: AgentSessionEffectAuthority
   beforeRun?: () => void
 }): MutationPlan<AgentSessionSendResult> {
   // The operation id IS the client message id: one send, one durable row, one
@@ -45,7 +47,10 @@ export function sendPlan(params: {
   return {
     method: 'agentSession.send',
     // A control signal is not payload; only the matching durable unknown unlocks redispatch.
-    fields: { body: params.body },
+    fields: {
+      body: params.body,
+      ...(params.effectAuthority ? { effectAuthority: params.effectAuthority } : {})
+    },
     ...(params.beforeRun ? { beforeRun: params.beforeRun } : {}),
     rerunWhenReplayMissing: (ctx) =>
       params.retryUnknown === true &&
@@ -59,6 +64,7 @@ export function sendPlan(params: {
         clientMessageId,
         payloadFingerprint: params.envelope.payloadFingerprint,
         body: params.body,
+        ...(params.effectAuthority ? { effectAuthority: params.effectAuthority } : {}),
         retryUnknown: params.retryUnknown
       }),
     replay: (ctx) => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
@@ -69,6 +69,7 @@ export function attachParamsForRecord(
     provider: 'codex',
     agent: 'codex',
     accountHome: record.accountHome,
+    ...(record.effectIsolation ? { effectIsolation: record.effectIsolation } : {}),
     runtimeKind: input.runtimeKind ?? record.lease.runtimeKind
   }
   return {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
@@ -52,6 +52,7 @@ type Harness = {
   root: string
   store: AgentSessionRecordStore
   host: StructuredAgentSessionHost
+  dispatch: Mock<StructuredAgentSessionAdapter['dispatch']>
   setOption: Mock<StructuredAgentSessionAdapter['setOption']>
 }
 
@@ -86,6 +87,10 @@ async function createHarness(options: { attached?: boolean; transport?: boolean 
     hostId: 'local'
   })
   const setOption = vi.fn<StructuredAgentSessionAdapter['setOption']>(async () => undefined)
+  const dispatch = vi.fn<StructuredAgentSessionAdapter['dispatch']>(async () => ({
+    state: 'accepted',
+    providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-1', ordinal: 1 }
+  }))
   const adapter: StructuredAgentSessionAdapter = {
     acquire: async ({ fence }) => ({
       process: {
@@ -102,10 +107,7 @@ async function createHarness(options: { attached?: boolean; transport?: boolean 
         observedAt: NOW
       }
     }),
-    dispatch: async () => ({
-      state: 'accepted',
-      providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-1', ordinal: 1 }
-    }),
+    dispatch,
     cancelTurn: async () => ({ cancelled: true }),
     answerPrompt: async () => undefined,
     setOption
@@ -119,7 +121,7 @@ async function createHarness(options: { attached?: boolean; transport?: boolean 
     now: () => NOW,
     ...(options.transport ? { handoffTransport: handoffTransport() } : {})
   })
-  const harness = { root, store, host, setOption }
+  const harness = { root, store, host, dispatch, setOption }
   harnesses.push(harness)
   if (options.attached !== false) {
     expect(await host.attach(CALLER, hostTestAttachParams(null))).toMatchObject({ ok: true })
@@ -243,6 +245,137 @@ async function fillOperationLedger(harness: Harness): Promise<void> {
     })
   }
 }
+
+function sendEnvelope(
+  harness: Harness,
+  operation: string,
+  body: ReturnType<typeof hostTestMessage>,
+  options: { effectAuthority?: 'local_structured_write'; expectedRuntimeFence?: number } = {}
+): AgentSessionMutationEnvelope {
+  const fields = {
+    body,
+    ...(options.effectAuthority ? { effectAuthority: options.effectAuthority } : {})
+  }
+  return {
+    sessionId: SESSION,
+    clientOperationId: operation,
+    expectedRuntimeFence:
+      options.expectedRuntimeFence ?? harness.store.getRecord(SESSION)?.lease.runtimeFence ?? 1,
+    payloadFingerprint: computeAgentSessionPayloadFingerprint({
+      method: 'agentSession.send',
+      sessionId: SESSION,
+      fields
+    })
+  }
+}
+
+describe('send admission side effects', () => {
+  it('does not run beforeRun for absent, conflicting, stale, or settled-replay sends', async () => {
+    const beforeRun = vi.fn()
+    const absent = await createHarness({ attached: false })
+    const absentBody = hostTestMessage('absent')
+    await absent.host.send(CALLER, {
+      envelope: sendEnvelope(absent, operationId(), absentBody),
+      body: absentBody,
+      beforeRun
+    })
+
+    const attached = await createHarness()
+    const conflictBody = hostTestMessage('conflict')
+    const conflictEnvelope = sendEnvelope(attached, operationId(), conflictBody)
+    await attached.host.send(CALLER, {
+      envelope: { ...conflictEnvelope, payloadFingerprint: 'wrong' },
+      body: conflictBody,
+      beforeRun
+    })
+
+    const staleBody = hostTestMessage('stale')
+    await attached.host.send(CALLER, {
+      envelope: sendEnvelope(attached, operationId(), staleBody, { expectedRuntimeFence: 99 }),
+      body: staleBody,
+      beforeRun
+    })
+
+    const replayBody = hostTestMessage('replay')
+    const replayParams = {
+      envelope: sendEnvelope(attached, operationId(), replayBody),
+      body: replayBody,
+      beforeRun
+    }
+    await attached.host.send(CALLER, replayParams)
+    await attached.host.send(CALLER, replayParams)
+
+    expect(beforeRun).toHaveBeenCalledOnce()
+    expect(attached.dispatch).toHaveBeenCalledOnce()
+  })
+
+  it('awaits beforeRun after admission and once per real unknown redispatch', async () => {
+    const harness = await createHarness()
+    const order: string[] = []
+    let dispatchAttempt = 0
+    harness.dispatch.mockImplementation(async () => {
+      dispatchAttempt += 1
+      order.push(`dispatch-${dispatchAttempt}`)
+      if (dispatchAttempt === 1) {
+        throw new Error('socket closed')
+      }
+      return {
+        state: 'accepted',
+        providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-2', ordinal: 2 }
+      }
+    })
+    let beforeAttempt = 0
+    const beforeRun = vi.fn(async () => {
+      beforeAttempt += 1
+      expect(operationState(harness, params.envelope.clientOperationId)).toBeDefined()
+      order.push(`before-${beforeAttempt}`)
+      await Promise.resolve()
+    })
+    const body = hostTestMessage('retry unknown')
+    const params = {
+      envelope: sendEnvelope(harness, operationId(), body),
+      body,
+      beforeRun
+    }
+
+    await harness.host.send(CALLER, params)
+    await harness.host.send(CALLER, { ...params, retryUnknown: true })
+
+    expect(beforeRun).toHaveBeenCalledTimes(2)
+    expect(harness.dispatch).toHaveBeenCalledTimes(2)
+    expect(order).toEqual(['before-1', 'dispatch-1', 'before-2', 'dispatch-2'])
+  })
+
+  it('binds host write authority to the admitted caller, payload, message, and fence', async () => {
+    const harness = await createHarness()
+    const body = hostTestMessage('change source.txt only')
+    const effectAuthority = 'local_structured_write' as const
+    const clientMessageId = operationId()
+
+    await harness.host.send(CALLER, {
+      envelope: sendEnvelope(harness, clientMessageId, body, { effectAuthority }),
+      body,
+      effectAuthority
+    })
+
+    const dispatched = harness.dispatch.mock.calls[0]?.[0]
+    expect(dispatched?.clientMessageId).toBe(clientMessageId)
+    expect(dispatched?.requestAuthority).toEqual({
+      effectAuthority,
+      requestReceiptId: computeAgentSessionPayloadFingerprint({
+        method: 'host.agentSession.effectAuthority',
+        sessionId: SESSION,
+        fields: {
+          callerKey: CALLER.callerKey,
+          clientMessageId,
+          fence: 1,
+          body,
+          effectAuthority
+        }
+      })
+    })
+  })
+})
 
 // sendPlan and setOptionPlan have no unsupported branch; only handoff checks transport.
 const UNREACHABLE = new Set<Pair>([

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
@@ -13,8 +13,10 @@ import type {
 } from '../../../shared/agent-session-journal-types'
 import { parseAgentJournalItemKey } from '../../../shared/agent-session-journal-item-key'
 import { decodeCodexQuestionOptionId } from '../../codex/codex-structured-prompt-replies'
+import { computeAgentSessionPayloadFingerprint } from '../../../shared/agent-session-mutation-envelope'
 import type {
   AgentSessionCancelResult,
+  AgentSessionEffectAuthority,
   AgentSessionOptionResult,
   AgentSessionPromptResult,
   AgentSessionSendResult,
@@ -53,18 +55,46 @@ function invalid(message: string): { ok: false; refusal: AgentSessionWireRefusal
 async function dispatchSafely(
   ctx: AgentSessionTurnContext,
   clientMessageId: string,
-  body: AgentJournalMessageItem
+  body: AgentJournalMessageItem,
+  effectAuthority?: AgentSessionEffectAuthority
 ): Promise<AgentSessionDispatchOutcome> {
   try {
     return await ctx.adapter.dispatch({
       sessionId: ctx.sessionId,
       clientMessageId,
       body,
-      fence: ctx.fence
+      fence: ctx.fence,
+      ...(effectAuthority
+        ? {
+            requestAuthority: {
+              effectAuthority,
+              requestReceiptId: hostRequestReceiptId(ctx, clientMessageId, body, effectAuthority)
+            }
+          }
+        : {})
     })
   } catch (error) {
     return { state: 'unknown', reason: error instanceof Error ? error.message : String(error) }
   }
+}
+
+function hostRequestReceiptId(
+  ctx: AgentSessionTurnContext,
+  clientMessageId: string,
+  body: AgentJournalMessageItem,
+  effectAuthority: AgentSessionEffectAuthority
+): string {
+  return computeAgentSessionPayloadFingerprint({
+    method: 'host.agentSession.effectAuthority',
+    sessionId: ctx.sessionId,
+    fields: {
+      callerKey: ctx.resolvedBy,
+      clientMessageId,
+      fence: ctx.fence,
+      body,
+      effectAuthority
+    }
+  })
 }
 
 async function appendStatus(
@@ -86,6 +116,7 @@ export async function performSend(
     clientMessageId: string
     payloadFingerprint: string
     body: AgentJournalMessageItem
+    effectAuthority?: AgentSessionEffectAuthority
     retryUnknown?: true
   }
 ): Promise<TurnOutcome<AgentSessionSendResult>> {
@@ -97,7 +128,12 @@ export async function performSend(
     ctx.publish()
   }
 
-  const outcome = await dispatchSafely(ctx, input.clientMessageId, input.body)
+  const outcome = await dispatchSafely(
+    ctx,
+    input.clientMessageId,
+    input.body,
+    input.effectAuthority
+  )
   await ctx.journal.resolveDispatch(
     outcome.state === 'accepted'
       ? {

--- a/src/main/runtime/agent-session-record-store-effect-isolation.test.ts
+++ b/src/main/runtime/agent-session-record-store-effect-isolation.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AgentSessionExecutionLocation } from '../../shared/agent-session-record'
+import { AgentSessionRecordStore } from './agent-session-record-store'
+import { agentSessionStorePath } from './agent-session-record-store-file'
+import type { AgentSessionReserveRequest } from './agent-session-reservation-admission'
+
+const NOW = 1_800_000_000_000
+const LOCATION: AgentSessionExecutionLocation = {
+  executionHostId: 'local',
+  wslDistro: null,
+  workspaceId: 'workspace-1',
+  workspaceKind: 'git-worktree'
+}
+
+let directory: string
+let operations = 0
+
+function reserveRequest(
+  overrides: Partial<AgentSessionReserveRequest> = {}
+): AgentSessionReserveRequest {
+  operations += 1
+  return {
+    sessionId: 'session-alpha',
+    location: LOCATION,
+    provider: 'claude',
+    accountHome: { variable: 'CLAUDE_CONFIG_DIR', path: '/home/dev/.claude-work' },
+    runtimeKind: 'native',
+    expectedFence: null,
+    spawnToken: `spawn-${operations}`,
+    claimKeyId: 'key-1',
+    handoffOperationId: null,
+    probe: { outcome: 'indeterminate', reason: 'no answer' },
+    operation: {
+      callerKey: 'client-1',
+      operationId: `${NOW}-${operations.toString(16).padStart(32, '0')}`,
+      fingerprint: `fp-${operations}`
+    },
+    now: NOW,
+    ...overrides
+  }
+}
+
+function writerRequest(
+  overrides: Partial<AgentSessionReserveRequest> = {}
+): AgentSessionReserveRequest {
+  return reserveRequest({
+    provider: 'codex',
+    accountHome: { variable: 'CODEX_HOME', path: '/home/dev/.codex' },
+    effectIsolation: 'local-structured-write',
+    ...overrides
+  })
+}
+
+beforeEach(async () => {
+  operations = 0
+  directory = await mkdtemp(join(tmpdir(), 'orca-agent-session-effect-store-'))
+})
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true })
+})
+
+describe('effect-isolated agent-session records', () => {
+  it('refuses to widen an existing normal session into a writer', async () => {
+    const store = await AgentSessionRecordStore.open({ directory, hostId: 'local' })
+    await store.reserveOwner(reserveRequest())
+
+    await expect(
+      store.reserveOwner(writerRequest({ expectedFence: 1, probe: { outcome: 'pid-absent' } }))
+    ).rejects.toThrow('agent_session_conflict')
+  })
+
+  it('persists writers as v2 so an older host quarantines rather than widens them', async () => {
+    const store = await AgentSessionRecordStore.open({ directory, hostId: 'local' })
+    const reserved = await store.reserveOwner(writerRequest())
+    expect(reserved.record).toMatchObject({
+      schemaVersion: 2,
+      effectIsolation: 'local-structured-write'
+    })
+
+    const path = agentSessionStorePath(directory)
+    const persisted = JSON.parse(await readFile(path, 'utf8'))
+    expect(persisted.records['session-alpha'].schemaVersion).toBe(2)
+    persisted.records['session-alpha'].schemaVersion = 1
+    await writeFile(path, JSON.stringify(persisted))
+
+    const downgraded = await AgentSessionRecordStore.open({ directory, hostId: 'local' })
+    expect(downgraded.getRecord('session-alpha')).toBeNull()
+    expect(downgraded.isSessionUnreadable('session-alpha')).toBe(true)
+  })
+})

--- a/src/main/runtime/agent-session-reservation-admission.ts
+++ b/src/main/runtime/agent-session-reservation-admission.ts
@@ -14,10 +14,12 @@ import {
 } from '../../shared/agent-session-operation-ledger'
 import type { AgentSessionOwnerProbe } from '../../shared/agent-session-lease-adjudication'
 import {
+  AGENT_SESSION_EFFECT_ISOLATED_RECORD_SCHEMA_VERSION,
   AGENT_SESSION_RECORD_SCHEMA_VERSION,
   agentSessionExecutionLocationsEqual,
   isAgentSessionLaunchEnv,
   type AgentSessionAccountHome,
+  type AgentSessionEffectIsolation,
   type AgentSessionExecutionLocation,
   type AgentSessionLaunchEnv,
   type AgentSessionRecord
@@ -34,6 +36,7 @@ export type AgentSessionReserveRequest = {
   location: AgentSessionExecutionLocation
   provider: AgentSessionHandleProvider
   accountHome: AgentSessionAccountHome
+  effectIsolation?: AgentSessionEffectIsolation
   launchEnv?: AgentSessionLaunchEnv
   runtimeKind: AgentSessionReservation['runtimeKind']
   /** Null when the session does not exist yet; otherwise the fence the caller last observed. */
@@ -99,6 +102,14 @@ export function applyAgentSessionReservation(
   if (request.launchEnv && !isAgentSessionLaunchEnv(request.launchEnv)) {
     throw new Error('agent_session_launch_env_invalid')
   }
+  if (
+    request.effectIsolation &&
+    (request.provider !== 'codex' ||
+      request.accountHome.variable !== 'CODEX_HOME' ||
+      request.runtimeKind !== 'native')
+  ) {
+    throw new Error('agent_session_operation_invalid')
+  }
   const reservation: AgentSessionReservation = {
     runtimeKind: request.runtimeKind,
     spawnToken: request.spawnToken,
@@ -121,7 +132,8 @@ export function applyAgentSessionReservation(
     !agentSessionExecutionLocationsEqual(existing.location, request.location) ||
     existing.provider !== request.provider ||
     existing.accountHome.variable !== request.accountHome.variable ||
-    existing.accountHome.path !== request.accountHome.path
+    existing.accountHome.path !== request.accountHome.path ||
+    existing.effectIsolation !== request.effectIsolation
   ) {
     // Why: location, provider, and account are the session identity; changing one is a fork.
     throw new Error('agent_session_conflict')
@@ -146,12 +158,15 @@ function createAgentSessionRecord(
   reservation: AgentSessionReservation
 ): AgentSessionRecord {
   return {
-    schemaVersion: AGENT_SESSION_RECORD_SCHEMA_VERSION,
+    schemaVersion: request.effectIsolation
+      ? AGENT_SESSION_EFFECT_ISOLATED_RECORD_SCHEMA_VERSION
+      : AGENT_SESSION_RECORD_SCHEMA_VERSION,
     sessionId: request.sessionId,
     location: request.location,
     provider: request.provider,
     providerHandleChain: [],
     accountHome: request.accountHome,
+    ...(request.effectIsolation ? { effectIsolation: request.effectIsolation } : {}),
     ...(request.launchEnv ? { launchEnv: { ...request.launchEnv } } : {}),
     createdAt: request.now,
     updatedAt: request.now,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -73,6 +73,7 @@ import {
   type AgentSessionClaimSigner
 } from './agent-session-claim-identity'
 import { ensureStructuredAgentSessionHost as installStructuredAgentSessionHost } from './structured-agent-session-runtime'
+import type { CodexStructuredWriteAuthority } from '../codex/codex-structured-write-authority'
 import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
 import type { AgentSessionAttachParams } from '../native-chat/agent-session-wire/structured-agent-session-attach'
 import {
@@ -3273,6 +3274,8 @@ export class OrcaRuntimeService {
     | ((input: { workspacePath: string; launchEnv: NodeJS.ProcessEnv }) => string | null)
     | null
   private readonly agentSessionClaimSigner: AgentSessionClaimSigner
+  private readonly codexStructuredWriteAuthority: CodexStructuredWriteAuthority | null
+  private readonly codexStructuredWriteEnabled: boolean
   private readonly agentSessionCreateOperations = new Map<string, AgentSessionCreateOperation>()
   private readonly orchestrationCompatibilitySshAttachments = new Map<
     string,
@@ -3356,6 +3359,9 @@ export class OrcaRuntimeService {
       buildAgentHookPtyEnv?: () => Record<string, string>
       getDesktopWindowStatus?: () => RuntimeDesktopWindowStatus
       agentSessionClaimSigner?: AgentSessionClaimSigner
+      /** Explicit host-owned admission for the local structured-writer spike. */
+      codexStructuredWriteAuthority?: CodexStructuredWriteAuthority
+      codexStructuredWriteEnabled?: boolean
       orchestrationEnvironmentTransport?: OrchestrationEnvironmentTransport
     }
   ) {
@@ -3406,6 +3412,8 @@ export class OrcaRuntimeService {
     this.prepareCodexStructuredLaunchFn = deps?.prepareCodexStructuredLaunch ?? null
     this.agentSessionClaimSigner =
       deps?.agentSessionClaimSigner ?? createEphemeralAgentSessionClaimSigner(this.runtimeId)
+    this.codexStructuredWriteAuthority = deps?.codexStructuredWriteAuthority ?? null
+    this.codexStructuredWriteEnabled = deps?.codexStructuredWriteEnabled === true
     this.onTerminalSideEffects = deps?.onTerminalSideEffects ?? null
     // Why: the ConPTY spawn mark can land after daemon stream data already
     // created this PTY's emulator; the mark retrofits the DA1 override here
@@ -9120,6 +9128,13 @@ export class OrcaRuntimeService {
       // in a plain folder lands in the folder rather than failing to resolve.
       resolveWorkspacePath: async (workspaceId) =>
         (await this.resolveRuntimeFileTarget(`id:${workspaceId}`)).worktree.path,
+      ...(this.codexStructuredWriteAuthority
+        ? {
+            codexStructuredWriteAuthority: this.codexStructuredWriteAuthority,
+            resolveCodexStructuredWriteSourceHome: () => getSystemCodexHomePath()
+          }
+        : {}),
+      ...(this.codexStructuredWriteEnabled ? { codexStructuredWriteEnabled: true } : {}),
       handoffTransport: this.createStructuredAgentSessionHandoffTransport()
     })
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9130,8 +9130,7 @@ export class OrcaRuntimeService {
         (await this.resolveRuntimeFileTarget(`id:${workspaceId}`)).worktree.path,
       ...(this.codexStructuredWriteAuthority
         ? {
-            codexStructuredWriteAuthority: this.codexStructuredWriteAuthority,
-            resolveCodexStructuredWriteSourceHome: () => getSystemCodexHomePath()
+            codexStructuredWriteAuthority: this.codexStructuredWriteAuthority
           }
         : {}),
       ...(this.codexStructuredWriteEnabled ? { codexStructuredWriteEnabled: true } : {}),
@@ -9716,10 +9715,18 @@ export class OrcaRuntimeService {
 
   async getStructuredAgentSessionCreateSupport(
     worktreeSelector: string,
-    agent: 'codex'
-  ): Promise<{ supported: boolean; reason?: 'agent' | 'remote' | 'wsl' }> {
+    agent: 'codex',
+    effectAuthority?: 'local_structured_write'
+  ): Promise<{ supported: boolean; reason?: 'agent' | 'remote' | 'wsl' | 'effect' }> {
     if (agent !== 'codex') {
       return { supported: false, reason: 'agent' }
+    }
+    if (
+      effectAuthority &&
+      !this.codexStructuredWriteEnabled &&
+      !this.codexStructuredWriteAuthority
+    ) {
+      return { supported: false, reason: 'effect' }
     }
     const location = await this.resolveStructuredAgentSessionLocation(worktreeSelector)
     await this.ensureStructuredAgentSessionHost()
@@ -9762,8 +9769,13 @@ export class OrcaRuntimeService {
     envelope: { sessionId: string; clientOperationId: string }
     worktree: string
     agent: 'codex'
+    effectAuthority?: 'local_structured_write'
   }): Promise<AgentSessionAttachParams> {
-    const support = await this.getStructuredAgentSessionCreateSupport(input.worktree, input.agent)
+    const support = await this.getStructuredAgentSessionCreateSupport(
+      input.worktree,
+      input.agent,
+      input.effectAuthority
+    )
     if (!support.supported) {
       throw new Error('structured_agent_session_unsupported')
     }
@@ -9792,6 +9804,7 @@ export class OrcaRuntimeService {
             : configuredHome?.trim()) ||
           getSystemCodexHomePath()
       },
+      ...(input.effectAuthority ? { effectIsolation: 'local-structured-write' as const } : {}),
       runtimeKind: 'native'
     }
   }

--- a/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
@@ -95,22 +95,20 @@ export const AttachParams = z
   })
   .strict()
 
-export const CreateIntentParams = z
-  .object({
-    envelope: MutationEnvelope,
-    worktree: Identifier('Invalid worktree selector'),
-    agent: z.literal('codex')
-  })
-  .strict()
+export const CreateIntentParams = z.strictObject({
+  envelope: MutationEnvelope,
+  worktree: Identifier('Invalid worktree selector'),
+  agent: z.literal('codex'),
+  effectAuthority: z.enum(AGENT_SESSION_EFFECT_AUTHORITIES).optional()
+})
 
 export const CreateParams = z.union([AttachParams, CreateIntentParams])
 
-export const CreateSupportParams = z
-  .object({
-    worktree: Identifier('Invalid worktree selector'),
-    agent: z.literal('codex')
-  })
-  .strict()
+export const CreateSupportParams = z.strictObject({
+  worktree: Identifier('Invalid worktree selector'),
+  agent: z.literal('codex'),
+  effectAuthority: z.enum(AGENT_SESSION_EFFECT_AUTHORITIES).optional()
+})
 
 /** Clients may only author user turns. Accepting an assistant or tool role here
  *  would let one client write words into the agent's mouth in another's

--- a/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod'
 import { isAgentSessionId } from '../../../../shared/agent-session-record'
 import {
+  AGENT_SESSION_EFFECT_AUTHORITIES,
   AGENT_SESSION_HISTORY_DIRECTIONS,
   AGENT_SESSION_HISTORY_MAX_LIMIT
 } from '../../../../shared/agent-session-wire'
@@ -134,6 +135,7 @@ export const SendParams = z
   .object({
     envelope: MutationEnvelope,
     retryUnknown: z.literal(true).optional(),
+    effectAuthority: z.enum(AGENT_SESSION_EFFECT_AUTHORITIES).optional(),
     body: z
       .object({
         kind: z.literal('message'),

--- a/src/main/runtime/rpc/methods/structured-agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.test.ts
@@ -87,7 +87,7 @@ function hostStub(): StructuredAgentSessionHost {
       }
     })),
     send: vi.fn(async (_caller, params) => {
-      params.beforeRun?.()
+      await params.beforeRun?.()
       return { ok: true, replayed: false }
     }),
     invalidateEffectAuthorityForTrustedUserTurn: vi.fn(async () => undefined),
@@ -258,13 +258,13 @@ describe('capability gating', () => {
     expect(response).toMatchObject({ ok: true })
   })
 
-  it('invalidates writer authority only for a trusted local desktop user turn', async () => {
+  it('defers writer invalidation to the trusted local desktop send execution seam', async () => {
     await call('agentSession.send', sendParams(), DESKTOP_CLIENT)
 
     expect(hostCalls.invalidateEffectAuthorityForTrustedUserTurn).toHaveBeenCalledWith(SESSION)
-    expect(
+    expect(hostCalls.send.mock.invocationCallOrder[0]).toBeLessThan(
       hostCalls.invalidateEffectAuthorityForTrustedUserTurn.mock.invocationCallOrder[0]
-    ).toBeLessThan(hostCalls.send.mock.invocationCallOrder[0])
+    )
 
     await call('agentSession.send', sendParams(), STRUCTURED_CLIENT)
     await call('agentSession.send', sendParams())

--- a/src/main/runtime/rpc/methods/structured-agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.test.ts
@@ -120,6 +120,7 @@ function dispatcher(): RpcDispatcher {
       provider: 'codex',
       agent: 'codex',
       accountHome: { variable: 'CODEX_HOME', path: '/host/.codex' },
+      ...(params.effectAuthority ? { effectIsolation: 'local-structured-write' as const } : {}),
       runtimeKind: 'native'
     })),
     publishStructuredAgentSessionTab: vi.fn()
@@ -163,6 +164,11 @@ async function call(
 
 const STRUCTURED_CLIENT = {
   clientKind: 'mobile' as const,
+  clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
+}
+const DESKTOP_CLIENT = {
+  clientId: 'desktop-renderer',
+  clientKind: 'runtime' as const,
   clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
 }
 
@@ -286,6 +292,70 @@ describe('method routing', () => {
     expect(runtimeCalls.publishStructuredAgentSessionTab).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: SESSION, activate: true })
     )
+  })
+
+  it('binds a local writer request to an effect-isolated session record', async () => {
+    const worktree = 'id:workspace-1'
+    const effectAuthority = 'local_structured_write' as const
+    const params = {
+      envelope: envelope({
+        expectedRuntimeFence: null,
+        payloadFingerprint: computeAgentSessionPayloadFingerprint({
+          method: 'agentSession.create',
+          sessionId: SESSION,
+          fields: { worktree, agent: 'codex', effectAuthority }
+        })
+      }),
+      worktree,
+      agent: 'codex',
+      effectAuthority
+    }
+
+    const created = await call('agentSession.create', params, DESKTOP_CLIENT)
+
+    expect(created).toMatchObject({ ok: true, result: { ok: true } })
+    expect(runtimeCalls.resolveStructuredAgentSessionCreateIntent).toHaveBeenCalledWith(params)
+    expect(hostCalls.attach).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ effectIsolation: 'local-structured-write' })
+    )
+  })
+
+  it('rejects writer creation and support checks from a remote client', async () => {
+    const effectAuthority = 'local_structured_write' as const
+    const worktree = 'id:workspace-1'
+    const support = await call(
+      'agentSession.createSupport',
+      { worktree, agent: 'codex', effectAuthority },
+      STRUCTURED_CLIENT
+    )
+    const create = await call(
+      'agentSession.create',
+      {
+        envelope: envelope({
+          expectedRuntimeFence: null,
+          payloadFingerprint: computeAgentSessionPayloadFingerprint({
+            method: 'agentSession.create',
+            sessionId: SESSION,
+            fields: { worktree, agent: 'codex', effectAuthority }
+          })
+        }),
+        worktree,
+        agent: 'codex',
+        effectAuthority
+      },
+      STRUCTURED_CLIENT
+    )
+
+    expect(support).toMatchObject({
+      ok: false,
+      error: { message: 'local_structured_write_requires_local_desktop_renderer' }
+    })
+    expect(create).toMatchObject({
+      ok: false,
+      error: { message: 'local_structured_write_requires_local_desktop_renderer' }
+    })
+    expect(runtimeCalls.resolveStructuredAgentSessionCreateIntent).not.toHaveBeenCalled()
   })
 
   it('separates create from ensure by the fence the client may declare', async () => {

--- a/src/main/runtime/rpc/methods/structured-agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.test.ts
@@ -90,6 +90,7 @@ function hostStub(): StructuredAgentSessionHost {
       params.beforeRun?.()
       return { ok: true, replayed: false }
     }),
+    invalidateEffectAuthorityForTrustedUserTurn: vi.fn(async () => undefined),
     cancel: vi.fn(async () => ({ ok: true, replayed: false })),
     respondToPrompt: vi.fn(async () => ({ ok: true, replayed: false })),
     setOption: vi.fn(async () => ({ ok: true, replayed: false })),
@@ -255,6 +256,19 @@ describe('capability gating', () => {
   it('serves an in-process caller, which negotiates no capabilities at all', async () => {
     const response = await call('agentSession.send', sendParams())
     expect(response).toMatchObject({ ok: true })
+  })
+
+  it('invalidates writer authority only for a trusted local desktop user turn', async () => {
+    await call('agentSession.send', sendParams(), DESKTOP_CLIENT)
+
+    expect(hostCalls.invalidateEffectAuthorityForTrustedUserTurn).toHaveBeenCalledWith(SESSION)
+    expect(
+      hostCalls.invalidateEffectAuthorityForTrustedUserTurn.mock.invocationCallOrder[0]
+    ).toBeLessThan(hostCalls.send.mock.invocationCallOrder[0])
+
+    await call('agentSession.send', sendParams(), STRUCTURED_CLIENT)
+    await call('agentSession.send', sendParams())
+    expect(hostCalls.invalidateEffectAuthorityForTrustedUserTurn).toHaveBeenCalledOnce()
   })
 
   it('reports the surface as absent when no host is installed', async () => {

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -90,6 +90,14 @@ function assertLocalEffectAuthority(ctx: RpcContext, effectAuthority: unknown): 
   }
 }
 
+function isTrustedLocalUserTurn(ctx: RpcContext): boolean {
+  return (
+    ctx.clientKind === 'runtime' &&
+    ctx.clientId === 'desktop-renderer' &&
+    ctx.connectionId === undefined
+  )
+}
+
 /** Attach is the only way a session comes into being, so it is the only call
  *  that builds the host. Every other method addresses a session that must
  *  already be attached, and correctly reports absent when none is. */
@@ -206,6 +214,9 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
     handler: async (params, ctx) => {
       const host = requireHost(ctx)
       assertLocalEffectAuthority(ctx, params.effectAuthority)
+      if (isTrustedLocalUserTurn(ctx)) {
+        await host.invalidateEffectAuthorityForTrustedUserTurn(params.envelope.sessionId)
+      }
       return host.send(callerFor(ctx), {
         ...params,
         beforeRun: () => assertMobileImageProvenance(ctx, params.body)

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -214,12 +214,15 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
     handler: async (params, ctx) => {
       const host = requireHost(ctx)
       assertLocalEffectAuthority(ctx, params.effectAuthority)
-      if (isTrustedLocalUserTurn(ctx)) {
-        await host.invalidateEffectAuthorityForTrustedUserTurn(params.envelope.sessionId)
-      }
+      const trustedLocalUserTurn = isTrustedLocalUserTurn(ctx)
       return host.send(callerFor(ctx), {
         ...params,
-        beforeRun: () => assertMobileImageProvenance(ctx, params.body)
+        beforeRun: async () => {
+          assertMobileImageProvenance(ctx, params.body)
+          if (trustedLocalUserTurn) {
+            await host.invalidateEffectAuthorityForTrustedUserTurn(params.envelope.sessionId)
+          }
+        }
       })
     }
   }),

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -77,6 +77,19 @@ function assertMobileImageProvenance(
   }
 }
 
+function assertLocalEffectAuthority(ctx: RpcContext, effectAuthority: unknown): void {
+  if (!effectAuthority) {
+    return
+  }
+  if (
+    ctx.clientKind !== 'runtime' ||
+    ctx.clientId !== 'desktop-renderer' ||
+    ctx.connectionId !== undefined
+  ) {
+    throw new Error('local_structured_write_requires_local_desktop_renderer')
+  }
+}
+
 /** Attach is the only way a session comes into being, so it is the only call
  *  that builds the host. Every other method addresses a session that must
  *  already be attached, and correctly reports absent when none is. */
@@ -181,6 +194,7 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
     params: SendParams,
     handler: async (params, ctx) => {
       const host = requireHost(ctx)
+      assertLocalEffectAuthority(ctx, params.effectAuthority)
       return host.send(callerFor(ctx), {
         ...params,
         beforeRun: () => assertMobileImageProvenance(ctx, params.body)

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -125,7 +125,12 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
       if (!supportsStructuredSessions(ctx)) {
         throw new Error('structured_agent_session_unsupported')
       }
-      return ctx.runtime.getStructuredAgentSessionCreateSupport(params.worktree, params.agent)
+      assertLocalEffectAuthority(ctx, params.effectAuthority)
+      return ctx.runtime.getStructuredAgentSessionCreateSupport(
+        params.worktree,
+        params.agent,
+        params.effectAuthority
+      )
     }
   }),
   defineMethod({
@@ -137,10 +142,15 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
         throw new Error('agent_session_operation_invalid')
       }
       if ('worktree' in params) {
+        assertLocalEffectAuthority(ctx, params.effectAuthority)
         const intentFingerprint = computeAgentSessionPayloadFingerprint({
           method: 'agentSession.create',
           sessionId: params.envelope.sessionId,
-          fields: { worktree: params.worktree, agent: params.agent }
+          fields: {
+            worktree: params.worktree,
+            agent: params.agent,
+            effectAuthority: params.effectAuthority
+          }
         })
         const conflict = agentSessionFingerprintConflict(params.envelope, intentFingerprint)
         if (conflict) {
@@ -155,6 +165,7 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
             provider: resolved.provider,
             agent: resolved.agent,
             accountHome: resolved.accountHome,
+            effectIsolation: resolved.effectIsolation,
             runtimeKind: resolved.runtimeKind,
             expectedRuntimeFence: null
           }

--- a/src/main/runtime/structured-agent-session-integration-test-helpers.ts
+++ b/src/main/runtime/structured-agent-session-integration-test-helpers.ts
@@ -1,0 +1,35 @@
+import type { AgentJournalRenderItem } from '../../shared/agent-session-journal-types'
+import type { AgentSessionSubscribeEvent } from '../../shared/agent-session-wire'
+
+/** Every item the subscription has published, latest revision per id. */
+export function itemsOf(frames: AgentSessionSubscribeEvent[]): AgentJournalRenderItem[] {
+  const items = new Map<string, AgentJournalRenderItem>()
+  for (const frame of frames) {
+    const published =
+      frame.type === 'snapshot' || frame.type === 'reset'
+        ? frame.snapshot.items
+        : frame.type === 'batch'
+          ? frame.batch.items
+          : []
+    for (const item of published) {
+      items.set(item.itemId, item)
+    }
+  }
+  return [...items.values()]
+}
+
+export function cursorOf(frames: AgentSessionSubscribeEvent[]): {
+  epoch: string
+  sequence: number
+} {
+  for (let index = frames.length - 1; index >= 0; index -= 1) {
+    const frame = frames[index] as AgentSessionSubscribeEvent
+    if (frame.type === 'batch') {
+      return frame.batch.cursor
+    }
+    if (frame.type === 'snapshot' || frame.type === 'reset') {
+      return frame.snapshot.cursor
+    }
+  }
+  throw new Error('subscription published no cursor')
+}

--- a/src/main/runtime/structured-agent-session-integration.test.ts
+++ b/src/main/runtime/structured-agent-session-integration.test.ts
@@ -54,6 +54,11 @@ const CLIENT = {
   clientKind: 'mobile' as const,
   clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
 }
+const DESKTOP_CLIENT = {
+  clientId: 'desktop-renderer',
+  clientKind: 'runtime' as const,
+  clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
+}
 
 // ─── the fake `codex app-server` ────────────────────────────────────────────
 
@@ -214,11 +219,63 @@ let root: string
 let dispatcher: RpcDispatcher
 let cleanups: Map<string, () => void>
 
+function createDispatcher(): RpcDispatcher {
+  const runtime = {
+    getRuntimeId: () => 'runtime-1',
+    getStructuredAgentSessionCreateSupport: async () => ({ supported: true }),
+    resolveStructuredAgentSessionCreateIntent: async () => {
+      const {
+        envelope: _envelope,
+        providerHandle: _providerHandle,
+        ...resolved
+      } = attachParams(null)
+      return resolved
+    },
+    publishStructuredAgentSessionTab: () => {},
+    ensureStructuredAgentSessionHost: () =>
+      ensureStructuredAgentSessionHost({
+        stateDirectory: root,
+        hostId: 'local',
+        claimKeyId: 'key-1',
+        resolveWorkspacePath: async (workspaceId) => `/repos/${workspaceId}`,
+        resolveCodexCommand: () => '/usr/local/bin/codex',
+        resolveLaunchEnv: async () => ({
+          EXAMPLE_GATEWAY_TOKEN: 'shell-exported',
+          CODEX_HOME: '/shell/home'
+        }),
+        openCodexConnection: codex.openConnection
+      }).then(() => undefined),
+    registerSubscriptionCleanup: vi.fn((id: string, dispose: () => void) =>
+      cleanups.set(id, dispose)
+    ),
+    cleanupSubscription: vi.fn((id: string) => {
+      cleanups.get(id)?.()
+      cleanups.delete(id)
+    }),
+    cleanupSubscriptionsByPrefix: vi.fn((prefix: string) => {
+      for (const [id, dispose] of cleanups) {
+        if (id.startsWith(prefix)) {
+          dispose()
+          cleanups.delete(id)
+        }
+      }
+    })
+  }
+  return new RpcDispatcher({
+    runtime: runtime as unknown as OrcaRuntimeService,
+    methods: STRUCTURED_AGENT_SESSION_METHODS
+  })
+}
+
 /** Runs a one-shot method and returns its decoded reply. */
-async function call(method: string, params: unknown): Promise<RpcResponse> {
+async function call(
+  method: string,
+  params: unknown,
+  client: typeof CLIENT | typeof DESKTOP_CLIENT = CLIENT
+): Promise<RpcResponse> {
   const replies: RpcResponse[] = []
   const request: RpcRequest = { id: `req-${operations}`, authToken: 'token', method, params }
-  await dispatcher.dispatchStreaming(request, (raw) => replies.push(JSON.parse(raw)), CLIENT)
+  await dispatcher.dispatchStreaming(request, (raw) => replies.push(JSON.parse(raw)), client)
   const first = replies[0]
   if (!first) {
     throw new Error(`no reply for ${method}`)
@@ -227,8 +284,12 @@ async function call(method: string, params: unknown): Promise<RpcResponse> {
 }
 
 /** Asserts success and unwraps the host's `{ok:true, value}` mutation result. */
-async function ok<T>(method: string, params: unknown): Promise<T> {
-  const response = await call(method, params)
+async function ok<T>(
+  method: string,
+  params: unknown,
+  client: typeof CLIENT | typeof DESKTOP_CLIENT = CLIENT
+): Promise<T> {
+  const response = await call(method, params, client)
   expect(response, `${method} failed: ${JSON.stringify(response)}`).toMatchObject({ ok: true })
   const result = (response as { result: { ok: boolean; value?: T; refusal?: unknown } }).result
   expect(result, `${method} refused: ${JSON.stringify(result.refusal)}`).toMatchObject({ ok: true })
@@ -290,51 +351,7 @@ beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), 'orca-structured-integration-'))
   codex = fakeCodex()
   cleanups = new Map()
-  const runtime = {
-    getRuntimeId: () => 'runtime-1',
-    getStructuredAgentSessionCreateSupport: async () => ({ supported: true }),
-    resolveStructuredAgentSessionCreateIntent: async () => {
-      const {
-        envelope: _envelope,
-        providerHandle: _providerHandle,
-        ...resolved
-      } = attachParams(null)
-      return resolved
-    },
-    publishStructuredAgentSessionTab: () => {},
-    ensureStructuredAgentSessionHost: () =>
-      ensureStructuredAgentSessionHost({
-        stateDirectory: root,
-        hostId: 'local',
-        claimKeyId: 'key-1',
-        resolveWorkspacePath: async (workspaceId) => `/repos/${workspaceId}`,
-        resolveCodexCommand: () => '/usr/local/bin/codex',
-        resolveLaunchEnv: async () => ({
-          EXAMPLE_GATEWAY_TOKEN: 'shell-exported',
-          CODEX_HOME: '/shell/home'
-        }),
-        openCodexConnection: codex.openConnection
-      }).then(() => undefined),
-    registerSubscriptionCleanup: vi.fn((id: string, dispose: () => void) =>
-      cleanups.set(id, dispose)
-    ),
-    cleanupSubscription: vi.fn((id: string) => {
-      cleanups.get(id)?.()
-      cleanups.delete(id)
-    }),
-    cleanupSubscriptionsByPrefix: vi.fn((prefix: string) => {
-      for (const [id, dispose] of cleanups) {
-        if (id.startsWith(prefix)) {
-          dispose()
-          cleanups.delete(id)
-        }
-      }
-    })
-  }
-  dispatcher = new RpcDispatcher({
-    runtime: runtime as unknown as OrcaRuntimeService,
-    methods: STRUCTURED_AGENT_SESSION_METHODS
-  })
+  dispatcher = createDispatcher()
 })
 
 afterEach(async () => {
@@ -427,6 +444,46 @@ describe('a structured codex session over agentSession.*', () => {
     await drainStreamedEvents()
 
     expect(itemsOf(stream).map(textOf).filter(Boolean)).toEqual(['hi', 'Hello.'])
+  })
+
+  it('rejects explicit write authority when the host feature is disabled', async () => {
+    const created = await ok<{ fence: number }>(
+      'agentSession.create',
+      createIntentParams(),
+      DESKTOP_CLIENT
+    )
+    const body = {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'change one file' }]
+    }
+    const effectAuthority = 'local_structured_write'
+    const sent = await ok<{ submission: { dispatchState: string; reason: string | null } }>(
+      'agentSession.send',
+      {
+        envelope: envelope('agentSession.send', { body, effectAuthority }, created.fence),
+        body,
+        effectAuthority
+      },
+      DESKTOP_CLIENT
+    )
+    expect(sent.submission).toMatchObject({
+      dispatchState: 'rejected',
+      reason: 'local structured write is not enabled on this execution host'
+    })
+    const remote = await call(
+      'agentSession.send',
+      {
+        envelope: envelope('agentSession.send', { body, effectAuthority }, created.fence),
+        body,
+        effectAuthority
+      },
+      CLIENT
+    )
+    expect(remote).toMatchObject({
+      ok: false,
+      error: { message: 'local_structured_write_requires_local_desktop_renderer' }
+    })
   })
 
   it('runs create → send → stream → approval → cancel → reconnect → page history', async () => {

--- a/src/main/runtime/structured-agent-session-integration.test.ts
+++ b/src/main/runtime/structured-agent-session-integration.test.ts
@@ -44,6 +44,7 @@ import {
   ensureStructuredAgentSessionHost,
   stopStructuredAgentSessionRuntime
 } from './structured-agent-session-runtime'
+import { cursorOf, itemsOf } from './structured-agent-session-integration-test-helpers'
 
 const SESSION = 'session-integration-1'
 const THREAD = 'thread-integration'
@@ -469,7 +470,7 @@ describe('a structured codex session over agentSession.*', () => {
     )
     expect(sent.submission).toMatchObject({
       dispatchState: 'rejected',
-      reason: 'local structured write is not enabled on this execution host'
+      reason: 'local structured write requires a dedicated writer session'
     })
     const remote = await call(
       'agentSession.send',
@@ -896,33 +897,3 @@ describe('a structured codex session over agentSession.*', () => {
     ).toBe(false)
   })
 })
-
-/** Every item the subscription has published, latest revision per id. */
-function itemsOf(frames: AgentSessionSubscribeEvent[]): AgentJournalRenderItem[] {
-  const items = new Map<string, AgentJournalRenderItem>()
-  for (const frame of frames) {
-    const published =
-      frame.type === 'snapshot' || frame.type === 'reset'
-        ? frame.snapshot.items
-        : frame.type === 'batch'
-          ? frame.batch.items
-          : []
-    for (const item of published) {
-      items.set(item.itemId, item)
-    }
-  }
-  return [...items.values()]
-}
-
-function cursorOf(frames: AgentSessionSubscribeEvent[]): { epoch: string; sequence: number } {
-  for (let index = frames.length - 1; index >= 0; index -= 1) {
-    const frame = frames[index] as AgentSessionSubscribeEvent
-    if (frame.type === 'batch') {
-      return frame.batch.cursor
-    }
-    if (frame.type === 'snapshot' || frame.type === 'reset') {
-      return frame.snapshot.cursor
-    }
-  }
-  throw new Error('subscription published no cursor')
-}

--- a/src/main/runtime/structured-agent-session-runtime.ts
+++ b/src/main/runtime/structured-agent-session-runtime.ts
@@ -11,6 +11,9 @@ import { join } from 'node:path'
 import type { AgentSessionOwnerProbe } from '../../shared/agent-session-lease-adjudication'
 import type { AgentSessionRecord } from '../../shared/agent-session-record'
 import { createCodexStructuredLaunchResolver } from '../codex/codex-structured-launch-resolution'
+import { CodexStructuredHomeIsolation } from '../codex/codex-structured-home-isolation'
+import type { CodexStructuredWriteAuthority } from '../codex/codex-structured-write-authority'
+import { createCodexStructuredWriteAuthority } from '../codex/codex-structured-write-runtime'
 import {
   CodexStructuredSessionAdapter,
   type CodexStructuredSessionAdapterDeps
@@ -41,6 +44,12 @@ export type StructuredAgentSessionRuntimeDeps = {
    *  against a scripted app-server; production spawns the real one. */
   openCodexConnection?: CodexStructuredSessionAdapterDeps['openConnection']
   resolveLaunchEnv?: () => Promise<NodeJS.ProcessEnv>
+  /** Host-owned, opt-in admission for one local structured writer. */
+  codexStructuredWriteAuthority?: CodexStructuredWriteAuthority
+  /** Canary switch. Authority is still minted only for an explicit `/edit` send. */
+  codexStructuredWriteEnabled?: boolean
+  /** Host registry lookup; never accept a client-provided credential path here. */
+  resolveCodexStructuredWriteSourceHome?: (sessionId: string) => Promise<string> | string
   onError?: (input: { scope: string; error: unknown }) => void
   handoffTransport?: StructuredAgentSessionHandoffTransport
 }
@@ -48,6 +57,8 @@ export type StructuredAgentSessionRuntimeDeps = {
 type InstalledRuntime = {
   host: StructuredAgentSessionHost
   adapter: CodexStructuredSessionAdapter
+  homeIsolation: CodexStructuredHomeIsolation | null
+  writeAuthority: CodexStructuredWriteAuthority | undefined
 }
 
 let installing: Promise<InstalledRuntime> | null = null
@@ -80,7 +91,15 @@ export async function stopStructuredAgentSessionRuntime(): Promise<void> {
   try {
     await installed.adapter.closeAll()
   } finally {
-    await installed.host.flushAllStreamedEvents()
+    try {
+      await installed.host.flushAllStreamedEvents()
+    } finally {
+      try {
+        await installed.writeAuthority?.flushReceipts()
+      } finally {
+        await installed.homeIsolation?.close()
+      }
+    }
   }
 }
 
@@ -90,14 +109,56 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
     hostId: deps.hostId
   })
   agentSessionPtyWriteGate.attachRecordLookup((sessionId) => store.getRecord(sessionId))
+  const writeAuthority =
+    deps.codexStructuredWriteAuthority ??
+    (deps.codexStructuredWriteEnabled
+      ? await createCodexStructuredWriteAuthority({
+          stateDirectory: deps.stateDirectory,
+          onTraceError: (error) => deps.onError?.({ scope: 'codex-structured-write-trace', error })
+        })
+      : undefined)
+  let homeIsolation: CodexStructuredHomeIsolation | null = null
   try {
+    if (writeAuthority) {
+      if (!deps.resolveCodexStructuredWriteSourceHome) {
+        throw new Error('structured writer has no host-owned credential source provider')
+      }
+      homeIsolation = await CodexStructuredHomeIsolation.open(
+        join(deps.stateDirectory, 'codex-structured-homes')
+      )
+    }
+    const structuredHomeIsolation = homeIsolation
     const adapter = new CodexStructuredSessionAdapter({
       resolveLaunch: createCodexStructuredLaunchResolver({
         store,
         resolveWorkspacePath: deps.resolveWorkspacePath,
+        localStructuredWriteOnly: writeAuthority !== undefined,
+        ...(deps.resolveCodexStructuredWriteSourceHome
+          ? { resolveStructuredWriteSourceHome: deps.resolveCodexStructuredWriteSourceHome }
+          : {}),
+        ...(structuredHomeIsolation
+          ? {
+              prepareStructuredWriteHome: (sessionId, sourceHome) =>
+                structuredHomeIsolation.prepare(sessionId, sourceHome)
+            }
+          : {}),
         ...(deps.resolveCodexCommand ? { resolveCommand: deps.resolveCodexCommand } : {})
       }),
-      ...(deps.openCodexConnection ? { openConnection: deps.openCodexConnection } : {})
+      ...(deps.openCodexConnection ? { openConnection: deps.openCodexConnection } : {}),
+      ...(writeAuthority
+        ? {
+            writeAuthority,
+            releaseStructuredWriteHome: (sessionId: string, isolatedHomePath: string) =>
+              structuredHomeIsolation!.release(sessionId, isolatedHomePath),
+            onStructuredWriteHomeError: ({
+              sessionId,
+              error
+            }: {
+              sessionId: string
+              error: unknown
+            }) => deps.onError?.({ scope: `codex-structured-home:${sessionId}`, error })
+          }
+        : {})
     })
     const host = new StructuredAgentSessionHost({
       store,
@@ -112,9 +173,15 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
       ...(deps.handoffTransport ? { handoffTransport: deps.handoffTransport } : {})
     })
     setStructuredAgentSessionHost(host)
-    return { host, adapter }
+    return {
+      host,
+      adapter,
+      homeIsolation: structuredHomeIsolation,
+      writeAuthority
+    }
   } catch (error) {
     agentSessionPtyWriteGate.detachRecordLookup()
+    await homeIsolation?.close()
     throw error
   }
 }

--- a/src/main/runtime/structured-agent-session-runtime.ts
+++ b/src/main/runtime/structured-agent-session-runtime.ts
@@ -120,9 +120,6 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
   let homeIsolation: CodexStructuredHomeIsolation | null = null
   try {
     if (writeAuthority) {
-      if (!deps.resolveCodexStructuredWriteSourceHome) {
-        throw new Error('structured writer has no host-owned credential source provider')
-      }
       homeIsolation = await CodexStructuredHomeIsolation.open(
         join(deps.stateDirectory, 'codex-structured-homes')
       )
@@ -132,10 +129,16 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
       resolveLaunch: createCodexStructuredLaunchResolver({
         store,
         resolveWorkspacePath: deps.resolveWorkspacePath,
-        localStructuredWriteOnly: writeAuthority !== undefined,
-        ...(deps.resolveCodexStructuredWriteSourceHome
-          ? { resolveStructuredWriteSourceHome: deps.resolveCodexStructuredWriteSourceHome }
-          : {}),
+        structuredWriteEnabled: writeAuthority !== undefined,
+        resolveStructuredWriteSourceHome:
+          deps.resolveCodexStructuredWriteSourceHome ??
+          ((sessionId) => {
+            const record = store.getRecord(sessionId)
+            if (!record || record.effectIsolation !== 'local-structured-write') {
+              throw new Error('structured writer has no host-pinned credential source')
+            }
+            return record.accountHome.path
+          }),
         ...(structuredHomeIsolation
           ? {
               prepareStructuredWriteHome: (sessionId, sourceHome) =>

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -130,7 +130,13 @@ export function ProviderFrameRow({ block }: { block: NativeChatBlock }): React.J
         <span className="transition-transform group-open:rotate-90">›</span>
         <span className="font-medium text-foreground">{frame.provider}</span>
         <span className="truncate">{frame.kind}</span>
-        {frame.payload.truncated ? <span>· {frame.payload.byteLength} bytes</span> : null}
+        {frame.payload.truncated ? (
+          <span>
+            {translate('components.native-chat.providerFrameBytes', '· {{value0}} bytes', {
+              value0: frame.payload.byteLength
+            })}
+          </span>
+        ) : null}
       </summary>
       <pre className="scrollbar-sleek mt-1 max-h-64 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-muted p-2 font-mono text-xs text-foreground">
         {frame.payload.head}

--- a/src/renderer/src/components/native-chat/native-chat-composer-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-types.ts
@@ -1,5 +1,6 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import type { StructuredAgentSessionCommandOutcome } from '../../../../shared/structured-agent-session-composer'
+import type { AgentSessionEffectAuthority } from '../../../../shared/agent-session-wire'
 import type {
   SessionOptionDescriptor,
   SessionOptionsSurface
@@ -7,7 +8,7 @@ import type {
 import type { NativeChatLaunchDraft } from '@/lib/native-chat-launch-prompt'
 
 export type NativeChatStructuredComposerTransport = {
-  send: (text: string) => boolean
+  send: (text: string, options?: { effectAuthority?: AgentSessionEffectAuthority }) => boolean
   dispatchCommand: (text: string) => Promise<StructuredAgentSessionCommandOutcome>
   optionsSurface: SessionOptionsSurface
   optionSnapshot: SessionOptionDescriptor[]

--- a/src/renderer/src/components/native-chat/native-chat-structured-composer-dispatch.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-structured-composer-dispatch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { dispatchNativeChatStructuredComposerText } from './native-chat-structured-composer-dispatch'
+import type { NativeChatStructuredComposerTransport } from './native-chat-composer-types'
+
+function transport(): NativeChatStructuredComposerTransport {
+  return {
+    send: vi.fn(() => true),
+    dispatchCommand: vi.fn(async () => ({ handled: false, accepted: false, error: null })),
+    optionsSurface: {
+      getSnapshot: () => [],
+      setOption: async () => ({ ok: false, error: 'unavailable', snapshot: [] }),
+      invokeAction: async () => ({ ok: false, error: 'unavailable', snapshot: [] }),
+      subscribe: () => () => {}
+    },
+    optionSnapshot: [],
+    onError: vi.fn(),
+    runtime: 'local'
+  }
+}
+
+describe('dispatchNativeChatStructuredComposerText', () => {
+  it('binds /edit to exactly one structured-write send', async () => {
+    const target = transport()
+    await expect(
+      dispatchNativeChatStructuredComposerText(target, '/edit update src/a.ts')
+    ).resolves.toEqual({ accepted: true, error: null })
+    expect(target.send).toHaveBeenCalledWith('update src/a.ts', {
+      effectAuthority: 'local_structured_write'
+    })
+    expect(target.dispatchCommand).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty edit request without sending', async () => {
+    const target = transport()
+    await expect(dispatchNativeChatStructuredComposerText(target, '/edit')).resolves.toEqual({
+      accepted: false,
+      error: '/edit requires a source-change request.'
+    })
+    expect(target.send).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-structured-composer-dispatch.ts
+++ b/src/renderer/src/components/native-chat/native-chat-structured-composer-dispatch.ts
@@ -1,5 +1,6 @@
 import type { NativeChatStructuredComposerTransport } from './native-chat-composer-types'
 import { parseStructuredAgentSessionEditRequest } from '../../../../shared/structured-agent-session-composer'
+import { translate } from '@/i18n/i18n'
 
 export async function dispatchNativeChatStructuredComposerText(
   transport: NativeChatStructuredComposerTransport,
@@ -13,7 +14,13 @@ export async function dispatchNativeChatStructuredComposerText(
     }
   }
   if (/^\/edit(?:\s|$)/i.test(text)) {
-    return { accepted: false, error: '/edit requires a source-change request.' }
+    return {
+      accepted: false,
+      error: translate(
+        'components.native-chat.composer.editSourceChangeRequired',
+        '/edit requires a source-change request.'
+      )
+    }
   }
   const command = await transport.dispatchCommand(text)
   if (command.handled) {

--- a/src/renderer/src/components/native-chat/native-chat-structured-composer-dispatch.ts
+++ b/src/renderer/src/components/native-chat/native-chat-structured-composer-dispatch.ts
@@ -1,9 +1,20 @@
 import type { NativeChatStructuredComposerTransport } from './native-chat-composer-types'
+import { parseStructuredAgentSessionEditRequest } from '../../../../shared/structured-agent-session-composer'
 
 export async function dispatchNativeChatStructuredComposerText(
   transport: NativeChatStructuredComposerTransport,
   text: string
 ): Promise<{ accepted: boolean; error: string | null }> {
+  const editRequest = parseStructuredAgentSessionEditRequest(text)
+  if (editRequest) {
+    return {
+      accepted: transport.send(editRequest, { effectAuthority: 'local_structured_write' }),
+      error: null
+    }
+  }
+  if (/^\/edit(?:\s|$)/i.test(text)) {
+    return { accepted: false, error: '/edit requires a source-change request.' }
+  }
   const command = await transport.dispatchCommand(text)
   if (command.handled) {
     return { accepted: command.accepted, error: command.error }

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-create.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-create.ts
@@ -23,8 +23,9 @@ const LOCAL_OWNER = 'local-structured-session'
 
 export function useStructuredAgentSessionCreate(worktreeId: string): {
   supported: boolean
+  writerSupported: boolean
   creating: boolean
-  create: () => Promise<boolean>
+  create: (effectAuthority?: 'local_structured_write') => Promise<boolean>
 } {
   const environmentId = useAppStore((state) =>
     getRuntimeEnvironmentIdForWorktree(state, worktreeId)
@@ -34,11 +35,13 @@ export function useStructuredAgentSessionCreate(worktreeId: string): {
     [environmentId]
   )
   const [supported, setSupported] = useState(false)
+  const [writerSupported, setWriterSupported] = useState(false)
   const [creating, setCreating] = useState(false)
 
   useEffect(() => {
     let stale = false
     setSupported(false)
+    setWriterSupported(false)
     void (async () => {
       const hostCapability =
         target.kind === 'local'
@@ -52,16 +55,35 @@ export function useStructuredAgentSessionCreate(worktreeId: string): {
       if (!hostCapability) {
         return
       }
-      const support = await callStructuredAgentSession<{ supported?: boolean }>(
-        target,
-        'agentSession.createSupport',
-        { worktree: toRuntimeWorktreeSelector(worktreeId), agent: 'codex' }
-      )
+      const [support, writerSupport] = await Promise.all([
+        callStructuredAgentSession<{ supported?: boolean }>(target, 'agentSession.createSupport', {
+          worktree: toRuntimeWorktreeSelector(worktreeId),
+          agent: 'codex'
+        }),
+        target.kind === 'local'
+          ? callStructuredAgentSession<{ supported?: boolean }>(
+              target,
+              'agentSession.createSupport',
+              {
+                worktree: toRuntimeWorktreeSelector(worktreeId),
+                agent: 'codex',
+                effectAuthority: 'local_structured_write'
+              }
+            ).catch(() => ({ supported: false }))
+          : Promise.resolve({ supported: false })
+      ])
       if (!stale) {
         setSupported(
           showStructuredAgentSessionChoice({
             hostCapability,
             workspaceSupport: support.supported === true,
+            agent: 'codex'
+          })
+        )
+        setWriterSupported(
+          showStructuredAgentSessionChoice({
+            hostCapability,
+            workspaceSupport: writerSupport.supported === true,
             agent: 'codex'
           })
         )
@@ -72,39 +94,47 @@ export function useStructuredAgentSessionCreate(worktreeId: string): {
     }
   }, [target, worktreeId])
 
-  const create = useCallback(async (): Promise<boolean> => {
-    if (!supported || creating) {
-      return false
-    }
-    setCreating(true)
-    const sessionId = `desktop_${Date.now().toString(36)}${crypto.randomUUID().slice(0, 8)}`
-    const worktree = toRuntimeWorktreeSelector(worktreeId)
-    try {
-      recordWebSessionFocusIntent(
-        { environmentId: target.kind === 'environment' ? target.environmentId : LOCAL_OWNER },
-        worktreeId,
-        `agent-session:${sessionId}`
-      )
-      const result = await callStructuredAgentSession<
-        AgentSessionMutationResult<AgentSessionAttachResult>
-      >(target, 'agentSession.create', {
-        envelope: {
-          sessionId,
-          clientOperationId: createStructuredAgentSessionOperationId(() => crypto.randomUUID()),
-          expectedRuntimeFence: null,
-          payloadFingerprint: structuredAgentSessionCreateFingerprint({ sessionId, worktree })
-        },
-        worktree,
-        agent: 'codex'
-      })
-      if (!result.ok) {
-        throw new Error(result.refusal.message)
+  const create = useCallback(
+    async (effectAuthority?: 'local_structured_write'): Promise<boolean> => {
+      if ((!effectAuthority && !supported) || (effectAuthority && !writerSupported) || creating) {
+        return false
       }
-      return true
-    } finally {
-      setCreating(false)
-    }
-  }, [creating, supported, target, worktreeId])
+      setCreating(true)
+      const sessionId = `desktop_${Date.now().toString(36)}${crypto.randomUUID().slice(0, 8)}`
+      const worktree = toRuntimeWorktreeSelector(worktreeId)
+      try {
+        recordWebSessionFocusIntent(
+          { environmentId: target.kind === 'environment' ? target.environmentId : LOCAL_OWNER },
+          worktreeId,
+          `agent-session:${sessionId}`
+        )
+        const result = await callStructuredAgentSession<
+          AgentSessionMutationResult<AgentSessionAttachResult>
+        >(target, 'agentSession.create', {
+          envelope: {
+            sessionId,
+            clientOperationId: createStructuredAgentSessionOperationId(() => crypto.randomUUID()),
+            expectedRuntimeFence: null,
+            payloadFingerprint: structuredAgentSessionCreateFingerprint({
+              sessionId,
+              worktree,
+              effectAuthority
+            })
+          },
+          worktree,
+          agent: 'codex',
+          ...(effectAuthority ? { effectAuthority } : {})
+        })
+        if (!result.ok) {
+          throw new Error(result.refusal.message)
+        }
+        return true
+      } finally {
+        setCreating(false)
+      }
+    },
+    [creating, supported, target, worktreeId, writerSupported]
+  )
 
-  return { supported, creating, create }
+  return { supported, writerSupported, creating, create }
 }

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/runtime/structured-agent-session-client', () => ({
 }))
 
 import { useStructuredAgentSessionOutbox } from './use-structured-agent-session-outbox'
+import { structuredAgentSessionPayloadFingerprint } from '../../../../shared/structured-agent-session-mutation'
 
 const LOCAL_TARGET = { kind: 'local' } as const
 
@@ -59,6 +60,39 @@ describe('useStructuredAgentSessionOutbox', () => {
     )
   })
 
+  it('persists one edit authority and binds it into the durable fingerprint', async () => {
+    mocks.call.mockResolvedValue(acceptedResult(1))
+    const { result } = renderHook(() =>
+      useStructuredAgentSessionOutbox({
+        sessionId: 'session-1',
+        target: LOCAL_TARGET,
+        fence: 1,
+        submissions: []
+      })
+    )
+    act(() =>
+      expect(
+        result.current.send('change one file', {
+          effectAuthority: 'local_structured_write'
+        })
+      ).toBe(true)
+    )
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(1))
+    const request = mocks.call.mock.calls[0]?.[2] as {
+      body: unknown
+      effectAuthority: 'local_structured_write'
+      envelope: { sessionId: string; payloadFingerprint: string }
+    }
+    expect(request.effectAuthority).toBe('local_structured_write')
+    expect(request.envelope.payloadFingerprint).toBe(
+      structuredAgentSessionPayloadFingerprint({
+        method: 'agentSession.send',
+        sessionId: request.envelope.sessionId,
+        fields: { body: request.body, effectAuthority: request.effectAuthority }
+      })
+    )
+  })
+
   it('requeues across a fence change and ignores the stale settlement', async () => {
     const first = deferred<ReturnType<typeof acceptedResult>>()
     const second = deferred<ReturnType<typeof acceptedResult>>()
@@ -91,7 +125,7 @@ describe('useStructuredAgentSessionOutbox', () => {
   })
 
   it.each(['agent_session_operation_conflict', 'agent_session_operation_expired'] as const)(
-    'rotates a send operation after %s',
+    'rotates a send operation after %s without dropping edit authority',
     async (code) => {
       vi.mocked(globalThis.crypto.randomUUID)
         .mockReturnValueOnce('11111111-1111-4111-8111-111111111111')
@@ -106,23 +140,30 @@ describe('useStructuredAgentSessionOutbox', () => {
         })
       )
 
-      act(() => expect(result.current.send('hello')).toBe(true))
+      act(() =>
+        expect(
+          result.current.send('change one file', {
+            effectAuthority: 'local_structured_write'
+          })
+        ).toBe(true)
+      )
       await waitFor(() => expect(result.current.outbox[0]?.state).toBe('queued'))
       const firstId = (mocks.call.mock.calls[0]![2] as { envelope: { clientOperationId: string } })
         .envelope.clientOperationId
-      const retryId = result.current.outbox[0]!.clientMessageId
-      expect(retryId).not.toBe(firstId)
+      const retry = result.current.outbox[0]!
+      expect(retry.clientMessageId).not.toBe(firstId)
+      expect(retry.effectAuthority).toBe('local_structured_write')
 
-      act(() => result.current.retry(retryId))
+      act(() => result.current.retry(retry.clientMessageId))
       await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
-      expect(
-        (mocks.call.mock.calls[1]![2] as { envelope: { clientOperationId: string } }).envelope
-          .clientOperationId
-      ).toBe(retryId)
+      expect(mocks.call.mock.calls[1]![2]).toMatchObject({
+        effectAuthority: 'local_structured_write',
+        envelope: { clientOperationId: retry.clientMessageId }
+      })
     }
   )
 
-  it('retains a send operation after a pending-admission refusal', async () => {
+  it('retains an operation after a pending-admission refusal', async () => {
     mocks.call
       .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))
       .mockResolvedValueOnce(acceptedResult(1))
@@ -143,9 +184,8 @@ describe('useStructuredAgentSessionOutbox', () => {
 
     act(() => result.current.retry(firstId))
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
-    expect(
-      (mocks.call.mock.calls[1]![2] as { envelope: { clientOperationId: string } }).envelope
-        .clientOperationId
-    ).toBe(firstId)
+    expect(mocks.call.mock.calls[1]![2]).toMatchObject({
+      envelope: { clientOperationId: firstId }
+    })
   })
 })

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { AgentJournalSubmission } from '../../../../shared/agent-session-journal-types'
 import type {
+  AgentSessionEffectAuthority,
   AgentSessionMutationResult,
   AgentSessionSendResult
 } from '../../../../shared/agent-session-wire'
@@ -220,7 +221,7 @@ export function useStructuredAgentSessionOutbox(args: {
   }, [fence, outbox, sessionId, target])
 
   const send = useCallback(
-    (text: string): boolean => {
+    (text: string, options?: { effectAuthority?: AgentSessionEffectAuthority }): boolean => {
       if (!text.trim()) {
         return false
       }
@@ -229,7 +230,8 @@ export function useStructuredAgentSessionOutbox(args: {
         sessionId,
         text,
         attachments: [],
-        queuedAt: Date.now()
+        queuedAt: Date.now(),
+        ...(options?.effectAuthority ? { effectAuthority: options.effectAuthority } : {})
       })
       const next = [...outboxRef.current, entry]
       if (!writeOutbox(sessionId, next)) {

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
@@ -94,6 +94,15 @@ vi.mock('@/lib/launch-agent-in-new-tab', () => ({
   launchAgentInNewTab: vi.fn()
 }))
 
+vi.mock('../native-chat/use-structured-agent-session-create', () => ({
+  useStructuredAgentSessionCreate: () => ({
+    supported: true,
+    writerSupported: true,
+    creating: false,
+    create: vi.fn()
+  })
+}))
+
 function renderAgentMenuItems(): string {
   return renderToStaticMarkup(
     React.createElement(QuickLaunchAgentMenuItems, {
@@ -128,6 +137,13 @@ beforeEach(() => {
 })
 
 describe('QuickLaunchAgentMenuItems', () => {
+  it('offers normal chat and the explicitly isolated writer as separate choices', () => {
+    const html = renderAgentMenuItems()
+
+    expect(html).toContain('Chat session')
+    expect(html).toContain('Writer session')
+  })
+
   it('renders the new-agent shortcut next to the configured default agent only', () => {
     shortcutLabelMock.mockReturnValue('⌘⌥T')
 

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { MessageSquare, Settings as SettingsIcon } from 'lucide-react'
+import { MessageSquare, SquarePen, Settings as SettingsIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { DropdownMenuItem, DropdownMenuShortcut } from '@/components/ui/dropdown-menu'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
@@ -243,6 +243,35 @@ function QuickLaunchAgentMenuItemsInner({
                   {translate(
                     'auto.components.tab.bar.QuickLaunchButton.0ea6a78efb',
                     'Chat session'
+                  )}
+                </span>
+              </DropdownMenuItem>
+            ) : null}
+            {agent === 'codex' && structuredSession.writerSupported ? (
+              <DropdownMenuItem
+                disabled={structuredSession.creating}
+                onSelect={() => {
+                  void structuredSession.create('local_structured_write').catch((error) => {
+                    toast.error(
+                      translate(
+                        'auto.components.tab.bar.QuickLaunchButton.writerCreateFailed',
+                        'Could not create writer session'
+                      ),
+                      { description: error instanceof Error ? error.message : String(error) }
+                    )
+                  })
+                }}
+                className="gap-2 rounded-[7px] px-2 py-1.5 pl-6 text-[12px] leading-5 font-medium"
+                title={translate(
+                  'auto.components.tab.bar.QuickLaunchButton.writerTitle',
+                  'Start an isolated Codex writer for this worktree'
+                )}
+              >
+                <SquarePen className="size-3.5 text-muted-foreground" />
+                <span className="flex-1">
+                  {translate(
+                    'auto.components.tab.bar.QuickLaunchButton.writerLabel',
+                    'Writer session'
                   )}
                 </span>
               </DropdownMenuItem>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3067,7 +3067,10 @@
             "8dea9b5cdf": "No enabled agents",
             "f378201fbd": "Could not create chat session",
             "a847779775": "Start Codex without a terminal",
-            "0ea6a78efb": "Chat session"
+            "0ea6a78efb": "Chat session",
+            "writerCreateFailed": "Could not create writer session",
+            "writerTitle": "Start an isolated Codex writer for this worktree",
+            "writerLabel": "Writer session"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "Switch Tab",
@@ -15081,6 +15084,7 @@
         "localAttachmentUnsupported": "Local attachments are not available for remote sessions.",
         "removeAttachment": "Remove attachment",
         "pastedImageLabel": "Pasted image",
+        "editSourceChangeRequired": "/edit requires a source-change request.",
         "imagePasteFailed": "Image paste failed.",
         "worktreeNotReady": "Worktree not ready — try again in a moment.",
         "uploadingAttachments": "Uploading {{value0}} file(s) to remote…",
@@ -15119,6 +15123,7 @@
       "status": {
         "responding": "Agent is responding"
       },
+      "providerFrameBytes": "· {{value0}} bytes",
       "handoff": {
         "mode": {
           "switching": "Switching",

--- a/src/shared/agent-session-record.ts
+++ b/src/shared/agent-session-record.ts
@@ -14,6 +14,8 @@ import {
 } from './agent-session-provider-handle'
 
 export const AGENT_SESSION_RECORD_SCHEMA_VERSION = 1 as const
+/** Writer records use a version older hosts reject instead of resuming without effect isolation. */
+export const AGENT_SESSION_EFFECT_ISOLATED_RECORD_SCHEMA_VERSION = 2 as const
 
 export type AgentSessionWorkspaceKind = 'git-worktree' | 'folder'
 
@@ -41,6 +43,9 @@ export type AgentSessionAccountHome = {
 export type AgentSessionLaunchEnv = Record<string, string>
 
 export type AgentSessionOwnerRuntimeKind = 'native' | 'tui'
+
+/** Process-level effect isolation pinned when the host creates the session. */
+export type AgentSessionEffectIsolation = 'local-structured-write'
 
 export type AgentSessionHandoffStage =
   | 'preparing'
@@ -103,12 +108,16 @@ export type AgentSessionLease = {
 }
 
 export type AgentSessionRecord = {
-  schemaVersion: typeof AGENT_SESSION_RECORD_SCHEMA_VERSION
+  schemaVersion:
+    | typeof AGENT_SESSION_RECORD_SCHEMA_VERSION
+    | typeof AGENT_SESSION_EFFECT_ISOLATED_RECORD_SCHEMA_VERSION
   sessionId: string
   location: AgentSessionExecutionLocation
   provider: AgentSessionHandleProvider
   providerHandleChain: AgentSessionProviderHandleLink[]
   accountHome: AgentSessionAccountHome
+  /** Optional for records created before effect-scoped sessions existed. */
+  effectIsolation?: AgentSessionEffectIsolation
   /** Provider options acknowledged for the next turn, restored across owner replacement. */
   options?: Record<string, string>
   launchEnv?: AgentSessionLaunchEnv
@@ -307,13 +316,20 @@ export function isAgentSessionRecord(value: unknown): value is AgentSessionRecor
     return false
   }
   const record = value as Partial<AgentSessionRecord>
+  const schemaValid =
+    (record.schemaVersion === AGENT_SESSION_RECORD_SCHEMA_VERSION &&
+      record.effectIsolation === undefined) ||
+    (record.schemaVersion === AGENT_SESSION_EFFECT_ISOLATED_RECORD_SCHEMA_VERSION &&
+      record.effectIsolation === 'local-structured-write')
   const shapeValid =
-    record.schemaVersion === AGENT_SESSION_RECORD_SCHEMA_VERSION &&
+    schemaValid &&
     isAgentSessionId(record.sessionId) &&
     isAgentSessionExecutionLocation(record.location) &&
     (record.provider === 'claude' || record.provider === 'codex') &&
     isAgentSessionProviderHandleChain(record.providerHandleChain) &&
     isAgentSessionAccountHome(record.accountHome) &&
+    (record.effectIsolation === undefined ||
+      (record.effectIsolation === 'local-structured-write' && record.provider === 'codex')) &&
     (record.options === undefined || isAgentSessionOptions(record.options)) &&
     (record.launchEnv === undefined || isAgentSessionLaunchEnv(record.launchEnv)) &&
     isAgentSessionLease(record.lease) &&
@@ -327,6 +343,7 @@ export function isAgentSessionRecord(value: unknown): value is AgentSessionRecor
   const head = validated.providerHandleChain.at(-1)
   return (
     validated.providerHandleChain.every((link) => link.handle.provider === validated.provider) &&
+    (validated.effectIsolation === undefined || validated.lease.runtimeKind === 'native') &&
     (validated.lease.claimStatus !== 'live' ||
       (validated.lease.ownerProcess !== null &&
         head?.linkId === validated.lease.provenHandleLinkId &&

--- a/src/shared/agent-session-wire.ts
+++ b/src/shared/agent-session-wire.ts
@@ -18,6 +18,12 @@ export type AgentSessionHandoffDirection = 'to-tui' | 'to-native'
 export type AgentSessionHandoffMode = 'now' | 'after-turn' | 'stop-turn'
 export type AgentSessionHandoffAction = 'start' | 'cancel-queued' | 'retry' | 'recover'
 
+/** Optional user-granted effect class for one durable send. Older peers omit
+ * it; hosts that do not understand it reject the strict request instead of
+ * silently widening authority. */
+export const AGENT_SESSION_EFFECT_AUTHORITIES = ['local_structured_write'] as const
+export type AgentSessionEffectAuthority = (typeof AGENT_SESSION_EFFECT_AUTHORITIES)[number]
+
 export type AgentSessionHandoffStatus = {
   owner: AgentSessionOwnerRuntimeKind | 'none'
   direction: AgentSessionHandoffDirection | null

--- a/src/shared/structured-agent-session-composer.test.ts
+++ b/src/shared/structured-agent-session-composer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { parseStructuredAgentSessionEditRequest } from './structured-agent-session-composer'
+
+describe('parseStructuredAgentSessionEditRequest', () => {
+  it('extracts one explicit edit request without forwarding the authority command', () => {
+    expect(parseStructuredAgentSessionEditRequest('/edit change src/a.ts only')).toBe(
+      'change src/a.ts only'
+    )
+  })
+
+  it('does not infer mutation authority from ordinary or empty text', () => {
+    expect(parseStructuredAgentSessionEditRequest('change src/a.ts only')).toBeNull()
+    expect(parseStructuredAgentSessionEditRequest('/edit')).toBeNull()
+    expect(parseStructuredAgentSessionEditRequest('/edit   ')).toBeNull()
+  })
+})

--- a/src/shared/structured-agent-session-composer.ts
+++ b/src/shared/structured-agent-session-composer.ts
@@ -8,11 +8,24 @@ const EFFORT_COMMAND: SlashCommandSuggestion = {
   description: 'Choose reasoning effort'
 }
 
+const EDIT_COMMAND: SlashCommandSuggestion = {
+  name: 'edit',
+  description: 'Allow one bounded local source edit'
+}
+
 export const STRUCTURED_AGENT_SESSION_SLASH_COMMANDS: readonly SlashCommandSuggestion[] = [
+  EDIT_COMMAND,
   ...getVerifiedNativeChatCommands('codex').slice(0, 1),
   EFFORT_COMMAND,
   ...getVerifiedNativeChatCommands('codex').slice(1)
 ]
+
+/** `/edit` is a host-visible speech act, not prompt classification. The command
+ * itself is removed before the model sees the exact user request. */
+export function parseStructuredAgentSessionEditRequest(text: string): string | null {
+  const command = commandParts(text)
+  return command?.name === EDIT_COMMAND.name && command.argument ? command.argument : null
+}
 
 export type StructuredAgentSessionComposerOptions = {
   agent?: AgentType

--- a/src/shared/structured-agent-session-mutation.test.ts
+++ b/src/shared/structured-agent-session-mutation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   showStructuredAgentSessionChoice,
+  structuredAgentSessionCreateFingerprint,
   structuredAgentSessionPayloadFingerprint
 } from './structured-agent-session-mutation'
 
@@ -50,5 +51,19 @@ describe('structured agent session client mutations', () => {
 
     expect(first).toBe(second)
     expect(first).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('binds writer creation authority into the durable create fingerprint', () => {
+    const plain = structuredAgentSessionCreateFingerprint({
+      sessionId: 'session-1',
+      worktree: 'id:workspace-1'
+    })
+    const writer = structuredAgentSessionCreateFingerprint({
+      sessionId: 'session-1',
+      worktree: 'id:workspace-1',
+      effectAuthority: 'local_structured_write'
+    })
+
+    expect(writer).not.toBe(plain)
   })
 })

--- a/src/shared/structured-agent-session-mutation.ts
+++ b/src/shared/structured-agent-session-mutation.ts
@@ -42,11 +42,16 @@ export function structuredAgentSessionCreateFingerprint(input: {
   sessionId: string
   worktree: string
   agent?: 'codex'
+  effectAuthority?: 'local_structured_write'
 }): string {
   return structuredAgentSessionPayloadFingerprint({
     method: 'agentSession.create',
     sessionId: input.sessionId,
-    fields: { worktree: input.worktree, agent: input.agent ?? 'codex' }
+    fields: {
+      worktree: input.worktree,
+      agent: input.agent ?? 'codex',
+      effectAuthority: input.effectAuthority
+    }
   })
 }
 

--- a/src/shared/structured-agent-session-outbox.ts
+++ b/src/shared/structured-agent-session-outbox.ts
@@ -1,6 +1,6 @@
 import type { AgentJournalMessageItem, AgentJournalSubmission } from './agent-session-journal-types'
 import { agentSessionRefusalOperationState } from './agent-session-refusal-retry'
-import type { AgentSessionWireRefusalCode } from './agent-session-wire'
+import type { AgentSessionEffectAuthority, AgentSessionWireRefusalCode } from './agent-session-wire'
 import { structuredAgentSessionPayloadFingerprint } from './structured-agent-session-mutation'
 
 export type StructuredAgentSessionOutboxState = 'queued' | 'dispatching' | 'unconfirmed'
@@ -14,6 +14,7 @@ export type StructuredAgentSessionOutboxEntry = {
   queuedAt: number
   lastAttemptAt: number | null
   retryAfterUnknownSubmittedAt: number | null
+  effectAuthority?: AgentSessionEffectAuthority
 }
 
 export type StructuredAgentSessionAttachment = {
@@ -41,6 +42,7 @@ export function createStructuredAgentSessionOutboxEntry(args: {
   text: string
   attachments: readonly StructuredAgentSessionAttachment[]
   queuedAt: number
+  effectAuthority?: AgentSessionEffectAuthority
 }): StructuredAgentSessionOutboxEntry {
   return {
     clientMessageId: args.clientMessageId,
@@ -50,7 +52,8 @@ export function createStructuredAgentSessionOutboxEntry(args: {
     state: 'queued',
     queuedAt: args.queuedAt,
     lastAttemptAt: null,
-    retryAfterUnknownSubmittedAt: null
+    retryAfterUnknownSubmittedAt: null,
+    ...(args.effectAuthority ? { effectAuthority: args.effectAuthority } : {})
   }
 }
 
@@ -139,7 +142,10 @@ export function parseStructuredAgentSessionOutboxEntry(
     retryAfterUnknownSubmittedAt:
       typeof entry.retryAfterUnknownSubmittedAt === 'number'
         ? entry.retryAfterUnknownSubmittedAt
-        : null
+        : null,
+    ...(entry.effectAuthority === 'local_structured_write'
+      ? { effectAuthority: entry.effectAuthority }
+      : {})
   }
 }
 
@@ -147,7 +153,10 @@ export function structuredAgentSessionSendRequest(
   entry: StructuredAgentSessionOutboxEntry,
   expectedRuntimeFence: number
 ): Record<string, unknown> {
-  const fields = { body: entry.body }
+  const fields = {
+    body: entry.body,
+    ...(entry.effectAuthority ? { effectAuthority: entry.effectAuthority } : {})
+  }
   return {
     envelope: {
       sessionId: entry.sessionId,

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -333,7 +333,7 @@ describe('cross-version structured agent sessions', () => {
   describe('an old client against a structured-owned AI Vault row', () => {
     let root: string
     let store: AgentSessionRecordStore
-    let runtime: ReturnType<typeof runtimeStub> & Record<string, unknown>
+    let runtime: Record<string, unknown>
     let createMobileSessionTerminal: ReturnType<typeof vi.fn>
 
     beforeEach(async () => {


### PR DESCRIPTION
## Summary

- add a host-owned, single-use structured source-write lease for one bound Git worktree
- deny shell, Python, MCP, Git, publication, and unbound/canonical/sibling writes in this activation lane
- bind request authority, turn epoch, root identity, before/after manifests, and durable enforcement receipts
- invalidate other writer leases only after durable admission of a trusted local user turn
- harden duplicate item-start handling and path/worktree replacement races before admission
- admit structured journal rows and blobs atomically against the physical snapshot/log/blob/temp footprint
- bind blob digests and row references, retain live and resumable-tail blobs, and fail closed on ambiguous writes, malformed tails, and non-ENOENT read failures

## Verification

- Node 24: 52 structured-session/journal test files; 51 passed and 1 skipped
- Node 24: 428 tests; 427 passed and 1 skipped
- `pnpm run typecheck:node`
- default and type-aware oxlint across 95 changed TypeScript files
- oxfmt across 96 changed files
- `check:max-lines-ratchet` and `git diff --check`
- earlier installed Codex App Server live E2E: one `apply_patch` accepted and a later shell write denied

## Scope and remaining boundary

This is intentionally stacked on #13438 and proves `local_structured_write` only. It does not claim enforcement for subprocess writers, local/hosted MCP, Git, publication, mobile/remote/TUI semantic user-turn invalidation, or the post-approval App Server write syscall race. Browser/CDP screenshot base64 generation is also outside this patch. The latest hardening and rebase were source/test verified on Node 24; no Orca app activation or process control was performed in this phase.
