### PR TITLE
fix(ai-vault): make the merged scan stamp independent of leg order

### DIFF
--- a/src/main/ai-vault/session-list-results.test.ts
+++ b/src/main/ai-vault/session-list-results.test.ts
@@ -151,6 +151,29 @@ describe('mergeAiVaultListResults', () => {
     ).toBe('2026-08-02T00:00:05.000Z')
   })
 
+  // `new Date(ms).toISOString()` throws RangeError outside +/-8.64e15. It cannot
+  // be reached because Date.parse applies TimeClip, so a non-NaN parse is always
+  // in range — pin both sides of that boundary so widening the accept guard
+  // turns a would-be crash on a hostile leg stamp into a test failure.
+  it('accepts the oldest representable stamp and rejects one millisecond beyond it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T00:00:10.000Z'))
+
+    expect(
+      mergeAiVaultListResults(
+        [{ ...listResult([]), scannedAt: '-271821-04-20T00:00:00.000Z' }],
+        undefined
+      ).scannedAt
+    ).toBe('-271821-04-20T00:00:00.000Z')
+
+    expect(
+      mergeAiVaultListResults(
+        [{ ...listResult([]), scannedAt: '-271821-04-19T23:59:59.999Z' }],
+        undefined
+      ).scannedAt
+    ).toBe('2026-08-02T00:00:10.000Z')
+  })
+
   it('does not cap an Unlimited all-host merge', () => {
     const sessions = Array.from({ length: 1001 }, (_, index) => session(index))
     const merged = mergeAiVaultListResults([{ ...listResult([]), sessions }], undefined, true)

--- a/src/main/ai-vault/session-list-results.test.ts
+++ b/src/main/ai-vault/session-list-results.test.ts
@@ -123,6 +123,34 @@ describe('mergeAiVaultListResults', () => {
     ).toBe('2026-08-02T00:00:04.000Z')
   })
 
+  // Leg order is host-enumeration order (local, then SSH, then runtime), so it
+  // must not decide the merged stamp.
+  it('resolves an equal-instant tie the same way in either leg order', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T00:00:10.000Z'))
+    const noMillis = { ...listResult([]), scannedAt: '2026-08-02T00:00:05Z' }
+    const withMillis = { ...listResult([]), scannedAt: '2026-08-02T00:00:05.000Z' }
+
+    expect(mergeAiVaultListResults([noMillis, withMillis], undefined).scannedAt).toBe(
+      '2026-08-02T00:00:05.000Z'
+    )
+    expect(mergeAiVaultListResults([withMillis, noMillis], undefined).scannedAt).toBe(
+      '2026-08-02T00:00:05.000Z'
+    )
+  })
+
+  it('normalizes the merged stamp so a leg ISO variant cannot leak into it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T00:00:10.000Z'))
+
+    expect(
+      mergeAiVaultListResults(
+        [{ ...listResult([]), scannedAt: '2026-08-01T19:00:05.000-05:00' }],
+        undefined
+      ).scannedAt
+    ).toBe('2026-08-02T00:00:05.000Z')
+  })
+
   it('does not cap an Unlimited all-host merge', () => {
     const sessions = Array.from({ length: 1001 }, (_, index) => session(index))
     const merged = mergeAiVaultListResults([{ ...listResult([]), sessions }], undefined, true)

--- a/src/main/ai-vault/session-list-results.ts
+++ b/src/main/ai-vault/session-list-results.ts
@@ -84,11 +84,9 @@ export function mergeAiVaultListResults(
 
 function latestAiVaultScannedAt(results: readonly AiVaultListResult[]): string {
   const nowMs = Date.now()
-  let latest: string | undefined
   let latestMs = Number.NEGATIVE_INFINITY
   for (const result of results) {
-    const stamp = result.scannedAt
-    const stampMs = Date.parse(stamp)
+    const stampMs = Date.parse(result.scannedAt)
     // Remote legs carry their own clock and only `z.string()` validation. An
     // unparsable or future stamp would pin the merged stamp above every local
     // rescan and silently freeze the renderer's scannedAt equality guard.
@@ -98,10 +96,10 @@ function latestAiVaultScannedAt(results: readonly AiVaultListResult[]): string {
     if (Number.isNaN(stampMs) || stampMs > nowMs) {
       continue
     }
-    if (stampMs > latestMs) {
-      latestMs = stampMs
-      latest = stamp
-    }
+    latestMs = Math.max(latestMs, stampMs)
   }
-  return latest ?? new Date(nowMs).toISOString()
+  // A merge has no single scan instant, so return the canonical form of the
+  // newest accepted one: echoing a winning leg's string made two legs at the
+  // same instant in different ISO shapes resolve by host-enumeration order.
+  return new Date(latestMs === Number.NEGATIVE_INFINITY ? nowMs : latestMs).toISOString()
 }

--- a/src/main/ipc/ai-vault-session-title-routing.ts
+++ b/src/main/ipc/ai-vault-session-title-routing.ts
@@ -4,8 +4,8 @@ import type {
 } from '../../shared/ai-vault-session-title'
 import {
   LOCAL_EXECUTION_HOST_ID,
-  normalizeExecutionHostScope,
-  parseExecutionHostId
+  parseExecutionHostId,
+  requestedExecutionHostScope
 } from '../../shared/execution-host'
 import { resolveLocalAiVaultSessionTitles } from '../ai-vault/session-title-resolver'
 import { parseAiVaultSessionTitlesResult } from '../ai-vault/session-title-result-validation'
@@ -20,9 +20,7 @@ export async function resolveAiVaultSessionTitlesByHost(
   args: AiVaultSessionTitlesArgs,
   resolveRuntime?: RuntimeAiVaultSessionTitleResolver
 ): Promise<AiVaultSessionTitlesResult> {
-  const executionHostScope = normalizeExecutionHostScope(
-    args.executionHostScope ?? LOCAL_EXECUTION_HOST_ID
-  )
+  const executionHostScope = requestedExecutionHostScope(args.executionHostScope)
   if (executionHostScope === LOCAL_EXECUTION_HOST_ID) {
     return resolveLocalAiVaultSessionTitles(args.requests)
   }

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -28,8 +28,8 @@ import { handleAiVaultGetFirstUserPrompt } from '../ai-vault/session-first-user-
 import { registerAiVaultResumeHandler, type AiVaultResumeHandlerOptions } from './ai-vault-resume'
 import {
   LOCAL_EXECUTION_HOST_ID,
-  normalizeExecutionHostScope,
   parseExecutionHostId,
+  requestedExecutionHostScope,
   toRuntimeExecutionHostId,
   toSshExecutionHostId,
   type ExecutionHostScope
@@ -91,9 +91,7 @@ async function listAiVaultSessions(
   args?: AiVaultListArgs,
   options: { signal?: AbortSignal } = {}
 ): Promise<AiVaultListResult> {
-  const executionHostScope = normalizeExecutionHostScope(
-    args?.executionHostScope ?? LOCAL_EXECUTION_HOST_ID
-  )
+  const executionHostScope = requestedExecutionHostScope(args?.executionHostScope)
   // Scope paths change the result set, so they must be part of the cache key.
   // A scanner consumes at most 64 paths, so smaller equivalent workspace sets
   // can share a snapshot regardless of which worktree was selected first.

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../shared/ai-vault-types'
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
-  normalizeExecutionHostScope,
+  requestedExecutionHostScope,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
 import { useAppStore } from '@/store'
@@ -36,10 +36,10 @@ export const isAiVaultScanCancellation = isAiVaultScanCancelledError
 
 type AiVaultRefreshArgs = { force?: boolean; background?: boolean; reuseLoadedDepth?: boolean }
 
-// Mirrors how the main process routes the scan: this scope answers with a merge
-// of several hosts' legs rather than one scanner's result.
+// Shares main's request resolver, so 'merged' here is exactly the scope that
+// fans out there: the answer is several hosts' legs, not one scanner's result.
 function isMergedAiVaultHostScope(scope: ExecutionHostScope): boolean {
-  return normalizeExecutionHostScope(scope) === ALL_EXECUTION_HOSTS_SCOPE
+  return requestedExecutionHostScope(scope) === ALL_EXECUTION_HOSTS_SCOPE
 }
 
 export function useAiVaultSessionRefresh(
@@ -160,8 +160,6 @@ export function useAiVaultSessionRefresh(
         // is a merge of legs on independent clocks stamped with the newest leg,
         // so a lagging host's leg can change while the merged stamp stands
         // still — there, only the structural reconcile below may decide.
-        // Normalized through the shared helper because that is what the main
-        // process routes on: an empty or unrecognized scope also merges.
         if (
           !isMergedAiVaultHostScope(hostScope) &&
           lastAppliedScanRef.current?.scopeKey === scanKey &&

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -36,8 +36,11 @@ export const isAiVaultScanCancellation = isAiVaultScanCancelledError
 
 type AiVaultRefreshArgs = { force?: boolean; background?: boolean; reuseLoadedDepth?: boolean }
 
-// Shares main's request resolver, so 'merged' here is exactly the scope that
-// fans out there: the answer is several hosts' legs, not one scanner's result.
+// Shares main's request resolver, so this is exactly the scope that fans out on
+// the desktop IPC path. Deliberately over-inclusive: the paired web transport
+// drops the scope and serves one host, so 'all' there costs a redundant
+// reconcile. Erring the other way would re-enable the stamp fast-path on a real
+// merge, which is the bug this guard exists to prevent.
 function isMergedAiVaultHostScope(scope: ExecutionHostScope): boolean {
   return requestedExecutionHostScope(scope) === ALL_EXECUTION_HOSTS_SCOPE
 }

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeExecutionHostScope,
   normalizeVisibleExecutionHostIds,
   parseExecutionHostId,
+  requestedExecutionHostScope,
   toRuntimeExecutionHostId,
   toSshExecutionHostId
 } from './execution-host'
@@ -64,6 +65,16 @@ describe('execution host identity', () => {
     expect(normalizeExecutionHostScope('bogus')).toBe(ALL_EXECUTION_HOSTS_SCOPE)
     expect(normalizeExecutionHostScope('ssh:')).toBe(ALL_EXECUTION_HOSTS_SCOPE)
     expect(normalizeExecutionHostScope('all')).toBe(ALL_EXECUTION_HOSTS_SCOPE)
+  })
+
+  it('defaults an omitted scope request to this host, not a fan-out', () => {
+    expect(requestedExecutionHostScope(undefined)).toBe(LOCAL_EXECUTION_HOST_ID)
+    expect(requestedExecutionHostScope(null)).toBe(LOCAL_EXECUTION_HOST_ID)
+    // An empty or unrecognized scope is a real value, so it still fans out.
+    expect(requestedExecutionHostScope('')).toBe(ALL_EXECUTION_HOSTS_SCOPE)
+    expect(requestedExecutionHostScope('bogus')).toBe(ALL_EXECUTION_HOSTS_SCOPE)
+    expect(requestedExecutionHostScope('all')).toBe(ALL_EXECUTION_HOSTS_SCOPE)
+    expect(requestedExecutionHostScope('ssh:dev%20box')).toBe('ssh:dev%20box')
   })
 
   it('normalizes visible host id arrays', () => {

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -113,6 +113,12 @@ export function normalizeExecutionHostScope(value: string | null | undefined): E
   return normalizeExecutionHostId(normalized) ?? ALL_EXECUTION_HOSTS_SCOPE
 }
 
+// An omitted scope on a request means this host, not a fan-out. Callers and the
+// renderer share this so both agree on which requests answer with a merge.
+export function requestedExecutionHostScope(value: string | null | undefined): ExecutionHostScope {
+  return normalizeExecutionHostScope(value ?? LOCAL_EXECUTION_HOST_ID)
+}
+
 export function normalizeVisibleExecutionHostIds(
   value: readonly string[] | null | undefined
 ): ExecutionHostId[] | null {


### PR DESCRIPTION
## ELI5

When the app shows your agent history "for every machine at once", it asks each machine separately and then stitches the answers together. It also writes down a single time on the stitched-together list, so the screen can tell whether anything is actually new. It picks the newest of the times the machines reported — but until now it copied that machine's timestamp text word-for-word. Two machines can report the exact same moment written two slightly different ways (like "3pm" vs "3:00:00pm"), and in that case the winner was whichever machine happened to be asked first, which depends on how many machines you have and in what order they were listed. Nothing visibly broke for anyone — this is a preventative cleanup — but a value that is supposed to describe *when* was quietly depending on *which order we asked*, which is exactly the kind of thing that turns into a confusing bug later. Now the stitched list writes the winning moment in one standard format of its own, so the answer is the same no matter what order the machines come back in.

## Summary

- `src/main/ai-vault/session-list-results.ts:85` — `latestAiVaultScannedAt` no longer tracks a winning leg's verbatim string. It tracks only `latestMs` and returns `new Date(latestMs).toISOString()` (falling back to `now` when every leg was rejected as unparsable/future). The skip condition and the existing WHY comment about remote clocks are unchanged.
- `src/shared/execution-host.ts:116` — new `requestedExecutionHostScope(value)`, which is exactly `normalizeExecutionHostScope(value ?? LOCAL_EXECUTION_HOST_ID)`: the "omitted scope means this host, not a fan-out" rule, in one place.
- `src/main/ipc/ai-vault.ts:94` — `listAiVaultSessions` now calls that resolver instead of open-coding the same expression. Behavior is unchanged by construction.
- `src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts:41` — `isMergedAiVaultHostScope` uses the same resolver, so the predicate is equivalent to main's routing rather than merely claiming to mirror it. The overclaiming comment above it and the now-duplicated tail of the guard comment at `:158` are replaced/trimmed.

### Why the previous behavior was wrong (item C)

#14261 switched the merged-stamp selection from a lexicographic max to `if (stampMs > latestMs)` over parsed instants. Parsing was the right call, but strict `>` over parsed instants plus echoing the raw string means an equal-instant tie is broken by array position. That array is built in `src/main/ipc/ai-vault.ts:141` in host-enumeration order — local, then SSH legs, then runtime legs, then discovery-issue rows — so the merged stamp became a function of how many hosts you have and how they are ordered. The lexicographic max it replaced was order-independent. That is a real (if benign) regression, and it had no test.

## Why this is correct

**The tie-break rule I chose: don't have one.** A merge is not a scan, so it has no scan instant of its own; its stamp is derived data. Returning `new Date(newestAcceptedMs).toISOString()` makes the output a pure function of the *set* of accepted instants, which is order-independent *and* format-independent by construction. There is nothing left to tie-break.

Alternatives rejected:
- **Lexicographic max as the tie-break** (keep the verbatim string, break ties by string compare). Fixes the order-dependence but leaves the merged stamp echoing whichever ISO shape a leg happened to send. To be precise about how reachable that is: every producer in this tree emits canonical `new Date().toISOString()` (`session-scanner.ts:157`, `remote-session-scanner.ts:126`, `runtime-session-scanner.ts:194`, `session-list-results.ts:26`, `relay/ai-vault-handler.ts:105`), and `restampAiVaultListResult` passes a remote's already-canonical string straight through — so shape variance across legs does **not** exist today. It is reachable only via version skew or a malformed/hostile remote, given `scannedAt` is `z.string()`-only. Canonicalizing is still the better rule because it removes the question rather than answering it, but it is hardening, not a fix for something live.
- **Prefer the longest/most-precise string on a tie.** Arbitrary, and still leaves the merged stamp echoing one leg's formatting choices.

**What this gives up:** the implicit invariant "the merged stamp is verbatim one of the input strings". I checked the consumers — nothing compares `merged.scannedAt` to a leg's `scannedAt`. The only stamp consumer is the renderer's single-host equality guard, which merged scopes skip, and `reuseAiVaultListResult`, which ignores `scannedAt`. Sub-millisecond precision in a leg stamp is also lost through `Date.parse`, which is irrelevant since `scannedAt` is only used for recency/equality and the pre-existing code already parsed every stamp.

**Wire compatibility:** no work needed. `mergeAiVaultListResults` has exactly one production caller — desktop main IPC, talking to a same-version renderer. The runtime RPC path never merges (`src/main/runtime/rpc/methods/ai-vault.ts:94` restamps a single host-local scan), so no remote host ever publishes a merged stamp to an older client.

**On the shared resolver (item A).** The old comment claimed the predicate "mirrors how the main process routes the scan"; it didn't. Main applies `?? LOCAL_EXECUTION_HOST_ID` *before* normalizing, so a nullish scope routes to local (single host) in main but classified as merged in the renderer. Empty string and unrecognized ids did agree, and the mismatch is unreachable through the hook's non-nullable `ExecutionHostScope` parameter and fails safe (an extra reconcile, never a skipped one). I chose exact equivalence over a corrected comment because a comment cannot stop drift: the whole failure mode here is that the two sides are edited independently. Semantics locked in by `requestedExecutionHostScope`, matching main exactly as it behaves today: `undefined`/`null` → `local`; `''` → `all` (`??` does not catch empty string); unrecognized / `'ssh:'` → `all`; valid ids preserved.

## Tests

- `src/main/ai-vault/session-list-results.test.ts` — `resolves an equal-instant tie the same way in either leg order`: legs at `'...:00:05Z'` and `'...:00:05.000Z'`, merged in both orders, both expected to be `'2026-08-02T00:00:05.000Z'`. **Evidence it is a real guard:** with `session-list-results.ts` stashed back to pre-fix, this fails with `expected '2026-08-02T00:00:05Z' to be '2026-08-02T00:00:05.000Z'` — i.e. the pre-fix code really does return a different stamp for the two orders.
- `src/main/ai-vault/session-list-results.test.ts` — `normalizes the merged stamp so a leg ISO variant cannot leak into it`: one leg at `'2026-08-01T19:00:05.000-05:00'`, expected `'2026-08-02T00:00:05.000Z'`. **Evidence:** pre-fix it fails with `expected '2026-08-01T19:00:05.000-05:00'`. This is the test that pins canonicalization specifically. (Correction: an earlier draft of this body claimed test 1 would also pass under a lexicographic tie-break. It would not — lexicographic max of `'2026-08-02T00:00:05Z'` and `'2026-08-02T00:00:05.000Z'` is the `...05Z` form, because `'Z'` > `'.'`, while test 1 expects `...05.000Z`. Both tests therefore pin canonicalization, not just this one.)
- `src/shared/execution-host.test.ts` — `defaults an omitted scope request to this host, not a fan-out`. **Evidence:** with `execution-host.ts` stashed back, it fails with `TypeError: requestedExecutionHostScope is not a function`. This is the only place the item-A change is observable; I deliberately did *not* add a renderer test casting `undefined as unknown as ExecutionHostScope`, because that would pin hook behavior for an input the type forbids, in the skip (unsafe) direction.
- `src/main/ai-vault/session-list-results.test.ts` — `accepts the oldest representable stamp and rejects one millisecond beyond it`: `new Date(ms).toISOString()` throws `RangeError` outside ±8.64e15, and that is unreachable only because `Date.parse` applies TimeClip — so the `Number.isNaN` guard alone constrains the argument. **Evidence:** dropping that guard makes both assertions fail with the exact `RangeError` they exist to prevent.
- The three pre-existing `mergeAiVaultListResults` stamp tests (six stamp assertions across them) already expected canonical `...000Z`/`...500Z` strings, so canonicalization is a no-op for them; they stayed green untouched.

## Verification

- `npx vitest run --config config/vitest.config.ts src/main/ai-vault src/main/ipc/ai-vault.test.ts src/main/ipc/ai-vault-host-leg-cache.test.ts src/shared/execution-host.test.ts src/renderer/src/components/right-sidebar` → **275 files, 2341 tests passed**
- Pre-fix baseline (production files stashed, tests kept): merge tests **2 failed | 7 passed**; execution-host test **1 failed | 8 passed**. Restored → all pass.
- `npx tsc --noEmit -p config/tsconfig.node.json` → **pass** (also catches the now-unused `normalizeExecutionHostScope` imports in both edited callers)
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` → **pass**
- `npx oxlint` on all six touched files → **clean**
- `npx oxlint --config config/oxlint-react-doctor.json src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts` → **clean**
- `npx oxfmt --check` on all six touched files → **clean**

Not run: the full suite, packaging, or any manual/UI verification. This is a pure main-process/shared-module change with no rendered-UI surface.

## Deliberately not done

**Item B (skip the merged-scope treatment when the client is web/paired) — dropped.** The premise checks out: `src/renderer/src/web/web-preload-api.ts:1575` accepts scope `'all'` but sends the runtime RPC only `{ limit, force, scopePaths, executionHostId }`, and `src/main/runtime/rpc/methods/ai-vault.ts` has no `executionHostScope` param at all, so web really does receive a single restamped host-local scan that the renderer classifies as merged. There *is* a cheap detector (`isWebClientLocation()`), but it answers the wrong question. What the hook needs to know is "does my transport merge legs" — a property of the preload implementation, not of the client's location. Baking "web never merges" into the hook means that the day web-preload does fan out, the hook silently re-enables the stamp fast-path on a genuinely merged result, reintroducing exactly the hidden-sessions bug #14261 fixed, in the unsafe direction, from a file nobody editing web-preload would think to open. The only non-brittle route is for the producer to declare it (an optional `merged?: boolean` on `AiVaultListResult`), which is a published-shape change reaching mixed-version clients. The entire saving is one `reuseEqualCatalogRows` pass over at most a few hundred rows per refocus, with no correctness impact. Not worth either version.

**Item E (make the merged-scope `lastAppliedScanRef` write conditional) — dropped, intentionally no code change.** Under a merged scope the ref is written but never read, since the guard short-circuits first. Leaving it is correct and safer: the ref is keyed by `scanKey`, built from `aiVaultSessionResultCacheKey(hostScope, scopePaths)` plus the limit, so a merged-scope entry can never satisfy the guard for a single-host scope — the write is inert, not a hazard. Making it conditional would add a *second* place that has to classify merged-vs-single (the exact duplication item A is about), and would leave the ref lying about what was last applied.

**`src/main/ipc/ai-vault-session-title-routing.ts` now adopts the shared resolver too.** It held a character-for-character copy of the same expression; leaving it would have left the resolver as the single source of truth for two of three sites, which is exactly the drift this PR exists to remove. Pure no-op substitution.

The four remaining `normalizeExecutionHostScope` call sites deliberately do **not** adopt it, because they encode a different default: `web-preload-api.ts:1578` defaults to the paired runtime host rather than local; `web-preload-api.ts:1597` is already guarded on a truthy value; and `store/slices/ui.ts:294,2028,2466` back a persisted workspace filter whose default is `'all'`, so migrating them would silently flip that filter from “show all” to “show local”.

## Open question

Canonicalizing changes the *string shape* the renderer receives when a winning leg sent a non-canonical ISO variant. I traced every consumer and found none that cares (details under "What this gives up"), but that is a code-reading argument, not something a test enforces. If a reviewer would rather preserve "the merged stamp is verbatim one of the inputs", the fallback that still fixes the order-dependence is a lexicographic tie-break on equal instants — strictly weaker, for the reasons above.

Made with [Orca](https://github.com/stablyai/orca) 🐋




---

**Review note on how reachable this is.** The ELI5 calls this preventative, and no user has hit it — every stamp producer in this tree emits canonical `toISOString()`. Worth stating the limit of that precisely, though: the SSH relay path passes a remote host's `scannedAt` through verbatim (`ssh-session-list.ts:80` → `restampAiVaultListResult`) under `z.string()`-only validation, and clients and hosts update independently. So the non-canonical case sits behind a real cross-version wire rather than being purely hypothetical — this is hardening on a live boundary, not a thought experiment.
