### PR TITLE
perf(worktrees): bound the duplicate-id scan in reuseEqualCatalogRows

### DIFF
--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.test.ts
@@ -71,4 +71,44 @@ describe('reuseEqualCatalogRows', () => {
     expect(reconciled[0]).toBe(current[1])
     expect(reconciled[1]).toBe(current[0])
   })
+
+  it('reuses a match inside the duplicate-id scan window', () => {
+    const current = [
+      { id: 'dup', marker: 'a' },
+      { id: 'dup', marker: 'b' },
+      { id: 'dup', marker: 'c' }
+    ]
+
+    const reconciled = reuseEqualCatalogRows(current, [{ id: 'dup', marker: 'c' }])
+
+    expect(reconciled[0]).toBe(current[2])
+  })
+
+  // Without the cap this walks the whole bucket, so a 64-row bucket costs 64
+  // deep compares per incoming row. Counting reads keeps the guard deterministic
+  // — a wall-clock assertion would be flaky on shared CI runners.
+  it('caps the deep compares for one id instead of scanning the whole bucket', () => {
+    const bucketSize = 64
+    const current = Array.from({ length: bucketSize }, (_, index) => ({
+      id: 'dup',
+      marker: `previous-${index}`
+    }))
+    let reads = 0
+    const incoming = [
+      {
+        id: 'dup',
+        get marker(): string {
+          reads++
+          return 'matches-nothing'
+        }
+      }
+    ]
+
+    const reconciled = reuseEqualCatalogRows(current, incoming)
+
+    // No match, so the incoming row is kept — a missed reuse costs identity, never correctness.
+    expect(reconciled[0]).toBe(incoming[0])
+    expect(reads).toBeLessThanOrEqual(8)
+    expect(reads).toBeLessThan(bucketSize)
+  })
 })

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -30,6 +30,14 @@ function catalogValuesEqual(left: unknown, right: unknown): boolean {
   return true
 }
 
+// Rows sharing an id are scanned linearly, so an unbounded bucket would cost
+// O(k^2) deep compares. Reuse is only an optimization — a missed match yields a
+// new object identity, never a wrong row — so cap the scan rather than build a
+// second index that would have to stay in step with catalogValuesEqual.
+// Both callers key on ids that are unique by construction, making this a bound
+// on damage rather than a live path.
+const MAX_DUPLICATE_ID_SCAN = 8
+
 export function reuseEqualCatalogRows<T extends CatalogRow>(
   current: readonly T[] | undefined,
   incoming: readonly T[]
@@ -48,10 +56,18 @@ export function reuseEqualCatalogRows<T extends CatalogRow>(
   }
   const reconciled = incoming.map((row) => {
     const candidates = currentById.get(row.id)
-    const previousIndex = candidates?.findIndex((candidate) => catalogValuesEqual(candidate, row))
-    return previousIndex !== undefined && previousIndex >= 0
-      ? candidates!.splice(previousIndex, 1)[0]
-      : row
+    if (!candidates) {
+      return row
+    }
+    const scanLimit = Math.min(candidates.length, MAX_DUPLICATE_ID_SCAN)
+    for (let index = 0; index < scanLimit; index++) {
+      const candidate = candidates[index]
+      if (candidate !== undefined && catalogValuesEqual(candidate, row)) {
+        candidates.splice(index, 1)
+        return candidate
+      }
+    }
+    return row
   })
   return current.length === reconciled.length &&
     current.every((row, index) => row === reconciled[index])

--- a/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
+++ b/src/renderer/src/store/slices/worktree-catalog-reconciliation.ts
@@ -30,12 +30,12 @@ function catalogValuesEqual(left: unknown, right: unknown): boolean {
   return true
 }
 
-// Rows sharing an id are scanned linearly, so an unbounded bucket would cost
-// O(k^2) deep compares. Reuse is only an optimization — a missed match yields a
-// new object identity, never a wrong row — so cap the scan rather than build a
-// second index that would have to stay in step with catalogValuesEqual.
-// Both callers key on ids that are unique by construction, making this a bound
-// on damage rather than a live path.
+// NOTHING HITS THIS TODAY: both callers key on ids that are unique by
+// construction, so buckets stay at 1-3. It only bounds the damage if that ever
+// changes — a same-id bucket costs one deep compare per candidate, so an
+// unbounded one is O(k^2). A cap beats a second index that would have to stay in
+// step with catalogValuesEqual, and reuse is only an optimization: dropping a
+// match past the window costs object identity, never correctness.
 const MAX_DUPLICATE_ID_SCAN = 8
 
 export function reuseEqualCatalogRows<T extends CatalogRow>(


### PR DESCRIPTION
## ELI5

The app keeps a list of things (worktrees, agent sessions) and refreshes it constantly. Almost everything in the refreshed list is identical to what was already on screen, so before redrawing, the app tries to match each new entry to the old one and keep the old copy — that way the screen doesn't have to rebuild parts that didn't change.

To match them it uses a name tag. Normally every entry has its own unique tag, so matching is instant. But the matching code didn't assume that: if a lot of entries somehow shared one tag, it would compare every new entry against every old one with the same tag — and that grows with the *square* of how many share it. A thousand of them took about 134 milliseconds; two thousand took over half a second.

**Nobody is hitting this today**, and this isn't fixing a bug anyone has seen — both places that use this code hand it tags that are unique by construction, so the buckets are always size one. This is purely about not leaving a loaded gun on the table. The fix is a limit: only check the first handful of same-tag entries and then stop. If that means occasionally missing a match, the worst outcome is that one entry gets redrawn when it didn't strictly need to be — never a wrong entry, never wrong data.

## Summary

`reuseEqualCatalogRows` (`src/renderer/src/store/slices/worktree-catalog-reconciliation.ts`) buckets previous rows by `id`, then resolves each incoming row by scanning its bucket with `catalogValuesEqual` — a deep structural compare — until one matches. Unique ids mean bucket size 1 and O(1) per row. A bucket of `k` duplicates whose match isn't near the head degenerates to O(k²) deep compares.

The fix caps the scan at `MAX_DUPLICATE_ID_SCAN = 8`. Worst case becomes O(8k), i.e. linear.

## Why a cap rather than an index

The obvious alternative is to index the bucket by a cheap fingerprint so lookup is O(1). I rejected it: a fingerprint is a **second implementation of equality** that must stay in step with `catalogValuesEqual` forever, with no type-level or automated guard. Someone later teaching `catalogValuesEqual` to compare `Date`s or `Set`s structurally would silently desynchronise the two, and the failure would be invisible — equal rows quietly stop being reused.

That's a permanent maintenance liability bought to speed up a path that **cannot currently be reached**. The cap gets the same asymptotic protection in four lines, adds no new invariant, and its failure mode is bounded and benign: reuse is an optimization, so a missed match costs one object identity, never correctness.

Worth being explicit about the trade the cap makes: in a hypothetical large-duplicate-bucket scenario, matches beyond the eighth candidate stop being reused. That's a deliberate loss of an optimization in a case no caller produces.

## Reachability — why this is hardening, not a fix

Both call sites keep buckets at size 1:
- `src/renderer/src/components/right-sidebar/ai-vault-session-identity.ts` — merged AI-vault results are deduped by a `Map` keyed on `session.id` in `src/main/ai-vault/session-list-results.ts` before they ever reach the reconciler.
- `src/renderer/src/store/slices/worktrees.ts` — worktree ids are unique per host. (Note the pre-existing test `reuses same-ID rows from different hosts independently`: the same `id` legitimately appears twice across hosts, so buckets of 2–3 do occur. Well inside the cap.)

## Measurements

Worst case (bucket of `k`, no incoming row matches — the full scan):

| duplicate bucket | before | after |
|---|---|---|
| k=500 | 39.7 ms | 0.66 ms |
| k=1000 | 134.0 ms | 1.20 ms |
| k=2000 | 540.8 ms | 2.22 ms |

Common path (unique ids, nothing changed — the case that actually runs):

| rows | before | after |
|---|---|---|
| 500 | 0.24 ms | 0.21 ms |
| 2000 | 0.86 ms | 0.86 ms |

No regression on the live path, which was the hard requirement.

## Tests

Two added to `worktree-catalog-reconciliation.test.ts`:

- **`caps the deep compares for one id instead of scanning the whole bucket`** — a 64-row bucket with no match, counting property reads on the incoming row via a getter (deterministic; a wall-clock assertion would be flaky on shared runners). **Evidence it is a real guard:** with the cap removed it fails with `expected 64 to be less than or equal to 8`. It also asserts the unmatched incoming row is returned as-is, pinning that a missed match costs identity and not correctness.
- **`reuses a match inside the duplicate-id scan window`** — parity: a match within the window is still reused.

Honest note: neither test *fails against `main` for the reason the change exists*, because the change is required to be semantically identical on every reachable input. The cap test fails only against a deliberately uncapped variant. The existing suite is what pins the unchanged semantics — whole-array reuse, consume-once, ordering, adds/removals/reorders — and all of it passes untouched.

## Verification

- `npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices src/renderer/src/components/right-sidebar` → **362 files, 4377 tests pass** (covers both callers)
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` → pass
- `npx oxlint` on both touched files → clean
- Benchmarks above run ad hoc against extracted copies of the old and new functions; no benchmark script is committed.

## History

An earlier revision of this PR was +373/−4 and used a fingerprint index. It was replaced with this after review concluded the complexity wasn't justified for an unreachable path — and after a reviewer found the fingerprint contract already broken for sparse arrays, which is exactly the class of bug a duplicated equality implementation invites.

Made with [Orca](https://github.com/stablyai/orca) 🐋
