### PR TITLE
fix(orchestration): release federation ack checkpoints once a dispatch settles

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -162,7 +162,10 @@ import type {
   OrchestrationEnvironmentTransport,
   OrchestrationWorkerServer
 } from './orchestration/environment-transport'
-import { clearFederationAckCheckpoints } from './orchestration/federation-ack-checkpoints'
+import {
+  clearFederationAckCheckpoints,
+  releaseFederationAckCheckpoint
+} from './orchestration/federation-ack-checkpoints'
 import { syncFederatedDispatch } from './orchestration/federation-sync'
 import { formatMessagePointer } from './orchestration/formatter'
 import { MailPointerRepointScheduler } from './orchestration/mail-pointer-repoint-scheduler'
@@ -4739,8 +4742,12 @@ export class OrcaRuntimeService {
         throw error
       })
       .finally(() => {
-        if (this.orchestrationFederationSyncs.get(dispatchId)?.promise === sync) {
-          this.orchestrationFederationSyncs.delete(dispatchId)
+        if (this.orchestrationFederationSyncs.get(dispatchId)?.promise !== sync) {
+          return
+        }
+        this.orchestrationFederationSyncs.delete(dispatchId)
+        if (!db.isFederatedDispatchRelayEligible(dispatchId)) {
+          releaseFederationAckCheckpoint(this, dispatchId)
         }
       })
     this.orchestrationFederationSyncs.set(dispatchId, { db, promise: sync })

--- a/src/main/runtime/orchestration/federation-ack-checkpoints.ts
+++ b/src/main/runtime/orchestration/federation-ack-checkpoints.ts
@@ -21,6 +21,14 @@ export function clearFederationAckCheckpoints(runtime: OrcaRuntimeService): void
   federationAckStates.delete(runtime)
 }
 
+/** Drops one settled dispatch's checkpoint; the durable ack watermark keeps replay suppressed. */
+export function releaseFederationAckCheckpoint(
+  runtime: OrcaRuntimeService,
+  dispatchId: string
+): void {
+  federationAckStates.get(runtime)?.byDispatch.delete(dispatchId)
+}
+
 export function acquireFederationAckLease(
   runtime: OrcaRuntimeService,
   dispatchId: string

--- a/src/main/runtime/orchestration/federation-sync.test.ts
+++ b/src/main/runtime/orchestration/federation-sync.test.ts
@@ -13,6 +13,7 @@ function createIdleSyncHarness() {
   let remoteRuntimeEpoch = 'remote_epoch_1'
   let blockedAck: { reached: () => void; released: Promise<void> } | null = null
   let blockedPull: { reached: () => void; released: Promise<void> } | null = null
+  let relayEligible = true
   const federated = {
     environment_id: 'environment_windows',
     environment_name: 'windows',
@@ -27,6 +28,7 @@ function createIdleSyncHarness() {
       getDispatchContextById: () => ({ run_id: 'run_home', task_id: 'task_home' }),
       getWorkerDispatch: () => ({ state: 'ready' }),
       listPendingFederationRelay: () => [],
+      isFederatedDispatchRelayEligible: () => relayEligible,
       recordFederatedHomeAcknowledgment: (params: {
         remoteRuntimeEpoch: string
         sequence: number
@@ -75,6 +77,9 @@ function createIdleSyncHarness() {
     },
     restartRemote: () => {
       remoteRuntimeEpoch = 'remote_epoch_2'
+    },
+    settleDispatch: () => {
+      relayEligible = false
     },
     replaceDb: () => runtime.setOrchestrationDb(createDb()),
     blockAck: () => {
@@ -335,6 +340,39 @@ describe('federation relay acknowledgments', () => {
     expect(
       remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
     ).toHaveLength(2)
+  })
+
+  it('releases the checkpoint once a dispatch is no longer relay eligible', async () => {
+    const { runtime, settleDispatch } = createIdleSyncHarness()
+    const identity: FederationAckIdentity = {
+      environmentId: 'environment_windows',
+      peerFingerprint: 'windows_peer_fingerprint',
+      remoteRuntimeEpoch: 'remote_epoch_1'
+    }
+    const ackedThrough = () =>
+      getFederationAckedThrough(acquireFederationAckLease(runtime, 'dispatch_remote'), identity)
+
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(ackedThrough()).toBe(2)
+
+    settleDispatch()
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(ackedThrough()).toBe(0)
+  })
+
+  it('leaves the durable watermark suppressing acks after the checkpoint is released', async () => {
+    const { runtime, remoteCall, settleDispatch } = createIdleSyncHarness()
+    const ackCalls = () =>
+      remoteCall.mock.calls.filter(([, method]) => method === 'orchestration.federationAck')
+
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    expect(ackCalls()).toHaveLength(1)
+
+    settleDispatch()
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+    await runtime.syncOrchestrationFederatedDispatch('dispatch_remote')
+
+    expect(ackCalls()).toHaveLength(1)
   })
 
   it('matches checkpoints only to their exact remote identity and never moves backward', () => {


### PR DESCRIPTION
Fixes **STA-4014**. Regression from #13671.

## Problem

`federation-ack-checkpoints.ts` keeps `byDispatch: Map<string, {checkpoint}>` inside a module `WeakMap` keyed on the process-singleton runtime. `acquireFederationAckLease` inserts on the first sync of a dispatch, and there is **no per-dispatch delete anywhere**. The only removal is `clearFederationAckCheckpoints`, which drops the whole map and is reached only from `stopOrchestrationFederationRelay`, `setOrchestrationDb`, and `orchestration.reset` — none of which fire in normal operation.

Entries are also re-created *after* settlement by the terminal-history recovery loop, which syncs already-terminal dispatches whose durable ack lags.

## Severity

Filed P2; it is realistically **P3**. Each entry is ~350–450 B and the count is bounded by distinct federated dispatches synced in one app session, so the worst case is single-digit MB with no correctness effect. Worth fixing as a cleanup, not as a release blocker.

## Fix

One hook, not two. The ticket suggested pruning at the relay tick's ineligible branch, but that only covers dispatches that own a timer and **misses three of the five entry points** that create checkpoints — `syncOrchestrationFederation`, and the `orchestration-worker-stop` / `orchestration-worker-control` RPCs, which sync an already-terminal dispatch with no timer to prune afterwards.

Instead, prune from the existing `.finally` of `syncOrchestrationFederatedDispatch`, which every one of those paths goes through. It uses the `db` captured at sync start rather than `getOrchestrationDb()`, so a mid-flight db swap cannot prune against an unrelated database, and it early-returns unless this sync is still the registered one so a newer in-flight sync's lease is never yanked.

`FederationAckLease` is unchanged and `recordFederationAckCheckpoint` gained no extra fencing — a write through a detached lease mutates an object nothing references, so it is already harmless.

## Replay hazard — checked explicitly

Dropping the checkpoint does **not** reintroduce the redundant acks #13671 removed:

1. The in-memory write at `federation-sync.ts:169` is unconditionally preceded by `db.recordFederatedHomeAcknowledgment` at `:164` with the identical `locallyAcknowledgedThrough` and `pulled.runtimeEpoch`. If the DB call throws (`request_mismatch`), the in-memory write never happens either.
2. `db.ts:5283-5301` sets `to_home_acknowledged_sequence = MAX(existing, sequence)` when the epoch already matched, else `= sequence`, and stores `remote_runtime_epoch` — so durable ≥ in-memory for the same identity in every branch.
3. The gate is `cursor > Math.max(inMemory, durable)`, so dropping the in-memory term only changes behavior if `inMemory > durable`, which never occurs. On a remote epoch change durable resets, but `getFederationAckedThrough` also returns 0 for a mismatched epoch, so that branch is a wash; a `peer_fingerprint` change throws `peer_changed` before any ack.

The regression guard was proven to be a real guard, not a tautology: forcing `durableAcknowledgedThrough` to 0 makes it fail with 2 acks instead of 1 (reverted).

## Tests

Two new cases in `federation-sync.test.ts`:
- releases the checkpoint once a dispatch is no longer relay eligible
- leaves the durable watermark suppressing acks after the checkpoint is released

15/15 across `federation-sync.test.ts` + `federation-terminal-recovery.test.ts`; 36/36 including `orchestration-federation-lifecycle-settlement.test.ts`. Typecheck and lint clean.

## Follow-up worth considering

Two independent reviewers concluded the in-memory checkpoint is not merely redundant but **entirely** redundant with the durable watermark added by #14105 — one verified that stubbing `getFederationAckedThrough` to 0 leaves 326/327 orchestration tests green, the sole failure being the module's own unit test. Deleting the module outright would remove this retention as a side effect, drop ~70 lines, and survive process restart (which the in-memory map does not). Not done here to keep this change small and behavior-preserving.