### PR TITLE
Remove icons from Non-Orca worktree sources

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { Folder, Grid2X2, SquareTerminal, Trash2 } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -200,19 +200,8 @@ export default function WorktreeVisibilitySourceList({
           return (
             <div
               key={key}
-              className={`grid min-h-14 grid-cols-[28px_minmax(0,1fr)_auto] items-center gap-2.5 px-2.5 py-2 ${index > 0 ? 'border-t border-border' : ''}`}
+              className={`grid min-h-14 grid-cols-[minmax(0,1fr)_auto] items-center gap-2.5 px-2.5 py-2 ${index > 0 ? 'border-t border-border' : ''}`}
             >
-              <span className="flex size-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
-                {source.kind === 'built-in' ? (
-                  source.id === 'claude' ? (
-                    <SquareTerminal className="size-3.5" />
-                  ) : (
-                    <Grid2X2 className="size-3.5" />
-                  )
-                ) : (
-                  <Folder className="size-3.5" />
-                )}
-              </span>
               <span className="min-w-0">
                 <span className="flex min-w-0 items-center gap-1.5">
                   <span className="truncate text-[13px] font-medium">{label}</span>


### PR DESCRIPTION
## ELI5

The Non-Orca worktree source rows now show only the useful labels, paths, counts, and controls—without decorative icons that did not communicate meaningful state.

## What Changed

- Removed the Claude Code, GSD, and other-location icons from source rows.
- Collapsed the source-row grid so text aligns directly with the card inset.
- Kept custom-location removal controls and source switches unchanged.

## Why

The source names already identify each row, so the icons added visual noise without helping users distinguish behavior or state.

## Linked Issue

N/A — direct product request.

## Visual Proof

| Before | After |
| --- | --- |
| ![Before: source rows with decorative icons](https://github.com/user-attachments/assets/d1472e5e-dd5c-4e4b-aadd-69f772114cd1) | ![After: source rows without decorative icons](https://github.com/user-attachments/assets/323d41b9-9be0-4905-8764-c6f4eca9e302) |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on macOS in the Electron app through Playwright CDP. Confirmed the dialog rendered three source rows with zero source-list SVGs and retained aligned switches.

- `pnpm exec vitest run src/renderer/src/components/sidebar/WorktreeVisibilityDialog.test.tsx --config config/vitest.config.ts` (31 tests)
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx --deny-warnings`
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx`
- `pnpm run typecheck:web`

No new automated test was added because this is a presentational deletion covered by renderer typechecking, linting, existing dialog behavior tests, and direct rendered validation.

## Review

No security, performance, mobile, SSH, remote-wire, path, shortcut, or platform-specific behavior changes. The layout uses existing responsive grid and design-system spacing classes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused lint, tests, formatting, and renderer typechecking pass locally; CI will cover the full repository matrix.

## Author

- X / Twitter: @BrennanKB5
