### PR TITLE
fix(worktree-scan): stop a stalled admin probe from poisoning repo refresh

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2550,10 +2550,11 @@ type RuntimeWorktreeScanCache = {
   result: RuntimeWorktreeScanResult
   expiresAt: number
   /**
-   * Git-admin state read as of the scan's start, kept unresolved so no caller ever waits on the
-   * probe to receive a scan result. Resolves to `null` when the state could not be read.
+   * Git-admin state read as of the scan's start, written back once the probe settles. Never holds a
+   * pending promise: a wedged mount would otherwise poison every later refresh that awaits it.
+   * `null` means "cannot prove unchanged" (unreadable layout, still probing, probe timed out).
    */
-  adminFingerprint: Promise<string | null>
+  adminFingerprint: string | null
   /** When the Git scan behind `result` actually ran, so reconciliation can be bounded. */
   scannedAt: number
 }
@@ -2566,7 +2567,9 @@ type RuntimeWorktreeScanInFlight = {
 
 type RuntimeWorktreeScanRefresh = {
   result: RuntimeWorktreeScanResult
-  adminFingerprint: Promise<string | null>
+  adminFingerprint: string | null
+  /** Still-running probe whose value the cache entry adopts if it settles; never awaited by a caller. */
+  adminFingerprintProbe: Promise<string | null> | null
   scannedAt: number
 }
 
@@ -2884,6 +2887,8 @@ export class OrcaRuntimeService {
   private worktreeScanGenerations = new Map<string, number>()
   private worktreeScanCache = new Map<string, RuntimeWorktreeScanCache>()
   private worktreeScanInFlight = new Map<string, RuntimeWorktreeScanInFlight>()
+  /** Repos whose Git-admin probe has not settled yet; caps abandoned fs work at one per repo. */
+  private worktreeAdminFingerprintProbes = new Set<string>()
   private cloneInFlightByPath = new Map<string, Promise<void>>()
   private agentDetector: AgentDetector | null = null
   private ptyForegroundAgentRefreshes = new Map<string, PtyForegroundAgentRefresh>()
@@ -29569,13 +29574,21 @@ export class OrcaRuntimeService {
         generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
         this.worktreeScanInFlight.get(repo.id)?.promise === promise
       ) {
-        this.worktreeScanCache.set(repo.id, {
+        const entry: RuntimeWorktreeScanCache = {
           generation,
           runtimeKey,
           result: refresh.result,
           expiresAt: Date.now() + resolveWorktreeScanCacheTtlMs(repo),
           adminFingerprint: refresh.adminFingerprint,
           scannedAt: refresh.scannedAt
+        }
+        this.worktreeScanCache.set(repo.id, entry)
+        // Why a writeback instead of storing the promise: a probe that never settles must not be
+        // awaited by a later refresh. Identity check keeps a stale probe out of a newer entry.
+        void refresh.adminFingerprintProbe?.then((fingerprint) => {
+          if (this.worktreeScanCache.get(repo.id) === entry) {
+            entry.adminFingerprint = fingerprint
+          }
         })
       }
       return refresh.result
@@ -29605,29 +29618,44 @@ export class OrcaRuntimeService {
       !getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime).wslDistro
     // Why issue it before the scan: a change landing while the scan runs must not be stamped as
     // already-observed, or the next probe would mask it until the reconciliation deadline.
-    const adminFingerprint = fingerprintCapable
-      ? readRepoWorktreeAdminFingerprint(repo.path)
-      : UNFINGERPRINTED_WORKTREE_SCAN
+    const probe = fingerprintCapable ? this.startRepoWorktreeAdminFingerprintProbe(repo) : null
     const reusable =
-      fingerprintCapable &&
       cached?.result.ok === true &&
       scannedAt - cached.scannedAt < WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS
         ? cached
         : null
-    if (reusable) {
+    if (probe && reusable) {
       // Why await only here: this is the one branch whose decision needs the probe. A scan-bound
       // caller must never wait on it, or every cold read pays filesystem latency it cannot use.
-      const [current, previous] = await Promise.all([adminFingerprint, reusable.adminFingerprint])
-      if (current !== null && current === previous) {
+      const current = await withTimeout(probe, WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS, null)
+      if (current !== null && current === reusable.adminFingerprint) {
         return {
           result: reusable.result,
-          adminFingerprint: reusable.adminFingerprint,
+          adminFingerprint: current,
+          adminFingerprintProbe: null,
           scannedAt: reusable.scannedAt
         }
       }
     }
     const result = await this.listRepoWorktreesForResolutionUncached(repo, projectRuntime)
-    return { result, adminFingerprint, scannedAt }
+    return { result, adminFingerprint: null, adminFingerprintProbe: probe, scannedAt }
+  }
+
+  /**
+   * Read one repo's Git-admin fingerprint, unless that repo's previous read is still outstanding.
+   * Why the gate: `withTimeout` abandons a probe without cancelling it, and readdir/stat take no
+   * AbortSignal — on a wedged mount a fresh probe per refresh would pin every libuv fs thread.
+   */
+  private startRepoWorktreeAdminFingerprintProbe(repo: Repo): Promise<string | null> | null {
+    if (this.worktreeAdminFingerprintProbes.has(repo.id)) {
+      return null
+    }
+    this.worktreeAdminFingerprintProbes.add(repo.id)
+    return readRepoWorktreeAdminFingerprint(repo.path)
+      .catch(() => null)
+      .finally(() => {
+        this.worktreeAdminFingerprintProbes.delete(repo.id)
+      })
   }
 
   private async listRepoWorktreesForResolutionUncached(
@@ -36011,8 +36039,10 @@ const WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS = 5 * 60_000
 // edits are invisible to it and a tip living in packed-refs or reftable only gets an mtime + size
 // stamp, so a real scan still runs on this interval even while the probe reports "unchanged".
 export const WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS = 5 * 60_000
-/** Stand-in for a repo the local admin probe cannot or need not describe; never matches a real read. */
-const UNFINGERPRINTED_WORKTREE_SCAN: Promise<string | null> = Promise.resolve(null)
+// Why so generous: a healthy but slow host (100+ linked worktrees, Windows Defender, cold dentry
+// cache, cloud placeholders) must still get to reuse its scan. Well under WORKTREE_LIST_TIMEOUT_MS,
+// and expiring yields `null` — the existing "cannot prove unchanged" sentinel, so a real scan runs.
+export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 10_000
 const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
 
 export function resolveWorktreeScanCacheTtlMs(repo: Pick<Repo, 'path' | 'connectionId'>): number {

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -36,7 +36,11 @@ vi.mock('./repo-worktree-admin-fingerprint', () => ({
   readRepoWorktreeAdminFingerprint: readRepoWorktreeAdminFingerprintMock
 }))
 
-import { OrcaRuntimeService, WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS } from './orca-runtime'
+import {
+  OrcaRuntimeService,
+  WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS,
+  WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS
+} from './orca-runtime'
 
 const REPO_ID = 'repo-local'
 const REPO_PATH = '/Users/me/dev/app'
@@ -121,6 +125,36 @@ function makeRuntime(
 
 function scanCount(): number {
   return listWorktreesStrictMock.mock.calls.length
+}
+
+/** Let every already-settled promise chain run without advancing the clock, so a stall stays a stall. */
+async function drainMicrotasks(): Promise<void> {
+  for (let tick = 0; tick < 200; tick += 1) {
+    await Promise.resolve()
+  }
+}
+
+function trackSettled(promise: Promise<unknown>): () => boolean {
+  let settled = false
+  void promise.then(
+    () => {
+      settled = true
+    },
+    () => {
+      settled = true
+    }
+  )
+  return () => settled
+}
+
+function stallProbeOnce(): (fingerprint: string | null) => void {
+  let release: (fingerprint: string | null) => void = () => {}
+  readRepoWorktreeAdminFingerprintMock.mockReturnValueOnce(
+    new Promise<string | null>((resolve) => {
+      release = resolve
+    })
+  )
+  return (fingerprint) => release(fingerprint)
 }
 
 describe('worktree scan admin-fingerprint gate', () => {
@@ -310,6 +344,111 @@ describe('worktree scan admin-fingerprint gate', () => {
       expect(ttlOnlyScans).toBe(600)
       expect(reconcileScans).toBe(60)
       expect(scanCount()).toBe(reconcileScans)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps refreshing when a probe on a wedged filesystem never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      stallProbeOnce()
+      const { list } = makeRuntime()
+
+      await list()
+      expect(scanCount()).toBe(1)
+
+      // No timer advance: the caller's 5s fallback cannot rescue this, so the refresh itself must
+      // not be waiting on the dead probe.
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const second = list()
+      const secondSettled = trackSettled(second)
+      await drainMicrotasks()
+      expect(secondSettled()).toBe(true)
+      await second
+      expect(scanCount()).toBe(2)
+
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const third = list()
+      const thirdSettled = trackSettled(third)
+      await drainMicrotasks()
+      expect(thirdSettled()).toBe(true)
+      await third
+      expect(scanCount()).toBe(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('issues no further probes while one is still outstanding', async () => {
+    vi.useFakeTimers()
+    try {
+      readRepoWorktreeAdminFingerprintMock.mockReturnValue(new Promise<string | null>(() => {}))
+      const { list } = makeRuntime()
+
+      await list()
+      expect(readRepoWorktreeAdminFingerprintMock).toHaveBeenCalledTimes(1)
+
+      for (let refresh = 0; refresh < 20; refresh += 1) {
+        vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+        await list()
+      }
+
+      // Each abandoned probe pins an fs work item on the 4-slot libuv pool forever.
+      expect(readRepoWorktreeAdminFingerprintMock).toHaveBeenCalledTimes(1)
+      expect(scanCount()).toBe(21)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resumes gating once the filesystem recovers', async () => {
+    vi.useFakeTimers()
+    try {
+      const releaseStalledProbe = stallProbeOnce()
+      const { list } = makeRuntime()
+
+      await list()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      await list()
+      expect(scanCount()).toBe(2)
+
+      // The mount unwedges; its stale answer must not gate anything, but the repo must probe again.
+      releaseStalledProbe('fp-stale')
+      await drainMicrotasks()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      await list()
+      expect(scanCount()).toBe(3)
+
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      await list()
+      expect(scanCount()).toBe(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('scans when the awaited probe outlives its deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const { list } = makeRuntime()
+
+      await list()
+      expect(scanCount()).toBe(1)
+
+      stallProbeOnce()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const second = list()
+      const secondSettled = trackSettled(second)
+      await drainMicrotasks()
+      // A reusable cache entry is the one case that genuinely waits on the probe.
+      expect(secondSettled()).toBe(false)
+      expect(scanCount()).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
+      await drainMicrotasks()
+      expect(scanCount()).toBe(2)
+      await second
     } finally {
       vi.useRealTimers()
     }


### PR DESCRIPTION
Fixes **STA-4171**. Regression from #14207.

## Problem

`RuntimeWorktreeScanCache.adminFingerprint` held an **unsettled promise**. `readRepoWorktreeAdminFingerprint` issues `readdir`/`readFile`/`stat` with no deadline, and its `try/catch` only converts *rejections* — a syscall that never returns yields a promise that never settles.

The reuse branch then did `await Promise.all([current, cached.adminFingerprint])`, awaiting that cached promise. That hung `refreshRepoWorktreeScan`, so its `finally` never deleted the `worktreeScanInFlight` entry, and every later refresh joined the poisoned entry. The outer `withTimeout(..., 5000, null)` only resolves the *caller's* view — it neither cancels nor evicts.

Two consequences:
- the repo's worktree catalog is frozen on persisted store rows until invalidation or restart;
- because `computeResolvedWorktrees` `Promise.all`s over repos, **every** repo's snapshot takes ≥5s.

Verified: even when only the *first* probe stalls and all later probes would resolve instantly, refreshes #2/#3/#4 each still stall the full 5s and issue no new probe — the stale cached promise is the blocker, not the current one.

Trigger is a local repo on a wedged mount (hard NFS/SMB, dead sshfs/FUSE, stuck cloud FileProvider). SSH, WSL-routed, and agent-scratch repos are already excluded by `fingerprintCapable`; folder workspaces never reach this path.

## Fix

1. **Cache the settled value.** `adminFingerprint` is now `string | null`, filled by a `.then` writeback that only writes while the cache entry is still identity-equal. No caller ever awaits a cross-call promise again — this is the actual defect.
2. **Bound the one awaited probe** with `WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS = 10_000`. Expiry yields `null`, already the "cannot prove unchanged" sentinel, so it degrades to a real `git worktree list` — never to incorrect data. Deliberately generous: a healthy-but-slow host (100+ linked worktrees, Windows Defender, cold dentry cache, cloud placeholders) must still get to reuse its scan.
3. **Outstanding-probe guard.** `withTimeout` does *not* cancel, and today's poisoned in-flight entry accidentally caps abandoned probes at one per repo. Adding a timeout alone would remove that cap — a wedged mount would get a fresh probe every refresh, each pinning an fs work item on the 4-slot libuv threadpool, blocking all four within ~2 minutes and deadlocking every filesystem operation in the main process. `worktreeAdminFingerprintProbes` keeps abandoned fs work at one item per repo.

Deliberately **not** done: no staleness cut on the `worktreeScanInFlight` join. A legitimate scan on a large repo, cold FS, or WSL-routed repo routinely exceeds 5s, and evicting there would yield ~4 concurrent `git worktree list` runs under the existing 1 Hz poll. The existing "bounds Git fan-out under a sustained 1 Hz polling workload" test guards that and stays green.

`repo-worktree-admin-fingerprint.ts` is untouched — `readdir`/`stat` take no `AbortSignal`, so bounding must happen at the promise level.

## Tests

Four new cases in `worktree-scan-admin-fingerprint-gate.test.ts`, all confirmed **failing before** the fix (two by assertion, two by test timeout on the hung refresh):
- keeps refreshing when a probe on a wedged filesystem never settles
- issues no further probes while one is still outstanding
- resumes gating once the filesystem recovers
- scans when the awaited probe outlives its deadline

14/14 in the file; 1129 passed with `orca-runtime.test.ts` + `repo-worktree-admin-fingerprint.test.ts` + the linked-issue integration test. Typecheck and all three oxlint layers clean.

## Note on tradeoff

While a probe stays wedged forever, that repo permanently loses the fingerprint gate and does a real `git worktree list` each 30s TTL. That is the intended pre-feature behavior; the only alternative is blocking again.