### PR TITLE
fix(terminal): name the POSIX interpreter directly when generating on Windows

### DIFF
--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants } from 'node:fs'
+import { accessSync, constants, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 const SHELL_DOLLAR = '$'
@@ -14,7 +14,15 @@ const POSIX_INTERPRETER_CANDIDATES = [
 ] as const
 
 function isExecutable(candidate: string): boolean {
+  // Why: a shebang has no quoting, so a path with whitespace is unusable as an interpreter.
+  if (/\s/.test(candidate)) {
+    return false
+  }
   try {
+    // Why: X_OK alone is true for a directory named `bash`, which cannot be exec'd.
+    if (!statSync(candidate).isFile()) {
+      return false
+    }
     accessSync(candidate, constants.X_OK)
     return true
   } catch {
@@ -22,12 +30,22 @@ function isExecutable(candidate: string): boolean {
   }
 }
 
+// Why: the POSIX tombstone is written on Windows too — Git Bash and WSL panes execute it — but
+// none of the absolute candidates below exist to a Windows Electron process, and PATH there is
+// `;`-separated, so the search cannot succeed either. Both MSYS and WSL map /bin/bash, so name it
+// directly rather than falling through to an ambient lookup.
+const WINDOWS_POSIX_INTERPRETER = '/bin/bash'
+
 export function resolvePosixTombstoneInterpreter(
   pathValue: string | undefined = process.env.PATH,
   // Why: injectable so the PATH-search branch below is reachable in tests on hosts that do have
   // a well-known bash.
-  candidates: readonly string[] = POSIX_INTERPRETER_CANDIDATES
+  candidates: readonly string[] = POSIX_INTERPRETER_CANDIDATES,
+  platform: NodeJS.Platform = process.platform
 ): string {
+  if (platform === 'win32') {
+    return WINDOWS_POSIX_INTERPRETER
+  }
   for (const candidate of candidates) {
     if (isExecutable(candidate)) {
       return candidate

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -118,7 +118,11 @@ describe('legacy terminal shim neutralization', () => {
       // spelled with one escapes self-exclusion and the wrapper tail-loops on itself.
       // Why: `if "%var:~-1%"=="\\"` breaks cmd's parser, so the trailing separator is stripped
       // with a sentinel instead. Verified on Windows.
-      expect(cmd).toContain('set "orca_candidate_dir=%orca_candidate_dir:\\#=#%"')
+      // Why: compared against a variable holding the separator — a literal backslash before the
+      // closing quote breaks cmd's parser, and a sentinel would corrupt paths containing it.
+      expect(cmd).toContain('set "orca_sep=')
+      expect(cmd).toContain('if "%orca_candidate_dir:~-1%"=="%orca_sep%"')
+      expect(cmd).not.toContain(':\\#=#%')
       // A candidate inside the wrapper directory must still be rejected, compared against the
       // cached wrapper dir because %~dp0 is rebound inside a CALL.
       expect(cmd).toContain('if /I "%orca_candidate_dir%\\"=="%orca_wrapper_dir%" exit /b')
@@ -186,6 +190,30 @@ describe('legacy terminal shim neutralization', () => {
         expect(cmd.indexOf(guard)).toBeLessThan(cmd.indexOf(loop))
       }
     }
+  })
+
+  it('never bakes an ambient interpreter lookup on Windows', () => {
+    // Why: the POSIX tombstone is written on Windows too (Git Bash and WSL panes run it), but no
+    // absolute candidate exists to a Windows process and PATH there is ';'-separated, so the
+    // search cannot succeed — without this the fallback reopened the interpreter hijack.
+    expect(resolvePosixTombstoneInterpreter(undefined, [], 'win32')).toBe('/bin/bash')
+    expect(resolvePosixTombstoneInterpreter('C:\\Git\\bin;C:\\Windows', [], 'win32')).toBe(
+      '/bin/bash'
+    )
+  })
+
+  itOnPosix('rejects interpreter candidates that are unusable in a shebang', () => {
+    const userData = makeUserDataDir()
+    const spaced = join(userData, 'a b')
+    const dirNamedBash = join(userData, 'dirbin')
+    mkdirSync(spaced, { recursive: true })
+    mkdirSync(join(dirNamedBash, 'bash'), { recursive: true })
+    writeFileSync(join(spaced, 'bash'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+    // A shebang cannot quote, so a path containing whitespace is unusable.
+    expect(resolvePosixTombstoneInterpreter(spaced, [], 'linux')).toBe('/usr/bin/env bash')
+    // X_OK is true for a directory; it still cannot be exec'd.
+    expect(resolvePosixTombstoneInterpreter(dirNamedBash, [], 'linux')).toBe('/usr/bin/env bash')
   })
 
   itOnPosix('resolves the interpreter from absolute PATH entries only', () => {
@@ -323,7 +351,7 @@ describe('legacy terminal shim neutralization', () => {
     // Why: `call :label && ...` is not valid cmd; the flag variable is what makes it work.
     expect(cmd).toContain('if defined orca_skip_entry exit /b')
     expect(cmd).not.toContain('call :orca_reject_legacy_dir &&')
-    expect(cmd).toContain('set "orca_path_entry_dir=%orca_path_entry_dir:\\#=#%"')
+    expect(cmd).toContain('if "%orca_path_entry_dir:~-1%"=="%orca_sep%"')
 
     const powershell = readFileSync(join(win32Dir, 'git-wrapper.ps1'), 'utf8')
     expect(powershell.indexOf('$legacyWrapperDir = $env:ORCA_ATTRIBUTION_SHIM_DIR')).toBeLessThan(

--- a/src/main/pty/legacy-terminal-windows-tombstone.ts
+++ b/src/main/pty/legacy-terminal-windows-tombstone.ts
@@ -7,6 +7,10 @@ set "orca_real=%ORCA_REAL___ORCA_UPPER_COMMAND__%"
 set "orca_wrapper_dir=%~dp0"
 set "orca_legacy_wrapper_dir=%ORCA_ATTRIBUTION_SHIM_DIR%"
 set "orca_clean_path="
+rem Why: holds a single separator so the trailing-separator tests below need neither a literal
+rem backslash before a quote (which breaks cmd parsing) nor a sentinel character (which would
+rem corrupt any path containing it).
+set "orca_sep=\"
 rem Why: an empty PATH leaves the substitution below with an unbalanced quote, which
 rem desynchronizes cmd parsing for the rest of the file. Skip the line entirely instead.
 if not defined PATH goto :orca_path_walked
@@ -54,9 +58,7 @@ for %%G in ("%~1") do set "orca_candidate_dir=%%~fG"
 rem Why: full-path expansion preserves a trailing separator, so without normalizing, the
 rem self-exclusion below misses a wrapper-dir entry spelled with one and the wrapper resolves
 rem to itself, looping forever.
-set "orca_candidate_dir=%orca_candidate_dir%#"
-set "orca_candidate_dir=%orca_candidate_dir:\#=#%"
-set "orca_candidate_dir=%orca_candidate_dir:~0,-1%"
+if "%orca_candidate_dir:~-1%"=="%orca_sep%" set "orca_candidate_dir=%orca_candidate_dir:~0,-1%"
 rem Why: the script-dir operator is rebound to this label inside CALL, so compare against the
 rem cached wrapper dir captured at top level.
 if /I "%orca_candidate_dir%\"=="%orca_wrapper_dir%" exit /b
@@ -68,9 +70,7 @@ exit /b
 :orca_append_path
 for %%G in ("%~1") do set "orca_path_entry_dir=%%~fG"
 rem Why: full-path expansion preserves a trailing separator; normalize before comparing.
-set "orca_path_entry_dir=%orca_path_entry_dir%#"
-set "orca_path_entry_dir=%orca_path_entry_dir:\#=#%"
-set "orca_path_entry_dir=%orca_path_entry_dir:~0,-1%"
+if "%orca_path_entry_dir:~-1%"=="%orca_sep%" set "orca_path_entry_dir=%orca_path_entry_dir:~0,-1%"
 set "orca_path_entry_dir=%orca_path_entry_dir%\"
 if /I "%orca_path_entry_dir%"=="%orca_wrapper_dir%" exit /b
 set "orca_skip_entry="
@@ -81,9 +81,7 @@ exit /b
 
 :orca_reject_legacy_dir
 for %%G in ("%orca_legacy_wrapper_dir%") do set "orca_legacy_norm=%%~fG"
-set "orca_legacy_norm=%orca_legacy_norm%#"
-set "orca_legacy_norm=%orca_legacy_norm:\#=#%"
-set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
+if "%orca_legacy_norm:~-1%"=="%orca_sep%" set "orca_legacy_norm=%orca_legacy_norm:~0,-1%"
 if /I "%orca_path_entry_dir%"=="%orca_legacy_norm%\" set "orca_skip_entry=1"
 exit /b
 `


### PR DESCRIPTION
## ELI5

Round-4 review. The interpreter hardening in #14382 had a gap: **on Windows it always fell back to the ambient lookup it was meant to replace**, so the POSIX tombstone kept the hijack there.

## 1. Windows generation always took the unsafe fallback

`resolvePosixTombstoneInterpreter` checked absolute paths (`/bin/bash`, …) and then searched PATH. To a Windows Electron process:

- none of the absolute candidates exist, and
- the PATH search split on `:` while Windows PATH is `;`-separated, so it could never match.

Result: `#!/usr/bin/env bash` every time. The POSIX tombstone **is** written on Windows — Git Bash and WSL panes execute it — so the interpreter hijack survived on exactly the platform the previous rounds were hardening.

Windows generation now names `/bin/bash` directly, which both MSYS and WSL map, instead of falling through to an ambient lookup.

## 2. Two candidate checks were wrong

- A shebang cannot quote, so an interpreter path containing whitespace is unusable — such candidates are now rejected rather than baked in.
- `access(X_OK)` is true for a **directory** named `bash`; the check now requires a regular file.

## 3. The `#` sentinel could corrupt real paths

The trailing-separator strip used `%var:\#=#%`, which mangles any directory containing `\#`. Replaced with a comparison against a variable holding the separator — this avoids both the sentinel collision and the `if "%var:~-1%"=="\"` parser trap that made the sentinel necessary in the first place.

## Verified on real Windows

`awin`, Windows 10.0.26200, git 2.55.0.windows.3:

| case | result |
|---|---|
| Normal | `git version 2.55.0.windows.3`, exit 0 |
| Hostile cwd with planted `git.exe` | real git; planted binary ignored |
| Wrapper dir on PATH with trailing `\` | exit 0, no loop |
| Empty `PATH` | clean message, exit 127 |

## Testing

- `pnpm typecheck`, `pnpm lint`: pass, no `max-lines` suppression
- Full suite: **51,899 passed**; 2 failures, both pre-existing and reproducible on `origin/main`
- New tests pin the Windows interpreter choice, the whitespace/directory rejections, and the separator comparison
