### PR TITLE
fix(editor): map Salesforce Apex extensions to the apex language id

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -70,6 +70,13 @@ describe('detectLanguage', () => {
     expect(detectLanguage('C:\\app\\WebContent\\WEB-INF\\jsp\\LIST.JSP')).toBe('html')
   })
 
+  it('maps Salesforce Apex sources to the apex language id (case-insensitive)', () => {
+    expect(detectLanguage('force-app/main/default/classes/AccountService.cls')).toBe('apex')
+    expect(detectLanguage('force-app/main/default/triggers/AccountTrigger.trigger')).toBe('apex')
+    expect(detectLanguage('scripts/apex/seed.apex')).toBe('apex')
+    expect(detectLanguage('C:\\repo\\force-app\\classes\\ACCOUNTSERVICE.CLS')).toBe('apex')
+  })
+
   it('keeps .json/.jsonc on the built-in json language and unknown on plaintext', () => {
     expect(detectLanguage('config/settings.json')).toBe('json')
     expect(detectLanguage('config/tsconfig.jsonc')).toBe('json')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -54,6 +54,13 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.cxx': 'cpp',
   '.hpp': 'cpp',
   '.cs': 'csharp',
+  // Why: Monaco's built-in registry already declares the 'apex' language for
+  // '.cls', but detectLanguage resolves before Monaco's own extension lookup,
+  // so Salesforce sources fell through to plaintext. '.trigger' and '.apex'
+  // share the same grammar and have no built-in extension mapping at all.
+  '.cls': 'apex',
+  '.trigger': 'apex',
+  '.apex': 'apex',
   '.rb': 'ruby',
   '.php': 'php',
   '.swift': 'swift',


### PR DESCRIPTION
Apex files (`.cls`, `.trigger`) open as plaintext in the editor, with no syntax highlighting.

## Cause

Monaco already ships an `apex` language and registers it for `.cls`:

```js
{ id: "apex", extensions: [".cls"], aliases: ["Apex", "apex"], mimetypes: ["text/x-apex-source", "text/x-apex"] }
```

The grammar chunk is in the built bundle, so nothing is missing — it is just never selected. `detectLanguage()` resolves the id from `EXT_TO_LANGUAGE` first, and `EditorPanel` passes the result to `MonacoEditor` as an explicit `language` prop (no `path` prop), so Monaco's own extension lookup never runs. `.cls` is absent from the map, so it falls through to `"plaintext"` and the bundled tokenizer is unreachable.

## Change

Map `.cls`, `.trigger` and `.apex` onto the existing `apex` grammar. `.trigger` and `.apex` share the Apex grammar and have no built-in Monaco extension mapping at all, so they need the entry regardless.

No new grammar, no new dependency — this only reaches one already bundled. Same shape as the existing `.jsp` and `.cts`/`.mts` entries.

## Verification

- Added a `detectLanguage` case covering `.cls`, `.trigger`, `.apex`, and an uppercase Windows path, matching the existing test style.
- Confirmed the test fails without the source change (`expected 'plaintext' to be 'apex'`) and passes with it.
- `vitest run src/renderer/src/lib/language-detect.test.ts` → 15 passed.
- `oxlint` clean, `oxfmt --check` reports correct format.

## Note for maintainers

`mobile/src/session/mobile-file-language.ts` holds a second copy of `EXT_TO_LANGUAGE` that has drifted from this one — it is missing `.jsonl`, `.ipynb`, `.mmd`/`.mermaid`, and `.jsp`/`.jspf`. I left it alone because I cannot verify the mobile viewer ships an Apex grammar. Worth a mirror commit from someone who can test that surface.

Related open reports of the same class: #13835 (Solidity), #11215 (justfile/tfvars), #11313 (zig), #10363 (MATLAB/LaTeX), #13028 (non-standard .env). #8093 would make all of them user-configurable.