### PR TITLE
feat(agent-map): flare fresh questions and finishes

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentMap.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMap.tsx
@@ -18,7 +18,7 @@ import {
   type AgentMapHostFilter
 } from './agent-map-filter'
 import { updateAgentMapLayout, type AgentMapLayoutCache } from './agent-map-layout'
-import { selectAgentMapRecentFinishPaneKeys } from './agent-map-node-metadata'
+import { selectAgentMapRecentFlareStatuses } from './agent-map-node-metadata'
 import './agent-map.css'
 
 type AgentMapProps = {
@@ -121,8 +121,8 @@ export function AgentMap({
     () => updateAgentMapLayout(layoutCacheRef.current, visibleCards, now, visibleWorkspaces),
     [visibleCards, visibleWorkspaces, now]
   )
-  const recentFinishPaneKeys = useMemo(
-    () => selectAgentMapRecentFinishPaneKeys(visibleCards),
+  const recentFlareStatuses = useMemo(
+    () => selectAgentMapRecentFlareStatuses(visibleCards),
     [visibleCards]
   )
   useEffect(() => {
@@ -178,7 +178,7 @@ export function AgentMap({
           selectedPaneKey={selectedPaneKey}
           allowAggregation
           showOrchestrationLinks={showOrchestrationLinks}
-          recentFinishPaneKeys={recentFinishPaneKeys}
+          recentFlareStatuses={recentFlareStatuses}
           launchableAgentsByWorktreeId={launchableAgentsByWorktreeId}
           workspaceContextMenusEnabled={workspaceContextMenusEnabled}
           onWorkspaceContextMenuOpenChange={onWorkspaceContextMenuOpenChange}

--- a/src/renderer/src/components/dashboard-popout/AgentMapCanvas.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapCanvas.tsx
@@ -17,6 +17,7 @@ import type {
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import type { TuiAgent } from '../../../../shared/types'
 import type { AgentMapAgentNode, AgentMapProjectRing, AgentMapLayout } from './agent-map-layout'
+import type { AgentMapFlareStatus } from './agent-map-node-metadata'
 import { AgentMapScene } from './AgentMapScene'
 import { agentFocusZoom, clamp, MAX_ZOOM, MIN_ZOOM } from './agent-map-canvas-zoom'
 import { AgentMapViewportControls } from './AgentMapViewportControls'
@@ -46,7 +47,7 @@ type AgentMapCanvasProps = {
   selectedPaneKey: string | null
   allowAggregation: boolean
   showOrchestrationLinks: boolean
-  recentFinishPaneKeys: ReadonlySet<string>
+  recentFlareStatuses: ReadonlyMap<string, AgentMapFlareStatus>
   launchableAgentsByWorktreeId?: Record<string, TuiAgent[]>
   workspaceContextMenusEnabled?: boolean
   onWorkspaceContextMenuOpenChange?: (open: boolean) => void
@@ -63,7 +64,7 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
       selectedPaneKey,
       allowAggregation,
       showOrchestrationLinks,
-      recentFinishPaneKeys,
+      recentFlareStatuses,
       launchableAgentsByWorktreeId,
       workspaceContextMenusEnabled = false,
       onWorkspaceContextMenuOpenChange,
@@ -114,7 +115,6 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
       [allowAggregation, layout, selectedPaneKey, zoom]
     )
     const hasProjects = layout.projects.length > 0
-    const hasMotionProjects = motionLayout.projects.length > 0
     const aspect = size.width / Math.max(1, size.height)
     const baseWidth = Math.max(layout.width, layout.height * aspect)
     const baseHeight = baseWidth / aspect
@@ -303,7 +303,7 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
 
     return (
       <div ref={containerRef} className="agent-map-canvas relative min-h-0 flex-1 overflow-hidden">
-        {!hasMotionProjects ? (
+        {motionLayout.projects.length === 0 ? (
           <div className="absolute inset-0 grid place-items-center text-center text-xs text-muted-foreground">
             {translate('dashboardPopout.map.empty', 'No agents match the current filters.')}
           </div>
@@ -387,7 +387,7 @@ export const AgentMapCanvas = forwardRef<AgentMapCanvasHandle, AgentMapCanvasPro
               selectedPaneKey={selectedPaneKey}
               allowAggregation={allowAggregation}
               showOrchestrationLinks={showOrchestrationLinks}
-              recentFinishPaneKeys={recentFinishPaneKeys}
+              recentFlareStatuses={recentFlareStatuses}
               launchableAgentsByWorktreeId={launchableAgentsByWorktreeId}
               nodeRefs={nodeRefs}
               onSelectAgent={onSelectAgent}

--- a/src/renderer/src/components/dashboard-popout/AgentMapProjectLabel.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapProjectLabel.test.tsx
@@ -45,7 +45,7 @@ describe('AgentMapScene project labels', () => {
           selectedPaneKey={null}
           allowAggregation
           showOrchestrationLinks
-          recentFinishPaneKeys={new Set()}
+          recentFlareStatuses={new Map()}
           nodeRefs={{ current: new Map() }}
           onSelectAgent={vi.fn()}
           onAgentKeyDown={vi.fn()}
@@ -109,7 +109,7 @@ describe('AgentMapScene project labels', () => {
             selectedPaneKey={null}
             allowAggregation
             showOrchestrationLinks
-            recentFinishPaneKeys={new Set()}
+            recentFlareStatuses={new Map()}
             nodeRefs={{ current: new Map() }}
             onSelectAgent={vi.fn()}
             onAgentKeyDown={vi.fn()}

--- a/src/renderer/src/components/dashboard-popout/AgentMapScene.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapScene.tsx
@@ -13,6 +13,7 @@ import type {
 import { AGENT_MAP_LINEAGE_RELATION, shouldAggregateAgentMapWorktree } from './agent-map-layout'
 import { selectVisibleAgentMapLabels } from './agent-map-label-declutter'
 import { agentMapDirectLineageChevronPath } from './agent-map-lineage-chevron-path'
+import type { AgentMapFlareStatus } from './agent-map-node-metadata'
 import { AgentMapWorktreeLabel } from './AgentMapWorktreeLabel'
 import { AgentMapWorktreeRingNode } from './AgentMapWorktreeRingNode'
 import { DashboardHostBadge } from './DashboardHostBadge'
@@ -29,7 +30,7 @@ type AgentMapSceneProps = {
   selectedPaneKey: string | null
   allowAggregation: boolean
   showOrchestrationLinks: boolean
-  recentFinishPaneKeys: ReadonlySet<string>
+  recentFlareStatuses: ReadonlyMap<string, AgentMapFlareStatus>
   launchableAgentsByWorktreeId?: Record<string, TuiAgent[]>
   nodeRefs: MutableRefObject<Map<string, SVGGElement>>
   onSelectAgent: (card: DashboardCard) => void
@@ -73,7 +74,7 @@ export const AgentMapScene = memo(function AgentMapScene({
   selectedPaneKey,
   allowAggregation,
   showOrchestrationLinks,
-  recentFinishPaneKeys,
+  recentFlareStatuses,
   launchableAgentsByWorktreeId,
   nodeRefs,
   onSelectAgent,
@@ -220,7 +221,7 @@ export const AgentMapScene = memo(function AgentMapScene({
                 selectedPaneKey={selectedPaneKey}
                 allowAggregation={allowAggregation}
                 showOrchestrationLinks={showOrchestrationLinks}
-                recentFinishPaneKeys={recentFinishPaneKeys}
+                recentFlareStatuses={recentFlareStatuses}
                 launchableAgents={launchableAgentsByWorktreeId?.[worktree.worktreeId]}
                 nodeRefs={nodeRefs}
                 onSelectAgent={onSelectAgent}

--- a/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx
@@ -30,7 +30,7 @@ describe('AgentMap status glow', () => {
     }
   )
 
-  it('caps a 200-completion burst at four flares without dropping static emphasis', () => {
+  it('caps a 200-status burst at four flares without dropping static emphasis', () => {
     const clock = vi.spyOn(Date, 'now').mockReturnValue(NOW)
     const { container } = renderMap(
       Array.from({ length: 200 }, (_, index) =>
@@ -47,10 +47,21 @@ describe('AgentMap status glow', () => {
     )
     clock.mockRestore()
 
-    expect(container.querySelectorAll('[data-agent-map-agent-finish-flare]')).toHaveLength(4)
+    expect(container.querySelectorAll('[data-agent-map-agent-status-flare]')).toHaveLength(4)
     expect(container.querySelectorAll('[data-agent-map-agent-status-glow]')).toHaveLength(200)
     expect(container.querySelectorAll('.fleet-status-done .agent-map-agent-mark')).toHaveLength(200)
     expect(container.querySelectorAll('[data-agent-unread-marker]')).toHaveLength(200)
+  })
+
+  it.each([
+    { bucket: 'attention', dotState: 'waiting', className: 'fleet-status-waiting' },
+    { bucket: 'done', dotState: 'done', className: 'fleet-status-done' }
+  ] as const)('flares a fresh $dotState state', ({ bucket, dotState, className }) => {
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(NOW)
+    const { container } = renderMap([card({ bucket, dotState, unseen: true, stateChangedAt: NOW })])
+    clock.mockRestore()
+
+    expect(container.querySelector('[data-agent-map-agent-status-flare]')).toHaveClass(className)
   })
 
   it.each([

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
@@ -15,6 +15,7 @@ import type {
 } from './agent-map-layout'
 import { AGENT_MAP_LINEAGE_RELATION, shouldAggregateAgentMapWorktree } from './agent-map-layout'
 import { AgentMapQuestionMarker } from './AgentMapQuestionMarker'
+import type { AgentMapFlareStatus } from './agent-map-node-metadata'
 import {
   agentMapAttentionMarkerScale,
   agentMapStatusLabel,
@@ -34,7 +35,7 @@ type AgentMapWorktreeRingNodeProps = {
   selectedPaneKey: string | null
   allowAggregation: boolean
   showOrchestrationLinks: boolean
-  recentFinishPaneKeys: ReadonlySet<string>
+  recentFlareStatuses: ReadonlyMap<string, AgentMapFlareStatus>
   launchableAgents?: readonly TuiAgent[]
   nodeRefs: MutableRefObject<Map<string, SVGGElement>>
   onSelectAgent: (card: DashboardCard) => void
@@ -167,7 +168,7 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
   selectedPaneKey,
   allowAggregation,
   showOrchestrationLinks,
-  recentFinishPaneKeys,
+  recentFlareStatuses,
   launchableAgents,
   nodeRefs,
   onSelectAgent,
@@ -296,6 +297,7 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
             {worktree.agents.map((agent) => {
               const iconSize = Math.max(12, Math.min(22, agent.radius * 1.05))
               const agentExiting = exiting || agent.motionState === 'exiting'
+              const flareStatus = recentFlareStatuses.get(agent.card.paneKey)
               // `done` here is the unread finish only — `done-seen` demotes to a bare
               // emerald ring so the halo keeps meaning "this one is still unread".
               const hasStatusGlow =
@@ -345,12 +347,11 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
                         aria-hidden="true"
                       />
                     ) : null}
-                    {/* One-shot ripple at the moment of finishing. Mounted only inside the
-                        flare window so animated paint stays off the resting fleet. */}
-                    {recentFinishPaneKeys.has(agent.card.paneKey) && !agentExiting ? (
+                    {/* One-shot ripple for fresh questions and finishes. */}
+                    {flareStatus && !agentExiting ? (
                       <circle
-                        className="agent-map-agent-finish-flare"
-                        data-agent-map-agent-finish-flare=""
+                        className={`agent-map-agent-status-flare fleet-status-${flareStatus}`}
+                        data-agent-map-agent-status-flare=""
                         r={agent.radius + 1}
                         aria-hidden="true"
                       />

--- a/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
@@ -55,31 +55,31 @@ describe('Agent Map glow performance boundary', () => {
     }
   })
 
-  it('confines the finish flare to nodes inside the recency window', () => {
+  it('confines status flares to nodes inside the recency window', () => {
     const component = source('AgentMapWorktreeRingNode.tsx')
     const metadata = source('agent-map-node-metadata.ts')
 
     // The flare is the one animated element on an agent node, so it must stay gated on
-    // the globally capped recent-finish set rather than on status alone.
-    expect(component.match(/data-agent-map-agent-finish-flare/g)).toHaveLength(1)
-    expect(component).toMatch(/recentFinishPaneKeys\.has\(agent\.card\.paneKey\)\s*&&/)
+    // the globally capped recent-status map rather than on status alone.
+    expect(component.match(/data-agent-map-agent-status-flare/g)).toHaveLength(1)
+    expect(component).toMatch(/recentFlareStatuses\.get\(agent\.card\.paneKey\)/)
     expect(component).not.toMatch(/<filter|filter=/)
 
     const css = source('agent-map.css')
-    const flareRule = css.match(/\.agent-map-agent-finish-flare\s*\{[^}]+\}/s)?.[0] ?? ''
+    const flareRule = css.match(/\.agent-map-agent-status-flare\s*\{[^}]+\}/s)?.[0] ?? ''
     expect(flareRule).toContain('pointer-events: none')
     expect(flareRule).toContain('vector-effect: non-scaling-stroke')
     // Transform and opacity only — no filter or layout-affecting paint work.
     expect(flareRule).not.toMatch(/filter:/)
-    expect(css).toMatch(/@keyframes agent-map-finish-flare/)
+    expect(css).toMatch(/@keyframes agent-map-status-flare/)
 
     // The mount window and the CSS duration are declared in different languages and
     // drift silently: too short a window unmounts the element mid-ripple, too long
     // leaves an invisible node animating. Pin them to the same number.
     const windowMs = Number(
-      metadata.match(/AGENT_MAP_FINISH_FLARE_MS = ([\d_]+)/)?.[1].replaceAll('_', '')
+      metadata.match(/AGENT_MAP_STATUS_FLARE_MS = ([\d_]+)/)?.[1].replaceAll('_', '')
     )
-    const cssMs = Number(flareRule.match(/animation: agent-map-finish-flare (\d+)ms/)?.[1])
+    const cssMs = Number(flareRule.match(/animation: agent-map-status-flare (\d+)ms/)?.[1])
     expect(windowMs).toBeGreaterThan(0)
     expect(cssMs).toBe(windowMs)
   })
@@ -88,7 +88,7 @@ describe('Agent Map glow performance boundary', () => {
     const map = source('AgentMap.tsx')
     const scene = source('AgentMapScene.tsx')
 
-    expect(map).toMatch(/selectAgentMapRecentFinishPaneKeys\(visibleCards\)/)
-    expect(scene).not.toContain('selectAgentMapRecentFinishPaneKeys')
+    expect(map).toMatch(/selectAgentMapRecentFlareStatuses\(visibleCards\)/)
+    expect(scene).not.toContain('selectAgentMapRecentFlareStatuses')
   })
 })

--- a/src/renderer/src/components/dashboard-popout/agent-map-node-metadata.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-node-metadata.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
 import {
-  AGENT_MAP_FINISH_FLARE_MS,
-  AGENT_MAP_MAX_CONCURRENT_FINISH_FLARES,
+  AGENT_MAP_MAX_CONCURRENT_STATUS_FLARES,
+  AGENT_MAP_STATUS_FLARE_MS,
+  agentMapRecentFlareStatus,
   agentMapNodeStatus,
   agentMapQuietCount,
   emptyAgentMapStatusCounts,
-  isAgentMapRecentFinish,
-  selectAgentMapRecentFinishPaneKeys
+  selectAgentMapRecentFlareStatuses
 } from './agent-map-node-metadata'
 
 const NOW = 2_000_000_000
@@ -59,7 +59,7 @@ describe('agentMapNodeStatus', () => {
   })
 })
 
-describe('isAgentMapRecentFinish', () => {
+describe('agentMapRecentFlareStatus', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
@@ -70,47 +70,84 @@ describe('isAgentMapRecentFinish', () => {
     vi.setSystemTime(NOW)
     const justFinished = card({ dotState: 'done', unseen: true, stateChangedAt: NOW })
 
-    expect(isAgentMapRecentFinish(justFinished)).toBe(true)
-    vi.setSystemTime(NOW + AGENT_MAP_FINISH_FLARE_MS - 1)
-    expect(isAgentMapRecentFinish(justFinished)).toBe(true)
-    vi.setSystemTime(NOW + AGENT_MAP_FINISH_FLARE_MS + 1)
-    expect(isAgentMapRecentFinish(justFinished)).toBe(false)
+    expect(agentMapRecentFlareStatus(justFinished)).toBe('done')
+    vi.setSystemTime(NOW + AGENT_MAP_STATUS_FLARE_MS - 1)
+    expect(agentMapRecentFlareStatus(justFinished)).toBe('done')
+    vi.setSystemTime(NOW + AGENT_MAP_STATUS_FLARE_MS + 1)
+    expect(agentMapRecentFlareStatus(justFinished)).toBeNull()
   })
 
-  it('samples the wall clock once and caps bursty fleet updates', () => {
+  it('flares on the transition into a question', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+
+    expect(
+      agentMapRecentFlareStatus(
+        card({ bucket: 'attention', dotState: 'waiting', unseen: true, stateChangedAt: NOW })
+      )
+    ).toBe('waiting')
+  })
+
+  it('does not reuse an earlier finish timestamp for a question with unknown timing', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+
+    expect(
+      agentMapRecentFlareStatus(
+        card({ dotState: 'waiting', stateChangedAt: 0, finishedAt: NOW, unseen: true })
+      )
+    ).toBeNull()
+  })
+
+  it('samples the wall clock once and caps mixed bursty fleet updates', () => {
     const clock = vi.spyOn(Date, 'now').mockReturnValue(NOW)
-    const selected = selectAgentMapRecentFinishPaneKeys(
+    const selected = selectAgentMapRecentFlareStatuses(
       Array.from({ length: 200 }, (_, index) =>
-        card({ paneKey: `pane-${index}`, unseen: true, stateChangedAt: NOW - index })
+        card({
+          paneKey: `pane-${index}`,
+          bucket: index % 2 === 0 ? 'done' : 'attention',
+          dotState: index % 2 === 0 ? 'done' : 'waiting',
+          unseen: true,
+          stateChangedAt: NOW - index
+        })
       )
     )
 
     expect(clock).toHaveBeenCalledOnce()
-    expect(selected.size).toBe(AGENT_MAP_MAX_CONCURRENT_FINISH_FLARES)
-    expect([...selected]).toEqual(['pane-0', 'pane-1', 'pane-2', 'pane-3'])
+    expect(selected.size).toBe(AGENT_MAP_MAX_CONCURRENT_STATUS_FLARES)
+    expect([...selected]).toEqual([
+      ['pane-0', 'done'],
+      ['pane-1', 'waiting'],
+      ['pane-2', 'done'],
+      ['pane-3', 'waiting']
+    ])
   })
 
-  it('does not flare work that finished before this session', () => {
+  it('does not flare status changes from before this session', () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)
     expect(
-      isAgentMapRecentFinish(card({ dotState: 'done', unseen: true, stateChangedAt: NOW - 60_000 }))
-    ).toBe(false)
+      agentMapRecentFlareStatus(
+        card({ dotState: 'done', unseen: true, stateChangedAt: NOW - 60_000 })
+      )
+    ).toBeNull()
     // A clock skew that puts the finish in the future must not latch a flare on forever.
     expect(
-      isAgentMapRecentFinish(card({ dotState: 'done', unseen: true, stateChangedAt: NOW + 5_000 }))
-    ).toBe(false)
+      agentMapRecentFlareStatus(
+        card({ dotState: 'done', unseen: true, stateChangedAt: NOW + 5_000 })
+      )
+    ).toBeNull()
   })
 
-  it('never flares a state that is not an unread finish', () => {
+  it('never flares a state that is not a question or unread finish', () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)
     expect(
-      isAgentMapRecentFinish(card({ dotState: 'done', unseen: false, stateChangedAt: NOW }))
-    ).toBe(false)
+      agentMapRecentFlareStatus(card({ dotState: 'done', unseen: false, stateChangedAt: NOW }))
+    ).toBeNull()
     expect(
-      isAgentMapRecentFinish(card({ dotState: 'working', unseen: true, stateChangedAt: NOW }))
-    ).toBe(false)
+      agentMapRecentFlareStatus(card({ dotState: 'working', unseen: true, stateChangedAt: NOW }))
+    ).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/dashboard-popout/agent-map-node-metadata.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-node-metadata.ts
@@ -25,56 +25,65 @@ export function agentMapNodeStatus(card: DashboardCard): AgentMapNodeStatus {
   return dashboardCardDisplayState(card)
 }
 
-/** How long a fresh finish keeps its one-shot flare. Long enough to catch the eye from
- *  across the map, short enough that a busy fleet is never permanently animating.
- *  Must stay in step with the `agent-map-finish-flare` duration in `agent-map.css`, or
- *  the element unmounts mid-ripple; the glow performance test asserts the two match. */
-export const AGENT_MAP_FINISH_FLARE_MS = 1_400
-// Static completion emphasis remains uncapped; this bounds animated SVG paint only.
-export const AGENT_MAP_MAX_CONCURRENT_FINISH_FLARES = 4
+export type AgentMapFlareStatus = Extract<DashboardCardDotState, 'waiting' | 'done'>
 
-/** Uses wall time because the map's relative-timestamp clock advances only every 30s. */
-export function isAgentMapRecentFinish(card: DashboardCard, currentTime = Date.now()): boolean {
-  if (card.dotState !== 'done' || !card.unseen) {
-    return false
-  }
-  const changedAt = card.stateChangedAt || card.finishedAt || 0
-  if (changedAt <= 0) {
-    return false
-  }
-  const elapsed = currentTime - changedAt
-  // A fleet that loads with finished work already on it must not flare all at once, so a
-  // finish that happened before this render window is never treated as fresh.
-  return elapsed >= 0 && elapsed < AGENT_MAP_FINISH_FLARE_MS
+/** How long a fresh question or finish keeps its one-shot flare. Long enough to catch
+ *  the eye from across the map, short enough that a busy fleet is never permanently
+ *  animating. Must stay in step with the `agent-map-status-flare` duration in
+ *  `agent-map.css`, or the element unmounts mid-ripple. */
+export const AGENT_MAP_STATUS_FLARE_MS = 1_400
+// Static status emphasis remains uncapped; this bounds animated SVG paint only.
+export const AGENT_MAP_MAX_CONCURRENT_STATUS_FLARES = 4
+
+function agentMapFlareChangedAt(card: DashboardCard): number {
+  return card.stateChangedAt || (card.dotState === 'done' ? card.finishedAt : 0) || 0
 }
 
-/** Selects only the freshest finishes so burst updates cannot animate the whole fleet. */
-export function selectAgentMapRecentFinishPaneKeys(
+/** Uses wall time because the map's relative-timestamp clock advances only every 30s. */
+export function agentMapRecentFlareStatus(
+  card: DashboardCard,
+  currentTime = Date.now()
+): AgentMapFlareStatus | null {
+  if (card.dotState !== 'waiting' && (card.dotState !== 'done' || !card.unseen)) {
+    return null
+  }
+  const changedAt = agentMapFlareChangedAt(card)
+  if (changedAt <= 0) {
+    return null
+  }
+  const elapsed = currentTime - changedAt
+  // A fleet that loads with old status changes must not flare all at once.
+  return elapsed >= 0 && elapsed < AGENT_MAP_STATUS_FLARE_MS ? card.dotState : null
+}
+
+/** Selects only the freshest question/finish changes so bursts cannot animate the fleet. */
+export function selectAgentMapRecentFlareStatuses(
   cards: readonly DashboardCard[]
-): ReadonlySet<string> {
+): ReadonlyMap<string, AgentMapFlareStatus> {
   const currentTime = Date.now()
-  const recent: { paneKey: string; changedAt: number }[] = []
+  const recent: { paneKey: string; changedAt: number; status: AgentMapFlareStatus }[] = []
   for (const card of cards) {
-    if (!isAgentMapRecentFinish(card, currentTime)) {
+    const status = agentMapRecentFlareStatus(card, currentTime)
+    if (!status) {
       continue
     }
-    const changedAt = card.stateChangedAt || card.finishedAt || 0
+    const changedAt = agentMapFlareChangedAt(card)
     const index = recent.findIndex(
       (item) =>
         changedAt > item.changedAt || (changedAt === item.changedAt && card.paneKey < item.paneKey)
     )
     if (index === -1) {
-      if (recent.length < AGENT_MAP_MAX_CONCURRENT_FINISH_FLARES) {
-        recent.push({ paneKey: card.paneKey, changedAt })
+      if (recent.length < AGENT_MAP_MAX_CONCURRENT_STATUS_FLARES) {
+        recent.push({ paneKey: card.paneKey, changedAt, status })
       }
       continue
     }
-    recent.splice(index, 0, { paneKey: card.paneKey, changedAt })
-    if (recent.length > AGENT_MAP_MAX_CONCURRENT_FINISH_FLARES) {
+    recent.splice(index, 0, { paneKey: card.paneKey, changedAt, status })
+    if (recent.length > AGENT_MAP_MAX_CONCURRENT_STATUS_FLARES) {
       recent.pop()
     }
   }
-  return new Set(recent.map((item) => item.paneKey))
+  return new Map(recent.map((item) => [item.paneKey, item.status]))
 }
 
 export type AgentMapStatusCounts = Record<AgentMapNodeStatus, number>

--- a/src/renderer/src/components/dashboard-popout/agent-map.css
+++ b/src/renderer/src/components/dashboard-popout/agent-map.css
@@ -329,20 +329,27 @@
   vector-effect: non-scaling-stroke;
 }
 
-.agent-map-agent-finish-flare {
+.agent-map-agent-status-flare {
   fill: none;
   pointer-events: none;
-  stroke: var(--color-emerald-500);
   stroke-width: 2;
   transform-box: fill-box;
   transform-origin: center;
   vector-effect: non-scaling-stroke;
-  /* Keep in step with AGENT_MAP_FINISH_FLARE_MS, which gates how long the element stays
+  /* Keep in step with AGENT_MAP_STATUS_FLARE_MS, which gates how long the element stays
      mounted. The performance test asserts the two agree. */
-  animation: agent-map-finish-flare 1400ms cubic-bezier(0.25, 0.5, 0.25, 1) both;
+  animation: agent-map-status-flare 1400ms cubic-bezier(0.25, 0.5, 0.25, 1) both;
 }
 
-@keyframes agent-map-finish-flare {
+.agent-map-agent-status-flare.fleet-status-waiting {
+  stroke: var(--agent-question);
+}
+
+.agent-map-agent-status-flare.fleet-status-done {
+  stroke: var(--color-emerald-500);
+}
+
+@keyframes agent-map-status-flare {
   0% {
     opacity: 0.9;
     transform: scale(0.62);
@@ -553,7 +560,7 @@
   .agent-map-agent-node,
   .agent-map-agent-visual,
   .agent-map-agent-mark,
-  .agent-map-agent-finish-flare,
+  .agent-map-agent-status-flare,
   .agent-map-lineage-link,
   .agent-map-worktree-lineage-link {
     animation: none;
@@ -561,7 +568,7 @@
   }
 
   /* No flare without motion — the halo and filled core already carry the state. */
-  .agent-map-agent-finish-flare {
+  .agent-map-agent-status-flare {
     display: none;
   }
 


### PR DESCRIPTION
## Summary

- extend the Agent Map's one-shot finish ripple to fresh waiting/question states
- tint the ripple by its destination state while preserving the existing emerald completion treatment
- keep the shared four-ripple concurrency cap and reduced-motion behavior

Follow-up to #14248.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard-popout/agent-map-node-metadata.test.ts src/renderer/src/components/dashboard-popout/AgentMapStatusGlow.test.tsx src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts src/renderer/src/components/dashboard-popout/AgentMapProjectLabel.test.tsx` (31 tests)
- `pnpm run typecheck:web`
- native and type-aware oxlint scans on all changed TypeScript files
- Electron CDP validation with simulated `working → waiting` and `working → done` transitions; verified the rendered orange and emerald SVG flare styles

## Visual proof

Simulated Agent Map data. The one-shot flares were replayed for capture visibility; production remains a 1.4-second animation.

![Agent Map showing question and completion states](https://github.com/user-attachments/assets/2f0d7a75-e228-43f8-b3bf-dc952cb4cab5)