### PR TITLE
fix(daemon): isolate durable-history checkpoints per session (STA-4173)

### DIFF
--- a/src/main/daemon/daemon-checkpoint-session-queue.test.ts
+++ b/src/main/daemon/daemon-checkpoint-session-queue.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CHECKPOINT_SESSION_QUEUE_MAX_PENDING,
+  CheckpointSessionQueue
+} from './daemon-checkpoint-session-queue'
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('CheckpointSessionQueue', () => {
+  it('serializes operations for one session', async () => {
+    const queue = new CheckpointSessionQueue()
+    const order: string[] = []
+    const first = deferred<void>()
+
+    const a = queue.run('s', async () => {
+      order.push('a:start')
+      await first.promise
+      order.push('a:end')
+    })
+    const b = queue.run('s', async () => {
+      order.push('b:start')
+    })
+
+    await vi.waitFor(() => expect(order).toEqual(['a:start']))
+    first.resolve()
+    await Promise.all([a, b])
+    expect(order).toEqual(['a:start', 'a:end', 'b:start'])
+  })
+
+  it('does not make one session wait on another', async () => {
+    const queue = new CheckpointSessionQueue()
+    const stalled = deferred<void>()
+    let stalledEntered = false
+
+    void queue
+      .run('stalled', async () => {
+        stalledEntered = true
+        await stalled.promise
+      })
+      .catch(() => {})
+
+    const healthy = await queue.run('healthy', async () => 'ran')
+
+    // Why assert entry: a stall that never started would prove nothing about isolation.
+    expect(stalledEntered).toBe(true)
+    expect(healthy).toBe('ran')
+    stalled.resolve()
+  })
+
+  it('resolves the fallback when the deadline fires and still runs the operation', async () => {
+    const queue = new CheckpointSessionQueue()
+    const stalled = deferred<void>()
+    let completed = false
+
+    const outcome = await queue.runWithDeadline(
+      'stalled',
+      async () => {
+        await stalled.promise
+        completed = true
+        return 'durable'
+      },
+      5,
+      'live'
+    )
+
+    expect(outcome).toBe('live')
+    // Why: abandoning the wait must not abandon the write, or a reattach deadline
+    // would drop durable history instead of merely delaying it.
+    expect(completed).toBe(false)
+    stalled.resolve()
+    await vi.waitFor(() => expect(completed).toBe(true))
+  })
+
+  it('keeps a later waiter behind an abandoned operation', async () => {
+    const queue = new CheckpointSessionQueue()
+    const stalled = deferred<void>()
+    const order: string[] = []
+
+    expect(
+      await queue.runWithDeadline<'ran' | 'timed-out'>(
+        's',
+        async () => {
+          order.push('stalled:start')
+          await stalled.promise
+          order.push('stalled:end')
+          return 'ran'
+        },
+        5,
+        'timed-out'
+      )
+    ).toBe('timed-out')
+
+    const later = queue.run('s', async () => {
+      order.push('later')
+    })
+    await vi.waitFor(() => expect(order).toEqual(['stalled:start']))
+    stalled.resolve()
+    await later
+    expect(order).toEqual(['stalled:start', 'stalled:end', 'later'])
+  })
+
+  it('reports saturation once the queue bound is reached and clears it after draining', async () => {
+    const queue = new CheckpointSessionQueue()
+    const blocker = deferred<void>()
+    const pending: Promise<void>[] = []
+
+    for (let index = 0; index < CHECKPOINT_SESSION_QUEUE_MAX_PENDING; index += 1) {
+      expect(queue.isSaturated('s')).toBe(false)
+      pending.push(queue.run('s', async () => await blocker.promise))
+    }
+
+    expect(queue.isSaturated('s')).toBe(true)
+    expect(queue.isSaturated('other')).toBe(false)
+
+    blocker.resolve()
+    await Promise.all(pending)
+    expect(queue.isSaturated('s')).toBe(false)
+  })
+
+  it('keeps a stalled session queued rather than admitting a second writer', async () => {
+    const queue = new CheckpointSessionQueue()
+    const stalled = deferred<void>()
+    let secondEntered = false
+
+    void queue.run('s', async () => await stalled.promise).catch(() => {})
+    const second = queue.run('s', async () => {
+      secondEntered = true
+    })
+
+    // Why this matters: two concurrent tmp-write/rename pairs in one session directory lose a
+    // checkpoint, so a parked write must hold its slot rather than be dropped.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(secondEntered).toBe(false)
+    stalled.resolve()
+    await second
+    expect(secondEntered).toBe(true)
+  })
+
+  it('does not strand a session after an operation rejects', async () => {
+    const queue = new CheckpointSessionQueue()
+    await expect(
+      queue.run('s', async () => {
+        throw new Error('checkpoint failed')
+      })
+    ).rejects.toThrow('checkpoint failed')
+
+    expect(queue.isSaturated('s')).toBe(false)
+    expect(await queue.run('s', async () => 'next')).toBe('next')
+  })
+})

--- a/src/main/daemon/daemon-checkpoint-session-queue.ts
+++ b/src/main/daemon/daemon-checkpoint-session-queue.ts
@@ -1,0 +1,83 @@
+/**
+ * Serializes terminal-history checkpoint work per session.
+ *
+ * Why per session and not one process-wide tail: checkpoint exclusivity only
+ * protects one session directory's tmp-write/rename pair. A single global tail
+ * made a warm reattach wait on every other session's checkpoint, so one
+ * never-settling checkpoint blocked every daemon-backed terminal (STA-4173).
+ *
+ * Why deadlines never cancel: an operation that blows its deadline keeps running
+ * to completion. Waiters degrade (older snapshot, retry next tick) instead of
+ * dropping durable history that a later reattach would need.
+ */
+
+/** Running plus queued operations one session may hold before callers are turned away. */
+export const CHECKPOINT_SESSION_QUEUE_MAX_PENDING = 3
+
+export class CheckpointSessionQueue {
+  private tails = new Map<string, Promise<unknown>>()
+  private pending = new Map<string, number>()
+
+  /** True when the session's queue is full and a new caller should degrade instead of wait. */
+  isSaturated(sessionId: string): boolean {
+    return (this.pending.get(sessionId) ?? 0) >= CHECKPOINT_SESSION_QUEUE_MAX_PENDING
+  }
+
+  /** Waits for the session's turn and resolves when the operation finishes. */
+  run<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    return this.enqueue(sessionId, operation)
+  }
+
+  /**
+   * Waits for the session's turn, giving up after `deadlineMs` and resolving
+   * `onDeadline`. The operation still runs to completion in the background.
+   */
+  runWithDeadline<T>(
+    sessionId: string,
+    operation: () => Promise<T>,
+    deadlineMs: number,
+    onDeadline: T
+  ): Promise<T> {
+    const work = this.enqueue(sessionId, operation)
+    return new Promise<T>((resolve) => {
+      const timer = setTimeout(() => resolve(onDeadline), deadlineMs)
+      timer.unref?.()
+      work.then(
+        (value) => {
+          clearTimeout(timer)
+          resolve(value)
+        },
+        () => {
+          clearTimeout(timer)
+          resolve(onDeadline)
+        }
+      )
+    })
+  }
+
+  // Why there is no clear(): dropping a tail while its write is parked would let the next caller
+  // into the same session directory, and two concurrent tmp-write/rename pairs lose a checkpoint.
+  // Entries remove themselves as operations settle, so a stalled session pins one entry at most.
+
+  private enqueue<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(sessionId) ?? Promise.resolve()
+    this.pending.set(sessionId, (this.pending.get(sessionId) ?? 0) + 1)
+    const next = previous.catch(() => {}).then(operation)
+    this.tails.set(sessionId, next)
+    const settle = (): void => {
+      const remaining = (this.pending.get(sessionId) ?? 1) - 1
+      if (remaining > 0) {
+        this.pending.set(sessionId, remaining)
+        return
+      }
+      this.pending.delete(sessionId)
+      if (this.tails.get(sessionId) === next) {
+        this.tails.delete(sessionId)
+      }
+    }
+    // Why a detached handler: `next` is the shared tail, so a rejection the caller
+    // already sees would still surface here as an unhandled rejection.
+    next.then(settle, settle)
+    return next
+  }
+}

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -69,6 +69,7 @@ import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 import { resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { ColdRestorePayloadCache, type ColdRestorePayload } from './cold-restore-payload-cache'
+import { CheckpointSessionQueue } from './daemon-checkpoint-session-queue'
 import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
 import { DAEMON_RESTORE_SCROLLBACK_ROWS } from './daemon-restore-scrollback-depth'
 import { DAEMON_SESSION_SCROLLBACK_ROWS } from './daemon-session-scrollback-window'
@@ -150,6 +151,15 @@ export type DaemonIdentityChangeEvent = {
 
 const MAX_TOMBSTONES = 1000
 const MAX_CONCURRENT_CHECKPOINTS = 4
+
+// Why a reattach deadline at all: a warm reattach is a user click, so it must never wait on a
+// stalled history filesystem. Why 5s: a healthy deep-history rebuild replays at most
+// DAEMON_RESTORE_SCROLLBACK_ROWS through the headless emulator in well under a second, so this
+// only fires when the write path is genuinely wedged (STA-4173).
+const DURABLE_HISTORY_OVERLAY_DEADLINE_MS = 5_000
+// Why the background pass gets a longer one: blowing it only defers a still-dirty session to the
+// next tick, so the budget should sit above any slow-but-working disk rather than churn it.
+const PERIODIC_CHECKPOINT_DEADLINE_MS = 15_000
 
 // Why far below the client's 30s default: a wedged daemon holds its socket open, so an unbounded
 // probe stalls a pane mount for the full request timeout — and the owner fan-out waits on every
@@ -238,6 +248,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private sessionsNeedingContinuityCheckpoint = new Set<string>()
   private checkpointTimer: ReturnType<typeof setTimeout> | null = null
   private checkpointInFlight: Promise<void> | null = null
+  // Why per session: exclusivity protects one session directory's tmp-write/rename, so ordering
+  // every session behind one tail let a single stalled checkpoint block all reattaches (STA-4173).
+  private checkpointQueue = new CheckpointSessionQueue()
   private keepHistoryShutdowns = new Set<Promise<void>>()
   private disconnectOnlyPromise: Promise<void> | null = null
   // Why: checkpoint persistence needs the getSnapshot RPC (v4+); legacy daemons reject it, spamming logs every 5s.
@@ -1299,23 +1312,45 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (!this.historyManager || !this.historyReader) {
       return liveSnapshot
     }
+    // Why turn the caller away instead of queueing: this session already has a
+    // compact in flight whose result a third one would only duplicate, and an
+    // unbounded queue is how a stalled history filesystem grows without limit.
+    if (this.checkpointQueue.isSaturated(sessionId)) {
+      return liveSnapshot
+    }
+    // Why per session with a deadline: a reattach is a user click, so it must wait
+    // on this session's own compact and nothing else. A blown deadline does not
+    // cancel that compact — it keeps running and still commits — so the fallback
+    // costs restore depth for this one reattach, never durable history (STA-4173).
+    return await this.checkpointQueue.runWithDeadline(
+      sessionId,
+      () => this.compactDurableRestoreSnapshot(sessionId, liveSnapshot, scrollbackRows),
+      DURABLE_HISTORY_OVERLAY_DEADLINE_MS,
+      liveSnapshot
+    )
+  }
+
+  private async compactDurableRestoreSnapshot(
+    sessionId: string,
+    liveSnapshot: NonNullable<GetSnapshotResult['snapshot']>,
+    scrollbackRows?: number
+  ): Promise<NonNullable<GetSnapshotResult['snapshot']>> {
+    if (!this.historyReader) {
+      return liveSnapshot
+    }
     try {
-      // Why exclusive compact: an independent take/append races the 5s tick, can
+      // Why compact before reading: an independent take/append races the 5s tick, can
       // seq-gap the log, and would remount a stale checkpoint over the live window.
-      const checkpointResult: { value?: SnapshotCheckpointResult } = {}
-      await this.runExclusiveCheckpoint(async () => {
-        checkpointResult.value = await this.takeSnapshotAndCheckpoint(sessionId, {
-          teardown: false,
-          forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId),
-          requireContinuityProof: this.sessionsNeedingContinuityCheckpoint.has(sessionId)
-        })
-        if (checkpointResult.value.checkpoint === 'committed') {
-          this.sessionsNeedingFullCheckpoint.delete(sessionId)
-        }
+      const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, {
+        teardown: false,
+        forceLiveSnapshot: this.sessionsNeedingLiveCheckpoint.has(sessionId),
+        requireContinuityProof: this.sessionsNeedingContinuityCheckpoint.has(sessionId)
       })
-      const checkpoint = checkpointResult.value
-      if (checkpoint?.checkpoint !== 'committed' || !checkpoint.snapshot) {
-        return checkpoint?.snapshot ?? liveSnapshot
+      if (checkpoint.checkpoint === 'committed') {
+        this.sessionsNeedingFullCheckpoint.delete(sessionId)
+      }
+      if (checkpoint.checkpoint !== 'committed' || !checkpoint.snapshot) {
+        return checkpoint.snapshot ?? liveSnapshot
       }
       if (scrollbackRows === undefined || scrollbackRows >= DAEMON_RESTORE_SCROLLBACK_ROWS) {
         return checkpoint.snapshot
@@ -2110,9 +2145,32 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return elapsed >= 0 && elapsed < DaemonPtyAdapter.FULL_CHECKPOINT_COOLDOWN_MS
   }
 
+  private async checkpointSession(
+    sessionId: string,
+    opts: { final: boolean; teardown: boolean }
+  ): Promise<'done' | 'deferred'> {
+    const run = (): Promise<'done' | 'deferred'> => this.writeSessionCheckpoint(sessionId, opts)
+    // Why final waits without a deadline: sleep/disconnect needs the last snapshot on disk, and
+    // deferring there would silently drop what the user left on screen rather than delay it.
+    if (opts.final) {
+      return await this.checkpointQueue.run(sessionId, run)
+    }
+    // Why 'deferred' is safe: the session stays dirty, so the operation that beat us to the queue
+    // still commits and the next tick retries this one. Nothing on disk is discarded.
+    if (this.checkpointQueue.isSaturated(sessionId)) {
+      return 'deferred'
+    }
+    return await this.checkpointQueue.runWithDeadline(
+      sessionId,
+      run,
+      PERIODIC_CHECKPOINT_DEADLINE_MS,
+      'deferred'
+    )
+  }
+
   // Why 'deferred' exists: a full snapshot inside the cooldown is postponed and the session stays dirty for retry;
   // skipping append meanwhile keeps the on-disk log a consistent (stale) prefix instead of punching a hole.
-  private async checkpointSession(
+  private async writeSessionCheckpoint(
     sessionId: string,
     opts: { final: boolean; teardown: boolean }
   ): Promise<'done' | 'deferred'> {

--- a/src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts
+++ b/src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonServer } from './daemon-server'
+import { getDaemonSocketPath } from './daemon-spawner'
+import type { DaemonFileLog } from './daemon-file-log'
+import { HistoryReader } from './history-reader'
+import type { HistoryCheckpointResult } from './terminal-history-manager-options'
+import type { SubprocessHandle } from './session'
+import type { TerminalSnapshot } from './types'
+
+const REATTACH_BUDGET_MS = 2_000
+// Why above DURABLE_HISTORY_OVERLAY_DEADLINE_MS: this asserts the reattach gives up on its own
+// stalled checkpoint, so the window must outlast the deadline it is proving.
+const DEADLINE_BUDGET_MS = 20_000
+
+function createMockSubprocess(): SubprocessHandle & { emitData: (data: string) => void } {
+  let onData: ((data: string) => void) | undefined
+  let onExit: ((code: number) => void) | undefined
+  return {
+    pid: 4242,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => setTimeout(() => onExit?.(0), 1)),
+    forceKill: vi.fn(() => onExit?.(137)),
+    signal: vi.fn(),
+    onData(callback) {
+      onData = callback
+    },
+    onExit(callback) {
+      onExit = callback
+    },
+    dispose: vi.fn(),
+    emitData(data) {
+      onData?.(data)
+    }
+  }
+}
+
+/** Resolves 'timed-out' instead of hanging, so a wedged reattach fails the test rather than the run. */
+async function withinBudget<T>(work: Promise<T>, budgetMs: number): Promise<T | 'timed-out'> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<'timed-out'>((resolve) => {
+    timer = setTimeout(() => resolve('timed-out'), budgetMs)
+  })
+  try {
+    return await Promise.race([work, deadline])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+describe('STA-4173 reattach isolation from a stalled checkpoint', () => {
+  let dir: string
+  let server: DaemonServer
+  let adapter: DaemonPtyAdapter
+  let subprocesses: ReturnType<typeof createMockSubprocess>[]
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-reattach-isolation-'))
+    subprocesses = []
+    const log: DaemonFileLog = { log: () => {}, close: () => {} }
+    server = new DaemonServer({
+      socketPath: getDaemonSocketPath(dir),
+      tokenPath: join(dir, 'test.token'),
+      log,
+      spawnSubprocess: () => {
+        const subprocess = createMockSubprocess()
+        subprocesses.push(subprocess)
+        return subprocess
+      }
+    })
+    await server.start()
+    adapter = new DaemonPtyAdapter({
+      socketPath: getDaemonSocketPath(dir),
+      tokenPath: join(dir, 'test.token'),
+      historyPath: join(dir, 'history')
+    })
+  })
+
+  afterEach(async () => {
+    adapter?.dispose()
+    await server?.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * Wedges one session's checkpoint at the history-write layer and reports how many times that
+   * stall was actually entered, so a swallowed TypeError cannot masquerade as a stall.
+   */
+  async function stallCheckpointFor(stalledSessionId: string): Promise<{
+    entered: () => number
+    release: () => void
+  }> {
+    const manager = adapter.getHistoryManager()
+    expect(manager).not.toBeNull()
+    const original = manager!.checkpoint.bind(manager!)
+    let entered = 0
+    let release = (): void => {}
+    const stalled = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    vi.spyOn(manager!, 'checkpoint').mockImplementation(
+      async (
+        sessionId: string,
+        snapshot: TerminalSnapshot,
+        opts?: { pendingOutputSeq?: number }
+      ): Promise<HistoryCheckpointResult> => {
+        if (sessionId !== stalledSessionId) {
+          return await original(sessionId, snapshot, opts)
+        }
+        entered += 1
+        await stalled
+        return await original(sessionId, snapshot, opts)
+      }
+    )
+    return { entered: () => entered, release }
+  }
+
+  async function spawnWithOutput(sessionId: string, output: string): Promise<string> {
+    const { id } = await adapter.spawn({ cols: 80, rows: 24, sessionId, cwd: '/tmp' })
+    subprocesses.at(-1)!.emitData(output)
+    return id
+  }
+
+  it('reattaches an unrelated session while another session checkpoint never settles', async () => {
+    const stalledId = await spawnWithOutput('stalled-session', 'STALLED_OUTPUT\r\n')
+    const healthyId = await spawnWithOutput('healthy-session', 'HEALTHY_OUTPUT\r\n')
+    const stall = await stallCheckpointFor(stalledId)
+
+    // Why start the stalled reattach first: it is the one that parks a checkpoint, and before the
+    // per-session queue that parked checkpoint owned the process-wide tail every reattach joined.
+    const stalledReattach = adapter.spawn({ cols: 80, rows: 24, sessionId: stalledId, cwd: '/tmp' })
+    void stalledReattach.catch(() => {})
+    await vi.waitFor(() => expect(stall.entered()).toBeGreaterThan(0))
+
+    const healthyReattach = await withinBudget(
+      adapter.spawn({ cols: 80, rows: 24, sessionId: healthyId, cwd: '/tmp' }),
+      REATTACH_BUDGET_MS
+    )
+
+    expect(healthyReattach).not.toBe('timed-out')
+    expect(healthyReattach).toMatchObject({ isReattach: true })
+    expect((healthyReattach as { snapshot: string }).snapshot).toContain('HEALTHY_OUTPUT')
+    // The stall must still be parked, or the healthy reattach proved nothing.
+    expect(stall.entered()).toBe(1)
+    stall.release()
+    await stalledReattach
+  })
+
+  it('falls back to the live window when the session own checkpoint blows the deadline', async () => {
+    const stalledId = await spawnWithOutput('deadline-session', 'DEADLINE_OUTPUT\r\n')
+    const stall = await stallCheckpointFor(stalledId)
+
+    const reattach = await withinBudget(
+      adapter.spawn({ cols: 80, rows: 24, sessionId: stalledId, cwd: '/tmp' }),
+      DEADLINE_BUDGET_MS
+    )
+
+    expect(stall.entered()).toBeGreaterThan(0)
+    expect(reattach).not.toBe('timed-out')
+    expect(reattach).toMatchObject({ isReattach: true })
+    // Degraded to the daemon's live window, not empty: the deadline costs restore depth, not history.
+    expect((reattach as { snapshot: string }).snapshot).toContain('DEADLINE_OUTPUT')
+    stall.release()
+  }, 30_000)
+
+  it('still commits the abandoned checkpoint once the history write completes', async () => {
+    const stalledId = await spawnWithOutput('resumed-session', 'RESUMED_OUTPUT\r\n')
+    const stall = await stallCheckpointFor(stalledId)
+
+    const reattach = await withinBudget(
+      adapter.spawn({ cols: 80, rows: 24, sessionId: stalledId, cwd: '/tmp' }),
+      DEADLINE_BUDGET_MS
+    )
+    expect(reattach).not.toBe('timed-out')
+
+    stall.release()
+    // Why this is the whole point of not cancelling: the reattach degraded, and the durable write
+    // the deadline walked away from still lands on disk for the next restore.
+    await vi.waitFor(async () => {
+      const restore = await new HistoryReader(join(dir, 'history')).detectColdRestore(stalledId, {
+        ignoreCleanEnd: true
+      })
+      expect(`${restore?.scrollbackAnsi ?? ''}${restore?.snapshotAnsi ?? ''}`).toContain(
+        'RESUMED_OUTPUT'
+      )
+    })
+  }, 30_000)
+})


### PR DESCRIPTION
## ELI5

Every terminal that reattaches after a relaunch first compacts its saved scrollback to disk. Since #14193 all of those compactions stood in **one** line, and reattach waited at the back of it with no time limit. If one terminal's disk write hung, every other terminal was stuck behind it and none could reattach. This gives each terminal its own line and a stopwatch: if your own compaction is too slow, you reattach with the shallower live window instead of waiting forever. The slow write is never cancelled, so nothing saved is lost — it just lands a moment later.

## What Changed

- New `src/main/daemon/daemon-checkpoint-session-queue.ts`: `CheckpointSessionQueue` serializes history-checkpoint work **per session** instead of on one process-wide promise tail, with a per-session queue bound and deadline-bounded waits that never cancel the running operation.
- `daemon-pty-adapter.ts`
  - `overlayDurableRestoreSnapshot` (warm reattach + deep `getBufferSnapshot`) no longer calls `runExclusiveCheckpoint`. It takes the session's own slot with a 5s deadline and falls back to the daemon's live snapshot on expiry; the compaction body moved to `compactDurableRestoreSnapshot`.
  - `checkpointSession` now routes through the same per-session queue so the 5s tick and the overlay still cannot interleave on one session directory. Non-final passes get a 15s deadline and return `deferred` (the session stays dirty and is retried); `final: true` passes still wait unbounded so sleep/disconnect never skips the last snapshot.
  - Queue bound: a saturated session degrades immediately (live snapshot / `deferred`) rather than growing the queue.

`runExclusiveCheckpoint` is unchanged and still orders the periodic, shutdown, and disconnect passes among themselves.

## Why

#14193 (the STA-4091 fix) newly routed core reattach and deep-snapshot paths through `overlayDurableRestoreSnapshot`, which called `runExclusiveCheckpoint`:

```ts
const previous = this.checkpointInFlight ?? Promise.resolve()
const checkpoint = previous.catch(() => {}).then(operation)
```

`checkpointInFlight` is one field for the whole process, and there is no deadline. If `previous` never settles, `operation` never even starts. The unbounded source is plain `fsPromises` work with no timeout — `terminal-history-session-writer.ts:89-92` writes a tmp file, renames it, then rewrites the log header.

**Concrete user-visible harm today:** on a host whose history directory stalls (a network/FUSE-mounted home on an SSH or remote workspace, or a Windows AV/indexer lock), one session's checkpoint parks forever and **every** daemon-backed terminal in the app hangs on reattach — blank panes that never restore, with no error and no recovery short of a restart. Even without a hard stall, `checkpointDirtySessions` fans out over all dirty sessions at up to 4 at a time with a 30s RPC cap each, so a slow daemon delays an unrelated reattach by `ceil(N/4) x 30s`.

Checkpoint exclusivity exists to protect one session directory's tmp-write/rename pair. It was never a cross-session invariant — the periodic pass already checkpoints 4 sessions concurrently. Per-session is the correct granularity; the global tail was over-broad.

### Failure-mode table

This PR fixes a regression that a previous fix created, so every cell was enumerated first. **No cell loses durable history.** The worst outcome anywhere is reduced restore *depth* for a single reattach, which is exactly the behavior that shipped before #14193.

| Scenario | Reattach | Durable history on disk |
| --- | --- | --- |
| **(a) checkpoint settles normally** | Waits on this session's compact only, returns the full-depth durable snapshot | Committed — unchanged from today |
| **(b) one session's checkpoint never settles** | That session's reattach returns the live daemon window after 5s. **Every other session reattaches immediately** — they never touch the stalled session's slot | The parked write is not cancelled and still commits if the fs recovers. The previous checkpoint stays on disk and remains the restore source meanwhile. Nothing dropped |
| **(c) history filesystem slow but eventually returns** | Reattach bounded at 5s, degrades to the live window | Fully preserved. The slow compact lands afterwards, so the *next* reattach/deep snapshot is full depth again |
| **(d) deadline fires with a write genuinely in flight** | Returns the live window | The write is **not** aborted — no cancellation is plumbed into the fs calls. `rename` is atomic, so the old checkpoint is readable until the new one replaces it. A later waiter queues behind the parked write rather than opening a second writer on the same directory (`CheckpointSessionQueue` deliberately has no `clear()`) |

The periodic pass follows the same rule: a blown 15s deadline returns `deferred`, which leaves the session dirty for the next tick while the running operation still commits. `final: true` never carries a deadline, because deferring a shutdown checkpoint *would* drop what the user left on screen.

## Linked Issue

Fixes STA-4173 — https://linear.app/stably/issue/STA-4173/p1-durable-history-overlay-blocks-reattach-on-the-global-checkpoint

Regression from #14193 (the STA-4091 fix). Distinct from STA-4091's window-shrink work, which is untouched.

## Visual Proof

Electron QA (Playwright CDP, no computer-use) on `8b357129d1`: three daemon-backed terminals with distinct scrollback, then quit only the QA app so the daemon stayed alive, then relaunch and warm reattach. All three session IDs unchanged, the same scrollback on screen, Resource Manager shows 3 sessions, no Reconnect control. Before/after screenshots: https://github.com/stablyai/orca/pull/14346#issuecomment-5286433782

The stall-degrade path is not UI-observable without an artificially wedged filesystem; it is covered by the automated tests above.

## Testing

`src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts` (new) drives a real `DaemonServer` + adapter + temp history dir, stalls one session at the `HistoryManager.checkpoint` layer, and races reattaches against a bounded timer so a hang fails loudly instead of wedging the suite:

- an unrelated session reattaches while the stalled checkpoint is parked
- the stalled session's *own* reattach degrades to the live window instead of hanging
- the abandoned checkpoint still lands on disk once the write completes (`detectColdRestore` finds it)

`src/main/daemon/daemon-checkpoint-session-queue.test.ts` (new) covers serialization, cross-session independence, deadline-without-cancellation, queue saturation, rejection recovery, and that a parked write keeps its slot.

**Non-vacuity, proved by mutation.** Every stall assertion also asserts the stall was *entered* (`stall.entered()`), so a `TypeError` swallowed by `compactDurableRestoreSnapshot`'s `catch` cannot pass for a stall. Reverting only the fix — putting the overlay back on `runExclusiveCheckpoint` with no deadline — fails all three adapter tests with `expected 'timed-out' not to be 'timed-out'`, i.e. the reattach genuinely never completes, while `stall.entered()` still passes:

```
 ❯ daemon-reattach-checkpoint-isolation.test.ts (3 tests | 3 failed)
   × reattaches an unrelated session while another session checkpoint never settles 2122ms
   × falls back to the live window when the session own checkpoint blows the deadline 20013ms
   × still commits the abandoned checkpoint once the history write completes 20012ms
```

Restoring the fix returns all three to green. This was independently reproduced by a second agent on a separate worktree (branch `sta-4173-repro`), which landed on the same root cause: skipping the process-wide `checkpointInFlight` tail takes the unrelated reattach from timeout to ~100ms.

Gates run locally on macOS: `vitest src/main/daemon` (1556 passed), `vitest terminal-pane` (272 files / 3448 passed), `pnpm typecheck` (all three projects), `oxlint` + `oxlint --type-aware`, `oxfmt --check`, `check:max-lines-ratchet` (no new suppressions; no `max-lines` disable added). Two real-zsh PTY tests in `repro-13767-shell-ready-marker-lost-to-exec.test.ts` time out under full-suite parallel load — confirmed pre-existing: the same suite on a clean checkout of this base fails *more* of them (4 vs 3), and the file passes 3/3 in isolation with this change applied.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Remote SSH:** in scope and improved. On remote workspaces the daemon and adapter run on the remote host, where a network-mounted history directory is the most likely stall — the exact case that previously wedged all reattaches.
- **Backwards compatibility / wire:** no wire change. No RPC params, stream opcodes, or published host content are touched; `getSnapshot` and `takePendingOutput` are called exactly as before. Only the local scheduling of those calls changed, and the degraded path returns the same snapshot shape #14193 already returns from its `catch`. Per `docs/reference/remote-wire-compatibility.md` there is nothing to negotiate.
- **Cross-platform:** pure promise scheduling, no platform-dependent behavior or paths. The Windows AV/indexer lock case is a beneficiary.
- **Folder workspaces:** unaffected — no git or worktree assumptions.
- **Performance:** strictly less blocking. Removes a process-wide serialization point from the reattach path; adds two `Map` lookups per checkpoint. The overlay no longer stops and restarts the 5s timer on every reattach.
- **Security:** no new I/O, surfaces, or inputs.
- **Mobile:** paired clients reattach through this same adapter and benefit identically; no client-side change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
