### PR TITLE
fix(native-chat): retire glued echoes when the input line kept a separator

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -128,9 +128,10 @@ export function matchingNativeChatUserTexts(
 }
 
 /**
- * How many leading pending texts concatenate exactly to `userText`.
- * Covers rapid-send glue ("joke"+"continue" → "jokecontinue") without matching
- * unrelated prefixes ("hi" ↛ "history").
+ * How many leading pending texts concatenate exactly to `userText`, allowing a
+ * single separator between bodies. Covers rapid-send glue both ways the TUI
+ * lands it ("joke"+"continue" → "jokecontinue" or "joke continue") without
+ * matching unrelated prefixes ("hi" ↛ "history").
  */
 export function countLeadingPendingTextsGluedToUserText(
   pendingTexts: readonly string[],
@@ -139,18 +140,23 @@ export function countLeadingPendingTextsGluedToUserText(
   if (pendingTexts.length === 0 || userText.length === 0) {
     return 0
   }
-  let combined = ''
+  let cursor = 0
   for (let index = 0; index < pendingTexts.length; index += 1) {
     const piece = pendingTexts[index]
     if (!piece) {
       return 0
     }
-    combined += piece
-    if (combined === userText) {
-      return index + 1
+    // Why: an unsubmitted input line can keep the separator that sat between the
+    // two bodies, so the glued row reads "joke continue" and never matched.
+    if (cursor > 0 && userText.startsWith(' ', cursor)) {
+      cursor += 1
     }
-    if (!userText.startsWith(combined)) {
+    if (!userText.startsWith(piece, cursor)) {
       return 0
+    }
+    cursor += piece.length
+    if (cursor === userText.length) {
+      return index + 1
     }
   }
   return 0

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -161,6 +161,28 @@ describe('prunePendingSends', () => {
     ).toEqual([])
   })
 
+  it('prunes glued sends the input line kept a separator between', () => {
+    const pending = [pendingOf('p1', 'tell me a joke'), pendingOf('p2', 'continue')]
+    expect(
+      prunePendingSends(pending, [
+        userMessage('u1', 'tell me a joke continue'),
+        assistantMessage('a1', 'a joke')
+      ])
+    ).toEqual([])
+  })
+
+  // Why: the composer writes the raw draft to the pty, so a trailing space the
+  // match key trims away still sits on the input line the next body glues onto.
+  it('prunes glued sends whose first draft carried a trailing space', () => {
+    const pending = [pendingOf('p1', 'tell me a joke '), pendingOf('p2', 'continue')]
+    expect(
+      prunePendingSends(pending, [
+        userMessage('u1', 'tell me a joke continue'),
+        assistantMessage('a1', 'a joke')
+      ])
+    ).toEqual([])
+  })
+
   it('does not treat an unrelated longer user turn as a glued match', () => {
     const pending = [pendingOf('p1', 'hi')]
     expect(
@@ -225,6 +247,19 @@ describe('pendingSendsAsMessages', () => {
     expect(pendingSendsAsMessages(pending, [userMessage('u1', 'tell me a jokecontinue')])).toEqual(
       []
     )
+  })
+
+  // Why: an echo that outlives its glued turn keeps `sentAt`, so it sorts past
+  // the newest real turn and reads as the conversation reordering.
+  it('hides separator-glued sends instead of pinning them after the newest turn', () => {
+    const pending = [pendingOf('p1', 'tell me a joke'), pendingOf('p2', 'continue')]
+    const transcript = [
+      userMessage('u1', 'tell me a joke continue'),
+      assistantMessage('a1', 'a joke'),
+      assistantMessage('a2', 'newest real turn')
+    ]
+
+    expect(pendingSendsAsMessages(pending, transcript)).toEqual([])
   })
 
   it('keeps a repeated prompt visible when its only match predates the send boundary', () => {

--- a/tests/e2e/native-chat-glued-echo-drift-repro.spec.ts
+++ b/tests/e2e/native-chat-glued-echo-drift-repro.spec.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  getTerminalContent,
+  waitForActivePaneHookDescriptor,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import type { GlobalSettings } from '../../src/shared/types'
+
+const FIRST_SEND = 'tell me a joke'
+const SECOND_SEND = 'continue'
+const SEED_ASSISTANT = 'seed turn so the transcript hydrates'
+const NEWEST_ASSISTANT = 'newest real turn from the agent'
+
+async function enableNativeChatSetting(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const nextSettings = await window.api.settings.set({ experimentalNativeChat: true })
+    window.__store?.setState({ settings: nextSettings as GlobalSettings })
+  })
+}
+
+// Why: mirrors native-chat-first-flush-race.spec.ts — drives the identical
+// store → NativeChatView path a real Claude Code hook would, with no CLI.
+// `idle` (not `working`) keeps the composer action a Send button.
+async function seedClaudeProviderSession(
+  page: Page,
+  args: { paneKey: string; worktreeId: string; sessionId: string; transcriptPath: string }
+): Promise<void> {
+  await page.evaluate(({ paneKey, worktreeId, sessionId, transcriptPath }) => {
+    window.__store
+      ?.getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'idle', prompt: 'e2e glued echo drift probe', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId },
+        { providerSession: { key: 'session_id', id: sessionId, transcriptPath } }
+      )
+  }, args)
+}
+
+async function toggleTerminalTabToChatView(
+  page: Page,
+  args: { tabId: string; worktreeId: string }
+): Promise<void> {
+  await page.evaluate(({ tabId, worktreeId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const unifiedTab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+    )
+    if (!unifiedTab) {
+      throw new Error('Unified terminal tab not found for chat toggle')
+    }
+    state.toggleTabViewMode(unifiedTab.id)
+  }, args)
+}
+
+function transcriptLines(
+  sessionId: string,
+  turns: readonly { role: 'user' | 'assistant'; text: string }[]
+): string {
+  const base = Date.now()
+  return `${turns
+    .map((turn, index) =>
+      JSON.stringify({
+        sessionId,
+        uuid: `${sessionId}-${index}`,
+        timestamp: new Date(base + index * 1_000).toISOString(),
+        type: turn.role,
+        message:
+          turn.role === 'user'
+            ? { role: 'user', content: [{ type: 'text', text: turn.text }] }
+            : { model: 'claude-opus-4', content: [{ type: 'text', text: turn.text }] }
+      })
+    )
+    .join('\n')}\n`
+}
+
+test.describe('Native chat glued optimistic echoes never retire', () => {
+  test('two rapid sends glued into one transcript row retire their echoes', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+    const [tabId] = descriptor.paneKey.split(':')
+    const sessionId = `e2e-glued-echo-${randomUUID()}`
+    const scratchDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-glued-echo-'))
+    const transcriptPath = path.join(scratchDir, `${sessionId}.jsonl`)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `native-chat-glued-echo-drift-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+
+    try {
+      writeFileSync(
+        transcriptPath,
+        transcriptLines(sessionId, [{ role: 'assistant', text: SEED_ASSISTANT }])
+      )
+
+      await enableNativeChatSetting(orcaPage)
+      await seedClaudeProviderSession(orcaPage, {
+        paneKey: descriptor.paneKey,
+        worktreeId: descriptor.worktreeId,
+        sessionId,
+        transcriptPath
+      })
+      await toggleTerminalTabToChatView(orcaPage, { tabId, worktreeId: descriptor.worktreeId })
+
+      await expect(orcaPage.locator('[data-native-chat-root="true"]')).toBeVisible({
+        timeout: 15_000
+      })
+      await expect(orcaPage.getByText(SEED_ASSISTANT)).toBeVisible({ timeout: 30_000 })
+
+      // Why: Enter is a separate delayed pty write, so a second send issued
+      // inside that window writes its body onto the same unsubmitted input line.
+      const composer = orcaPage.getByPlaceholder('Send a message…')
+      await composer.fill(FIRST_SEND)
+      await composer.press('Enter')
+      await composer.fill(SECOND_SEND)
+      await composer.press('Enter')
+
+      await expect(orcaPage.getByText(FIRST_SEND, { exact: true })).toBeVisible({ timeout: 10_000 })
+      await orcaPage.screenshot({ path: path.join(screenshotDir, '01-two-optimistic-echoes.png') })
+
+      // Evidence: what the two bodies actually look like on the pty input line.
+      const terminalText = await getTerminalContent(orcaPage)
+      await testInfo.attach('pty-input-line', {
+        body: terminalText,
+        contentType: 'text/plain'
+      })
+
+      // The agent accepts both bodies as one prompt, separated as the pty saw it.
+      writeFileSync(
+        transcriptPath,
+        transcriptLines(sessionId, [
+          { role: 'assistant', text: SEED_ASSISTANT },
+          { role: 'user', text: `${FIRST_SEND} ${SECOND_SEND}` },
+          { role: 'assistant', text: NEWEST_ASSISTANT }
+        ])
+      )
+
+      await expect(orcaPage.getByText(NEWEST_ASSISTANT)).toBeVisible({ timeout: 30_000 })
+      await orcaPage.screenshot({ path: path.join(screenshotDir, '02-after-glued-turn.png') })
+
+      // Both optimistic echoes are represented by the glued row and must go.
+      await expect(orcaPage.getByText(FIRST_SEND, { exact: true })).toHaveCount(0)
+      await expect(orcaPage.getByText(SECOND_SEND, { exact: true })).toHaveCount(0)
+    } finally {
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## ELI5

When you send a message in the native Chat view, Orca shows it instantly as a "queued" bubble, and that bubble is supposed to disappear the moment the real message appears in the agent's transcript. If you send two messages very quickly, the terminal can merge them into one turn — and Orca already knows how to recognize the merged form. But it only recognized a merge with **no space** between the texts (`tell me a joke` + `continue` = `tell me a jokecontinue`). When the merged turn kept a space (`tell me a joke continue`), nothing recognized it — and since nothing else ever removes a queued bubble, both bubbles sat below the agent's newest reply forever, looking like the conversation had reordered itself. This PR teaches the matcher to accept a single space between the merged pieces.

## What Changed

The whole fix is one function — everything else is tests:

| File | Change |
| --- | --- |
| `src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts` | `countLeadingPendingTextsGluedToUserText` walks the transcript row with a cursor instead of building a concatenated string, skipping one optional space before each subsequent piece |
| `src/renderer/src/components/native-chat/native-chat-pending.test.ts` | 3 regression cases (see Testing) |
| `tests/e2e/native-chat-glued-echo-drift-repro.spec.ts` | New hermetic e2e repro of the drift — failed before the fix, passes after |

**Before** — exact concatenation only:

```ts
let combined = ''
for (let index = 0; index < pendingTexts.length; index += 1) {
  const piece = pendingTexts[index]
  if (!piece) {
    return 0
  }
  combined += piece
  if (combined === userText) {
    return index + 1
  }
  if (!userText.startsWith(combined)) {
    return 0
  }
}
return 0
```

**After** — cursor walk, one optional separator between bodies:

```ts
let cursor = 0
for (let index = 0; index < pendingTexts.length; index += 1) {
  const piece = pendingTexts[index]
  if (!piece) {
    return 0
  }
  // Why: an unsubmitted input line can keep the separator that sat between the
  // two bodies, so the glued row reads "joke continue" and never matched.
  if (cursor > 0 && userText.startsWith(' ', cursor)) {
    cursor += 1
  }
  if (!userText.startsWith(piece, cursor)) {
    return 0
  }
  cursor += piece.length
  if (cursor === userText.length) {
    return index + 1
  }
}
return 0
```

> [!NOTE]
> Unrelated-prefix protection is unchanged: the pieces must still consume the row **exactly**, so `"hi"` still does not match `"history"`. The separator skip is optional, so every row that matched before still matches — the matcher is strictly more permissive, never less. Side benefit: dropping the repeated string concatenation means the walk allocates nothing.

## Why

**Symptom:** a prompt the user already sent keeps rendering as a bubble below the agent's newest reply, permanently — the conversation looks reordered and never heals.

```mermaid
flowchart TD
    A["send #1: 'tell me a joke␣'<br/>(trailing space in draft)"] --> B["queued bubble #1"]
    A --> C["raw draft → pty<br/>buildNativeChatPasteBytes, no trim"]
    D["send #2: 'continue'"] --> E["queued bubble #2"]
    D --> C
    C --> F["ONE glued transcript user row:<br/>'tell me a joke continue'"]
    F --> G{"exact normalized match?"}
    G -- "no" --> H{"glue matcher:<br/>combined += piece"}
    H -- "'tell me a jokecontinue' ≠ row" --> I["no retirement path left"]
    I --> J["both bubbles pinned after the newest turn<br/>(timestamp: sentAt) until 8 later sends evict them"]
```

Three facts make the drift permanent:

1. **Retirement is match-or-nothing.** `prunePendingSends` / `pendingSendsAsMessages` retire an optimistic echo only on a normalized-text match against a real transcript user turn. No timeout, no error, no delivery result retires one.
2. **The glue matcher missed the separator form.** Rapid sends landing as one glued row is already handled — but `combined += piece` only recognized `"jokecontinue"`, never `"joke continue"`.
3. **A missed echo pins itself.** `pendingSendsAsMessages` stamps echoes with `timestamp: entry.sentAt`, so a stale one sorts past every newer real turn until `PENDING_SEND_LIMIT = 8` later sends evict it.

<details>
<summary>Why a separator is really there (not a hypothetical)</summary>

`sendNativeChatMessage` writes the **raw** draft to the pty (`buildNativeChatPasteBytes(text)`, no trim), while the match key is `normalizeNativeChatPendingText` — trim plus whitespace collapse. A trailing space in the draft is therefore invisible to matching but real on the wire: it survives on the unsubmitted input line and becomes exactly the separator the next body glues onto. The send path is `1. clear unsubmitted line → 2. write framed body → 3. delayed Enter as a separate write`, and glue is an already-observed phenomenon here — the glue helper and its comment exist precisely for it.

</details>

**Not a duplicate.** Four open PRs touch pending echoes, each for a different trigger; this PR covers the remaining gap:

| PR | Trigger it covers |
| --- | --- |
| #11509 | Conversation replaced out from under the echo (`/clear`, agent restart, resuming a different session) |
| #13513 | A cancelled send never releases the occurrence slot it reserved |
| #12643 | Delivery itself unconfirmed (8s timeout, recovery card) |
| #13613 | Renderer vs host clock domains |
| **this PR** | Delivery **succeeded** and the turn **is** in the transcript — but the glued row carries a separator |

## Linked Issue

Fixes #14262

## Visual Proof

<details open>
<summary><b>Before</b> — two stale echoes pinned below the newest reply</summary>

<img src="https://github.com/user-attachments/assets/69b4c14b-a2c9-4ce8-b630-23b4eca8898b" width="900" alt="Before — two stale queued bubbles pinned below the newest reply" />

Order in the shot: `seed turn…` (assistant) → `tell me a joke continue` (the real glued user turn) → `newest real turn from the agent` (assistant) → **`tell me a joke`** and **`continue`** stuck below it.

</details>

<details>
<summary><b>After</b> — only the three real turns remain</summary>

<img src="https://github.com/user-attachments/assets/f1988785-aef7-41ee-81ab-93b8bbe40b6e" width="900" alt="After — only the three real turns remain" />

Order in the shot: `seed turn…` → `tell me a joke continue` → `newest real turn from the agent`. No stale bubbles.

</details>

## Testing

| Gate | Result |
| --- | --- |
| 3 new unit cases in `native-chat-pending.test.ts` — separator-glued prune; trailing-space draft; `pendingSendsAsMessages` returning nothing instead of pinning an echo after the newest turn | ✅ file passes 49/49 |
| All native-chat renderer tests | ✅ 74 files, 748 tests pass |
| New e2e regression spec `tests/e2e/native-chat-glued-echo-drift-repro.spec.ts` — hermetic, follows the `native-chat-first-flush-race.spec.ts` technique (seed the provider session via `setAgentStatus`, toggle the pane to chat view, write the transcript JSONL directly; no Claude CLI needed) | ✅ **failed before the fix** (`getByText('tell me a joke', { exact: true })` resolved 1 element, expected 0), passes after |
| `pnpm lint` | ✅ exit 0 |
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm build` | ✅ exit 0 |
| `pnpm test` (full suite) | ✅ 51,081 passed / 114 skipped. 4 failures are **pre-existing on `main`**, in files this PR does not touch — `src/relay/agent-exec-handler.test.ts` (2) and `src/main/repo-icon-autodetect.test.ts` (2). Verified by running both files on a clean `main` checkout, where they fail identically (4 failed / 20 passed). |

Platforms actually exercised: **macOS only.** The change is pure string logic in the renderer with no platform, runtime, or provider branch, so Linux / Windows / SSH / remote behavior is unaffected by construction — but only macOS was tested.

To verify locally: run `native-chat-pending.test.ts` and the new e2e spec, or reproduce manually — send a prompt ending in a trailing space, immediately send a second prompt, and watch the queued bubbles retire once the glued turn lands.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 (Claude Code) was used to investigate the bug, write the fix, the unit cases, and the e2e spec.

## Review

| Axis | Assessment |
| --- | --- |
| Security | No new input surface — a string comparison over text the renderer already holds. |
| Cross-platform (macOS / Linux / Windows) | No platform branch; pure string logic. Only macOS exercised (stated above). |
| Remote / SSH | Matching runs in the renderer against a transcript it already received; no wire or protocol change. |
| Mobile | Unaffected — `countLeadingPendingTextsGluedToUserText` has no mobile caller; grep shows the only call site is in this same desktop file. |
| Agent / integration compatibility | Provider-neutral; no agent- or provider-specific branch touched. |
| Backwards compatibility | Strictly more permissive matcher: the separator skip is optional, so every previously matching glued row still matches. |
| Performance | The cursor walk drops the per-iteration string concatenation and allocates nothing. |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — all four run locally; the only `pnpm test` failures are the 4 pre-existing ones described above, reproduced identically on a clean `main`
