### PR TITLE
fix(terminal): make the bold font weight its own setting

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -75,6 +75,7 @@ function createSettings(overrides: TestSettingsOverrides = {}): GlobalSettings {
     markdownReviewToolsEnabled: true,
     terminalFontSize: 14,
     terminalFontFamily: 'JetBrains Mono',
+    terminalFontWeightBold: 700,
     terminalFontWeight: 500,
     terminalLineHeight: 1,
     terminalScrollSensitivity: 1.15,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -67,6 +67,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     markdownReviewToolsEnabled: true,
     terminalFontSize: 14,
     terminalFontFamily: 'JetBrains Mono',
+    terminalFontWeightBold: 700,
     terminalFontWeight: 500,
     terminalLineHeight: 1,
     terminalScrollSensitivity: 1.15,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -685,6 +685,7 @@ describe('Store', () => {
     expect(settings.editorAutoSaveDelayMs).toBe(1000)
     expect(settings.terminalFontSize).toBe(14)
     expect(settings.terminalFontWeight).toBe(500)
+    expect(settings.terminalFontWeightBold).toBe(700)
     expect(settings.terminalScrollSensitivity).toBe(1.15)
     expect(settings.terminalFastScrollSensitivity).toBe(5)
     expect(settings.terminalTuiScrollSensitivity).toBe(1)
@@ -5831,7 +5832,8 @@ describe('Store', () => {
       editorAutoSaveDelayMs: 1500,
       appFontFamily: 'Inter',
       terminalFontSize: 16,
-      terminalFontWeight: 600
+      terminalFontWeight: 600,
+      terminalFontWeightBold: 800
     })
     expect(updated.theme).toBe('dark')
     expect(updated.editorAutoSave).toBe(true)
@@ -5839,6 +5841,7 @@ describe('Store', () => {
     expect(updated.appFontFamily).toBe('Inter')
     expect(updated.terminalFontSize).toBe(16)
     expect(updated.terminalFontWeight).toBe(600)
+    expect(updated.terminalFontWeightBold).toBe(800)
     // Other fields preserved
     expect(updated.branchPrefix).toBe('git-username')
   })

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
@@ -10,6 +10,8 @@ import {
 const SETTINGS = {
   terminalFontSize: 17,
   terminalFontFamily: 'Fira Code',
+  terminalFontWeight: 500,
+  terminalFontWeightBold: 800,
   terminalCursorStyle: 'bar',
   terminalCursorBlink: false,
   terminalLineHeight: 1.4,
@@ -22,6 +24,8 @@ describe('buildPreviewAppearanceOptions', () => {
     const options = buildPreviewAppearanceOptions(SETTINGS, false)
     expect(options.fontSize).toBe(17)
     expect(options.fontFamily).toContain('Fira Code')
+    expect(options.fontWeight).toBe(500)
+    expect(options.fontWeightBold).toBe(800)
     expect(options.cursorStyle).toBe('bar')
     expect(options.cursorBlink).toBe(false)
     expect(options.lineHeight).toBe(1.4)

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
@@ -19,7 +19,10 @@ export function buildPreviewAppearanceOptions(
   macOptionIsMeta: boolean
 ): Partial<ITerminalOptions> {
   const cursorStyle = settings?.terminalCursorStyle ?? 'block'
-  const fontWeights = resolveTerminalFontWeights(settings?.terminalFontWeight)
+  const fontWeights = resolveTerminalFontWeights(
+    settings?.terminalFontWeight,
+    settings?.terminalFontWeightBold
+  )
   return {
     fontSize: settings?.terminalFontSize ?? 14,
     fontFamily: buildFontFamily(settings?.terminalFontFamily ?? ''),

--- a/src/renderer/src/components/settings/TerminalAdvancedTypographyControls.tsx
+++ b/src/renderer/src/components/settings/TerminalAdvancedTypographyControls.tsx
@@ -1,10 +1,12 @@
 import type { GlobalSettings } from '../../../../shared/types'
 import {
   DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
   TERMINAL_FONT_WEIGHT_MAX,
   TERMINAL_FONT_WEIGHT_MIN,
   TERMINAL_FONT_WEIGHT_STEP,
-  normalizeTerminalFontWeight
+  normalizeTerminalFontWeight,
+  normalizeTerminalFontWeightBold
 } from '../../../../shared/terminal-fonts'
 import {
   fontFamilyHasKnownLigatures,
@@ -54,6 +56,35 @@ export function TerminalAdvancedTypographyControls({
           suffix="100-900"
           onChange={(value) =>
             updateSettings({ terminalFontWeight: normalizeTerminalFontWeight(value) })
+          }
+        />
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.TerminalAppearanceSection.80bfdf3fac',
+          'Bold Font Weight'
+        )}
+        description={translate(
+          'auto.components.settings.TerminalAppearanceSection.ff65195bcd',
+          'Weight used for bold text. Fonts expose only a few real weights, so set this above Font Weight or bold will look identical to normal text.'
+        )}
+        keywords={['terminal', 'typography', 'weight', 'bold']}
+      >
+        <NumberField
+          label={translate(
+            'auto.components.settings.TerminalAppearanceSection.80bfdf3fac',
+            'Bold Font Weight'
+          )}
+          description=""
+          value={normalizeTerminalFontWeightBold(settings.terminalFontWeightBold)}
+          defaultValue={DEFAULT_TERMINAL_FONT_WEIGHT_BOLD}
+          min={TERMINAL_FONT_WEIGHT_MIN}
+          max={TERMINAL_FONT_WEIGHT_MAX}
+          step={TERMINAL_FONT_WEIGHT_STEP}
+          suffix="100-900"
+          onChange={(value) =>
+            updateSettings({ terminalFontWeightBold: normalizeTerminalFontWeightBold(value) })
           }
         />
       </SearchableSetting>

--- a/src/renderer/src/components/settings/TerminalAdvancedTypographyControls.tsx
+++ b/src/renderer/src/components/settings/TerminalAdvancedTypographyControls.tsx
@@ -62,18 +62,18 @@ export function TerminalAdvancedTypographyControls({
 
       <SearchableSetting
         title={translate(
-          'auto.components.settings.TerminalAppearanceSection.80bfdf3fac',
+          'auto.components.settings.TerminalAdvancedTypographyControls.f5fa1a08f1',
           'Bold Font Weight'
         )}
         description={translate(
-          'auto.components.settings.TerminalAppearanceSection.ff65195bcd',
-          'Weight used for bold text. Fonts expose only a few real weights, so set this above Font Weight or bold will look identical to normal text.'
+          'auto.components.settings.TerminalAdvancedTypographyControls.0e0d1ee15a',
+          'Adjust independently from Font Weight. Some fonts map several values to one face, so lower Font Weight or choose another font if bold looks unchanged.'
         )}
         keywords={['terminal', 'typography', 'weight', 'bold']}
       >
         <NumberField
           label={translate(
-            'auto.components.settings.TerminalAppearanceSection.80bfdf3fac',
+            'auto.components.settings.TerminalAdvancedTypographyControls.f5fa1a08f1',
             'Bold Font Weight'
           )}
           description=""

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -117,7 +117,10 @@ export function TerminalSettingsPreview({
     if (!container) {
       return
     }
-    const weights = resolveTerminalFontWeights(settings.terminalFontWeight)
+    const weights = resolveTerminalFontWeights(
+      settings.terminalFontWeight,
+      settings.terminalFontWeightBold
+    )
     skipInitialOptionMutationRef.current = true
     skipInitialThemeRewriteRef.current = true
     // Why: DOM renderer only — WebGL contexts are scarce and multiple previews can mount at once.
@@ -171,7 +174,10 @@ export function TerminalSettingsPreview({
       skipInitialOptionMutationRef.current = false
       return
     }
-    const weights = resolveTerminalFontWeights(settings.terminalFontWeight)
+    const weights = resolveTerminalFontWeights(
+      settings.terminalFontWeight,
+      settings.terminalFontWeightBold
+    )
     terminal.options.fontSize = settings.terminalFontSize
     terminal.options.fontFamily = buildFontFamily(effectiveFontFamily)
     terminal.options.fontWeight = weights.fontWeight
@@ -183,6 +189,7 @@ export function TerminalSettingsPreview({
     terminal.options.cursorBlink = settings.terminalCursorBlink
   }, [
     settings.terminalFontSize,
+    settings.terminalFontWeightBold,
     effectiveFontFamily,
     settings.terminalFontWeight,
     terminalLineHeight,

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -193,6 +193,16 @@ describe('applyTerminalAppearance theme assignment', () => {
     expect(pane.terminal.options.fontSize).toBe(settings.terminalFontSize + 2)
   })
 
+  it('applies regular and bold font weights independently', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, terminalFontWeight: 400, terminalFontWeightBold: 800 })
+
+    expect(pane.terminal.options.fontWeight).toBe(400)
+    expect(pane.terminal.options.fontWeightBold).toBe(800)
+  })
+
   it('still assigns a fresh theme when composed values actually change', () => {
     const pane = makePane(1)
     const settings = getDefaultSettings('/tmp')

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -150,7 +150,10 @@ export function applyTerminalAppearance(
   publishTerminalViewAttributes(theme, appearance.mode, settings)
   const paneBackground = theme?.background ?? '#000000'
 
-  const terminalFontWeights = resolveTerminalFontWeights(settings.terminalFontWeight)
+  const terminalFontWeights = resolveTerminalFontWeights(
+    settings.terminalFontWeight,
+    settings.terminalFontWeightBold
+  )
   const ligaturesEnabled = resolveTerminalLigaturesEnabled(
     settings.terminalLigatures,
     settings.terminalFontFamily

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1508,7 +1508,10 @@ export function useTerminalPaneLifecycle({
       onExternalPaneDrop,
       terminalOptions: () => {
         const currentSettings = settingsRef.current
-        const terminalFontWeights = resolveTerminalFontWeights(currentSettings?.terminalFontWeight)
+        const terminalFontWeights = resolveTerminalFontWeights(
+          currentSettings?.terminalFontWeight,
+          currentSettings?.terminalFontWeightBold
+        )
         const cursorStyle = currentSettings?.terminalCursorStyle ?? 'block'
         const storeState = useAppStore.getState()
         const currentTab = storeState.tabsByWorktree[worktreeId]?.find(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7629,7 +7629,9 @@
           "e90afcc44f": "off",
           "16c471ee03": "on",
           "typographyAdvanced": "Typography",
-          "dimUnfocusedPanes": "Dim unfocused panes."
+          "dimUnfocusedPanes": "Dim unfocused panes.",
+          "80bfdf3fac": "Bold Font Weight",
+          "ff65195bcd": "Weight used for bold text. Fonts expose only a few real weights, so set this above Font Weight or bold will look identical to normal text."
         },
         "TerminalFontSizeSetting": {
           "9b5252c85a": "px",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7629,9 +7629,11 @@
           "e90afcc44f": "off",
           "16c471ee03": "on",
           "typographyAdvanced": "Typography",
-          "dimUnfocusedPanes": "Dim unfocused panes.",
-          "80bfdf3fac": "Bold Font Weight",
-          "ff65195bcd": "Weight used for bold text. Fonts expose only a few real weights, so set this above Font Weight or bold will look identical to normal text."
+          "dimUnfocusedPanes": "Dim unfocused panes."
+        },
+        "TerminalAdvancedTypographyControls": {
+          "f5fa1a08f1": "Bold Font Weight",
+          "0e0d1ee15a": "Adjust independently from Font Weight. Some fonts map several values to one face, so lower Font Weight or choose another font if bold looks unchanged."
         },
         "TerminalFontSizeSetting": {
           "9b5252c85a": "px",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -12,7 +12,7 @@ import type {
 } from './types'
 import { EMPTY_CODEX_RESET_CREDIT_ATTEMPT_LEDGER } from './codex-reset-credit-attempt-ledger'
 import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
-import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
+import { DEFAULT_TERMINAL_FONT_WEIGHT, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD } from './terminal-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 import type { VoiceSettings } from './speech-types'
 import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
@@ -205,6 +205,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontSize: 14,
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
+    terminalFontWeightBold: DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
     terminalLineHeight: 1,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,

--- a/src/shared/terminal-fonts.test.ts
+++ b/src/shared/terminal-fonts.test.ts
@@ -1,28 +1,52 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
   resolveTerminalFontWeights,
-  normalizeTerminalFontWeight
+  normalizeTerminalFontWeight,
+  normalizeTerminalFontWeightBold
 } from './terminal-fonts'
 
 describe('terminal font weights', () => {
   it('falls back to the Orca default when the value is missing', () => {
     expect(normalizeTerminalFontWeight(undefined)).toBe(DEFAULT_TERMINAL_FONT_WEIGHT)
+    expect(normalizeTerminalFontWeightBold(undefined)).toBe(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD)
   })
 
-  it('clamps weights to the supported xterm range', () => {
+  it('clamps both weights to the supported xterm range', () => {
     expect(normalizeTerminalFontWeight(10)).toBe(100)
     expect(normalizeTerminalFontWeight(1200)).toBe(900)
+    expect(normalizeTerminalFontWeightBold(10)).toBe(100)
+    expect(normalizeTerminalFontWeightBold(1200)).toBe(900)
   })
 
-  it('keeps bold text heavier than the base terminal weight', () => {
-    expect(resolveTerminalFontWeights(500)).toEqual({
+  it('defaults to a pair that straddles the boundary between real font faces', () => {
+    expect(resolveTerminalFontWeights(undefined, undefined)).toEqual({
       fontWeight: 500,
       fontWeightBold: 700
     })
-    expect(resolveTerminalFontWeights(800)).toEqual({
+  })
+
+  // STA-4071: the old behaviour derived bold as max(700, regular + 200). That
+  // reads as "always heavier" but is not, because a family exposes only a few
+  // real faces — the monospace the default chain resolves to on macOS has two,
+  // splitting at 600. So a base weight of 800 derived 900, both rasterized
+  // identically, and bold silently stopped existing for every base weight at or
+  // above 600 with no way to fix it from the UI.
+  it('does not derive bold from the base weight', () => {
+    expect(resolveTerminalFontWeights(800, undefined)).toEqual({
       fontWeight: 800,
-      fontWeightBold: 900
+      fontWeightBold: DEFAULT_TERMINAL_FONT_WEIGHT_BOLD
+    })
+    // The user owns the pair, including combinations the derivation could never
+    // produce — a collision is now a choice they can see and undo.
+    expect(resolveTerminalFontWeights(300, 400)).toEqual({
+      fontWeight: 300,
+      fontWeightBold: 400
+    })
+    expect(resolveTerminalFontWeights(700, 700)).toEqual({
+      fontWeight: 700,
+      fontWeightBold: 700
     })
   })
 })

--- a/src/shared/terminal-fonts.test.ts
+++ b/src/shared/terminal-fonts.test.ts
@@ -27,19 +27,11 @@ describe('terminal font weights', () => {
     })
   })
 
-  // STA-4071: the old behaviour derived bold as max(700, regular + 200). That
-  // reads as "always heavier" but is not, because a family exposes only a few
-  // real faces — the monospace the default chain resolves to on macOS has two,
-  // splitting at 600. So a base weight of 800 derived 900, both rasterized
-  // identically, and bold silently stopped existing for every base weight at or
-  // above 600 with no way to fix it from the UI.
   it('does not derive bold from the base weight', () => {
     expect(resolveTerminalFontWeights(800, undefined)).toEqual({
       fontWeight: 800,
       fontWeightBold: DEFAULT_TERMINAL_FONT_WEIGHT_BOLD
     })
-    // The user owns the pair, including combinations the derivation could never
-    // produce — a collision is now a choice they can see and undo.
     expect(resolveTerminalFontWeights(300, 400)).toEqual({
       fontWeight: 300,
       fontWeightBold: 400

--- a/src/shared/terminal-fonts.ts
+++ b/src/shared/terminal-fonts.ts
@@ -25,20 +25,7 @@ export function normalizeTerminalFontWeightBold(fontWeight: number | null | unde
   return normalizeWeight(fontWeight, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD)
 }
 
-/**
- * Why the bold weight is now its own setting instead of `max(700, regular + 200)`:
- * that derivation silently destroyed bold. A family exposes a small number of
- * real faces — the monospace the default chain resolves to on macOS has exactly
- * two, so every weight 100-500 rasterizes identically and every weight 600-900
- * rasterizes identically. Any regular weight at or above 600 put both values in
- * the same face, so bold stopped existing, with no error and nothing the user
- * could do about it (STA-4071).
- *
- * Arithmetic cannot fix that: on a two-face family there is no heavier face to
- * escape to. So the pair is user-owned. A collision is now a choice the user
- * made and can undo rather than something the app did to them, and the default
- * pair (500/700) straddles the boundary on the families we ship.
- */
+// Numeric weight gaps do not guarantee distinct font faces, so bold stays independently configurable.
 export function resolveTerminalFontWeights(
   fontWeight: number | null | undefined,
   fontWeightBold: number | null | undefined

--- a/src/shared/terminal-fonts.ts
+++ b/src/shared/terminal-fonts.ts
@@ -2,13 +2,13 @@ export const DEFAULT_TERMINAL_FONT_WEIGHT = 500
 export const TERMINAL_FONT_WEIGHT_MIN = 100
 export const TERMINAL_FONT_WEIGHT_MAX = 900
 export const TERMINAL_FONT_WEIGHT_STEP = 100
-const DEFAULT_TERMINAL_FONT_WEIGHT_BOLD = 700
+export const DEFAULT_TERMINAL_FONT_WEIGHT_BOLD = 700
 
-export function normalizeTerminalFontWeight(fontWeight: number | null | undefined): number {
+function normalizeWeight(fontWeight: number | null | undefined, fallback: number): number {
   const numericFontWeight = typeof fontWeight === 'number' ? fontWeight : Number.NaN
 
   if (!Number.isFinite(numericFontWeight)) {
-    return DEFAULT_TERMINAL_FONT_WEIGHT
+    return fallback
   }
 
   return Math.min(
@@ -17,17 +17,37 @@ export function normalizeTerminalFontWeight(fontWeight: number | null | undefine
   )
 }
 
-export function resolveTerminalFontWeights(fontWeight: number | null | undefined): {
+export function normalizeTerminalFontWeight(fontWeight: number | null | undefined): number {
+  return normalizeWeight(fontWeight, DEFAULT_TERMINAL_FONT_WEIGHT)
+}
+
+export function normalizeTerminalFontWeightBold(fontWeight: number | null | undefined): number {
+  return normalizeWeight(fontWeight, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD)
+}
+
+/**
+ * Why the bold weight is now its own setting instead of `max(700, regular + 200)`:
+ * that derivation silently destroyed bold. A family exposes a small number of
+ * real faces — the monospace the default chain resolves to on macOS has exactly
+ * two, so every weight 100-500 rasterizes identically and every weight 600-900
+ * rasterizes identically. Any regular weight at or above 600 put both values in
+ * the same face, so bold stopped existing, with no error and nothing the user
+ * could do about it (STA-4071).
+ *
+ * Arithmetic cannot fix that: on a two-face family there is no heavier face to
+ * escape to. So the pair is user-owned. A collision is now a choice the user
+ * made and can undo rather than something the app did to them, and the default
+ * pair (500/700) straddles the boundary on the families we ship.
+ */
+export function resolveTerminalFontWeights(
+  fontWeight: number | null | undefined,
+  fontWeightBold: number | null | undefined
+): {
   fontWeight: number
   fontWeightBold: number
 } {
-  const normalizedFontWeight = normalizeTerminalFontWeight(fontWeight)
-
   return {
-    fontWeight: normalizedFontWeight,
-    fontWeightBold: Math.min(
-      TERMINAL_FONT_WEIGHT_MAX,
-      Math.max(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD, normalizedFontWeight + 200)
-    )
+    fontWeight: normalizeTerminalFontWeight(fontWeight),
+    fontWeightBold: normalizeTerminalFontWeightBold(fontWeightBold)
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2851,6 +2851,7 @@ export type GlobalSettings = {
   terminalFontSize: number
   terminalFontFamily: string
   terminalFontWeight: number
+  terminalFontWeightBold: number
   terminalLineHeight: number
   terminalScrollSensitivity: number
   terminalFastScrollSensitivity: number


### PR DESCRIPTION
## ELI5

Orca had one "Font Weight" slider and worked out the bold weight from it by adding 200. But a font only ships a handful of real weights — the default one on macOS has exactly two. So if you set the slider to 600 or higher, the normal weight and the computed bold weight both landed on the *same* face, and bold silently stopped existing. Now you set bold yourself.

## What Changed

`terminalFontWeightBold` is a real setting with its own control, defaulting to 700. `resolveTerminalFontWeights` no longer derives it.

```diff
-fontWeightBold: Math.min(900, Math.max(700, normalizedFontWeight + 200))
+fontWeightBold: normalizeTerminalFontWeightBold(fontWeightBold)
```

## Why

The derivation reads as "bold is always heavier," and numerically it is. It isn't in pixels.

A family exposes a small number of real faces. Rasterizing each weight to a canvas and measuring ink, on the family Orca's default chain actually resolves to:

```
w300  ink 3023   advance 354.0059
w400  ink 3023   advance 354.0059     <- 100-500 byte-identical
w500  ink 3023   advance 354.0059
w600  ink 3855   advance 354.0059
w700  ink 3855   advance 354.0059     <- 600-900 byte-identical
w800  ink 3855   advance 354.0059
w900  ink 3855   advance 354.0059
```

Two faces, splitting at 600. So the pairs the derivation produced were:

| base weight | derived bold | rendered result |
| -- | -- | -- |
| 100–500 | 700 | distinct ✅ |
| 600 | 800 | **identical** ❌ |
| 700 | 900 | **identical** ❌ |
| 800 | 900 | **identical** ❌ |
| 900 | 900 | **identical** ❌ |

Four of the nine slider positions destroyed bold, silently, with no way to recover from the UI. Arithmetic cannot fix that: on a two-face family there is no heavier face to escape to, so no formula produces a distinguishable pair.

Making the pair user-owned is the smallest honest fix. A collision is now visible and recoverable instead of being presented as a guaranteed bold face. Bold weight is configured independently rather than derived.

## Linked Issue

Fixes STA-4071.

Related: STA-4042 / #14241, which produced the same user complaint ("terminal text is bold") from a completely different cause — a stranded SGR pen after dropped bytes. Same symptom, unrelated mechanism; both are worth having.

## Visual Proof

N/A — no visual change in the default configuration. The default pair remains 500/700. On a two-face font, a regular weight of 600 or above can still map to the same face as bold; the settings now expose both values independently and explain that lowering Font Weight or choosing another font restores the distinction.

## Testing

- `terminal-fonts.test.ts` rewritten. The old test asserted `800 → {800, 900}` under the name "keeps bold text heavier than the base terminal weight" — numerically true, identically rendered. That test is where this hid, so it is replaced with one that pins the non-derivation and documents the two-face reality.
- 8958 tests pass across `shared`, `settings` and `terminal-pane`.
- `pnpm typecheck`, `oxlint`, `oxfmt --check`, React Doctor on changed lines, and `verify:localization-coverage` all clean. New UI strings go through `translate()` and the catalog is synced.

**Compatibility:** the new setting is absent from existing profiles, so the 700 default applies. Existing 100–500 profiles retain their distinction. Profiles at ≥600 keep their configured regular weight and receive an explicit bold value; a two-face font can still collapse that pair, but the UI now makes the limitation and recovery path visible.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform:** the face measurements above are macOS. Windows and Linux ship different monospace families that may expose more faces — which only makes the derivation *more* wrong there, never less, since the fix removes an assumption rather than adding one.
- **Remote SSH / mobile:** font weights are a renderer appearance concern; the preview and dashboard-popout paths take the same pair and were updated together.
- **Backwards compatibility:** covered above.
- **Performance:** none — two normalizations replace one normalization plus arithmetic.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
