### PR TITLE
test(release): block Cut Release on #14302 terminal goldens

### DIFF
--- a/.github/workflows/golden-e2e-experiment.yml
+++ b/.github/workflows/golden-e2e-experiment.yml
@@ -68,9 +68,7 @@ jobs:
         run: |
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden
-          if [ -f tests/e2e/golden-fresh-profile-terminal.spec.ts ]; then
-            xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts
-          fi
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:fresh-terminal-golden
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:agent-tui-golden
@@ -81,9 +79,7 @@ jobs:
         run: |
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden
-          if [ -f tests/e2e/golden-fresh-profile-terminal.spec.ts ]; then
-            env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts
-          fi
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:fresh-terminal-golden
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:agent-tui-golden
@@ -97,9 +93,7 @@ jobs:
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
           pnpm run --if-present test:e2e:workspace-session-golden
           pnpm run --if-present test:e2e:windows-fresh-startup-golden
-          if (Test-Path tests/e2e/golden-fresh-profile-terminal.spec.ts) {
-            pnpm run test:e2e -- tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts
-          }
+          pnpm run --if-present test:e2e:fresh-terminal-golden
           pnpm run --if-present test:e2e:source-control-golden
 
       - name: Upload Playwright traces

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -879,6 +879,7 @@ jobs:
         run: |
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:fresh-terminal-golden
           xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
       - name: Run source-control golden on Linux
@@ -890,6 +891,7 @@ jobs:
         run: |
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:fresh-terminal-golden
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
 
       - name: Run agent TUI golden on Linux
@@ -911,8 +913,13 @@ jobs:
           $env:SKIP_BUILD = '1'
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
           pnpm run --if-present test:e2e:workspace-session-golden
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           pnpm run --if-present test:e2e:windows-fresh-startup-golden
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          pnpm run --if-present test:e2e:fresh-terminal-golden
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           pnpm run --if-present test:e2e:source-control-golden
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload Playwright traces
         if: failure()

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -79,6 +79,7 @@ describe('Electron runtime package contract', () => {
       'build:mac:release',
       'build:linux',
       'test:e2e',
+      'test:e2e:fresh-terminal-golden',
       'test:e2e:terminal-rendering-golden',
       'test:e2e:posix-profile-index-golden',
       'test:e2e:terminal-rendering-release-evidence',
@@ -529,6 +530,12 @@ describe('Electron runtime package contract', () => {
     expect(packageScripts['test:e2e:terminal-rendering-golden']).toContain(
       '@terminal-rendering-golden'
     )
+    expect(packageScripts['test:e2e:fresh-terminal-golden']).toContain(
+      'golden-fresh-profile-terminal.spec.ts'
+    )
+    expect(packageScripts['test:e2e:fresh-terminal-golden']).toContain(
+      'golden-shell-command.spec.ts'
+    )
     expect(packageScripts['test:e2e:terminal-rendering-golden']).toContain(
       'terminal-raw-emoji-table-scroll-restore.spec.ts'
     )
@@ -570,9 +577,15 @@ describe('Electron runtime package contract', () => {
     expect(goldenRunSteps.get('linux')?.run).toContain(
       'pnpm run --if-present test:e2e:posix-profile-index-golden'
     )
+    expect(goldenRunSteps.get('linux')?.run).toContain(
+      'pnpm run --if-present test:e2e:fresh-terminal-golden'
+    )
     expect(goldenRunSteps.get('mac')?.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
     expect(goldenRunSteps.get('mac')?.run).toContain(
       'pnpm run --if-present test:e2e:posix-profile-index-golden'
+    )
+    expect(goldenRunSteps.get('mac')?.run).toContain(
+      'pnpm run --if-present test:e2e:fresh-terminal-golden'
     )
     expect(goldenRunSteps.get('windows')).toMatchObject({
       if: "runner.os == 'Windows'",
@@ -580,6 +593,9 @@ describe('Electron runtime package contract', () => {
     })
     expect(goldenRunSteps.get('windows').run).toContain(
       'pnpm run --if-present test:e2e:windows-fresh-startup-golden'
+    )
+    expect(goldenRunSteps.get('windows').run).toContain(
+      'pnpm run --if-present test:e2e:fresh-terminal-golden'
     )
     expect(goldenWorkflow.on.pull_request).toBeUndefined()
     expect(goldenWorkflow.on.workflow_dispatch).toBeDefined()
@@ -597,6 +613,9 @@ describe('Electron runtime package contract', () => {
     expect(releaseLinuxRunStep.run).toContain(
       'pnpm run --if-present test:e2e:posix-profile-index-golden'
     )
+    expect(releaseLinuxRunStep.run).toContain(
+      'pnpm run --if-present test:e2e:fresh-terminal-golden'
+    )
     const releaseMacRunStep = releaseGoldenJob.steps.find(
       (step) => step.name === 'Run terminal rendering golden on macOS'
     )
@@ -604,6 +623,7 @@ describe('Electron runtime package contract', () => {
     expect(releaseMacRunStep.run).toContain(
       'pnpm run --if-present test:e2e:posix-profile-index-golden'
     )
+    expect(releaseMacRunStep.run).toContain('pnpm run --if-present test:e2e:fresh-terminal-golden')
     const releaseWindowsRunStep = releaseGoldenJob.steps.find(
       (step) => step.name === 'Run fresh-startup golden on Windows'
     )
@@ -614,6 +634,19 @@ describe('Electron runtime package contract', () => {
     expect(releaseWindowsRunStep.run).toContain(
       'pnpm run --if-present test:e2e:windows-fresh-startup-golden'
     )
+    expect(releaseWindowsRunStep.run).toContain(
+      'pnpm run --if-present test:e2e:fresh-terminal-golden'
+    )
+    for (const scriptName of [
+      'test:e2e:workspace-session-golden',
+      'test:e2e:windows-fresh-startup-golden',
+      'test:e2e:fresh-terminal-golden',
+      'test:e2e:source-control-golden'
+    ]) {
+      expect(releaseWindowsRunStep.run).toContain(
+        `pnpm run --if-present ${scriptName}\nif ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`
+      )
+    }
     expect(releaseEvidenceJob['continue-on-error']).toBe(true)
     expect(
       releaseEvidenceJob.strategy.matrix.include.map(({ platform }) => platform).sort()

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build:linux": "pnpm run build:desktop && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --linux AppImage deb",
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project=electron-headless",
     "test:e2e:workspace-session-golden": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/golden-quit-relaunch-session.spec.ts tests/e2e/golden-terminal-file-link.spec.ts tests/e2e/golden-worktree-create-switch.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+    "test:e2e:fresh-terminal-golden": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/golden-fresh-profile-terminal.spec.ts tests/e2e/golden-shell-command.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
     "test:e2e:multi-client-navigation": "node config/scripts/run-multi-client-navigation-e2e.mjs",
     "test:e2e:floating-mobile-emulator": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/floating-mobile-emulator-tab.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
     "test:e2e:terminal-rendering-golden": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts tests/e2e/terminal-webgl-atlas-budget.spec.ts --grep @terminal-rendering-golden --config tests/playwright.config.ts --project electron-headless --workers=1",

--- a/tests/e2e/golden-fresh-profile-terminal.spec.ts
+++ b/tests/e2e/golden-fresh-profile-terminal.spec.ts
@@ -93,9 +93,16 @@ test('fresh profile opens a live project terminal @golden', async ({
   await focusActiveTerminalInput(orcaPage)
   await orcaPage.keyboard.type('git rev-parse --show-toplevel')
   await orcaPage.keyboard.press('Enter')
+  // Why: Windows realpathSync can return RUNNER~1 while git prints runneradmin.
+  const gitToplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: repoPath,
+    encoding: 'utf8'
+  })
+    .trim()
+    .replaceAll('\\', '/')
   await expect
     .poll(async () => (await getTerminalContent(orcaPage)).replaceAll('\\', '/'), {
       message: 'fresh project terminal should start in the selected repository'
     })
-    .toContain(repoPath.replaceAll('\\', '/'))
+    .toContain(gitToplevel)
 })


### PR DESCRIPTION
## Summary

- Make the #14302 fresh-profile terminal and shell-command goldens a hard `terminal-rendering-golden` gate for Cut Release on Linux, macOS, and Windows.
- Compare the terminal cwd with Git's own toplevel so Windows 8.3 `RUNNER~1` paths do not fail against Git's long `runneradmin` form.
- Keep every release-cut invocation `--if-present`, preserving older-tag cuts that do not yet define this script; make the Windows PowerShell block fail after each `pnpm` command.

The experiment workflow now invokes the same suite script to keep its coverage aligned with Cut Release.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm run test:e2e:fresh-terminal-golden`