### PR TITLE
fix(renderer): guard Add Project dialog dismissal while cloning

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -283,6 +283,7 @@ export default React.memo(function AddRepoDialog({
       isOpen={isOpen}
       step={step}
       isAdding={isAdding}
+      isCloning={isCloning}
       onBack={handleBack}
       onCloseAutoFocus={hosted?.onCloseAutoFocus}
       onOpenChange={handleOpenChange}

--- a/src/renderer/src/components/sidebar/AddRepoDialogChrome.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogChrome.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+// Why: react-dom act() requires this flag outside react-test-renderer setups.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { act } from 'react'
+import type { ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { describe, expect, it, vi } from 'vitest'
+
+// Why: capture the props AddRepoDialogChrome passes to DialogContent so the
+// Radix dismissal handlers can be invoked directly without a real portal.
+const contentProps = vi.hoisted(() => ({ capture: vi.fn() }))
+
+vi.mock('@/components/ui/dialog', () => {
+  const Dialog = ({ children }: { children: ReactNode }) => <>{children}</>
+  const DialogContent = (props: { children?: ReactNode } & Record<string, unknown>) => {
+    contentProps.capture(props)
+    return <div data-dialog-content>{props.children}</div>
+  }
+  return { Dialog, DialogContent }
+})
+
+import { AddRepoDialogChrome } from './AddRepoDialogChrome'
+
+type ChromeProps = Parameters<typeof AddRepoDialogChrome>[0]
+
+function renderChrome(overrides: Partial<ChromeProps>): { root: Root; container: HTMLElement } {
+  const props: ChromeProps = {
+    children: <div>step content</div>,
+    isAdding: false,
+    isCloning: false,
+    isOpen: true,
+    onBack: vi.fn(),
+    onOpenChange: vi.fn(),
+    step: 'clone',
+    ...overrides
+  }
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(<AddRepoDialogChrome {...props} />)
+  })
+  return { root, container }
+}
+
+function lastContentProps(): Record<string, unknown> {
+  const calls = contentProps.capture.mock.calls
+  return calls.at(-1)![0] as Record<string, unknown>
+}
+
+function dismissalHandlers(): [
+  string,
+  ((event: { preventDefault: () => void }) => void) | undefined
+][] {
+  const props = lastContentProps()
+  return [
+    [
+      'onPointerDownOutside',
+      props.onPointerDownOutside as ((event: { preventDefault: () => void }) => void) | undefined
+    ],
+    [
+      'onInteractOutside',
+      props.onInteractOutside as ((event: { preventDefault: () => void }) => void) | undefined
+    ],
+    [
+      'onEscapeKeyDown',
+      props.onEscapeKeyDown as ((event: { preventDefault: () => void }) => void) | undefined
+    ]
+  ]
+}
+
+describe('AddRepoDialogChrome dismissal guard', () => {
+  it('prevents dismissal events while a clone is in flight', () => {
+    const { root, container } = renderChrome({ isCloning: true })
+
+    for (const [name, handler] of dismissalHandlers()) {
+      expect(handler, `${name} must be wired`).toBeTypeOf('function')
+      const preventDefault = vi.fn()
+      handler!({ preventDefault })
+      expect(preventDefault, `${name} must preventDefault during clone`).toHaveBeenCalledTimes(1)
+    }
+    unmount(root, container)
+  })
+
+  it('lets dismissal events through when no clone is running', () => {
+    const { root, container } = renderChrome({ isCloning: false })
+
+    for (const [name, handler] of dismissalHandlers()) {
+      expect(handler, `${name} must be wired`).toBeTypeOf('function')
+      const preventDefault = vi.fn()
+      handler!({ preventDefault })
+      expect(preventDefault, `${name} must not preventDefault without clone`).not.toHaveBeenCalled()
+    }
+    unmount(root, container)
+  })
+})
+
+function unmount(root: Root, container: HTMLElement): void {
+  act(() => root.unmount())
+  container.remove()
+}

--- a/src/renderer/src/components/sidebar/AddRepoDialogChrome.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogChrome.tsx
@@ -6,6 +6,7 @@ import { AddRepoStepIndicator } from './AddRepoStepIndicator'
 export function AddRepoDialogChrome({
   children,
   isAdding,
+  isCloning,
   isOpen,
   onBack,
   onCloseAutoFocus,
@@ -14,16 +15,26 @@ export function AddRepoDialogChrome({
 }: {
   children: ReactNode
   isAdding: boolean
+  isCloning: boolean
   isOpen: boolean
   onBack: () => void
   onCloseAutoFocus?: (event: Event) => void
   onOpenChange: (open: boolean) => void
   step: AddRepoDialogStep
 }) {
+  // Why: a stray backdrop click or ESC during a long clone must not dismiss the dialog and abort it; explicit close still can.
+  const preventDismissalWhileCloning = (event: Event) => {
+    if (isCloning) {
+      event.preventDefault()
+    }
+  }
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         onCloseAutoFocus={onCloseAutoFocus}
+        onEscapeKeyDown={preventDismissalWhileCloning}
+        onInteractOutside={preventDismissalWhileCloning}
+        onPointerDownOutside={preventDismissalWhileCloning}
         className={`min-w-0 overflow-hidden sm:max-w-lg [&>*]:min-w-0 ${
           step === 'nested' ? 'max-h-[calc(100vh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)]' : ''
         }`}


### PR DESCRIPTION
## ELI5

Cloning a big repo takes a while. If you accidentally click outside the Add Project dialog (or press ESC) while it's cloning, the dialog treats that as "cancel" and kills the clone. This PR makes those accidental dismissals do nothing while a clone is running — you can still close the dialog deliberately with the X button, which cancels the clone on purpose.

## What Changed

- `AddRepoDialogChrome.tsx`: new `isCloning` prop; while it is true, the three Radix dismissal events (`onPointerDownOutside`, `onInteractOutside`, `onEscapeKeyDown`) call `preventDefault()` so the dialog stays open.
- `AddRepoDialog.tsx`: one line — pass the already-available `isCloning` from `useAddRepoCloneFlow` into the chrome.
- `AddRepoDialogChrome.test.tsx`: new — captures the props passed to `DialogContent` and asserts each dismissal handler calls `preventDefault` when `isCloning=true` and does not when `isCloning=false`.

## Why

`resetState()` in `AddRepoDialog.tsx` unconditionally calls `window.api.repos.cloneAbort()` on every dialog close (by design, so a closed dialog doesn't leave a half-finished clone on disk). Radix's default outside-interaction behavior routes accidental backdrop clicks and ESC through the same close path, so a stray click silently aborts a clone the user is waiting on. Guarding at the Radix event level (rather than in `handleOpenChange`) keeps the distinction the user actually makes: backdrop/ESC = accidental, X button = intentional cancel. Explicit close still aborts, preserving the half-clone cleanup intent.

## Linked Issue

Fixes #14265

## Visual Proof

N/A — no visual change. The dialog simply no longer closes on backdrop click / ESC while `isCloning` is true; all other behavior is identical.

## Testing

- [x] `vitest run src/renderer/src/components/sidebar/AddRepoDialogChrome.test.tsx` — 2/2 (TDD: watched both fail before wiring, pass after)
- [x] Full sidebar suite — 232 files / 2131 tests passing on top of latest `main`
- [x] `pnpm typecheck:tsc:web` clean
- [x] `oxlint` clean on changed files
- [x] `oxfmt --check` clean
- [x] Manual end-to-end on device — not performed here; reproducing needs a slow clone plus a stray click. Unit tests pin the handler contract.

## AI Disclosure

Bug diagnosed and fix co-authored interactively with Claude Code (Anthropic); each commit carries a `Co-Authored-By: Claude Opus 4.6` trailer. Reviewed by the PR author.

## Review

- **Security**: no new trust boundaries; only UI event gating in the renderer.
- **Cross-platform (Linux/Windows/Mac)**: pure renderer change, no platform-specific paths.
- **Remote SSH**: N/A — dialog-level change; SSH clone paths share the same dialog and get the same guard.
- **Mobile**: N/A — desktop renderer only.
- **Backwards compatibility**: with `isCloning=false` (the previous universal state for dismissal purposes) all three handlers are no-ops, so behavior is byte-identical outside the clone window. Explicit close (X) still aborts.
- **Performance**: three extra event listeners per dialog mount, each a boolean check.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A for this change)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass; `pnpm build` deferred to CI

## Author

- X / Twitter: @StillTogether2