### PR TITLE
Fix paired remote terminal browser link creation

### DIFF
--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
-import * as clientCreationActionPolicy from './client-creation-action-policy'
 import {
   canOpenWorkspaceBrowserTabOnRuntime,
   openWorkspaceBrowserTab
@@ -132,7 +131,7 @@ describe('openWorkspaceBrowserTab', () => {
     expect(createBrowserTab).not.toHaveBeenCalled()
   })
 
-  it('keeps an asserted paired-runtime link on the runtime when client policy selects local', async () => {
+  it('waits for host registration before reconciling an asserted runtime link', async () => {
     const createBrowserTab = vi.fn()
     mocks.state = {
       ...ownerState(toRuntimeExecutionHostId('hub-a')),
@@ -141,32 +140,21 @@ describe('openWorkspaceBrowserTab', () => {
       defaultBrowserSessionProfileId: 'client-profile',
       defaultBrowserSessionProfileIdByHostId: {}
     }
-    const policySpy = vi
-      .spyOn(clientCreationActionPolicy, 'getClientCreationActionPolicy')
-      .mockReturnValue({
-        'managed-browser': { state: 'enabled', provider: 'local-client' },
-        'mobile-emulator': { state: 'enabled', provider: 'local-client' }
-      })
+    await openWorkspaceBrowserTab({
+      workspaceId: WORKSPACE_ID,
+      url: 'https://example.com/pinned',
+      intent: { kind: 'url' },
+      expectedRuntimeEnvironmentId: 'hub-a'
+    })
 
-    try {
-      await openWorkspaceBrowserTab({
-        workspaceId: WORKSPACE_ID,
-        url: 'https://example.com/pinned',
-        intent: { kind: 'url' },
-        expectedRuntimeEnvironmentId: 'hub-a'
+    expect(mocks.createRemote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environmentId: 'hub-a',
+        waitForRegistration: true,
+        worktreeId: WORKSPACE_ID
       })
-
-      expect(mocks.createRemote).toHaveBeenCalledWith(
-        expect.objectContaining({
-          environmentId: 'hub-a',
-          waitForRegistration: true,
-          worktreeId: WORKSPACE_ID
-        })
-      )
-      expect(createBrowserTab).not.toHaveBeenCalled()
-    } finally {
-      policySpy.mockRestore()
-    }
+    )
+    expect(createBrowserTab).not.toHaveBeenCalled()
   })
 
   it('fails closed when the workspace route swaps away from the pane runtime before opening', async () => {

--- a/src/renderer/src/lib/workspace-browser-tab-open.test.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import * as clientCreationActionPolicy from './client-creation-action-policy'
 import {
   canOpenWorkspaceBrowserTabOnRuntime,
   openWorkspaceBrowserTab
@@ -129,6 +130,43 @@ describe('openWorkspaceBrowserTab', () => {
       failureLogMode: 'operation-only'
     })
     expect(createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps an asserted paired-runtime link on the runtime when client policy selects local', async () => {
+    const createBrowserTab = vi.fn()
+    mocks.state = {
+      ...ownerState(toRuntimeExecutionHostId('hub-a')),
+      ...browserCapableRuntime('hub-a'),
+      createBrowserTab,
+      defaultBrowserSessionProfileId: 'client-profile',
+      defaultBrowserSessionProfileIdByHostId: {}
+    }
+    const policySpy = vi
+      .spyOn(clientCreationActionPolicy, 'getClientCreationActionPolicy')
+      .mockReturnValue({
+        'managed-browser': { state: 'enabled', provider: 'local-client' },
+        'mobile-emulator': { state: 'enabled', provider: 'local-client' }
+      })
+
+    try {
+      await openWorkspaceBrowserTab({
+        workspaceId: WORKSPACE_ID,
+        url: 'https://example.com/pinned',
+        intent: { kind: 'url' },
+        expectedRuntimeEnvironmentId: 'hub-a'
+      })
+
+      expect(mocks.createRemote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: 'hub-a',
+          waitForRegistration: true,
+          worktreeId: WORKSPACE_ID
+        })
+      )
+      expect(createBrowserTab).not.toHaveBeenCalled()
+    } finally {
+      policySpy.mockRestore()
+    }
   })
 
   it('fails closed when the workspace route swaps away from the pane runtime before opening', async () => {

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -212,9 +212,7 @@ export async function openWorkspaceBrowserTab(
       `host ${route.executionHostId} does not own runtime ${environmentId}`
     )
   }
-  // A terminal link is pinned to its source runtime after the assertion above;
-  // provider policy may describe the client surface rather than that owner.
-  if (expectedEnvironmentId === null && availability.provider === 'local-client') {
+  if (availability.provider === 'local-client') {
     const localHostId = host && host.kind !== 'runtime' ? host.id : LOCAL_EXECUTION_HOST_ID
     createClientBrowserTab(state, request, localHostId, presentation)
     return
@@ -226,7 +224,7 @@ export async function openWorkspaceBrowserTab(
       environmentId,
       url: request.url,
       targetGroupId: request.targetGroupId,
-      // Pinned terminal links must wait for the host tab to publish before reconciling the client.
+      // Owner-pinned links need the host tab published before client reconciliation.
       ...(expectedEnvironmentId !== null ? { waitForRegistration: true } : {}),
       // Why: the tab is opened from this workspace's tab bar, so surface that
       // workspace — otherwise a background worktree looks like nothing happened.

--- a/src/renderer/src/lib/workspace-browser-tab-open.ts
+++ b/src/renderer/src/lib/workspace-browser-tab-open.ts
@@ -212,7 +212,9 @@ export async function openWorkspaceBrowserTab(
       `host ${route.executionHostId} does not own runtime ${environmentId}`
     )
   }
-  if (availability.provider === 'local-client') {
+  // A terminal link is pinned to its source runtime after the assertion above;
+  // provider policy may describe the client surface rather than that owner.
+  if (expectedEnvironmentId === null && availability.provider === 'local-client') {
     const localHostId = host && host.kind !== 'runtime' ? host.id : LOCAL_EXECUTION_HOST_ID
     createClientBrowserTab(state, request, localHostId, presentation)
     return
@@ -224,6 +226,8 @@ export async function openWorkspaceBrowserTab(
       environmentId,
       url: request.url,
       targetGroupId: request.targetGroupId,
+      // Pinned terminal links must wait for the host tab to publish before reconciling the client.
+      ...(expectedEnvironmentId !== null ? { waitForRegistration: true } : {}),
       // Why: the tab is opened from this workspace's tab bar, so surface that
       // workspace — otherwise a background worktree looks like nothing happened.
       selectWorktree: true,

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -463,6 +463,7 @@ export async function createWebRuntimeSessionBrowserTab(args: {
   clientTargetGroupId?: string
   clientTargetGroupCreated?: boolean
   focusOnCreate?: boolean
+  /** Wait until a renderer-backed host can publish the new page in its session snapshot. */
   waitForRegistration?: boolean
   selectWorktree?: boolean
   stagedTitle?: string

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -463,6 +463,7 @@ export async function createWebRuntimeSessionBrowserTab(args: {
   clientTargetGroupId?: string
   clientTargetGroupCreated?: boolean
   focusOnCreate?: boolean
+  waitForRegistration?: boolean
   selectWorktree?: boolean
   stagedTitle?: string
   stagedFocusAddressBar?: boolean
@@ -549,7 +550,7 @@ export async function createWebRuntimeSessionBrowserTab(args: {
           // Why: place the new browser in the clicked split group so the host snapshot is authoritative for it (no left-snap).
           ...(args.targetGroupId ? { targetGroupId: args.targetGroupId } : {}),
           // Why: web clients need the local tab now; waiting for host webview registration makes the workspace appear to close.
-          waitForRegistration: false
+          waitForRegistration: args.waitForRegistration ?? false
         },
         timeoutMs: 15_000
       })) as RuntimeRpcResponse<BrowserTabCreateResult>


### PR DESCRIPTION
## Summary

Fixes [STA-4181](https://linear.app/stably/issue/STA-4181/release-blocking-paired-remote-terminal-browser-link-does-not-create).

The release failure surfaced after #14194, but the failing path is an ordering interaction with #14100 strict browser-materialization cleanup: a renderer-backed host can return `browser.tabCreate` before its webview registers, the paired client immediately lists tabs, does not see the unregistered page, and closes it as unreconciled.

Fix:
- For owner-pinned runtime link opens, wait for host browser registration before client reconciliation.
- Preserve the existing non-blocking behavior for ordinary, unpinned browser opens.
- Keep headless/offscreen hosts unchanged; their registration is synchronous and this flag is ignored on that path.

The existing optional `browser.tabCreate.waitForRegistration` field is used, so there is no new wire shape.

## Validation

- Exact renderer-backed paired remote terminal E2E
- 83 focused unit tests
- `oxlint`
- `typecheck:web`
- `git diff --check`