### PR TITLE
fix(terminal): migrate custom font weights to independent bold (STA-4236)

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2569,6 +2569,49 @@ describe('Store', () => {
     expect(store.getSettings().terminalFontWeightBold).toBe(400)
   })
 
+  it('persists the derived bold weight without another settings change', async () => {
+    const settledStore = await createStore()
+    settledStore.flush()
+    const settled = readDataFile() as PersistedState
+    settled.settings.terminalFontWeight = 800
+    delete (settled.settings as Partial<GlobalSettings>).terminalFontWeightBold
+    writeDataFile(settled)
+
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+
+      expect(store.getSettings().terminalFontWeightBold).toBe(900)
+      vi.advanceTimersByTime(1_000)
+      await store.waitForPendingWrite()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect((readDataFile() as PersistedState).settings.terminalFontWeightBold).toBe(900)
+  })
+
+  it('persists a normalized explicit bold weight', async () => {
+    const settledStore = await createStore()
+    settledStore.flush()
+    const settled = readDataFile() as PersistedState
+    settled.settings.terminalFontWeightBold = 1200
+    writeDataFile(settled)
+
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+
+      expect(store.getSettings().terminalFontWeightBold).toBe(900)
+      vi.advanceTimersByTime(1_000)
+      await store.waitForPendingWrite()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect((readDataFile() as PersistedState).settings.terminalFontWeightBold).toBe(900)
+  })
+
   it('preserves TUI scroll sensitivity choices after the one-report migration', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2508,6 +2508,67 @@ describe('Store', () => {
     expect((readDataFile() as PersistedState).settings.terminalTuiScrollSensitivity).toBe(1)
   })
 
+  it.each([
+    [600, 800],
+    [700, 900],
+    [800, 900],
+    [900, 900]
+  ])(
+    'migrates a pre-split regular weight of %i to the bold weight it already rendered (%i)',
+    async (terminalFontWeight, expectedBold) => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: { terminalFontWeight },
+        ui: {},
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+
+      const store = await createStore()
+
+      expect(store.getSettings().terminalFontWeightBold).toBe(expectedBold)
+      // The regression: an unmigrated profile fell back to 700, lighter than its own regular weight.
+      expect(store.getSettings().terminalFontWeightBold).toBeGreaterThanOrEqual(terminalFontWeight)
+      store.flush()
+      expect((readDataFile() as PersistedState).settings.terminalFontWeightBold).toBe(expectedBold)
+    }
+  )
+
+  it('leaves light pre-split profiles on the 700 bold default', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalFontWeight: 300 },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().terminalFontWeight).toBe(300)
+    expect(store.getSettings().terminalFontWeightBold).toBe(700)
+  })
+
+  it('keeps an explicitly configured bold weight instead of re-deriving it', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalFontWeight: 800, terminalFontWeightBold: 400 },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().terminalFontWeightBold).toBe(400)
+  })
+
   it('preserves TUI scroll sensitivity choices after the one-report migration', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -725,9 +725,10 @@ function migrateTerminalFontWeightBold(settings: unknown): {
     settings && typeof settings === 'object' ? (settings as LegacyTerminalFontWeightSettings) : {}
 
   if (Object.hasOwn(legacySettings, 'terminalFontWeightBold')) {
+    const fontWeightBold = normalizeTerminalFontWeightBold(legacySettings.terminalFontWeightBold)
     return {
-      fontWeightBold: normalizeTerminalFontWeightBold(legacySettings.terminalFontWeightBold),
-      needsSave: false
+      fontWeightBold,
+      needsSave: legacySettings.terminalFontWeightBold !== fontWeightBold
     }
   }
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -181,6 +181,11 @@ import {
   normalizeRuntimePathForComparison
 } from '../shared/cross-platform-path'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
+import {
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  legacyDerivedTerminalFontWeightBold,
+  normalizeTerminalFontWeightBold
+} from '../shared/terminal-fonts'
 import { normalizeTaskProviderSettings } from '../shared/task-providers'
 import { normalizeAutoRenameBranchFromWorkDefaultOn } from '../shared/auto-rename-branch-from-work-settings'
 import {
@@ -661,6 +666,11 @@ type LegacyTerminalScrollbackSettings = {
   terminalScrollbackBytes?: unknown
 }
 
+type LegacyTerminalFontWeightSettings = {
+  terminalFontWeight?: number | null
+  terminalFontWeightBold?: number | null
+}
+
 type RetiredGlobalSettings = {
   terminalScrollbackBytes?: unknown
   enableGitHubAttribution?: unknown
@@ -701,6 +711,31 @@ function migrateTerminalScrollbackRows(settings: unknown): {
   return {
     rows,
     needsSave: !hasRows || hasLegacyBytes || legacySettings.terminalScrollbackRows !== rows
+  }
+}
+
+// Why (STA-4236): #14368 split bold out of terminalFontWeight. Profiles saved before it have no
+// bold value, and the 700 default renders lighter than a regular weight of 800 or 900. Carry the
+// weight those profiles were already rendering forward once.
+function migrateTerminalFontWeightBold(settings: unknown): {
+  fontWeightBold: number
+  needsSave: boolean
+} {
+  const legacySettings =
+    settings && typeof settings === 'object' ? (settings as LegacyTerminalFontWeightSettings) : {}
+
+  if (Object.hasOwn(legacySettings, 'terminalFontWeightBold')) {
+    return {
+      fontWeightBold: normalizeTerminalFontWeightBold(legacySettings.terminalFontWeightBold),
+      needsSave: false
+    }
+  }
+
+  return {
+    fontWeightBold: Object.hasOwn(legacySettings, 'terminalFontWeight')
+      ? legacyDerivedTerminalFontWeightBold(legacySettings.terminalFontWeight)
+      : DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+    needsSave: true
   }
 }
 
@@ -3252,6 +3287,10 @@ export class Store {
         if (migratedTerminalTuiScrollSensitivity.needsSave) {
           this.loadNeedsSave = true
         }
+        const migratedTerminalFontWeightBold = migrateTerminalFontWeightBold(parsed.settings)
+        if (migratedTerminalFontWeightBold.needsSave) {
+          this.loadNeedsSave = true
+        }
         const rawSourceControlAi = parsed.settings?.sourceControlAi
         const rawSourceControlAiMissing = rawSourceControlAi === undefined
         const rawSourceControlAiActionsMissing =
@@ -3550,6 +3589,7 @@ export class Store {
                 : defaults.settings.terminalRightClickToPaste,
             terminalRightClickToPasteDefaultedForPlatform: true,
             ...migratedTerminalTuiScrollSensitivity.settings,
+            terminalFontWeightBold: migratedTerminalFontWeightBold.fontWeightBold,
             experimentalActivity: migratedExperimentalActivity,
             experimentalActivityDefaultedOffForAllUsers: true,
             // Why: compact worktree cards graduated from Experimental; preserve the old opt-in for rollout-era profiles.

--- a/src/shared/terminal-fonts.test.ts
+++ b/src/shared/terminal-fonts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_TERMINAL_FONT_WEIGHT,
   DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  legacyDerivedTerminalFontWeightBold,
   resolveTerminalFontWeights,
   normalizeTerminalFontWeight,
   normalizeTerminalFontWeightBold
@@ -25,6 +26,16 @@ describe('terminal font weights', () => {
       fontWeight: 500,
       fontWeightBold: 700
     })
+  })
+
+  it('reproduces the pre-split derivation for migrating old profiles', () => {
+    expect(legacyDerivedTerminalFontWeightBold(undefined)).toBe(700)
+    expect(legacyDerivedTerminalFontWeightBold(300)).toBe(700)
+    expect(legacyDerivedTerminalFontWeightBold(500)).toBe(700)
+    expect(legacyDerivedTerminalFontWeightBold(600)).toBe(800)
+    expect(legacyDerivedTerminalFontWeightBold(700)).toBe(900)
+    expect(legacyDerivedTerminalFontWeightBold(800)).toBe(900)
+    expect(legacyDerivedTerminalFontWeightBold(900)).toBe(900)
   })
 
   it('does not derive bold from the base weight', () => {

--- a/src/shared/terminal-fonts.ts
+++ b/src/shared/terminal-fonts.ts
@@ -25,6 +25,15 @@ export function normalizeTerminalFontWeightBold(fontWeight: number | null | unde
   return normalizeWeight(fontWeight, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD)
 }
 
+// The pre-#14368 derivation. Kept only so profiles saved before bold became its own setting
+// migrate to the weight they were already rendering, instead of dropping to the 700 default.
+export function legacyDerivedTerminalFontWeightBold(fontWeight: number | null | undefined): number {
+  return Math.min(
+    TERMINAL_FONT_WEIGHT_MAX,
+    Math.max(DEFAULT_TERMINAL_FONT_WEIGHT_BOLD, normalizeTerminalFontWeight(fontWeight) + 200)
+  )
+}
+
 // Numeric weight gaps do not guarantee distinct font faces, so bold stays independently configurable.
 export function resolveTerminalFontWeights(
   fontWeight: number | null | undefined,


### PR DESCRIPTION
## ELI5

There used to be one Font Weight slider, and Orca worked bold out from it by adding 200. #14368 split bold into its own slider — but nobody told the profiles that were already saved. They arrive with no bold value, so they get the new 700 default. If you had turned the slider up to 800 or 900, your *bold* is now **lighter than your normal text** until you notice and fix it yourself.

This carries those saved profiles forward to the weight they were already rendering.

## What Changed

One-shot migration in `Store.load()`. A persisted profile that has `terminalFontWeight` but no `terminalFontWeightBold` gets the old derived value instead of the default:

```
600 -> 800    700 -> 900    800 -> 900    900 -> 900
100-500 -> 700  (unchanged; the old formula already floored at 700)
```

The formula is the exact pre-#14368 one, lifted out of `resolveTerminalFontWeights` into `legacyDerivedTerminalFontWeightBold` in `src/shared/terminal-fonts.ts` so it is named, pinned by a test, and obviously historical rather than re-derived by hand:

```ts
Math.min(900, Math.max(700, normalizeTerminalFontWeight(fontWeight) + 200))
```

A profile that already carries an explicit `terminalFontWeightBold` is never touched — including one deliberately set lighter than regular. Only the absent field is filled.

## Why

A missing field taking a default is normally fine. It is not fine here, because the field was never absent by choice: every pre-#14368 profile has an *implied* bold weight that the app was rendering, and defaulting throws it away. For four of the nine slider positions the replacement is strictly worse than what the old code produced — it inverts the pair.

Migration, not read-time defaulting, because read-time cannot tell "user has never had a bold setting" from "user chose 700." Once the field is stamped, later reads are unambiguous. That matches how `terminalScrollbackRows`, `terminalTuiScrollSensitivity`, and `terminalMacOptionAsAlt` are handled in `persistence.ts` — resolve on load, set `loadNeedsSave`, stamp the field.

Note this restores the *stored* value, not a claim about faces: #14368 established that on a two-face family (Menlo) 700/800/900 all paint the same face, so on the default macOS chain 800/900 and 800/700 look alike. The defect this fixes is that the setting itself is now inverted — which is visible in the Settings panel on every platform, and visible in the terminal on any family with more than two faces.

## Linked Issue

Fixes https://linear.app/stably/issue/STA-4236

Regression from #14368 (which fixed STA-4071). #14368's compatibility note said "the new setting is absent from existing profiles, so the 700 default applies" — correct for 100–500, but it does not hold for 600+, which is what this PR closes.

## Visual Proof

N/A for a before/after image, and the reason matters:

- There is **no UI change** in this PR. No component, string, or layout is touched — only the number a pre-#14368 profile loads with.
- The surface where the difference is visible is Settings → Appearance → Terminal Typography → Advanced. Before: `Font Weight 800`, `Bold Font Weight 700`. After: `Font Weight 800`, `Bold Font Weight 900`. That is a slider position, and it is asserted end-to-end through the real `Store` in `persistence.test.ts` rather than photographed.
- Rendered terminal text is deliberately **not** offered as proof: on the default macOS family both pairs resolve to the same face (measured in #14368), so a screenshot there would show no difference and would misrepresent the fix.

## Testing

`src/main/persistence.test.ts` — real `Store` over a written data file, so the assertion covers the whole load path, not the migration function in isolation:

- Parameterized over the four broken positions (600/700/800/900), asserting both the exact migrated value and the invariant that matters — bold is never lighter than regular. **Verified RED:** removing only the wiring line makes all four fail with `expected 700 to be 800/900`.
- A 300-weight profile still lands on 700 (no gratuitous change for light profiles).
- A profile with `terminalFontWeightBold: 400` explicitly set under a regular weight of 800 keeps 400 — the migration does not overrule a user choice.
- Migrated value is asserted after `flush()` against the re-read file, so it is persisted, not just computed.

`src/shared/terminal-fonts.test.ts` pins the recovered formula across all nine positions.

Checks run on macOS: `vitest run --config config/vitest.config.ts` over `src/main/persistence.test.ts src/shared src/renderer/src/components/{settings,terminal-pane,dashboard-popout}` — 9784 passed / 19 skipped, 903 files. `pnpm typecheck` clean. All three changed-code oxlint scans (code quality, type-aware, React Doctor) clean on the four changed files. `oxfmt --check` clean. `check:max-lines-ratchet` clean — no suppression added or bumped.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Backwards compatibility:** the whole point. Runs once — after it stamps the field, `Object.hasOwn` short-circuits and the value is never recomputed, so a user who later lowers bold below regular keeps that choice permanently. Downgrading to a pre-#14368 build is also safe: the older code ignores `terminalFontWeightBold` entirely and re-derives from `terminalFontWeight`, which this PR does not modify.
- **Cross-platform:** pure arithmetic over persisted numbers, no path or platform branch. Identical on macOS, Linux, Windows.
- **Remote SSH:** no wire surface. `terminalFontWeightBold` is a local renderer appearance setting resolved in the client's own `Store`; nothing is exchanged with a remote host, so no capability negotiation applies.
- **Mobile:** `mobile/src/terminal/terminal-webview-html.ts` hardcodes `fontWeightBold: '500'` and does not read this setting. Untouched.
- **Folder workspaces / worktrees:** global settings, not per-workspace. No workspace-shape assumption.
- **Security:** no new input surface. Values are clamped to 100–900 by the existing normalizer, so a hand-edited or corrupt `terminalFontWeight` cannot produce an out-of-range bold.
- **Performance:** one `Object.hasOwn` pair and two comparisons, once per app load.

## Related open PR

#14175 ("keep bold distinct when font weight is 600+") is an alternative fix for STA-4071 — a face-probing resolver — and is currently CONFLICTING. It was superseded by #14368, which shipped the independent-setting approach instead. This PR does not overlap it: #14175 rewrites `resolveTerminalFontWeights` in the renderer, this one adds a load-time migration in `persistence.ts` and leaves the resolver alone. #14175 should be closed on its own merits, not by this PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
