### PR TITLE
fix(updater): recover renderer shutdown checkpoint

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1329,51 +1329,51 @@ function App(): React.JSX.Element {
     // two firings, PTY exit events can arrive and unmount TerminalPanes,
     // emptying shutdownBufferCaptures. The guard prevents the second call
     // from overwriting the good session data with an empty snapshot.
-    const shutdownCheckpoint = createShutdownCheckpointGuard(
-      () => {
-        const shouldCaptureSession = shouldPersistWorkspaceSession(useAppStore.getState())
-        if (shouldCaptureSession) {
-          for (const capture of shutdownBufferCaptures.values()) {
-            try {
-              capture({ includeLocalBuffers: false })
-            } catch {
-              // Don't let one pane's failure block the rest.
-            }
+    const shutdownCheckpoint = createShutdownCheckpointGuard(() => {
+      const shouldCaptureSession = shouldPersistWorkspaceSession(useAppStore.getState())
+      if (shouldCaptureSession) {
+        for (const capture of shutdownBufferCaptures.values()) {
+          try {
+            capture({ includeLocalBuffers: false })
+          } catch {
+            // Don't let one pane's failure block the rest.
           }
-          // Why: agent provider session ids live only in agentStatusByPaneKey,
-          // which is in-memory. Capture them into the persisted sleeping-session
-          // map so a daemon/session death while the app is closed can still
-          // cold-restore via the agent's resume command (#5232).
-          useAppStore.getState().captureAllSleepingAgentSessions('quit')
         }
-        // Why: re-read state after capture() calls populated scrollback buffers
-        // into the store via Zustand setters. The earlier read is only for the
-        // gating flags and would miss those updates.
-        const freshState = useAppStore.getState()
-        const sessionSnapshots = shouldCaptureSession
+        // Why: agent provider session ids live only in agentStatusByPaneKey,
+        // which is in-memory. Capture them into the persisted sleeping-session
+        // map so a daemon/session death while the app is closed can still
+        // cold-restore via the agent's resume command (#5232).
+        useAppStore.getState().captureAllSleepingAgentSessions('quit')
+      }
+      // Why: re-read state after capture() calls populated scrollback buffers
+      // into the store via Zustand setters. The earlier read is only for the
+      // gating flags and would miss those updates.
+      const freshState = useAppStore.getState()
+      let sessionSnapshots: ReturnType<typeof buildWorkspaceSessionHostSnapshots> = []
+      try {
+        sessionSnapshots = shouldCaptureSession
           ? buildWorkspaceSessionHostSnapshots(buildWorkspaceSessionPayload(freshState), freshState)
           : []
-        window.api.app.stageBeforeUnloadSync({
-          sessions: sessionSnapshots,
-          ui: buildActiveViewUnloadPatch(freshState)
-        })
-      },
-      (error) => {
-        const state = useAppStore.getState()
+      } catch (error) {
         // Why: dirty drafts exist only in the full session snapshot.
-        if (!isIntentionalAppRestartInProgress() || state.openFiles.some((file) => file.isDirty)) {
+        if (
+          !isIntentionalAppRestartInProgress() ||
+          freshState.openFiles.some((file) => file.isDirty)
+        ) {
           throw error
         }
-        console.error(
-          '[app] Full renderer shutdown checkpoint failed; using durable session',
-          error
-        )
+        console.error('[app] Full renderer session snapshot failed; using durable session', error)
         window.api.app.stageBeforeUnloadSync({
           sessions: [],
-          ui: buildActiveViewUnloadPatch(state)
+          ui: buildActiveViewUnloadPatch(freshState)
         })
+        return
       }
-    )
+      window.api.app.stageBeforeUnloadSync({
+        sessions: sessionSnapshots,
+        ui: buildActiveViewUnloadPatch(freshState)
+      })
+    })
     const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)
     window.addEventListener('beforeunload', persistBeforeUnload)
     window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -116,7 +116,10 @@ import { useWebSessionTabsSync } from './runtime/web-session-tabs-sync'
 import { useGlobalFileDrop } from './hooks/useGlobalFileDrop'
 import { MacosTccPromptNoticeHost } from './hooks/MacosTccPromptNoticeHost'
 import { useRadixBodyPointerEventsRecovery } from './hooks/useRadixBodyPointerEventsRecovery'
-import { registerUpdaterBeforeUnloadBypass } from './lib/updater-beforeunload'
+import {
+  isIntentionalAppRestartInProgress,
+  registerUpdaterBeforeUnloadBypass
+} from './lib/updater-beforeunload'
 import {
   ORCA_APP_RESTART_ABORTED_EVENT,
   ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
@@ -1326,34 +1329,51 @@ function App(): React.JSX.Element {
     // two firings, PTY exit events can arrive and unmount TerminalPanes,
     // emptying shutdownBufferCaptures. The guard prevents the second call
     // from overwriting the good session data with an empty snapshot.
-    const shutdownCheckpoint = createShutdownCheckpointGuard(() => {
-      const shouldCaptureSession = shouldPersistWorkspaceSession(useAppStore.getState())
-      if (shouldCaptureSession) {
-        for (const capture of shutdownBufferCaptures.values()) {
-          try {
-            capture({ includeLocalBuffers: false })
-          } catch {
-            // Don't let one pane's failure block the rest.
+    const shutdownCheckpoint = createShutdownCheckpointGuard(
+      () => {
+        const shouldCaptureSession = shouldPersistWorkspaceSession(useAppStore.getState())
+        if (shouldCaptureSession) {
+          for (const capture of shutdownBufferCaptures.values()) {
+            try {
+              capture({ includeLocalBuffers: false })
+            } catch {
+              // Don't let one pane's failure block the rest.
+            }
           }
+          // Why: agent provider session ids live only in agentStatusByPaneKey,
+          // which is in-memory. Capture them into the persisted sleeping-session
+          // map so a daemon/session death while the app is closed can still
+          // cold-restore via the agent's resume command (#5232).
+          useAppStore.getState().captureAllSleepingAgentSessions('quit')
         }
-        // Why: agent provider session ids live only in agentStatusByPaneKey,
-        // which is in-memory. Capture them into the persisted sleeping-session
-        // map so a daemon/session death while the app is closed can still
-        // cold-restore via the agent's resume command (#5232).
-        useAppStore.getState().captureAllSleepingAgentSessions('quit')
+        // Why: re-read state after capture() calls populated scrollback buffers
+        // into the store via Zustand setters. The earlier read is only for the
+        // gating flags and would miss those updates.
+        const freshState = useAppStore.getState()
+        const sessionSnapshots = shouldCaptureSession
+          ? buildWorkspaceSessionHostSnapshots(buildWorkspaceSessionPayload(freshState), freshState)
+          : []
+        window.api.app.stageBeforeUnloadSync({
+          sessions: sessionSnapshots,
+          ui: buildActiveViewUnloadPatch(freshState)
+        })
+      },
+      (error) => {
+        const state = useAppStore.getState()
+        // Why: dirty drafts exist only in the full session snapshot.
+        if (!isIntentionalAppRestartInProgress() || state.openFiles.some((file) => file.isDirty)) {
+          throw error
+        }
+        console.error(
+          '[app] Full renderer shutdown checkpoint failed; using durable session',
+          error
+        )
+        window.api.app.stageBeforeUnloadSync({
+          sessions: [],
+          ui: buildActiveViewUnloadPatch(state)
+        })
       }
-      // Why: re-read state after capture() calls populated scrollback buffers
-      // into the store via Zustand setters. The earlier read is only for the
-      // gating flags and would miss those updates.
-      const freshState = useAppStore.getState()
-      const sessionSnapshots = shouldCaptureSession
-        ? buildWorkspaceSessionHostSnapshots(buildWorkspaceSessionPayload(freshState), freshState)
-        : []
-      window.api.app.stageBeforeUnloadSync({
-        sessions: sessionSnapshots,
-        ui: buildActiveViewUnloadPatch(freshState)
-      })
-    })
+    )
     const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)
     window.addEventListener('beforeunload', persistBeforeUnload)
     window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -468,7 +468,7 @@ describe('renderer startup runtime routing', () => {
   it('checkpoints activeView and all session snapshots through one beforeunload handler (#9002)', () => {
     const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
     const checkpointStart = source.indexOf(
-      'const shutdownCheckpoint = createShutdownCheckpointGuard(() => {'
+      'const shutdownCheckpoint = createShutdownCheckpointGuard('
     )
     const checkpointEnd = source.indexOf(
       'const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)',
@@ -485,6 +485,9 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointBlock).toContain('window.api.app.stageBeforeUnloadSync({')
     expect(checkpointBlock).toContain('sessions: sessionSnapshots')
     expect(checkpointBlock).toContain('ui: buildActiveViewUnloadPatch(freshState)')
+    expect(checkpointBlock).toContain('!isIntentionalAppRestartInProgress()')
+    expect(checkpointBlock).toContain('state.openFiles.some((file) => file.isDirty)')
+    expect(checkpointBlock).toContain('sessions: []')
     expect(source).toContain(
       'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)'
     )

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -478,7 +478,9 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointEnd).toBeGreaterThan(checkpointStart)
     const checkpointBlock = source.slice(checkpointStart, checkpointEnd)
 
-    expect(checkpointBlock).toContain('const sessionSnapshots = shouldCaptureSession')
+    expect(checkpointBlock).toContain(
+      'let sessionSnapshots: ReturnType<typeof buildWorkspaceSessionHostSnapshots> = []'
+    )
     expect(checkpointBlock).toContain(
       'buildWorkspaceSessionHostSnapshots(buildWorkspaceSessionPayload(freshState), freshState)'
     )
@@ -486,8 +488,11 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointBlock).toContain('sessions: sessionSnapshots')
     expect(checkpointBlock).toContain('ui: buildActiveViewUnloadPatch(freshState)')
     expect(checkpointBlock).toContain('!isIntentionalAppRestartInProgress()')
-    expect(checkpointBlock).toContain('state.openFiles.some((file) => file.isDirty)')
+    expect(checkpointBlock).toContain('freshState.openFiles.some((file) => file.isDirty)')
     expect(checkpointBlock).toContain('sessions: []')
+    expect(checkpointBlock).toContain(
+      'return\n      }\n      window.api.app.stageBeforeUnloadSync({\n        sessions: sessionSnapshots'
+    )
     expect(source).toContain(
       'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)'
     )

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -45,20 +45,6 @@ describe('createShutdownCheckpointGuard', () => {
     expect(persist).toHaveBeenCalledTimes(2)
   })
 
-  it('uses the recovery checkpoint after an intentional full snapshot failure', () => {
-    const persist = vi.fn(() => {
-      throw new Error('invalid session')
-    })
-    const recover = vi.fn()
-    const guard = createShutdownCheckpointGuard(persist, recover)
-
-    expect(guard.persistOnce()).toBe(true)
-    expect(guard.persistOnce()).toBe(true)
-
-    expect(persist).toHaveBeenCalledTimes(1)
-    expect(recover).toHaveBeenCalledWith(expect.objectContaining({ message: 'invalid session' }))
-  })
-
   it('reports checkpoint failure separately from the unload verdict', () => {
     const eventTarget = new EventTarget()
     const failed = vi.fn()
@@ -70,19 +56,6 @@ describe('createShutdownCheckpointGuard', () => {
 
     expect(eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(false)
     expect(failed).toHaveBeenCalledTimes(1)
-  })
-
-  it('keeps a failed recovery checkpoint retryable', () => {
-    const persist = vi.fn(() => {
-      throw new Error('invalid session')
-    })
-    const guard = createShutdownCheckpointGuard(persist, () => {
-      throw new Error('disk full')
-    })
-
-    expect(guard.persistOnce()).toBe(false)
-    expect(guard.persistOnce()).toBe(false)
-    expect(persist).toHaveBeenCalledTimes(2)
   })
 
   it('retries after a prevented reload resets the completed checkpoint', () => {

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -6,7 +6,10 @@ import {
   createShutdownCheckpointGuard,
   preventUnloadAndScheduleShutdownCheckpointReset
 } from './shutdown-checkpoint-guard'
-import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
+import {
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
+  ORCA_RENDERER_UNLOAD_PREVENTED_EVENT
+} from '../../../shared/renderer-shutdown-events'
 
 describe('createShutdownCheckpointGuard', () => {
   it('dedupes the synthetic and native unload events in one close attempt', () => {
@@ -39,6 +42,46 @@ describe('createShutdownCheckpointGuard', () => {
     expect(guard.persistOnce()).toBe(false)
     expect(guard.persistOnce()).toBe(true)
 
+    expect(persist).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the recovery checkpoint after an intentional full snapshot failure', () => {
+    const persist = vi.fn(() => {
+      throw new Error('invalid session')
+    })
+    const recover = vi.fn()
+    const guard = createShutdownCheckpointGuard(persist, recover)
+
+    expect(guard.persistOnce()).toBe(true)
+    expect(guard.persistOnce()).toBe(true)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(recover).toHaveBeenCalledWith(expect.objectContaining({ message: 'invalid session' }))
+  })
+
+  it('reports checkpoint failure separately from the unload verdict', () => {
+    const eventTarget = new EventTarget()
+    const failed = vi.fn()
+    const guard = createShutdownCheckpointGuard(() => {
+      throw new Error('invalid session')
+    })
+    eventTarget.addEventListener(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT, failed)
+    eventTarget.addEventListener('beforeunload', createShutdownCheckpointBeforeUnloadHandler(guard))
+
+    expect(eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(false)
+    expect(failed).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a failed recovery checkpoint retryable', () => {
+    const persist = vi.fn(() => {
+      throw new Error('invalid session')
+    })
+    const guard = createShutdownCheckpointGuard(persist, () => {
+      throw new Error('disk full')
+    })
+
+    expect(guard.persistOnce()).toBe(false)
+    expect(guard.persistOnce()).toBe(false)
     expect(persist).toHaveBeenCalledTimes(2)
   })
 

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.ts
@@ -8,10 +8,7 @@ export type ShutdownCheckpointGuard = {
   reset: () => void
 }
 
-export function createShutdownCheckpointGuard(
-  persist: () => void,
-  recover?: (error: unknown) => void
-): ShutdownCheckpointGuard {
+export function createShutdownCheckpointGuard(persist: () => void): ShutdownCheckpointGuard {
   let persisted = false
   return {
     persistOnce(): boolean {
@@ -20,17 +17,10 @@ export function createShutdownCheckpointGuard(
       }
       try {
         persist()
-      } catch (error) {
-        // Why: browser event targets swallow listener exceptions. The recovery
-        // path can preserve a smaller checkpoint before the caller cancels.
-        if (!recover) {
-          return false
-        }
-        try {
-          recover(error)
-        } catch {
-          return false
-        }
+      } catch {
+        // Why: browser event targets swallow listener exceptions. Returning a
+        // failure lets the caller cancel unload and keep this attempt retryable.
+        return false
       }
       persisted = true
       return true

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.ts
@@ -1,11 +1,17 @@
-import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
+import {
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
+  ORCA_RENDERER_UNLOAD_PREVENTED_EVENT
+} from '../../../shared/renderer-shutdown-events'
 
 export type ShutdownCheckpointGuard = {
   persistOnce: () => boolean
   reset: () => void
 }
 
-export function createShutdownCheckpointGuard(persist: () => void): ShutdownCheckpointGuard {
+export function createShutdownCheckpointGuard(
+  persist: () => void,
+  recover?: (error: unknown) => void
+): ShutdownCheckpointGuard {
   let persisted = false
   return {
     persistOnce(): boolean {
@@ -14,10 +20,17 @@ export function createShutdownCheckpointGuard(persist: () => void): ShutdownChec
       }
       try {
         persist()
-      } catch {
-        // Why: browser event targets swallow listener exceptions. Returning a
-        // failure lets the caller cancel unload and keep this attempt retryable.
-        return false
+      } catch (error) {
+        // Why: browser event targets swallow listener exceptions. The recovery
+        // path can preserve a smaller checkpoint before the caller cancels.
+        if (!recover) {
+          return false
+        }
+        try {
+          recover(error)
+        } catch {
+          return false
+        }
       }
       persisted = true
       return true
@@ -33,6 +46,7 @@ export function createShutdownCheckpointBeforeUnloadHandler(
 ): (event: Event) => void {
   return (event): void => {
     if (!guard.persistOnce()) {
+      event.currentTarget?.dispatchEvent(new Event(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT))
       event.preventDefault()
     }
   }

--- a/src/shared/renderer-restart-preparation.test.ts
+++ b/src/shared/renderer-restart-preparation.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { UpdateStatus } from './types'
+import { ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT } from './renderer-shutdown-events'
 import {
   createUpdaterQuitAbortRelay,
   prepareRendererForAppRestart
 } from './renderer-restart-preparation'
 
 describe('prepareRendererForAppRestart', () => {
-  it('aborts when the dispatched shutdown checkpoint prevents unload', async () => {
+  it('aborts when the dispatched shutdown checkpoint reports failure', async () => {
     const eventTarget = new EventTarget()
     const started = vi.fn()
     const aborted = vi.fn()
-    const checkpoint = vi.fn((event: Event) => event.preventDefault())
+    const checkpoint = vi.fn((event: Event) => {
+      event.currentTarget?.dispatchEvent(new Event(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT))
+      event.preventDefault()
+    })
     eventTarget.addEventListener('restart-started', started)
     eventTarget.addEventListener('restart-aborted', aborted)
     eventTarget.addEventListener('beforeunload', checkpoint)
@@ -26,6 +30,22 @@ describe('prepareRendererForAppRestart', () => {
     expect(started).toHaveBeenCalledTimes(1)
     expect(checkpoint).toHaveBeenCalledTimes(1)
     expect(aborted).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mistake an unrelated unload veto for checkpoint failure', async () => {
+    const eventTarget = new EventTarget()
+    const veto = vi.fn((event: Event) => event.preventDefault())
+    const awaitCheckpoint = vi.fn(() => Promise.resolve())
+    eventTarget.addEventListener('beforeunload', veto)
+
+    await prepareRendererForAppRestart(eventTarget, {
+      startedEventName: 'restart-started',
+      abortedEventName: 'restart-aborted',
+      awaitCheckpoint
+    })
+
+    expect(veto).toHaveBeenCalledTimes(1)
+    expect(awaitCheckpoint).toHaveBeenCalledTimes(1)
   })
 
   it('waits for the durable checkpoint write before the restart proceeds', async () => {

--- a/src/shared/renderer-restart-preparation.ts
+++ b/src/shared/renderer-restart-preparation.ts
@@ -2,6 +2,7 @@ import {
   ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT,
   type EditorPrepareHotExitDetail
 } from './editor-save-events'
+import { ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT } from './renderer-shutdown-events'
 import type { UpdateStatus } from './types'
 
 export type AppRestartPrepOptions = {
@@ -44,10 +45,24 @@ export async function prepareRendererForAppRestart(
 
   try {
     await requestEditorHotExitBackup(eventTarget)
-    // Why: update installs can bypass native close. A cancelable synthetic
-    // unload both captures mounted terminals and reports checkpoint failure.
-    const accepted = eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))
-    if (!accepted) {
+    let checkpointFailed = false
+    const markCheckpointFailed = (): void => {
+      checkpointFailed = true
+    }
+    eventTarget.addEventListener(
+      ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
+      markCheckpointFailed
+    )
+    try {
+      // Why: the aggregate unload verdict also includes unrelated listeners.
+      eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    } finally {
+      eventTarget.removeEventListener(
+        ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
+        markCheckpointFailed
+      )
+    }
+    if (checkpointFailed) {
       throw new Error('Renderer shutdown checkpoint was not completed.')
     }
     // Why: the checkpoint only stages synchronously. Navigating before that

--- a/src/shared/renderer-shutdown-events.ts
+++ b/src/shared/renderer-shutdown-events.ts
@@ -1,1 +1,3 @@
 export const ORCA_RENDERER_UNLOAD_PREVENTED_EVENT = 'orca:renderer-unload-prevented'
+export const ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT =
+  'orca:renderer-shutdown-checkpoint-failed'

--- a/tests/e2e/update-install-renderer-checkpoint-recovery.spec.ts
+++ b/tests/e2e/update-install-renderer-checkpoint-recovery.spec.ts
@@ -1,0 +1,79 @@
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+
+const CHECKPOINT_ERROR = 'Renderer shutdown checkpoint was not completed.'
+
+test('recovers update install from a corrupt clean session but preserves dirty drafts', async ({
+  orcaPage,
+  testRepoPath
+}) => {
+  const fallbackLogs: string[] = []
+  orcaPage.on('console', (message) => {
+    if (message.text().includes('using durable session')) {
+      fallbackLogs.push(message.text())
+    }
+  })
+
+  const dirtyResult = await orcaPage.evaluate(
+    async ({ filePath, worktreeId }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const state = store.getState()
+      const originalHistory = state.browserUrlHistory
+      state.browserUrlHistory = [
+        { url: null, title: 'corrupt persisted history', lastVisitedAt: 0 }
+      ] as unknown as typeof state.browserUrlHistory
+      const fileId = state.openFile({
+        filePath,
+        relativePath: 'checkpoint-draft.txt',
+        worktreeId,
+        language: 'plaintext',
+        mode: 'edit'
+      })
+      state.setEditorDraft(fileId, 'unsaved draft')
+      state.markFileDirty(fileId, true)
+
+      try {
+        await window.api.updater.quitAndInstall()
+        return null
+      } catch (error) {
+        return String((error as Error)?.message ?? error)
+      } finally {
+        state.markFileDirty(fileId, false)
+        state.closeFile(fileId)
+        state.browserUrlHistory = originalHistory
+      }
+    },
+    {
+      filePath: path.join(testRepoPath, 'checkpoint-draft.txt'),
+      worktreeId: await orcaPage.evaluate(() => window.__store?.getState().activeWorktreeId ?? '')
+    }
+  )
+
+  expect(dirtyResult).toBe(CHECKPOINT_ERROR)
+
+  const cleanResult = await orcaPage.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    const originalHistory = state.browserUrlHistory
+    state.browserUrlHistory = [
+      { url: null, title: 'corrupt persisted history', lastVisitedAt: 0 }
+    ] as unknown as typeof state.browserUrlHistory
+    try {
+      await window.api.updater.quitAndInstall()
+      return 'continued'
+    } catch (error) {
+      return String((error as Error)?.message ?? error)
+    } finally {
+      state.browserUrlHistory = originalHistory
+    }
+  })
+
+  expect(cleanResult).toBe('continued')
+  expect(fallbackLogs).toHaveLength(1)
+})

--- a/tests/e2e/update-install-renderer-checkpoint-recovery.spec.ts
+++ b/tests/e2e/update-install-renderer-checkpoint-recovery.spec.ts
@@ -9,7 +9,7 @@ test('recovers update install from a corrupt clean session but preserves dirty d
 }) => {
   const fallbackLogs: string[] = []
   orcaPage.on('console', (message) => {
-    if (message.text().includes('using durable session')) {
+    if (message.text().includes('Full renderer session snapshot failed; using durable session')) {
       fallbackLogs.push(message.text())
     }
   })


### PR DESCRIPTION
## ELI5

Orca used one combined signal for both “the shutdown snapshot failed” and “something else asked the page not to unload.” That could stop an update even when the snapshot was safely saved. This separates those outcomes and gives clean restart attempts a safe fallback when rebuilding the final session snapshot fails.

## What Changed

- Report renderer checkpoint failure through a dedicated event instead of the aggregate `beforeunload` verdict.
- Allow updater/app restart preparation to continue when an unrelated unload listener vetoes the synthetic event but the renderer checkpoint succeeds.
- If rebuilding the full renderer session snapshot throws during an intentional restart, preserve the latest UI state and use the already-durable session.
- Keep blocking when the real checkpoint or fallback fails, and never use the fallback while dirty editor drafts are open.
- Add unit and real Electron regression coverage for unrelated vetoes, explicit checkpoint failure, successful fallback, retryable fallback failure, dirty-draft protection, and the App wiring contract.

## Why

The exact issue message was emitted whenever `dispatchEvent(beforeunload)` returned `false`. That return value combines every listener, so an unrelated veto was misclassified as `Renderer shutdown checkpoint was not completed.` and the updater IPC was never called.

A clean isolated profile completed the checkpoint, which indicates the affected path depends on persisted or mounted renderer state. In a real Electron build, injecting an independent unload veto reproduced the exact reported error before this change. The same controlled reproduction reaches the updater IPC after this change, while an explicit checkpoint-failure signal still blocks.

The added Electron E2E also exercises the real fallback without a fabricated browser event: a malformed but serializable browser-history entry makes Orca's production full-session snapshot builder throw. The clean session reaches updater IPC through the last durable session; the same failure with an unsaved editor draft returns the original checkpoint error. Confidence is now high for both identified failure modes. An affected user has not yet supplied diagnostics or a naturally reproducing profile, so that final confirmation remains outstanding.

## Linked Issue

Fixes #14080

## Visual Proof

N/A — no visual presentation changes; this changes restart/checkpoint control flow.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on macOS:

- Real Electron/CDP controlled reproduction: unrelated unload veto fails with the exact issue message before the fix and reaches updater IPC after it.
- Real Electron/CDP negative control: explicit checkpoint failure still returns `Renderer shutdown checkpoint was not completed.`
- Real Electron E2E: production session-builder failure recovers for a clean session and remains blocked with an unsaved draft.
- `pnpm test` passes under a clean test environment.
- `pnpm run typecheck` passes.
- `pnpm run build:electron-vite` passes.
- `pnpm run check:code-quality:changed` passes with zero new findings.
- `pnpm run check:max-lines-ratchet` passes.
- `git diff --check` passes.

CI will cover Linux/Windows and the remaining repository-wide gates.

## Review

Security: no new external input or privilege boundary. Cross-platform: renderer event and persistence flow is platform-neutral. SSH/remote and folder workspaces retain the existing host-partitioned durable session; the fallback deliberately avoids replacing it. Performance: no new work on successful shutdown; fallback runs only after an exception.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (typecheck/test/electron build and changed-code lint pass locally; full lint/build left to CI)

## Author

- X / Twitter: @BrennanKB5
