### PR TITLE
fix(browser): restore cookies that arrive during cookie-clear fallback (STA-4170)

### DIFF
--- a/src/main/browser/browser-cookie-import-clear-atomicity.test.ts
+++ b/src/main/browser/browser-cookie-import-clear-atomicity.test.ts
@@ -150,6 +150,129 @@ describe('STA-4090 failed full cookie clear', () => {
     )
   })
 
+  // Why (STA-4170): fallback re-reads the live jar, so a login cookie that arrives after
+  // the pre-clear snapshot can be deleted. Rollback must restore that arrival too.
+  it('restores a post-snapshot arrival when a later fallback removal fails', async () => {
+    let jar = [
+      cookie('.example.com', 'pre-existing', '/one'),
+      cookie('.other.test', 'later-fail', '/two')
+    ]
+    const removedNames: string[] = []
+    const restoredNames: string[] = []
+    const session: CookieClearSession & { names: () => string[] } = {
+      cookies: {
+        get: async () => [...jar],
+        remove: async (_url, name) => {
+          if (name === 'later-fail') {
+            throw new Error('cookie store unavailable')
+          }
+          removedNames.push(name)
+          jar = jar.filter((entry) => entry.name !== name)
+        }
+      },
+      clearData: async () => {
+        jar = [
+          cookie('.login.test', 'arrived-during-clear'),
+          cookie('.other.test', 'later-fail', '/two')
+        ]
+        throw new Error('storage busy')
+      },
+      snapshotClearIdentities: async (items) => identitiesFromClearCookies(items),
+      restoreClearIdentities: async (identities) => {
+        restoredNames.push(...identities.map((identity) => identity.name))
+        for (const identity of identities) {
+          if (jar.some((entry) => entry.name === identity.name)) {
+            continue
+          }
+          jar.push(cookie(identity.domain ?? '', identity.name, identity.path, identity.secure))
+        }
+      },
+      names: () => jar.map((entry) => entry.name).sort()
+    }
+
+    await expect(removeTransplantableCookies(session)).rejects.toThrow(
+      /existing cookies were restored/
+    )
+
+    expect(removedNames).toEqual(['arrived-during-clear'])
+    expect(restoredNames).toEqual(expect.arrayContaining(['arrived-during-clear', 'pre-existing']))
+    expect(session.names()).toEqual(['arrived-during-clear', 'later-fail', 'pre-existing'])
+  })
+
+  it('restores the pre-clear snapshot when leftover identity capture fails', async () => {
+    let jar = [
+      cookie('.example.com', 'pre-existing', '/one'),
+      cookie('.other.test', 'leftover', '/two')
+    ]
+    let snapshotCalls = 0
+    const removedNames: string[] = []
+    const session: CookieClearSession & { names: () => string[] } = {
+      cookies: {
+        get: async () => [...jar],
+        remove: async (_url, name) => {
+          removedNames.push(name)
+          jar = jar.filter((entry) => entry.name !== name)
+        }
+      },
+      clearData: async () => {
+        jar = [cookie('.other.test', 'leftover', '/two')]
+        throw new Error('storage busy')
+      },
+      snapshotClearIdentities: async (items) => {
+        snapshotCalls += 1
+        if (snapshotCalls > 1) {
+          throw new Error('could not snapshot leftover cookies')
+        }
+        return identitiesFromClearCookies(items)
+      },
+      restoreClearIdentities: async (identities) => {
+        for (const identity of identities) {
+          if (jar.some((entry) => entry.name === identity.name)) {
+            continue
+          }
+          jar.push(cookie(identity.domain ?? '', identity.name, identity.path, identity.secure))
+        }
+      },
+      names: () => jar.map((entry) => entry.name).sort()
+    }
+
+    await expect(removeTransplantableCookies(session)).rejects.toThrow(
+      /existing cookies were restored/
+    )
+    expect(removedNames).toEqual([])
+    expect(session.names()).toEqual(['leftover', 'pre-existing'])
+  })
+
+  it('does not remove cookies that arrive after the leftover set is fenced', async () => {
+    let jar = [cookie('.example.com', 'survived'), cookie('.other.test', 'tracker')]
+    const removedNames: string[] = []
+    const session: CookieClearSession & { names: () => string[] } = {
+      cookies: {
+        get: async () => [...jar],
+        remove: async (_url, name) => {
+          removedNames.push(name)
+          jar = jar.filter((entry) => entry.name !== name)
+          if (name === 'survived') {
+            jar.push(cookie('.late.test', 'late-arrival'))
+          }
+        }
+      },
+      clearData: async () => {
+        throw new Error('storage busy')
+      },
+      snapshotClearIdentities: async (items) => identitiesFromClearCookies(items),
+      restoreClearIdentities: async () => undefined,
+      names: () => jar.map((entry) => entry.name).sort()
+    }
+
+    await removeTransplantableCookies(session)
+
+    expect(removedNames).toHaveLength(2)
+    expect(removedNames).toEqual(expect.arrayContaining(['survived', 'tracker']))
+    expect(removedNames).not.toContain('late-arrival')
+    expect(session.names()).toEqual(['late-arrival'])
+  })
+
   it('serializes concurrent clears on the same session', async () => {
     const activeClears: number[] = []
     let inClear = 0

--- a/src/main/browser/browser-cookie-import-clear.ts
+++ b/src/main/browser/browser-cookie-import-clear.ts
@@ -49,6 +49,33 @@ function cookieClearKey(url: string, name: string): string {
   return JSON.stringify([url, name])
 }
 
+function cookieRestoreKey(identity: CookieClearIdentity): string {
+  return JSON.stringify([
+    identity.url,
+    identity.name,
+    identity.domain ?? null,
+    identity.path ?? null,
+    identity.partitionKey ?? null
+  ])
+}
+
+function mergeClearIdentities(
+  primary: readonly CookieClearIdentity[],
+  extras: readonly CookieClearIdentity[]
+): CookieClearIdentity[] {
+  const seen = new Set<string>()
+  const merged: CookieClearIdentity[] = []
+  for (const identity of [...primary, ...extras]) {
+    const key = cookieRestoreKey(identity)
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    merged.push(identity)
+  }
+  return merged
+}
+
 export function identitiesFromClearCookies(
   cookies: readonly { cookie: Cookie; url: string }[]
 ): CookieClearIdentity[] {
@@ -150,6 +177,20 @@ async function restoreClearedCookies(
   )
 }
 
+async function snapshotFencedClearIdentities(
+  targetSession: CookieClearSession,
+  fencedRemovable: readonly { cookie: Cookie; url: string }[],
+  initialIdentities: readonly CookieClearIdentity[]
+): Promise<CookieClearIdentity[]> {
+  try {
+    const fencedIdentities = await targetSession.snapshotClearIdentities(fencedRemovable)
+    assertClearIdentitiesCoverRemovable(fencedRemovable, fencedIdentities)
+    return fencedIdentities
+  } catch (error) {
+    return restoreClearedCookies(targetSession, initialIdentities, [error])
+  }
+}
+
 export async function removeTransplantableCookies(
   targetSession: CookieClearSession
 ): Promise<void> {
@@ -179,10 +220,22 @@ export async function removeTransplantableCookies(
       // Why: a rejected bulk clear can still have emptied part of the jar.
     }
 
-    const existingCookies = await store.get({})
-    const removableGroups = groupRemovableCookies(removableCookieEntries(existingCookies))
+    const leftoverCookies = await store.get({})
+    const fencedRemovable = removableCookieEntries(leftoverCookies)
+    if (fencedRemovable.length === 0) {
+      return
+    }
+
+    // Why (STA-4170): snapshot the exact leftover set before any fallback remove so an
+    // arrival can be restored if a later removal fails. Fail closed on snapshot errors.
+    const fencedIdentities = await snapshotFencedClearIdentities(
+      targetSession,
+      fencedRemovable,
+      identities
+    )
+
     const results = await mapSettledWithConcurrency(
-      [...removableGroups.values()],
+      [...groupRemovableCookies(fencedRemovable).values()],
       COOKIE_CLEAR_CONCURRENCY,
       async (group) => {
         // Why: identical removal coordinates must stay ordered instead of racing.
@@ -195,7 +248,11 @@ export async function removeTransplantableCookies(
       result.status === 'rejected' ? [result.reason] : []
     )
     if (failures.length > 0) {
-      await restoreClearedCookies(targetSession, identities, failures)
+      await restoreClearedCookies(
+        targetSession,
+        mergeClearIdentities(fencedIdentities, identities),
+        failures
+      )
     }
   })
 }

--- a/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts
@@ -24,6 +24,7 @@ type FixtureResult = {
   remainingChips: CdpCookie[]
   remainingPlain: CdpCookie[]
   remainingExcluded: CdpCookie[]
+  remainingArrived: CdpCookie[]
 }
 
 const EXPECTED_PARTITION_KEY = {
@@ -31,7 +32,7 @@ const EXPECTED_PARTITION_KEY = {
   hasCrossSiteAncestor: true
 }
 
-function buildFixtureMain(bundlePath: string, resultPath: string): string {
+function buildFixtureMain(bundlePath: string, resultPath: string, injectArrival: boolean): string {
   return `
 const { app, BrowserWindow, session } = require('electron')
 const { writeFileSync } = require('node:fs')
@@ -95,6 +96,14 @@ async function run() {
     },
     clearData: async () => {
       bulkClearCalls++
+      if (${injectArrival}) {
+        await targetSession.cookies.set({
+          url: 'https://login.example/',
+          name: 'arrived-during-clear',
+          value: 'fresh-login',
+          secure: true
+        })
+      }
       throw new Error('forced bulk clear failure')
     },
     snapshotClearIdentities: (cookies) => cookieClearStore.snapshotClearIdentities(cookies),
@@ -122,7 +131,8 @@ async function run() {
     bulkClearCalls,
     remainingChips: project('chips-auth'),
     remainingPlain: project('plain'),
-    remainingExcluded: project('SID')
+    remainingExcluded: project('SID'),
+    remainingArrived: project('arrived-during-clear')
   }))
   debug.detach()
   window.destroy()
@@ -136,7 +146,7 @@ run().catch((error) => {
 `
 }
 
-async function runFixture(): Promise<FixtureResult> {
+async function runFixture(injectArrival = false): Promise<FixtureResult> {
   const root = mkdtempSync(join(tmpdir(), 'orca-partition-rollback-'))
   fixtureRoots.push(root)
   const bundlePath = join(root, 'cookie-clear-rollback.cjs')
@@ -165,7 +175,7 @@ async function runFixture(): Promise<FixtureResult> {
       rollupOptions: { external: ['electron', /^node:/] }
     }
   })
-  writeFileSync(fixturePath, buildFixtureMain(bundlePath, resultPath))
+  writeFileSync(fixturePath, buildFixtureMain(bundlePath, resultPath, injectArrival))
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
   const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
   const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
@@ -198,5 +208,22 @@ describe('non-Google partitioned cookie under a failed Electron cookie clear', (
       { name: 'chips-auth', value: 'keep-me', partitionKey: EXPECTED_PARTITION_KEY }
     ])
     expect(result.remainingPlain).toEqual([{ name: 'plain', value: 'stale' }])
+  }, 90_000)
+
+  // Why (STA-4170): a login cookie that lands after the pre-clear snapshot must come back
+  // when a later fallback removal rejects, including through the real CDP restore path.
+  it('restores a cookie that arrived during the rejected bulk clear', async () => {
+    const result = await runFixture(true)
+
+    expect(result.bulkClearCalls).toBe(1)
+    expect(result.clearError).toContain('existing cookies were restored')
+    expect(result.remainingExcluded.map(({ name }) => name)).toEqual(['SID'])
+    expect(result.remainingChips).toEqual([
+      { name: 'chips-auth', value: 'keep-me', partitionKey: EXPECTED_PARTITION_KEY }
+    ])
+    expect(result.remainingPlain).toEqual([{ name: 'plain', value: 'stale' }])
+    expect(result.remainingArrived).toEqual([
+      { name: 'arrived-during-clear', value: 'fresh-login' }
+    ])
   }, 90_000)
 })


### PR DESCRIPTION
## ELI5

Wiping cookies before an import has a backup plan if the fast wipe fails. That backup could delete a login cookie that showed up *after* the backup started, then say "don't worry, we put everything back" even though that new login stayed gone. This change remembers every cookie the backup actually touches, so a later failure can put the new login back too.

## What Changed

`removeTransplantableCookies` still snapshots removable identities before the bulk `clearData` call. After a rejected bulk clear it now:

- Re-reads the live jar once and **fences** that leftover removal set
- Snapshots those leftover identities (including arrivals) before any fallback `remove()`
- Fail-closes and restores the pre-clear snapshot if leftover identity capture fails
- On a later fallback removal failure, restores the **union** of leftover identities and the pre-clear snapshot

`cookies.set()` remains unreachable on this path.

## Why

PR #14131 re-reads the jar after a rejected bulk clear so leftover cookies (including arrivals) get removed. PR #14191 snapshots only the **pre-clear** removable set for rollback. Those two facts combine into a P0:

1. A cookie that arrives during fallback is removed
2. Rollback cannot restore it
3. The error still says existing cookies were restored

A cookie-jar clone/swap is not available on the session API, and skipping leftover arrivals would mix live logins with the imported set (the reason this path clears first). The structural invariant is: never mutate a cookie without a restore identity captured first.

## Linked Issue

Fixes [STA-4170](https://linear.app/stably/issue/STA-4170/p0-cookie-clear-fallback-can-delete-post-snapshot-login-cookies-after)

Follow-up to #14131 / #14191.

## Visual Proof

N/A for UI chrome — this is a main-process restore-set fix with no renderer or layout change.

CDP on a live Orca dev build of this branch (`Orca: brennanb2025/sta-4170-cookie-clear-fence`) confirmed Settings → Browser → Session & Cookies still opens and the Import Cookies menu still lists Chrome, Safari, and From File.

![Settings Browser Session & Cookies](https://github.com/user-attachments/assets/3972cb3a-9432-469b-a01c-6f192265743b)

![Import Cookies menu](https://github.com/user-attachments/assets/5527a200-491f-4974-967a-94d97ab4868d)

The defect itself is not clickable in the UI (needs a rejected `clearData` plus a later `remove` failure). Real-Electron proof is the fixture below.

## Testing

macOS. No platform-conditional code, filesystem paths, Git commands, or remote-wire changes. Linux / Windows / SSH / folder workspaces are unaffected.

**Before-fix (origin/main):** `restores a post-snapshot arrival when a later fallback removal fails` failed. Fallback deleted `arrived-during-clear`; restore only returned `later-fail` and `pre-existing`.

**After-fix:**

- `npx vitest run --config config/vitest.config.ts src/main/browser/browser-cookie-import-clear-atomicity.test.ts src/main/browser/browser-cookie-import-policy.test.ts` — 31 passed
- `npx vitest run --config config/vitest.config.ts src/main/browser/browser-cookie-import-partition-rollback.electron.test.ts` — 2 passed, including arrival restore through real CDP `Network.setCookie`
- `pnpm run typecheck:node` — clean
- oxlint + oxfmt + changed-code quality — clean

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

N/A — internal.

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security / data loss:** the P0. Restore set now covers every identity the fallback mutates. Residual: if restore itself fails, the error still says the session was left partially cleared.
- **Backwards compatibility:** no wire, IPC, or persisted format change.
- **Cross-platform / SSH / Mobile:** main-process only; no platform branches.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5