### PR TITLE
fix(serve): exit cleanly after headless Linux signals

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -383,7 +383,10 @@ jobs:
       - name: Package unpacked app
         env:
           ORCA_REUSE_PREPARED_NATIVE_RUNTIME: '1'
-        run: pnpm exec electron-builder --config config/electron-builder.config.cjs --dir
+        run: pnpm exec electron-builder --config config/electron-builder.config.cjs --linux AppImage --x64 --publish never
+
+      - name: Verify headless serve signal shutdown
+        run: node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage
 
       - name: Smoke packaged CLI
         run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked

--- a/config/docker/headless-serve-shutdown/Dockerfile
+++ b/config/docker/headless-serve-shutdown/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    dbus-x11 \
+    iproute2 \
+    jq \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libasound2t64 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnss3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxss1 \
+    p7zip-full \
+    procps \
+    util-linux \
+    xauth \
+    xvfb \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash orca
+
+COPY run-signal-case.sh /usr/local/bin/run-signal-case
+
+ENTRYPOINT ["/usr/local/bin/run-signal-case"]

--- a/config/docker/headless-serve-shutdown/run-signal-case.sh
+++ b/config/docker/headless-serve-shutdown/run-signal-case.sh
@@ -34,7 +34,6 @@ export HOME="$state_dir/home"
 export XDG_CONFIG_HOME="$state_dir/config"
 export XDG_CACHE_HOME="$state_dir/cache"
 export XDG_RUNTIME_DIR="$state_dir/runtime"
-export APPDIR="$app_root"
 export LIBGL_ALWAYS_SOFTWARE=1
 mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_RUNTIME_DIR"
 chmod 700 "$XDG_RUNTIME_DIR"
@@ -53,24 +52,17 @@ env -u DISPLAY "${entrypoint[@]}" serve --port 0 --pairing-address 127.0.0.1 --j
 app_pid=$!
 app_start_ticks=$(awk '{print $22}' "/proc/$app_pid/stat")
 
-deadline=$((SECONDS + startup_timeout_seconds))
-ready_line=
-while [[ -z "$ready_line" ]]; do
-  ready_line=$(jq -c 'select(.type == "orca_server_ready" and .schemaVersion == 1)' \
-    "$stdout_log" 2>/dev/null | head -n 1 || true)
-  if ! kill -0 "$app_pid" 2>/dev/null; then
-    wait "$app_pid" || true
-    cat "$stdout_log" "$stderr_log" >&2
-    echo "FAIL: AppRun exited before orca_server_ready" >&2
-    exit 1
-  fi
-  if ((SECONDS >= deadline)); then
-    cat "$stdout_log" "$stderr_log" >&2
-    echo "FAIL: timed out waiting for orca_server_ready" >&2
-    exit 1
-  fi
-  [[ -n "$ready_line" ]] || sleep 0.05
-done
+# The inner shell expands its positional parameters.
+# shellcheck disable=SC2016
+ready_line=$(timeout "$startup_timeout_seconds" bash -c '
+  tail --pid="$1" -n +1 -F "$2" 2>/dev/null \
+    | jq --unbuffered -nc '\''first(inputs | select(.type == "orca_server_ready" and .schemaVersion == 1))'\''
+' bash "$app_pid" "$stdout_log" || true)
+if [[ -z "$ready_line" ]]; then
+  cat "$stdout_log" "$stderr_log" >&2
+  echo "FAIL: AppRun exited or timed out before orca_server_ready" >&2
+  exit 1
+fi
 
 bound_endpoint=$(jq -r '.boundEndpoint' <<<"$ready_line")
 bound_port=${bound_endpoint##*:}
@@ -81,13 +73,18 @@ if [[ -z "$listener_before" ]]; then
 fi
 
 tree_pids=()
+declare -A tree_start_ticks
+tree_start_ticks["$app_pid"]=$app_start_ticks
 frontier=("$app_pid")
 while ((${#frontier[@]})); do
   parent=${frontier[0]}
   frontier=("${frontier[@]:1}")
   while read -r child; do
     [[ -n "$child" ]] || continue
+    child_start_ticks=$(awk '{print $22}' "/proc/$child/stat" 2>/dev/null || true)
+    [[ -n "$child_start_ticks" ]] || continue
     tree_pids+=("$child")
+    tree_start_ticks["$child"]=$child_start_ticks
     frontier+=("$child")
   done < <(ps -o pid= --ppid "$parent" | tr -d ' ')
 done
@@ -113,32 +110,33 @@ elif [[ "$signal_target_kind" != app ]]; then
   exit 64
 fi
 
-if [[ $(awk '{print $22}' "/proc/$app_pid/stat") != "$app_start_ticks" ]]; then
-  echo "FAIL: AppRun identity changed before signal delivery" >&2
+signal_target_start_ticks=${tree_start_ticks[$signal_target_pid]:-}
+if [[ -z "$signal_target_start_ticks" ]] \
+  || [[ $(awk '{print $22}' "/proc/$signal_target_pid/stat") != "$signal_target_start_ticks" ]]; then
+  echo "FAIL: signal target identity changed before delivery" >&2
   exit 1
 fi
 kill -s "$signal_name" "$signal_target_pid"
 
-shutdown_deadline=$((SECONDS + 30))
-while kill -0 "$app_pid" 2>/dev/null; do
-  app_state=$(ps -o stat= -p "$app_pid" 2>/dev/null || true)
-  [[ "$app_state" == Z* ]] && break
-  if ((SECONDS >= shutdown_deadline)); then
-    echo "FAIL: foreground AppRun did not exit after $signal_name" >&2
-    exit 1
-  fi
-  sleep 0.05
-done
-
+sleep 30 &
+watchdog_pid=$!
 set +e
-wait "$app_pid"
+wait -n -p completed_pid "$app_pid" "$watchdog_pid"
 wait_status=$?
 set -e
+if [[ "$completed_pid" == "$watchdog_pid" ]]; then
+  echo "FAIL: foreground AppRun did not exit after $signal_name" >&2
+  exit 1
+fi
+kill "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
 
 listener_after=$(ss -H -ltnp "sport = :$bound_port" || true)
 survivors=()
 for pid in "${tree_pids[@]}"; do
-  if ps -o stat= -p "$pid" 2>/dev/null | grep -qv '^Z'; then
+  if [[ -r "/proc/$pid/stat" ]] \
+    && [[ $(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true) == "${tree_start_ticks[$pid]}" ]] \
+    && ps -o stat= -p "$pid" 2>/dev/null | grep -qv '^Z'; then
     survivors+=("$pid")
   fi
 done

--- a/config/docker/headless-serve-shutdown/run-signal-case.sh
+++ b/config/docker/headless-serve-shutdown/run-signal-case.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+signal_name=${1:?signal name is required}
+app_root=${ORCA_TEST_APP_ROOT:-/artifacts/root}
+signal_target_kind=${ORCA_SIGNAL_TARGET:-app}
+entrypoint_kind=${ORCA_TEST_ENTRYPOINT:-app}
+startup_timeout_seconds=${ORCA_STARTUP_TIMEOUT_SECONDS:-90}
+
+if ((EUID == 0)); then
+  exec runuser --user orca --preserve-environment -- "$0" "$@"
+fi
+
+case "$signal_name" in
+  INT|TERM) ;;
+  *) echo "unsupported signal: $signal_name" >&2; exit 64 ;;
+esac
+
+state_dir=$(mktemp -d "/tmp/orca-shutdown-${signal_name}.XXXXXX")
+stdout_log="$state_dir/stdout.log"
+stderr_log="$state_dir/stderr.log"
+ulimit -c 0
+
+sleep 300 &
+canary_pid=$!
+canary_start_ticks=$(awk '{print $22}' "/proc/$canary_pid/stat")
+cleanup() {
+  kill "$canary_pid" 2>/dev/null || true
+  wait "$canary_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+export HOME="$state_dir/home"
+export XDG_CONFIG_HOME="$state_dir/config"
+export XDG_CACHE_HOME="$state_dir/cache"
+export XDG_RUNTIME_DIR="$state_dir/runtime"
+export APPDIR="$app_root"
+export LIBGL_ALWAYS_SOFTWARE=1
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+case "$entrypoint_kind" in
+  app) entrypoint=("$app_root/AppRun" --no-sandbox) ;;
+  launcher)
+    export ELECTRON_DISABLE_SANDBOX=1
+    entrypoint=("$app_root/resources/bin/orca-ide")
+    ;;
+  *) echo "unsupported entrypoint: $entrypoint_kind" >&2; exit 64 ;;
+esac
+
+env -u DISPLAY "${entrypoint[@]}" serve --port 0 --pairing-address 127.0.0.1 --json \
+  >"$stdout_log" 2>"$stderr_log" &
+app_pid=$!
+app_start_ticks=$(awk '{print $22}' "/proc/$app_pid/stat")
+
+deadline=$((SECONDS + startup_timeout_seconds))
+ready_line=
+while [[ -z "$ready_line" ]]; do
+  ready_line=$(jq -c 'select(.type == "orca_server_ready" and .schemaVersion == 1)' \
+    "$stdout_log" 2>/dev/null | head -n 1 || true)
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    wait "$app_pid" || true
+    cat "$stdout_log" "$stderr_log" >&2
+    echo "FAIL: AppRun exited before orca_server_ready" >&2
+    exit 1
+  fi
+  if ((SECONDS >= deadline)); then
+    cat "$stdout_log" "$stderr_log" >&2
+    echo "FAIL: timed out waiting for orca_server_ready" >&2
+    exit 1
+  fi
+  [[ -n "$ready_line" ]] || sleep 0.05
+done
+
+bound_endpoint=$(jq -r '.boundEndpoint' <<<"$ready_line")
+bound_port=${bound_endpoint##*:}
+listener_before=$(ss -H -ltnp "sport = :$bound_port" || true)
+if [[ -z "$listener_before" ]]; then
+  echo "FAIL: ready listener has no socket owner at $bound_endpoint" >&2
+  exit 1
+fi
+
+tree_pids=()
+frontier=("$app_pid")
+while ((${#frontier[@]})); do
+  parent=${frontier[0]}
+  frontier=("${frontier[@]:1}")
+  while read -r child; do
+    [[ -n "$child" ]] || continue
+    tree_pids+=("$child")
+    frontier+=("$child")
+  done < <(ps -o pid= --ppid "$parent" | tr -d ' ')
+done
+
+tree_pid_csv="$app_pid"
+for pid in "${tree_pids[@]}"; do
+  tree_pid_csv+=",$pid"
+done
+tree_snapshot=$(ps -o pid=,ppid=,pgid=,lstart=,stat=,args= -p "$tree_pid_csv" 2>/dev/null || true)
+xvfb_pids=$(awk '/[X]vfb :99 / {print $1}' <<<"$tree_snapshot" | paste -sd, -)
+if [[ -z "$xvfb_pids" ]]; then
+  echo "$tree_snapshot" >&2
+  echo "FAIL: no run-owned Xvfb :99 process found after readiness" >&2
+  exit 1
+fi
+
+signal_target_pid=$app_pid
+if [[ "$signal_target_kind" == serving-electron ]]; then
+  signal_target_pid=$(awk '/\/orca-ide .* --serve / {print $1; exit}' <<<"$tree_snapshot")
+  [[ -n "$signal_target_pid" ]] || { echo "FAIL: serving Electron process not found" >&2; exit 1; }
+elif [[ "$signal_target_kind" != app ]]; then
+  echo "unsupported signal target: $signal_target_kind" >&2
+  exit 64
+fi
+
+if [[ $(awk '{print $22}' "/proc/$app_pid/stat") != "$app_start_ticks" ]]; then
+  echo "FAIL: AppRun identity changed before signal delivery" >&2
+  exit 1
+fi
+kill -s "$signal_name" "$signal_target_pid"
+
+shutdown_deadline=$((SECONDS + 30))
+while kill -0 "$app_pid" 2>/dev/null; do
+  app_state=$(ps -o stat= -p "$app_pid" 2>/dev/null || true)
+  [[ "$app_state" == Z* ]] && break
+  if ((SECONDS >= shutdown_deadline)); then
+    echo "FAIL: foreground AppRun did not exit after $signal_name" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+set +e
+wait "$app_pid"
+wait_status=$?
+set -e
+
+listener_after=$(ss -H -ltnp "sport = :$bound_port" || true)
+survivors=()
+for pid in "${tree_pids[@]}"; do
+  if ps -o stat= -p "$pid" 2>/dev/null | grep -qv '^Z'; then
+    survivors+=("$pid")
+  fi
+done
+owned_residue=$(ps -eo pid=,ppid=,stat=,args= | awk -v state="$state_dir" \
+  '($0 ~ state || $0 ~ /\/artifacts\/root\/orca-ide/ || $0 ~ /[X]vfb :99 /) && $0 !~ /awk -v state=/ {print}' || true)
+
+canary_alive=false
+if kill -0 "$canary_pid" 2>/dev/null \
+  && [[ $(awk '{print $22}' "/proc/$canary_pid/stat") == "$canary_start_ticks" ]]; then
+  canary_alive=true
+fi
+fatal_evidence=false
+if grep -Eq 'Failed to shutdown|SIGTRAP|Trace/breakpoint trap|core dumped' \
+  "$stdout_log" "$stderr_log"; then
+  fatal_evidence=true
+fi
+
+jq -nc \
+  --arg signal "$signal_name" \
+  --arg entrypointKind "$entrypoint_kind" \
+  --arg signalTargetKind "$signal_target_kind" \
+  --argjson appPid "$app_pid" \
+  --argjson signalTargetPid "$signal_target_pid" \
+  --arg endpoint "$bound_endpoint" \
+  --arg listenerBefore "$listener_before" \
+  --arg listenerAfter "$listener_after" \
+  --arg xvfbPids "$xvfb_pids" \
+  --arg treeBefore "$tree_snapshot" \
+  --argjson waitStatus "$wait_status" \
+  --argjson fatalEvidence "$fatal_evidence" \
+  --argjson canaryAlive "$canary_alive" \
+  --arg survivors "${survivors[*]:-}" \
+  --arg residue "$owned_residue" \
+  --arg corePattern "$(cat /proc/sys/kernel/core_pattern)" \
+  '{signal:$signal,entrypointKind:$entrypointKind,signalTargetKind:$signalTargetKind,appPid:$appPid,signalTargetPid:$signalTargetPid,boundEndpoint:$endpoint,listenerBefore:$listenerBefore,listenerAfter:$listenerAfter,xvfbPids:$xvfbPids,treeBefore:$treeBefore,waitStatus:$waitStatus,fatalEvidence:$fatalEvidence,canaryAlive:$canaryAlive,survivingTreePids:$survivors,ownedResidue:$residue,corePattern:$corePattern}'
+
+if ((wait_status != 0)) || [[ -n "$listener_after" ]] || [[ "$fatal_evidence" != false ]] \
+  || [[ "$canary_alive" != true ]] || ((${#survivors[@]})) || [[ -n "$owned_residue" ]]; then
+  echo "--- stdout ---" >&2
+  cat "$stdout_log" >&2
+  echo "--- stderr ---" >&2
+  cat "$stderr_log" >&2
+  exit 1
+fi

--- a/config/docker/headless-serve-shutdown/run-signal-case.sh
+++ b/config/docker/headless-serve-shutdown/run-signal-case.sh
@@ -5,6 +5,7 @@ signal_name=${1:?signal name is required}
 app_root=${ORCA_TEST_APP_ROOT:-/artifacts/root}
 signal_target_kind=${ORCA_SIGNAL_TARGET:-app}
 entrypoint_kind=${ORCA_TEST_ENTRYPOINT:-app}
+int_delivery=${ORCA_INT_DELIVERY:-foreground-process-group}
 startup_timeout_seconds=${ORCA_STARTUP_TIMEOUT_SECONDS:-90}
 
 if ((EUID == 0)); then
@@ -47,7 +48,7 @@ case "$entrypoint_kind" in
   *) echo "unsupported entrypoint: $entrypoint_kind" >&2; exit 64 ;;
 esac
 
-env -u DISPLAY "${entrypoint[@]}" serve --port 0 --pairing-address 127.0.0.1 --json \
+setsid env -u DISPLAY "${entrypoint[@]}" serve --port 0 --pairing-address 127.0.0.1 --json \
   >"$stdout_log" 2>"$stderr_log" &
 app_pid=$!
 app_start_ticks=$(awk '{print $22}' "/proc/$app_pid/stat")
@@ -116,7 +117,13 @@ if [[ -z "$signal_target_start_ticks" ]] \
   echo "FAIL: signal target identity changed before delivery" >&2
   exit 1
 fi
-kill -s "$signal_name" "$signal_target_pid"
+signal_delivery=pid
+if [[ "$signal_name" == INT && "$int_delivery" == foreground-process-group ]]; then
+  signal_delivery=$int_delivery
+  kill -s "$signal_name" -- "-$signal_target_pid"
+else
+  kill -s "$signal_name" "$signal_target_pid"
+fi
 
 sleep 30 &
 watchdog_pid=$!
@@ -156,6 +163,7 @@ fi
 
 jq -nc \
   --arg signal "$signal_name" \
+  --arg signalDelivery "$signal_delivery" \
   --arg entrypointKind "$entrypoint_kind" \
   --arg signalTargetKind "$signal_target_kind" \
   --argjson appPid "$app_pid" \
@@ -171,7 +179,7 @@ jq -nc \
   --arg survivors "${survivors[*]:-}" \
   --arg residue "$owned_residue" \
   --arg corePattern "$(cat /proc/sys/kernel/core_pattern)" \
-  '{signal:$signal,entrypointKind:$entrypointKind,signalTargetKind:$signalTargetKind,appPid:$appPid,signalTargetPid:$signalTargetPid,boundEndpoint:$endpoint,listenerBefore:$listenerBefore,listenerAfter:$listenerAfter,xvfbPids:$xvfbPids,treeBefore:$treeBefore,waitStatus:$waitStatus,fatalEvidence:$fatalEvidence,canaryAlive:$canaryAlive,survivingTreePids:$survivors,ownedResidue:$residue,corePattern:$corePattern}'
+  '{signal:$signal,signalDelivery:$signalDelivery,entrypointKind:$entrypointKind,signalTargetKind:$signalTargetKind,appPid:$appPid,signalTargetPid:$signalTargetPid,boundEndpoint:$endpoint,listenerBefore:$listenerBefore,listenerAfter:$listenerAfter,xvfbPids:$xvfbPids,treeBefore:$treeBefore,waitStatus:$waitStatus,fatalEvidence:$fatalEvidence,canaryAlive:$canaryAlive,survivingTreePids:$survivors,ownedResidue:$residue,corePattern:$corePattern}'
 
 if ((wait_status != 0)) || [[ -n "$listener_after" ]] || [[ "$fatal_evidence" != false ]] \
   || [[ "$canary_alive" != true ]] || ((${#survivors[@]})) || [[ -n "$owned_residue" ]]; then

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11656,13 +11656,13 @@
       "providers": ["local-daemon"],
       "coveredPlatforms": ["linux"],
       "coveredProviders": ["local-daemon"],
-      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, leaves APPDIR unset to preserve extracted-AppRun direct serve mode, waits for structured serve readiness, then exercises terminal-style foreground-process-group SIGINT and service-manager-style AppRun-PID SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host; native amd64 PR CI repeats the same foreground AppRun identity contract.",
+      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, leaves APPDIR unset to preserve extracted-AppRun direct serve mode, waits for structured serve readiness, then exercises terminal-style foreground-process-group SIGINT and the documented systemd KillMode=mixed main-PID SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host; native amd64 PR CI repeats the same foreground AppRun identity contract.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/14109",
         "https://linear.app/stably/issue/STA-4051"
       ],
       "invariant": "After packaged foreground headless serve publishes structured readiness, one SIGINT or SIGTERM exits successfully without an Electron fatal trap or core evidence, releases the exact listener and owned Xvfb/process tree, and leaves an unrelated process identity untouched.",
-      "oracle": "For each signal, start a fresh unprivileged Ubuntu 26.04 container with disposable profile and runtime directories, a random loopback port, DISPLAY unset, software GL, and the extracted AppImage in a fresh session. Wait for orca_server_ready schema version 1, record the listener owner, process tree, owned Xvfb, and unrelated canary identities, deliver SIGINT to the foreground process group or SIGTERM to the AppRun PID, then require wait status zero, no Failed to shutdown, SIGTRAP, core, listener, recorded descendant, profile/AppImage/Xvfb residue, or changed canary identity. The 30-second bounds are failure deadlines, never success conditions.",
+      "oracle": "For each signal, start a fresh unprivileged Ubuntu 26.04 container with disposable profile and runtime directories, a random loopback port, DISPLAY unset, software GL, and the extracted AppImage in a fresh session. Wait for orca_server_ready schema version 1, record the listener owner, process tree, owned Xvfb, and unrelated canary identities, deliver SIGINT to the foreground process group or the documented KillMode=mixed graceful SIGTERM to the AppRun PID, then require wait status zero, no Failed to shutdown, SIGTRAP, core, listener, recorded descendant, profile/AppImage/Xvfb residue, or changed canary identity. The 30-second bounds are failure deadlines, never success conditions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/startup/ensure-virtual-display.test.ts config/scripts/headless-serve-shutdown-workflow.test.mjs --reporter=dot",
         "shellcheck config/docker/headless-serve-shutdown/run-signal-case.sh",
@@ -11689,7 +11689,8 @@
         {
           "file": "config/scripts/headless-serve-shutdown-workflow.test.mjs",
           "assertions": [
-            "PR CI builds an x64 AppImage before invoking the packaged shutdown oracle"
+            "PR CI builds an x64 AppImage before invoking the packaged shutdown oracle",
+            "the documented systemd unit uses KillMode=mixed so graceful TERM targets Orca before its owned Xvfb"
           ]
         },
         {
@@ -11705,7 +11706,7 @@
           "file": "config/docker/headless-serve-shutdown/run-signal-case.sh",
           "assertions": [
             "SIGINT reaches the isolated foreground process group while owned Xvfb stays in its own group",
-            "SIGTERM reaches the exact AppRun PID",
+            "SIGTERM reaches the exact AppRun PID under the documented systemd KillMode=mixed policy",
             "target and descendant identities are fenced by PID start ticks before signaling and residue checks"
           ]
         }
@@ -11727,7 +11728,7 @@
           "command": "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64",
           "result": "passed",
           "durationSeconds": 48,
-          "summary": "The extracted candidate AppRun passed process-group SIGINT and direct-PID SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
+          "summary": "The extracted candidate AppRun passed process-group SIGINT and systemd-mixed main-PID SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
         }
       ],
       "runtimeBudget": {
@@ -11740,7 +11741,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical Docker oracle failed process-group SIGINT and direct-PID SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 133 plus Electron Failed to shutdown and SIGTRAP. The prior candidate 5b94b86a9879 passed PID signals but failed process-group SIGINT with status 133, proving Xvfb also needed an independent process group. Final candidate AppImage 5c82936043e4 passed both signals with status zero and complete cleanup. Applying PR #14071's launcher exec semantics with PID delivery left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
+        "evidence": "The byte-identical Docker oracle failed process-group SIGINT and main-PID SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 133 plus Electron Failed to shutdown and SIGTRAP. The prior candidate 5b94b86a9879 passed PID signals but failed process-group SIGINT with status 133, proving Xvfb also needed an independent process group. Final candidate AppImage 5c82936043e4 passed process-group SIGINT and the documented systemd KillMode=mixed main-PID SIGTERM with status zero and complete cleanup. A control-group TERM that also targets Xvfb remains red, proving KillMode=mixed is required for the documented owned-Xvfb unit. Applying PR #14071's launcher exec semantics with PID delivery left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
       },
       "performanceBudget": {
         "required": true,
@@ -11754,6 +11755,7 @@
       "knownGaps": [
         "The local arm64 Docker host uses Rosetta for amd64 containers; native amd64 PR CI supplies the non-emulated repeat of the same extracted-AppRun PID contract.",
         "Ubuntu 20.04 is covered by the packaged native-binary glibc floor gate; this lifecycle journey runs on the reported Ubuntu 26.04 topology.",
+        "Systemd units that override or omit the documented KillMode=mixed policy can still terminate owned Xvfb before Electron disconnects.",
         "The harness exercises foreground headless Linux shutdown and does not replace desktop, updater, SSH, or detached PTY lifecycle coverage."
       ],
       "demotionRule": "Keep experimental or demote if either signal traps, returns nonzero, retains its listener/Xvfb/run-owned process identity, touches the unrelated canary, or the focused gate flakes without an identified product or harness defect."

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11656,28 +11656,31 @@
       "providers": ["local-daemon"],
       "coveredPlatforms": ["linux"],
       "coveredProviders": ["local-daemon"],
-      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, leaves APPDIR unset to preserve extracted-AppRun direct serve mode, waits for structured serve readiness, and exercises SIGINT and SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host; native amd64 PR CI repeats the same foreground AppRun identity contract.",
+      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, leaves APPDIR unset to preserve extracted-AppRun direct serve mode, waits for structured serve readiness, then exercises terminal-style foreground-process-group SIGINT and service-manager-style AppRun-PID SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host; native amd64 PR CI repeats the same foreground AppRun identity contract.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/14109",
         "https://linear.app/stably/issue/STA-4051"
       ],
       "invariant": "After packaged foreground headless serve publishes structured readiness, one SIGINT or SIGTERM exits successfully without an Electron fatal trap or core evidence, releases the exact listener and owned Xvfb/process tree, and leaves an unrelated process identity untouched.",
-      "oracle": "For each signal, start a fresh unprivileged Ubuntu 26.04 container with disposable profile and runtime directories, a random loopback port, DISPLAY unset, software GL, and the extracted AppImage. Wait for orca_server_ready schema version 1, record the listener owner, process tree, owned Xvfb, and unrelated canary identities, deliver one signal, then require wait status zero, no Failed to shutdown, SIGTRAP, core, listener, recorded descendant, profile/AppImage/Xvfb residue, or changed canary identity. The 30-second bounds are failure deadlines, never success conditions.",
+      "oracle": "For each signal, start a fresh unprivileged Ubuntu 26.04 container with disposable profile and runtime directories, a random loopback port, DISPLAY unset, software GL, and the extracted AppImage in a fresh session. Wait for orca_server_ready schema version 1, record the listener owner, process tree, owned Xvfb, and unrelated canary identities, deliver SIGINT to the foreground process group or SIGTERM to the AppRun PID, then require wait status zero, no Failed to shutdown, SIGTRAP, core, listener, recorded descendant, profile/AppImage/Xvfb residue, or changed canary identity. The 30-second bounds are failure deadlines, never success conditions.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/startup/ensure-virtual-display.test.ts config/scripts/headless-serve-shutdown-workflow.test.mjs --reporter=dot",
+        "shellcheck config/docker/headless-serve-shutdown/run-signal-case.sh",
         "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage",
         "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64"
       ],
       "testFiles": [
         "src/main/startup/ensure-virtual-display.test.ts",
         "config/scripts/headless-serve-shutdown-workflow.test.mjs",
-        "config/scripts/run-headless-serve-shutdown-docker.mjs"
+        "config/scripts/run-headless-serve-shutdown-docker.mjs",
+        "config/docker/headless-serve-shutdown/run-signal-case.sh"
       ],
       "assertionRefs": [
         {
           "file": "src/main/startup/ensure-virtual-display.test.ts",
           "assertions": [
             "owned Xvfb starts with terminate-after-last-client semantics",
+            "owned Xvfb uses an independent process group so terminal Ctrl-C cannot preempt Electron teardown",
             "owned Xvfb retains an early-process-exit guard until Electron is ready",
             "owned Xvfb is not stopped from Electron's cancelable will-quit event",
             "external displays and non-Linux startup remain untouched"
@@ -11696,6 +11699,14 @@
             "both signal failures are reported before the oracle exits",
             "the exact AppImage SHA-256, entrypoint, and signal target are published",
             "the launcher exec overlay isolates the related STA-4017 signal boundary"
+          ]
+        },
+        {
+          "file": "config/docker/headless-serve-shutdown/run-signal-case.sh",
+          "assertions": [
+            "SIGINT reaches the isolated foreground process group while owned Xvfb stays in its own group",
+            "SIGTERM reaches the exact AppRun PID",
+            "target and descendant identities are fenced by PID start ticks before signaling and residue checks"
           ]
         }
       ],
@@ -11716,7 +11727,7 @@
           "command": "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64",
           "result": "passed",
           "durationSeconds": 48,
-          "summary": "The extracted candidate AppRun passed direct PID SIGINT and SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
+          "summary": "The extracted candidate AppRun passed process-group SIGINT and direct-PID SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
         }
       ],
       "runtimeBudget": {
@@ -11729,11 +11740,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical Docker oracle failed SIGINT and SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 133 plus Electron Failed to shutdown and SIGTRAP. Final candidate AppImage 5b94b86a9879 passed both signals with status zero and complete cleanup. Applying PR #14071's launcher exec semantics left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
+        "evidence": "The byte-identical Docker oracle failed process-group SIGINT and direct-PID SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 133 plus Electron Failed to shutdown and SIGTRAP. The prior candidate 5b94b86a9879 passed PID signals but failed process-group SIGINT with status 133, proving Xvfb also needed an independent process group. Final candidate AppImage 5c82936043e4 passed both signals with status zero and complete cleanup. Applying PR #14071's launcher exec semantics with PID delivery left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The product change adds one standard Xvfb startup flag, replaces one Electron lifecycle listener with a process listener that is removed at ready, and adds no polling, timer, subprocess, IPC, provider fanout, renderer work, retained payload, native dependency, or recurring hot-path work. After ready, Xvfb exits from its existing client-disconnect path."
+        "evidence": "The product change adds one standard Xvfb startup flag, isolates the existing Xvfb child from foreground process-group signals, replaces one Electron lifecycle listener with a process listener that is removed at ready, and adds no polling, timer, subprocess, IPC, provider fanout, renderer work, retained payload, native dependency, or recurring hot-path work. After ready, Xvfb exits from its existing client-disconnect path."
       },
       "promotionCriteria": [
         "Collect 100 consecutive native amd64 CI or soak passes or 14 days without an unexplained flake.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11645,6 +11645,108 @@
       "demotionRule": "Demote if any exit duration can evade the spawn budget, concurrent children or timers appear, cleanup retains resources, or a transient failure cannot recover within the budget."
     },
     {
+      "id": "runtime.headless-serve-graceful-signal-exit",
+      "title": "Packaged headless Linux serve exits cleanly after foreground signals",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "runtime-platform",
+      "layer": "electron-headless-quit-lifecycle",
+      "surfaces": ["packaged Linux AppImage", "headless orca serve", "owned Xvfb lifecycle"],
+      "platforms": ["linux"],
+      "providers": ["local-daemon"],
+      "coveredPlatforms": ["linux"],
+      "coveredProviders": ["local-daemon"],
+      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, waits for structured serve readiness, and exercises SIGINT and SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host and therefore targets the serving Electron child; native amd64 PR CI targets the foreground AppRun process.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/14109",
+        "https://linear.app/stably/issue/STA-4051"
+      ],
+      "invariant": "After packaged foreground headless serve publishes structured readiness, one SIGINT or SIGTERM exits successfully without an Electron fatal trap or core evidence, releases the exact listener and owned Xvfb/process tree, and leaves an unrelated process identity untouched.",
+      "oracle": "For each signal, start a fresh unprivileged Ubuntu 26.04 container with disposable profile and runtime directories, a random loopback port, DISPLAY unset, software GL, and the extracted AppImage. Wait for orca_server_ready schema version 1, record the listener owner, process tree, owned Xvfb, and unrelated canary identities, deliver one signal, then require wait status zero, no Failed to shutdown, SIGTRAP, core, listener, recorded descendant, profile/AppImage/Xvfb residue, or changed canary identity. The 30-second bounds are failure deadlines, never success conditions.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/startup/ensure-virtual-display.test.ts config/scripts/headless-serve-shutdown-workflow.test.mjs --reporter=dot",
+        "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage",
+        "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64 --signal-target serving-electron"
+      ],
+      "testFiles": [
+        "src/main/startup/ensure-virtual-display.test.ts",
+        "config/scripts/headless-serve-shutdown-workflow.test.mjs",
+        "config/scripts/run-headless-serve-shutdown-docker.mjs"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/startup/ensure-virtual-display.test.ts",
+          "assertions": [
+            "owned Xvfb starts with terminate-after-last-client semantics",
+            "owned Xvfb is not stopped from Electron's cancelable will-quit event",
+            "external displays and non-Linux startup remain untouched"
+          ]
+        },
+        {
+          "file": "config/scripts/headless-serve-shutdown-workflow.test.mjs",
+          "assertions": [
+            "PR CI builds an x64 AppImage before invoking the packaged shutdown oracle"
+          ]
+        },
+        {
+          "file": "config/scripts/run-headless-serve-shutdown-docker.mjs",
+          "assertions": [
+            "SIGINT and SIGTERM run in separate disposable containers",
+            "both signal failures are reported before the oracle exits",
+            "the exact AppImage SHA-256, entrypoint, and signal target are published",
+            "the launcher exec overlay isolates the related STA-4017 signal boundary"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "linux",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/startup/ensure-virtual-display.test.ts config/scripts/headless-serve-shutdown-workflow.test.mjs --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 1,
+          "summary": "The focused startup and workflow contracts passed with owned-display termination semantics and native amd64 CI wiring."
+        },
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "linux",
+          "command": "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64 --signal-target serving-electron",
+          "result": "passed",
+          "durationSeconds": 48,
+          "summary": "The candidate AppImage passed SIGINT and SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 240,
+        "scope": "two fresh Ubuntu 26.04 containers, one per foreground signal"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "The event- and identity-driven harness is new; native amd64 CI and soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The byte-identical Docker oracle failed SIGINT and SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 1 plus Electron Failed to shutdown and SIGTRAP. Candidate AppImage afeb8f6ef996 passed both signals with status zero and complete cleanup. Applying PR #14071's launcher exec semantics left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The product change adds one standard Xvfb startup flag and removes one Electron lifecycle listener. It adds no polling, timer, subprocess, IPC, provider fanout, renderer work, retained payload, native dependency, or recurring hot-path work; Xvfb exits from its existing client-disconnect path."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive native amd64 CI or soak passes or 14 days without an unexplained flake.",
+        "Collect one native Ubuntu 26.04 AppRun signal run with foreground wait status zero for both signals.",
+        "Keep exact listener, Xvfb, descendant, fatal-evidence, and canary identity assertions green."
+      ],
+      "knownGaps": [
+        "The local arm64 Docker host uses Rosetta for amd64 containers, so local signaling targets the serving Electron child instead of claiming top-level AppRun signal fidelity.",
+        "Ubuntu 20.04 is covered by the packaged native-binary glibc floor gate; this lifecycle journey runs on the reported Ubuntu 26.04 topology.",
+        "The harness exercises foreground headless Linux shutdown and does not replace desktop, updater, SSH, or detached PTY lifecycle coverage."
+      ],
+      "demotionRule": "Keep experimental or demote if either signal traps, returns nonzero, retains its listener/Xvfb/run-owned process identity, touches the unrelated canary, or the focused gate flakes without an identified product or harness defect."
+    },
+    {
       "id": "ssh-managed-hooks.node18-runtime-compatibility",
       "title": "SSH managed-hook companions load and install hooks on Node 18",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11656,7 +11656,7 @@
       "providers": ["local-daemon"],
       "coveredPlatforms": ["linux"],
       "coveredProviders": ["local-daemon"],
-      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, waits for structured serve readiness, and exercises SIGINT and SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host and therefore targets the serving Electron child; native amd64 PR CI targets the foreground AppRun process.",
+      "coverageNotes": "An Ubuntu 26.04 amd64 container extracts the packaged AppImage into disposable HOME and XDG directories, leaves APPDIR unset to preserve extracted-AppRun direct serve mode, waits for structured serve readiness, and exercises SIGINT and SIGTERM in separate containers. Local evidence runs under Rosetta on an arm64 Docker host; native amd64 PR CI repeats the same foreground AppRun identity contract.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/14109",
         "https://linear.app/stably/issue/STA-4051"
@@ -11666,7 +11666,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/startup/ensure-virtual-display.test.ts config/scripts/headless-serve-shutdown-workflow.test.mjs --reporter=dot",
         "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage",
-        "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64 --signal-target serving-electron"
+        "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64"
       ],
       "testFiles": [
         "src/main/startup/ensure-virtual-display.test.ts",
@@ -11678,6 +11678,7 @@
           "file": "src/main/startup/ensure-virtual-display.test.ts",
           "assertions": [
             "owned Xvfb starts with terminate-after-last-client semantics",
+            "owned Xvfb retains an early-process-exit guard until Electron is ready",
             "owned Xvfb is not stopped from Electron's cancelable will-quit event",
             "external displays and non-Linux startup remain untouched"
           ]
@@ -11712,10 +11713,10 @@
           "date": "2026-08-13",
           "runner": "local",
           "platform": "linux",
-          "command": "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64 --signal-target serving-electron",
+          "command": "node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage --platform linux/amd64",
           "result": "passed",
           "durationSeconds": 48,
-          "summary": "The candidate AppImage passed SIGINT and SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
+          "summary": "The extracted candidate AppRun passed direct PID SIGINT and SIGTERM under Ubuntu 26.04 amd64 emulation with status zero, no fatal evidence, full listener/Xvfb/tree cleanup, and an unchanged canary identity."
         }
       ],
       "runtimeBudget": {
@@ -11724,15 +11725,15 @@
       },
       "flakeHistory": {
         "status": "not-started",
-        "evidence": "The event- and identity-driven harness is new; native amd64 CI and soak history are not yet available."
+        "evidence": "The event- and identity-driven harness is new; soak history is not yet available."
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical Docker oracle failed SIGINT and SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 1 plus Electron Failed to shutdown and SIGTRAP. Candidate AppImage afeb8f6ef996 passed both signals with status zero and complete cleanup. Applying PR #14071's launcher exec semantics left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
+        "evidence": "The byte-identical Docker oracle failed SIGINT and SIGTERM on v1.4.180 AppImage af3b6e6a67fc, launch-day main AppImage 017ff5abc35a, and candidate-with-fix-disabled AppImage f409f58dd9c3 with wait status 133 plus Electron Failed to shutdown and SIGTRAP. Final candidate AppImage 5b94b86a9879 passed both signals with status zero and complete cleanup. Applying PR #14071's launcher exec semantics left v1.4.180 red and the candidate green, proving the launcher and Electron/Xvfb fixes are independent and composable."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The product change adds one standard Xvfb startup flag and removes one Electron lifecycle listener. It adds no polling, timer, subprocess, IPC, provider fanout, renderer work, retained payload, native dependency, or recurring hot-path work; Xvfb exits from its existing client-disconnect path."
+        "evidence": "The product change adds one standard Xvfb startup flag, replaces one Electron lifecycle listener with a process listener that is removed at ready, and adds no polling, timer, subprocess, IPC, provider fanout, renderer work, retained payload, native dependency, or recurring hot-path work. After ready, Xvfb exits from its existing client-disconnect path."
       },
       "promotionCriteria": [
         "Collect 100 consecutive native amd64 CI or soak passes or 14 days without an unexplained flake.",
@@ -11740,7 +11741,7 @@
         "Keep exact listener, Xvfb, descendant, fatal-evidence, and canary identity assertions green."
       ],
       "knownGaps": [
-        "The local arm64 Docker host uses Rosetta for amd64 containers, so local signaling targets the serving Electron child instead of claiming top-level AppRun signal fidelity.",
+        "The local arm64 Docker host uses Rosetta for amd64 containers; native amd64 PR CI supplies the non-emulated repeat of the same extracted-AppRun PID contract.",
         "Ubuntu 20.04 is covered by the packaged native-binary glibc floor gate; this lifecycle journey runs on the reported Ubuntu 26.04 topology.",
         "The harness exercises foreground headless Linux shutdown and does not replace desktop, updater, SSH, or detached PTY lifecycle coverage."
       ],

--- a/config/scripts/headless-serve-shutdown-workflow.test.mjs
+++ b/config/scripts/headless-serve-shutdown-workflow.test.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+const workflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
+
+describe('headless serve shutdown PR gate', () => {
+  it('packages an x64 AppImage before running the Docker signal oracle', () => {
+    const steps = workflow.jobs.package.steps
+    const packageStep = steps.find((step) => step.name === 'Package unpacked app')
+    const shutdownStep = steps.find((step) => step.name === 'Verify headless serve signal shutdown')
+
+    expect(packageStep.run).toContain('--linux AppImage --x64 --publish never')
+    expect(shutdownStep.run).toBe(
+      'node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage'
+    )
+    expect(steps.indexOf(shutdownStep)).toBeGreaterThan(steps.indexOf(packageStep))
+  })
+})

--- a/config/scripts/headless-serve-shutdown-workflow.test.mjs
+++ b/config/scripts/headless-serve-shutdown-workflow.test.mjs
@@ -7,13 +7,29 @@ const workflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
 const headlessLinuxGuide = readFileSync('docs/reference/headless-linux-server.md', 'utf8')
 
 function readSystemdUnitBlocks(doc, unitName) {
-  return [...doc.matchAll(new RegExp(`^# /etc/systemd/system/${unitName}$`, 'gm'))].map((match) => {
-    const start = match.index + match[0].length
-    return doc.slice(start, doc.indexOf('```', start))
-  })
+  const escapedUnitName = unitName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return [...doc.matchAll(new RegExp(`^# /etc/systemd/system/${escapedUnitName}$`, 'gm'))].map(
+    (match) => {
+      const start = match.index + match[0].length
+      const end = doc.indexOf('```', start)
+      if (end === -1) {
+        throw new Error(`Missing closing code fence for ${unitName}`)
+      }
+      return doc.slice(start, end)
+    }
+  )
 }
 
 describe('headless serve shutdown PR gate', () => {
+  it('reads only exact, closed systemd unit blocks', () => {
+    expect(
+      readSystemdUnitBlocks('# /etc/systemd/system/orca-serveXservice\n```', 'orca-serve.service')
+    ).toEqual([])
+    expect(() =>
+      readSystemdUnitBlocks('# /etc/systemd/system/orca-serve.service\n', 'orca-serve.service')
+    ).toThrow('Missing closing code fence for orca-serve.service')
+  })
+
   it('packages an x64 AppImage before running the Docker signal oracle', () => {
     const steps = workflow.jobs.package.steps
     const packageStep = steps.find((step) => step.name === 'Package unpacked app')

--- a/config/scripts/headless-serve-shutdown-workflow.test.mjs
+++ b/config/scripts/headless-serve-shutdown-workflow.test.mjs
@@ -6,6 +6,13 @@ import { describe, expect, it } from 'vitest'
 const workflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
 const headlessLinuxGuide = readFileSync('docs/reference/headless-linux-server.md', 'utf8')
 
+function readSystemdUnitBlocks(doc, unitName) {
+  return [...doc.matchAll(new RegExp(`^# /etc/systemd/system/${unitName}$`, 'gm'))].map((match) => {
+    const start = match.index + match[0].length
+    return doc.slice(start, doc.indexOf('```', start))
+  })
+}
+
 describe('headless serve shutdown PR gate', () => {
   it('packages an x64 AppImage before running the Docker signal oracle', () => {
     const steps = workflow.jobs.package.steps
@@ -20,8 +27,14 @@ describe('headless serve shutdown PR gate', () => {
   })
 
   it('keeps owned Xvfb alive during the documented systemd graceful stop', () => {
-    expect(headlessLinuxGuide).toMatch(
-      /\[Service\][\s\S]*?^ExecStart=.*orca-linux\.AppImage serve.*\n[\s\S]*?^KillMode=mixed$/m
-    )
+    const serveUnits = readSystemdUnitBlocks(headlessLinuxGuide, 'orca-serve.service')
+    const ownedXvfbUnits = serveUnits.filter((unit) => !/^Environment=DISPLAY=/m.test(unit))
+    const managedXvfbUnits = serveUnits.filter((unit) => /^Environment=DISPLAY=/m.test(unit))
+
+    expect(ownedXvfbUnits).toHaveLength(1)
+    expect(ownedXvfbUnits[0]).toMatch(/^ExecStart=.*orca-linux\.AppImage serve.*$/m)
+    expect(ownedXvfbUnits[0]).toMatch(/^KillMode=mixed$/m)
+    expect(managedXvfbUnits).toHaveLength(1)
+    expect(managedXvfbUnits[0]).not.toMatch(/^KillMode=/m)
   })
 })

--- a/config/scripts/headless-serve-shutdown-workflow.test.mjs
+++ b/config/scripts/headless-serve-shutdown-workflow.test.mjs
@@ -4,6 +4,7 @@ import { parse } from 'yaml'
 import { describe, expect, it } from 'vitest'
 
 const workflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
+const headlessLinuxGuide = readFileSync('docs/reference/headless-linux-server.md', 'utf8')
 
 describe('headless serve shutdown PR gate', () => {
   it('packages an x64 AppImage before running the Docker signal oracle', () => {
@@ -16,5 +17,11 @@ describe('headless serve shutdown PR gate', () => {
       'node config/scripts/run-headless-serve-shutdown-docker.mjs --appimage dist/orca-linux.AppImage'
     )
     expect(steps.indexOf(shutdownStep)).toBeGreaterThan(steps.indexOf(packageStep))
+  })
+
+  it('keeps owned Xvfb alive during the documented systemd graceful stop', () => {
+    expect(headlessLinuxGuide).toMatch(
+      /\[Service\][\s\S]*?^ExecStart=.*orca-linux\.AppImage serve.*\n[\s\S]*?^KillMode=mixed$/m
+    )
   })
 })

--- a/config/scripts/headless-serve-shutdown-workflow.test.mjs
+++ b/config/scripts/headless-serve-shutdown-workflow.test.mjs
@@ -12,7 +12,9 @@ function readSystemdUnitBlocks(doc, unitName) {
     (match) => {
       const start = match.index + match[0].length
       const end = doc.indexOf('```', start)
-      if (end === -1) {
+      const nextUnitHeaderOffset = doc.slice(start).search(/^# \/etc\/systemd\/system\/.+$/m)
+      const nextUnitHeader = nextUnitHeaderOffset === -1 ? -1 : start + nextUnitHeaderOffset
+      if (end === -1 || (nextUnitHeader !== -1 && end > nextUnitHeader)) {
         throw new Error(`Missing closing code fence for ${unitName}`)
       }
       return doc.slice(start, end)
@@ -27,6 +29,14 @@ describe('headless serve shutdown PR gate', () => {
     ).toEqual([])
     expect(() =>
       readSystemdUnitBlocks('# /etc/systemd/system/orca-serve.service\n', 'orca-serve.service')
+    ).toThrow('Missing closing code fence for orca-serve.service')
+    expect(() =>
+      readSystemdUnitBlocks(
+        '# /etc/systemd/system/orca-serve.service\n' +
+          'KillMode=mixed\n' +
+          '# /etc/systemd/system/other.service\n```',
+        'orca-serve.service'
+      )
     ).toThrow('Missing closing code fence for orca-serve.service')
   })
 

--- a/config/scripts/run-headless-serve-shutdown-docker.mjs
+++ b/config/scripts/run-headless-serve-shutdown-docker.mjs
@@ -9,6 +9,7 @@ const appImageArg = valueAfter('--appimage')
 const platform = valueAfter('--platform') ?? 'linux/amd64'
 const signalTarget = valueAfter('--signal-target') ?? 'app'
 const entrypoint = valueAfter('--entrypoint') ?? 'app'
+const intDelivery = valueAfter('--int-delivery') ?? 'foreground-process-group'
 const launcherExecOverlay = args.includes('--launcher-exec-overlay')
 if (!appImageArg) {
   fail('Usage: run-headless-serve-shutdown-docker.mjs --appimage /path/to/orca.AppImage')
@@ -18,6 +19,12 @@ if (!['app', 'serving-electron'].includes(signalTarget)) {
 }
 if (!['app', 'launcher'].includes(entrypoint)) {
   fail(`Unsupported --entrypoint: ${entrypoint}`)
+}
+if (!['pid', 'foreground-process-group'].includes(intDelivery)) {
+  fail(`Unsupported --int-delivery: ${intDelivery}`)
+}
+if (intDelivery === 'foreground-process-group' && signalTarget !== 'app') {
+  fail('--int-delivery foreground-process-group requires --signal-target app')
 }
 if (launcherExecOverlay && entrypoint !== 'launcher') {
   fail('--launcher-exec-overlay requires --entrypoint launcher')
@@ -75,6 +82,7 @@ try {
       platform,
       signalTarget,
       entrypoint,
+      intDelivery,
       launcherExecOverlay
     })
   )
@@ -95,6 +103,8 @@ try {
         `ORCA_SIGNAL_TARGET=${signalTarget}`,
         '-e',
         `ORCA_TEST_ENTRYPOINT=${entrypoint}`,
+        '-e',
+        `ORCA_INT_DELIVERY=${intDelivery}`,
         '-v',
         `${artifactVolume}:/artifacts:ro`,
         image,

--- a/config/scripts/run-headless-serve-shutdown-docker.mjs
+++ b/config/scripts/run-headless-serve-shutdown-docker.mjs
@@ -31,6 +31,8 @@ if (launcherExecOverlay && entrypoint !== 'launcher') {
 }
 
 const appImage = resolve(appImageArg)
+const shutdownDockerDirectory = resolve('config', 'docker', 'headless-serve-shutdown')
+const shutdownDockerfile = resolve(shutdownDockerDirectory, 'Dockerfile')
 if (!existsSync(appImage)) {
   fail(`AppImage not found: ${appImage}`)
 }
@@ -46,10 +48,10 @@ try {
     '--platform',
     platform,
     '-f',
-    'config/docker/headless-serve-shutdown/Dockerfile',
+    shutdownDockerfile,
     '-t',
     image,
-    'config/docker/headless-serve-shutdown'
+    shutdownDockerDirectory
   ])
   docker(['volume', 'create', artifactVolume])
   docker([

--- a/config/scripts/run-headless-serve-shutdown-docker.mjs
+++ b/config/scripts/run-headless-serve-shutdown-docker.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const args = process.argv.slice(2)
+const appImageArg = valueAfter('--appimage')
+const platform = valueAfter('--platform') ?? 'linux/amd64'
+const signalTarget = valueAfter('--signal-target') ?? 'app'
+const entrypoint = valueAfter('--entrypoint') ?? 'app'
+const launcherExecOverlay = args.includes('--launcher-exec-overlay')
+if (!appImageArg) {
+  fail('Usage: run-headless-serve-shutdown-docker.mjs --appimage /path/to/orca.AppImage')
+}
+if (!['app', 'serving-electron'].includes(signalTarget)) {
+  fail(`Unsupported --signal-target: ${signalTarget}`)
+}
+if (!['app', 'launcher'].includes(entrypoint)) {
+  fail(`Unsupported --entrypoint: ${entrypoint}`)
+}
+if (launcherExecOverlay && entrypoint !== 'launcher') {
+  fail('--launcher-exec-overlay requires --entrypoint launcher')
+}
+
+const appImage = resolve(appImageArg)
+if (!existsSync(appImage)) {
+  fail(`AppImage not found: ${appImage}`)
+}
+
+const suffix = `${process.pid}-${Date.now()}`
+const image = `orca-headless-serve-shutdown:${suffix}`
+const artifactVolume = `orca-headless-serve-shutdown-${suffix}`
+const sha256 = createHash('sha256').update(readFileSync(appImage)).digest('hex')
+
+try {
+  docker([
+    'build',
+    '--platform',
+    platform,
+    '-f',
+    'config/docker/headless-serve-shutdown/Dockerfile',
+    '-t',
+    image,
+    'config/docker/headless-serve-shutdown'
+  ])
+  docker(['volume', 'create', artifactVolume])
+  docker([
+    'run',
+    '--rm',
+    '--platform',
+    platform,
+    '--entrypoint',
+    'bash',
+    '-v',
+    `${appImage}:/input/orca.AppImage:ro`,
+    '-v',
+    `${artifactVolume}:/artifacts`,
+    image,
+    '-lc',
+    [
+      '7z x /input/orca.AppImage -o/artifacts/root -y >/dev/null',
+      launcherExecOverlay
+        ? "sed -i 's/^ELECTRON_RUN_AS_NODE=1 /export ELECTRON_RUN_AS_NODE=1\\nexec /' /artifacts/root/resources/bin/orca-ide"
+        : ':',
+      'chmod -R a+rX /artifacts/root'
+    ].join(' && ')
+  ])
+
+  console.log(
+    JSON.stringify({
+      type: 'appimage_under_test',
+      appImage,
+      sha256,
+      platform,
+      signalTarget,
+      entrypoint,
+      launcherExecOverlay
+    })
+  )
+  const failedSignals = []
+  for (const signal of ['INT', 'TERM']) {
+    const result = docker(
+      [
+        'run',
+        '--rm',
+        '--init',
+        '--platform',
+        platform,
+        '--shm-size',
+        '256m',
+        '--name',
+        `orca-headless-serve-shutdown-${signal.toLowerCase()}-${suffix}`,
+        '-e',
+        `ORCA_SIGNAL_TARGET=${signalTarget}`,
+        '-e',
+        `ORCA_TEST_ENTRYPOINT=${entrypoint}`,
+        '-v',
+        `${artifactVolume}:/artifacts:ro`,
+        image,
+        signal
+      ],
+      { allowFailure: true }
+    )
+    process.stdout.write(result.stdout)
+    process.stderr.write(result.stderr)
+    if (result.status !== 0) {
+      failedSignals.push(`${signal}:${result.status}`)
+    }
+  }
+  if (failedSignals.length > 0) {
+    fail(`Shutdown oracle failed: ${failedSignals.join(', ')}`)
+  }
+  console.log('Headless serve packaged shutdown Docker validation passed.')
+} finally {
+  docker(['volume', 'rm', artifactVolume], { allowFailure: true })
+  docker(['image', 'rm', image], { allowFailure: true })
+}
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag)
+  return index === -1 ? null : (args[index + 1] ?? null)
+}
+
+function docker(dockerArgs, options = {}) {
+  const result = spawnSync('docker', dockerArgs, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024
+  })
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0 && !options.allowFailure) {
+    process.stdout.write(result.stdout)
+    process.stderr.write(result.stderr)
+    fail(`docker ${dockerArgs[0]} failed with status ${result.status}`)
+  }
+  return result
+}
+
+function fail(message) {
+  console.error(message)
+  process.exitCode = 1
+  throw new Error(message)
+}

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -166,6 +166,7 @@ Environment=LIBGL_ALWAYS_SOFTWARE=1
 ExecStart=/opt/orca/orca-linux.AppImage serve --port 6768 --pairing-address 100.64.1.20
 StandardOutput=journal
 StandardError=journal
+KillMode=mixed
 Restart=on-failure
 RestartPreventExitStatus=3
 RestartSec=5
@@ -176,6 +177,10 @@ WantedBy=multi-user.target
 
 Replace `100.64.1.20` with the LAN, Tailscale, tunnel, or public hostname that
 clients should use.
+
+`KillMode=mixed` sends the graceful stop signal only to Orca's main process,
+then retains systemd's cgroup-wide `SIGKILL` fallback if shutdown times out.
+This lets Orca keep its owned Xvfb alive until Electron disconnects cleanly.
 
 Exit status `3` means another process already owns this userData profile, so
 `RestartPreventExitStatus=3` stops the unit instead of retrying a launch that

--- a/src/main/startup/ensure-virtual-display.test.ts
+++ b/src/main/startup/ensure-virtual-display.test.ts
@@ -110,7 +110,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       'Xvfb',
       expect.arrayContaining([':99', '-terminate']),
-      expect.anything()
+      expect.objectContaining({ detached: true })
     )
     expect(process.env.DISPLAY).toBe(':99')
     expect(appMock.disableHardwareAcceleration).toHaveBeenCalled()
@@ -121,7 +121,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(readyHandler).toBeTypeOf('function')
     readyHandler()
     expect(processRemoveListenerSpy).toHaveBeenCalledWith('exit', stopVirtualDisplay)
-    expect(appMock.once).not.toHaveBeenCalledWith('will-quit', stopVirtualDisplay)
+    expect(appMock.once.mock.calls.some(([event]) => event === 'will-quit')).toBe(false)
   })
 
   it('reuses an existing virtual display only when its X server is alive', async () => {
@@ -158,7 +158,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       'Xvfb',
       expect.arrayContaining([':99', '-terminate']),
-      expect.anything()
+      expect.objectContaining({ detached: true })
     )
     expect(process.env.DISPLAY).toBe(':99')
     killSpy.mockRestore()

--- a/src/main/startup/ensure-virtual-display.test.ts
+++ b/src/main/startup/ensure-virtual-display.test.ts
@@ -44,6 +44,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
 
   afterEach(async () => {
     const { stopVirtualDisplay } = await import('./ensure-virtual-display')
+    process.removeListener('exit', stopVirtualDisplay)
     stopVirtualDisplay()
     vi.restoreAllMocks()
     setPlatform(ORIGINAL_PLATFORM)
@@ -100,6 +101,8 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     // First existsSync (stale-socket check) false; later (socket-ready poll) true.
     existsSyncMock.mockReturnValueOnce(false).mockReturnValue(true)
     spawnMock.mockReturnValue({ once: vi.fn(), kill: vi.fn(), killed: false })
+    const processOnceSpy = vi.spyOn(process, 'once')
+    const processRemoveListenerSpy = vi.spyOn(process, 'removeListener')
     const { ensureVirtualDisplayForHeadlessServe, stopVirtualDisplay } =
       await import('./ensure-virtual-display')
 
@@ -113,6 +116,11 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(appMock.disableHardwareAcceleration).toHaveBeenCalled()
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-dev-shm-usage')
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu')
+    expect(processOnceSpy).toHaveBeenCalledWith('exit', stopVirtualDisplay)
+    const readyHandler = appMock.once.mock.calls.find(([event]) => event === 'ready')?.[1]
+    expect(readyHandler).toBeTypeOf('function')
+    readyHandler()
+    expect(processRemoveListenerSpy).toHaveBeenCalledWith('exit', stopVirtualDisplay)
     expect(appMock.once).not.toHaveBeenCalledWith('will-quit', stopVirtualDisplay)
   })
 

--- a/src/main/startup/ensure-virtual-display.test.ts
+++ b/src/main/startup/ensure-virtual-display.test.ts
@@ -44,7 +44,6 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
 
   afterEach(async () => {
     const { stopVirtualDisplay } = await import('./ensure-virtual-display')
-    process.removeListener('exit', stopVirtualDisplay)
     stopVirtualDisplay()
     vi.restoreAllMocks()
     setPlatform(ORIGINAL_PLATFORM)
@@ -101,21 +100,19 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     // First existsSync (stale-socket check) false; later (socket-ready poll) true.
     existsSyncMock.mockReturnValueOnce(false).mockReturnValue(true)
     spawnMock.mockReturnValue({ once: vi.fn(), kill: vi.fn(), killed: false })
-    const processOnceSpy = vi.spyOn(process, 'once')
     const { ensureVirtualDisplayForHeadlessServe, stopVirtualDisplay } =
       await import('./ensure-virtual-display')
 
     expect(ensureVirtualDisplayForHeadlessServe({ isServeMode: true })).toBe(true)
     expect(spawnMock).toHaveBeenCalledWith(
       'Xvfb',
-      expect.arrayContaining([':99']),
+      expect.arrayContaining([':99', '-terminate']),
       expect.anything()
     )
     expect(process.env.DISPLAY).toBe(':99')
     expect(appMock.disableHardwareAcceleration).toHaveBeenCalled()
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-dev-shm-usage')
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu')
-    expect(processOnceSpy).toHaveBeenCalledWith('exit', stopVirtualDisplay)
     expect(appMock.once).not.toHaveBeenCalledWith('will-quit', stopVirtualDisplay)
   })
 
@@ -152,7 +149,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(rmSyncMock).toHaveBeenCalled()
     expect(spawnMock).toHaveBeenCalledWith(
       'Xvfb',
-      expect.arrayContaining([':99']),
+      expect.arrayContaining([':99', '-terminate']),
       expect.anything()
     )
     expect(process.env.DISPLAY).toBe(':99')

--- a/src/main/startup/ensure-virtual-display.test.ts
+++ b/src/main/startup/ensure-virtual-display.test.ts
@@ -42,7 +42,11 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     delete process.env.DISPLAY
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    const { stopVirtualDisplay } = await import('./ensure-virtual-display')
+    process.removeListener('exit', stopVirtualDisplay)
+    stopVirtualDisplay()
+    vi.restoreAllMocks()
     setPlatform(ORIGINAL_PLATFORM)
     if (ORIGINAL_DISPLAY === undefined) {
       delete process.env.DISPLAY
@@ -97,7 +101,9 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     // First existsSync (stale-socket check) false; later (socket-ready poll) true.
     existsSyncMock.mockReturnValueOnce(false).mockReturnValue(true)
     spawnMock.mockReturnValue({ once: vi.fn(), kill: vi.fn(), killed: false })
-    const { ensureVirtualDisplayForHeadlessServe } = await import('./ensure-virtual-display')
+    const processOnceSpy = vi.spyOn(process, 'once')
+    const { ensureVirtualDisplayForHeadlessServe, stopVirtualDisplay } =
+      await import('./ensure-virtual-display')
 
     expect(ensureVirtualDisplayForHeadlessServe({ isServeMode: true })).toBe(true)
     expect(spawnMock).toHaveBeenCalledWith(
@@ -109,6 +115,8 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(appMock.disableHardwareAcceleration).toHaveBeenCalled()
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-dev-shm-usage')
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu')
+    expect(processOnceSpy).toHaveBeenCalledWith('exit', stopVirtualDisplay)
+    expect(appMock.once).not.toHaveBeenCalledWith('will-quit', stopVirtualDisplay)
   })
 
   it('reuses an existing virtual display only when its X server is alive', async () => {

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -140,7 +140,8 @@ export function ensureVirtualDisplayForHeadlessServe(options: { isServeMode: boo
       [VIRTUAL_DISPLAY, '-screen', '0', '1280x1024x24', '-nolisten', 'tcp', '-terminate'],
       {
         stdio: 'ignore',
-        detached: false
+        // Why: foreground Ctrl-C must not kill Xvfb before Electron disconnects.
+        detached: true
       }
     )
     xvfbProcess.once('error', (error) => {

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -163,6 +163,10 @@ export function ensureVirtualDisplayForHeadlessServe(options: { isServeMode: boo
 
   process.env.DISPLAY = VIRTUAL_DISPLAY
 
+  // Why: -terminate only takes effect after Xvfb accepts its first client.
+  process.once('exit', stopVirtualDisplay)
+  app.once('ready', () => process.removeListener('exit', stopVirtualDisplay))
+
   return true
 }
 

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -137,7 +137,7 @@ export function ensureVirtualDisplayForHeadlessServe(options: { isServeMode: boo
   try {
     xvfbProcess = spawn(
       'Xvfb',
-      [VIRTUAL_DISPLAY, '-screen', '0', '1280x1024x24', '-nolisten', 'tcp'],
+      [VIRTUAL_DISPLAY, '-screen', '0', '1280x1024x24', '-nolisten', 'tcp', '-terminate'],
       {
         stdio: 'ignore',
         detached: false
@@ -162,9 +162,6 @@ export function ensureVirtualDisplayForHeadlessServe(options: { isServeMode: boo
   }
 
   process.env.DISPLAY = VIRTUAL_DISPLAY
-
-  // Why: Electron can cancel will-quit for async teardown and still needs X11 until its event loop stops.
-  process.once('exit', stopVirtualDisplay)
 
   return true
 }

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -163,8 +163,8 @@ export function ensureVirtualDisplayForHeadlessServe(options: { isServeMode: boo
 
   process.env.DISPLAY = VIRTUAL_DISPLAY
 
-  // Why: don't leave a stray Xvfb process behind when serve exits.
-  app.once('will-quit', stopVirtualDisplay)
+  // Why: Electron can cancel will-quit for async teardown and still needs X11 until its event loop stops.
+  process.once('exit', stopVirtualDisplay)
 
   return true
 }


### PR DESCRIPTION
## ELI5

Headless Orca creates an invisible X screen. It used to switch that screen off while Electron was still connected—either from Orca's first, cancelable quit pass, because terminal Ctrl-C hit Xvfb in the same foreground process group, or because systemd's default stop policy signaled both processes together. Electron treated that ordinary stop as a fatal display loss.

Keep Xvfb outside the terminal signal group, let it terminate itself only after Electron's last X client disconnects, and document `KillMode=mixed` so systemd gracefully signals Orca first while retaining its cgroup-wide forced-stop fallback.

## Problem and root cause

Direct extracted-AppImage `orca serve` reaches structured `orca_server_ready`, but SIGINT or SIGTERM makes Electron abort with `Failed to shutdown`, SIGTRAP, and a service-visible failure.

Three paths could remove the display before Electron finished teardown:

1. `ensureVirtualDisplayForHeadlessServe()` registered owned-Xvfb cleanup before the global async `will-quit` barrier. The first quit pass killed Xvfb and was then canceled for runtime teardown.
2. Xvfb shared the foreground process group, so terminal Ctrl-C delivered SIGINT to Electron and Xvfb simultaneously.
3. systemd's default `KillMode=control-group` delivers graceful SIGTERM to both Orca and its owned Xvfb.

Electron 43 still had a live X11/Ozone connection in each case. X server loss invoked Electron's fatal I/O-error handler before Orca could complete shutdown.

## Change

- Start owned Xvfb with its standard `-terminate` option.
- Start Xvfb in an independent process group so terminal Ctrl-C reaches Orca, not its display server.
- Remove premature Xvfb cleanup from Electron's cancelable `will-quit` event.
- Retain a process-exit guard only until Electron reaches `ready`, covering startup failure before Xvfb accepts its first client.
- Add `KillMode=mixed` to the documented systemd unit, with a contract test that pins the policy.
- Add a deterministic Ubuntu 26.04 packaged-AppImage Docker oracle to PR CI and the reliability manifest.

After Electron is ready, Xvfb owns the authoritative shutdown truth: it exits after the final X client disconnects. `KillMode=mixed` directs systemd's graceful TERM to Orca's main process, then still applies cgroup-wide SIGKILL if shutdown exceeds the timeout. Desktop, updater, runtime teardown, macOS, Windows, SSH, folder workspaces, wire formats, and native dependencies are otherwise unchanged.

## Docker evidence

Topology: Ubuntu 26.04 x86_64/glibc 2.43, extracted AppImage, unprivileged user, disposable HOME/XDG dirs, random port, `APPDIR` unset exactly as extracted AppRun presents it to Electron, no DISPLAY, software GL, auto-Xvfb, structured readiness barrier, fresh container per signal.

The byte-identical oracle delivers terminal-style SIGINT to an isolated foreground process group and documented-systemd-style SIGTERM to the exact AppRun PID. It records wait status plus fatal evidence, listener/process/Xvfb identities with PID start ticks, and an unrelated canary:

| Artifact | Process-group SIGINT | Main-PID SIGTERM |
| --- | --- | --- |
| v1.4.180 `af3b6e6a67fc` | red: status 133, FATAL/SIGTRAP | red: status 133, FATAL/SIGTRAP |
| launch-day main `0824ed39ea`, AppImage `017ff5abc35a` | red: status 133, FATAL/SIGTRAP | red: status 133, FATAL/SIGTRAP |
| candidate with fix disabled `f409f58dd9c3` | red: status 133, FATAL/SIGTRAP | red: status 133, FATAL/SIGTRAP |
| prior candidate without process-group isolation `5b94b86a9879` | red: status 133, FATAL/SIGTRAP | green: status 0 |
| final product candidate `5c82936043e4` | green: status 0, clean teardown | green: status 0, clean teardown |

All cases released the target listener/tree and preserved the canary. The final candidate also released exact owned Xvfb with no fatal/core evidence or profile/AppImage residue. It passed the Ubuntu 20.04/glibc 2.31 floor gate for all 18 bundled native binaries.

The candidate's explicit cgroup-wide TERM red control still exits 133 with `Failed to shutdown`, proving `KillMode=mixed` is part of the service contract rather than an optional hardening detail. Units that omit or override it remain a documented gap.

This Apple Silicon host runs amd64 containers through Docker Desktop Rosetta. Native amd64 PR CI supplies the required non-emulated repeat. A previous CI run was invalidated because the harness exported `APPDIR`, causing Orca to take a CLI-supervisor path that extracted AppRun itself does not export.

## #14071 interaction

An extracted-launcher overlay applied #14071's exact `exec` semantics. With PID delivery, the exec'd launcher exposed the downstream v1.4.180 FATAL/SIGTRAP for both signals, while the final candidate exited 0 and cleaned up for both. The launcher boundary fix and this Electron/Xvfb fix are independent and compose cleanly.

## Alternatives rejected

- Permanent `process.once('exit')` cleanup: packaged candidate still trapped because Node exit remained inside Electron's live X11 failure window.
- Electron `quit`/second `will-quit`: still couples Xvfb lifetime to Electron event ordering.
- Signal-ignoring Xvfb wrapper: Xvfb installs its own handlers, so inherited ignored TERM did not survive.
- `app.exit(0)`: bypasses authoritative desktop/updater/runtime teardown and broadens risk.
- Global quit-lifecycle rewrite: unnecessary for an ownership bug local to Orca-owned Xvfb.

## Validation

- [x] Focused startup/workflow tests at final HEAD: 10 passed
- [x] Full repository lint and Node typecheck
- [x] Changed-code quality: 0 findings
- [x] Reliability manifest: 79 gates valid
- [x] Shellcheck, repository formatter for changed code, and max-lines ratchet
- [x] Baseline/latest/candidate/revert Docker matrix
- [x] Foreground process-group red/green matrix
- [x] systemd control-group TERM red control and `KillMode=mixed` contract
- [x] #14071 PID-delivery red/green composition matrix
- [x] Ubuntu 20.04/glibc 2.31 package floor: 18 native binaries
- [x] Prior native amd64 PR CI lifecycle gate at product HEAD `41788d678d`
- [x] Final native amd64 PR CI at `4a37067230`
- [x] Final performance and adversarial product review; CodeRabbit gate findings addressed at `4a37067230`

Fixes #14109

Linear: STA-4051

## AI disclosure

OpenAI Codex was used for reproduction, implementation, validation, and review. Claims are backed by packaged binaries, deterministic tests, source history, or CI.
