### PR TITLE
fix(ai-vault): stop the scan-stamp guard from deciding merged results

### DIFF
--- a/src/main/ai-vault/session-list-results.test.ts
+++ b/src/main/ai-vault/session-list-results.test.ts
@@ -91,6 +91,38 @@ describe('mergeAiVaultListResults', () => {
     ).toBe('2026-08-02T00:00:10.000Z')
   })
 
+  // `scannedAt` is only `z.string()` on the wire, so a leg may legally send an
+  // ISO variant that sorts against the local stamp differently than it reads.
+  // Both cases below invert under a lexicographic compare.
+  it('orders remote stamps by instant, not by string', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T00:00:10.000Z'))
+
+    // '...:05Z' sorts after '...:05.500Z' ('Z' > '.') but is half a second older.
+    expect(
+      mergeAiVaultListResults(
+        [
+          { ...listResult([]), scannedAt: '2026-08-02T00:00:05Z' },
+          { ...listResult([]), scannedAt: '2026-08-02T00:00:05.500Z' }
+        ],
+        undefined
+      ).scannedAt
+    ).toBe('2026-08-02T00:00:05.500Z')
+
+    // A -05:00 offset makes this five hours in the future, but it sorts below
+    // the local stamp ('-' < '.'), so a string compare would accept it and pin
+    // the merged stamp above every later local rescan.
+    expect(
+      mergeAiVaultListResults(
+        [
+          { ...listResult([]), scannedAt: '2026-08-02T00:00:10-05:00' },
+          { ...listResult([]), scannedAt: '2026-08-02T00:00:04.000Z' }
+        ],
+        undefined
+      ).scannedAt
+    ).toBe('2026-08-02T00:00:04.000Z')
+  })
+
   it('does not cap an Unlimited all-host merge', () => {
     const sessions = Array.from({ length: 1001 }, (_, index) => session(index))
     const merged = mergeAiVaultListResults([{ ...listResult([]), sessions }], undefined, true)

--- a/src/main/ai-vault/session-list-results.ts
+++ b/src/main/ai-vault/session-list-results.ts
@@ -83,19 +83,25 @@ export function mergeAiVaultListResults(
 }
 
 function latestAiVaultScannedAt(results: readonly AiVaultListResult[]): string {
-  const now = new Date().toISOString()
+  const nowMs = Date.now()
   let latest: string | undefined
+  let latestMs = Number.NEGATIVE_INFINITY
   for (const result of results) {
     const stamp = result.scannedAt
+    const stampMs = Date.parse(stamp)
     // Remote legs carry their own clock and only `z.string()` validation. An
     // unparsable or future stamp would pin the merged stamp above every local
     // rescan and silently freeze the renderer's scannedAt equality guard.
-    if (Number.isNaN(Date.parse(stamp)) || stamp > now) {
+    // Compare parsed instants, not strings: `z.string()` does not pin the stamp
+    // to the exact `toISOString()` shape, and a legal variant (no milliseconds,
+    // a `+00:00` offset) orders wrongly under lexicographic compare.
+    if (Number.isNaN(stampMs) || stampMs > nowMs) {
       continue
     }
-    if (latest === undefined || stamp > latest) {
+    if (stampMs > latestMs) {
+      latestMs = stampMs
       latest = stamp
     }
   }
-  return latest ?? now
+  return latest ?? new Date(nowMs).toISOString()
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-identity.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-identity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { AiVaultListResult, AiVaultSession } from '../../../../shared/ai-vault-types'
-import { reuseAiVaultListResult } from './ai-vault-session-identity'
+import { EMPTY_AI_VAULT_SESSIONS, reuseAiVaultListResult } from './ai-vault-session-identity'
 
 // Why: production rows carry nested previewMessages + subagent. A scalar
 // {id, title} fixture reconciles even when the walker is broken, which is how
@@ -130,5 +130,13 @@ describe('reuseAiVaultListResult', () => {
     expect(reused.sessions).toBe(current.sessions)
     expect(reused.issues).toEqual([])
     expect(reused.issues).toBe(incoming.issues)
+  })
+})
+
+describe('EMPTY_AI_VAULT_SESSIONS', () => {
+  // Every mounted hook returns this same array before its first scan lands.
+  it('is frozen so one panel cannot mutate the sentinel for the others', () => {
+    expect(EMPTY_AI_VAULT_SESSIONS).toHaveLength(0)
+    expect(Object.isFrozen(EMPTY_AI_VAULT_SESSIONS)).toBe(true)
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-identity.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-identity.ts
@@ -2,7 +2,9 @@ import type { AiVaultListResult, AiVaultSession } from '../../../../shared/ai-va
 import { areValuesEqual } from '@/store/slices/repo-identity-reconcile'
 import { reuseEqualCatalogRows } from '@/store/slices/worktree-catalog-reconciliation'
 
-export const EMPTY_AI_VAULT_SESSIONS: AiVaultSession[] = []
+// One instance is shared by every mounted hook, so it is frozen: an in-place
+// sort or push by any consumer would otherwise leak into every other panel.
+export const EMPTY_AI_VAULT_SESSIONS: readonly AiVaultSession[] = Object.freeze([])
 
 // Why: listSessions always structured-clones nested session rows (previewMessages,
 // subagent). A TTL miss remints scannedAt even when the disk contents did not

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
@@ -441,6 +441,81 @@ describe('useAiVaultSessionRefresh refocus behavior', () => {
     expect(latest?.scanResult).toBe(firstResult)
   })
 
+  // An 'all' result is a merge of legs on independent clocks, stamped with the
+  // newest leg. A paired host whose clock lags the desktop can return new
+  // sessions while the merged stamp repeats, so the stamp guard above must not
+  // decide anything under 'all' — only the structural reconcile may.
+  it('applies a changed all-host result whose merged scannedAt stood still', async () => {
+    const pinned = '2026-07-01T00:00:00.000Z'
+    listSessionsMock.mockResolvedValueOnce({
+      sessions: [makeVaultSession(1)],
+      issues: [],
+      scannedAt: pinned
+    })
+    await renderHook([], 'all')
+    await flushMicrotasks()
+    expect(latest?.sessions).toHaveLength(1)
+
+    listSessionsMock.mockResolvedValueOnce({
+      sessions: [makeVaultSession(1), makeVaultSession(2)],
+      issues: [],
+      scannedAt: pinned
+    })
+    await advance(THROTTLE_MS + 1)
+    await fireWindowFocused()
+
+    expect(latest?.sessions).toHaveLength(2)
+    expect(latest?.sessions[1]?.id).toBe('session-2')
+  })
+
+  // The main process routes an empty or unrecognized scope to the same all-host
+  // merge, so the renderer has to read those as merged too or the guard returns
+  // for exactly the results it cannot reason about.
+  it('treats a scope that normalizes to all-host as merged', async () => {
+    const pinned = '2026-07-01T00:00:00.000Z'
+    listSessionsMock.mockResolvedValueOnce({
+      sessions: [makeVaultSession(1)],
+      issues: [],
+      scannedAt: pinned
+    })
+    await renderHook([], '' as ExecutionHostScope)
+    await flushMicrotasks()
+    expect(latest?.sessions).toHaveLength(1)
+
+    listSessionsMock.mockResolvedValueOnce({
+      sessions: [makeVaultSession(1), makeVaultSession(2)],
+      issues: [],
+      scannedAt: pinned
+    })
+    await advance(THROTTLE_MS + 1)
+    await fireWindowFocused()
+
+    expect(latest?.sessions).toHaveLength(2)
+  })
+
+  it('still reuses all-host identity when a repeated stamp carries an unchanged body', async () => {
+    const pinned = '2026-07-01T00:00:00.000Z'
+    const first: AiVaultListResult = {
+      sessions: [makeVaultSession(1)],
+      issues: [],
+      scannedAt: pinned
+    }
+    listSessionsMock.mockResolvedValueOnce(first)
+    await renderHook([], 'all')
+    await flushMicrotasks()
+    const applied = latest?.scanResult
+    const appliedSessions = latest?.sessions
+
+    // Dropping the stamp guard for 'all' must not reintroduce the churn: the
+    // reconcile still has to recognise an independently cloned identical body.
+    listSessionsMock.mockResolvedValueOnce(structuredClone(first))
+    await advance(THROTTLE_MS + 1)
+    await fireWindowFocused()
+
+    expect(latest?.scanResult).toBe(applied)
+    expect(latest?.sessions).toBe(appliedSessions)
+  })
+
   it('keeps session row identity when a reminted scan is a structuredClone of the same nested rows', async () => {
     const session = makeVaultSession(1)
     const first: AiVaultListResult = {
@@ -501,9 +576,7 @@ describe('useAiVaultSessionRefresh refocus behavior', () => {
       sessions: [
         {
           ...session,
-          previewMessages: [
-            { role: 'user', text: 'original ask', timestamp: session.modifiedAt }
-          ]
+          previewMessages: [{ role: 'user', text: 'original ask', timestamp: session.modifiedAt }]
         },
         sibling
       ],

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -4,7 +4,11 @@ import {
   type AiVaultListResult,
   type AiVaultSession
 } from '../../../../shared/ai-vault-types'
-import type { ExecutionHostScope } from '../../../../shared/execution-host'
+import {
+  ALL_EXECUTION_HOSTS_SCOPE,
+  normalizeExecutionHostScope,
+  type ExecutionHostScope
+} from '../../../../shared/execution-host'
 import { useAppStore } from '@/store'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 import { AiVaultSessionPublicationGate } from './ai-vault-session-publication-gate'
@@ -32,6 +36,12 @@ export const isAiVaultScanCancellation = isAiVaultScanCancelledError
 
 type AiVaultRefreshArgs = { force?: boolean; background?: boolean; reuseLoadedDepth?: boolean }
 
+// Mirrors how the main process routes the scan: this scope answers with a merge
+// of several hosts' legs rather than one scanner's result.
+function isMergedAiVaultHostScope(scope: ExecutionHostScope): boolean {
+  return normalizeExecutionHostScope(scope) === ALL_EXECUTION_HOSTS_SCOPE
+}
+
 export function useAiVaultSessionRefresh(
   scopePaths: readonly string[],
   executionHostScope: ExecutionHostScope,
@@ -41,7 +51,7 @@ export function useAiVaultSessionRefresh(
   loading: boolean
   refresh: (args?: AiVaultRefreshArgs) => Promise<void>
   scanResult: AiVaultListResult | null
-  sessions: AiVaultSession[]
+  sessions: readonly AiVaultSession[]
 } {
   const [scanResult, setScanResult] = useState<AiVaultListResult | null>(null)
   const sessions = scanResult?.sessions ?? EMPTY_AI_VAULT_SESSIONS
@@ -145,7 +155,15 @@ export function useAiVaultSessionRefresh(
         }
         // A cache hit returns the snapshot already on screen; skip the state
         // updates so refocus flips don't force pointless re-renders.
+        // Single-host results carry one scanner's stamp minted when that scan
+        // finished, so an equal stamp does mean equal content. An 'all' result
+        // is a merge of legs on independent clocks stamped with the newest leg,
+        // so a lagging host's leg can change while the merged stamp stands
+        // still — there, only the structural reconcile below may decide.
+        // Normalized through the shared helper because that is what the main
+        // process routes on: an empty or unrecognized scope also merges.
         if (
+          !isMergedAiVaultHostScope(hostScope) &&
           lastAppliedScanRef.current?.scopeKey === scanKey &&
           lastAppliedScanRef.current.scannedAt === result.scannedAt
         ) {


### PR DESCRIPTION
## Summary

Follow-up to #14245, which made `scannedAt` load-bearing again: the all-host merge stopped reminting `Date.now()` and now keeps the newest leg stamp, and the renderer reconciles session rows structurally before `setState`. Reviewing that change surfaced three loose ends, all in the seams it created.

## 1. The stamp guard must not decide merged results

`useAiVaultSessionRefresh` skips the whole apply when `scannedAt` matches what it last applied:

```ts
if (lastAppliedScanRef.current?.scopeKey === scanKey &&
    lastAppliedScanRef.current.scannedAt === result.scannedAt) {
  return
}
```

That guard is sound only when the stamp is a content token. For a single-host scan it is — one scanner mints it at scan completion, so two real scans can never collide. For `'all'` it is not, and #14245 is what made that true: the merged stamp is now the **newest leg's** stamp, and legs run on independent clocks.

Concretely, with the local leg's 60s cache (`cached-session-list.ts:20`) and the 15s per-leg cache (`ai-vault-host-leg-cache.ts:8`):

- `t=0` — full scan. Local leg stamps `L0` off the desktop clock; a paired `runtime:` host stamps `R0` off **its own** clock (`runtime-session-scanner.ts:161` preserves it).
- `t=20s` — the outer 15s cache expired, so the merge re-runs. The local leg is still a cache hit, so it replays `L0`. The runtime leg re-scans and returns genuinely new sessions stamped `R1`.
- If that host's clock lags the desktop by more than the elapsed time, `R1 < L0`, so the merge returns `L0` again — **the same stamp it returned at `t=0`, over changed content.** The renderer hard-skips, and the new remote sessions stay invisible until the local leg's 60s TTL expires.

Bounded and self-healing, and the "a session just started" path uses `force: true`, which bypasses every cache — which is why this is a correctness cleanup rather than a release blocker. But it is the exact failure mode #14245 argues against: treating a wall-clock stamp as a content fingerprint.

The fix restricts the guard to single-host scopes and lets the structural reconcile decide for merged ones. The scope test routes through the shared `normalizeExecutionHostScope` rather than comparing to the `'all'` literal, because the main process also merges for an empty or unrecognized scope (`execution-host.ts:108-114`) — a literal compare would silently drift from what actually merges.

**Cost:** merged scopes now pay one deep reconcile per refocus instead of a string compare — ~0.4 ms at the default 250-session limit, ~1.8 ms at 1000. The expensive part that #14245 set out to eliminate (`sessionProjectById`, the session×worktree path map, and the virtual list re-render) is still skipped, because the reconcile returns the previous result object and React bails out. A test pins that: an unchanged all-host body with a repeated stamp still yields `scanResult === previous`.

## 2. `latestAiVaultScannedAt` compared stamps as strings

`scannedAt` is `z.string()` on the wire (`session-list-result-validation.ts:91`), not a pinned `toISOString()` shape. The merge validated it with `Date.parse` and then compared **lexicographically**, which inverts for legal ISO variants:

| stamps | lexicographic | chronological |
|---|---|---|
| `...:05Z` vs `...:05.500Z` | `...:05Z` wins (`'Z'` > `'.'`) | `...:05.500Z` is 500 ms later |
| `...:10-05:00` vs local `...:10.000Z` | sorts **below** local (`'-'` < `'.'`), so accepted as past | five hours in the **future** |

The second row is the one that bites: the future-stamp rejection this function exists for could be bypassed by an offset-form stamp, pinning the merged stamp above every later local rescan and freezing the renderer guard for real. Now it compares parsed instants, using the `Date.parse` result it already computed.

## 3. `EMPTY_AI_VAULT_SESSIONS` was a shared mutable array

Every mounted hook returns the same instance before its first scan lands. No consumer mutates it today (checked: `filterAiVaultSessions`, `buildAiVaultSessionProjectById`, `useAiVaultSessionWorktreeMap`, `.length`), but an in-place `sort` would have leaked across panels. Frozen, and the hook now returns `readonly AiVaultSession[]` — no ripple, all three tsc projects clean.

## Tests

Each new test was verified to fail against the pre-fix logic, not just pass against the new one:

- `ai-vault-session-refresh.test.ts` — an all-host result whose merged stamp stood still but whose body grew is applied (fails when the guard runs for `'all'`); a scope that normalizes to all-host is treated as merged (fails against a literal `!== 'all'`); an unchanged all-host body with a repeated stamp still reuses `scanResult` and `sessions` identity, so removing the guard did not reintroduce the churn.
- `session-list-results.test.ts` — both inverting stamp pairs above (fails under lexicographic compare).
- `ai-vault-session-identity.test.ts` — the sentinel is frozen.

The existing "skips state updates when a refresh returns the applied snapshot" test runs on `'local'` scope and is the regression guard for keeping the single-host fast path.

## Verification

`typecheck:node`, `typecheck:web`, `typecheck:cli`, oxlint and react-doctor all clean; 5224 tests pass across `right-sidebar/`, `ai-vault/`, and `ipc/`.

No wire, schema, or persisted-state change. `scannedAt` stays an ISO string and is still read only by the renderer's refresh guard — mobile calls `aiVault.listSessions` but consumes only `sessions`/`issues` (`use-mobile-agent-history-state.ts:129`), so no mobile-facing surface is touched.

Made with [Orca](https://github.com/stablyai/orca) 🐋
