### PR TITLE
fix(terminal): ground the emulator to the snapshot's baseline after a byte gap

### DIFF
--- a/src/main/daemon/terminal-snapshot-color-parity.test.ts
+++ b/src/main/daemon/terminal-snapshot-color-parity.test.ts
@@ -21,7 +21,7 @@ async function restoreSerializedTerminal(source: ParityTerminal): Promise<Parity
   const restored = createRendererParityTerminal({ cols: snapshot.cols, rows: snapshot.rows })
   const preamble =
     snapshot.alternateScreen && snapshot.scrollbackAnsi !== undefined
-      ? `\x1b[?1049l\x1b[2J\x1b[3J\x1b[H${snapshot.scrollbackAnsi}${SNAPSHOT_REPLAY_PREAMBLE_ALT}`
+      ? `${SNAPSHOT_REPLAY_PREAMBLE_NORMAL}${snapshot.scrollbackAnsi}${SNAPSHOT_REPLAY_PREAMBLE_ALT}`
       : snapshot.alternateScreen
         ? SNAPSHOT_REPLAY_PREAMBLE_ALT
         : SNAPSHOT_REPLAY_PREAMBLE_NORMAL

--- a/src/renderer/src/components/terminal-pane/hidden-reveal-reconciliation.fuzz.test.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-reveal-reconciliation.fuzz.test.ts
@@ -133,7 +133,7 @@ async function revealFromSnapshot(
     // The pending escape tail must be the FINAL replay write (mirrors applyMainBufferSnapshot); a later ESC would abort the dangling sequence.
     const preamble =
       alt && snapshot.scrollbackAnsi !== undefined
-        ? `\x1b[?1049l\x1b[2J\x1b[3J\x1b[H${snapshot.scrollbackAnsi}${SNAPSHOT_REPLAY_PREAMBLE_ALT}`
+        ? `${SNAPSHOT_REPLAY_PREAMBLE_NORMAL}${snapshot.scrollbackAnsi}${SNAPSHOT_REPLAY_PREAMBLE_ALT}`
         : alt
           ? SNAPSHOT_REPLAY_PREAMBLE_ALT
           : SNAPSHOT_REPLAY_PREAMBLE_NORMAL

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -9,10 +9,14 @@ import {
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
   POST_REPLAY_REATTACH_RESET_KEEP_MOUSE,
+  ABORT_TRUNCATED_CONTROL_STRING,
+  buildSnapshotReplayPrologue,
   RESET_AFTER_BYTE_GAP,
   RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from '../../../../shared/terminal-mode-reset-profiles'
+
+const NORMAL_BUFFER_PROLOGUE = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue({ targetAlternateScreen: false, paneOnAlternateScreen: false })}`
 import { buildFreshShellViewportBlankingSequence } from './terminal-restored-viewport'
 import { DEFAULT_DA1_RESPONSE } from './terminal-capability-replies'
 import { TERMINAL_PASTE_DIRECT_MAX_BYTES } from './terminal-paste-coordinator'
@@ -500,7 +504,9 @@ function createPaneContainer(): HTMLElement {
 function createPane(paneId: number) {
   const leafId = leafIdForPane(paneId)
   const activeBuffer = {
-    type: 'normal' as const,
+    // Mutable so a test can put the pane on the alt screen: the replay prologue
+    // only switches buffers when this disagrees with the snapshot.
+    type: 'normal' as 'normal' | 'alternate',
     viewportY: 0,
     baseY: 0,
     cursorY: 0,
@@ -10565,7 +10571,7 @@ describe('connectPanePty', () => {
       claim: true
     })
     expect(written).toContain(viewportClear)
-    expect(written).not.toContain(`${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`)
+    expect(written).not.toContain(NORMAL_BUFFER_PROLOGUE)
     expect(written).toEqual(
       expect.arrayContaining([coldScrollback, POST_REPLAY_MODE_RESET, blankViewport])
     )
@@ -15610,6 +15616,10 @@ describe('connectPanePty', () => {
       4
     )
     expect(actual).toEqual(expected)
+    // The imageless snapshot skips the repaint, but the gap still happened — so
+    // the pen is grounded anyway, with the live-path constant since nothing
+    // repaints over whatever is still running here.
+    expect(restoreWrites).toContain(RESET_AFTER_BYTE_GAP)
     expect(transport.serializeBufferOutcome).toHaveBeenCalledTimes(1)
     expect(transport.serializeBuffer).not.toHaveBeenCalled()
     disposable.dispose()
@@ -15796,6 +15806,56 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  // The conditional buffer switch is the riskiest logic in the replay prologue,
+  // and the pane mock is on the normal buffer everywhere else — so a stubbed
+  // `() => false` would pass the whole suite. Put the pane on the alt screen and
+  // pin that a normal-buffer snapshot really does emit the `?1049l` unstick.
+  it('emits the alt-screen unstick when the pane is on alt and the model is not', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible-after\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'snapshot-state\r\n',
+      cols: 100,
+      rows: 30,
+      seq: hidden.length + live.length
+    })
+
+    const pane = createPane(1)
+    // The gap ate the TUI's own `?1049l`, so the renderer is still on alt.
+    pane.terminal.buffer.active.type = 'alternate'
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    const written = pane.terminal.write.mock.calls.map(([data]) => data as string)
+    const prologue = written.find((data) => data.startsWith(ABORT_TRUNCATED_CONTROL_STRING))
+    expect(prologue).toBeDefined()
+    expect(prologue).toContain('\x1b[?1049l')
+    expect(prologue).not.toBe(NORMAL_BUFFER_PROLOGUE)
+    disposable.dispose()
+  })
+
   // Why: pins the switch-off hidden fallback chain — 2MB lossy cap drops the backlog, latches restore, and reveal repaints from the model snapshot.
   it('restores hidden backlog overflow from the main terminal snapshot on foreground output', async () => {
     const { connectPanePty } = await import('./pty-connection')
@@ -15840,10 +15900,7 @@ describe('connectPanePty', () => {
 
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
     expect(pane.terminal.resize).toHaveBeenCalledWith(100, 30)
-    expect(pane.terminal.write).toHaveBeenCalledWith(
-      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
-      expect.any(Function)
-    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(NORMAL_BUFFER_PROLOGUE, expect.any(Function))
     expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
     disposable.dispose()
@@ -15893,27 +15950,28 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(20)
 
     expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
-    expect(pane.terminal.write).toHaveBeenCalledWith(
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
-      expect.any(Function)
-    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(NORMAL_BUFFER_PROLOGUE, expect.any(Function))
     expect(pane.terminal.write).toHaveBeenCalledWith(
       'preserved-shell-history\r\n',
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
+      buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: false }),
       expect.any(Function)
     )
     const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
       (call) => call[0]
     )
     expect(writes.indexOf('preserved-shell-history\r\n')).toBeLessThan(
-      writes.indexOf(`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`)
+      writes.indexOf(
+        buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: false })
+      )
     )
-    expect(writes.indexOf(`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`)).toBeLessThan(
-      writes.indexOf('altscreen-snapshot\r\n')
-    )
+    expect(
+      writes.indexOf(
+        buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: false })
+      )
+    ).toBeLessThan(writes.indexOf('altscreen-snapshot\r\n'))
     expect(pane.terminal.write).toHaveBeenCalledWith('altscreen-snapshot\r\n', expect.any(Function))
     disposable.dispose()
   })
@@ -16176,6 +16234,9 @@ describe('connectPanePty', () => {
     const combinedLiveIndex = written.indexOf(firstLive + secondLive)
     expect(warningIndex).toBeGreaterThanOrEqual(0)
     expect(written[warningIndex - 1]).toBe(RESET_AFTER_BYTE_GAP)
+    // Exactly one: writeRestoreUnavailableWarning already grounds the gap, so a
+    // second unconditional write here was pure duplication.
+    expect(written.filter((data) => data === RESET_AFTER_BYTE_GAP)).toHaveLength(1)
     expect(combinedLiveIndex).toBeGreaterThan(warningIndex)
 
     snapshot.resolve({
@@ -16289,6 +16350,9 @@ describe('connectPanePty', () => {
     const liveIndex = written.indexOf(live)
     expect(resetIndex).toBeGreaterThanOrEqual(0)
     expect(liveIndex).toBeGreaterThan(resetIndex)
+    // The re-arm arm grounds in rearmRemoteHiddenOutputRestoreInsteadOfWarning,
+    // so the abandon body must not ground a second time.
+    expect(written.filter((data) => data === RESET_AFTER_BYTE_GAP)).toHaveLength(1)
     expect(written.join('')).not.toContain('main recovery was unavailable')
 
     disposable.dispose()
@@ -16344,6 +16408,10 @@ describe('connectPanePty', () => {
     expect(getMainBufferSnapshot).toHaveBeenCalledTimes(4)
     expect(warningIndex).toBeGreaterThanOrEqual(0)
     expect(liveIndex).toBeGreaterThan(warningIndex)
+    // This arm gives up on recovery too, so the gap is grounded exactly once
+    // before the blocked foreground is drained under it.
+    expect(written.filter((data) => data === RESET_AFTER_BYTE_GAP)).toHaveLength(1)
+    expect(written.indexOf(RESET_AFTER_BYTE_GAP)).toBeLessThan(liveIndex)
     disposable.dispose()
   })
 
@@ -16810,7 +16878,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.clear).toHaveBeenCalled()
     expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
+      NORMAL_BUFFER_PROLOGUE,
       expect.any(Function)
     )
     disposable.dispose()
@@ -17708,7 +17776,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
+      NORMAL_BUFFER_PROLOGUE,
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -6474,6 +6474,20 @@ export function connectPanePty(
     liveScrollbackRestore?.dispose()
     liveScrollbackRestore = installTerminalLiveScrollbackRestore(pane.terminal)
 
+    // Why read it live: `?1049` is not a no-op when the pane is already on the
+    // target buffer — xterm still runs restoreCursor and swaps the kitty flag
+    // registers — so the replay prologue must only switch when it truly differs.
+    //
+    // Best-effort by design. xterm parses asynchronously, so this sees only
+    // PARSED writes; a `?1049` transition still queued reads stale. Draining
+    // first with a write sentinel was tried and reverted: it puts the repaint
+    // behind xterm's queue, so a wedged terminal stalls recovery, and it breaks
+    // the disposal/cancellation ordering the restore paths rely on. A stale read
+    // costs one mis-scoped buffer switch; the barrier costs the repaint.
+    function isPaneOnAlternateScreen(): boolean {
+      return pane.terminal.buffer.active.type === 'alternate'
+    }
+
     function writePtyOutputToXterm(
       data: string,
       foreground: boolean,
@@ -7174,11 +7188,11 @@ export function connectPanePty(
         clearHiddenOutputRestoreFloodRepaintTimer()
         writeRestoreUnavailableWarning()
       }
-      // Why not an else: the unavailable warning is plain text and carries no SGR
-      // of its own, so folding the reset into the other branch skipped it on the
-      // primary abandon path — the one that declares the bytes unrecoverable.
-      // Guarded only against the remote re-arm, which writes its own reset.
-      if (!rearmedRemoteRestore) {
+      // Why an else: the branch above already grounds the gap inside
+      // writeRestoreUnavailableWarning, and the remote re-arm grounds it in
+      // rearmRemoteHiddenOutputRestoreInsteadOfWarning. Only the quiet
+      // flood-abandon reaches neither, and it still drains chunks below.
+      else if (!rearmedRemoteRestore) {
         writePtyOutputToXterm(RESET_AFTER_BYTE_GAP, true)
       }
       if (hadPendingOverflow) {
@@ -7410,9 +7424,16 @@ export function connectPanePty(
             // Why: an imageless success is not proof the pane is empty; normal replay clears screen and scrollback.
             const snapshotCarriesNoImage =
               snapshot.alternateScreen !== true && snapshot.data === '' && !snapshot.scrollbackAnsi
-            if (!snapshotCarriesNoImage) {
+            if (snapshotCarriesNoImage) {
+              // Why still ground: a restore only runs because bytes were dropped, so
+              // the gap's pen outlives a snapshot that cannot repaint over it. The
+              // live-path constant, not the replay baseline — nothing repaints here,
+              // so the pane is handed back to whatever is still running.
+              writeReplayData(RESET_AFTER_BYTE_GAP)
+            } else {
               for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
-                skipAltFrame: skippedAltFrame
+                skipAltFrame: skippedAltFrame,
+                paneOnAlternateScreen: isPaneOnAlternateScreen()
               })) {
                 writeReplayData(replayChunk)
               }
@@ -8124,7 +8145,9 @@ export function connectPanePty(
                 snapshotSeq: snapshot.seq
               })
               // Why keep a too-wide frame: preconnect SSH has no live repaint owner or post-restore fit.
-              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot)) {
+              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
+                paneOnAlternateScreen: isPaneOnAlternateScreen()
+              })) {
                 writeReplayData(replayChunk)
               }
               writeReplayData(reattachReplayResetSequence(modelData))
@@ -8433,7 +8456,8 @@ export function connectPanePty(
               skipAltFrame: shouldSkipAltFrameForWidthMismatch(
                 modelCols,
                 readProposedTerminalCols(pane)
-              )
+              ),
+              paneOnAlternateScreen: isPaneOnAlternateScreen()
             })) {
               writeReplayData(replayChunk)
             }

--- a/src/renderer/src/components/terminal-pane/terminal-replay-application-continuity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-application-continuity.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
+import {
+  buildParityMainBufferSnapshot,
+  createRendererParityTerminal,
+  writeToTerminal
+} from '../../../../shared/terminal-restore-parity-fixture'
+import { buildMainModelSnapshotReplayWrites } from './terminal-snapshot-replay-paint'
+
+/**
+ * What a LIVE application sees after its pane is restored from a main-model
+ * snapshot. The sibling suite proves the restored frame is correct; this one
+ * proves the replay does not confiscate state the application still owns and
+ * will not re-declare.
+ *
+ * Grounded in real capability strings (`infocmp`), because the one regression
+ * that reached review here was a terminfo family nobody had enumerated.
+ */
+
+async function replayInto(
+  terminal: Terminal,
+  model: ReturnType<typeof createRendererParityTerminal>,
+  paneOnAlternateScreen: boolean
+): Promise<void> {
+  const snapshot = buildParityMainBufferSnapshot(model, 1)
+  for (const write of buildMainModelSnapshotReplayWrites(snapshot, { paneOnAlternateScreen })) {
+    await writeToTerminal(terminal, write)
+  }
+}
+
+function row(terminal: Terminal, index: number): string {
+  return terminal.buffer.active.getLine(index)?.translateToString(true) ?? ''
+}
+
+/** Text alone cannot see a stranded pen: include the attributes per cell. */
+function rowWithAttributes(terminal: Terminal, index: number): string {
+  const line = terminal.buffer.active.getLine(index)
+  if (!line) {
+    return ''
+  }
+  const cells: string[] = []
+  for (let column = 0; column < line.length; column++) {
+    const cell = line.getCell(column)
+    if (!cell) {
+      continue
+    }
+    cells.push(
+      `${cell.getChars()}|${cell.isBold() ? 'b' : ''}${cell.isInverse() ? 'i' : ''}${cell.getFgColor()}`
+    )
+  }
+  return cells.join(',')
+}
+
+describe('line-drawing survives a replay for every real terminfo strategy', () => {
+  // Verbatim from `infocmp`. The two families differ in who owns the
+  // designation: xterm/alacritty re-designate G0 on every smacs, so they
+  // self-heal; the SO/SI family designates G1 once via enacs and never again.
+  const acsStrategies = [
+    { term: 'xterm-256color', enacs: '', smacs: '\x1b(0', rmacs: '\x1b(B' },
+    { term: 'alacritty', enacs: '', smacs: '\x1b(0', rmacs: '\x1b(B' },
+    { term: 'screen-256color', enacs: '\x1b(B\x1b)0', smacs: '\x0e', rmacs: '\x0f' },
+    { term: 'tmux-256color', enacs: '\x1b(B\x1b)0', smacs: '\x0e', rmacs: '\x0f' },
+    { term: 'vt100', enacs: '\x1b(B\x1b)0', smacs: '\x0e', rmacs: '\x0f' },
+    { term: 'linux', enacs: '\x1b)0', smacs: '\x0e', rmacs: '\x0f' }
+  ] as const
+
+  for (const { term, enacs, smacs, rmacs } of acsStrategies) {
+    it(`draws a box after a normal-buffer replay under ${term}`, async () => {
+      const model = createRendererParityTerminal({ cols: 20, rows: 4 })
+      const pane = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+      try {
+        await writeToTerminal(model.terminal, 'restored output')
+        // The application initialises its charsets once, before the gap.
+        await writeToTerminal(pane, enacs)
+
+        await replayInto(pane, model, false)
+        await writeToTerminal(pane, `\r\n${smacs}lqqqk${rmacs}`)
+
+        expect(row(pane, 1)).toBe('┌───┐')
+      } finally {
+        model.terminal.dispose()
+        pane.dispose()
+      }
+    })
+
+    it(`draws a box after an alt-screen replay under ${term}`, async () => {
+      const model = createRendererParityTerminal({ cols: 20, rows: 4 })
+      const pane = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+      try {
+        await writeToTerminal(model.terminal, '\x1b[?1049hTUI FRAME')
+        await writeToTerminal(pane, `\x1b[?1049h${enacs}`)
+
+        await replayInto(pane, model, true)
+        await writeToTerminal(pane, `\r\n${smacs}lqqqk${rmacs}`)
+
+        expect(row(pane, 1)).toBe('┌───┐')
+      } finally {
+        model.terminal.dispose()
+        pane.dispose()
+      }
+    })
+  }
+
+  // The gap can also strand a shift-out mid-run. GL is the one piece of charset
+  // state the replay does ground, because the payload renders through it.
+  it('renders the restored frame as ASCII even if the gap stranded a shift-out', async () => {
+    const model = createRendererParityTerminal({ cols: 20, rows: 4 })
+    const pane = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+    try {
+      await writeToTerminal(model.terminal, 'qqq plain text')
+      await writeToTerminal(pane, '\x1b(B\x1b)0\x0e')
+
+      await replayInto(pane, model, false)
+
+      expect(row(pane, 0)).toBe('qqq plain text')
+    } finally {
+      model.terminal.dispose()
+      pane.dispose()
+    }
+  })
+})
+
+describe('real TUI shapes survive a replay', () => {
+  // A vim-like editor: alt screen, a scroll region reserving the status line,
+  // and its own saved cursor. All of it is re-declared by the model snapshot,
+  // so the pane must end up matching the model rather than the gap.
+  it('keeps an editor scroll region and status line after a replay', async () => {
+    const model = createRendererParityTerminal({ cols: 20, rows: 6 })
+    const pane = new Terminal({ cols: 20, rows: 6, allowProposedApi: true })
+    try {
+      await writeToTerminal(model.terminal, '\x1b[?1049h\x1b[1;5r\x1b[1;1Hline one')
+      await writeToTerminal(model.terminal, '\x1b[6;1H-- INSERT --')
+      // The gap left a different region and a stranded origin mode behind.
+      await writeToTerminal(pane, '\x1b[?1049h\x1b[2;3r\x1b[?6h')
+
+      await replayInto(pane, model, true)
+      // Scroll INSIDE the restored region: reading the painted rows alone would
+      // pass even if `1;5r` never came back, so make the region do work.
+      await writeToTerminal(pane, '\x1b[5;1H\n\nscrolled')
+
+      // Row 6 is outside the model's 1;5 region and must not have moved.
+      expect(row(pane, 5)).toBe('-- INSERT --')
+      expect(row(pane, 4)).toBe('scrolled')
+    } finally {
+      model.terminal.dispose()
+      pane.dispose()
+    }
+  })
+
+  // A pager filling the viewport. Deliberately a NORMAL-buffer snapshot with the
+  // pane already on normal, so no `?1049` is emitted at all: on the alt path the
+  // split branch's `?1049l` restores saved modes and would grant autowrap back
+  // for free, and the test would pass without the baseline doing anything.
+  it('keeps every column of a pager frame when the gap stranded autowrap off', async () => {
+    const model = createRendererParityTerminal({ cols: 10, rows: 4 })
+    const pane = new Terminal({ cols: 10, rows: 4, allowProposedApi: true })
+    try {
+      await writeToTerminal(model.terminal, 'ABCDEFGHIJKLMN')
+      await writeToTerminal(pane, '\x1b[?7l')
+
+      await replayInto(pane, model, false)
+
+      expect([row(pane, 0), row(pane, 1)]).toEqual(['ABCDEFGHIJ', 'KLMN'])
+    } finally {
+      model.terminal.dispose()
+      pane.dispose()
+    }
+  })
+
+  // Same reasoning for insert mode: a later in-place repaint by the app must
+  // overwrite, not shift. No buffer switch, so the baseline is the only source.
+  it('keeps a live repaint overwriting when the gap stranded insert mode', async () => {
+    const model = createRendererParityTerminal({ cols: 12, rows: 3 })
+    const pane = new Terminal({ cols: 12, rows: 3, allowProposedApi: true })
+    try {
+      await writeToTerminal(model.terminal, 'OLDTEXT')
+      await writeToTerminal(pane, '\x1b[4h')
+
+      await replayInto(pane, model, false)
+      await writeToTerminal(pane, '\x1b[1;1HNEW')
+
+      expect(row(pane, 0)).toBe('NEWTEXT')
+    } finally {
+      model.terminal.dispose()
+      pane.dispose()
+    }
+  })
+
+  // And reverse wraparound, which only manifests through a later backspace.
+  it('keeps a live backspace from chewing the row above after a replay', async () => {
+    const model = createRendererParityTerminal({ cols: 8, rows: 3 })
+    const pane = new Terminal({ cols: 8, rows: 3, allowProposedApi: true })
+    try {
+      await writeToTerminal(model.terminal, 'AAAAAAAABBBB')
+      await writeToTerminal(pane, '\x1b[?45h')
+
+      await replayInto(pane, model, false)
+      await writeToTerminal(pane, '\b\b\b\b\bX')
+
+      expect([row(pane, 0), row(pane, 1)]).toEqual(['AAAAAAAA', 'XBBB'])
+    } finally {
+      model.terminal.dispose()
+      pane.dispose()
+    }
+  })
+
+  // An agent that negotiated the kitty keyboard protocol keeps it: the pane is
+  // already on the buffer the snapshot describes, so nothing should switch.
+  it('keeps a live agent kitty negotiation when no buffer switch is needed', async () => {
+    const options = {
+      cols: 20,
+      rows: 4,
+      allowProposedApi: true,
+      vtExtensions: { kittyKeyboard: true }
+    }
+    const readFlags = (term: Terminal): unknown => {
+      const flags = (term as unknown as { _core: { coreService: { kittyKeyboard: unknown } } })
+        ._core.coreService.kittyKeyboard
+      expect(flags).toBeDefined()
+      return flags
+    }
+    const model = createRendererParityTerminal({ cols: 20, rows: 4 })
+    const pane = new Terminal(options)
+    const untouched = new Terminal(options)
+    try {
+      await writeToTerminal(model.terminal, 'shell output')
+      await writeToTerminal(pane, '\x1b[>1u')
+      await writeToTerminal(untouched, '\x1b[>1u')
+
+      await replayInto(pane, model, false)
+
+      expect(readFlags(pane)).toEqual(readFlags(untouched))
+    } finally {
+      model.terminal.dispose()
+      pane.dispose()
+      untouched.dispose()
+    }
+  })
+})
+
+describe('repeated gap and restore cycles', () => {
+  // Each restore must be idempotent: three gaps in a row should leave the pane
+  // exactly where one does, with no state accumulating across the prologues.
+  it('converges on the same frame after three successive restores', async () => {
+    const model = createRendererParityTerminal({ cols: 20, rows: 4 })
+    const once = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+    const thrice = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+    // Attributes and a mode-sensitive operation, not just text: stranded bold,
+    // margins and autowrap are all invisible to a text-only comparison.
+    const describeFrame = async (terminal: Terminal): Promise<string> => {
+      await writeToTerminal(terminal, '\x1b[3;1Hzz\bY')
+      return JSON.stringify({
+        type: terminal.buffer.active.type,
+        rows: [0, 1, 2, 3].map((index) => rowWithAttributes(terminal, index)),
+        cursor: [terminal.buffer.active.cursorX, terminal.buffer.active.cursorY]
+      })
+    }
+    try {
+      await writeToTerminal(model.terminal, '\x1b[?1049hframe body')
+
+      await replayInto(once, model, false)
+      for (let cycle = 0; cycle < 3; cycle++) {
+        // A fresh gap strands new state before each restore.
+        await writeToTerminal(thrice, '\x1b[1m\x1b[2;3r\x1b[?7l\x1b]0;TRUNC')
+        // Only the first restore starts from the normal buffer.
+        await replayInto(thrice, model, cycle !== 0)
+      }
+
+      expect(await describeFrame(thrice)).toBe(await describeFrame(once))
+    } finally {
+      model.terminal.dispose()
+      once.dispose()
+      thrice.dispose()
+    }
+  })
+})
+
+describe('content fidelity through a replay', () => {
+  // Wide glyphs, combining sequences and an exact-width wrap are where a
+  // mis-grounded autowrap or insert mode shows up as lost or shifted cells.
+  const payloads = [
+    { label: 'CJK wide glyphs', body: '日本語テキスト' },
+    { label: 'emoji with ZWJ', body: 'a👩‍💻b' },
+    { label: 'exact-width wrap', body: 'ABCDEFGHIJKLMNOPQRST' },
+    { label: 'combining marks', body: 'ééé' }
+  ] as const
+
+  for (const { label, body } of payloads) {
+    it(`replays ${label} identically into a gap-dirtied pane`, async () => {
+      const model = createRendererParityTerminal({ cols: 20, rows: 4 })
+      const clean = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+      const dirty = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
+      try {
+        await writeToTerminal(model.terminal, body)
+        await replayInto(clean, model, false)
+
+        await writeToTerminal(dirty, '\x1b[1m\x1b(0\x1b[2;3r\x1b[?7l\x1b[4h\x1b7')
+        await replayInto(dirty, model, false)
+
+        expect([0, 1, 2, 3].map((index) => rowWithAttributes(dirty, index))).toEqual(
+          [0, 1, 2, 3].map((index) => rowWithAttributes(clean, index))
+        )
+      } finally {
+        model.terminal.dispose()
+        clean.dispose()
+        dirty.dispose()
+      }
+    })
+  }
+})

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@xterm/headless'
-import { RESET_AFTER_BYTE_GAP } from '../../../../shared/terminal-mode-reset-profiles'
+import {
+  ABORT_TRUNCATED_CONTROL_STRING,
+  buildSnapshotReplayPrologue,
+  RESET_AFTER_BYTE_GAP
+} from '../../../../shared/terminal-mode-reset-profiles'
+import {
+  buildParityMainBufferSnapshot,
+  createRendererParityTerminal,
+  cursorPosition,
+  normalBufferRowsTrimmed,
+  visibleRowStyles,
+  writeToTerminal
+} from '../../../../shared/terminal-restore-parity-fixture'
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
@@ -12,10 +24,22 @@ function writeTerminal(terminal: Terminal, data: string): Promise<void> {
   return new Promise((resolve) => terminal.write(data, resolve))
 }
 
+const NORMAL_BUFFER_PROLOGUE_FROM_ALT = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue({ targetAlternateScreen: false, paneOnAlternateScreen: true })}`
+const NORMAL_BUFFER_PROLOGUE = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue({ targetAlternateScreen: false, paneOnAlternateScreen: false })}`
+const ALT_BUFFER_PROLOGUE = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: false })}`
+// A pane already in alt screen is the production case for an alt snapshot, and
+// it is NOT the same bytes: no switch, so none of `?1049h`'s side effects run.
+const ALT_BUFFER_PROLOGUE_FROM_ALT = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: true })}`
+
+function readRows(terminal: Terminal, count: number): (string | undefined)[] {
+  return Array.from({ length: count }, (_, row) =>
+    terminal.buffer.active.getLine(row)?.translateToString(true)
+  )
+}
+
 describe('RESET_AFTER_BYTE_GAP', () => {
   // Real emulator rather than a mock: the guarantee is that a cell written after
-  // the gap reset carries none of the pen the gap stranded (STA-4042). Scoped to
-  // SGR — see RESET_AFTER_BYTE_GAP for why the wider grounding was dropped.
+  // the gap reset carries none of the pen the gap stranded (STA-4042).
   it('grounds the SGR pen so post-gap cells are not bold', async () => {
     const terminal = new Terminal({ cols: 40, rows: 2, allowProposedApi: true })
     try {
@@ -29,6 +53,559 @@ describe('RESET_AFTER_BYTE_GAP', () => {
       expect(line?.getCell(0)?.isBold()).not.toBe(0)
       expect(line?.getCell(4)?.isBold()).toBe(0)
       expect(line?.getCell(8)?.isBold()).toBe(0)
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // xterm dispatches OSC/DCS/APC with `success = code !== 0x18 && code !== 0x1a`,
+  // so a bare ESC would COMMIT whatever the gap truncated. Without the CAN this
+  // retitles the pane from a half-read OSC 0 (and writes the clipboard from a
+  // half-read OSC 52).
+  it('discards a control string the gap truncated instead of committing it', async () => {
+    const terminal = new Terminal({ cols: 40, rows: 2, allowProposedApi: true })
+    let title = ''
+    terminal.onTitleChange((next) => {
+      title = next
+    })
+    try {
+      await writeTerminal(terminal, '\x1b]0;real-title-TRUNCA')
+      await writeTerminal(terminal, `${RESET_AFTER_BYTE_GAP}after`)
+
+      expect(title).toBe('')
+      // Still resynchronised: the bytes after the reset render as text.
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('after')
+    } finally {
+      terminal.dispose()
+    }
+  })
+})
+
+// The end-to-end invariant, built through the SAME composer production uses
+// (buildParityMainBufferSnapshot mirrors HeadlessEmulator.getSnapshot: absolute
+// cursor + DECSC epilogue, the alt frame split from normal scrollback, and the
+// rehydrate prefix owning the single `?1049h`). Whatever the gap stranded, a
+// dirty renderer must land on exactly the frame a clean one produces. The
+// per-element tests below pin *why*; this pins what a user would notice.
+describe('replay convergence with a production-composed snapshot', () => {
+  const strandedByTheGap: Record<string, string> = {
+    'bold pen': '\x1b[1m',
+    'G0 line drawing': '\x1b(0',
+    'scroll margins': '\x1b[2;3r',
+    'origin mode': '\x1b[2;3r\x1b[?6h',
+    'autowrap off': '\x1b[?7l',
+    'insert mode': '\x1b[4h',
+    'reverse wraparound': '\x1b[?45h',
+    'saved-cursor register': '\x1b7',
+    'truncated OSC': '\x1b]0;TRUNCATED',
+    'all of them at once':
+      '\x1b[1m\x1b(0\x1b)0\x1b[2;3r\x1b[?6h\x1b[?7l\x1b[?45h\x1b[4h\x1b7\x1b]0;TRUNCATED'
+  }
+
+  function describeFrame(terminal: Terminal): string {
+    return JSON.stringify({
+      buffer: terminal.buffer.active.type,
+      rows: readRows(terminal, terminal.rows),
+      normal: readRows(terminal, terminal.rows).length > 0 ? normalBufferRowsTrimmed(terminal) : [],
+      styles: visibleRowStyles(terminal),
+      cursor: cursorPosition(terminal)
+    })
+  }
+
+  for (const alternateScreen of [true, false]) {
+    const branch = alternateScreen ? 'alt-screen' : 'normal-buffer'
+    it(`lands on the same ${branch} frame from any stranded state`, async () => {
+      const model = createRendererParityTerminal({ cols: 20, rows: 5 })
+      try {
+        const enterAlt = alternateScreen ? '\x1b[?1049h' : ''
+        // The DECSC makes readSavedCursorRegister return a real register, so the
+        // snapshot carries the absolute-cursor epilogue (`\x1b[r`, `?6l`, CUP,
+        // `\x1b7`) — without it that whole branch of the payload never fires.
+        await writeToTerminal(
+          model.terminal,
+          `${enterAlt}\x1b[2;5H\x1b7\x1b[33mONE\r\nplain two\r\n\x1b[1mbold three`
+        )
+        const snapshot = buildParityMainBufferSnapshot(model, 1)
+        expect(snapshot.alternateScreen).toBe(alternateScreen)
+        // Pin that this is the production shape: the alt case must take the
+        // split branch, and the payload must carry the cursor epilogue.
+        expect(snapshot.scrollbackAnsi === undefined).toBe(!alternateScreen)
+        expect(snapshot.data).toContain('\x1b7')
+
+        const replay = async (terminal: Terminal): Promise<void> => {
+          for (const write of buildMainModelSnapshotReplayWrites(snapshot, {
+            paneOnAlternateScreen: alternateScreen
+          })) {
+            await writeTerminal(terminal, write)
+          }
+        }
+
+        const clean = createRendererParityTerminal({ cols: 20, rows: 5 })
+        let expected: string
+        try {
+          await writeToTerminal(clean.terminal, enterAlt)
+          await replay(clean.terminal)
+          expected = describeFrame(clean.terminal)
+        } finally {
+          clean.terminal.dispose()
+        }
+
+        for (const [label, stranded] of Object.entries(strandedByTheGap)) {
+          const dirty = createRendererParityTerminal({ cols: 20, rows: 5 })
+          try {
+            await writeToTerminal(dirty.terminal, enterAlt)
+            await writeToTerminal(dirty.terminal, stranded)
+            await replay(dirty.terminal)
+            expect(`${label}: ${describeFrame(dirty.terminal)}`).toBe(`${label}: ${expected}`)
+          } finally {
+            dirty.terminal.dispose()
+          }
+        }
+      } finally {
+        model.terminal.dispose()
+      }
+    })
+  }
+})
+
+// Each case strands one piece of carried state, then replays a payload through
+// the real prologue. SerializeAddon diffs against the default cell and emits no
+// charset at all, so anything the gap left set silently rewrites the frame.
+describe('replay baseline grounding', () => {
+  const strandedState: Record<string, string> = {
+    'bold pen': '\x1b[1m',
+    'DEC line-drawing charset': '\x1b(0',
+    'scroll region': '\x1b[2;3r',
+    'origin mode': '\x1b[2;3r\x1b[?6h'
+  }
+
+  for (const [label, stranded] of Object.entries(strandedState)) {
+    it(`replays a normal-buffer snapshot unchanged despite a stranded ${label}`, async () => {
+      const terminal = new Terminal({ cols: 10, rows: 6, allowProposedApi: true })
+      try {
+        await writeTerminal(terminal, stranded)
+        await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE}qqq\r\nB\r\nC\r\nD\r\nE\r\nF`)
+
+        expect(readRows(terminal, 6)).toEqual(['qqq', 'B', 'C', 'D', 'E', 'F'])
+        expect(terminal.buffer.active.getLine(0)?.getCell(0)?.isBold()).toBe(0)
+      } finally {
+        terminal.dispose()
+      }
+    })
+  }
+
+  // The field path, driven through the REAL builder output rather than a
+  // hand-written prologue: an alt-screen agent whose snapshot splits normal
+  // scrollback from the alt frame. This is the branch STA-4042 was reported on.
+  it('replays a split alt-screen snapshot clean when the TUI entered alt with a pen set', async () => {
+    const terminal = new Terminal({ cols: 24, rows: 4, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[1m\x1b(0')
+      // ?1049h saves that pen and charset into the register ?1049l restores from.
+      await writeTerminal(terminal, '\x1b[?1049hTUI FRAME')
+
+      for (const write of buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true, scrollbackAnsi: 'qqq scrollback' },
+        { paneOnAlternateScreen: true }
+      )) {
+        await writeTerminal(terminal, write)
+      }
+
+      // The alt frame is what shows; the rebuilt normal history must be clean too.
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('alt-frame')
+      expect(terminal.buffer.active.getLine(0)?.getCell(0)?.isBold()).toBe(0)
+      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('qqq scrollback')
+      expect(terminal.buffer.normal.getLine(0)?.getCell(0)?.isBold()).toBe(0)
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // Ordering regression. xterm answers `?1049l` with restoreCursor(), which
+  // reloads the pen, every G-set designation, GL, origin mode and wraparound
+  // from the register `?1049h` saved. A TUI that was bold and line-drawing when
+  // it entered the alt screen therefore gets all of that RESTORED on the way
+  // out — so grounding emitted ahead of the buffer switch is silently undone,
+  // and the exact bold-bleed this whole path exists to prevent comes back.
+  it('grounds after the buffer switch, not before, so ?1049l cannot restore the stale pen', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 3, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[1m\x1b(0\x1b[?7l')
+      // ?1049h saves that pen, charset and wraparound into the restore register.
+      await writeTerminal(terminal, '\x1b[?1049hTUI FRAME')
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE_FROM_ALT}qqq restored`)
+
+      const line = terminal.buffer.active.getLine(0)
+      expect(line?.translateToString(true)).toBe('qqq restored')
+      expect(line?.getCell(0)?.isBold()).toBe(0)
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // `?1049l` runs restoreCursor() unconditionally, which rewrites the pen, all
+  // four G-sets, GL, origin, wraparound and the cursor from the register saved
+  // at `?1049h`. Poison every one of those at once and prove the prologue after
+  // the switch neutralises the lot — this is the guard on adding `?1049l` at all.
+  it('neutralises every field ?1049l restores, even with the saved register poisoned', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 6, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[1;31;44m') // pen: bold + fg + bg
+      await writeTerminal(terminal, '\x1b(0\x1b)0\x1b*0\x1b+0') // G0..G3 -> line drawing
+      await writeTerminal(terminal, '\x0e') // LS1: GL -> G1
+      await writeTerminal(terminal, '\x1b[2;5r\x1b[?6h\x1b[?7l\x1b[4h') // margins, origin, no wrap, insert
+      await writeTerminal(terminal, '\x1b[3;7H') // non-home cursor
+      await writeTerminal(terminal, '\x1b[?1049hTUI FRAME') // saveCursor() captures all of it
+
+      // 24 columns of `q` into a 20-column grid: only autowrap on, GL=G0 and
+      // G0=ASCII produce this, and only a homed cursor starts it on row 0.
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE_FROM_ALT}${'q'.repeat(24)}`)
+
+      expect(terminal.buffer.active.type).toBe('normal')
+      expect(readRows(terminal, 2)).toEqual(['q'.repeat(20), 'qqqq'])
+      const cell = terminal.buffer.active.getLine(0)?.getCell(0)
+      expect(cell?.isBold()).toBe(0)
+      expect(cell?.isFgDefault()).toBe(true)
+      expect(cell?.isBgDefault()).toBe(true)
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // Panes run with vtExtensions.kittyKeyboard on, and xterm swaps the kitty
+  // flag registers on the ?1049 transition. Without the ?1049l the renderer
+  // keeps the agent's negotiated flags after the agent exited, so the pane
+  // sends CSI-u key encodings to a plain shell that never asked for them.
+  // Replaying the snapshot must land on the same state the model already has.
+  it('converges on the model kitty keyboard state when the gap ate the alt-screen exit', async () => {
+    const options = {
+      cols: 20,
+      rows: 4,
+      allowProposedApi: true,
+      vtExtensions: { kittyKeyboard: true }
+    }
+    const readKittyFlags = (term: Terminal): unknown => {
+      const flags = (term as unknown as { _core: { coreService: { kittyKeyboard: unknown } } })
+        ._core.coreService.kittyKeyboard
+      // Without this the assertion passes vacuously if xterm renames the field.
+      expect(flags).toBeDefined()
+      return flags
+    }
+
+    // The model ingested every byte: agent entered alt, negotiated kitty, exited.
+    const model = new Terminal(options)
+    // The renderer missed the exit and is still on alt with the agent's flags.
+    const renderer = new Terminal(options)
+    try {
+      await writeTerminal(model, '\x1b[?1049h\x1b[>1u')
+      await writeTerminal(model, '\x1b[?1049l')
+
+      await writeTerminal(renderer, '\x1b[?1049h\x1b[>1u')
+      for (const write of buildMainModelSnapshotReplayWrites(
+        { data: 'shell prompt $' },
+        { paneOnAlternateScreen: true }
+      )) {
+        await writeTerminal(renderer, write)
+      }
+
+      expect(renderer.buffer.active.type).toBe(model.buffer.active.type)
+      expect(readKittyFlags(renderer)).toEqual(readKittyFlags(model))
+    } finally {
+      model.dispose()
+      renderer.dispose()
+    }
+  })
+
+  // Delayed arm of the same defect. `?1049h` banks the CURRENT pen and charsets
+  // into the register the TUI's eventual `?1049l` restores from, so grounding
+  // only after the switch leaves the gap's state saved for later: the repaint
+  // looks clean and the shell prompt comes back bold whenever the agent exits.
+  it('grounds before the switch too, so the alt-exit later cannot restore the gap state', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 3, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[1m\x1b(0\x1b[?7l')
+      await writeTerminal(terminal, `${ALT_BUFFER_PROLOGUE}alt frame`)
+      // The agent exits the alt screen some time after the repaint.
+      await writeTerminal(terminal, '\x1b[?1049l')
+      await writeTerminal(terminal, 'qqq shell prompt')
+
+      const line = terminal.buffer.active.getLine(0)
+      expect(line?.translateToString(true)).toBe('qqq shell prompt')
+      expect(line?.getCell(0)?.isBold()).toBe(0)
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // `?1049` is NOT a no-op when the pane is already on the target buffer: xterm
+  // skips only the buffer swap and still swaps the kitty flag registers. An
+  // agent that negotiated kitty on the normal screen and never entered alt
+  // would lose its flags (1 -> 0, Option chords dead) on every normal-buffer
+  // restore, so the prologue must not switch when there is nothing to switch.
+  it('leaves kitty flags alone when the pane is already on the target buffer', async () => {
+    const options = {
+      cols: 20,
+      rows: 3,
+      allowProposedApi: true,
+      vtExtensions: { kittyKeyboard: true }
+    }
+    const readKittyFlags = (term: Terminal): unknown => {
+      const flags = (term as unknown as { _core: { coreService: { kittyKeyboard: unknown } } })
+        ._core.coreService.kittyKeyboard
+      // Without this the assertion passes vacuously if xterm renames the field.
+      expect(flags).toBeDefined()
+      return flags
+    }
+
+    const model = new Terminal(options)
+    const renderer = new Terminal(options)
+    try {
+      await writeTerminal(model, '\x1b[>1u')
+      await writeTerminal(renderer, '\x1b[>1u')
+
+      const writes = buildMainModelSnapshotReplayWrites(
+        { data: 'restored' },
+        { paneOnAlternateScreen: false }
+      )
+      for (const write of writes) {
+        await writeTerminal(renderer, write)
+      }
+
+      expect(writes[0]).not.toContain('\x1b[?1049')
+      expect(readKittyFlags(renderer)).toEqual(readKittyFlags(model))
+    } finally {
+      model.dispose()
+      renderer.dispose()
+    }
+  })
+
+  // Reverse wraparound is the same shape as insert and autowrap: the model
+  // re-emits `?45h` only when IT has the mode on, so a stranded ON survives the
+  // repaint and the live app's next backspace at column 0 eats into the row
+  // above instead of staying put.
+  it('leaves reverse wraparound off so a later backspace cannot chew the row above', async () => {
+    const terminal = new Terminal({ cols: 8, rows: 3, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[?45h')
+      // 12 columns into 8 makes row 1 a SOFT wrap of row 0 — the only kind
+      // reverse wraparound reverses.
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE}AAAAAAAABBBB`)
+      await writeTerminal(terminal, '\b\b\b\b\bX')
+
+      expect(readRows(terminal, 2)).toEqual(['AAAAAAAA', 'XBBB'])
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // The alt branch cannot make the same promise, and the earlier version of this
+  // test only appeared to because it used synthetic payload data. Production alt
+  // payloads carry their OWN `\x1b[0m\x1b[?1049h` (buildRehydrateSequences /
+  // frameRestoreAnsi), so the flags of an agent that negotiated kitty on the alt
+  // screen are still pushed into the main register by the payload. The prologue's
+  // contribution is what is testable here: it adds no switch of its own.
+  it('adds no buffer switch of its own when the pane is already on the alt screen', async () => {
+    const options = {
+      cols: 20,
+      rows: 3,
+      allowProposedApi: true,
+      vtExtensions: { kittyKeyboard: true }
+    }
+    const readKittyFlags = (term: Terminal): unknown => {
+      const flags = (term as unknown as { _core: { coreService: { kittyKeyboard: unknown } } })
+        ._core.coreService.kittyKeyboard
+      // Without this the assertion passes vacuously if xterm renames the field.
+      expect(flags).toBeDefined()
+      return flags
+    }
+
+    const renderer = new Terminal(options)
+    try {
+      await writeTerminal(renderer, '\x1b[?1049h\x1b[>1u')
+      const before = JSON.stringify(readKittyFlags(renderer))
+
+      const writes = buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true },
+        { paneOnAlternateScreen: true }
+      )
+      expect(writes[0]).not.toContain('\x1b[?1049')
+      for (const write of writes) {
+        await writeTerminal(renderer, write)
+      }
+      // Nothing in the prologue moved them; only a payload `?1049h` could.
+      expect(JSON.stringify(readKittyFlags(renderer))).toBe(before)
+    } finally {
+      renderer.dispose()
+    }
+  })
+
+  // Margins are per buffer and the switch does not carry them across, so an
+  // alt-target replay from a normal pane must ground the buffer it leaves too —
+  // otherwise the stale region resurfaces the moment the TUI exits to normal.
+  it('grounds the source buffer margins when switching to the alt screen', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 6, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[2;3r')
+      for (const write of buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true },
+        { paneOnAlternateScreen: false }
+      )) {
+        await writeTerminal(terminal, write)
+      }
+      await writeTerminal(terminal, '\x1b[?1049l')
+      await writeTerminal(terminal, 'AAAA\r\nBBBB\r\nCCCC\r\nDDDD\r\nEEEE\r\nFFFF')
+
+      expect(readRows(terminal, 6)).toEqual(['AAAA', 'BBBB', 'CCCC', 'DDDD', 'EEEE', 'FFFF'])
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // The inverse of what an earlier revision asserted. Grounding G1-G3 looked
+  // right against a stranded designation, but the payload never leaves G0 so it
+  // cannot affect the frame, and `enacs=\E(B\E)0` (screen/tmux/vt100 terminfo)
+  // designates G1 once at init and then uses bare SO/SI — grounding it renders a
+  // live app's box drawing as letters. The model never re-asserts charsets, so
+  // there is nothing to complete the reset. Leave the app's G-sets alone.
+  it('leaves an app-designated G1 intact so its later shift-out still draws boxes', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 3, allowProposedApi: true })
+    try {
+      // enacs: G0 = ASCII, G1 = DEC line drawing. Runs once, at init.
+      await writeTerminal(terminal, '\x1b(B\x1b)0')
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE}restored`)
+      // smacs / box / rmacs, the way the app draws for the rest of the session.
+      await writeTerminal(terminal, '\r\n\x0elqqqk\x0f')
+
+      expect(terminal.buffer.active.getLine(1)?.translateToString(true)).toBe('┌───┐')
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // The baseline is reachable around if the saved-cursor register still holds
+  // the gap's state: the live TUI's next `ESC 8` restores that pen and charset
+  // straight over the repaint. The prologue's trailing DECSC closes that door.
+  it('grounds the saved-cursor register so a later ESC 8 cannot restore the stale pen', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 3, allowProposedApi: true })
+    try {
+      // The gap strands a DECSC taken while bold + line-drawing were set.
+      await writeTerminal(terminal, '\x1b[1m\x1b(0\x1b7')
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE}restored`)
+      // The live TUI restores its cursor, then draws.
+      await writeTerminal(terminal, '\x1b8qqq')
+
+      const line = terminal.buffer.active.getLine(0)
+      expect(line?.translateToString(true)).toBe('qqqtored')
+      expect(line?.getCell(0)?.isBold()).toBe(0)
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // A serialized row exactly `cols` wide relies on autowrap to continue onto the
+  // next row. With DECAWM stranded off, every character past the margin
+  // overwrites the last cell and the restored history silently loses text.
+  it('replays a row wider than the grid instead of dropping it at the margin', async () => {
+    const terminal = new Terminal({ cols: 10, rows: 4, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[?7l')
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE}ABCDEFGHIJKLMNO`)
+
+      expect(readRows(terminal, 2)).toEqual(['ABCDEFGHIJ', 'KLMNO'])
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // Origin mode is invisible during the replay itself (the baseline resets the
+  // margins, so margin-relative and absolute addressing coincide), but nothing
+  // in the snapshot re-emits `ESC[?6l`. Left stranded, the first scroll region
+  // the live TUI sets makes all of its cursor addressing margin-relative.
+  it('leaves origin mode off so later cursor addressing stays absolute', async () => {
+    const terminal = new Terminal({ cols: 10, rows: 6, allowProposedApi: true })
+    try {
+      // Alt branch: `?1049h` on an already-alt pane is a no-op, so unlike the
+      // normal branch's `?1049l` it restores nothing on its own.
+      await writeTerminal(terminal, '\x1b[?1049h')
+      await writeTerminal(terminal, '\x1b[2;3r\x1b[?6h')
+      await writeTerminal(terminal, `${ALT_BUFFER_PROLOGUE_FROM_ALT}restored`)
+      // The live TUI re-establishes its own region and homes the cursor.
+      await writeTerminal(terminal, '\x1b[4;6r\x1b[1;1HTOP')
+
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('TOPtored')
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // Insert mode survives the replay itself (the frame is painted onto a cleared
+  // screen), but the model only re-emits `ESC[4h` when IT has insert mode on —
+  // so a stranded-on renderer keeps it, and every later repaint by the live TUI
+  // shifts existing cells right instead of overwriting them.
+  it('leaves insert mode off so later repaints overwrite rather than shift', async () => {
+    const terminal = new Terminal({ cols: 10, rows: 4, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[4h')
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE}OLDTEXT`)
+      // A live in-place repaint after the replay, exactly as a TUI would send it.
+      await writeTerminal(terminal, '\x1b[1;1HNEW')
+
+      expect(readRows(terminal, 1)).toEqual(['NEWTEXT'])
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // The alt branch needs its own coverage: leaving the alt screen restores
+  // saved modes, so `?1049l` on the normal branch happens to clear autowrap and
+  // origin mode for free. `?1049h` does not, and on a pane already in alt screen
+  // it is a no-op — nothing but the explicit baseline grounds these.
+  for (const [label, stranded, replayed, expected] of [
+    ['autowrap off', '\x1b[?7l', 'ABCDEFGHIJKLMNO', ['ABCDEFGHIJ', 'KLMNO']],
+    ['origin mode', '\x1b[2;3r\x1b[?6h', 'A\r\nB\r\nC', ['A', 'B', 'C']],
+    ['DEC line-drawing charset', '\x1b(0', 'qqq', ['qqq', '']]
+  ] as const) {
+    it(`grounds a stranded ${label} on the alt-screen branch`, async () => {
+      const terminal = new Terminal({ cols: 10, rows: 4, allowProposedApi: true })
+      try {
+        await writeTerminal(terminal, '\x1b[?1049h')
+        await writeTerminal(terminal, stranded)
+        await writeTerminal(terminal, `${ALT_BUFFER_PROLOGUE_FROM_ALT}${replayed}`)
+
+        expect(readRows(terminal, expected.length)).toEqual([...expected])
+      } finally {
+        terminal.dispose()
+      }
+    })
+  }
+
+  // Margins are per buffer and `?1049h` only clears them when it actually
+  // switches, so a pane already in alt screen keeps the stale region.
+  it('grounds the alt buffer margins even when already on the alt screen', async () => {
+    const terminal = new Terminal({ cols: 10, rows: 6, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[?1049h')
+      await writeTerminal(terminal, '\x1b[2;3r')
+      await writeTerminal(terminal, `${ALT_BUFFER_PROLOGUE_FROM_ALT}A\r\nB\r\nC\r\nD\r\nE\r\nF`)
+
+      expect(readRows(terminal, 6)).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
+    } finally {
+      terminal.dispose()
+    }
+  })
+
+  // The gap can eat the TUI's own `?1049l`, leaving the renderer on the alt
+  // screen while the model already moved back to normal. Painting the restored
+  // history into the alt buffer looks right but leaves scrollback empty and the
+  // content vanishes on the next buffer switch.
+  it('returns to the normal buffer before replaying a normal-buffer snapshot', async () => {
+    const terminal = new Terminal({ cols: 20, rows: 3, allowProposedApi: true })
+    try {
+      await writeTerminal(terminal, '\x1b[?1049hSTALE TUI FRAME')
+      await writeTerminal(terminal, `${NORMAL_BUFFER_PROLOGUE_FROM_ALT}shell prompt $`)
+
+      expect(terminal.buffer.active.type).toBe('normal')
+      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('shell prompt $')
     } finally {
       terminal.dispose()
     }
@@ -65,10 +642,9 @@ describe('resolvePositiveTerminalDimensions', () => {
 
 describe('buildMainModelSnapshotReplayWrites', () => {
   it('clears normal buffer + scrollback before a normal-buffer snapshot', () => {
-    expect(buildMainModelSnapshotReplayWrites({ data: 'shell-output' })).toEqual([
-      `${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`,
-      'shell-output'
-    ])
+    expect(
+      buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { paneOnAlternateScreen: false })
+    ).toEqual([NORMAL_BUFFER_PROLOGUE, 'shell-output'])
   })
 
   // Why: main strips the ?1049h marker when splitting scrollbackAnsi from an
@@ -77,23 +653,25 @@ describe('buildMainModelSnapshotReplayWrites', () => {
   // the normal buffer.
   it('rebuilds normal buffer then paints a clean alt frame for alt-screen snapshots', () => {
     expect(
-      buildMainModelSnapshotReplayWrites({
-        data: 'alt-frame',
-        alternateScreen: true,
-        scrollbackAnsi: 'normal-history'
-      })
+      buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true, scrollbackAnsi: 'normal-history' },
+        { paneOnAlternateScreen: false }
+      )
     ).toEqual([
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
+      NORMAL_BUFFER_PROLOGUE,
       'normal-history',
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
+      buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: false }),
       'alt-frame'
     ])
   })
 
   it('enters a cleared alt screen when no split scrollback is available', () => {
     expect(
-      buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
-    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, 'alt-frame'])
+      buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true },
+        { paneOnAlternateScreen: false }
+      )
+    ).toEqual([ALT_BUFFER_PROLOGUE, 'alt-frame'])
   })
 })
 
@@ -127,7 +705,10 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
 
     try {
       const skipAltFrame = shouldSkipAltFrameForWidthMismatch(12, undefined)
-      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame })) {
+      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, {
+        skipAltFrame,
+        paneOnAlternateScreen: false
+      })) {
         await writeTerminal(terminal, chunk)
       }
 
@@ -152,7 +733,10 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     }
 
     try {
-      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame: true })) {
+      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, {
+        skipAltFrame: true,
+        paneOnAlternateScreen: false
+      })) {
         await writeTerminal(terminal, chunk)
       }
       terminal.resize(4, 5)
@@ -174,12 +758,12 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
           alternateScreen: true,
           scrollbackAnsi: 'normal-history'
         },
-        { skipAltFrame: true }
+        { skipAltFrame: true, paneOnAlternateScreen: false }
       )
     ).toEqual([
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
+      NORMAL_BUFFER_PROLOGUE,
       'normal-history',
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
+      buildSnapshotReplayPrologue({ targetAlternateScreen: true, paneOnAlternateScreen: false }),
       'complete-live-state'
     ])
   })
@@ -194,24 +778,27 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
           frameRestoreAnsi: 'complete-live-state',
           alternateScreen: true
         },
-        { skipAltFrame: true }
+        { skipAltFrame: true, paneOnAlternateScreen: false }
       )
-    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, 'complete-live-state'])
+    ).toEqual([ALT_BUFFER_PROLOGUE, 'complete-live-state'])
   })
 
   it('keeps composed data when an older producer omits the mode boundary', () => {
     expect(
       buildMainModelSnapshotReplayWrites(
         { data: 'legacy-modes-and-frame', alternateScreen: true },
-        { skipAltFrame: true }
+        { skipAltFrame: true, paneOnAlternateScreen: false }
       )
-    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, 'legacy-modes-and-frame'])
+    ).toEqual([ALT_BUFFER_PROLOGUE, 'legacy-modes-and-frame'])
   })
 
   it('never drops a normal-buffer snapshot, whose rows reflow correctly', () => {
     expect(
-      buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
-    ).toEqual([`${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`, 'shell-output'])
+      buildMainModelSnapshotReplayWrites(
+        { data: 'shell-output' },
+        { skipAltFrame: true, paneOnAlternateScreen: false }
+      )
+    ).toEqual([NORMAL_BUFFER_PROLOGUE, 'shell-output'])
   })
 
   // STA-4042: a replay only runs because renderer-bound bytes were dropped, so
@@ -219,18 +806,42 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
   // BEFORE replaying content, or the whole restored buffer inherits it — the
   // "regular text renders bold" field report.
   it('clears the SGR pen before any replayed content in every branch', () => {
+    // Each built for a pane that genuinely has to switch, so there is a switch
+    // to bracket; when the pane is already on target no switch is emitted and
+    // there is nothing for restoreCursor to undo.
     const branches = [
-      buildMainModelSnapshotReplayWrites({ data: 'normal-buffer' }),
-      buildMainModelSnapshotReplayWrites({
-        data: 'alt-frame',
-        alternateScreen: true,
-        scrollbackAnsi: 'scrollback'
-      }),
-      buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
+      buildMainModelSnapshotReplayWrites(
+        { data: 'normal-buffer' },
+        { paneOnAlternateScreen: true }
+      ),
+      buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true, scrollbackAnsi: 'scrollback' },
+        { paneOnAlternateScreen: true }
+      ),
+      buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true },
+        { paneOnAlternateScreen: false }
+      )
     ]
     for (const writes of branches) {
-      expect(writes[0].startsWith(RESET_AFTER_BYTE_GAP)).toBe(true)
-      // Nothing may be replayed ahead of the first reset.
+      // CAN leads, so a truncated control string is aborted rather than
+      // committed by the first ESC that follows.
+      expect(writes[0].startsWith('\x18')).toBe(true)
+      // Literal bytes, not the imported constant: asserting the constant against
+      // itself would pass for any value it happened to hold.
+      const prologue = writes[0]
+      expect(prologue).toContain('\x1b[0m') // SGR
+      expect(prologue).toContain('\x0f\x1b(B') // GL -> G0, G0 -> ASCII
+      expect(prologue).toContain('\x1b[r') // margins
+      expect(prologue.endsWith('\x1b7')).toBe(true) // saved-cursor floor, last
+      // The baseline brackets the buffer switch: once before, so `?1049h` banks
+      // grounded state rather than the gap's, and once after, so `?1049l`'s
+      // restore cannot reapply the old register over it.
+      const switchAt = prologue.indexOf('\x1b[?1049')
+      expect(switchAt).toBeGreaterThanOrEqual(0)
+      expect(prologue.indexOf('\x1b[0m')).toBeLessThan(switchAt)
+      expect(prologue.lastIndexOf('\x1b[0m')).toBeGreaterThan(switchAt)
+      // Nothing may be replayed ahead of the first prologue.
       expect(writes.indexOf('scrollback')).not.toBe(0)
     }
   })

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,6 +1,15 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
 import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
-import { RESET_AFTER_BYTE_GAP } from '../../../../shared/terminal-mode-reset-profiles'
+import {
+  ABORT_TRUNCATED_CONTROL_STRING,
+  buildSnapshotReplayPrologue
+} from '../../../../shared/terminal-mode-reset-profiles'
+
+// Once only: CAN must precede the first ESC of the replay, but the split branch
+// builds two prologues and later writes follow well-formed payloads.
+function abortGapBeforeFirstWrite(writes: string[]): string[] {
+  return [`${ABORT_TRUNCATED_CONTROL_STRING}${writes[0]}`, ...writes.slice(1)]
+}
 
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
@@ -77,16 +86,26 @@ export function buildMainModelSnapshotReplayWrites(
     alternateScreen?: boolean
     scrollbackAnsi?: string
   },
-  options: { skipAltFrame?: boolean } = {}
+  options: { skipAltFrame?: boolean; paneOnAlternateScreen: boolean }
 ): string[] {
+  const { paneOnAlternateScreen } = options
+  const normalPrologue = buildSnapshotReplayPrologue({
+    targetAlternateScreen: false,
+    paneOnAlternateScreen
+  })
+  // The alt payload always follows a hop through the normal buffer in the split
+  // branch, so its own switch is judged from there, not from where we started.
+  const altPrologue = (fromAlternateScreen: boolean): string =>
+    buildSnapshotReplayPrologue({
+      targetAlternateScreen: true,
+      paneOnAlternateScreen: fromAlternateScreen
+    })
   if (!snapshot.alternateScreen) {
-    // Why: \x1b[3J wipes xterm scrollback; safe here because a normal-buffer
-    // snapshot carries its own history in data (mirrors pty-transport.ts).
-    // Why the leading SGR reset: a replay only happens because renderer-bound
-    // bytes were dropped, so the pen the drop interrupted is unknown — without
-    // clearing it the whole replayed buffer inherits it (STA-4042). The
-    // alt-screen branches below already reset; this one did not.
-    return [`${RESET_AFTER_BYTE_GAP}\x1b[2J\x1b[3J\x1b[H`, snapshot.data]
+    // Why the switch can be needed here: the gap can eat the TUI's own exit
+    // sequence, leaving the renderer on alt while the model moved to normal —
+    // the restored history would paint into the alt buffer, looking right while
+    // scrollback stays empty (STA-4042).
+    return abortGapBeforeFirstWrite([normalPrologue, snapshot.data])
   }
   // Older snapshot producers do not expose the mode/frame boundary. Keep their
   // composed data rather than dropping terminal modes together with the frame.
@@ -95,20 +114,17 @@ export function buildMainModelSnapshotReplayWrites(
       ? [snapshot.frameRestoreAnsi]
       : [snapshot.data]
   if (snapshot.scrollbackAnsi !== undefined) {
-    // Why: main serializes normal + alt buffers separately; rebuild normal
-    // while active, then return to a clean alt frame.
-    // Why the reset moved to the front too: scrollbackAnsi was replayed BEFORE
-    // the existing \x1b[0m, so the normal-buffer history inherited the stale pen
-    // even though the alt frame after it did not (STA-4042).
-    return [
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049l\x1b[2J\x1b[3J\x1b[H`,
+    // Why a prologue per payload: main serializes the buffers separately and
+    // each is diffed against the baseline. scrollbackAnsi used to replay before
+    // any reset at all, so the history inherited the stale state (STA-4042).
+    return abortGapBeforeFirstWrite([
+      normalPrologue,
       snapshot.scrollbackAnsi,
-      `${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`,
+      altPrologue(false),
       ...altFrame
-    ]
+    ])
   }
-  // Why: the snapshot's ?1049h no-ops when already on alt screen and skips
-  // blank cells; clear the alt buffer so the pre-hide frame can't bleed
-  // through blank cells (spares normal-buffer scrollback).
-  return [`${RESET_AFTER_BYTE_GAP}\x1b[?1049h\x1b[2J\x1b[H`, ...altFrame]
+  // Why the prologue clears: `?1049h` does not clear the alt buffer, so the
+  // pre-hide frame would bleed through the snapshot's blank cells.
+  return abortGapBeforeFirstWrite([altPrologue(paneOnAlternateScreen), ...altFrame])
 }

--- a/src/shared/terminal-mode-reset-profiles.ts
+++ b/src/shared/terminal-mode-reset-profiles.ts
@@ -40,24 +40,69 @@ export const COLD_RESTORE_SEED_MODE_RESET = RESET_MOUSE_REPORTING
 // drains queued foreground chunks under the stale pen).
 export const RESET_GRAPHIC_RENDITION = '\x1b[0m'
 
+// CAN, not a bare ESC: xterm dispatches OSC/DCS/APC with
+// `success = code !== 0x18 && code !== 0x1a`, so ESC grounds the parser but
+// COMMITS what the gap truncated — a half-read OSC 0 retitles the pane, OSC 52
+// writes the clipboard.
+export const ABORT_TRUNCATED_CONTROL_STRING = '\x18'
+
+// Live-stream grounding: the drop marker and the abandon paths, which drain
+// queued chunks instead of repainting. Parser + pen only — a live TUI keeps
+// writing here and owns its charset and margins. Not DECSTR: xterm's soft reset
+// wipes the kitty flags agents negotiate only at startup.
+export const RESET_AFTER_BYTE_GAP = `${ABORT_TRUNCATED_CONTROL_STRING}${RESET_GRAPHIC_RENDITION}`
+
+// The baseline a serialized snapshot assumes it lands on: SerializeAddon diffs
+// cells against DEFAULT attributes and emits no charset at all.
+//
+// The rule for what belongs here is "state the model re-asserts": `?6l`/`?7h`/
+// `?45l`/`4l` are safe because the model re-emits those when SET, so grounding
+// plus its re-assertion leaves the renderer matching the model. G1-G3 are
+// deliberately NOT grounded — the payload never leaves G0, so they cannot
+// affect the restored frame, and the model never speaks about them, so
+// resetting is unilateral. `enacs=\E(B\E)0` (screen/tmux/vt100 terminfo)
+// designates G1 once at init and then uses bare SO/SI, so grounding G1 would
+// render a live app's box drawing as letters.
+const REPLAY_BASELINE_TERMINAL_RESET = `${RESET_GRAPHIC_RENDITION}\x0f\x1b(B\x1b[?6l\x1b[?7h\x1b[?45l\x1b[4l`
+
+// Buffer-scoped: margins live on the xterm buffer, and `?1049` neither carries
+// them across nor clears them unless it actually swaps.
+const REPLAY_BASELINE_BUFFER_RESET = '\x1b[r'
+
+// Last, so the saved-cursor register holds grounded state — otherwise a stranded
+// `ESC 7` is reachable through the live TUI's next `ESC 8`. Only a floor: a
+// snapshot carrying the model's own DECSC epilogue overwrites it.
+const SAVE_GROUNDED_CURSOR = '\x1b7'
+
 /**
- * State to re-establish when renderer-bound bytes were dropped and the gap
- * cannot be replayed away.
+ * Prologue that puts a pane on `targetAlternateScreen` and grounds it for a
+ * serialized snapshot. Shared because the parity/fuzz harnesses replay the same
+ * contract, and re-spelling the literals is what drifted them apart (#12101).
  *
- * Scoped to the pen on purpose. A gap can in principle strand other carried
- * state — an ISO 2022 charset designation, an open OSC 8 hyperlink, a partial
- * escape — and earlier revisions of this reset covered those too. They are
- * dropped here because each one changes what a live TUI sees on a path that
- * runs in production, none of them has a reported symptom behind it, and the
- * pen is what the field reports actually show (STA-4042). Widen this only with
- * a symptom to point at.
+ * The switch is conditional: `?1049` is not a no-op on the target buffer — xterm
+ * skips only the swap and still runs restoreCursor() and the kitty flag swap, so
+ * emitting it regardless parks a live agent's kitty flags.
  *
- * Deliberately NOT a soft reset (DECSTR) either: xterm's DECSTR wipes kitty
- * flags and stacks (see terminal-kitty-keyboard-mode-tracker applySoftReset),
- * which would silence Option chords for a live agent that negotiates them only
- * at startup.
+ * Grounding brackets a real switch because each side does a different job:
+ * before, `?1049h`'s saveCursor() must bank grounded state (and the source
+ * buffer's margins get grounded); after, `?1049l`'s restoreCursor() must not
+ * reapply the old register over it.
  */
-export const RESET_AFTER_BYTE_GAP = RESET_GRAPHIC_RENDITION
+export function buildSnapshotReplayPrologue(args: {
+  targetAlternateScreen: boolean
+  paneOnAlternateScreen: boolean
+}): string {
+  // Why explicit: `?1049h` does not clear the alt buffer (xterm's own
+  // `1049 should clear altbuffer` FIXME); `\x1b[3J` is safe only for a
+  // normal-buffer payload, which carries its own history.
+  const clear = args.targetAlternateScreen ? '\x1b[2J\x1b[H' : '\x1b[2J\x1b[3J\x1b[H'
+  const ground = `${REPLAY_BASELINE_TERMINAL_RESET}${REPLAY_BASELINE_BUFFER_RESET}`
+  if (args.paneOnAlternateScreen === args.targetAlternateScreen) {
+    return `${ground}${clear}${SAVE_GROUNDED_CURSOR}`
+  }
+  const bufferSwitch = args.targetAlternateScreen ? '\x1b[?1049h' : '\x1b[?1049l'
+  return `${ground}${bufferSwitch}${ground}${clear}${SAVE_GROUNDED_CURSOR}`
+}
 
 // Why: DECTCEM applies in emission order, so the payload's last ?25l/?25h is the cursor state the TUI left.
 export function replayPayloadEndsWithCursorHidden(payload: string): boolean {

--- a/src/shared/terminal-restore-parity-fixture.ts
+++ b/src/shared/terminal-restore-parity-fixture.ts
@@ -13,6 +13,10 @@ import {
   readSavedCursorRegister,
   serializeWithAbsoluteCursor
 } from './terminal-serialize-absolute-cursor'
+import {
+  ABORT_TRUNCATED_CONTROL_STRING,
+  buildSnapshotReplayPrologue
+} from './terminal-mode-reset-profiles'
 
 export type ParityTerminal = {
   terminal: Terminal
@@ -170,11 +174,18 @@ export function normalBufferStylesTrimmed(terminal: Terminal): string[] {
   return rows
 }
 
-// Mirror of applyMainBufferSnapshot's clear preamble (pty-connection.ts):
-// normal-buffer restores wipe screen+scrollback+home; alt-screen restores
-// clear only the alt screen so the normal buffer's scrollback survives.
-export const SNAPSHOT_REPLAY_PREAMBLE_NORMAL = '\x1b[2J\x1b[3J\x1b[H'
-export const SNAPSHOT_REPLAY_PREAMBLE_ALT = '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H'
+// Re-exported, never re-spelled: these had drifted from production twice
+// (they still carried the pre-#14241 preambles), which left the fuzz and
+// colour-parity harnesses asserting against bytes the restorer no longer
+// emits — precisely the failure this module's own header warns about (#12101).
+// The harnesses replay into a fresh terminal, which starts on the normal
+// buffer, so that is the pane state they ground from.
+export const SNAPSHOT_REPLAY_PREAMBLE_NORMAL = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue(
+  { targetAlternateScreen: false, paneOnAlternateScreen: false }
+)}`
+export const SNAPSHOT_REPLAY_PREAMBLE_ALT = `${ABORT_TRUNCATED_CONTROL_STRING}${buildSnapshotReplayPrologue(
+  { targetAlternateScreen: true, paneOnAlternateScreen: false }
+)}`
 
 export { POST_REPLAY_LIVE_SNAPSHOT_RESET as POST_REPLAY_LIVE_SNAPSHOT_RESET_PARITY } from './terminal-mode-reset-profiles'
 


### PR DESCRIPTION
## ELI5

When you switch away from a terminal, Orca stops sending it output. If it stops mid-way through styled text, the pane is left holding a "bold pen" it never put down. #14241 taught the recovery paths to put the pen down.

It turns out the pen is not the only thing left in mid-air — the pane can also be left holding the wrong alphabet, the wrong margins, and the wrong screen. And on the path the bug was actually reported on, the pen never got put down at all: the very next byte after the reset picks it straight back up.

## Severity: High — silent corruption and content loss, default config, no user mitigation

This follows up **#14241** by @brennanb2025 (*fix(terminal): clear the SGR pen on hidden-output restore and abandon*). That PR correctly identified the layer and the mechanism, and its diagnosis work is what made this findable. Two things did not hold:

**1. The reset it added is undone before any content is painted, on the branch the field reports come from.**

xterm answers `?1049l` with `restoreCursor()`, which reloads the pen, all four G-set designations, GL, origin mode and wraparound from the register saved at `?1049h` (`InputHandler.ts` `restoreCursor`, and the `case 1049` fall-through in the DEC reset handler — note it runs *unconditionally* for 1049, not only when the buffer actually switches). #14241's split alt-screen branch emits `\x1b[0m` and then `\x1b[?1049l`, so a TUI that was bold when it entered the alt screen has its bold handed straight back:

```
prologue                                    replayed "qqq scrollback" renders as
PR #14241  \x1b[0m\x1b[?1049l\x1b[2J\x1b[3J\x1b[H   "─── ⎽␌⎼⎺┌┌␉▒␌┐"   bold=YES
this PR                                            "qqq scrollback"   bold=no
```

That is the reported symptom, on the reported path — an alt-screen agent whose snapshot splits normal scrollback from the alt frame — surviving the fix. Grounding has to **bracket** the buffer switch: after it, so the restore cannot undo it; and before it, so `?1049h` does not bank the gap's state for a later `?1049l` to hand back.

**2. Scoping to the pen was right for one call site and wrong for the other.**

#14241 used one constant for both live-stream recovery and full-frame replay, and argued against widening it because "each changes what a live TUI sees." That is correct for the live paths and I have kept it there. It is backwards for the replay prologue: `SerializeAddon` diffs every cell against the **default** attribute set and emits no charset designation at all — serializing plain text yields the bare text with zero SGR bytes. The payload is only correct on a terminal at default pen, `GL=G0`, `G0=ASCII`, origin off, autowrap on, insert off. A replay runs *precisely because* bytes were dropped, so none of that can be assumed.

## User-visible effects this fixes

| Stranded by the gap | What the user sees | Severity |
| -- | -- | -- |
| Pen, on the split alt-screen path | Regular text renders bold — the original STA-4042 symptom, unfixed by #14241 | High |
| `ESC(0` charset | The **entire** restored pane renders as line-drawing glyphs (`qqq lqk` → `─── ┌─┐`) — unreadable | High |
| `ESC[?1049h` (renderer stuck on alt) | Restored history paints into the alt buffer. Looks correct, but normal-buffer scrollback is **empty** and the content vanishes on the next buffer switch | High — scrollback loss |
| `ESC[?1049h` — keyboard side of the same divergence | Panes run with `vtExtensions.kittyKeyboard` on, and xterm swaps the kitty flag registers on the `?1049` transition. Staying on alt keeps the exited agent's negotiated flags, so the pane sends CSI-u key encodings to a plain shell that never asked for them — **typing is mis-encoded** | High — broken input |
| `DECSTBM` scroll region | Restored frame scrolls inside a stale 2-row window; 6 replayed rows land as `[A, E, F, "", "", ""]` — most of the frame is gone | High |
| `DECAWM` off | Every character past the right margin overwrites the last cell; `ABCDEFGHIJKLMNO` → `ABCDEFGHIJO` | High |
| `DECOM` origin mode | Restored content offset by the stale margin; later TUI cursor addressing stays margin-relative | Medium |
| `DECRWM` reverse wraparound | The live app's next backspace at column 0 chews into the row above the restored frame | Medium |
| Truncated OSC | #14241 removed a pre-existing `\x18`, so a half-read control string is now **committed** instead of discarded: wrong window/tab title (OSC 0/2), wrong cwd (OSC 7), wrong link target (OSC 8), and truncated clipboard writes (OSC 52) | Medium |

Reachability is ordinary use: hide a pane (switch worktree or tab), let it produce output, reveal it. No user action prevents or works around any of these.

## What Changed

**`src/shared/terminal-mode-reset-profiles.ts`**

- `RESET_AFTER_BYTE_GAP` is now `\x18\x1b[0m`. The CAN is not decoration: xterm dispatches `OSC_END`/`DCS_UNHOOK`/`APC_END` with `success = code !== 0x18 && code !== 0x1a`, so a bare ESC grounds the parser *and commits* whatever the gap truncated. Only CAN discards it. This restores the `\x18` that led the warning constant before #14241. Still deliberately parser + pen only — the live paths hand the emulator back to a running TUI that owns its own charset and margins, and it is still not DECSTR (xterm's soft reset wipes the kitty flags and stacks that agents negotiate only at startup).
- New `REPLAY_BASELINE_TERMINAL_RESET` (`\x1b[0m\x0f\x1b(B\x1b[?6l\x1b[?7h\x1b[?45l\x1b[4l`) and `REPLAY_BASELINE_BUFFER_RESET` (`\x1b[r`), used only by the replay prologue. Split in two because scroll margins are **per buffer**, so that half has to follow the buffer switch — and `?1049h` only clears them when it actually switches, which on a pane already in alt screen (the field case) it does not.
- `buildSnapshotReplayPrologue(...)`, so the renderer and the parity/fuzz harnesses cannot spell the contract differently again.

**`terminal-snapshot-replay-paint.ts`** — one `buildSnapshotReplayPrologue` for all three branches, in a load-bearing order: **CAN → baseline → buffer switch → baseline → `\x1b[r` → clear → DECSC**.

- **CAN must lead.** An ESC would commit the truncated control string it exists to discard. It leads the *first write only*; later writes follow well-formed snapshot payloads.
- **The baseline brackets the switch, and neither copy is redundant.** `?1049h` runs `saveCursor()`, banking whatever is live into the register the TUI's eventual `?1049l` restores from — ground it first, or the gap's state is saved for later and comes back as a bold prompt long after the repaint looked clean. `?1049l` runs `restoreCursor()`, which would otherwise reapply that register over the grounding.
- **`\x1b[r` is emitted on both sides** because margins are per buffer and the switch does not carry them across: an alt-target replay from a normal pane must ground the buffer it leaves, or the stale region resurfaces the moment the TUI exits.
- **The trailing DECSC** grounds the saved-cursor register, so a stranded `ESC 7` cannot be reached through the live TUI's next `ESC 8`. A snapshot carrying the model's own DECSC epilogue overwrites it, so it only ever acts as a floor.
- **The buffer switch is conditional.** `?1049` is *not* a no-op when the pane is already on the target: xterm skips only the buffer swap and still runs `restoreCursor()` **and swaps the kitty flag registers**. Emitting it unconditionally would park the flags of an agent that negotiated kitty on the normal screen — flags 1 → 0, Option chords dead — on every normal-buffer restore. Switching only on a genuine mismatch is exactly the divergence the gap creates, and there the swap is what makes the pane match the model again.

`restoreCursor()` is the riskiest surface, so one test poisons **every field it writes** at once — pen fg/bg/bold, all four G-sets, GL, origin, wraparound, cursor, insert, margins — lets `?1049h` bank the lot, and asserts the prologue neutralises all of it. G1–G3 are in the baseline for exactly this reason: the payload never leaves G0 so the frame looks right, but a single SO from the live TUI afterwards selects the stranded designation, and the trailing DECSC would otherwise bank it too. Two further tests assert the renderer lands on **byte-identical kitty flag registers and buffer type** to a model terminal that ingested the whole stream — in both directions: converge when the pane is stranded on alt, and leave the registers untouched when it is not.

**`pty-connection.ts`** — the abandon path grounded the gap twice (verified: count = 2). Now an `else if`, so it grounds exactly once on each of the three arms: warning, remote re-arm, quiet flood-abandon. All three call sites of the replay builder now pass the pane's real buffer type.

**`terminal-restore-parity-fixture.ts`** — `SNAPSHOT_REPLAY_PREAMBLE_NORMAL`/`_ALT` still held pre-#14241 literals, so the fuzz and colour-parity harnesses guarding this exact path were asserting against bytes production no longer emitted. They are now derived from the same builder, which is what this module's own header (#12101) asks for.

## Why not wider

The rule is **ground state the model re-asserts.** `?6l`/`?7h`/`?45l`/`4l` qualify — the model re-emits those only when SET, so grounding plus its re-assertion leaves the renderer matching the model; they are mode-sync rather than frame-correctness (`?45l` provably cannot cause a frame failure — xterm wires reverse-wraparound only into `backspace()` and the payload contains no BS). **G-set designations do not qualify and are deliberately not grounded**: the payload never leaves G0, so they cannot affect the frame, and the model never speaks about them. An earlier revision reset G1–G3 and that was actively harmful — `enacs=\E(B\E)0` (screen/tmux/vt100 terminfo) designates G1 once at init and then uses bare SO/SI, so grounding it renders a live app's box drawing as letters. Caught in review by @brennanb2025.

The old wording, kept for the other bits: `?6l` and `4l` are in only because the model restores those bits *conditionally* — `buildTerminalFrameRestoreSequences` emits `\x1b[4h` only when the model has insert mode on — so a stranded-on renderer keeps it and every later TUI repaint shifts cells instead of overwriting. Anything I could not tie to a demonstrable effect is out:

- **DECSTR (`CSI ! p`)** — xterm's soft reset wipes the kitty flags and stacks agents negotiate only at startup. Portability is the stronger reason though: it is unimplemented in several current terminals, and DEC's own definition sets autowrap *off* while xterm restores it to the resource default, so the explicit `?7h` here is better defined than DECSTR would have been.
- **DECSCNM (`?5l`)** — xterm.js carries a `FIXME: implement DECSCNM`; reverse video cannot be stranded in this emulator, so the byte would be dead weight.
- **Mouse modes, bracketed paste, cursor visibility** — already owned by the `POST_REPLAY_*` profiles written after the payload, and deliberately left alone for live agents.

Every byte is mutation-verified below; nothing is in on theory.

## Testing

`pnpm typecheck`, `oxlint`, `oxfmt --check` clean. **12,480 tests pass** across `terminal-pane` + `shared` + `main/daemon` + `main/ipc`; 42 in `terminal-snapshot-replay-paint.test.ts`, 584 in `pty-connection.test.ts`. A full-repo run was green apart from one pre-existing flake in an unrelated virtual-file-list suite, which passes in isolation on this branch and on the base commit and shares no code with this change.

A second suite, `terminal-replay-application-continuity.test.ts`, covers what a **live application** sees after its pane is restored — the class of defect adversarial review kept missing. Its line-drawing cases are parameterised over real `infocmp` capability strings for `xterm-256color`, `alacritty`, `screen-256color`, `tmux-256color`, `vt100` and `linux`, so the two ACS strategies (G0-swapping vs `enacs` + bare SO/SI) are both exercised. Re-introducing the G1–G3 reset fails 8 of them and correctly leaves the self-healing xterm/alacritty cases green.

Headline coverage is a **convergence test built through the same composer production uses** (`buildParityMainBufferSnapshot`, which mirrors `HeadlessEmulator.getSnapshot`: absolute cursor + DECSC epilogue, alt frame split from normal scrollback, rehydrate prefix owning the single `?1049h`): a renderer dirtied by any of eleven stranded states must land on the byte-identical frame a clean one produces, on both branches. Around it, per-element tests drive a **real headless emulator**, not a mock, and assert rendered cells:

- the field path end to end, through the actual builder output, for a split alt-screen snapshot whose TUI entered alt with a pen set
- the delayed arm: the agent exits the alt screen long after the repaint, and the prompt must still not be bold
- a post-replay SO must not paint line drawing (the G1–G3 case)
- a stranded `ESC 7` followed by the live TUI's `ESC 8`
- kitty flags preserved when the pane is already on the target buffer
- one case per stranded state (pen, charset, margins, origin, autowrap, insert), on both the normal and alt branches — they need separate coverage, because `?1049l` restores saved modes and so grounds some state for free while `?1049h` grounds none
- every field `restoreCursor()` writes, poisoned simultaneously
- kitty flag + buffer-type convergence against a model terminal that saw the whole stream
- the truncated-OSC case, asserting the title is *not* set
- the alt/normal buffer divergence, asserting `buffer.active.type` and that `buffer.normal` actually received the history
- the ordering itself: grounding before the switch must fail

**Coverage verified non-vacuous by mutation.** Removing each element independently breaks tests, so nothing here is dead weight:

| removed | tests failing |
| -- | -- |
| `\x18` (CAN) | 2 |
| `\x0f\x1b(B` (SI + G0→ASCII) | 10 |
| `\x1b[?6l` (DECOM) | 1 |
| `\x1b[?7h` (DECAWM) | 3 |
| `\x1b[?45l` (DECRWM) | 1 |
| `\x1b[4l` (IRM) | 1 |
| `\x1b[r` (DECSTBM) | 6 |
| `\x1b7` (DECSC) | 2 |
| grounding placed only before the buffer switch | 8 |

Reverting `buildMainModelSnapshotReplayWrites` to #14241's exact shape fails 9, including the behavioural field-path test.

Several existing tests pinned the literal replay write arrays and were updated. The SSH reattach replay clear in `pty-transport.ts` is deliberately untouched: it replays **raw** eager-buffered PTY bytes, which carry their own SGR, so the serializer-baseline argument does not apply there.

## Visual Proof

N/A — the defect is a transient render state, so a static screenshot cannot show it. The before/after is the byte-level A/B above, measured from the emulator's buffer rather than pixels.

## Known adjacent gaps, deliberately not in scope

- `snapshotCarriesNoImage` skips the *repaint* for an empty normal-buffer snapshot. That path now still grounds the gap — with the live-path constant, since nothing repaints over whatever is running — but it deliberately does not clear or switch buffers, so a pane stranded on alt with nothing to replay still does not return to normal. Closing that would trade a stale frame for a blank one, which is what the guard exists to prevent.
- **The alt branch cannot promise kitty preservation.** The prologue no longer contributes a switch, but production alt payloads carry their own `\x1b[0m\x1b[?1049h` (`buildRehydrateSequences`, and `frameRestoreAnsi`), so an agent that negotiated kitty *on the alt screen* still has its flags pushed into the main register by the payload. Fixing that means changing what the daemon emits, not the prologue. An earlier revision of this PR claimed the conditional switch fixed it — that was wrong, and only looked right because the test used synthetic payload data.
- `isPaneOnAlternateScreen()` is a best-effort read: xterm parses asynchronously, so a `?1049` transition still queued reads stale and the switch scopes wrong. Draining first with a write sentinel was implemented and reverted — it puts the repaint behind xterm's queue (a wedged terminal stalls recovery) and breaks the disposal/cancellation ordering the restore paths rely on. A stale read costs one mis-scoped switch; the barrier costs the repaint.
- The **daemon-snapshot and raw-relay reattach paints** still bare-clear with `\x1b[2J\x1b[3J\x1b[H` before their payload. The daemon one replays a serialized snapshot, so on an in-place reattach into a dirty emulator it has the same bleed this PR fixes for the model-snapshot sibling. Left out deliberately: different trigger, and it touches cold-restore/SSH choreography with its own test surface. Worth a follow-up.
- The live-stream constant is a mitigation, not a restoration: a gap could equally have swallowed a mode set, half a DECSTBM, or an OSC 4 palette write. The honest recovery on that path is a repaint, which is what the snapshot path does; the pen reset is what is safe to do when no snapshot is coming.

## Linked Issue

Related: STA-4042 / STA-4060. Follow-up to #14241.

Still **not** marked as fixing them. #14241 could not attribute the field reports to this path, and neither can I; what has changed is that the reported symptom is now shown to survive #14241 on the branch those reports come from, which makes this path a materially better candidate than it was. Treat it as a correctness fix on the recovery paths.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Cross-platform / SSH / mobile:** renderer-side and protocol-level — bytes written into the local xterm, identical on every platform and transport. No mobile surface imports these profiles.
- **Remote wire:** nothing crosses the wire. No RPC params, stream opcodes, or published host content change; the snapshot shape is untouched. Old clients and old hosts are unaffected.
- **Backwards compatibility:** the added bytes prefix writes that already cleared the screen in the same chunk. A live TUI re-arms its own state on its next write; a shell inherits a defined baseline instead of an undefined one.
- **Performance:** ~20 bytes per recovery event, still not emitted per-marker under flood.
- **Security:** the CAN restores discarding of truncated control strings, which *removes* a path where a half-read OSC 52 could write the clipboard.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)








