### PR TITLE
Fix native chat watcher identity race

### DIFF
--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -159,6 +159,8 @@ export async function installTranscriptWatcher(
     if (contentReplaced) {
       resetIncrementalTranscriptState(state)
     }
+    // Why: subscriber callbacks may replace the path before the drain can finish.
+    watchedVersion ??= current
 
     const replacementSnapshot =
       // Why: 0 is a valid window — an explicit undefined check keeps an empty

--- a/src/main/native-chat/transcript-watch-liveness.test.ts
+++ b/src/main/native-chat/transcript-watch-liveness.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
-import type { FSWatcher } from 'node:fs'
+import { renameSync, type FSWatcher } from 'node:fs'
 import type * as NodeFs from 'node:fs'
-import { appendFile, mkdir, mkdtemp, rename, rm, utimes, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -33,7 +33,6 @@ vi.mock('node:fs', async () => {
 import { subscribeNativeChatTranscript } from './transcript-watch'
 
 const roots: string[] = []
-const HOST_FILESYSTEM_RECONCILIATION_TIMEOUT_MS = 8_000
 
 afterEach(async () => {
   vi.useRealTimers()
@@ -187,7 +186,7 @@ describe('native chat transcript watcher liveness', () => {
     const root = dirname(filePath)
     const oldRoot = `${root}.old`
     roots.push(oldRoot)
-    const snapshots = vi.fn()
+    const snapshots = vi.fn(() => renameSync(root, oldRoot))
     const replacements = vi.fn()
     const appends = vi.fn()
     const subscription = await subscribeNativeChatTranscript({
@@ -203,13 +202,9 @@ describe('native chat transcript watcher liveness', () => {
     })
     await waitFor(() => snapshots.mock.calls.length === 1)
 
-    await rename(root, oldRoot)
     await mkdir(root)
-    await writeFile(filePath, claudeLine('new-file', 'user', 'after'))
-    await waitFor(
-      () => replacements.mock.calls.length === 1 && watchers.length === 2,
-      HOST_FILESYSTEM_RECONCILIATION_TIMEOUT_MS
-    )
+    await writeFile(filePath, claudeLine('new-file', 'user', 'after!'))
+    await waitFor(() => replacements.mock.calls.length === 1 && watchers.length === 2)
     await appendFile(filePath, claudeLine('new-followup', 'assistant', 'event-driven'))
     watchCallbacks[1]!('change', 'transcript.jsonl')
     await waitFor(() => appends.mock.calls.flat(2).some((message) => message.id === 'new-followup'))


### PR DESCRIPTION
## Summary

- retain the start-of-drain transcript identity before subscriber callbacks can replace the watched path
- make the silent parent-directory replacement race deterministic in the liveness regression test
- remove the prior eight-second timeout workaround

## Verification

- Node 24 transcript watcher liveness: 7/7
- transcript-watch suites: 55/55
- Node typecheck
- focused lint and formatting

Author: @BrennanKB5