### PR TITLE
perf(orchestration): cancel redundant mail repair after immediate delivery (STA-4235)

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -34638,6 +34638,90 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('retires the bounded repair once the immediate push points every pending row', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const db = new InMemoryOrchestrationMessages()
+      const write = vi.fn().mockReturnValue(true)
+      setInMemoryOrchestrationMessages(runtime, db)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+      // Why: let the restore scan settle on an empty mailbox so only the arrival path is measured.
+      await vi.advanceTimersByTimeAsync(0)
+      db.insertMessage({ from: 'term_worker', to: terminal.handle, subject: 'pointed on arrival' })
+
+      const readPending = vi.spyOn(db, 'getUndeliveredUnreadMessages')
+      runtime.notifyMessageArrived(terminal.handle, 'status')
+      await Promise.resolve()
+      expect(write).toHaveBeenCalledWith(
+        'pty-1',
+        expect.stringContaining('You have 1 orchestration message')
+      )
+
+      const readsAfterImmediatePush = readPending.mock.calls.length
+      await vi.advanceTimersByTimeAsync(2_500)
+      expect(readPending.mock.calls.length).toBe(readsAfterImmediatePush)
+      db.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('spreads restored repairs instead of scanning and firing them on one deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const db = new InMemoryOrchestrationMessages()
+      // Why write=false: a landed pointer arms a delivery flight that parks the next handle's
+      // repair, which would hide whether the repairs were actually spread.
+      const write = vi.fn().mockReturnValue(false)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+      const runIds = ['run_restored_a', 'run_restored_b', 'run_restored_c']
+      for (const id of runIds) {
+        db.setRun({ id, coordinator_handle: terminal.handle })
+        db.insertMessage({ from: 'term_worker', to: `run:${id}`, subject: `pending ${id}` })
+      }
+
+      const scanMailboxes = vi.spyOn(db, 'getUndeliveredUnreadMailboxHandles')
+      const readPending = vi.spyOn(db, 'getUndeliveredUnreadMessages')
+      setInMemoryOrchestrationMessages(runtime, db)
+      expect(scanMailboxes).not.toHaveBeenCalled()
+
+      const repairedHandles = (): string[] =>
+        readPending.mock.calls
+          .map(([handle]) => handle)
+          .filter((handle) => handle.startsWith('run:'))
+
+      await vi.advanceTimersByTimeAsync(2_000)
+      expect(scanMailboxes).toHaveBeenCalledTimes(1)
+      expect(repairedHandles()).toEqual(['run:run_restored_a'])
+
+      await vi.advanceTimersByTimeAsync(600)
+      expect(repairedHandles()).toEqual(runIds.map((id) => `run:${id}`))
+      db.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('stops a pending repoint after its database closes', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -34638,7 +34638,7 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('retires the bounded repair once the immediate push points every pending row', async () => {
+  it('does not re-arm repair when immediate delivery precedes the deferred restore scan', async () => {
     vi.useFakeTimers()
     try {
       const runtime = new OrcaRuntimeService(store)
@@ -34655,10 +34655,9 @@ describe('OrcaRuntimeService', () => {
       const [terminal] = (await runtime.listTerminals()).terminals
       runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07', 100)
       runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
-      // Why: let the restore scan settle on an empty mailbox so only the arrival path is measured.
-      await vi.advanceTimersByTimeAsync(0)
       db.insertMessage({ from: 'term_worker', to: terminal.handle, subject: 'pointed on arrival' })
 
+      const scanMailboxes = vi.spyOn(db, 'getUndeliveredUnreadMailboxHandles')
       const readPending = vi.spyOn(db, 'getUndeliveredUnreadMessages')
       runtime.notifyMessageArrived(terminal.handle, 'status')
       await Promise.resolve()
@@ -34669,6 +34668,7 @@ describe('OrcaRuntimeService', () => {
 
       const readsAfterImmediatePush = readPending.mock.calls.length
       await vi.advanceTimersByTimeAsync(2_500)
+      expect(scanMailboxes).toHaveBeenCalledTimes(1)
       expect(readPending.mock.calls.length).toBe(readsAfterImmediatePush)
       db.close()
     } finally {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2854,6 +2854,7 @@ export class OrcaRuntimeService {
     this.repointPendingMessagesForHandle(handle)
   )
   private restoredMessageRepointScanTimer: ReturnType<typeof setTimeout> | null = null
+  private restoredMessageRepointScanRetiredHandles: Set<string> | null = null
   private syntheticTerminalHandles = new Set<string>()
   private detachedPreAllocatedLeaves = new Map<string, RuntimeLeafRecord>()
   private graphSyncCallbacks: (() => void)[] = []
@@ -32101,15 +32102,18 @@ export class OrcaRuntimeService {
       clearTimeout(this.restoredMessageRepointScanTimer)
     }
     const db = this._orchestrationDb
+    const retiredHandles = new Set<string>()
+    this.restoredMessageRepointScanRetiredHandles = retiredHandles
     const timer = setTimeout(() => {
       this.restoredMessageRepointScanTimer = null
+      this.restoredMessageRepointScanRetiredHandles = null
       if (this._orchestrationDb !== db) {
         return
       }
       try {
         this.mailPointerRepointScheduler.scheduleStaggered(
           (db?.getUndeliveredUnreadMailboxHandles?.() ?? []).filter(
-            (handle) => !handle.startsWith('dispatch:')
+            (handle) => !handle.startsWith('dispatch:') && !retiredHandles.has(handle)
           )
         )
       } catch {
@@ -32118,6 +32122,11 @@ export class OrcaRuntimeService {
     }, 0)
     timer.unref?.()
     this.restoredMessageRepointScanTimer = timer
+  }
+
+  private retireMessageRepoint(handle: string): void {
+    this.mailPointerRepointScheduler.cancel(handle)
+    this.restoredMessageRepointScanRetiredHandles?.add(handle)
   }
 
   private repointPendingMessagesForHandle(handle: string): void {
@@ -32889,7 +32898,7 @@ export class OrcaRuntimeService {
     const coversEveryPendingRow = unread.length === pending.length
     if (unread.length === 0) {
       if (pending.length === 0) {
-        this.mailPointerRepointScheduler.cancel(mailboxHandle)
+        this.retireMessageRepoint(mailboxHandle)
       }
       return
     }
@@ -32990,7 +32999,7 @@ export class OrcaRuntimeService {
       }
       this.pointedMessageIdsByHandle.set(mailboxHandle, pointedIdsAfterWrite)
       if (coversEveryPendingRow) {
-        this.mailPointerRepointScheduler.cancel(mailboxHandle)
+        this.retireMessageRepoint(mailboxHandle)
       }
 
       const tabTitle = this.tabs.get(leaf.tabId)?.title

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2853,6 +2853,7 @@ export class OrcaRuntimeService {
   private readonly mailPointerRepointScheduler = new MailPointerRepointScheduler((handle) =>
     this.repointPendingMessagesForHandle(handle)
   )
+  private restoredMessageRepointScanTimer: ReturnType<typeof setTimeout> | null = null
   private syntheticTerminalHandles = new Set<string>()
   private detachedPreAllocatedLeaves = new Map<string, RuntimeLeafRecord>()
   private graphSyncCallbacks: (() => void)[] = []
@@ -32093,13 +32094,30 @@ export class OrcaRuntimeService {
     }
   }
 
+  // Why deferred: the pending-mailbox scan reads the whole message table, and running it inline
+  // makes the first orchestration-db access on startup pay for it.
   private scheduleRestoredMessageRepoints(): void {
-    const handles = this._orchestrationDb?.getUndeliveredUnreadMailboxHandles?.() ?? []
-    for (const handle of handles) {
-      if (!handle.startsWith('dispatch:')) {
-        this.mailPointerRepointScheduler.schedule(handle)
-      }
+    if (this.restoredMessageRepointScanTimer) {
+      clearTimeout(this.restoredMessageRepointScanTimer)
     }
+    const db = this._orchestrationDb
+    const timer = setTimeout(() => {
+      this.restoredMessageRepointScanTimer = null
+      if (this._orchestrationDb !== db) {
+        return
+      }
+      try {
+        this.mailPointerRepointScheduler.scheduleStaggered(
+          (db?.getUndeliveredUnreadMailboxHandles?.() ?? []).filter(
+            (handle) => !handle.startsWith('dispatch:')
+          )
+        )
+      } catch {
+        // A runtime- or test-owned database can close before this deferred scan runs.
+      }
+    }, 0)
+    timer.unref?.()
+    this.restoredMessageRepointScanTimer = timer
   }
 
   private repointPendingMessagesForHandle(handle: string): void {
@@ -32866,7 +32884,13 @@ export class OrcaRuntimeService {
         !options.reservedTypes?.has(message.type) &&
         !messageTypeHasLiveWaiter(waiters, message.type)
     )
+    // Why: rows withheld for a waiter still need the repair if that waiter wakes without
+    // consuming them, so only a batch covering every pending row retires the retry.
+    const coversEveryPendingRow = unread.length === pending.length
     if (unread.length === 0) {
+      if (pending.length === 0) {
+        this.mailPointerRepointScheduler.cancel(mailboxHandle)
+      }
       return
     }
 
@@ -32965,6 +32989,9 @@ export class OrcaRuntimeService {
         pointedIdsAfterWrite.add(message.id)
       }
       this.pointedMessageIdsByHandle.set(mailboxHandle, pointedIdsAfterWrite)
+      if (coversEveryPendingRow) {
+        this.mailPointerRepointScheduler.cancel(mailboxHandle)
+      }
 
       const tabTitle = this.tabs.get(leaf.tabId)?.title
       if (isCursorAgentOrchestrationTarget(leaf, tabTitle)) {

--- a/src/main/runtime/orchestration/mail-pointer-repoint-scheduler.ts
+++ b/src/main/runtime/orchestration/mail-pointer-repoint-scheduler.ts
@@ -1,11 +1,15 @@
 const MAIL_POINTER_REPOINT_DELAY_MS = 2_000
+// Why: restore can hold dozens of pending mailboxes, and one shared deadline collapses their
+// SQLite reads into a single tick. Spread them across a bounded window instead.
+const MAIL_POINTER_REPOINT_RESTORE_WINDOW_MS = 15_000
+const MAIL_POINTER_REPOINT_RESTORE_STEP_MS = 250
 
 export class MailPointerRepointScheduler {
   private readonly timersByHandle = new Map<string, ReturnType<typeof setTimeout>>()
 
   constructor(private readonly repoint: (handle: string) => void) {}
 
-  schedule(handle: string): void {
+  schedule(handle: string, delayMs: number = MAIL_POINTER_REPOINT_DELAY_MS): void {
     if (this.timersByHandle.has(handle)) {
       return
     }
@@ -15,9 +19,32 @@ export class MailPointerRepointScheduler {
       }
       this.timersByHandle.delete(handle)
       this.repoint(handle)
-    }, MAIL_POINTER_REPOINT_DELAY_MS)
+    }, delayMs)
     timer.unref?.()
     this.timersByHandle.set(handle, timer)
+  }
+
+  scheduleStaggered(handles: readonly string[]): void {
+    const step =
+      handles.length > 1
+        ? Math.min(
+            MAIL_POINTER_REPOINT_RESTORE_STEP_MS,
+            MAIL_POINTER_REPOINT_RESTORE_WINDOW_MS / (handles.length - 1)
+          )
+        : 0
+    handles.forEach((handle, index) => {
+      this.schedule(handle, MAIL_POINTER_REPOINT_DELAY_MS + index * step)
+    })
+  }
+
+  // Why: the repair only covers a pointer that never landed, so a definitive delivery retires it.
+  cancel(handle: string): void {
+    const timer = this.timersByHandle.get(handle)
+    if (!timer) {
+      return
+    }
+    clearTimeout(timer)
+    this.timersByHandle.delete(handle)
   }
 
   clear(): void {


### PR DESCRIPTION
## ELI5

When a message arrives for an agent, Orca points the agent at it right away. It *also* sets a two-second alarm to try again in case the first attempt silently failed. The bug: the alarm was never turned off after the first attempt succeeded, so every normal message paid for a pointless timer and an extra database read two seconds later. On restore it was worse — Orca looked up every waiting mailbox all at once and set all their alarms to ring on the exact same second.

This turns the alarm off once delivery is definitely done, and spreads the restore alarms out.

## What Changed

**`mail-pointer-repoint-scheduler.ts`**
- `schedule(handle, delayMs?)` — the delay is now a parameter (default unchanged at 2s).
- New `cancel(handle)` — retires a single handle's repair without touching the others.
- New `scheduleStaggered(handles)` — spreads restored repairs across a bounded 15s window (250ms step, compressed if there are many handles) instead of one shared deadline.

**`orca-runtime.ts`**
- `deliverPendingMessages` cancels the handle's repair when delivery is definitive: either the mailbox has no pending rows at all, or the pointer write landed and covered *every* pending row (`coversEveryPendingRow`).
- `scheduleRestoredMessageRepoints` now defers the pending-mailbox scan off the orchestration-db getter and hands the result to `scheduleStaggered`. The deferred scan is guarded by a db-identity check and a try/catch so a superseded or closed database can't fire it.

Delivery semantics are unchanged — this only removes work that was provably a no-op.

## Why

Regression from #14332, which added the bounded mail-pointer repair. The repair is the right idea, but it was armed unconditionally in `notifyMessageArrived` and never retired:

1. **Per-message.** Every non-`dispatch:` message armed a 2s timer. When the immediate push succeeded, the timer still fired, re-read the mailbox from SQLite, hit the watermark short-circuit, and returned having done nothing. Deterministic extra timer + query on every normal message.
2. **Restore herd.** `scheduleRestoredMessageRepoints` ran a full-table `SELECT DISTINCT` inline on the first orchestration-db access, then put a repair for *every* pending mailbox on the same 2s deadline — N synchronous SQLite reads collapsed into one tick at startup.

**Why cancel only on `coversEveryPendingRow`, not on any successful write:** the push filters out rows reserved by a live waiter. If that waiter wakes without consuming them (#14332's `repoints worker_done when a stale waiter wakes without consuming it`), the repair is exactly what recovers them. Cancelling on any write would drop a repair that is still needed, so only a batch covering the full pending set retires it.

**Why cancelling is safe for the covered case:** after a landed write, `lastPointedMessageSequenceByHandle` and `pointedMessageIdsByHandle` are both updated, so a subsequent repair hits the watermark short-circuit and returns without re-writing. The cancelled work was already a guaranteed no-op. Anything that genuinely needs a repair re-arms it: a new message (`notifyMessageArrived`), a pty death (`retirePendingMessageDeliveryForPty`), or a db swap (`setOrchestrationDb`).

## Linked Issue

[STA-4235](https://linear.app/stably/issue/STA-4235) — mail repair schedules redundant delayed mailbox queries (P2). Fixes a regression from #14332.

## Visual Proof

`N/A` — no UI surface. This is main-process timer/query scheduling; the only observable difference is less background work for identical delivery behavior.

## Testing

Two new tests in `src/main/runtime/orca-runtime.test.ts`, both verified to **fail on the pre-fix source** (stashed the two source files, kept the tests) and pass with it:

1. **`retires the bounded repair once the immediate push points every pending row`** — spies on `getUndeliveredUnreadMessages`, delivers a message through the arrival path, then advances 2.5s and asserts the query count did not grow.
   - Pre-fix: `AssertionError: expected 2 to be 1` — the redundant delayed query.
2. **`spreads restored repairs instead of scanning and firing them on one deadline`** — three restored run mailboxes; asserts the mailbox scan is not called synchronously by `setOrchestrationDb`, that only the first repair has run at t=2000ms, and that all three have run by t=2600ms.
   - Pre-fix, on the synchronous scan: `expected "getUndeliveredUnreadMailboxHandles" to not be called at all, but actually been called 1 times`.
   - Pre-fix, with that assertion relaxed to isolate the herd: `expected [ 'run:run_restored_a', 'run:run_restored_b', 'run:run_restored_c' ] to deeply equal [ 'run:run_restored_a' ]` — all three fired on the same deadline.

Suites run (`pnpm vitest run --config config/vitest.config.ts`):
- `src/main/runtime/orca-runtime.test.ts` — 1104 passed, 1 skipped. Includes all four of #14332's own repair tests (stale-waiter repair, retry edge, restore repoint, db-close), which still pass unchanged.
- `src/main/runtime/orchestration/` — 37 files, 335 passed.
- Broad sweep of `src/main/runtime/`, the two orchestration SSH suites, and `tests/e2e/completed-worker-retirement-resume.unit.test.ts` — 4085 passed. Two files failed only under parallel load (`orchestration-creator-authority-performance` at 218ms vs a 200ms budget, and an 800-trial fuzz hitting the 30s cap); both pass in isolation, and I confirmed the perf test behaves identically with the fix stashed — neither file touches the changed code paths.

Also clean: `typecheck:node`, `oxlint`, `oxlint --config config/oxlint-code-quality-native-plugins.json --deny-warnings`, `oxlint --type-aware --config config/oxlint-code-quality-type-aware.json --deny-warnings`, `check:max-lines-ratchet` (no new suppressions), and `oxfmt --write`.

Platform: developed and tested on macOS. No platform-specific code paths — no shell, path, keyboard, or Git-binary surface is touched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security:** none — no new inputs, no IPC/RPC surface, no persistence change.
- **Cross-platform (Linux / Windows / macOS):** `setTimeout`/`clearTimeout` and `unref?.()` only; no paths, shells, or accelerators.
- **Remote SSH:** none — this is main-process scheduling around a local SQLite mailbox. No RPC params, stream frames, or published content changed, so no wire-compatibility concern per `docs/reference/remote-wire-compatibility.md`. Behavior is identical for local, SSH, and folder workspaces since none of it is worktree- or host-shaped.
- **Mobile:** unaffected; delivery semantics are unchanged, and mobile consumes the same mailbox through the same path.
- **Backwards compatibility:** no schema, wire, or API change. `schedule()`'s new second parameter is optional and defaults to the previous constant.
- **Performance:** the point of the PR — removes one timer and one SQLite read per delivered message, drops a full-table scan off the startup path, and un-stacks the restore herd.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
