### PR TITLE
fix(docs): replace stale preload typecheck reference

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ If your change affects UI or interaction behavior, verify it on the platforms it
 
 Project-owned type declarations belong in `.ts` files. `.d.ts` is reserved for ambient shims (e.g., `env.d.ts`, `vite/client.d.ts`). TypeScript's `skipLibCheck: true` setting applies globally, including to our own `.d.ts` files, which means any unresolved type reference in a `.d.ts` silently becomes `any` at its call sites. Write your types in `.ts` files so the compiler actually checks them.
 
-CI enforces this for `src/preload/` and `src/shared/` — see `docs/preload-typecheck-hole.md`.
+CI enforces this for `src/preload/` and `src/shared/` through the “Guard against project-owned .d.ts in preload/shared” step in [`.github/workflows/pr.yml`](./workflows/pr.yml).
 
 ## Pull Requests
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ If your change affects UI or interaction behavior, verify it on the platforms it
 
 Project-owned type declarations belong in `.ts` files. `.d.ts` is reserved for ambient shims (e.g., `env.d.ts`, `vite/client.d.ts`). TypeScript's `skipLibCheck: true` setting applies globally, including to our own `.d.ts` files, which means any unresolved type reference in a `.d.ts` silently becomes `any` at its call sites. Write your types in `.ts` files so the compiler actually checks them.
 
-CI enforces this for `src/preload/` and `src/shared/` through the “Guard against project-owned .d.ts in preload/shared” step in [`.github/workflows/pr.yml`](./workflows/pr.yml).
+CI enforces this for `src/preload/` and `src/shared/`.
 
 ## Pull Requests
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,13 +74,14 @@ jobs:
       # actually checks them. TypeScript's skipLibCheck: true (inherited
       # from @electron-toolkit/tsconfig) silently widens unresolved names
       # in .d.ts to `any`, which is how #1186 shipped a broken IPC signature
-      # past typecheck.
+      # past typecheck. See .github/CONTRIBUTING.md#type-declarations-prefer-ts-over-dts.
       - name: Guard against project-owned .d.ts in preload/shared
         run: |
           matches=$(find src/preload src/shared -name '*.d.ts' 2>/dev/null || true)
           if [ -n "$matches" ]; then
             echo "::error::Project-owned .d.ts files are not allowed under src/preload or src/shared."
             echo "Move type declarations into a .ts file so skipLibCheck does not hide errors."
+            echo "See .github/CONTRIBUTING.md#type-declarations-prefer-ts-over-dts."
             echo "Found:"
             echo "$matches"
             exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,14 +74,13 @@ jobs:
       # actually checks them. TypeScript's skipLibCheck: true (inherited
       # from @electron-toolkit/tsconfig) silently widens unresolved names
       # in .d.ts to `any`, which is how #1186 shipped a broken IPC signature
-      # past typecheck. See docs/preload-typecheck-hole.md.
+      # past typecheck.
       - name: Guard against project-owned .d.ts in preload/shared
         run: |
           matches=$(find src/preload src/shared -name '*.d.ts' 2>/dev/null || true)
           if [ -n "$matches" ]; then
             echo "::error::Project-owned .d.ts files are not allowed under src/preload or src/shared."
             echo "Move type declarations into a .ts file so skipLibCheck does not hide errors."
-            echo "See docs/preload-typecheck-hole.md."
             echo "Found:"
             echo "$matches"
             exit 1


### PR DESCRIPTION
## ELI5

[`.github/CONTRIBUTING.md`](https://github.com/stablyai/orca/blob/9a81874bc15e5381c131488a49bbb1d8fbb7f823/.github/CONTRIBUTING.md#type-declarations-prefer-ts-over-dts) references `docs/preload-typecheck-hole.md`, but that file no longer exists. [`.github/workflows/pr.yml`](https://github.com/stablyai/orca/blob/9a81874bc15e5381c131488a49bbb1d8fbb7f823/.github/workflows/pr.yml#L77) also references the same missing file in the `.d.ts` guard.

This PR updates or removes those stale references so contributors are no longer pointed to a missing document.

## What Changed

- `.github/CONTRIBUTING.md`
  - Updated the Type Declarations section. 
  ```diff
  - CI enforces this for `src/preload/` and `src/shared/` — see `docs/preload-typecheck-hole.md`.
  + CI enforces this for `src/preload/` and `src/shared/` through the “Guard against project-owned .d.ts in preload/shared” step in [`.github/workflows/pr.yml`](./workflows/pr.yml).
  ```

- `.github/workflows/pr.yml`
  - removed the stale comment reference.
  ```diff
  - # past typecheck. See docs/preload-typecheck-hole.md.
  + # past typecheck.

  - echo "See docs/preload-typecheck-hole.md."
  ```

## Why

`docs/preload-typecheck-hole.md` no longer exists, so the current references can send contributors to a dead path.

The removed `preload-typecheck-hole.md` document from #1425 explained that the `src/preload/` and `src/shared/` `.d.ts` rule is enforced through `.github/workflows/pr.yml`. This PR removes the stale path and keeps that enforcement context by pointing contributors to the relevant CI step instead.

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #14297 

## Visual Proof

N/A - documentation and CI failure message only.

## Testing

<!-- How did you verify this? Steps a reviewer can follow. Which platforms did you actually test (macOS / Linux / Windows / SSH)? -->

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Docs-only change; self-reviewed the rendered Markdown and verified the stale path is removed.
Automated tests were not added because this only updates documentation and CI failure message text.

## AI Disclosure
<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

Used OpenAI Codex to inspect the repository references and draft the issue/PR text.

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Security: N/A, no runtime behavior changes.
- Cross-platform support: N/A, documentation and CI message text only.
- Remote SSH: N/A.
- Mobile: N/A.
- Backwards compatibility: N/A.
- Performance: N/A.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
