### PR TITLE
fix(orchestration): wait for Claude composer render

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -8278,8 +8278,8 @@
       "coveredProviders": ["local"],
       "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, a live dev-runtime CLI repro, and a Haiku composer trace. The Claude render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, and Windows live journeys remain gaps.",
       "motivatingLinks": ["https://github.com/stablyai/orca/issues/7226"],
-      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude must acknowledge the post-paste composer render or reach the bounded fallback first.",
-      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, and a Claude-shaped delayed render where Enter at the legacy 500 ms boundary is premature but the post-paste show-cursor marker submits exactly once. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
+      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude must emit a post-paste composer marker and then settle, or reach the bounded fallback first.",
+      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, and a Claude-shaped multi-frame render where the legacy 500 ms delay and first show-cursor marker are both premature. The candidate waits for post-marker output quiescence before one submit, resets that window on later frames, and still submits once at the hard deadline if output never settles. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts",
         "node tests/tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
@@ -8305,8 +8305,9 @@
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
             "runtime writes bracketed paste before a delayed submit",
-            "Claude ignores unrelated and split pre-marker output, then submits once after the post-paste show-cursor render",
+            "Claude ignores unrelated and split pre-marker output, then waits for post-marker render quiescence before one submit",
             "a silent Claude composer reaches one bounded fallback submit",
+            "a marked Claude composer with continuous render output reaches one bounded fallback submit",
             "large prompt frames are chunked and reconstructed before submit",
             "partial prompt write failure closes the paste frame and does not submit"
           ]
@@ -8336,6 +8337,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts",
+          "result": "passed",
+          "durationSeconds": 13.3,
+          "summary": "4 files and 1,283 tests passed. The hardened multi-frame oracle failed on the first-marker candidate because it submitted at 751 ms during an intermediate Claude frame; the quiescence candidate waited through the final 1,000 ms frame and submitted once at 2,500 ms. Continuous render output remained bounded to one fallback submit at 8 seconds. An isolated Claude Code 2.1.231 Haiku probe saw the first marker at 400 ms, continued output through 1,500 ms, sent one Enter at 3,000 ms after 1.5 seconds quiet, and created the expected marker; no Fable or Opus probe was used."
+        },
         {
           "date": "2026-08-13",
           "runner": "local",
@@ -8374,11 +8384,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The Claude-shaped runtime oracle fails on unmodified main and passes with the render gate; the earlier live harness also reproduced the unsafe raw multiline contract before its framing fix. Intentional-break evidence remains local rather than a separate CI job."
+        "evidence": "The original Claude-shaped oracle fails on unmodified main and passes with the render gate. The hardened multi-frame oracle then fails on the first-marker candidate, which submits at 751 ms during an intermediate frame, and passes when the gate requires post-marker quiescence. The earlier live harness also reproduced the unsafe raw multiline contract before its framing fix. Intentional-break evidence remains local rather than a separate CI job."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude adds one PTY-local output listener until its normal post-paste show-cursor frame or an 8s fallback; other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
+        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude adds one PTY-local output listener until 1.5s of post-marker output quiescence or an 8s fallback; each later frame resets one timer. Other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
       },
       "promotionCriteria": [
         "Run the live harness in soak with a self-starting dev runtime or provider-contract fixture.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -8276,10 +8276,10 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract and a live dev-runtime CLI repro. SSH, daemon, remote-runtime, Linux, and Windows remain provider/platform gaps; the product path stays provider-owned and does not add local filesystem or process assumptions.",
+      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract, a live dev-runtime CLI repro, and a Haiku composer trace. The Claude render gate stays on the PTY-owning runtime, so paired and SSH callers use the same provider write/output path without a wire change. SSH, daemon, remote-runtime, Linux, and Windows live journeys remain gaps.",
       "motivatingLinks": ["https://github.com/stablyai/orca/issues/7226"],
-      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and send Enter only after the paste frame completes.",
-      "oracle": "Runtime tests assert the exact PTY write sequence and failure cleanup; orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness dispatches a 32KB task to a fake Codex-like TUI and requires marker present, bracketed paste present, zero unframed line breaks, and submit observed.",
+      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and submit exactly once only after the agent can accept Enter. Claude must acknowledge the post-paste composer render or reach the bounded fallback first.",
+      "oracle": "Runtime tests assert the exact PTY write sequence, failure cleanup, and a Claude-shaped delayed render where Enter at the legacy 500 ms boundary is premature but the post-paste show-cursor marker submits exactly once. Orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness covers long Codex-like framing.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts",
         "node tests/tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
@@ -8305,6 +8305,8 @@
           "file": "src/main/runtime/orca-runtime.test.ts",
           "assertions": [
             "runtime writes bracketed paste before a delayed submit",
+            "Claude ignores unrelated and split pre-marker output, then submits once after the post-paste show-cursor render",
+            "a silent Claude composer reaches one bounded fallback submit",
             "large prompt frames are chunked and reconstructed before submit",
             "partial prompt write failure closes the paste frame and does not submit"
           ]
@@ -8335,6 +8337,15 @@
       ],
       "evidenceRuns": [
         {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts",
+          "result": "passed",
+          "durationSeconds": 16.9,
+          "summary": "4 files and 1,282 tests passed. Unmodified main wrote Enter at 500 ms before the deterministic Claude composer rendered at 750 ms; the candidate waited for the split show-cursor marker and wrote one Enter. A live Claude Code 2.1.231 Haiku trace rendered the pasted marker and show-cursor in one 523-byte frame without submitting a model request."
+        },
+        {
           "date": "2026-07-07",
           "runner": "local",
           "platform": "macos",
@@ -8363,11 +8374,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The live harness reproduced the unsafe raw multiline contract before the fix and passes after the fix; intentional-break evidence is local only and not yet in CI."
+        "evidence": "The Claude-shaped runtime oracle fails on unmodified main and passes with the render gate; the earlier live harness also reproduced the unsafe raw multiline contract before its framing fix. Intentional-break evidence remains local rather than a separate CI job."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Agent prompt dispatch remains O(prompt bytes), uses the existing 16KB terminal input chunking and one existing 500ms submit delay, and adds no polling, provider listing, subprocess churn, hidden-pane wakeups, or renderer work."
+        "evidence": "Agent prompt dispatch remains O(prompt bytes) with existing 16KB chunking. Claude adds one PTY-local output listener until its normal post-paste show-cursor frame or an 8s fallback; other agents retain the platform delay. No polling, provider listing, subprocess churn, hidden-pane wakeups, renderer work, or wire traffic is added."
       },
       "promotionCriteria": [
         "Run the live harness in soak with a self-starting dev runtime or provider-contract fixture.",

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16375,6 +16375,96 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('waits for Claude to render the pasted composer before submitting exactly once', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      let composerReady = false
+      let prematureEnters = 0
+      let submissions = 0
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+            setTimeout(() => {
+              runtime.onPtyData('pty-bg', 'partial redraw without cursor', Date.now())
+            }, 650)
+            setTimeout(() => {
+              runtime.onPtyData('pty-bg', '\x1b[?2', Date.now())
+            }, 750)
+            setTimeout(() => {
+              composerReady = true
+              runtime.onPtyData('pty-bg', '5h', Date.now())
+            }, 751)
+          }
+          if (data === '\r') {
+            if (composerReady) {
+              submissions += 1
+            } else {
+              prematureEnters += 1
+            }
+          }
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'claude'
+      })
+      const assertAuthority = vi.fn()
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+        beforeWrite: assertAuthority
+      })
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(writes).not.toContain('\r')
+      await vi.advanceTimersByTimeAsync(150)
+      expect(writes).not.toContain('\r')
+      await vi.advanceTimersByTimeAsync(101)
+      await sendPromise
+      expect(prematureEnters).toBe(0)
+      expect(submissions).toBe(1)
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+      expect(assertAuthority).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('submits a silent Claude composer once after the bounded render fallback', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'claude'
+      })
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      await vi.advanceTimersByTimeAsync(7_999)
+      expect(writes).not.toContain('\r')
+
+      await vi.advanceTimersByTimeAsync(1)
+      await sendPromise
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('chunks large agent prompt paste frames before delayed submit', async () => {
     vi.useFakeTimers()
     try {
@@ -16389,7 +16479,9 @@ describe('OrcaRuntimeService', () => {
         kill: () => true,
         getForegroundProcess: async () => null
       })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'claude'
+      })
       const prompt = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}\ntail`
 
       const sendPromise = runtime.sendTerminalAgentPrompt(handle, prompt)
@@ -16426,7 +16518,9 @@ describe('OrcaRuntimeService', () => {
         kill: () => true,
         getForegroundProcess: async () => null
       })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'claude'
+      })
       const prompt = 'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES + 1)
 
       const sendPromise = runtime.sendTerminalAgentPrompt(handle, prompt)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16375,7 +16375,7 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('waits for Claude to render the pasted composer before submitting exactly once', async () => {
+  it('waits for Claude output to settle after its first render marker before one submit', async () => {
     vi.useFakeTimers()
     try {
       const writes: string[] = []
@@ -16395,9 +16395,15 @@ describe('OrcaRuntimeService', () => {
               runtime.onPtyData('pty-bg', '\x1b[?2', Date.now())
             }, 750)
             setTimeout(() => {
-              composerReady = true
-              runtime.onPtyData('pty-bg', '5h', Date.now())
+              runtime.onPtyData('pty-bg', '5h intermediate frame', Date.now())
             }, 751)
+            setTimeout(() => {
+              runtime.onPtyData('pty-bg', 'continued composer render', Date.now())
+            }, 900)
+            setTimeout(() => {
+              composerReady = true
+              runtime.onPtyData('pty-bg', 'final composer frame', Date.now())
+            }, 1_000)
           }
           if (data === '\r') {
             if (composerReady) {
@@ -16425,6 +16431,10 @@ describe('OrcaRuntimeService', () => {
       await vi.advanceTimersByTimeAsync(150)
       expect(writes).not.toContain('\r')
       await vi.advanceTimersByTimeAsync(101)
+      expect(writes).not.toContain('\r')
+      await vi.advanceTimersByTimeAsync(1_748)
+      expect(writes).not.toContain('\r')
+      await vi.advanceTimersByTimeAsync(1)
       await sendPromise
       expect(prematureEnters).toBe(0)
       expect(submissions).toBe(1)
@@ -16444,6 +16454,45 @@ describe('OrcaRuntimeService', () => {
         spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
         write: (_ptyId, data) => {
           writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'claude'
+      })
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      await vi.advanceTimersByTimeAsync(7_999)
+      expect(writes).not.toContain('\r')
+
+      await vi.advanceTimersByTimeAsync(1)
+      await sendPromise
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds a Claude render that never settles to one fallback submit', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+            setTimeout(() => runtime.onPtyData('pty-bg', '\x1b[?25h', Date.now()), 100)
+            for (const delay of [1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000]) {
+              setTimeout(
+                () => runtime.onPtyData('pty-bg', `render frame ${delay}`, Date.now()),
+                delay
+              )
+            }
+          }
           return true
         },
         kill: () => true,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1830,6 +1830,9 @@ const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const DRAFT_PASTE_READY_TIMEOUT_MS = 8000
+const CLAUDE_AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
+// Why: Claude emits show-cursor only after its composer has rendered the pasted draft.
+const CLAUDE_AGENT_PROMPT_RENDER_MARKER = '\x1b[?25h'
 const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 // Why: the split already failed; the caller waits on this teardown only to learn whether the
 // fallback kill is needed, so keep it short — an unreachable host must not stall the rejection.
@@ -17380,19 +17383,24 @@ export class OrcaRuntimeService {
       suffixFailureError?: string
     } = {}
   ): Promise<void> {
+    const renderGate = this.createClaudeAgentPromptRenderGate(ptyId)
     let wrotePasteBytes = false
     let completedPaste = false
     try {
       const chunks = iterateTerminalInputChunks(pastePayload)
       let chunk = chunks.next()
       while (!chunk.done) {
+        const nextChunk = chunks.next()
         await options.beforeWrite?.(ptyId)
+        if (nextChunk.done) {
+          renderGate?.arm()
+        }
         const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
         if (!wrote) {
           throw new Error('terminal_not_writable')
         }
         wrotePasteBytes = true
-        chunk = chunks.next()
+        chunk = nextChunk
         if (!chunk.done) {
           await new Promise((resolve) => setTimeout(resolve, 0))
         }
@@ -17402,10 +17410,16 @@ export class OrcaRuntimeService {
       if (wrotePasteBytes && !completedPaste) {
         this.ptyController?.write(ptyId, AGENT_PROMPT_BRACKETED_PASTE_END)
       }
+      renderGate?.dispose()
       throw error
     }
 
-    await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
+    if (renderGate) {
+      await renderGate.wait()
+      renderGate.dispose()
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
+    }
     try {
       await options.beforeWrite?.(ptyId)
     } catch (error) {
@@ -17417,6 +17431,62 @@ export class OrcaRuntimeService {
     const suffixWrote = this.ptyController?.write(ptyId, AGENT_PROMPT_SUBMIT) ?? false
     if (!suffixWrote) {
       throw new Error(options.suffixFailureError ?? 'terminal_not_writable')
+    }
+  }
+
+  private createClaudeAgentPromptRenderGate(ptyId: string): {
+    arm: () => void
+    wait: () => Promise<void>
+    dispose: () => void
+  } | null {
+    const pty = this.ptysById.get(ptyId)
+    if ((pty?.launchAgent ?? pty?.foregroundAgent) !== 'claude') {
+      return null
+    }
+    let armed = false
+    let observed = false
+    let markerCarry = ''
+    let resolveRender!: () => void
+    const rendered = new Promise<void>((resolve) => {
+      resolveRender = resolve
+    })
+    const dispose = this.subscribeToTerminalData(ptyId, (data) => {
+      if (!armed || observed) {
+        return
+      }
+      const combined = markerCarry + data
+      markerCarry = combined.slice(-(CLAUDE_AGENT_PROMPT_RENDER_MARKER.length - 1))
+      if (!combined.includes(CLAUDE_AGENT_PROMPT_RENDER_MARKER)) {
+        return
+      }
+      observed = true
+      resolveRender()
+    })
+    return {
+      arm: () => {
+        armed = true
+        markerCarry = ''
+      },
+      wait: async () => {
+        if (observed) {
+          return
+        }
+        await new Promise<void>((resolve) => {
+          let settled = false
+          let timer: NodeJS.Timeout
+          const finish = (): void => {
+            if (settled) {
+              return
+            }
+            settled = true
+            clearTimeout(timer)
+            resolve()
+          }
+          timer = setTimeout(finish, CLAUDE_AGENT_PROMPT_RENDER_TIMEOUT_MS)
+          void rendered.then(finish)
+        })
+      },
+      dispose
     }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1831,7 +1831,8 @@ const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const DRAFT_PASTE_READY_TIMEOUT_MS = 8000
 const CLAUDE_AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
-// Why: Claude emits show-cursor only after its composer has rendered the pasted draft.
+const CLAUDE_AGENT_PROMPT_RENDER_QUIET_MS = 1500
+// Why: Claude emits show-cursor while rendering its composer; output must settle afterward.
 const CLAUDE_AGENT_PROMPT_RENDER_MARKER = '\x1b[?25h'
 const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 // Why: the split already failed; the caller waits on this teardown only to learn whether the
@@ -17444,23 +17445,50 @@ export class OrcaRuntimeService {
       return null
     }
     let armed = false
-    let observed = false
+    let observedMarker = false
+    let settled = false
     let markerCarry = ''
+    let quietTimer: NodeJS.Timeout | null = null
+    let hardTimer: NodeJS.Timeout | null = null
     let resolveRender!: () => void
     const rendered = new Promise<void>((resolve) => {
       resolveRender = resolve
     })
-    const dispose = this.subscribeToTerminalData(ptyId, (data) => {
-      if (!armed || observed) {
+
+    const finish = (): void => {
+      if (settled) {
         return
       }
-      const combined = markerCarry + data
-      markerCarry = combined.slice(-(CLAUDE_AGENT_PROMPT_RENDER_MARKER.length - 1))
-      if (!combined.includes(CLAUDE_AGENT_PROMPT_RENDER_MARKER)) {
-        return
+      settled = true
+      if (quietTimer) {
+        clearTimeout(quietTimer)
+        quietTimer = null
       }
-      observed = true
+      if (hardTimer) {
+        clearTimeout(hardTimer)
+        hardTimer = null
+      }
       resolveRender()
+    }
+    const armQuietTimer = (): void => {
+      if (quietTimer) {
+        clearTimeout(quietTimer)
+      }
+      quietTimer = setTimeout(finish, CLAUDE_AGENT_PROMPT_RENDER_QUIET_MS)
+    }
+    const unsubscribe = this.subscribeToTerminalData(ptyId, (data) => {
+      if (!armed || settled) {
+        return
+      }
+      if (!observedMarker) {
+        const combined = markerCarry + data
+        markerCarry = combined.slice(-(CLAUDE_AGENT_PROMPT_RENDER_MARKER.length - 1))
+        if (!combined.includes(CLAUDE_AGENT_PROMPT_RENDER_MARKER)) {
+          return
+        }
+        observedMarker = true
+      }
+      armQuietTimer()
     })
     return {
       arm: () => {
@@ -17468,25 +17496,23 @@ export class OrcaRuntimeService {
         markerCarry = ''
       },
       wait: async () => {
-        if (observed) {
+        if (settled) {
           return
         }
-        await new Promise<void>((resolve) => {
-          let settled = false
-          let timer: NodeJS.Timeout
-          const finish = (): void => {
-            if (settled) {
-              return
-            }
-            settled = true
-            clearTimeout(timer)
-            resolve()
-          }
-          timer = setTimeout(finish, CLAUDE_AGENT_PROMPT_RENDER_TIMEOUT_MS)
-          void rendered.then(finish)
-        })
+        hardTimer = setTimeout(finish, CLAUDE_AGENT_PROMPT_RENDER_TIMEOUT_MS)
+        await rendered
       },
-      dispose
+      dispose: () => {
+        unsubscribe()
+        if (quietTimer) {
+          clearTimeout(quietTimer)
+          quietTimer = null
+        }
+        if (hardTimer) {
+          clearTimeout(hardTimer)
+          hardTimer = null
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## ELI5

Orca could finish pasting a worker task and press Enter before Claude finished drawing that text into its composer. The terminal accepted the bytes, so orchestration reported success, but Claude stayed idle with the task visible. This waits for Claude to finish rendering and for its terminal output to settle before pressing Enter exactly once.

## What Changed

- Add a Claude-only gate between the final bracketed-paste write and the submit Enter.
- Treat Claude's post-paste show-cursor sequence as the start of render settlement, including markers split across PTY chunks.
- Require 1.5 seconds of output quiescence after that marker; each later Claude frame resets the window.
- Recheck dispatch ownership immediately before the single submit write.
- Fall back to one submit after 8 seconds if the marker is absent or rendering never settles.
- Keep the existing platform delay for non-Claude agents and make no RPC, schema, or remote-wire changes.
- Add deterministic delayed/multi-frame composer oracles plus exact-once and bounded-fallback coverage.

## Why

PTY write acceptance only proves that the terminal received input; it does not prove Claude processed Enter after its asynchronous composer render. A deterministic fake Claude composer reproduced both failure boundaries: unmodified main sent Enter at the fixed 500 ms delay, and the initial candidate sent Enter on a 751 ms show-cursor marker while later render frames were still pending. The hardened candidate waits through the final frame and submits once only after output settles.

A live Claude Code 2.1.231 Haiku probe independently confirmed the sequence: first marker at 400 ms, additional output through 1,500 ms, one Enter at 3,000 ms after 1.5 seconds quiet, and successful work start.

The gate runs on the PTY-owning runtime, so local, SSH, daemon, and paired routing retain dispatch ownership and mixed-version compatibility.

## Linked Issue

Follow-up discovered while reviewing #14281. Related injection-boundary history: #7226.

## Visual Proof

N/A — runtime PTY sequencing only; there is no renderer or UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally on macOS:

- Prompt/orchestration suite: 4 files, 1,283 passed, 1 skipped
- Setup/federation suite: 4 files, 41 passed
- Post-commit focused boundary oracle: 5 passed
- `pnpm typecheck`
- Focused regular, native-plugin, and type-aware `oxlint`
- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`
- Live Claude Code 2.1.231 Haiku exact-once probe completed and started work

Linux, Windows/ConPTY, SSH, and paired-runtime live journeys were not run locally. They are covered structurally by keeping the gate inside the existing provider-owned PTY input/output path without changing the wire contract. CI covers the remaining repository-wide and Windows packaging checks.

## AI Disclosure

## Review

The change preserves the existing authority check before both paste and submit, sanitizes and chunks the same bracketed-paste payload, adds no remote protocol fields, and disposes the temporary PTY listener and timers after quiescence, timeout, or write failure. The bounded fallback prevents an upstream Claude rendering change or continuous redraw from blocking dispatch indefinitely.

The cursor marker is an observed Claude TUI heuristic, not an official prompt-accepted protocol event. Requiring post-marker quiescence avoids relying on the first intermediate Ink frame; moving to ACP/headless acknowledgments would be a separate architecture change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused lint/tests and full typecheck passed; CI covers remaining full checks)

## Author
