### PR TITLE
fix(sidebar): keep manual worktree order stable across agent activity

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -418,8 +418,10 @@ function WorkspaceKanbanDrawerContent({
             for (const group of boardDragGroups) {
               for (const worktreeId of group.worktreeIds) {
                 const worktree = worktreeById.get(worktreeId)
-                if (worktree) {
-                  ranks.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+                // Why: only real manualOrder ranks here — holes get backfilled by the
+                // ranker, not masked with the mutable sortOrder.
+                if (worktree?.manualOrder !== undefined) {
+                  ranks.set(worktreeId, worktree.manualOrder)
                 }
               }
             }

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
@@ -597,9 +597,14 @@ describe('workspace kanban sidebar drop updates', () => {
     })
 
     expect(result.shouldSwitchToManual).toBe(true)
+    // Why: with no prior manualOrder anywhere, the drop backfills every visible row
+    // so the manual order is stable (doing-a > todo-a > doing-b) instead of sparse-
+    // ranking only the dropped row onto the mutable sortOrder.
     expect(result.updates.get('todo-a')).toEqual({
       workspaceStatus: 'doing',
-      manualOrder: 1500
+      manualOrder: 9000
     })
+    expect(result.updates.get('doing-a')).toEqual({ manualOrder: 10_000 })
+    expect(result.updates.get('doing-b')).toEqual({ manualOrder: 8000 })
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
@@ -237,8 +237,10 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
         for (const group of args.groups) {
           for (const worktreeId of group.worktreeIds) {
             const worktree = args.worktreeById.get(worktreeId)
-            if (worktree) {
-              ranks.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+            // Why: only real manualOrder ranks here — holes get backfilled by the ranker,
+            // not masked with the mutable sortOrder.
+            if (worktree?.manualOrder !== undefined) {
+              ranks.set(worktreeId, worktree.manualOrder)
             }
           }
         }

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-status-mutations.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-status-mutations.ts
@@ -25,8 +25,10 @@ function buildRankByWorktreeId(
   for (const group of groups) {
     for (const worktreeId of group.worktreeIds) {
       const worktree = worktreeMap.get(worktreeId)
-      if (worktree) {
-        rankByWorktreeId.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+      // Why: only real manualOrder ranks here — a row still lacking one is a hole
+      // the ranker backfills, rather than masking it with the mutable sortOrder.
+      if (worktree?.manualOrder !== undefined) {
+        rankByWorktreeId.set(worktreeId, worktree.manualOrder)
       }
     }
   }

--- a/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
@@ -41,6 +41,18 @@ export function buildSparseManualOrderUpdates(args: {
     return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
   }
 
+  // Why: any non-moved row without a persisted manualOrder would otherwise keep
+  // falling back to the mutable sortOrder in the comparator and jump on later
+  // activity, so backfill the whole visible group instead of sparse-ranking only
+  // the moved rows.
+  const ranks = args.rankByWorktreeId
+  if (
+    ranks !== undefined &&
+    args.orderedIds.some((id) => !movedSet.has(id) && getManualOrderRank(ranks, id) === null)
+  ) {
+    return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
+  }
+
   const firstMovedIndex = args.orderedIds.findIndex((id) => movedSet.has(id))
   const lastMovedIndex = args.orderedIds.findLastIndex((id) => movedSet.has(id))
   const beforeId = args.orderedIds.slice(0, firstMovedIndex).findLast((id) => !movedSet.has(id))

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -283,6 +283,27 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
     expect(Array.from(result.updates)).toEqual([['b', { manualOrder: 0 }]])
   })
 
+  it('backfills manualOrder for every visible row when an unmoved row lacks one', () => {
+    // Why: an unmoved row without a persisted manualOrder would otherwise keep
+    // falling back to the mutable sortOrder in the comparator and jump on later
+    // activity, so a reorder must stamp every visible row — not just the moved one.
+    const result = buildManualOrderUpdatesForVisibleGroups({
+      groups: [{ key: 'repo:one', worktreeIds: ['a', 'b', 'c', 'd'] }],
+      sourceGroupKey: 'repo:one',
+      draggedIds: ['b'],
+      dropIndex: 4,
+      now: 10_000,
+      rankByWorktreeId: new Map([
+        ['a', 4000],
+        ['b', 3000],
+        ['d', 1000]
+      ])
+    })
+
+    expect(result.orderedIds).toEqual(['a', 'c', 'd', 'b'])
+    expect(Array.from(result.updates.keys()).sort()).toEqual(['a', 'b', 'c', 'd'])
+  })
+
   it('moves an expanded lineage cluster as one ranked unit', () => {
     const result = buildManualOrderUpdatesForVisibleGroups({
       groups: [{ key: 'all', worktreeIds: ['parent', 'child', 'other'] }],


### PR DESCRIPTION
## ELI5

When you manually drag workspaces into a custom order in the sidebar, rows you never touched were still ranked by an old activity snapshot (`sortOrder`). Whenever that snapshot got rewritten — a pass through the "Agent Activity" sort, a newly created workspace, a paired remote client pushing ranks — those rows re-ranked and your arrangement was lost. Manual ordering now sticks until you change it again.

## What Changed

- `buildSparseManualOrderUpdates` now backfills a `manualOrder` for **every** visible row in a reordered group whenever any non-moved row still lacks one, instead of persisting a rank for only the dragged row(s).
- The manual-reorder rank-seeding call sites — the consolidated `buildRankByWorktreeId` helper for the list drag + cross-status drop (`worktree-list/drag/use-status-mutations.ts:20-35`), the board drawer (`WorkspaceKanbanDrawer.tsx:420-425`), and the kanban sidebar drop helper (`workspace-kanban-sidebar-drop.ts:239-244`) — now feed the ranker **real `manualOrder` ranks only** — not `manualOrder ?? sortOrder` — so a row lacking `manualOrder` is detected as a hole and backfilled, rather than masked by the mutable `sortOrder`.
- The manual comparator (`smart-sort.ts`) is **unchanged**.

## Why

A manual drag persisted `manualOrder` only for the moved row(s). Every other visible row kept `manualOrder = undefined` and the manual comparator ranked it by `sortOrder`. That fallback is the problem: `sortOrder` is written in three ways, none of which respect a manual arrangement —

1. the sidebar persist effect re-snapshots it from the smart ranking, but only while `sortBy === 'smart'` (`worktree-list/listing/use-sort-order.ts:212-219`);
2. creation-time and meta-row minting stamp `Date.now()` (`src/main/persistence/loading-store/store.ts:3915`, the default worktree-meta base);
3. paired remote/CLI clients can push `worktree.persistSortOrder` at any time, mode-agnostic (`src/main/runtime/rpc/methods/worktree.ts:174`).

So staying inside Manual mode does not rewrite `sortOrder` on activity by itself — agent activity there writes only `lastActivityAt`/`isUnread`, which the manual comparator ignores. But any Smart episode ("Agent Activity" — the mode users pass through) rewrites every fallback rank, and rows sitting on the two mixed scales re-rank on return to Manual or on reload. That is what users experience as "agent activity broke my manual order" (issue #13847 has the fuller analysis). Mixing the scales also corrupted drag-time rank seeding, since the call sites seeded ranks with `manualOrder ?? sortOrder`, masking exactly the rows the sparse ranker's neighbour hole-check was meant to catch.

Backfilling every visible row on reorder means the `?? sortOrder` fallback no longer drives any row after a drag, so the order survives Smart episodes, reloads, meta-row minting, and remote pushes. Legacy manual mode (a user who has never reordered — no `manualOrder` anywhere) is unchanged: it still restores the familiar `sortOrder` snapshot.

## Linked Issue

Fixes #13847

## Visual Proof

No visual/layout change — the fix is to ordering stability (an interaction behavior), not appearance. Repro in Testing; a short screen recording of the repro can be attached.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally

- `worktree-manual-order.test.ts` — new test: a reorder backfills `manualOrder` for every visible row when an unmoved row lacks one (previously only the moved row was updated).
- `workspace-kanban-sidebar-drop.test.ts` — updated the cross-lane manual-drop case: with no prior `manualOrder`, the drop now backfills every visible row (doing-a > dropped > doing-b) instead of sparse-ranking only the dropped row onto `sortOrder`.
- Full sidebar + worktree-store + sort-order-persistence suites pass (4733 tests) on the pre-rebase tree. `pnpm typecheck:web`, `oxlint`, and `oxfmt` clean on the changed files.
- Rebased onto `main` on 2026-08-23 after the #14486 worktree-list reorg: the two former `WorktreeList.tsx` seeding sites now live in `buildRankByWorktreeId` (`worktree-list/drag/use-status-mutations.ts:20-35`). Re-verified on the rebased tree: targeted suites (manual-order, kanban sidebar drop, sort-order persistence + host split — 47 tests), `pnpm typecheck:web`, `oxlint`, `oxfmt` all clean.

Repro a reviewer can follow (desktop sidebar):
1. Drag two or more workspaces into a custom manual order (the drag itself switches the sort to Manual).
2. Switch the sort menu to **Agent Activity** (Smart) and trigger agent activity — new output in a workspace that is NOT first.
3. Switch the sort menu back to **Manual**.
4. Before: rows that were never dragged have re-ranked against the fresh Smart snapshot — the manual arrangement is lost. After: the manual order holds.

(Staying in Manual and waiting for activity shows no before/after on a single desktop — nothing rewrites `sortOrder` in that mode; see Why. Newly created workspaces and remote `persistSortOrder` pushes hit the same fallback pre-fix.)

## AI Disclosure

Developed with assistance from Claude (Anthropic). Root-cause analysis, approach, and tests reviewed by the contributor.

## Review

- **Cross-platform:** renderer-only change; no platform-specific code.
- **Backwards compatibility:** the manual comparator is untouched; users with no prior `manualOrder` (legacy) still see the restored `sortOrder` snapshot. After the first manual reorder, all visible rows gain a stable `manualOrder`.
- **Performance:** sparse ranking is preserved in steady state (all rows already have `manualOrder`); full backfill only runs when a hole exists (typically the first reorder). Cheap metadata writes only.
- **Wire / SSH / remote:** no host or transport changes — renderer sort state only.
- **Security:** no auth/transport surface changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (renderer-only)
- [x] `pnpm lint`, `pnpm typecheck`, and in-scope `pnpm test` pass (CI covers the full suite)

## Author

- X / Twitter: _(optional — add your handle to be shouted out on merge)_
