### PR TITLE
fix(right-sidebar): release the file search field on Escape

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.escape-blur.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.escape-blur.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFileSearchPanel } from './useFileSearchPanel'
+
+const mocks = vi.hoisted(() => ({
+  clearFileSearch: vi.fn(),
+  updateFileSearchState: vi.fn(),
+  consumeFileSearchSeedRequest: vi.fn(),
+  toggleFileSearchCollapsedFile: vi.fn(),
+  openFile: vi.fn(),
+  setPendingEditorReveal: vi.fn(),
+  executeSearch: vi.fn(),
+  cancelPendingSearch: vi.fn(),
+  query: ''
+}))
+
+const WORKTREE_ID = 'repo::/repo'
+
+function buildState(): Record<string, unknown> {
+  return {
+    activeWorktreeId: WORKTREE_ID,
+    openFile: mocks.openFile,
+    setPendingEditorReveal: mocks.setPendingEditorReveal,
+    fileSearchStateByWorktree: {
+      [WORKTREE_ID]: { query: mocks.query }
+    },
+    updateFileSearchState: mocks.updateFileSearchState,
+    consumeFileSearchSeedRequest: mocks.consumeFileSearchSeedRequest,
+    toggleFileSearchCollapsedFile: mocks.toggleFileSearchCollapsedFile,
+    clearFileSearch: mocks.clearFileSearch
+  }
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector(buildState()),
+    { getState: () => buildState() }
+  )
+}))
+
+vi.mock('@/store/selectors', () => ({
+  useActiveWorktree: () => ({ id: WORKTREE_ID, path: '/repo' })
+}))
+
+vi.mock('./useFileSearchRunner', () => ({
+  useFileSearchRunner: () => ({
+    executeSearch: mocks.executeSearch,
+    cancelPendingSearch: mocks.cancelPendingSearch
+  })
+}))
+
+// Escape must always release the query field: with text it also clears, empty it
+// still backs out. Asserted against real focus, not a spy, so a handler that
+// "handles" Escape without blurring still fails.
+function pressEscapeOnFocusedInput(query: string): {
+  activeAfter: Element | null
+  input: HTMLInputElement
+} {
+  mocks.query = query
+  const { result } = renderHook(() => useFileSearchPanel('search'))
+
+  const input = document.createElement('input')
+  document.body.appendChild(input)
+  ;(result.current.queryRowProps.inputRef as { current: HTMLInputElement | null }).current = input
+  input.focus()
+  expect(document.activeElement).toBe(input)
+
+  act(() => {
+    result.current.queryRowProps.onKeyDown?.({
+      key: 'Escape',
+      nativeEvent: { isComposing: false }
+    } as unknown as React.KeyboardEvent)
+  })
+
+  return { activeAfter: document.activeElement, input }
+}
+
+describe('file search panel Escape handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('releases focus and clears when the query is non-empty', () => {
+    const { activeAfter, input } = pressEscapeOnFocusedInput('useCallback')
+
+    expect(activeAfter).not.toBe(input)
+    expect(mocks.clearFileSearch).toHaveBeenCalledWith(WORKTREE_ID)
+  })
+
+  it('releases focus when the query is empty without clearing', () => {
+    const { activeAfter, input } = pressEscapeOnFocusedInput('')
+
+    expect(activeAfter).not.toBe(input)
+    expect(mocks.clearFileSearch).not.toHaveBeenCalled()
+  })
+
+  it('leaves focus alone for other keys', () => {
+    mocks.query = 'useCallback'
+    const { result } = renderHook(() => useFileSearchPanel('search'))
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    ;(result.current.queryRowProps.inputRef as { current: HTMLInputElement | null }).current = input
+    input.focus()
+
+    act(() => {
+      result.current.queryRowProps.onKeyDown?.({
+        key: 'Enter',
+        nativeEvent: { isComposing: false }
+      } as unknown as React.KeyboardEvent)
+    })
+
+    expect(document.activeElement).toBe(input)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
@@ -213,6 +213,9 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
         if (fileSearchQuery) {
           handleClearSearch()
         }
+        // Why: Esc must back out of the field even with an empty query; other
+        // search surfaces close on Esc, and this panel has no close to fall back on.
+        inputRef.current?.blur()
       }
       if (e.key === 'Enter') {
         executeSearch(fileSearchQuery)


### PR DESCRIPTION
## ELI5

You could type into the sidebar's file search box, but you could never get *out* of it with the keyboard. Pressing `Esc` wiped your text and then just sat there — every key you pressed next still went into the search box. Now `Esc` lets go of the field.

## What Changed

`Escape` in the right-sidebar file search input now blurs the query input, in addition to the existing clear-on-non-empty-query behavior.

One line in `useFileSearchPanel.ts`'s `handleKeyDown`, plus regression coverage.

## Why

The handler only called `handleClearSearch()`, and only when the query was non-empty. So:

- **Non-empty query:** text cleared, focus stayed trapped in the input.
- **Empty query:** `Esc` did nothing at all.

Either way the field was a keyboard trap — the user's next keystrokes kept landing in the search box with no way out except the mouse.

Blurring is the right "back out" here: sibling search surfaces already do this via `onClose()` (`TerminalSearch.tsx`), but this panel is a persistent sidebar view with no close to fall back on. This also matches the `docs/STYLEGUIDE.md` rule: "Esc should back out without adding visual noise."

## Linked Issue

Fixes #12292

## Visual Proof

Focus itself has no visible ring on this input, so the proof shown is the **user-visible consequence**: what happens to keystrokes typed *after* `Esc`. In both shots the sequence is identical — type `useCallback`, press `Esc`, then type `zzz` — and the image is the search field itself.

**BEFORE** — `zzz` still lands in the search field (focus never released):

![BEFORE-fix-typing-still-enters-field.png](https://github.com/user-attachments/assets/6bb57fad-0aee-42c9-8353-8d3df2a3f4ec)

**AFTER** — the field is released, so `zzz` goes nowhere and the placeholder remains:

![AFTER-fix-typing-does-not-enter-field.png](https://github.com/user-attachments/assets/e03eed75-dd5f-4bc8-a049-7537e3ed59c3)

## Testing

Reproduced live and re-verified in the Electron dev build (macOS, isolated profile, CDP-attached to this worktree's own instance — identity confirmed as `brennanb2025/sta-3301-sidebar-search-escape-blur`).

Live rig, right sidebar → Search, real click/type/keypress via CDP, observing `document.activeElement`:

| Case | Before | After |
| --- | --- | --- |
| `Esc` with query `useCallback` | query cleared, `activeElement` still `Search files` input | query cleared, `activeElement` → `BODY` |
| `Esc` with empty query | nothing happens, still focused | `activeElement` → `BODY` |
| Typing after `Esc` | lands in the field (`zzz`) | goes nowhere (field stays empty) |

Automated:
- New `useFileSearchPanel.escape-blur.test.tsx` — 3 tests asserting real `document.activeElement`, not a spy.
- **Non-vacuity proven:** with the one-line fix reverted, 2 of the 3 fail (both blur assertions); the "other keys leave focus alone" control still passes.
- `src/renderer/src/components/right-sidebar` suite: 202 files / 1845 tests pass.
- `typecheck:web`, `oxlint`, and `check:code-quality:changed` (code quality + type-aware + React Doctor) all clean on the changed files.

Platforms: renderer-only keyboard handling with no platform branches, so behavior is identical on macOS/Linux/Windows, and over SSH/remote-runtime and folder workspaces (the panel is worktree-path driven, untouched here). Verified on macOS.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security:** none — no data, IPC, or path handling touched.
- **Cross-platform:** no platform branches; `Escape` is not a platform-specific key and no modifier check was added.
- **Remote SSH / remote runtime:** unaffected; this is renderer-local focus handling with no RPC.
- **Mobile:** unaffected; `mobile/` has its own search surfaces and does not import this hook.
- **Backwards compatibility:** no wire, storage, or API surface change.
- **Performance:** no new subscription, effect, or render path; one `blur()` on an existing keydown branch.
