### PR TITLE
perf(runtime): avoid quadratic terminal-tail whitespace trimming

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -36274,7 +36274,7 @@ function appendNormalizedToMultilineTailBuffer(
     const line = lines[index]!
     const lastChar = line.charCodeAt(line.length - 1)
     if (lastChar === 32 || lastChar === 9) {
-      lines[index] = line.replace(/[ \t]+$/g, '')
+      lines[index] = trimTerminalLineRight(line)
     }
   }
   for (const line of windowed.lines) {
@@ -36488,7 +36488,7 @@ function finalizeRetainedTerminalRows(
   newlyCompletedLines: string[]
 } {
   let truncated = initialTruncated
-  let retainedRows = rows.map((row) => ({ ...row, text: row.text.replace(/[ \t]+$/g, '') }))
+  let retainedRows = rows.map((row) => ({ ...row, text: trimTerminalLineRight(row.text) }))
 
   if (retainedRows.length > MAX_TAIL_LINES + 1) {
     const removeCount = retainedRows.length - (MAX_TAIL_LINES + 1)

--- a/src/main/runtime/retained-tail-redraw-window.equivalence.test.ts
+++ b/src/main/runtime/retained-tail-redraw-window.equivalence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   appendNormalizedToTailBuffer,
   appendNormalizedToMultilineTailBufferUnwindowed
@@ -58,6 +58,35 @@ function randomRedrawChunk(rng: () => number): string {
 }
 
 describe('windowed redraw tail equivalence', () => {
+  it('trims redraw rows without the quadratic whitespace regex', () => {
+    const replaceSpy = vi.spyOn(String.prototype, 'replace')
+    try {
+      const directResult = appendNormalizedToMultilineTailBufferUnwindowed(
+        [],
+        `${' '.repeat(3994)}status`,
+        '\rnext',
+        false,
+        null
+      )
+      const windowedResult = appendNormalizedToTailBuffer(
+        [`${' '.repeat(3990)}status `, ...Array.from({ length: 50 }, (_, i) => `line ${i}`)],
+        '',
+        '\x1b[1A\rnext',
+        null
+      )
+
+      expect(directResult.partialLine).toBe(`next${' '.repeat(3990)}status`)
+      expect(windowedResult.lines[0]).toBe(`${' '.repeat(3990)}status`)
+      expect(
+        replaceSpy.mock.calls.some(
+          ([search]) => search instanceof RegExp && search.source === String.raw`[ \t]+$`
+        )
+      ).toBe(false)
+    } finally {
+      replaceSpy.mockRestore()
+    }
+  })
+
   it('matches the unwindowed reference across 500 randomized cases', () => {
     const rng = mulberry32(42)
     for (let round = 0; round < 500; round++) {


### PR DESCRIPTION
## ELI5

A terminal status line can contain thousands of spaces before its visible text. Orca checked those spaces repeatedly on every redraw, which could keep Electron's main thread busy and make a healthy remote runtime appear offline. This change uses the existing backward scanner instead.

## What Changed

- Replaced two terminal-tail uses of `/[ \t]+$/g` with `trimTerminalLineRight()`.
- Added a deterministic regression for the observed long internal-whitespace shape through both changed paths.
- Preserved the existing output behavior of removing only trailing spaces and tabs.

## Why

A retained terminal row can contain about 4,000 internal spaces followed by text. The end-anchored regex retries across that whitespace and scales quadratically.

In the affected live Electron session, terminal finalization invoked this path about 36 times per second. The callback used 86.8% self and inclusive CPU. Runtime status requests timed out while ping and TCP remained healthy.

Observed row arrays contained four or nine rows. One row contained about 4,001 internal spaces followed by status text.

With the equivalent substitution applied to that session, a follow-up profile was 99.1% idle. Six status requests that previously timed out after about 73 seconds completed in 0.23–0.34 seconds.

## Linked Issue

Fixes #14331

## Visual Proof

N/A — this changes terminal-tail processing performance without changing rendered output or interaction behavior.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated with Node 24 and pnpm 10.24.0:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/retained-tail-redraw-window.equivalence.test.ts`
- `pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/retained-tail-redraw-window.equivalence.test.ts`
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/retained-tail-redraw-window.equivalence.test.ts --deny-warnings`
- `pnpm run typecheck:node`
- `git diff --check`

The regression verifies output semantics through both changed paths and rejects the problematic regex. The old implementation fails it. A wall-clock assertion is not used because performance timing depends on the host environment.

Platforms exercised: Linux remote runtime over SSH/IAP and macOS client. The source test and typecheck ran on macOS with Node 24.

## AI Disclosure

Prime Agent coordinated the investigation and implementation. Claude Fable 5 was requested but did not return a review. GPT-5.6 Sol performed the adversarial performance review and three independent PR reviews. I verified the conclusions with live CPU profiles, runtime measurements, source inspection, and repository tests.

## Review

Reviewed for security, cross-platform support, remote SSH behavior, backwards compatibility, and performance. The change uses an existing platform-independent string helper and does not alter RPC or terminal output formats.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused lint, Node typecheck, regression tests, and formatting pass. Full repository lint, all-platform typecheck, full test suite, and build are left to CI.

## Author

- X / Twitter: N/A
