### PR TITLE
fix(browser): restore replaced cookies through CDP identities

### DIFF
--- a/src/main/browser/browser-cookie-import-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-policy.test.ts
@@ -3,7 +3,8 @@ import { DatabaseSync } from 'node:sqlite'
 import type { Cookie } from 'electron'
 import {
   identitiesFromClearCookies,
-  removeTransplantableCookies
+  removeTransplantableCookies,
+  type CookieClearIdentity
 } from './browser-cookie-import-clear'
 import {
   isGoogleSourceBoundCookie,
@@ -49,6 +50,29 @@ describe('isGoogleSourceBoundCookie', () => {
   })
 })
 
+// Why: mirrors what openCookieClearStore returns — get/remove plus the CDP identity pair, and
+// deliberately no 'set', so a partition-dropping reconstruction cannot be written against it.
+function replaceStore(
+  existing: Cookie[],
+  overrides: {
+    remove?: Mock
+    snapshot?: Mock
+    restore?: Mock
+  } = {}
+) {
+  const get = vi.fn().mockResolvedValue(existing)
+  const remove = overrides.remove ?? vi.fn().mockResolvedValue(undefined)
+  const snapshotClearIdentities =
+    overrides.snapshot ??
+    vi
+      .fn()
+      .mockImplementation(async (cookies: readonly { cookie: Cookie; url: string }[]) =>
+        identitiesFromClearCookies(cookies)
+      )
+  const restoreClearIdentities = overrides.restore ?? vi.fn().mockResolvedValue(undefined)
+  return { get, remove, snapshotClearIdentities, restoreClearIdentities }
+}
+
 describe('replaceCookiesForImportedDomains', () => {
   it('removes parent, exact, and child-domain cookies while preserving unrelated sites', async () => {
     const existing = [
@@ -59,99 +83,129 @@ describe('replaceCookiesForImportedDomains', () => {
       cookie('.google.com.evil.example', 'suffix-confusion'),
       cookie('.example.com', 'unrelated')
     ]
-    const get = vi.fn().mockResolvedValue(existing)
-    const remove = vi.fn().mockResolvedValue(undefined)
-    const set = vi.fn().mockResolvedValue(undefined)
+    const store = replaceStore(existing)
 
-    const removed = await replaceCookiesForImportedDomains({ get, remove, set }, [
-      'accounts.google.com'
-    ])
+    const { removed } = await replaceCookiesForImportedDomains(store, ['accounts.google.com'])
 
     expect(removed).toHaveLength(3)
-    expect(get).toHaveBeenCalledWith({})
-    expect(remove.mock.calls).toEqual([
+    expect(store.get).toHaveBeenCalledWith({})
+    expect(store.remove.mock.calls).toEqual([
       ['https://google.com/', 'parent'],
       ['https://accounts.google.com/signin', 'exact'],
       ['http://child.accounts.google.com/nested', 'child']
     ])
-    expect(set).not.toHaveBeenCalled()
+    // Why: the snapshot must cover the whole removal plan before the first removal runs.
+    expect(store.snapshotClearIdentities).toHaveBeenCalledOnce()
+    expect(
+      store.snapshotClearIdentities.mock.calls[0]?.[0].map(
+        ({ cookie: entry }: { cookie: Cookie }) => entry.name
+      )
+    ).toEqual(['parent', 'exact', 'child'])
+    expect(store.restoreClearIdentities).not.toHaveBeenCalled()
   })
 
   it('does not replace a private-suffix host cookie for a tenant import', async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue([
-        { ...cookie('github.io', 'host-only-suffix'), hostOnly: true },
-        cookie('.user.github.io', 'tenant')
-      ])
-    const remove = vi.fn().mockResolvedValue(undefined)
-    const set = vi.fn().mockResolvedValue(undefined)
+    const store = replaceStore([
+      { ...cookie('github.io', 'host-only-suffix'), hostOnly: true },
+      cookie('.user.github.io', 'tenant')
+    ])
 
-    const removed = await replaceCookiesForImportedDomains({ get, remove, set }, ['user.github.io'])
+    const { removed } = await replaceCookiesForImportedDomains(store, ['user.github.io'])
 
     expect(removed.map(({ name }) => name)).toEqual(['tenant'])
-    expect(remove).toHaveBeenCalledWith('https://user.github.io/', 'tenant')
+    expect(store.remove).toHaveBeenCalledWith('https://user.github.io/', 'tenant')
   })
 
   it('does not read or mutate the store when no valid domain scope exists', async () => {
-    const get = vi.fn()
-    const remove = vi.fn()
-    const set = vi.fn()
+    const store = replaceStore([])
 
     await expect(
-      replaceCookiesForImportedDomains({ get, remove, set }, [
-        '',
-        '...',
-        'com',
-        'co.uk',
-        'github.io'
-      ])
-    ).resolves.toEqual([])
-    expect(get).not.toHaveBeenCalled()
-    expect(remove).not.toHaveBeenCalled()
-    expect(set).not.toHaveBeenCalled()
+      replaceCookiesForImportedDomains(store, ['', '...', 'com', 'co.uk', 'github.io'])
+    ).resolves.toEqual({ removed: [], identities: [] })
+    expect(store.get).not.toHaveBeenCalled()
+    expect(store.remove).not.toHaveBeenCalled()
+    expect(store.snapshotClearIdentities).not.toHaveBeenCalled()
+    expect(store.restoreClearIdentities).not.toHaveBeenCalled()
   })
 
   it('keeps single-label intranet scopes from selecting descendant hosts', async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue([cookie('local', 'exact'), cookie('.service.local', 'descendant')])
-    const remove = vi.fn().mockResolvedValue(undefined)
-    const set = vi.fn().mockResolvedValue(undefined)
+    const store = replaceStore([cookie('local', 'exact'), cookie('.service.local', 'descendant')])
 
-    const removed = await replaceCookiesForImportedDomains({ get, remove, set }, ['local'])
+    const { removed } = await replaceCookiesForImportedDomains(store, ['local'])
 
     expect(removed.map(({ name }) => name)).toEqual(['exact'])
-    expect(remove).toHaveBeenCalledOnce()
-    expect(remove).toHaveBeenCalledWith('https://local/', 'exact')
+    expect(store.remove).toHaveBeenCalledOnce()
+    expect(store.remove).toHaveBeenCalledWith('https://local/', 'exact')
   })
 
-  it('restores cookies removed before a later removal fails', async () => {
+  // Why (STA-4097): cookies.get strips partitionKey and cookies.set ignores it, so a rollback
+  // that rebuilds cookies through the Electron API silently downgrades CHIPS cookies. The undo
+  // has to travel back through the CDP identities that actually carry the partition.
+  it('restores removed cookies through CDP identities, keeping partition identity', async () => {
     const existing = [
       cookie('.example.com', 'first', '/one'),
       cookie('.example.com', 'second', '/two')
     ]
-    const get = vi.fn().mockResolvedValue(existing)
+    const partitionKey = { topLevelSite: 'https://top.example', hasCrossSiteAncestor: true }
+    const snapshot = vi
+      .fn()
+      .mockImplementation(async (cookies: readonly { cookie: Cookie; url: string }[]) =>
+        identitiesFromClearCookies(cookies).map((identity) =>
+          identity.name === 'first' ? { ...identity, partitionKey } : identity
+        )
+      )
     const remove = vi
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('cookie store unavailable'))
-    const set = vi.fn().mockResolvedValue(undefined)
+    const store = replaceStore(existing, { remove, snapshot })
 
-    await expect(
-      replaceCookiesForImportedDomains({ get, remove, set }, ['example.com'])
-    ).rejects.toThrow('cookie store unavailable')
-    expect(set).toHaveBeenCalledOnce()
-    expect(set).toHaveBeenCalledWith({
-      url: 'https://example.com/one',
-      name: 'first',
-      value: 'secret',
-      domain: '.example.com',
-      path: '/one',
-      secure: true,
-      httpOnly: undefined,
-      sameSite: 'unspecified'
-    })
+    await expect(replaceCookiesForImportedDomains(store, ['example.com'])).rejects.toThrow(
+      'cookie store unavailable'
+    )
+
+    expect(store.restoreClearIdentities).toHaveBeenCalledOnce()
+    const restored = store.restoreClearIdentities.mock.calls[0]?.[0] as CookieClearIdentity[]
+    // Why: the failing coordinate is restored too — a rejected remove cannot prove it survived.
+    expect(restored.map(({ name }) => name)).toEqual(['second', 'first'])
+    expect(restored.find(({ name }) => name === 'first')?.partitionKey).toEqual(partitionKey)
+    expect(restored.find(({ name }) => name === 'first')?.url).toBe('https://example.com/one')
+  })
+
+  it('aborts without removing anything when the snapshot cannot cover the removal plan', async () => {
+    const existing = [
+      cookie('.example.com', 'first', '/one'),
+      cookie('.example.com', 'second', '/two')
+    ]
+    const snapshot = vi
+      .fn()
+      .mockImplementation(async (cookies: readonly { cookie: Cookie; url: string }[]) =>
+        identitiesFromClearCookies(cookies).filter((identity) => identity.name !== 'second')
+      )
+    const store = replaceStore(existing, { snapshot })
+
+    await expect(replaceCookiesForImportedDomains(store, ['example.com'])).rejects.toThrow(
+      'the session was left unchanged'
+    )
+    expect(store.remove).not.toHaveBeenCalled()
+    expect(store.restoreClearIdentities).not.toHaveBeenCalled()
+  })
+
+  it('reports both failures when the CDP rollback itself fails', async () => {
+    const remove = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('cookie store unavailable'))
+    const restore = vi.fn().mockRejectedValue(new Error('debugger detached'))
+    const store = replaceStore(
+      [cookie('.example.com', 'first', '/one'), cookie('.example.com', 'second', '/two')],
+      { remove, restore }
+    )
+
+    await expect(replaceCookiesForImportedDomains(store, ['example.com'])).rejects.toThrow(
+      'Cookie replacement and rollback failed'
+    )
+    expect(restore).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/main/browser/browser-cookie-import-policy.ts
+++ b/src/main/browser/browser-cookie-import-policy.ts
@@ -1,5 +1,7 @@
 import type { Cookie, Cookies } from 'electron'
 import { parse as parseDomain } from 'psl'
+// Why: type-only, so this does not create a runtime cycle with the clear module.
+import type { CookieClearIdentity } from './browser-cookie-import-clear'
 
 const GOOGLE_SOURCE_BOUND_COOKIE_NAMES = new Set([
   'SIDCC',
@@ -167,69 +169,102 @@ export function cookieRemovalUrl(cookie: Cookie, domain: string): string | null 
   }
 }
 
-export async function restoreImportedDomainCookies(
-  store: Pick<Cookies, 'set'>,
-  cookies: readonly Cookie[]
-): Promise<void> {
-  const failures: unknown[] = []
-  for (const cookie of cookies) {
-    try {
-      const domain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null
-      const url = domain ? cookieRemovalUrl(cookie, domain) : null
-      if (!url) {
-        continue
-      }
-      await store.set({
-        url,
-        name: cookie.name,
-        value: cookie.value,
-        ...(cookie.hostOnly ? {} : { domain: cookie.domain }),
-        ...(cookie.path ? { path: cookie.path } : {}),
-        secure: cookie.secure,
-        httpOnly: cookie.httpOnly,
-        sameSite: cookie.sameSite,
-        ...(cookie.expirationDate ? { expirationDate: cookie.expirationDate } : {})
-      })
-    } catch (err) {
-      failures.push(err)
+// Why (STA-4097): 'set' stays out so the partition-dropping reconstruction cannot return.
+// Undoing a removal is only possible through CDP identities, which carry partitionKey.
+export type ImportedDomainReplaceStore = Pick<Cookies, 'get' | 'remove'> & {
+  snapshotClearIdentities(
+    cookies: readonly { cookie: Cookie; url: string }[]
+  ): Promise<CookieClearIdentity[]>
+  restoreClearIdentities(identities: readonly CookieClearIdentity[]): Promise<void>
+}
+
+export type ReplacedImportedDomainCookies = {
+  removed: Cookie[]
+  identities: CookieClearIdentity[]
+}
+
+function replaceRemovalKey(url: string, name: string): string {
+  return JSON.stringify([url, name])
+}
+
+function assertIdentitiesCoverRemovable(
+  removable: readonly { cookie: Cookie; url: string }[],
+  identities: readonly CookieClearIdentity[]
+): void {
+  const covered = new Set(
+    identities.map((identity) => replaceRemovalKey(identity.url, identity.name))
+  )
+  for (const item of removable) {
+    if (!covered.has(replaceRemovalKey(item.url, item.cookie.name))) {
+      throw new Error('Could not replace existing cookies; the session was left unchanged')
     }
-  }
-  if (failures.length > 0) {
-    throw new AggregateError(failures, 'Could not restore replaced cookies')
   }
 }
 
 export async function replaceCookiesForImportedDomains(
-  store: Pick<Cookies, 'get' | 'remove' | 'set'>,
+  store: ImportedDomainReplaceStore,
   importedDomains: readonly string[]
-): Promise<Cookie[]> {
+): Promise<ReplacedImportedDomainCookies> {
   const scopes = importedDomainScopes(importedDomains)
   if (scopes.exact.size === 0) {
-    return []
+    return { removed: [], identities: [] }
   }
 
+  // Why (STA-4170): the removal plan is fixed here, beside the identities that can undo it, so
+  // the restorable set always equals the mutated set. Re-reading the jar later would widen the
+  // removal past what the snapshot can restore.
   const existingCookies = await store.get({})
-  const removedCookies: Cookie[] = []
+  const removable: { cookie: Cookie; url: string }[] = []
   for (const cookie of existingCookies) {
     const domain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null
     if (!domain || !overlapsImportedDomain(cookie, domain, scopes)) {
       continue
     }
     const url = cookieRemovalUrl(cookie, domain)
-    if (!url) {
-      continue
+    if (url) {
+      removable.push({ cookie, url })
+    }
+  }
+  if (removable.length === 0) {
+    return { removed: [], identities: [] }
+  }
+
+  // Why: snapshotting before the first removal is what makes the rollback lossless; an
+  // incomplete snapshot aborts while the session is still untouched.
+  const identities = await store.snapshotClearIdentities(removable)
+  assertIdentitiesCoverRemovable(removable, identities)
+  const identitiesByKey = new Map<string, CookieClearIdentity[]>()
+  for (const identity of identities) {
+    const key = replaceRemovalKey(identity.url, identity.name)
+    const group = identitiesByKey.get(key) ?? []
+    group.push(identity)
+    identitiesByKey.set(key, group)
+  }
+
+  const removed: Cookie[] = []
+  // Why: one remove(url, name) deletes every cookie at that coordinate, partitioned twins
+  // included, so the rollback set is tracked per coordinate rather than per cookie.
+  const attemptedKeys = new Set<string>()
+  const attemptedIdentities: CookieClearIdentity[] = []
+  for (const { cookie, url } of removable) {
+    const key = replaceRemovalKey(url, cookie.name)
+    if (!attemptedKeys.has(key)) {
+      attemptedKeys.add(key)
+      attemptedIdentities.push(...(identitiesByKey.get(key) ?? []))
     }
     try {
       await store.remove(url, cookie.name)
-      removedCookies.push(cookie)
+      removed.push(cookie)
     } catch (err) {
       try {
-        await restoreImportedDomainCookies(store, removedCookies)
+        // Why: the failing coordinate is included because a rejected remove cannot prove the
+        // cookie survived; restoring a live cookie rewrites the value it was snapshotted with.
+        await store.restoreClearIdentities(attemptedIdentities.toReversed())
       } catch (restoreError) {
         throw new AggregateError([err, restoreError], 'Cookie replacement and rollback failed')
       }
       throw err
     }
   }
-  return removedCookies
+  return { removed, identities }
 }

--- a/src/main/browser/browser-cookie-import-replace-partition-rollback.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-replace-partition-rollback.electron.test.ts
@@ -1,0 +1,293 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { build as buildVite } from 'vite'
+
+const electronBinary = createRequire(import.meta.url)('electron') as string
+const fixtureRoots: string[] = []
+
+afterAll(() => {
+  for (const root of fixtureRoots) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+})
+
+type CdpCookie = { name: string; value: string; partitionKey?: Record<string, unknown> }
+
+type FixtureResult = {
+  beforePartitionKey: Record<string, unknown> | undefined
+  electronGetSawPartitionKey: boolean
+  removeCalls: number
+  removeCallsBeforeThrow: number
+  snapshotCalls: number
+  restoreCalls: number
+  importedRemoveCalls: number
+  replaceError: string | null
+  chipsAfterReplace: CdpCookie[]
+  chipsAfter: CdpCookie[]
+  plainAfter: CdpCookie[]
+}
+
+const EXPECTED_PARTITION_KEY = {
+  topLevelSite: 'https://top.example',
+  hasCrossSiteAncestor: true
+}
+
+type FixtureMode = 'site-a' | 'site-b'
+
+function buildFixtureMain(bundlePath: string, resultPath: string, mode: FixtureMode): string {
+  return `
+const { app, BrowserWindow, session } = require('electron')
+const { writeFileSync } = require('node:fs')
+const { openCookieClearStore, replaceCookiesForImportedDomains } = require(${JSON.stringify(bundlePath)})
+const resultPath = ${JSON.stringify(resultPath)}
+const mode = ${JSON.stringify(mode)}
+const expectedPartitionKey = ${JSON.stringify(EXPECTED_PARTITION_KEY)}
+let currentStep = 'starting'
+const mark = (step) => {
+  currentStep = step
+  writeFileSync(resultPath, JSON.stringify({ step }))
+}
+
+const project = (cookies, name) => cookies
+  .filter((cookie) => cookie.name === name)
+  .map((cookie) => ({ name: cookie.name, value: cookie.value, partitionKey: cookie.partitionKey }))
+
+async function run() {
+  const timeout = setTimeout(() => {
+    writeFileSync(resultPath, JSON.stringify({ step: 'timed out after ' + currentStep }))
+    app.exit(1)
+  }, 20000)
+  await app.whenReady()
+  mark('ready')
+  const partition = 'persist:replace-partition-rollback-' + mode
+  const targetSession = session.fromPartition(partition)
+  const window = new BrowserWindow({ show: false, webPreferences: { partition } })
+  mark('window created')
+  await window.loadURL('data:text/html,<title>replace partition rollback fixture</title>')
+  mark('window loaded')
+  const debug = window.webContents.debugger
+  debug.attach('1.3')
+  mark('debugger attached')
+
+  // Only CDP can create a partitioned cookie; Electron's cookies API has no partitionKey.
+  await debug.sendCommand('Network.setCookie', {
+    url: 'https://app.acme-chips.test/',
+    name: 'chips-auth',
+    value: 'keep-me',
+    secure: true,
+    sameSite: 'None',
+    partitionKey: expectedPartitionKey
+  })
+  const beforeChips = (await debug.sendCommand('Network.getAllCookies')).cookies
+    .find((cookie) => cookie.name === 'chips-auth')
+  if (!beforeChips || !beforeChips.partitionKey) {
+    throw new Error('CHIPS fixture cookie was not stored partitioned')
+  }
+  mark('partitioned cookie set')
+
+  await targetSession.cookies.set({
+    url: 'https://plain.acme-chips.test/',
+    name: 'plain',
+    value: 'original',
+    secure: true
+  })
+  await targetSession.cookies.set({
+    url: 'https://victim.acme-chips.test/',
+    name: 'victim',
+    value: 'original',
+    secure: true
+  })
+  mark('ordinary cookies set')
+
+  let removeCalls = 0
+  let removeCallsBeforeThrow = 0
+  let snapshotCalls = 0
+  let restoreCalls = 0
+  let importedRemoveCalls = 0
+  let chipsRemoved = false
+  let electronGetSawPartitionKey = false
+  let replaceError = null
+  let chipsAfterReplace = []
+
+  const cookieClearStore = openCookieClearStore(targetSession)
+  const store = {
+    get: async (filter) => {
+      const cookies = await targetSession.cookies.get(filter)
+      // Why: proves the Electron API cannot see the partition it is about to destroy.
+      electronGetSawPartitionKey = cookies.some(
+        (cookie) => cookie.name === 'chips-auth' && cookie.partitionKey !== undefined
+      )
+      // Why: cookies.get order is not a contract; put CHIPS first so it is provably already
+      // removed by the time a later removal rejects.
+      return [...cookies].sort((left, right) => {
+        if (left.name === 'chips-auth') return -1
+        if (right.name === 'chips-auth') return 1
+        return 0
+      })
+    },
+    remove: async (url, name) => {
+      removeCalls++
+      if (mode === 'site-a' && chipsRemoved) {
+        removeCallsBeforeThrow = removeCalls - 1
+        throw new Error('forced removal failure after chips was removed')
+      }
+      await targetSession.cookies.remove(url, name)
+      if (name === 'chips-auth') chipsRemoved = true
+    },
+    snapshotClearIdentities: async (cookies) => {
+      snapshotCalls++
+      return cookieClearStore.snapshotClearIdentities(cookies)
+    },
+    restoreClearIdentities: async (identities) => {
+      restoreCalls++
+      return cookieClearStore.restoreClearIdentities(identities)
+    }
+  }
+
+  try {
+    if (mode === 'site-a') {
+      try {
+        await replaceCookiesForImportedDomains(store, ['acme-chips.test'])
+      } catch (error) {
+        replaceError = String(error && error.message ? error.message : error)
+      }
+      mark('site-a replace finished')
+    } else {
+      const replaced = await replaceCookiesForImportedDomains(store, ['acme-chips.test'])
+      chipsAfterReplace = project((await debug.sendCommand('Network.getAllCookies')).cookies, 'chips-auth')
+      mark('site-b replace finished')
+      // Why: stands in for importValidatedCookies' mid-import cookies.set rejection — the
+      // imported cookie is removed (lossless) and the user's originals go back through CDP.
+      await targetSession.cookies.set({
+        url: 'https://imported.acme-chips.test/',
+        name: 'imported-new',
+        value: 'new',
+        secure: true
+      })
+      await targetSession.cookies.remove('https://imported.acme-chips.test/', 'imported-new')
+      importedRemoveCalls = 1
+      mark('site-b imported cookies rolled back')
+      restoreCalls++
+      await cookieClearStore.restoreClearIdentities(replaced.identities.toReversed())
+      mark('site-b restore finished')
+    }
+  } finally {
+    cookieClearStore.dispose()
+  }
+
+  const afterCookies = (await debug.sendCommand('Network.getAllCookies')).cookies
+  clearTimeout(timeout)
+  writeFileSync(resultPath, JSON.stringify({
+    beforePartitionKey: beforeChips.partitionKey,
+    electronGetSawPartitionKey,
+    removeCalls,
+    removeCallsBeforeThrow,
+    snapshotCalls,
+    restoreCalls,
+    importedRemoveCalls,
+    replaceError,
+    chipsAfterReplace,
+    chipsAfter: project(afterCookies, 'chips-auth'),
+    plainAfter: project(afterCookies, 'plain')
+  }))
+  debug.detach()
+  window.destroy()
+  app.exit(0)
+}
+
+run().catch((error) => {
+  writeFileSync(resultPath, JSON.stringify({ step: currentStep, error: String(error && error.stack ? error.stack : error) }))
+  app.exit(1)
+})
+`
+}
+
+async function runFixture(mode: FixtureMode): Promise<FixtureResult> {
+  const root = mkdtempSync(join(tmpdir(), `orca-replace-partition-rollback-${mode}-`))
+  fixtureRoots.push(root)
+  const bundlePath = join(root, 'cookie-replace-rollback.cjs')
+  const bundleEntryPath = join(root, 'cookie-replace-rollback.ts')
+  const resultPath = join(root, 'result.json')
+  const fixturePath = join(root, 'main.cjs')
+  writeFileSync(
+    bundleEntryPath,
+    [
+      `export { openCookieClearStore } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-clear-store.ts'))}`,
+      `export { replaceCookiesForImportedDomains } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-import-policy.ts'))}`
+    ].join('\n')
+  )
+  await buildVite({
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      emptyOutDir: false,
+      lib: {
+        entry: bundleEntryPath,
+        formats: ['cjs'],
+        fileName: () => 'cookie-replace-rollback.cjs'
+      },
+      outDir: root,
+      target: 'node20',
+      rollupOptions: { external: ['electron', /^node:/] }
+    }
+  })
+  writeFileSync(fixturePath, buildFixtureMain(bundlePath, resultPath, mode))
+  const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
+  const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
+  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
+  const args =
+    process.platform === 'linux'
+      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
+      : electronArgs
+  const run = spawnSync(executable, args, {
+    encoding: 'utf8',
+    env,
+    timeout: 60_000
+  })
+  const fixtureResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
+  expect(run.error).toBeUndefined()
+  expect(run.status, `${fixtureResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
+  return JSON.parse(fixtureResult) as FixtureResult
+}
+
+describe('partitioned cookies under a failed replace-imported-domains import', () => {
+  // Why (STA-4097): this rollback undoes deletions the import already made to the user's own
+  // cookies. Rebuilding them with cookies.set dropped partitionKey silently, so a CHIPS cookie
+  // came back as an ordinary one and no restart recovered it.
+  it('site A: restores a CHIPS cookie with its partition after a later removal rejects', async () => {
+    const result = await runFixture('site-a')
+
+    expect(result.beforePartitionKey).toEqual(EXPECTED_PARTITION_KEY)
+    // Why: without this the fixture could pass on a cookie that was never partitioned.
+    expect(result.electronGetSawPartitionKey).toBe(false)
+    // Why: assert the rollback was reached, not just that the jar looks right at the end.
+    expect(result.snapshotCalls).toBe(1)
+    expect(result.removeCallsBeforeThrow).toBeGreaterThanOrEqual(1)
+    expect(result.restoreCalls).toBe(1)
+    expect(result.replaceError).toContain('forced removal failure after chips was removed')
+    expect(result.chipsAfter).toEqual([
+      { name: 'chips-auth', value: 'keep-me', partitionKey: EXPECTED_PARTITION_KEY }
+    ])
+    expect(result.plainAfter).toEqual([{ name: 'plain', value: 'original' }])
+  }, 90_000)
+
+  it('site B: restores a CHIPS cookie with its partition after a mid-import set failure', async () => {
+    const result = await runFixture('site-b')
+
+    expect(result.beforePartitionKey).toEqual(EXPECTED_PARTITION_KEY)
+    expect(result.electronGetSawPartitionKey).toBe(false)
+    expect(result.snapshotCalls).toBe(1)
+    // Why: the replace really emptied the scope, so the restore below is doing the work.
+    expect(result.chipsAfterReplace).toEqual([])
+    expect(result.importedRemoveCalls).toBe(1)
+    expect(result.restoreCalls).toBe(1)
+    expect(result.chipsAfter).toEqual([
+      { name: 'chips-auth', value: 'keep-me', partitionKey: EXPECTED_PARTITION_KEY }
+    ])
+    expect(result.plainAfter).toEqual([{ name: 'plain', value: 'original' }])
+  }, 90_000)
+})

--- a/src/main/browser/browser-cookie-import-replacement.test.ts
+++ b/src/main/browser/browser-cookie-import-replacement.test.ts
@@ -192,6 +192,27 @@ describe('validated cookie replacement', () => {
     expect(disposeClearStoreMock).toHaveBeenCalledOnce()
   })
 
+  // Why: restoreClearIdentities attaches a debugger before it iterates, so calling it with an
+  // empty restore set would create a hidden BrowserWindow to put nothing back.
+  it('does not reach for CDP when the rollback has nothing to restore', async () => {
+    cookiesGetMock.mockResolvedValue([])
+    cookiesSetMock
+      .mockResolvedValue(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('cookie rejected'))
+    const filePath = writeCookies([
+      { domain: '.example.com', name: 'first', value: 'new', secure: true },
+      { domain: '.example.com', name: 'second', value: 'new', secure: true }
+    ])
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+
+    expect(result.ok).toBe(false)
+    // Why: the imported cookie is still removed — that half of the rollback is lossless.
+    expect(cookiesRemoveMock.mock.calls).toEqual([['https://example.com/', 'first']])
+    expect(restoreClearIdentitiesMock).not.toHaveBeenCalled()
+  })
+
   it('fails closed when existing cookies cannot be replaced', async () => {
     cookiesGetMock.mockRejectedValue(new Error('cookie store unavailable'))
     const filePath = writeCookies([

--- a/src/main/browser/browser-cookie-import-replacement.test.ts
+++ b/src/main/browser/browser-cookie-import-replacement.test.ts
@@ -3,15 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   appGetPathMock,
   clearPendingCookieImportMock,
+  disposeClearStoreMock,
   execFileSyncMock,
+  restoreClearIdentitiesMock,
   sessionFromPartitionMock,
-  setPendingCookieImportMock
+  setPendingCookieImportMock,
+  snapshotClearIdentitiesMock
 } = vi.hoisted(() => ({
   appGetPathMock: vi.fn(),
   clearPendingCookieImportMock: vi.fn(),
+  disposeClearStoreMock: vi.fn(),
   execFileSyncMock: vi.fn(),
+  restoreClearIdentitiesMock: vi.fn(),
   sessionFromPartitionMock: vi.fn(),
-  setPendingCookieImportMock: vi.fn()
+  setPendingCookieImportMock: vi.fn(),
+  snapshotClearIdentitiesMock: vi.fn()
 }))
 
 vi.mock('./browser-session-registry', () => ({
@@ -26,6 +32,7 @@ vi.mock('electron', () => ({
   dialog: { showOpenDialog: vi.fn() },
   session: { fromPartition: sessionFromPartitionMock }
 }))
+// Why: snapshot/restore are spies, not no-ops, so a rollback that never ran cannot pass as one.
 vi.mock('./browser-cookie-clear-store', () => ({
   openCookieClearStore: (targetSession: {
     cookies: {
@@ -35,10 +42,9 @@ vi.mock('./browser-cookie-clear-store', () => ({
   }) => ({
     get: (filter: object) => targetSession.cookies.get(filter),
     remove: (url: string, name: string) => targetSession.cookies.remove(url, name),
-    snapshotClearIdentities: async (items: { cookie: Record<string, unknown>; url: string }[]) =>
-      items.map(({ cookie, url }) => ({ url, ...cookie })),
-    restoreClearIdentities: async () => undefined,
-    dispose: () => undefined
+    snapshotClearIdentities: snapshotClearIdentitiesMock,
+    restoreClearIdentities: restoreClearIdentitiesMock,
+    dispose: disposeClearStoreMock
   })
 }))
 
@@ -47,6 +53,16 @@ import { createChromiumCookieTestDatabase } from './browser-cookie-import-test-d
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+beforeEach(() => {
+  snapshotClearIdentitiesMock
+    .mockReset()
+    .mockImplementation(async (items: { cookie: Record<string, unknown>; url: string }[]) =>
+      items.map(({ cookie: entry, url }) => ({ url, ...entry }))
+    )
+  restoreClearIdentitiesMock.mockReset().mockResolvedValue(undefined)
+  disposeClearStoreMock.mockReset()
+})
 
 describe('validated cookie replacement', () => {
   let cookiesGetMock: ReturnType<typeof vi.fn>
@@ -139,8 +155,17 @@ describe('validated cookie replacement', () => {
     expect(cookiesSetMock).not.toHaveBeenCalled()
   })
 
-  it('restores the previous snapshot when an incoming cookie is rejected', async () => {
+  // Why (STA-4097): this rollback puts back the user's ORIGINAL cookies, which the import had
+  // already deleted. cookies.get drops partitionKey and cookies.set ignores it, so rebuilding
+  // them through the Electron API resurrected CHIPS cookies unpartitioned. The undo now travels
+  // back through the CDP identities, which are the only thing that carries the partition.
+  it('restores the previous cookies through CDP identities when an incoming cookie is rejected', async () => {
+    const partitionKey = { topLevelSite: 'https://top.example', hasCrossSiteAncestor: true }
     cookiesGetMock.mockResolvedValue([cookie('.example.com', 'existing')])
+    snapshotClearIdentitiesMock.mockImplementation(
+      async (items: { cookie: Record<string, unknown>; url: string }[]) =>
+        items.map(({ cookie: entry, url }) => ({ url, ...entry, partitionKey }))
+    )
     cookiesSetMock
       .mockResolvedValue(undefined)
       .mockResolvedValueOnce(undefined)
@@ -157,16 +182,14 @@ describe('validated cookie replacement', () => {
       ['https://example.com/', 'existing'],
       ['https://example.com/', 'first']
     ])
-    expect(cookiesSetMock).toHaveBeenLastCalledWith({
-      url: 'https://example.com/',
-      name: 'existing',
-      value: 'old',
-      domain: '.example.com',
-      path: '/',
-      secure: true,
-      httpOnly: undefined,
-      sameSite: 'unspecified'
-    })
+    expect(restoreClearIdentitiesMock).toHaveBeenCalledOnce()
+    expect(restoreClearIdentitiesMock.mock.calls[0]?.[0]).toEqual([
+      { url: 'https://example.com/', ...cookie('.example.com', 'existing'), partitionKey }
+    ])
+    // Why: cookies.set is only ever the two imported cookies — a third call would mean the
+    // partition-dropping reconstruction came back.
+    expect(cookiesSetMock.mock.calls.map(([details]) => details.name)).toEqual(['first', 'second'])
+    expect(disposeClearStoreMock).toHaveBeenCalledOnce()
   })
 
   it('fails closed when existing cookies cannot be replaced', async () => {

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: cookie import is one pipeline (detect → decrypt → stage → swap) that must stay together to keep encryption/schema/staging in sync. */
-import { app, type BrowserWindow, type Cookie, dialog, session } from 'electron'
+import { app, type BrowserWindow, dialog, session } from 'electron'
 import { execFileSync } from 'node:child_process'
 import { createDecipheriv, pbkdf2Sync, randomUUID } from 'node:crypto'
 import {
@@ -81,8 +81,8 @@ import {
   normalizeCookieDomain,
   normalizeCookieImportDomain,
   replaceCookiesForImportedDomains,
-  restoreImportedDomainCookies,
-  type CookieImportMode
+  type CookieImportMode,
+  type ReplacedImportedDomainCookies
 } from './browser-cookie-import-policy'
 import { removeTransplantableCookies, withCookieClearLock } from './browser-cookie-import-clear'
 import { openCookieClearStore } from './browser-cookie-clear-store'
@@ -594,97 +594,108 @@ async function importValidatedCookies(
   let importedCount = 0
   let skipped = totalInput - importableCookies.length
   const domainSet = new Set<string>()
-  let replacedCookies: Cookie[] | null = null
+  let replaced: ReplacedImportedDomainCookies | null = null
+  // Why (STA-4097): the rollback below has to put back cookies this import already deleted, and
+  // only CDP identities carry partitionKey — rebuilding them with cookies.set drops it silently.
+  const cookieClearStore =
+    mode === 'replace-imported-domains' && importableCookies.length > 0
+      ? openCookieClearStore(targetSession)
+      : null
 
-  if (mode === 'replace-imported-domains' && importableCookies.length > 0) {
-    try {
-      replacedCookies = await replaceCookiesForImportedDomains(
-        targetSession.cookies,
-        importableCookies.map((cookie) => cookie.domain)
-      )
-      diag(`  removed ${replacedCookies.length} existing cookies in imported domain scopes`)
-    } catch (err) {
-      diag(`  existing cookie replacement failed: ${summarizeCookieImportError(err)}`)
-      return {
-        ok: false,
-        reason: reasonWithDiagLog('Could not replace existing cookies for the imported sites.')
-      }
-    }
-  }
-
-  // Why: Electron's cookies.set() rejects any non-printable-ASCII byte; strip as a safety net.
-  const stripNonPrintable = (s: string): string => s.replace(/[^\x20-\x7E]/g, '')
-  const importedCookieKeys: { url: string; name: string }[] = []
-  let setFailure: unknown = null
-
-  for (const cookie of importableCookies) {
-    try {
-      // Why: Chromium rejects __Host- cookies unless they omit domain and use path=/.
-      const isHostPrefixed = cookie.name.startsWith('__Host-')
-      const path = isHostPrefixed ? '/' : cookie.path
-      await targetSession.cookies.set({
-        url: cookie.url,
-        name: cookie.name,
-        value: stripNonPrintable(cookie.value),
-        ...(isHostPrefixed ? {} : { domain: cookie.domain }),
-        path,
-        secure: cookie.secure,
-        httpOnly: cookie.httpOnly,
-        sameSite: cookie.sameSite,
-        expirationDate: cookie.expirationDate
-      })
-      const removalUrl = new URL(cookie.url)
-      removalUrl.pathname = path.startsWith('/') ? path : '/'
-      importedCookieKeys.push({ url: removalUrl.toString(), name: cookie.name })
-      importedCount++
-      // Why: surface only the domain (never name/value/path) so the summary doesn't leak secret cookie data.
-      const cleanDomain = cookie.domain.startsWith('.') ? cookie.domain.slice(1) : cookie.domain
-      domainSet.add(cleanDomain)
-    } catch (err) {
-      skipped++
-      setFailure = err
-      if (skipped <= 5) {
-        // Find the exact offending character position and code
-        const val = cookie.value
-        let badInfo = 'none found'
-        for (let i = 0; i < val.length; i++) {
-          const code = val.charCodeAt(i)
-          if (code < 0x20 || code > 0x7e) {
-            badInfo = `pos=${i} char=U+${code.toString(16).padStart(4, '0')}`
-            break
-          }
-        }
-        diag(
-          `  cookie.set FAILED: domain=${cookie.domain} name=${cookie.name} valLen=${val.length} badChar=${badInfo} err=${String(err)}`
-        )
-      }
-      if (replacedCookies) {
-        break
-      }
-    }
-  }
-
-  if (setFailure && replacedCookies) {
-    const rollbackFailures: unknown[] = []
-    for (const cookie of importedCookieKeys.toReversed()) {
+  try {
+    if (cookieClearStore) {
       try {
-        await targetSession.cookies.remove(cookie.url, cookie.name)
+        replaced = await replaceCookiesForImportedDomains(
+          cookieClearStore,
+          importableCookies.map((cookie) => cookie.domain)
+        )
+        diag(`  removed ${replaced.removed.length} existing cookies in imported domain scopes`)
+      } catch (err) {
+        diag(`  existing cookie replacement failed: ${summarizeCookieImportError(err)}`)
+        return {
+          ok: false,
+          reason: reasonWithDiagLog('Could not replace existing cookies for the imported sites.')
+        }
+      }
+    }
+
+    // Why: Electron's cookies.set() rejects any non-printable-ASCII byte; strip as a safety net.
+    const stripNonPrintable = (s: string): string => s.replace(/[^\x20-\x7E]/g, '')
+    const importedCookieKeys: { url: string; name: string }[] = []
+    let setFailure: unknown = null
+
+    for (const cookie of importableCookies) {
+      try {
+        // Why: Chromium rejects __Host- cookies unless they omit domain and use path=/.
+        const isHostPrefixed = cookie.name.startsWith('__Host-')
+        const path = isHostPrefixed ? '/' : cookie.path
+        await targetSession.cookies.set({
+          url: cookie.url,
+          name: cookie.name,
+          value: stripNonPrintable(cookie.value),
+          ...(isHostPrefixed ? {} : { domain: cookie.domain }),
+          path,
+          secure: cookie.secure,
+          httpOnly: cookie.httpOnly,
+          sameSite: cookie.sameSite,
+          expirationDate: cookie.expirationDate
+        })
+        const removalUrl = new URL(cookie.url)
+        removalUrl.pathname = path.startsWith('/') ? path : '/'
+        importedCookieKeys.push({ url: removalUrl.toString(), name: cookie.name })
+        importedCount++
+        // Why: surface only the domain (never name/value/path) so the summary doesn't leak secret cookie data.
+        const cleanDomain = cookie.domain.startsWith('.') ? cookie.domain.slice(1) : cookie.domain
+        domainSet.add(cleanDomain)
+      } catch (err) {
+        skipped++
+        setFailure = err
+        if (skipped <= 5) {
+          // Find the exact offending character position and code
+          const val = cookie.value
+          let badInfo = 'none found'
+          for (let i = 0; i < val.length; i++) {
+            const code = val.charCodeAt(i)
+            if (code < 0x20 || code > 0x7e) {
+              badInfo = `pos=${i} char=U+${code.toString(16).padStart(4, '0')}`
+              break
+            }
+          }
+          diag(
+            `  cookie.set FAILED: domain=${cookie.domain} name=${cookie.name} valLen=${val.length} badChar=${badInfo} err=${String(err)}`
+          )
+        }
+        if (replaced) {
+          break
+        }
+      }
+    }
+
+    // Why: replaced is only ever set alongside cookieClearStore, which owns the CDP restore.
+    if (setFailure && replaced && cookieClearStore) {
+      const rollbackFailures: unknown[] = []
+      for (const cookie of importedCookieKeys.toReversed()) {
+        try {
+          await targetSession.cookies.remove(cookie.url, cookie.name)
+        } catch (err) {
+          rollbackFailures.push(err)
+        }
+      }
+      try {
+        await cookieClearStore.restoreClearIdentities(replaced.identities.toReversed())
       } catch (err) {
         rollbackFailures.push(err)
       }
+      if (rollbackFailures.length > 0) {
+        diag(`  cookie replacement rollback failed: ${rollbackFailures.length} operation(s)`)
+      }
+      return {
+        ok: false,
+        reason: reasonWithDiagLog('Could not safely replace cookies for the imported sites.')
+      }
     }
-    try {
-      await restoreImportedDomainCookies(targetSession.cookies, replacedCookies)
-    } catch (err) {
-      rollbackFailures.push(err)
-    }
-    if (rollbackFailures.length > 0) {
-      diag(`  cookie replacement rollback failed: ${rollbackFailures.length} operation(s)`)
-    }
-    return {
-      ok: false,
-      reason: reasonWithDiagLog('Could not safely replace cookies for the imported sites.')
-    }
+  } finally {
+    cookieClearStore?.dispose()
   }
 
   diag(

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -681,10 +681,14 @@ async function importValidatedCookies(
           rollbackFailures.push(err)
         }
       }
-      try {
-        await cookieClearStore.restoreClearIdentities(replaced.identities.toReversed())
-      } catch (err) {
-        rollbackFailures.push(err)
+      // Why: restoreClearIdentities attaches the debugger before it iterates, so an empty
+      // restore set would spin up a hidden BrowserWindow to put nothing back.
+      if (replaced.identities.length > 0) {
+        try {
+          await cookieClearStore.restoreClearIdentities(replaced.identities.toReversed())
+        } catch (err) {
+          rollbackFailures.push(err)
+        }
       }
       if (rollbackFailures.length > 0) {
         diag(`  cookie replacement rollback failed: ${rollbackFailures.length} operation(s)`)


### PR DESCRIPTION
## ELI5

When you import cookies and the import fails halfway, Orca tries to put your old cookies back. It was rebuilding them with an Electron API that cannot see or write a cookie's *partition*. So a cookie that was scoped to one specific site-embedding context came back as a plain, global cookie — same name, same value, wrong scope, forever. This makes the undo travel back through CDP instead, which does carry the partition.

## What Changed

`replaceCookiesForImportedDomains` now snapshots CDP cookie identities **before** it removes anything, and undoes removals through `restoreClearIdentities` instead of `cookies.set`.

- `browser-cookie-import-policy.ts` — the store parameter is now `Pick<Cookies, 'get' | 'remove'>` plus the CDP identity pair. **`set` is gone from the type**, so a partition-dropping reconstruction cannot be written against it. Returns `{ removed, identities }`.
- `browser-cookie-import.ts` — `importValidatedCookies` opens a `CookieClearStore` for replace-mode imports and rolls back through it. The lossless half of the rollback (removing the cookies this import wrote) is unchanged.
- `restoreImportedDomainCookies` is **deleted** — both callers are gone.

The removal plan is fixed beside the snapshot that can undo it, and an incomplete snapshot aborts before the first mutation, so the restorable set always equals the mutated set.

## Why

Two callers still rebuilt removed cookies with `cookies.set`. On Electron 43.1.0, measured against a real `persist:` jar:

- `cookies.get({})` returns partitioned cookies but **strips** `partitionKey`
- `cookies.set({ partitionKey })` **silently ignores** it — no error, attribute dropped
- `electron.d.ts` v43 has no `partitionKey` anywhere; only CDP can see or write one

**The concrete user-visible harm.** In `importValidatedCookies`, `replacedCookies` holds the user's **own pre-existing cookies**, which the import already deleted. One `cookies.set` rejection aborts the whole import (`if (replaced) break`) and triggers this rollback. So a CHIPS cookie that kept you signed in to a site embedded inside another site came back as an ordinary top-level cookie: the partitioned original is gone, a wrongly-scoped twin is now sent in every context, and the auth material crosses the partition boundary it was created to respect. It survives restart, and re-importing re-downgrades it.

Every Firefox, Safari and JSON/paste import runs in `replace-imported-domains` mode, and these set rejections are deterministic (malformed value, oversize, prefix violation — the value is already run through `stripNonPrintable`), so retrying reproduces the failure identically.

**Why not just delete the restore, as STA-4097 originally prescribed.** The ticket assumed the rollback was putting *imported* cookies back and that leftover state was retryable. It is putting the **user's originals** back. Deleting it would destroy every pre-existing cookie for every imported domain — ordinary and partitioned alike — with no retry path, trading a downgrade of the partitioned minority for total loss of everything. That is the STA-4090 shape (a restore deleted with no replacement, which became a P0). Confirmed with the issue author; the ticket description has been corrected.

Reusing `snapshotClearIdentities`/`restoreClearIdentities` is what this module already converged on: STA-4061 was fixed by moving restore onto CDP, and `CookieClearSession` deliberately omits `set` for exactly this reason. This applies the same pattern to the two sites that were left out of scope there.

## Failure-Mode Table

Cookie classes: **bystander** = outside the imported-domain scopes; **in-scope** = a cookie for a domain being imported (i.e. one the user asked to replace).

### Site A — `replaceCookiesForImportedDomains`

| Cookie | Snapshot incomplete / CDP unavailable | Success | A `remove` rejects mid-plan | Rollback itself also fails |
|---|---|---|---|---|
| Bystander, ordinary | untouched | untouched | untouched | untouched |
| Bystander, CHIPS | untouched | untouched | untouched | untouched |
| In-scope, ordinary | **untouched — aborts before mutating** | removed (intended; import replaces it) | **restored, value intact** | `AggregateError`; may stay removed |
| In-scope, CHIPS | **untouched — aborts before mutating** | removed (intended) | **restored *with* `partitionKey`** | `AggregateError`; may stay removed |
| Import's own cookies | not written (import aborts) | written next | not written (import aborts) | not written |

### Site B — `importValidatedCookies` rollback after a `cookies.set` rejection

| Cookie | Snapshot incomplete / CDP unavailable | Success | `set` rejects → rollback | Rollback itself also fails |
|---|---|---|---|---|
| Bystander, ordinary | untouched | untouched | untouched | untouched |
| Bystander, CHIPS | untouched | untouched | untouched | untouched |
| In-scope, ordinary (user's original) | **untouched** | removed, replaced by import (intended) | **restored, value intact** | logged; may stay removed |
| In-scope, CHIPS (user's original) | **untouched** | removed, replaced by import (intended) | **restored *with* `partitionKey`** | logged; may stay removed |
| Import's own cookies | not written | live | removed (lossless `remove`) | may linger; import reports failure |

The snapshot happens inside site A, so an unavailable snapshot aborts there and `importValidatedCookies` returns `ok: false` on the replace-failure branch before a single `cookies.set` runs — site B's rollback is never reached and the session is left exactly as it was.

### What this replaces

| Cookie | Before this PR | After |
|---|---|---|
| In-scope CHIPS, site A rollback | **silently DOWNGRADED** to unpartitioned | restored with partition |
| In-scope CHIPS, site B rollback | **silently DOWNGRADED** to unpartitioned | restored with partition |
| In-scope ordinary, either rollback | restored | restored |

**Independent review.** A reviewer enumerated the outcome paths independently, without seeing this table first, and every populated cell agreed. Its one finding — that the Site B table had no explicit snapshot-unavailable column — is now fixed above.

**Residual risk, stated honestly.** The only remaining cell where a cookie can be lost is a *double* failure — a removal rejects **and** the CDP restore also rejects. That surfaces as an explicit `AggregateError` / diagnostic and a failed import, never as silent corruption, and it is the same floor `removeTransplantableCookies` already ships with. No path silently downgrades a cookie any more. Single-failure paths are all lossless.

## Linked Issue

Fixes [STA-4097](https://linear.app/stably/issue/STA-4097/p1-cookie-import-rollback-still-downgrades-partitioned-cookies-in-two)

Follows STA-4061 (#14132) and STA-4065 (#14131), both of which flagged these two sites as known follow-up work.

## Visual Proof

N/A — main-process cookie-store behavior with no UI surface. The observable state is the cookie jar, which is asserted directly against real Electron via CDP in the new fixtures below.

## Testing

**New real-Electron regression fixture** — `browser-cookie-import-replace-partition-rollback.electron.test.ts`. Spawns the real Electron binary, seeds a genuine CHIPS cookie via CDP `Network.setCookie`, drives each rollback path, and reads the jar back through `Network.getAllCookies`.

Both fixtures were **proved non-vacuous by mutation**: dropping `partitionKey` from `cdpRestoreParamsFromIdentity` makes both fail with exactly the missing partition, and they pass again once reverted.

Anti-vacuity measures, given three fixtures in this module previously passed for the wrong reason:
- `electronGetSawPartitionKey` asserts `cookies.get` really did strip the partition — so the fixture cannot pass on a cookie that was never partitioned in the first place.
- Call counts (`snapshotCalls`, `removeCallsBeforeThrow`, `restoreCalls`, `importedRemoveCalls`) assert the failure path was **reached**, not just that the jar looks right at the end.
- The `browser-cookie-clear-store` mock in `browser-cookie-import-replacement.test.ts` was a no-op `restoreClearIdentities: async () => undefined`; it is now a real spy, so a rollback that never ran can no longer pass as one.
- That test also asserts `cookies.set` is called *exactly* for the two imported cookies — a third call would mean the partition-dropping reconstruction came back.

Unit coverage added for the new abort-before-mutating path and for CDP rollback failure surfacing both errors.

**Real-Electron QA on the happy path** (comment below): booted an isolated Orca dev build on this commit and ran Settings → Browser → Import Cookies → From File with throwaway `app.acme-chips.test` data. Clean boot, both imports succeeded, and the second one logged `removed 3 existing cookies in imported domain scopes` — which is the new replace path with the `CookieClearStore` open. The rollback path was **not** driven by hand (a mid-import `cookies.set` rejection is not reachable from the UI); it stays covered by the automated fixtures above.

**Second commit** (`52e4c32`) fixes a small regression this PR had introduced: `restoreClearIdentities` attaches the debugger *before* it iterates, so an empty restore set would spin up a hidden `BrowserWindow` to put nothing back — the old `cookies.set` path did nothing at all in that case. Guarded by `replaced.identities.length > 0`, with a test that also asserts the lossless half of the rollback still runs. Proved non-vacuous by mutation.

The related review point — that one rejected `cookies.set` aborts the whole import even when nothing was removed — is **pre-existing and unchanged here**: the old `replacedCookies` was a `Cookie[]` that was `[]` in the same case, and `[]` is equally truthy. Changing it alters import semantics and changes when the rollback fires, so it is filed separately as [STA-4240](https://linear.app/stably/issue/STA-4240/cookie-import-aborts-entirely-on-one-bad-cookie-even-when-nothing-was) rather than riding along in a PR that is stabilizing exactly that machinery.

Reproduction of the original defect was built first, independently, against unmodified `main`: both sites resurrected `chips-auth` with `partitionKey` undefined.

Commands run (macOS):

- `pnpm vitest run --config config/vitest.config.ts src/main/browser` — 40 files, 637 tests, all pass
- `pnpm run typecheck` (node + cli + web) — clean
- `pnpm run audit:code-quality:native`, `audit:code-quality:type-aware` — clean
- `oxlint src/main/browser/`, `oxfmt --check` — clean
- `pnpm run check:max-lines-ratchet` — OK, no new bypasses (no `max-lines` disable added)

Platforms: macOS. This is desktop main-process only — not mobile, not Windows/WSL, not SSH. Behavior is platform-independent (Electron/Chromium cookie store), and the fixture runs under `xvfb-run` on Linux like the existing one.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security** — improves it. The bug broke cookie partition isolation: a CHIPS cookie scoped to one top-level site was resurrected unpartitioned and then sent in every context. No new attack surface; the CDP debugger attach is the same one `removeTransplantableCookies` already uses on the Chromium import path.
- **Performance** — replace-mode imports now attach a debugger. `openCookieClearStore` reuses an existing `webContents` for the partition when one exists, which is the normal case for a browser session being imported into; the hidden-`BrowserWindow` path is the fallback. One `Network.getAllCookies` per import. Already-shipped cost on the Chromium path.
- **Cross-platform** — no platform-specific code; no paths, shells, or shortcuts touched.
- **Remote SSH / mobile** — not involved; this is local main-process session state.
- **Backwards compatibility** — no wire format, no IPC, no persisted schema change. `replaceCookiesForImportedDomains` is module-internal; both call sites are updated in this PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
