### PR TITLE
fix: suppress startup noise and guard zero-turn TUI resume

### DIFF
--- a/mobile/src/session/MobileStructuredAgentSessionView.test.tsx
+++ b/mobile/src/session/MobileStructuredAgentSessionView.test.tsx
@@ -114,6 +114,27 @@ describe('MobileStructuredAgentSessionView command seam', () => {
     expect(onSend).not.toHaveBeenCalled()
   })
 
+  it('disables zero-turn TUI resume with truthful guidance', () => {
+    render({
+      handoff: {
+        owner: 'native',
+        direction: null,
+        phase: 'idle',
+        stage: null,
+        operationId: null
+      }
+    })
+
+    const label = renderer!.root
+      .findAllByType('Text')
+      .find((node) => node.children.includes('Open agent TUI'))
+    expect(label?.parent?.props).toMatchObject({
+      disabled: true,
+      accessibilityState: { disabled: true },
+      accessibilityHint: 'Send a message first to open the agent TUI.'
+    })
+  })
+
   it('renders an explicit refusal for unsupported advertised commands', async () => {
     await submit('/review')
 

--- a/mobile/src/session/MobileStructuredAgentSessionView.tsx
+++ b/mobile/src/session/MobileStructuredAgentSessionView.tsx
@@ -33,6 +33,7 @@ import {
   restoreMobileStructuredAttachments,
   type MobileStructuredTimelineRow
 } from './mobile-structured-session-timeline'
+import { hasPersistedStructuredAgentSessionTurn } from '../../../src/shared/structured-agent-session-projection'
 import {
   admitStructuredOlderPage,
   beginStructuredUserScroll,
@@ -128,6 +129,7 @@ export function MobileStructuredAgentSessionView(props: Props): React.JSX.Elemen
       <MobileStructuredHandoffBanner
         status={props.handoff}
         isWorking={turnId !== null}
+        hasPersistedTurn={hasPersistedStructuredAgentSessionTurn(props.items)}
         onRequest={props.onRequestHandoff}
       />
       <FlatList
@@ -295,6 +297,7 @@ export function MobileStructuredAgentSessionView(props: Props): React.JSX.Elemen
 function MobileStructuredHandoffBanner(props: {
   status: AgentSessionHandoffStatus | null
   isWorking: boolean
+  hasPersistedTurn: boolean
   onRequest: Props['onRequestHandoff']
 }): React.JSX.Element | null {
   const status = props.status
@@ -321,7 +324,17 @@ function MobileStructuredHandoffBanner(props: {
           </>
         ) : (
           <Pressable
-            style={({ pressed }) => [styles.handoffButton, pressed && styles.pressed]}
+            style={({ pressed }) => [
+              styles.handoffButton,
+              !props.hasPersistedTurn && styles.disabled,
+              pressed && props.hasPersistedTurn && styles.pressed
+            ]}
+            disabled={!props.hasPersistedTurn}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !props.hasPersistedTurn }}
+            accessibilityHint={
+              props.hasPersistedTurn ? undefined : 'Send a message first to open the agent TUI.'
+            }
             // A submitted turn can reach the host before isWorking updates; after-turn is immediate when idle.
             onPress={() => void props.onRequest('to-tui', 'after-turn')}
           >

--- a/mobile/src/session/mobile-structured-agent-session-view-styles.ts
+++ b/mobile/src/session/mobile-structured-agent-session-view-styles.ts
@@ -36,6 +36,7 @@ export const styles = StyleSheet.create({
   },
   cancelText: { color: colors.statusRed, fontSize: typography.metaSize, fontWeight: '600' },
   pressed: { opacity: 0.7 },
+  disabled: { opacity: 0.45 },
   writeError: {
     alignItems: 'center',
     paddingHorizontal: spacing.lg,

--- a/src/main/codex/codex-structured-item-translation.ts
+++ b/src/main/codex/codex-structured-item-translation.ts
@@ -243,10 +243,8 @@ export function codexJournalItem(item: CodexThreadItem): CodexJournalItem {
       handled: true
     }
   }
-  return {
-    ...unhandledProviderFrameJournalItem('codex', `item:${item.type}`, item),
-    handled: false
-  }
+  const unhandled = unhandledProviderFrameJournalItem('codex', `item:${item.type}`, item)
+  return unhandled ? { ...unhandled, handled: false } : { body: null, blobs: [], handled: true }
 }
 
 export function codexItemBody(item: CodexThreadItem): AgentJournalItemBody | null {

--- a/src/main/codex/codex-structured-journal-translation.test.ts
+++ b/src/main/codex/codex-structured-journal-translation.test.ts
@@ -4,6 +4,7 @@ import type {
   AgentJournalItemIdentity
 } from '../../shared/agent-session-journal-types'
 import { agentJournalItemKey } from '../../shared/agent-session-journal-item-key'
+import { projectStructuredItemsToNativeChat } from '../../shared/structured-agent-session-projection'
 import type { StructuredAgentSessionEventSink } from '../native-chat/agent-session-wire/structured-agent-session-event-sink'
 import { createCodexJournalTranslator } from './codex-structured-journal-translation'
 import {
@@ -440,6 +441,32 @@ describe('codex journal translation', () => {
     expect(
       tap.rows.map((row) => (row.body.kind === 'status' ? row.body.providerFrame?.kind : undefined))
     ).toEqual(['notification:future/notification', 'request:future/request', 'frame:unclassified'])
+  })
+
+  it('keeps a fresh session timeline empty through startup and status notifications', () => {
+    const { translator, tap } = translatorWith()
+
+    translator.handle(notification('thread/started', { thread: { id: THREAD_ID } }))
+    for (let index = 0; index < 8; index += 1) {
+      translator.handle(
+        notification('mcpServer/startupStatus/updated', {
+          server: `server-${index}`,
+          status: 'starting'
+        })
+      )
+    }
+    translator.handle(notification('remoteControl/status/changed', { status: 'disabled' }))
+
+    const timeline = projectStructuredItemsToNativeChat(
+      tap.rows.map((row, index) => ({
+        itemId: row.key,
+        revision: 1,
+        sequence: index + 1,
+        observedAt: index + 1,
+        body: row.body
+      }))
+    )
+    expect(timeline).toEqual([])
   })
 
   it('writes nothing more after dispose', () => {

--- a/src/main/codex/codex-structured-journal-translation.test.ts
+++ b/src/main/codex/codex-structured-journal-translation.test.ts
@@ -469,6 +469,39 @@ describe('codex journal translation', () => {
     expect(timeline).toEqual([])
   })
 
+  it('renders a system error carried by a suppressed status kind', () => {
+    const { translator, tap } = translatorWith()
+
+    translator.handle(
+      notification('thread/status/changed', {
+        threadId: THREAD_ID,
+        status: { type: 'systemError' }
+      })
+    )
+
+    const timeline = projectStructuredItemsToNativeChat(
+      tap.rows.map((row, index) => ({
+        itemId: row.key,
+        revision: 1,
+        sequence: index + 1,
+        observedAt: index + 1,
+        body: row.body
+      }))
+    )
+    expect(timeline).toEqual([
+      expect.objectContaining({
+        role: 'system',
+        blocks: [
+          expect.objectContaining({
+            providerFrame: expect.objectContaining({
+              kind: 'notification:thread/status/changed'
+            })
+          })
+        ]
+      })
+    ])
+  })
+
   it('writes nothing more after dispose', () => {
     const { translator, tap, window } = translatorWith()
 

--- a/src/main/codex/codex-structured-journal-translation.ts
+++ b/src/main/codex/codex-structured-journal-translation.ts
@@ -70,8 +70,11 @@ export function createCodexJournalTranslator(
   let fallbackSequence = 0
 
   const appendUnhandled = (kind: string, payload: unknown): void => {
-    fallbackSequence += 1
     const translated = unhandledProviderFrameJournalItem('codex', kind, payload)
+    if (!translated) {
+      return
+    }
+    fallbackSequence += 1
     deps.sink.appendItem(
       { provider: 'orca', clientMessageId: `provider-frame:codex:${fallbackSequence}` },
       translated.body,

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
@@ -1,5 +1,50 @@
 export type ProviderFrameDisposition = 'debug-only' | 'timeline'
 
+const ERROR_VARIANT_KEYS = new Set(['type', 'status', 'state', 'subtype', 'outcome'])
+const ERROR_VALUE_KEYS = new Set(['error', 'failureReason', 'failure_reason'])
+
+function isErrorVariant(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false
+  }
+  const normalized = value.replace(/[_\s-]/g, '').toLowerCase()
+  return (
+    normalized.startsWith('error') || normalized.startsWith('fail') || normalized === 'systemerror'
+  )
+}
+
+function hasProviderError(payload: unknown): boolean {
+  const pending = [payload]
+  const seen = new WeakSet<object>()
+  while (pending.length > 0) {
+    const value = pending.pop()
+    if (typeof value !== 'object' || value === null || seen.has(value)) {
+      continue
+    }
+    seen.add(value)
+    if (Array.isArray(value)) {
+      pending.push(...value)
+      continue
+    }
+    for (const [key, nested] of Object.entries(value)) {
+      if ((key === 'isError' || key === 'is_error') && nested === true) {
+        return true
+      }
+      if (key === 'success' && nested === false) {
+        return true
+      }
+      if (ERROR_VARIANT_KEYS.has(key) && isErrorVariant(nested)) {
+        return true
+      }
+      if (ERROR_VALUE_KEYS.has(key) && nested !== null && nested !== false && nested !== '') {
+        return true
+      }
+      pending.push(nested)
+    }
+  }
+  return false
+}
+
 function notificationKind(kind: string): string {
   return kind.startsWith('notification:') ? kind.slice('notification:'.length) : kind
 }
@@ -27,11 +72,25 @@ function isClaudeStatusFrame(kind: string): boolean {
   )
 }
 
-export function classifyProviderFrame(provider: string, kind: string): ProviderFrameDisposition {
+export function classifyProviderFrame(
+  provider: string,
+  kind: string,
+  payload: unknown
+): ProviderFrameDisposition {
+  if (hasProviderError(payload)) {
+    return 'timeline'
+  }
   if (provider === 'codex' && isCodexStatusFrame(kind)) {
     return 'debug-only'
   }
   if (provider === 'claude' && isClaudeStatusFrame(kind)) {
+    if (kind === 'message:result') {
+      const record =
+        typeof payload === 'object' && payload !== null
+          ? (payload as Record<string, unknown>)
+          : null
+      return record?.subtype === 'success' ? 'debug-only' : 'timeline'
+    }
     return 'debug-only'
   }
   return 'timeline'

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
@@ -1,0 +1,38 @@
+export type ProviderFrameDisposition = 'debug-only' | 'timeline'
+
+function notificationKind(kind: string): string {
+  return kind.startsWith('notification:') ? kind.slice('notification:'.length) : kind
+}
+
+function isCodexStatusFrame(kind: string): boolean {
+  const method = notificationKind(kind)
+  return (
+    /^(?:thread\/(?:started|closed|archived|unarchived)|thread\/(?:name|status)\/(?:changed|updated))$/.test(
+      method
+    ) ||
+    /^thread\/(?:tokenUsage\/updated|goal\/(?:updated|cleared))$/.test(method) ||
+    method === 'mcpServer/startupStatus/updated' ||
+    method === 'remoteControl/status/changed'
+  )
+}
+
+function isClaudeStatusFrame(kind: string): boolean {
+  return (
+    kind === 'message:system:init' ||
+    kind === 'message:system:status' ||
+    kind === 'message:result' ||
+    /^message:stream_event:(?:message_start|message_stop|content_block_start|content_block_stop)$/.test(
+      kind
+    )
+  )
+}
+
+export function classifyProviderFrame(provider: string, kind: string): ProviderFrameDisposition {
+  if (provider === 'codex' && isCodexStatusFrame(kind)) {
+    return 'debug-only'
+  }
+  if (provider === 'claude' && isClaudeStatusFrame(kind)) {
+    return 'debug-only'
+  }
+  return 'timeline'
+}

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { projectStructuredItemToNativeChat } from '../../../shared/structured-agent-session-projection'
 import { unhandledProviderFrameJournalItem } from './unhandled-provider-frame'
 
 describe('unhandled provider frame journal fallback', () => {
@@ -63,7 +64,72 @@ describe('unhandled provider frame journal fallback', () => {
       unhandledProviderFrameJournalItem('codex', 'notification:thread/goal/cleared', {})
     ).toBeNull()
     expect(unhandledProviderFrameJournalItem('claude', 'message:system:init', {})).toBeNull()
-    expect(unhandledProviderFrameJournalItem('claude', 'message:result', {})).toBeNull()
+    expect(
+      unhandledProviderFrameJournalItem('claude', 'message:result', {
+        subtype: 'success',
+        is_error: false
+      })
+    ).toBeNull()
+  })
+
+  it('renders codex systemError and Claude error result variants', () => {
+    const codex = unhandledProviderFrameJournalItem('codex', 'notification:thread/status/changed', {
+      threadId: 'thread-1',
+      status: { type: 'systemError' }
+    })
+    const claude = unhandledProviderFrameJournalItem('claude', 'message:result', {
+      subtype: 'error_during_execution',
+      is_error: true,
+      result: 'Provider request failed'
+    })
+
+    expect(codex?.body.providerFrame).toMatchObject({
+      provider: 'codex',
+      kind: 'notification:thread/status/changed'
+    })
+    expect(claude?.body.providerFrame).toMatchObject({
+      provider: 'claude',
+      kind: 'message:result'
+    })
+    expect(
+      claude
+        ? projectStructuredItemToNativeChat({
+            itemId: 'claude-error',
+            revision: 1,
+            sequence: 1,
+            observedAt: 1,
+            body: claude.body
+          })
+        : null
+    ).toMatchObject({
+      role: 'system',
+      blocks: [
+        expect.objectContaining({
+          providerFrame: expect.objectContaining({ kind: 'message:result' })
+        })
+      ]
+    })
+  })
+
+  it('keeps failed startup variants visible while suppressing startup progress', () => {
+    const kind = 'notification:mcpServer/startupStatus/updated'
+
+    expect(
+      unhandledProviderFrameJournalItem('codex', kind, {
+        name: 'filesystem',
+        status: 'starting',
+        error: null,
+        failureReason: null
+      })
+    ).toBeNull()
+    expect(
+      unhandledProviderFrameJournalItem('codex', kind, {
+        name: 'filesystem',
+        status: 'failed',
+        error: 'server exited',
+        failureReason: null
+      })
+    ).not.toBeNull()
   })
 
   it('keeps unknown substantive frames visible for both providers', () => {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -15,6 +15,10 @@ describe('unhandled provider frame journal fallback', () => {
       }
     )
 
+    expect(item).not.toBeNull()
+    if (!item) {
+      throw new Error('expected substantive provider frame')
+    }
     expect(item.body).toMatchObject({
       kind: 'status',
       text: 'future-provider · notification:new/event',
@@ -41,6 +45,31 @@ describe('unhandled provider frame journal fallback', () => {
 
     const item = unhandledProviderFrameJournalItem('codex', 'frame', cyclic)
 
-    expect(item.body.providerFrame?.payload.head).toContain('unserializable payload')
+    expect(item?.body.providerFrame?.payload.head).toContain('unserializable payload')
+  })
+
+  it('routes provider lifecycle, startup, and status frames away from the timeline', () => {
+    expect(unhandledProviderFrameJournalItem('codex', 'notification:thread/started', {})).toBeNull()
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:mcpServer/startupStatus/updated', {})
+    ).toBeNull()
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:remoteControl/status/changed', {})
+    ).toBeNull()
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:thread/tokenUsage/updated', {})
+    ).toBeNull()
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:thread/goal/cleared', {})
+    ).toBeNull()
+    expect(unhandledProviderFrameJournalItem('claude', 'message:system:init', {})).toBeNull()
+    expect(unhandledProviderFrameJournalItem('claude', 'message:result', {})).toBeNull()
+  })
+
+  it('keeps unknown substantive frames visible for both providers', () => {
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:future/event', {})
+    ).not.toBeNull()
+    expect(unhandledProviderFrameJournalItem('claude', 'message:future/event', {})).not.toBeNull()
   })
 })

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_JOURNAL_PAYLOAD_LIMITS,
   type JournalPayloadLimits
 } from '../agent-session-journal/journal-payload-bounds'
+import { classifyProviderFrame } from './provider-frame-disposition'
 
 export type UnhandledProviderFrameJournalItem = {
   body: AgentJournalStatusItem
@@ -19,13 +20,16 @@ function serializeProviderPayload(payload: unknown): string {
   }
 }
 
-/** Every adapter fallback becomes a visible, bounded journal row. */
+/** Substantive adapter fallbacks become visible, bounded journal rows. */
 export function unhandledProviderFrameJournalItem(
   provider: string,
   kind: string,
   payload: unknown,
   limits: JournalPayloadLimits = DEFAULT_JOURNAL_PAYLOAD_LIMITS
-): UnhandledProviderFrameJournalItem {
+): UnhandledProviderFrameJournalItem | null {
+  if (classifyProviderFrame(provider, kind) === 'debug-only') {
+    return null
+  }
   const serialized = serializeProviderPayload(payload)
   const bounded = boundPayload(serialized, limits)
   return {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -27,7 +27,7 @@ export function unhandledProviderFrameJournalItem(
   payload: unknown,
   limits: JournalPayloadLimits = DEFAULT_JOURNAL_PAYLOAD_LIMITS
 ): UnhandledProviderFrameJournalItem | null {
-  if (classifyProviderFrame(provider, kind) === 'debug-only') {
+  if (classifyProviderFrame(provider, kind, payload) === 'debug-only') {
     return null
   }
   const serialized = serializeProviderPayload(payload)

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -103,6 +103,7 @@ export function NativeChatStructuredSession(props: {
       <StructuredAgentSessionHandoffChrome
         status={controller.handoff}
         isWorking={controller.isWorking}
+        hasPersistedTurn={controller.hasPersistedTurn}
         onRequest={(direction, mode, action) => {
           void controller.requestHandoff(direction, mode, action)
         }}

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionHandoffChrome.test.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionHandoffChrome.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentSessionHandoffStatus } from '../../../../shared/agent-session-wire'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { StructuredAgentSessionHandoffChrome } from './StructuredAgentSessionHandoffChrome'
 
 const IDLE_NATIVE: AgentSessionHandoffStatus = {
@@ -22,13 +23,34 @@ describe('StructuredAgentSessionHandoffChrome', () => {
       <StructuredAgentSessionHandoffChrome
         status={IDLE_NATIVE}
         isWorking={false}
+        hasPersistedTurn
         onRequest={onRequest}
-      />
+      />,
+      { wrapper: TooltipProvider }
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Open agent TUI' }))
 
     expect(onRequest).toHaveBeenCalledWith('to-tui', 'after-turn')
+  })
+
+  it('disables zero-turn TUI resume with truthful guidance', async () => {
+    render(
+      <StructuredAgentSessionHandoffChrome
+        status={IDLE_NATIVE}
+        isWorking={false}
+        hasPersistedTurn={false}
+        onRequest={vi.fn()}
+      />,
+      { wrapper: TooltipProvider }
+    )
+
+    const button = screen.getByRole('button', { name: 'Open agent TUI' })
+    expect(button.hasAttribute('disabled')).toBe(true)
+    fireEvent.pointerMove(button.parentElement!)
+    expect(
+      await screen.findAllByText('Send a message first to open the agent TUI.')
+    ).not.toHaveLength(0)
   })
 
   it('offers one Retry action for a recoverable dead TUI owner', () => {
@@ -47,8 +69,10 @@ describe('StructuredAgentSessionHandoffChrome', () => {
           }
         }}
         isWorking={false}
+        hasPersistedTurn
         onRequest={onRequest}
-      />
+      />,
+      { wrapper: TooltipProvider }
     )
 
     expect(screen.queryByRole('button', { name: 'Return to chat' })).toBeNull()

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionHandoffChrome.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionHandoffChrome.tsx
@@ -5,11 +5,13 @@ import type {
 } from '../../../../shared/agent-session-wire'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 
 type Props = {
   status: AgentSessionHandoffStatus | null
   isWorking: boolean
+  hasPersistedTurn: boolean
   onRequest: (
     direction: AgentSessionHandoffDirection,
     mode: AgentSessionHandoffMode,
@@ -54,6 +56,7 @@ function handoffStageCopy(status: AgentSessionHandoffStatus): string {
 export function StructuredAgentSessionHandoffChrome({
   status,
   isWorking,
+  hasPersistedTurn,
   onRequest
 }: Props): React.JSX.Element | null {
   if (!status) {
@@ -122,15 +125,30 @@ export function StructuredAgentSessionHandoffChrome({
                 </Button>
               </>
             ) : (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                // A submitted turn can reach the host before isWorking updates; after-turn is immediate when idle.
-                onClick={() => onRequest('to-tui', 'after-turn')}
-              >
-                {translate('components.native-chat.handoff.openAgentTui', 'Open agent TUI')}
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      disabled={!hasPersistedTurn}
+                      // A submitted turn can reach the host before isWorking updates; after-turn is immediate when idle.
+                      onClick={() => onRequest('to-tui', 'after-turn')}
+                    >
+                      {translate('components.native-chat.handoff.openAgentTui', 'Open agent TUI')}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                {!hasPersistedTurn ? (
+                  <TooltipContent side="bottom" sideOffset={4}>
+                    {translate(
+                      'components.native-chat.handoff.sendFirst',
+                      'Send a message first to open the agent TUI.'
+                    )}
+                  </TooltipContent>
+                ) : null}
+              </Tooltip>
             )
           ) : owner === 'tui' && phase === 'idle' ? (
             <Button

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../../shared/structured-agent-session-options'
 import {
   activeStructuredAgentSessionTurnId,
+  hasPersistedStructuredAgentSessionTurn,
   projectStructuredItemsToNativeChat
 } from '../../../../shared/structured-agent-session-projection'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
@@ -233,6 +234,7 @@ export function useStructuredAgentSession(args: {
     send: outboxController.send,
     retry: outboxController.retry,
     isWorking: turnId !== null,
+    hasPersistedTurn: hasPersistedStructuredAgentSessionTurn(state.items),
     turnId,
     cancel: (turnId: string) => mutate('agentSession.cancel', 'agentSession.cancel', { turnId }),
     respond: (item: StructuredPromptItem, optionId: string) =>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15131,6 +15131,7 @@
         "switchAfterTurn": "Switch after this turn",
         "stopTurnAndSwitch": "Stop turn and switch",
         "openAgentTui": "Open agent TUI",
+        "sendFirst": "Send a message first to open the agent TUI.",
         "returnAfterTurn": "Return after this turn",
         "returnToChat": "Return to chat",
         "agentOpen": "Agent is open in terminal.",

--- a/src/shared/structured-agent-session-projection.test.ts
+++ b/src/shared/structured-agent-session-projection.test.ts
@@ -3,6 +3,7 @@ import type { AgentJournalRenderItem } from './agent-session-journal-types'
 import { parsePaneKey } from './stable-pane-id'
 import {
   activeStructuredAgentSessionTurnId,
+  hasPersistedStructuredAgentSessionTurn,
   projectStructuredItemToNativeChat,
   projectStructuredAgentSessionStatus,
   structuredAgentSessionPaneKey
@@ -48,6 +49,15 @@ describe('structured agent session status projection', () => {
 
     expect(structuredAgentSessionPaneKey('structured-agent-session-1', 'session-1')).toBe(paneKey)
     expect(parsePaneKey(paneKey)).toMatchObject({ tabId: 'structured-agent-session-1' })
+  })
+
+  it('requires a persisted provider conversation turn before TUI resume', () => {
+    const status = item('status', 1, { kind: 'status', text: 'Connected' })
+    const user = item('user', 2, { kind: 'message', role: 'user', blocks: [] })
+
+    expect(hasPersistedStructuredAgentSessionTurn([])).toBe(false)
+    expect(hasPersistedStructuredAgentSessionTurn([status])).toBe(false)
+    expect(hasPersistedStructuredAgentSessionTurn([status, user])).toBe(true)
   })
 
   it('preserves provider-frame detail on the backward-compatible status line', () => {

--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -116,6 +116,15 @@ export function activeStructuredAgentSessionTurnId(
   return null
 }
 
+export function hasPersistedStructuredAgentSessionTurn(
+  items: readonly AgentJournalRenderItem[]
+): boolean {
+  return items.some(
+    (item) =>
+      item.body.kind === 'message' && (item.body.role === 'user' || item.body.role === 'assistant')
+  )
+}
+
 export type StructuredAgentSessionProjectedStatus = 'working' | 'attention' | 'idle'
 
 export function projectStructuredAgentSessionStatus(


### PR DESCRIPTION
## Summary

- Keep provider lifecycle, startup, and status notifications out of structured-session timelines while preserving bounded rows for unknown substantive items.
- Disable Open agent TUI on desktop and mobile until a persisted provider turn exists, with the truthful Send a message first tooltip or accessibility hint.
- Add provider classification and zero-turn regression coverage across shared, desktop, and mobile paths.

Author: @BrennanKB5

## Screenshots

No screenshot attached. Electron CDP live validation confirmed zero startup rows and a disabled TUI action for a fresh Codex session, plus an enabled TUI action for an existing persisted session.

## Testing

- [x] pnpm lint
- [x] pnpm typecheck (Node, web, CLI, and mobile targets)
- [ ] pnpm test (focused desktop: 43 passed; focused mobile: 10 passed; full mobile: 3508 passed with one unrelated Node 26 child-process tsx resolution failure; concurrent full desktop runs were stopped after relay resource-contention failures)
- [ ] pnpm build (not run)
- [x] Added high-quality regression tests for startup classification, unknown substantive fallbacks, and zero-turn desktop/mobile TUI guards
- Structured-session mixed-version suite: 10 passed
- Code-quality, reliability, localization, and max-lines gates passed

## AI Review Report

Reviewed provider-frame classification boundaries, journaling order, persisted-turn derivation, and desktop/mobile parity. Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows; this change adds no shortcut, path, shell, or platform-specific Electron behavior. The main risk was suppressing genuinely substantive unknown notifications, so the classifier is allowlisted to known lifecycle/status families and regression tests preserve bounded unknown rows.

## Security Audit

No new command execution, path handling, authentication, secrets, dependencies, or IPC surfaces were introduced. Provider payloads continue through existing bounded rendering behavior for unknown substantive items; known non-content status frames are discarded before journaling. No security follow-up is required.

## Notes

- The shared classifier recognizes both Codex and Claude notification namespaces; this branch wires the Codex adapter present on the target branch, allowing the Claude branch to adopt the same classifier without a conflicting duplicate.
- No remote wire schema or opcode changes.
