### PR TITLE
fix(browser): fence the cookie-clear fallback to the pre-clear snapshot (STA-4170)

### DIFF
--- a/src/main/browser/browser-cookie-import-clear-atomicity.test.ts
+++ b/src/main/browser/browser-cookie-import-clear-atomicity.test.ts
@@ -24,13 +24,16 @@ function createJarSession(
     failOn?: string
     restoreError?: Error
     snapshot?: CookieClearSession['snapshotClearIdentities']
+    arrivalDuringClear?: Cookie
   } = {}
 ) {
   let jar = [...initial]
   const removedNames: string[] = []
+  const restoredNames: string[] = []
   const session: CookieClearSession & {
     names: () => string[]
     removedNames: () => string[]
+    restoredNames: () => string[]
   } = {
     cookies: {
       get: async () => [...jar],
@@ -43,11 +46,16 @@ function createJarSession(
       }
     },
     clearData: async () => {
+      // Why: a cookie the user creates mid-clear lands before the rejection surfaces.
+      if (options.arrivalDuringClear) {
+        jar.push(options.arrivalDuringClear)
+      }
       throw new Error('storage busy')
     },
     snapshotClearIdentities:
       options.snapshot ?? (async (items) => identitiesFromClearCookies(items)),
     restoreClearIdentities: async (identities) => {
+      restoredNames.push(...identities.map((identity) => identity.name))
       if (options.restoreError) {
         throw options.restoreError
       }
@@ -59,7 +67,8 @@ function createJarSession(
       }
     },
     names: () => jar.map((entry) => entry.name).sort(),
-    removedNames: () => [...removedNames]
+    removedNames: () => [...removedNames],
+    restoredNames: () => [...restoredNames].sort()
   }
   return session
 }
@@ -148,6 +157,24 @@ describe('STA-4090 failed full cookie clear', () => {
         expect.objectContaining({ name: 'stale' })
       ])
     )
+  })
+
+  // Why (STA-4170): the fallback used to re-read the jar, so a login completed mid-clear was
+  // deleted with no snapshot identity to restore it — permanent auth loss reported as a restore.
+  it('leaves a cookie that arrived during the clear in the jar', async () => {
+    const session = createJarSession(
+      [cookie('.example.com', 'removed-first', '/one'), cookie('.other.test', 'stale', '/two')],
+      { arrivalDuringClear: cookie('.arrived.test', 'fresh-login') }
+    )
+
+    await expect(removeTransplantableCookies(session)).rejects.toThrow(
+      /existing cookies were restored/
+    )
+
+    expect(session.removedNames()).toEqual(['removed-first'])
+    expect(session.names()).toEqual(['fresh-login', 'removed-first', 'stale'])
+    // The restore set is exactly the mutated set: the arrival never needed restoring.
+    expect(session.restoredNames()).toEqual(['removed-first', 'stale'])
   })
 
   it('serializes concurrent clears on the same session', async () => {

--- a/src/main/browser/browser-cookie-import-clear-atomicity.test.ts
+++ b/src/main/browser/browser-cookie-import-clear-atomicity.test.ts
@@ -18,6 +18,10 @@ function cookie(domain: string, name: string, path = '/', secure = true): Cookie
   }
 }
 
+function valueCookie(domain: string, name: string, value: string): Cookie {
+  return { ...cookie(domain, name), value }
+}
+
 function createJarSession(
   initial: Cookie[],
   options: {
@@ -175,6 +179,51 @@ describe('STA-4090 failed full cookie clear', () => {
     expect(session.names()).toEqual(['fresh-login', 'removed-first', 'stale'])
     // The restore set is exactly the mutated set: the arrival never needed restoring.
     expect(session.restoredNames()).toEqual(['removed-first', 'stale'])
+  })
+
+  // Why (STA-4170): an arrival that reuses a snapshotted url+name IS removed — that coordinate is
+  // what the clear was asked to empty. It is not a loss: the identity is in the snapshot, so the
+  // rollback repopulates it with the pre-clear value and the coordinate is never left empty.
+  it('rolls a same-coordinate arrival back to its pre-clear value', async () => {
+    let jar = [valueCookie('.example.com', 'session', 'pre-clear'), cookie('.other.test', 'stale')]
+    const restored: CookieClearIdentity[] = []
+    const session: CookieClearSession = {
+      cookies: {
+        get: async () => [...jar],
+        remove: async (_url, name) => {
+          if (name === 'stale') {
+            throw new Error('cookie store unavailable')
+          }
+          jar = jar.filter((entry) => entry.name !== name)
+        }
+      },
+      clearData: async () => {
+        // The site re-sets the same cookie while the bulk clear is failing.
+        jar = jar.filter((entry) => entry.name !== 'session')
+        jar.push(valueCookie('.example.com', 'session', 'mid-clear'))
+        throw new Error('storage busy')
+      },
+      snapshotClearIdentities: async (items) => identitiesFromClearCookies(items),
+      restoreClearIdentities: async (identities) => {
+        restored.push(...identities)
+        for (const identity of identities) {
+          if (jar.some((entry) => entry.name === identity.name)) {
+            continue
+          }
+          jar.push(valueCookie(identity.domain ?? '', identity.name, identity.value))
+        }
+      }
+    }
+
+    await expect(removeTransplantableCookies(session)).rejects.toThrow(
+      /existing cookies were restored/
+    )
+
+    expect(jar.map((entry) => [entry.name, entry.value])).toEqual([
+      ['stale', 'stale-value'],
+      ['session', 'pre-clear']
+    ])
+    expect(restored.map((identity) => identity.name)).toContain('session')
   })
 
   it('serializes concurrent clears on the same session', async () => {

--- a/src/main/browser/browser-cookie-import-clear.ts
+++ b/src/main/browser/browser-cookie-import-clear.ts
@@ -84,10 +84,7 @@ export async function withCookieClearLock<T>(owner: object, run: () => Promise<T
   }
 }
 
-function removableCookieEntries(
-  cookies: readonly Cookie[],
-  requireAddressable = false
-): { cookie: Cookie; url: string }[] {
+function removableCookieEntries(cookies: readonly Cookie[]): { cookie: Cookie; url: string }[] {
   const removable: { cookie: Cookie; url: string }[] = []
   for (const cookie of cookies) {
     if (isNonTransplantableCookieDomain(cookie.domain ?? '')) {
@@ -96,10 +93,7 @@ function removableCookieEntries(
     const domain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null
     const url = domain ? cookieRemovalUrl(cookie, domain) : null
     if (!url) {
-      if (requireAddressable) {
-        throw new Error('Could not clear existing cookies; the session was left unchanged')
-      }
-      continue
+      throw new Error('Could not clear existing cookies; the session was left unchanged')
     }
     removable.push({ cookie, url })
   }
@@ -160,12 +154,18 @@ export async function removeTransplantableCookies(
       return
     }
 
-    const initialRemovable = removableCookieEntries(initialCookies, true)
+    const initialRemovable = removableCookieEntries(initialCookies)
     if (initialRemovable.length === 0) {
       return
     }
     const identities = await targetSession.snapshotClearIdentities(initialRemovable)
     assertClearIdentitiesCoverRemovable(initialRemovable, identities)
+    // Why (STA-4170): fixing the removal plan here, beside the identities that can undo it, is what
+    // keeps the two sets equal. Re-reading the jar in the fallback widened the removal set past the
+    // restore set, so a cookie that arrived mid-clear — a login the user had just completed — was
+    // deleted with nothing able to put it back. Removing an already-deleted cookie is a harmless
+    // no-op, so the stale plan costs nothing; only its narrowness matters.
+    const removalGroups = [...groupRemovableCookies(initialRemovable).values()]
 
     try {
       // Why (STA-4065): excludeOrigins keeps the google.com family, including partitioned
@@ -179,10 +179,8 @@ export async function removeTransplantableCookies(
       // Why: a rejected bulk clear can still have emptied part of the jar.
     }
 
-    const existingCookies = await store.get({})
-    const removableGroups = groupRemovableCookies(removableCookieEntries(existingCookies))
     const results = await mapSettledWithConcurrency(
-      [...removableGroups.values()],
+      removalGroups,
       COOKIE_CLEAR_CONCURRENCY,
       async (group) => {
         // Why: identical removal coordinates must stay ordered instead of racing.

--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -333,26 +333,71 @@ describe('removeTransplantableCookies', () => {
     ])
   })
 
-  it('re-reads the jar after a rejected bulk clear', async () => {
-    const beforeAttempt = [cookie('.removed.test', 'gone-before-fallback')]
-    const afterAttempt = [
-      cookie('.google.com', 'SID'),
-      cookie('.survivor.test', 'survived'),
-      cookie('.arrived.test', 'arrived-during-clear')
+  // Why (STA-4170): the fallback may only mutate what the identity snapshot can undo. Re-reading
+  // the jar here widened the removal set past the restore set. Re-removing a cookie the partial
+  // bulk clear already deleted is a harmless no-op, so the narrower stale plan costs nothing.
+  it('removes only the pre-clear snapshot after a rejected bulk clear', async () => {
+    const beforeAttempt = [
+      cookie('.removed.test', 'gone-before-fallback'),
+      cookie('.survivor.test', 'survived')
     ]
-    const get = vi.fn().mockResolvedValueOnce(beforeAttempt).mockResolvedValueOnce(afterAttempt)
-    const { session, remove } = clearSession(beforeAttempt, {
+    const get = vi
+      .fn()
+      .mockResolvedValue([
+        cookie('.google.com', 'SID'),
+        cookie('.survivor.test', 'survived'),
+        cookie('.arrived.test', 'arrived-during-clear')
+      ])
+      .mockResolvedValueOnce(beforeAttempt)
+    const { session, remove, clearData } = clearSession(beforeAttempt, {
       get,
       clearData: rejectingBulkClear()
     })
 
     await removeTransplantableCookies(session)
 
-    expect(get).toHaveBeenCalledTimes(2)
+    expect(clearData).toHaveBeenCalledOnce()
+    expect(get).toHaveBeenCalledOnce()
     expect(remove.mock.calls).toEqual([
-      ['https://survivor.test/', 'survived'],
-      ['https://arrived.test/', 'arrived-during-clear']
+      ['https://removed.test/', 'gone-before-fallback'],
+      ['https://survivor.test/', 'survived']
     ])
+  })
+
+  // Why (STA-4170): arrival plus a later removal failure is the exact shape that deleted a login
+  // the user had just completed and still reported restoration. Mutated set must equal restore set.
+  it('never touches a cookie that arrives while a rejected clear falls back', async () => {
+    const beforeAttempt = [
+      cookie('.example.com', 'first', '/one'),
+      cookie('.example.com', 'second', '/two')
+    ]
+    const get = vi
+      .fn()
+      .mockResolvedValue([...beforeAttempt, cookie('.arrived.test', 'fresh-login')])
+      .mockResolvedValueOnce(beforeAttempt)
+    const { session, remove, restoreClearIdentities } = clearSession(beforeAttempt, {
+      get,
+      clearData: rejectingBulkClear(),
+      remove: vi.fn().mockImplementation(async (_url: string, name: string) => {
+        if (name === 'second') {
+          throw new Error('store unavailable')
+        }
+      })
+    })
+
+    await expect(removeTransplantableCookies(session)).rejects.toThrow(
+      'existing cookies were restored'
+    )
+
+    expect(remove.mock.calls).toEqual([
+      ['https://example.com/one', 'first'],
+      ['https://example.com/two', 'second']
+    ])
+    expect(restoreClearIdentities).toHaveBeenCalledOnce()
+    const restored = restoreClearIdentities.mock.calls[0][0].map(
+      (identity: { name: string }) => identity.name
+    )
+    expect([...restored].sort()).toEqual(['first', 'second'])
   })
 
   // Why: the fallback carries the same exclusion as the bulk call, so a rejected clearData must


### PR DESCRIPTION
## ELI5

When Orca imports cookies it first empties the existing cookie jar. If the fast "empty everything at once" call fails, it falls back to deleting cookies one at a time. That fallback used to look at the jar **again** and delete whatever it found — including a cookie that had just appeared because you signed into a site a second earlier. But the undo list was taken *before* the clear started, so that brand-new login cookie could be deleted with nothing able to bring it back — and the error message still said your cookies were restored.

Now the fallback deletes only the exact cookies it wrote down at the start. Anything that shows up mid-clear is never touched, so it can't be lost.

## What Changed

`removeTransplantableCookies` in `src/main/browser/browser-cookie-import-clear.ts`:

- The removal plan is now fixed at the same point as the restore-identity snapshot (`groupRemovableCookies(initialRemovable)`), immediately after `assertClearIdentitiesCoverRemovable`.
- The fallback's `store.get({})` re-read is gone. The fallback iterates the fixed plan.
- `removableCookieEntries` loses its `requireAddressable` parameter. It was `true` at the only surviving call site; the lenient "silently skip unaddressable cookies" mode existed solely for the deleted re-read, and leaving it in place would invite a future lenient path back in.

Net effect: **the set of cookies the fallback mutates is now identical to the set `restoreClearIdentities` can restore.** `assertClearIdentitiesCoverRemovable` already enforced that equality — it just no longer covers only part of the mutation set.

## Why

`snapshotClearIdentities` captured identities for the pre-clear removable set only (`:161`). The fallback then re-read the live jar and removed everything currently removable (`:182-183` before this change), and `restoreClearedCookies` restored only the pre-clear identities (`:192-197`). A cookie arriving between the snapshot and the fallback was inside the *deletion* set and outside the *restore* set.

**Concrete user-visible harm** (stated explicitly, because this chain has produced a regression at every step):

1. A cookie import starts. Orca snapshots the jar.
2. The bulk `clearData` rejects (storage busy / partition contention).
3. In that window the user finishes a login in the embedded browser; the site sets a session cookie.
4. The fallback re-reads the jar, sees that fresh auth cookie, and deletes it.
5. Either the fallback fully succeeds — the user is **silently signed out**, no error at all, restore never even attempted — or another removal fails and the user is signed out *and* told `existing cookies were restored`.

That cookie is structurally unrecoverable: no identity for it was ever captured.

### Why fencing, and not "snapshot the full post-rejection set"

Two designs were on the table.

**(a) Fence the fallback to the initial snapshot — chosen.** Arrivals are never in the removal plan, so there is nothing to restore and no restore that can fail. The harm becomes *impossible* rather than *handled*.

It also makes the fallback agree with the primary path. `clearData` is point-in-time: on the **success** path a cookie that lands after the call already survives. The re-read made the failure path delete cookies the success path would have kept — the fallback was strictly more destructive than the operation it was standing in for. Fencing removes that asymmetry.

**(b) Snapshot identities for the full post-rejection removal set — rejected.** It still *deletes* the user's fresh login and then tries to put it back, so safety depends on a restore succeeding. It needs a second `snapshotClearIdentities` CDP round-trip on a path that is already failing, which is itself a new failure mode with no good answer (abort and leave the jar half-cleared?). And it adds machinery to the exact code path that has now produced three P0s. More moving parts on the failure path is how this chain got here.

### On the "stale snapshot" review finding from #14131

The re-read was added during #14131's review to fix a reported "stale snapshot" bug: the fallback used the pre-attempt snapshot, so it re-tried removals for cookies already gone and was blind to arrivals. Neither half was a real defect:

- **Re-removing an already-deleted cookie is a no-op.** `session.cookies.remove(url, name)` resolves for a cookie that isn't there. The cost is one redundant IPC call on an already-failed path.
- **Being blind to arrivals was the protective property**, not the bug. It is what kept the mutation set inside the restore set.

The confident finding was correct about the mechanism and wrong about the harm. That is what this PR reverts, with the invariant now written down at the point that enforces it.

## Linked Issue

Fixes STA-4170 — https://linear.app/stably/issue/STA-4170/p0-cookie-clear-fallback-can-delete-post-snapshot-login-cookies-after

Regression from #14131. Incomplete follow-up: #14191. Third in the chain STA-4061 → STA-4090 → STA-4170.

## Mandatory Safety Analysis

Every cookie category against all three outcomes. **No cell permanently loses a cookie.**

| Cookie category | Bulk clear succeeds | Rejection → fallback fully succeeds | Rejection → a fallback removal fails |
|---|---|---|---|
| **Non-transplantable (google.com family)** | Preserved. `excludeOrigins` keeps the whole registrable family, partitioned rows included. | Preserved. `isNonTransplantableCookieDomain` keeps it out of `initialRemovable`, so it is not in the removal plan. | Preserved. Never removed, never restored, never touched. |
| **Ordinary removable, present at snapshot** | Deleted — intended. | Deleted — intended. | Every removed one is restored from its CDP identity; throws `existing cookies were restored`. No loss. |
| **Cookie ARRIVING during the clear, at a NEW `url`+`name`** | Survives. `clearData` is point-in-time; an arrival after it lands is not deleted. | **Survives** — not in the fenced plan. *(Before: deleted, silently, no error.)* | **Survives** — never mutated, so there is nothing to restore and no restore that can fail it. *(Before: deleted, unrestorable, reported as restored.)* |
| **Cookie ARRIVING during the clear, REUSING a snapshotted `url`+`name`** | Deleted — that coordinate is exactly what the clear was asked to empty. | Deleted — same as the success path above. Not a loss the fence can or should prevent. | Removed, then the coordinate is **repopulated from its snapshot identity** with the pre-clear value. The coordinate is never left empty and nothing is unrecoverable. |
| **Partitioned / CHIPS** | Preserved if google-family (`excludeOrigins` covers partitioned rows); otherwise deleted — intended. | Deleted — intended. | Restored via CDP `Network.setCookie` **with** `partitionKey`, snapshotted from `Network.getAllCookies`. Never routed through Electron `cookies.get`/`set`, which strip and silently ignore `partitionKey` (measured on Electron 43) — that was STA-4061, and the `CookieClearSession` type still excludes `set` to keep it unreachable. |
| **Already deleted by the partial bulk clear** | n/a — clear succeeded. | Still in the plan, so `remove()` is re-issued: a harmless no-op. | Restored from its snapshot identity like any other. No loss. |

### The same-coordinate arrival, in detail

An independent reviewer flagged the same-coordinate row as refuting the table, so it was measured rather than argued. Setup: the snapshot holds `example.com/session=V1`; the partial bulk clear deletes it; the site re-sets `example.com/session=V2` (the fresh login); a later removal then fails, so the rollback runs. Measured against this PR's head:

```
FINAL JAR:  [["stale","x"],["session","V1"]]
RESTORED:   [["stale","x"],["session","V1"]]
```

The coordinate is **not** left empty and nothing becomes unrecoverable — that identity is in the snapshot, so the rollback repopulates it. What is lost is the *value update* (V2 superseded by V1), not the cookie. The jar ends in exactly its pre-clear state, which is precisely what `existing cookies were restored` promises.

That is a materially different severity from the bug being fixed, where a **new-coordinate** arrival left the coordinate empty with no identity in existence to restore it: the user was signed out with no session at all and told it had been restored.

Critically, **this sub-case is not a regression**: the same-coordinate regression test passes *identically* against the pre-fix code, and against pre-#14131 `main`. This PR does not introduce it, worsen it, or touch it. It is a restore-*fidelity* gap that predates the bug being fixed here.

Refreshing restore identities via CDP for the fenced coordinates — so V2 rather than V1 is preserved — is a real improvement and is filed as **STA-4183**. It is deliberately not done here: it adds store API surface and reconciliation to the failure path of a P0 hotfix, on a pre-existing issue, and deserves review on its own merits. The current behavior is locked by the `rolls a same-coordinate arrival back to its pre-clear value` regression instead.

### Does this create a fourth regression?

The failure mode of each prior fix was a widened blast radius: STA-4061 restored through a lossy channel, STA-4090 deleted without a restore path, STA-4170 deleted outside the restore set. This change only ever **narrows** what is mutated, and narrows it to a set already proven restorable by an assertion that runs before any mutation. There is no new write, no new channel, and no new failure path — the diff deletes a read.

It also closes a smaller pre-existing loss path as a side effect: the deleted `store.get({})` sat between the mutating `clearData` and the removals, so if *it* rejected, the function threw with no restore attempted. After this change there is no throwing awaited I/O between `clearData` and the remove loop at all.

The one way this PR could still have created a fourth regression is if `remove()` rejected for a cookie the partial bulk clear had already deleted — the redundant no-op would then trigger a restore that put back cookies the clear had legitimately removed. That premise was checked against real Electron 43.1.0 during review: `cookies.remove()` resolves for an already-deleted cookie, a never-existed cookie, and a blank-host cookie. The no-op is genuinely a no-op.

## Visual Proof

`N/A` — main-process cookie-jar logic with no UI surface. The change is only reachable on a rejected `clearData` during a cookie import; it renders nothing and alters no user-visible control. Behavior is covered by the automated regressions below, including an independently authored reproduction.

## Testing

Platform: macOS. This is Electron main-process cookie logic — not mobile, not Windows/WSL-specific, not SSH-specific (it runs against the local Electron session in every case).

**Independent reproduction (pre-fix).** A separate agent, given only the ticket, wrote a stateful-jar reproduction on `brennanb2025/sta-4170-repro` (`134b7cd`) without seeing this fix. Against unmodified `main` both of its cases fail: the mid-clear arrival appears in the fallback's `remove()` calls and is gone from the final jar. Against this fix, its behavioral assertions all pass — including `session.names()` still containing `arrived-during-clear`. Its one failing assertion here is `expect(get).toHaveBeenCalledTimes(2)`, which pins the deleted re-read, i.e. the bug itself. That file is deliberately **not** merged: its coverage is equivalent to the regressions below and its `get`-count assertion encodes the old implementation.

**Regressions added/changed in this PR:**

- `browser-cookie-import-policy.test.ts` — the existing `re-reads the jar after a rejected bulk clear` test asserted `arrived-during-clear` **is** removed. It pinned the harmful behavior and is replaced by `removes only the pre-clear snapshot after a rejected bulk clear` (asserts `get` called once, `clearData` once, and the exact `remove()` argument list, including the harmless no-op re-removal of a cookie the partial bulk clear already deleted).
- `browser-cookie-import-policy.test.ts` — new `never touches a cookie that arrives while a rejected clear falls back`: the combined arrival + later-removal-failure case the ticket asks for. Asserts the mutated set **equals** the restored set.
- `browser-cookie-import-clear-atomicity.test.ts` — new `leaves a cookie that arrived during the clear in the jar`: stateful jar, arrival injected inside the rejecting `clearData` call, asserting the end state (`fresh-login` still present) and that the restore set is exactly the mutated set.
- `browser-cookie-import-clear-atomicity.test.ts` — new `rolls a same-coordinate arrival back to its pre-clear value`: locks the sub-case above, asserting the coordinate ends holding the pre-clear value rather than being left empty. Mutation-checked: emptying the restore identity list makes it fail.

**Non-vacuousness proven by mutation.** This module has repeatedly produced tests that pass for the wrong reason (a fixture missing a method throws a `TypeError` the fallback `catch` swallows, silently routing the test down another path), so each new test asserts the path was *attempted* via call counts, not just the end state. Reverting the fix in place makes all three fail with exactly the right signatures:

```
× leaves a cookie that arrived during the clear in the jar
    AssertionError: expected [ 'removed-first', 'fresh-login' ] to deeply equal [ 'removed-first' ]
× removes only the pre-clear snapshot after a rejected bulk clear
    AssertionError: expected "vi.fn()" to be called once, but got 2 times
× never touches a cookie that arrives while a rejected clear falls back
    AssertionError: expected [ [ …(2) ], [ …(2) ], [ …(2) ] ] to deeply equal [ [ …(2) ], [ …(2) ] ]
```

The first is the P0 itself: on the pre-fix code the arrival is deleted.

**Gates run locally, all green:**

- `pnpm vitest run --config config/vitest.config.ts src/main/browser/` — 39 files, 631 tests passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean (includes `check:max-lines-ratchet`: 346 grandfathered, no new bypasses)
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings across 3 changed files (native, type-aware, React Doctor)

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — strictly reduces what is deleted; adds no new write path. `CookieClearSession` still omits `set`, so the lossy STA-4061 reconstruction stays unreachable.
- **Cross-platform** — no platform-conditional code, no paths, no shortcuts. Electron session API only.
- **Remote SSH** — unchanged; this runs against the local Electron session in both local and SSH workspaces. No wire format, RPC param, or stream frame is touched, so there is no mixed-version client/host concern.
- **Mobile** — not reachable; desktop main-process cookie import only.
- **Backwards compatibility** — no signature change to any exported function. `removableCookieEntries` is module-private.
- **Performance** — strictly better on the fallback path: one fewer full `cookies.get({})` of the entire jar. The removal plan is computed once instead of rebuilt after the failure. The success path is untouched.

## Scope

STA-4170 only. STA-4090's remaining work and the STA-4097 sibling-rollback follow-up are **not** included — the minimal correct fix here does not cover them, and neither is required to close this data-loss path.

**STA-4183** was filed from this PR's review loop for the same-coordinate restore-fidelity gap described above (pre-existing, unchanged by this PR).

### Review

Two independent reviewers ran against this PR in their own worktrees; both returned clean with no blocking findings.

One of them refuted the original safety table's "cookie ARRIVING during the clear" row as overclaimed — it was, for same-coordinate arrivals. That row is now split and the sub-case documented, measured, regression-tested, and filed as STA-4183. No behavior change was made for it, because the pre-fix measurement showed it is not something this PR introduces. That finding was correct and is the reason this section exists.

## Author

- X / Twitter: @BrennanKB5
