### PR TITLE
fix(workspaces): gate the GitLab palette number match on repo identity

### DIFF
--- a/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
@@ -28,11 +28,16 @@ function gitLabLinksEqual(left: GitLabIssueOrMRLink, right: GitLabIssueOrMRLink)
 
 /** Tri-state like `repoMatchesGitHubSlug`: `'unknown'` stays permissive for forks and host aliases. */
 function repoMatchesGitLabSlug(repo: Repo | undefined, slug: ProjectSlug): boolean | 'unknown' {
-  const canonicalKey = repo?.gitRemoteIdentity?.canonicalKey
-  if (!canonicalKey) {
+  const identity = repo?.gitRemoteIdentity
+  if (!identity?.canonicalKey) {
     return 'unknown'
   }
-  return canonicalKey.replace(/\/+$/, '').toLowerCase() === gitLabProjectKey(slug)
+  if (identity.canonicalKey.replace(/\/+$/, '').toLowerCase() === gitLabProjectKey(slug)) {
+    return true
+  }
+  // Why not false: identity keeps one remote and prefers `upstream`, so a fork's own `origin` is
+  // invisible here. Rejecting would drop MR URLs from the fork the user actually checked out.
+  return identity.remoteName === 'upstream' ? 'unknown' : false
 }
 
 export function worktreeMatchesGitLabUrl(

--- a/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
@@ -35,8 +35,9 @@ function repoMatchesGitLabSlug(repo: Repo | undefined, slug: ProjectSlug): boole
   if (identity.canonicalKey.replace(/\/+$/, '').toLowerCase() === gitLabProjectKey(slug)) {
     return true
   }
-  // Why not false: identity keeps one remote and prefers `upstream`, so a fork's own `origin` is
-  // invisible here. Rejecting would drop MR URLs from the fork the user actually checked out.
+  // Why not false: identity keeps one remote, chosen when the repo was added and never re-probed.
+  // An `upstream` pick means a fork's `origin` existed and is invisible here, so rejecting would
+  // drop MR URLs from the fork itself. A stale snapshot can still misjudge a renamed project.
   return identity.remoteName === 'upstream' ? 'unknown' : false
 }
 

--- a/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-gitlab-url-match.ts
@@ -1,0 +1,79 @@
+import type { HostedReviewInfo } from '../../../shared/hosted-review'
+import {
+  parseGitLabIssueOrMRLink,
+  type ProjectSlug
+} from '../../../shared/new-workspace/gitlab-links'
+import type { Repo, Worktree } from '../../../shared/types'
+
+export type GitLabIssueOrMRLink = NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
+
+/** Same shape as `GitRemoteIdentity.canonicalKey`: lowercased host (no port) + normalized project path. */
+function gitLabProjectKey(slug: ProjectSlug): string {
+  const host = slug.host.replace(/:\d+$/, '').toLowerCase()
+  const path = slug.path
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '')
+    .toLowerCase()
+  return `${host}/${path}`
+}
+
+function gitLabLinksEqual(left: GitLabIssueOrMRLink, right: GitLabIssueOrMRLink): boolean {
+  return (
+    left.type === right.type &&
+    left.number === right.number &&
+    gitLabProjectKey(left.slug) === gitLabProjectKey(right.slug)
+  )
+}
+
+/** Tri-state like `repoMatchesGitHubSlug`: `'unknown'` stays permissive for forks and host aliases. */
+function repoMatchesGitLabSlug(repo: Repo | undefined, slug: ProjectSlug): boolean | 'unknown' {
+  const canonicalKey = repo?.gitRemoteIdentity?.canonicalKey
+  if (!canonicalKey) {
+    return 'unknown'
+  }
+  return canonicalKey.replace(/\/+$/, '').toLowerCase() === gitLabProjectKey(slug)
+}
+
+export function worktreeMatchesGitLabUrl(
+  worktree: Worktree,
+  link: GitLabIssueOrMRLink,
+  repo: Repo | undefined,
+  review: HostedReviewInfo | null | undefined
+): boolean {
+  const linkedUrl = worktree.linkedWorkItem?.url
+    ? parseGitLabIssueOrMRLink(worktree.linkedWorkItem.url)
+    : null
+  if (linkedUrl && gitLabLinksEqual(linkedUrl, link)) {
+    return true
+  }
+
+  const reviewUrl =
+    review?.provider === 'gitlab' && review.url ? parseGitLabIssueOrMRLink(review.url) : null
+  if (reviewUrl && gitLabLinksEqual(reviewUrl, link)) {
+    return true
+  }
+
+  const linkedItem = worktree.linkedWorkItem
+  const linkedItemMatches =
+    linkedItem?.provider === 'gitlab' &&
+    linkedItem.type === link.type &&
+    linkedItem.number === link.number
+  const numberMatches =
+    linkedItemMatches ||
+    (link.type === 'mr'
+      ? worktree.linkedGitLabMR === link.number
+      : worktree.linkedGitLabIssue === link.number)
+  if (!numberMatches) {
+    return false
+  }
+
+  // Why: iids are per-project, so a bare number only survives when the repo remote agrees.
+  const repoMatch = repoMatchesGitLabSlug(repo, link.slug)
+  if (repoMatch !== 'unknown') {
+    return repoMatch
+  }
+  // Identity unresolvable: stay permissive unless the stored URL names the same type+number in a
+  // different project, which is a contradiction rather than a plausible cross-project reference.
+  return !(linkedUrl && linkedUrl.type === link.type && linkedUrl.number === link.number)
+}

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -282,6 +282,33 @@ describe('matchWorktreePaletteTaskUrl', () => {
     ).toMatchObject({ matchedField: 'pr' })
   })
 
+  it('stays permissive for a fork whose identity resolved to the upstream remote', () => {
+    // `deriveGitRemoteIdentity` prefers `upstream`, so the fork's own `origin` is not visible here.
+    const forkRepo: Repo = {
+      ...gitLabRepo('gitlab.com/acme/orca'),
+      gitRemoteIdentity: {
+        canonicalKey: 'gitlab.com/acme/orca',
+        remoteName: 'upstream',
+        remoteUrl: 'git@gitlab.com:acme/orca.git'
+      }
+    }
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: parseCmdJTaskSourceUrl('https://gitlab.com/me/orca/-/merge_requests/17')!,
+        repo: forkRepo
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+    // An `origin`-derived identity is authoritative, so a different project still loses.
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: parseCmdJTaskSourceUrl('https://gitlab.com/me/orca/-/merge_requests/17')!,
+        repo: gitLabRepo('gitlab.com/acme/orca')
+      })
+    ).toBeNull()
+  })
+
   it('matches both GitLab issue URL forms and rejects other projects', () => {
     for (const url of [
       'https://gitlab.com/acme/orca/-/issues/17',

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -38,6 +38,18 @@ const orcaRepo: Repo = {
   addedAt: 0
 }
 
+function gitLabRepo(canonicalKey: string): Repo {
+  return {
+    ...orcaRepo,
+    displayName: 'orca',
+    gitRemoteIdentity: {
+      canonicalKey,
+      remoteName: 'origin',
+      remoteUrl: `git@${canonicalKey.replace('/', ':')}.git`
+    }
+  }
+}
+
 describe('parseCmdJTaskSourceUrl', () => {
   it('parses GitHub issue and pull URLs', () => {
     expect(parseCmdJTaskSourceUrl('https://github.com/stablyai/orca/issues/14198')).toEqual({
@@ -151,6 +163,171 @@ describe('matchWorktreePaletteTaskUrl', () => {
         repo: { ...orcaRepo, displayName: 'Repo 1' }
       })
     ).toMatchObject({ matchedField: 'pr', supportingText: { text: 'PR #12789' } })
+  })
+
+  it('rejects a GitLab MR URL from a different project than the stored URL', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedGitLabMR: 17,
+          linkedWorkItem: {
+            provider: 'gitlab',
+            type: 'mr',
+            number: 17,
+            title: 'Other project MR',
+            url: 'https://gitlab.example.com/other/project/-/merge_requests/17'
+          }
+        }),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.example.com/other/project')
+      })
+    ).toBeNull()
+  })
+
+  it('matches a GitLab MR URL for the same project', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedGitLabMR: 17,
+          linkedWorkItem: {
+            provider: 'gitlab',
+            type: 'mr',
+            number: 17,
+            title: 'Same project MR',
+            url: 'https://gitlab.com/acme/orca/-/merge_requests/17'
+          }
+        }),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.example.com/other/project')
+      })
+    ).toMatchObject({
+      matchedField: 'pr',
+      supportingText: { labelKind: 'mr', text: 'MR #17' }
+    })
+  })
+
+  it('does not match a GitLab issue URL against a stored MR of the same number', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedGitLabIssue: 17,
+          linkedWorkItem: {
+            provider: 'gitlab',
+            type: 'issue',
+            number: 17,
+            title: 'Issue',
+            url: 'https://gitlab.com/acme/orca/-/issues/17'
+          }
+        }),
+        intent: intent!
+      })
+    ).toBeNull()
+  })
+
+  it('does not match a GitLab URL on a different host for the same project path', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          linkedGitLabMR: 17,
+          linkedWorkItem: {
+            provider: 'gitlab',
+            type: 'mr',
+            number: 17,
+            title: 'Self-hosted MR',
+            url: 'https://gitlab.example.com/acme/orca/-/merge_requests/17'
+          }
+        }),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.example.com/acme/orca')
+      })
+    ).toBeNull()
+  })
+
+  it('gates a stored GitLab number with no work item on the repo remote identity', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.example.com/other/project')
+      })
+    ).toBeNull()
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.com/acme/orca')
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('stays permissive for GitLab numbers when the repo remote identity is unknown', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: intent!,
+        repo: orcaRepo
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({ linkedGitLabMR: 17 }),
+        intent: intent!
+      })
+    ).toMatchObject({ matchedField: 'pr' })
+  })
+
+  it('matches both GitLab issue URL forms and rejects other projects', () => {
+    for (const url of [
+      'https://gitlab.com/acme/orca/-/issues/17',
+      'https://gitlab.com/acme/orca/-/work_items/17'
+    ]) {
+      const intent = parseCmdJTaskSourceUrl(url)
+      expect(intent).toMatchObject({ provider: 'gitlab', link: { type: 'issue', number: 17 } })
+      expect(
+        matchWorktreePaletteTaskUrl({
+          worktree: makeWorktree({ linkedGitLabIssue: 17 }),
+          intent: intent!,
+          repo: gitLabRepo('gitlab.com/acme/orca')
+        })
+      ).toMatchObject({
+        matchedField: 'issue',
+        supportingText: { labelKind: 'issue', text: 'Issue #17' }
+      })
+      expect(
+        matchWorktreePaletteTaskUrl({
+          worktree: makeWorktree({ linkedGitLabIssue: 17 }),
+          intent: intent!,
+          repo: gitLabRepo('gitlab.example.com/other/project')
+        })
+      ).toBeNull()
+    }
+  })
+
+  it('matches a GitLab MR URL via the linked review URL', () => {
+    const intent = parseCmdJTaskSourceUrl('https://gitlab.com/acme/orca/-/merge_requests/17')
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree(),
+        intent: intent!,
+        repo: gitLabRepo('gitlab.example.com/other/project'),
+        review: {
+          provider: 'gitlab',
+          number: 17,
+          title: 'Fork MR',
+          state: 'open',
+          url: 'https://gitlab.com/acme/orca/-/merge_requests/17',
+          status: 'pending',
+          updatedAt: '2026-01-01T00:00:00Z',
+          mergeable: 'UNKNOWN'
+        }
+      })
+    ).toMatchObject({ matchedField: 'pr' })
   })
 
   it('matches a Linear issue URL and rejects a different organization', () => {

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -10,16 +10,17 @@ import { parseJiraIssueUrl, type ParsedJiraIssueUrl } from '../../../shared/jira
 import { parseLinearIssueUrlIntent, type LinearIssueUrlIntent } from '../../../shared/linear-links'
 import type { Repo, Worktree } from '../../../shared/types'
 import { normalizeLinearIdentifier } from './linear-issue-workspace-attachment'
+import {
+  worktreeMatchesGitLabUrl,
+  type GitLabIssueOrMRLink
+} from './worktree-palette-gitlab-url-match'
 import { isWorktreePaletteQueryTooLarge } from './worktree-palette-query-bounds'
 import type { PaletteSearchResult, PaletteSupportingText } from './worktree-palette-search'
 
 export type CmdJTaskSourceUrl =
   | { provider: 'github'; link: GitHubIssueOrPRLink }
   | { provider: 'linear'; intent: LinearIssueUrlIntent }
-  | {
-      provider: 'gitlab'
-      link: NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
-    }
+  | { provider: 'gitlab'; link: GitLabIssueOrMRLink }
   | { provider: 'jira'; parsed: ParsedJiraIssueUrl }
 
 export type CmdJTaskUrlCreatePreview = {
@@ -237,27 +238,6 @@ function worktreeMatchesLinearUrl(worktree: Worktree, intent: LinearIssueUrlInte
   return true
 }
 
-function worktreeMatchesGitLabUrl(
-  worktree: Worktree,
-  link: NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
-): boolean {
-  const linkedUrl = worktree.linkedWorkItem?.url
-    ? parseGitLabIssueOrMRLink(worktree.linkedWorkItem.url)
-    : null
-  if (
-    linkedUrl &&
-    linkedUrl.number === link.number &&
-    linkedUrl.type === link.type &&
-    linkedUrl.slug.host.toLowerCase() === link.slug.host.toLowerCase() &&
-    linkedUrl.slug.path.toLowerCase() === link.slug.path.toLowerCase()
-  ) {
-    return true
-  }
-  return link.type === 'mr'
-    ? worktree.linkedGitLabMR === link.number
-    : worktree.linkedGitLabIssue === link.number
-}
-
 function worktreeMatchesJiraUrl(worktree: Worktree, parsed: ParsedJiraIssueUrl): boolean {
   if (worktree.linkedWorkItem?.jiraIdentifier?.toUpperCase() === parsed.issueKey) {
     return true
@@ -300,7 +280,7 @@ export function matchWorktreePaletteTaskUrl(args: {
     return result(worktree.id, 'issue', supportingText('issue', intent.intent.identifier))
   }
   if (intent.provider === 'gitlab') {
-    if (!worktreeMatchesGitLabUrl(worktree, intent.link)) {
+    if (!worktreeMatchesGitLabUrl(worktree, intent.link, repo, review)) {
       return null
     }
     return result(


### PR DESCRIPTION
Fixes **STA-4155**. Regression from #14190.

## Problem

`worktreeMatchesGitLabUrl` did a full identity compare (number + type + host + path) and then, on **any** failure of that compare, unconditionally fell through to a bare iid compare against `linkedGitLabMR` / `linkedGitLabIssue`. The fallback was not gated on "identity unavailable" — it ran even when the stored URL parsed cleanly into a *different* project.

Reproduced: a workspace whose stored URL is `https://gitlab.example.com/other/project/-/merge_requests/17` matches a pasted `https://gitlab.com/acme/orca/-/merge_requests/17`.

GitLab iids are per-project and start at 1, so small-number collisions across projects are the norm, not an edge case. `searchWorktrees` fans the false match across every non-archived worktree in every repo, and the `taskSourceUrl` branch places the worktree section *above* the Create row — so the wrong-project workspace becomes the default Enter target, and the user cannot just press Enter to create the workspace they intended.

## Why not the fix the ticket asked for

The ticket asked to return false whenever a stored GitLab URL parses and differs. That trades a false positive for **false negatives** in ordinary flows:

- A workspace created from issue `acme/orca#17` that later opens MR `acme/orca!42` (so `linkedGitLabMR: 42`, stored URL still the issue) would stop matching its own MR URL.
- Same for the common layout where issues live in a separate tracker project, and for fork checkouts targeting an upstream's numbers — `normalizeGitLabLinkQuery` documents that acceptance as intentional.

The GitHub path deliberately does not short-circuit for exactly this reason, so a hard reject would make GitLab *stricter* than GitHub — the opposite of the symmetry the ticket wanted.

The ticket also missed the **dominant real-world trigger**: workspaces with `linkedGitLabMR` set and no `linkedWorkItem` at all. `linkedGitLabMR` is written by ordinary MR creation, while `linkedWorkItem` is only set when a work item is explicitly linked. For those the number-only path is the *only* matching mechanism, so hardening just the parsed-URL branch would have left the main exposure open.

## Fix

New `worktree-palette-gitlab-url-match.ts` holding `gitLabProjectKey`, `gitLabLinksEqual` (the extracted 4-field compare, paralleling `githubLinksEqual`), tri-state `repoMatchesGitLabSlug`, and `worktreeMatchesGitLabUrl(worktree, link, repo, review)`.

- The number-only fallback now survives only when `repoMatchesGitLabSlug(repo, link.slug) !== false`, comparing `repo.gitRemoteIdentity?.canonicalKey` against `host/path` (stripping a `:port` from `slug.host`, since `canonicalKey` uses `url.hostname`).
- `'unknown'` stays **permissive**, exactly like GitHub, so forks and host aliases are unaffected.
- Narrow contradiction check for when identity is unknown: a stored GitLab URL with the same type and number but a different project is rejected. Deliberately not extended to differing numbers or types.
- Positive matching now also accepts `review.url` when `review.provider === 'gitlab'`, mirroring the GitHub branch.

The split into a new module was forced by the oxlint `max-lines` limit on `worktree-palette-task-url-match.ts`; per AGENTS.md, disables are not an option. The GitHub path is untouched.

## Tests

Eight new cases in `worktree-palette-task-url-match.test.ts` — the file previously had **zero** cases calling `matchWorktreePaletteTaskUrl` with a `gitlab` intent. Confirmed **failing before** the fix (5 failed / 12 passed with the source stashed and the tests kept):

- the filed repro (different project → null)
- same-project positive still matches, with `matchedField: 'pr'` and `MR #17`
- type discrimination (`/-/issues/17` vs `/-/merge_requests/17`)
- host discrimination (same path, different host)
- the dominant trigger: stored number with no work item, gated on repo identity both ways
- permissive `'unknown'` parity for forks, with and without a repo
- both issue URL forms (`/-/issues/N` and `/-/work_items/N`)
- match via the linked review URL

43/43 across the match and search test files. Typecheck and all three oxlint layers clean.

## Known limits

- The gate depends on `repo.gitRemoteIdentity`. For folder (non-git) workspaces, repos where remote derivation failed, or older persisted records it is undefined, so those take the permissive `'unknown'` path and the original false match remains possible when there is no stored work-item URL. That is the deliberate GitHub-parity choice.
- **GitHub has the same hole**, and I left it alone to keep this change scoped: `repoMatchesGitHubSlug` returns `'unknown'` whenever `displayName` is not `owner/repo` (the common basename-named non-fork repo) and `upstream` is absent, and the `!== false` gate lets it through. A cross-repo GitHub false match is reachable and was reproduced during review. It could use the same `gitRemoteIdentity.canonicalKey` fallback — filing separately.