### PR TITLE
fix(ci): skip missing golden scripts on older release tags

### DIFF
--- a/.github/workflows/golden-e2e-experiment.yml
+++ b/.github/workflows/golden-e2e-experiment.yml
@@ -61,19 +61,21 @@ jobs:
       - name: Build Electron app for E2E
         run: npx electron-vite build --mode e2e
 
+      # Why: this workflow can check out an older ref than the YAML that
+      # invoked it. Skip goldens the checked-out tree does not define.
       - name: Run golden E2E tests on Linux
         if: runner.os == 'Linux'
         run: |
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:posix-profile-index-golden
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
       - name: Run golden E2E tests on macOS
         if: runner.os == 'macOS'
         run: |
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:posix-profile-index-golden
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
       - name: Run golden E2E tests on Windows
         if: runner.os == 'Windows'
@@ -81,7 +83,7 @@ jobs:
         run: |
           $env:SKIP_BUILD = '1'
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
-          pnpm run test:e2e:windows-fresh-startup-golden
+          pnpm run --if-present test:e2e:windows-fresh-startup-golden
 
       - name: Upload Playwright traces
         if: failure()

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -869,17 +869,21 @@ jobs:
       - name: Build Electron app for platform golden
         run: npx electron-vite build --mode e2e
 
+      # Why: this job is defined on the dispatch ref (usually main) but checks
+      # out the release tag. Cherry-pick / hotfix tags can predate a golden
+      # script that main already calls; --if-present keeps those cuts green
+      # instead of failing with ERR_PNPM_NO_SCRIPT.
       - name: Run terminal rendering golden on Linux
         if: runner.os == 'Linux'
         run: |
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:posix-profile-index-golden
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
       - name: Run terminal rendering golden on macOS
         if: runner.os == 'macOS'
         run: |
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:posix-profile-index-golden
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
       - name: Run fresh-startup golden on Windows
         if: runner.os == 'Windows'
@@ -887,7 +891,7 @@ jobs:
         run: |
           $env:SKIP_BUILD = '1'
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
-          pnpm run test:e2e:windows-fresh-startup-golden
+          pnpm run --if-present test:e2e:windows-fresh-startup-golden
 
       - name: Upload Playwright traces
         if: failure()

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -568,16 +568,18 @@ describe('Electron runtime package contract', () => {
       'pnpm run test:e2e:terminal-rendering-golden'
     )
     expect(goldenRunSteps.get('linux')?.run).toContain(
-      'pnpm run test:e2e:posix-profile-index-golden'
+      'pnpm run --if-present test:e2e:posix-profile-index-golden'
     )
     expect(goldenRunSteps.get('mac')?.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
-    expect(goldenRunSteps.get('mac')?.run).toContain('pnpm run test:e2e:posix-profile-index-golden')
+    expect(goldenRunSteps.get('mac')?.run).toContain(
+      'pnpm run --if-present test:e2e:posix-profile-index-golden'
+    )
     expect(goldenRunSteps.get('windows')).toMatchObject({
       if: "runner.os == 'Windows'",
       shell: 'pwsh'
     })
     expect(goldenRunSteps.get('windows').run).toContain(
-      'pnpm run test:e2e:windows-fresh-startup-golden'
+      'pnpm run --if-present test:e2e:windows-fresh-startup-golden'
     )
     expect(goldenWorkflow.on.pull_request).toBeUndefined()
     expect(goldenWorkflow.on.workflow_dispatch).toBeDefined()
@@ -592,12 +594,16 @@ describe('Electron runtime package contract', () => {
       (step) => step.name === 'Run terminal rendering golden on Linux'
     )
     expect(releaseLinuxRunStep.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
-    expect(releaseLinuxRunStep.run).toContain('pnpm run test:e2e:posix-profile-index-golden')
+    expect(releaseLinuxRunStep.run).toContain(
+      'pnpm run --if-present test:e2e:posix-profile-index-golden'
+    )
     const releaseMacRunStep = releaseGoldenJob.steps.find(
       (step) => step.name === 'Run terminal rendering golden on macOS'
     )
     expect(releaseMacRunStep.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
-    expect(releaseMacRunStep.run).toContain('pnpm run test:e2e:posix-profile-index-golden')
+    expect(releaseMacRunStep.run).toContain(
+      'pnpm run --if-present test:e2e:posix-profile-index-golden'
+    )
     const releaseWindowsRunStep = releaseGoldenJob.steps.find(
       (step) => step.name === 'Run fresh-startup golden on Windows'
     )
@@ -605,7 +611,9 @@ describe('Electron runtime package contract', () => {
       if: "runner.os == 'Windows'",
       shell: 'pwsh'
     })
-    expect(releaseWindowsRunStep.run).toContain('pnpm run test:e2e:windows-fresh-startup-golden')
+    expect(releaseWindowsRunStep.run).toContain(
+      'pnpm run --if-present test:e2e:windows-fresh-startup-golden'
+    )
     expect(releaseEvidenceJob['continue-on-error']).toBe(true)
     expect(
       releaseEvidenceJob.strategy.matrix.include.map(({ platform }) => platform).sort()


### PR DESCRIPTION
## ELI5

Cut Release runs the workflow file from `main`, but it tests the code on the release tag. When those two disagree about which golden scripts exist, Windows CI used to die before any test ran. It now skips goldens the tag does not define.

## What Changed

`release-cut.yml` and `golden-e2e-experiment.yml` run tag-optional goldens with `pnpm run --if-present`. The original terminal-rendering golden stays required. The package contract test now pins that `--if-present` so it cannot be "simplified" away.

## Why

[Cut Release `v1.4.182-rc.1`](https://github.com/stablyai/orca/actions/runs/31682551181/job/94391407960) was dispatched from `main` against `adhoc/1.4.182-cherrypicks`. The Windows job checked out the tag and failed immediately:

```
ERR_PNPM_NO_SCRIPT  Missing script: test:e2e:windows-fresh-startup-golden
```

That script exists on `main`. It does not exist on the cherry-pick tag. The next cut from `main` will stay green; tags that do define the script still run it.

To actually execute the Windows fresh-startup golden on 1.4.182, cherry-pick the spec + `package.json` script onto `adhoc/1.4.182-cherrypicks` and cut a new RC.

## Linked Issue

Related: https://github.com/stablyai/orca/actions/runs/31682551181/job/94391407960

## Visual Proof

N/A — CI workflow / package-script wiring only. No UI or interaction change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs` — 22 passed
- [x] `pnpm run --if-present test:e2e:this-script-does-not-exist` exits 0
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Windows golden still cannot be executed on this machine. After merge, re-dispatch Cut Release from `main` so the updated workflow YAML is what runs.

## AI Disclosure

<!-- Internal contributor -->

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
