### PR TITLE
fix(browser): detect Comet under its Perplexity vendor directory on Windows

### DIFF
--- a/src/main/browser/browser-cookie-import.comet.test.ts
+++ b/src/main/browser/browser-cookie-import.comet.test.ts
@@ -222,6 +222,72 @@ describe('detectInstalledBrowsers — Comet', () => {
   })
 })
 
+describe('detectInstalledBrowsers — Comet on Windows', () => {
+  const originalPlatform = process.platform
+  const originalLocalAppData = process.env.LOCALAPPDATA
+
+  const localAppData = 'C:\\Users\\test\\AppData\\Local'
+  // Why: on Windows Comet installs under a Perplexity vendor directory, unlike its
+  // macOS layout where the data dir sits directly under Application Support.
+  const cometRoot = `${slashPath(localAppData)}/Perplexity/Comet/User Data`
+
+  beforeEach(() => {
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    process.env.LOCALAPPDATA = localAppData
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    if (originalLocalAppData === undefined) {
+      delete process.env.LOCALAPPDATA
+    } else {
+      process.env.LOCALAPPDATA = originalLocalAppData
+    }
+    vi.restoreAllMocks()
+  })
+
+  // Why: these mocks compare the whole path instead of calling .includes(). A substring
+  // match on 'Comet/Local State' is satisfied by both '<root>/Comet/User Data' and
+  // '<root>/Perplexity/Comet/User Data', so it cannot tell a correct winRoot from one
+  // that dropped the vendor segment — which is the regression these cases exist to catch.
+  function mockCometInstallAt(rootPath: string): void {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) =>
+          slashPath(p) === `${rootPath}/Local State` ||
+          slashPath(p) === `${rootPath}/Default/Network/Cookies`,
+        readFileSync: (p: string, enc?: string) => {
+          if (typeof p === 'string' && slashPath(p) === `${rootPath}/Local State`) {
+            return JSON.stringify({ profile: { info_cache: { Default: { name: 'Default' } } } })
+          }
+          return actual.readFileSync(p as never, enc as never)
+        }
+      }
+    })
+  }
+
+  it('detects Comet under the Perplexity vendor directory', async () => {
+    mockCometInstallAt(cometRoot)
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const comet = detectInstalledBrowsers().find((b) => b.family === 'comet')
+
+    expect(comet).toBeDefined()
+    expect(slashPath(comet?.cookiesPath ?? '')).toBe(`${cometRoot}/Default/Network/Cookies`)
+  })
+
+  it('does not detect a Comet data directory sitting directly under LOCALAPPDATA', async () => {
+    mockCometInstallAt(`${slashPath(localAppData)}/Comet/User Data`)
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+
+    expect(detectInstalledBrowsers().find((b) => b.family === 'comet')).toBeUndefined()
+  })
+})
+
 describe('BROWSER_FAMILY_LABELS — Comet', () => {
   it('maps the comet family key to the user-facing label "Comet"', () => {
     expect(BROWSER_FAMILY_LABELS.comet).toBe('Comet')

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -164,7 +164,9 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
     keychainService: 'Comet Safe Storage',
     keychainAccount: 'Comet',
     macRoot: 'Comet',
-    winRoot: 'Comet/User Data'
+    // Why: on Windows Comet installs under a Perplexity vendor directory
+    // (%LOCALAPPDATA%\Perplexity\Comet\User Data), unlike its macOS layout.
+    winRoot: 'Perplexity/Comet/User Data'
     // linuxRoot intentionally omitted — Comet does not ship a Linux build as of 2026-05-15
   },
   {


### PR DESCRIPTION
## ELI5

On Windows, Orca was looking for Comet's data in the wrong folder, so Comet never appeared in the cookie-import menu no matter what you did. Comet actually installs one level deeper, inside a `Perplexity` folder. This points Orca at the real location and adds Windows tests so that path cannot quietly break again.

## What Changed

- `src/main/browser/browser-cookie-import.ts` — the `comet` entry's `winRoot` is now `Perplexity/Comet/User Data` (was `Comet/User Data`). One line; `macRoot` is untouched because the macOS layout was already correct.
- `src/main/browser/browser-cookie-import.comet.test.ts` — new `detectInstalledBrowsers — Comet on Windows` suite with two cases: Comet under the vendor directory is detected with the exact expected `cookiesPath`, and a data directory sitting directly under `%LOCALAPPDATA%` is **not** detected.

## Why

`browserRootPath()` resolves the Windows root as `join(process.env.LOCALAPPDATA, def.winRoot)`, which gave `%LOCALAPPDATA%\Comet\User Data`. A real Comet install (151.0.7922.249, Windows 11 build 26300) lays out:

```
%LOCALAPPDATA%\Perplexity\Comet\Application\comet.exe
%LOCALAPPDATA%\Perplexity\Comet\User Data\Local State
%LOCALAPPDATA%\Perplexity\Comet\User Data\Default\Network\Cookies
```

`%LOCALAPPDATA%\Comet` does not exist, so `detectInstalledBrowsers()` skipped Comet on every Windows machine. Brave already carries its vendor segment (`BraveSoftware/Brave-Browser/User Data`); Comet was simply missing its own.

I confirmed the path is the only thing wrong before writing the fix: creating a junction so Orca's expected path resolves to the real directory makes Comet appear in the menu and the import complete successfully, cookies and all. So `keychainService`, the profile discovery, and the decryption path all already work — nothing else needed changing.

**On the second test.** The existing macOS cases match paths with `.includes('Comet/Local State')`, and `.../Perplexity/Comet/Local State` satisfies that substring just as well as the vendor-less path. That is why the whole suite stayed green with a broken `winRoot`: it had no sample that could tell the two apart. The new cases compare the full path, and the negative case fails if `winRoot` is reverted *or* if someone widens detection to accept both locations.

## Linked Issue

Fixes #14295

## Visual Proof

The whole user-visible change is one extra entry in the **Import browser cookies** menu (Settings → Session & Cookies, and the browser toolbar's import hint):

```
 Google Chrome から   >
 Microsoft Edge から  >
+Comet から
 Firefox から         >
 ファイルから…
```

- **Before** — with Comet installed and signed in, the menu is that list minus `Comet から`. There is no way to reach Comet's cookies from Orca on Windows at all.
- **After** — `Comet から` appears, and choosing it imports the session.

<img width="322" height="321" alt="image" src="https://github.com/user-attachments/assets/19d7ade1-aab6-47c2-aec4-e23c5861f56d" />

The capture above is the post-fix state, taken from the browser toolbar's import hint (same menu the Settings pane drives). Note the header line — `Detected: Google Chrome, Microsoft Edge, Comet, Firefox.` — and that `Comet から` has no submenu arrow, because the install exposes a single `Default` profile.

I can't attach a matching "before": the machine that reproduced this now has the workaround from #14295 applied, so the pre-fix menu is no longer reachable there without reverting it and restarting. The pre-fix state needs no special setup to see, though — on any Windows machine with Comet installed, Comet is simply absent from that list.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Automated.** The two new cases fail on `main` and pass with the fix:

With `main`'s `winRoot` and the new cases in place — both fail, and the second one prints the bug directly:

```
 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)

 FAIL  detectInstalledBrowsers — Comet on Windows > detects Comet under the Perplexity vendor directory
 AssertionError: expected undefined to be defined

 FAIL  detectInstalledBrowsers — Comet on Windows > does not detect a Comet data directory sitting directly under LOCALAPPDATA
 AssertionError: expected { family: 'comet', …(6) } to be undefined
 + Received: { "cookiesPath": "C:\\Users\\test\\AppData\\Local\\Comet\\User Data\\Default\\Network\\Cookies", … }
```

With the one-line fix:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Wider run over `src/main/browser` plus `src/shared/browser-cookie-import-sources.test.ts`: **40 files / 634 tests passed**.

`pnpm typecheck` and `pnpm lint` both pass locally. I did not run `pnpm build` on this machine — its `postinstall` native rebuild needs Windows SDK 10.0.19041.0, which isn't installed here. Nothing in this diff is native code, so CI should cover it.

**Manual.** Windows 11 (build 26300) with Comet 151.0.7922.249 and Orca 1.4.180: with the real install path made reachable, Comet appears in the import menu and the cookie import completes — imported sessions authenticate normally in Orca's browser.

I did not manually verify macOS or Linux. Neither is affected by this diff: `macRoot` is unchanged, and Comet has no Linux build so `linuxRoot` remains intentionally omitted.

Note for anyone verifying: detection results are read once per app launch (`fetchDetectedBrowsers` is guarded by `detectedBrowsersLoaded` in the renderer store), so Orca has to be restarted before a newly-reachable browser shows up in the menu.

## AI Disclosure

Written with Claude Opus 5 via Claude Code. The root cause, the real Comet install layout, and the end-to-end import were verified against the actual filesystem and a running Orca build rather than inferred; the model wrote the diff and the tests.

## Review

- **Security** — no change to what is read or where it is written. The path is still built with `path.join` from `process.env.LOCALAPPDATA`, and `isSafeBrowserProfileDirectory()` still rejects profile directories that try to escape the root (the existing traversal cases still pass).
- **Cross-platform** — Windows-only data change. `macRoot` and the omitted `linuxRoot` are untouched. The new tests normalise separators with the file's existing `slashPath()` helper, so they pass whichever platform CI runs them on.
- **Remote SSH** — none. Detection runs in the main process against the local profile as before; nothing about the remote path changed.
- **Mobile** — not applicable.
- **Backwards compatibility** — the old path never resolved on any Windows install, so nothing could depend on it. Already-imported cookies are unaffected: this only changes where the source browser is looked up.
- **Performance** — same single `existsSync` walk over the same browser list; no new I/O.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass locally; `pnpm build` left to CI (local native rebuild needs a Windows SDK this machine doesn't have)

## Author

- X / Twitter: @nnasaki

