### PR TITLE
fix(agent-status): register and handle Claude SessionEnd

### DIFF
--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -419,6 +419,9 @@ describe('ClaudeHookService.installRemote', () => {
       'UserPromptSubmit',
       'Stop',
       'StopFailure',
+      // Why: the backstop for sessions that exit without a Stop (STA-3149); remote panes
+      // need it most, since the OSC-133 exit fallback is disabled for SSH/WSL PTYs.
+      'SessionEnd',
       'SubagentStart',
       'SubagentStop',
       'TeammateIdle',

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -40,6 +40,10 @@ export const CLAUDE_EVENTS = [
   // Why: OpenClaude skips normal Stop hooks after API/model errors and emits
   // StopFailure instead; without this hook Orca leaves the turn spinning.
   { eventName: 'StopFailure', definition: { hooks: [{ type: 'command', command: '' }] } },
+  // Why: last line of defense for every missed Stop (STA-3149). A session that exits
+  // mid-turn — /exit, Ctrl+D, crash, interrupt — emits no Stop, so without this the pane
+  // keeps its non-done row indefinitely. Older Claude builds ignore it (StopFailure precedent).
+  { eventName: 'SessionEnd', definition: { hooks: [{ type: 'command', command: '' }] } },
   // Why: subagent/teammate lifecycle feeds the sidebar's child rows and keeps
   // a pane 'working' while background children outlive the lead's turn.
   // TeammateIdle parks turn-based teammates without trusting their permanently

--- a/src/shared/agent-hook-listener-claude-session-end.test.ts
+++ b/src/shared/agent-hook-listener-claude-session-end.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createHookListenerState,
+  normalizeHookPayload,
+  type HookListenerState
+} from './agent-hook-listener'
+import { makePaneKey } from './stable-pane-id'
+
+const LEAF_ID = '33333333-3333-4333-8333-333333333333'
+
+function claudeEvent(
+  state: HookListenerState,
+  paneKey: string,
+  payload: Record<string, unknown>
+): ReturnType<typeof normalizeHookPayload> {
+  return normalizeHookPayload(state, 'claude', { paneKey, payload }, 'production')
+}
+
+// A session that exits mid-turn (/exit, Ctrl+D, crash) never emits Stop, so SessionEnd is the
+// only event that can retire the pane's row.
+describe('Claude SessionEnd', () => {
+  it('retires a turn left working by a missing Stop', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('session-end-working', LEAF_ID)
+
+    const working = claudeEvent(state, paneKey, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'do a thing'
+    })
+    expect(working?.payload.state).toBe('working')
+
+    const ended = claudeEvent(state, paneKey, {
+      hook_event_name: 'SessionEnd',
+      reason: 'prompt_input_exit'
+    })
+    expect(ended?.payload.state).toBe('done')
+  })
+
+  it('retires a pane still gated up by a live subagent roster', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('session-end-roster', LEAF_ID)
+
+    claudeEvent(state, paneKey, { hook_event_name: 'UserPromptSubmit', prompt: 'spawn' })
+    claudeEvent(state, paneKey, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'achild-0000000000000011',
+      agent_type: 'reviewer'
+    })
+
+    const ended = claudeEvent(state, paneKey, { hook_event_name: 'SessionEnd', reason: 'other' })
+
+    expect(ended?.payload.state).toBe('done')
+    expect(state.claudeSubagentRosterByPaneKey.has(paneKey)).toBe(false)
+  })
+
+  it('marks the row a session boundary so it is not read as a turn completion', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('session-end-boundary', LEAF_ID)
+
+    claudeEvent(state, paneKey, { hook_event_name: 'UserPromptSubmit', prompt: 'work' })
+    const ended = claudeEvent(state, paneKey, { hook_event_name: 'SessionEnd', reason: 'logout' })
+
+    expect(ended?.payload.sessionBoundary).toBe(true)
+  })
+
+  it('accepts every reason, including ones Orca does not know', () => {
+    for (const reason of ['clear', 'logout', 'prompt_input_exit', 'other', 'some_future_reason']) {
+      const state = createHookListenerState()
+      const paneKey = makePaneKey(`session-end-${reason}`, LEAF_ID)
+      claudeEvent(state, paneKey, { hook_event_name: 'UserPromptSubmit', prompt: 'work' })
+
+      const ended = claudeEvent(state, paneKey, { hook_event_name: 'SessionEnd', reason })
+
+      expect(ended?.payload.state).toBe('done')
+    }
+  })
+
+  it('ignores a child-attributed SessionEnd so a subagent cannot retire the lead turn', () => {
+    const state = createHookListenerState()
+    const paneKey = makePaneKey('session-end-child', LEAF_ID)
+
+    claudeEvent(state, paneKey, { hook_event_name: 'UserPromptSubmit', prompt: 'work' })
+    const ended = claudeEvent(state, paneKey, {
+      hook_event_name: 'SessionEnd',
+      reason: 'other',
+      agent_id: 'achild-0000000000000012'
+    })
+
+    expect(ended).toBeNull()
+    expect(state.claudeLeadStateByPaneKey.get(paneKey)?.state).toBe('working')
+  })
+})

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2779,6 +2779,25 @@ function normalizeClaudeEvent(
       sessionBoundary: true
     })
   }
+  if (eventName === 'SessionEnd') {
+    // Why: the session exited, so no Stop is ever coming (STA-3149). Unlike SessionStart this
+    // accepts every reason — failing closed on an unknown one would forfeit the backstop the
+    // event exists to provide — but a child-attributed end must not retire the lead's turn.
+    if (eventAgentId !== undefined) {
+      return null
+    }
+    // Why: nothing survives the process; leaving children/tasks/crons behind would gate the
+    // pane back up to 'working' through resolveClaudePaneState and re-strand it.
+    state.claudeSubagentRosterByPaneKey.delete(paneKey)
+    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    state.claudeActiveSessionCronPaneKeys.delete(paneKey)
+    state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done' })
+    return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
+      stateName: 'done',
+      updateToolSnapshot: true,
+      sessionBoundary: true
+    })
+  }
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
   // Why: only a turn boundary may declare an interrupt or carry a prior one forward; any other event starts a fresh turn and drops it.
   const isTurnBoundary = eventName === 'Stop' || eventName === 'StopFailure'


### PR DESCRIPTION
## ELI5

When a Claude session ends, it can tell Orca so — via a `SessionEnd` hook. Orca was never listening for it, so a session that quit mid-turn left its spinner running forever. This starts listening.

It is **not** a complete safety net: two of the most common exit paths don't fire the event at all (upstream bugs, below). It strictly improves coverage on the paths that do work.

## What Changed

- `src/main/claude/hook-settings.ts` — register `SessionEnd` in `CLAUDE_EVENTS` (11 events → 12)
- `src/shared/agent-hook-listener.ts` — add the `SessionEnd` branch to `normalizeClaudeEvent`
- `src/main/claude/hook-service.test.ts` — pin `SessionEnd` in the remote-install assertion
- `src/shared/agent-hook-listener-claude-session-end.test.ts` — new coverage

On `SessionEnd` the pane is retired: clear the subagent roster, running background tasks, and session crons — otherwise `resolveClaudePaneState` gates the pane straight back up to `working` — then land a **session-boundary `done`** so notifications and automation runs don't read it as a turn completing.

Two deliberate asymmetries vs `SessionStart`:

- **Accepts every `reason`.** `SessionStart` fails closed on unknown sources because it can fire mid-turn. `SessionEnd` cannot: the session is over. The documented reasons are `clear | resume | logout | prompt_input_exit | bypass_permissions_disabled | other`, and failing closed on an unrecognized one would forfeit the point of a backstop.
- **Ignores child-attributed events.** A `SessionEnd` carrying `agent_id` is a subagent's and must not retire the lead's turn.

## Why

`normalizeClaudeEvent` maps unknown event names to `null`, so before this change `SessionEnd` was dropped twice over — never registered, and unhandled if it had arrived. Every other lifecycle-complete provider already registers it (`devin/hook-settings.ts`, `grok/hook-service.ts`, `copilot/hook-service.ts`).

Consequence today: a session that exits mid-turn leaves its last non-`done` row standing. `AGENT_STATUS_STALE_AFTER_MS` only decays the sidebar dot after 30 minutes; the stored row stays `working` and re-hydrates on next launch. Orca's own shell wrappers name this gap — the OSC-133 workaround is commented as covering "a stuck 'working' spinner for up to 30 min after the CLI exits without sending a Stop/SessionEnd hook" — and that workaround is disabled for SSH/WSL/remote PTYs.

## The SessionEnd contract, as measured on 2.1.231

I verified this rather than assuming it, because it determines what this PR can honestly claim.

| Exit path | Fires? | Evidence |
| --- | --- | --- |
| Print mode (`-p`) session end | **yes** | measured: `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd` all fired |
| `Ctrl+D` | **yes** | documented + upstream issue #17885 |
| **`/exit`** | **no** | measured twice (real TTY via pty, and in-app); upstream bug **#17885**, closed as not planned |
| **`/clear`** | **no** | upstream bug **#6428**, closed as not planned |
| `Ctrl+C` | no | suspends rather than ends; resumes via `SessionStart:resume` |
| SIGKILL / terminal close / crash | no | no opportunity to run |

Two further constraints worth knowing:

- **`SessionEnd` hooks share a ~1.5s budget** (raisable via an explicit per-hook `timeout`). Orca's managed hook shells out to `curl` with `--connect-timeout 0.5 --max-time 1.5`, which fits only if the shell spawn is fast. On a loaded machine this could be cut off. Not a regression — the current behavior is that nothing is sent at all — but it argues for an explicit `timeout` on this entry if we see flakiness.
- **Hooks are snapshotted at session start.** Editing `settings.json` mid-session has no effect, so this only takes effect for sessions started after install.

**What this means for STA-3149:** the ticket's premise — that registering `SessionEnd` is "the last line of defense for every missed Stop" — **does not hold**. The two most common interactive exits are exactly the ones that don't fire. This PR is a real but partial improvement; a complete backstop has to come from a liveness signal (process-exit / foreground-pgroup) rather than a hook. I'd suggest rewriting STA-3149 accordingly and tracking the liveness backstop separately.

## Linked Issue

Linear **STA-3149** (premise needs correcting — see above). No GitHub issue exists.

Companion PR **#14375** fixes a *different* mechanism behind the same symptom (start-less `SubagentStop` minting a phantom `working`); that one is reproduced and verified end to end. The two are independent.

Upstream: anthropics/claude-code **#17885** (`/exit`), **#6428** (`/clear`), **#41577** (async work in SessionEnd hooks killed early).

## Visual Proof

`N/A` — no UI or copy change. The user-visible effect is an existing status row resolving to `done` on session exit rather than persisting.

Registration is observable in a fresh `~/.claude/settings.json` written by this build:

```
before: SessionStart UserPromptSubmit Stop StopFailure SubagentStart SubagentStop
        TeammateIdle PreToolUse PostToolUse PostToolUseFailure PermissionRequest
after:  ... Stop StopFailure SessionEnd SubagentStart ...   (12 events)
```

## Testing

**Automated** — 5 new normalizer cases plus the remote-install assertion. Verified non-vacuous: removing the registration and the normalizer branch fails exactly 5 tests.

- `npx vitest` — 1061 passed / 6 skipped across 64 agent-hook, agent-status, and claude files
- `oxlint` + `oxfmt` clean (pre-commit hook)

**Manual (macOS, isolated dev instance, throwaway repo)**

1. Registration lands: a fresh `HOME` gets `SessionEnd` in `settings.json`. ✅
2. Control — real Claude Code's own hooks reach Orca: `SessionStart` landed a `sessionBoundary: true` `done` row. ✅
3. Forced the pane to `working`, exited with `/exit`. Process exited, PTY stayed alive, row stayed `working`. ❌ — now explained: `/exit` does not emit the event (#17885).
4. Isolated confirmation outside Orca: a print-mode session with probe hooks fired `SessionEnd`; a pty-driven interactive session exited with `/exit` fired only `SessionStart`.

Note for reviewers: an earlier round of test 3 was **invalid** — I had hand-edited the managed `settings.json` mid-session, which both broke hook delivery and, per the snapshot-at-start rule, could not have taken effect anyway. The runs above are the clean redo with a control.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — no new input surface. `SessionEnd` posts through the existing authenticated hook endpoint with the same token, paneKey validation, and fail-closed parsing as every other event.
- **Cross-platform (Linux/Windows/Mac)** — `CLAUDE_EVENTS` drives the POSIX script, the Windows `.cmd`, and the PowerShell branch from one list, so all three hosts get the event with no per-platform code. Normalizer logic is platform-independent.
- **Remote SSH** — no wire change: no new opcode, no new field, and the normalized status crossing the wire is an existing `done`. A new host with an old client publishes an ordinary `done`; a new client against an old host simply never receives the event, since old hosts drop unknown names. Remote panes benefit most, as the OSC-133 exit fallback is disabled for SSH/WSL PTYs. Covered by the updated `installRemote` test.
- **Mobile** — no mobile surface changed; mobile consumes the same normalized status.
- **Backwards compatibility** — additive. Older Claude builds ignore unregistered event names (the `StopFailure` precedent), and `applyManagedHooks` installs idempotently, so existing configs converge on next install.
- **Performance** — one additional hook invocation per session exit, and one fewer permanently-stuck row.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint/tests run locally as listed; full build and remaining typecheck projects left to CI

## Author

- X / Twitter: @BrennanKB5
