### PR TITLE
fix(vm): make hidden SSH cleanup retryable

### DIFF
--- a/src/main/ephemeral-vm-runtime-service.test.ts
+++ b/src/main/ephemeral-vm-runtime-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -76,6 +76,7 @@ describe('ephemeral VM runtime service', () => {
         '  const payload = JSON.parse(input)',
         '  if (payload.recipeResult.projectRoot !== "/workspace/repo") process.exit(12)',
         '  if (!payload.recipeResult.userData.providerResourceId) process.exit(13)',
+        "  require('fs').appendFileSync('cleanup-count.txt', 'x')",
         '  console.error(`cleanup:${payload.instanceId}`)',
         '})'
       ].join('\n')
@@ -118,13 +119,17 @@ describe('ephemeral VM runtime service', () => {
     })
     expect(listEphemeralVmRuntimes(userDataPath)).toEqual([provisioned.runtime])
 
-    const cleanup = await cleanupEphemeralVmRuntime({
+    const cleanupArgs = {
       userDataPath,
       repoPath,
       recipe,
       runtimeId: provisioned.runtime.id,
       now: 2_000
-    })
+    }
+    const [cleanup] = await Promise.all([
+      cleanupEphemeralVmRuntime(cleanupArgs),
+      cleanupEphemeralVmRuntime(cleanupArgs)
+    ])
 
     expect(cleanup).toMatchObject({
       ok: true,
@@ -136,6 +141,13 @@ describe('ephemeral VM runtime service', () => {
         cleanupLastAttemptAt: 2_000
       }
     })
+    expect(readFileSync(join(repoPath, 'cleanup-count.txt'), 'utf8')).toBe('x')
+
+    await expect(cleanupEphemeralVmRuntime(cleanupArgs)).resolves.toMatchObject({
+      ok: true,
+      runtime: { status: 'cleaned' }
+    })
+    expect(readFileSync(join(repoPath, 'cleanup-count.txt'), 'utf8')).toBe('x')
   })
 
   it('does not persist a runtime when recipe output cannot be parsed', async () => {

--- a/src/main/ephemeral-vm-runtime-service.ts
+++ b/src/main/ephemeral-vm-runtime-service.ts
@@ -92,6 +92,8 @@ export type ResumeEphemeralVmRuntimeResult =
       error: string
     }
 
+const cleanupInFlight = new Map<string, Promise<CleanupEphemeralVmRuntimeResult>>()
+
 export async function provisionEphemeralVmRuntime(
   args: ProvisionEphemeralVmRuntimeArgs
 ): Promise<ProvisionEphemeralVmRuntimeResult> {
@@ -137,7 +139,27 @@ export async function provisionEphemeralVmRuntime(
   return { ok: true, start, runtime }
 }
 
-export async function cleanupEphemeralVmRuntime(
+export function cleanupEphemeralVmRuntime(
+  args: CleanupEphemeralVmRuntimeArgs
+): Promise<CleanupEphemeralVmRuntimeResult> {
+  const key = `${args.userDataPath}\0${args.runtimeId}`
+  const existing = cleanupInFlight.get(key)
+  if (existing) {
+    return existing
+  }
+
+  const cleanup = cleanupEphemeralVmRuntimeOnce(args)
+  cleanupInFlight.set(key, cleanup)
+  const forget = (): void => {
+    if (cleanupInFlight.get(key) === cleanup) {
+      cleanupInFlight.delete(key)
+    }
+  }
+  void cleanup.then(forget, forget)
+  return cleanup
+}
+
+async function cleanupEphemeralVmRuntimeOnce(
   args: CleanupEphemeralVmRuntimeArgs
 ): Promise<CleanupEphemeralVmRuntimeResult> {
   const existing = listEphemeralVmRuntimes(args.userDataPath).find(
@@ -145,6 +167,13 @@ export async function cleanupEphemeralVmRuntime(
   )
   if (!existing) {
     throw new Error(`Unknown ephemeral VM runtime: ${args.runtimeId}`)
+  }
+  if (existing.status === 'cleaned') {
+    return {
+      ok: true,
+      runtime: existing,
+      skipped: existing.cleanupStatus === 'disabled'
+    }
   }
 
   const now = args.now ?? Date.now()

--- a/src/main/ephemeral-vm-runtime-ssh-cleanup.test.ts
+++ b/src/main/ephemeral-vm-runtime-ssh-cleanup.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it, vi } from 'vitest'
+import { upsertEphemeralVmRuntime } from '../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
+import { removeEphemeralVmRuntimeSshTarget } from './ephemeral-vm-runtime-ssh-cleanup'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function createRuntime(
+  userDataPath: string,
+  status: 'cleaned' | 'cleanup_failed',
+  overrides: Partial<EphemeralVmRuntimeRecord> = {}
+): EphemeralVmRuntimeRecord {
+  return upsertEphemeralVmRuntime(userDataPath, {
+    id: 'runtime-1',
+    recipeId: 'cloud-sandbox',
+    status,
+    cleanupStatus: status === 'cleaned' ? 'succeeded' : 'failed',
+    connectionMode: 'ssh',
+    sshTargetId: 'runtime-ssh-1',
+    createdAt: 1,
+    updatedAt: 1,
+    recipeResult: {
+      schemaVersion: 1,
+      connection: {
+        type: 'ssh',
+        projectRoot: '/workspace/repo',
+        target: { label: 'VM', host: 'host', port: 22, username: 'orca' }
+      }
+    },
+    ...overrides
+  })
+}
+
+it('retains the hidden target identity when removal fails', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-vm-ssh-cleanup-'))
+  tempDirs.push(userDataPath)
+
+  await expect(
+    removeEphemeralVmRuntimeSshTarget({
+      userDataPath,
+      runtime: createRuntime(userDataPath, 'cleanup_failed'),
+      removeTarget: vi.fn().mockRejectedValue(new Error('store unavailable'))
+    })
+  ).resolves.toMatchObject({
+    status: 'cleanup_failed',
+    sshTargetId: 'runtime-ssh-1',
+    cleanupLastError: 'Failed to remove the hidden SSH target.'
+  })
+})
+
+it('keeps provider cleanup retryable until target removal succeeds', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-vm-ssh-cleanup-'))
+  tempDirs.push(userDataPath)
+  const failed = await removeEphemeralVmRuntimeSshTarget({
+    userDataPath,
+    runtime: createRuntime(userDataPath, 'cleaned'),
+    removeTarget: vi.fn().mockRejectedValue(new Error('store unavailable'))
+  })
+
+  expect(failed).toMatchObject({
+    status: 'cleanup_failed',
+    cleanupStatus: 'succeeded',
+    sshTargetId: 'runtime-ssh-1'
+  })
+  await expect(
+    removeEphemeralVmRuntimeSshTarget({
+      userDataPath,
+      runtime: failed,
+      removeTarget: vi.fn().mockResolvedValue(undefined)
+    })
+  ).resolves.toMatchObject({
+    status: 'cleaned',
+    cleanupStatus: 'succeeded',
+    sshTargetId: undefined
+  })
+})
+
+it('preserves the provider destroy error after target removal', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-vm-ssh-cleanup-'))
+  tempDirs.push(userDataPath)
+  const runtime = createRuntime(userDataPath, 'cleanup_failed', {
+    cleanupStatus: 'failed',
+    cleanupLastError: 'Destroy failed.'
+  })
+
+  await expect(
+    removeEphemeralVmRuntimeSshTarget({
+      userDataPath,
+      runtime,
+      removeTarget: vi.fn().mockResolvedValue(undefined)
+    })
+  ).resolves.toMatchObject({
+    status: 'cleanup_failed',
+    cleanupStatus: 'failed',
+    cleanupLastError: 'Destroy failed.',
+    sshTargetId: undefined
+  })
+})
+
+it('does not let a stale concurrent failure regress completed cleanup', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-vm-ssh-cleanup-'))
+  tempDirs.push(userDataPath)
+  const runtime = createRuntime(userDataPath, 'cleaned')
+  let rejectStaleRemoval!: (error: Error) => void
+  const staleRemoval = removeEphemeralVmRuntimeSshTarget({
+    userDataPath,
+    runtime,
+    removeTarget: vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectStaleRemoval = reject
+        })
+    )
+  })
+  await Promise.resolve()
+
+  await removeEphemeralVmRuntimeSshTarget({
+    userDataPath,
+    runtime,
+    removeTarget: vi.fn().mockResolvedValue(undefined)
+  })
+  rejectStaleRemoval(new Error('stale removal failed'))
+
+  const cleaned = await staleRemoval
+  expect(cleaned).toMatchObject({
+    status: 'cleaned',
+    cleanupStatus: 'succeeded'
+  })
+  expect(cleaned).not.toHaveProperty('sshTargetId')
+})
+
+it('repairs completed cleanup records that already lost their target id', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-vm-ssh-cleanup-'))
+  tempDirs.push(userDataPath)
+  const runtime = createRuntime(userDataPath, 'cleanup_failed', {
+    cleanupStatus: 'succeeded',
+    sshTargetId: undefined
+  })
+
+  await expect(
+    removeEphemeralVmRuntimeSshTarget({
+      userDataPath,
+      runtime,
+      removeTarget: vi.fn()
+    })
+  ).resolves.toMatchObject({
+    status: 'cleaned',
+    cleanupStatus: 'succeeded',
+    sshTargetId: undefined
+  })
+})

--- a/src/main/ephemeral-vm-runtime-ssh-cleanup.ts
+++ b/src/main/ephemeral-vm-runtime-ssh-cleanup.ts
@@ -1,0 +1,58 @@
+import {
+  listEphemeralVmRuntimes,
+  updateEphemeralVmRuntimeStatus
+} from '../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
+
+export async function removeEphemeralVmRuntimeSshTarget(args: {
+  userDataPath: string
+  runtime: EphemeralVmRuntimeRecord
+  removeTarget: (targetId: string) => Promise<void>
+}): Promise<EphemeralVmRuntimeRecord> {
+  const current = getCurrentRuntime(args.userDataPath, args.runtime)
+  if (!current.sshTargetId) {
+    return finishCompletedCleanup(args.userDataPath, current)
+  }
+  try {
+    await args.removeTarget(current.sshTargetId)
+  } catch {
+    const latest = getCurrentRuntime(args.userDataPath, current)
+    if (!latest.sshTargetId) {
+      return finishCompletedCleanup(args.userDataPath, latest)
+    }
+    return updateEphemeralVmRuntimeStatus(args.userDataPath, latest.id, {
+      status: 'cleanup_failed',
+      cleanupLastError: 'Failed to remove the hidden SSH target.'
+    })
+  }
+  const latest = getCurrentRuntime(args.userDataPath, current)
+  const status = latest.cleanupStatus === 'succeeded' ? 'cleaned' : latest.status
+  return updateEphemeralVmRuntimeStatus(args.userDataPath, latest.id, {
+    status,
+    ...(status === 'cleaned' ? { cleanupLastError: null } : {}),
+    connectionMode: null,
+    sshTargetId: null
+  })
+}
+
+function getCurrentRuntime(
+  userDataPath: string,
+  fallback: EphemeralVmRuntimeRecord
+): EphemeralVmRuntimeRecord {
+  return listEphemeralVmRuntimes(userDataPath).find((entry) => entry.id === fallback.id) ?? fallback
+}
+
+function finishCompletedCleanup(
+  userDataPath: string,
+  runtime: EphemeralVmRuntimeRecord
+): EphemeralVmRuntimeRecord {
+  if (runtime.cleanupStatus !== 'succeeded' || runtime.status === 'cleaned') {
+    return runtime
+  }
+  return updateEphemeralVmRuntimeStatus(userDataPath, runtime.id, {
+    status: 'cleaned',
+    cleanupLastError: null,
+    connectionMode: null,
+    sshTargetId: null
+  })
+}

--- a/src/main/ipc/ephemeral-vm-runtime-handler-cleanup.test.ts
+++ b/src/main/ipc/ephemeral-vm-runtime-handler-cleanup.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { upsertEphemeralVmRuntime } from '../../shared/ephemeral-vm-runtime-store'
+
+const handlers = new Map<string, (_event: unknown, args: { runtimeId: string }) => unknown>()
+const { getPathMock, handleMock, removeRuntimeOwnedSshTargetMock, removeHandlerMock } = vi.hoisted(
+  () => ({
+    getPathMock: vi.fn(),
+    handleMock: vi.fn(),
+    removeRuntimeOwnedSshTargetMock: vi.fn(),
+    removeHandlerMock: vi.fn()
+  })
+)
+
+vi.mock('electron', () => ({
+  app: { getPath: getPathMock },
+  ipcMain: { handle: handleMock, removeHandler: removeHandlerMock }
+}))
+
+vi.mock('../ephemeral-vm-runtime-ssh', () => ({
+  connectRuntimeOwnedSshTarget: vi.fn(),
+  disconnectRuntimeOwnedSshTarget: vi.fn(),
+  removeRuntimeOwnedSshTarget: removeRuntimeOwnedSshTargetMock
+}))
+
+import { registerEphemeralVmRuntimeHandlers } from './ephemeral-vm-runtime-handlers'
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  handlers.clear()
+  handleMock.mockReset()
+  removeRuntimeOwnedSshTargetMock.mockReset().mockResolvedValue(undefined)
+  removeHandlerMock.mockReset()
+  handleMock.mockImplementation(
+    (channel: string, handler: (_event: unknown, args: { runtimeId: string }) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  )
+})
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+it('removes the hidden SSH target when recipe context is unavailable', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-vm-runtime-handler-'))
+  tempDirs.push(userDataPath)
+  getPathMock.mockReturnValue(userDataPath)
+  upsertEphemeralVmRuntime(userDataPath, {
+    id: 'runtime-missing-context',
+    recipeId: 'cloud-sandbox',
+    repoId: 'missing-repo',
+    status: 'cleanup_failed',
+    cleanupStatus: 'not_started',
+    connectionMode: 'ssh',
+    sshTargetId: 'runtime-ssh-missing-context',
+    createdAt: 1,
+    updatedAt: 1,
+    recipeResult: {
+      schemaVersion: 1,
+      connection: {
+        type: 'ssh',
+        projectRoot: '/workspace/repo',
+        target: { label: 'VM', host: 'host', port: 22, username: 'orca' }
+      }
+    }
+  })
+  registerEphemeralVmRuntimeHandlers({ getRepo: vi.fn() } as never)
+
+  const cleaned = await handlers.get('ephemeralVm:cleanup')?.(null, {
+    runtimeId: 'runtime-missing-context'
+  })
+
+  expect(cleaned).toMatchObject({
+    status: 'cleanup_failed',
+    cleanupStatus: 'failed',
+    sshTargetId: undefined
+  })
+  expect(removeRuntimeOwnedSshTargetMock).toHaveBeenCalledWith('runtime-ssh-missing-context')
+})

--- a/src/main/ipc/ephemeral-vm-runtime-handlers.ts
+++ b/src/main/ipc/ephemeral-vm-runtime-handlers.ts
@@ -18,6 +18,7 @@ import {
   resumeEphemeralVmRuntime,
   suspendEphemeralVmRuntime
 } from '../ephemeral-vm-runtime-service'
+import { removeEphemeralVmRuntimeSshTarget } from '../ephemeral-vm-runtime-ssh-cleanup'
 import {
   buildEphemeralVmRecipeCleanupCommand,
   buildEphemeralVmRecipeCleanupPayload
@@ -73,23 +74,33 @@ export function registerEphemeralVmRuntimeHandlers(store: Store): void {
       if (!runtime.repoId) {
         throw new Error(`Ephemeral VM runtime has no repo id: ${args.runtimeId}`)
       }
-      let resolved: ReturnType<typeof getRuntimeRecipeContext>
-      try {
-        resolved = getRuntimeRecipeContext(store, userDataPath, runtime.id)
-      } catch (error) {
-        return updateEphemeralVmRuntimeStatus(userDataPath, runtime.id, {
-          status: 'cleanup_failed',
-          cleanupStatus: 'failed',
-          cleanupLastAttemptAt: Date.now(),
-          cleanupLastError: error instanceof Error ? error.message : String(error)
+      let result
+      if (runtime.cleanupStatus === 'succeeded') {
+        result = { ok: true as const, runtime, skipped: false }
+      } else {
+        let resolved: ReturnType<typeof getRuntimeRecipeContext>
+        try {
+          resolved = getRuntimeRecipeContext(store, userDataPath, runtime.id)
+        } catch (error) {
+          const failed = updateEphemeralVmRuntimeStatus(userDataPath, runtime.id, {
+            status: 'cleanup_failed',
+            cleanupStatus: 'failed',
+            cleanupLastAttemptAt: Date.now(),
+            cleanupLastError: error instanceof Error ? error.message : String(error)
+          })
+          return removeEphemeralVmRuntimeSshTarget({
+            userDataPath,
+            runtime: failed,
+            removeTarget: removeRuntimeOwnedSshTarget
+          })
+        }
+        result = await cleanupEphemeralVmRuntime({
+          userDataPath,
+          repoPath: resolved.repo.repo.path,
+          recipe: resolved.recipe,
+          runtimeId: runtime.id
         })
       }
-      const result = await cleanupEphemeralVmRuntime({
-        userDataPath,
-        repoPath: resolved.repo.repo.path,
-        recipe: resolved.recipe,
-        runtimeId: runtime.id
-      })
       if (result.ok && runtime.runtimeEnvironmentId) {
         try {
           removeEnvironment(userDataPath, runtime.runtimeEnvironmentId)
@@ -100,14 +111,11 @@ export function registerEphemeralVmRuntimeHandlers(store: Store): void {
       }
       // Remove even on cleanup_failed (removal is idempotent via the deterministic
       // id) so a terminal cleanup never orphans the hidden SSH target.
-      if (runtime.sshTargetId) {
-        await removeRuntimeOwnedSshTarget(runtime.sshTargetId).catch(() => undefined)
-        return updateEphemeralVmRuntimeStatus(userDataPath, runtime.id, {
-          connectionMode: null,
-          sshTargetId: null
-        })
-      }
-      return result.runtime
+      return removeEphemeralVmRuntimeSshTarget({
+        userDataPath,
+        runtime: result.runtime,
+        removeTarget: removeRuntimeOwnedSshTarget
+      })
     }
   )
 

--- a/src/main/ipc/ephemeral-vm.test.ts
+++ b/src/main/ipc/ephemeral-vm.test.ts
@@ -545,12 +545,65 @@ describe('registerEphemeralVmHandlers', () => {
 
     const cleaned = (await handlers.get('ephemeralVm:cleanup')?.(null, {
       runtimeId: provisioned.runtime.id
-    } as never)) as { status?: string; connectionMode?: string; sshTargetId?: string }
+    } as never)) as {
+      status?: string
+      cleanupLastError?: string
+      connectionMode?: string
+      sshTargetId?: string
+    }
 
     expect(cleaned).toEqual(expect.objectContaining({ status: 'cleanup_failed' }))
+    expect(cleaned.cleanupLastError).toBeTruthy()
     expect(removeRuntimeOwnedSshTargetMock).toHaveBeenCalledWith('runtime-ssh-orca-instance-1')
     expect(cleaned.connectionMode).toBeUndefined()
     expect(cleaned.sshTargetId).toBeUndefined()
+  })
+
+  it('retries hidden SSH teardown without rerunning completed provider cleanup', async () => {
+    const userDataPath = makeDir('orca-ephemeral-vm-ipc-user-data-')
+    const repoPath = makeDir('orca-ephemeral-vm-ipc-repo-')
+    getPathMock.mockReturnValue(userDataPath)
+    upsertEphemeralVmRuntime(userDataPath, {
+      id: 'runtime-cleanup-retry',
+      recipeId: 'cloud-sandbox',
+      repoId: 'repo-1',
+      status: 'cleanup_failed',
+      cleanupStatus: 'succeeded',
+      connectionMode: 'ssh',
+      sshTargetId: 'runtime-ssh-cleanup-retry',
+      createdAt: 1,
+      updatedAt: 1,
+      recipeResult: {
+        schemaVersion: 1,
+        connection: {
+          type: 'ssh',
+          projectRoot: '/workspace/repo',
+          target: { label: 'VM', host: 'host', port: 22, username: 'orca' }
+        }
+      }
+    })
+    registerEphemeralVmHandlers(makeStore(repoPath) as never)
+    removeRuntimeOwnedSshTargetMock.mockRejectedValueOnce(new Error('store unavailable'))
+
+    const failed = await handlers.get('ephemeralVm:cleanup')?.(null, {
+      runtimeId: 'runtime-cleanup-retry'
+    } as never)
+    expect(failed).toMatchObject({
+      status: 'cleanup_failed',
+      cleanupStatus: 'succeeded',
+      sshTargetId: 'runtime-ssh-cleanup-retry'
+    })
+
+    removeRuntimeOwnedSshTargetMock.mockResolvedValue(undefined)
+    const cleaned = await handlers.get('ephemeralVm:cleanup')?.(null, {
+      runtimeId: 'runtime-cleanup-retry'
+    } as never)
+    expect(cleaned).toMatchObject({
+      status: 'cleaned',
+      cleanupStatus: 'succeeded',
+      sshTargetId: undefined
+    })
+    expect(removeRuntimeOwnedSshTargetMock).toHaveBeenCalledTimes(2)
   })
 
   it('runs suspend and resume for an attached ephemeral VM workspace', async () => {

--- a/src/renderer/src/components/settings/EphemeralVmRuntimesSection.test.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmRuntimesSection.test.tsx
@@ -65,6 +65,17 @@ describe('EphemeralVmRuntimesSection helpers', () => {
     ).toEqual(['new', 'old'])
   })
 
+  it('keeps a cleaned runtime visible while hidden SSH teardown is incomplete', () => {
+    const runtime = makeRuntime({
+      status: 'cleaned',
+      cleanupStatus: 'succeeded',
+      sshTargetId: 'runtime-ssh-cleanup-retry'
+    })
+
+    expect(getVisibleEphemeralVmRuntimes([runtime])).toEqual([runtime])
+    expect(getEphemeralVmRuntimeStatusLabel(runtime)).toBe('Cleanup failed')
+  })
+
   it('prioritizes cleanup status in the visible label', () => {
     expect(getEphemeralVmRuntimeStatusLabel(makeRuntime())).toBe('Running')
     expect(getEphemeralVmRuntimeStatusLabel(makeRuntime({ cleanupStatus: 'failed' }))).toBe(
@@ -192,5 +203,24 @@ describe('EphemeralVmRuntimesSection', () => {
       expect.stringContaining('Cleanup payload:')
     )
     expect(toastMocks.success).toHaveBeenCalledWith('Copied cleanup command.')
+  })
+
+  it('offers retry when provider cleanup succeeded but hidden SSH teardown failed', async () => {
+    window.api.ephemeralVm.listRuntimes = vi.fn().mockResolvedValue([
+      makeRuntime({
+        status: 'cleanup_failed',
+        cleanupStatus: 'succeeded',
+        sshTargetId: 'runtime-ssh-cleanup-retry',
+        cleanupLastError: 'Failed to remove the hidden SSH target.'
+      })
+    ])
+    const container = await renderSection()
+
+    await vi.waitFor(() => expect(container.textContent).toContain('Cleanup failed'))
+    expect(
+      [...container.querySelectorAll('button')].some(
+        (button) => button.textContent === 'Retry cleanup'
+      )
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/settings/EphemeralVmRuntimesSection.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmRuntimesSection.tsx
@@ -9,18 +9,24 @@ import { translate } from '@/i18n/i18n'
 import { Button } from '../ui/button'
 import { cn } from '@/lib/utils'
 
-const CLEANED_STATUSES = new Set<EphemeralVmRuntimeRecord['status']>(['cleaned'])
+function hasCleanupFailed(runtime: EphemeralVmRuntimeRecord): boolean {
+  return (
+    runtime.cleanupStatus === 'failed' ||
+    runtime.status === 'cleanup_failed' ||
+    (runtime.status === 'cleaned' && runtime.sshTargetId !== undefined)
+  )
+}
 
 export function getVisibleEphemeralVmRuntimes(
   runtimes: readonly EphemeralVmRuntimeRecord[]
 ): EphemeralVmRuntimeRecord[] {
   return runtimes
-    .filter((runtime) => !CLEANED_STATUSES.has(runtime.status))
+    .filter((runtime) => runtime.status !== 'cleaned' || runtime.sshTargetId !== undefined)
     .sort((a, b) => b.createdAt - a.createdAt || a.id.localeCompare(b.id))
 }
 
 export function getEphemeralVmRuntimeStatusLabel(runtime: EphemeralVmRuntimeRecord): string {
-  if (runtime.cleanupStatus === 'failed') {
+  if (hasCleanupFailed(runtime)) {
     return translate(
       'auto.components.settings.EphemeralVmRuntimesSection.cleanupFailed',
       'Cleanup failed'
@@ -88,7 +94,7 @@ export function EphemeralVmRuntimesSection(): React.JSX.Element {
     setCleaningId(runtime.id)
     try {
       const cleaned = await window.api.ephemeralVm.cleanup({ runtimeId: runtime.id })
-      if (cleaned.cleanupStatus === 'failed') {
+      if (hasCleanupFailed(cleaned)) {
         throw new Error(
           cleaned.cleanupLastError ??
             translate(
@@ -247,7 +253,8 @@ function EphemeralVmRuntimeRow({
   onCopyCleanupCommand: () => void
 }): React.JSX.Element {
   const statusLabel = getEphemeralVmRuntimeStatusLabel(runtime)
-  const hasError = runtime.cleanupStatus === 'failed' || runtime.status === 'failed'
+  const cleanupFailed = hasCleanupFailed(runtime)
+  const hasError = cleanupFailed || runtime.status === 'failed'
   return (
     <div className="flex items-center gap-3 px-4 py-3">
       <div
@@ -297,7 +304,7 @@ function EphemeralVmRuntimeRow({
           disabled={disabled}
         >
           {isCleaning ? <Loader2 className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
-          {runtime.cleanupStatus === 'failed'
+          {cleanupFailed
             ? translate(
                 'auto.components.settings.EphemeralVmRuntimesSection.retry',
                 'Retry cleanup'

--- a/src/renderer/src/lib/ephemeral-vm-runtime-cleanup.test.ts
+++ b/src/renderer/src/lib/ephemeral-vm-runtime-cleanup.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const listRuntimes = vi.fn()
-const cleanup = vi.fn().mockResolvedValue({})
+const cleanup = vi.fn().mockResolvedValue({ status: 'cleaned' })
 
 // @ts-expect-error -- test shim for the preload bridge
 globalThis.window = { api: { ephemeralVm: { listRuntimes, cleanup } } }
@@ -15,7 +15,7 @@ function runtime(overrides: Record<string, unknown>): Record<string, unknown> {
 describe('cleanupEphemeralVmRuntimesForDeleted', () => {
   beforeEach(() => {
     listRuntimes.mockReset()
-    cleanup.mockClear()
+    cleanup.mockReset().mockResolvedValue({ status: 'cleaned' })
   })
 
   it('cleans runtimes matched by workspace id and returns destroyed SSH target ids', async () => {
@@ -59,6 +59,39 @@ describe('cleanupEphemeralVmRuntimesForDeleted', () => {
 
     expect(cleanup).not.toHaveBeenCalled()
     expect(destroyed).toEqual([])
+  })
+
+  it('retries a completed provider cleanup while its SSH target remains', async () => {
+    listRuntimes.mockResolvedValue([
+      runtime({
+        id: 'rt-1',
+        workspaceId: 'wt-1',
+        status: 'cleanup_failed',
+        cleanupStatus: 'succeeded',
+        sshTargetId: 'runtime-ssh-a'
+      })
+    ])
+    cleanup.mockResolvedValue({ status: 'cleaned', cleanupStatus: 'succeeded' })
+
+    await expect(cleanupEphemeralVmRuntimesForDeleted({ workspaceIds: ['wt-1'] })).resolves.toEqual(
+      ['runtime-ssh-a']
+    )
+    expect(cleanup).toHaveBeenCalledWith({ runtimeId: 'rt-1' })
+  })
+
+  it('does not report a retained SSH target as destroyed', async () => {
+    listRuntimes.mockResolvedValue([
+      runtime({ id: 'rt-1', workspaceId: 'wt-1', sshTargetId: 'runtime-ssh-a' })
+    ])
+    cleanup.mockResolvedValue({
+      status: 'cleanup_failed',
+      cleanupStatus: 'failed',
+      sshTargetId: 'runtime-ssh-a'
+    })
+
+    await expect(cleanupEphemeralVmRuntimesForDeleted({ workspaceIds: ['wt-1'] })).resolves.toEqual(
+      []
+    )
   })
 
   it('swallows listRuntimes failures', async () => {

--- a/src/renderer/src/lib/ephemeral-vm-runtime-cleanup.ts
+++ b/src/renderer/src/lib/ephemeral-vm-runtime-cleanup.ts
@@ -28,15 +28,15 @@ export async function cleanupEphemeralVmRuntimesForDeleted(args: {
     const runtimes = await window.api.ephemeralVm.listRuntimes()
     const matchingRuntimes = runtimes.filter(
       (runtime) =>
-        runtime.cleanupStatus !== 'succeeded' &&
+        (runtime.cleanupStatus !== 'succeeded' || runtime.sshTargetId !== undefined) &&
         ((runtime.workspaceId !== undefined && workspaceIdSet.has(runtime.workspaceId)) ||
           (runtime.sshTargetId !== undefined && sshTargetIdSet.has(runtime.sshTargetId)))
     )
     for (const runtime of matchingRuntimes) {
-      if (runtime.sshTargetId) {
+      const cleaned = await window.api.ephemeralVm.cleanup({ runtimeId: runtime.id })
+      if (runtime.sshTargetId && !cleaned.sshTargetId) {
         destroyedSshTargetIds.push(runtime.sshTargetId)
       }
-      await window.api.ephemeralVm.cleanup({ runtimeId: runtime.id })
     }
   } catch (error) {
     console.error('Failed to clean up ephemeral VM runtime for deleted workspace:', error)

--- a/tests/e2e/ephemeral-vm-cleanup-retry.spec.ts
+++ b/tests/e2e/ephemeral-vm-cleanup-retry.spec.ts
@@ -1,0 +1,58 @@
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+
+test.use({ seedTestRepo: false })
+
+test('shows interrupted hidden SSH cleanup as retryable', async ({ electronApp, orcaPage }) => {
+  const userDataPath = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+  writeFileSync(
+    path.join(userDataPath, 'orca-ephemeral-vm-runtimes.json'),
+    JSON.stringify({
+      version: 1,
+      runtimes: [
+        {
+          id: 'runtime-cleanup-retry',
+          recipeId: 'cloud-sandbox',
+          repoId: 'repo-1',
+          workspaceName: 'Interrupted cleanup',
+          status: 'cleaned',
+          cleanupStatus: 'succeeded',
+          connectionMode: 'ssh',
+          sshTargetId: 'runtime-ssh-cleanup-retry',
+          createdAt: 1,
+          updatedAt: 1,
+          recipeResult: {
+            schemaVersion: 1,
+            connection: {
+              type: 'ssh',
+              projectRoot: '/workspace/repo',
+              target: {
+                label: 'Cloud VM',
+                host: 'vm.example.com',
+                port: 22,
+                username: 'developer'
+              }
+            }
+          }
+        }
+      ]
+    })
+  )
+
+  await orcaPage.evaluate(() => {
+    const state = window.__store!.getState()
+    state.openSettingsTarget({ pane: 'servers', repoId: null })
+    state.openSettingsPage()
+  })
+  await expect(orcaPage.getByPlaceholder('Search settings')).toBeVisible()
+  await orcaPage
+    .getByRole('group', { name: 'Remote server workflow' })
+    .getByRole('button', { name: /^Cloud VM/ })
+    .click()
+
+  const runtimes = orcaPage.locator('[data-settings-section="temporary-vm-runtimes"]')
+  await expect(runtimes.getByText('Interrupted cleanup')).toBeVisible()
+  await expect(runtimes.getByText('Cleanup failed')).toBeVisible()
+  await expect(runtimes.getByRole('button', { name: 'Retry cleanup' })).toBeVisible()
+})


### PR DESCRIPTION
## ELI5

If VM teardown finished but removing Orca's temporary SSH entry failed, Retry could no longer complete the cleanup. This preserves that failure as retryable and coalesces duplicate cleanup requests.

## What Changed

- Keep the hidden SSH target until its removal succeeds.
- Retry SSH-target removal without rerunning an already-successful provider destroy hook.
- Coalesce concurrent cleanup calls and make already-cleaned cleanup idempotent.
- Surface the retryable state in the runtime settings UI.

Stack: **1/4** → #14352 → #14353 → #14359

## Why

Provisioned-root workspaces rely on the hidden SSH runtime being cleaned up deterministically. This is a standalone lifecycle hardening layer and does not change recipe defaults.

## Linked Issue

Relates to #13044

## Visual Proof

https://github.com/user-attachments/assets/b9b59c9c-57ef-49f2-b7c5-c5dc3fc4c0fa

Three recorded runs passed before this proof was uploaded.

## Testing

- [x] Automated unit/integration coverage for retry, idempotency, and concurrent cleanup.
- [x] Electron E2E: interrupted hidden SSH cleanup remains visible and retryable.
- [x] Relevant typecheck, changed-code quality, max-lines, formatting, and build gates pass.

## Review

Please focus on lifecycle idempotency, hidden SSH target retention, and behavior after process interruption.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof attached
- [x] Self-reviewed for correctness, security, and performance
- [x] SSH, cross-platform, and backwards-compatibility impact considered
- [x] Relevant lint, typecheck, tests, and build pass; CI will run the full suite