### PR TITLE
fix(native-chat): show prompts Claude queued while the agent was busy

### DIFF
--- a/src/main/native-chat/__fixtures__/queued-prompt-trace.ts
+++ b/src/main/native-chat/__fixtures__/queued-prompt-trace.ts
@@ -1,0 +1,27 @@
+/**
+ * A synthetic transcript window around a prompt sent while the agent was
+ * mid-turn. Every value here is invented; the shape mirrors what the agent
+ * writes — the queue pair, the `queued_command` attachment, and the assistant
+ * turns that bracket them.
+ *
+ * The attachment is placed after the row it follows while carrying the earlier
+ * enqueue time, which is the ordering the file-order anchoring exists for.
+ */
+export const QUEUED_PROMPT_TRACE: readonly string[] = [
+  '{"parentUuid":null,"isSidechain":false,"message":{"model":"synthetic-model","id":"msg-0001","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"THINKING_1","signature":"SIGNATURE"}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}},"requestId":"req-0001","type":"assistant","uuid":"a-001","timestamp":"2019-03-04T05:00:00.000Z","sessionId":"sess-0001","version":"2.1.220"}',
+  '{"parentUuid":"a-001","isSidechain":false,"message":{"model":"synthetic-model","id":"msg-0001","type":"message","role":"assistant","content":[{"type":"text","text":"ASSISTANT_TEXT_1"}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}},"requestId":"req-0001","type":"assistant","uuid":"a-002","timestamp":"2019-03-04T05:00:01.000Z","sessionId":"sess-0001","version":"2.1.220"}',
+  '{"parentUuid":"a-002","isSidechain":false,"message":{"model":"synthetic-model","id":"msg-0001","type":"message","role":"assistant","content":[{"type":"tool_use","id":"tool-001","name":"Bash","input":{"command":"TOOL_COMMAND"}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}},"requestId":"req-0001","type":"assistant","uuid":"a-003","timestamp":"2019-03-04T05:00:18.000Z","sessionId":"sess-0001","version":"2.1.220"}',
+  '{"type":"queue-operation","operation":"enqueue","timestamp":"2019-03-04T05:00:24.000Z","sessionId":"sess-0001","content":"QUEUED_COMMAND"}',
+  '{"type":"queue-operation","operation":"remove","timestamp":"2019-03-04T05:01:17.000Z","sessionId":"sess-0001","content":"QUEUED_COMMAND"}',
+  '{"parentUuid":"a-003","isSidechain":false,"promptId":"prompt-0001","type":"user","message":{"role":"user","content":[{"tool_use_id":"tool-001","type":"tool_result","content":"TOOL_RESULT","is_error":false}]},"uuid":"a-004","timestamp":"2019-03-04T05:01:17.000Z","toolUseResult":{"stdout":"TOOL_RESULT","stderr":"","interrupted":false,"isImage":false},"sourceToolAssistantUUID":"asst-0001","sessionId":"sess-0001","version":"2.1.220"}',
+  '{"parentUuid":"a-004","isSidechain":false,"type":"attachment","attachment":{"type":"queued_command","prompt":"QUEUED_COMMAND","commandMode":"prompt","origin":{"kind":"human"},"timestamp":"2019-03-04T05:00:24.000Z"},"uuid":"a-005","timestamp":"2019-03-04T05:00:24.000Z","sessionId":"sess-0001","version":"2.1.220"}',
+  '{"type":"last-prompt","lastPrompt":"LAST_PROMPT","sessionId":"sess-0001"}',
+  '{"type":"ai-title","aiTitle":"AI_TITLE","sessionId":"sess-0001"}',
+  '{"type":"mode","mode":"MODE","sessionId":"sess-0001"}',
+  '{"type":"permission-mode","permissionMode":"PERMISSION_MODE","sessionId":"sess-0001"}',
+  '{"parentUuid":"a-004","isSidechain":false,"message":{"model":"synthetic-model","id":"msg-0001","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"THINKING_2","signature":"SIGNATURE"}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}},"requestId":"req-0001","type":"assistant","uuid":"a-006","timestamp":"2019-03-04T05:01:31.000Z","sessionId":"sess-0001","version":"2.1.220"}',
+  '{"parentUuid":"a-006","isSidechain":false,"message":{"model":"synthetic-model","id":"msg-0001","type":"message","role":"assistant","content":[{"type":"text","text":"ASSISTANT_TEXT_2"}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}},"requestId":"req-0001","type":"assistant","uuid":"a-007","timestamp":"2019-03-04T05:01:34.000Z","sessionId":"sess-0001","version":"2.1.220"}'
+]
+
+/** Sentinel standing in for the prompt text. */
+export const QUEUED_PROMPT_TEXT = 'QUEUED_COMMAND'

--- a/src/main/native-chat/queued-prompt-anchor.ts
+++ b/src/main/native-chat/queued-prompt-anchor.ts
@@ -1,0 +1,31 @@
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { anchorQueuedPromptsToFileOrder, lastAnchorTimestamp } from './queued-prompt-file-order'
+
+export type QueuedPromptAnchor = {
+  /** Anchor a batch and remember what the next one should anchor against. */
+  apply: (messages: NativeChatMessage[]) => NativeChatMessage[]
+  /** Adopt an already-anchored snapshot as the starting point. */
+  adopt: (messages: readonly NativeChatMessage[]) => void
+  reset: () => void
+}
+
+/**
+ * Carries the predecessor timestamp across reads. A live append batch can hold
+ * only the queued record, leaving nothing in-batch to anchor against.
+ */
+export function createQueuedPromptAnchor(): QueuedPromptAnchor {
+  let previous: number | null = null
+  return {
+    apply(messages) {
+      const anchored = anchorQueuedPromptsToFileOrder(messages, previous)
+      previous = lastAnchorTimestamp(anchored, previous)
+      return anchored
+    },
+    adopt(messages) {
+      previous = lastAnchorTimestamp(messages, null)
+    },
+    reset() {
+      previous = null
+    }
+  }
+}

--- a/src/main/native-chat/queued-prompt-file-order.test.ts
+++ b/src/main/native-chat/queued-prompt-file-order.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { anchorQueuedPromptsToFileOrder, lastAnchorTimestamp } from './queued-prompt-file-order'
+
+function message(overrides: Partial<NativeChatMessage> & { id: string }): NativeChatMessage {
+  return {
+    role: 'user',
+    blocks: [{ type: 'text', text: overrides.id }],
+    timestamp: 0,
+    source: 'transcript',
+    ...overrides
+  }
+}
+
+describe('anchorQueuedPromptsToFileOrder', () => {
+  it('lifts a queued prompt stamped before the record it was appended after', () => {
+    const messages = [
+      message({ id: 'u1', timestamp: 100 }),
+      message({ id: 'a1', role: 'assistant', timestamp: 300 }),
+      message({ id: 'q1', timestamp: 200, queued: true })
+    ]
+
+    expect(anchorQueuedPromptsToFileOrder(messages).map((m) => m.timestamp)).toEqual([
+      100, 300, 301
+    ])
+  })
+
+  it('leaves a queued prompt that already sorts where the file put it', () => {
+    const messages = [
+      message({ id: 'u1', timestamp: 100 }),
+      message({ id: 'q1', timestamp: 200, queued: true }),
+      message({ id: 'a1', role: 'assistant', timestamp: 300 })
+    ]
+
+    expect(anchorQueuedPromptsToFileOrder(messages)).toBe(messages)
+  })
+
+  it('returns the same array when nothing is queued', () => {
+    const messages = [
+      message({ id: 'u1', timestamp: 300 }),
+      message({ id: 'a1', role: 'assistant', timestamp: 100 })
+    ]
+
+    expect(anchorQueuedPromptsToFileOrder(messages)).toBe(messages)
+  })
+
+  it('anchors each queued prompt to its own predecessor', () => {
+    const messages = [
+      message({ id: 'a1', role: 'assistant', timestamp: 300 }),
+      message({ id: 'q1', timestamp: 200, queued: true }),
+      message({ id: 'a2', role: 'assistant', timestamp: 800 }),
+      message({ id: 'q2', timestamp: 500, queued: true })
+    ]
+
+    expect(anchorQueuedPromptsToFileOrder(messages).map((m) => m.timestamp)).toEqual([
+      300, 301, 800, 801
+    ])
+  })
+
+  // Why: a live append batch can start with the queued record, so the previous
+  // batch's last timestamp is the only predecessor available.
+  it('anchors a batch that opens with a queued prompt against the seed', () => {
+    const batch = [message({ id: 'q1', timestamp: 200, queued: true })]
+
+    expect(anchorQueuedPromptsToFileOrder(batch, 500).map((m) => m.timestamp)).toEqual([501])
+  })
+
+  it('leaves a seeded batch alone when the queued prompt already sorts after it', () => {
+    const batch = [message({ id: 'q1', timestamp: 900, queued: true })]
+
+    expect(anchorQueuedPromptsToFileOrder(batch, 500)).toBe(batch)
+  })
+
+  it('reports the timestamp a following batch should anchor against', () => {
+    const batch = [
+      message({ id: 'a1', role: 'assistant', timestamp: 300 }),
+      message({ id: 'q1', timestamp: 100, queued: true })
+    ]
+    const anchored = anchorQueuedPromptsToFileOrder(batch, null)
+
+    expect(lastAnchorTimestamp(anchored, null)).toBe(301)
+  })
+
+  it('carries the fallback when a batch supplies no timestamp at all', () => {
+    expect(lastAnchorTimestamp([message({ id: 'x', timestamp: null })], 700)).toBe(700)
+  })
+
+  it('keeps a null-timestamped queued prompt untouched', () => {
+    const messages = [
+      message({ id: 'u1', timestamp: 100 }),
+      message({ id: 'q1', timestamp: null, queued: true })
+    ]
+
+    expect(anchorQueuedPromptsToFileOrder(messages)).toBe(messages)
+  })
+})

--- a/src/main/native-chat/queued-prompt-file-order.test.ts
+++ b/src/main/native-chat/queued-prompt-file-order.test.ts
@@ -25,6 +25,17 @@ describe('anchorQueuedPromptsToFileOrder', () => {
     ])
   })
 
+  // Why: equal timestamps fall to the id tie-break, which can put the queued
+  // prompt above the record it was appended after.
+  it('anchors a queued prompt stamped exactly at its predecessor', () => {
+    const messages = [
+      message({ id: 'work', role: 'assistant', timestamp: 300 }),
+      message({ id: 'queued', timestamp: 300, queued: true })
+    ]
+
+    expect(anchorQueuedPromptsToFileOrder(messages).map((m) => m.timestamp)).toEqual([300, 301])
+  })
+
   it('leaves a queued prompt that already sorts where the file put it', () => {
     const messages = [
       message({ id: 'u1', timestamp: 100 }),

--- a/src/main/native-chat/queued-prompt-file-order.ts
+++ b/src/main/native-chat/queued-prompt-file-order.ts
@@ -22,10 +22,12 @@ export function anchorQueuedPromptsToFileOrder(
       previousTimestamp = message.timestamp ?? previousTimestamp
       return message
     }
+    // Why: an equal timestamp is not safe either — the sorter breaks those ties
+    // on id, which can lift the queued prompt above the record it followed.
     if (
       previousTimestamp === null ||
       message.timestamp === null ||
-      message.timestamp >= previousTimestamp
+      message.timestamp > previousTimestamp
     ) {
       previousTimestamp = message.timestamp ?? previousTimestamp
       return message

--- a/src/main/native-chat/queued-prompt-file-order.ts
+++ b/src/main/native-chat/queued-prompt-file-order.ts
@@ -1,0 +1,54 @@
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+
+/**
+ * A queued prompt is stamped when it was enqueued, but the transcript appends it
+ * where the agent finally took it — after records that are newer. Sorting by time
+ * would lift it back above them, so give it a timestamp just past the record it
+ * was written after and let it keep the position the file already assigned.
+ *
+ * `seedTimestamp` carries that predecessor across reads: a live append batch can
+ * start with the queued record itself, and without the previous batch's last
+ * timestamp there would be nothing to anchor it to.
+ */
+export function anchorQueuedPromptsToFileOrder(
+  messages: readonly NativeChatMessage[],
+  seedTimestamp: number | null = null
+): NativeChatMessage[] {
+  let previousTimestamp = seedTimestamp
+  let changed = false
+
+  const anchored = messages.map((message) => {
+    if (!message.queued) {
+      previousTimestamp = message.timestamp ?? previousTimestamp
+      return message
+    }
+    if (
+      previousTimestamp === null ||
+      message.timestamp === null ||
+      message.timestamp >= previousTimestamp
+    ) {
+      previousTimestamp = message.timestamp ?? previousTimestamp
+      return message
+    }
+    // Why: one tick past the predecessor, not equal to it — equal timestamps tie
+    // break on id, which would sort the queued prompt back above it.
+    const anchoredAt = previousTimestamp + 1
+    previousTimestamp = anchoredAt
+    changed = true
+    return { ...message, timestamp: anchoredAt }
+  })
+
+  return changed ? anchored : (messages as NativeChatMessage[])
+}
+
+/** Last timestamp a following batch should anchor against. */
+export function lastAnchorTimestamp(
+  messages: readonly NativeChatMessage[],
+  fallback: number | null
+): number | null {
+  let last = fallback
+  for (const message of messages) {
+    last = message.timestamp ?? last
+  }
+  return last
+}

--- a/src/main/native-chat/queued-prompt-trace-replay.test.ts
+++ b/src/main/native-chat/queued-prompt-trace-replay.test.ts
@@ -1,0 +1,108 @@
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { isTextBlock, type NativeChatMessage } from '../../shared/native-chat-types'
+import { QUEUED_PROMPT_TRACE, QUEUED_PROMPT_TEXT } from './__fixtures__/queued-prompt-trace'
+import { readIncrementalTranscriptMessages } from './transcript-incremental-reader'
+import { readNativeChatTranscript } from './transcript-reader'
+import { nativeChatLineDecoderForAgent } from './transcript-tail-reader'
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+async function tempTranscript(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-queued-prompt-trace-'))
+  tempRoots.push(root)
+  return join(root, 'transcript.jsonl')
+}
+
+function textOf(message: NativeChatMessage): string {
+  return message.blocks
+    .filter(isTextBlock)
+    .map((block) => block.text)
+    .join(' ')
+    .trim()
+}
+
+/** Thinking and tool rows carry no conversation text; this is what a person reads. */
+function conversationTexts(messages: readonly NativeChatMessage[]): string[] {
+  return messages
+    .map(textOf)
+    .filter((text) => text.startsWith('ASSISTANT_TEXT') || text === QUEUED_PROMPT_TEXT)
+}
+
+async function replay(lines: readonly string[]): Promise<NativeChatMessage[]> {
+  const filePath = await tempTranscript()
+  await writeFile(filePath, `${lines.join('\n')}\n`)
+  const result = await readNativeChatTranscript('claude', 'replay', { filePath })
+  if ('error' in result) {
+    throw new Error(result.error)
+  }
+  return result.messages
+}
+
+describe('a prompt sent while the agent was mid-turn', () => {
+  it('lands between the turns that bracket it', async () => {
+    expect(conversationTexts(await replay(QUEUED_PROMPT_TRACE))).toStrictEqual([
+      'ASSISTANT_TEXT_1',
+      QUEUED_PROMPT_TEXT,
+      'ASSISTANT_TEXT_2'
+    ])
+  })
+
+  it('arrives once, as a queued user turn', async () => {
+    const carrying = (await replay(QUEUED_PROMPT_TRACE)).filter(
+      (message) => textOf(message) === QUEUED_PROMPT_TEXT
+    )
+
+    expect(carrying).toHaveLength(1)
+    expect(carrying[0]).toMatchObject({ role: 'user', queued: true, source: 'transcript' })
+  })
+
+  it('stays out when the attachment is one the agent queued for itself', async () => {
+    const lines = QUEUED_PROMPT_TRACE.map((line) =>
+      line.includes('"queued_command"')
+        ? line.replace('"commandMode":"prompt"', '"commandMode":"task-notification"')
+        : line
+    )
+
+    expect(conversationTexts(await replay(lines))).toStrictEqual([
+      'ASSISTANT_TEXT_1',
+      'ASSISTANT_TEXT_2'
+    ])
+  })
+
+  it('lands the same way when the records arrive while the pane is open', async () => {
+    // The field case is an append into an open pane, not a cold read: the
+    // attachment reaches the reader in a later batch than the turn it follows.
+    const filePath = await tempTranscript()
+    const split = QUEUED_PROMPT_TRACE.findIndex((line) => line.includes('"queued_command"'))
+    const state = {
+      offset: 0,
+      pendingChunks: [],
+      pendingStart: 0,
+      pendingBytes: 0,
+      droppingOversizedRecord: false
+    }
+    const decode = nativeChatLineDecoderForAgent('claude')
+    if (!decode) {
+      throw new Error('no claude decoder')
+    }
+
+    await writeFile(filePath, `${QUEUED_PROMPT_TRACE.slice(0, split).join('\n')}\n`)
+    const before = await readIncrementalTranscriptMessages(filePath, state, decode)
+    await appendFile(filePath, `${QUEUED_PROMPT_TRACE.slice(split).join('\n')}\n`)
+    const after = await readIncrementalTranscriptMessages(filePath, state, decode)
+
+    expect(conversationTexts([...before, ...after])).toStrictEqual([
+      'ASSISTANT_TEXT_1',
+      QUEUED_PROMPT_TEXT,
+      'ASSISTANT_TEXT_2'
+    ])
+  })
+})

--- a/src/main/native-chat/queued-prompt-trace-replay.test.ts
+++ b/src/main/native-chat/queued-prompt-trace-replay.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { isTextBlock, type NativeChatMessage } from '../../shared/native-chat-types'
 import { QUEUED_PROMPT_TRACE, QUEUED_PROMPT_TEXT } from './__fixtures__/queued-prompt-trace'
+import { createQueuedPromptAnchor } from './queued-prompt-anchor'
 import { readIncrementalTranscriptMessages } from './transcript-incremental-reader'
 import { readNativeChatTranscript } from './transcript-reader'
 import { nativeChatLineDecoderForAgent } from './transcript-tail-reader'
@@ -94,15 +95,34 @@ describe('a prompt sent while the agent was mid-turn', () => {
       throw new Error('no claude decoder')
     }
 
-    await writeFile(filePath, `${QUEUED_PROMPT_TRACE.slice(0, split).join('\n')}\n`)
-    const before = await readIncrementalTranscriptMessages(filePath, state, decode)
-    await appendFile(filePath, `${QUEUED_PROMPT_TRACE.slice(split).join('\n')}\n`)
-    const after = await readIncrementalTranscriptMessages(filePath, state, decode)
+    // The reader hands back physical file order, but the pane sorts by
+    // timestamp — so the batches go through the same anchor the watcher holds
+    // across reads, and the assertion sorts the way the pane would.
+    const anchor = createQueuedPromptAnchor()
 
-    expect(conversationTexts([...before, ...after])).toStrictEqual([
+    await writeFile(filePath, `${QUEUED_PROMPT_TRACE.slice(0, split).join('\n')}\n`)
+    const before = anchor.apply(await readIncrementalTranscriptMessages(filePath, state, decode))
+    await appendFile(filePath, `${QUEUED_PROMPT_TRACE.slice(split).join('\n')}\n`)
+    const after = anchor.apply(await readIncrementalTranscriptMessages(filePath, state, decode))
+
+    const fileOrder = [...before, ...after]
+    const rendered = [...fileOrder].sort(
+      (left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0)
+    )
+
+    expect(conversationTexts(rendered)).toStrictEqual([
       'ASSISTANT_TEXT_1',
       QUEUED_PROMPT_TEXT,
       'ASSISTANT_TEXT_2'
     ])
+
+    // Why: the record the prompt has to stay behind is a tool result, which
+    // carries no conversation text — so the text assertion above cannot see the
+    // anchoring at all. Its enqueue stamp predates that record; only the anchor
+    // moves it past.
+    const queuedIndex = fileOrder.findIndex((message) => textOf(message) === QUEUED_PROMPT_TEXT)
+    const predecessor = fileOrder[queuedIndex - 1]
+    expect(predecessor).toBeDefined()
+    expect(fileOrder[queuedIndex]?.timestamp ?? 0).toBeGreaterThan(predecessor?.timestamp ?? 0)
   })
 })

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -22,6 +22,9 @@ export function decodeClaudeTranscriptLine(
   if (!record) {
     return null
   }
+  if (record.type === 'attachment') {
+    return decodeQueuedCommandAttachment(record, fallbackId)
+  }
   const role = record.type
   if (role !== 'user' && role !== 'assistant') {
     return null
@@ -62,6 +65,35 @@ export function decodeClaudeTranscriptLine(
     blocks,
     timestamp,
     source: 'transcript'
+  }
+}
+
+// Why: a prompt sent mid-turn is queued, and the queue entry is almost always
+// the only record it gets — undecoded, it is missing from chat entirely.
+function decodeQueuedCommandAttachment(
+  record: Record<string, unknown>,
+  fallbackId: string
+): NativeChatMessage | null {
+  const attachment = asRecord(record.attachment)
+  if (extractString(attachment?.type) !== 'queued_command') {
+    return null
+  }
+  // Why: ~46% of these are harness task-notification blobs the agent queues for
+  // itself, not typed input; only `prompt` mode is a user turn.
+  if (extractString(attachment?.commandMode) !== 'prompt') {
+    return null
+  }
+  const blocks = claudeContentBlocks(attachment?.prompt)
+  if (blocks.length === 0) {
+    return null
+  }
+  return {
+    id: extractString(record.uuid) ?? fallbackId,
+    role: 'user',
+    blocks,
+    timestamp: parseTimestamp(record.timestamp),
+    source: 'transcript',
+    queued: true
   }
 }
 

--- a/src/main/native-chat/transcript-line-decoders.claude.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.claude.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+
+const ENQUEUED_AT = '2026-08-13T13:01:09.710Z'
+
+function queuedCommandLine(
+  overrides: { attachment?: Record<string, unknown> } & Record<string, unknown> = {}
+): string {
+  const { attachment, ...rest } = overrides
+  return JSON.stringify({
+    type: 'attachment',
+    uuid: '6c98913b-d79d-4075-b44b-2f73789ead21',
+    parentUuid: 'bf4ba06c-ffc5-4d62-94af-5e857d74ed11',
+    isSidechain: false,
+    timestamp: ENQUEUED_AT,
+    ...rest,
+    attachment: {
+      type: 'queued_command',
+      prompt: 'take a look while you are at it',
+      commandMode: 'prompt',
+      origin: { kind: 'human' },
+      timestamp: ENQUEUED_AT,
+      ...attachment
+    }
+  })
+}
+
+describe('decodeClaudeTranscriptLine — queued prompts', () => {
+  it('decodes a queued command as a user message stamped at enqueue time', () => {
+    expect(decodeClaudeTranscriptLine(queuedCommandLine(), 'fallback')).toEqual({
+      id: '6c98913b-d79d-4075-b44b-2f73789ead21',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'take a look while you are at it' }],
+      timestamp: Date.parse(ENQUEUED_AT),
+      source: 'transcript',
+      queued: true
+    })
+  })
+
+  // Why: `origin` is absent on many real records, so it cannot gate the decode.
+  it('decodes a queued command that carries no origin field', () => {
+    const line = JSON.stringify({
+      type: 'attachment',
+      uuid: 'no-origin',
+      timestamp: ENQUEUED_AT,
+      attachment: { type: 'queued_command', prompt: 'no origin here', commandMode: 'prompt' }
+    })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text: 'no origin here' }]
+    })
+  })
+
+  // Why: these are ~46% of queued_command records, and the orchestration
+  // transcript path has no noise filter to catch them downstream.
+  it('drops task-notification queue entries the harness enqueues for itself', () => {
+    const line = queuedCommandLine({
+      attachment: {
+        commandMode: 'task-notification',
+        prompt: '<task-notification>\n<task-id>abc</task-id>\n</task-notification>'
+      }
+    })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toBeNull()
+  })
+
+  // Why: an image-carrying queued prompt stores `prompt` as content blocks.
+  it('decodes a queued command whose prompt is content blocks', () => {
+    const line = queuedCommandLine({
+      attachment: { prompt: [{ type: 'text', text: '[Image #1] look at this' }] }
+    })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text: '[Image #1] look at this' }]
+    })
+  })
+
+  it('ignores attachments that are not queued commands', () => {
+    const line = queuedCommandLine({ attachment: { type: 'file' } })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toBeNull()
+  })
+
+  it('ignores a queued command with no prompt text', () => {
+    const line = queuedCommandLine({ attachment: { prompt: '   ' } })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toBeNull()
+  })
+
+  it('still drops queue bookkeeping records', () => {
+    const line = JSON.stringify({
+      type: 'queue-operation',
+      operation: 'remove',
+      timestamp: ENQUEUED_AT,
+      content: 'take a look while you are at it'
+    })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toBeNull()
+  })
+
+  it('leaves ordinary user turns unchanged', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      uuid: 'u1',
+      timestamp: ENQUEUED_AT,
+      message: { role: 'user', content: [{ type: 'text', text: 'first prompt' }] }
+    })
+    expect(decodeClaudeTranscriptLine(line, 'fallback')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text: 'first prompt' }]
+    })
+  })
+})

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -15,6 +15,7 @@ import {
   decodeOmpTranscriptLine
 } from './transcript-line-decoders'
 import { decodeTranscriptStream } from './transcript-stream-lines'
+import { anchorQueuedPromptsToFileOrder } from './queued-prompt-file-order'
 
 export type ReadTranscriptResult =
   | {
@@ -56,7 +57,8 @@ export async function readNativeChatTranscript(
   try {
     const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
     if (transcriptAgent === 'claude') {
-      return { messages: await readTranscript(filePath, decodeClaudeTranscriptLine) }
+      const messages = await readTranscript(filePath, decodeClaudeTranscriptLine)
+      return { messages: anchorQueuedPromptsToFileOrder(messages) }
     }
     if (transcriptAgent === 'codex') {
       return { messages: await readTranscript(filePath, decodeCodexTranscriptLine) }

--- a/src/main/native-chat/transcript-tail-reader-queued-page.test.ts
+++ b/src/main/native-chat/transcript-tail-reader-queued-page.test.ts
@@ -11,7 +11,8 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
-const AT = (seconds: number): string => `2026-06-01T10:00:${String(seconds).padStart(2, '0')}.000Z`
+// Why: built through Date so a value past 59 rolls into the next minute.
+const AT = (seconds: number): string => new Date(Date.UTC(2026, 5, 1, 10, 0, seconds)).toISOString()
 
 function turn(uuid: string, role: 'user' | 'assistant', text: string, seconds: number): string {
   return `${JSON.stringify({

--- a/src/main/native-chat/transcript-tail-reader-queued-page.test.ts
+++ b/src/main/native-chat/transcript-tail-reader-queued-page.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+import { readNativeChatTranscriptTailFile } from './transcript-tail-reader'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const AT = (seconds: number): string => `2026-06-01T10:00:${String(seconds).padStart(2, '0')}.000Z`
+
+function turn(uuid: string, role: 'user' | 'assistant', text: string, seconds: number): string {
+  return `${JSON.stringify({
+    type: role,
+    uuid,
+    timestamp: AT(seconds),
+    message: { role, content: role === 'user' ? text : [{ type: 'text', text }] }
+  })}\n`
+}
+
+function queuedPrompt(uuid: string, text: string, enqueuedAt: number): string {
+  return `${JSON.stringify({
+    type: 'attachment',
+    uuid,
+    timestamp: AT(enqueuedAt),
+    attachment: { type: 'queued_command', prompt: text, commandMode: 'prompt' }
+  })}\n`
+}
+
+async function transcript(body: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-tail-queued-page-'))
+  roots.push(root)
+  const filePath = join(root, 'transcript.jsonl')
+  await writeFile(filePath, body)
+  return filePath
+}
+
+describe('queued prompts at a pagination boundary', () => {
+  // Why: the predecessor a queued prompt anchors to can fall outside the window,
+  // so anchoring has to happen before the page is sliced.
+  it('anchors a queued prompt that opens the page against a predecessor outside it', async () => {
+    const filePath = await transcript(
+      turn('u1', 'user', 'first prompt', 0) +
+        turn('a1', 'assistant', 'reply to first', 30) +
+        queuedPrompt('q1', 'queued while busy', 10) +
+        turn('a2', 'assistant', 'final reply', 60)
+    )
+
+    // A window of 2 starts at the queued record, leaving its predecessor behind.
+    const page = await readNativeChatTranscriptTailFile(filePath, 2, decodeClaudeTranscriptLine)
+
+    expect(page.messages.map((message) => message.id)).toEqual(['q1', 'a2'])
+    const queued = page.messages[0]
+    expect(queued?.timestamp).toBe(Date.parse(AT(30)) + 1)
+    expect(queued?.timestamp).not.toBe(Date.parse(AT(10)))
+  })
+
+  it('keeps the full read anchored too', async () => {
+    const filePath = await transcript(
+      turn('u1', 'user', 'first prompt', 0) +
+        turn('a1', 'assistant', 'reply to first', 30) +
+        queuedPrompt('q1', 'queued while busy', 10)
+    )
+
+    const page = await readNativeChatTranscriptTailFile(filePath, 50, decodeClaudeTranscriptLine)
+
+    expect(page.messages.map((message) => message.timestamp)).toEqual([
+      Date.parse(AT(0)),
+      Date.parse(AT(30)),
+      Date.parse(AT(30)) + 1
+    ])
+  })
+})

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -142,12 +142,16 @@ export async function readNativeChatTranscriptTailFile(
       decodeLine(0, newestFirst)
     }
     const chronological = newestFirst.toReversed()
+    // Why: anchor before windowing — the predecessor a queued prompt anchors to
+    // may sit just outside the page, and slicing first would strand it.
+    // No-op for agents that never mark a message queued.
+    const anchored = anchorQueuedPromptsToFileOrder(chronological.map((entry) => entry.message))
     // Why: slice(-0) returns the whole array, so a non-positive limit must
     // window to nothing explicitly rather than leak every buffered record.
-    const selected = limit > 0 ? chronological.slice(Math.max(0, chronological.length - limit)) : []
+    const windowStart = limit > 0 ? Math.max(0, chronological.length - limit) : chronological.length
+    const selected = chronological.slice(windowStart)
     return {
-      // No-op for agents that never mark a message queued.
-      messages: anchorQueuedPromptsToFileOrder(selected.map((entry) => entry.message)),
+      messages: anchored.slice(windowStart),
       ...(lifecycle ? { lifecycle } : {}),
       consumedTo,
       hasMore: limit > 0 && chronological.length > limit,

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -28,6 +28,7 @@ import {
   wslGatedStat
 } from './wsl-transcript-fs-access'
 import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
+import { anchorQueuedPromptsToFileOrder } from './queued-prompt-file-order'
 
 export const MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES = 2 * 1024 * 1024
 
@@ -145,7 +146,8 @@ export async function readNativeChatTranscriptTailFile(
     // window to nothing explicitly rather than leak every buffered record.
     const selected = limit > 0 ? chronological.slice(Math.max(0, chronological.length - limit)) : []
     return {
-      messages: selected.map((entry) => entry.message),
+      // No-op for agents that never mark a message queued.
+      messages: anchorQueuedPromptsToFileOrder(selected.map((entry) => entry.message)),
       ...(lifecycle ? { lifecycle } : {}),
       consumedTo,
       hasMore: limit > 0 && chronological.length > limit,

--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -11,6 +11,7 @@ import {
   resetIncrementalTranscriptState
 } from './transcript-incremental-reader'
 import { readNativeChatTranscriptTailFile } from './transcript-tail-reader'
+import { anchorQueuedPromptsToFileOrder, lastAnchorTimestamp } from './queued-prompt-file-order'
 import { emitTranscriptUnavailableSnapshot } from './transcript-unavailable-snapshot'
 import { transcriptWatcherPathIsInstallable } from './transcript-watcher-install-probe'
 import { nativeChatTurnLifecycleDecoderForAgent } from './transcript-turn-lifecycle'
@@ -56,6 +57,9 @@ export async function installTranscriptWatcher(
   let reading = false
   let pendingReadRequested = false
   let rotationRetryCount = 0
+  // Why: an append batch can begin with the queued record itself, so the
+  // predecessor it anchors to has to survive across reads.
+  let queuedAnchorTimestamp: number | null = null
 
   function scheduleRotationRetry(): void {
     if (closed) {
@@ -75,7 +79,9 @@ export async function installTranscriptWatcher(
       decode,
       (messages) => {
         if (!closed) {
-          onAppend(messages)
+          const anchored = anchorQueuedPromptsToFileOrder(messages, queuedAnchorTimestamp)
+          queuedAnchorTimestamp = lastAnchorTimestamp(anchored, queuedAnchorTimestamp)
+          onAppend(anchored)
         }
       },
       decodeLifecycle ?? undefined,
@@ -85,7 +91,9 @@ export async function installTranscriptWatcher(
       gateAbort.signal
     )
     if (!closed && (remaining.length > 0 || lifecycle)) {
-      onAppend(remaining, lifecycle)
+      const anchored = anchorQueuedPromptsToFileOrder(remaining, queuedAnchorTimestamp)
+      queuedAnchorTimestamp = lastAnchorTimestamp(anchored, queuedAnchorTimestamp)
+      onAppend(anchored, lifecycle)
     }
   }
 
@@ -134,6 +142,7 @@ export async function installTranscriptWatcher(
     }
     if (contentReplaced) {
       resetIncrementalTranscriptState(state)
+      queuedAnchorTimestamp = null
     }
     // Why: subscriber callbacks may replace the path before the drain can finish.
     watchedVersion ??= current
@@ -158,6 +167,7 @@ export async function installTranscriptWatcher(
     if (replacementSnapshot && onReplace) {
       state.offset = replacementSnapshot.consumedTo
       state.pendingStart = state.offset
+      queuedAnchorTimestamp = lastAnchorTimestamp(replacementSnapshot.messages, null)
       onReplace(
         replacementSnapshot.messages,
         replacementSnapshot.hasMore,
@@ -189,6 +199,7 @@ export async function installTranscriptWatcher(
       if (initialSnapshot) {
         state.offset = initialSnapshot.consumedTo
         state.pendingStart = state.offset
+        queuedAnchorTimestamp = lastAnchorTimestamp(initialSnapshot.messages, null)
         onInitialSnapshot(
           initialSnapshot.messages,
           initialSnapshot.hasMore,

--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -11,7 +11,7 @@ import {
   resetIncrementalTranscriptState
 } from './transcript-incremental-reader'
 import { readNativeChatTranscriptTailFile } from './transcript-tail-reader'
-import { anchorQueuedPromptsToFileOrder, lastAnchorTimestamp } from './queued-prompt-file-order'
+import { createQueuedPromptAnchor } from './queued-prompt-anchor'
 import { emitTranscriptUnavailableSnapshot } from './transcript-unavailable-snapshot'
 import { transcriptWatcherPathIsInstallable } from './transcript-watcher-install-probe'
 import { nativeChatTurnLifecycleDecoderForAgent } from './transcript-turn-lifecycle'
@@ -57,9 +57,7 @@ export async function installTranscriptWatcher(
   let reading = false
   let pendingReadRequested = false
   let rotationRetryCount = 0
-  // Why: an append batch can begin with the queued record itself, so the
-  // predecessor it anchors to has to survive across reads.
-  let queuedAnchorTimestamp: number | null = null
+  const queuedAnchor = createQueuedPromptAnchor()
 
   function scheduleRotationRetry(): void {
     if (closed) {
@@ -79,9 +77,7 @@ export async function installTranscriptWatcher(
       decode,
       (messages) => {
         if (!closed) {
-          const anchored = anchorQueuedPromptsToFileOrder(messages, queuedAnchorTimestamp)
-          queuedAnchorTimestamp = lastAnchorTimestamp(anchored, queuedAnchorTimestamp)
-          onAppend(anchored)
+          onAppend(queuedAnchor.apply(messages))
         }
       },
       decodeLifecycle ?? undefined,
@@ -91,9 +87,7 @@ export async function installTranscriptWatcher(
       gateAbort.signal
     )
     if (!closed && (remaining.length > 0 || lifecycle)) {
-      const anchored = anchorQueuedPromptsToFileOrder(remaining, queuedAnchorTimestamp)
-      queuedAnchorTimestamp = lastAnchorTimestamp(anchored, queuedAnchorTimestamp)
-      onAppend(anchored, lifecycle)
+      onAppend(queuedAnchor.apply(remaining), lifecycle)
     }
   }
 
@@ -142,7 +136,7 @@ export async function installTranscriptWatcher(
     }
     if (contentReplaced) {
       resetIncrementalTranscriptState(state)
-      queuedAnchorTimestamp = null
+      queuedAnchor.reset()
     }
     // Why: subscriber callbacks may replace the path before the drain can finish.
     watchedVersion ??= current
@@ -167,7 +161,7 @@ export async function installTranscriptWatcher(
     if (replacementSnapshot && onReplace) {
       state.offset = replacementSnapshot.consumedTo
       state.pendingStart = state.offset
-      queuedAnchorTimestamp = lastAnchorTimestamp(replacementSnapshot.messages, null)
+      queuedAnchor.adopt(replacementSnapshot.messages)
       onReplace(
         replacementSnapshot.messages,
         replacementSnapshot.hasMore,
@@ -199,7 +193,7 @@ export async function installTranscriptWatcher(
       if (initialSnapshot) {
         state.offset = initialSnapshot.consumedTo
         state.pendingStart = state.offset
-        queuedAnchorTimestamp = lastAnchorTimestamp(initialSnapshot.messages, null)
+        queuedAnchor.adopt(initialSnapshot.messages)
         onInitialSnapshot(
           initialSnapshot.messages,
           initialSnapshot.hasMore,
@@ -224,7 +218,7 @@ export async function installTranscriptWatcher(
         if (closed) {
           return
         }
-        onInitialSnapshot(messages, false, 0, undefined, lifecycle)
+        onInitialSnapshot(queuedAnchor.apply(messages), false, 0, undefined, lifecycle)
       }
     } else {
       initialDrain = false

--- a/src/main/native-chat/transcript-watch-queued-prompt.test.ts
+++ b/src/main/native-chat/transcript-watch-queued-prompt.test.ts
@@ -11,7 +11,8 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
-const AT = (seconds: number): string => `2026-06-01T10:00:${String(seconds).padStart(2, '0')}.000Z`
+// Why: built through Date so a value past 59 rolls into the next minute.
+const AT = (seconds: number): string => new Date(Date.UTC(2026, 5, 1, 10, 0, seconds)).toISOString()
 
 function turn(uuid: string, role: 'user' | 'assistant', text: string, seconds: number): string {
   return `${JSON.stringify({

--- a/src/main/native-chat/transcript-watch-queued-prompt.test.ts
+++ b/src/main/native-chat/transcript-watch-queued-prompt.test.ts
@@ -1,0 +1,87 @@
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { subscribeNativeChatTranscript } from './transcript-watch'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const AT = (seconds: number): string => `2026-06-01T10:00:${String(seconds).padStart(2, '0')}.000Z`
+
+function turn(uuid: string, role: 'user' | 'assistant', text: string, seconds: number): string {
+  return `${JSON.stringify({
+    type: role,
+    uuid,
+    timestamp: AT(seconds),
+    message: { role, content: role === 'user' ? text : [{ type: 'text', text }] }
+  })}\n`
+}
+
+/** Stamped when enqueued, appended only once the agent takes it. */
+function queuedPrompt(uuid: string, text: string, enqueuedAt: number): string {
+  return `${JSON.stringify({
+    type: 'attachment',
+    uuid,
+    timestamp: AT(enqueuedAt),
+    attachment: { type: 'queued_command', prompt: text, commandMode: 'prompt' }
+  })}\n`
+}
+
+async function tempFile(initial: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-queued-'))
+  roots.push(root)
+  const filePath = join(root, 'transcript.jsonl')
+  await writeFile(filePath, initial)
+  return filePath
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+describe('queued prompts arriving on the live tail', () => {
+  // Why: the append batch holds only the queued record, so without the previous
+  // batch's timestamp it would sort back above the reply already on screen.
+  it('anchors a queued prompt that arrives alone, after the reply it followed', async () => {
+    const filePath = await tempFile(turn('u1', 'user', 'first prompt', 0))
+    const snapshots = vi.fn()
+    const appended: NativeChatMessage[] = []
+
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      onInitialSnapshot: snapshots,
+      onAppend: (messages) => appended.push(...messages),
+      debounceMs: 0,
+      reconciliationIntervalMs: 20
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+
+    await appendFile(filePath, turn('a1', 'assistant', 'reply to first', 30))
+    await waitFor(() => appended.some((message) => message.id === 'a1'))
+
+    await appendFile(filePath, queuedPrompt('q1', 'queued while busy', 10))
+    await waitFor(() => appended.some((message) => message.id === 'q1'))
+
+    subscription.unsubscribe()
+
+    const reply = appended.find((message) => message.id === 'a1')
+    const queued = appended.find((message) => message.id === 'q1')
+    expect(queued?.blocks).toEqual([{ type: 'text', text: 'queued while busy' }])
+    // Sorts after the reply it was appended behind, not back at its enqueue time.
+    expect(queued?.timestamp).toBeGreaterThan(reply?.timestamp ?? 0)
+    expect(queued?.timestamp).not.toBe(Date.parse(AT(10)))
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -77,6 +77,28 @@ describe('prunePendingSends', () => {
     expect(next).toEqual([])
   })
 
+  // Why: a prompt typed mid-turn used to leave no user row at all, so its echo
+  // never matched, and the echo carries the send time — it sat below the turns
+  // that landed after it rather than in place.
+  it('strands the echo while the mid-turn prompt leaves no user turn behind', () => {
+    const pending = [pendingOf('p1', 'also check the cache')]
+    const next = prunePendingSends(pending, [
+      assistantMessage('m1', 'reading the file'),
+      assistantMessage('m2', 'done')
+    ])
+    expect(next).toBe(pending)
+  })
+
+  it('drops the echo once that prompt is decoded as a queued user turn', () => {
+    const pending = [pendingOf('p1', 'also check the cache')]
+    const next = prunePendingSends(pending, [
+      assistantMessage('m1', 'reading the file'),
+      { ...userMessage('m2', 'also check the cache'), queued: true },
+      assistantMessage('m3', 'done')
+    ])
+    expect(next).toEqual([])
+  })
+
   it('matches advanced turns ignoring surrounding/collapsed whitespace', () => {
     const pending = [pendingOf('p1', '  do   the   thing ')]
     const next = prunePendingSends(pending, [

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -88,6 +88,11 @@ export type NativeChatMessage = {
   /** Optional explicit turn key. When present, two messages with the same
    *  `turnId` are treated as the same turn for dedup regardless of `id`. */
   turnId?: string
+  /** Queued while the agent was busy. Its timestamp is the enqueue moment, which
+   *  predates the records it was appended after, so ordering must anchor it to
+   *  the position the transcript file gave it rather than sort by time.
+   *  Main-process ordering pass only — renderers must not branch on this. */
+  queued?: boolean
 }
 
 export const NATIVE_CHAT_TURN_LIFECYCLE_STATES = ['working', 'completed', 'interrupted'] as const

--- a/tests/e2e/native-chat-queued-prompt-visible.spec.ts
+++ b/tests/e2e/native-chat-queued-prompt-visible.spec.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
+import type { GlobalSettings } from '../../src/shared/types'
+
+const FIRST_PROMPT = 'start the long running task'
+const QUEUED_PROMPT = 'and check the config while you are at it'
+const FIRST_REPLY = 'working through the first task now'
+const REPLY = 'both done'
+
+async function enableNativeChatSetting(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const nextSettings = await window.api.settings.set({ experimentalNativeChat: true })
+    window.__store?.setState({ settings: nextSettings as GlobalSettings })
+  })
+}
+
+// Mirrors native-chat-first-flush-race.spec.ts: drive the same store → NativeChatView
+// path a real Claude Code hook would, without an installed CLI.
+async function seedClaudeProviderSession(
+  page: Page,
+  args: { paneKey: string; worktreeId: string; sessionId: string; transcriptPath: string }
+): Promise<void> {
+  await page.evaluate(({ paneKey, worktreeId, sessionId, transcriptPath }) => {
+    window.__store
+      ?.getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'working', prompt: 'e2e queued prompt probe', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId },
+        { providerSession: { key: 'session_id', id: sessionId, transcriptPath } }
+      )
+  }, args)
+}
+
+async function toggleTerminalTabToChatView(
+  page: Page,
+  args: { tabId: string; worktreeId: string }
+): Promise<void> {
+  await page.evaluate(({ tabId, worktreeId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const unifiedTab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+    )
+    if (!unifiedTab) {
+      throw new Error('Unified terminal tab not found for chat toggle')
+    }
+    state.toggleTabViewMode(unifiedTab.id)
+  }, args)
+}
+
+/** A session where the second prompt arrived mid-turn and Claude queued it. */
+function transcriptWithQueuedPrompt(sessionId: string): string {
+  const base = Date.now()
+  const at = (offsetMs: number): string => new Date(base + offsetMs).toISOString()
+  const lines = [
+    {
+      sessionId,
+      uuid: `${sessionId}-user`,
+      timestamp: at(0),
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: FIRST_PROMPT }] }
+    },
+    { type: 'queue-operation', operation: 'enqueue', timestamp: at(2_000), content: QUEUED_PROMPT },
+    // Why: the queue drains later, so the reply to the FIRST prompt lands before
+    // the queued one is taken — keep that gap rather than a 0-gap ideal.
+    {
+      sessionId,
+      uuid: `${sessionId}-work`,
+      parentUuid: `${sessionId}-user`,
+      timestamp: at(3_000),
+      type: 'assistant',
+      message: { model: 'claude-opus-4', content: [{ type: 'text', text: FIRST_REPLY }] }
+    },
+    { type: 'queue-operation', operation: 'remove', timestamp: at(4_000), content: QUEUED_PROMPT },
+    // Why: a prompt sent while the agent is busy is almost always recorded only
+    // like this — no `user` record is written for it — and Claude appends it once
+    // the queue drains, so it lands here while still stamped at enqueue time.
+    {
+      sessionId,
+      uuid: `${sessionId}-queued`,
+      parentUuid: `${sessionId}-work`,
+      timestamp: at(2_000),
+      type: 'attachment',
+      attachment: {
+        type: 'queued_command',
+        prompt: QUEUED_PROMPT,
+        commandMode: 'prompt',
+        origin: { kind: 'human' },
+        timestamp: at(2_000)
+      }
+    },
+    {
+      sessionId,
+      uuid: `${sessionId}-assistant`,
+      parentUuid: `${sessionId}-work`,
+      timestamp: at(6_000),
+      type: 'assistant',
+      message: { model: 'claude-opus-4', content: [{ type: 'text', text: REPLY }] }
+    }
+  ]
+  return `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`
+}
+
+test.describe('Native chat shows prompts the agent queued mid-turn', () => {
+  test('renders a queued prompt where the agent took it, matching the terminal', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+    const [tabId] = descriptor.paneKey.split(':')
+    const sessionId = `e2e-queued-prompt-${randomUUID()}`
+    const scratchDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-queued-prompt-'))
+    const transcriptPath = path.join(scratchDir, `${sessionId}.jsonl`)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `native-chat-queued-prompt-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+
+    try {
+      writeFileSync(transcriptPath, transcriptWithQueuedPrompt(sessionId))
+
+      await enableNativeChatSetting(orcaPage)
+      await seedClaudeProviderSession(orcaPage, {
+        paneKey: descriptor.paneKey,
+        worktreeId: descriptor.worktreeId,
+        sessionId,
+        transcriptPath
+      })
+      await toggleTerminalTabToChatView(orcaPage, { tabId, worktreeId: descriptor.worktreeId })
+
+      const chat = orcaPage.locator('[data-native-chat-root="true"]')
+      await expect(chat).toBeVisible({ timeout: 15_000 })
+      await expect(chat.getByText(FIRST_PROMPT)).toBeVisible({ timeout: 30_000 })
+      await expect(chat.getByText(REPLY)).toBeVisible({ timeout: 30_000 })
+
+      // The queued prompt is the one that used to vanish from chat entirely.
+      // Count first: a strict-mode locator assertion would fail confusingly on a
+      // double render instead of reporting the count.
+      await expect(chat.getByText(QUEUED_PROMPT)).toHaveCount(1, { timeout: 30_000 })
+      await expect(chat.getByText(QUEUED_PROMPT)).toBeVisible()
+      await orcaPage.screenshot({ path: path.join(screenshotDir, '01-queued-prompt-visible.png') })
+
+      const order = await chat.evaluate(
+        (root, texts) => {
+          const body = root.textContent ?? ''
+          return texts.map((text) => body.indexOf(text))
+        },
+        [FIRST_PROMPT, FIRST_REPLY, QUEUED_PROMPT, REPLY]
+      )
+
+      expect(order).not.toContain(-1)
+      // Why: the queued prompt sits after the reply that preceded it in the file,
+      // so chat reads in the same order the terminal showed.
+      expect(order).toEqual([...order].sort((left, right) => left - right))
+    } finally {
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Still needed after #16117

#16117 (`fix(native-chat): anchor an unmatched chat echo where it was sent`, merged 2026-08-27) diagnosed the same root cause this PR fixes: Claude consumes a mid-turn send through a `queued_command` attachment and writes no `type:"user"` record — 1,049 of 1,132 human queued sends in that PR's measurement. It concluded "no amount of better matching changes that" and fixed the **placement of the unmatched echo bubble**. This PR makes the queued record decode into a real user message in the transcript read. Three reasons #16117 does not cover it, each verified:

1. **#16117 is mobile-only.** All four of its files are under `mobile/`; it touches zero files under `src/`. The desktop chat pane is untouched — on desktop the prompt is still absent entirely, not merely misplaced.
2. **The echo is memory-only.** `native-chat-pending.ts` holds pending sends in `const pendingSendCache = new Map<...>()`. #16117 keeps that in-flight bubble in the right position, but the bubble does not exist after a reload, on another client, or for anyone reading the session later. This PR puts the prompt into the transcript read itself, so it is durable.
3. **The gap is still open on `main`.** Current `main` (`df14d1a29`) has no `queued_command` handling and no `attachment` decoding anywhere under `src/main/native-chat/`. Running the production reader on current `main` over the synthetic 13-record fixture that ships with this PR:

   ```
   [main] rendered texts: ["THINKING_1","ASSISTANT_TEXT_1","","","THINKING_2","ASSISTANT_TEXT_2"]
   [main] queued prompt present? false
   ```

   The mid-turn prompt is missing. With this PR the same fixture renders it between the turns that bracket it. (The harness for this check was a throwaway test importing only `main`'s `readNativeChatTranscript`; it is not part of the diff.)

The two changes are complementary and do not conflict: this PR touches only `src/` and `tests/`, #16117 only `mobile/`. Once a mid-turn prompt decodes into a real user row, echoes for it become matchable normally, and #16117's anchoring becomes the fallback rather than the only answer.

## ELI5

Send a prompt while the agent is mid-turn and, in the desktop chat pane today, it never appears — the terminal shows it, the agent answers it, chat has no trace it was ever said. The mechanism: when you message a coworker who's busy, they finish what they're doing, *then* read your message. Claude Code does the same — a mid-turn prompt gets queued, and its transcript record is stamped when you sent it but written to the file when the agent finally took it. Chat did two wrong things with that record: it threw it away entirely, and — once taught to read it — sorted it by its stamp, placing it *before* a reply the terminal showed it *after*. This PR decodes the queue record as a normal user message and pins it to the spot the transcript file gave it, so chat and terminal tell the same story. A second visible fix falls out of the same change: the temporary echo bubble chat shows the instant you hit send used to linger forever at the bottom after a mid-turn send — no real message ever arrived to confirm it — and now retires normally.

## What Changed

**Where to look first:** the whole change is two small pieces — everything else is wiring and tests.

| File | What it does |
|---|---|
| `src/main/native-chat/transcript-line-decoders-claude.ts` | 🔍 **Start here.** Decodes `queued_command` attachments into `role:'user'` messages |
| `src/main/native-chat/queued-prompt-file-order.ts` | 🔍 **Then here.** Anchors a queued prompt's timestamp to its file position |
| `src/main/native-chat/transcript-reader.ts` / `transcript-tail-reader.ts` / `transcript-watch-engine.ts` | Wires the anchoring pass into every seam chat reads through |
| `src/shared/native-chat-types.ts` | New optional `queued` flag on `NativeChatMessage` |
| `queued-prompt-file-order.test.ts` / `transcript-line-decoders.claude.test.ts` / `transcript-watch-queued-prompt.test.ts` | Unit + live-tail regression coverage |
| `src/renderer/src/components/native-chat/native-chat-pending.test.ts` | Characterization tests: the composer's optimistic echo retires once the queued user turn lands (behaviour only, no production change) |
| `tests/e2e/native-chat-queued-prompt-visible.spec.ts` | Hermetic e2e proving the prompt renders once, in file order |

**1 — Decode the record instead of dropping it.**

```ts
// BEFORE — anything not user/assistant fell through:
const role = record.type
if (role !== 'user' && role !== 'assistant') {
  return null // ← queued prompts died here
}
```

```ts
// AFTER — attachment records get their own decoder:
if (record.type === 'attachment') {
  return decodeQueuedCommandAttachment(record, fallbackId) // → role:'user', queued: true
}
```

Content goes through `claudeContentBlocks`, the same path ordinary turns take, so image-carrying queued prompts decode too. Restricted to `commandMode === 'prompt'` (see Why).

**2 — Anchor it to file order.** `anchorQueuedPromptsToFileOrder` walks a batch in file order; when a queued prompt's timestamp precedes its predecessor's, it restamps to `predecessor + 1`. One tick, not equal — `compareMessages` breaks timestamp ties on `id` lexicographically, so an equal stamp would sort it right back up.

**3 — Apply it at every seam chat reads through:** `readNativeChatTranscriptTailFile` (initial snapshot, replacement, pagination), `readNativeChatTranscript`, and the watch engine's append emit. The watch engine carries the predecessor timestamp **across** reads (`queuedAnchorTimestamp`) and resets it on file replacement — a live append batch can contain *only* the queued record, leaving nothing in-batch to anchor against.

## Why

Claude stamps the queue record at **enqueue** time but appends it once the queue **drains**, so timestamp and file position disagree — and the queue entry is almost always the only record the prompt ever gets (no `type:"user"` line is written for it):

```mermaid
sequenceDiagram
    participant T as Terminal
    participant C as Claude Code
    participant F as transcript.jsonl
    T->>C: prompt B (agent mid-turn)
    Note over C: B queued — record stamped NOW (enqueue time)
    C->>F: append reply to prompt A (newer timestamp)
    C->>F: append B's queued record (older timestamp)
    Note over F: file order: reply, B — time order: B, reply ⚠️
```

Time-sorting trusts the stamp; the terminal and the agent followed file order. Anchoring keeps the position the file already assigned, which is the order the user actually experienced.

**Why the `commandMode` filter:** across real transcripts, `commandMode: 'prompt'` is a typed prompt and `task-notification` is a harness-generated XML blob the agent queues for itself — roughly half (~46%) of all `queued_command` records, and no other values exist. The orchestration transcript path (`src/main/runtime/orchestration/worker-transcript-read.ts` → `boundWorkerTranscriptMessages`) has **no** `stripNoiseMessages` and a 40-message window, so without the filter a supervising agent would read harness XML as human input.

**A second fix that falls out: the stranded composer echo.** Sending from the chat composer immediately renders an optimistic "queued" echo bubble so the send feels instant. `prunePendingSends` (`src/renderer/src/components/native-chat/native-chat-pending.ts`) retires that echo via `advancedNativeChatUserContentCounts` (`native-chat-pending-occurrence.ts`), which tallies `role: 'user'` messages by normalized content key and promotes a tally only once a non-user turn follows it. Before this PR a mid-turn prompt produced no user record at all, so its content key never appeared, the advanced count stayed at zero, and the echo was kept indefinitely — and because `pendingSendsAsMessages` stamps the echo with the local send time, it sorted to the end of the list, sinking below turns that landed after it instead of holding its position. With this PR the decoder emits that prompt as a real `role:'user'` turn anchored between its bracketing turns, the following assistant turn advances the count, and the echo retires normally. The counter filters on neither `source` nor the `queued` flag, so no renderer change was needed. This is the same stranded echo #16117 anchors on mobile; here it retires because a real user row now lands. Found by @grboy6770 while independently replaying a redacted production transcript against the branch; verified by reading the code path and pinned by two characterization tests (see Testing) — not exercised in a running app.

<details>
<summary>Blast radius — verified by reading each call site, not assumed</summary>

`attachment` records previously **always** decoded to `null`, so the decode change is structurally "was null → now a message". Checked against everything downstream of the shared decoder:

- **Turn lifecycle** (`transcript-turn-lifecycle.ts`) filters to user/assistant before the shared decoder — unaffected.
- **AI-Vault scanners** use their own parsers — unaffected.
- **Double processing impossible:** the anchoring pass is idempotent — a second pass changes nothing and returns the same array reference — so the two entry points cannot compound.
- **`/clear` boundaries, id/turnId dedup, tail-reader offsets:** safe. `turnId` is intentionally unset, matching all four sibling decoders.
- **`isSidechain: true` queued commands:** none exist in the data, so subagent chatter cannot leak in.
- **Provider neutrality:** the decoder change is Claude-only; the ordering pass is a no-op for agents that never mark a message queued.

</details>

**Known limitations, stated honestly:**

1. **The `+1` tick** could collide if the following record's timestamp were within 1ms of the predecessor's. Simulated over 2,407 local transcripts: 0 collisions; 866 of 881 queued prompts restamped, median shift 17.5s.
2. **Rare double render.** If the same prompt is *also* re-recorded as a real `user` line (~0.45% in local data), both survive — the assembler deliberately refuses to merge two same-source prompts with identical text, so genuine repeats are preserved.
3. The 40-record mid-batch emit path inside the incremental reader is covered by the same anchoring call but is not separately tested.

## Linked Issue

Fixes #14308

## Visual Proof

<details open>
<summary>🔴 BEFORE — chat is missing the queued prompt the terminal shows</summary>

<img src="https://github.com/user-attachments/assets/26eae40e-88c5-4fbc-a2e1-b6672cea3145" width="900" alt="Before — the queued prompt is absent from chat" />

Order on screen: `start the long running task` → `working through the first task now` → `both done`. The queued prompt (`and check the config while you are at it`) is nowhere, even though the agent answered it.

</details>

<details>
<summary>🟢 AFTER — same transcript; the prompt is present, in the order the terminal showed</summary>

<img src="https://github.com/user-attachments/assets/73f95239-26f3-4235-9c4c-58ac19c2bc15" width="900" alt="After — the queued prompt is present, after the reply it followed" />

Order on screen: `start the long running task` → `working through the first task now` → **`and check the config while you are at it`** → `both done`. The prompt sits after the reply it was appended behind — the same order the terminal showed.

</details>

## Branch State

- Rebased onto `main` at `df14d1a29`; branch head `1710575bb`; 0 commits behind; GitHub reports `MERGEABLE`.
- The rebase had one conflicted file, `transcript-watch-engine.ts`; both conflicts were import blocks only — upstream added imports where this branch also adds one. No logic conflict.
- Size: **+143 / −6 production code across 7 files**; **+741 tests and fixtures across 8 files**.
- **CI has never run for this PR** (first-time-contributor workflow gate), so nothing below is verified by the project's own pipeline — all gates are local runs after the rebase.

## Testing

| Gate | Result |
|---|---|
| `pnpm typecheck` / `pnpm lint` | ✅ clean |
| Build (`electron-vite build`, both desktop targets) | ✅ exit 0 |
| Unit — native-chat suites | ✅ 1,628 tests across 179 files pass |
| Page-boundary regression (`transcript-tail-reader-queued-page.test.ts`) | ✅ a window that starts at the queued record still anchors it against a predecessor outside the page; **mutation-checked** — anchoring after the slice fails both cases |
| Live-tail regression (`transcript-watch-queued-prompt.test.ts`) | ✅ subscribes to a real temp transcript, appends a reply, then appends the queued record **alone**; asserts it sorts after the reply rather than back at enqueue time |
| E2e (`tests/e2e/native-chat-queued-prompt-visible.spec.ts`) | ✅ hermetic, no Claude CLI; fixture places an assistant turn between the queued prompt and its reply; asserts the prompt renders exactly once and all four texts appear in file order. **Verified failing without the fix** (`element(s) not found`), passing with it |
| Echo-retirement characterization tests (`native-chat-pending.test.ts`) | ✅ one case keeps the composer echo when no user row lands, one retires it once the queued user turn is present; removing the queued row from the second case fails it, so the pair is not vacuous. Behaviour pinned by code reading and unit tests only — not verified in a running app |
| Contributed replay (`src/main/native-chat/queued-prompt-trace-replay.test.ts`) | ✅ 4 cases driving the production reader over a synthetic 13-record trace, contributed by @grboy6770: the prompt lands between its bracketing turns, arrives once as a queued user turn, stays out when the attachment is self-queued, and behaves the same when records arrive while the pane is open (incremental path). **3 of the 4 fail without the fix** — verified on the pre-rebase base, and the check on current `main` at the top of this description shows the same gap |
| Mutation checks (×2) | ✅ disabling the `commandMode` guard fails *exactly* the task-notification test; disabling live-append anchoring fails *exactly* the new live-tail test — both guards genuinely covered, not incidentally passing |
| Full suite, vitest run directly with the same command on both | ⚠️ clean `main` (`df14d1a29`): **66,720 passed / 44 failed in 16 files**. This branch: **66,743 passed / 48 failed in 18 files**. The three files failing only on this branch — `transcript-watch.test.ts`, `run-electron-vite-dev.test.ts`, `relay/subprocess.test.ts` — each pass in isolation (28, 6, 31 tests), and clean `main` has one failure this branch does not (`git-admission-storm-measurement.test.ts`). Load-dependent flakiness on both sides; **this PR introduces no failure**, but neither run is green |
| Project CI | ⚠️ never run — awaiting first-time-contributor workflow approval |
| Real dev build | ✅ confirmed by the reporting user: chat and terminal now show the same order |
| Platforms | macOS only |

`pnpm test` itself could not start locally — `main` now pins `pnpm@12.0.0` and the local toolchain could not switch to it — so vitest was invoked directly.

Three independent code review passes ran before this PR (architecture, TypeScript/runtime, ordering); findings are folded in — including one blocker, where the first ordering fix missed the live-append path entirely.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 (Claude Code) investigated the bug, wrote the fix, the unit and live-tail tests, and the e2e spec.

## Review

- **Security:** no new input surface — the same local transcript file, and queued-prompt content flows through `claudeContentBlocks`, the exact path ordinary user turns already take.
- **Cross-platform:** pure TypeScript over the existing transcript-read abstractions; no paths, shortcuts, or platform branches. Runtime-tested on macOS only.
- **Remote SSH / wire:** no new opcode. The `queued` flag is a new *optional* field (safe per `docs/reference/remote-wire-compatibility.md`), documented as main-process-ordering only — renderers must not branch on it.
- **Mobile:** works — the tail reader anchors the whole chronological read before windowing, so prompts at a page edge anchor too (regression-tested above). Touches no `mobile/` files, so no overlap with #16117.
- **Backwards compatibility:** strictly additive — records that previously decoded to `null` now decode to a message; nothing that decoded before decodes differently.
- **Performance:** the new decoder branch runs only for `type === 'attachment'`; the anchoring pass is a single linear walk that returns the same array reference when nothing changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
