### PR TITLE
fix(ai-vault): explain SSH workspace hosts missing from the all-hosts session list

### DIFF
--- a/src/main/ai-vault/unscanned-ssh-host-issues.test.ts
+++ b/src/main/ai-vault/unscanned-ssh-host-issues.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { unscannedSshHostIssues, type ExpectedSshAiVaultHost } from './unscanned-ssh-host-issues'
+
+const host = (
+  targetId: string,
+  connectionStatus?: ExpectedSshAiVaultHost['connectionStatus']
+): ExpectedSshAiVaultHost => ({ targetId, label: targetId, connectionStatus })
+
+describe('unscannedSshHostIssues', () => {
+  it('explains workspace hosts that produced no leg', () => {
+    const issues = unscannedSshHostIssues({
+      expectedHosts: [host('dev-box', 'disconnected'), host('gpu-1')],
+      scannedTargetIds: new Set()
+    })
+
+    expect(issues).toEqual([
+      {
+        agent: 'codex',
+        kind: 'scope',
+        path: 'SSH hosts',
+        message: "Agent sessions from dev-box, gpu-1 aren't listed — not connected."
+      }
+    ])
+  })
+
+  it('omits hosts that already contributed a leg', () => {
+    const issues = unscannedSshHostIssues({
+      expectedHosts: [host('dev-box'), host('gpu-1')],
+      scannedTargetIds: new Set(['dev-box'])
+    })
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toContain('gpu-1')
+    expect(issues[0]?.message).not.toContain('dev-box')
+  })
+
+  it.each(['connecting', 'deploying-relay', 'reconnecting', 'connected'] as const)(
+    'reports %s hosts as still connecting, never as a host failure',
+    (status) => {
+      const issues = unscannedSshHostIssues({
+        expectedHosts: [host('dev-box', status), host('gpu-1', 'auth-failed')],
+        scannedTargetIds: new Set()
+      })
+
+      expect(issues.map((issue) => issue.kind)).toEqual(['scope', 'scope'])
+      expect(issues[0]?.message).toBe(
+        "Agent sessions from dev-box aren't listed yet — still connecting."
+      )
+      expect(issues[1]?.message).toBe("Agent sessions from gpu-1 aren't listed — not connected.")
+    }
+  )
+
+  it('says nothing when every expected host was scanned', () => {
+    expect(
+      unscannedSshHostIssues({
+        expectedHosts: [host('dev-box'), host('gpu-1')],
+        scannedTargetIds: new Set(['dev-box', 'gpu-1'])
+      })
+    ).toEqual([])
+  })
+
+  it('collapses a long host list into one capped row', () => {
+    const issues = unscannedSshHostIssues({
+      expectedHosts: ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((id) => host(id, 'disconnected')),
+      scannedTargetIds: new Set()
+    })
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toBe(
+      "Agent sessions from a, b, c, d, e and 2 more aren't listed — not connected."
+    )
+  })
+})

--- a/src/main/ai-vault/unscanned-ssh-host-issues.ts
+++ b/src/main/ai-vault/unscanned-ssh-host-issues.ts
@@ -1,0 +1,76 @@
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import type { SshConnectionStatus } from '../../shared/ssh-types'
+
+/** An SSH host the user owns a workspace on, so its sessions belong in an
+ *  all-hosts list whether or not the connection is currently up. */
+export type ExpectedSshAiVaultHost = {
+  targetId: string
+  label: string
+  connectionStatus?: SshConnectionStatus
+}
+
+// Three offline workspace hosts must not become three banners, so each bucket
+// collapses into one row and only the first few hosts are named.
+const NAMED_HOST_LIMIT = 5
+
+// 'connected' is pending too: the relay CLI bridge can still be deploying when
+// the fan-out reads host infos, and that host is about to appear on its own.
+const PENDING_CONNECTION_STATUSES: ReadonlySet<SshConnectionStatus> = new Set([
+  'connecting',
+  'deploying-relay',
+  'reconnecting',
+  'connected'
+])
+
+/**
+ * Explains the workspace SSH hosts that contributed no leg to an all-hosts scan,
+ * which otherwise just show fewer sessions with no reason given.
+ *
+ * Why kind 'scope' and not 'host': an offline host is a routine state, not a
+ * scan failure — 'host' renders destructive AND makes the leg cache refuse to
+ * store the merged result, forcing a full multi-host rescan on every panel open.
+ */
+export function unscannedSshHostIssues(args: {
+  expectedHosts: readonly ExpectedSshAiVaultHost[]
+  scannedTargetIds: ReadonlySet<string>
+}): AiVaultScanIssue[] {
+  const pendingLabels: string[] = []
+  const offlineLabels: string[] = []
+  for (const host of args.expectedHosts) {
+    if (args.scannedTargetIds.has(host.targetId)) {
+      continue
+    }
+    const bucket =
+      host.connectionStatus && PENDING_CONNECTION_STATUSES.has(host.connectionStatus)
+        ? pendingLabels
+        : offlineLabels
+    bucket.push(host.label)
+  }
+  const issues: AiVaultScanIssue[] = []
+  if (pendingLabels.length > 0) {
+    issues.push(
+      unscannedHostIssue(
+        `Agent sessions from ${joinHostLabels(pendingLabels)} aren't listed yet — still connecting.`
+      )
+    )
+  }
+  if (offlineLabels.length > 0) {
+    issues.push(
+      unscannedHostIssue(
+        `Agent sessions from ${joinHostLabels(offlineLabels)} aren't listed — not connected.`
+      )
+    )
+  }
+  return issues
+}
+
+// No executionHostId: one row can stand for several hosts.
+function unscannedHostIssue(message: string): AiVaultScanIssue {
+  return { agent: 'codex', kind: 'scope', path: 'SSH hosts', message }
+}
+
+function joinHostLabels(labels: readonly string[]): string {
+  const named = labels.slice(0, NAMED_HOST_LIMIT).join(', ')
+  const remaining = labels.length - NAMED_HOST_LIMIT
+  return remaining > 0 ? `${named} and ${remaining} more` : named
+}

--- a/src/main/ipc/ai-vault-all-host-scan.ts
+++ b/src/main/ipc/ai-vault-all-host-scan.ts
@@ -1,0 +1,104 @@
+import type { AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
+import type { AiVaultSessionDepth } from '../../shared/ai-vault-session-depth'
+import { toSshExecutionHostId } from '../../shared/execution-host'
+import { mergeAiVaultListResults } from '../ai-vault/session-list-results'
+import { scanSshAiVaultSessions } from '../ai-vault/ssh-session-list'
+import {
+  unscannedSshHostIssues,
+  type ExpectedSshAiVaultHost
+} from '../ai-vault/unscanned-ssh-host-issues'
+import { discoverAiVaultHosts, type AiVaultHostDiscoveryResult } from './ai-vault-host-discovery'
+import { scanHostLegWithCache } from './ai-vault-host-leg-cache'
+import {
+  scanRuntimeAiVaultSessions,
+  type RuntimeAiVaultHostInfo,
+  type RuntimeAiVaultScanner
+} from './ai-vault-runtime-scan'
+import { getActiveSshAiVaultHostInfos } from './ssh'
+
+const AI_VAULT_ALL_HOST_RUNTIME_TIMEOUT_MS = 3_000
+// Why: a remote home with many agent roots routinely needs seconds to walk,
+// stat and parse. The old shared 3s bound emptied healthy SSH hosts in the
+// all-hosts view; the relay gets a real scan budget and the whole leg (relay
+// attempt plus any legacy crawl) stays bounded so one host can't hold the
+// merge open.
+const AI_VAULT_ALL_HOST_SSH_RELAY_TIMEOUT_MS = 15_000
+const AI_VAULT_ALL_HOST_SSH_TIMEOUT_MS = 20_000
+
+export type AllHostAiVaultScanParams = {
+  args?: AiVaultListArgs
+  signal?: AbortSignal
+  cacheKey: string
+  depth: AiVaultSessionDepth
+  scopePaths: readonly string[]
+  scanLocal: () => Promise<AiVaultListResult>
+  runtimeScanner?: RuntimeAiVaultScanner
+  getActiveRuntimeAiVaultHostInfos?: () => readonly RuntimeAiVaultHostInfo[]
+  getExpectedSshAiVaultHosts?: () => readonly ExpectedSshAiVaultHost[]
+}
+
+export async function scanAllHostAiVaultSessions(
+  params: AllHostAiVaultScanParams
+): Promise<AiVaultListResult> {
+  const { args, signal, cacheKey, depth, scopePaths } = params
+  const force = args?.force === true
+  const runtimeHosts = discoverAiVaultHosts(
+    () => params.getActiveRuntimeAiVaultHostInfos?.() ?? [],
+    { path: 'runtime environments', fallbackMessage: 'Runtime hosts are unavailable.' }
+  )
+  const sshHosts: AiVaultHostDiscoveryResult<{ targetId: string }> = discoverAiVaultHosts(
+    getActiveSshAiVaultHostInfos,
+    { path: 'SSH hosts', fallbackMessage: 'SSH hosts are unavailable.' }
+  )
+  const expectedSshHosts = discoverAiVaultHosts(() => params.getExpectedSshAiVaultHosts?.() ?? [], {
+    path: 'SSH hosts',
+    fallbackMessage: 'SSH workspace hosts are unavailable.'
+  })
+  const discoveryResults = [runtimeHosts.issue, sshHosts.issue, expectedSshHosts.issue].filter(
+    (issue): issue is AiVaultListResult => issue !== undefined
+  )
+  const scannedResults = await Promise.all([
+    params.scanLocal(),
+    ...sshHosts.hostInfos.map((hostInfo) =>
+      scanHostLegWithCache({
+        cacheKey: `${cacheKey}|${toSshExecutionHostId(hostInfo.targetId)}`,
+        depth,
+        scopePaths,
+        force,
+        scan: () =>
+          scanSshAiVaultSessions(hostInfo.targetId, args, {
+            signal,
+            timeoutMs: AI_VAULT_ALL_HOST_SSH_TIMEOUT_MS,
+            relayTimeoutMs: AI_VAULT_ALL_HOST_SSH_RELAY_TIMEOUT_MS
+          })
+      })
+    ),
+    ...runtimeHosts.hostInfos.map((hostInfo) =>
+      scanHostLegWithCache({
+        cacheKey: `${cacheKey}|${hostInfo.executionHostId}`,
+        depth,
+        scopePaths,
+        force,
+        scan: () =>
+          scanRuntimeAiVaultSessions({
+            hostInfo,
+            scanner: params.runtimeScanner,
+            listArgs: args,
+            options: { signal, timeoutMs: AI_VAULT_ALL_HOST_RUNTIME_TIMEOUT_MS }
+          })
+      })
+    )
+  ])
+  const merged = mergeAiVaultListResults(
+    [...scannedResults, ...discoveryResults],
+    args?.limit,
+    args?.unlimited
+  )
+  // Appended after the merge, never as a merge input: a synthetic result would
+  // feed the merged scannedAt and remint a stamp the renderer compares on.
+  const unscanned = unscannedSshHostIssues({
+    expectedHosts: expectedSshHosts.hostInfos,
+    scannedTargetIds: new Set(sshHosts.hostInfos.map((hostInfo) => hostInfo.targetId))
+  })
+  return unscanned.length > 0 ? { ...merged, issues: [...merged.issues, ...unscanned] } : merged
+}

--- a/src/main/ipc/ai-vault-unscanned-ssh-hosts.test.ts
+++ b/src/main/ipc/ai-vault-unscanned-ssh-hosts.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AiVaultListResult, AiVaultSession } from '../../shared/ai-vault-types'
+import type { IFilesystemProvider } from '../providers/types'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import type { ExpectedSshAiVaultHost } from '../ai-vault/unscanned-ssh-host-issues'
+
+const mocks = vi.hoisted(() => ({
+  scanAiVaultSessionsInWorker: vi.fn(),
+  resolveAiVaultSessionTitlesInWorker: vi.fn(),
+  scanRemoteAiVaultSessions: vi.fn(),
+  getSshFilesystemProvider: vi.fn(),
+  getActiveSshAiVaultHostInfo: vi.fn(),
+  getActiveSshAiVaultHostInfos: vi.fn(),
+  requestActiveSshAiVaultSessionList: vi.fn(),
+  requestActiveSshAiVaultSessionTitles: vi.fn(),
+  ipcHandle: vi.fn()
+}))
+
+vi.mock('electron', () => ({ app: { on: vi.fn() }, ipcMain: { handle: mocks.ipcHandle } }))
+vi.mock('../ai-vault/session-scanner-worker-spawn', () => ({
+  scanAiVaultSessionsInWorker: mocks.scanAiVaultSessionsInWorker,
+  resolveAiVaultSessionTitlesInWorker: mocks.resolveAiVaultSessionTitlesInWorker,
+  resetAiVaultScannerWorkerForTests: vi.fn()
+}))
+vi.mock('../ai-vault/remote-session-scanner', () => ({
+  scanRemoteAiVaultSessions: mocks.scanRemoteAiVaultSessions
+}))
+vi.mock('../wsl', () => ({
+  getWslHomeAsync: vi.fn(),
+  listWslDistrosAsync: vi.fn().mockResolvedValue([])
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE: 'SSH unavailable',
+  getSshFilesystemProvider: mocks.getSshFilesystemProvider
+}))
+vi.mock('./ssh', () => ({
+  getActiveSshAiVaultHostInfo: mocks.getActiveSshAiVaultHostInfo,
+  getActiveSshAiVaultHostInfos: mocks.getActiveSshAiVaultHostInfos,
+  requestActiveSshAiVaultSessionList: mocks.requestActiveSshAiVaultSessionList,
+  requestActiveSshAiVaultSessionTitles: mocks.requestActiveSshAiVaultSessionTitles
+}))
+
+const { _internals, registerAiVaultHandlers } = await import('./ai-vault')
+
+const LOCAL_RESULT: AiVaultListResult = {
+  sessions: [session('local', 'local-1')],
+  issues: [],
+  scannedAt: '2026-07-27T00:00:00.000Z'
+}
+const SSH_RESULT: AiVaultListResult = {
+  sessions: [session('ssh:dev-box', 'ssh-1')],
+  issues: [],
+  scannedAt: '2026-07-27T00:00:01.000Z'
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  _internals.resetAiVaultCacheForTests()
+  mocks.scanAiVaultSessionsInWorker.mockResolvedValue(LOCAL_RESULT)
+  mocks.resolveAiVaultSessionTitlesInWorker.mockResolvedValue({ titles: [] })
+  mocks.scanRemoteAiVaultSessions.mockResolvedValue(SSH_RESULT)
+  mocks.getSshFilesystemProvider.mockReturnValue({} as IFilesystemProvider)
+  mocks.getActiveSshAiVaultHostInfo.mockReturnValue(hostInfo())
+  mocks.getActiveSshAiVaultHostInfos.mockReturnValue([])
+  mocks.requestActiveSshAiVaultSessionList.mockResolvedValue(null)
+  mocks.requestActiveSshAiVaultSessionTitles.mockResolvedValue(null)
+})
+
+describe('all-host Agent Session History with an unreachable SSH host', () => {
+  it('explains an SSH host that is not connected instead of silently dropping it', async () => {
+    register([expectedHost('dev-box', 'disconnected')])
+
+    const result = await _internals.listAiVaultSessions({ executionHostScope: 'all' })
+
+    expect(result.sessions.map((entry) => entry.id)).toEqual([LOCAL_RESULT.sessions[0]?.id])
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        kind: 'scope',
+        path: 'SSH hosts',
+        message: expect.stringContaining('dev-box')
+      })
+    )
+    // The notice must not remint the merged stamp; #14245/#14261 rely on it.
+    expect(result.scannedAt).toBe(LOCAL_RESULT.scannedAt)
+  })
+
+  it('only names hosts that produced no leg', async () => {
+    mocks.getActiveSshAiVaultHostInfos.mockReturnValue([hostInfo()])
+    register([expectedHost('dev-box', 'connected'), expectedHost('gpu-1', 'disconnected')])
+
+    const result = await _internals.listAiVaultSessions({ executionHostScope: 'all' })
+
+    const notices = result.issues.filter((issue) => issue.path === 'SSH hosts')
+    expect(notices).toHaveLength(1)
+    expect(notices[0]?.message).toContain('gpu-1')
+    expect(notices[0]?.message).not.toContain('dev-box')
+  })
+
+  it('startup: a host that is still connecting gets a non-blocking notice', async () => {
+    register([expectedHost('dev-box', 'connecting')])
+
+    const result = await _internals.listAiVaultSessions({ executionHostScope: 'all' })
+
+    const notice = result.issues.find((issue) => issue.path === 'SSH hosts')
+    // 'scope' keeps this out of the destructive/blocking banner slot.
+    expect(notice?.kind).toBe('scope')
+    expect(notice?.message).toContain('still connecting')
+  })
+
+  it('clears the notice once the host reconnects', async () => {
+    register([expectedHost('dev-box', 'reconnecting')])
+
+    const disconnected = await _internals.listAiVaultSessions({ executionHostScope: 'all' })
+    expect(disconnected.sessions.map((entry) => entry.id)).toEqual([LOCAL_RESULT.sessions[0]?.id])
+    expect(disconnected.issues.some((issue) => issue.path === 'SSH hosts')).toBe(true)
+
+    mocks.getActiveSshAiVaultHostInfos.mockReturnValue([hostInfo()])
+    register([expectedHost('dev-box', 'connected')])
+    // force bypasses the 15s merged/leg cache the way the panel's Refresh does.
+    const reconnected = await _internals.listAiVaultSessions({
+      executionHostScope: 'all',
+      force: true
+    })
+
+    expect(reconnected.sessions.map((entry) => entry.id)).toContain(SSH_RESULT.sessions[0]?.id)
+    expect(reconnected.issues.some((issue) => issue.path === 'SSH hosts')).toBe(false)
+  })
+})
+
+function register(expectedSshHosts: readonly ExpectedSshAiVaultHost[]): void {
+  registerAiVaultHandlers({ getExpectedSshAiVaultHosts: () => expectedSshHosts })
+}
+
+function expectedHost(
+  targetId: string,
+  connectionStatus: ExpectedSshAiVaultHost['connectionStatus']
+): ExpectedSshAiVaultHost {
+  return { targetId, label: targetId, connectionStatus }
+}
+
+function session(executionHostId: string, sessionId: string): AiVaultSession {
+  return {
+    id: `${executionHostId}:codex:${sessionId}:/transcripts/${sessionId}.jsonl`,
+    agent: 'codex',
+    sessionId,
+    filePath: `/transcripts/${sessionId}.jsonl`,
+    updatedAt: '2026-07-27T00:00:00.000Z',
+    executionHostId
+  } as AiVaultSession
+}
+
+function hostInfo() {
+  return {
+    targetId: 'dev-box',
+    executionHostId: 'ssh:dev-box' as const,
+    remoteHome: '/home/ada',
+    hostPlatform: getRemoteHostPlatform('linux-x64')
+  }
+}

--- a/src/main/ipc/ai-vault-workspace-ssh-hosts.test.ts
+++ b/src/main/ipc/ai-vault-workspace-ssh-hosts.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { SshConnectionStatus, SshTarget } from '../../shared/ssh-types'
+import { listWorkspaceSshAiVaultHosts } from './ai-vault-workspace-ssh-hosts'
+
+const target = (id: string, overrides: Partial<SshTarget> = {}): SshTarget => ({
+  id,
+  label: id,
+  host: `${id}.example`,
+  port: 22,
+  username: 'ada',
+  ...overrides
+})
+
+function listHosts(args: {
+  repos: readonly { connectionId?: string | null; kind?: 'git' | 'folder' }[]
+  targets: readonly SshTarget[]
+  statuses?: Record<string, SshConnectionStatus>
+}) {
+  return listWorkspaceSshAiVaultHosts({
+    getRepos: () => args.repos,
+    listTargets: () => args.targets,
+    getConnectionStatus: (targetId) => args.statuses?.[targetId]
+  })
+}
+
+describe('listWorkspaceSshAiVaultHosts', () => {
+  it('ignores registered targets that own no workspace', () => {
+    expect(
+      listHosts({
+        repos: [{ connectionId: 'dev-box' }],
+        targets: [target('dev-box'), target('imported-alias')]
+      })
+    ).toEqual([{ targetId: 'dev-box', label: 'dev-box', connectionStatus: undefined }])
+  })
+
+  it('drops repos pointing at a removed target', () => {
+    expect(listHosts({ repos: [{ connectionId: 'gone' }], targets: [] })).toEqual([])
+  })
+
+  it('excludes runtime-owned targets', () => {
+    expect(
+      listHosts({
+        repos: [{ connectionId: 'runtime-ssh-vm-1' }, { connectionId: 'owned' }],
+        targets: [
+          target('runtime-ssh-vm-1'),
+          target('owned', { owner: { type: 'on-demand-runtime', runtimeId: 'vm-2' } })
+        ]
+      })
+    ).toEqual([])
+  })
+
+  it('dedupes a host that owns both a git repo and a folder workspace', () => {
+    expect(
+      listHosts({
+        repos: [
+          { connectionId: 'dev-box', kind: 'git' },
+          { connectionId: 'dev-box', kind: 'folder' }
+        ],
+        targets: [target('dev-box', { label: '  Dev Box  ' })],
+        statuses: { 'dev-box': 'disconnected' }
+      })
+    ).toEqual([{ targetId: 'dev-box', label: 'Dev Box', connectionStatus: 'disconnected' }])
+  })
+
+  it('passes the live connection status through', () => {
+    expect(
+      listHosts({
+        repos: [{ connectionId: 'dev-box' }, { connectionId: 'gpu-1' }],
+        targets: [target('dev-box'), target('gpu-1')],
+        statuses: { 'dev-box': 'connecting' }
+      })
+    ).toEqual([
+      { targetId: 'dev-box', label: 'dev-box', connectionStatus: 'connecting' },
+      { targetId: 'gpu-1', label: 'gpu-1', connectionStatus: undefined }
+    ])
+  })
+})

--- a/src/main/ipc/ai-vault-workspace-ssh-hosts.ts
+++ b/src/main/ipc/ai-vault-workspace-ssh-hosts.ts
@@ -1,0 +1,40 @@
+import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
+import type { SshConnectionStatus, SshTarget } from '../../shared/ssh-types'
+import type { Repo } from '../../shared/types'
+import type { ExpectedSshAiVaultHost } from '../ai-vault/unscanned-ssh-host-issues'
+
+/**
+ * The SSH hosts an all-hosts session list is expected to cover: those that own
+ * at least one Orca repo or folder workspace and still exist as a target.
+ *
+ * Why gate on owning a workspace rather than taking every registered target:
+ * `ssh:importConfig` can register dozens of ~/.ssh/config aliases the user never
+ * opens, and each would otherwise turn into a permanent "not connected" row.
+ */
+export function listWorkspaceSshAiVaultHosts(deps: {
+  getRepos: () => readonly Pick<Repo, 'connectionId'>[]
+  listTargets: () => readonly Pick<SshTarget, 'id' | 'label' | 'owner'>[]
+  getConnectionStatus: (targetId: string) => SshConnectionStatus | undefined
+}): ExpectedSshAiVaultHost[] {
+  const workspaceTargetIds = new Set<string>()
+  for (const repo of deps.getRepos()) {
+    if (repo.connectionId) {
+      workspaceTargetIds.add(repo.connectionId)
+    }
+  }
+  // Iterating targets (not repos) dedupes hosts with several workspaces, keeps a
+  // stable order, and drops repos still pointing at a removed target.
+  return deps
+    .listTargets()
+    .filter(
+      (target) =>
+        workspaceTargetIds.has(target.id) &&
+        target.owner === undefined &&
+        !isRuntimeOwnedSshTargetId(target.id)
+    )
+    .map((target) => ({
+      targetId: target.id,
+      label: target.label.trim() || target.id,
+      connectionStatus: deps.getConnectionStatus(target.id)
+    }))
+}

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -9,8 +9,7 @@ import { deleteAiVaultSession, registerAiVaultDeleteHandler } from './ai-vault-d
 import { listAiVaultSubagentSessions } from './ai-vault-subagent-list'
 import {
   aiVaultScanIssueResult,
-  cancelledAiVaultListResult,
-  mergeAiVaultListResults
+  cancelledAiVaultListResult
 } from '../ai-vault/session-list-results'
 import { scanSshAiVaultSessions } from '../ai-vault/ssh-session-list'
 import { AiVaultScanCoordinator } from '../ai-vault/ai-vault-scan-coordinator'
@@ -31,12 +30,11 @@ import {
   normalizeExecutionHostScope,
   parseExecutionHostId,
   toRuntimeExecutionHostId,
-  toSshExecutionHostId,
   type ExecutionHostScope
 } from '../../shared/execution-host'
-import { getActiveSshAiVaultHostInfos } from './ssh'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
-import { discoverAiVaultHosts, type AiVaultHostDiscoveryResult } from './ai-vault-host-discovery'
+import { scanAllHostAiVaultSessions } from './ai-vault-all-host-scan'
+import type { ExpectedSshAiVaultHost } from '../ai-vault/unscanned-ssh-host-issues'
 import {
   scanRuntimeAiVaultSessions,
   type RuntimeAiVaultHostInfo,
@@ -57,18 +55,12 @@ import {
   type RuntimeAiVaultSessionTitleResolver
 } from './ai-vault-session-title-routing'
 
-const AI_VAULT_ALL_HOST_RUNTIME_TIMEOUT_MS = 3_000
-// Why: a remote home with many agent roots routinely needs seconds to walk,
-// stat and parse. The old shared 3s bound emptied healthy SSH hosts in the
-// all-hosts view; the relay gets a real scan budget and the whole leg (relay
-// attempt plus any legacy crawl) stays bounded so one host can't hold the
-// merge open.
-const AI_VAULT_ALL_HOST_SSH_RELAY_TIMEOUT_MS = 15_000
-const AI_VAULT_ALL_HOST_SSH_TIMEOUT_MS = 20_000
-
 type AiVaultHandlerOptions = AiVaultSessionSources &
   AiVaultResumeHandlerOptions & {
     getActiveRuntimeAiVaultHostInfos?: () => readonly RuntimeAiVaultHostInfo[]
+    /** SSH hosts whose sessions belong in an all-hosts list even when the
+     *  connection is down, so a missing host is explained instead of silent. */
+    getExpectedSshAiVaultHosts?: () => readonly ExpectedSshAiVaultHost[]
     scanRuntimeAiVaultSessions?: RuntimeAiVaultScanner
     resolveRuntimeAiVaultSessionTitles?: RuntimeAiVaultSessionTitleResolver
   }
@@ -142,49 +134,17 @@ async function scanAiVaultSessionsByHostScope(
     return scanLocalAiVaultSessionsAsIssue(args, signal)
   }
   if (executionHostScope === 'all') {
-    const runtimeHosts = getActiveRuntimeAiVaultHostInfosResult()
-    const sshHosts = getActiveSshAiVaultHostInfosResult()
-    const runtimeResults = [
-      ...(runtimeHosts.issue ? [runtimeHosts.issue] : []),
-      ...(sshHosts.issue ? [sshHosts.issue] : [])
-    ]
-    const scannedResults = await Promise.all([
-      scanLocalAiVaultSessionsAsIssue(args, signal),
-      ...sshHosts.hostInfos.map((hostInfo) =>
-        scanHostLegWithCache({
-          cacheKey: `${cacheKey}|${toSshExecutionHostId(hostInfo.targetId)}`,
-          depth,
-          scopePaths,
-          force: args?.force === true,
-          scan: () =>
-            scanSshAiVaultSessions(hostInfo.targetId, args, {
-              signal,
-              timeoutMs: AI_VAULT_ALL_HOST_SSH_TIMEOUT_MS,
-              relayTimeoutMs: AI_VAULT_ALL_HOST_SSH_RELAY_TIMEOUT_MS
-            })
-        })
-      ),
-      ...runtimeHosts.hostInfos.map((hostInfo) =>
-        scanHostLegWithCache({
-          cacheKey: `${cacheKey}|${hostInfo.executionHostId}`,
-          depth,
-          scopePaths,
-          force: args?.force === true,
-          scan: () =>
-            scanRuntimeAiVaultSessions({
-              hostInfo,
-              scanner: handlerOptions.scanRuntimeAiVaultSessions,
-              listArgs: args,
-              options: { signal, timeoutMs: AI_VAULT_ALL_HOST_RUNTIME_TIMEOUT_MS }
-            })
-        })
-      )
-    ])
-    return mergeAiVaultListResults(
-      [...scannedResults, ...runtimeResults],
-      args?.limit,
-      args?.unlimited
-    )
+    return scanAllHostAiVaultSessions({
+      args,
+      signal,
+      cacheKey,
+      depth,
+      scopePaths,
+      scanLocal: () => scanLocalAiVaultSessionsAsIssue(args, signal),
+      runtimeScanner: handlerOptions.scanRuntimeAiVaultSessions,
+      getActiveRuntimeAiVaultHostInfos: handlerOptions.getActiveRuntimeAiVaultHostInfos,
+      getExpectedSshAiVaultHosts: handlerOptions.getExpectedSshAiVaultHosts
+    })
   }
 
   const parsed = parseExecutionHostId(executionHostScope)
@@ -207,20 +167,6 @@ async function scanAiVaultSessionsByHostScope(
     executionHostId: executionHostScope,
     path: executionHostScope,
     message: 'Agent Session History is not available for this execution host.'
-  })
-}
-
-function getActiveRuntimeAiVaultHostInfosResult(): AiVaultHostDiscoveryResult<RuntimeAiVaultHostInfo> {
-  return discoverAiVaultHosts(() => handlerOptions.getActiveRuntimeAiVaultHostInfos?.() ?? [], {
-    path: 'runtime environments',
-    fallbackMessage: 'Runtime hosts are unavailable.'
-  })
-}
-
-function getActiveSshAiVaultHostInfosResult(): AiVaultHostDiscoveryResult<{ targetId: string }> {
-  return discoverAiVaultHosts(getActiveSshAiVaultHostInfos, {
-    path: 'SSH hosts',
-    fallbackMessage: 'SSH hosts are unavailable.'
   })
 }
 

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -25,6 +25,8 @@ import { registerRuntimeHandlers } from './runtime'
 import { registerRuntimeEnvironmentHandlers } from './runtime-environments'
 import { registerEphemeralVmHandlers } from './ephemeral-vm'
 import { registerAiVaultHandlers } from './ai-vault'
+import { listWorkspaceSshAiVaultHosts } from './ai-vault-workspace-ssh-hosts'
+import { getRegisteredSshState, listRegisteredSshTargets } from './ssh'
 import { registerNativeChatHandlers } from './native-chat'
 import { registerNotificationHandlers } from './notifications'
 import { registerNotebookHandlers } from './notebook'
@@ -220,6 +222,12 @@ export function registerCoreHandlers(
     prepareSessionResume: lifecycleOptions.prepareAiVaultSessionResume,
     getActiveRuntimeAiVaultHostInfos: () =>
       getSavedRuntimeAiVaultHostInfos(app.getPath('userData')),
+    getExpectedSshAiVaultHosts: () =>
+      listWorkspaceSshAiVaultHosts({
+        getRepos: () => store.getRepos(),
+        listTargets: listRegisteredSshTargets,
+        getConnectionStatus: (targetId) => getRegisteredSshState(targetId)?.status
+      }),
     scanRuntimeAiVaultSessions: async (environmentId, args, options) =>
       scanRuntimeAiVaultSessions(app.getPath('userData'), environmentId, args, options),
     resolveRuntimeAiVaultSessionTitles: async (environmentId, args) =>


### PR DESCRIPTION
## ELI5

Orca can show your recent AI coding sessions from several machines at once — your laptop plus any remote machines you work on. Until now, if one of those remote machines was switched off or the connection had dropped, its sessions just quietly disappeared from the list. Nothing said why, so it looked like the sessions had been lost rather than merely being out of reach. This change adds a short grey line at the top of the list saying which machines aren't showing up right now, and whether they are still in the middle of connecting or simply not connected. This is a real gap people can hit today (any dropped or not-yet-connected remote machine triggers it), not a hypothetical one — but it only ever adds an explanation, never changes which sessions are shown.

## Summary

The all-hosts fan-out enumerated SSH hosts via `getActiveSshAiVaultHostInfos()` (`src/main/ipc/ssh.ts:166`), which walks the live `activeSessions` map and, stricter still, only yields a host once `SshRelaySession.remoteCliBridgeEnv` is set (`src/main/ssh/ssh-relay-session.ts:430`). A host that is disconnected, still connecting, or whose relay bridge never deployed therefore contributed **neither a leg nor an issue row** — its rows simply vanished from the merged result. A host that fails *while connected* is fine: `scanSshAiVaultSessions` converts the throw into a `kind:'host'` banner (`src/main/ai-vault/ssh-session-list.ts:44`).

- `src/main/ai-vault/unscanned-ssh-host-issues.ts` (new): pure function turning "expected hosts minus hosts that produced a leg" into at most two `kind:'scope'` issue rows — one *still connecting*, one *not connected* — capped at 5 named hosts plus `and N more`.
- `src/main/ipc/ai-vault-workspace-ssh-hosts.ts` (new): composes the expected-host set from persisted state — SSH targets that own at least one repo/folder workspace (`Repo.connectionId`) and still exist in the target store, excluding runtime-owned targets. Deps are injected, so it needs no `vi.mock` and no Electron import.
- `src/main/ipc/ai-vault-all-host-scan.ts` (new): the `'all'` fan-out moved out of `ai-vault.ts` verbatim, plus the new post-merge append at `src/main/ipc/ai-vault-all-host-scan.ts:92`. The move was forced: `ai-vault.ts` was at 296 of the 300 counted-line oxlint budget and a `max-lines` disable is forbidden by AGENTS.md.
- `src/main/ipc/ai-vault.ts:134` now delegates; `src/main/ipc/ai-vault.ts:60` adds the optional `getExpectedSshAiVaultHosts` handler option (same injection shape as `getActiveRuntimeAiVaultHostInfos`).
- `src/main/ipc/register-core-handlers.ts:222` wires the real implementation from `store.getRepos()` + `listRegisteredSshTargets()` + `getRegisteredSshState()`. No new IPC channel, no `src/main/ipc/ssh.ts` change.

### Design answers the brief asked for

**"A host the user expects to see" = an SSH target that owns at least one Orca repo or folder workspace and still exists in the target store.** Rejected alternatives: *all configured targets* (`ssh:importConfig` can register dozens of `~/.ssh/config` aliases the user never opens — exactly the noisy-banner failure mode the brief rules out); *`session.activeConnectionIdsAtShutdown`* (renderer-authored, and `buildActiveConnectionIdsAtShutdown` filters on `status === 'connected'`, so it drops a host the moment it starts dropping — the case we need to explain); *"hosts that returned sessions earlier this run"* (new tracking state the brief forbids, and empty right after launch, which is the worst moment for this bug).

**Where the list comes from:** entirely from main-process state already in the process (`Store.getRepos`, the SSH target store, live connection state). No new IPC, no new wire field, no renderer change.

**Kind:** reused `kind:'scope'`, no new kind. `AiVaultScanIssueBanners.tsx:32` renders only `'host'` as destructive and everything else muted; `blockingAiVaultScanIssue` only ever picks `'host'`; `skippedAiVaultTranscriptCount` only counts rows with no `kind`. Adding a kind would also be wire-*breaking* in one direction: `aiVaultScanIssueSchema` is `z.enum(['host','scope','notice'])` (`src/main/ai-vault/session-list-result-validation.ts:83`), so an unknown kind fails issue parse on an older peer.

**Startup:** `connecting`, `deploying-relay`, `reconnecting` and `connected` all get the softer "still connecting" copy. `connected` is included deliberately — the relay CLI bridge can still be deploying when the fan-out reads host infos, so a freshly-connected host is momentarily legless and must not be called "not connected".

## Why this is correct

- **`'scope'` over `'host'` is not just cosmetic.** `ai-vault-host-leg-cache.ts:54` refuses to cache any result containing a `'host'` issue. Using `'host'` for a routinely-offline workspace host would have forced a full multi-host rescan on every panel open — a direct regression of the perf work in #14245/#14261.
- **The rows are appended *after* `mergeAiVaultListResults`, never as a merge input.** A synthetic result would feed `latestAiVaultScannedAt` and remint the merged stamp, undoing #14245/#14261. There is an explicit assertion for this (`result.scannedAt === localLegResult.scannedAt`).
- **The renderer needed no change.** `'all'` results bypass the `scannedAt` fast path (`ai-vault-session-refresh.ts:165`) and go through `reuseAiVaultListResult`, which compares `issues` with `areValuesEqual` — so the new row propagates even when sessions and stamp are unchanged.
- **Existing tests are the guard for the extraction.** The fan-out move is a pure move; `ai-vault.test.ts` and `ai-vault-scan-coalescing.test.ts` pass unchanged, and their `vi.mock('./ssh')` factories still apply because the new module sits in the same directory and imports the same names.
- **Default-absent option.** `getExpectedSshAiVaultHosts` is optional, so every existing caller (including the runtime/mobile path) keeps byte-identical `issues` arrays.

## Tests

`src/main/ai-vault/unscanned-ssh-host-issues.test.ts` — 5 cases (offline row content; scanned hosts omitted; each of the four pending statuses producing the separate "still connecting" row alongside an offline row, both `kind:'scope'`; empty when everything was scanned; 7 hosts collapsing to `a, b, c, d, e and 2 more`).

`src/main/ipc/ai-vault-workspace-ssh-hosts.test.ts` — 5 cases (target with no workspace excluded; repo pointing at a removed target yields nothing; runtime-owned id and `owner: on-demand-runtime` both excluded; a git repo + a folder workspace on one host dedupe to one entry with the trimmed target label; connection status passthrough incl. `undefined`).

`src/main/ipc/ai-vault-unscanned-ssh-hosts.test.ts` — 4 integration cases through the real handler: disconnected host explained while local sessions survive **and `scannedAt` is not reminted**; only unscanned hosts named; startup "still connecting" row is `kind:'scope'`; SSH reconnect (`force: true` past the 15s cache) restores the sessions and clears the notice.

**Evidence they are real guards.** All three files fail wholesale on `main` — the modules do not exist there. Beyond that I neutered the production logic on this branch and re-ran:

- `return []` at the top of `unscannedSshHostIssues` → **11 of 12** unit + integration cases fail. The one that still passes is `says nothing when every expected host was scanned`, which is intrinsically a negative assertion; its only guard is that the module exists. I am calling that out rather than pretending otherwise.
- `listWorkspaceSshAiVaultHosts` returning every target unfiltered → 3 of 5 fail.
- `listWorkspaceSshAiVaultHosts` built by iterating repos instead of targets → a different 3 of 5 fail (including the removed-target case).

Every case except `passes the live connection status through` fails under at least one plausible wrong implementation.

## Verification

- `npx vitest run --config config/vitest.config.ts` on the 3 new files → 17 passed.
- Regression: same command over `src/main/ipc/ai-vault.test.ts`, `ai-vault-scan-coalescing.test.ts`, `session-list-results.test.ts`, `ssh-session-list.test.ts`, `ai-vault-scan-issue-state.test.ts`, `ai-vault-session-identity.test.ts`, `ai-vault-session-refresh.test.ts` + the 3 new files → **10 files, 133 tests passed**.
- `npx tsc --noEmit -p config/tsconfig.node.json` → clean. `npx tsc --noEmit -p config/tsconfig.tc.web.json` → clean.
- `npx oxlint` (whole repo) → clean, **no `max-lines` disable added**; `ai-vault.ts` is back under the 300-line budget.
- `npm run check:max-lines-ratchet` → OK, no new bypasses. `npm run audit:code-quality:native` → clean. `npm run check:reliability-gates` → 78 gates pass. `npx oxfmt --check` on all touched files → clean.
- Not run: the app itself. This is main-process logic with no renderer change, so it is covered by unit/integration tests only — I have not seen the banner render in a live Orca window.

## Open question

**Is "owns a workspace" the right bar for a permanent notice?** A user who keeps an SSH workspace but only connects that host occasionally will see one muted row every time they select *All hosts* while it is down. That is the intended trade (it explains the missing rows), but it is a product call, not one derivable from the code. If it proves noisy the narrowing knob is obvious: only warn about hosts whose workspace is currently selected, or only for hosts that were connected earlier in this app run.

## Deliberately not done

- **New `AiVaultScanIssue` kind** — wire-breaking against older peers (see above); `'scope'` already renders exactly as wanted on current *and* old clients.
- **Any renderer change** — `AiVaultScanIssueBanners` already handles `'scope'` correctly.
- **Runtime / paired-runtime hosts** — no bug: `getSavedRuntimeAiVaultHostInfos` reads the persisted environment list, so an unreachable runtime env still gets a leg and an error row.
- **Single-host SSH scope** — already explains itself: `requestActiveSshAiVaultSessionList` throws `SSH relay is not ready` and that becomes a `kind:'host'` banner. `'all'` is the only scope that loses a host silently.
- **Invalidating the host-leg cache on SSH state transitions** — scope creep (couples `ipc/ssh.ts` to the AI-vault cache). **Known consequence:** the merged `'all'` result is cached for 15s, so the "not connected" row can outlive a reconnect by up to one TTL before the next scan clears it. A user-initiated Refresh (`force: true`) clears it immediately.
- **Per-host rows / including the SSH error string** — one row can stand for several hosts, and three offline hosts must not become three banners. Per-target error text is already in the SSH status bar.

Known limitation, stated plainly: a connect that fails hard removes the connection from the manager map, so `getRegisteredSshState` returns `undefined` rather than `auth-failed`. That falls into the "not connected" bucket — correct copy, but the row cannot surface the underlying SSH error.

Made with [Orca](https://github.com/stablyai/orca) 🐋
