### PR TITLE
feat(vm): add main-owned provisioned SSH root adoption

### DIFF
--- a/src/main/ephemeral-vm-runtime-attachment.ts
+++ b/src/main/ephemeral-vm-runtime-attachment.ts
@@ -1,0 +1,25 @@
+import {
+  listEphemeralVmRuntimes,
+  updateEphemeralVmRuntimeStatus
+} from '../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
+
+export function attachEphemeralVmRuntimeToWorkspace(args: {
+  userDataPath: string
+  runtimeId: string
+  workspaceId: string
+}): EphemeralVmRuntimeRecord {
+  const runtime = listEphemeralVmRuntimes(args.userDataPath).find(
+    (entry) => entry.id === args.runtimeId
+  )
+  if (!runtime) {
+    throw new Error(`Unknown ephemeral VM runtime: ${args.runtimeId}`)
+  }
+  if (['cleanup_pending', 'cleanup_failed', 'cleaned'].includes(runtime.status)) {
+    throw new Error(`Cannot attach cleaned ephemeral VM runtime: ${args.runtimeId}`)
+  }
+  return updateEphemeralVmRuntimeStatus(args.userDataPath, args.runtimeId, {
+    status: 'running',
+    workspaceId: args.workspaceId
+  })
+}

--- a/src/main/ipc/ephemeral-vm-runtime-handlers.ts
+++ b/src/main/ipc/ephemeral-vm-runtime-handlers.ts
@@ -30,6 +30,7 @@ import {
 } from '../ephemeral-vm-runtime-ssh'
 import { getRuntimeRecipeContext } from './ephemeral-vm-recipe-context'
 import { invalidateRuntimeEnvironmentTransport } from './runtime-environments'
+import { attachEphemeralVmRuntimeToWorkspace } from '../ephemeral-vm-runtime-attachment'
 
 export type EphemeralVmCleanupCommandResult = {
   runtimeId: string
@@ -54,8 +55,9 @@ export function registerEphemeralVmRuntimeHandlers(store: Store): void {
   ipcMain.handle(
     'ephemeralVm:attachWorkspace',
     (_event, args: { runtimeId: string; workspaceId: string }): EphemeralVmRuntimeRecord => {
-      return updateEphemeralVmRuntimeStatus(app.getPath('userData'), args.runtimeId, {
-        status: 'running',
+      return attachEphemeralVmRuntimeToWorkspace({
+        userDataPath: app.getPath('userData'),
+        runtimeId: args.runtimeId,
         workspaceId: args.workspaceId
       })
     }

--- a/src/main/ipc/ephemeral-vm.ts
+++ b/src/main/ipc/ephemeral-vm.ts
@@ -9,6 +9,7 @@ import {
   redactEphemeralVmRecipeDiagnosticText,
   type EphemeralVmRecipeResultWarning
 } from '../../shared/ephemeral-vm-recipe-diagnostics'
+import { getProvisionedRootRecipeRepoUrl } from '../../shared/ephemeral-vm-recipe-repo-url'
 // Why: import directly from the doctor module (not the barrel) — it uses Node
 // fs/path and must stay out of the browser bundle that imports the barrel.
 import { doctorEphemeralVmRecipe } from '../../shared/ephemeral-vm-recipe-doctor'
@@ -110,6 +111,8 @@ export function registerEphemeralVmHandlers(store: Store, pluginService?: Plugin
         workspaceName?: string
         projectId?: string
         workspaceId?: string
+        branch?: string
+        ref?: string
         provisionId?: string
       }
     ): Promise<EphemeralVmProvisionIpcResult> => {
@@ -125,6 +128,10 @@ export function registerEphemeralVmHandlers(store: Store, pluginService?: Plugin
       if (!recipe) {
         return { ok: false, error: `Recipe not found: ${args.recipeId}`, stdout: '', stderr: '' }
       }
+      const repoUrl = getProvisionedRootRecipeRepoUrl(
+        recipe.checkoutMode,
+        repo.repo.gitRemoteIdentity?.remoteUrl
+      )
       const controller = args.provisionId ? new AbortController() : null
       if (args.provisionId && controller) {
         activeProvisionControllers.set(args.provisionId, controller)
@@ -152,6 +159,9 @@ export function registerEphemeralVmHandlers(store: Store, pluginService?: Plugin
           projectId: args.projectId,
           workspaceId: args.workspaceId,
           workspaceName: args.workspaceName,
+          ...(repoUrl ? { repoUrl } : {}),
+          ...(args.branch ? { branch: args.branch } : {}),
+          ...(args.ref ? { ref: args.ref } : {}),
           ...(controller ? { signal: controller.signal } : {}),
           onStdout: (chunk) => sendProvisionEvent('stdout', chunk),
           onStderr: (chunk) => sendProvisionEvent('stderr', chunk)

--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -24,6 +24,9 @@ export function mergeWorktree(
     ...(meta?.projectHostSetupId !== undefined
       ? { projectHostSetupId: meta.projectHostSetupId }
       : {}),
+    ...(meta?.ephemeralVmCheckoutMode !== undefined
+      ? { ephemeralVmCheckoutMode: meta.ephemeralVmCheckoutMode }
+      : {}),
     ...(creatorProvenance ? { creatorProvenance } : {}),
     path: git.path,
     head: git.head,

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import { ipcMain, type BrowserWindow } from 'electron'
+import { app, ipcMain, type BrowserWindow } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
@@ -19,6 +19,7 @@ import { isPathInsideOrEqual, isWindowsAbsolutePathLike } from '../../shared/cro
 import { deleteWorktreeHistoryDir } from '../terminal-history-deletion'
 import type {
   AutomationWorkspaceProvenance,
+  AdoptProvisionedRootArgs,
   CliWorkspaceProvenance,
   CreateWorktreeArgs,
   CreateWorktreeResult,
@@ -146,6 +147,7 @@ import {
 } from '../ssh/ssh-provider-authority'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
 import { preservedBranchCleanupScopeKey } from '../../shared/preserved-branch-cleanup'
+import { adoptProvisionedRootSshCheckout } from '../provisioned-root-ssh-adoption'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -1825,6 +1827,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:forgetRemovedForExecutionHost')
   ipcMain.removeHandler('worktrees:cancelListDetected')
   ipcMain.removeHandler('worktrees:create')
+  ipcMain.removeHandler('worktrees:adoptProvisionedRoot')
   ipcMain.removeHandler('worktrees:prefetchCreateBase')
   ipcMain.removeHandler('worktrees:resolvePrBase')
   ipcMain.removeHandler('worktrees:resolveMrBase')
@@ -2257,6 +2260,59 @@ export function registerWorktreeHandlers(
           branch: result.worktree.branch
         })
 
+        return result
+      })
+    }
+  )
+
+  ipcMain.handle(
+    'worktrees:adoptProvisionedRoot',
+    async (_event, rawArgs: AdoptProvisionedRootArgs): Promise<CreateWorktreeResult> => {
+      const args = normalizeLinkedWorkItemFields(rawArgs)
+      return withWorktreeSpan({ stage: 'create' }, async () => {
+        const repo = findExactRepoOwner(store, args.repoId, args.executionHostId)
+        if (!repo || isFolderRepo(repo)) {
+          throw new Error('Provisioned-root repository ownership is missing or ambiguous.')
+        }
+        const sourceParse = workspaceSourceSchema.safeParse(args.telemetrySource)
+        const source: WorkspaceSource = sourceParse.success ? sourceParse.data : 'unknown'
+        const automationProvenance = resolveAutomationWorkspaceProvenance({
+          authority: runtime,
+          repoSelector: args.repoId,
+          repo,
+          request: args.automationProvenanceRequest
+        })
+        let result: CreateWorktreeResult
+        try {
+          result = await adoptProvisionedRootSshCheckout({
+            userDataPath: app.getPath('userData'),
+            request: { ...args, automationProvenance },
+            repo,
+            store,
+            isRepoCurrent: () => isCapturedRepoCurrent(store, repo, args.executionHostId)
+          })
+        } catch (error) {
+          releaseAutomationWorkspaceProvenanceRequest(args.automationProvenanceRequest)
+          track('workspace_create_failed', {
+            source,
+            error_class: classifyWorkspaceCreateError(error),
+            ...getCohortAtEmit()
+          })
+          throw error
+        }
+        finishAutomationWorkspaceProvenanceRequest(args.automationProvenanceRequest)
+        track('workspace_created', {
+          source,
+          from_existing_branch: false,
+          ...getCohortAtEmit()
+        })
+        notifyWorktreesChanged(mainWindow, repo.id)
+        options?.onWorktreeLifecycle?.({
+          kind: 'created',
+          worktreeId: result.worktree.id,
+          path: result.worktree.path,
+          branch: result.worktree.branch
+        })
         return result
       })
     }

--- a/src/main/provisioned-root-ssh-adoption.test.ts
+++ b/src/main/provisioned-root-ssh-adoption.test.ts
@@ -1,0 +1,297 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from './persistence'
+import type { AdoptProvisionedRootArgs, GitWorktreeInfo, Repo, WorktreeMeta } from '../shared/types'
+import {
+  listEphemeralVmRuntimes,
+  upsertEphemeralVmRuntime
+} from '../shared/ephemeral-vm-runtime-store'
+import { registerSshGitProvider, unregisterSshGitProvider } from './providers/ssh-git-dispatch'
+import {
+  resetSshProviderAuthorities,
+  rotateSshProviderAuthority
+} from './ssh/ssh-provider-authority'
+import { adoptProvisionedRootSshCheckout } from './provisioned-root-ssh-adoption'
+
+const connectionId = 'runtime-ssh-test'
+const projectRoot = '/workspace/orca'
+
+describe('adoptProvisionedRootSshCheckout', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-provisioned-root-'))
+    resetSshProviderAuthorities()
+  })
+
+  afterEach(() => {
+    unregisterSshGitProvider(connectionId)
+    resetSshProviderAuthorities()
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('adopts the exact primary checkout, persists host metadata, and attaches the runtime', async () => {
+    seedRuntime(userDataPath, projectRoot)
+    registerSshGitProvider(connectionId, {
+      listWorktrees: vi.fn().mockResolvedValue([gitWorktree(projectRoot)]),
+      exec: sparseCheckoutProbe(false)
+    } as never)
+    const { store, setWorktreeMeta } = makeStore()
+
+    const result = await adoptProvisionedRootSshCheckout({
+      userDataPath,
+      request: request(projectRoot),
+      repo: repo(projectRoot),
+      store,
+      isRepoCurrent: () => true
+    })
+
+    expect(result.worktree).toMatchObject({
+      id: `repo-1::${projectRoot}`,
+      path: projectRoot,
+      isMainWorktree: true,
+      hostId: `ssh:${connectionId}`,
+      ephemeralVmCheckoutMode: 'provisioned-root',
+      linkedGitLabIssue: 17
+    })
+    expect(setWorktreeMeta).toHaveBeenCalledWith(
+      `repo-1::${projectRoot}`,
+      expect.objectContaining({
+        hostId: `ssh:${connectionId}`,
+        ephemeralVmCheckoutMode: 'provisioned-root',
+        linkedGitLabIssue: 17
+      })
+    )
+    expect(listEphemeralVmRuntimes(userDataPath)[0]).toMatchObject({
+      workspaceId: `repo-1::${projectRoot}`,
+      status: 'running'
+    })
+  })
+
+  it('rejects a linked worktree and sparse checkout', async () => {
+    seedRuntime(userDataPath, projectRoot)
+    const listWorktrees = vi
+      .fn()
+      .mockResolvedValue([gitWorktree(projectRoot, { isMainWorktree: false })])
+    registerSshGitProvider(connectionId, {
+      listWorktrees,
+      exec: sparseCheckoutProbe(false)
+    } as never)
+    const { store, setWorktreeMeta } = makeStore()
+
+    await expect(
+      adoptProvisionedRootSshCheckout({
+        userDataPath,
+        request: request(projectRoot),
+        repo: repo(projectRoot),
+        store,
+        isRepoCurrent: () => true
+      })
+    ).rejects.toThrow('must be the repository primary checkout')
+    await expect(
+      adoptProvisionedRootSshCheckout({
+        userDataPath,
+        request: { ...request(projectRoot), sparseCheckout: { directories: ['src'] } },
+        repo: repo(projectRoot),
+        store,
+        isRepoCurrent: () => true
+      })
+    ).rejects.toThrow('do not support sparse checkout')
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('rejects path and runtime target mismatches', async () => {
+    seedRuntime(userDataPath, projectRoot)
+    registerSshGitProvider(connectionId, {
+      listWorktrees: vi.fn().mockResolvedValue([gitWorktree(projectRoot)]),
+      exec: sparseCheckoutProbe(false)
+    } as never)
+    const { store } = makeStore()
+
+    await expect(
+      adoptProvisionedRootSshCheckout({
+        userDataPath,
+        request: request('/workspace/other'),
+        repo: repo(projectRoot),
+        store,
+        isRepoCurrent: () => true
+      })
+    ).rejects.toThrow('does not match')
+    await expect(
+      adoptProvisionedRootSshCheckout({
+        userDataPath,
+        request: { ...request(projectRoot), executionHostId: 'ssh:runtime-ssh-other' },
+        repo: repo(projectRoot),
+        store,
+        isRepoCurrent: () => true
+      })
+    ).rejects.toThrow('host does not match')
+  })
+
+  it('rejects provider rotation during verification', async () => {
+    seedRuntime(userDataPath, projectRoot)
+    let resolveList: (value: ReturnType<typeof gitWorktree>[]) => void = () => undefined
+    const listWorktrees = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof gitWorktree>[]>((resolve) => {
+          resolveList = resolve
+        })
+    )
+    registerSshGitProvider(connectionId, {
+      listWorktrees,
+      exec: sparseCheckoutProbe(false)
+    } as never)
+    const { store } = makeStore()
+    const adoption = adoptProvisionedRootSshCheckout({
+      userDataPath,
+      request: request(projectRoot),
+      repo: repo(projectRoot),
+      store,
+      isRepoCurrent: () => true
+    })
+    await vi.waitFor(() => expect(listWorktrees).toHaveBeenCalledOnce())
+    rotateSshProviderAuthority(connectionId)
+    resolveList([gitWorktree(projectRoot)])
+
+    await expect(adoption).rejects.toThrow('changed during checkout verification')
+  })
+
+  it('compares Windows checkout roots using runtime path semantics', async () => {
+    const windowsRoot = 'C:\\Workspace\\Orca'
+    seedRuntime(userDataPath, windowsRoot)
+    registerSshGitProvider(connectionId, {
+      listWorktrees: vi.fn().mockResolvedValue([gitWorktree('c:/workspace/orca/')]),
+      exec: sparseCheckoutProbe(false)
+    } as never)
+    const { store } = makeStore()
+
+    const result = await adoptProvisionedRootSshCheckout({
+      userDataPath,
+      request: request('C:/WORKSPACE/ORCA'),
+      repo: repo('c:\\workspace\\orca'),
+      store,
+      isRepoCurrent: () => true
+    })
+
+    expect(result.worktree.path).toBe('c:/workspace/orca/')
+  })
+
+  it('rejects sparse checkout enabled in the remote Git config', async () => {
+    seedRuntime(userDataPath, projectRoot)
+    const exec = sparseCheckoutProbe(true)
+    registerSshGitProvider(connectionId, {
+      listWorktrees: vi.fn().mockResolvedValue([gitWorktree(projectRoot)]),
+      exec
+    } as never)
+    const { store, setWorktreeMeta } = makeStore()
+
+    await expect(
+      adoptProvisionedRootSshCheckout({
+        userDataPath,
+        request: request(projectRoot),
+        repo: repo(projectRoot),
+        store,
+        isRepoCurrent: () => true
+      })
+    ).rejects.toThrow('cannot adopt a sparse checkout')
+    expect(exec).toHaveBeenCalledWith(
+      ['config', '--bool', '--get', '--default=false', 'core.sparseCheckout'],
+      projectRoot
+    )
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+  })
+})
+
+function seedRuntime(userDataPath: string, root: string): void {
+  upsertEphemeralVmRuntime(userDataPath, {
+    id: 'runtime-1',
+    recipeId: 'sandbox',
+    recipe: {
+      id: 'sandbox',
+      name: 'Sandbox',
+      create: 'sandbox create',
+      checkoutMode: 'provisioned-root'
+    },
+    connectionMode: 'ssh',
+    sshTargetId: connectionId,
+    status: 'running',
+    cleanupStatus: 'not_started',
+    createdAt: 1,
+    updatedAt: 1,
+    recipeResult: {
+      schemaVersion: 2,
+      checkoutMode: 'provisioned-root',
+      connection: {
+        type: 'ssh',
+        target: { label: 'Sandbox', host: '127.0.0.1', port: 22, username: 'orca' },
+        projectRoot: root
+      }
+    }
+  })
+}
+
+function repo(path: string): Repo {
+  return {
+    id: 'repo-1',
+    path,
+    displayName: 'orca',
+    badgeColor: '#000000',
+    addedAt: 1,
+    connectionId,
+    executionHostId: `ssh:${connectionId}`
+  }
+}
+
+function request(expectedPath: string): AdoptProvisionedRootArgs {
+  return {
+    repoId: 'repo-1',
+    name: 'fix-sandbox',
+    runtimeId: 'runtime-1',
+    executionHostId: `ssh:${connectionId}`,
+    expectedPath,
+    linkedGitLabIssue: 17
+  }
+}
+
+function gitWorktree(path: string, overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo {
+  return {
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/fix-sandbox',
+    isBare: false,
+    isMainWorktree: true,
+    ...overrides
+  }
+}
+
+function sparseCheckoutProbe(enabled: boolean): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({ stdout: `${enabled}\n`, stderr: '' })
+}
+
+function makeStore(): {
+  store: Store
+  setWorktreeMeta: ReturnType<typeof vi.fn>
+} {
+  const setWorktreeMeta = vi.fn((_: string, updates: Partial<WorktreeMeta>) => ({
+    displayName: '',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...updates
+  }))
+  return {
+    store: {
+      getSettings: () => ({ nestWorkspaces: false, workspaceDir: '.orca/worktrees' }),
+      setWorktreeMeta
+    } as unknown as Store,
+    setWorktreeMeta
+  }
+}

--- a/src/main/provisioned-root-ssh-adoption.ts
+++ b/src/main/provisioned-root-ssh-adoption.ts
@@ -1,0 +1,196 @@
+import { randomUUID } from 'node:crypto'
+import type { Store } from './persistence'
+import type {
+  AdoptProvisionedRootArgs,
+  AutomationWorkspaceProvenance,
+  CreateWorktreeResult,
+  Repo,
+  WorktreeMeta
+} from '../shared/types'
+import { isRuntimeOwnedSshTargetId, toSshExecutionHostId } from '../shared/execution-host'
+import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
+import {
+  getEphemeralVmRecipeResultCheckoutMode,
+  getEphemeralVmRecipeResultProjectRoot
+} from '../shared/ephemeral-vm-recipes'
+import { listEphemeralVmRuntimes } from '../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
+import { getProjectHostSetupWorktreeMeta } from '../shared/project-host-setup-projection'
+import { isTuiAgent } from '../shared/tui-agent-config'
+import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import {
+  getSshProviderAuthority,
+  isCurrentSshProviderAuthority
+} from './ssh/ssh-provider-authority'
+import { attachEphemeralVmRuntimeToWorkspace } from './ephemeral-vm-runtime-attachment'
+import { getWorktreeCreationLayout, mergeWorktree } from './ipc/worktree-logic'
+
+type AdoptionArgs = AdoptProvisionedRootArgs & {
+  automationProvenance?: AutomationWorkspaceProvenance
+}
+
+export async function adoptProvisionedRootSshCheckout(args: {
+  userDataPath: string
+  request: AdoptionArgs
+  repo: Repo
+  store: Store
+  isRepoCurrent: () => boolean
+}): Promise<CreateWorktreeResult> {
+  const { request, repo, store } = args
+  if (request.sparseCheckout) {
+    throw new Error('Provisioned-root recipes do not support sparse checkout.')
+  }
+  const connectionId = repo.connectionId
+  if (!connectionId || !isRuntimeOwnedSshTargetId(connectionId)) {
+    throw new Error('Provisioned-root adoption requires a runtime-owned SSH target.')
+  }
+  if (request.executionHostId !== toSshExecutionHostId(connectionId)) {
+    throw new Error('Provisioned-root workspace host does not match its SSH target.')
+  }
+
+  const runtime = requireOwnedProvisionedRootRuntime(
+    args.userDataPath,
+    request.runtimeId,
+    connectionId
+  )
+  const projectRoot = getEphemeralVmRecipeResultProjectRoot(runtime.recipeResult)
+  if (!pathsEqual(request.expectedPath, projectRoot) || !pathsEqual(repo.path, projectRoot)) {
+    throw new Error('The recipe projectRoot does not match the imported Git checkout root.')
+  }
+
+  const provider = getSshGitProvider(connectionId)
+  if (!provider) {
+    throw new Error('The recipe-created SSH connection is no longer available.')
+  }
+  const authority = { ...getSshProviderAuthority(connectionId) }
+  const [worktrees, sparseCheckoutEnabled] = await Promise.all([
+    provider.listWorktrees(repo.path),
+    isSparseCheckoutEnabled(provider, projectRoot)
+  ])
+  if (
+    getSshGitProvider(connectionId) !== provider ||
+    !isCurrentSshProviderAuthority(authority) ||
+    !args.isRepoCurrent()
+  ) {
+    throw new Error('The recipe-created SSH connection changed during checkout verification.')
+  }
+  requireOwnedProvisionedRootRuntime(args.userDataPath, request.runtimeId, connectionId)
+
+  const matches = worktrees.filter((worktree) => pathsEqual(worktree.path, projectRoot))
+  if (matches.length !== 1) {
+    throw new Error('The recipe projectRoot is not a unique Git checkout root.')
+  }
+  const gitWorktree = matches[0]
+  if (!gitWorktree.isMainWorktree) {
+    throw new Error('The recipe projectRoot must be the repository primary checkout.')
+  }
+  if (gitWorktree.isBare) {
+    throw new Error('Provisioned-root recipes cannot adopt a bare repository.')
+  }
+  if (gitWorktree.isSparse || sparseCheckoutEnabled) {
+    throw new Error('Provisioned-root recipes cannot adopt a sparse checkout.')
+  }
+
+  const worktreeId = `${repo.id}::${gitWorktree.path}`
+  attachEphemeralVmRuntimeToWorkspace({
+    userDataPath: args.userDataPath,
+    runtimeId: request.runtimeId,
+    workspaceId: worktreeId
+  })
+  const now = Date.now()
+  const meta = store.setWorktreeMeta(
+    worktreeId,
+    buildProvisionedRootMeta(store, repo, request, now)
+  )
+  return { worktree: mergeWorktree(repo.id, gitWorktree, meta) }
+}
+
+async function isSparseCheckoutEnabled(
+  provider: NonNullable<ReturnType<typeof getSshGitProvider>>,
+  projectRoot: string
+): Promise<boolean> {
+  const { stdout } = await provider.exec(
+    ['config', '--bool', '--get', '--default=false', 'core.sparseCheckout'],
+    projectRoot
+  )
+  return stdout.trim() === 'true'
+}
+
+function requireOwnedProvisionedRootRuntime(
+  userDataPath: string,
+  runtimeId: string,
+  connectionId: string
+): EphemeralVmRuntimeRecord {
+  const runtime = listEphemeralVmRuntimes(userDataPath).find((entry) => entry.id === runtimeId)
+  if (!runtime) {
+    throw new Error(`Unknown ephemeral VM runtime: ${runtimeId}`)
+  }
+  if (
+    runtime.connectionMode !== 'ssh' ||
+    runtime.sshTargetId !== connectionId ||
+    runtime.recipe?.checkoutMode !== 'provisioned-root' ||
+    getEphemeralVmRecipeResultCheckoutMode(runtime.recipeResult) !== 'provisioned-root' ||
+    ['cleanup_pending', 'cleanup_failed', 'cleaned'].includes(runtime.status)
+  ) {
+    throw new Error('The ephemeral VM runtime does not own this provisioned SSH checkout.')
+  }
+  return runtime
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  return normalizeRuntimePathForComparison(left) === normalizeRuntimePathForComparison(right)
+}
+
+function buildProvisionedRootMeta(
+  store: Store,
+  repo: Repo,
+  args: AdoptionArgs,
+  now: number
+): Partial<WorktreeMeta> {
+  return {
+    instanceId: randomUUID(),
+    ...(store.getProjectHostSetups
+      ? getProjectHostSetupWorktreeMeta(store.getProjectHostSetups(), repo)
+      : {}),
+    hostId: args.executionHostId,
+    ephemeralVmCheckoutMode: 'provisioned-root',
+    displayName: args.displayName || args.name,
+    lastActivityAt: now,
+    createdAt: now,
+    orcaCreatedAt: now,
+    orcaCreationSource: 'ssh',
+    creatorProvenance: { kind: 'host' },
+    orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, store.getSettings()),
+    ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
+    ...(args.compareBaseRef || args.baseBranch
+      ? { baseRef: args.compareBaseRef ?? args.baseBranch }
+      : {}),
+    ...(args.pushTarget ? { pushTarget: args.pushTarget } : {}),
+    ...(isTuiAgent(args.createdWithAgent) ? { createdWithAgent: args.createdWithAgent } : {}),
+    ...(args.pendingFirstAgentMessageRename === true && isTuiAgent(args.createdWithAgent)
+      ? { pendingFirstAgentMessageRename: true }
+      : {}),
+    ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
+    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {}),
+    ...(args.linkedLinearIssue !== undefined ? { linkedLinearIssue: args.linkedLinearIssue } : {}),
+    ...(args.linkedLinearIssueWorkspaceId !== undefined
+      ? { linkedLinearIssueWorkspaceId: args.linkedLinearIssueWorkspaceId }
+      : {}),
+    ...(args.linkedLinearIssueOrganizationUrlKey !== undefined
+      ? { linkedLinearIssueOrganizationUrlKey: args.linkedLinearIssueOrganizationUrlKey }
+      : {}),
+    ...(args.manualOrder !== undefined ? { manualOrder: args.manualOrder } : {}),
+    ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {}),
+    ...(args.linkedGitLabIssue !== undefined ? { linkedGitLabIssue: args.linkedGitLabIssue } : {}),
+    ...(args.linkedGitLabMR !== undefined ? { linkedGitLabMR: args.linkedGitLabMR } : {}),
+    ...(args.linkedBitbucketPR !== undefined ? { linkedBitbucketPR: args.linkedBitbucketPR } : {}),
+    ...(args.linkedAzureDevOpsPR !== undefined
+      ? { linkedAzureDevOpsPR: args.linkedAzureDevOpsPR }
+      : {}),
+    ...(args.linkedGiteaPR !== undefined ? { linkedGiteaPR: args.linkedGiteaPR } : {}),
+    ...(args.linkedWorkItem !== undefined ? { linkedWorkItem: args.linkedWorkItem } : {}),
+    ...(args.linkedTaskSourceContext !== undefined
+      ? { linkedTaskSourceContext: args.linkedTaskSourceContext }
+      : {})
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -147,6 +147,7 @@ import type {
   ClaudeRateLimitAccountsState,
   ClassifiedError,
   CodexRateLimitAccountsState,
+  AdoptProvisionedRootArgs,
   CreateWorktreeArgs,
   CreateWorktreeResult,
   CustomPet,
@@ -1370,6 +1371,7 @@ export type PreloadApi = {
     cancelListDetected?: (args: { providerRequestId: ProviderRequestId }) => Promise<void>
     listAll: () => Promise<Worktree[]>
     create: (args: CreateWorktreeArgs) => Promise<CreateWorktreeResult>
+    adoptProvisionedRoot: (args: AdoptProvisionedRootArgs) => Promise<CreateWorktreeResult>
     /** Two-phase progress for a background `create`, correlated by `creationId`. The remote/runtime
      *  create path emits nothing, so the surface falls back to an indeterminate spinner. */
     onCreateProgress: (
@@ -2638,6 +2640,8 @@ export type PreloadApi = {
       workspaceName?: string
       projectId?: string
       workspaceId?: string
+      branch?: string
+      ref?: string
       provisionId?: string
     }) => Promise<
       | {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -797,6 +797,8 @@ const api = {
 
     create: (args) => ipcRenderer.invoke('worktrees:create', args),
 
+    adoptProvisionedRoot: (args) => ipcRenderer.invoke('worktrees:adoptProvisionedRoot', args),
+
     onCreateProgress: (
       callback: (data: { creationId?: string; phase: 'fetching' | 'creating' }) => void
     ): (() => void) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1821,6 +1821,11 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         worktree: withRuntimeWorktreeOwner(owned.result.worktree, owned.hostId)
       }
     },
+    // Why: adoption verifies a desktop-owned hidden SSH target and is intentionally not a remote-server operation.
+    adoptProvisionedRoot: () =>
+      Promise.reject(
+        new Error('Provisioned-root recipes require a direct SSH connection from the desktop app.')
+      ),
     // Why: the runtime create path emits no two-phase progress, so the panel falls back to an indeterminate spinner.
     onCreateProgress: () => noopUnsubscribe,
     prefetchCreateBase: async ({ repoId, baseBranch }) => {

--- a/src/shared/ephemeral-vm-recipe-diagnostics.ts
+++ b/src/shared/ephemeral-vm-recipe-diagnostics.ts
@@ -1,4 +1,5 @@
 import { parsePairingCode } from './pairing'
+import { stripCredentialsFromMessage } from './git-remote-error'
 import {
   getEphemeralVmRecipeResultConnection,
   type EphemeralVmRecipeConnection,
@@ -38,7 +39,7 @@ export function redactEphemeralVmRecipeDiagnosticText(text: string): string {
   if (!text) {
     return text
   }
-  return text
+  return stripCredentialsFromMessage(text)
     .replace(/orca:\/\/pair\?code=[A-Za-z0-9_-]+/g, 'orca://pair?code=[redacted]')
     .replace(
       /("(?:pairingCode|deviceToken|publicKeyB64|token|secret|password|apiKey|accessToken|identityFile|identityAgent|proxyCommand)"\s*:\s*)"[^"]*"/gi,

--- a/src/shared/ephemeral-vm-recipe-repo-url.test.ts
+++ b/src/shared/ephemeral-vm-recipe-repo-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getProvisionedRootRecipeRepoUrl } from './ephemeral-vm-recipe-repo-url'
+
+describe('getProvisionedRootRecipeRepoUrl', () => {
+  it('does not expose the repository URL to ordinary recipes', () => {
+    expect(
+      getProvisionedRootRecipeRepoUrl(
+        undefined,
+        'https://recipe-user:recipe-token@git.example.com/team/repo.git'
+      )
+    ).toBeUndefined()
+  })
+
+  it('removes credentials before exposing the URL to a provisioned-root recipe', () => {
+    expect(
+      getProvisionedRootRecipeRepoUrl(
+        'provisioned-root',
+        'https://recipe-user:recipe-token@git.example.com/team/repo.git'
+      )
+    ).toBe('https://git.example.com/team/repo.git')
+  })
+
+  it('preserves the SSH username required by scp-style remotes', () => {
+    expect(getProvisionedRootRecipeRepoUrl('provisioned-root', 'git@host:team/repo.git')).toBe(
+      'git@host:team/repo.git'
+    )
+  })
+})

--- a/src/shared/ephemeral-vm-recipe-repo-url.ts
+++ b/src/shared/ephemeral-vm-recipe-repo-url.ts
@@ -1,0 +1,12 @@
+import { stripCredentialsFromMessage } from './git-remote-error'
+import type { OrcaVmRecipe } from './types'
+
+export function getProvisionedRootRecipeRepoUrl(
+  checkoutMode: OrcaVmRecipe['checkoutMode'],
+  remoteUrl: string | undefined
+): string | undefined {
+  if (checkoutMode !== 'provisioned-root' || !remoteUrl) {
+    return undefined
+  }
+  return stripCredentialsFromMessage(remoteUrl)
+}

--- a/src/shared/ephemeral-vm-recipes.test.ts
+++ b/src/shared/ephemeral-vm-recipes.test.ts
@@ -286,6 +286,11 @@ describe('parseEphemeralVmRecipeResult', () => {
       '{"pairingCode":"[redacted]","token":"[redacted]","identityFile":"[redacted]","proxyCommand":"[redacted]","ok":true}'
     )
     expect(
+      redactEphemeralVmRecipeDiagnosticText(
+        'clone https://recipe-user:recipe-token@git.example.com/team/repo.git'
+      )
+    ).toBe('clone https://git.example.com/team/repo.git')
+    expect(
       redactEphemeralVmRecipeResultForDiagnostics({
         schemaVersion: 1,
         pairingCode,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -518,6 +518,8 @@ export type Worktree = {
   creatorProvenance?: WorkspaceCreatorProvenance
   /** Host-specific setup used to create/run this workspace. */
   projectHostSetupId?: string
+  /** Checkout ownership for a recipe-provisioned main workspace. */
+  ephemeralVmCheckoutMode?: EphemeralVmCheckoutMode
   displayName: string
   comment: string
   linkedIssue: number | null
@@ -650,6 +652,8 @@ export type WorktreeMeta = {
   hostId?: ExecutionHostId
   /** See Worktree.projectHostSetupId. Persisted for project-first workspace ownership. */
   projectHostSetupId?: string
+  /** See Worktree.ephemeralVmCheckoutMode. */
+  ephemeralVmCheckoutMode?: EphemeralVmCheckoutMode
   /** See Worktree.creatorProvenance. */
   creatorProvenance?: WorkspaceCreatorProvenance
   displayName: string
@@ -2362,6 +2366,12 @@ export type CreateWorktreeArgs = {
   creationId?: string
   /** Authorizes the host to mint system-owned automation provenance. */
   automationProvenanceRequest?: AutomationWorkspaceProvenanceRequest
+}
+
+export type AdoptProvisionedRootArgs = CreateWorktreeArgs & {
+  runtimeId: string
+  executionHostId: ExecutionHostId
+  expectedPath: string
 }
 
 export type CreateWorktreeResult = {


### PR DESCRIPTION
## ELI5

After a recipe creates a checkout, Orca needs to prove that checkout belongs to the exact temporary SSH runtime before trusting it. This adds one narrow desktop-main operation that performs those checks and adopts it.

## What Changed

- Add `worktrees:adoptProvisionedRoot`.
- Verify runtime ownership, hidden SSH target identity, exact persisted `projectRoot`, current provider authority, and one unique primary checkout.
- Reject linked, bare, sparse, stale-provider, mismatched-host, and mismatched-path checkouts.
- Persist host-qualified workspace metadata and attach the runtime before returning.
- Keep paired web/Orca-server clients explicitly unsupported; no remote wire opcode is added.

Stack: #14351 → #14352 → **3/4** → #14359

## Why

The main process owns hidden SSH credentials and provider authority, so it is the only layer that can make this decision safely. This replaces the earlier renderer-authoritative scan architecture.

## Linked Issue

Relates to #13044

## Visual Proof

N/A — this layer is an internal main/preload API with no standalone UI.

## Testing

- [x] Exact success plus linked, bare, sparse, path, host, provider-rotation, and Windows-path cases.
- [x] Full desktop, CLI, and paired-web typecheck.
- [x] Relevant changed-code quality, max-lines, formatting, and build gates pass.

## Review

Please focus on the trust boundary, time-of-check/provider-rotation guards, path semantics, and absence of remote-wire changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is not applicable to this internal layer
- [x] Self-reviewed for correctness, security, and performance
- [x] SSH, Windows paths, paired clients, and backwards compatibility considered
- [x] Relevant lint, typecheck, and tests pass; CI will run the full suite