### PR TITLE
fix(agent-status): stop start-less child stops from minting phantom working

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7178,6 +7178,75 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('does not confirm restored child work from an unrelated stop', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a0000000000000003',
+        agent_type: 'reviewer'
+      })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      const restored = server.getStatusSnapshot()[0]
+      expect(restored).toMatchObject({ state: 'working', restoredUnconfirmed: true })
+
+      await postHookEvent(
+        server,
+        buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000004' })
+      )
+
+      expect(server.getStatusSnapshot()[0]).toEqual(restored)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('confirms done when a post-restart idle matches a restored teammate', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'areviewer-6d3cb5b5',
+        agent_type: 'reviewer'
+      })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true,
+        subagents: [expect.objectContaining({ id: 'areviewer-6d3cb5b5' })]
+      })
+
+      await postHookEvent(
+        server,
+        buildBody({ hook_event_name: 'TeammateIdle', teammate_name: 'reviewer' })
+      )
+
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'done',
+        subagents: [expect.objectContaining({ id: 'areviewer-6d3cb5b5', state: 'idle' })]
+      })
+      expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
+    } finally {
+      server.stop()
+    }
+  })
+
   it('lets an identical live OSC observation confirm a hydrated row', async () => {
     const payload = {
       state: 'working' as const,

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7209,6 +7209,56 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('keeps an unmatched restored child unconfirmed after current-runtime work drains', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a0000000000000005',
+        agent_type: 'reviewer'
+      })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      await postHookEvent(
+        server,
+        buildBody({
+          hook_event_name: 'SubagentStart',
+          agent_id: 'a0000000000000006',
+          agent_type: 'reviewer'
+        })
+      )
+      expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
+
+      await postHookEvent(
+        server,
+        buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000006' })
+      )
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true,
+        subagents: [expect.objectContaining({ id: 'a0000000000000005' })]
+      })
+      expect(server.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
+
+      await postHookEvent(
+        server,
+        buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000005' })
+      )
+      expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'done' })
+      expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
+      expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+    } finally {
+      server.stop()
+    }
+  })
+
   it('confirms done when a post-restart idle matches a restored teammate', async () => {
     const firstServer = new AgentHookServer()
     await firstServer.start({ env: 'production', userDataPath })

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7173,17 +7173,95 @@ describe('Last-status persistence', () => {
         buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000002' })
       )
 
-      expect(server.getStatusSnapshot()[0]).toEqual(restored)
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true,
+        subagents: undefined
+      })
       expect(server.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
       expect(server._getStateForTests().claudeSubagentRosterByPaneKey.size).toBe(0)
-      expect(statusListener).not.toHaveBeenCalled()
+      expect(statusListener).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ restoredUnconfirmed: true })
+      )
 
       await postHookEvent(server, buildBody({ hook_event_name: 'Stop', background_tasks: [] }))
 
       expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'done' })
       expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
       expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
-      expect(statusListener).toHaveBeenCalledTimes(1)
+      expect(statusListener).toHaveBeenCalledTimes(2)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not resurrect a matched restored child across a second restart', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a0000000000000012',
+        agent_type: 'reviewer'
+      })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const secondServer = new AgentHookServer()
+    await secondServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      secondServer,
+      buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000012' })
+    )
+    expect(secondServer.getStatusSnapshot()[0]).toMatchObject({
+      state: 'working',
+      restoredUnconfirmed: true,
+      subagents: undefined
+    })
+    secondServer.flushStatusPersistSync()
+    secondServer.stop()
+
+    const thirdServer = new AgentHookServer()
+    await thirdServer.start({ env: 'production', userDataPath })
+    try {
+      expect(thirdServer._getStateForTests().claudeSubagentRosterByPaneKey.size).toBe(0)
+
+      await postHookEvent(thirdServer, buildBody({ hook_event_name: 'Stop' }))
+
+      expect(thirdServer.getStatusSnapshot()[0]).toMatchObject({ state: 'done' })
+      expect(thirdServer.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
+    } finally {
+      thirdServer.stop()
+    }
+  })
+
+  it('keeps a legacy Stop unconfirmed when only a restored child gates it', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a0000000000000013',
+        agent_type: 'reviewer'
+      })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      await postHookEvent(server, buildBody({ hook_event_name: 'Stop' }))
+
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true,
+        subagents: [expect.objectContaining({ id: 'a0000000000000013' })]
+      })
+      expect(server.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
     } finally {
       server.stop()
     }
@@ -7308,7 +7386,11 @@ describe('Last-status persistence', () => {
         buildBody({ hook_event_name: 'TeammateIdle', teammate_name: 'reviewer' })
       )
 
-      expect(server.getStatusSnapshot()[0]).toEqual(restored)
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true,
+        subagents: [expect.objectContaining({ id: 'areviewer-6d3cb5b5', state: 'idle' })]
+      })
       expect(server.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
 
       await postHookEvent(

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7114,6 +7114,70 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('keeps an unknown post-restart child stop from confirming a stale working row', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({ hook_event_name: 'UserPromptSubmit', prompt: 'may finish offline' })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      const restored = server.getStatusSnapshot()[0]
+      expect(restored).toMatchObject({ state: 'working', restoredUnconfirmed: true })
+
+      await postHookEvent(
+        server,
+        buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000001' })
+      )
+
+      expect(server.getStatusSnapshot()[0]).toEqual(restored)
+      expect(server._getStateForTests().claudeSubagentRosterByPaneKey.size).toBe(0)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('confirms done when a post-restart stop matches a restored child identity', async () => {
+    const firstServer = new AgentHookServer()
+    await firstServer.start({ env: 'production', userDataPath })
+    await postHookEvent(
+      firstServer,
+      buildBody({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a0000000000000002',
+        agent_type: 'reviewer'
+      })
+    )
+    firstServer.flushStatusPersistSync()
+    firstServer.stop()
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true,
+        subagents: [expect.objectContaining({ id: 'a0000000000000002' })]
+      })
+
+      await postHookEvent(
+        server,
+        buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000002' })
+      )
+
+      expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'done' })
+      expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
+      expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+    } finally {
+      server.stop()
+    }
+  })
+
   it('lets an identical live OSC observation confirm a hydrated row', async () => {
     const payload = {
       state: 'working' as const,

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7142,7 +7142,7 @@ describe('Last-status persistence', () => {
     }
   })
 
-  it('confirms done when a post-restart stop matches a restored child identity', async () => {
+  it('waits for a lead boundary after a post-restart stop matches a restored child', async () => {
     const firstServer = new AgentHookServer()
     await firstServer.start({ env: 'production', userDataPath })
     await postHookEvent(
@@ -7159,7 +7159,10 @@ describe('Last-status persistence', () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production', userDataPath })
     try {
-      expect(server.getStatusSnapshot()[0]).toMatchObject({
+      const statusListener = vi.fn()
+      server.subscribeEnrichedStatus(statusListener)
+      const restored = server.getStatusSnapshot()[0]
+      expect(restored).toMatchObject({
         state: 'working',
         restoredUnconfirmed: true,
         subagents: [expect.objectContaining({ id: 'a0000000000000002' })]
@@ -7170,9 +7173,17 @@ describe('Last-status persistence', () => {
         buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000002' })
       )
 
+      expect(server.getStatusSnapshot()[0]).toEqual(restored)
+      expect(server.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
+      expect(server._getStateForTests().claudeSubagentRosterByPaneKey.size).toBe(0)
+      expect(statusListener).not.toHaveBeenCalled()
+
+      await postHookEvent(server, buildBody({ hook_event_name: 'Stop', background_tasks: [] }))
+
       expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'done' })
       expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
       expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+      expect(statusListener).toHaveBeenCalledTimes(1)
     } finally {
       server.stop()
     }
@@ -7251,6 +7262,15 @@ describe('Last-status persistence', () => {
         server,
         buildBody({ hook_event_name: 'SubagentStop', agent_id: 'a0000000000000005' })
       )
+
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        restoredUnconfirmed: true
+      })
+      expect(server._getStateForTests().claudeSubagentRosterByPaneKey.size).toBe(0)
+
+      await postHookEvent(server, buildBody({ hook_event_name: 'Stop', background_tasks: [] }))
+
       expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'done' })
       expect(server.getStatusSnapshot()[0]?.restoredUnconfirmed).toBeUndefined()
       expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
@@ -7259,7 +7279,7 @@ describe('Last-status persistence', () => {
     }
   })
 
-  it('confirms done when a post-restart idle matches a restored teammate', async () => {
+  it('waits for a lead boundary after a post-restart idle matches a restored teammate', async () => {
     const firstServer = new AgentHookServer()
     await firstServer.start({ env: 'production', userDataPath })
     await postHookEvent(
@@ -7276,7 +7296,8 @@ describe('Last-status persistence', () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production', userDataPath })
     try {
-      expect(server.getStatusSnapshot()[0]).toMatchObject({
+      const restored = server.getStatusSnapshot()[0]
+      expect(restored).toMatchObject({
         state: 'working',
         restoredUnconfirmed: true,
         subagents: [expect.objectContaining({ id: 'areviewer-6d3cb5b5' })]
@@ -7285,6 +7306,17 @@ describe('Last-status persistence', () => {
       await postHookEvent(
         server,
         buildBody({ hook_event_name: 'TeammateIdle', teammate_name: 'reviewer' })
+      )
+
+      expect(server.getStatusSnapshot()[0]).toEqual(restored)
+      expect(server.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
+
+      await postHookEvent(
+        server,
+        buildBody({
+          hook_event_name: 'Stop',
+          background_tasks: [{ id: 'treviewer', type: 'teammate', status: 'running' }]
+        })
       )
 
       expect(server.getStatusSnapshot()[0]).toMatchObject({

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1274,7 +1274,12 @@ export class AgentHookServer {
     }
     const cachedPayload = resolveCachedClaudeCompactOwnership(previous, effectivePayload)
     const enriched = this.attachStatusTiming(cachedPayload, now)
-    this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
+    // Why: an identity-matched event can still leave the aggregate backed only by another restored child; keep liveness reconciliation eligible.
+    if (enriched.restoredUnconfirmed) {
+      this.runtimeObservedStatusPaneKeys.delete(enriched.paneKey)
+    } else {
+      this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
+    }
     this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()

--- a/src/shared/agent-hook-listener-roster-retention.test.ts
+++ b/src/shared/agent-hook-listener-roster-retention.test.ts
@@ -29,6 +29,22 @@ describe('Claude hook roster retention', () => {
     expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
+  it('does not retain rosters for unknown child endings across unique panes', () => {
+    const state = createHookListenerState()
+    for (let index = 0; index <= MAX_AGENT_HOOK_STATUS_CACHE_PANES; index += 1) {
+      const paneKey = makePaneKey(`unknown-stop-${index}`, LEAF_ID)
+      expect(
+        claudeEvent(state, paneKey, {
+          hook_event_name: 'SubagentStop',
+          agent_id: 'a0000000000000001'
+        })
+      ).toBeNull()
+    }
+
+    expect(state.lastStatusByPaneKey.size).toBe(0)
+    expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
+  })
+
   it('preserves ordinary teammate lifecycle updates', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('valid-lifecycle', LEAF_ID)

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -102,6 +102,50 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
+  it('resolves an exact-name teammate idle to done with no cached lead', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-known-idle', LEAF_ID)
+
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'areviewer-6d3cb5b5',
+      agent_type: 'reviewer'
+    })
+    state.claudeLeadStateByPaneKey.delete(paneKey)
+
+    const idled = claudeEvent(state, paneKey, {
+      hook_event_name: 'TeammateIdle',
+      teammate_name: 'reviewer'
+    })
+
+    expect(idled?.payload.state).toBe('done')
+    expect(idled?.payload.subagents).toEqual([
+      expect.objectContaining({ id: 'areviewer-6d3cb5b5', state: 'idle' })
+    ])
+  })
+
+  it('resolves a known teammate-shaped stop to done with no cached lead', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-known-teammate-stop', LEAF_ID)
+
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'areviewer-7e4cb6c6',
+      agent_type: 'reviewer'
+    })
+    state.claudeLeadStateByPaneKey.delete(paneKey)
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'areviewer-7e4cb6c6'
+    })
+
+    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.subagents).toEqual([
+      expect.objectContaining({ id: 'areviewer-7e4cb6c6', state: 'idle' })
+    ])
+  })
+
   it('resolves a first-event child wait when that child stops', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-wait-stop', LEAF_ID)

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createHookListenerState,
   normalizeHookPayload,
+  seedClaudeSubagentRosterFromSnapshots,
   type HookListenerState
 } from './agent-hook-listener'
 import { makePaneKey } from './stable-pane-id'
@@ -121,6 +122,35 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     expect(idled?.payload.state).toBe('done')
     expect(idled?.payload.subagents).toEqual([
       expect.objectContaining({ id: 'areviewer-6d3cb5b5', state: 'idle' })
+    ])
+  })
+
+  it('keeps a restored teammate after its exact idle proves the live identity', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('restored-known-idle', LEAF_ID)
+    seedClaudeSubagentRosterFromSnapshots(state, paneKey, [
+      {
+        id: 'areviewer-8f5dc7d7',
+        state: 'working',
+        startedAt: 100,
+        agentType: 'reviewer'
+      }
+    ])
+
+    expect(
+      claudeEvent(state, paneKey, {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'reviewer'
+      })?.payload.state
+    ).toBe('done')
+
+    const leadStop = claudeEvent(state, paneKey, {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'treviewer', type: 'teammate', status: 'running' }]
+    })
+
+    expect(leadStop?.payload.subagents).toEqual([
+      expect.objectContaining({ id: 'areviewer-8f5dc7d7', state: 'idle' })
     ])
   })
 

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   seedClaudeSubagentRosterFromSnapshots,
   type HookListenerState
 } from './agent-hook-listener'
+import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
 import { makePaneKey } from './stable-pane-id'
 
 const LEAF_ID = '22222222-2222-4222-8222-222222222222'
@@ -142,7 +143,13 @@ describe('Claude child lifecycle events with no cached lead state', () => {
         hook_event_name: 'TeammateIdle',
         teammate_name: 'reviewer'
       })
-    ).toBeNull()
+    ).toMatchObject({
+      restoredUnconfirmed: true,
+      payload: {
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'areviewer-8f5dc7d7', state: 'idle' })]
+      }
+    })
 
     const leadStop = claudeEvent(state, paneKey, {
       hook_event_name: 'Stop',
@@ -222,7 +229,10 @@ describe('Claude child lifecycle events with no cached lead state', () => {
         hook_event_name: 'SubagentStop',
         agent_id: 'a0000000000000008'
       })
-    ).toBeNull()
+    ).toMatchObject({
+      restoredUnconfirmed: true,
+      payload: { state: 'working', subagents: undefined }
+    })
     expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
@@ -247,6 +257,49 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     expect(stopped?.payload.subagents).toEqual([
       expect.objectContaining({ id: 'a0000000000000010', state: 'working' })
     ])
+  })
+
+  it('keeps a legacy lead Stop unconfirmed when only a restored child gates it', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('restored-child-legacy-stop', LEAF_ID)
+    seedClaudeSubagentRosterFromSnapshots(state, paneKey, [
+      { id: 'a0000000000000012', state: 'working', startedAt: 100 }
+    ])
+
+    const stopped = claudeEvent(state, paneKey, { hook_event_name: 'Stop' })
+
+    expect(stopped).toMatchObject({
+      restoredUnconfirmed: true,
+      payload: {
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'a0000000000000012' })]
+      }
+    })
+  })
+
+  it('does not let a truncated terminal inventory confirm a restored child', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('restored-child-truncated-inventory', LEAF_ID)
+    seedClaudeSubagentRosterFromSnapshots(state, paneKey, [
+      { id: 'arestored', state: 'working', startedAt: 100 }
+    ])
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'Stop',
+      background_tasks: Array.from({ length: AGENT_STATUS_MAX_SUBAGENTS + 1 }, (_, index) => ({
+        id: `finished-${index}`,
+        type: 'subagent',
+        status: 'completed'
+      }))
+    })
+
+    expect(stopped).toMatchObject({
+      restoredUnconfirmed: true,
+      payload: {
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'arestored' })]
+      }
+    })
   })
 
   it('resolves a first-event child wait back to working when that child stops', () => {

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createHookListenerState,
+  normalizeHookPayload,
+  type HookListenerState
+} from './agent-hook-listener'
+import { makePaneKey } from './stable-pane-id'
+
+const LEAF_ID = '22222222-2222-4222-8222-222222222222'
+
+function claudeEvent(
+  state: HookListenerState,
+  paneKey: string,
+  payload: Record<string, unknown>
+): ReturnType<typeof normalizeHookPayload> {
+  return normalizeHookPayload(state, 'claude', { paneKey, payload }, 'production')
+}
+
+// A fresh listener state is what Orca has after a restart: the lead-turn cache is in-memory only,
+// so a session that outlived the app reports its next child event with no cached lead.
+describe('Claude child lifecycle events with no cached lead state', () => {
+  it('does not mint working from a start-less SubagentStop', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-stop', LEAF_ID)
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'achild-0000000000000001'
+    })
+
+    expect(stopped?.payload.state).not.toBe('working')
+    expect(stopped?.payload.state).toBe('done')
+  })
+
+  it('does not mint working from a start-less TeammateIdle', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-idle', LEAF_ID)
+
+    const idled = claudeEvent(state, paneKey, {
+      hook_event_name: 'TeammateIdle',
+      teammate_name: 'reviewer'
+    })
+
+    expect(idled?.payload.state).not.toBe('working')
+    expect(idled?.payload.state).toBe('done')
+  })
+
+  it('still reports working for a start-less SubagentStart, which proves activity', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-start', LEAF_ID)
+
+    const started = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'achild-0000000000000002',
+      agent_type: 'reviewer'
+    })
+
+    expect(started?.payload.state).toBe('working')
+  })
+
+  it('still gates a start-less SubagentStop up to working while another child runs', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-stop-sibling', LEAF_ID)
+
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'achild-0000000000000003',
+      agent_type: 'reviewer'
+    })
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'achild-0000000000000004',
+      agent_type: 'reviewer'
+    })
+    state.claudeLeadStateByPaneKey.delete(paneKey)
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'achild-0000000000000003'
+    })
+
+    expect(stopped?.payload.state).toBe('working')
+  })
+
+  it('keeps a live lead working when its child stops', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('live-lead-stop', LEAF_ID)
+
+    claudeEvent(state, paneKey, { hook_event_name: 'UserPromptSubmit', prompt: 'spawn reviewer' })
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'achild-0000000000000005',
+      agent_type: 'reviewer'
+    })
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'achild-0000000000000005'
+    })
+
+    expect(stopped?.payload.state).toBe('working')
+  })
+})

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -19,7 +19,7 @@ function claudeEvent(
 // A fresh listener state is what Orca has after a restart: the lead-turn cache is in-memory only,
 // so a session that outlived the app reports its next child event with no cached lead.
 describe('Claude child lifecycle events with no cached lead state', () => {
-  it('does not mint working from a start-less SubagentStop', () => {
+  it('makes no status claim from an unknown start-less SubagentStop', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-stop', LEAF_ID)
 
@@ -28,11 +28,11 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       agent_id: 'achild-0000000000000001'
     })
 
-    expect(stopped?.payload.state).not.toBe('working')
-    expect(stopped?.payload.state).toBe('done')
+    expect(stopped).toBeNull()
+    expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
-  it('does not mint working from a start-less TeammateIdle', () => {
+  it('makes no status claim from an unknown start-less TeammateIdle', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-idle', LEAF_ID)
 
@@ -41,8 +41,8 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       teammate_name: 'reviewer'
     })
 
-    expect(idled?.payload.state).not.toBe('working')
-    expect(idled?.payload.state).toBe('done')
+    expect(idled).toBeNull()
+    expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
   it('still reports working for a start-less SubagentStart, which proves activity', () => {
@@ -80,6 +80,46 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     })
 
     expect(stopped?.payload.state).toBe('working')
+  })
+
+  it('resolves an identity-matched child drain to done with no cached lead', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-known-stop', LEAF_ID)
+
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'a0000000000000006',
+      agent_type: 'reviewer'
+    })
+    state.claudeLeadStateByPaneKey.delete(paneKey)
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a0000000000000006'
+    })
+
+    expect(stopped?.payload.state).toBe('done')
+    expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
+  })
+
+  it('resolves a first-event child wait when that child stops', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('startless-wait-stop', LEAF_ID)
+
+    expect(
+      claudeEvent(state, paneKey, {
+        hook_event_name: 'PermissionRequest',
+        agent_id: 'a0000000000000007',
+        tool_name: 'Bash'
+      })?.payload.state
+    ).toBe('waiting')
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a0000000000000007'
+    })
+
+    expect(stopped?.payload.state).toBe('done')
   })
 
   it('keeps a live lead working when its child stops', () => {

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -176,7 +176,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     ])
   })
 
-  it('does not reconfirm an unrelated restored child after runtime work drains', () => {
+  it('leaves an unrelated restored child explicitly unconfirmed after runtime work drains', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('restored-sibling-after-runtime-drain', LEAF_ID)
     seedClaudeSubagentRosterFromSnapshots(state, paneKey, [
@@ -201,8 +201,28 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       agent_id: 'a0000000000000009'
     })
 
-    expect(stopped?.payload.state).toBe('done')
-    expect(stopped?.payload.subagents).toBeUndefined()
+    expect(stopped).toMatchObject({
+      restoredUnconfirmed: true,
+      payload: {
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'a0000000000000008', state: 'working' })]
+      }
+    })
+    expect(state.claudeSubagentRosterByPaneKey.get(paneKey)).toEqual(
+      new Map([
+        [
+          'a0000000000000008',
+          expect.objectContaining({ state: 'working', restoredFromSnapshot: true })
+        ]
+      ])
+    )
+
+    expect(
+      claudeEvent(state, paneKey, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a0000000000000008'
+      })?.payload.state
+    ).toBe('done')
     expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -176,6 +176,59 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     ])
   })
 
+  it('does not reconfirm an unrelated restored child after runtime work drains', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('restored-sibling-after-runtime-drain', LEAF_ID)
+    seedClaudeSubagentRosterFromSnapshots(state, paneKey, [
+      {
+        id: 'a0000000000000008',
+        state: 'working',
+        startedAt: 100,
+        agentType: 'reviewer'
+      }
+    ])
+
+    expect(
+      claudeEvent(state, paneKey, {
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a0000000000000009',
+        agent_type: 'reviewer'
+      })?.payload.state
+    ).toBe('working')
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a0000000000000009'
+    })
+
+    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.subagents).toBeUndefined()
+    expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
+  })
+
+  it('keeps a restored sibling gated when a current lead is still working', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('restored-sibling-with-live-lead', LEAF_ID)
+    seedClaudeSubagentRosterFromSnapshots(state, paneKey, [
+      { id: 'a0000000000000010', state: 'working', startedAt: 100 }
+    ])
+    claudeEvent(state, paneKey, { hook_event_name: 'UserPromptSubmit', prompt: 'continue' })
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'a0000000000000011'
+    })
+
+    const stopped = claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a0000000000000011'
+    })
+
+    expect(stopped?.payload.state).toBe('working')
+    expect(stopped?.payload.subagents).toEqual([
+      expect.objectContaining({ id: 'a0000000000000010', state: 'working' })
+    ])
+  })
+
   it('resolves a first-event child wait when that child stops', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-wait-stop', LEAF_ID)

--- a/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-startless-child-lifecycle.test.ts
@@ -83,7 +83,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     expect(stopped?.payload.state).toBe('working')
   })
 
-  it('resolves an identity-matched child drain to done with no cached lead', () => {
+  it('keeps the parent working when a current-runtime child drains with no cached lead', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-known-stop', LEAF_ID)
 
@@ -99,11 +99,11 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       agent_id: 'a0000000000000006'
     })
 
-    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.state).toBe('working')
     expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
-  it('resolves an exact-name teammate idle to done with no cached lead', () => {
+  it('keeps the parent working when an exact-name teammate idles with no cached lead', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-known-idle', LEAF_ID)
 
@@ -119,7 +119,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       teammate_name: 'reviewer'
     })
 
-    expect(idled?.payload.state).toBe('done')
+    expect(idled?.payload.state).toBe('working')
     expect(idled?.payload.subagents).toEqual([
       expect.objectContaining({ id: 'areviewer-6d3cb5b5', state: 'idle' })
     ])
@@ -141,8 +141,8 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       claudeEvent(state, paneKey, {
         hook_event_name: 'TeammateIdle',
         teammate_name: 'reviewer'
-      })?.payload.state
-    ).toBe('done')
+      })
+    ).toBeNull()
 
     const leadStop = claudeEvent(state, paneKey, {
       hook_event_name: 'Stop',
@@ -154,7 +154,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     ])
   })
 
-  it('resolves a known teammate-shaped stop to done with no cached lead', () => {
+  it('keeps the parent working when a known teammate-shaped child stops', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-known-teammate-stop', LEAF_ID)
 
@@ -170,7 +170,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       agent_id: 'areviewer-7e4cb6c6'
     })
 
-    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.state).toBe('working')
     expect(stopped?.payload.subagents).toEqual([
       expect.objectContaining({ id: 'areviewer-7e4cb6c6', state: 'idle' })
     ])
@@ -221,8 +221,8 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       claudeEvent(state, paneKey, {
         hook_event_name: 'SubagentStop',
         agent_id: 'a0000000000000008'
-      })?.payload.state
-    ).toBe('done')
+      })
+    ).toBeNull()
     expect(state.claudeSubagentRosterByPaneKey.size).toBe(0)
   })
 
@@ -249,7 +249,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
     ])
   })
 
-  it('resolves a first-event child wait when that child stops', () => {
+  it('resolves a first-event child wait back to working when that child stops', () => {
     const state = createHookListenerState()
     const paneKey = makePaneKey('startless-wait-stop', LEAF_ID)
 
@@ -266,7 +266,7 @@ describe('Claude child lifecycle events with no cached lead state', () => {
       agent_id: 'a0000000000000007'
     })
 
-    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.state).toBe('working')
   })
 
   it('keeps a live lead working when its child stops', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3866,6 +3866,9 @@ describe('shared agent-hook-listener', () => {
     })
 
     it('scopes TeammateIdle to the exact teammate name for hyphen-prefix names', () => {
+      // Anchor the emit to a completed lead; no-lead idle events deliberately make no status claim.
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'spawn lanes' })
+      claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
       claudeEvent({
         hook_event_name: 'SubagentStart',
         agent_id: 'alane-hooks-6d3cb5b5',

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -33,7 +33,7 @@ import {
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
   idleClaudeTeammateByName,
-  reapRestoredClaudeSubagentsWithoutLiveAgent,
+  reapUnconfirmedRestoredClaudeSubagents,
   stopClaudeSubagent,
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
@@ -2600,6 +2600,15 @@ function normalizeClaudeSubagentLifecycleEvent(
   if (!lifecycleId) {
     return null
   }
+  const cachedLead = state.claudeLeadStateByPaneKey.get(paneKey)
+  const ownsUnbackedWait =
+    cachedLead?.state === 'waiting' &&
+    cachedLead.stateBeforeWait === undefined &&
+    cachedLead.waitingAgentId !== undefined &&
+    (eventName === 'TeammateIdle'
+      ? claudeTeammateIdMatchesName(cachedLead.waitingAgentId, lifecycleId)
+      : cachedLead.waitingAgentId === lifecycleId)
+  const hasCachedLeadEvidence = cachedLead !== undefined && !ownsUnbackedWait
   let roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   let endedChildWork = false
   if (eventName === 'TeammateIdle') {
@@ -2640,12 +2649,15 @@ function normalizeClaudeSubagentLifecycleEvent(
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
     }
   }
+  const workingChildEvidence = claudeRosterHasRuntimeWorkingSubagent(roster)
+  if (!hasCachedLeadEvidence && endedChildWork && !workingChildEvidence && roster) {
+    reapUnconfirmedRestoredClaudeSubagents(roster)
+  }
   if (roster?.size === 0) {
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
   }
   return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
-    workingChildEvidence:
-      eventName === 'SubagentStart' || claudeRosterHasRuntimeWorkingSubagent(roster),
+    workingChildEvidence,
     endedChildWork
   })
 }
@@ -2695,7 +2707,7 @@ export function reapRestoredClaudeSubagentsForDeadPane(
   paneKey: string
 ): boolean {
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
-  if (!roster || !reapRestoredClaudeSubagentsWithoutLiveAgent(roster)) {
+  if (!roster || !reapUnconfirmedRestoredClaudeSubagents(roster)) {
     return false
   }
   if (roster.size === 0) {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -27,6 +27,7 @@ import {
 import { normalizeOptionalField } from './agent-status-field-normalization'
 import { isAskUserQuestionTool } from './agent-question-answered-intent'
 import {
+  claudeRosterHasRuntimeWorkingSubagent,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
@@ -2643,7 +2644,8 @@ function normalizeClaudeSubagentLifecycleEvent(
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
   }
   return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
-    childActivity: eventName === 'SubagentStart',
+    workingChildEvidence:
+      eventName === 'SubagentStart' || claudeRosterHasRuntimeWorkingSubagent(roster),
     endedChildWork
   })
 }
@@ -2743,10 +2745,10 @@ function buildClaudeCachedLeadStatusPayload(
   eventName: unknown,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  evidence: { childActivity?: boolean; endedChildWork?: boolean } = {}
+  evidence: { workingChildEvidence?: boolean; endedChildWork?: boolean } = {}
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
-  if (!lead && !evidence.childActivity && !evidence.endedChildWork) {
+  if (!lead && !evidence.workingChildEvidence && !evidence.endedChildWork) {
     return null
   }
   // Why: no-lead completion requires an identity-matched work ending; delayed unknown stops cannot retire newer work.
@@ -2904,7 +2906,7 @@ function normalizeClaudeEvent(
     const lead = state.claudeLeadStateByPaneKey.get(paneKey)
     if (lead?.state !== 'waiting' || lead.waitingAgentId !== subagentOriginId) {
       return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
-        childActivity: true
+        workingChildEvidence: true
       })
     }
     const isParallelSiblingCompletionDuringChildQuestion =
@@ -2914,7 +2916,7 @@ function normalizeClaudeEvent(
       eventToolUseId !== lead.waitingToolUseId
     if (isParallelSiblingCompletionDuringChildQuestion) {
       return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
-        childActivity: true
+        workingChildEvidence: true
       })
     }
     // Why: approval granted — update the tool snapshot (drop the pending card) as the lead's own next tool event would.
@@ -2930,7 +2932,11 @@ function normalizeClaudeEvent(
 
   // Why: lead events never carry agent_id; even a child missed by lifecycle tracking cannot own the lead turn or its background-work evidence.
   if (eventAgentId && !isWaitingInducing) {
-    return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload)
+    return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+      workingChildEvidence: claudeRosterHasRuntimeWorkingSubagent(
+        state.claudeSubagentRosterByPaneKey.get(paneKey)
+      )
+    })
   }
 
   if (isTurnBoundary && eventAgentId === undefined) {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2620,6 +2620,7 @@ function normalizeClaudeSubagentLifecycleEvent(
   const hasCachedLeadEvidence = cachedLead !== undefined && !ownsUnbackedWait
   let roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   let endedChildWork = false
+  let endedRuntimeChildWork = false
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
@@ -2628,7 +2629,7 @@ function normalizeClaudeSubagentLifecycleEvent(
       for (const [id, tracked] of roster) {
         if (tracked.state === 'working' && claudeTeammateIdMatchesName(id, teammateName)) {
           wasWorking = true
-          break
+          endedRuntimeChildWork ||= tracked.restoredFromSnapshot !== true
         }
       }
       idleClaudeTeammateByName(roster, teammateName)
@@ -2649,7 +2650,9 @@ function normalizeClaudeSubagentLifecycleEvent(
       )
     } else {
       if (roster) {
-        const wasWorking = roster.get(agentId)?.state === 'working'
+        const tracked = roster.get(agentId)
+        const wasWorking = tracked?.state === 'working'
+        endedRuntimeChildWork = wasWorking && tracked.restoredFromSnapshot !== true
         // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
         stopClaudeSubagent(roster, agentId)
         endedChildWork = wasWorking && roster.get(agentId)?.state !== 'working'
@@ -2669,7 +2672,8 @@ function normalizeClaudeSubagentLifecycleEvent(
   }
   return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
     workingChildEvidence,
-    endedChildWork
+    endedChildWork,
+    endedRuntimeChildWork
   })
 }
 
@@ -2727,7 +2731,7 @@ export function reapRestoredClaudeSubagentsForDeadPane(
   return true
 }
 
-/** Drop a child-owned wait when it stops/idles; without a prior lead state, the child ending resolves the pane. */
+/** Drop a child-owned waiting state when the child stops/idles, restoring the displaced lead state. */
 function clearClaudePendingWaitForAgent(
   state: HookListenerState,
   paneKey: string,
@@ -2737,7 +2741,7 @@ function clearClaudePendingWaitForAgent(
   if (lead?.state !== 'waiting' || !lead.waitingAgentId || !ownsWait(lead.waitingAgentId)) {
     return
   }
-  state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait ?? { state: 'done' })
+  state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait ?? { state: 'working' })
 }
 
 /** Clear an AskUserQuestion wait after the answer is typed (answering emits no hook event; the caller infers it from the submit keystroke). Restores the stashed pre-wait lead state or 'working', drops the cached card, and returns the pane state to emit (gated up to 'working' while children run). */
@@ -2768,14 +2772,28 @@ function buildClaudeCachedLeadStatusPayload(
   eventName: unknown,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  evidence: { workingChildEvidence?: boolean; endedChildWork?: boolean } = {}
+  evidence: {
+    workingChildEvidence?: boolean
+    endedChildWork?: boolean
+    endedRuntimeChildWork?: boolean
+  } = {}
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
-  if (!lead && !evidence.workingChildEvidence && !evidence.endedChildWork) {
-    return null
+  let leadState = lead?.state
+  if (!leadState) {
+    if (evidence.workingChildEvidence || evidence.endedRuntimeChildWork) {
+      // Why: ending a current-runtime child wakes its parent; only a cached lead boundary can prove the whole pane completed.
+      leadState = 'working'
+    } else if (
+      evidence.endedChildWork &&
+      resolveClaudePaneState(state, paneKey, { state: 'done' }) !== 'done'
+    ) {
+      // Why: a restored child ending proves only that child ended; publish only when independent pane work still gates the aggregate.
+      leadState = 'done'
+    } else {
+      return null
+    }
   }
-  // Why: no-lead completion requires an identity-matched work ending; delayed unknown stops cannot retire newer work.
-  const leadState = lead?.state ?? (evidence.endedChildWork ? 'done' : 'working')
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName: resolveClaudePaneState(state, paneKey, {
       state: leadState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2666,8 +2666,13 @@ function normalizeClaudeSubagentLifecycleEvent(
   if (roster?.size === 0) {
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
   }
-  if (!hasCachedLeadEvidence && endedChildWork && !workingChildEvidence && hasUnconfirmedChild) {
-    // Why: this ending proves nothing about a different child restored from disk; keep the aggregate explicitly unconfirmed instead of publishing fresh work or completion.
+  if (
+    !hasCachedLeadEvidence &&
+    endedChildWork &&
+    !workingChildEvidence &&
+    (hasUnconfirmedChild || !endedRuntimeChildWork)
+  ) {
+    // Why: a restored-only ending proves no lead boundary, and an unmatched restored sibling proves no current liveness; persist the roster transition without publishing fresh work or completion.
     state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
   }
   return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
@@ -2784,12 +2789,9 @@ function buildClaudeCachedLeadStatusPayload(
     if (evidence.workingChildEvidence || evidence.endedRuntimeChildWork) {
       // Why: ending a current-runtime child wakes its parent; only a cached lead boundary can prove the whole pane completed.
       leadState = 'working'
-    } else if (
-      evidence.endedChildWork &&
-      resolveClaudePaneState(state, paneKey, { state: 'done' }) !== 'done'
-    ) {
-      // Why: a restored child ending proves only that child ended; publish only when independent pane work still gates the aggregate.
-      leadState = 'done'
+    } else if (evidence.endedChildWork) {
+      // Why: a restored child ending proves only that child ended; persist its roster transition as unconfirmed working, never as lead completion.
+      leadState = 'working'
     } else {
       return null
     }
@@ -3020,6 +3022,19 @@ function normalizeClaudeEvent(
     state: reportedStateName,
     interrupted
   })
+  const effectiveRoster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  if (
+    isTurnBoundary &&
+    eventAgentId === undefined &&
+    effectiveState === 'working' &&
+    claudeRosterHasRestoredSnapshotSubagent(effectiveRoster) &&
+    !claudeRosterHasRuntimeWorkingSubagent(effectiveRoster) &&
+    !state.claudeRunningNonAgentTaskPaneKeys.has(paneKey) &&
+    !state.claudeActiveSessionCronPaneKeys.has(paneKey)
+  ) {
+    // Why: a legacy or partial Stop confirms the lead boundary, not a child restored from disk; keep the child-only gate eligible for reconciliation.
+    state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
+  }
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2587,6 +2587,11 @@ function resolveClaudePaneState(
     : 'done'
 }
 
+/** Child lifecycle events that end work. They say nothing about the lead being busy, so they must never be the reason a pane reads 'working'. */
+function isClaudeChildTerminatingEvent(eventName: unknown): boolean {
+  return eventName === 'SubagentStop' || eventName === 'TeammateIdle'
+}
+
 /** SubagentStart/Stop/TeammateIdle update the roster and re-emit the lead's last known state with the fresh child list, so the sidebar reflects spawn/finish even when a background child outlives the lead turn with no other hook traffic. */
 function normalizeClaudeSubagentLifecycleEvent(
   state: HookListenerState,
@@ -2722,9 +2727,12 @@ function buildClaudeCachedLeadStatusPayload(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
-  // Why: default 'working' — a spawn proves activity even before the lead's first state-bearing event (e.g. Orca restarted mid-session).
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
-  const leadState = lead?.state ?? 'working'
+  // Why: with no cached lead (Orca restarted mid-session) the fallback must follow the event's
+  // evidence. A spawn or child tool call proves activity; a stop/idle proves the opposite, so
+  // defaulting those to 'working' mints a phantom no Stop will ever clear. 'done' still gates up
+  // through resolveClaudePaneState when the roster or background work proves the pane is busy.
+  const leadState = lead?.state ?? (isClaudeChildTerminatingEvent(eventName) ? 'done' : 'working')
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName: resolveClaudePaneState(state, paneKey, {
       state: leadState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -27,6 +27,7 @@ import {
 import { normalizeOptionalField } from './agent-status-field-normalization'
 import { isAskUserQuestionTool } from './agent-question-answered-intent'
 import {
+  claudeRosterHasRestoredSnapshotSubagent,
   claudeRosterHasRuntimeWorkingSubagent,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
@@ -134,6 +135,8 @@ export type HookListenerState = {
   claudeSubagentRosterByPaneKey: Map<string, ClaudeSubagentRoster>
   /** Last state from the LEAD session's own events (subagent events carry agent_id, excluded), so a SubagentStop can re-emit pane status; `interrupted` persists so the eventual done still carries it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
+  /** One-normalization provenance marker for a status backed only by restored child state. */
+  claudeUnconfirmedRestoredStatusPaneKeys: Set<string>
   /** Panes whose latest authoritative Claude task inventory still has running non-agent work. */
   claudeRunningNonAgentTaskPaneKeys: Set<string>
   /** Panes whose latest authoritative Claude cron inventory still has a scheduled job. */
@@ -173,6 +176,7 @@ export function createHookListenerState(): HookListenerState {
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map(),
+    claudeUnconfirmedRestoredStatusPaneKeys: new Set(),
     claudeRunningNonAgentTaskPaneKeys: new Set(),
     claudeActiveSessionCronPaneKeys: new Set(),
     codexSubagentRosterByPaneKey: new Map(),
@@ -189,6 +193,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
+  state.claudeUnconfirmedRestoredStatusPaneKeys.delete(paneKey)
   state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
   state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   state.codexSubagentRosterByPaneKey.delete(paneKey)
@@ -235,6 +240,7 @@ export function movePaneCacheState(
   movePaneScopedSetEntries(state.ampCompletedCacheKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeLeadStateByPaneKey, fromPaneKey, toPaneKey)
+  movePaneScopedSetEntries(state.claudeUnconfirmedRestoredStatusPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedSetEntries(state.claudeRunningNonAgentTaskPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedSetEntries(state.claudeActiveSessionCronPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
@@ -279,6 +285,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
+  state.claudeUnconfirmedRestoredStatusPaneKeys.clear()
   state.claudeRunningNonAgentTaskPaneKeys.clear()
   state.claudeActiveSessionCronPaneKeys.clear()
   state.codexSubagentRosterByPaneKey.clear()
@@ -329,6 +336,8 @@ export type AgentHookEventPayload = {
   connectionId: string | null
   /** True when the event carried prompt text directly, not the listener's cached prompt from an earlier event in the pane. */
   hasExplicitPrompt?: boolean
+  /** The emitted nonterminal state is backed only by child state restored from disk. */
+  restoredUnconfirmed?: true
   /** Stable per-turn key to distinguish duplicate hook delivery from a same-text prompt rerun (when the source exposes enough context). */
   promptInteractionKey?: string
   /** Raw agent hook event name, used by main-process transition guards. */
@@ -2650,11 +2659,13 @@ function normalizeClaudeSubagentLifecycleEvent(
     }
   }
   const workingChildEvidence = claudeRosterHasRuntimeWorkingSubagent(roster)
-  if (!hasCachedLeadEvidence && endedChildWork && !workingChildEvidence && roster) {
-    reapUnconfirmedRestoredClaudeSubagents(roster)
-  }
+  const hasUnconfirmedChild = claudeRosterHasRestoredSnapshotSubagent(roster)
   if (roster?.size === 0) {
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
+  }
+  if (!hasCachedLeadEvidence && endedChildWork && !workingChildEvidence && hasUnconfirmedChild) {
+    // Why: this ending proves nothing about a different child restored from disk; keep the aggregate explicitly unconfirmed instead of publishing fresh work or completion.
+    state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
   }
   return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
     workingChildEvidence,
@@ -4230,6 +4241,9 @@ export function normalizeHookPayload(
   const launchToken = readStringField(record, 'launchToken')
 
   const hookPayloadRecord = hookPayload as Record<string, unknown>
+  if (source === 'claude') {
+    state.claudeUnconfirmedRestoredStatusPaneKeys.delete(paneKey)
+  }
   let promptInteractionKey: string | undefined
   const eventName =
     readFirstString(record, ['hook_event_name', 'hookEventName', 'hook_type', 'hookType']) ??
@@ -4421,6 +4435,8 @@ export function normalizeHookPayload(
     (providerSessionOnly
       ? normalizeAgentStatusPayload({ state: 'done', prompt: '', agentType: source })
       : null)
+  const restoredUnconfirmed =
+    source === 'claude' && state.claudeUnconfirmedRestoredStatusPaneKeys.delete(paneKey)
   return transportPayload
     ? {
         paneKey,
@@ -4430,6 +4446,7 @@ export function normalizeHookPayload(
         worktreeId,
         // Why: normalization is transport-agnostic — only ingestRemote knows the mux identity to stamp here.
         connectionId: null,
+        ...(restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
         hasExplicitPrompt:
           source === 'amp'
             ? hasExplicitPromptForSource(source, eventName, promptText, hookPayloadRecord)

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2600,12 +2600,20 @@ function normalizeClaudeSubagentLifecycleEvent(
     return null
   }
   let roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
-  let removedChild = false
+  let endedChildWork = false
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
     if (roster) {
+      let wasWorking = false
+      for (const [id, tracked] of roster) {
+        if (tracked.state === 'working' && claudeTeammateIdMatchesName(id, teammateName)) {
+          wasWorking = true
+          break
+        }
+      }
       idleClaudeTeammateByName(roster, teammateName)
+      endedChildWork = wasWorking
     }
     clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
       claudeTeammateIdMatchesName(waitingAgentId, teammateName)
@@ -2622,10 +2630,10 @@ function normalizeClaudeSubagentLifecycleEvent(
       )
     } else {
       if (roster) {
-        const hadChild = roster.has(agentId)
+        const wasWorking = roster.get(agentId)?.state === 'working'
         // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
         stopClaudeSubagent(roster, agentId)
-        removedChild = hadChild && !roster.has(agentId)
+        endedChildWork = wasWorking && roster.get(agentId)?.state !== 'working'
       }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
@@ -2635,7 +2643,8 @@ function normalizeClaudeSubagentLifecycleEvent(
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
   }
   return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
-    removedChild
+    childActivity: eventName === 'SubagentStart',
+    endedChildWork
   })
 }
 
@@ -2734,15 +2743,14 @@ function buildClaudeCachedLeadStatusPayload(
   eventName: unknown,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  evidence: { removedChild?: boolean } = {}
+  evidence: { childActivity?: boolean; endedChildWork?: boolean } = {}
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
-  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
-  if (!lead && !claudeRosterHasWorkingSubagent(roster) && !evidence.removedChild) {
+  if (!lead && !evidence.childActivity && !evidence.endedChildWork) {
     return null
   }
-  // Why: no-lead completion requires an identity-matched removal; delayed unknown stops cannot retire newer work.
-  const leadState = lead?.state ?? (evidence.removedChild ? 'done' : 'working')
+  // Why: no-lead completion requires an identity-matched work ending; delayed unknown stops cannot retire newer work.
+  const leadState = lead?.state ?? (evidence.endedChildWork ? 'done' : 'working')
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName: resolveClaudePaneState(state, paneKey, {
       state: leadState,
@@ -2895,7 +2903,9 @@ function normalizeClaudeEvent(
   if (subagentOriginId) {
     const lead = state.claudeLeadStateByPaneKey.get(paneKey)
     if (lead?.state !== 'waiting' || lead.waitingAgentId !== subagentOriginId) {
-      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload)
+      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+        childActivity: true
+      })
     }
     const isParallelSiblingCompletionDuringChildQuestion =
       (eventName === 'PostToolUse' || eventName === 'PostToolUseFailure') &&
@@ -2903,7 +2913,9 @@ function normalizeClaudeEvent(
       eventToolUseId !== undefined &&
       eventToolUseId !== lead.waitingToolUseId
     if (isParallelSiblingCompletionDuringChildQuestion) {
-      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload)
+      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+        childActivity: true
+      })
     }
     // Why: approval granted — update the tool snapshot (drop the pending card) as the lead's own next tool event would.
     // Restore the stashed lead state, not this child's 'working': the lead may already be done, and the done-gate never upgrades working back to done once the roster drains.

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2587,11 +2587,6 @@ function resolveClaudePaneState(
     : 'done'
 }
 
-/** Child lifecycle events that end work. They say nothing about the lead being busy, so they must never be the reason a pane reads 'working'. */
-function isClaudeChildTerminatingEvent(eventName: unknown): boolean {
-  return eventName === 'SubagentStop' || eventName === 'TeammateIdle'
-}
-
 /** SubagentStart/Stop/TeammateIdle update the roster and re-emit the lead's last known state with the fresh child list, so the sidebar reflects spawn/finish even when a background child outlives the lead turn with no other hook traffic. */
 function normalizeClaudeSubagentLifecycleEvent(
   state: HookListenerState,
@@ -2604,17 +2599,21 @@ function normalizeClaudeSubagentLifecycleEvent(
   if (!lifecycleId) {
     return null
   }
-  const roster = getOrCreateClaudeSubagentRoster(state, paneKey)
+  let roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  let removedChild = false
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
-    idleClaudeTeammateByName(roster, teammateName)
+    if (roster) {
+      idleClaudeTeammateByName(roster, teammateName)
+    }
     clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
       claudeTeammateIdMatchesName(waitingAgentId, teammateName)
     )
   } else {
     const agentId = lifecycleId
     if (eventName === 'SubagentStart') {
+      roster = getOrCreateClaudeSubagentRoster(state, paneKey)
       upsertWorkingClaudeSubagent(
         roster,
         agentId,
@@ -2622,13 +2621,22 @@ function normalizeClaudeSubagentLifecycleEvent(
         Date.now()
       )
     } else {
-      // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
-      stopClaudeSubagent(roster, agentId)
+      if (roster) {
+        const hadChild = roster.has(agentId)
+        // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
+        stopClaudeSubagent(roster, agentId)
+        removedChild = hadChild && !roster.has(agentId)
+      }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
     }
   }
-  return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload)
+  if (roster?.size === 0) {
+    state.claudeSubagentRosterByPaneKey.delete(paneKey)
+  }
+  return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+    removedChild
+  })
 }
 
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
@@ -2685,7 +2693,7 @@ export function reapRestoredClaudeSubagentsForDeadPane(
   return true
 }
 
-/** Drop a child-owned waiting state when the child stops/idles, restoring the displaced lead state; without a stash, fall back to 'working' (a transient spinner beats a permanently stuck card). */
+/** Drop a child-owned wait when it stops/idles; without a prior lead state, the child ending resolves the pane. */
 function clearClaudePendingWaitForAgent(
   state: HookListenerState,
   paneKey: string,
@@ -2695,7 +2703,7 @@ function clearClaudePendingWaitForAgent(
   if (lead?.state !== 'waiting' || !lead.waitingAgentId || !ownsWait(lead.waitingAgentId)) {
     return
   }
-  state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait ?? { state: 'working' })
+  state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait ?? { state: 'done' })
 }
 
 /** Clear an AskUserQuestion wait after the answer is typed (answering emits no hook event; the caller infers it from the submit keystroke). Restores the stashed pre-wait lead state or 'working', drops the cached card, and returns the pane state to emit (gated up to 'working' while children run). */
@@ -2725,14 +2733,16 @@ function buildClaudeCachedLeadStatusPayload(
   state: HookListenerState,
   eventName: unknown,
   paneKey: string,
-  hookPayload: Record<string, unknown>
+  hookPayload: Record<string, unknown>,
+  evidence: { removedChild?: boolean } = {}
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
-  // Why: with no cached lead (Orca restarted mid-session) the fallback must follow the event's
-  // evidence. A spawn or child tool call proves activity; a stop/idle proves the opposite, so
-  // defaulting those to 'working' mints a phantom no Stop will ever clear. 'done' still gates up
-  // through resolveClaudePaneState when the roster or background work proves the pane is busy.
-  const leadState = lead?.state ?? (isClaudeChildTerminatingEvent(eventName) ? 'done' : 'working')
+  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  if (!lead && !claudeRosterHasWorkingSubagent(roster) && !evidence.removedChild) {
+    return null
+  }
+  // Why: no-lead completion requires an identity-matched removal; delayed unknown stops cannot retire newer work.
+  const leadState = lead?.state ?? (evidence.removedChild ? 'done' : 'working')
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName: resolveClaudePaneState(state, paneKey, {
       state: leadState,

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -6,6 +6,7 @@ import {
   markClaudeLeadTurnInterrupted,
   movePaneCacheState,
   normalizeHookPayload,
+  seedClaudeSubagentRosterFromSnapshots,
   type HookListenerState
 } from './agent-hook-listener'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
@@ -445,6 +446,21 @@ describe('Claude background task status', () => {
       state: 'working',
       subagents: [expect.objectContaining({ id: 'child-1', state: 'working' })]
     })
+  })
+
+  it('does not mint working from an unconfirmed child-attributed Stop', () => {
+    const state = createHookListenerState()
+    seedClaudeSubagentRosterFromSnapshots(state, SOURCE_PANE, [
+      { id: 'restored-child', state: 'working', startedAt: 100 }
+    ])
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        agent_id: 'unknown-child',
+        background_tasks: []
+      })
+    ).toBeUndefined()
   })
 
   it('does not let an unknown child interrupt lead-owned background work', () => {

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -8,7 +8,7 @@ import {
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
   idleClaudeTeammateByName,
-  reapRestoredClaudeSubagentsWithoutLiveAgent,
+  reapUnconfirmedRestoredClaudeSubagents,
   stopClaudeSubagent,
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
@@ -497,7 +497,7 @@ describe('restored-row liveness reap', () => {
   it('drops a restored row when no agent process is left behind it', () => {
     const roster = restored('areview-loop-c237a4c577493352')
     expect(claudeRosterHasRuntimeWorkingSubagent(roster)).toBe(false)
-    expect(reapRestoredClaudeSubagentsWithoutLiveAgent(roster)).toBe(true)
+    expect(reapUnconfirmedRestoredClaudeSubagents(roster)).toBe(true)
     expect(claudeRosterHasWorkingSubagent(roster)).toBe(false)
   })
 
@@ -505,21 +505,21 @@ describe('restored-row liveness reap', () => {
     const roster = restored('areview-loop-c237a4c577493352')
     upsertWorkingClaudeSubagent(roster, 'areview-loop-c237a4c577493352', {}, 150)
     expect(claudeRosterHasRuntimeWorkingSubagent(roster)).toBe(true)
-    expect(reapRestoredClaudeSubagentsWithoutLiveAgent(roster)).toBe(false)
+    expect(reapUnconfirmedRestoredClaudeSubagents(roster)).toBe(false)
     expect(claudeRosterHasWorkingSubagent(roster)).toBe(true)
   })
 
   it('keeps a row a live inventory confirmed as running', () => {
     const roster = restored('a9')
     foldClaudeBackgroundTasksIntoRoster(roster, [task({ id: 'a9' })], 150)
-    expect(reapRestoredClaudeSubagentsWithoutLiveAgent(roster)).toBe(false)
+    expect(reapUnconfirmedRestoredClaudeSubagents(roster)).toBe(false)
     expect(claudeRosterHasWorkingSubagent(roster)).toBe(true)
   })
 
   it('leaves rows this listener tracked from live events alone', () => {
     const roster: ClaudeSubagentRoster = new Map()
     upsertWorkingClaudeSubagent(roster, 'a1', {}, 100)
-    expect(reapRestoredClaudeSubagentsWithoutLiveAgent(roster)).toBe(false)
+    expect(reapUnconfirmedRestoredClaudeSubagents(roster)).toBe(false)
     expect(roster.has('a1')).toBe(true)
   })
 

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
 import { readClaudeBackgroundAgentTasks } from './claude-background-task-inventory'
 import {
+  claudeRosterHasRuntimeWorkingSubagent,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
@@ -495,6 +496,7 @@ describe('restored-row liveness reap', () => {
 
   it('drops a restored row when no agent process is left behind it', () => {
     const roster = restored('areview-loop-c237a4c577493352')
+    expect(claudeRosterHasRuntimeWorkingSubagent(roster)).toBe(false)
     expect(reapRestoredClaudeSubagentsWithoutLiveAgent(roster)).toBe(true)
     expect(claudeRosterHasWorkingSubagent(roster)).toBe(false)
   })
@@ -502,6 +504,7 @@ describe('restored-row liveness reap', () => {
   it('keeps a row a live lifecycle event re-tracked', () => {
     const roster = restored('areview-loop-c237a4c577493352')
     upsertWorkingClaudeSubagent(roster, 'areview-loop-c237a4c577493352', {}, 150)
+    expect(claudeRosterHasRuntimeWorkingSubagent(roster)).toBe(true)
     expect(reapRestoredClaudeSubagentsWithoutLiveAgent(roster)).toBe(false)
     expect(claudeRosterHasWorkingSubagent(roster)).toBe(true)
   })

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -126,6 +126,8 @@ export function stopClaudeSubagent(roster: ClaudeSubagentRoster, id: string): vo
     roster.delete(id)
     return
   }
+  tracked.backgroundTasksAuthoritative = undefined
+  tracked.restoredFromSnapshot = undefined
   tracked.state = 'idle'
 }
 
@@ -297,6 +299,8 @@ export function idleClaudeTeammateByName(roster: ClaudeSubagentRoster, name: str
   for (const [id, tracked] of roster) {
     if (claudeTeammateIdMatchesName(id, name)) {
       changed = changed || tracked.state !== 'idle' || tracked.confirmedTeammate !== true
+      tracked.backgroundTasksAuthoritative = undefined
+      tracked.restoredFromSnapshot = undefined
       tracked.state = 'idle'
       tracked.confirmedTeammate = true
     }

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -318,6 +318,21 @@ export function claudeRosterHasWorkingSubagent(roster: ClaudeSubagentRoster | un
   return false
 }
 
+/** A working child observed in this listener runtime, not merely restored from disk. */
+export function claudeRosterHasRuntimeWorkingSubagent(
+  roster: ClaudeSubagentRoster | undefined
+): boolean {
+  if (!roster) {
+    return false
+  }
+  for (const tracked of roster.values()) {
+    if (tracked.state === 'working' && tracked.restoredFromSnapshot !== true) {
+      return true
+    }
+  }
+  return false
+}
+
 export function claudeRosterToSnapshots(
   roster: ClaudeSubagentRoster | undefined
 ): AgentSubagentSnapshot[] | undefined {

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -247,13 +247,8 @@ export function foldClaudeBackgroundTasksIntoRoster(
   }
 }
 
-/** Second reap path for restored rows, used when the agent process that wrote
- *  the snapshot is gone. The inventory reap needs the parent to emit a complete
- *  `background_tasks` list; a parent that went idle before Orca restarted never
- *  emits one, so an unconfirmed row would gate the pane 'working' forever and
- *  keep it out of hibernation. Rows confirmed by live activity are untouched.
- *  Returns whether anything was dropped. */
-export function reapRestoredClaudeSubagentsWithoutLiveAgent(roster: ClaudeSubagentRoster): boolean {
+/** Drop restored rows that no current-runtime child activity has confirmed. */
+export function reapUnconfirmedRestoredClaudeSubagents(roster: ClaudeSubagentRoster): boolean {
   let changed = false
   for (const [id, tracked] of roster) {
     if (tracked.restoredFromSnapshot === true) {


### PR DESCRIPTION
## ELI5

When Orca restarts, it forgets what each Claude pane was doing. If a subagent then finished, Orca used to guess "the parent must be busy" and show a spinner forever. Now it only says "busy" when something actually proves it, and records when its guess is based on stale, restored data.

## What Changed

`buildClaudeCachedLeadStatusPayload` (`src/shared/agent-hook-listener.ts:2775-2812`) previously did:

```ts
const leadState = lead?.state ?? 'working'   // no cached lead ⇒ always working
```

It now takes an `evidence` object and, **only in the no-cached-lead case**, decides:

| evidence | result |
| --- | --- |
| `workingChildEvidence` — a roster row is `working` and was seen this runtime | `working` |
| `endedRuntimeChildWork` — the row that just stopped was working *and* seen this runtime | `working` |
| `endedChildWork` — a restored (disk-hydrated) row ended | `working` + `restoredUnconfirmed` |
| none of the above | **`null`** — emit nothing at all |

Behavior with a cached lead is unchanged.

Two supporting pieces carry most of the weight:

- **`hasCachedLeadEvidence`** (`:2612-2620`) — a cached `waiting` state minted by *this child's own* permission/question event isn't treated as lead evidence; it's the child's footprint, not a turn boundary.
- **`restoredUnconfirmed` provenance** — new `claudeUnconfirmedRestoredStatusPaneKeys` set (`:139`), stamped onto the payload (`:4482`). Downstream, `isFreshNonDoneAgentStatus` returns false for these, so the sidebar dot, tab spinner, smart-attention and `worktree ps` treat the pane as not-live, and `server.ts:1279` drops it from `runtimeObservedStatusPaneKeys` so it stays reap-eligible.

Roster changes (`src/shared/claude-subagent-roster.ts`): new `claudeRosterHasRuntimeWorkingSubagent`; `stopClaudeSubagent`/`idleClaudeTeammateByName` now clear `restoredFromSnapshot` and `backgroundTasksAuthoritative` on the row they park; `reapRestoredClaudeSubagentsWithoutLiveAgent` renamed to `reapUnconfirmedRestoredClaudeSubagents`.

## Why

`claudeLeadStateByPaneKey` is in-memory only, so **every app restart empties it**. A Claude session that outlives the restart (PTYs live on the daemon) reports its next child event into an empty map. On main that unconditionally minted `working` with an empty roster — no `Stop` is coming, since the turn ended before the restart. `AGENT_STATUS_STALE_AFTER_MS` only decays the sidebar dot after 30 minutes; the stored row stays `working` and re-hydrates on next launch.

Reported as: *"stuck in loading even when AI is done working — maybe coming back from sleep or from app restart (installing new update), happens fairly often."*

The principle: **absence of evidence must not become evidence of activity.** A child stopping is the weakest possible ground for claiming the parent is busy.

## Linked Issue

Linear **STA-4144** (Urgent), with duplicate reports **STA-3532** and **STA-3522**.

## Visual Proof

⚠️ **These captures are from the first commit on this branch and no longer depict the current implementation.** They document the original defect and are kept for that purpose; the mechanism has since been reworked (see the risk section). No capture exists for the current code.

Before — Claude idle at its prompt (`- · - tokens`, empty input) while the sidebar card spins:

![phantom-working-repro.png](https://github.com/user-attachments/assets/e0a619f5-0ae3-4f7a-8d51-9b7b0e7e17a6)

After (commit 1 only) — same input, same conditions, completed glyph:

![phantom-working-fixed.png](https://github.com/user-attachments/assets/aa234829-ab93-419b-bd93-257776bd48ae)

## Testing

**Automated** — 897 passed / 4 skipped across 51 agent-hook, agent-status, roster and server files, run against the current head. `tsc --noEmit -p config/tsconfig.node.json` exit 0; `oxlint` clean.

New coverage (`agent-hook-listener-startless-child-lifecycle.test.ts`, 14 cases; `server.test.ts`, +297 lines / 7 cases) spans: unknown stop/idle with no roster → `null`; runtime children draining → `working`; restored children → `working` + `restoredUnconfirmed`; full persist → restart → hydrate → live-event round trips asserting the flag clears only on a real lead `Stop`; and a truncated `background_tasks` inventory not confirming a restored row.

**Manual** — the original defect was reproduced end to end against Claude Code 2.1.229 in an isolated dev instance: launch Claude, kill only the app process group so the daemon and session survive, relaunch (fresh process, empty lead cache), deliver the child event. That reproduction validated **commit 1**, not the current implementation.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new input surface; strictly narrows when a `working` state can be fabricated.
- **Cross-platform** — pure state-resolution logic in `src/shared`. No paths, shells, shortcuts, or platform branches.
- **Remote SSH** — no wire schema change. **But** `restoredUnconfirmed` is added to `AgentHookEventPayload`, a local main-process type; it is **not** on `AgentHookRelayEnvelope` and is not forwarded by `relay/agent-hook-server.ts` or accepted by `ingestRemote`. So for SSH/relay-hosted panes the marker is computed relay-side and dropped in transit — remote panes get the state-value changes but none of the provenance mitigation, and they were already excluded from the liveness reap by `connectionId === null`. Not a regression (main emitted a bare `working` too), but the fix does not cover the SSH case.
- **Mobile** — locally-hosted panes now set the existing optional `RuntimeWorktreeAgentRow.restoredUnconfirmed` in new circumstances. Older paired clients that predate the field render those rows as ordinary fresh `working`: additive-optional, decodes fine, mixed-version rendering divergence rather than a wire break.
- **Backwards compatibility** — panes with **no subagents** (the common case) are unaffected: every new gate is subagent-conditional. The one residual is that a pane with no roster receiving a stray `SubagentStop` now emits nothing where it previously emitted `working`.
- **Performance** — fewer phantom transitions, so less status churn and IPC fanout.

## Open questions for review

Three things a reviewer should decide on deliberately:

1. **The original phantom is still reachable, unmarked.** Verified by running the listener directly: `SubagentStart` → clear the lead cache → `SubagentStop` yields `state=working, restoredUnconfirmed=undefined, rosterSize=0`. Because `endedRuntimeChildWork` is true and no restored child exists, the marker condition at `:2669-2675` is false, so `server.ts:1281` adds the pane to `runtimeObservedStatusPaneKeys`, which permanently disqualifies it from the liveness reap. This is asserted as intended behavior by the test *"keeps the parent working when a current-runtime child drains with no cached lead"*. The real-world path is the same missed-lead-event class that emptied the cache in the first place. Is holding `working` here deliberate?

2. **`endedChildWork → 'working'` for a restored child has no guaranteed clearer.** The marker correctly suppresses freshness everywhere, but the only things that can clear the state are another Claude hook (requires the user to prompt again) or the liveness reap — and the reap can't fire, for two independent reasons: candidate selection requires `claudeRosterHasRestoredSnapshotSubagent`, which `idleClaudeTeammateByName` just cleared on that row, and the reap also requires the pane to be dead, whereas the pane just proved it's alive by delivering the hook. Concrete case: restart, surviving session, teammate emits `TeammateIdle`, lead's turn ended pre-restart so no `Stop` follows, user leaves the pane at the prompt → stored `working` indefinitely. The visible symptom isn't a spinner but **hibernation lockout**, since `agent-hibernation-planner.ts:147-152` rejects `state !== 'done'` and doesn't consult `restoredUnconfirmed`. Should `restoredUnconfirmed` make a `working` row hibernation-eligible, given it already means "never fresh" everywhere else?

3. **Two inference paths are disabled for marked panes** — `server.ts:794` and `:886` skip Ctrl+C interrupt inference and AskUserQuestion answered-inference while `restoredUnconfirmed` is set, and `running-agent-targets.ts:74-75` labels the pane "Agent status is stale" and disables it as a dispatch target. Both were designed for genuinely hydrated rows; they now also apply to a pane that just proved it is live. Intended?

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint/typecheck/tests run locally as listed; full build and remaining typecheck projects left to CI

## Author

- X / Twitter: @BrennanKB5
