### PR TITLE
fix(terminal): bake the wrapper interpreter and emit CRLF for cmd

### DIFF
--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -1,4 +1,5 @@
 import { accessSync, constants } from 'node:fs'
+import { join } from 'node:path'
 
 const SHELL_DOLLAR = '$'
 
@@ -12,16 +13,41 @@ const POSIX_INTERPRETER_CANDIDATES = [
   '/opt/homebrew/bin/bash'
 ] as const
 
-export function resolvePosixTombstoneInterpreter(): string {
-  for (const candidate of POSIX_INTERPRETER_CANDIDATES) {
-    try {
-      accessSync(candidate, constants.X_OK)
+function isExecutable(candidate: string): boolean {
+  try {
+    accessSync(candidate, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function resolvePosixTombstoneInterpreter(
+  pathValue: string | undefined = process.env.PATH,
+  // Why: injectable so the PATH-search branch below is reachable in tests on hosts that do have
+  // a well-known bash.
+  candidates: readonly string[] = POSIX_INTERPRETER_CANDIDATES
+): string {
+  for (const candidate of candidates) {
+    if (isExecutable(candidate)) {
       return candidate
-    } catch {
-      // Try the next well-known location.
     }
   }
-  // Why: distributions without any of the above (NixOS, Guix) still need a working wrapper.
+  // Why: distributions that put bash outside the well-known locations (NixOS, Guix) would
+  // otherwise fall back to an ambient lookup. Search absolute PATH entries only — a relative or
+  // empty one means the current directory, which is the exposure this whole function exists to
+  // close.
+  for (const directory of pathValue?.split(':') ?? []) {
+    if (!directory.startsWith('/')) {
+      continue
+    }
+    const candidate = join(directory, 'bash')
+    if (isExecutable(candidate)) {
+      return candidate
+    }
+  }
+  // Why: last resort. Leaves the ambient lookup in place, but only when no absolute bash exists
+  // anywhere, in which case the wrapper would not run at all otherwise.
   return '/usr/bin/env bash'
 }
 

--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -1,6 +1,31 @@
+import { accessSync, constants } from 'node:fs'
+
 const SHELL_DOLLAR = '$'
 
-const POSIX_TOMBSTONE = String.raw`#!/usr/bin/env bash
+// Why: the shebang is the one command resolved before any of the script's own PATH hygiene runs.
+// `env` uses execvp, so an empty or relative PATH element means the current directory and an
+// untrusted checkout can supply the interpreter. Bake an absolute one when we can verify it.
+const POSIX_INTERPRETER_CANDIDATES = [
+  '/bin/bash',
+  '/usr/bin/bash',
+  '/usr/local/bin/bash',
+  '/opt/homebrew/bin/bash'
+] as const
+
+export function resolvePosixTombstoneInterpreter(): string {
+  for (const candidate of POSIX_INTERPRETER_CANDIDATES) {
+    try {
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      // Try the next well-known location.
+    }
+  }
+  // Why: distributions without any of the above (NixOS, Guix) still need a working wrapper.
+  return '/usr/bin/env bash'
+}
+
+const POSIX_TOMBSTONE = String.raw`#!__ORCA_INTERPRETER__
 set -u
 
 command_name="__ORCA_COMMAND__"
@@ -78,6 +103,12 @@ fi
 PATH="$cleaned_path" exec "$real_command" "$@"
 `
 
-export function renderLegacyTerminalPosixTombstone(command: 'git' | 'gh'): string {
-  return POSIX_TOMBSTONE.replaceAll('__ORCA_COMMAND__', command)
+export function renderLegacyTerminalPosixTombstone(
+  command: 'git' | 'gh',
+  interpreter = resolvePosixTombstoneInterpreter()
+): string {
+  return POSIX_TOMBSTONE.replaceAll('__ORCA_INTERPRETER__', interpreter).replaceAll(
+    '__ORCA_COMMAND__',
+    command
+  )
 }

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -112,10 +112,15 @@ describe('legacy terminal shim neutralization', () => {
       // No where.exe at all: it searches cwd first, so the wrapper walks the cleaned PATH.
       expect(cmd).not.toContain('where.exe')
       expect(cmd).toContain('for %%P in ("%orca_clean_path:;=" "%") do call :orca_try_candidate')
-      expect(cmd).toContain(`if exist "%%~fG\\${command}.exe"`)
+      expect(cmd).toContain(`if exist "%orca_candidate_dir%\\${command}.exe"`)
+      // Why: %~f preserves a trailing separator; without normalizing, a wrapper-dir entry
+      // spelled with one escapes self-exclusion and the wrapper tail-loops on itself.
+      // Why: `if "%var:~-1%"=="\\"` breaks cmd's parser, so the trailing separator is stripped
+      // with a sentinel instead. Verified on Windows.
+      expect(cmd).toContain('set "orca_candidate_dir=%orca_candidate_dir:\\#=#%"')
       // A candidate inside the wrapper directory must still be rejected, compared against the
       // cached wrapper dir because %~dp0 is rebound inside a CALL.
-      expect(cmd).toContain('if /I not "%%~fG\\"=="%orca_wrapper_dir%"')
+      expect(cmd).toContain('if /I "%orca_candidate_dir%\\"=="%orca_wrapper_dir%" exit /b')
       // Relative entries resolve against the cwd, so they must be rejected like empty ones.
       // Why: the rooted-path test must not shell out — an external tool would itself be
       // resolved from the cwd, reintroducing the hijack.
@@ -135,6 +140,23 @@ describe('legacy terminal shim neutralization', () => {
       expect(powershell).toContain("-notmatch '^([A-Za-z]:")
       expect(powershell).toContain('if (-not $dir) { continue }')
       expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
+    }
+  })
+
+  it('emits Windows wrappers with CRLF line endings', () => {
+    // Why: cmd resolves `call :label` by byte offset and that lookup is unreliable in LF-only
+    // files — the same script worked at 2.4 KB and failed with "cannot find the batch label"
+    // once it grew past ~3.7 KB. Verified on Windows.
+    const userData = makeUserDataDir()
+    const win32Dir = join(userData, 'orca-terminal-attribution', 'win32')
+    mkdirSync(win32Dir, { recursive: true })
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    for (const file of ['git.cmd', 'gh.cmd', 'git-wrapper.ps1', 'gh-wrapper.ps1']) {
+      const body = readFileSync(join(win32Dir, file), 'utf8')
+      expect(body, file).toContain('\r\n')
+      expect(body.replaceAll('\r\n', ''), file).not.toContain('\n')
     }
   })
 
@@ -162,6 +184,41 @@ describe('legacy terminal shim neutralization', () => {
         expect(cmd.indexOf(guard)).toBeGreaterThan(-1)
         expect(cmd.indexOf(guard)).toBeLessThan(cmd.indexOf(loop))
       }
+    }
+  })
+
+  itOnPosix('does not let the cwd supply the script interpreter', async () => {
+    // Why: the shebang is resolved before any of the script's own PATH hygiene runs, so with
+    // `env` an empty or relative PATH element lets an untrusted checkout supply bash itself.
+    const userData = makeUserDataDir()
+    const shimDir = join(userData, 'orca-terminal-attribution', 'posix')
+    const realBin = join(userData, 'real-bin')
+    const hostile = join(userData, 'hostile')
+    for (const dir of [shimDir, realBin, hostile]) {
+      mkdirSync(dir, { recursive: true })
+    }
+    writeFileSync(join(shimDir, 'git'), 'legacy attribution wrapper')
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    expect(readFileSync(join(shimDir, 'git'), 'utf8').split('\n')[0]).not.toContain('/usr/bin/env')
+
+    writeFileSync(join(realBin, 'git'), "#!/bin/bash\nprintf 'REAL\\n'\n", { mode: 0o755 })
+    writeFileSync(join(hostile, 'bash'), "#!/bin/sh\nprintf 'HOSTILE-BASH\\n'\nexit 66\n", {
+      mode: 0o755
+    })
+
+    for (const hostilePath of [
+      `${shimDir}::${realBin}:/usr/bin:/bin`,
+      `${shimDir}:.:${realBin}:/usr/bin:/bin`
+    ]) {
+      const run = spawnSync(join(shimDir, 'git'), ['--version'], {
+        cwd: hostile,
+        env: { ...process.env, PATH: hostilePath },
+        encoding: 'utf8'
+      })
+      expect(run.stdout, `PATH=${hostilePath}`).toContain('REAL')
+      expect(run.stdout, `PATH=${hostilePath}`).not.toContain('HOSTILE-BASH')
     }
   })
 
@@ -242,9 +299,11 @@ describe('legacy terminal shim neutralization', () => {
     expect(cmd.indexOf(cmdCapture)).toBeLessThan(cmd.indexOf('set "ORCA_ATTRIBUTION_SHIM_DIR="'))
     expect(cmd).toContain('for %%P in ("%PATH:;=" "%") do call :orca_append_path "%%~P"')
     expect(cmd).toContain('if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b')
-    expect(cmd).toContain(
-      'if defined orca_legacy_wrapper_dir for %%G in ("%orca_legacy_wrapper_dir%") do if /I "%orca_path_entry_dir%"=="%%~fG\\" exit /b'
-    )
+    expect(cmd).toContain('if defined orca_legacy_wrapper_dir call :orca_reject_legacy_dir')
+    // Why: `call :label && ...` is not valid cmd; the flag variable is what makes it work.
+    expect(cmd).toContain('if defined orca_skip_entry exit /b')
+    expect(cmd).not.toContain('call :orca_reject_legacy_dir &&')
+    expect(cmd).toContain('set "orca_path_entry_dir=%orca_path_entry_dir:\\#=#%"')
 
     const powershell = readFileSync(join(win32Dir, 'git-wrapper.ps1'), 'utf8')
     expect(powershell.indexOf('$legacyWrapperDir = $env:ORCA_ATTRIBUTION_SHIM_DIR')).toBeLessThan(

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolvePosixTombstoneInterpreter } from './legacy-terminal-posix-tombstone'
 import {
   __resetLegacyTerminalShimNeutralizationForTests,
   neutralizeLegacyTerminalShimDir,
@@ -185,6 +186,25 @@ describe('legacy terminal shim neutralization', () => {
         expect(cmd.indexOf(guard)).toBeLessThan(cmd.indexOf(loop))
       }
     }
+  })
+
+  itOnPosix('resolves the interpreter from absolute PATH entries only', () => {
+    // Why: with no well-known bash (NixOS/Guix), the fallback search must still refuse relative
+    // and empty entries — those mean the current directory, the exposure being closed.
+    const userData = makeUserDataDir()
+    const absDir = join(userData, 'absbin')
+    const relDir = join(userData, 'relbin')
+    mkdirSync(absDir, { recursive: true })
+    mkdirSync(relDir, { recursive: true })
+    for (const dir of [absDir, relDir]) {
+      writeFileSync(join(dir, 'bash'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    }
+
+    // No well-known candidates: force the PATH search.
+    expect(resolvePosixTombstoneInterpreter(`${absDir}:/usr/bin`, [])).toBe(join(absDir, 'bash'))
+    // Relative and empty entries must be skipped even though they contain an executable bash.
+    expect(resolvePosixTombstoneInterpreter(`:relbin:${absDir}`, [])).toBe(join(absDir, 'bash'))
+    expect(resolvePosixTombstoneInterpreter('.:relbin', [])).toBe('/usr/bin/env bash')
   })
 
   itOnPosix('does not let the cwd supply the script interpreter', async () => {

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -50,21 +50,41 @@ if "%orca_candidate:~1,2%"==":\" goto orca_candidate_rooted
 if "%orca_candidate:~1,2%"==":/" goto orca_candidate_rooted
 exit /b
 :orca_candidate_rooted
-rem Why: %~dp0 is rebound to this label inside CALL, so compare against the cached wrapper dir.
-for %%G in ("%~1") do (
-  if /I not "%%~fG\"=="%orca_wrapper_dir%" (
-    if exist "%%~fG\__ORCA_COMMAND__.exe" set "orca_real=%%~fG\__ORCA_COMMAND__.exe"
-    if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.cmd" set "orca_real=%%~fG\__ORCA_COMMAND__.cmd"
-    if not defined orca_real if exist "%%~fG\__ORCA_COMMAND__.bat" set "orca_real=%%~fG\__ORCA_COMMAND__.bat"
-  )
-)
+for %%G in ("%~1") do set "orca_candidate_dir=%%~fG"
+rem Why: full-path expansion preserves a trailing separator, so without normalizing, the
+rem self-exclusion below misses a wrapper-dir entry spelled with one and the wrapper resolves
+rem to itself, looping forever.
+set "orca_candidate_dir=%orca_candidate_dir%#"
+set "orca_candidate_dir=%orca_candidate_dir:\#=#%"
+set "orca_candidate_dir=%orca_candidate_dir:~0,-1%"
+rem Why: the script-dir operator is rebound to this label inside CALL, so compare against the
+rem cached wrapper dir captured at top level.
+if /I "%orca_candidate_dir%\"=="%orca_wrapper_dir%" exit /b
+if exist "%orca_candidate_dir%\__ORCA_COMMAND__.exe" set "orca_real=%orca_candidate_dir%\__ORCA_COMMAND__.exe"
+if not defined orca_real if exist "%orca_candidate_dir%\__ORCA_COMMAND__.cmd" set "orca_real=%orca_candidate_dir%\__ORCA_COMMAND__.cmd"
+if not defined orca_real if exist "%orca_candidate_dir%\__ORCA_COMMAND__.bat" set "orca_real=%orca_candidate_dir%\__ORCA_COMMAND__.bat"
 exit /b
 
 :orca_append_path
-for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG\"
+for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG"
+rem Why: full-path expansion preserves a trailing separator; normalize before comparing.
+set "orca_path_entry_dir=%orca_path_entry_dir%#"
+set "orca_path_entry_dir=%orca_path_entry_dir:\#=#%"
+set "orca_path_entry_dir=%orca_path_entry_dir:~0,-1%"
+set "orca_path_entry_dir=%orca_path_entry_dir%\"
 if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b
-if defined orca_legacy_wrapper_dir for %%G in ("%orca_legacy_wrapper_dir%") do if /I "%orca_path_entry_dir%"=="%%~fG\" exit /b
+set "orca_skip_entry="
+if defined orca_legacy_wrapper_dir call :orca_reject_legacy_dir
+if defined orca_skip_entry exit /b
 if defined orca_clean_path (set "orca_clean_path=%orca_clean_path%;%~1") else set "orca_clean_path=%~1"
+exit /b
+
+:orca_reject_legacy_dir
+for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
+set "orca_legacy_norm=%orca_legacy_norm%#"
+set "orca_legacy_norm=%orca_legacy_norm:\#=#%"
+set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
+if /I "%orca_path_entry_dir%"=="%orca_legacy_norm%\" set "orca_skip_entry=1"
 exit /b
 `
 
@@ -124,10 +144,19 @@ function renderWindowsWrapper(template: string, command: string, upperCommand: s
     .replaceAll('__ORCA_COMMAND__', command)
 }
 
+// Why: cmd locates `call :label` targets by byte offset and that lookup is unreliable in
+// LF-only files — the same script worked at 2.4 KB and failed with "cannot find the batch label"
+// once it grew. Emit CRLF, which is what cmd expects.
+function toCrlf(text: string): string {
+  return text.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n')
+}
+
 export function renderLegacyTerminalWindowsCmdTombstone(command: 'git' | 'gh'): string {
-  return renderWindowsWrapper(WIN32_PASSTHROUGH_WRAPPER, command, command.toUpperCase())
+  return toCrlf(renderWindowsWrapper(WIN32_PASSTHROUGH_WRAPPER, command, command.toUpperCase()))
 }
 
 export function renderLegacyTerminalWindowsPowerShellTombstone(command: 'git' | 'gh'): string {
-  return renderWindowsWrapper(POWERSHELL_PASSTHROUGH_WRAPPER, command, command.toUpperCase())
+  return toCrlf(
+    renderWindowsWrapper(POWERSHELL_PASSTHROUGH_WRAPPER, command, command.toUpperCase())
+  )
 }


### PR DESCRIPTION
## ELI5

Round-3 adversarial review of the retained `git`/`gh` wrappers. Two real defects plus one I found while verifying the fix on Windows — that last one would have broken `git` outright.

## 1. The shebang was the last cwd-resolved command (ACE)

`#!/usr/bin/env bash` resolves the interpreter through the **inherited** PATH, before any of the script's own hygiene runs. An empty or relative PATH element means the current directory, so an untrusted checkout could supply `bash` itself and get the user's full `git` argv.

Reachable through Orca's own sanitization, not just user rc files — `stripLegacyTerminalShimEnv` drops empty entries but **keeps relative ones**, confirmed by executing it:

```
posix  '/usr/bin::.:node_modules/.bin:/bin:'  ->  '/usr/bin:.:node_modules/.bin:/bin'
win32  'C:\W;;.;rel\bin;C:\S'                 ->  'C:\W;.;rel\bin;C:\S'
```

Now an absolute, `X_OK`-verified interpreter is baked in at generation time, falling back to `/usr/bin/env bash` only when none of the well-known paths exist (NixOS/Guix). Mutation-proven: with `env bash` the planted interpreter runs (`rc=66`, `HOSTILE-BASH`); with the baked path it does not.

## 2. cmd did not normalize trailing separators — `git` could hang forever

Verified the premise on Windows first:

```
for %G in ("C:\Windows\") do echo [%~fG]   ->  [C:\Windows\]     (separator preserved)
```

So a wrapper-dir PATH entry spelled with a trailing `\` escaped self-exclusion, the wrapper resolved to itself, and since it is invoked without `call` that is a tail chain — an unbounded loop with no stack growth. POSIX and PowerShell both already trimmed; cmd did not. Now normalized in all three comparison sites.

## 3. Found while verifying: the generated `.cmd` used LF, and cmd could not find its own labels

Not in any report — it surfaced only because the file grew. `cmd` resolves `call :label` by byte offset and that lookup is unreliable in LF-only files:

```
2.4 KB, LF  -> worked
3.7 KB, LF  -> "The system cannot find the batch label specified - orca_append_path", exit 127
CRLF        -> works
```

Latent since the wrappers were introduced; it would have shipped as "git is broken on Windows" the moment the file crossed the threshold. Windows wrappers now emit CRLF.

Two smaller ones found the same way, both cmd parser traps: `if "%var:~-1%"=="\"` is invalid (trailing backslash before the quote), and **`rem` comments are still expanded** — a comment containing `%~f` produced `The following usage of the path operator in batch-parameter substitution is invalid`. Comments are now percent-free and the strip uses a sentinel.

## Verified on real Windows

`awin`, Windows 10.0.26200, git 2.55.0.windows.3, PowerShell 5.1:

| case | result |
|---|---|
| Normal | `git version 2.55.0.windows.3`, exit 0 |
| Wrapper dir on PATH with trailing `\` | exit 0, no loop |
| Hostile cwd with planted `git.exe` + `findstr.exe` | real git; both hijacks blocked |
| Hostile cwd + `PATH=.;C:foo` | exit 0, real git |
| Stale `ORCA_REAL_GIT` | exit 0, real git |
| Empty `PATH` | clean message, exit 127 |

## Testing

- `pnpm typecheck`, `pnpm lint`: pass, no `max-lines` suppression
- Full suite: **51,554 passed**; 2 failures, both pre-existing and reproducible on `origin/main`
- New tests: interpreter hijack (mutation-proven), CRLF emission, trailing-separator normalization, and the cmd parser traps
