### PR TITLE
fix(pty): arm PtyStartupIngress for non-agent panes to suppress OSC 10/11 reply echo on POSIX

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -196,7 +196,10 @@ import {
   isNativeWindowsLocalPtySpawn,
   markNativeWindowsConptyPty
 } from '../runtime/terminal-model-query-authority'
-import { setTerminalViewAttributes } from '../runtime/terminal-view-attribute-store'
+import {
+  getTerminalViewColorQueryReplyColors,
+  setTerminalViewAttributes
+} from '../runtime/terminal-view-attribute-store'
 import { validateTerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyModelRestoreReason } from '../../shared/pty-model-restore-marker'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
@@ -4816,7 +4819,13 @@ export function registerPtyHandlers(
       if (!args.connectionId && !isDaemonHostSpawn) {
         spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }
       }
-      const startupTerminalColorQueryReplyColors = getStartupTerminalColorQueryReplyColors(args)
+      // Why fallback: non-agent panes (e.g. a shell with Oh My Posh) also emit
+      // OSC 10/11 during startup; without ingress the renderer answers the query
+      // and the cooked-mode echo leaks as visible text (#12112 for agents, same
+      // root cause for plain shells on POSIX). The view-attribute store holds the
+      // renderer-pushed theme colors, so every pane can suppress its own echo.
+      const startupTerminalColorQueryReplyColors =
+        getStartupTerminalColorQueryReplyColors(args) ?? getTerminalViewColorQueryReplyColors()
       if (startupTerminalColorQueryReplyColors) {
         spawnOptions.startupIngress = {
           colors: startupTerminalColorQueryReplyColors,
@@ -6257,7 +6266,10 @@ export function registerPtyHandlers(
         }
         // Why: the daemon-backed provider skips LocalPtyProvider's buildSpawnEnv, so assemble the same host-local env here for parity.
         // Safety: skip entirely for SSH — every injection is a loopback secret or a local path that leaks or misleads on the remote host.
-        const startupTerminalColorQueryReplyColors = getStartupTerminalColorQueryReplyColors(args)
+        // Why fallback: same rationale as the local path — non-agent panes
+        // also leak OSC 10/11 reply echoes on POSIX without ingress.
+        const startupTerminalColorQueryReplyColors =
+          getStartupTerminalColorQueryReplyColors(args) ?? getTerminalViewColorQueryReplyColors()
         // Why: forward pane env to SSH only when the relay hook path is enabled, or a newer relay could emit statuses this build can't route.
         const sshSourceEnv = stripRemotePaneEnvWhenHooksDisabled(args.connectionId, args.env)
         const baseEnvWithAuth = claudeAuth

--- a/src/renderer/src/components/terminal-pane/issue-non-agent-pane-startup-color-reply-leak.repro.test.ts
+++ b/src/renderer/src/components/terminal-pane/issue-non-agent-pane-startup-color-reply-leak.repro.test.ts
@@ -96,6 +96,8 @@ describe('non-agent pane OSC 10/11 reply echo leak on POSIX', () => {
     ingress.drainAndClose()
 
     expect(emitted.join('')).not.toMatch(LEAKED_COLOR_REPLY_TEXT)
+    // Guard against ingress dropping the whole chunk: prompt must remain visible.
+    expect(emitted.join('')).toContain('❭ ')
   })
 
   it('without ingress, the renderer reply echo leaks as visible text (baseline)', () => {

--- a/src/renderer/src/components/terminal-pane/issue-non-agent-pane-startup-color-reply-leak.repro.test.ts
+++ b/src/renderer/src/components/terminal-pane/issue-non-agent-pane-startup-color-reply-leak.repro.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PtyStartupIngress } from '../../../../shared/pty-startup-ingress'
+import type { PtyIngressEmission } from '../../../../shared/pty-startup-ingress'
+
+// Reproduction for the non-agent-pane OSC 10/11 reply echo leak on POSIX.
+//
+// A plain shell with a prompt theme (e.g. Oh My Posh) emits OSC 10;? / 11;?
+// during startup to detect the terminal's color scheme. On POSIX, the
+// renderer's xterm answers the query via sendInputImmediate, but the PTY is
+// still in cooked mode (the prompt theme has not entered raw mode yet), so
+// readline echoes the reply as visible text:
+//
+//   ❭ 10;rgb:ffff/ffff/ffff11;rgb:2828/2c2c/3434
+//
+// The fix arms PtyStartupIngress for ALL panes (not just agent panes) by
+// falling back to the terminal view-attribute store colors when
+// getStartupTerminalColorQueryReplyColors returns null for non-agent panes.
+// PtyStartupIngress intercepts the query on the main side, answers it, and
+// suppresses the cooked echo — the renderer never sees the query or its echo.
+
+// Oh My Posh-style startup query burst (BEL-terminated).
+const OMP_STARTUP_QUERY_BURST = '\x1b]10;?\x07\x1b]11;?\x07'
+// Orca's One Dark terminal theme — the values that appear in the leaked text.
+const ORCA_TERMINAL_THEME = { foreground: '#ffffff', background: '#282c34' }
+const OSC10_REPLY = '\x1b]10;rgb:ffff/ffff/ffff\x1b\\'
+const OSC11_REPLY = '\x1b]11;rgb:2828/2c2c/3434\x1b\\'
+const LEAKED_COLOR_REPLY_TEXT = /\d\d;rgb:[0-9a-f]{4}\//
+
+/**
+ * bash/readline echo projection: `\e]` is an unbound binding, so readline eats
+ * ESC + `]` and beeps, then self-inserts the rest; the ST is eaten the same way.
+ */
+function readlineEchoOf(reply: string): string {
+  return reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', '')
+}
+
+function visible(emissions: readonly PtyIngressEmission[]): string {
+  return emissions.map((emission) => emission.data).join('')
+}
+
+afterEach(() => vi.useRealTimers())
+
+describe('non-agent pane OSC 10/11 reply echo leak on POSIX', () => {
+  it('PtyStartupIngress with view-attribute colors suppresses the cooked echo', () => {
+    vi.useFakeTimers()
+    const writes: string[] = []
+    const emissions: PtyIngressEmission[] = []
+    let ingress: PtyStartupIngress | undefined
+
+    // Simulate the fix: PtyStartupIngress is armed with the terminal
+    // view-attribute store colors (the same colors the renderer would use).
+    ingress = new PtyStartupIngress({
+      intent: { colors: ORCA_TERMINAL_THEME, deadlineMs: 5_000 },
+      ownerBackend: 'posix-pty',
+      write: (data) => {
+        writes.push(data)
+        // The PTY echoes the reply in cooked mode (readline projection).
+        ingress?.accept(readlineEchoOf(data))
+      },
+      onEmission: (emission) => emissions.push(emission)
+    })
+
+    // OMP emits the startup query burst.
+    ingress.accept(OMP_STARTUP_QUERY_BURST)
+    // Why: the posix write is deferred, so advance timers to flush.
+    vi.advanceTimersByTime(0)
+
+    // The ingress answered both queries.
+    expect(writes).toEqual([OSC10_REPLY, OSC11_REPLY])
+    // No leaked color reply text in the visible output.
+    expect(visible(emissions)).not.toMatch(LEAKED_COLOR_REPLY_TEXT)
+    expect(visible(emissions)).toBe('')
+
+    ingress.drainAndClose()
+  })
+
+  it('renders no reply text when OMP echo is coalesced with shell prompt output', () => {
+    vi.useFakeTimers()
+    const emitted: string[] = []
+    const writes: string[] = []
+    const ingress = new PtyStartupIngress({
+      intent: { colors: ORCA_TERMINAL_THEME, deadlineMs: 5_000 },
+      ownerBackend: 'posix-pty',
+      write: (data) => writes.push(data),
+      onEmission: (emission) => emitted.push(emission.data)
+    })
+
+    // OMP emits the startup query burst.
+    ingress.accept(OMP_STARTUP_QUERY_BURST)
+    vi.advanceTimersByTime(0)
+    expect(writes).toEqual([OSC10_REPLY, OSC11_REPLY])
+
+    // The shell echoes the reply coalesced with its own prompt output.
+    const coalescedEcho = `❭ ${writes.map(readlineEchoOf).join('')}`
+    ingress.accept(coalescedEcho)
+    ingress.drainAndClose()
+
+    expect(emitted.join('')).not.toMatch(LEAKED_COLOR_REPLY_TEXT)
+  })
+
+  it('without ingress, the renderer reply echo leaks as visible text (baseline)', () => {
+    // This test documents the bug: without PtyStartupIngress, the renderer
+    // answers the query and the cooked echo leaks. It serves as the
+    // before-fix baseline.
+    vi.useFakeTimers()
+
+    // Simulate the renderer answering the query (no ingress on main side).
+    const rendererReply = (query: string): string => {
+      if (query === '\x1b]10;?\x07') {
+        return OSC10_REPLY
+      }
+      if (query === '\x1b]11;?\x07') {
+        return OSC11_REPLY
+      }
+      return ''
+    }
+
+    // The PTY echoes the reply in cooked mode.
+    const visibleOutput = OMP_STARTUP_QUERY_BURST.split('\x07')
+      .filter((s) => s.startsWith('\x1b]'))
+      .map((q) => `${q}\x07`)
+      .map(rendererReply)
+      .map(readlineEchoOf)
+      .join('')
+
+    // Without ingress, the echo leaks as visible text.
+    expect(visibleOutput).toMatch(LEAKED_COLOR_REPLY_TEXT)
+    expect(visibleOutput).toContain('10;rgb:ffff/ffff/ffff')
+    expect(visibleOutput).toContain('11;rgb:2828/2c2c/3434')
+  })
+})

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3511,6 +3511,18 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "CaffeinateStatusSegment": {
+            "on": "Activado",
+            "auto": "Agente",
+            "off": "Desactivado",
+            "active": "Activo",
+            "inactive": "Inactivo",
+            "ariaLabel": "Evitar reposo, {{status}}",
+            "title": "Evitar reposo",
+            "onDescription": "Mantener este equipo despierto continuamente",
+            "autoDescription": "Mantener despierto mientras un agente trabaja",
+            "offDescription": "Permitir el comportamiento normal de reposo del sistema"
           }
         }
       },
@@ -9138,7 +9150,10 @@
         "agent-awake-copy": {
           "e5995ce268": "Mantener la computadora activa mientras los agentes están trabajando",
           "95d3031db2": "Mantiene esta computadora y la pantalla activas mientras los agentes están trabajando. El comportamiento al cerrar la tapa sigue la configuración de energía de este dispositivo.",
-          "a42f6fbdd8": "Mantiene esta computadora y la pantalla activas mientras los agentes están trabajando. Orca también le pide a este dispositivo que permanezca activo cuando la tapa está cerrada, sujeto a su política de energía."
+          "a42f6fbdd8": "Mantiene esta computadora y la pantalla activas mientras los agentes están trabajando. Orca también le pide a este dispositivo que permanezca activo cuando la tapa está cerrada, sujeto a su política de energía.",
+          "modeTitle": "Mantener equipo despierto",
+          "modeDescriptionWindows": "Elige Activado, Agente o Desactivado. El modo Agente se mantiene despierto mientras los agentes trabajan; el comportamiento al cerrar la tapa sigue la configuración de energía de este dispositivo.",
+          "modeDescriptionDefault": "Elige Activado, Agente o Desactivado. El modo Agente se mantiene despierto mientras los agentes trabajan. Orca también solicita que este dispositivo se mantenga despierto al cerrar la tapa, según su política de energía."
         },
         "agent-status-hooks-copy": {
           "7707c15abb": "Hooks de estado del agente",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3511,6 +3511,18 @@
             "stoppingLabel": "更新を停止しています",
             "stoppingTooltip": "スキルの更新を停止しています…",
             "stoppingAria": "スキルの更新を停止しています。クリックすると詳細を開きます。"
+          },
+          "CaffeinateStatusSegment": {
+            "on": "オン",
+            "auto": "Agent",
+            "off": "オフ",
+            "active": "アクティブ",
+            "inactive": "非アクティブ",
+            "ariaLabel": "スリープ防止, {{status}}",
+            "title": "スリープ防止",
+            "onDescription": "このコンピューターを継続的にスリープさせない",
+            "autoDescription": "Agent の作業中はスリープさせない",
+            "offDescription": "通常のシステムスリープ動作を許可"
           }
         }
       },
@@ -9160,7 +9172,10 @@
         "agent-awake-copy": {
           "e5995ce268": "Agent 作業中はコンピュータを起きたままにする",
           "95d3031db2": "Agent が作業している間、このコンピュータとディスプレイを起きたままにします。蓋を閉じたときの動作は、このデバイスの電源設定に従います。",
-          "a42f6fbdd8": "Agent が作業している間、このコンピュータとディスプレイを起きたままにします。Orca は電源ポリシーに従い、蓋が閉じているときもこのデバイスを起きたままにするよう要求します。"
+          "a42f6fbdd8": "Agent が作業している間、このコンピュータとディスプレイを起きたままにします。Orca は電源ポリシーに従い、蓋が閉じているときもこのデバイスを起きたままにするよう要求します。",
+          "modeTitle": "コンピューターをスリープさせない",
+          "modeDescriptionWindows": "オン、Agent、オフから選択。Agent モードは Agent の作業中はスリープしません。蓋を閉じたときの動作はこのデバイスの電源設定に従います。",
+          "modeDescriptionDefault": "オン、Agent、オフから選択。Agent モードは Agent の作業中はスリープしません。Orca は電源ポリシーに従い、蓋を閉じたときもこのデバイスのスリープを防ぎます。"
         },
         "agent-status-hooks-copy": {
           "7707c15abb": "Agent 状態フック",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3511,6 +3511,18 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "CaffeinateStatusSegment": {
+            "on": "켜기",
+            "auto": "에이전트",
+            "off": "끄기",
+            "active": "활성",
+            "inactive": "비활성",
+            "ariaLabel": "절전 모드 방지, {{status}}",
+            "title": "절전 모드 방지",
+            "onDescription": "이 컴퓨터를 계속 켜둡니다",
+            "autoDescription": "에이전트가 작업하는 동안 켜둡니다",
+            "offDescription": "정상적인 시스템 절전 동작 허용"
           }
         }
       },
@@ -9123,7 +9135,10 @@
         "agent-awake-copy": {
           "e5995ce268": "agents 작업 중 컴퓨터를 깨어 있게 유지",
           "95d3031db2": "agents가 작업하는 동안 이 컴퓨터와 디스플레이를 깨어 있게 유지합니다. 뚜껑을 닫을 때의 동작은 이 기기의 전원 설정을 따릅니다.",
-          "a42f6fbdd8": "agents가 작업하는 동안 이 컴퓨터와 디스플레이를 깨어 있게 유지합니다. Orca는 전원 정책에 따라 뚜껑이 닫혀 있을 때도 이 기기를 깨어 있게 유지하도록 요청합니다."
+          "a42f6fbdd8": "agents가 작업하는 동안 이 컴퓨터와 디스플레이를 깨어 있게 유지합니다. Orca는 전원 정책에 따라 뚜껑이 닫혀 있을 때도 이 기기를 깨어 있게 유지하도록 요청합니다.",
+          "modeTitle": "컴퓨터 절전 모드 방지",
+          "modeDescriptionWindows": "켜기, 에이전트 또는 끄기를 선택하세요. 에이전트 모드는 에이전트가 작업하는 동안 켜둡니다. 덮개를 닫을 때의 동작은 이 장치의 전원 설정을 따릅니다.",
+          "modeDescriptionDefault": "켜기, 에이전트 또는 끄기를 선택하세요. 에이전트 모드는 에이전트가 작업하는 동안 켜둡니다. Orca는 전원 정책에 따라 덮개를 닫을 때도 이 장치를 켜두도록 요청합니다."
         },
         "agent-status-hooks-copy": {
           "7707c15abb": "Agent 상태 훅",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3523,6 +3523,18 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "正在停止技能更新…",
             "stoppingAria": "正在停止技能更新。点击查看详情。"
+          },
+          "CaffeinateStatusSegment": {
+            "on": "开启",
+            "auto": "智能体",
+            "off": "关闭",
+            "active": "活跃",
+            "inactive": "未活跃",
+            "ariaLabel": "保持唤醒, {{status}}",
+            "title": "保持唤醒",
+            "onDescription": "持续保持此电脑唤醒",
+            "autoDescription": "智能体工作时保持唤醒",
+            "offDescription": "允许正常的系统休眠行为"
           }
         }
       },
@@ -9135,7 +9147,10 @@
         "agent-awake-copy": {
           "e5995ce268": "智能体工作时保持电脑唤醒",
           "95d3031db2": "在智能体工作时保持此电脑和显示器唤醒。合盖行为遵循此设备的电源设置。",
-          "a42f6fbdd8": "在智能体工作时保持此电脑和显示器唤醒。Orca 还会根据电源策略，在合盖时请求此设备保持唤醒。"
+          "a42f6fbdd8": "在智能体工作时保持此电脑和显示器唤醒。Orca 还会根据电源策略，在合盖时请求此设备保持唤醒。",
+          "modeTitle": "保持电脑唤醒",
+          "modeDescriptionWindows": "选择开启、智能体或关闭。智能体模式在智能体工作时保持唤醒；合盖行为遵循此设备的电源设置。",
+          "modeDescriptionDefault": "选择开启、智能体或关闭。智能体模式在智能体工作时保持唤醒。Orca 还会根据电源策略，在合盖时请求此设备保持唤醒。"
         },
         "agent-status-hooks-copy": {
           "7707c15abb": "智能体状态钩子",


### PR DESCRIPTION
## Summary

- Non-agent terminal panes (plain shells with prompt themes like Oh My Posh, starship, powerlevel10k) leak OSC 10/11 color query reply echoes as visible text on POSIX (macOS + Linux/Ubuntu)
- The fix for #12112 only armed `PtyStartupIngress` for agent panes; this extends it to all panes by falling back to `getTerminalViewColorQueryReplyColors()` (the terminal view-attribute store) when `getStartupTerminalColorQueryReplyColors()` returns null for non-agent panes
- This is the same pattern already used in `orca-runtime.ts` for the daemon/remote path: `launchOpts.terminalColorQueryReplies ?? getTerminalViewColorQueryReplyColors()`

## Root cause

1. Prompt theme (OMP) sends `OSC 10;?` / `OSC 11;?` during startup
2. For non-agent panes, `PtyStartupIngress` is not armed, so the query reaches the renderer's xterm
3. Renderer answers via `sendInputImmediate` — reply goes back to the PTY
4. PTY is still in cooked mode (prompt theme hasn't entered raw mode yet)
5. Readline echoes the reply as visible text: `10;rgb:ffff/ffff/ffff11;rgb:2828/2c2c/3434`

## Changes

- `src/main/ipc/pty.ts`: Added `?? getTerminalViewColorQueryReplyColors()` fallback at both local (line ~4822) and daemon (line ~6269) spawn paths
- `src/renderer/src/components/terminal-pane/issue-non-agent-pane-startup-color-reply-leak.repro.test.ts`: New repro test verifying echo suppression with view-attribute colors on POSIX

#### Test plan

- [x] New repro test passes (3 tests: ingress suppresses echo, coalesced echo, baseline without ingress)
- [x] Existing `pty-startup-ingress.test.ts` — 42 tests pass
- [x] Existing `pty-startup-ingress-live-query-reply.test.ts` — 10 tests pass
- [x] Existing `issue-12112-agent-pane-startup-color-reply-leak.repro.test.ts` — 4 tests pass
- [x] Existing `terminal-capability-replies.test.ts` — 14 tests pass
- [x] oxlint clean (0 warnings, 0 errors)

Fixes #14306
