### PR TITLE
test(terminal): pin the wrapper security properties that survived mutation

### DIFF
--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -705,6 +705,22 @@ describe('legacy terminal shim neutralization', () => {
     expect(posixEnv).toEqual({ PATH: '' })
   })
 
+  it('strips legacy shim entries that carry a trailing separator', () => {
+    // Why: without normalizing the trailing separator the entry does not match, so Orca's own
+    // scrub leaves the legacy shim directory on the spawned PATH and the wrapper stays reachable.
+    const posix: Record<string, string> = {
+      PATH: '/home/u/.orca/orca-terminal-attribution/posix/:/usr/bin'
+    }
+    stripLegacyTerminalShimEnv(posix, 'linux')
+    expect(posix.PATH).toBe('/usr/bin')
+
+    const win: Record<string, string> = {
+      Path: 'C:\\Users\\u\\orca-terminal-attribution\\win32\\;C:\\Windows'
+    }
+    stripLegacyTerminalShimEnv(win, 'win32')
+    expect(win.Path).toBe('C:\\Windows')
+  })
+
   it('keeps neighbouring directories that merely share the name prefix', () => {
     const env: Record<string, string> = {
       PATH: '/opt/orca-terminal-attribution:/opt/orca-terminal-attribution/custom-tools:/home/u/orca-terminal-attribution-notes/bin:/usr/bin'

--- a/src/main/pty/legacy-terminal-shim-dir.test.ts
+++ b/src/main/pty/legacy-terminal-shim-dir.test.ts
@@ -147,7 +147,23 @@ describe('legacy terminal shim neutralization', () => {
       // Why: the rooted check must reject drive-relative 'C:foo', which still resolves against
       // the cwd — so the IsPathRooted call must be gone, replaced by an explicit prefix match.
       expect(powershell).not.toContain('[IO.Path]::IsPathRooted(')
-      expect(powershell).toContain("-notmatch '^([A-Za-z]:")
+      // Why the full pattern, not a prefix: `^([A-Za-z]:|\\\\)` also starts with this and would
+      // accept drive-relative `C:foo`, which still resolves against the cwd on that drive.
+      expect(powershell).toContain("-notmatch '^([A-Za-z]:[\\\\/]|\\\\\\\\)'")
+      // Why: trailing-separator normalization is what makes wrapper self-exclusion work; every
+      // one of these survived mutation with the suite green.
+      expect(powershell).toContain("ForEach-Object { $_.TrimEnd('\\') }")
+      expect(powershell).toContain("$pathEntry.TrimEnd('\\')")
+      expect(powershell).toContain("$dir.TrimEnd('\\')")
+      expect(powershell).toContain("$capturedDir.TrimEnd('\\')")
+      // Why: the fallback loop must skip wrapper dirs, or the wrapper can resolve to itself.
+      expect(powershell).toContain(
+        "$dir.TrimEnd('\\'), [StringComparison]::OrdinalIgnoreCase) }) { continue }"
+      )
+      // Why: `C:/Program Files/Git/cmd` style entries are legitimate and must stay accepted.
+      expect(cmd).toContain('if "%orca_candidate:~1,2%"==":/" goto orca_candidate_rooted')
+      // Why: the legacy-dir compare needs the same trailing-separator strip as its twins.
+      expect(cmd).toContain('if "%orca_legacy_norm:~-1%"=="%orca_sep%"')
       expect(powershell).toContain('if (-not $dir) { continue }')
       expect(powershell).toContain('Test-Path -LiteralPath $candidate -PathType Leaf')
     }
@@ -315,6 +331,38 @@ describe('legacy terminal shim neutralization', () => {
     // dirname left the substitution empty and cd into it silently made wrapper_dir the cwd.
     expect(wrapper).not.toMatch(/\$\(dirname\b/)
     expect(wrapper).toContain('CDPATH= cd -P --')
+  })
+
+  itOnPosix('rejects a distinct legacy shim directory named by the environment', () => {
+    // Why: ORCA_ATTRIBUTION_SHIM_DIR can name a *different* directory than the wrapper's own (an
+    // older install's dir inherited by a pre-upgrade pane). Nothing exercised that reject, so
+    // neutering it left the suite green.
+    const userData = makeUserDataDir()
+    const posixDir = join(userData, 'orca-terminal-attribution', 'posix')
+    const legacyDir = join(userData, 'legacy-shim')
+    const realBin = join(userData, 'real-bin')
+    for (const dir of [posixDir, legacyDir, realBin]) {
+      mkdirSync(dir, { recursive: true })
+    }
+    writeFileSync(join(posixDir, 'git'), 'legacy attribution wrapper')
+
+    neutralizeLegacyTerminalShimDir(userData)
+
+    writeFileSync(join(legacyDir, 'git'), "#!/bin/bash\nprintf 'HOSTILE\\n'\n", { mode: 0o755 })
+    writeFileSync(join(realBin, 'git'), "#!/bin/bash\nprintf 'REAL\\n'\n", { mode: 0o755 })
+
+    const run = spawnSync(join(posixDir, 'git'), ['--version'], {
+      env: {
+        ...process.env,
+        ORCA_ATTRIBUTION_SHIM_DIR: legacyDir,
+        PATH: `${legacyDir}:${realBin}:/usr/bin:/bin`
+      },
+      encoding: 'utf8',
+      timeout: 20_000
+    })
+
+    expect(run.stdout).toContain('REAL')
+    expect(run.stdout).not.toContain('HOSTILE')
   })
 
   itOnPosix('does not let the cwd supply the script interpreter', async () => {


### PR DESCRIPTION
## ELI5

Test-only change. Round 6 found **no new defects in the wrappers**, but its mutation campaign showed seven security properties were still unpinned — a refactor could silently reopen a cwd hijack with the suite green. This closes all of them.

## The one that mattered most

The PowerShell drive-relative check was pinned as:

```js
expect(powershell).toContain("-notmatch '^([A-Za-z]:")
```

That prefix matches the **insecure** regex too. Weakening `^([A-Za-z]:[\\/]|\\\\)` to `^([A-Za-z]:|\\\\)` re-accepts drive-relative `C:foo` — which still resolves against the cwd on that drive — and every test stayed green.

That is the same "passes for the wrong reason" class an earlier round flagged, in a pin I had written *to fix* that class. Now asserts the full pattern.

## Also pinned

- All four PowerShell `TrimEnd('\')` sites — trailing-separator self-exclusion had zero coverage
- The fallback loop's wrapper-dir skip
- The cmd legacy-dir trailing-separator strip (its two twins were pinned; this one was not)
- `C:/`-style drive-with-forward-slash acceptance, so legitimate `C:/Program Files/Git/cmd` entries keep working
- A behavioural test for the POSIX legacy-dir reject, where `ORCA_ATTRIBUTION_SHIM_DIR` names a *different* directory containing a hostile `git` — neutering that reject previously left the suite green

## Verification

Every pin is mutation-verified: revert the property, confirm the suite fails, restore. All eight targeted mutations now **KILLED**.

Worth recording: my first mutation harness reported four false survivors because its shell-nested escaping silently no-op'd the replacement. I caught it by diffing the file to confirm the mutation actually applied, then re-ran with a harness that fails loudly when the target string is absent. A mutation run that cannot prove it changed the file proves nothing.

- `pnpm typecheck`, `pnpm lint`: pass, no `max-lines` suppression
- Full suite: **51,927 passed**; 2 failures, both pre-existing and reproducible on `origin/main`
