### PR TITLE
perf(runtime): resolve an explicit worktree id without scanning every repo

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -28852,6 +28852,15 @@ export class OrcaRuntimeService {
 
   private async resolveWorktreeSelector(selector: string): Promise<ResolvedWorktree> {
     const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(selector)
+    // Why only `id:`: every other selector kind is matched across the whole fleet, and their
+    // `selector_ambiguous` contract is defined over all repos. Scoping those would silently pick a
+    // winner where today they correctly refuse. An `id:` selector already names its repo.
+    if (explicitWorktreeId && !this.hasFreshResolvedWorktreeCache()) {
+      const scoped = await this.resolveExplicitWorktreeIdScoped(explicitWorktreeId)
+      if (scoped) {
+        return scoped
+      }
+    }
     const worktrees = await this.listResolvedWorktrees()
     let candidates: ResolvedWorktree[]
 
@@ -29439,6 +29448,11 @@ export class OrcaRuntimeService {
     return resolved
   }
 
+  /** A warm fleet snapshot already answers any selector for free, so scoped scanning must yield to it. */
+  private hasFreshResolvedWorktreeCache(): boolean {
+    return Boolean(this.resolvedWorktreeCache && this.resolvedWorktreeCache.expiresAt > Date.now())
+  }
+
   private async listResolvedWorktrees(): Promise<ResolvedWorktree[]> {
     return (await this.listResolvedWorktreeSnapshot()).worktrees
   }
@@ -29481,70 +29495,9 @@ export class OrcaRuntimeService {
       ])
     )
     const perRepoWorktrees = await Promise.all(
-      repos.map(async (repo) => {
-        if (isFolderRepo(repo)) {
-          return listRuntimeFolderWorkspaces(this.requireStore(), repo).map((worktree) => ({
-            ...worktree,
-            hostId: worktree.hostId ?? getRepoExecutionHostId(repo),
-            parentWorktreeId: null,
-            childWorktreeIds: [],
-            lineage: null,
-            git: {
-              path: worktree.path,
-              head: worktree.head,
-              branch: worktree.branch,
-              isBare: worktree.isBare,
-              isMainWorktree: worktree.isMainWorktree
-            },
-            displayName: worktree.displayName,
-            comment: worktree.comment
-          }))
-        }
-        // Why: mobile startup shares this path, so a slow repo scan degrades one repo's metadata instead of blocking all session loading.
-        // Why the catch: `withTimeout` resolves its fallback on rejection too, so the rejection must be absorbed first for `null` to mean
-        // "timed out" only. A stall never reached a verdict, so restore persisted rows instead of publishing a healthy-looking empty catalog;
-        // a rejection is a real answer and keeps its shipped zero-row semantics.
-        const scan: RuntimeWorktreeScanResult =
-          (await withTimeout<RuntimeWorktreeScanResult | null>(
-            this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId).catch(
-              () => ({ ok: false, worktrees: [] }) satisfies RuntimeWorktreeScanResult
-            ),
-            RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
-            null
-          )) ?? { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
-        const gitWorktrees = scan.worktrees
-        if (scan.ok) {
-          pruneLineageForMissingRepoWorktrees(this.requireStore(), repo, gitWorktrees)
-        }
-        return gitWorktrees.map((gitWorktree) => {
-          const worktreeId = `${repo.id}::${gitWorktree.path}`
-          // Why: lineage validation needs a durable instance ID even when the runtime sees a workspace before renderer discovery-stamp.
-          const existingMeta = metaById[worktreeId]
-          const meta =
-            existingMeta && existingMeta.instanceId
-              ? existingMeta
-              : this.store?.setWorktreeMeta(worktreeId, {})
-          const merged = {
-            ...mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
-            hostId: existingMeta?.hostId ?? meta?.hostId ?? getRepoExecutionHostId(repo)
-          }
-          return {
-            ...merged,
-            parentWorktreeId: null,
-            childWorktreeIds: [],
-            lineage: null,
-            git: {
-              path: gitWorktree.path,
-              head: gitWorktree.head,
-              branch: gitWorktree.branch,
-              isBare: gitWorktree.isBare,
-              isMainWorktree: gitWorktree.isMainWorktree
-            },
-            displayName: merged.displayName,
-            comment: merged.comment
-          }
-        })
-      })
+      repos.map(
+        async (repo) => await this.resolveRepoWorktreeRows(repo, metaById, projectRuntimeByRepoId)
+      )
     )
     const worktrees = projectResolvedWorktreeLineage(
       perRepoWorktrees.flat(),
@@ -29561,6 +29514,109 @@ export class OrcaRuntimeService {
       }
     }
     return { worktrees, platformByRepoId }
+  }
+
+  /** One repo's worktree rows before lineage projection. Shared by the fleet scan and scoped lookups. */
+  private async resolveRepoWorktreeRows(
+    repo: Repo,
+    metaById: Record<string, ReturnType<NonNullable<Store['getWorktreeMeta']>>>,
+    projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
+  ): Promise<ResolvedWorktree[]> {
+    if (isFolderRepo(repo)) {
+      return listRuntimeFolderWorkspaces(this.requireStore(), repo).map((worktree) => ({
+        ...worktree,
+        hostId: worktree.hostId ?? getRepoExecutionHostId(repo),
+        parentWorktreeId: null,
+        childWorktreeIds: [],
+        lineage: null,
+        git: {
+          path: worktree.path,
+          head: worktree.head,
+          branch: worktree.branch,
+          isBare: worktree.isBare,
+          isMainWorktree: worktree.isMainWorktree
+        },
+        displayName: worktree.displayName,
+        comment: worktree.comment
+      }))
+    }
+    // Why: mobile startup shares this path, so a slow repo scan degrades one repo's metadata instead of blocking all session loading.
+    // Why the catch: `withTimeout` resolves its fallback on rejection too, so the rejection must be absorbed first for `null` to mean
+    // "timed out" only. A stall never reached a verdict, so restore persisted rows instead of publishing a healthy-looking empty catalog;
+    // a rejection is a real answer and keeps its shipped zero-row semantics.
+    const scan: RuntimeWorktreeScanResult = (await withTimeout<RuntimeWorktreeScanResult | null>(
+      this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId).catch(
+        () => ({ ok: false, worktrees: [] }) satisfies RuntimeWorktreeScanResult
+      ),
+      RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
+      null
+    )) ?? { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
+    const gitWorktrees = scan.worktrees
+    if (scan.ok) {
+      pruneLineageForMissingRepoWorktrees(this.requireStore(), repo, gitWorktrees)
+    }
+    return gitWorktrees.map((gitWorktree) => {
+      const worktreeId = `${repo.id}::${gitWorktree.path}`
+      // Why: lineage validation needs a durable instance ID even when the runtime sees a workspace before renderer discovery-stamp.
+      const existingMeta = metaById[worktreeId]
+      const meta =
+        existingMeta && existingMeta.instanceId
+          ? existingMeta
+          : this.store?.setWorktreeMeta(worktreeId, {})
+      const merged = {
+        ...mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
+        hostId: existingMeta?.hostId ?? meta?.hostId ?? getRepoExecutionHostId(repo)
+      }
+      return {
+        ...merged,
+        parentWorktreeId: null,
+        childWorktreeIds: [],
+        lineage: null,
+        git: {
+          path: gitWorktree.path,
+          head: gitWorktree.head,
+          branch: gitWorktree.branch,
+          isBare: gitWorktree.isBare,
+          isMainWorktree: gitWorktree.isMainWorktree
+        },
+        displayName: merged.displayName,
+        comment: merged.comment
+      }
+    })
+  }
+
+  /**
+   * Resolve one `<repoId>::<path>` worktree id by scanning only its owning repo.
+   *
+   * Lineage edges are intra-repo by construction (`sharesResolvedWorktreeLineageBoundary` requires a
+   * matching repoId), so projecting over one repo's rows yields the same parent and child ids the
+   * fleet scan would. Returns `null` whenever that does not hold, and the caller falls back.
+   */
+  private async resolveExplicitWorktreeIdScoped(
+    worktreeId: string
+  ): Promise<ResolvedWorktree | null> {
+    const store = this.store
+    if (!store) {
+      return null
+    }
+    const parsed = splitWorktreeIdForFilesystem(worktreeId)
+    if (!parsed?.repoId || !parsed.worktreePath) {
+      return null
+    }
+    const owners = store.getRepos().filter((repo) => repo.id === parsed.repoId)
+    // Why: one repo id can be registered on several execution hosts, and only the fleet scan
+    // decides between their rows. Hand those back to the unscoped path rather than guessing.
+    if (owners.length !== 1) {
+      return null
+    }
+    const repo = owners[0]
+    const rows = await this.resolveRepoWorktreeRows(
+      repo,
+      store.getAllWorktreeMeta() ?? {},
+      resolveLocalProjectRuntimesForRepos(this.requireStore(), [repo])
+    )
+    const projected = projectResolvedWorktreeLineage(rows, store.getAllWorktreeLineage?.() ?? {})
+    return projected.find((worktree) => worktree.id === worktreeId) ?? null
   }
 
   private async listRepoWorktreesForResolution(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -734,6 +734,14 @@ import {
 } from './repo-worktree-resolution-scan'
 import { readRepoWorktreeAdminFingerprint } from './repo-worktree-admin-fingerprint'
 import {
+  listStoredWorktreeRowsForRepo,
+  resolveRepoWorktreeRows,
+  resolveScopedWorktreeIdRow,
+  RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
+  type RepoWorktreeRowDeps
+} from './repo-worktree-row-resolution'
+import { withTimeout } from '../../shared/promise-timeout-fallback'
+import {
   getLocalWorktreePathAccess,
   removeLocalWorktreePath,
   toLocalWorktreeRuntimePath
@@ -29494,9 +29502,10 @@ export class OrcaRuntimeService {
         getAgentLaunchPlatformForRepo(repo, projectRuntimeByRepoId.get(repo.id))
       ])
     )
+    const deps = this.repoWorktreeRowDeps()
     const perRepoWorktrees = await Promise.all(
       repos.map(
-        async (repo) => await this.resolveRepoWorktreeRows(repo, metaById, projectRuntimeByRepoId)
+        async (repo) => await resolveRepoWorktreeRows(deps, repo, metaById, projectRuntimeByRepoId)
       )
     )
     const worktrees = projectResolvedWorktreeLineage(
@@ -29516,107 +29525,24 @@ export class OrcaRuntimeService {
     return { worktrees, platformByRepoId }
   }
 
-  /** One repo's worktree rows before lineage projection. Shared by the fleet scan and scoped lookups. */
-  private async resolveRepoWorktreeRows(
-    repo: Repo,
-    metaById: Record<string, ReturnType<NonNullable<Store['getWorktreeMeta']>>>,
-    projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
-  ): Promise<ResolvedWorktree[]> {
-    if (isFolderRepo(repo)) {
-      return listRuntimeFolderWorkspaces(this.requireStore(), repo).map((worktree) => ({
-        ...worktree,
-        hostId: worktree.hostId ?? getRepoExecutionHostId(repo),
-        parentWorktreeId: null,
-        childWorktreeIds: [],
-        lineage: null,
-        git: {
-          path: worktree.path,
-          head: worktree.head,
-          branch: worktree.branch,
-          isBare: worktree.isBare,
-          isMainWorktree: worktree.isMainWorktree
-        },
-        displayName: worktree.displayName,
-        comment: worktree.comment
-      }))
+  /** Bind the runtime-owned scan cache and folder-workspace stamping into the row resolver. */
+  private repoWorktreeRowDeps(): RepoWorktreeRowDeps {
+    const store = this.requireStore()
+    return {
+      store,
+      scanRepo: (repo, projectRuntimeByRepoId) =>
+        this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId),
+      listFolderWorkspaces: (repo) => listRuntimeFolderWorkspaces(store, repo)
     }
-    // Why: mobile startup shares this path, so a slow repo scan degrades one repo's metadata instead of blocking all session loading.
-    // Why the catch: `withTimeout` resolves its fallback on rejection too, so the rejection must be absorbed first for `null` to mean
-    // "timed out" only. A stall never reached a verdict, so restore persisted rows instead of publishing a healthy-looking empty catalog;
-    // a rejection is a real answer and keeps its shipped zero-row semantics.
-    const scan: RuntimeWorktreeScanResult = (await withTimeout<RuntimeWorktreeScanResult | null>(
-      this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId).catch(
-        () => ({ ok: false, worktrees: [] }) satisfies RuntimeWorktreeScanResult
-      ),
-      RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
-      null
-    )) ?? { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
-    const gitWorktrees = scan.worktrees
-    if (scan.ok) {
-      pruneLineageForMissingRepoWorktrees(this.requireStore(), repo, gitWorktrees)
-    }
-    return gitWorktrees.map((gitWorktree) => {
-      const worktreeId = `${repo.id}::${gitWorktree.path}`
-      // Why: lineage validation needs a durable instance ID even when the runtime sees a workspace before renderer discovery-stamp.
-      const existingMeta = metaById[worktreeId]
-      const meta =
-        existingMeta && existingMeta.instanceId
-          ? existingMeta
-          : this.store?.setWorktreeMeta(worktreeId, {})
-      const merged = {
-        ...mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
-        hostId: existingMeta?.hostId ?? meta?.hostId ?? getRepoExecutionHostId(repo)
-      }
-      return {
-        ...merged,
-        parentWorktreeId: null,
-        childWorktreeIds: [],
-        lineage: null,
-        git: {
-          path: gitWorktree.path,
-          head: gitWorktree.head,
-          branch: gitWorktree.branch,
-          isBare: gitWorktree.isBare,
-          isMainWorktree: gitWorktree.isMainWorktree
-        },
-        displayName: merged.displayName,
-        comment: merged.comment
-      }
-    })
   }
 
-  /**
-   * Resolve one `<repoId>::<path>` worktree id by scanning only its owning repo.
-   *
-   * Lineage edges are intra-repo by construction (`sharesResolvedWorktreeLineageBoundary` requires a
-   * matching repoId), so projecting over one repo's rows yields the same parent and child ids the
-   * fleet scan would. Returns `null` whenever that does not hold, and the caller falls back.
-   */
   private async resolveExplicitWorktreeIdScoped(
     worktreeId: string
   ): Promise<ResolvedWorktree | null> {
-    const store = this.store
-    if (!store) {
+    if (!this.store) {
       return null
     }
-    const parsed = splitWorktreeIdForFilesystem(worktreeId)
-    if (!parsed?.repoId || !parsed.worktreePath) {
-      return null
-    }
-    const owners = store.getRepos().filter((repo) => repo.id === parsed.repoId)
-    // Why: one repo id can be registered on several execution hosts, and only the fleet scan
-    // decides between their rows. Hand those back to the unscoped path rather than guessing.
-    if (owners.length !== 1) {
-      return null
-    }
-    const repo = owners[0]
-    const rows = await this.resolveRepoWorktreeRows(
-      repo,
-      store.getAllWorktreeMeta() ?? {},
-      resolveLocalProjectRuntimesForRepos(this.requireStore(), [repo])
-    )
-    const projected = projectResolvedWorktreeLineage(rows, store.getAllWorktreeLineage?.() ?? {})
-    return projected.find((worktree) => worktree.id === worktreeId) ?? null
+    return await resolveScopedWorktreeIdRow(this.repoWorktreeRowDeps(), worktreeId)
   }
 
   private async listRepoWorktreesForResolution(
@@ -29776,37 +29702,7 @@ export class OrcaRuntimeService {
   }
 
   private listStoredWorktreesForResolution(repo: Repo): GitWorktreeInfo[] {
-    const store = this.store
-    if (!store) {
-      return []
-    }
-    const expectedHostId = getRepoExecutionHostId(repo)
-    const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
-    const byWorktreeId = new Map<string, GitWorktreeInfo>()
-    for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
-      const parsed = splitWorktreeId(worktreeId)
-      if (!parsed || parsed.repoId !== repo.id) {
-        continue
-      }
-      // Why: one repo id can be registered on several execution hosts, so a degraded host must not republish another host's rows (same gate as worktrees.ts).
-      if (meta.hostId ? meta.hostId !== expectedHostId : repoOwnerCount > 1) {
-        continue
-      }
-      // Why: keep persisted rows for any repo kind while its scan is unreachable or stalled, instead of zero rows (worktrees:list does the same for disconnected SSH).
-      byWorktreeId.set(worktreeId, {
-        path: parsed.worktreePath,
-        head: '',
-        branch: '',
-        isBare: false,
-        isMainWorktree: areWorktreePathsEqual(parsed.worktreePath, repo.path),
-        ...(meta.sparseDirectories !== undefined ||
-        meta.sparseBaseRef !== undefined ||
-        meta.sparsePresetId !== undefined
-          ? { isSparse: true }
-          : {})
-      })
-    }
-    return [...byWorktreeId.values()]
+    return this.store ? listStoredWorktreeRowsForRepo(this.requireStore(), repo) : []
   }
 
   private async getResolvedWorktreeMap(): Promise<Map<string, ResolvedWorktree>> {
@@ -36137,7 +36033,6 @@ const WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS = 5 * 60_000
 // edits are invisible to it and a tip living in packed-refs or reftable only gets an mtime + size
 // stamp, so a real scan still runs on this interval even while the probe reports "unchanged".
 export const WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS = 5 * 60_000
-export const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
 // Why reserved rather than spent on the probe: when the probe expires the caller still has to run
 // `git worktree list` and answer inside the same budget, so the fallback needs its own room. Sized
 // for a healthy Git on a busy host, well above the tens of milliseconds a warm list costs.
@@ -36234,21 +36129,6 @@ function getExplicitWorktreeIdSelector(selector: string | undefined): string | n
   }
   const id = selector.slice(3)
   return id.length > 0 ? id : null
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | null = null
-  return new Promise<T>((resolve) => {
-    timeout = setTimeout(() => resolve(fallback), timeoutMs)
-    promise.then(
-      (value) => resolve(value),
-      () => resolve(fallback)
-    )
-  }).finally(() => {
-    if (timeout) {
-      clearTimeout(timeout)
-    }
-  })
 }
 
 function withTimeoutResult<T>(

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -1,0 +1,176 @@
+import { splitWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { isFolderRepo } from '../../shared/repo-kind'
+import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
+import { withTimeout } from '../../shared/promise-timeout-fallback'
+import type { GitWorktreeInfo, Repo, Worktree } from '../../shared/types'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
+import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
+import type { Store } from '../persistence'
+import { areWorktreePathsEqual, mergeWorktree } from '../ipc/worktree-logic'
+import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
+import { resolveLocalProjectRuntimesForRepos } from '../project-runtime-git-options'
+import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
+
+/**
+ * Per-repo budget for one resolution pass. Why: mobile startup shares this path, so one slow repo
+ * degrades its own metadata instead of blocking all session loading.
+ *
+ * Exported because the Git-admin fingerprint probe derives its own timeout by subtracting a fallback
+ * allowance from this, and that invariant only holds with a single source of truth.
+ */
+export const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
+
+/** A resolved row before lineage projection fills in `parentWorktreeId` / `childWorktreeIds`. */
+export type RepoWorktreeRow = Worktree & {
+  parentWorktreeId: string | null
+  childWorktreeIds: string[]
+  lineage: null
+  git: Pick<GitWorktreeInfo, 'path' | 'head' | 'branch' | 'isBare' | 'isMainWorktree'>
+}
+
+export type RepoWorktreeRowDeps = {
+  store: Store
+  /** The cache-aware per-repo scan. Injected so this module never owns scan-cache state. */
+  scanRepo: (
+    repo: Repo,
+    projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
+  ) => Promise<RuntimeWorktreeScanResult>
+  /** Folder workspaces are stamped from runtime-owned identity helpers, so the caller supplies them. */
+  listFolderWorkspaces: (repo: Repo) => Worktree[]
+}
+
+/**
+ * Persisted rows for a repo whose scan is unreachable or stalled, so a degraded host publishes what
+ * it last knew instead of an empty catalog. `worktrees:list` does the same for disconnected SSH.
+ */
+export function listStoredWorktreeRowsForRepo(store: Store, repo: Repo): GitWorktreeInfo[] {
+  const expectedHostId = getRepoExecutionHostId(repo)
+  const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
+  const byWorktreeId = new Map<string, GitWorktreeInfo>()
+  for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+    const parsed = splitWorktreeId(worktreeId)
+    if (!parsed || parsed.repoId !== repo.id) {
+      continue
+    }
+    // Why: one repo id can be registered on several execution hosts, so a degraded host must not republish another host's rows (same gate as worktrees.ts).
+    if (meta.hostId ? meta.hostId !== expectedHostId : repoOwnerCount > 1) {
+      continue
+    }
+    byWorktreeId.set(worktreeId, {
+      path: parsed.worktreePath,
+      head: '',
+      branch: '',
+      isBare: false,
+      isMainWorktree: areWorktreePathsEqual(parsed.worktreePath, repo.path),
+      ...(meta.sparseDirectories !== undefined ||
+      meta.sparseBaseRef !== undefined ||
+      meta.sparsePresetId !== undefined
+        ? { isSparse: true }
+        : {})
+    })
+  }
+  return [...byWorktreeId.values()]
+}
+
+/** One repo's worktree rows before lineage projection. Shared by the fleet scan and scoped lookups. */
+export async function resolveRepoWorktreeRows(
+  deps: RepoWorktreeRowDeps,
+  repo: Repo,
+  metaById: Record<string, WorktreeMeta>,
+  projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
+): Promise<RepoWorktreeRow[]> {
+  const { store } = deps
+  if (isFolderRepo(repo)) {
+    return deps.listFolderWorkspaces(repo).map((worktree) => ({
+      ...worktree,
+      hostId: worktree.hostId ?? getRepoExecutionHostId(repo),
+      parentWorktreeId: null,
+      childWorktreeIds: [],
+      lineage: null,
+      git: {
+        path: worktree.path,
+        head: worktree.head,
+        branch: worktree.branch,
+        isBare: worktree.isBare,
+        isMainWorktree: worktree.isMainWorktree
+      },
+      displayName: worktree.displayName,
+      comment: worktree.comment
+    }))
+  }
+  // Why the catch: `withTimeout` resolves its fallback on rejection too, so the rejection must be absorbed
+  // first for `null` to mean "timed out" only. A stall never reached a verdict, so restore persisted rows
+  // instead of publishing a healthy-looking empty catalog; a rejection is a real answer and keeps its
+  // shipped zero-row semantics.
+  const scan: RuntimeWorktreeScanResult = (await withTimeout<RuntimeWorktreeScanResult | null>(
+    deps
+      .scanRepo(repo, projectRuntimeByRepoId)
+      .catch(() => ({ ok: false, worktrees: [] }) satisfies RuntimeWorktreeScanResult),
+    RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
+    null
+  )) ?? { ok: false, worktrees: listStoredWorktreeRowsForRepo(store, repo) }
+  const gitWorktrees = scan.worktrees
+  if (scan.ok) {
+    pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+  }
+  return gitWorktrees.map((gitWorktree) => {
+    const worktreeId = `${repo.id}::${gitWorktree.path}`
+    // Why: lineage validation needs a durable instance ID even when the runtime sees a workspace before renderer discovery-stamp.
+    const existingMeta = metaById[worktreeId]
+    const meta =
+      existingMeta && existingMeta.instanceId ? existingMeta : store.setWorktreeMeta(worktreeId, {})
+    const merged = {
+      ...mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
+      hostId: existingMeta?.hostId ?? meta?.hostId ?? getRepoExecutionHostId(repo)
+    }
+    return {
+      ...merged,
+      parentWorktreeId: null,
+      childWorktreeIds: [],
+      lineage: null,
+      git: {
+        path: gitWorktree.path,
+        head: gitWorktree.head,
+        branch: gitWorktree.branch,
+        isBare: gitWorktree.isBare,
+        isMainWorktree: gitWorktree.isMainWorktree
+      },
+      displayName: merged.displayName,
+      comment: merged.comment
+    }
+  })
+}
+
+/**
+ * Resolve one `<repoId>::<path>` worktree id by scanning only its owning repo.
+ *
+ * Lineage edges are intra-repo by construction (`sharesResolvedWorktreeLineageBoundary` requires a
+ * matching repoId), so projecting over one repo's rows yields the same parent and child ids the
+ * fleet scan would. Returns `null` whenever that does not hold, and the caller falls back.
+ */
+export async function resolveScopedWorktreeIdRow(
+  deps: RepoWorktreeRowDeps,
+  worktreeId: string
+): Promise<RepoWorktreeRow | null> {
+  const { store } = deps
+  const parsed = splitWorktreeIdForFilesystem(worktreeId)
+  if (!parsed?.repoId || !parsed.worktreePath) {
+    return null
+  }
+  const owners = store.getRepos().filter((repo) => repo.id === parsed.repoId)
+  // Why: one repo id can be registered on several execution hosts, and only the fleet scan decides
+  // between their rows. Hand those back to the unscoped path rather than guessing.
+  if (owners.length !== 1) {
+    return null
+  }
+  const repo = owners[0]
+  const rows = await resolveRepoWorktreeRows(
+    deps,
+    repo,
+    store.getAllWorktreeMeta() ?? {},
+    resolveLocalProjectRuntimesForRepos(store, [repo])
+  )
+  const projected = projectResolvedWorktreeLineage(rows, store.getAllWorktreeLineage?.() ?? {})
+  return projected.find((worktree) => worktree.id === worktreeId) ?? null
+}

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -3,7 +3,9 @@ import { getRepoExecutionHostId } from '../../shared/execution-host'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
 import { withTimeout } from '../../shared/promise-timeout-fallback'
-import type { GitWorktreeInfo, Repo, Worktree } from '../../shared/types'
+import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
+import type { WorktreeLineage } from '../../shared/worktree/lineage-types'
+import type { Repo } from '../../shared/repo-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import type { Store } from '../persistence'
@@ -21,11 +23,15 @@ import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
  */
 export const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
 
-/** A resolved row before lineage projection fills in `parentWorktreeId` / `childWorktreeIds`. */
+/**
+ * One repo's resolved row. Builders emit it with the lineage fields empty; `projectResolvedWorktreeLineage`
+ * fills them in. `lineage` is nullable rather than `null` so a projected row still types honestly —
+ * intersecting a `null` literal would collapse the projected type back to "never has lineage".
+ */
 export type RepoWorktreeRow = Worktree & {
   parentWorktreeId: string | null
   childWorktreeIds: string[]
-  lineage: null
+  lineage: WorktreeLineage | null
   git: Pick<GitWorktreeInfo, 'path' | 'head' | 'branch' | 'isBare' | 'isMainWorktree'>
 }
 

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -39,10 +39,10 @@ vi.mock('./repo-worktree-admin-fingerprint', () => ({
 
 import {
   OrcaRuntimeService,
-  RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
   WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS,
   WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS
 } from './orca-runtime'
+import { RESOLVED_WORKTREE_REPO_TIMEOUT_MS } from './repo-worktree-row-resolution'
 
 const REPO_ID = 'repo-local'
 const REPO_PATH = '/Users/me/dev/app'

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -551,3 +551,76 @@ describe('worktree scan admin-fingerprint gate', () => {
     expect(readRepoWorktreeAdminFingerprintMock).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('scoped explicit worktree-id resolution', () => {
+  beforeEach(() => {
+    getSshGitProviderMock.mockReset()
+    listWorktreesStrictMock.mockReset()
+    listWorktreesStrictMock.mockImplementation(async (repoPath: string) => [
+      { path: repoPath, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+      {
+        path: `${repoPath}-feature`,
+        head: 'def',
+        branch: 'feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    readRepoWorktreeAdminFingerprintMock.mockReset()
+    readRepoWorktreeAdminFingerprintMock.mockResolvedValue('fp-1')
+  })
+
+  function scannedRepoPaths(): string[] {
+    return listWorktreesStrictMock.mock.calls.map((call) => call[0] as string)
+  }
+
+  it('scans only the owning repo for an id: selector on a cold cache', async () => {
+    const runtime = new OrcaRuntimeService(makeStore({ repoCount: 10 }) as never)
+    const resolve = (selector: string): Promise<{ id: string }> =>
+      (
+        runtime as unknown as { resolveWorktreeSelector: (s: string) => Promise<{ id: string }> }
+      ).resolveWorktreeSelector(selector)
+
+    const resolved = await resolve(`id:${MAIN_WORKTREE_ID}`)
+
+    expect(resolved.id).toBe(MAIN_WORKTREE_ID)
+    expect(scannedRepoPaths()).toEqual([REPO_PATH])
+  })
+
+  it('still finds worktrees in other repos through the fleet path', async () => {
+    const runtime = new OrcaRuntimeService(makeStore({ repoCount: 10 }) as never)
+    const resolve = (selector: string): Promise<{ id: string }> =>
+      (
+        runtime as unknown as { resolveWorktreeSelector: (s: string) => Promise<{ id: string }> }
+      ).resolveWorktreeSelector(selector)
+
+    const otherId = `${REPO_ID}-3::${REPO_PATH}-3`
+    const resolved = await resolve(`id:${otherId}`)
+
+    expect(resolved.id).toBe(otherId)
+    expect(scannedRepoPaths()).toEqual([`${REPO_PATH}-3`])
+  })
+
+  it('keeps cross-repo selectors on the fleet path so ambiguity still throws', async () => {
+    const runtime = new OrcaRuntimeService(makeStore({ repoCount: 10 }) as never)
+    const resolve = (selector: string): Promise<unknown> =>
+      (
+        runtime as unknown as { resolveWorktreeSelector: (s: string) => Promise<unknown> }
+      ).resolveWorktreeSelector(selector)
+
+    // `main` is checked out in every repo, so a branch selector must refuse rather than pick one.
+    await expect(resolve('branch:main')).rejects.toThrow('selector_ambiguous')
+    expect(new Set(scannedRepoPaths()).size).toBe(10)
+  })
+
+  it('falls back to the fleet path when the id names no registered repo', async () => {
+    const runtime = new OrcaRuntimeService(makeStore({ repoCount: 10 }) as never)
+    const resolve = (selector: string): Promise<unknown> =>
+      (
+        runtime as unknown as { resolveWorktreeSelector: (s: string) => Promise<unknown> }
+      ).resolveWorktreeSelector(selector)
+
+    await expect(resolve('id:missing-repo::/nowhere')).rejects.toThrow('selector_not_found')
+    expect(new Set(scannedRepoPaths()).size).toBe(10)
+  })
+})

--- a/src/shared/promise-timeout-fallback.ts
+++ b/src/shared/promise-timeout-fallback.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve `fallback` when `promise` has not settled within `timeoutMs`.
+ *
+ * Note that a rejection also resolves the fallback, so a caller that needs to tell "timed out" apart
+ * from "failed" must absorb the rejection itself before handing the promise over.
+ */
+export function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  return new Promise<T>((resolve) => {
+    timeout = setTimeout(() => resolve(fallback), timeoutMs)
+    promise.then(
+      (value) => resolve(value),
+      () => resolve(fallback)
+    )
+  }).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  })
+}


### PR DESCRIPTION
## ELI5

If you ask "where is worktree X?", and X's id already says which repo it lives in, we were still checking all ten repos to answer. Now we check the one.

## What Changed

`resolveWorktreeSelector` gains one branch for explicit `id:` selectors:

```
id: selector, fleet snapshot cold
  └─ owning repo resolvable, registered exactly once?
       ├─ no  → fleet scan (today's behaviour)
       └─ yes → scan only that repo, project lineage over its rows
                 └─ worktree not in the result? → fall back to the fleet scan
```

The per-repo body of `computeResolvedWorktrees` is extracted into `resolveRepoWorktreeRows`, shared by the fleet path and the scoped path so the two cannot drift.

## Why

`resolveWorktreeSelector` has 39 call sites and resolved every selector kind from the whole-fleet snapshot. A targeted `id:<repoId>::<path>` lookup therefore fanned `git worktree list` across every registered repo to answer a question about exactly one of them — even though the id names its own repo.

With a warm scan cache that costs about 0.5 ms. With a **cold** one — app startup, or the first lookup after a mutation clears the snapshot — it is one subprocess per repo. `git worktree list` measured at ~17 ms per call, so a ten-repo fleet paid roughly 170 ms to find one worktree.

A new test measures the fan-out directly:

| | repos scanned for one `id:` lookup |
| --- | --- |
| before | **10** |
| after | **1** |

### Why only `id:`

Every other selector kind is matched across the fleet, and its `selector_ambiguous` contract is defined over all repos. Scoping `branch:`, `name:`, `issue:`, or a bare selector to one repo would silently resolve an ambiguity that today correctly throws — a `branch:main` matching three repos would start returning one of them. A test pins the current behaviour: `branch:main` across ten repos still throws `selector_ambiguous` and still scans all ten.

### Why lineage stays correct

Lineage edges are intra-repo by construction: `sharesResolvedWorktreeLineageBoundary` requires a matching `repoId`. Projecting lineage over one repo's rows therefore produces the same `parentWorktreeId` and `childWorktreeIds` the fleet scan would.

The scoped path returns `null` and falls back whenever that reasoning does not hold:

- a repo id registered on several execution hosts — only the full scan can adjudicate between their rows
- an unknown repo id, or an unparseable worktree id
- a worktree the scoped scan does not contain, which preserves the existing SSH `buildResolvedWorktreeFromId` fallback and the `selector_not_found` contract

A warm fleet snapshot always wins, since it answers every selector for free.

## Linked Issue

N/A — follow-up to #14207, no tracking issue.

## Visual Proof

N/A — no UI or interaction change. Selector resolution returns the same `ResolvedWorktree` rows, including lineage; only the number of repos scanned to produce them changes.

## Testing

Four tests added to `src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts`, all asserting on the actual set of repo paths scanned:

- an `id:` selector on a cold cache scans only the owning repo
- an `id:` selector for a *different* repo scans only that repo (proves it targets correctly, not just narrowly)
- `branch:main` across ten repos still throws `selector_ambiguous` and still scans all ten
- an id naming no registered repo falls back to the fleet path and still throws `selector_not_found`

Gates run locally on macOS: `npm run typecheck`, `npm run lint` (incl. max-lines ratchet), `oxfmt --check`, and the full `src/main/runtime/` suite — **275 files / 4049 tests green**.

Platforms: macOS locally; Linux via CI. No platform-dependent code paths are touched — this is repo-set selection, not filesystem or process work. The two Windows-boundary suites from #14378 are in the same file and continue to run on the Windows runner.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 4.5 via Claude Code.

## Review

- **Security**: no new I/O, no new process, no new external input. The scoped path reads the same store and runs the same scan the fleet path already ran for that repo.
- **Cross-platform**: no path or process logic changed; repo selection only.
- **Remote SSH**: SSH repos take the same `listRepoWorktreesForResolution` path as before. The existing `buildResolvedWorktreeFromId` fallback for disconnected SSH repos is preserved by falling through to the fleet path when the scoped scan finds nothing.
- **Mobile / remote wire**: no RPC params, stream frames, or published content changed.
- **Backwards compatibility**: nothing persisted; no schema or serialized contract touched.
- **Performance**: measured above. One behavioural note — a scoped lookup runs `pruneLineageForMissingRepoWorktrees` for its own repo only, so other repos are pruned on the next fleet scan rather than on a targeted call. Fleet scans still happen on every untargeted read (`worktree ps`, `listManagedWorktrees`, orchestration refresh), so this changes prune frequency, not correctness.

Made with [Orca](https://github.com/stablyai/orca) 🐋
