### PR TITLE
Add golden E2E tests for fresh terminal and shell commands

### DIFF
--- a/.github/workflows/golden-e2e-experiment.yml
+++ b/.github/workflows/golden-e2e-experiment.yml
@@ -23,7 +23,7 @@ jobs:
             platform: linux
           - os: macos-15
             platform: mac
-          # Match the release gate: Windows runs the fresh-startup golden only.
+          # Match the release gate: Windows runs a focused golden subset.
           - os: windows-2022
             platform: windows
 
@@ -67,6 +67,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+          if [ -f tests/e2e/golden-fresh-profile-terminal.spec.ts ]; then
+            xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts
+          fi
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
@@ -74,6 +77,9 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+          if [ -f tests/e2e/golden-fresh-profile-terminal.spec.ts ]; then
+            env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts
+          fi
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
@@ -84,6 +90,9 @@ jobs:
           $env:SKIP_BUILD = '1'
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
           pnpm run --if-present test:e2e:windows-fresh-startup-golden
+          if (Test-Path tests/e2e/golden-fresh-profile-terminal.spec.ts) {
+            pnpm run test:e2e -- tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts
+          }
 
       - name: Upload Playwright traces
         if: failure()

--- a/src/main/ssh/ssh-relay-upload-stage-commands.test.ts
+++ b/src/main/ssh/ssh-relay-upload-stage-commands.test.ts
@@ -115,26 +115,30 @@ describe.each([
     RemoteHostPlatform
   ])[])
 ])('%s relay upload stage commands', (_label, host) => {
-  it.each([0, 1, 7, 8, 9])('bounds reservation with %i occupied entries', (count) => {
-    const pool = createPool()
-    for (let index = 0; index < Math.min(count, RELAY_UPLOAD_STAGE_SLOT_COUNT); index += 1) {
-      createStage(host, pool, index)
-    }
-    if (count > RELAY_UPLOAD_STAGE_SLOT_COUNT) {
-      mkdirSync(join(pool, 'foreign-extra'))
-    }
+  it.each([0, 1, 7, 8, 9])(
+    'bounds reservation with %i occupied entries',
+    (count) => {
+      const pool = createPool()
+      for (let index = 0; index < Math.min(count, RELAY_UPLOAD_STAGE_SLOT_COUNT); index += 1) {
+        createStage(host, pool, index)
+      }
+      if (count > RELAY_UPLOAD_STAGE_SLOT_COUNT) {
+        mkdirSync(join(pool, 'foreign-extra'))
+      }
 
-    const result = runCommand(host, reserveRelayUploadStageCommand(host, pool, owner))
-    if (count < RELAY_UPLOAD_STAGE_SLOT_COUNT) {
-      expect(result.status, result.stderr).toBe(0)
-      expect(parseReservedRelayUploadStage(host, pool, owner, result.stdout).slotName).toBe(
-        `slot-${count}`
-      )
-    } else {
-      expect(result.status).not.toBe(0)
-      expect(result.stderr).toContain('staging quota is full')
-    }
-  })
+      const result = runCommand(host, reserveRelayUploadStageCommand(host, pool, owner))
+      if (count < RELAY_UPLOAD_STAGE_SLOT_COUNT) {
+        expect(result.status, result.stderr).toBe(0)
+        expect(parseReservedRelayUploadStage(host, pool, owner, result.stdout).slotName).toBe(
+          `slot-${count}`
+        )
+      } else {
+        expect(result.status).not.toBe(0)
+        expect(result.stderr).toContain('staging quota is full')
+      }
+    },
+    120_000
+  )
 
   it('promotes only the post-claim owned payload and removes its fixed stage', () => {
     const pool = createPool()
@@ -201,7 +205,7 @@ describe.each([
     expect(existsSync(join(pool, 'slot-0'))).toBe(true)
     expect(existsSync(join(pool, 'slot-1'))).toBe(true)
     expect(existsSync(join(pool, 'slot-2'))).toBe(false)
-  })
+  }, 120_000)
 
   it('drains fixed stale claim and delete states across repeated deployments', () => {
     const pool = createPool()

--- a/tests/e2e/golden-fresh-profile-terminal.spec.ts
+++ b/tests/e2e/golden-fresh-profile-terminal.spec.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtemp } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+test.use({ dismissOnboarding: false, seedTestRepo: false })
+
+async function createGitRepo(): Promise<string> {
+  const root = realpathSync(await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-golden-fresh-')))
+  const repoPath = path.join(root, 'golden-fresh-project')
+  mkdirSync(repoPath)
+  execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'e2e@test.local'], { cwd: repoPath })
+  execFileSync('git', ['config', 'user.name', 'E2E Test'], { cwd: repoPath })
+  writeFileSync(path.join(repoPath, 'README.md'), '# golden-fresh-project\n')
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: repoPath })
+  return repoPath
+}
+
+async function stubFolderPicker(
+  electronApp: ElectronApplication,
+  selectedPath: string
+): Promise<void> {
+  await electronApp.evaluate(({ dialog }, folderPath) => {
+    dialog.showOpenDialog = async () => ({
+      canceled: false,
+      filePaths: [folderPath],
+      bookmarks: []
+    })
+  }, selectedPath)
+}
+
+async function selectCodexAndSkipToProject(page: Page): Promise<void> {
+  const codexButton = page.getByRole('button', { name: /^Codex\s/ }).first()
+  if (!(await codexButton.isVisible())) {
+    await page.getByText(/Show \d+ more agents/).click()
+  }
+  await codexButton.click()
+  const footer = page.locator('footer').filter({ has: page.getByRole('button', { name: /Skip/i }) })
+  await footer.getByRole('button', { name: /^Skip to project setup$/i }).click()
+  await expect(page.getByRole('dialog', { name: /Add a project/i })).toBeVisible()
+}
+
+test('fresh profile opens a live project terminal @golden', async ({
+  electronApp,
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  await waitForSessionReady(orcaPage)
+  await expect(orcaPage.locator('#root')).toBeVisible()
+  await expect(orcaPage.getByRole('heading', { name: /Pick your default agent/i })).toBeVisible()
+
+  await selectCodexAndSkipToProject(orcaPage)
+  const repoPath = await createGitRepo()
+  registerPostElectronShutdownCleanup(async () =>
+    rmSync(path.dirname(repoPath), { recursive: true, force: true })
+  )
+  await stubFolderPicker(electronApp, repoPath)
+  await orcaPage
+    .getByRole('button', { name: /Browse for a folder|Open a folder|Browse folder/i })
+    .click()
+
+  await expect(orcaPage.getByText(path.basename(repoPath), { exact: true }).first()).toBeVisible({
+    timeout: 30_000
+  })
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage, 30_000)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+  const ptyId = await waitForActivePanePtyId(orcaPage, 30_000)
+  await expect.poll(() => orcaPage.evaluate((id) => window.api.pty.hasPty(id), ptyId)).toBe(true)
+
+  const marker = `orca-e2e-fresh-${Date.now()}`
+  await focusActiveTerminalInput(orcaPage)
+  await orcaPage.keyboard.type(`echo ${marker}`)
+  await orcaPage.keyboard.press('Enter')
+  await expect
+    .poll(async () => (await getTerminalContent(orcaPage)).split(marker).length - 1, {
+      message: 'marker should appear in both the echoed command and command output'
+    })
+    .toBeGreaterThanOrEqual(2)
+
+  await focusActiveTerminalInput(orcaPage)
+  await orcaPage.keyboard.type('git rev-parse --show-toplevel')
+  await orcaPage.keyboard.press('Enter')
+  await expect
+    .poll(async () => (await getTerminalContent(orcaPage)).replaceAll('\\', '/'), {
+      message: 'fresh project terminal should start in the selected repository'
+    })
+    .toContain(repoPath.replaceAll('\\', '/'))
+})

--- a/tests/e2e/golden-shell-command.spec.ts
+++ b/tests/e2e/golden-shell-command.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+const CSI_REPLY_RE = /997;[12]n/
+
+function shellBasename(processName: string): string {
+  return processName
+    .replaceAll('\\', '/')
+    .split('/')
+    .pop()!
+    .toLowerCase()
+    .replace(/\.exe$/, '')
+}
+
+test('seeded project terminal runs a typed shell command @golden', async ({ orcaPage }) => {
+  await ensureTerminalVisible(orcaPage, 30_000)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+  const ptyId = await waitForActivePanePtyId(orcaPage, 30_000)
+  expect(await getTerminalContent(orcaPage)).not.toMatch(CSI_REPLY_RE)
+
+  const marker = `orca-e2e-alive-${Date.now()}`
+  await focusActiveTerminalInput(orcaPage)
+  await orcaPage.keyboard.type(`echo ${marker}`)
+  await orcaPage.keyboard.press('Enter')
+  await expect
+    .poll(async () => (await getTerminalContent(orcaPage)).split(marker).length - 1, {
+      message: 'marker should appear in both the echoed command and command output'
+    })
+    .toBeGreaterThanOrEqual(2)
+
+  if (process.platform === 'win32') {
+    let foregroundProcess = ''
+    await expect
+      .poll(async () => {
+        foregroundProcess =
+          (await orcaPage.evaluate((id) => window.api.pty.inspectProcess(id), ptyId))
+            .foregroundProcess ?? ''
+        return foregroundProcess
+      })
+      .not.toBe('')
+    const shell = shellBasename(foregroundProcess)
+    if (shell === 'cmd') {
+      const pwshAvailable = await orcaPage.evaluate(() => window.api.pwsh.isAvailable())
+      expect(pwshAvailable, 'cmd.exe must not replace an available PowerShell default').toBe(false)
+    }
+    const begin = 'ORCA_E2E_PATH_BEGIN'
+    const end = 'ORCA_E2E_PATH_END'
+    const pathCommand =
+      shell === 'pwsh' || shell === 'powershell'
+        ? `Write-Output ${begin}; Write-Output $env:LOCALAPPDATA; Write-Output ${end}`
+        : shell === 'cmd'
+          ? `echo ${begin} & echo %LOCALAPPDATA% & echo ${end}`
+          : `printf '${begin}\\n%s\\n${end}\\n' "$LOCALAPPDATA"`
+    await focusActiveTerminalInput(orcaPage)
+    await orcaPage.keyboard.type(pathCommand)
+    await orcaPage.keyboard.press('Enter')
+    let expandedPath = ''
+    await expect
+      .poll(async () => {
+        const lines = (await getTerminalContent(orcaPage, 8_000)).split(/\r?\n/)
+        const beginLine = lines.findIndex((line) => line.includes(begin) && !line.includes(end))
+        expandedPath = beginLine !== -1 ? (lines[beginLine + 1]?.trim() ?? '') : ''
+        return expandedPath
+      })
+      .not.toBe('')
+
+    expect(expandedPath).not.toBe('')
+    expect(expandedPath).not.toBe('%LOCALAPPDATA%')
+    expect(expandedPath).not.toBe('$env:LOCALAPPDATA')
+    expect(expandedPath).toMatch(/(?:[A-Za-z]:\\|\\\\)/)
+  }
+
+  const finalBuffer = await getTerminalContent(orcaPage, 8_000)
+  expect(finalBuffer).not.toMatch(CSI_REPLY_RE)
+})

--- a/tests/e2e/golden-shell-command.spec.ts
+++ b/tests/e2e/golden-shell-command.spec.ts
@@ -1,3 +1,4 @@
+import { stripAnsiEscapeSequences } from '../../src/shared/ansi-escape-sequences'
 import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible } from './helpers/store'
 import {
@@ -63,9 +64,15 @@ test('seeded project terminal runs a typed shell command @golden', async ({ orca
     let expandedPath = ''
     await expect
       .poll(async () => {
-        const lines = (await getTerminalContent(orcaPage, 8_000)).split(/\r?\n/)
-        const beginLine = lines.findIndex((line) => line.includes(begin) && !line.includes(end))
-        expandedPath = beginLine !== -1 ? (lines[beginLine + 1]?.trim() ?? '') : ''
+        // Why: the echoed command can wrap or be clipped by the buffer tail, so only a
+        // line that is exactly the marker — bracketed by both markers — is real output.
+        const lines = stripAnsiEscapeSequences(await getTerminalContent(orcaPage, 8_000))
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+        const beginLine = lines.lastIndexOf(begin)
+        const endLine = beginLine === -1 ? -1 : lines.indexOf(end, beginLine + 1)
+        expandedPath =
+          endLine === -1 ? '' : (lines.slice(beginLine + 1, endLine).find(Boolean) ?? '')
         return expandedPath
       })
       .not.toBe('')


### PR DESCRIPTION
## Problem

Golden test suite was missing coverage for fresh terminal initialization and shell command execution workflows.

## Solution

Added two new E2E golden test specs and integrated them into CI:

- **golden-fresh-profile-terminal.spec.ts**: Tests opening a fresh git repo, setting up a terminal from project selection, and verifying terminal initialization in a new workspace
- **golden-shell-command.spec.ts**: Tests typing and executing shell commands in a seeded project terminal, with platform-specific validation (Windows path expansion, shell type detection)

Both tests verify cross-platform behavior (Linux, macOS, Windows) and are now run in CI workflows. Also fixed test timeouts in ssh relay upload stage command tests.

## Testing

- Tests added for fresh terminal initialization and shell command execution
- Integrated into GitHub Actions workflows for all platforms
- Platform-specific validations included (Windows %LOCALAPPDATA% expansion, shell detection)