### PR TITLE
feat(cli): close browser tabs by page id

### DIFF
--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -126,6 +126,40 @@ describe('orca cli browser page targeting', () => {
     })
   })
 
+  it('passes page-targeted tab closes through without resolving the current worktree', async () => {
+    queueFixtures(callMock, okFixture('req_close', { closed: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['tab', 'close', '--page', 'page-2', '--json'], '/tmp/not-an-orca-worktree')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabClose', {
+      index: undefined,
+      page: 'page-2'
+    })
+  })
+
+  it('validates page-targeted tab closes against an explicit current worktree', async () => {
+    queueFixtures(
+      callMock,
+      worktreeListFixture([buildWorktree('/tmp/repo/feature', 'feature/foo')]),
+      okFixture('req_close', { closed: true })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'close', '--page', 'page-2', '--worktree', 'current', '--json'],
+      '/tmp/repo/feature/src'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.list', { limit: 10_000 })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'browser.tabClose', {
+      index: undefined,
+      page: 'page-2',
+      worktree: 'id:repo::/tmp/repo/feature'
+    })
+  })
+
   it('passes focus: true through to browser.tabSwitch when --focus is set', async () => {
     queueFixtures(callMock, okFixture('req_switch', { switched: 1, browserPageId: 'page-1' }))
     vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -1,3 +1,4 @@
+import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()
@@ -39,6 +40,10 @@ import { RuntimeClientError } from './runtime-client'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
 
 describe('orca cli browser page targeting', () => {
+  const managedWorktreePath = resolve('test-fixtures', 'repo', 'feature')
+  const nestedManagedPath = join(managedWorktreePath, 'src')
+  const unmanagedPath = resolve('test-fixtures', 'unmanaged')
+
   beforeEach(() => {
     callMock.mockReset()
   })
@@ -130,7 +135,7 @@ describe('orca cli browser page targeting', () => {
     queueFixtures(callMock, okFixture('req_close', { closed: true }))
     vi.spyOn(console, 'log').mockImplementation(() => {})
 
-    await main(['tab', 'close', '--page', 'page-2', '--json'], '/tmp/not-an-orca-worktree')
+    await main(['tab', 'close', '--page', 'page-2', '--json'], unmanagedPath)
 
     expect(callMock).toHaveBeenCalledTimes(1)
     expect(callMock).toHaveBeenCalledWith('browser.tabClose', {
@@ -142,21 +147,21 @@ describe('orca cli browser page targeting', () => {
   it('validates page-targeted tab closes against an explicit current worktree', async () => {
     queueFixtures(
       callMock,
-      worktreeListFixture([buildWorktree('/tmp/repo/feature', 'feature/foo')]),
+      worktreeListFixture([buildWorktree(managedWorktreePath, 'feature/foo')]),
       okFixture('req_close', { closed: true })
     )
     vi.spyOn(console, 'log').mockImplementation(() => {})
 
     await main(
       ['tab', 'close', '--page', 'page-2', '--worktree', 'current', '--json'],
-      '/tmp/repo/feature/src'
+      nestedManagedPath
     )
 
     expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.list', { limit: 10_000 })
     expect(callMock).toHaveBeenNthCalledWith(2, 'browser.tabClose', {
       index: undefined,
       page: 'page-2',
-      worktree: 'id:repo::/tmp/repo/feature'
+      worktree: `id:repo::${managedWorktreePath}`
     })
   })
 

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -228,8 +228,8 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['tab', 'close'],
     summary: 'Close a browser tab',
-    usage: 'orca tab close [--index <n>] [--worktree <selector>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'index', 'worktree']
+    usage: 'orca tab close [--index <n> | --page <id>] [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'index', 'page', 'worktree']
   },
   {
     path: ['exec'],


### PR DESCRIPTION
## ELI5

Browser tab numbers can change while an integration is working. This lets integrations close the exact tab they created by using its stable page ID instead of a moving index.

## What Changed

- Allowed --page on orca tab close.
- Updated command usage to show index and page targeting.
- Added regression coverage for global page targeting and explicit current-worktree validation.

## Why

Closing by index requires listing tabs first and can target the wrong tab if the list changes before the close command runs. The runtime already supports stable browser page IDs; this exposes that support through the typed CLI command.

## Linked Issue

Fixes #14052

## Visual Proof

N/A — this is a CLI-only option with no UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS with Node 24.18.0:

- pnpm lint — passed
- pnpm typecheck — passed
- pnpm test — passed
- pnpm build — passed
- pnpm exec vitest run src/cli/browser.test.ts — 35 passed
- focused oxlint and oxfmt checks — passed
- git diff --check — passed

The full suite used the isolated Orca contribution environment: OpenClaw CODEX variables unset, TMPDIR=/tmp, umask 0027, and ORCA_CROSS_VERSION_BASELINE_REF=v1.4.180.

## AI Disclosure

OpenAI Codex GPT-5 was used to inspect the existing CLI/runtime boundary, implement the scoped command-spec change, add regression tests, and review the diff. All commands above were run locally and the final diff was manually reviewed.

## Review

- Security: no authentication, secret handling, or permission behavior changed.
- Cross-platform: command parsing and stable page IDs are platform-independent.
- SSH/remote: explicit page IDs remain globally targeted by default; an explicit worktree selector still validates ownership on the target runtime.
- Folder workspaces: uses the same browser targeting path as git worktrees.
- Backwards compatibility: adds an optional CLI flag; existing index and implicit-current-tab behavior are unchanged.
- Performance: removes the need for an integration-side list-before-close lookup and adds no runtime work.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why including ELI5
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered or N/A
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass or CI will cover; local preferred

All four commands were executed locally and passed.

## Author

- X / Twitter: N/A