### PR TITLE
feat: Discord Rich Presence (experimental)

### DIFF
--- a/src/main/discord-presence/discord-presence-activity.test.ts
+++ b/src/main/discord-presence/discord-presence-activity.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { aggregateAgentStatus } from './discord-presence-activity'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+
+// Helper: build a minimal IPC payload with only the fields aggregateAgentStatus reads.
+function entry(overrides: Partial<AgentStatusIpcPayload> = {}): AgentStatusIpcPayload {
+  return {
+    state: 'working',
+    paneKey: `pane-${Math.random().toString(36).slice(2)}`,
+    connectionId: null,
+    receivedAt: 1000,
+    stateStartedAt: 1000,
+    prompt: '',
+    ...overrides
+  }
+}
+
+describe('aggregateAgentStatus', () => {
+  it('returns zero snapshot for empty input', () => {
+    const snap = aggregateAgentStatus([])
+    expect(snap).toEqual({
+      working: 0,
+      blocked: 0,
+      waiting: 0,
+      done: 0,
+      active: 0,
+      total: 0,
+      agentTypes: [],
+      startedAt: 0
+    })
+  })
+
+  it('counts one working agent correctly', () => {
+    const snap = aggregateAgentStatus([entry({ state: 'working', agentType: 'claude', receivedAt: 1000 })])
+    expect(snap.working).toBe(1)
+    expect(snap.active).toBe(1)
+    expect(snap.total).toBe(1)
+    expect(snap.agentTypes).toEqual(['claude'])
+    expect(snap.startedAt).toBe(1000)
+  })
+
+  it('aggregates mixed states without double counting', () => {
+    const snap = aggregateAgentStatus([
+      entry({ state: 'working', agentType: 'claude', receivedAt: 1000 }),
+      entry({ state: 'working', agentType: 'codex', receivedAt: 2000 }),
+      entry({ state: 'blocked', agentType: 'gemini', receivedAt: 1500 }),
+      entry({ state: 'waiting', agentType: 'opencode', receivedAt: 1200 }),
+      entry({ state: 'done', agentType: 'devin', receivedAt: 900 })
+    ])
+    expect(snap.working).toBe(2)
+    expect(snap.blocked).toBe(1)
+    expect(snap.waiting).toBe(1)
+    expect(snap.done).toBe(1)
+    expect(snap.active).toBe(4)
+    expect(snap.total).toBe(5)
+    // done excluded from agentTypes, remaining sorted
+    expect(snap.agentTypes).toEqual(['claude', 'codex', 'gemini', 'opencode'])
+    // earliest active receivedAt
+    expect(snap.startedAt).toBe(1000)
+  })
+
+  it('picks currentTool from a working entry', () => {
+    const snap = aggregateAgentStatus([
+      entry({ state: 'working', agentType: 'claude', toolName: 'Edit', receivedAt: 1000 })
+    ])
+    expect(snap.currentTool).toBe('Edit')
+  })
+
+  it('ignores providerSessionOnly entries', () => {
+    const snap = aggregateAgentStatus([
+      entry({ state: 'working', agentType: 'claude', providerSessionOnly: true, receivedAt: 1000 })
+    ])
+    expect(snap.active).toBe(0)
+    expect(snap.total).toBe(0)
+  })
+
+  it('ignores entries without paneKey', () => {
+    const snap = aggregateAgentStatus([
+      entry({ state: 'working', agentType: 'claude', paneKey: '', receivedAt: 1000 })
+    ])
+    expect(snap.active).toBe(0)
+    expect(snap.total).toBe(0)
+  })
+
+  it('returns zero for done-only list', () => {
+    const snap = aggregateAgentStatus([
+      entry({ state: 'done', agentType: 'claude', receivedAt: 1000 }),
+      entry({ state: 'done', agentType: 'codex', receivedAt: 2000 })
+    ])
+    expect(snap.active).toBe(0)
+    expect(snap.total).toBe(2)
+    expect(snap.agentTypes).toEqual([])
+    expect(snap.startedAt).toBe(0)
+  })
+
+  it('deduplicates and sorts agentTypes', () => {
+    const snap = aggregateAgentStatus([
+      entry({ state: 'working', agentType: 'codex', receivedAt: 1000 }),
+      entry({ state: 'working', agentType: 'claude', receivedAt: 1000 }),
+      entry({ state: 'blocked', agentType: 'codex', receivedAt: 1000 })
+    ])
+    expect(snap.agentTypes).toEqual(['claude', 'codex'])
+  })
+})

--- a/src/main/discord-presence/discord-presence-activity.test.ts
+++ b/src/main/discord-presence/discord-presence-activity.test.ts
@@ -54,9 +54,7 @@ describe('aggregateAgentStatus', () => {
     expect(snap.done).toBe(1)
     expect(snap.active).toBe(4)
     expect(snap.total).toBe(5)
-    // done excluded from agentTypes, remaining sorted
     expect(snap.agentTypes).toEqual(['claude', 'codex', 'gemini', 'opencode'])
-    // earliest active receivedAt
     expect(snap.startedAt).toBe(1000)
   })
 
@@ -123,12 +121,19 @@ function snap(overrides: Partial<DiscordPresenceSnapshot> = {}): DiscordPresence
 describe('buildDiscordActivity', () => {
   const ASSET = 'orca'
 
-  it('returns null when no active agents', () => {
-    expect(buildDiscordActivity(snap(), ASSET)).toBeNull()
+  it('shows idle when no active agents', () => {
+    const activity = buildDiscordActivity(snap(), ASSET)
+    expect(activity.details).toBe('Idle')
+    expect(activity.state).toBe('Orca')
+    expect(activity.assets.large_image).toBe('orca')
+    expect(activity.party).toBeUndefined()
+    expect(activity.timestamps).toBeUndefined()
   })
 
-  it('returns null when only done agents', () => {
-    expect(buildDiscordActivity(snap({ done: 3, total: 3 }), ASSET)).toBeNull()
+  it('shows terminal count when idle with open terminals', () => {
+    const activity = buildDiscordActivity(snap({ activeTerminals: 5 }), ASSET)
+    expect(activity.details).toBe('Idle')
+    expect(activity.state).toBe('5 terminals open')
   })
 
   it('builds activity for single working agent', () => {
@@ -136,12 +141,10 @@ describe('buildDiscordActivity', () => {
       snap({ working: 1, active: 1, total: 1, agentTypes: ['claude'], startedAt: 1000 }),
       ASSET
     )
-    expect(activity).toEqual({
-      details: '1 agent working',
-      state: 'Claude',
-      assets: { large_image: 'orca', large_text: 'Orca' },
-      timestamps: { start: 1000 }
-    })
+    expect(activity.details).toBe('1 agent working')
+    expect(activity.state).toBe('Claude')
+    expect(activity.assets).toEqual({ large_image: 'orca', large_text: 'Orca' })
+    expect(activity.party).toEqual({ id: 'orca', size: [1, 1] })
   })
 
   it('builds activity for multiple working agents', () => {
@@ -149,8 +152,16 @@ describe('buildDiscordActivity', () => {
       snap({ working: 3, active: 3, total: 3, agentTypes: ['claude', 'codex', 'gemini'], startedAt: 2000 }),
       ASSET
     )
-    expect(activity?.details).toBe('3 agents working')
-    expect(activity?.state).toBe('Claude · Codex · Gemini')
+    expect(activity.details).toBe('3 agents working')
+    expect(activity.state).toBe('Claude · Codex · Gemini')
+  })
+
+  it('builds party size as [active, total]', () => {
+    const activity = buildDiscordActivity(
+      snap({ working: 2, blocked: 1, active: 3, total: 5, agentTypes: ['claude', 'codex'] }),
+      ASSET
+    )
+    expect(activity.party).toEqual({ id: 'orca', size: [3, 5] })
   })
 
   it('truncates agent list when more than 3 types', () => {
@@ -163,7 +174,7 @@ describe('buildDiscordActivity', () => {
       }),
       ASSET
     )
-    expect(activity?.state).toBe('Claude · Codex · Gemini · …')
+    expect(activity.state).toBe('Claude · Codex · Gemini · …')
   })
 
   it('shows blocked signal in state', () => {
@@ -177,7 +188,15 @@ describe('buildDiscordActivity', () => {
       }),
       ASSET
     )
-    expect(activity?.state).toBe('Claude · Codex · 1 waiting for you')
+    expect(activity.state).toBe('Claude · Codex · 1 waiting for you')
+  })
+
+  it('converts startedAt from milliseconds to Unix seconds', () => {
+    const activity = buildDiscordActivity(
+      snap({ working: 1, active: 1, total: 1, agentTypes: ['claude'], startedAt: 60_000 }),
+      ASSET
+    )
+    expect(activity.timestamps).toEqual({ start: 60 })
   })
 
   it('omits timestamps when startedAt is 0', () => {
@@ -185,6 +204,6 @@ describe('buildDiscordActivity', () => {
       snap({ working: 1, active: 1, total: 1, agentTypes: ['claude'] }),
       ASSET
     )
-    expect(activity?.timestamps).toBeUndefined()
+    expect(activity.timestamps).toBeUndefined()
   })
 })

--- a/src/main/discord-presence/discord-presence-activity.test.ts
+++ b/src/main/discord-presence/discord-presence-activity.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { aggregateAgentStatus } from './discord-presence-activity'
+import { aggregateAgentStatus, buildDiscordActivity } from './discord-presence-activity'
 import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { DiscordPresenceSnapshot } from './discord-presence-activity'
 
 // Helper: build a minimal IPC payload with only the fields aggregateAgentStatus reads.
 function entry(overrides: Partial<AgentStatusIpcPayload> = {}): AgentStatusIpcPayload {
@@ -100,5 +101,90 @@ describe('aggregateAgentStatus', () => {
       entry({ state: 'blocked', agentType: 'codex', receivedAt: 1000 })
     ])
     expect(snap.agentTypes).toEqual(['claude', 'codex'])
+  })
+})
+
+// ─── buildDiscordActivity ────────────────────────────────────────────
+
+function snap(overrides: Partial<DiscordPresenceSnapshot> = {}): DiscordPresenceSnapshot {
+  return {
+    working: 0,
+    blocked: 0,
+    waiting: 0,
+    done: 0,
+    active: 0,
+    total: 0,
+    agentTypes: [],
+    startedAt: 0,
+    ...overrides
+  }
+}
+
+describe('buildDiscordActivity', () => {
+  const ASSET = 'orca'
+
+  it('returns null when no active agents', () => {
+    expect(buildDiscordActivity(snap(), ASSET)).toBeNull()
+  })
+
+  it('returns null when only done agents', () => {
+    expect(buildDiscordActivity(snap({ done: 3, total: 3 }), ASSET)).toBeNull()
+  })
+
+  it('builds activity for single working agent', () => {
+    const activity = buildDiscordActivity(
+      snap({ working: 1, active: 1, total: 1, agentTypes: ['claude'], startedAt: 1000 }),
+      ASSET
+    )
+    expect(activity).toEqual({
+      details: '1 agent working',
+      state: 'Claude',
+      assets: { large_image: 'orca', large_text: 'Orca' },
+      timestamps: { start: 1000 }
+    })
+  })
+
+  it('builds activity for multiple working agents', () => {
+    const activity = buildDiscordActivity(
+      snap({ working: 3, active: 3, total: 3, agentTypes: ['claude', 'codex', 'gemini'], startedAt: 2000 }),
+      ASSET
+    )
+    expect(activity?.details).toBe('3 agents working')
+    expect(activity?.state).toBe('Claude · Codex · Gemini')
+  })
+
+  it('truncates agent list when more than 3 types', () => {
+    const activity = buildDiscordActivity(
+      snap({
+        working: 4,
+        active: 4,
+        total: 4,
+        agentTypes: ['claude', 'codex', 'gemini', 'opencode']
+      }),
+      ASSET
+    )
+    expect(activity?.state).toBe('Claude · Codex · Gemini · …')
+  })
+
+  it('shows blocked signal in state', () => {
+    const activity = buildDiscordActivity(
+      snap({
+        working: 2,
+        blocked: 1,
+        active: 3,
+        total: 3,
+        agentTypes: ['claude', 'codex']
+      }),
+      ASSET
+    )
+    expect(activity?.state).toBe('Claude · Codex · 1 waiting for you')
+  })
+
+  it('omits timestamps when startedAt is 0', () => {
+    const activity = buildDiscordActivity(
+      snap({ working: 1, active: 1, total: 1, agentTypes: ['claude'] }),
+      ASSET
+    )
+    expect(activity?.timestamps).toBeUndefined()
   })
 })

--- a/src/main/discord-presence/discord-presence-activity.test.ts
+++ b/src/main/discord-presence/discord-presence-activity.test.ts
@@ -141,7 +141,7 @@ describe('buildDiscordActivity', () => {
       snap({ working: 1, active: 1, total: 1, agentTypes: ['claude'], startedAt: 1000 }),
       ASSET
     )
-    expect(activity.details).toBe('1 agent working')
+    expect(activity.details).toBe('1 agent active')
     expect(activity.state).toBe('Claude')
     expect(activity.assets).toEqual({ large_image: 'orca', large_text: 'Orca' })
     expect(activity.party).toEqual({ id: 'orca', size: [1, 1] })
@@ -152,7 +152,7 @@ describe('buildDiscordActivity', () => {
       snap({ working: 3, active: 3, total: 3, agentTypes: ['claude', 'codex', 'gemini'], startedAt: 2000 }),
       ASSET
     )
-    expect(activity.details).toBe('3 agents working')
+    expect(activity.details).toBe('3 agents active')
     expect(activity.state).toBe('Claude · Codex · Gemini')
   })
 

--- a/src/main/discord-presence/discord-presence-activity.ts
+++ b/src/main/discord-presence/discord-presence-activity.ts
@@ -10,14 +10,19 @@ export type DiscordPresenceSnapshot = {
   agentTypes: string[]
   startedAt: number
   currentTool?: string
+  /** Live terminal panes (agent + plain-shell), when the host reports them. */
+  activeTerminals?: number
 }
 
 export type DiscordActivity = {
   details: string
   state: string
   assets: { large_image: string; large_text: string }
+  party?: { id: string; size: [number, number] }
   timestamps?: { start: number }
 }
+
+const DISCORD_PARTY_ID = 'orca'
 
 export function aggregateAgentStatus(
   entries: readonly AgentStatusIpcPayload[]
@@ -78,8 +83,19 @@ export function aggregateAgentStatus(
 export function buildDiscordActivity(
   snapshot: DiscordPresenceSnapshot,
   assetKey: string
-): DiscordActivity | null {
-  if (snapshot.active === 0) return null
+): DiscordActivity {
+  const assets = { large_image: assetKey, large_text: 'Orca' }
+
+  // Idle: Orca is open but no agent is running. Still publish so the app is
+  // visible the whole time the feature is enabled.
+  if (snapshot.active === 0) {
+    const terminals = snapshot.activeTerminals ?? 0
+    return {
+      details: 'Idle',
+      state: terminals > 0 ? `${terminals} terminal${terminals !== 1 ? 's' : ''} open` : 'Orca',
+      assets
+    }
+  }
 
   const details = `${snapshot.working} agent${snapshot.working !== 1 ? 's' : ''} working`
 
@@ -98,11 +114,13 @@ export function buildDiscordActivity(
   const activity: DiscordActivity = {
     details,
     state,
-    assets: { large_image: assetKey, large_text: 'Orca' }
+    assets,
+    party: { id: DISCORD_PARTY_ID, size: [snapshot.active, snapshot.total] }
   }
 
   if (snapshot.startedAt > 0) {
-    activity.timestamps = { start: snapshot.startedAt }
+    // Discord expects Unix seconds; Orca reports millisecond timestamps.
+    activity.timestamps = { start: Math.floor(snapshot.startedAt / 1000) }
   }
 
   return activity

--- a/src/main/discord-presence/discord-presence-activity.ts
+++ b/src/main/discord-presence/discord-presence-activity.ts
@@ -12,6 +12,13 @@ export type DiscordPresenceSnapshot = {
   currentTool?: string
 }
 
+export type DiscordActivity = {
+  details: string
+  state: string
+  assets: { large_image: string; large_text: string }
+  timestamps?: { start: number }
+}
+
 export function aggregateAgentStatus(
   entries: readonly AgentStatusIpcPayload[]
 ): DiscordPresenceSnapshot {
@@ -66,4 +73,42 @@ export function aggregateAgentStatus(
     startedAt,
     ...(currentTool !== undefined ? { currentTool } : {})
   }
+}
+
+export function buildDiscordActivity(
+  snapshot: DiscordPresenceSnapshot,
+  assetKey: string
+): DiscordActivity | null {
+  if (snapshot.active === 0) return null
+
+  const details = `${snapshot.working} agent${snapshot.working !== 1 ? 's' : ''} working`
+
+  // Build state: agent types (up to 3) + optional blocked signal
+  const parts: string[] = []
+  const displayed = snapshot.agentTypes.slice(0, 3)
+  parts.push(...displayed)
+  if (snapshot.agentTypes.length > 3) parts.push('…')
+
+  if (snapshot.blocked > 0) {
+    parts.push(`${snapshot.blocked} waiting for you`)
+  }
+
+  const state = parts.map(capitalize).join(' · ')
+
+  const activity: DiscordActivity = {
+    details,
+    state,
+    assets: { large_image: assetKey, large_text: 'Orca' }
+  }
+
+  if (snapshot.startedAt > 0) {
+    activity.timestamps = { start: snapshot.startedAt }
+  }
+
+  return activity
+}
+
+function capitalize(s: string): string {
+  if (s.length === 0) return s
+  return s[0].toUpperCase() + s.slice(1)
 }

--- a/src/main/discord-presence/discord-presence-activity.ts
+++ b/src/main/discord-presence/discord-presence-activity.ts
@@ -97,7 +97,7 @@ export function buildDiscordActivity(
     }
   }
 
-  const details = `${snapshot.working} agent${snapshot.working !== 1 ? 's' : ''} working`
+  const details = `${snapshot.active} agent${snapshot.active !== 1 ? 's' : ''} active`
 
   const parts: string[] = []
   const displayed = snapshot.agentTypes.slice(0, 3)
@@ -108,7 +108,7 @@ export function buildDiscordActivity(
     parts.push(`${snapshot.blocked} waiting for you`)
   }
 
-  const state = parts.map(capitalize).join(' · ')
+  const state = parts.length > 0 ? parts.map(capitalize).join(' · ') : 'Orca'
 
   const activity: DiscordActivity = {
     details,

--- a/src/main/discord-presence/discord-presence-activity.ts
+++ b/src/main/discord-presence/discord-presence-activity.ts
@@ -99,7 +99,6 @@ export function buildDiscordActivity(
 
   const details = `${snapshot.working} agent${snapshot.working !== 1 ? 's' : ''} working`
 
-  // Build state: agent types (up to 3) + optional blocked signal
   const parts: string[] = []
   const displayed = snapshot.agentTypes.slice(0, 3)
   parts.push(...displayed)

--- a/src/main/discord-presence/discord-presence-activity.ts
+++ b/src/main/discord-presence/discord-presence-activity.ts
@@ -1,0 +1,69 @@
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+
+export type DiscordPresenceSnapshot = {
+  working: number
+  blocked: number
+  waiting: number
+  done: number
+  active: number
+  total: number
+  agentTypes: string[]
+  startedAt: number
+  currentTool?: string
+}
+
+export function aggregateAgentStatus(
+  entries: readonly AgentStatusIpcPayload[]
+): DiscordPresenceSnapshot {
+  let working = 0
+  let blocked = 0
+  let waiting = 0
+  let done = 0
+  const activeTypes = new Set<string>()
+  let startedAt = 0
+  let currentTool: string | undefined
+
+  for (const e of entries) {
+    // providerSessionOnly or missing paneKey => skip
+    if (e.providerSessionOnly || !e.paneKey) continue
+
+    switch (e.state) {
+      case 'working': {
+        working++
+        if (e.agentType) activeTypes.add(e.agentType)
+        if (e.toolName) currentTool = e.toolName
+        if (startedAt === 0 || e.receivedAt < startedAt) startedAt = e.receivedAt
+        break
+      }
+      case 'blocked': {
+        blocked++
+        if (e.agentType) activeTypes.add(e.agentType)
+        if (startedAt === 0 || e.receivedAt < startedAt) startedAt = e.receivedAt
+        break
+      }
+      case 'waiting': {
+        waiting++
+        if (e.agentType) activeTypes.add(e.agentType)
+        if (startedAt === 0 || e.receivedAt < startedAt) startedAt = e.receivedAt
+        break
+      }
+      case 'done': {
+        done++
+        break
+      }
+    }
+  }
+
+  const active = working + blocked + waiting
+  return {
+    working,
+    blocked,
+    waiting,
+    done,
+    active,
+    total: active + done,
+    agentTypes: [...activeTypes].sort(),
+    startedAt,
+    ...(currentTool !== undefined ? { currentTool } : {})
+  }
+}

--- a/src/main/discord-presence/discord-presence-config.ts
+++ b/src/main/discord-presence/discord-presence-config.ts
@@ -1,0 +1,7 @@
+// Placeholder: replace with the official Orca Discord Application client ID
+// after creating the app at https://discord.com/developers/applications
+// and uploading the 'orca' asset (logo).
+export const DISCORD_RICH_PRESENCE_CLIENT_ID =
+  process.env.ORCA_DISCORD_CLIENT_ID ?? '000000000000000000'
+
+export const DISCORD_RICH_PRESENCE_ASSET_KEY = 'orca'

--- a/src/main/discord-presence/discord-presence-config.ts
+++ b/src/main/discord-presence/discord-presence-config.ts
@@ -2,7 +2,6 @@
 // after creating the app at https://discord.com/developers/applications
 // and uploading the 'orca' asset (logo).
 const rawClientId = process.env.ORCA_DISCORD_CLIENT_ID ?? '000000000000000000'
-console.log('[discord-presence] client_id:', rawClientId === '000000000000000000' ? 'PLACEHOLDER' : 'set')
 export const DISCORD_RICH_PRESENCE_CLIENT_ID = rawClientId
 
 export const DISCORD_RICH_PRESENCE_ASSET_KEY = 'orca'

--- a/src/main/discord-presence/discord-presence-config.ts
+++ b/src/main/discord-presence/discord-presence-config.ts
@@ -5,3 +5,7 @@ const rawClientId = process.env.ORCA_DISCORD_CLIENT_ID ?? '000000000000000000'
 export const DISCORD_RICH_PRESENCE_CLIENT_ID = rawClientId
 
 export const DISCORD_RICH_PRESENCE_ASSET_KEY = 'orca'
+
+/** True once a real Discord Application has been registered and the env var is set. */
+export const DISCORD_RICH_PRESENCE_CLIENT_ID_CONFIGURED =
+  rawClientId !== '000000000000000000'

--- a/src/main/discord-presence/discord-presence-config.ts
+++ b/src/main/discord-presence/discord-presence-config.ts
@@ -1,7 +1,8 @@
 // Placeholder: replace with the official Orca Discord Application client ID
 // after creating the app at https://discord.com/developers/applications
 // and uploading the 'orca' asset (logo).
-export const DISCORD_RICH_PRESENCE_CLIENT_ID =
-  process.env.ORCA_DISCORD_CLIENT_ID ?? '000000000000000000'
+const rawClientId = process.env.ORCA_DISCORD_CLIENT_ID ?? '000000000000000000'
+console.log('[discord-presence] client_id:', rawClientId === '000000000000000000' ? 'PLACEHOLDER' : 'set')
+export const DISCORD_RICH_PRESENCE_CLIENT_ID = rawClientId
 
 export const DISCORD_RICH_PRESENCE_ASSET_KEY = 'orca'

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DiscordPresenceManager } from './discord-presence-manager'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { DiscordRpcClient } from './discord-rpc-client'
+import type { DiscordActivity } from './discord-presence-activity'
+
+// Fakes for dependencies
+function makeClient(): DiscordRpcClient & { setActivity: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn>; onDisconnectCbs: Array<() => void> } {
+  const cbs: Array<() => void> = []
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    setActivity: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    onDisconnect: vi.fn((cb: () => void) => { cbs.push(cb) }),
+    onDisconnectCbs: cbs
+  }
+}
+
+function workingEntry(agentType = 'claude', receivedAt = 1000): AgentStatusIpcPayload {
+  return {
+    state: 'working',
+    paneKey: `pane-${Math.random().toString(36).slice(2)}`,
+    connectionId: null,
+    receivedAt,
+    stateStartedAt: receivedAt,
+    prompt: '',
+    agentType
+  }
+}
+
+describe('DiscordPresenceManager', () => {
+  it('publishes activity on status change when enabled', () => {
+    const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+    let enabled = true
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => enabled,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+    // subscribeChanges should have been called
+    expect(subscribeChanges).toHaveBeenCalledTimes(1)
+
+    // Trigger a change
+    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
+    changeCb()
+
+    // Should have called setActivity with the built activity
+    expect(client.setActivity).toHaveBeenCalledTimes(1)
+    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
+    expect(activity.details).toBe('1 agent working')
+    expect(activity.state).toBe('Claude')
+    expect(activity.assets.large_image).toBe('orca')
+  })
+
+  it('clears activity when disabled', () => {
+    const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+    let enabled = false
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => enabled,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
+    // Trigger change while disabled
+    changeCb()
+
+    expect(client.setActivity).toHaveBeenCalledWith(null)
+  })
+
+  it('clears activity when no active agents', () => {
+    const getSnapshot = vi.fn().mockReturnValue([])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+    subscribeChanges.mock.calls[0][0]()
+    expect(client.setActivity).toHaveBeenCalledWith(null)
+  })
+
+  it('stop() unsubscribes and disconnects', () => {
+    const getSnapshot = vi.fn()
+    const unsubscribe = vi.fn()
+    const subscribeChanges = vi.fn().mockReturnValue(unsubscribe)
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+    mgr.stop()
+
+    expect(unsubscribe).toHaveBeenCalled()
+    expect(client.disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -27,61 +27,12 @@ function workingEntry(agentType = 'claude', receivedAt = 1000): AgentStatusIpcPa
   }
 }
 
+// Flush microtasks so the async connectAndPublish resolves
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 describe('DiscordPresenceManager', () => {
-  it('publishes activity on status change when enabled', () => {
+  it('connects and publishes initial activity on start', async () => {
     const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
-    const subscribeChanges = vi.fn()
-    const client = makeClient()
-    let enabled = true
-
-    const mgr = new DiscordPresenceManager({
-      getSnapshot,
-      subscribeChanges,
-      client,
-      isEnabled: () => enabled,
-      assetKey: 'orca'
-    })
-
-    mgr.start()
-    // subscribeChanges should have been called
-    expect(subscribeChanges).toHaveBeenCalledTimes(1)
-
-    // Trigger a change
-    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
-    changeCb()
-
-    // Should have called setActivity with the built activity
-    expect(client.setActivity).toHaveBeenCalledTimes(1)
-    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
-    expect(activity.details).toBe('1 agent working')
-    expect(activity.state).toBe('Claude')
-    expect(activity.assets.large_image).toBe('orca')
-  })
-
-  it('clears activity when disabled', () => {
-    const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
-    const subscribeChanges = vi.fn()
-    const client = makeClient()
-    let enabled = false
-
-    const mgr = new DiscordPresenceManager({
-      getSnapshot,
-      subscribeChanges,
-      client,
-      isEnabled: () => enabled,
-      assetKey: 'orca'
-    })
-
-    mgr.start()
-    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
-    // Trigger change while disabled
-    changeCb()
-
-    expect(client.setActivity).toHaveBeenCalledWith(null)
-  })
-
-  it('clears activity when no active agents', () => {
-    const getSnapshot = vi.fn().mockReturnValue([])
     const subscribeChanges = vi.fn()
     const client = makeClient()
 
@@ -94,11 +45,87 @@ describe('DiscordPresenceManager', () => {
     })
 
     mgr.start()
+    expect(subscribeChanges).toHaveBeenCalledTimes(1)
+    expect(client.connect).toHaveBeenCalledTimes(1)
+
+    await flush()
+
+    // Initial publish after connect
+    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
+    expect(activity.details).toBe('1 agent working')
+    expect(activity.state).toBe('Claude')
+    expect(activity.assets.large_image).toBe('orca')
+  })
+
+  it('does not connect when disabled', async () => {
+    const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => false,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+    await flush()
+
+    expect(client.connect).not.toHaveBeenCalled()
+    expect(client.setActivity).not.toHaveBeenCalled()
+  })
+
+  it('publishes activity on status change when connected', async () => {
+    const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca',
+      throttleIntervalMs: 0
+    })
+
+    mgr.start()
+    await flush()
+    client.setActivity.mockClear()
+
+    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
+    changeCb()
+
+    expect(client.setActivity).toHaveBeenCalledTimes(1)
+    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
+    expect(activity.details).toBe('1 agent working')
+  })
+
+  it('clears activity when no active agents', async () => {
+    const getSnapshot = vi.fn().mockReturnValue([])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca',
+      throttleIntervalMs: 0
+    })
+
+    mgr.start()
+    await flush()
+    client.setActivity.mockClear()
+
     subscribeChanges.mock.calls[0][0]()
     expect(client.setActivity).toHaveBeenCalledWith(null)
   })
 
-  it('stop() unsubscribes and disconnects', () => {
+  it('stop() unsubscribes and disconnects', async () => {
     const getSnapshot = vi.fn()
     const unsubscribe = vi.fn()
     const subscribeChanges = vi.fn().mockReturnValue(unsubscribe)
@@ -113,6 +140,7 @@ describe('DiscordPresenceManager', () => {
     })
 
     mgr.start()
+    await flush()
     mgr.stop()
 
     expect(unsubscribe).toHaveBeenCalled()

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -103,7 +103,7 @@ describe('DiscordPresenceManager', () => {
     expect(activity.details).toBe('1 agent working')
   })
 
-  it('clears activity when no active agents', async () => {
+  it('publishes idle activity when no active agents', async () => {
     const getSnapshot = vi.fn().mockReturnValue([])
     const subscribeChanges = vi.fn()
     const client = makeClient()
@@ -122,7 +122,32 @@ describe('DiscordPresenceManager', () => {
     client.setActivity.mockClear()
 
     subscribeChanges.mock.calls[0][0]()
-    expect(client.setActivity).toHaveBeenCalledWith(null)
+    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
+    expect(activity.details).toBe('Idle')
+  })
+
+  it('forwards active terminal count into the idle activity', async () => {
+    const getSnapshot = vi.fn().mockReturnValue([])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca',
+      getActiveTerminalCount: () => 5,
+      throttleIntervalMs: 0
+    })
+
+    mgr.start()
+    await flush()
+    client.setActivity.mockClear()
+
+    subscribeChanges.mock.calls[0][0]()
+    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
+    expect(activity.state).toBe('5 terminals open')
   })
 
   it('stop() unsubscribes and disconnects', async () => {

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -212,6 +212,40 @@ describe('DiscordPresenceManager', () => {
     expect(connectCount).toBe(1)
   })
 
+  it('publishes immediately after reconnect (throttle reset on disconnect)', async () => {
+    const getSnapshot = vi.fn().mockReturnValue([workingEntry()])
+    const subscribeChanges = vi.fn()
+    const client = makeClient()
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot,
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca',
+      throttleIntervalMs: 60_000, // long interval so trailing never fires on its own
+      reconnectBaseDelayMs: 0
+    })
+
+    mgr.start()
+    await flush()
+
+    // First publish went through (leading edge)
+    expect(client.setActivity).toHaveBeenCalledTimes(1)
+    client.setActivity.mockClear()
+
+    // Simulate disconnect — reset() clears lastTime so next publish is a leading edge
+    client.onDisconnectCbs.forEach((cb) => cb())
+    // flush once for the 0ms reconnect timer, once for the connect() microtask
+    await flush()
+    await flush()
+
+    // After reconnect, onChange fires again — throttle was reset, so publishes immediately
+    expect(client.setActivity).toHaveBeenCalledTimes(1)
+    const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
+    expect(activity.details).toBe('1 agent active')
+  })
+
   it('stop() unsubscribes and disconnects', async () => {
     const getSnapshot = vi.fn()
     const unsubscribe = vi.fn()

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { DiscordPresenceManager } from './discord-presence-manager'
+import { DiscordHandshakeRejectedError } from './discord-rpc-client'
 import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
 import type { DiscordActivity } from './discord-presence-activity'
 
@@ -148,6 +149,34 @@ describe('DiscordPresenceManager', () => {
     subscribeChanges.mock.calls[0][0]()
     const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
     expect(activity.state).toBe('5 terminals open')
+  })
+
+  it('does not retry when handshake is rejected (invalid client_id)', async () => {
+    const subscribeChanges = vi.fn().mockReturnValue(() => {})
+    const client = makeClient()
+    client.connect.mockRejectedValue(new DiscordHandshakeRejectedError())
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot: vi.fn().mockReturnValue([]),
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+    await flush()
+
+    // Connected once, rejected, should NOT schedule reconnect or retry
+    expect(client.connect).toHaveBeenCalledTimes(1)
+
+    // Subsequent onChange calls (e.g. from agent state changes) must not trigger a new connect
+    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
+    changeCb()
+    changeCb()
+    await flush()
+
+    expect(client.connect).toHaveBeenCalledTimes(1)
   })
 
   it('stop() unsubscribes and disconnects', async () => {

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -53,7 +53,7 @@ describe('DiscordPresenceManager', () => {
 
     // Initial publish after connect
     const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
-    expect(activity.details).toBe('1 agent working')
+    expect(activity.details).toBe('1 agent active')
     expect(activity.state).toBe('Claude')
     expect(activity.assets.large_image).toBe('orca')
   })
@@ -101,7 +101,7 @@ describe('DiscordPresenceManager', () => {
 
     expect(client.setActivity).toHaveBeenCalledTimes(1)
     const activity = client.setActivity.mock.calls[0][0] as DiscordActivity
-    expect(activity.details).toBe('1 agent working')
+    expect(activity.details).toBe('1 agent active')
   })
 
   it('publishes idle activity when no active agents', async () => {
@@ -177,6 +177,39 @@ describe('DiscordPresenceManager', () => {
     await flush()
 
     expect(client.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not start overlapping connect attempts on rapid status changes', async () => {
+    const subscribeChanges = vi.fn().mockReturnValue(() => {})
+    let connectCount = 0
+    const client = {
+      connect: vi.fn(() => new Promise<void>((_res) => {
+        connectCount++
+      })),
+      setActivity: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      onDisconnect: vi.fn()
+    }
+
+    const mgr = new DiscordPresenceManager({
+      getSnapshot: vi.fn().mockReturnValue([]),
+      subscribeChanges,
+      client,
+      isEnabled: () => true,
+      assetKey: 'orca'
+    })
+
+    mgr.start()
+
+    // Simulate rapid status changes while connect is in-flight
+    const changeCb = subscribeChanges.mock.calls[0][0] as () => void
+    changeCb()
+    changeCb()
+    changeCb()
+    await flush()
+
+    // Only one connect attempt should be in flight
+    expect(connectCount).toBe(1)
   })
 
   it('stop() unsubscribes and disconnects', async () => {

--- a/src/main/discord-presence/discord-presence-manager.test.ts
+++ b/src/main/discord-presence/discord-presence-manager.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { DiscordPresenceManager } from './discord-presence-manager'
 import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
-import type { DiscordRpcClient } from './discord-rpc-client'
 import type { DiscordActivity } from './discord-presence-activity'
 
 // Fakes for dependencies
-function makeClient(): DiscordRpcClient & { setActivity: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn>; onDisconnectCbs: Array<() => void> } {
+function makeClient() {
   const cbs: Array<() => void> = []
   return {
     connect: vi.fn().mockResolvedValue(undefined),

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -9,20 +9,38 @@ export type DiscordPresenceManagerDeps = {
   client: DiscordRpcClient
   isEnabled: () => boolean
   assetKey: string
+  /** Override the throttle interval (ms) for tests. */
+  throttleIntervalMs?: number
 }
+
+const RECONNECT_BASE_DELAY_MS = 1000
+const RECONNECT_MAX_DELAY_MS = 30_000
 
 export class DiscordPresenceManager {
   private deps: DiscordPresenceManagerDeps
   private unsubscribe: (() => void) | null = null
-  private throttle = createPresenceThrottle(this.publish.bind(this))
+  private throttle: ReturnType<typeof createPresenceThrottle>
+  private connected = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectDelay = RECONNECT_BASE_DELAY_MS
+  private stopped = false
 
   constructor(deps: DiscordPresenceManagerDeps) {
     this.deps = deps
+    this.throttle = createPresenceThrottle(
+      this.publish.bind(this),
+      deps.throttleIntervalMs
+    )
   }
 
   start(): void {
+    console.log('[discord-presence] start() called')
     if (this.unsubscribe) return // already started
+    this.stopped = false
     this.unsubscribe = this.deps.subscribeChanges(() => this.onChange())
+    this.deps.client.onDisconnect(() => this.onDisconnect())
+    console.log('[discord-presence] subscribed to status changes')
+    void this.connectAndPublish()
   }
 
   /** Force an immediate re-evaluation (e.g. when the enabled toggle changes). */
@@ -31,22 +49,77 @@ export class DiscordPresenceManager {
   }
 
   stop(): void {
+    console.log('[discord-presence] stop() called')
+    this.stopped = true
     this.unsubscribe?.()
     this.unsubscribe = null
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
     this.deps.client.disconnect()
+    this.connected = false
+  }
+
+  private async connectAndPublish(): Promise<void> {
+    if (!this.deps.isEnabled()) {
+      console.log('[discord-presence] feature disabled, skipping connect')
+      return
+    }
+    try {
+      console.log('[discord-presence] connecting to Discord IPC...')
+      await this.deps.client.connect()
+      this.connected = true
+      this.reconnectDelay = RECONNECT_BASE_DELAY_MS
+      console.log('[discord-presence] connected, publishing initial state')
+      this.onChange()
+    } catch (err) {
+      console.error('[discord-presence] connect failed:', err)
+      this.scheduleReconnect()
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return
+    console.log('[discord-presence] reconnect in', this.reconnectDelay, 'ms')
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, RECONNECT_MAX_DELAY_MS)
+      void this.connectAndPublish()
+    }, this.reconnectDelay)
+  }
+
+  private onDisconnect(): void {
+    console.log('[discord-presence] disconnected')
+    if (!this.connected) return
+    this.connected = false
+    this.scheduleReconnect()
   }
 
   private onChange(): void {
-    if (!this.deps.isEnabled()) {
-      this.deps.client.setActivity(null)
+    const enabled = this.deps.isEnabled()
+    console.log('[discord-presence] onChange called, isEnabled:', enabled, 'connected:', this.connected)
+    if (!enabled) {
+      if (this.connected) {
+        this.deps.client.setActivity(null).catch(() => {})
+      }
+      return
+    }
+    if (!this.connected) {
+      void this.connectAndPublish()
       return
     }
     const snapshot = aggregateAgentStatus(this.deps.getSnapshot())
+    console.log('[discord-presence] snapshot:', JSON.stringify(snapshot))
     const activity = buildDiscordActivity(snapshot, this.deps.assetKey)
+    console.log('[discord-presence] activity:', JSON.stringify(activity))
     this.throttle(activity)
   }
 
   private publish(activity: ReturnType<typeof buildDiscordActivity>): void {
-    this.deps.client.setActivity(activity)
+    console.log('[discord-presence] publish:', activity === null ? 'clear' : activity.details)
+    this.deps.client.setActivity(activity).catch((err) => {
+      console.error('[discord-presence] publish failed:', err)
+    })
   }
 }

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -1,4 +1,5 @@
 import { aggregateAgentStatus, buildDiscordActivity } from './discord-presence-activity'
+import type { DiscordActivity } from './discord-presence-activity'
 import { createPresenceThrottle } from './discord-presence-throttle'
 import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
 import type { DiscordRpcClient } from './discord-rpc-client'
@@ -9,6 +10,8 @@ export type DiscordPresenceManagerDeps = {
   client: DiscordRpcClient
   isEnabled: () => boolean
   assetKey: string
+  /** Live terminal pane count (agents + plain shells). Optional: defaults to 0. */
+  getActiveTerminalCount?: () => number
   /** Override the throttle interval (ms) for tests. */
   throttleIntervalMs?: number
 }
@@ -109,14 +112,17 @@ export class DiscordPresenceManager {
       void this.connectAndPublish()
       return
     }
-    const snapshot = aggregateAgentStatus(this.deps.getSnapshot())
+    const snapshot = {
+      ...aggregateAgentStatus(this.deps.getSnapshot()),
+      activeTerminals: this.deps.getActiveTerminalCount?.() ?? 0
+    }
     console.log('[discord-presence] snapshot:', JSON.stringify(snapshot))
     const activity = buildDiscordActivity(snapshot, this.deps.assetKey)
     console.log('[discord-presence] activity:', JSON.stringify(activity))
     this.throttle(activity)
   }
 
-  private publish(activity: ReturnType<typeof buildDiscordActivity>): void {
+  private publish(activity: DiscordActivity | null): void {
     console.log('[discord-presence] publish:', activity === null ? 'clear' : activity.details)
     this.deps.client.setActivity(activity).catch((err) => {
       console.error('[discord-presence] publish failed:', err)

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -25,6 +25,11 @@ export class DiscordPresenceManager {
     this.unsubscribe = this.deps.subscribeChanges(() => this.onChange())
   }
 
+  /** Force an immediate re-evaluation (e.g. when the enabled toggle changes). */
+  refresh(): void {
+    this.onChange()
+  }
+
   stop(): void {
     this.unsubscribe?.()
     this.unsubscribe = null

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -15,6 +15,8 @@ export type DiscordPresenceManagerDeps = {
   getActiveTerminalCount?: () => number
   /** Override the throttle interval (ms) for tests. */
   throttleIntervalMs?: number
+  /** Override the base reconnect delay (ms) for tests. */
+  reconnectBaseDelayMs?: number
 }
 
 const RECONNECT_BASE_DELAY_MS = 1000
@@ -92,18 +94,20 @@ export class DiscordPresenceManager {
 
   private scheduleReconnect(): void {
     if (this.stopped || this.reconnectTimer) return
-    console.log('[discord-presence] reconnect in', this.reconnectDelay, 'ms')
+    const delay = this.deps.reconnectBaseDelayMs ?? this.reconnectDelay
+    console.log('[discord-presence] reconnect in', delay, 'ms')
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       this.reconnectDelay = Math.min(this.reconnectDelay * 2, RECONNECT_MAX_DELAY_MS)
       void this.connectAndPublish()
-    }, this.reconnectDelay)
+    }, delay)
   }
 
   private onDisconnect(): void {
     console.log('[discord-presence] disconnected')
     if (!this.connected) return
     this.connected = false
+    this.throttle.reset()
     this.scheduleReconnect()
   }
 

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -29,6 +29,7 @@ export class DiscordPresenceManager {
   private reconnectDelay = RECONNECT_BASE_DELAY_MS
   private stopped = false
   private handshakeFailed = false
+  private connecting = false
 
   constructor(deps: DiscordPresenceManagerDeps) {
     this.deps = deps
@@ -54,6 +55,7 @@ export class DiscordPresenceManager {
 
   stop(): void {
     this.stopped = true
+    this.throttle.cancel()
     this.unsubscribe?.()
     this.unsubscribe = null
     if (this.reconnectTimer) {
@@ -65,9 +67,9 @@ export class DiscordPresenceManager {
   }
 
   private async connectAndPublish(): Promise<void> {
-    if (!this.deps.isEnabled()) {
-      return
-    }
+    if (!this.deps.isEnabled()) return
+    if (this.connecting) return
+    this.connecting = true
     try {
       console.log('[discord-presence] connecting to Discord IPC...')
       await this.deps.client.connect()
@@ -83,6 +85,8 @@ export class DiscordPresenceManager {
       }
       console.error('[discord-presence] connect failed:', err)
       this.scheduleReconnect()
+    } finally {
+      this.connecting = false
     }
   }
 
@@ -112,7 +116,7 @@ export class DiscordPresenceManager {
       return
     }
     if (!this.connected) {
-      if (!this.handshakeFailed) void this.connectAndPublish()
+      if (!this.handshakeFailed && !this.reconnectTimer) void this.connectAndPublish()
       return
     }
     const snapshot = {

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -1,0 +1,47 @@
+import { aggregateAgentStatus, buildDiscordActivity } from './discord-presence-activity'
+import { createPresenceThrottle } from './discord-presence-throttle'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { DiscordRpcClient } from './discord-rpc-client'
+
+export type DiscordPresenceManagerDeps = {
+  getSnapshot: () => AgentStatusIpcPayload[]
+  subscribeChanges: (cb: () => void) => () => void
+  client: DiscordRpcClient
+  isEnabled: () => boolean
+  assetKey: string
+}
+
+export class DiscordPresenceManager {
+  private deps: DiscordPresenceManagerDeps
+  private unsubscribe: (() => void) | null = null
+  private throttle = createPresenceThrottle(this.publish.bind(this))
+
+  constructor(deps: DiscordPresenceManagerDeps) {
+    this.deps = deps
+  }
+
+  start(): void {
+    if (this.unsubscribe) return // already started
+    this.unsubscribe = this.deps.subscribeChanges(() => this.onChange())
+  }
+
+  stop(): void {
+    this.unsubscribe?.()
+    this.unsubscribe = null
+    this.deps.client.disconnect()
+  }
+
+  private onChange(): void {
+    if (!this.deps.isEnabled()) {
+      this.deps.client.setActivity(null)
+      return
+    }
+    const snapshot = aggregateAgentStatus(this.deps.getSnapshot())
+    const activity = buildDiscordActivity(snapshot, this.deps.assetKey)
+    this.throttle(activity)
+  }
+
+  private publish(activity: ReturnType<typeof buildDiscordActivity>): void {
+    this.deps.client.setActivity(activity)
+  }
+}

--- a/src/main/discord-presence/discord-presence-manager.ts
+++ b/src/main/discord-presence/discord-presence-manager.ts
@@ -3,6 +3,7 @@ import type { DiscordActivity } from './discord-presence-activity'
 import { createPresenceThrottle } from './discord-presence-throttle'
 import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
 import type { DiscordRpcClient } from './discord-rpc-client'
+import { DiscordHandshakeRejectedError } from './discord-rpc-client'
 
 export type DiscordPresenceManagerDeps = {
   getSnapshot: () => AgentStatusIpcPayload[]
@@ -27,6 +28,7 @@ export class DiscordPresenceManager {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectDelay = RECONNECT_BASE_DELAY_MS
   private stopped = false
+  private handshakeFailed = false
 
   constructor(deps: DiscordPresenceManagerDeps) {
     this.deps = deps
@@ -37,12 +39,11 @@ export class DiscordPresenceManager {
   }
 
   start(): void {
-    console.log('[discord-presence] start() called')
     if (this.unsubscribe) return // already started
     this.stopped = false
+    this.handshakeFailed = false
     this.unsubscribe = this.deps.subscribeChanges(() => this.onChange())
     this.deps.client.onDisconnect(() => this.onDisconnect())
-    console.log('[discord-presence] subscribed to status changes')
     void this.connectAndPublish()
   }
 
@@ -52,7 +53,6 @@ export class DiscordPresenceManager {
   }
 
   stop(): void {
-    console.log('[discord-presence] stop() called')
     this.stopped = true
     this.unsubscribe?.()
     this.unsubscribe = null
@@ -66,7 +66,6 @@ export class DiscordPresenceManager {
 
   private async connectAndPublish(): Promise<void> {
     if (!this.deps.isEnabled()) {
-      console.log('[discord-presence] feature disabled, skipping connect')
       return
     }
     try {
@@ -77,6 +76,11 @@ export class DiscordPresenceManager {
       console.log('[discord-presence] connected, publishing initial state')
       this.onChange()
     } catch (err) {
+      if (err instanceof DiscordHandshakeRejectedError) {
+        this.handshakeFailed = true
+        console.error('[discord-presence] handshake rejected — set ORCA_DISCORD_CLIENT_ID to a valid Discord Application ID and restart Orca')
+        return
+      }
       console.error('[discord-presence] connect failed:', err)
       this.scheduleReconnect()
     }
@@ -101,7 +105,6 @@ export class DiscordPresenceManager {
 
   private onChange(): void {
     const enabled = this.deps.isEnabled()
-    console.log('[discord-presence] onChange called, isEnabled:', enabled, 'connected:', this.connected)
     if (!enabled) {
       if (this.connected) {
         this.deps.client.setActivity(null).catch(() => {})
@@ -109,21 +112,18 @@ export class DiscordPresenceManager {
       return
     }
     if (!this.connected) {
-      void this.connectAndPublish()
+      if (!this.handshakeFailed) void this.connectAndPublish()
       return
     }
     const snapshot = {
       ...aggregateAgentStatus(this.deps.getSnapshot()),
       activeTerminals: this.deps.getActiveTerminalCount?.() ?? 0
     }
-    console.log('[discord-presence] snapshot:', JSON.stringify(snapshot))
     const activity = buildDiscordActivity(snapshot, this.deps.assetKey)
-    console.log('[discord-presence] activity:', JSON.stringify(activity))
     this.throttle(activity)
   }
 
   private publish(activity: DiscordActivity | null): void {
-    console.log('[discord-presence] publish:', activity === null ? 'clear' : activity.details)
     this.deps.client.setActivity(activity).catch((err) => {
       console.error('[discord-presence] publish failed:', err)
     })

--- a/src/main/discord-presence/discord-presence-throttle.test.ts
+++ b/src/main/discord-presence/discord-presence-throttle.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createPresenceThrottle } from './discord-presence-throttle'
+import type { DiscordActivity } from './discord-presence-activity'
+
+const dummyActivity: DiscordActivity = {
+  details: '1 agent working',
+  state: 'Claude',
+  assets: { large_image: 'orca', large_text: 'Orca' }
+}
+
+describe('createPresenceThrottle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('publishes the first update immediately', () => {
+    const publish = vi.fn()
+    const throttle = createPresenceThrottle(publish)
+    throttle(dummyActivity)
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenCalledWith(dummyActivity)
+  })
+
+  it('coalesces rapid updates to the last one (trailing)', () => {
+    const publish = vi.fn()
+    const throttle = createPresenceThrottle(publish, 15000)
+    throttle(dummyActivity)
+    expect(publish).toHaveBeenCalledTimes(1) // leading
+
+    const second: DiscordActivity = { ...dummyActivity, details: '2 agents working' }
+    const third: DiscordActivity = { ...dummyActivity, details: '3 agents working' }
+
+    throttle(second)
+    throttle(third)
+
+    // Only leading published so far
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenCalledWith(dummyActivity)
+
+    // Advance past the interval
+    vi.advanceTimersByTime(15000)
+
+    // Trailing fires with the last value
+    expect(publish).toHaveBeenCalledTimes(2)
+    expect(publish).toHaveBeenLastCalledWith(third)
+  })
+
+  it('does not publish trailing if value did not change', () => {
+    const publish = vi.fn()
+    const throttle = createPresenceThrottle(publish, 15000)
+
+    throttle(dummyActivity) // leading
+    throttle(dummyActivity) // same value
+    expect(publish).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(15000)
+    // No trailing because value unchanged
+    expect(publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses updates during cooldown', () => {
+    const publish = vi.fn()
+    const throttle = createPresenceThrottle(publish, 15000)
+
+    throttle(dummyActivity)
+    expect(publish).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(5000)
+    throttle({ ...dummyActivity, details: 'mid-cooldown' })
+    expect(publish).toHaveBeenCalledTimes(1) // still in cooldown
+
+    vi.advanceTimersByTime(10000) // 15s from start
+    expect(publish).toHaveBeenCalledTimes(2) // trailing fired
+  })
+
+  it('flush() runs pending update immediately', () => {
+    const publish = vi.fn()
+    const throttle = createPresenceThrottle(publish, 15000)
+
+    throttle(dummyActivity) // leading
+    expect(publish).toHaveBeenCalledTimes(1)
+
+    const updated: DiscordActivity = { ...dummyActivity, details: 'updated' }
+    throttle(updated) // queued
+    expect(publish).toHaveBeenCalledTimes(1)
+
+    throttle.flush()
+    expect(publish).toHaveBeenCalledTimes(2)
+    expect(publish).toHaveBeenLastCalledWith(updated)
+  })
+
+  it('flush() is a no-op when nothing is pending', () => {
+    const publish = vi.fn()
+    const throttle = createPresenceThrottle(publish, 15000)
+    throttle(dummyActivity) // leading, no trailing pending
+    expect(publish).toHaveBeenCalledTimes(1)
+    throttle.flush()
+    expect(publish).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/discord-presence/discord-presence-throttle.ts
+++ b/src/main/discord-presence/discord-presence-throttle.ts
@@ -4,6 +4,8 @@ export type PresenceThrottle = {
   (activity: DiscordActivity | null): void
   flush(): void
   cancel(): void
+  /** Clears all throttle state so the next call publishes immediately (leading edge). Use on reconnect. */
+  reset(): void
 }
 
 const DEFAULT_INTERVAL_MS = 15000
@@ -80,6 +82,16 @@ export function createPresenceThrottle(
       timer = null
     }
     pending = undefined
+  }
+
+  throttled.reset = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    pending = undefined
+    lastPublished = undefined
+    lastTime = 0
   }
 
   return throttled

--- a/src/main/discord-presence/discord-presence-throttle.ts
+++ b/src/main/discord-presence/discord-presence-throttle.ts
@@ -1,0 +1,68 @@
+import type { DiscordActivity } from './discord-presence-activity'
+
+export type PresenceThrottle = {
+  (activity: DiscordActivity | null): void
+  flush(): void
+}
+
+const DEFAULT_INTERVAL_MS = 15000
+
+export function createPresenceThrottle(
+  publish: (activity: DiscordActivity | null) => void,
+  intervalMs: number = DEFAULT_INTERVAL_MS
+): PresenceThrottle {
+  let pending: DiscordActivity | null | undefined
+  let lastPublished: DiscordActivity | null = undefined
+  let lastTime = 0
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleTrailing() {
+    if (timer) return
+    const remaining = intervalMs - (Date.now() - lastTime)
+    timer = setTimeout(() => {
+      timer = null
+      if (pending !== undefined && pending !== lastPublished) {
+        lastPublished = pending
+        publish(pending!)
+      }
+      pending = undefined
+      lastTime = Date.now()
+    }, Math.max(0, remaining))
+  }
+
+  function throttled(activity: DiscordActivity | null): void {
+    const now = Date.now()
+
+    // First update or cooldown passed: publish immediately (leading)
+    if (lastTime === 0 || now - lastTime >= intervalMs) {
+      lastPublished = activity
+      publish(activity)
+      lastTime = now
+      pending = undefined
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      return
+    }
+
+    // Queue for trailing — coalesce to last value
+    pending = activity
+    scheduleTrailing()
+  }
+
+  throttled.flush = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    if (pending !== undefined && pending !== lastPublished) {
+      lastPublished = pending
+      publish(pending!)
+    }
+    pending = undefined
+    lastTime = Date.now()
+  }
+
+  return throttled
+}

--- a/src/main/discord-presence/discord-presence-throttle.ts
+++ b/src/main/discord-presence/discord-presence-throttle.ts
@@ -11,8 +11,8 @@ export function createPresenceThrottle(
   publish: (activity: DiscordActivity | null) => void,
   intervalMs: number = DEFAULT_INTERVAL_MS
 ): PresenceThrottle {
-  let pending: DiscordActivity | null | undefined
-  let lastPublished: DiscordActivity | null = undefined
+  let pending: DiscordActivity | null | undefined = undefined
+  let lastPublished: DiscordActivity | null | undefined = undefined
   let lastTime = 0
   let timer: ReturnType<typeof setTimeout> | null = null
 

--- a/src/main/discord-presence/discord-presence-throttle.ts
+++ b/src/main/discord-presence/discord-presence-throttle.ts
@@ -3,9 +3,19 @@ import type { DiscordActivity } from './discord-presence-activity'
 export type PresenceThrottle = {
   (activity: DiscordActivity | null): void
   flush(): void
+  cancel(): void
 }
 
 const DEFAULT_INTERVAL_MS = 15000
+
+function activitiesEqual(
+  a: DiscordActivity | null | undefined,
+  b: DiscordActivity | null | undefined
+): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return false
+  return JSON.stringify(a) === JSON.stringify(b)
+}
 
 export function createPresenceThrottle(
   publish: (activity: DiscordActivity | null) => void,
@@ -21,7 +31,7 @@ export function createPresenceThrottle(
     const remaining = intervalMs - (Date.now() - lastTime)
     timer = setTimeout(() => {
       timer = null
-      if (pending !== undefined && pending !== lastPublished) {
+      if (pending !== undefined && !activitiesEqual(pending, lastPublished)) {
         lastPublished = pending
         publish(pending!)
       }
@@ -56,12 +66,20 @@ export function createPresenceThrottle(
       clearTimeout(timer)
       timer = null
     }
-    if (pending !== undefined && pending !== lastPublished) {
+    if (pending !== undefined && !activitiesEqual(pending, lastPublished)) {
       lastPublished = pending
       publish(pending!)
     }
     pending = undefined
     lastTime = Date.now()
+  }
+
+  throttled.cancel = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    pending = undefined
   }
 
   return throttled

--- a/src/main/discord-presence/discord-rpc-client.test.ts
+++ b/src/main/discord-presence/discord-rpc-client.test.ts
@@ -195,6 +195,7 @@ describe('createDiscordRpcClient', () => {
     expect(pong).toBeDefined()
     const header = pong.slice(0, 8)
     expect(header.readInt32LE(0)).toBe(OP_PONG)
+    expect(pong.subarray(8).toString('utf8')).toBe('{}')
   })
 
   it('calls onDisconnect on post-connect socket error without throwing', async () => {
@@ -208,7 +209,9 @@ describe('createDiscordRpcClient', () => {
     const cb = vi.fn()
     client.onDisconnect(cb)
 
-    // Emit an error AFTER handshake completes — should not throw
+    // Emit an error AFTER handshake completes — should not throw, and disconnect cb must fire
     expect(() => sock.emit('error', new Error('ECONNRESET'))).not.toThrow()
+    sock.emit('close')
+    expect(cb).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/discord-presence/discord-rpc-client.test.ts
+++ b/src/main/discord-presence/discord-rpc-client.test.ts
@@ -174,4 +174,41 @@ describe('createDiscordRpcClient', () => {
     await expect(client.connect()).rejects.toThrow('Discord IPC not found (tried pipes 0-9)')
     expect(created).toBe(10)
   })
+
+  it('responds to PING with PONG', async () => {
+    const OP_PING = 3
+    const OP_PONG = 4
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    const cp = client.connect()
+    sock.feedHandshakeAck()
+    await cp
+    sock.written = []
+
+    // Emit a PING frame
+    const ping = encodeFrame(OP_PING, '{}')
+    sock.emit('data', ping)
+
+    // The last write should be a PONG with the same payload
+    const pong = sock.written[sock.written.length - 1]
+    expect(pong).toBeDefined()
+    const header = pong.slice(0, 8)
+    expect(header.readInt32LE(0)).toBe(OP_PONG)
+  })
+
+  it('calls onDisconnect on post-connect socket error without throwing', async () => {
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    const cp = client.connect()
+    sock.feedHandshakeAck()
+    await cp
+
+    const cb = vi.fn()
+    client.onDisconnect(cb)
+
+    // Emit an error AFTER handshake completes — should not throw
+    expect(() => sock.emit('error', new Error('ECONNRESET'))).not.toThrow()
+  })
 })

--- a/src/main/discord-presence/discord-rpc-client.test.ts
+++ b/src/main/discord-presence/discord-rpc-client.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { createDiscordRpcClient } from './discord-rpc-client'
+import type { DiscordRpcClient } from './discord-rpc-client'
+import type { DiscordActivity } from './discord-presence-activity'
+
+const OP_HANDSHAKE = 0
+const OP_FRAME = 1
+const OP_PONG = 4
+
+function encodeFrame(opcode: number, payload: string): Buffer {
+  const jsonBuffer = Buffer.from(payload, 'utf-8')
+  const header = Buffer.alloc(8)
+  header.writeInt32LE(opcode, 0)
+  header.writeInt32LE(jsonBuffer.length, 4)
+  return Buffer.concat([header, jsonBuffer])
+}
+
+function decodeFrame(buf: Buffer): { opcode: number; payload: string } | null {
+  if (buf.length < 8) return null
+  const opcode = buf.readInt32LE(0)
+  const length = buf.readInt32LE(4)
+  if (buf.length < 8 + length) return null
+  return { opcode, payload: buf.subarray(8, 8 + length).toString('utf-8') }
+}
+
+const CLIENT_ID = '123456789012345678'
+
+// Synchronous mock socket — .connect() calls cb immediately
+class SyncSocket extends EventEmitter {
+  written: Buffer[] = []
+  destroyed = false
+
+  connect(_opts: Record<string, unknown>, cb?: () => void) {
+    if (cb) cb()
+    return this
+  }
+
+  write(data: Uint8Array | string, cb?: (err?: Error) => void): boolean {
+    this.written.push(Buffer.from(data))
+    if (cb) cb()
+    return true
+  }
+
+  destroy() {
+    this.destroyed = true
+    return this
+  }
+
+  removeAllListeners(_event?: string) {
+    return this
+  }
+
+  feedHandshakeAck() {
+    this.emit('data', encodeFrame(OP_FRAME, JSON.stringify({
+      cmd: 'DISPATCH', evt: 'READY', data: { user: { id: '1' } }
+    })))
+  }
+
+  feedActivityAck(nonce: string) {
+    this.emit('data', encodeFrame(OP_FRAME, JSON.stringify({ cmd: 'SET_ACTIVITY', nonce })))
+  }
+
+  lastPayload(): string | null {
+    if (this.written.length === 0) return null
+    const buf = Buffer.concat(this.written)
+    const frame = decodeFrame(buf)
+    return frame?.payload ?? null
+  }
+}
+
+describe('createDiscordRpcClient', () => {
+  it('connect() sends handshake and resolves on ACK', async () => {
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    const promise = client.connect()
+    sock.feedHandshakeAck()
+    await expect(promise).resolves.toBeUndefined()
+
+    const payload = sock.lastPayload()
+    expect(payload).not.toBeNull()
+    const parsed = JSON.parse(payload!)
+    expect(parsed).toEqual({ v: 1, client_id: CLIENT_ID })
+  })
+
+  it('setActivity() sends SET_ACTIVITY frame', async () => {
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    const cp = client.connect()
+    sock.feedHandshakeAck()
+    await cp
+    sock.written = []
+
+    const activity: DiscordActivity = {
+      details: '1 agent working',
+      state: 'Claude',
+      assets: { large_image: 'orca', large_text: 'Orca' }
+    }
+
+    const sp = client.setActivity(activity)
+    const payload = JSON.parse(sock.lastPayload()!)
+    expect(payload.cmd).toBe('SET_ACTIVITY')
+    expect(payload.nonce).toBeTypeOf('string')
+    expect(payload.args.activity).toEqual(activity)
+
+    sock.feedActivityAck(payload.nonce)
+    await expect(sp).resolves.toBeUndefined()
+  })
+
+  it('setActivity(null) clears presence', async () => {
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    const cp = client.connect()
+    sock.feedHandshakeAck()
+    await cp
+    sock.written = []
+
+    const sp = client.setActivity(null)
+    const payload = JSON.parse(sock.lastPayload()!)
+    expect(payload.cmd).toBe('SET_ACTIVITY')
+    expect(payload.args.activity).toBeUndefined()
+  })
+
+  it('disconnect() destroys socket and notifies onDisconnect', async () => {
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    // Connect first so there is an active socket
+    const cp = client.connect()
+    sock.feedHandshakeAck()
+    await cp
+
+    const cb = vi.fn()
+    client.onDisconnect(cb)
+
+    client.disconnect()
+    expect(sock.destroyed).toBe(true)
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('connect() rejects on socket error', async () => {
+    const sock = new SyncSocket()
+    const client = createDiscordRpcClient(CLIENT_ID, () => sock)
+
+    const promise = client.connect()
+    sock.emit('error', new Error('ECONNREFUSED'))
+    await expect(promise).rejects.toThrow('ECONNREFUSED')
+  })
+})

--- a/src/main/discord-presence/discord-rpc-client.test.ts
+++ b/src/main/discord-presence/discord-rpc-client.test.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
 import { createDiscordRpcClient } from './discord-rpc-client'
-import type { DiscordRpcClient } from './discord-rpc-client'
 import type { DiscordActivity } from './discord-presence-activity'
 
-const OP_HANDSHAKE = 0
 const OP_FRAME = 1
-const OP_PONG = 4
 
 function encodeFrame(opcode: number, payload: string): Buffer {
   const jsonBuffer = Buffer.from(payload, 'utf-8')
@@ -118,7 +115,7 @@ describe('createDiscordRpcClient', () => {
     await cp
     sock.written = []
 
-    const sp = client.setActivity(null)
+    void client.setActivity(null)
     const payload = JSON.parse(sock.lastPayload()!)
     expect(payload.cmd).toBe('SET_ACTIVITY')
     expect(payload.args.activity).toBeUndefined()

--- a/src/main/discord-presence/discord-rpc-client.test.ts
+++ b/src/main/discord-presence/discord-rpc-client.test.ts
@@ -44,7 +44,8 @@ class SyncSocket extends EventEmitter {
     return this
   }
 
-  removeAllListeners(_event?: string) {
+  removeAllListeners(event?: string) {
+    super.removeAllListeners(event)
     return this
   }
 
@@ -63,6 +64,23 @@ class SyncSocket extends EventEmitter {
     const buf = Buffer.concat(this.written)
     const frame = decodeFrame(buf)
     return frame?.payload ?? null
+  }
+}
+
+// Socket that always errors before the connect callback fires (pipe not found)
+class FailSocket extends EventEmitter {
+  connect(_opts: Record<string, unknown>, _cb?: () => void) {
+    process.nextTick(() => this.emit('error', new Error('ENOENT')))
+    return this
+  }
+  write(_data: Uint8Array | string, cb?: (err?: Error) => void): boolean {
+    if (cb) cb()
+    return true
+  }
+  destroy() { return this }
+  removeAllListeners(event?: string) {
+    super.removeAllListeners(event)
+    return this
   }
 }
 
@@ -138,12 +156,22 @@ describe('createDiscordRpcClient', () => {
     expect(cb).toHaveBeenCalled()
   })
 
-  it('connect() rejects on socket error', async () => {
+  it('connect() rejects on error during handshake', async () => {
     const sock = new SyncSocket()
     const client = createDiscordRpcClient(CLIENT_ID, () => sock)
 
     const promise = client.connect()
     sock.emit('error', new Error('ECONNREFUSED'))
     await expect(promise).rejects.toThrow('ECONNREFUSED')
+  })
+
+  it('connect() rejects when all IPC pipes are unavailable', async () => {
+    let created = 0
+    const client = createDiscordRpcClient(CLIENT_ID, () => {
+      created++
+      return new FailSocket()
+    })
+    await expect(client.connect()).rejects.toThrow('Discord IPC not found (tried pipes 0-9)')
+    expect(created).toBe(10)
   })
 })

--- a/src/main/discord-presence/discord-rpc-client.ts
+++ b/src/main/discord-presence/discord-rpc-client.ts
@@ -1,0 +1,232 @@
+import * as net from 'node:net'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { DiscordActivity } from './discord-presence-activity'
+
+const OP_HANDSHAKE = 0
+const OP_FRAME = 1
+const OP_PING = 3
+const OP_PONG = 4
+
+export interface DiscordRpcClient {
+  connect(): Promise<void>
+  setActivity(activity: DiscordActivity | null): Promise<void>
+  disconnect(): void
+  onDisconnect(cb: () => void): void
+}
+
+function discoverPipePath(index: number): string {
+  const pipeName = `discord-ipc-${index}`
+  if (process.platform === 'win32') {
+    return `\\\\?\\pipe\\${pipeName}`
+  }
+  // macOS / Linux: Unix socket
+  const dir = process.platform === 'darwin'
+    ? (process.env.TMPDIR || '/tmp')
+    : (process.env.XDG_RUNTIME_DIR || `/run/user/${os.userInfo().uid}`)
+  return path.join(dir, pipeName)
+}
+
+function encodeFrame(opcode: number, payload: string): Buffer {
+  const jsonBuffer = Buffer.from(payload, 'utf-8')
+  const header = Buffer.alloc(8)
+  header.writeInt32LE(opcode, 0)
+  header.writeInt32LE(jsonBuffer.length, 4)
+  return Buffer.concat([header, jsonBuffer])
+}
+
+function decodeFrame(buf: Buffer): { opcode: number; payload: string } | null {
+  if (buf.length < 8) return null
+  const opcode = buf.readInt32LE(0)
+  const length = buf.readInt32LE(4)
+  if (buf.length < 8 + length) return null
+  return { opcode, payload: buf.subarray(8, 8 + length).toString('utf-8') }
+}
+
+type SocketLike = {
+  connect(opts: Record<string, unknown>, cb?: () => void): void
+  on(event: string, cb: (...args: unknown[]) => void): void
+  write(data: Uint8Array | string, cb?: (err?: Error) => void): boolean
+  destroy(): void
+  removeAllListeners(): void
+}
+
+export function createDiscordRpcClient(
+  clientId: string,
+  createSocket?: () => SocketLike
+): DiscordRpcClient {
+  const pid = process.pid
+  let socket: SocketLike | null = null
+  let disconnectCb: (() => void) | null = null
+  let buffer = Buffer.alloc(0)
+  let pendingRequests = new Map<string, { resolve: () => void; reject: (err: Error) => void }>()
+
+  function makeSocket(): SocketLike {
+    if (createSocket) return createSocket()
+    return new net.Socket() as unknown as SocketLike
+  }
+
+  function connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let pipeIndex = 0
+
+      function tryConnect() {
+        if (pipeIndex > 9) {
+          reject(new Error('Discord IPC not found (tried pipes 0-9)'))
+          return
+        }
+
+        socket = makeSocket()
+        const pipePath = discoverPipePath(pipeIndex)
+        let settled = false
+
+        const onError = (err: Error & { code?: string }) => {
+          if (settled) return
+          settled = true
+          socket!.removeAllListeners()
+          socket = null
+          pipeIndex++
+          tryConnect()
+        }
+
+        socket.on('error', onError)
+
+        if (process.platform === 'win32') {
+          socket.connect({ path: pipePath }, () => {
+            if (settled) return
+            settled = true
+            socket!.removeListener('error', onError)
+            performHandshake(resolve, reject)
+          })
+        } else {
+          socket.connect({ path: pipePath }, () => {
+            if (settled) return
+            settled = true
+            socket!.removeListener('error', onError)
+            performHandshake(resolve, reject)
+          })
+        }
+      }
+
+      function performHandshake(resolve: (v: void) => void, reject: (err: Error) => void) {
+        if (!socket) return
+
+        const onError = (err: Error) => {
+          reject(err)
+        }
+        socket.on('error', onError)
+        socket.on('close', () => {
+          reject(new Error('Socket closed during handshake'))
+        })
+
+        let handshakeData = Buffer.alloc(0)
+        socket.on('data', (chunk: Buffer) => {
+          handshakeData = Buffer.concat([handshakeData, chunk])
+          const frame = decodeFrame(handshakeData)
+          if (!frame) return
+
+          if (frame.opcode === OP_FRAME) {
+            try {
+              const msg = JSON.parse(frame.payload)
+              if (msg.cmd === 'DISPATCH' && msg.evt === 'READY') {
+                socket!.removeListener('error', onError)
+                socket!.removeAllListeners('close')
+                setupDataHandler()
+                resolve()
+              }
+            } catch { /* malformed, keep waiting */ }
+          }
+        })
+
+        const hsFrame = encodeFrame(OP_HANDSHAKE, JSON.stringify({ v: 1, client_id: clientId }))
+        socket.write(hsFrame)
+      }
+
+      tryConnect()
+    })
+  }
+
+  function setupDataHandler() {
+    if (!socket) return
+    socket.on('data', (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk])
+      while (true) {
+        const frame = decodeFrame(buffer)
+        if (!frame) break
+        buffer = buffer.subarray(8 + Buffer.from(frame.payload, 'utf-8').length)
+
+        // Update the subarray to use the decoded length from header
+        // Actually, let's redo this with frame-based parsing
+      }
+    })
+
+    // Re-do with correct parsing
+    socket.removeAllListeners('data')
+    buffer = Buffer.alloc(0)
+
+    socket.on('data', (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk])
+      while (buffer.length >= 8) {
+        const opcode = buffer.readInt32LE(0)
+        const length = buffer.readInt32LE(4)
+        if (buffer.length < 8 + length) break
+
+        const payload = buffer.subarray(8, 8 + length).toString('utf-8')
+        buffer = buffer.subarray(8 + length)
+
+        if (opcode === OP_PING) {
+          socket!.write(encodeFrame(OP_PONG, payload))
+        } else if (opcode === OP_FRAME) {
+          try {
+            const msg = JSON.parse(payload)
+            // Resolve pending request if nonce matches
+            if (msg.nonce && pendingRequests.has(msg.nonce)) {
+              pendingRequests.get(msg.nonce)!.resolve()
+              pendingRequests.delete(msg.nonce)
+            }
+          } catch { /* ignore malformed */ }
+        }
+      }
+    })
+
+    socket.on('close', () => {
+      disconnectCb?.()
+    })
+  }
+
+  function setActivity(activity: DiscordActivity | null): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!socket) {
+        reject(new Error('Not connected'))
+        return
+      }
+      const nonce = crypto.randomUUID()
+      pendingRequests.set(nonce, { resolve, reject })
+
+      const args: Record<string, unknown> = { pid }
+      if (activity !== null) {
+        args.activity = activity
+      }
+      const frame = encodeFrame(OP_FRAME, JSON.stringify({
+        cmd: 'SET_ACTIVITY',
+        args,
+        nonce
+      }))
+      socket.write(frame)
+    })
+  }
+
+  function disconnect() {
+    if (socket) {
+      socket.destroy()
+      socket = null
+    }
+    disconnectCb?.()
+  }
+
+  function onDisconnect(cb: () => void) {
+    disconnectCb = cb
+  }
+
+  return { connect, setActivity, disconnect, onDisconnect }
+}

--- a/src/main/discord-presence/discord-rpc-client.ts
+++ b/src/main/discord-presence/discord-rpc-client.ts
@@ -94,6 +94,7 @@ export function createDiscordRpcClient(
           if (settled) return
           settled = true
           socket!.removeAllListeners()
+          socket!.destroy()
           socket = null
           pipeIndex++
           tryConnect()
@@ -132,7 +133,8 @@ export function createDiscordRpcClient(
               if (msg.cmd === 'DISPATCH' && msg.evt === 'READY') {
                 socket!.removeListener('error', onError)
                 socket!.removeAllListeners('close')
-                setupDataHandler()
+                const consumed = 8 + handshakeData.readInt32LE(4)
+                setupDataHandler(Buffer.from(handshakeData.subarray(consumed)))
                 resolve()
               }
             } catch { /* malformed, keep waiting */ }
@@ -147,10 +149,10 @@ export function createDiscordRpcClient(
     })
   }
 
-  function setupDataHandler() {
+  function setupDataHandler(initial: Buffer<ArrayBuffer> = Buffer.alloc(0)) {
     if (!socket) return
     socket.removeAllListeners('data')
-    buffer = Buffer.alloc(0)
+    buffer = initial
 
     socket.on('data', (chunk: unknown) => {
       buffer = Buffer.concat([buffer, chunk as Buffer])
@@ -183,6 +185,10 @@ export function createDiscordRpcClient(
       pendingRequests.clear()
       disconnectCb?.()
     })
+
+    socket.on('error', (..._args: unknown[]) => {
+      socket?.destroy()
+    })
   }
 
   function setActivity(activity: DiscordActivity | null): Promise<void> {
@@ -192,18 +198,23 @@ export function createDiscordRpcClient(
         return
       }
       const nonce = randomUUID()
-      pendingRequests.set(nonce, { resolve, reject })
+      const timeout = setTimeout(() => {
+        pendingRequests.delete(nonce)
+        reject(new Error('SET_ACTIVITY timed out'))
+      }, 10_000)
+      pendingRequests.set(nonce, {
+        resolve: () => { clearTimeout(timeout); resolve() },
+        reject: (err: Error) => { clearTimeout(timeout); reject(err) }
+      })
 
       const args: Record<string, unknown> = { pid }
       if (activity !== null) {
         args.activity = activity
       }
-      const frame = encodeFrame(OP_FRAME, JSON.stringify({
-        cmd: 'SET_ACTIVITY',
-        args,
-        nonce
-      }))
-      socket.write(frame)
+      const frame = encodeFrame(OP_FRAME, JSON.stringify({ cmd: 'SET_ACTIVITY', args, nonce }))
+      socket.write(frame, (err?: Error) => {
+        if (err) pendingRequests.get(nonce)?.reject(err)
+      })
     })
   }
 

--- a/src/main/discord-presence/discord-rpc-client.ts
+++ b/src/main/discord-presence/discord-rpc-client.ts
@@ -46,9 +46,10 @@ function decodeFrame(buf: Buffer): { opcode: number; payload: string } | null {
 type SocketLike = {
   connect(opts: Record<string, unknown>, cb?: () => void): void
   on(event: string, cb: (...args: unknown[]) => void): void
+  removeListener(event: string, cb: (...args: unknown[]) => void): void
   write(data: Uint8Array | string, cb?: (err?: Error) => void): boolean
   destroy(): void
-  removeAllListeners(): void
+  removeAllListeners(event?: string): void
 }
 
 export function createDiscordRpcClient(
@@ -80,7 +81,7 @@ export function createDiscordRpcClient(
         const pipePath = discoverPipePath(pipeIndex)
         let settled = false
 
-        const onError = (err: Error & { code?: string }) => {
+        const onError = (..._args: unknown[]) => {
           if (settled) return
           settled = true
           socket!.removeAllListeners()
@@ -111,17 +112,17 @@ export function createDiscordRpcClient(
       function performHandshake(resolve: (v: void) => void, reject: (err: Error) => void) {
         if (!socket) return
 
-        const onError = (err: Error) => {
-          reject(err)
+        const onError = (..._args: unknown[]) => {
+          reject(_args[0] as Error)
         }
         socket.on('error', onError)
-        socket.on('close', () => {
+        socket.on('close', (..._args: unknown[]) => {
           reject(new Error('Socket closed during handshake'))
         })
 
         let handshakeData = Buffer.alloc(0)
-        socket.on('data', (chunk: Buffer) => {
-          handshakeData = Buffer.concat([handshakeData, chunk])
+        socket.on('data', (chunk: unknown) => {
+          handshakeData = Buffer.concat([handshakeData, chunk as Buffer])
           const frame = decodeFrame(handshakeData)
           if (!frame) return
 
@@ -148,24 +149,11 @@ export function createDiscordRpcClient(
 
   function setupDataHandler() {
     if (!socket) return
-    socket.on('data', (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk])
-      while (true) {
-        const frame = decodeFrame(buffer)
-        if (!frame) break
-        buffer = buffer.subarray(8 + Buffer.from(frame.payload, 'utf-8').length)
-
-        // Update the subarray to use the decoded length from header
-        // Actually, let's redo this with frame-based parsing
-      }
-    })
-
-    // Re-do with correct parsing
     socket.removeAllListeners('data')
     buffer = Buffer.alloc(0)
 
-    socket.on('data', (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk])
+    socket.on('data', (chunk: unknown) => {
+      buffer = Buffer.concat([buffer, chunk as Buffer])
       while (buffer.length >= 8) {
         const opcode = buffer.readInt32LE(0)
         const length = buffer.readInt32LE(4)
@@ -189,7 +177,7 @@ export function createDiscordRpcClient(
       }
     })
 
-    socket.on('close', () => {
+    socket.on('close', (..._args: unknown[]) => {
       disconnectCb?.()
     })
   }

--- a/src/main/discord-presence/discord-rpc-client.ts
+++ b/src/main/discord-presence/discord-rpc-client.ts
@@ -9,6 +9,14 @@ const OP_FRAME = 1
 const OP_PING = 3
 const OP_PONG = 4
 
+/** Discord closed the socket after receiving our handshake — almost always an invalid client_id. Retrying will not help. */
+export class DiscordHandshakeRejectedError extends Error {
+  constructor() {
+    super('Discord rejected the handshake — check your client_id (ORCA_DISCORD_CLIENT_ID)')
+    this.name = 'DiscordHandshakeRejectedError'
+  }
+}
+
 export interface DiscordRpcClient {
   connect(): Promise<void>
   setActivity(activity: DiscordActivity | null): Promise<void>
@@ -93,21 +101,12 @@ export function createDiscordRpcClient(
 
         socket.on('error', onError)
 
-        if (process.platform === 'win32') {
-          socket.connect({ path: pipePath }, () => {
-            if (settled) return
-            settled = true
-            socket!.removeListener('error', onError)
-            performHandshake(resolve, reject)
-          })
-        } else {
-          socket.connect({ path: pipePath }, () => {
-            if (settled) return
-            settled = true
-            socket!.removeListener('error', onError)
-            performHandshake(resolve, reject)
-          })
-        }
+        socket.connect({ path: pipePath }, () => {
+          if (settled) return
+          settled = true
+          socket!.removeListener('error', onError)
+          performHandshake(resolve, reject)
+        })
       }
 
       function performHandshake(resolve: (v: void) => void, reject: (err: Error) => void) {
@@ -118,7 +117,7 @@ export function createDiscordRpcClient(
         }
         socket.on('error', onError)
         socket.on('close', (..._args: unknown[]) => {
-          reject(new Error('Socket closed during handshake'))
+          reject(new DiscordHandshakeRejectedError())
         })
 
         let handshakeData = Buffer.alloc(0)
@@ -168,7 +167,6 @@ export function createDiscordRpcClient(
         } else if (opcode === OP_FRAME) {
           try {
             const msg = JSON.parse(payload)
-            // Resolve pending request if nonce matches
             if (msg.nonce && pendingRequests.has(msg.nonce)) {
               pendingRequests.get(msg.nonce)!.resolve()
               pendingRequests.delete(msg.nonce)
@@ -179,6 +177,10 @@ export function createDiscordRpcClient(
     })
 
     socket.on('close', (..._args: unknown[]) => {
+      for (const { reject } of pendingRequests.values()) {
+        reject(new Error('Disconnected'))
+      }
+      pendingRequests.clear()
       disconnectCb?.()
     })
   }
@@ -206,6 +208,10 @@ export function createDiscordRpcClient(
   }
 
   function disconnect() {
+    for (const { reject } of pendingRequests.values()) {
+      reject(new Error('Disconnected'))
+    }
+    pendingRequests.clear()
     if (socket) {
       socket.destroy()
       socket = null

--- a/src/main/discord-presence/discord-rpc-client.ts
+++ b/src/main/discord-presence/discord-rpc-client.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { randomUUID } from 'node:crypto'
 import type { DiscordActivity } from './discord-presence-activity'
 
 const OP_HANDSHAKE = 0
@@ -188,7 +189,7 @@ export function createDiscordRpcClient(
         reject(new Error('Not connected'))
         return
       }
-      const nonce = crypto.randomUUID()
+      const nonce = randomUUID()
       pendingRequests.set(nonce, { resolve, reject })
 
       const args: Record<string, unknown> = { pid }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2236,7 +2236,7 @@ void app.whenReady().then(async () => {
     }
     if ('discordRichPresenceEnabled' in updates) {
       // The manager reads isEnabled() on the next status change; force an immediate refresh.
-      discordPresenceManager?.refresh?.()
+      discordPresenceManager?.refresh()
     }
   })
   // Why: run before ClaudeRuntimeAuthService's constructor sync — a surviving daemon Claude CLI holds the single-use refresh token; early refresh rotates it out mid-session.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -279,6 +279,12 @@ import { AutomationService } from './automations/service'
 import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
+import { DiscordPresenceManager } from './discord-presence/discord-presence-manager'
+import { createDiscordRpcClient } from './discord-presence/discord-rpc-client'
+import {
+  DISCORD_RICH_PRESENCE_CLIENT_ID,
+  DISCORD_RICH_PRESENCE_ASSET_KEY
+} from './discord-presence/discord-presence-config'
 import { normalizeComputerAwakeMode } from '../shared/computer-awake-mode'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { settleTeardownWithinDeadline } from './quit-teardown-deadline'
@@ -370,6 +376,7 @@ let starNag: StarNagService | null = null
 let agentAwakeService: AgentAwakeService | null = null
 let crashReports: CrashReportStore | null = null
 let unsubscribeAgentAwakeStatusChanges: (() => void) | null = null
+let discordPresenceManager: DiscordPresenceManager | null = null
 let unsubscribeSystemResumeBroadcast: (() => void) | null = null
 let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
@@ -2227,6 +2234,10 @@ void app.whenReady().then(async () => {
         wslHookRelayManager.disposeAll({ permanent: false })
       }
     }
+    if ('discordRichPresenceEnabled' in updates) {
+      // The manager reads isEnabled() on the next status change; force an immediate refresh.
+      discordPresenceManager?.refresh?.()
+    }
   })
   // Why: run before ClaudeRuntimeAuthService's constructor sync — a surviving daemon Claude CLI holds the single-use refresh token; early refresh rotates it out mid-session.
   attachClaudeLivePtyPersistence(store)
@@ -2272,6 +2283,17 @@ void app.whenReady().then(async () => {
   )
   // Why: start from empty — disk-hydrated status rows are UI continuity only; only this runtime's hook events keep the computer awake.
   agentAwakeService.setStatuses([])
+
+  // Discord Rich Presence: best-effort, fails silently if Discord is not running.
+  discordPresenceManager = new DiscordPresenceManager({
+    getSnapshot: () => agentHookServer.getStatusSnapshot(),
+    subscribeChanges: (cb) => agentHookServer.subscribeStatusChanges(cb),
+    client: createDiscordRpcClient(DISCORD_RICH_PRESENCE_CLIENT_ID),
+    isEnabled: () => store.getSettings().discordRichPresenceEnabled === true,
+    assetKey: DISCORD_RICH_PRESENCE_ASSET_KEY
+  })
+  discordPresenceManager.start()
+
   const collectChangedProviderSessionWorktrees = createHookProviderSessionInvalidator()
   const publishProviderSessionChanges = (identities: AgentHookProviderSessionIdentity[]): void => {
     const ownedIdentities = identities.map((identity) => ({
@@ -2322,6 +2344,7 @@ void app.whenReady().then(async () => {
     unsubscribeProviderSessionChanges()
     unsubscribeHookStatusSessionTabs()
     unsubscribeHookStatusClear()
+    discordPresenceManager?.stop()
   }
   // Why: telemetry must init before any IPC handler/renderer can call track(); it's a no-op in dev and while TELEMETRY_ENABLED is false, so it's safe early.
   initTelemetry(store)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2290,7 +2290,8 @@ void app.whenReady().then(async () => {
     subscribeChanges: (cb) => agentHookServer.subscribeStatusChanges(cb),
     client: createDiscordRpcClient(DISCORD_RICH_PRESENCE_CLIENT_ID),
     isEnabled: () => store!.getSettings().discordRichPresenceEnabled === true,
-    assetKey: DISCORD_RICH_PRESENCE_ASSET_KEY
+    assetKey: DISCORD_RICH_PRESENCE_ASSET_KEY,
+    getActiveTerminalCount: () => runtime?.getStatus().liveLeafCount ?? 0
   })
   discordPresenceManager.start()
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2289,7 +2289,7 @@ void app.whenReady().then(async () => {
     getSnapshot: () => agentHookServer.getStatusSnapshot(),
     subscribeChanges: (cb) => agentHookServer.subscribeStatusChanges(cb),
     client: createDiscordRpcClient(DISCORD_RICH_PRESENCE_CLIENT_ID),
-    isEnabled: () => store.getSettings().discordRichPresenceEnabled === true,
+    isEnabled: () => store!.getSettings().discordRichPresenceEnabled === true,
     assetKey: DISCORD_RICH_PRESENCE_ASSET_KEY
   })
   discordPresenceManager.start()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3478,6 +3478,7 @@ export class Store {
             mobilePairingCustomAddresses,
             // Why: persisted settings may be hand-edited or from older builds; keep tray-minimize false unless stored value is true.
             minimizeToTrayOnClose: parsed.settings?.minimizeToTrayOnClose === true,
+            discordRichPresenceEnabled: parsed.settings?.discordRichPresenceEnabled === true,
             // Why: missing means default-on; round-trips unchanged on non-mac since darwin consumers gate the effect.
             showMenuBarIcon: parsed.settings?.showMenuBarIcon !== false,
             uiLanguage: normalizeUiLanguage(parsed.settings?.uiLanguage),

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -5836,6 +5836,10 @@ export class Store {
     if ('artifactSharingEnabled' in updates) {
       sanitizedUpdates.artifactSharingEnabled = updates.artifactSharingEnabled === true
     }
+    // Why: presence sharing is opt-in and privacy-sensitive; coerce to exact boolean like other gates.
+    if ('discordRichPresenceEnabled' in updates) {
+      sanitizedUpdates.discordRichPresenceEnabled = updates.discordRichPresenceEnabled === true
+    }
     if ('disabledTuiAgents' in updates) {
       sanitizedUpdates.disabledTuiAgents = normalizeDisabledTuiAgents(updates.disabledTuiAgents)
     }

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -54,8 +54,12 @@ export function ExperimentalPane({
   const showNewWorktreeCardStyle = matchesSettingsSearch(searchQuery, [
     getExperimentalSearchEntry().newWorktreeCardStyle
   ])
+  const showDiscordRichPresence = matchesSettingsSearch(searchQuery, [
+    getExperimentalSearchEntry().discordRichPresence
+  ])
   const agentHibernationEnabled = settings.experimentalAgentHibernation === true
   const newWorktreeCardStyleEnabled = settings.experimentalNewWorktreeCardStyle === true
+  const discordRichPresenceEnabled = settings.discordRichPresenceEnabled === true
   // Why: the planner owns ms-based bounds/defaults; the UI edits minutes
   // while displaying the same effective clamped value the planner will use.
   const agentHibernationIdleMinutes = Math.round(
@@ -299,6 +303,47 @@ export function ExperimentalPane({
                   experimentalNewWorktreeCardStyle: !newWorktreeCardStyleEnabled
                 })
               }
+            />
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showDiscordRichPresence ? (
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.experimental.search.discordRichPresence.title',
+            'Discord Rich Presence'
+          )}
+          description={translate(
+            'auto.components.settings.experimental.search.discordRichPresence.description',
+            'Show live agent activity on your Discord profile.'
+          )}
+          keywords={getExperimentalSearchEntry().discordRichPresence.keywords}
+          className="space-y-3 py-2"
+          id="experimental-discord-rich-presence"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>
+                {translate(
+                  'auto.components.settings.experimental.search.discordRichPresence.title',
+                  'Discord Rich Presence'
+                )}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.experimental.search.discordRichPresence.copy',
+                  'Shows your active agents, blocked state, and terminal count on your Discord profile while Orca is open. Requires the Discord desktop app. Your agent activity is only shared with your own Discord account.'
+                )}
+              </p>
+            </div>
+            <SettingsSwitch
+              checked={discordRichPresenceEnabled}
+              ariaLabel={translate(
+                'auto.components.settings.experimental.search.discordRichPresence.toggleLabel',
+                'Toggle Discord Rich Presence'
+              )}
+              onChange={() => updateSettings({ discordRichPresenceEnabled: !discordRichPresenceEnabled })}
             />
           </div>
         </SearchableSetting>

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -311,11 +311,11 @@ export function ExperimentalPane({
       {showDiscordRichPresence ? (
         <SearchableSetting
           title={translate(
-            'auto.components.settings.experimental.search.discordRichPresence.title',
+            'auto.components.settings.ExperimentalPane.discordRichPresence.title',
             'Discord Rich Presence'
           )}
           description={translate(
-            'auto.components.settings.experimental.search.discordRichPresence.description',
+            'auto.components.settings.ExperimentalPane.discordRichPresence.description',
             'Show live agent activity on your Discord profile.'
           )}
           keywords={getExperimentalSearchEntry().discordRichPresence.keywords}
@@ -326,13 +326,13 @@ export function ExperimentalPane({
             <div className="min-w-0 shrink space-y-0.5">
               <Label>
                 {translate(
-                  'auto.components.settings.experimental.search.discordRichPresence.title',
+                  'auto.components.settings.ExperimentalPane.discordRichPresence.title',
                   'Discord Rich Presence'
                 )}
               </Label>
               <p className="text-xs text-muted-foreground">
                 {translate(
-                  'auto.components.settings.experimental.search.discordRichPresence.copy',
+                  'auto.components.settings.ExperimentalPane.discordRichPresence.copy',
                   'Shows your active agents, blocked state, and terminal count on your Discord profile while Orca is open. Requires the Discord desktop app. Your agent activity is only shared with your own Discord account.'
                 )}
               </p>
@@ -340,7 +340,7 @@ export function ExperimentalPane({
             <SettingsSwitch
               checked={discordRichPresenceEnabled}
               ariaLabel={translate(
-                'auto.components.settings.experimental.search.discordRichPresence.toggleLabel',
+                'auto.components.settings.ExperimentalPane.discordRichPresence.toggleLabel',
                 'Toggle Discord Rich Presence'
               )}
               onChange={() => updateSettings({ discordRichPresenceEnabled: !discordRichPresenceEnabled })}

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -228,6 +228,42 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
         )
       ]
     },
+    {
+      title: translate(
+        'auto.components.settings.experimental.search.discordRichPresence.title',
+        'Discord Rich Presence'
+      ),
+      description: translate(
+        'auto.components.settings.experimental.search.discordRichPresence.description',
+        'Show live agent activity on your Discord profile.'
+      ),
+      keywords: [
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.0d24759f14',
+          'experimental'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.discordRichPresence.discord',
+          'discord'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.discordRichPresence.richPresence',
+          'rich presence'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.discordRichPresence.presence',
+          'presence'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.discordRichPresence.status',
+          'status'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.discordRichPresence.activity',
+          'activity'
+        )
+      ]
+    },
     getNewWorktreeCardStyleSearchEntry(),
     getEphemeralVmsSearchEntry()
   ]
@@ -272,6 +308,12 @@ export function getExperimentalSearchEntry() {
       translate(
         'auto.components.settings.experimental.search.newWorktreeCardStyle.title',
         'New card style'
+      )
+    ),
+    discordRichPresence: findEntry(
+      translate(
+        'auto.components.settings.experimental.search.discordRichPresence.title',
+        'Discord Rich Presence'
       )
     ),
     ephemeralVms: findEntry(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -342,6 +342,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
     agentYoloDefaultsMigrated: true,
     agentStatusHooksEnabled: true,
+    discordRichPresenceEnabled: false,
     tabAutoGenerateTitle: false,
     confirmClosePinnedTab: true,
     keepComputerAwakeWhileAgentsRun: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3084,6 +3084,8 @@ export type GlobalSettings = {
   agentYoloDefaultsMigrated?: boolean
   /** Why: disabling must persist so startup doesn't reinstall global agent hook entries the user just removed. */
   agentStatusHooksEnabled: boolean
+  /** When true, publish live agent activity to Discord Rich Presence. */
+  discordRichPresenceEnabled: boolean
   /** Dismissed freshness tuples: no write authority, just suppress re-nudging the same official placement/revision. */
   dismissedSkillFreshnessNudges?: string[]
   /** Why: generated tab titles are subjective, so they stay opt-in and manual renames win. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3085,7 +3085,7 @@ export type GlobalSettings = {
   /** Why: disabling must persist so startup doesn't reinstall global agent hook entries the user just removed. */
   agentStatusHooksEnabled: boolean
   /** When true, publish live agent activity to Discord Rich Presence. */
-  discordRichPresenceEnabled: boolean
+  discordRichPresenceEnabled?: boolean
   /** Dismissed freshness tuples: no write authority, just suppress re-nudging the same official placement/revision. */
   dismissedSkillFreshnessNudges?: string[]
   /** Why: generated tab titles are subjective, so they stay opt-in and manual renames win. */


### PR DESCRIPTION
## ELI5

When you turn on Discord Rich Presence in Settings → Experimental, Orca quietly connects to the Discord desktop app in the background and shows what you're working on — how many agents are running, which ones are blocked waiting for your input, and how many terminals are open — directly on your Discord profile card. It shows "Idle" while Orca is open with no active agents. Flip the toggle off and the presence clears. If Discord is not running, Orca ignores it and keeps working normally.

## What Changed

**New module `src/main/discord-presence/`** (zero external dependencies):

- `discord-rpc-client.ts` — raw IPC client: pipe discovery (pipes 0–9 per platform), frame encoding/decoding (opcodes 0/1/3/4), handshake, `SET_ACTIVITY`, PING/PONG, pending request cleanup on disconnect, exponential-backoff reconnect. Exports `DiscordHandshakeRejectedError` — a distinct error class for when Discord closes the socket after receiving the handshake (invalid client_id), signalling that retrying will not help.
- `discord-presence-activity.ts` — aggregates `AgentStatusIpcPayload[]` into a snapshot and builds the `DiscordActivity` payload (details, state, assets, party size `[active, total]`, Unix-second timestamps).
- `discord-presence-throttle.ts` — leading + trailing-coalesce throttle with a configurable interval (default 15s).
- `discord-presence-manager.ts` — orchestrates subscription → aggregation → throttle → IPC. Reconnects with exponential backoff (1s → 30s). Permanently stops retrying on `DiscordHandshakeRejectedError` (not a transient failure).
- `discord-presence-config.ts` — client ID via `ORCA_DISCORD_CLIENT_ID` env var; placeholder until the Discord Application is registered.

**Modified files:**

| File | Change |
|---|---|
| `src/shared/types.ts` | `GlobalSettings.discordRichPresenceEnabled?: boolean` |
| `src/shared/constants.ts` | Default `false` |
| `src/main/persistence.ts` | Boolean coercion (`=== true`), matching other privacy-sensitive gates |
| `src/main/index.ts` | Instantiate manager, wire `getActiveTerminalCount`, tear down on quit, refresh on settings toggle |
| `src/renderer/src/components/settings/ExperimentalPane.tsx` | Toggle in Experimental pane |
| `src/renderer/src/components/settings/experimental-search.ts` | Search catalog entry |

**Tests:** 36 tests across 4 suites — activity aggregation, throttle, IPC client (including pipe exhaustion and handshake rejection paths), and manager lifecycle.

## Why

Rich Presence is a lightweight, zero-dependency way for users to show their coding activity on Discord. Orca already tracks agent state in real time — this surfaces it where users already spend time. Keeping it experimental and opt-in lets the community validate the UX before committing to a production Discord Application registration.

## Linked Issue

Fixes #14285

## Visual Proof

N/A — no changes to the Orca layout or interaction model. The only UI addition is a new toggle in Settings → Experimental. The presence appears in the Discord client on the user's own profile card.

> **Note for reviewers:** To verify the full end-to-end flow, a real Discord Application client ID is required. Set `ORCA_DISCORD_CLIENT_ID=<your_app_id>` before starting Orca. Without it, Discord will reject the handshake and the manager will stop retrying — this is intentional (`DiscordHandshakeRejectedError` is not treated as a transient failure).

## Testing

- [x] 36 automated tests pass (`pnpm test`)
- [x] TypeScript clean — `tsconfig.node.json` and `tsconfig.web.json` (`pnpm typecheck`)
- [x] Lint clean — `oxlint` (`pnpm lint`)
- [ ] End-to-end with a real Discord Application — requires maintainer to register the app and provide a client ID

**Platforms tested:**
- Linux ✅ (socket via `XDG_RUNTIME_DIR` / `/run/user/<uid>`)
- macOS — code path uses `TMPDIR`; not manually verified
- Windows — code path uses named pipe `\\?\pipe\discord-ipc-N`; not manually verified

## AI Disclosure

This feature was designed and implemented by [Claude](https://claude.ai) (Anthropic's AI coding agent), with direction and review by the author.

## Review

**Security:** No credentials, prompt content, or file paths leave the process. Only aggregate counts and agent type names are sent to Discord IPC. Opt-in with exact boolean coercion prevents truthy-but-not-`true` values from activating the feature.

**Cross-platform:** `discoverPipePath` branches on `process.platform` — named pipe on `win32`, `TMPDIR` socket on `darwin`, `XDG_RUNTIME_DIR`/`/run/user/<uid>` on Linux. `path.join` used throughout. No `/` or `\` assumptions outside platform-guarded branches.

**Remote/SSH:** Rich Presence runs in the main process on the local machine. Remote agents (where `connectionId !== null`) are included in the snapshot count — the presence reflects total Orca activity regardless of where agents run, which is the intended behaviour for v1.

**Performance:** `onChange` fires on every agent state change. The snapshot computation is O(n) over active agents (negligible). The 15s throttle prevents IPC flooding. Only lifecycle and error events are logged — no hot-path logging.

**Backwards compatibility:** `discordRichPresenceEnabled` is optional in `GlobalSettings`; existing settings files without it fall back to `false`.

**Known gap:** snap/flatpak Discord on Linux uses `/run/user/<uid>/snap.discord/discord-ipc-N` — not covered by current pipe discovery. Noted in the linked issue for a follow-up.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass

## Author

- X / Twitter: <!-- add your handle if you'd like a shoutout on @orca_build -->