### PR TITLE
fix structured session reveal races

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-reverse.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-reverse.ts
@@ -114,6 +114,10 @@ export async function handoffStructuredSessionToNative(
     throw error
   }
   context.releaseOwner(sessionId)
+  deps.transport?.revealNativeSession?.({
+    workspaceId: record.location.workspaceId,
+    sessionId
+  })
   context.setStatus(sessionId, {
     owner: 'native',
     direction: null,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-types.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-types.ts
@@ -39,6 +39,7 @@ export type StructuredAgentSessionHandoffTransport = {
   recoverTuiOwner(record: AgentSessionRecord): Promise<StructuredTuiOwner>
   stopRecoveredOwner(record: AgentSessionRecord): Promise<void>
   closeTuiOwner?(owner: StructuredTuiOwner): Promise<{ transcriptPath?: string }>
+  revealNativeSession?(input: { workspaceId: string; sessionId: string }): void
   waitForTuiExit(owner: StructuredTuiOwner): Promise<{ transcriptPath?: string }>
   waitForTuiIdleOrExit(
     owner: StructuredTuiOwner,

--- a/src/main/runtime/orca-runtime-structured-tui-tab-binding.test.ts
+++ b/src/main/runtime/orca-runtime-structured-tui-tab-binding.test.ts
@@ -45,7 +45,32 @@ function notifier(revealTerminalSession: ReturnType<typeof vi.fn>) {
   }
 }
 
+function structuredTabNotifier() {
+  return {
+    ...notifier(vi.fn()),
+    focusEditorTab: vi.fn()
+  }
+}
+
 describe('structured TUI launch tab binding', () => {
+  it('reveals the structured chat tab when reverse handoff completes', () => {
+    const runtime = new OrcaRuntimeService()
+    const targetNotifier = structuredTabNotifier()
+    runtime.setNotifier(targetNotifier as never)
+    const transport = (
+      runtime as unknown as {
+        createStructuredAgentSessionHandoffTransport(): StructuredAgentSessionHandoffTransport
+      }
+    ).createStructuredAgentSessionHandoffTransport()
+
+    transport.revealNativeSession?.({ workspaceId: WORKTREE_ID, sessionId: 'session-1' })
+
+    expect(targetNotifier.focusEditorTab).toHaveBeenCalledWith(
+      'structured-agent-session-session-1',
+      WORKTREE_ID
+    )
+  })
+
   it('recovers a live TUI from durable owner inventory in a fresh runtime', async () => {
     const namespace = {
       machine: 'native:test',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -172,6 +172,7 @@ import type { ArtifactCloudService } from '../artifacts/artifact-cloud-service'
 import { ORCHESTRATION_MESSAGE_WAIT_DEFAULT_TIMEOUT_MS } from '../../shared/orchestration-message-wait-timeout'
 import { shouldForwardHeadlessTerminalQueryReply } from './headless-terminal-query-reply-policy'
 import type { TerminalRevealIdentity } from '../../shared/terminal-reveal-identity'
+import { structuredAgentSessionTabId } from '../../shared/structured-agent-session-projection'
 import type {
   OrchestrationCompatibilityEvidence,
   OrchestrationCompatibilityHostStamp
@@ -9348,6 +9349,15 @@ export class OrcaRuntimeService {
       stopRecoveredOwner: (record) => this.stopStructuredSessionProcess(record),
       tuiStatus: (owner) => this.structuredTuiStatus(owner),
       closeTuiOwner: (owner) => this.closeStructuredTuiOwner(owner),
+      revealNativeSession: ({ workspaceId, sessionId }) => {
+        this.publishStructuredAgentSessionTab({
+          workspaceId,
+          sessionId,
+          agent: 'codex',
+          activate: false
+        })
+        this.notifier?.focusEditorTab?.(structuredAgentSessionTabId(sessionId), workspaceId)
+      },
       stopFailedTuiLaunch: async (owner) => void (await this.closeStructuredTuiOwner(owner))
     }
   }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -86,7 +86,8 @@ export function useAiVaultSessionLaunchActions({
 
   const handleResume = useCallback(
     (session: AiVaultSession, targetWorktreeId?: string): void => {
-      if (activateAiVaultStructuredSession(session)) {
+      if (session.structuredSession) {
+        void activateAiVaultStructuredSession(session)
         return
       }
       const targetId = resolveAiVaultSessionLaunchTargetOrNotify({

--- a/src/renderer/src/hooks/ipc-events-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-test-harness.ts
@@ -121,6 +121,7 @@ export type IpcEventsHarness = {
   useIpcEvents: () => void
   createTerminal: (request: CreateTerminalRequest) => void
   requestTerminalCreate: (request: RequestTerminalCreateRequest) => void
+  focusEditorTab: (request: { tabId: string; worktreeId: string }) => void
   replyTerminalCreate: ReturnType<typeof vi.fn>
   /** Fire a main-process digit chord (zero-based index). */
   jumpToWorktreeIndex: (index: number) => void
@@ -136,8 +137,7 @@ export type IpcEventsHarnessOptions = {
 }
 
 /**
- * Loads useIpcEvents against a stubbed preload API and returns a driver for the
- * create-terminal IPC, so reveal/adoption behavior is asserted through the hook.
+ * Loads useIpcEvents against a stubbed preload API so IPC behavior is asserted through the hook.
  */
 export async function loadIpcEventsHarness(
   storeState: HarnessStoreState,
@@ -147,6 +147,8 @@ export async function loadIpcEventsHarness(
   const activateAndRevealWorkspace = vi.fn()
   let createTerminalListener: ((request: CreateTerminalRequest) => void) | null = null
   let requestTerminalCreateListener: ((request: RequestTerminalCreateRequest) => void) | null = null
+  let focusEditorTabListener: ((request: { tabId: string; worktreeId: string }) => void) | null =
+    null
   let navigationUpdateListener:
     | ((event: { browserPageId: string; url: string; title: string }) => void)
     | null = null
@@ -207,6 +209,12 @@ export async function loadIpcEventsHarness(
           },
           onRequestTerminalCreate: (listener: (request: RequestTerminalCreateRequest) => void) => {
             requestTerminalCreateListener = listener
+            return () => {}
+          },
+          onFocusEditorTab: (
+            listener: (request: { tabId: string; worktreeId: string }) => void
+          ) => {
+            focusEditorTabListener = listener
             return () => {}
           },
           onJumpToWorktreeIndex: (listener: (index: number) => void) => {
@@ -278,6 +286,12 @@ export async function loadIpcEventsHarness(
         throw new Error('Expected the request-terminal-create listener to be registered')
       }
       requestTerminalCreateListener(request)
+    },
+    focusEditorTab: (request) => {
+      if (typeof focusEditorTabListener !== 'function') {
+        throw new Error('Expected the focus-editor-tab listener to be registered')
+      }
+      focusEditorTabListener(request)
     },
     replyTerminalCreate,
     jumpToWorktreeIndex: (index) => fireIndexJump(indexJumpListeners, 'worktree', index),

--- a/src/renderer/src/hooks/structured-session-completion-focus.test.ts
+++ b/src/renderer/src/hooks/structured-session-completion-focus.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createHarnessStoreState,
+  loadIpcEventsHarness,
+  type HarnessStoreState
+} from './ipc-events-test-harness'
+
+const SESSION_WORKSPACE_ID = 'repo-1::/session-workspace'
+const OTHER_WORKSPACE_ID = 'repo-1::/other-workspace'
+const TAB_ID = 'structured-agent-session-session-1'
+
+function createStoreState(activeWorktreeId: string): HarnessStoreState {
+  return createHarnessStoreState({
+    tabsByWorktree: {},
+    activeWorktreeId,
+    unifiedTabsByWorktree: {
+      [SESSION_WORKSPACE_ID]: [
+        {
+          id: TAB_ID,
+          entityId: 'session-1',
+          groupId: 'group-1',
+          worktreeId: SESSION_WORKSPACE_ID,
+          contentType: 'agent-session'
+        }
+      ]
+    },
+    focusGroup: vi.fn(),
+    activateTab: vi.fn()
+  })
+}
+
+describe('structured session completion focus', () => {
+  it('focuses the chat tab when its workspace is active', async () => {
+    const store = createStoreState(SESSION_WORKSPACE_ID)
+    const harness = await loadIpcEventsHarness(store)
+    harness.useIpcEvents()
+
+    harness.focusEditorTab({ tabId: TAB_ID, worktreeId: SESSION_WORKSPACE_ID })
+
+    expect(store.focusGroup).toHaveBeenCalledWith(SESSION_WORKSPACE_ID, 'group-1')
+    expect(store.activateTab).toHaveBeenCalledWith(TAB_ID)
+    expect(store.setActiveTabType).toHaveBeenCalledWith('agent-session')
+  })
+
+  it('does not apply focus after the user moves to another workspace', async () => {
+    const store = createStoreState(OTHER_WORKSPACE_ID)
+    const harness = await loadIpcEventsHarness(store)
+    harness.useIpcEvents()
+
+    harness.focusEditorTab({ tabId: TAB_ID, worktreeId: SESSION_WORKSPACE_ID })
+
+    expect(store.setActiveWorktree).not.toHaveBeenCalled()
+    expect(store.markWorktreeVisited).not.toHaveBeenCalled()
+    expect(store.setActiveView).not.toHaveBeenCalled()
+    expect(store.focusGroup).not.toHaveBeenCalled()
+    expect(store.activateTab).not.toHaveBeenCalled()
+    expect(store.setActiveTabType).not.toHaveBeenCalled()
+    expect(store.revealWorktreeInSidebar).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1884,7 +1884,9 @@ export function useIpcEvents(): void {
         store.setActiveView('terminal')
         store.focusGroup(worktreeId, tab.groupId)
         store.activateTab(tab.id)
-        if (browserTarget) {
+        if (tab.contentType === 'agent-session') {
+          store.setActiveTabType('agent-session')
+        } else if (browserTarget) {
           // Why: browser tabs need their own active-page state, not the editor file activation path.
           store.setActiveBrowserTab(browserTarget.workspaceId)
           store.setActiveTabType('browser')

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1867,6 +1867,9 @@ export function useIpcEvents(): void {
           (item) => item.id === tabId
         )
         const browserTarget = resolveBrowserSessionTabTarget(store, worktreeId, tabId)
+        if (tab?.contentType === 'agent-session' && store.activeWorktreeId !== worktreeId) {
+          return
+        }
         if (!tab) {
           if (browserTarget) {
             // Why: older/mobile fallback snapshots identify browser tabs by workspace id when no unified tab wrapper exists.

--- a/src/renderer/src/lib/activate-ai-vault-structured-session.test.ts
+++ b/src/renderer/src/lib/activate-ai-vault-structured-session.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AiVaultSession } from '../../../shared/ai-vault-types'
+import { activateAiVaultStructuredSession } from './activate-ai-vault-structured-session'
+
+const structuredSession = {
+  structuredSession: { sessionId: 'session-1', workspaceId: 'workspace-1' }
+} as AiVaultSession
+
+describe('activateAiVaultStructuredSession', () => {
+  it('refreshes an unpublished structured tab before activating it', async () => {
+    const activate = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)
+    const refresh = vi.fn(async () => undefined)
+    const unavailable = vi.fn()
+
+    await expect(
+      activateAiVaultStructuredSession(structuredSession, { activate, refresh, unavailable })
+    ).resolves.toBe(true)
+
+    expect(refresh).toHaveBeenCalledWith('workspace-1')
+    expect(activate).toHaveBeenCalledTimes(2)
+    expect(unavailable).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a retryable state when the structured tab remains unavailable', async () => {
+    const activate = vi.fn(() => false)
+    const refresh = vi.fn(async () => undefined)
+    const unavailable = vi.fn()
+
+    await expect(
+      activateAiVaultStructuredSession(structuredSession, { activate, refresh, unavailable })
+    ).resolves.toBe(true)
+
+    expect(activate).toHaveBeenCalledTimes(2)
+    expect(unavailable).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/lib/activate-ai-vault-structured-session.ts
+++ b/src/renderer/src/lib/activate-ai-vault-structured-session.ts
@@ -4,28 +4,92 @@ import { translate } from '@/i18n/i18n'
 import { activateAndRevealWorktree } from './worktree-activation'
 import { activateStructuredAgentSessionById } from './structured-agent-session-tab-activation'
 import { useAppStore } from '@/store'
+import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
+import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { applyStructuredSessionTabSnapshots } from '@/runtime/local-structured-session-tabs-sync'
 
-export function activateAiVaultStructuredSession(session: AiVaultSession): boolean {
-  const structured = session.structuredSession
-  if (!structured) {
-    return false
-  }
-  if (
-    !activateStructuredAgentSessionById({
-      worktreeId: structured.workspaceId,
-      sessionId: structured.sessionId
-    })
-  ) {
+const STRUCTURED_SESSION_RESTORE_TIMEOUT_MS = 5_000
+
+type StructuredSessionActivationDeps = {
+  activate: typeof activateStructuredAgentSessionById
+  refresh: (worktreeId: string) => Promise<void>
+  unavailable: () => void
+}
+
+const defaultDeps: StructuredSessionActivationDeps = {
+  activate: activateStructuredAgentSessionById,
+  refresh: refreshStructuredSessionTabs,
+  unavailable: () => {
     toast.error(
       translate(
         'auto.lib.activateAiVaultStructuredSession.unavailable',
         'The structured agent session is not available yet. Retry in a moment.'
       )
     )
-    return true
+  }
+}
+
+export async function activateAiVaultStructuredSession(
+  session: AiVaultSession,
+  deps: StructuredSessionActivationDeps = defaultDeps
+): Promise<boolean> {
+  const structured = session.structuredSession
+  if (!structured) {
+    return false
+  }
+  const target = { worktreeId: structured.workspaceId, sessionId: structured.sessionId }
+  if (!deps.activate(target)) {
+    try {
+      await deps.refresh(structured.workspaceId)
+    } catch {
+      deps.unavailable()
+      return true
+    }
+    if (!deps.activate(target)) {
+      deps.unavailable()
+      return true
+    }
   }
   if (useAppStore.getState().activeWorktreeId !== structured.workspaceId) {
     activateAndRevealWorktree(structured.workspaceId)
   }
   return true
+}
+
+async function refreshStructuredSessionTabs(worktreeId: string): Promise<void> {
+  const state = useAppStore.getState()
+  const environmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  const snapshot = await withStructuredSessionRestoreTimeout(
+    callRuntimeRpc<RuntimeMobileSessionTabsResult>(
+      getActiveRuntimeTarget({ activeRuntimeEnvironmentId: environmentId }),
+      'session.tabs.list',
+      { worktree: toRuntimeWorktreeSelector(worktreeId) },
+      { timeoutMs: STRUCTURED_SESSION_RESTORE_TIMEOUT_MS }
+    )
+  )
+  applyStructuredSessionTabSnapshots(
+    [snapshot],
+    environmentId ? `structured-session:${environmentId}` : undefined
+  )
+}
+
+async function withStructuredSessionRestoreTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('structured_session_restore_timeout')),
+          STRUCTURED_SESSION_RESTORE_TIMEOUT_MS
+        )
+      })
+    ])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
 }

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -34,14 +34,17 @@ export function projectLocalStructuredSessionTabs(
   }
 }
 
-function applySnapshots(snapshots: readonly RuntimeMobileSessionTabsResult[]): void {
+export function applyStructuredSessionTabSnapshots(
+  snapshots: readonly RuntimeMobileSessionTabsResult[],
+  owner = LOCAL_STRUCTURED_SESSION_OWNER
+): void {
   applyWebSessionTabsStorePatch((state) => {
     let next = state
     for (const snapshot of snapshots) {
       const patch = applyWebSessionTabsSnapshot(
         next,
         projectLocalStructuredSessionTabs(snapshot),
-        LOCAL_STRUCTURED_SESSION_OWNER,
+        owner,
         Date.now(),
         { preserveLocalLayout: true }
       )
@@ -63,7 +66,7 @@ async function startLocalStructuredSessionTabsSync(args: {
   void window.api.runtime.call({ method: 'session.tabs.listAll', params: {} }).then((response) => {
     if (!args.isDisposed() && response.ok) {
       const result = response.result as { snapshots?: RuntimeMobileSessionTabsResult[] }
-      applySnapshots(result.snapshots ?? [])
+      applyStructuredSessionTabSnapshots(result.snapshots ?? [])
     }
   })
   if (!supported) {
@@ -77,9 +80,9 @@ async function startLocalStructuredSessionTabsSync(args: {
       }
       const event = response.result as SessionTabsEvent
       if (event.type === 'snapshots') {
-        applySnapshots(event.snapshots)
+        applyStructuredSessionTabSnapshots(event.snapshots)
       } else if (event.type === 'snapshot' || event.type === 'updated') {
-        applySnapshots([event])
+        applyStructuredSessionTabSnapshots([event])
       }
     }
   )

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -75,6 +75,7 @@ import {
   shouldSkipWebRuntimeWakeTerminalRespawn
 } from './web-runtime-wake-terminal-respawn'
 import { isRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
+import { structuredAgentSessionTabId } from '../../../shared/structured-agent-session-projection'
 import { queueAcceptedWebSessionTerminalSnapshot } from './web-session-terminal-handle-events'
 import { recoverWebSessionTerminalOrphansBeforeApply } from './web-session-terminal-orphan-recovery'
 import {
@@ -836,7 +837,7 @@ function buildMirroredAgentTabs(
   now: number
 ): MirroredAgentTab[] {
   return snapshot.tabs.filter(isAgentSessionTab).map((tab, index) => {
-    const localId = `structured-agent-session-${tab.sessionId}`
+    const localId = structuredAgentSessionTabId(tab.sessionId)
     const existing = currentUnifiedTabs.find(
       (candidate) => candidate.contentType === 'agent-session' && candidate.id === localId
     )

--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -118,6 +118,10 @@ export function activeStructuredAgentSessionTurnId(
 
 export type StructuredAgentSessionProjectedStatus = 'working' | 'attention' | 'idle'
 
+export function structuredAgentSessionTabId(sessionId: string): string {
+  return `structured-agent-session-${sessionId}`
+}
+
 export function projectStructuredAgentSessionStatus(
   items: readonly AgentJournalRenderItem[]
 ): StructuredAgentSessionProjectedStatus {


### PR DESCRIPTION
## Summary

- Reveal and focus the structured chat tab after a successful TUI-to-native handoff, using the renderer-local structured tab identity and the agent-session active pane type.
- Make Vault structured-session resume refresh the authoritative session tab snapshot with a five-second bound, retry activation, and surface the existing retryable error when the tab remains unavailable.
- Cover the reverse reveal seam plus Vault refresh success and explicit unavailable outcomes.

Follow-up to packaged-context QA in https://github.com/stablyai/orca/pull/13438#issuecomment-5286389932.

## Verification

- Targeted Vitest: 6 files, 35 tests passed.
- pnpm typecheck passed.
- Focused oxlint and oxfmt checks passed; git diff --check passed.
- Full pnpm lint passed oxlint, native/type-aware audits, reliability gates, max-lines ratchet, skill checks, and catalog/extraction checks, then hit the existing base-branch localization finding at src/renderer/src/components/native-chat/NativeChatMessageList.tsx:133 (unlocalized “bytes”); this PR does not touch that file.
- Electron dev build validated through Playwright CDP with an isolated profile: the structured Codex Chat tab and Open agent TUI control rendered. The complete reverse interaction could not be exercised in the fresh fixture because Codex app-server thread resume returned “no rollout found”; no desktop-control automation was used.

## Compatibility

No persisted schema, mobile-facing wire contract, shell/path behavior, or provider-specific review behavior changes.
