### PR TITLE
Deflake native chat watcher rebind test

### DIFF
--- a/src/main/native-chat/transcript-watch-liveness.test.ts
+++ b/src/main/native-chat/transcript-watch-liveness.test.ts
@@ -33,6 +33,7 @@ vi.mock('node:fs', async () => {
 import { subscribeNativeChatTranscript } from './transcript-watch'
 
 const roots: string[] = []
+const HOST_FILESYSTEM_RECONCILIATION_TIMEOUT_MS = 8_000
 
 afterEach(async () => {
   vi.useRealTimers()
@@ -205,7 +206,10 @@ describe('native chat transcript watcher liveness', () => {
     await rename(root, oldRoot)
     await mkdir(root)
     await writeFile(filePath, claudeLine('new-file', 'user', 'after'))
-    await waitFor(() => replacements.mock.calls.length === 1 && watchers.length === 2)
+    await waitFor(
+      () => replacements.mock.calls.length === 1 && watchers.length === 2,
+      HOST_FILESYSTEM_RECONCILIATION_TIMEOUT_MS
+    )
     await appendFile(filePath, claudeLine('new-followup', 'assistant', 'event-driven'))
     watchCallbacks[1]!('change', 'transcript.jsonl')
     await waitFor(() => appends.mock.calls.flat(2).some((message) => message.id === 'new-followup'))


### PR DESCRIPTION
## Summary

- allow the real-filesystem parent-replacement assertion enough time under loaded sharded CI
- keep the existing tight timeout for every other watcher-liveness assertion
- leave production watcher timing and behavior unchanged

## Context

The Node 24 shard in PR #14326 timed out while waiting for the native watcher to rebind after a silent parent-directory replacement. That shard was concurrently running roughly 4,000 tests; the assertion checks eventual filesystem reconciliation rather than a two-second latency contract. The scoped eight-second deadline matches the repository's existing real-filesystem watcher-test convention.

Failing job: https://github.com/stablyai/orca/actions/runs/31734058370/job/94561297743

## Validation

- 64 concurrent focused runs under Node 24
- focused watcher-liveness test: 7 passed
- Node typecheck
- formatting and changed-code quality
- reliability gates and max-lines ratchet