### PR TITLE
fix(terminal): reject cwd-resolving PATH entries and harden the legacy wrappers

### DIFF
--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -4,7 +4,12 @@ const POSIX_TOMBSTONE = String.raw`#!/usr/bin/env bash
 set -u
 
 command_name="__ORCA_COMMAND__"
-wrapper_dir="$(cd -- "$(dirname -- "${SHELL_DOLLAR}{BASH_SOURCE[0]}")" && pwd)"
+# Why: parameter expansion, not the external dirname — if that were unresolvable the substitution
+# would be empty and cd into it succeeds, silently making wrapper_dir the cwd so the wrapper
+# fails to exclude itself from PATH.
+wrapper_src="${SHELL_DOLLAR}{BASH_SOURCE[0]}"
+wrapper_dir="$(cd -- "${SHELL_DOLLAR}{wrapper_src%/*}" 2>/dev/null && pwd)"
+[[ -n "$wrapper_dir" ]] || wrapper_dir="${SHELL_DOLLAR}{wrapper_src%/*}"
 legacy_wrapper_dir="${SHELL_DOLLAR}{ORCA_ATTRIBUTION_SHIM_DIR:-}"
 cleaned_path="${SHELL_DOLLAR}{PATH:-}"
 
@@ -32,9 +37,9 @@ filter_path() {
       normalized="${SHELL_DOLLAR}{normalized%/}"
     done
     candidate="${SHELL_DOLLAR}{entry:-.}"
-    if [[ -z "$entry" ]]; then
-      # Why: an empty PATH element means the current directory, so keeping it would let a
-      # repository-local git/gh win the lookup below.
+    if [[ "$entry" != /* ]]; then
+      # Why: an empty or relative PATH element resolves against the current directory, so keeping
+      # it would let a repository-local git/gh win the lookup below.
       :
     elif [[ -n "$legacy_target" && "$normalized" == "$legacy_target" ]]; then
       :

--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -8,8 +8,13 @@ command_name="__ORCA_COMMAND__"
 # would be empty and cd into it succeeds, silently making wrapper_dir the cwd so the wrapper
 # fails to exclude itself from PATH.
 wrapper_src="${SHELL_DOLLAR}{BASH_SOURCE[0]}"
-wrapper_dir="$(cd -- "${SHELL_DOLLAR}{wrapper_src%/*}" 2>/dev/null && pwd)"
-[[ -n "$wrapper_dir" ]] || wrapper_dir="${SHELL_DOLLAR}{wrapper_src%/*}"
+case "$wrapper_src" in
+  # Why: with no slash the %/* strip yields the file name, not a directory, so self-exclusion
+  # would miss the wrapper's own dir and the lookup would resolve back to this script.
+  */*) wrapper_dir="$(cd -- "${SHELL_DOLLAR}{wrapper_src%/*}" 2>/dev/null && pwd)" ;;
+  *) wrapper_dir="$PWD" ;;
+esac
+[[ -n "$wrapper_dir" ]] || wrapper_dir="$PWD"
 legacy_wrapper_dir="${SHELL_DOLLAR}{ORCA_ATTRIBUTION_SHIM_DIR:-}"
 cleaned_path="${SHELL_DOLLAR}{PATH:-}"
 

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -113,12 +113,16 @@ describe('legacy terminal shim neutralization', () => {
       expect(cmd).not.toContain('where.exe')
       expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate')
       expect(cmd).toContain(`if exist "%%~fG\\${command}.exe"`)
-      // A candidate inside the wrapper directory must still be rejected.
-      expect(cmd).toContain('if /I not "%%~fG\\"=="%~dp0"')
+      // A candidate inside the wrapper directory must still be rejected, compared against the
+      // cached wrapper dir because %~dp0 is rebound inside a CALL.
+      expect(cmd).toContain('if /I not "%%~fG\\"=="%orca_wrapper_dir%"')
+      // Relative entries resolve against the cwd, so they must be rejected like empty ones.
+      expect(cmd).toContain('findstr /R')
 
       const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
       expect(powershell).not.toContain('Get-Command')
       expect(powershell).toContain("($env:PATH -split ';')")
+      expect(powershell).toContain('[IO.Path]::IsPathRooted($dir)')
       expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
     }
   })
@@ -168,6 +172,13 @@ describe('legacy terminal shim neutralization', () => {
     writeFileSync(join(hostile, 'git'), "#!/usr/bin/env bash\nprintf 'HOSTILE\\n'\n", {
       mode: 0o755
     })
+    // Reachable only through a relative PATH entry resolved against the hostile cwd.
+    mkdirSync(join(hostile, 'node_modules', '.bin'), { recursive: true })
+    writeFileSync(
+      join(hostile, 'node_modules', '.bin', 'git'),
+      "#!/usr/bin/env bash\nprintf 'HOSTILE\\n'\n",
+      { mode: 0o755 }
+    )
 
     const result = spawnSync(join(shimDir, 'git'), ['--version'], {
       cwd: hostile,
@@ -179,6 +190,24 @@ describe('legacy terminal shim neutralization', () => {
 
     expect(result.stdout).toContain('REAL')
     expect(result.stdout).not.toContain('HOSTILE')
+
+    // Why: every spelling that means "current directory" must lose — a leading/trailing empty
+    // element, and any relative entry (`.`, or a repo-local bin dir).
+    for (const cwdSpelling of [
+      `:${realBin}:/usr/bin:/bin`,
+      `${realBin}:/usr/bin:/bin:`,
+      `.:${realBin}:/usr/bin:/bin`,
+      `..:${realBin}:/usr/bin:/bin`,
+      `node_modules/.bin:${realBin}:/usr/bin:/bin`
+    ]) {
+      const run = spawnSync(join(shimDir, 'git'), ['--version'], {
+        cwd: hostile,
+        env: { ...process.env, PATH: cwdSpelling },
+        encoding: 'utf8'
+      })
+      expect(run.stdout, `PATH=${cwdSpelling}`).toContain('REAL')
+      expect(run.stdout, `PATH=${cwdSpelling}`).not.toContain('HOSTILE')
+    }
   })
 
   it('removes every Windows PATH occurrence of both captured wrapper directories', () => {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -123,6 +123,33 @@ describe('legacy terminal shim neutralization', () => {
     }
   })
 
+  it('guards both cmd PATH walks so an empty variable cannot break parsing', () => {
+    // Why: `%VAR:;=" "%` on an empty variable leaves an unbalanced quote that desynchronizes
+    // cmd parsing for the rest of the file, turning the not-found branch into
+    // `1>&2 was unexpected at this time.` Reproduced on Windows before this guard.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const command of ['git', 'gh'] as const) {
+      const cmd = readFileSync(join(win32Dir, `${command}.cmd`), 'utf8')
+      expect(cmd).toContain('if not defined PATH goto :orca_path_walked')
+      expect(cmd).toContain('if not defined orca_clean_path goto :orca_candidates_walked')
+      for (const [guard, loop] of [
+        ['if not defined PATH goto :orca_path_walked', 'for %%P in ("%PATH:;='],
+        [
+          'if not defined orca_clean_path goto :orca_candidates_walked',
+          'for %%P in ("%orca_clean_path:;='
+        ]
+      ] as const) {
+        expect(cmd.indexOf(guard)).toBeGreaterThan(-1)
+        expect(cmd.indexOf(guard)).toBeLessThan(cmd.indexOf(loop))
+      }
+    }
+  })
+
   itOnPosix('does not let an empty PATH element resolve the command from the cwd', async () => {
     // Why (STA-4169): an empty PATH element means the current directory on POSIX.
     const userData = makeUserDataDir()

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -129,7 +129,10 @@ describe('legacy terminal shim neutralization', () => {
       const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
       expect(powershell).not.toContain('Get-Command')
       expect(powershell).toContain("($env:PATH -split ';')")
-      expect(powershell).toContain('[IO.Path]::IsPathRooted($dir)')
+      // Why: the rooted check must reject drive-relative 'C:foo', which still resolves against
+      // the cwd — so the IsPathRooted call must be gone, replaced by an explicit prefix match.
+      expect(powershell).not.toContain('[IO.Path]::IsPathRooted(')
+      expect(powershell).toContain("-notmatch '^([A-Za-z]:")
       expect(powershell).toContain('if (-not $dir) { continue }')
       expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
     }
@@ -216,6 +219,15 @@ describe('legacy terminal shim neutralization', () => {
       expect(run.stdout, `PATH=${cwdSpelling}`).toContain('REAL')
       expect(run.stdout, `PATH=${cwdSpelling}`).not.toContain('HOSTILE')
     }
+
+    // Why: invoked with no slash in $0, `${BASH_SOURCE%/*}` yields the file name rather than a
+    // directory, so self-exclusion missed the shim dir and the lookup resolved back to itself.
+    const noSlash = spawnSync('bash', ['git', '--version'], {
+      cwd: shimDir,
+      env: { ...process.env, PATH: `${shimDir}:${realBin}:/usr/bin:/bin` },
+      encoding: 'utf8'
+    })
+    expect(noSlash.stdout).toContain('REAL')
   })
 
   it('removes every Windows PATH occurrence of both captured wrapper directories', () => {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -117,12 +117,20 @@ describe('legacy terminal shim neutralization', () => {
       // cached wrapper dir because %~dp0 is rebound inside a CALL.
       expect(cmd).toContain('if /I not "%%~fG\\"=="%orca_wrapper_dir%"')
       // Relative entries resolve against the cwd, so they must be rejected like empty ones.
-      expect(cmd).toContain('findstr /R')
+      // Why: the rooted-path test must not shell out — an external tool would itself be
+      // resolved from the cwd, reintroducing the hijack.
+      expect(cmd).not.toContain('findstr')
+      expect(cmd).toContain('if "%orca_candidate:~1,2%"==":\\" goto orca_candidate_rooted')
+      expect(cmd).toContain('if "%orca_candidate:~0,2%"=="\\\\" goto orca_candidate_rooted')
+      // Why: these two guards are the only thing stopping an empty element reaching the cwd on
+      // Windows; deleting either left every other assertion green.
+      expect(cmd).toContain('if "%~1"=="" exit /b')
 
       const powershell = readFileSync(join(win32Dir, `${command}-wrapper.ps1`), 'utf8')
       expect(powershell).not.toContain('Get-Command')
       expect(powershell).toContain("($env:PATH -split ';')")
       expect(powershell).toContain('[IO.Path]::IsPathRooted($dir)')
+      expect(powershell).toContain('if (-not $dir) { continue }')
       expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
     }
   })

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -31,7 +31,11 @@ set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
 set "orca_wrapper_dir=%~dp0"
 set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"
 set "orca_clean_path="
+rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
+rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
+if not defined PATH goto :orca_path_walked
 for %%P in ("%PATH:;=" "%") do call :orca_append_path "%%~P"
+:orca_path_walked
 set "PATH=%orca_clean_path%"
 set "ORCA_ENABLE_GIT_ATTRIBUTION="
 set "ORCA_GIT_COMMIT_TRAILER="
@@ -47,7 +51,9 @@ if defined orca_real if not exist "%orca_real%" set "orca_real="
 if defined orca_real goto run
 rem Why: an unqualified Windows command lookup searches the current directory before PATH, so a
 rem repository-local __ORCA_COMMAND__.exe would win. Walk the cleaned PATH ourselves instead.
+if not defined orca_clean_path goto :orca_candidates_walked
 for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate "%%~P"
+:orca_candidates_walked
 if not defined orca_real (
   echo Orca compatibility wrapper could not locate __ORCA_COMMAND__ on PATH. 1>&2
   exit /b 127

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -1,6 +1,10 @@
 import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { renderLegacyTerminalPosixTombstone } from './legacy-terminal-posix-tombstone'
+import {
+  renderLegacyTerminalWindowsCmdTombstone,
+  renderLegacyTerminalWindowsPowerShellTombstone
+} from './legacy-terminal-windows-tombstone'
 
 const LEGACY_TERMINAL_ATTRIBUTION_ENABLE_ENV_KEY = 'ORCA_ENABLE_GIT_ATTRIBUTION'
 const LEGACY_TERMINAL_ATTRIBUTION_BYPASS_ENV_KEY = 'ORCA_ATTRIBUTION_BYPASS'
@@ -24,112 +28,6 @@ export const LEGACY_TERMINAL_SHIM_ENV_KEYS = [
 export const LEGACY_TERMINAL_SHIM_REMOTE_ENV_KEYS = [
   LEGACY_TERMINAL_ATTRIBUTION_ENABLE_ENV_KEY
 ] as const
-
-const WIN32_PASSTHROUGH_WRAPPER = String.raw`@echo off
-setlocal
-set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
-set "orca_wrapper_dir=%~dp0"
-set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"
-set "orca_clean_path="
-rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
-rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
-if not defined PATH goto :orca_path_walked
-for %%P in ("%PATH:;=" "%") do call :orca_append_path "%%~P"
-:orca_path_walked
-set "PATH=%orca_clean_path%"
-set "ORCA_ENABLE_GIT_ATTRIBUTION="
-set "ORCA_GIT_COMMIT_TRAILER="
-set "ORCA_GH_PR_FOOTER="
-set "ORCA_GH_ISSUE_FOOTER="
-set "ORCA_ATTRIBUTION_SHIM_DIR="
-set "ORCA_ATTRIBUTION_BYPASS="
-set "ORCA_REAL_GIT="
-set "ORCA_REAL_GH="
-if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="
-rem Why: clear a captured path that no longer exists, or the PATH walk below is skipped.
-if defined orca_real if not exist "%orca_real%" set "orca_real="
-if defined orca_real goto run
-rem Why: an unqualified Windows command lookup searches the current directory before PATH, so a
-rem repository-local __ORCA_COMMAND__.exe would win. Walk the cleaned PATH ourselves instead.
-if not defined orca_clean_path goto :orca_candidates_walked
-for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate "%%~P"
-:orca_candidates_walked
-if not defined orca_real (
-  echo Orca compatibility wrapper could not locate __ORCA_COMMAND__ on PATH. 1>&2
-  exit /b 127
-)
-:run
-"%orca_real%" %*
-exit /b %ERRORLEVEL%
-
-:orca_try_candidate
-if defined orca_real exit /b
-if "%~1"=="" exit /b
-rem Why: a relative entry resolves against the current directory, same exposure as an empty one.
-echo "%~1" | findstr /R /C:"^\"[A-Za-z]:[\\/]" /C:"^\"[\\][\\]" >nul || exit /b
-rem Why: %~dp0 is rebound to this label inside CALL, so compare against the cached wrapper dir.
-for %%G in ("%~1") do (
-  if /I not "%%~fG\"=="%orca_wrapper_dir%" (
-    if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
-    if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.cmd" set "orca_real=%%~fG\__ORCA_COMMAND__.cmd"
-  )
-)
-exit /b
-
-:orca_append_path
-for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG\"
-if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b
-if defined orca_legacy_wrapper_dir for %%G in ("%orca_legacy_wrapper_dir%") do if /I "%orca_path_entry_dir%"=="%%~fG\" exit /b
-if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%~1") else set "orca_clean_path=%~1"
-exit /b
-`
-
-const POWERSHELL_PASSTHROUGH_WRAPPER = String.raw`$ErrorActionPreference = 'Stop'
-$commandName = '__ORCA_COMMAND__'
-$realCommand = [Environment]::GetEnvironmentVariable('ORCA_REAL___ORCA_UPPER_COMMAND__')
-$wrapperDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$legacyWrapperDir = $env:ORCA_ATTRIBUTION_SHIM_DIR
-$wrapperDirs = @($wrapperDir, $legacyWrapperDir) | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\') }
-$env:PATH = (($env:PATH -split ';') | Where-Object {
-  $pathEntry = $_
-  $pathEntry -and -not ($wrapperDirs | Where-Object {
-    [string]::Equals($_, $pathEntry.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)
-  })
-}) -join ';'
-'ORCA_ENABLE_GIT_ATTRIBUTION', 'ORCA_GIT_COMMIT_TRAILER', 'ORCA_GH_PR_FOOTER', 'ORCA_GH_ISSUE_FOOTER', 'ORCA_ATTRIBUTION_SHIM_DIR', 'ORCA_REAL_GIT', 'ORCA_REAL_GH', 'ORCA_ATTRIBUTION_BYPASS' | ForEach-Object { Remove-Item "Env:$_" -ErrorAction SilentlyContinue }
-if ($realCommand) {
-  try {
-    $capturedDir = Split-Path -Parent ([IO.Path]::GetFullPath($realCommand))
-    if ([string]::Equals($capturedDir.TrimEnd('\'), $wrapperDir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) {
-      $realCommand = $null
-    }
-  } catch {
-    $realCommand = $null
-  }
-}
-if (-not $realCommand -or -not (Test-Path -LiteralPath $realCommand)) {
-  # Why: resolve only against the cleaned PATH directories. Ambient lookup could pick up a
-  # repository-local git.exe/gh.exe from the current directory.
-  $realCommand = $null
-  foreach ($dir in ($env:PATH -split ';')) {
-    if (-not $dir) { continue }
-    # Why: a relative entry resolves against the current directory, same exposure as an empty one.
-    if (-not [IO.Path]::IsPathRooted($dir)) { continue }
-    if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
-    foreach ($ext in @('.exe', '.cmd')) {
-      $candidate = Join-Path $dir "$commandName$ext"
-      if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }
-    }
-    if ($realCommand) { break }
-  }
-}
-if (-not $realCommand) {
-  [Console]::Error.WriteLine("Orca compatibility wrapper could not locate $commandName on PATH.")
-  exit 127
-}
-& $realCommand @args
-exit $LASTEXITCODE
-`
 
 let neutralized = false
 let neutralizationRetryTimer: ReturnType<typeof setTimeout> | null = null
@@ -198,25 +96,18 @@ function writeNeutralWrappers(rootDir: string): void {
   mkdirSync(posixDir, { recursive: true })
   mkdirSync(win32Dir, { recursive: true })
   for (const command of ['git', 'gh'] as const) {
-    const upperCommand = command.toUpperCase()
     writeFileAtomically(join(posixDir, command), renderLegacyTerminalPosixTombstone(command), 0o755)
     writeFileAtomically(
       join(win32Dir, `${command}.cmd`),
-      renderWindowsWrapper(WIN32_PASSTHROUGH_WRAPPER, command, upperCommand),
+      renderLegacyTerminalWindowsCmdTombstone(command),
       0o755
     )
     writeFileAtomically(
       join(win32Dir, `${command}-wrapper.ps1`),
-      renderWindowsWrapper(POWERSHELL_PASSTHROUGH_WRAPPER, command, upperCommand),
+      renderLegacyTerminalWindowsPowerShellTombstone(command),
       0o755
     )
   }
-}
-
-function renderWindowsWrapper(template: string, command: string, upperCommand: string): string {
-  return template
-    .replaceAll('__ORCA_UPPER_COMMAND__', upperCommand)
-    .replaceAll('__ORCA_COMMAND__', command)
 }
 
 function writeFileAtomically(filePath: string, contents: string, mode: number): void {

--- a/src/main/pty/legacy-terminal-shim-dir.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.ts
@@ -65,7 +65,15 @@ exit /b %ERRORLEVEL%
 :orca_try_candidate
 if defined orca_real exit /b
 if "%~1"=="" exit /b
-for %%G in ("%~1") do if /I not "%%~fG\"=="%~dp0" if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
+rem Why: a relative entry resolves against the current directory, same exposure as an empty one.
+echo "%~1" | findstr /R /C:"^\"[A-Za-z]:[\\/]" /C:"^\"[\\][\\]" >nul || exit /b
+rem Why: %~dp0 is rebound to this label inside CALL, so compare against the cached wrapper dir.
+for %%G in ("%~1") do (
+  if /I not "%%~fG\"=="%orca_wrapper_dir%" (
+    if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
+    if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.cmd" set "orca_real=%%~fG\__ORCA_COMMAND__.cmd"
+  )
+)
 exit /b
 
 :orca_append_path
@@ -105,9 +113,14 @@ if (-not $realCommand -or -not (Test-Path -LiteralPath $realCommand)) {
   $realCommand = $null
   foreach ($dir in ($env:PATH -split ';')) {
     if (-not $dir) { continue }
+    # Why: a relative entry resolves against the current directory, same exposure as an empty one.
+    if (-not [IO.Path]::IsPathRooted($dir)) { continue }
     if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
-    $candidate = Join-Path $dir "$commandName.exe"
-    if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }
+    foreach ($ext in @('.exe', '.cmd')) {
+      $candidate = Join-Path $dir "$commandName$ext"
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }
+    }
+    if ($realCommand) { break }
   }
 }
 if (-not $realCommand) {

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -55,6 +55,7 @@ for %%G in ("%~1") do (
   if /I not "%%~fG\"=="%orca_wrapper_dir%" (
     if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
     if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.cmd" set "orca_real=%%~fG\__ORCA_COMMAND__.cmd"
+    if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.bat" set "orca_real=%%~fG\__ORCA_COMMAND__.bat"
   )
 )
 exit /b
@@ -97,9 +98,12 @@ if (-not $realCommand -or -not (Test-Path -LiteralPath $realCommand)) {
   foreach ($dir in ($env:PATH -split ';')) {
     if (-not $dir) { continue }
     # Why: a relative entry resolves against the current directory, same exposure as an empty one.
-    if (-not [IO.Path]::IsPathRooted($dir)) { continue }
+    # IsPathRooted is not enough: it accepts drive-relative 'C:foo', which resolves against the
+    # current directory on that drive. IsPathFullyQualified is absent on Windows PowerShell 5.1,
+    # so match the same prefixes the cmd wrapper accepts.
+    if ($dir -notmatch '^([A-Za-z]:[\\/]|\\\\)') { continue }
     if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
-    foreach ($ext in @('.exe', '.cmd')) {
+    foreach ($ext in @('.exe', '.cmd', '.bat')) {
       $candidate = Join-Path $dir "$commandName$ext"
       if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }
     }

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -1,0 +1,129 @@
+// Why: kept beside the POSIX tombstone so the generated wrapper text for every platform lives
+// in one place, and so the shim-dir module stays under the max-lines limit.
+
+const WIN32_PASSTHROUGH_WRAPPER = String.raw`@echo off
+setlocal
+set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
+set "orca_wrapper_dir=%~dp0"
+set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"
+set "orca_clean_path="
+rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
+rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
+if not defined PATH goto :orca_path_walked
+for %%P in ("%PATH:;=" "%") do call :orca_append_path "%%~P"
+:orca_path_walked
+set "PATH=%orca_clean_path%"
+set "ORCA_ENABLE_GIT_ATTRIBUTION="
+set "ORCA_GIT_COMMIT_TRAILER="
+set "ORCA_GH_PR_FOOTER="
+set "ORCA_GH_ISSUE_FOOTER="
+set "ORCA_ATTRIBUTION_SHIM_DIR="
+set "ORCA_ATTRIBUTION_BYPASS="
+set "ORCA_REAL_GIT="
+set "ORCA_REAL_GH="
+if defined orca_real for %%G in ("%orca_real%") do if /I "%%~dpG"=="%~dp0" set "orca_real="
+rem Why: clear a captured path that no longer exists, or the PATH walk below is skipped.
+if defined orca_real if not exist "%orca_real%" set "orca_real="
+if defined orca_real goto run
+rem Why: an unqualified Windows command lookup searches the current directory before PATH, so a
+rem repository-local __ORCA_COMMAND__.exe would win. Walk the cleaned PATH ourselves instead.
+if not defined orca_clean_path goto :orca_candidates_walked
+for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate "%%~P"
+:orca_candidates_walked
+if not defined orca_real (
+  echo Orca compatibility wrapper could not locate __ORCA_COMMAND__ on PATH. 1>&2
+  exit /b 127
+)
+:run
+"%orca_real%" %*
+exit /b %ERRORLEVEL%
+
+:orca_try_candidate
+if defined orca_real exit /b
+if "%~1"=="" exit /b
+rem Why: a relative entry resolves against the current directory, same exposure as an empty one.
+rem Tested in pure batch on purpose: an external tool invoked here would itself be resolved from
+rem the current directory, reintroducing the very hijack this guard exists to prevent.
+set "orca_candidate=%~1"
+if "%orca_candidate:~0,2%"=="\\" goto orca_candidate_rooted
+if "%orca_candidate:~1,2%"==":\" goto orca_candidate_rooted
+if "%orca_candidate:~1,2%"==":/" goto orca_candidate_rooted
+exit /b
+:orca_candidate_rooted
+rem Why: %~dp0 is rebound to this label inside CALL, so compare against the cached wrapper dir.
+for %%G in ("%~1") do (
+  if /I not "%%~fG\"=="%orca_wrapper_dir%" (
+    if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
+    if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.cmd" set "orca_real=%%~fG\__ORCA_COMMAND__.cmd"
+  )
+)
+exit /b
+
+:orca_append_path
+for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG\"
+if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b
+if defined orca_legacy_wrapper_dir for %%G in ("%orca_legacy_wrapper_dir%") do if /I "%orca_path_entry_dir%"=="%%~fG\" exit /b
+if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%~1") else set "orca_clean_path=%~1"
+exit /b
+`
+
+const POWERSHELL_PASSTHROUGH_WRAPPER = String.raw`$ErrorActionPreference = 'Stop'
+$commandName = '__ORCA_COMMAND__'
+$realCommand = [Environment]::GetEnvironmentVariable('ORCA_REAL___ORCA_UPPER_COMMAND__')
+$wrapperDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$legacyWrapperDir = $env:ORCA_ATTRIBUTION_SHIM_DIR
+$wrapperDirs = @($wrapperDir, $legacyWrapperDir) | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\') }
+$env:PATH = (($env:PATH -split ';') | Where-Object {
+  $pathEntry = $_
+  $pathEntry -and -not ($wrapperDirs | Where-Object {
+    [string]::Equals($_, $pathEntry.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)
+  })
+}) -join ';'
+'ORCA_ENABLE_GIT_ATTRIBUTION', 'ORCA_GIT_COMMIT_TRAILER', 'ORCA_GH_PR_FOOTER', 'ORCA_GH_ISSUE_FOOTER', 'ORCA_ATTRIBUTION_SHIM_DIR', 'ORCA_REAL_GIT', 'ORCA_REAL_GH', 'ORCA_ATTRIBUTION_BYPASS' | ForEach-Object { Remove-Item "Env:$_" -ErrorAction SilentlyContinue }
+if ($realCommand) {
+  try {
+    $capturedDir = Split-Path -Parent ([IO.Path]::GetFullPath($realCommand))
+    if ([string]::Equals($capturedDir.TrimEnd('\'), $wrapperDir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) {
+      $realCommand = $null
+    }
+  } catch {
+    $realCommand = $null
+  }
+}
+if (-not $realCommand -or -not (Test-Path -LiteralPath $realCommand)) {
+  # Why: resolve only against the cleaned PATH directories. Ambient lookup could pick up a
+  # repository-local git.exe/gh.exe from the current directory.
+  $realCommand = $null
+  foreach ($dir in ($env:PATH -split ';')) {
+    if (-not $dir) { continue }
+    # Why: a relative entry resolves against the current directory, same exposure as an empty one.
+    if (-not [IO.Path]::IsPathRooted($dir)) { continue }
+    if ($wrapperDirs | Where-Object { [string]::Equals($_, $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }
+    foreach ($ext in @('.exe', '.cmd')) {
+      $candidate = Join-Path $dir "$commandName$ext"
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) { $realCommand = $candidate; break }
+    }
+    if ($realCommand) { break }
+  }
+}
+if (-not $realCommand) {
+  [Console]::Error.WriteLine("Orca compatibility wrapper could not locate $commandName on PATH.")
+  exit 127
+}
+& $realCommand @args
+exit $LASTEXITCODE
+`
+
+function renderWindowsWrapper(template: string, command: string, upperCommand: string): string {
+  return template
+    .replaceAll('__ORCA_UPPER_COMMAND__', upperCommand)
+    .replaceAll('__ORCA_COMMAND__', command)
+}
+
+export function renderLegacyTerminalWindowsCmdTombstone(command: 'git' | 'gh'): string {
+  return renderWindowsWrapper(WIN32_PASSTHROUGH_WRAPPER, command, command.toUpperCase())
+}
+
+export function renderLegacyTerminalWindowsPowerShellTombstone(command: 'git' | 'gh'): string {
+  return renderWindowsWrapper(POWERSHELL_PASSTHROUGH_WRAPPER, command, command.toUpperCase())
+}


### PR DESCRIPTION
## ELI5

Hardening for the retained Windows/POSIX `git`/`gh` compatibility wrappers, from adversarial review of the STA-4169 fix. **One item extends that security fix: it was incomplete.**

## 1. Relative PATH entries still executed a repo-local binary (extends STA-4169)

STA-4169 dropped **empty** PATH elements because an empty element means the current directory. A **relative** element means exactly the same thing and was still kept. Two independent reviewers reproduced a repo-local `git` executing:

```
PATH=".:<realbin>:/usr/bin:/bin"                  → HOSTILE
PATH="node_modules/.bin:<realbin>:/usr/bin:/bin"  → REPO_LOCAL
```

`node_modules/.bin` on PATH is common in JS environments, so this is not exotic. All three wrappers now accept only absolute entries — POSIX `/*`, cmd via a `findstr` anchored drive/UNC match, PowerShell via `IsPathRooted`.

Mutation-tested: weakening the guard back to empty-only makes the test execute `HOSTILE`.

## 2. Empty PATH broke cmd parsing

`%VAR:;=" "%` on an empty variable leaves an unbalanced quote that desynchronizes cmd's parsing for the rest of the file, so the not-found branch emitted `1>&2 was unexpected at this time.` Both substitution loops are now skipped by `goto` when their variable is empty.

## 3. `dirname` dependency could break `git` entirely

The POSIX wrapper computed its own directory by shelling out to `dirname`. If `dirname` was unresolvable the substitution was empty and `cd -- ""` **succeeds**, silently making `wrapper_dir` the cwd — so the wrapper failed to exclude itself, resolved to itself, and reported `git` missing while a working `git` was on PATH. Now uses parameter expansion, no external binary.

## 4. Smaller

- cmd subroutine compares against the cached `%orca_wrapper_dir%`; `%~dp0` is rebound to the label inside `CALL`, which the neighbouring subroutine already accounted for.
- PATH walk probes `.cmd` after `.exe` so a non-`.exe` git is still found.

## Verified on real Windows

`awin`, Windows 10.0.26200, git 2.55.0.windows.3, using the actual generated wrapper:

| case | result |
|---|---|
| Normal | `git version 2.55.0.windows.3`, exit 0 |
| Hostile cwd with planted `git.exe` | real git usage — planted binary ignored |
| `PATH=.;%PATH%` + hostile cwd | `git version …`, exit 0 — relative entry rejected |
| Empty `PATH` | `Orca compatibility wrapper could not locate git on PATH.`, exit **127** |

## Testing

- `pnpm typecheck`, `pnpm lint`: pass
- Full suite: **51,527 passed**; 3 failures, all pre-existing/load-flaky and reproducible on `origin/main`
- POSIX behavioral test extended to leading `:`, trailing `:`, middle `::`, `.`, `..`, and `node_modules/.bin`; mutation-tested
