### PR TITLE
fix(daemon): harden checkpoint admission after per-session isolation

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11930,7 +11930,7 @@
           "result": "passed",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-checkpoint-session-queue.test.ts src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts src/main/daemon/daemon-pty-adapter.test.ts --reporter=dot",
           "durationSeconds": 15,
-          "summary": "Three focused files passed 180 tests, including unrelated-session reattach, five-second fallback, post-deadline durable commit, aggregate overlay admission, rejection diagnostics, and final-checkpoint behavior."
+          "summary": "Three focused files passed, including unrelated-session reattach, five-second fallback, post-deadline durable commit, aggregate non-final admission, late-rejection diagnostics, and final-checkpoint behavior."
         }
       ],
       "runtimeBudget": {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11884,7 +11884,7 @@
         "https://linear.app/stably/issue/STA-4173",
         "https://github.com/stablyai/orca/pull/14346"
       ],
-      "invariant": "A stalled durable-history checkpoint may delay only its own daemon session. Warm reattach and deep snapshots degrade to the live window after five seconds, non-final background checkpoints defer after fifteen seconds, same-session writes remain serialized, running plus queued work stays bounded to three per session, overlay compacts stay bounded to four across sessions, and final sleep or disconnect checkpoints remain deadline-free.",
+      "invariant": "A stalled durable-history checkpoint may delay only its own daemon session. Warm reattach and deep snapshots degrade to the live window after five seconds, non-final background checkpoints defer after fifteen seconds, same-session writes remain serialized, non-final running plus queued work stays bounded to three per session, overlay compacts stay bounded to four across sessions, and final sleep or disconnect checkpoints remain deadline-free.",
       "oracle": "Park one session inside the real history checkpoint write, then require an unrelated warm reattach to return within two seconds with its own output while the first write remains parked. Require the stalled session to return its live window after the overlay deadline and later commit the abandoned write. Park four distinct overlay compacts, require a fifth reattach to return its live window without starting another compact, and require fast non-final RPC rejection plus both deadlines to leave diagnostic breadcrumbs.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-checkpoint-session-queue.test.ts src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts src/main/daemon/daemon-pty-adapter.test.ts --reporter=dot"
@@ -11947,7 +11947,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Per-session running plus queued work is capped at three and aggregate overlay admission at four; the existing periodic worker cap remains four. Deadline timers are unrefed, abandoned waits retain admission until the actual write settles, dirty-gated polling remains unchanged, final checkpoints remain unbounded, and the change adds no subprocess, renderer, store, startup probe, or wire work."
+        "evidence": "Non-final per-session running plus queued work is capped at three and aggregate overlay admission at four; the existing periodic worker cap remains four. Deadline timers are unrefed, abandoned waits retain admission until the actual write settles, dirty-gated polling remains unchanged, final checkpoints remain unbounded, and the change adds no subprocess, renderer, store, startup probe, or wire work."
       },
       "promotionCriteria": [
         "Execute the oracle against an affected baseline and retain the exact red result.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-12",
+  "updatedAt": "2026-08-13",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -11862,6 +11862,105 @@
         "Platform-named bundles are loaded on macOS locally; physical Linux and Windows evidence is not yet recorded."
       ],
       "demotionRule": "Demote if any shipped companion stops loading on Node 18, selected installers mutate outside the isolated home, or the CI lane no longer runs the built artifact with Node 18."
+    },
+    {
+      "id": "terminal-history.daemon-checkpoint-session-isolation",
+      "title": "Daemon history checkpoints isolate stalled terminal sessions",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "daemon-terminal",
+      "layer": "main-process-daemon-history",
+      "surfaces": [
+        "warm daemon terminal reattach",
+        "deep daemon buffer snapshots",
+        "periodic and final durable-history checkpoints"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local-daemon", "ssh-daemon", "wsl-daemon", "paired-runtime-host"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local-daemon"],
+      "coverageNotes": "A real daemon server and adapter on macOS cover per-session isolation, same-session deadlines, post-deadline commit, aggregate overlay admission, and live-window fallback. The provider-neutral adapter has no new path or wire assumptions; a live Linux SSH-relay journey covers the unchanged remote consumer, while live Linux daemon, Windows, WSL, and paired-runtime-host journeys remain gaps.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4173",
+        "https://github.com/stablyai/orca/pull/14346"
+      ],
+      "invariant": "A stalled durable-history checkpoint may delay only its own daemon session. Warm reattach and deep snapshots degrade to the live window after five seconds, non-final background checkpoints defer after fifteen seconds, same-session writes remain serialized, running plus queued work stays bounded to three per session, overlay compacts stay bounded to four across sessions, and final sleep or disconnect checkpoints remain deadline-free.",
+      "oracle": "Park one session inside the real history checkpoint write, then require an unrelated warm reattach to return within two seconds with its own output while the first write remains parked. Require the stalled session to return its live window after the overlay deadline and later commit the abandoned write. Park four distinct overlay compacts, require a fifth reattach to return its live window without starting another compact, and require fast non-final RPC rejection plus both deadlines to leave diagnostic breadcrumbs.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-checkpoint-session-queue.test.ts src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts src/main/daemon/daemon-pty-adapter.test.ts --reporter=dot"
+      ],
+      "testFiles": [
+        "src/main/daemon/daemon-checkpoint-session-queue.test.ts",
+        "src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts",
+        "src/main/daemon/daemon-pty-adapter.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/daemon/daemon-checkpoint-session-queue.test.ts",
+          "assertions": [
+            "same-session operations serialize while unrelated sessions run independently",
+            "deadline fallback leaves the operation running and retains later waiter ordering",
+            "operation rejection remains distinct from a deadline",
+            "running plus queued work is bounded per session and drains"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts",
+          "assertions": [
+            "an unrelated session reattaches while another checkpoint remains parked",
+            "same-session deadline fallback returns the live window and logs a breadcrumb",
+            "an abandoned checkpoint commits when the stalled write resumes",
+            "four parked overlays turn away a fifth compact without blocking its reattach"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-pty-adapter.test.ts",
+          "assertions": [
+            "periodic checkpoint work caps concurrent snapshot and disk operations at four",
+            "non-final checkpoint RPC failures retain the existing warning path",
+            "final checkpoints bypass cooldown and remain awaited"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-checkpoint-session-queue.test.ts src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts src/main/daemon/daemon-pty-adapter.test.ts --reporter=dot",
+          "durationSeconds": 15,
+          "summary": "Three focused files passed 180 tests, including unrelated-session reattach, five-second fallback, post-deadline durable commit, aggregate overlay admission, rejection diagnostics, and final-checkpoint behavior."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "focused queue, real daemon-adapter isolation, and daemon adapter regression suite"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Fresh deterministic local runs pass; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Origin main routes the parked overlay through one process-wide checkpoint tail, while the candidate oracle observes unrelated reattach at about 79 milliseconds. The exact reverted-source oracle was not executed in this review worktree."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Per-session running plus queued work is capped at three and aggregate overlay admission at four; the existing periodic worker cap remains four. Deadline timers are unrefed, abandoned waits retain admission until the actual write settles, dirty-gated polling remains unchanged, final checkpoints remain unbounded, and the change adds no subprocess, renderer, store, startup probe, or wire work."
+      },
+      "promotionCriteria": [
+        "Execute the oracle against an affected baseline and retain the exact red result.",
+        "Collect 100 consecutive focused CI passes or 14 days of soak history.",
+        "Collect live Linux daemon, Windows, WSL, and paired-runtime-host reattach evidence.",
+        "Keep per-session and aggregate admission, deadline, diagnostics, and final-checkpoint assertions green."
+      ],
+      "knownGaps": [
+        "Live Electron evidence covers the unchanged Linux SSH-relay consumer rather than a daemon running on the SSH host.",
+        "Physical Windows, WSL, Linux daemon, and paired-runtime-host journeys were not run.",
+        "The reverted-source failure is established from the old process-wide call path but was not executed."
+      ],
+      "demotionRule": "Demote if unrelated reattach joins a stalled session tail, overlay or periodic work exceeds its admission bound, a deadline cancels durable work, final checkpoints defer, or failures and deadline fallbacks lose their diagnostic breadcrumbs."
     }
   ]
 }

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11916,7 +11916,7 @@
         {
           "file": "src/main/daemon/daemon-pty-adapter.test.ts",
           "assertions": [
-            "periodic checkpoint work caps concurrent snapshot and disk operations at four",
+            "periodic checkpoint work caps concurrent snapshot, disk operations, and admission probes at four",
             "non-final checkpoint RPC failures retain the existing warning path",
             "final checkpoints bypass cooldown and remain awaited"
           ]
@@ -11947,7 +11947,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Non-final per-session running plus queued work is capped at three and aggregate overlay admission at four; the existing periodic worker cap remains four. Deadline timers are unrefed, abandoned waits retain admission until the actual write settles, dirty-gated polling remains unchanged, final checkpoints remain unbounded, and the change adds no subprocess, renderer, store, startup probe, or wire work."
+        "evidence": "Non-final work holds one admission per session and four globally; a full admission set stops the current periodic pass after four probes, and its diagnostic state stays bounded to the active admissions plus one global marker. Deadline timers are unrefed, abandoned waits retain admission until the actual write settles, dirty-gated polling remains unchanged, final checkpoints remain deadline-free, and the change adds no subprocess, renderer, store, startup probe, or wire work."
       },
       "promotionCriteria": [
         "Execute the oracle against an affected baseline and retain the exact red result.",

--- a/src/main/daemon/daemon-checkpoint-session-queue.test.ts
+++ b/src/main/daemon/daemon-checkpoint-session-queue.test.ts
@@ -4,12 +4,18 @@ import {
   CheckpointSessionQueue
 } from './daemon-checkpoint-session-queue'
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((res) => {
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
     resolve = res
+    reject = rej
   })
-  return { promise, resolve }
+  return { promise, reject, resolve }
 }
 
 describe('CheckpointSessionQueue', () => {
@@ -68,7 +74,7 @@ describe('CheckpointSessionQueue', () => {
       },
       5,
       'live',
-      onDeadlineFired
+      { onDeadline: onDeadlineFired }
     )
 
     expect(outcome).toBe('live')
@@ -92,10 +98,33 @@ describe('CheckpointSessionQueue', () => {
         },
         50,
         'timed-out',
-        onDeadlineFired
+        { onDeadline: onDeadlineFired }
       )
     ).rejects.toThrow('daemon unavailable')
     expect(onDeadlineFired).not.toHaveBeenCalled()
+  })
+
+  it('reports an operation rejection that arrives after the deadline', async () => {
+    const queue = new CheckpointSessionQueue()
+    const stalled = deferred<void>()
+    const onAbandonedRejection = vi.fn()
+
+    await expect(
+      queue.runWithDeadline<void | 'timed-out'>(
+        'failed-late',
+        async () => await stalled.promise,
+        5,
+        'timed-out',
+        { onAbandonedRejection }
+      )
+    ).resolves.toBe('timed-out')
+
+    stalled.reject(new Error('late failure'))
+    await vi.waitFor(() =>
+      expect(onAbandonedRejection).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'late failure' })
+      )
+    )
   })
 
   it('keeps a later waiter behind an abandoned operation', async () => {

--- a/src/main/daemon/daemon-checkpoint-session-queue.test.ts
+++ b/src/main/daemon/daemon-checkpoint-session-queue.test.ts
@@ -57,6 +57,7 @@ describe('CheckpointSessionQueue', () => {
     const queue = new CheckpointSessionQueue()
     const stalled = deferred<void>()
     let completed = false
+    const onDeadlineFired = vi.fn()
 
     const outcome = await queue.runWithDeadline(
       'stalled',
@@ -66,15 +67,35 @@ describe('CheckpointSessionQueue', () => {
         return 'durable'
       },
       5,
-      'live'
+      'live',
+      onDeadlineFired
     )
 
     expect(outcome).toBe('live')
+    expect(onDeadlineFired).toHaveBeenCalledOnce()
     // Why: abandoning the wait must not abandon the write, or a reattach deadline
     // would drop durable history instead of merely delaying it.
     expect(completed).toBe(false)
     stalled.resolve()
     await vi.waitFor(() => expect(completed).toBe(true))
+  })
+
+  it('propagates operation failures instead of reporting a deadline', async () => {
+    const queue = new CheckpointSessionQueue()
+    const onDeadlineFired = vi.fn()
+
+    await expect(
+      queue.runWithDeadline(
+        'failed',
+        async () => {
+          throw new Error('daemon unavailable')
+        },
+        50,
+        'timed-out',
+        onDeadlineFired
+      )
+    ).rejects.toThrow('daemon unavailable')
+    expect(onDeadlineFired).not.toHaveBeenCalled()
   })
 
   it('keeps a later waiter behind an abandoned operation', async () => {

--- a/src/main/daemon/daemon-checkpoint-session-queue.ts
+++ b/src/main/daemon/daemon-checkpoint-session-queue.ts
@@ -36,20 +36,27 @@ export class CheckpointSessionQueue {
     sessionId: string,
     operation: () => Promise<T>,
     deadlineMs: number,
-    onDeadline: T
+    onDeadline: T,
+    onDeadlineFired?: () => void
   ): Promise<T> {
     const work = this.enqueue(sessionId, operation)
-    return new Promise<T>((resolve) => {
-      const timer = setTimeout(() => resolve(onDeadline), deadlineMs)
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        try {
+          onDeadlineFired?.()
+        } finally {
+          resolve(onDeadline)
+        }
+      }, deadlineMs)
       timer.unref?.()
       work.then(
         (value) => {
           clearTimeout(timer)
           resolve(value)
         },
-        () => {
+        (error: unknown) => {
           clearTimeout(timer)
-          resolve(onDeadline)
+          reject(error)
         }
       )
     })

--- a/src/main/daemon/daemon-checkpoint-session-queue.ts
+++ b/src/main/daemon/daemon-checkpoint-session-queue.ts
@@ -14,6 +14,11 @@
 /** Running plus queued operations one session may hold before callers are turned away. */
 export const CHECKPOINT_SESSION_QUEUE_MAX_PENDING = 3
 
+type DeadlineCallbacks = {
+  onDeadline?: () => void
+  onAbandonedRejection?: (error: unknown) => void
+}
+
 export class CheckpointSessionQueue {
   private tails = new Map<string, Promise<unknown>>()
   private pending = new Map<string, number>()
@@ -37,13 +42,15 @@ export class CheckpointSessionQueue {
     operation: () => Promise<T>,
     deadlineMs: number,
     onDeadline: T,
-    onDeadlineFired?: () => void
+    callbacks: DeadlineCallbacks = {}
   ): Promise<T> {
     const work = this.enqueue(sessionId, operation)
     return new Promise<T>((resolve, reject) => {
+      let deadlineFired = false
       const timer = setTimeout(() => {
+        deadlineFired = true
         try {
-          onDeadlineFired?.()
+          callbacks.onDeadline?.()
         } finally {
           resolve(onDeadline)
         }
@@ -56,6 +63,10 @@ export class CheckpointSessionQueue {
         },
         (error: unknown) => {
           clearTimeout(timer)
+          if (deadlineFired) {
+            callbacks.onAbandonedRejection?.(error)
+            return
+          }
           reject(error)
         }
       )

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2568,6 +2568,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         }
         checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>>
         nonFinalCheckpointAdmissionSessionIds: Set<string>
+        tryAdmitNonFinalCheckpoint(sessionId: string): boolean
       }
       internals.client = { request, disconnect: vi.fn() }
       internals.historyManager = {
@@ -2576,6 +2577,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         dispose: vi.fn(async () => {})
       }
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const tryAdmit = vi.spyOn(internals, 'tryAdmitNonFinalCheckpoint')
 
       try {
         const checkpointing = internals.checkpointSessions(['a', 'b', 'c', 'd', 'e', 'f'])
@@ -2583,6 +2585,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         await expect(checkpointing).resolves.toEqual(new Set())
 
         expect(requestedSessionIds).toEqual(['a', 'b', 'c', 'd'])
+        expect(tryAdmit).toHaveBeenCalledTimes(4)
         expect(internals.nonFinalCheckpointAdmissionSessionIds).toEqual(
           new Set(['a', 'b', 'c', 'd'])
         )
@@ -2604,6 +2607,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         tryAdmitNonFinalCheckpoint(sessionId: string): boolean
         releaseNonFinalCheckpointAdmission(sessionId: string): void
         nonFinalCheckpointAdmissionSessionIds: Set<string>
+        nonFinalAdmissionDeniedSessionIds: Set<string>
       }
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -2618,16 +2622,25 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         expect(internals.tryAdmitNonFinalCheckpoint('healthy-b')).toBe(true)
         expect(internals.tryAdmitNonFinalCheckpoint('healthy-c')).toBe(true)
         expect(internals.tryAdmitNonFinalCheckpoint('overflow')).toBe(false)
+        expect(internals.tryAdmitNonFinalCheckpoint('another-overflow')).toBe(false)
 
         expect(internals.nonFinalCheckpointAdmissionSessionIds).toEqual(
           new Set(['stalled', 'healthy-a', 'healthy-b', 'healthy-c'])
         )
+        expect(internals.nonFinalAdmissionDeniedSessionIds).toEqual(new Set(['stalled']))
         expect(warn).toHaveBeenCalledWith(
           '[history] non-final checkpoint global admission limit reached:',
           'overflow'
         )
+        expect(
+          warn.mock.calls.filter(
+            ([message]) =>
+              message === '[history] non-final checkpoint global admission limit reached:'
+          )
+        ).toHaveLength(1)
 
         internals.releaseNonFinalCheckpointAdmission('stalled')
+        expect(internals.nonFinalAdmissionDeniedSessionIds).toEqual(new Set())
         expect(internals.tryAdmitNonFinalCheckpoint('overflow')).toBe(true)
       } finally {
         warn.mockRestore()

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2610,6 +2610,10 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       try {
         expect(internals.tryAdmitNonFinalCheckpoint('stalled')).toBe(true)
         expect(internals.tryAdmitNonFinalCheckpoint('stalled')).toBe(false)
+        expect(warn).toHaveBeenCalledWith(
+          '[history] non-final checkpoint already in flight:',
+          'stalled'
+        )
         expect(internals.tryAdmitNonFinalCheckpoint('healthy-a')).toBe(true)
         expect(internals.tryAdmitNonFinalCheckpoint('healthy-b')).toBe(true)
         expect(internals.tryAdmitNonFinalCheckpoint('healthy-c')).toBe(true)
@@ -2619,7 +2623,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           new Set(['stalled', 'healthy-a', 'healthy-b', 'healthy-c'])
         )
         expect(warn).toHaveBeenCalledWith(
-          '[history] non-final checkpoint admission limit reached:',
+          '[history] non-final checkpoint global admission limit reached:',
           'overflow'
         )
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2539,6 +2539,60 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(checkpoint).not.toHaveBeenCalled()
     })
 
+    it('keeps abandoned periodic checkpoints within the global work cap', async () => {
+      const adapterClass = DaemonPtyAdapter as unknown as {
+        PERIODIC_CHECKPOINT_DEADLINE_MS: number
+      }
+      const previousDeadline = adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS
+      adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS = 5
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const releases: (() => void)[] = []
+      const requestedSessionIds: string[] = []
+      const request = vi.fn(async (_type: string, payload: { sessionId: string }) => {
+        requestedSessionIds.push(payload.sessionId)
+        await new Promise<void>((resolve) => releases.push(resolve))
+        return {
+          records: [{ kind: 'output', data: payload.sessionId }],
+          seq: 1,
+          overflowed: false,
+          snapshot: null
+        }
+      })
+      const appendIncrements = vi.fn(async () => 'ok' as const)
+      const internals = historyAdapter as unknown as {
+        client: { request: typeof request; disconnect: ReturnType<typeof vi.fn> }
+        historyManager: {
+          checkpoint: ReturnType<typeof vi.fn>
+          appendIncrements: typeof appendIncrements
+          dispose: ReturnType<typeof vi.fn>
+        }
+        checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>>
+        nonFinalCheckpointAdmissions: number
+      }
+      internals.client = { request, disconnect: vi.fn() }
+      internals.historyManager = {
+        checkpoint: vi.fn(async () => 'committed' as const),
+        appendIncrements,
+        dispose: vi.fn(async () => {})
+      }
+
+      try {
+        const checkpointing = internals.checkpointSessions(['a', 'b', 'c', 'd', 'e', 'f'])
+        await waitFor(() => requestedSessionIds.length === 4)
+        await expect(checkpointing).resolves.toEqual(new Set())
+
+        expect(requestedSessionIds).toEqual(['a', 'b', 'c', 'd'])
+        expect(internals.nonFinalCheckpointAdmissions).toBe(4)
+
+        for (const release of releases) {
+          release()
+        }
+        await waitFor(() => internals.nonFinalCheckpointAdmissions === 0)
+      } finally {
+        adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS = previousDeadline
+      }
+    })
+
     it('logs non-final checkpoint RPC failures', async () => {
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
       const request = vi.fn(async () => {
@@ -2559,6 +2613,48 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           expect.objectContaining({ message: 'daemon socket unavailable' })
         )
       } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('logs a periodic checkpoint failure that arrives after its deadline', async () => {
+      const adapterClass = DaemonPtyAdapter as unknown as {
+        PERIODIC_CHECKPOINT_DEADLINE_MS: number
+      }
+      const previousDeadline = adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS
+      adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS = 5
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      let rejectRequest!: (error: unknown) => void
+      const request = vi.fn(
+        async () =>
+          await new Promise<never>((_resolve, reject) => {
+            rejectRequest = reject
+          })
+      )
+      const internals = historyAdapter as unknown as {
+        client: { request: typeof request; disconnect: ReturnType<typeof vi.fn> }
+        checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>>
+      }
+      internals.client = { request, disconnect: vi.fn() }
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        const checkpointing = internals.checkpointSessions(['late-failure'])
+        await waitFor(() => request.mock.calls.length === 1)
+        await expect(checkpointing).resolves.toEqual(new Set())
+
+        rejectRequest(new Error('late daemon failure'))
+        await waitFor(() =>
+          warn.mock.calls.some(
+            ([message, sessionId, error]) =>
+              message === '[history] checkpoint failed:' &&
+              sessionId === 'late-failure' &&
+              error instanceof Error &&
+              error.message === 'late daemon failure'
+          )
+        )
+      } finally {
+        adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS = previousDeadline
         warn.mockRestore()
       }
     })

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2567,7 +2567,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           dispose: ReturnType<typeof vi.fn>
         }
         checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>>
-        nonFinalCheckpointAdmissions: number
+        nonFinalCheckpointAdmissionSessionIds: Set<string>
       }
       internals.client = { request, disconnect: vi.fn() }
       internals.historyManager = {
@@ -2575,6 +2575,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         appendIncrements,
         dispose: vi.fn(async () => {})
       }
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       try {
         const checkpointing = internals.checkpointSessions(['a', 'b', 'c', 'd', 'e', 'f'])
@@ -2582,14 +2583,50 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         await expect(checkpointing).resolves.toEqual(new Set())
 
         expect(requestedSessionIds).toEqual(['a', 'b', 'c', 'd'])
-        expect(internals.nonFinalCheckpointAdmissions).toBe(4)
+        expect(internals.nonFinalCheckpointAdmissionSessionIds).toEqual(
+          new Set(['a', 'b', 'c', 'd'])
+        )
+        expect(warn).toHaveBeenCalledWith('[history] periodic checkpoint deadline exceeded:', 'a')
 
         for (const release of releases) {
           release()
         }
-        await waitFor(() => internals.nonFinalCheckpointAdmissions === 0)
+        await waitFor(() => internals.nonFinalCheckpointAdmissionSessionIds.size === 0)
       } finally {
         adapterClass.PERIODIC_CHECKPOINT_DEADLINE_MS = previousDeadline
+        warn.mockRestore()
+      }
+    })
+
+    it('lets one session hold only one global non-final admission', () => {
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const internals = historyAdapter as unknown as {
+        tryAdmitNonFinalCheckpoint(sessionId: string): boolean
+        releaseNonFinalCheckpointAdmission(sessionId: string): void
+        nonFinalCheckpointAdmissionSessionIds: Set<string>
+      }
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        expect(internals.tryAdmitNonFinalCheckpoint('stalled')).toBe(true)
+        expect(internals.tryAdmitNonFinalCheckpoint('stalled')).toBe(false)
+        expect(internals.tryAdmitNonFinalCheckpoint('healthy-a')).toBe(true)
+        expect(internals.tryAdmitNonFinalCheckpoint('healthy-b')).toBe(true)
+        expect(internals.tryAdmitNonFinalCheckpoint('healthy-c')).toBe(true)
+        expect(internals.tryAdmitNonFinalCheckpoint('overflow')).toBe(false)
+
+        expect(internals.nonFinalCheckpointAdmissionSessionIds).toEqual(
+          new Set(['stalled', 'healthy-a', 'healthy-b', 'healthy-c'])
+        )
+        expect(warn).toHaveBeenCalledWith(
+          '[history] non-final checkpoint admission limit reached:',
+          'overflow'
+        )
+
+        internals.releaseNonFinalCheckpointAdmission('stalled')
+        expect(internals.tryAdmitNonFinalCheckpoint('overflow')).toBe(true)
+      } finally {
+        warn.mockRestore()
       }
     })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2539,6 +2539,30 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(checkpoint).not.toHaveBeenCalled()
     })
 
+    it('logs non-final checkpoint RPC failures', async () => {
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const request = vi.fn(async () => {
+        throw new Error('daemon socket unavailable')
+      })
+      const internals = historyAdapter as unknown as {
+        client: { request: typeof request; disconnect: ReturnType<typeof vi.fn> }
+        checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>>
+      }
+      internals.client = { request, disconnect: vi.fn() }
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        await expect(internals.checkpointSessions(['broken'])).resolves.toEqual(new Set())
+        expect(warn).toHaveBeenCalledWith(
+          '[history] checkpoint failed:',
+          'broken',
+          expect.objectContaining({ message: 'daemon socket unavailable' })
+        )
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
     describe('full-snapshot cooldown', () => {
       type CooldownInternals = {
         client: { request: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1368,13 +1368,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private tryAdmitNonFinalCheckpoint(sessionId: string): boolean {
-    if (
-      this.nonFinalCheckpointAdmissionSessionIds.has(sessionId) ||
-      this.nonFinalCheckpointAdmissionSessionIds.size >= MAX_CONCURRENT_CHECKPOINTS
-    ) {
+    if (this.nonFinalCheckpointAdmissionSessionIds.has(sessionId)) {
       if (!this.nonFinalAdmissionDeniedSessionIds.has(sessionId)) {
         this.nonFinalAdmissionDeniedSessionIds.add(sessionId)
-        console.warn('[history] non-final checkpoint admission limit reached:', sessionId)
+        console.warn('[history] non-final checkpoint already in flight:', sessionId)
+      }
+      return false
+    }
+    if (this.nonFinalCheckpointAdmissionSessionIds.size >= MAX_CONCURRENT_CHECKPOINTS) {
+      if (!this.nonFinalAdmissionDeniedSessionIds.has(sessionId)) {
+        this.nonFinalAdmissionDeniedSessionIds.add(sessionId)
+        console.warn('[history] non-final checkpoint global admission limit reached:', sessionId)
       }
       return false
     }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -257,6 +257,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private checkpointQueue = new CheckpointSessionQueue()
   private nonFinalCheckpointAdmissionSessionIds = new Set<string>()
   private nonFinalAdmissionDeniedSessionIds = new Set<string>()
+  private nonFinalGlobalAdmissionWarningActive = false
   private overlayDeadlineWarnedSessionIds = new Set<string>()
   private periodicDeadlineWarnedSessionIds = new Set<string>()
   private keepHistoryShutdowns = new Set<Promise<void>>()
@@ -1376,10 +1377,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return false
     }
     if (this.nonFinalCheckpointAdmissionSessionIds.size >= MAX_CONCURRENT_CHECKPOINTS) {
-      if (!this.nonFinalAdmissionDeniedSessionIds.has(sessionId)) {
-        this.nonFinalAdmissionDeniedSessionIds.add(sessionId)
-        console.warn('[history] non-final checkpoint global admission limit reached:', sessionId)
-      }
+      this.reportNonFinalGlobalAdmissionDenial(sessionId)
       return false
     }
     this.nonFinalAdmissionDeniedSessionIds.delete(sessionId)
@@ -1387,8 +1385,18 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return true
   }
 
+  private reportNonFinalGlobalAdmissionDenial(sessionId: string): void {
+    if (!this.nonFinalGlobalAdmissionWarningActive) {
+      this.nonFinalGlobalAdmissionWarningActive = true
+      console.warn('[history] non-final checkpoint global admission limit reached:', sessionId)
+    }
+  }
+
   private releaseNonFinalCheckpointAdmission(sessionId: string): void {
-    this.nonFinalCheckpointAdmissionSessionIds.delete(sessionId)
+    if (this.nonFinalCheckpointAdmissionSessionIds.delete(sessionId)) {
+      this.nonFinalAdmissionDeniedSessionIds.delete(sessionId)
+      this.nonFinalGlobalAdmissionWarningActive = false
+    }
   }
 
   private async compactDurableRestoreSnapshot(
@@ -2174,6 +2182,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     const checkpointNext = async (): Promise<void> => {
       for (;;) {
+        // No worker in this pass awaits abandoned work, so a full admission set cannot open here.
+        if (
+          opts?.final !== true &&
+          this.nonFinalCheckpointAdmissionSessionIds.size >= MAX_CONCURRENT_CHECKPOINTS
+        ) {
+          const deferredSessionId = ids[nextIndex]
+          if (deferredSessionId !== undefined) {
+            this.reportNonFinalGlobalAdmissionDenial(deferredSessionId)
+          }
+          return
+        }
         const index = nextIndex
         nextIndex++
         if (index >= ids.length) {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -255,7 +255,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // Why per session: exclusivity protects one session directory's tmp-write/rename, so ordering
   // every session behind one tail let a single stalled checkpoint block all reattaches (STA-4173).
   private checkpointQueue = new CheckpointSessionQueue()
-  private nonFinalCheckpointAdmissions = 0
+  private nonFinalCheckpointAdmissionSessionIds = new Set<string>()
+  private nonFinalAdmissionDeniedSessionIds = new Set<string>()
   private overlayDeadlineWarnedSessionIds = new Set<string>()
   private periodicDeadlineWarnedSessionIds = new Set<string>()
   private keepHistoryShutdowns = new Set<Promise<void>>()
@@ -1178,6 +1179,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingContinuityCheckpoint.delete(id)
     this.overlayDeadlineWarnedSessionIds.delete(id)
     this.periodicDeadlineWarnedSessionIds.delete(id)
+    this.nonFinalAdmissionDeniedSessionIds.delete(id)
     this.lastFullCheckpointAt.delete(id)
     this.stopCheckpointTimerIfIdle()
     this.initialCwds.delete(id)
@@ -1335,7 +1337,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     // Why reserve before enqueueing: pane mounts can arrive in one turn, before any compact starts.
     // Count abandoned waits until their writes settle so a relaunch cannot fan out unbounded work.
-    if (!this.tryAdmitNonFinalCheckpoint()) {
+    if (!this.tryAdmitNonFinalCheckpoint(sessionId)) {
       return liveSnapshot
     }
     // Why per session with a deadline: a reattach is a user click, so it must wait
@@ -1348,7 +1350,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         try {
           return await this.compactDurableRestoreSnapshot(sessionId, liveSnapshot, scrollbackRows)
         } finally {
-          this.releaseNonFinalCheckpointAdmission()
+          this.releaseNonFinalCheckpointAdmission(sessionId)
           this.overlayDeadlineWarnedSessionIds.delete(sessionId)
         }
       },
@@ -1365,16 +1367,24 @@ export class DaemonPtyAdapter implements IPtyProvider {
     )
   }
 
-  private tryAdmitNonFinalCheckpoint(): boolean {
-    if (this.nonFinalCheckpointAdmissions >= MAX_CONCURRENT_CHECKPOINTS) {
+  private tryAdmitNonFinalCheckpoint(sessionId: string): boolean {
+    if (
+      this.nonFinalCheckpointAdmissionSessionIds.has(sessionId) ||
+      this.nonFinalCheckpointAdmissionSessionIds.size >= MAX_CONCURRENT_CHECKPOINTS
+    ) {
+      if (!this.nonFinalAdmissionDeniedSessionIds.has(sessionId)) {
+        this.nonFinalAdmissionDeniedSessionIds.add(sessionId)
+        console.warn('[history] non-final checkpoint admission limit reached:', sessionId)
+      }
       return false
     }
-    this.nonFinalCheckpointAdmissions++
+    this.nonFinalAdmissionDeniedSessionIds.delete(sessionId)
+    this.nonFinalCheckpointAdmissionSessionIds.add(sessionId)
     return true
   }
 
-  private releaseNonFinalCheckpointAdmission(): void {
-    this.nonFinalCheckpointAdmissions--
+  private releaseNonFinalCheckpointAdmission(sessionId: string): void {
+    this.nonFinalCheckpointAdmissionSessionIds.delete(sessionId)
   }
 
   private async compactDurableRestoreSnapshot(
@@ -1711,6 +1721,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingContinuityCheckpoint.clear()
     this.overlayDeadlineWarnedSessionIds.clear()
     this.periodicDeadlineWarnedSessionIds.clear()
+    this.nonFinalAdmissionDeniedSessionIds.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
     this.stopCheckpointTimer()
@@ -1823,6 +1834,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingContinuityCheckpoint.clear()
     this.overlayDeadlineWarnedSessionIds.clear()
     this.periodicDeadlineWarnedSessionIds.clear()
+    this.nonFinalAdmissionDeniedSessionIds.clear()
     this.coldRestoreCache.clear()
     this.wslDistrosBySessionId.clear()
     this.pausedProducerSessionIds.clear()
@@ -2209,14 +2221,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     // Why 'deferred' is safe: the session stays dirty, so the operation that beat us to the queue
     // still commits and the next tick retries this one. Nothing on disk is discarded.
-    if (this.checkpointQueue.isSaturated(sessionId) || !this.tryAdmitNonFinalCheckpoint()) {
+    if (
+      this.checkpointQueue.isSaturated(sessionId) ||
+      !this.tryAdmitNonFinalCheckpoint(sessionId)
+    ) {
       return 'deferred'
     }
     const run = async (): Promise<'done' | 'deferred'> => {
       try {
         return await this.writeSessionCheckpoint(sessionId, opts)
       } finally {
-        this.releaseNonFinalCheckpointAdmission()
+        this.releaseNonFinalCheckpointAdmission(sessionId)
         this.periodicDeadlineWarnedSessionIds.delete(sessionId)
       }
     }
@@ -2755,6 +2770,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.sessionsNeedingContinuityCheckpoint.delete(event.sessionId)
         this.overlayDeadlineWarnedSessionIds.delete(event.sessionId)
         this.periodicDeadlineWarnedSessionIds.delete(event.sessionId)
+        this.nonFinalAdmissionDeniedSessionIds.delete(event.sessionId)
         // Why: a reused sessionId (renderer respawns a persisted ptyId) must not inherit the dead session's snapshot cooldown.
         this.lastFullCheckpointAt.delete(event.sessionId)
         this.stopCheckpointTimerIfIdle()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -162,9 +162,6 @@ const MAX_CONCURRENT_CHECKPOINTS = 4
 // DAEMON_RESTORE_SCROLLBACK_ROWS through the headless emulator in well under a second, so this
 // only fires when the write path is genuinely wedged (STA-4173).
 const DURABLE_HISTORY_OVERLAY_DEADLINE_MS = 5_000
-// Why the background pass gets a longer one: blowing it only defers a still-dirty session to the
-// next tick, so the budget should sit above any slow-but-working disk rather than churn it.
-const PERIODIC_CHECKPOINT_DEADLINE_MS = 15_000
 
 // Why far below the client's 30s default: a wedged daemon holds its socket open, so an unbounded
 // probe stalls a pane mount for the full request timeout — and the owner fan-out waits on every
@@ -258,7 +255,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // Why per session: exclusivity protects one session directory's tmp-write/rename, so ordering
   // every session behind one tail let a single stalled checkpoint block all reattaches (STA-4173).
   private checkpointQueue = new CheckpointSessionQueue()
-  private overlayCheckpointAdmissions = 0
+  private nonFinalCheckpointAdmissions = 0
   private overlayDeadlineWarnedSessionIds = new Set<string>()
   private periodicDeadlineWarnedSessionIds = new Set<string>()
   private keepHistoryShutdowns = new Set<Promise<void>>()
@@ -277,6 +274,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // Why: a daemon surviving a socket drop can hold a pause whose resume died with the connection; owe a resume on reconnect (daemon's 5s failsafe covers the gap).
   private producerResumesOwedOnReconnect = new Set<string>()
   private static CHECKPOINT_INTERVAL_MS = 5_000
+  // Why the background pass gets a longer deadline: deferral keeps the session dirty, so this
+  // should sit above slow-but-working disk rather than churn it.
+  private static PERIODIC_CHECKPOINT_DEADLINE_MS = 15_000
   // Why: streaming sessions re-trigger full multi-MB checkpoints every tick; this cooldown caps cap/overflow snapshots per session (~9x less writes, bounded cold-crash staleness).
   private static FULL_CHECKPOINT_COOLDOWN_MS = 45_000
   private lastFullCheckpointAt = new Map<string, number>()
@@ -1335,10 +1335,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     // Why reserve before enqueueing: pane mounts can arrive in one turn, before any compact starts.
     // Count abandoned waits until their writes settle so a relaunch cannot fan out unbounded work.
-    if (this.overlayCheckpointAdmissions >= MAX_CONCURRENT_CHECKPOINTS) {
+    if (!this.tryAdmitNonFinalCheckpoint()) {
       return liveSnapshot
     }
-    this.overlayCheckpointAdmissions++
     // Why per session with a deadline: a reattach is a user click, so it must wait
     // on this session's own compact and nothing else. A blown deadline does not
     // cancel that compact — it keeps running and still commits — so the fallback
@@ -1349,19 +1348,33 @@ export class DaemonPtyAdapter implements IPtyProvider {
         try {
           return await this.compactDurableRestoreSnapshot(sessionId, liveSnapshot, scrollbackRows)
         } finally {
-          this.overlayCheckpointAdmissions--
+          this.releaseNonFinalCheckpointAdmission()
           this.overlayDeadlineWarnedSessionIds.delete(sessionId)
         }
       },
       DURABLE_HISTORY_OVERLAY_DEADLINE_MS,
       liveSnapshot,
-      () => {
-        if (!this.overlayDeadlineWarnedSessionIds.has(sessionId)) {
-          this.overlayDeadlineWarnedSessionIds.add(sessionId)
-          console.warn('[history] durable snapshot overlay deadline exceeded:', sessionId)
+      {
+        onDeadline: () => {
+          if (!this.overlayDeadlineWarnedSessionIds.has(sessionId)) {
+            this.overlayDeadlineWarnedSessionIds.add(sessionId)
+            console.warn('[history] durable snapshot overlay deadline exceeded:', sessionId)
+          }
         }
       }
     )
+  }
+
+  private tryAdmitNonFinalCheckpoint(): boolean {
+    if (this.nonFinalCheckpointAdmissions >= MAX_CONCURRENT_CHECKPOINTS) {
+      return false
+    }
+    this.nonFinalCheckpointAdmissions++
+    return true
+  }
+
+  private releaseNonFinalCheckpointAdmission(): void {
+    this.nonFinalCheckpointAdmissions--
   }
 
   private async compactDurableRestoreSnapshot(
@@ -2187,32 +2200,40 @@ export class DaemonPtyAdapter implements IPtyProvider {
     sessionId: string,
     opts: { final: boolean; teardown: boolean }
   ): Promise<'done' | 'deferred'> {
+    // Why final waits without a deadline: sleep/disconnect needs the last snapshot on disk, and
+    // deferring there would silently drop what the user left on screen rather than delay it.
+    if (opts.final) {
+      return await this.checkpointQueue.run(sessionId, () =>
+        this.writeSessionCheckpoint(sessionId, opts)
+      )
+    }
+    // Why 'deferred' is safe: the session stays dirty, so the operation that beat us to the queue
+    // still commits and the next tick retries this one. Nothing on disk is discarded.
+    if (this.checkpointQueue.isSaturated(sessionId) || !this.tryAdmitNonFinalCheckpoint()) {
+      return 'deferred'
+    }
     const run = async (): Promise<'done' | 'deferred'> => {
       try {
         return await this.writeSessionCheckpoint(sessionId, opts)
       } finally {
+        this.releaseNonFinalCheckpointAdmission()
         this.periodicDeadlineWarnedSessionIds.delete(sessionId)
       }
-    }
-    // Why final waits without a deadline: sleep/disconnect needs the last snapshot on disk, and
-    // deferring there would silently drop what the user left on screen rather than delay it.
-    if (opts.final) {
-      return await this.checkpointQueue.run(sessionId, run)
-    }
-    // Why 'deferred' is safe: the session stays dirty, so the operation that beat us to the queue
-    // still commits and the next tick retries this one. Nothing on disk is discarded.
-    if (this.checkpointQueue.isSaturated(sessionId)) {
-      return 'deferred'
     }
     return await this.checkpointQueue.runWithDeadline(
       sessionId,
       run,
-      PERIODIC_CHECKPOINT_DEADLINE_MS,
+      DaemonPtyAdapter.PERIODIC_CHECKPOINT_DEADLINE_MS,
       'deferred',
-      () => {
-        if (!this.periodicDeadlineWarnedSessionIds.has(sessionId)) {
-          this.periodicDeadlineWarnedSessionIds.add(sessionId)
-          console.warn('[history] periodic checkpoint deadline exceeded:', sessionId)
+      {
+        onDeadline: () => {
+          if (!this.periodicDeadlineWarnedSessionIds.has(sessionId)) {
+            this.periodicDeadlineWarnedSessionIds.add(sessionId)
+            console.warn('[history] periodic checkpoint deadline exceeded:', sessionId)
+          }
+        },
+        onAbandonedRejection: (error) => {
+          console.warn('[history] checkpoint failed:', sessionId, error)
         }
       }
     )

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -258,6 +258,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // Why per session: exclusivity protects one session directory's tmp-write/rename, so ordering
   // every session behind one tail let a single stalled checkpoint block all reattaches (STA-4173).
   private checkpointQueue = new CheckpointSessionQueue()
+  private overlayCheckpointAdmissions = 0
+  private overlayDeadlineWarnedSessionIds = new Set<string>()
+  private periodicDeadlineWarnedSessionIds = new Set<string>()
   private keepHistoryShutdowns = new Set<Promise<void>>()
   private disconnectOnlyPromise: Promise<void> | null = null
   // Why: checkpoint persistence needs the getSnapshot RPC (v4+); legacy daemons reject it, spamming logs every 5s.
@@ -1173,6 +1176,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingFullCheckpoint.delete(id)
     this.sessionsNeedingLiveCheckpoint.delete(id)
     this.sessionsNeedingContinuityCheckpoint.delete(id)
+    this.overlayDeadlineWarnedSessionIds.delete(id)
+    this.periodicDeadlineWarnedSessionIds.delete(id)
     this.lastFullCheckpointAt.delete(id)
     this.stopCheckpointTimerIfIdle()
     this.initialCwds.delete(id)
@@ -1328,15 +1333,34 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (this.checkpointQueue.isSaturated(sessionId)) {
       return liveSnapshot
     }
+    // Why reserve before enqueueing: pane mounts can arrive in one turn, before any compact starts.
+    // Count abandoned waits until their writes settle so a relaunch cannot fan out unbounded work.
+    if (this.overlayCheckpointAdmissions >= MAX_CONCURRENT_CHECKPOINTS) {
+      return liveSnapshot
+    }
+    this.overlayCheckpointAdmissions++
     // Why per session with a deadline: a reattach is a user click, so it must wait
     // on this session's own compact and nothing else. A blown deadline does not
     // cancel that compact — it keeps running and still commits — so the fallback
     // costs restore depth for this one reattach, never durable history (STA-4173).
     return await this.checkpointQueue.runWithDeadline(
       sessionId,
-      () => this.compactDurableRestoreSnapshot(sessionId, liveSnapshot, scrollbackRows),
+      async () => {
+        try {
+          return await this.compactDurableRestoreSnapshot(sessionId, liveSnapshot, scrollbackRows)
+        } finally {
+          this.overlayCheckpointAdmissions--
+          this.overlayDeadlineWarnedSessionIds.delete(sessionId)
+        }
+      },
       DURABLE_HISTORY_OVERLAY_DEADLINE_MS,
-      liveSnapshot
+      liveSnapshot,
+      () => {
+        if (!this.overlayDeadlineWarnedSessionIds.has(sessionId)) {
+          this.overlayDeadlineWarnedSessionIds.add(sessionId)
+          console.warn('[history] durable snapshot overlay deadline exceeded:', sessionId)
+        }
+      }
     )
   }
 
@@ -1672,6 +1696,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingFullCheckpoint.clear()
     this.sessionsNeedingLiveCheckpoint.clear()
     this.sessionsNeedingContinuityCheckpoint.clear()
+    this.overlayDeadlineWarnedSessionIds.clear()
+    this.periodicDeadlineWarnedSessionIds.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
     this.stopCheckpointTimer()
@@ -1782,6 +1808,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingFullCheckpoint.clear()
     this.sessionsNeedingLiveCheckpoint.clear()
     this.sessionsNeedingContinuityCheckpoint.clear()
+    this.overlayDeadlineWarnedSessionIds.clear()
+    this.periodicDeadlineWarnedSessionIds.clear()
     this.coldRestoreCache.clear()
     this.wslDistrosBySessionId.clear()
     this.pausedProducerSessionIds.clear()
@@ -2159,7 +2187,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
     sessionId: string,
     opts: { final: boolean; teardown: boolean }
   ): Promise<'done' | 'deferred'> {
-    const run = (): Promise<'done' | 'deferred'> => this.writeSessionCheckpoint(sessionId, opts)
+    const run = async (): Promise<'done' | 'deferred'> => {
+      try {
+        return await this.writeSessionCheckpoint(sessionId, opts)
+      } finally {
+        this.periodicDeadlineWarnedSessionIds.delete(sessionId)
+      }
+    }
     // Why final waits without a deadline: sleep/disconnect needs the last snapshot on disk, and
     // deferring there would silently drop what the user left on screen rather than delay it.
     if (opts.final) {
@@ -2174,7 +2208,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
       sessionId,
       run,
       PERIODIC_CHECKPOINT_DEADLINE_MS,
-      'deferred'
+      'deferred',
+      () => {
+        if (!this.periodicDeadlineWarnedSessionIds.has(sessionId)) {
+          this.periodicDeadlineWarnedSessionIds.add(sessionId)
+          console.warn('[history] periodic checkpoint deadline exceeded:', sessionId)
+        }
+      }
     )
   }
 
@@ -2692,6 +2732,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.sessionsNeedingFullCheckpoint.delete(event.sessionId)
         this.sessionsNeedingLiveCheckpoint.delete(event.sessionId)
         this.sessionsNeedingContinuityCheckpoint.delete(event.sessionId)
+        this.overlayDeadlineWarnedSessionIds.delete(event.sessionId)
+        this.periodicDeadlineWarnedSessionIds.delete(event.sessionId)
         // Why: a reused sessionId (renderer respawns a persisted ptyId) must not inherit the dead session's snapshot cooldown.
         this.lastFullCheckpointAt.delete(event.sessionId)
         this.stopCheckpointTimerIfIdle()

--- a/src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts
+++ b/src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts
@@ -154,19 +154,71 @@ describe('STA-4173 reattach isolation from a stalled checkpoint', () => {
   it('falls back to the live window when the session own checkpoint blows the deadline', async () => {
     const stalledId = await spawnWithOutput('deadline-session', 'DEADLINE_OUTPUT\r\n')
     const stall = await stallCheckpointFor(stalledId)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    const reattach = await withinBudget(
-      adapter.spawn({ cols: 80, rows: 24, sessionId: stalledId, cwd: '/tmp' }),
-      DEADLINE_BUDGET_MS
-    )
+    try {
+      const reattach = await withinBudget(
+        adapter.spawn({ cols: 80, rows: 24, sessionId: stalledId, cwd: '/tmp' }),
+        DEADLINE_BUDGET_MS
+      )
 
-    expect(stall.entered()).toBeGreaterThan(0)
-    expect(reattach).not.toBe('timed-out')
-    expect(reattach).toMatchObject({ isReattach: true })
-    // Degraded to the daemon's live window, not empty: the deadline costs restore depth, not history.
-    expect((reattach as { snapshot: string }).snapshot).toContain('DEADLINE_OUTPUT')
-    stall.release()
+      expect(stall.entered()).toBeGreaterThan(0)
+      expect(reattach).not.toBe('timed-out')
+      expect(reattach).toMatchObject({ isReattach: true })
+      // Degraded to the daemon's live window, not empty: the deadline costs restore depth, not history.
+      expect((reattach as { snapshot: string }).snapshot).toContain('DEADLINE_OUTPUT')
+      expect(warn).toHaveBeenCalledWith(
+        '[history] durable snapshot overlay deadline exceeded:',
+        stalledId
+      )
+    } finally {
+      stall.release()
+      warn.mockRestore()
+    }
   }, 30_000)
+
+  it('bounds overlay compacts across distinct sessions without blocking reattach', async () => {
+    const stalledIds = ['fanout-a', 'fanout-b', 'fanout-c', 'fanout-d']
+    for (const sessionId of stalledIds) {
+      await spawnWithOutput(sessionId, `${sessionId.toUpperCase()}\r\n`)
+    }
+    const overflowId = await spawnWithOutput('fanout-overflow', 'FANOUT_OVERFLOW\r\n')
+    const manager = adapter.getHistoryManager()!
+    const original = manager.checkpoint.bind(manager)
+    const entered = new Set<string>()
+    const checkpointed: string[] = []
+    let release = (): void => {}
+    const stalled = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    vi.spyOn(manager, 'checkpoint').mockImplementation(async (sessionId, snapshot, opts) => {
+      checkpointed.push(sessionId)
+      if (stalledIds.includes(sessionId)) {
+        entered.add(sessionId)
+        await stalled
+      }
+      return await original(sessionId, snapshot, opts)
+    })
+
+    const reattaches = stalledIds.map((sessionId) =>
+      adapter.spawn({ cols: 80, rows: 24, sessionId, cwd: '/tmp' })
+    )
+    try {
+      await vi.waitFor(() => expect(entered.size).toBe(stalledIds.length))
+
+      const overflowReattach = await withinBudget(
+        adapter.spawn({ cols: 80, rows: 24, sessionId: overflowId, cwd: '/tmp' }),
+        REATTACH_BUDGET_MS
+      )
+      expect(overflowReattach).not.toBe('timed-out')
+      expect(overflowReattach).toMatchObject({ isReattach: true })
+      expect((overflowReattach as { snapshot: string }).snapshot).toContain('FANOUT_OVERFLOW')
+      expect(checkpointed).not.toContain(overflowId)
+    } finally {
+      release()
+      await Promise.allSettled(reattaches)
+    }
+  })
 
   it('still commits the abandoned checkpoint once the history write completes', async () => {
     const stalledId = await spawnWithOutput('resumed-session', 'RESUMED_OUTPUT\r\n')

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -248,7 +248,7 @@ export class HistoryManager {
 
     try {
       // Why: tmp+rename is atomic (corrupt checkpoint > stale); async so a sync ~MB write can't stall IPC (worse under Windows AV).
-      // The adapter's checkpointInFlight guard serializes checkpoints, so concurrent async writes can't collide on the fixed .tmp path.
+      // The adapter's per-session checkpoint queue prevents concurrent writes from colliding on the fixed .tmp path.
       const checkpoint = await writer.checkpoint(snapshot, opts)
       if (checkpoint.result === 'retryable') {
         this.onWriteError?.(sessionId, checkpoint.error)


### PR DESCRIPTION
Follow-up to #14346 and [STA-4173](https://linear.app/stably/issue/STA-4173/p1-durable-history-overlay-blocks-reattach-on-the-global-checkpoint).

## Summary

- preserve checkpoint rejection diagnostics across deadline fallback;
- add one-shot overlay, periodic, and admission breadcrumbs;
- cap non-final checkpoint work at one admission per session and four sessions globally;
- retain admission until abandoned work actually settles;
- keep final sleep/disconnect checkpoints deadline-free and lossless;
- register deterministic daemon checkpoint-isolation reliability coverage.

The scheduling policy remains in `DaemonPtyAdapter`, which owns the complete output-drain, snapshot-build, and durable-write transaction. The per-session queue remains policy-free and provides same-session serialization.

## Validation

- 208 focused checkpoint, reattach, and deep-history tests;
- Node 24 full typecheck;
- changed-code quality gate;
- 80 reliability-gate manifest checks;
- max-lines ratchet and `git diff --check`;
- broad daemon suite, relay/Electron builds, 9/9 cross-version wire checks, and 26/26 terminal-cardinality checks during internal review;
- real local Electron reattach via Playwright CDP;
- real Ubuntu 20.04 Docker SSH relay reattach with remote PID and post-reconnect command proof.

### SSH terminal reattach

![SSH terminal reattach](https://github.com/user-attachments/assets/f6035cab-66c6-4cc2-a1b1-b10d4032e79a)

### Local terminal reattach

![Local terminal reattach](https://github.com/user-attachments/assets/1959bca7-3850-4604-90d4-02c522f146e7)

## Compatibility

No RPC, stream, or published payload shape changes. The follow-up adds no Git commands, provider-specific behavior, renderer surface, or mobile surface. Final checkpoint semantics remain unchanged.

Live physical Windows, WSL, direct Linux-daemon, and paired-runtime-host journeys remain recorded as explicit experimental-gate gaps; Windows packaging and mixed-version wire checks are green.
