### PR TITLE
feat(sidebar): show linked PR/MR numbers on workspace cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -169,4 +169,21 @@ describe('WorktreeCard hosted review refresh', () => {
 
     expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
   })
+
+  it('polls hosted reviews when only the PR link property is visible', async () => {
+    worktreeCardProperties = ['pr']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(<WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />)
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -26,6 +26,54 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   )
 }))
 
+describe('WorktreeCardMetaBadges', () => {
+  it('shows a linked review number as a direct provider link', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardMetaBadges
+        issue={null}
+        linearIssue={null}
+        review={{
+          provider: 'github',
+          number: 456,
+          title: 'Fix stale GH PR',
+          state: 'open',
+          url: 'https://github.com/acme/orca/pull/456',
+          status: 'success'
+        }}
+        comment={null}
+      />
+    )
+
+    expect(markup).toContain('data-worktree-review-number=""')
+    expect(markup).toContain('href="https://github.com/acme/orca/pull/456"')
+    expect(markup).toContain('target="_blank"')
+    expect(markup).toContain('aria-label="Linked PR #456"')
+    expect(markup).toContain('>#456</a>')
+  })
+
+  it('keeps an MR number visible while its provider URL is unavailable', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardMetaBadges
+        issue={null}
+        linearIssue={null}
+        review={{
+          provider: 'gitlab',
+          number: 77,
+          title: 'Fix GitLab MR display',
+          state: 'open',
+          status: 'pending'
+        }}
+        comment={null}
+      />
+    )
+
+    expect(markup).toContain('data-worktree-review-number=""')
+    expect(markup).toContain('aria-label="Linked MR #77"')
+    expect(markup).toContain('>#77</span>')
+    expect(markup).not.toContain('href=')
+  })
+})
+
 describe('WorktreeCardDetailsHover', () => {
   it('wraps workspace and branch identity so long names stay readable in the hover panel', () => {
     const markup = renderToStaticMarkup(

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -48,7 +48,9 @@ describe('WorktreeCardMetaBadges', () => {
     expect(markup).toContain('href="https://github.com/acme/orca/pull/456"')
     expect(markup).toContain('target="_blank"')
     expect(markup).toContain('aria-label="Linked PR #456"')
-    expect(markup).toContain('>#456</a>')
+    expect(markup).toContain('text-emerald-500/80')
+    expect(markup).toContain('viewBox="0 0 16 16"')
+    expect(markup).toContain('#456</a>')
   })
 
   it('keeps an MR number visible while its provider URL is unavailable', () => {
@@ -69,7 +71,9 @@ describe('WorktreeCardMetaBadges', () => {
 
     expect(markup).toContain('data-worktree-review-number=""')
     expect(markup).toContain('aria-label="Linked MR #77"')
-    expect(markup).toContain('>#77</span>')
+    expect(markup).toContain('lucide-git-merge')
+    expect(markup).toContain('text-amber-500/85')
+    expect(markup).toContain('#77</span>')
     expect(markup).not.toContain('href=')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { CalendarClock, CircleDot, SquareTerminal, StickyNote } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { MetaIconBadge } from './WorktreeCardMetadataControls'
-import { getReviewLabel, ReviewIcon } from './worktree-review-helpers'
+import { getReviewLabel } from './worktree-review-helpers'
 import type {
   WorktreeCardMetaBadgesProps,
   WorktreeCardMetaBadgesRootProps
@@ -13,6 +14,48 @@ import { translate } from '@/i18n/i18n'
 
 function hasComment(comment: string | null): boolean {
   return (comment ?? '').trim().length > 0
+}
+
+function ReviewNumberBadge({
+  review
+}: {
+  review: NonNullable<WorktreeCardMetaBadgesProps['review']>
+}) {
+  const label = translate(
+    'auto.components.sidebar.WorktreeCardMeta.3ea2702e62',
+    'Linked {{value0}} #{{value1}}',
+    { value0: getReviewLabel(review), value1: review.number }
+  )
+  const className =
+    'h-4 rounded-full border-worktree-sidebar-border bg-worktree-sidebar-accent/55 px-1.5 py-0 font-mono text-[10px] leading-none text-muted-foreground shadow-none hover:bg-worktree-sidebar-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-worktree-sidebar-ring'
+
+  if (review.url) {
+    return (
+      <Badge asChild variant="outline" className={className}>
+        <a
+          href={review.url}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={label}
+          data-worktree-review-number=""
+          onClick={(event) => event.stopPropagation()}
+        >
+          #{review.number}
+        </a>
+      </Badge>
+    )
+  }
+
+  return (
+    <Badge
+      variant="outline"
+      className={className}
+      aria-label={label}
+      data-worktree-review-number=""
+    >
+      #{review.number}
+    </Badge>
+  )
 }
 
 export function hasWorktreeCardDetails({
@@ -141,17 +184,7 @@ export const WorktreeCardMetaBadges = React.forwardRef<
           <JiraIcon className="text-muted-foreground" />
         </MetaIconBadge>
       )}
-      {review && (
-        <MetaIconBadge
-          label={translate(
-            'auto.components.sidebar.WorktreeCardMeta.3ea2702e62',
-            'Linked {{value0}} #{{value1}}',
-            { value0: getReviewLabel(review), value1: review.number }
-          )}
-        >
-          <ReviewIcon review={review} />
-        </MetaIconBadge>
-      )}
+      {review && <ReviewNumberBadge review={review} />}
     </div>
   )
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { MetaIconBadge } from './WorktreeCardMetadataControls'
-import { getReviewLabel } from './worktree-review-helpers'
+import { getReviewLabel, ReviewIcon } from './worktree-review-helpers'
 import type {
   WorktreeCardMetaBadgesProps,
   WorktreeCardMetaBadgesRootProps
@@ -28,6 +28,11 @@ function ReviewNumberBadge({
   )
   const className =
     'h-4 rounded-full border-worktree-sidebar-border bg-worktree-sidebar-accent/55 px-1.5 py-0 font-mono text-[10px] leading-none text-muted-foreground shadow-none hover:bg-worktree-sidebar-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-worktree-sidebar-ring'
+  const content = (
+    <>
+      <ReviewIcon review={review} className="size-3 shrink-0" />#{review.number}
+    </>
+  )
 
   if (review.url) {
     return (
@@ -40,7 +45,7 @@ function ReviewNumberBadge({
           data-worktree-review-number=""
           onClick={(event) => event.stopPropagation()}
         >
-          #{review.number}
+          {content}
         </a>
       </Badge>
     )
@@ -53,7 +58,7 @@ function ReviewNumberBadge({
       aria-label={label}
       data-worktree-review-number=""
     >
-      #{review.number}
+      {content}
     </Badge>
   )
 }

--- a/src/renderer/src/components/sidebar/use-worktree-card-controller.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-controller.ts
@@ -40,7 +40,7 @@ export function useWorktreeCardController(props: ResolvedWorktreeCardProps) {
   const showCli = foundation.cardProps.includes('cli')
   const showComment = foundation.cardProps.includes('comment')
   const showPorts = foundation.cardProps.includes('ports')
-  const shouldRefreshHostedReview = foundation.newCardStyle ? showStatus : showPR
+  const shouldRefreshHostedReview = foundation.newCardStyle ? showStatus || showPR : showPR
   const detailsHoverControl = useWorktreeCardDetailsHoverControl()
   const hoverDetailsOpen = detailsHoverControl.hoverOpen
 

--- a/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.store-subscriptions.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.store-subscriptions.test.tsx
@@ -170,6 +170,34 @@ describe('useWorktreeCardSecondaryDetails store subscriptions', () => {
     expect(cacheTtlMs).toBe(0)
   })
 
+  it('includes the PR link property in new-style card details', () => {
+    let hasDetails = false
+    let reviewNumber: number | null = null
+    function Probe(): null {
+      const details = useWorktreeCardSecondaryDetails({
+        ...secondaryDetailsArgs(makeSettings(300_000)),
+        showPR: true,
+        newCardStyle: true,
+        prDisplay: {
+          provider: 'github',
+          number: 456,
+          title: 'Show review number',
+          state: 'open',
+          status: 'success',
+          url: 'https://github.com/acme/orca/pull/456'
+        }
+      })
+      hasDetails = details.hasDetails
+      reviewNumber = details.metaReview?.number ?? null
+      return null
+    }
+
+    mount(<Probe />)
+
+    expect(hasDetails).toBe(true)
+    expect(reviewNumber).toBe(456)
+  })
+
   it('writes a suppression tombstone when the user unlinks a displayed GitHub PR', async () => {
     const updateWorktreeMeta = vi.fn().mockResolvedValue({ ok: true })
     let unlink: (() => Promise<void>) | null = null

--- a/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.ts
@@ -231,7 +231,7 @@ export function useWorktreeCardSecondaryDetails({
     issue: metaIssue,
     linearIssue: metaLinearIssue,
     jiraIssue: metaJiraIssue,
-    review: newCardStyle ? null : metaReview,
+    review: metaReview,
     comment: metaComment,
     automationProvenance: metaAutomationProvenance,
     cliProvenance: metaCliProvenance

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -211,7 +211,7 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
             issue={metaIssue}
             linearIssue={metaLinearIssue}
             jiraIssue={metaJiraIssue}
-            review={newCardStyle ? null : metaReview}
+            review={metaReview}
             comment={metaComment}
             automationProvenance={metaAutomationProvenance}
             cliProvenance={metaCliProvenance}

--- a/src/renderer/src/components/sidebar/worktree-card-review-number-presentation.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-review-number-presentation.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { WorktreeCardController } from './use-worktree-card-controller'
+import { buildWorktreeCardPresentation } from './worktree-card-presentation'
+
+function makeCard(overrides: Partial<WorktreeCardController> = {}): WorktreeCardController {
+  return {
+    worktree: {
+      id: 'repo-1::/repo/worktrees/review-number',
+      repoId: 'repo-1',
+      path: '/repo/worktrees/review-number',
+      displayName: 'Show review number',
+      branch: 'feature/review-number',
+      head: 'abc123',
+      isBare: false,
+      isMainWorktree: false,
+      comment: '',
+      linkedIssue: null,
+      linkedPR: 456,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 1
+    },
+    newCardStyle: true,
+    compactCards: false,
+    isFolder: false,
+    branch: 'feature/review-number',
+    visibleCardTitle: 'Show review number',
+    cardProps: ['pr'],
+    workspacePorts: [],
+    hasDetails: true,
+    hasPorts: false,
+    showStatus: false,
+    showInlineAgentList: false,
+    showLineageChildChip: false,
+    showIdentityInNewCard: false,
+    showDeleteQuickAction: false,
+    metaReview: {
+      provider: 'github',
+      number: 456,
+      title: 'Show review number',
+      state: 'open',
+      status: 'success',
+      url: 'https://github.com/acme/orca/pull/456'
+    },
+    ...overrides
+  } as WorktreeCardController
+}
+
+describe('worktree card review number presentation', () => {
+  it('renders the selected review link in the new-style title row', () => {
+    const presentation = buildWorktreeCardPresentation(makeCard())
+    const markup = renderToStaticMarkup(<>{presentation.titleRowIndicators}</>)
+
+    expect(markup).toContain('data-worktree-review-number=""')
+    expect(markup).toContain('href="https://github.com/acme/orca/pull/456"')
+    expect(markup).toContain('aria-label="Linked PR #456"')
+    expect(markup).toContain('>#456</a>')
+  })
+
+  it('keeps the review number out of the card when the property is hidden', () => {
+    const presentation = buildWorktreeCardPresentation(
+      makeCard({ hasDetails: false, metaReview: null })
+    )
+    const markup = renderToStaticMarkup(<>{presentation.titleRowIndicators}</>)
+
+    expect(markup).not.toContain('data-worktree-review-number')
+    expect(markup).not.toContain('#456')
+  })
+})


### PR DESCRIPTION
## ELI5

Workspace cards now show the linked pull request or merge request number and state directly, so you can identify it without hovering. The number remains clickable and the existing rich hover details still work.

## What Changed

- Replaced the icon-only linked review indicator with a compact state icon + `#number` badge.
- Reused Orca's existing review glyphs and colors for open/passing, failing, pending, draft, closed, and merged reviews.
- Linked the badge directly to the provider URL when one is available, while keeping the number visible when it is not.
- Made the new card style honor the existing PR card-property toggle and refresh hosted review data when that property is enabled.
- Added coverage for GitHub PRs, GitLab MRs, provider URL fallback, refresh behavior, settings subscriptions, and new-card presentation.

## Why

When several workspaces have active reviews, requiring a hover on each card makes it slow to find a particular PR/MR. Showing the number in the existing metadata area improves scanability without adding another setting or removing the richer hover card.

## Linked Issue

Fixes #13329

## Visual Proof

| Before | After |
| --- | --- |
| ![Workspace card before: linked review number is not visible](https://github.com/user-attachments/assets/6b86813b-6142-4815-862c-786d5f38fdcc) | ![Workspace card after: linked review state icon and number are visible](https://github.com/user-attachments/assets/8b813d23-9862-4d79-bbbf-ed03fcb36ca7) |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual verification:

- macOS Electron app, light theme: confirmed the green open/passing review icon and `#14269` are visible without hovering.
- Confirmed the badge links to the provider PR URL and the existing detailed hover card still opens.

Automated verification:

- `pnpm lint`
- `pnpm typecheck`
- Focused Vitest suite: 6 files, 54 tests passed
- `pnpm build`
- Full Vitest suite: 51,660 tests passed and 117 skipped; one unrelated half-open socket liveness test failed once and passed immediately in an isolated rerun (28/28). CI can confirm under the repository's Node 24 environment.

## AI Disclosure

OpenAI Codex was used for implementation, test authoring, code review, and local validation.

## Review

- Security: reuses the existing provider URL and opens it with `rel="noreferrer"`; no new data flow or IPC surface.
- Cross-platform: renderer-only React/CSS change using existing components; no OS-specific behavior.
- Remote SSH and Mobile: no protocol, storage, or mobile code changes. Existing hosted-review data remains the source of truth.
- Backward compatibility: no schema or wire-format changes; cards without a provider URL still show a non-clickable number.
- Performance: the existing hosted-review refresh runs when either the status or PR property needs it; no additional polling interval or store subscription was added.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A (not provided)
