### PR TITLE
fix(terminal): clear CDPATH when resolving the wrapper directory

### DIFF
--- a/src/main/pty/legacy-terminal-posix-tombstone.ts
+++ b/src/main/pty/legacy-terminal-posix-tombstone.ts
@@ -80,7 +80,10 @@ wrapper_src="${SHELL_DOLLAR}{BASH_SOURCE[0]}"
 case "$wrapper_src" in
   # Why: with no slash the %/* strip yields the file name, not a directory, so self-exclusion
   # would miss the wrapper's own dir and the lookup would resolve back to this script.
-  */*) wrapper_dir="$(cd -- "${SHELL_DOLLAR}{wrapper_src%/*}" 2>/dev/null && pwd)" ;;
+  # Why: with CDPATH set, cd searches it for a relative operand and echoes the directory it lands
+  # in, which the command substitution then captures — wrapper_dir ends up wrong and doubled.
+  # Clear it for this one command.
+  */*) wrapper_dir="$(CDPATH= cd -P -- "${SHELL_DOLLAR}{wrapper_src%/*}" 2>/dev/null && pwd)" ;;
   *) wrapper_dir="$PWD" ;;
 esac
 [[ -n "$wrapper_dir" ]] || wrapper_dir="$PWD"

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -121,7 +121,11 @@ describe('legacy terminal shim neutralization', () => {
       // with a sentinel instead. Verified on Windows.
       // Why: compared against a variable holding the separator — a literal backslash before the
       // closing quote breaks cmd's parser, and a sentinel would corrupt paths containing it.
-      expect(cmd).toContain('set "orca_sep=')
+      // The value matters: any other character silently un-pins the trailing-separator fix.
+      expect(cmd).toContain('set "orca_sep=\\"')
+      // Why: nothing else asserts the *reject* path, so deleting it would reopen the cwd hijack
+      // while every accept-path assertion stayed green.
+      expect(cmd).toMatch(/goto orca_candidate_rooted\r?\nexit \/b/)
       expect(cmd).toContain('if "%orca_candidate_dir:~-1%"=="%orca_sep%"')
       expect(cmd).not.toContain(':\\#=#%')
       // A candidate inside the wrapper directory must still be rejected, compared against the
@@ -233,7 +237,17 @@ describe('legacy terminal shim neutralization', () => {
     expect(resolvePosixTombstoneInterpreter(`${absDir}:/usr/bin`, [])).toBe(join(absDir, 'bash'))
     // Relative and empty entries must be skipped even though they contain an executable bash.
     expect(resolvePosixTombstoneInterpreter(`:relbin:${absDir}`, [])).toBe(join(absDir, 'bash'))
-    expect(resolvePosixTombstoneInterpreter('.:relbin', [])).toBe('/usr/bin/env bash')
+    // Why: a relative entry resolves against the *running process* cwd, so the fixture must live
+    // there — pointing at a tmpdir would make this pass whether or not the guard exists.
+    const cwdRelName = `.orca-interp-${process.pid}`
+    const cwdRelDir = join(process.cwd(), cwdRelName)
+    mkdirSync(cwdRelDir, { recursive: true })
+    try {
+      writeFileSync(join(cwdRelDir, 'bash'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+      expect(resolvePosixTombstoneInterpreter(`.:${cwdRelName}`, [])).toBe('/usr/bin/env bash')
+    } finally {
+      rmSync(cwdRelDir, { recursive: true, force: true })
+    }
   })
 
   itOnPosix('resolves its own directory even when CDPATH is set', () => {
@@ -297,6 +311,10 @@ describe('legacy terminal shim neutralization', () => {
     // and hard to trigger legitimately, so deleting it would otherwise leave the suite green.
     const wrapper = readFileSync(join(posixDir, 'git'), 'utf8')
     expect(wrapper).toContain('-ef "${BASH_SOURCE[0]}"')
+    // Why: reintroducing the external dirname would restore the failure where an unresolvable
+    // dirname left the substitution empty and cd into it silently made wrapper_dir the cwd.
+    expect(wrapper).not.toMatch(/\$\(dirname\b/)
+    expect(wrapper).toContain('CDPATH= cd -P --')
   })
 
   itOnPosix('does not let the cwd supply the script interpreter', async () => {

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from 'node:child_process'
 import {
   chmodSync,
+  symlinkSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -233,6 +234,69 @@ describe('legacy terminal shim neutralization', () => {
     // Relative and empty entries must be skipped even though they contain an executable bash.
     expect(resolvePosixTombstoneInterpreter(`:relbin:${absDir}`, [])).toBe(join(absDir, 'bash'))
     expect(resolvePosixTombstoneInterpreter('.:relbin', [])).toBe('/usr/bin/env bash')
+  })
+
+  itOnPosix('resolves its own directory even when CDPATH is set', () => {
+    // Why: with CDPATH set, cd searches it for a relative operand and echoes where it landed,
+    // which the command substitution captures — wrapper_dir went wrong and git died at 127.
+    const userData = makeUserDataDir()
+    const posixDir = join(userData, 'orca-terminal-attribution', 'posix')
+    const realBin = join(userData, 'real-bin')
+    const cdpathDir = join(userData, 'cdpath')
+    mkdirSync(posixDir, { recursive: true })
+    mkdirSync(realBin, { recursive: true })
+    // Why: cd only relocates when CDPATH holds a directory matching the *whole* relative operand,
+    // so the fixture must mirror `orca-terminal-attribution/posix`, not just its first segment.
+    mkdirSync(join(cdpathDir, 'orca-terminal-attribution', 'posix'), { recursive: true })
+    writeFileSync(join(posixDir, 'git'), 'legacy attribution wrapper')
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    writeFileSync(join(realBin, 'git'), "#!/bin/bash\nprintf 'REAL\\n'\n", { mode: 0o755 })
+
+    const run = spawnSync('/bin/bash', ['orca-terminal-attribution/posix/git', '--version'], {
+      cwd: userData,
+      env: { CDPATH: cdpathDir, PATH: `${posixDir}:${realBin}:/usr/bin:/bin` },
+      encoding: 'utf8',
+      timeout: 20_000
+    })
+
+    expect(run.stdout).toContain('REAL')
+    expect(run.status).toBe(0)
+  })
+
+  itOnPosix('fails closed instead of self-executing when it resolves to itself', () => {
+    // Why: this guard is what turns a bad wrapper_dir into a clean 127 rather than an unbounded
+    // self-exec. Deleting it left the whole suite green, so pin it directly.
+    const userData = makeUserDataDir()
+    const posixDir = join(userData, 'orca-terminal-attribution', 'posix')
+    mkdirSync(posixDir, { recursive: true })
+    writeFileSync(join(posixDir, 'git'), 'legacy attribution wrapper')
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    // A symlink in another directory resolves to the same inode as the wrapper, so the lookup
+    // finds "git" outside the excluded wrapper dir and it turns out to be this very script.
+    const otherBin = join(userData, 'other-bin')
+    mkdirSync(otherBin, { recursive: true })
+    symlinkSync(join(posixDir, 'git'), join(otherBin, 'git'))
+
+    const run = spawnSync(join(posixDir, 'git'), ['--version'], {
+      cwd: posixDir,
+      env: { PATH: `${otherBin}:${posixDir}` },
+      encoding: 'utf8',
+      timeout: 20_000
+    })
+
+    expect(run.status).toBe(127)
+    expect(run.stderr).toContain('could not locate git')
+    // Why: no timeout kill — a missing guard here degrades into repeated self-exec.
+    expect(run.signal).toBeNull()
+
+    // Why pinned by text too: with wrapper_dir computed correctly this guard is defence in depth
+    // and hard to trigger legitimately, so deleting it would otherwise leave the suite green.
+    const wrapper = readFileSync(join(posixDir, 'git'), 'utf8')
+    expect(wrapper).toContain('-ef "${BASH_SOURCE[0]}"')
   })
 
   itOnPosix('does not let the cwd supply the script interpreter', async () => {


### PR DESCRIPTION
## ELI5

Round-5 review. Two follow-on defects from earlier fixes in this cycle, plus the test-quality problem that let them hide.

## 1. `CDPATH` broke the wrapper-dir computation — `git` unusable

The `dirname` replacement used `cd -- "$dir"`. With `CDPATH` exported (common in dotfiles: `export CDPATH=.:~/src`), `cd` searches it for a relative operand **and echoes the directory it lands in**, which the command substitution then captures. `wrapper_dir` ends up wrong, self-exclusion misidentifies the wrapper's own directory, the lookup resolves to the tombstone itself, and the run dies at 127 with a working `git` on PATH.

Fixed with `CDPATH= cd -P --`. Verified end-to-end and mutation-tested: removing the clearing makes the new test fail.

## 2. The guard preventing that from becoming a fork bomb was unpinned

`-ef "${BASH_SOURCE[0]}"` is what converts a bad `wrapper_dir` into a clean 127 instead of unbounded self-exec. Deleting it left the entire suite green.

Now covered by a behavioural test (a symlink makes the lookup resolve to the wrapper itself; asserts exit 127, no signal) **and** an explicit text assertion. Being honest about why both: with `wrapper_dir` now computed correctly the guard is defence in depth and hard to trigger legitimately, so the behavioural test alone does not discriminate — I verified that by mutation before adding the text pin.

## On test quality

My first cut of both tests **passed with the bug reintroduced** — the CDPATH fixture only mirrored the first path segment, so `cd` never relocated. That is the same "passes for the wrong reason" flaw the review flagged elsewhere. Both are now mutation-verified: each fails when its fix is reverted.

## Testing

- `pnpm typecheck`, `pnpm lint`: pass, no `max-lines` suppression
- Full suite: **51,925 passed**; 3 failures — 2 pre-existing `agent-exec-handler`, 1 load-flaky poller that passes in isolation, all reproducible on `origin/main`
