### PR TITLE
fix(terminal): resolve legacy wrapper fallbacks from PATH only (STA-4169)

### DIFF
--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -32,7 +32,11 @@ filter_path() {
       normalized="${SHELL_DOLLAR}{normalized%/}"
     done
     candidate="${SHELL_DOLLAR}{entry:-.}"
-    if [[ -n "$legacy_target" && "$normalized" == "$legacy_target" ]]; then
+    if [[ -z "$entry" ]]; then
+      # Why: an empty PATH element means the current directory, so keeping it would let a
+      # repository-local git/gh win the lookup below.
+      :
+    elif [[ -n "$legacy_target" && "$normalized" == "$legacy_target" ]]; then
       :
     elif [[ "$candidate" -ef "$wrapper_dir" ]]; then
       :

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import {
   chmodSync,
   existsSync,
@@ -87,13 +87,71 @@ describe('legacy terminal shim neutralization', () => {
     // Why: a captured path that no longer exists must be cleared, or the where.exe fallback below
     // is skipped and the wrapper execs a missing binary.
     expect(cmd).toContain('if defined orca_real if not exist "%orca_real%" set "orca_real="')
-    expect(cmd.indexOf('if not exist "%orca_real%"')).toBeLessThan(cmd.indexOf('where.exe git.exe'))
+    expect(cmd.indexOf('if not exist "%orca_real%"')).toBeLessThan(
+      cmd.indexOf(':orca_try_candidate')
+    )
     const powershell = readFileSync(join(win32Dir, 'git-wrapper.ps1'), 'utf8')
     expect(powershell).toContain('[StringComparison]::OrdinalIgnoreCase')
     expect(powershell).toContain('$realCommand = $null')
     expect(powershell.indexOf('[StringComparison]::OrdinalIgnoreCase')).toBeLessThan(
       powershell.indexOf('Test-Path -LiteralPath $realCommand')
     )
+  })
+
+  it('resolves Windows fallbacks against PATH only, never the current directory', () => {
+    // Why (STA-4169): bare `where.exe git.exe` searches cwd before PATH, so a repository-local
+    // git.exe/gh.exe could be executed with the user's arguments.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const command of ['git', 'gh'] as const) {
+      const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
+      // No where.exe at all: it searches cwd first, so the wrapper walks the cleaned PATH.
+      expect(cmd).not.toContain('where.exe')
+      expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate')
+      expect(cmd).toContain(`if exist "%%~fG\\${command}.exe"`)
+      // A candidate inside the wrapper directory must still be rejected.
+      expect(cmd).toContain('if /I not "%%~fG\\"=="%~dp0"')
+
+      const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
+      expect(powershell).not.toContain('Get-Command')
+      expect(powershell).toContain("($env:PATH -split ';')")
+      expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
+    }
+  })
+
+  itOnPosix('does not let an empty PATH element resolve the command from the cwd', async () => {
+    // Why (STA-4169): an empty PATH element means the current directory on POSIX.
+    const userData = makeUserDataDir()
+    const shimDir = join(userData, 'orca-terminal-attribution', 'posix')
+    const realBin = join(userData, 'real-bin')
+    mkdirSync(shimDir, { recursive: true })
+    mkdirSync(realBin, { recursive: true })
+    writeFileSync(join(shimDir, 'git'), 'legacy attribution wrapper')
+    writeFileSync(join(realBin, 'git'), "#!/usr/bin/env bash\nprintf 'REAL\\n'\n", { mode: 0o755 })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    // A hostile cwd containing its own `git`, reached only via the empty PATH element.
+    const hostile = join(userData, 'hostile')
+    mkdirSync(hostile, { recursive: true })
+    writeFileSync(join(hostile, 'git'), "#!/usr/bin/env bash\nprintf 'HOSTILE\\n'\n", {
+      mode: 0o755
+    })
+
+    const result = spawnSync(join(shimDir, 'git'), ['--version'], {
+      cwd: hostile,
+      // Why: keep real system dirs so the fixture's `env bash` shebang still resolves; the
+      // empty element between shimDir and realBin is the cwd exposure under test.
+      env: { ...process.env, PATH: `${shimDir}::${realBin}:/usr/bin:/bin` },
+      encoding: 'utf8'
+    })
+
+    expect(result.stdout).toContain('REAL')
+    expect(result.stdout).not.toContain('HOSTILE')
   })
 
   it('removes every Windows PATH occurrence of both captured wrapper directories', () => {

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -42,10 +42,12 @@ set "ORCA_ATTRIBUTION_BYPASS="
 set "ORCA_REAL_GIT="
 set "ORCA_REAL_GH="
 if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="
-rem Why: clear a captured path that no longer exists, or the where.exe fallback below is skipped.
+rem Why: clear a captured path that no longer exists, or the PATH walk below is skipped.
 if defined orca_real if not exist "%orca_real%" set "orca_real="
 if defined orca_real goto run
-for /f "delims=" %%G in ('where.exe __ORCA_COMMAND__.exe 2^>nul') do if not defined orca_real set "orca_real=%%G"
+rem Why: an unqualified Windows command lookup searches the current directory before PATH, so a
+rem repository-local __ORCA_COMMAND__.exe would win. Walk the cleaned PATH ourselves instead.
+for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate "%%~P"
 if not defined orca_real (
   echo Orca compatibility wrapper could not locate __ORCA_COMMAND__ on PATH. 1>&2
   exit /b 127
@@ -53,6 +55,12 @@ if not defined orca_real (
 :run
 "%orca_real%" %*
 exit /b %ERRORLEVEL%
+
+:orca_try_candidate
+if defined orca_real exit /b
+if "%~1"=="" exit /b
+for %%G in ("%~1") do if /I not "%%~fG\"=="%~dp0" if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
+exit /b
 
 :orca_append_path
 for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG\"
@@ -86,8 +94,15 @@ if ($realCommand) {
   }
 }
 if (-not $realCommand -or -not (Test-Path -LiteralPath $realCommand)) {
-  $resolved = Get-Command "$commandName.exe" -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-  $realCommand = if ($resolved) { $resolved.Source } else { $null }
+  # Why: resolve only against the cleaned PATH directories. Ambient lookup could pick up a
+  # repository-local git.exe/gh.exe from the current directory.
+  $realCommand = $null
+  foreach ($dir in ($env:PATH -split ';')) {
+    if (-not $dir) { continue }
+    if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
+    $candidate = Join-Path $dir "$commandName.exe"
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }
+  }
 }
 if (-not $realCommand) {
   [Console]::Error.WriteLine("Orca compatibility wrapper could not locate $commandName on PATH.")


### PR DESCRIPTION
## ELI5

The retained `git`/`gh` compatibility wrappers looked up the real binary with an unqualified command lookup. On Windows that searches the **current directory before PATH**, so a repository containing its own `git.exe` could get it executed with the user's arguments. Fixes **STA-4169 (P0)**.

## The defect

`src/main/ipc/command-path-resolver.ts:83-88` already documents the behavior the wrapper depended on: `searchDirs = isWin ? [cwd, ...pathDirs] : pathDirs` — "on win32, `where.exe` searches the current directory first."

The wrapper cleared a stale `ORCA_REAL_GIT`/`ORCA_REAL_GH` and then ran a bare `where.exe git.exe`, executing the first result. Repo content → arbitrary code execution with user privileges.

**Note:** #14255 made the Windows path *more* reachable. Before it, a stale-but-defined `ORCA_REAL_*` dead-ended at exit 3; after, it clears the value and proceeds to the vulnerable lookup.

## Not Windows-only

The ticket scoped this to Windows. It is not. The POSIX wrapper preserved **empty PATH elements**, which mean the current directory, so the same repo-local `git` could win. Proven by mutation test — with the guard removed the wrapper executes the planted binary:

```
AssertionError: expected 'HOSTILE\n' to contain 'REAL'
```

## The fix

All three wrappers now resolve only against the cleaned PATH:

- **cmd** — walks `%orca_clean_path%` explicitly via `:orca_try_candidate`; no `where.exe` at all
- **PowerShell** — walks `$env:PATH` explicitly; no `Get-Command`
- **POSIX** — `filter_path` drops empty elements

Candidates resolving inside the wrapper directory remain rejected in all three.

### Why an explicit walk rather than `where "$PATH:git.exe"`

`where`'s `$PATH:` form would also exclude the cwd and is a smaller diff. I did not use it: the Windows box was offline when I wrote this, and if that syntax were wrong the fallback silently finds nothing and `git` hard-breaks in every retained pane. The explicit walk uses only batch constructs already executed successfully on real Windows in #14255's verification (`for %%P in ("%VAR:;=" "%")`, `%%~fG`, `if exist`).

## Testing

- `pnpm typecheck`, `pnpm lint`: pass
- Full suite: **51,758 passed**; 3 failures, all pre-existing and reproducible on `origin/main` (`agent-exec-handler` ×2, plus the `project-view-wrapper` co-run timeout)
- New: POSIX hostile-cwd regression test, mutation-proven; Windows string contracts pinning the PATH walk and the absence of `where.exe`/`Get-Command`

### Verified on real Windows

Executed on `awin` (Windows 10.0.26200, git 2.55.0.windows.3) with a hostile cwd containing `git.exe` (a copy of `whoami.exe`):

| | result |
|---|---|
| **Pre-fix wrapper**, hostile cwd | printed `awin\neil` — **executed the planted binary** |
| **Fixed wrapper**, hostile cwd | printed real `git` usage — planted binary ignored |
| Fixed, clean cwd | `git version 2.55.0.windows.3`, exit 0 |
| Fixed, stale `ORCA_REAL_GIT` | exit 0, real git |
| Fixed, trailing-backslash PATH entry | exit 0, real git |
| Fixed, on PATH in a hostile repo + real commit | commit created, **0 attribution trailers** |

The ACE is reproduced and the fix is confirmed on the platform it affects.
