### PR TITLE
fix(browser): acknowledge paired tab before navigation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -244,8 +244,12 @@ jobs:
           if printf '%s\n' "${TEST_FILES[@]}" | grep -qx 'tests/e2e/ephemeral-vm-provisioned-root.spec.ts'; then
             E2E_ENV+=(ORCA_E2E_SSH_DOCKER=1)
           fi
+          E2E_PROJECT_ARGS=()
+          if grep -l '@headful' "${TEST_FILES[@]}" >/dev/null; then
+            E2E_PROJECT_ARGS+=(--project=electron-headful)
+          fi
           xvfb-run --auto-servernum env "${E2E_ENV[@]}" \
-            pnpm run test:e2e "${TEST_FILES[@]}" --workers=1
+            pnpm run test:e2e "${TEST_FILES[@]}" --workers=1 "${E2E_PROJECT_ARGS[@]}"
 
       - name: Upload Playwright traces
         if: failure()

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-12",
+  "updatedAt": "2026-08-13",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -1817,19 +1817,23 @@
       "providers": ["remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime"],
-      "coverageNotes": "A headed macOS desktop host and separate paired client exercise the Explorer eye-button path with a real remote file URL, host browser DOM, renderer split layout, background preview creation, explicit browser activation, browser close, forced capability rejection after caller preflight, and a forced post-create reconciliation timeout. The same fault oracles pass against a live headless server. Unit contracts cover absent, unknown, and mixed-version capabilities, visible rejection, empty-split cleanup, owning-runtime routing, exact client materialization, confirmed rollback, ambiguous cleanup, and teardown. Linux and Windows live journeys remain gaps.",
+      "coverageNotes": "A headed macOS desktop host and separate paired client exercise the Explorer eye-button path with a real remote file URL, host browser DOM, renderer split layout, background preview creation, explicit browser activation, browser close, forced capability rejection after caller preflight, a forced post-create reconciliation timeout, and navigation held beyond the client create deadline. The same reconciliation fault oracles pass against a live headless server. Unit contracts cover absent, unknown, and mixed-version capabilities, visible rejection, empty-split cleanup, owning-runtime routing, canonical preallocated page identity, navigation-independent acknowledgement, exact client materialization, confirmed rollback, ambiguous cleanup, and teardown. Linux and Windows live journeys remain gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-3872/unable-to-open-html-files-in-remote-server",
         "https://linear.app/stably/issue/STA-4025/p1-browser-create-reports-success-when-tab-reconcile-fails-after-pr",
         "https://linear.app/stably/issue/STA-4063/p1-paired-html-preview-rejects-outside-cleanup-after-pr-13909",
+        "https://linear.app/stably/issue/STA-4231/p1-owner-pinned-paired-browser-create-can-time-out-after-host-tab",
+        "https://github.com/stablyai/orca/pull/14363",
         "https://github.com/stablyai/orca/pull/13876"
       ],
-      "invariant": "Opening one HTML preview from a paired client succeeds only after exactly one browser page on the worktree-owning runtime materializes as exactly one client browser workspace and unified tab in the requested group. Capability rejection before host mutation must preserve the original error, issue no RPC, surface a failure toast, and remove only a caller-declared newly-created empty split. Post-create reconciliation failure requires exact rollback; ambiguous rollback rejects without local fallback. Preview focus and close preserve the source editor and terminal.",
-      "oracle": "Run one unchanged contract oracle for direct create and side-preview callers with absent status, unknown capabilities, and a mixed-version host. Require the original unsupported error or visible toast, zero RPCs, and no retained new split. Run it on the scan target, latest main, candidate, and candidate with the cleanup boundary disabled. In headed paired Electron, arm capability rejection after the caller preflight, invoke the visible HTML side-preview action, require the failure toast, and compare exact host/client browser, editor, terminal, and group inventories to baseline. Repeat against headless serve. Retain the separate exact-page reconciliation rollback oracle.",
+      "invariant": "Opening one HTML preview from a paired client succeeds only after exactly one browser page on the worktree-owning runtime materializes as exactly one client browser workspace and unified tab in the requested group. Owner-pinned creation returns the canonical host page identity before navigation readiness; delayed navigation cannot turn a created page into an unidentifiable failure or a duplicate retry. Capability rejection before host mutation must preserve the original error, issue no RPC, surface a failure toast, and remove only a caller-declared newly-created empty split. Post-create reconciliation failure requires exact rollback; ambiguous rollback rejects without local fallback. Preview focus and close preserve the source editor and terminal.",
+      "oracle": "Run one unchanged contract oracle for direct create and side-preview callers with absent status, unknown capabilities, and a mixed-version host. Require the original unsupported error or visible toast, zero RPCs, and no retained new split. Run it on the scan target, latest main, candidate, and candidate with the cleanup boundary disabled. In headed paired Electron, arm capability rejection after the caller preflight, invoke the visible HTML side-preview action, require the failure toast, and compare exact host/client browser, editor, terminal, and group inventories to baseline. Hold a real navigation response beyond the 15-second client deadline after host creation; require the first RPC to return the exact host inventory page ID, one host page, and no retry. Repeat reconciliation faults against headless serve. Retain the separate exact-page reconciliation rollback oracle.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-browser.test.ts src/main/runtime/rpc/methods/browser.test.ts src/renderer/src/lib/file-preview.test.ts src/renderer/src/runtime/web-session-browser-placement.test.ts src/renderer/src/runtime/web-runtime-session.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/runtime/remote-server-parity.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-runtime-browser-materialization.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-runtime-browser-capability-cleanup.test.ts src/renderer/src/lib/file-preview-capability-cleanup.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-browser.test.ts src/renderer/src/runtime/web-runtime-session.test.ts",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-browser-create-navigation-deadline.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
         "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm exec playwright test tests/e2e/paired-remote-html-browser-focus.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm exec playwright test tests/e2e/paired-remote-html-browser-focus.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=3",
         "SKIP_BUILD=1 ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 pnpm exec playwright test tests/e2e/paired-remote-html-browser-focus.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -1849,6 +1853,7 @@
         "src/renderer/src/runtime/web-session-tabs-sync.test.ts",
         "src/renderer/src/runtime/remote-server-parity.test.ts",
         "tests/e2e/paired-remote-html-browser-focus.spec.ts",
+        "tests/e2e/paired-browser-create-navigation-deadline.spec.ts",
         "tests/e2e/paired-browser-creation-reconciliation-failure.spec.ts"
       ],
       "assertionRefs": [
@@ -1884,6 +1889,8 @@
           "file": "src/renderer/src/runtime/web-runtime-session.test.ts",
           "assertions": [
             "a post-create timeout returns false only after exact host close and a confirming snapshot",
+            "owner-pinned creation launches navigation separately and materializes without awaiting it",
+            "a lost create acknowledgement cleans the capability-gated canonical page ID",
             "unconfirmed cleanup rejects so callers cannot create a competing local fallback",
             "the canonical placement and a newly-created empty split are released on rollback",
             "one failed preview cannot remove a shared split still reserved after an environment ownership change",
@@ -1919,6 +1926,13 @@
             "one HTML open produces one client workspace, one client unified tab, and one host page",
             "the source editor and remote frame remain visible in separate groups",
             "preview creation leaves the editor active, an explicit browser click is authoritative, and close preserves the editor and terminal"
+          ]
+        },
+        {
+          "file": "tests/e2e/paired-browser-create-navigation-deadline.spec.ts",
+          "assertions": [
+            "a held navigation exceeds the former create deadline while the first RPC returns the exact authoritative host page ID",
+            "host inventory contains exactly one new page and the user retry branch is never entered"
           ]
         },
         {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1833,6 +1833,7 @@
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-runtime-browser-materialization.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-runtime-browser-capability-cleanup.test.ts src/renderer/src/lib/file-preview-capability-cleanup.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-browser.test.ts src/renderer/src/runtime/web-runtime-session.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime-browser.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/store/slices/browser.test.ts src/renderer/src/runtime/web-runtime-session.test.ts",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-browser-create-navigation-deadline.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
         "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm exec playwright test tests/e2e/paired-remote-html-browser-focus.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "ORCA_E2E_WEB_CLIENT=1 ORCA_E2E_FORCE_HEADFUL=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm exec playwright test tests/e2e/paired-remote-html-browser-focus.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=3",
@@ -1852,6 +1853,8 @@
         "src/renderer/src/runtime/web-runtime-session.test.ts",
         "src/renderer/src/runtime/web-session-tabs-sync.test.ts",
         "src/renderer/src/runtime/remote-server-parity.test.ts",
+        "src/renderer/src/hooks/useIpcEvents.test.ts",
+        "src/renderer/src/store/slices/browser.test.ts",
         "tests/e2e/paired-remote-html-browser-focus.spec.ts",
         "tests/e2e/paired-browser-create-navigation-deadline.spec.ts",
         "tests/e2e/paired-browser-creation-reconciliation-failure.spec.ts"
@@ -1895,6 +1898,20 @@
             "the canonical placement and a newly-created empty split are released on rollback",
             "one failed preview cannot remove a shared split still reserved after an environment ownership change",
             "if every overlapping creation fails, the last reservation closes the caller-created empty split"
+          ]
+        },
+        {
+          "file": "src/renderer/src/hooks/useIpcEvents.test.ts",
+          "assertions": [
+            "renderer-backed creation preserves the requested canonical page ID while keeping its workspace identity independent",
+            "closing an absent renderer page returns browser_tab_not_found instead of an untyped failure"
+          ]
+        },
+        {
+          "file": "src/renderer/src/store/slices/browser.test.ts",
+          "assertions": [
+            "a requested canonical page ID is stored on the page rather than reused as its workspace ID",
+            "duplicate canonical page IDs are rejected before a second tab can materialize"
           ]
         },
         {
@@ -2089,6 +2106,24 @@
           "result": "failed",
           "durationSeconds": 12.3,
           "summary": "Candidate d05217c40d with only the side-preview focusOnCreate:false call disabled failed the byte-identical 2ec1dcf1 oracle because preview creation activated the browser instead of preserving editor focus."
+        },
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime-browser.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/store/slices/browser.test.ts src/renderer/src/runtime/web-runtime-session.test.ts",
+          "result": "passed",
+          "durationSeconds": 10.83,
+          "summary": "Five post-review host, IPC, store, and client lifecycle files passed 1,356 tests with one pre-existing skip, including both shards that failed before the canonical page/workspace identity and typed missing-page cleanup corrections."
+        },
+        {
+          "date": "2026-08-13",
+          "runner": "local",
+          "platform": "macos",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-browser-create-navigation-deadline.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 18.1,
+          "summary": "Two isolated headed Electron/CDP journeys passed: the direct owner-pinned call returned one canonical host ID before held navigation, and the real remote-pane context-menu route materialized that one page without retry or duplicate."
         }
       ],
       "runtimeBudget": {
@@ -2101,11 +2136,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The unchanged STA-4063 five-assertion oracle is red 5/5 on scan e4c278eb52 and latest main bc2e30000b, partially green 2/5 on pre-fix PR #14100, green 5/5 on candidate 14b5877a75, and red 3/5 when only the new transaction cleanup boundary is disabled on final candidate a9e6fb7716. The earlier STA-4025 transaction oracle remains red on the post-#13909 base and green on this candidate. The byte-identical 2ec1dcf1 Electron oracle remains red on latest main 346e59c879, green on candidate d05217c40d, and red with only side-preview focus disabled; historical 5806b23f evidence separately proves owning-runtime routing."
+        "evidence": "The unchanged STA-4063 five-assertion oracle is red 5/5 on scan e4c278eb52 and latest main bc2e30000b, partially green 2/5 on pre-fix PR #14100, green 5/5 on candidate 14b5877a75, and red 3/5 when only the new transaction cleanup boundary is disabled on final candidate a9e6fb7716. The earlier STA-4025 transaction oracle remains red on the post-#13909 base and green on this candidate. The byte-identical STA-4231 headed oracle is red on latest-main b19d99bd00: both 15-second creates return runtime_timeout without a page ID while the host retains two distinct pages after retry. The relevant behavior is unchanged through 0a0ae974d4. The candidate is green with one returned canonical ID, one host/client page, and no retry; disabling only the navigation-independent acknowledgement is red with the same two orphaned pages. The byte-identical 2ec1dcf1 Electron oracle remains red on latest main 346e59c879, green on candidate d05217c40d, and red with only side-preview focus disabled; historical 5806b23f evidence separately proves owning-runtime routing."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The transaction adds no timer, polling, retry, subprocess, RPC method, stream opcode, or host publication. Capability rejection performs zero RPCs and one bounded empty-group close. Successful creation adds one post-operation list; known-page failure adds one exact close and one confirming list. The E2E-only one-shot faults are build-gated, retain one promise/flag and a bounded page-id set, and reset after each run. Pending client placements remain capped at 128 and clear on adoption, failure, or teardown."
+        "evidence": "The transaction adds no timer, polling, retry, subprocess, RPC method, stream opcode, or global host publication. Owner-pinned success performs one create RPC followed by one asynchronous goto, retains one page, and performs zero retry or cleanup calls. A lost create acknowledgement performs one exact close by the preallocated canonical ID and at most one confirming snapshot. Headless goto publishes one worktree-scoped session snapshot after navigation. Capability rejection performs zero RPCs and one bounded empty-group close. The E2E-only one-shot faults are build-gated, retain one promise/flag and a bounded page-id set, and reset after each run. Pending client placements remain capped at 128 and clear on adoption, failure, or teardown."
       },
       "promotionCriteria": [
         "Collect Linux and physical Windows paired-server evidence.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1901,10 +1901,18 @@
           ]
         },
         {
+          "file": "src/main/runtime/orca-runtime-browser.test.ts",
+          "assertions": [
+            "explicit renderer cleanup bypasses guest registration while retaining typed missing-page behavior",
+            "offscreen cleanup rejects a page outside the requested worktree"
+          ]
+        },
+        {
           "file": "src/renderer/src/hooks/useIpcEvents.test.ts",
           "assertions": [
             "renderer-backed creation preserves the requested canonical page ID while keeping its workspace identity independent",
-            "closing an absent renderer page returns browser_tab_not_found instead of an untyped failure"
+            "closing an absent renderer page returns browser_tab_not_found instead of an untyped failure",
+            "explicit cleanup cannot close a page owned by another worktree"
           ]
         },
         {

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -75,7 +75,11 @@ describe('PR E2E gate contract', () => {
     expect(changedRun.run).toContain('. != "tests/e2e/ssh-startup-exec-readiness.spec.ts"')
     expect(changedRun.run).toContain('. != "tests/e2e/paired-startup-exec-readiness.spec.ts"')
     expect(changedRun.run).toContain('if [ "${#TEST_FILES[@]}" -eq 0 ]')
-    expect(changedRun.run).toContain('pnpm run test:e2e "${TEST_FILES[@]}" --workers=1')
+    expect(changedRun.run).toContain('grep -l \'@headful\' "${TEST_FILES[@]}"')
+    expect(changedRun.run).toContain('E2E_PROJECT_ARGS+=(--project=electron-headful)')
+    expect(changedRun.run).toContain(
+      'pnpm run test:e2e "${TEST_FILES[@]}" --workers=1 "${E2E_PROJECT_ARGS[@]}"'
+    )
   })
 
   it('keeps startup-exec live parity in the isolated SSH lane', () => {

--- a/src/main/browser/browser-backend.ts
+++ b/src/main/browser/browser-backend.ts
@@ -10,6 +10,7 @@ export type BrowserBackendCreateTab = {
   url: string
   worktreeId?: string
   profileId?: string
+  browserPageId?: string
 }
 
 export type BrowserBackend = {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -23,7 +23,10 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   constructor(private readonly browserManager: BrowserManager) {}
 
   async createTab(params: BrowserBackendCreateTab): Promise<{ browserPageId: string }> {
-    const browserPageId = randomUUID()
+    const browserPageId = params.browserPageId ?? randomUUID()
+    if (this.windowsByPageId.has(browserPageId)) {
+      throw new Error(`Browser page ${browserPageId} already exists`)
+    }
     // Why: profiles map to Electron partitions; using the profile's partition
     // makes cookies/storage persist in the same SQLite DB the desktop path uses.
     const profile = params.profileId

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -559,7 +559,7 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     expect(result.browserPageId).toBe('page-target')
   })
 
-  it('wakes the requested page before closing a page-scoped tab', async () => {
+  it('closes the requested renderer page without waiting for guest registration', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
     webContentsFromIdMock.mockReturnValue({ isDestroyed: () => true })
     const send = vi.fn((channel: string, data: { requestId?: string }) => {
@@ -587,15 +587,48 @@ describe('RuntimeBrowserCommands browser screencast', () => {
       commands.browserTabClose({ worktree: 'id:wt-1', page: 'page-target' })
     ).resolves.toEqual({ closed: true })
 
-    expect(send).toHaveBeenCalledWith('browser:activateView', {
-      worktreeId: 'wt-1',
-      browserPageId: 'page-target'
-    })
-    expect(waitForTabRegistrationMock).toHaveBeenCalledWith('page-target')
+    expect(send).not.toHaveBeenCalledWith('browser:activateView', expect.anything())
+    expect(waitForTabRegistrationMock).not.toHaveBeenCalled()
     expect(waitForWorktreeTabRegistrationMock).not.toHaveBeenCalled()
     expect(send).toHaveBeenCalledWith(
       'browser:requestTabClose',
       expect.objectContaining({ tabId: 'page-target', worktreeId: 'wt-1' })
+    )
+  })
+
+  it('lets the renderer close an acknowledged page whose guest never registered', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const send = vi.fn((channel: string, data: { requestId?: string }) => {
+      if (channel !== 'browser:requestTabClose') {
+        return
+      }
+      const handler = ipcMainOnMock.mock.calls.find(
+        ([eventName]) => eventName === 'browser:tabCloseReply'
+      )?.[1] as ((event: unknown, reply: { requestId: string }) => void) | undefined
+      handler?.({} as never, { requestId: data.requestId ?? '' })
+    })
+    const bridge = {
+      getRegisteredTabs: vi.fn(() => new Map()),
+      getActivePageId: vi.fn(() => null),
+      getActiveWebContentsId: vi.fn(() => null)
+    } as unknown as AgentBrowserBridge
+    const authoritativeWindow = { webContents: { send } } as never
+    const commands = new RuntimeBrowserCommands(
+      createHost({
+        getAgentBrowserBridge: () => bridge,
+        getAvailableAuthoritativeWindow: vi.fn(() => authoritativeWindow),
+        getAuthoritativeWindow: vi.fn(() => authoritativeWindow)
+      })
+    )
+
+    await expect(
+      commands.browserTabClose({ worktree: 'id:wt-1', page: 'page-canonical' })
+    ).resolves.toEqual({ closed: true })
+
+    expect(waitForTabRegistrationMock).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith(
+      'browser:requestTabClose',
+      expect.objectContaining({ tabId: 'page-canonical', worktreeId: 'wt-1' })
     )
   })
 

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -698,6 +698,34 @@ describe('RuntimeBrowserCommands headless offscreen routing', () => {
     expect(setActiveTab).toHaveBeenCalledWith(202, 'wt-1')
   })
 
+  it('publishes a headless session snapshot after explicit navigation', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    webContentsFromIdMock.mockReturnValue({ isDestroyed: () => false })
+    const notifyHeadlessBrowserSessionTabsChanged = vi.fn()
+    const bridge = {
+      getRegisteredTabs: vi.fn(() => new Map([['page-offscreen', 202]])),
+      getActivePageId: vi.fn(() => 'page-offscreen'),
+      goto: vi.fn(async () => ({ title: 'Loaded', url: 'https://example.com/loaded' }))
+    } as unknown as AgentBrowserBridge
+    const commands = new RuntimeBrowserCommands(
+      createHost({
+        getAgentBrowserBridge: () => bridge,
+        getAvailableAuthoritativeWindow: vi.fn(() => null),
+        notifyHeadlessBrowserSessionTabsChanged
+      })
+    )
+
+    await expect(
+      commands.browserGoto({
+        worktree: 'id:wt-1',
+        page: 'page-offscreen',
+        url: 'https://example.com/loaded'
+      })
+    ).resolves.toEqual({ title: 'Loaded', url: 'https://example.com/loaded' })
+
+    expect(notifyHeadlessBrowserSessionTabsChanged).toHaveBeenCalledWith('wt-1')
+  })
+
   it('rejects tab creation when neither a renderer nor an offscreen backend is available', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
     const commands = new RuntimeBrowserCommands(

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -797,6 +797,10 @@ describe('RuntimeBrowserCommands headless offscreen routing', () => {
     expect(closeTab).toHaveBeenCalledWith('page-offscreen')
     // The renderer close IPC must not be used in headless mode.
     expect(ipcMainOnMock).not.toHaveBeenCalledWith('browser:tabCloseReply', expect.anything())
+    await expect(
+      commands.browserTabClose({ worktree: 'id:wt-1', page: 'page-other' })
+    ).rejects.toMatchObject({ code: 'browser_tab_not_found' })
+    expect(closeTab).toHaveBeenCalledTimes(1)
   })
 
   it('closes the active headless tab on an implicit close', async () => {

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -329,6 +329,56 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     )
   })
 
+  it('returns the renderer page identity before navigation settles', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const navigation = deferred<{ title: string; url: string }>()
+    const webContents = { send: vi.fn() }
+    webContents.send = vi.fn((_channel: string, data: { requestId: string }) => {
+      const handler = ipcMainOnMock.mock.calls.find(
+        ([eventName]) => eventName === 'browser:tabCreateReply'
+      )?.[1] as
+        | ((event: unknown, reply: { requestId: string; browserPageId?: string }) => void)
+        | undefined
+      handler?.({ sender: webContents } as never, {
+        requestId: data.requestId,
+        browserPageId: 'page-slow-navigation'
+      })
+    })
+    const bridge = {
+      getRegisteredTabs: vi.fn(() => new Map([['page-slow-navigation', 101]])),
+      goto: vi.fn(() => navigation.promise),
+      setActiveTab: vi.fn()
+    } as unknown as AgentBrowserBridge
+    const commands = new RuntimeBrowserCommands(
+      createHost({
+        getAgentBrowserBridge: () => bridge,
+        getAvailableAuthoritativeWindow: vi.fn(() => ({}) as never),
+        getAuthoritativeWindow: vi.fn(() => ({ webContents }) as never)
+      })
+    )
+
+    let created: { browserPageId: string } | null = null
+    const creation = commands
+      .browserTabCreate({
+        worktree: 'id:wt-1',
+        url: 'https://example.com/slow',
+        waitForRegistration: true
+      })
+      .then((result) => {
+        created = result
+        return result
+      })
+    await vi.waitFor(() => expect(bridge.goto).toHaveBeenCalledOnce())
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    try {
+      expect(created).toEqual({ browserPageId: 'page-slow-navigation' })
+    } finally {
+      navigation.resolve({ title: 'Slow page', url: 'https://example.com/slow' })
+      await creation
+    }
+  })
+
   it('rejects unknown explicit profile ids before requesting a renderer tab', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
     const send = vi.fn()

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -1294,6 +1294,7 @@ export class RuntimeBrowserCommands {
   async browserTabCreate(params: {
     url?: string
     worktree?: string
+    page?: string
     profileId?: string
     waitForRegistration?: boolean
     activate?: boolean
@@ -1322,7 +1323,8 @@ export class RuntimeBrowserCommands {
         worktreeId,
         params.profileId,
         params.activate,
-        params.targetGroupId
+        params.targetGroupId,
+        params.page
       )
     }
     const { browserPageId } = await this.createBrowserTabInRenderer(
@@ -1330,7 +1332,8 @@ export class RuntimeBrowserCommands {
       worktreeId,
       params.profileId,
       params.profileId ? sessionPartition : undefined,
-      params.activate
+      params.activate,
+      params.page
     )
 
     // Why: the webview must mount and register before the tab is operable, so wait here (returning the ID anyway on timeout).
@@ -1351,9 +1354,16 @@ export class RuntimeBrowserCommands {
 
     // Why: the webview loads about:blank first; route navigation through the bridge so its registered owner remains authoritative.
     if (url && url !== 'about:blank') {
-      try {
+      const navigate = async (): Promise<void> => {
         const result = await bridge.goto(url, worktreeId, browserPageId)
         this.notifyRendererNavigation(browserPageId, result.url, result.title)
+      }
+      if (params.waitForRegistration === true) {
+        void navigate().catch(() => {})
+        return { browserPageId }
+      }
+      try {
+        await navigate()
       } catch {
         // Tab exists but navigation failed — caller can retry with explicit goto
       }
@@ -1596,13 +1606,6 @@ export class RuntimeBrowserCommands {
 
     let tabId: string | null = null
     if (typeof params.page === 'string' && params.page.length > 0) {
-      if (!bridge.getRegisteredTabs(worktreeId).has(params.page)) {
-        const scope = worktreeId ? ' in this worktree' : ''
-        throw new BrowserError(
-          'browser_tab_not_found',
-          `Browser page ${params.page} was not found${scope}`
-        )
-      }
       tabId = params.page
     } else if (params.index !== undefined) {
       const tabs = bridge.getRegisteredTabs(worktreeId)
@@ -1645,7 +1648,7 @@ export class RuntimeBrowserCommands {
 
       const handler = (
         _event: Electron.IpcMainEvent,
-        reply: { requestId: string; error?: string }
+        reply: { requestId: string; error?: string; code?: 'browser_tab_not_found' }
       ): void => {
         if (reply.requestId !== requestId) {
           return
@@ -1653,7 +1656,11 @@ export class RuntimeBrowserCommands {
         clearTimeout(timer)
         ipcMain.removeListener('browser:tabCloseReply', handler)
         if (reply.error) {
-          reject(new Error(reply.error))
+          reject(
+            reply.code === 'browser_tab_not_found'
+              ? new BrowserError('browser_tab_not_found', reply.error)
+              : new Error(reply.error)
+          )
         } else {
           resolve()
         }
@@ -1706,9 +1713,15 @@ export class RuntimeBrowserCommands {
     worktreeId?: string,
     profileId?: string,
     activate?: boolean,
-    targetGroupId?: string
+    targetGroupId?: string,
+    requestedPageId?: string
   ): Promise<{ browserPageId: string }> {
-    const { browserPageId } = await offscreen.createTab({ url, worktreeId, profileId })
+    const { browserPageId } = await offscreen.createTab({
+      url,
+      worktreeId,
+      profileId,
+      ...(requestedPageId ? { browserPageId: requestedPageId } : {})
+    })
     const bridge = this.host.getAgentBrowserBridge()
     const wcId = bridge?.getRegisteredTabs(worktreeId).get(browserPageId)
     if (bridge && wcId != null) {
@@ -1726,7 +1739,8 @@ export class RuntimeBrowserCommands {
     worktreeId: string | undefined,
     profileId: string | undefined,
     sessionPartition: string | undefined,
-    activate?: boolean
+    activate?: boolean,
+    requestedPageId?: string
   ): Promise<{ browserPageId: string }> {
     const win = this.host.getAuthoritativeWindow()
     const requestId = randomUUID()
@@ -1757,6 +1771,7 @@ export class RuntimeBrowserCommands {
         requestId,
         url,
         worktreeId,
+        ...(requestedPageId ? { browserPageId: requestedPageId } : {}),
         // Why: keep these undefined (not null) when no profile is chosen so the renderer still applies default-profile inheritance.
         sessionProfileId: profileId,
         sessionPartition,

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -1640,6 +1640,13 @@ export class RuntimeBrowserCommands {
       if (!resolvedTabId) {
         return { closed: false }
       }
+      if (explicitPage && !bridge.getRegisteredTabs(worktreeId).has(resolvedTabId)) {
+        const scope = worktreeId ? ' in this worktree' : ''
+        throw new BrowserError(
+          'browser_tab_not_found',
+          `Browser page ${resolvedTabId} was not found${scope}`
+        )
+      }
       await offscreen.closeTab(resolvedTabId)
       return { closed: true }
     }

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -156,6 +156,7 @@ export type RuntimeBrowserCommandHost = {
     browserPageId: string,
     targetGroupId?: string
   ): void
+  notifyHeadlessBrowserSessionTabsChanged?(worktreeId: string): void
 }
 
 export class RuntimeBrowserCommands {
@@ -357,6 +358,9 @@ export class RuntimeBrowserCommands {
     const pageId = bridge.getActivePageId(target.worktreeId, target.browserPageId)
     if (pageId) {
       this.notifyRendererNavigation(pageId, result.url, result.title)
+    }
+    if (!this.host.getAvailableAuthoritativeWindow() && target.worktreeId) {
+      this.host.notifyHeadlessBrowserSessionTabsChanged?.(target.worktreeId)
     }
     return result
   }
@@ -1357,6 +1361,9 @@ export class RuntimeBrowserCommands {
       const navigate = async (): Promise<void> => {
         const result = await bridge.goto(url, worktreeId, browserPageId)
         this.notifyRendererNavigation(browserPageId, result.url, result.title)
+        if (!this.host.getAvailableAuthoritativeWindow() && worktreeId) {
+          this.host.notifyHeadlessBrowserSessionTabsChanged?.(worktreeId)
+        }
       }
       if (params.waitForRegistration === true) {
         void navigate().catch(() => {})

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -1604,12 +1604,12 @@ export class RuntimeBrowserCommands {
     worktree?: string
   }): Promise<{ closed: boolean }> {
     const bridge = this.requireAgentBrowserBridge()
-    const pageTarget =
-      typeof params.page === 'string' && params.page.length > 0
-        ? await this.resolveBrowserCommandTarget({ worktree: params.worktree, page: params.page })
-        : null
-    const worktreeId =
-      pageTarget?.worktreeId ?? (await this.resolveBrowserWorktreeId(params.worktree))
+    const explicitPage = typeof params.page === 'string' && params.page.length > 0
+    const worktreeId = explicitPage
+      ? params.worktree
+        ? (await this.host.resolveWorktreeSelector(params.worktree)).id
+        : undefined
+      : await this.resolveBrowserWorktreeId(params.worktree)
 
     let tabId: string | null = null
     if (typeof params.page === 'string' && params.page.length > 0) {
@@ -1632,9 +1632,8 @@ export class RuntimeBrowserCommands {
     }
 
     // Why: headless serve has no renderer to ask, so destroy the offscreen page directly.
-    const offscreen = this.host.getAvailableAuthoritativeWindow()
-      ? null
-      : this.host.getOffscreenBrowserBackend()
+    const authoritativeWindow = this.host.getAvailableAuthoritativeWindow()
+    const offscreen = authoritativeWindow ? null : this.host.getOffscreenBrowserBackend()
     if (offscreen) {
       // Why: resolve the active page for implicit close so we don't report success while closing nothing.
       const resolvedTabId = tabId ?? bridge.getActivePageId(worktreeId)
@@ -1645,7 +1644,12 @@ export class RuntimeBrowserCommands {
       return { closed: true }
     }
 
-    const win = this.host.getAuthoritativeWindow()
+    if (!authoritativeWindow && tabId && !bridge.getRegisteredTabs(worktreeId).has(tabId)) {
+      const scope = worktreeId ? ' in this worktree' : ''
+      throw new BrowserError('browser_tab_not_found', `Browser page ${tabId} was not found${scope}`)
+    }
+
+    const win = authoritativeWindow ?? this.host.getAuthoritativeWindow()
     const requestId = randomUUID()
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -35540,7 +35540,9 @@ export class OrcaRuntimeService {
     getAvailableAuthoritativeWindow: () => this.getAvailableAuthoritativeWindow(),
     getOffscreenBrowserBackend: () => this.offscreenBrowserBackend,
     // Why: bind directly, not a wrapper arrow — a hand-listed wrapper dropped targetGroupId, so a right-split browser landed in the left.
-    markHeadlessBrowserSessionTabActive: this.markHeadlessBrowserSessionTabActive.bind(this)
+    markHeadlessBrowserSessionTabActive: this.markHeadlessBrowserSessionTabActive.bind(this),
+    notifyHeadlessBrowserSessionTabsChanged: (worktreeId) =>
+      this.notifyMobileSessionTabsChanged(worktreeId)
   })
 
   private readonly emulatorCommands = new RuntimeEmulatorCommands({

--- a/src/main/runtime/rpc/methods/browser-core.ts
+++ b/src/main/runtime/rpc/methods/browser-core.ts
@@ -24,7 +24,6 @@ import {
   TabCurrent,
   TabSetProfile,
   TabClose,
-  TabCreate,
   TabList,
   TabProfileClone,
   TabShow,
@@ -32,6 +31,7 @@ import {
   Upload,
   Wait
 } from './browser-schemas'
+import { BrowserTabCreateParams } from './browser-tab-create-schema'
 import { BROWSER_TEXT_METHODS } from './browser-text-rpc-methods'
 
 const CertificateProceed = BrowserTarget.extend({
@@ -112,7 +112,7 @@ export const BROWSER_CORE_METHODS: RpcMethod[] = [
   }),
   defineMethod({
     name: 'browser.tabCreate',
-    params: TabCreate,
+    params: BrowserTabCreateParams,
     handler: async (params, { runtime }) => runtime.browserTabCreate(params)
   }),
   defineMethod({

--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -84,7 +84,6 @@ export const Eval = BrowserTarget.extend({
 })
 
 export const TabList = z.object({ worktree: OptionalString })
-
 // Why: --index xor --page must be present. The refine guards that invariant
 // so the dispatcher surfaces a single legible error instead of either shape
 // leaking into the runtime.
@@ -110,18 +109,6 @@ export const TabSwitch = BrowserTarget.extend({
   },
   { message: 'Missing required --index (non-negative integer) or --page' }
 )
-
-export const TabCreate = z.object({
-  url: OptionalString,
-  worktree: OptionalString,
-  profileId: OptionalString,
-  waitForRegistration: z.boolean().optional(),
-  // User-initiated opens focus the tab; agent/automation opens stay background.
-  activate: z.boolean().optional(),
-  // Why: the split group whose "+" was clicked, so a headless host places the
-  // new browser tab there instead of coalescing into the first/active group.
-  targetGroupId: OptionalString
-})
 
 export const TabShow = z.object({
   page: requiredString('Missing required --page'),

--- a/src/main/runtime/rpc/methods/browser-tab-create-schema.ts
+++ b/src/main/runtime/rpc/methods/browser-tab-create-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+import { OptionalString } from '../schemas'
+
+export const BrowserTabCreateParams = z.object({
+  url: OptionalString,
+  worktree: OptionalString,
+  page: OptionalString,
+  profileId: OptionalString,
+  waitForRegistration: z.boolean().optional(),
+  activate: z.boolean().optional(),
+  targetGroupId: OptionalString
+})

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -63,6 +63,7 @@ export type UiCommandEventApi = {
       requestId: string
       url: string
       worktreeId?: string
+      browserPageId?: string
       sessionProfileId?: string | null
       sessionPartition?: string
       activate?: boolean
@@ -81,7 +82,11 @@ export type UiCommandEventApi = {
   onRequestTabClose: (
     callback: (data: { requestId: string; tabId: string | null; worktreeId?: string }) => void
   ) => () => void
-  replyTabClose: (reply: { requestId: string; error?: string }) => void
+  replyTabClose: (reply: {
+    requestId: string
+    error?: string
+    code?: 'browser_tab_not_found'
+  }) => void
   onNewTerminalTab: (callback: () => void) => () => void
   onFocusBrowserAddressBar: (callback: () => void) => () => void
   onFindInBrowserPage: (source: BrowserFindSource, callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3652,6 +3652,7 @@ const api = {
         requestId: string
         url: string
         worktreeId?: string
+        browserPageId?: string
         sessionProfileId?: string | null
         sessionPartition?: string
         activate?: boolean
@@ -3663,6 +3664,7 @@ const api = {
           requestId: string
           url: string
           worktreeId?: string
+          browserPageId?: string
           sessionProfileId?: string | null
           sessionPartition?: string
           activate?: boolean
@@ -3711,7 +3713,11 @@ const api = {
       ipcRenderer.on('browser:requestTabClose', listener)
       return () => ipcRenderer.removeListener('browser:requestTabClose', listener)
     },
-    replyTabClose: (reply: { requestId: string; error?: string }): void => {
+    replyTabClose: (reply: {
+      requestId: string
+      error?: string
+      code?: 'browser_tab_not_found'
+    }): void => {
       ipcRenderer.send('browser:tabCloseReply', reply)
     },
     onNewTerminalTab: (callback: () => void): (() => void) => {

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -3714,6 +3714,46 @@ describe('useIpcEvents browser tab close routing', () => {
     )
   })
 
+  it('refuses to close a browser page outside the requested worktree', async () => {
+    const requestTabCloseListenerRef: { current: RequestTabCloseListener | null } = {
+      current: null
+    }
+    const closeBrowserTab = vi.fn()
+    const closeBrowserPage = vi.fn()
+    const replyTabClose = vi.fn()
+
+    await useIpcEventsForCloseRouting({
+      requestTabCloseListenerRef,
+      replyTabClose,
+      getState: () => ({
+        closeBrowserTab,
+        closeBrowserPage,
+        browserTabsByWorktree: {
+          'wt-1': [{ id: 'workspace-1' }],
+          'wt-2': [{ id: 'workspace-2' }]
+        },
+        browserPagesByWorkspace: {
+          'workspace-1': [{ id: 'page-1', workspaceId: 'workspace-1' }],
+          'workspace-2': [{ id: 'page-2', workspaceId: 'workspace-2' }]
+        }
+      })
+    })
+
+    requestTabCloseListenerRef.current?.({
+      requestId: 'req-wrong-worktree',
+      tabId: 'page-2',
+      worktreeId: 'wt-1'
+    })
+
+    expect(closeBrowserPage).not.toHaveBeenCalled()
+    expect(closeBrowserTab).not.toHaveBeenCalled()
+    expect(replyTabClose).toHaveBeenCalledWith({
+      requestId: 'req-wrong-worktree',
+      code: 'browser_tab_not_found',
+      error: 'Browser tab page-2 not found'
+    })
+  })
+
   it('closes the active browser tab for the requested worktree when main does not provide a tab id', async () => {
     const closeBrowserTab = vi.fn()
     const closeBrowserPage = vi.fn()

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -900,6 +900,7 @@ describe('useIpcEvents browser tab create routing', () => {
         | ((data: {
             requestId: string
             worktreeId?: string | null
+            browserPageId?: string
             url: string
             sessionProfileId?: string
           }) => void)
@@ -961,10 +962,15 @@ describe('useIpcEvents browser tab create routing', () => {
         ]
       },
       createBrowserTab: vi.fn(
-        (_worktreeId: string, _url: string, options: { activate?: boolean }) => {
-          const workspace = { id: 'workspace-new', activePageId: 'page-new', pageIds: ['page-new'] }
+        (
+          _worktreeId: string,
+          _url: string,
+          options: { activate?: boolean; browserPageId?: string }
+        ) => {
+          const pageId = options.browserPageId ?? 'page-new'
+          const workspace = { id: 'workspace-new', activePageId: pageId, pageIds: [pageId] }
           state.browserTabsByWorktree['wt-1'].push(workspace)
-          state.browserPagesByWorkspace['workspace-new'] = [{ id: 'page-new', worktreeId: 'wt-1' }]
+          state.browserPagesByWorkspace['workspace-new'] = [{ id: pageId, worktreeId: 'wt-1' }]
           expect(options.activate).toBe(false)
           return workspace
         }
@@ -1128,20 +1134,21 @@ describe('useIpcEvents browser tab create routing', () => {
     requestTabCreateListenerRef.current?.({
       requestId: 'req-create',
       worktreeId: 'wt-1',
+      browserPageId: 'page-canonical',
       url: 'https://example.com'
     })
 
-    expect(acquireBrowserAutomationVisibility).toHaveBeenCalledWith('page-new')
+    expect(acquireBrowserAutomationVisibility).toHaveBeenCalledWith('page-canonical')
     expect(acquireBrowserAutomationVisibility).not.toHaveBeenCalledWith('page-active')
     expect(state.createBrowserTab).toHaveBeenCalledWith(
       'wt-1',
       'https://example.com',
-      expect.objectContaining({ activate: false })
+      expect.objectContaining({ activate: false, browserPageId: 'page-canonical' })
     )
     expect(state.createBrowserTab.mock.calls[0]?.[2]).not.toHaveProperty('allowWindowClose')
     expect(replyTabCreate).toHaveBeenCalledWith({
       requestId: 'req-create',
-      browserPageId: 'page-new'
+      browserPageId: 'page-canonical'
     })
     expect(dispatchEvent).toHaveBeenCalled()
     expect(releaseBrowserAutomationVisibility).not.toHaveBeenCalled()
@@ -4361,6 +4368,7 @@ describe('useIpcEvents browser tab close routing', () => {
     expect(closeBrowserTab).not.toHaveBeenCalled()
     expect(replyTabClose).toHaveBeenCalledWith({
       requestId: 'req-3',
+      code: 'browser_tab_not_found',
       error: 'Browser tab missing-page not found'
     })
   })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2316,6 +2316,7 @@ export function useIpcEvents(): void {
           // Agent/automation opens stay in the background (activate:false) in the active browser group.
           const workspace = store.createBrowserTab(worktreeId, data.url, {
             title: data.url,
+            browserPageId: data.browserPageId,
             targetGroupId: data.activate ? undefined : activeBrowserUnifiedTab?.groupId,
             sessionProfileId: data.sessionProfileId,
             sessionPartition: data.sessionPartition,
@@ -2483,6 +2484,7 @@ export function useIpcEvents(): void {
           if (explicitTargetId) {
             window.api.ui.replyTabClose({
               requestId: data.requestId,
+              code: 'browser_tab_not_found',
               error: translate(
                 'auto.hooks.useIpcEvents.0e3cf53060',
                 'Browser tab {{value0}} not found',

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2405,6 +2405,17 @@ export function useIpcEvents(): void {
           }
           const store = useAppStore.getState()
           const explicitTargetId = data.tabId ?? null
+          const replyBrowserTabNotFound = (tabId: string): void => {
+            window.api.ui.replyTabClose({
+              requestId: data.requestId,
+              code: 'browser_tab_not_found',
+              error: translate(
+                'auto.hooks.useIpcEvents.0e3cf53060',
+                'Browser tab {{value0}} not found',
+                { value0: tabId }
+              )
+            })
+          }
           const replyPinnedBrowserCloseCanceled = (tabId: string): void => {
             window.api.ui.replyTabClose({
               requestId: data.requestId,
@@ -2456,11 +2467,15 @@ export function useIpcEvents(): void {
             )
             if (owningWorkspace) {
               const [workspaceId, pages] = owningWorkspace
+              const owningWorktreeId =
+                Object.entries(store.browserTabsByWorktree).find(([, tabs]) =>
+                  tabs.some((tab) => tab.id === workspaceId)
+                )?.[0] ?? null
+              if (data.worktreeId && owningWorktreeId !== data.worktreeId) {
+                replyBrowserTabNotFound(tabToClose)
+                return
+              }
               if (pages.length <= 1) {
-                const owningWorktreeId =
-                  Object.entries(store.browserTabsByWorktree).find(([, tabs]) =>
-                    tabs.some((tab) => tab.id === workspaceId)
-                  )?.[0] ?? null
                 if (owningWorktreeId) {
                   closeBrowserWorkspaceWithReply(owningWorktreeId, workspaceId)
                   return
@@ -2478,19 +2493,15 @@ export function useIpcEvents(): void {
               tabs.some((tab) => tab.id === tabToClose)
             )?.[0] ?? null
           if (owningWorktreeId) {
+            if (data.worktreeId && owningWorktreeId !== data.worktreeId) {
+              replyBrowserTabNotFound(tabToClose)
+              return
+            }
             closeBrowserWorkspaceWithReply(owningWorktreeId, tabToClose)
             return
           }
           if (explicitTargetId) {
-            window.api.ui.replyTabClose({
-              requestId: data.requestId,
-              code: 'browser_tab_not_found',
-              error: translate(
-                'auto.hooks.useIpcEvents.0e3cf53060',
-                'Browser tab {{value0}} not found',
-                { value0: explicitTargetId }
-              )
-            })
+            replyBrowserTabNotFound(explicitTargetId)
             return
           }
           store.closeBrowserTab(tabToClose)

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -638,6 +638,110 @@ describe('createWebRuntimeSessionBrowserTab', () => {
     expect(mocks.createBrowserTab).not.toHaveBeenCalled()
   })
 
+  it('cleans up a known page identity when the create acknowledgement is lost', async () => {
+    mocks.getState.mockReturnValue({
+      ...mocks.getState(),
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          ENVIRONMENT_ID,
+          {
+            status: {
+              capabilities: ['browser.screencast.v1', 'browser.tab-create-known-id.v1']
+            },
+            checkedAt: 1
+          }
+        ]
+      ])
+    })
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create-lost',
+        ok: false,
+        error: { code: 'runtime_timeout', message: 'response lost' }
+      })
+      .mockResolvedValueOnce({
+        id: 'close-missing',
+        ok: false,
+        error: { code: 'browser_tab_not_found', message: 'page was not created' }
+      })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      createWebRuntimeSessionBrowserTab({
+        worktreeId: WORKTREE_ID,
+        url: 'https://example.com/',
+        waitForRegistration: true
+      })
+    ).resolves.toBe(false)
+
+    const createPage = runtimeCall.mock.calls[0]?.[0].params.page
+    expect(createPage).toMatch(/^[0-9a-f-]{36}$/)
+    expect(runtimeCall).toHaveBeenNthCalledWith(2, {
+      selector: ENVIRONMENT_ID,
+      method: 'browser.tabClose',
+      params: { worktree: `id:${WORKTREE_ID}`, page: createPage },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('materializes an owner-pinned tab without waiting for its navigation', async () => {
+    mocks.getState.mockReturnValue({
+      ...mocks.getState(),
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          ENVIRONMENT_ID,
+          {
+            status: {
+              capabilities: ['browser.screencast.v1', 'browser.tab-create-known-id.v1']
+            },
+            checkedAt: 1
+          }
+        ]
+      ])
+    })
+    let resolveNavigation!: (value: unknown) => void
+    const navigation = new Promise<unknown>((resolve) => {
+      resolveNavigation = resolve
+    })
+    const runtimeCall = vi.fn((request: { method: string; params: { page?: string } }) => {
+      if (request.method === 'browser.tabCreate') {
+        return Promise.resolve({
+          id: 'create',
+          ok: true,
+          result: { browserPageId: request.params.page }
+        })
+      }
+      if (request.method === 'browser.goto') {
+        return navigation
+      }
+      return Promise.resolve({ id: 'list', ok: true, result: makeSnapshot() })
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const created = createWebRuntimeSessionBrowserTab({
+      worktreeId: WORKTREE_ID,
+      url: 'https://example.com/slow',
+      waitForRegistration: true
+    })
+
+    await expect(created).resolves.toBe(true)
+    expect(runtimeCall.mock.calls.map(([request]) => request.method)).toEqual([
+      'browser.tabCreate',
+      'browser.goto',
+      'session.tabs.list'
+    ])
+    expect(runtimeCall.mock.calls[0]?.[0].params).toMatchObject({
+      url: undefined,
+      waitForRegistration: true
+    })
+    expect(runtimeCall.mock.calls[1]?.[0].params).toMatchObject({
+      page: runtimeCall.mock.calls[0]?.[0].params.page,
+      url: 'https://example.com/slow'
+    })
+    resolveNavigation({ id: 'goto', ok: true, result: { url: 'https://example.com/slow' } })
+  })
+
   it.each(['browser_error', 'invalid_argument', 'method_not_found'])(
     'reports a definitive browser-create %s as a soft failure',
     async (code) => {

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -19,7 +19,10 @@ import type {
   SleepingAgentLaunchConfig,
   AgentProviderSessionMetadata
 } from '../../../shared/agent-session-resume'
-import { AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import {
+  AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY
+} from '../../../shared/protocol-version'
 import type {
   AgentLaunchPreferences,
   AgentPromptDelivery,
@@ -482,6 +485,10 @@ export async function createWebRuntimeSessionBrowserTab(args: {
   const shouldFocusOnCreate = args.focusOnCreate !== false
   const shouldSelectWorktree = args.selectWorktree !== false
   const provisionalPageId = createBrowserUuid()
+  const hostSupportsKnownPageId = useAppStore
+    .getState()
+    .runtimeStatusByEnvironmentId?.get(environmentId)
+    ?.status?.capabilities?.includes(BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY)
   let unsubscribeFocusGuard = (): void => {}
   let guardedPageId = provisionalPageId
   let createdPageId: string | null = null
@@ -540,12 +547,15 @@ export async function createWebRuntimeSessionBrowserTab(args: {
       })
     }
     createAttempted = true
+    const navigateAfterCreate =
+      args.waitForRegistration === true && args.url && args.url !== 'about:blank'
     const created = unwrapRuntimeRpcResult(
       (await callEnvironment({
         method: 'browser.tabCreate',
         params: {
           worktree: toRuntimeWorktreeSelector(args.worktreeId),
-          url: args.url,
+          url: navigateAfterCreate ? undefined : args.url,
+          ...(hostSupportsKnownPageId ? { page: provisionalPageId } : {}),
           profileId: args.profileId ?? undefined,
           activate: shouldFocusOnCreate,
           // Why: place the new browser in the clicked split group so the host snapshot is authoritative for it (no left-snap).
@@ -557,6 +567,24 @@ export async function createWebRuntimeSessionBrowserTab(args: {
       })) as RuntimeRpcResponse<BrowserTabCreateResult>
     )
     createdPageId = created.browserPageId
+    if (navigateAfterCreate) {
+      void callEnvironment({
+        method: 'browser.goto',
+        params: {
+          worktree: toRuntimeWorktreeSelector(args.worktreeId),
+          page: created.browserPageId,
+          url: args.url
+        },
+        timeoutMs: 15_000
+      })
+        .then((response) => unwrapRuntimeRpcResult(response))
+        .catch((error) => {
+          console.warn(
+            '[web-runtime-session] created browser tab navigation failed:',
+            error instanceof Error ? error.message : String(error)
+          )
+        })
+    }
     await pauseAfterE2eWebRuntimeBrowserCreate(created.browserPageId)
     if (created.browserPageId !== provisionalPageId) {
       moveWebSessionBrowserPlacement({
@@ -635,7 +663,11 @@ export async function createWebRuntimeSessionBrowserTab(args: {
   } catch (error) {
     unsubscribeFocusGuard()
     let recoveryError: unknown = null
-    const createOutcomeUnknown = !createdPageId && !isDefinitiveBrowserCreateFailure(error)
+    const createFailureDefinitive = isDefinitiveBrowserCreateFailure(error)
+    const cleanupPageId =
+      createdPageId ??
+      (!createFailureDefinitive && hostSupportsKnownPageId ? provisionalPageId : null)
+    const createOutcomeUnknown = !cleanupPageId && !createFailureDefinitive
     const ownsClientGroupCleanup = args.clientTargetGroupId
       ? releaseWebSessionBrowserPlacementGroup({
           environmentId,
@@ -652,14 +684,14 @@ export async function createWebRuntimeSessionBrowserTab(args: {
         remotePageId: guardedPageId
       })
     }
-    if (createdPageId) {
+    if (cleanupPageId) {
       try {
         const closeResult = unwrapRuntimeRpcResult(
           (await callEnvironment({
             method: 'browser.tabClose',
             params: {
               worktree: toRuntimeWorktreeSelector(args.worktreeId),
-              page: createdPageId
+              page: cleanupPageId
             },
             timeoutMs: 15_000
           })) as RuntimeRpcResponse<{ closed: boolean }>
@@ -677,17 +709,25 @@ export async function createWebRuntimeSessionBrowserTab(args: {
             useAppStore.getState(),
             environmentId,
             args.worktreeId,
-            createdPageId
+            cleanupPageId
           )
         ) {
           throw new Error('The closed browser tab remained materialized in the client.')
         }
       } catch (cleanupError) {
-        recoveryError = cleanupError
-        console.warn(
-          '[web-runtime-session] failed to clean up unreconciled browser tab:',
-          cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
-        )
+        if (
+          !createdPageId &&
+          hostSupportsKnownPageId &&
+          hasRuntimeRpcErrorCode(cleanupError, 'browser_tab_not_found')
+        ) {
+          recoveryError = null
+        } else {
+          recoveryError = cleanupError
+          console.warn(
+            '[web-runtime-session] failed to clean up unreconciled browser tab:',
+            cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+          )
+        }
       }
     }
     if (shouldFocusOnCreate) {

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -164,6 +164,22 @@ function makeAnnotation(pageId: string, id = 'annotation-1'): BrowserPageAnnotat
 }
 
 describe('createBrowserSlice annotations', () => {
+  it('keeps a requested canonical page identity distinct from its workspace', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'about:blank', {
+      browserPageId: 'page-canonical'
+    })
+
+    expect(tab.id).not.toBe('page-canonical')
+    expect(tab.activePageId).toBe('page-canonical')
+    expect(store.getState().browserPagesByWorkspace[tab.id]?.[0]?.id).toBe('page-canonical')
+    expect(() =>
+      store.getState().createBrowserTab('wt-1', 'about:blank', {
+        browserPageId: 'page-canonical'
+      })
+    ).toThrow('Browser page page-canonical already exists')
+  })
+
   it('records browser-tab-created only for the explicit new-tab action', async () => {
     const store = createTestStore()
 

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -391,11 +391,12 @@ function buildBrowserPage(
   worktreeId: string,
   url: string,
   title?: string,
-  browserRuntimeEnvironmentId?: string | null
+  browserRuntimeEnvironmentId?: string | null,
+  browserPageId?: string
 ): BrowserPage {
   const normalizedUrl = normalizeUrl(url)
   return {
-    id: createBrowserUuid(),
+    id: browserPageId ?? createBrowserUuid(),
     workspaceId,
     worktreeId,
     url: normalizedUrl,
@@ -599,19 +600,22 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
 
   createBrowserTab: (worktreeId, url, options) => {
     assertManagedBrowserMaterializationAllowed(get(), options?.browserRuntimeEnvironmentId)
-    const workspaceId = options?.browserPageId ?? createBrowserUuid()
+    const workspaceId = createBrowserUuid()
+    const browserPageId = options?.browserPageId
     if (
-      findWorkspace(get().browserTabsByWorktree, workspaceId) ||
-      findPage(get().browserPagesByWorkspace, workspaceId)
+      browserPageId &&
+      (findWorkspace(get().browserTabsByWorktree, browserPageId) ||
+        findPage(get().browserPagesByWorkspace, browserPageId))
     ) {
-      throw new Error(`Browser page ${workspaceId} already exists`)
+      throw new Error(`Browser page ${browserPageId} already exists`)
     }
     const page = buildBrowserPage(
       workspaceId,
       worktreeId,
       url,
       options?.title,
-      options?.browserRuntimeEnvironmentId
+      options?.browserRuntimeEnvironmentId,
+      browserPageId
     )
     // Why: with no explicit profile, inherit the user's default so a Settings preference applies to new tabs.
     const sessionProfileId =

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -68,6 +68,7 @@ import {
 
 type CreateBrowserTabOptions = {
   activate?: boolean
+  browserPageId?: string
   title?: string
   sessionProfileId?: string | null
   sessionPartition?: string | null
@@ -598,7 +599,13 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
 
   createBrowserTab: (worktreeId, url, options) => {
     assertManagedBrowserMaterializationAllowed(get(), options?.browserRuntimeEnvironmentId)
-    const workspaceId = createBrowserUuid()
+    const workspaceId = options?.browserPageId ?? createBrowserUuid()
+    if (
+      findWorkspace(get().browserTabsByWorktree, workspaceId) ||
+      findPage(get().browserPagesByWorkspace, workspaceId)
+    ) {
+      throw new Error(`Browser page ${workspaceId} already exists`)
+    }
     const page = buildBrowserPage(
       workspaceId,
       worktreeId,

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -56,6 +56,10 @@ export const AI_VAULT_SESSION_TITLES_RUNTIME_CAPABILITY = 'aiVault.session-title
 export const BROWSER_HEADLESS_RUNTIME_CAPABILITY = 'browser.headless.v1' as const
 export const BROWSER_SCREENCAST_RUNTIME_CAPABILITY = 'browser.screencast.v1' as const
 export const BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY = 'browser.certificate-trust.v1' as const
+// Why: older hosts discard browser.tabCreate's page field, so clients may only
+// treat a preallocated page ID as canonical when this is advertised.
+export const BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY =
+  'browser.tab-create-known-id.v1' as const
 // Why: hosts without this strip terminal.send's inputKind (zod object drops
 // unknown keys), so a mobile xterm query reply would land as ordinary
 // floor-taking input. Mobile must not forward replies unless advertised.
@@ -99,6 +103,7 @@ export const RUNTIME_CAPABILITIES = [
   ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY,
   ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY,
   BROWSER_SCREENCAST_RUNTIME_CAPABILITY,
+  BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY,
   'terminal.binary-stream.v1',
   'terminal.multiplex.v1',
   'workspace-ports.v1',

--- a/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
+++ b/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
@@ -192,12 +192,16 @@ async function findMirroredPageId(
   )
 }
 
-async function openLinkFromRemotePane(page: Page): Promise<void> {
+async function openLinkFromRemotePane(page: Page, testInfo: TestInfo): Promise<void> {
   const frame = page.locator('[data-testid="remote-browser-frame"]:visible').first()
   await expect(frame).toBeVisible({ timeout: 60_000 })
   await frame.click({ button: 'right', position: { x: 60, y: 60 }, force: true })
   const open = page.getByRole('menuitem', { name: 'Open Link In Orca Browser' })
   await expect(open).toBeVisible({ timeout: 30_000 })
+  await page.screenshot({
+    path: testInfo.outputPath('sta-4231-owner-pinned-link-route.png'),
+    fullPage: true
+  })
   await open.click()
 }
 
@@ -336,7 +340,7 @@ test('opens the held URL through the owner-pinned remote-pane link route @headfu
     )
     const baselineHostPageIds = await readHostBrowserPageIds(hostClient, worktreeId)
 
-    await openLinkFromRemotePane(client.page)
+    await openLinkFromRemotePane(client.page, testInfo)
     await expect.poll(fixture.pendingCount, { timeout: 30_000 }).toBe(1)
     const createdPageId = await expect
       .poll(async () => {

--- a/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
+++ b/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
@@ -1,0 +1,222 @@
+import { createServer, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { RuntimeClient } from '../../src/cli/runtime/client'
+import type { RuntimeMobileSessionTabsResult } from '../../src/shared/runtime-types'
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const OPERATION_ID = 'sta-4231-owner-pinned-navigation-hold'
+
+type HeldNavigationServer = {
+  close: () => Promise<void>
+  pendingCount: () => number
+  release: () => void
+  url: string
+}
+
+type CreateOutcome = {
+  error: string | null
+  ok: boolean
+  pageId: string | null
+}
+
+async function startHeldNavigationServer(): Promise<HeldNavigationServer> {
+  const pending = new Set<ServerResponse>()
+  const server: Server = createServer((_request, response) => {
+    pending.add(response)
+    response.once('close', () => pending.delete(response))
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const { port } = server.address() as AddressInfo
+  const release = (): void => {
+    for (const response of pending) {
+      if (!response.destroyed && !response.writableEnded) {
+        response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+        response.end('<!doctype html><html><body>released</body></html>')
+      }
+    }
+    pending.clear()
+  }
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        release()
+        server.closeAllConnections()
+        server.close((error) => (error ? reject(error) : resolve()))
+      }),
+    pendingCount: () => pending.size,
+    release,
+    url: `http://127.0.0.1:${port}/hold?operation=${OPERATION_ID}`
+  }
+}
+
+async function readHostBrowserPageIds(
+  hostClient: RuntimeClient,
+  worktreeId: string
+): Promise<string[]> {
+  const response = await hostClient.call<RuntimeMobileSessionTabsResult>('session.tabs.list', {
+    worktree: `id:${worktreeId}`
+  })
+  return response.result.tabs.flatMap((tab) =>
+    tab.type === 'browser' && tab.browserPageId ? [tab.browserPageId] : []
+  )
+}
+
+async function createOwnerPinnedBrowser(
+  page: Page,
+  environmentId: string,
+  worktreeId: string,
+  url: string
+): Promise<CreateOutcome> {
+  return page.evaluate(
+    async ({ environmentId, url, worktreeId }) => {
+      try {
+        const response = await window.api.runtimeEnvironments.call({
+          selector: environmentId,
+          method: 'browser.tabCreate',
+          params: {
+            activate: true,
+            url,
+            waitForRegistration: true,
+            worktree: `id:${worktreeId}`
+          },
+          timeoutMs: 15_000
+        })
+        if (!response.ok) {
+          return {
+            error: `${response.error.code}: ${response.error.message}`,
+            ok: false,
+            pageId: null
+          }
+        }
+        const result = response.result as { browserPageId: string }
+        return { error: null, ok: true, pageId: result.browserPageId }
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          ok: false,
+          pageId: null
+        }
+      }
+    },
+    { environmentId, url, worktreeId }
+  )
+}
+
+async function findPairedWorktreeId(
+  client: PairedElectronClient,
+  repoPath: string
+): Promise<string> {
+  const worktreeId = await expect
+    .poll(
+      () =>
+        client.page.evaluate(
+          (path) =>
+            window.__store
+              ?.getState()
+              .allWorktrees()
+              .find((worktree) => worktree.path === path)?.id ?? null,
+          repoPath
+        ),
+      { timeout: 60_000, message: 'paired client never received the host worktree' }
+    )
+    .not.toBeNull()
+    .then(() =>
+      client.page.evaluate(
+        (path) =>
+          window.__store
+            ?.getState()
+            .allWorktrees()
+            .find((worktree) => worktree.path === path)?.id ?? null,
+        repoPath
+      )
+    )
+  if (!worktreeId) {
+    throw new Error('Paired worktree disappeared after discovery')
+  }
+  return worktreeId
+}
+
+test('returns a headed host page identity before owner-pinned navigation can time out @headful', async ({
+  electronApp,
+  orcaPage,
+  testRepoPath
+}, testInfo: TestInfo) => {
+  test.setTimeout(300_000)
+  const fixture = await startHeldNavigationServer()
+  let client: PairedElectronClient | null = null
+  try {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+    const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+    const hostClient = new RuntimeClient(userDataDir, 5_000)
+    client = await launchPairedElectronClient(offer, testInfo, 'STA-4231 navigation deadline')
+    const worktreeId = await findPairedWorktreeId(client, testRepoPath)
+    const baselineHostPageIds = await readHostBrowserPageIds(hostClient, worktreeId)
+    await client.page.evaluate(
+      ({ environmentId, worktreeId }) => {
+        window.__store?.getState().setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+      },
+      { environmentId: client.environmentId, worktreeId }
+    )
+
+    const firstPromise = createOwnerPinnedBrowser(
+      client.page,
+      client.environmentId,
+      worktreeId,
+      fixture.url
+    )
+    await expect.poll(fixture.pendingCount, { timeout: 30_000 }).toBe(1)
+    const firstHostPageId = await expect
+      .poll(async () => {
+        const ids = await readHostBrowserPageIds(hostClient, worktreeId)
+        return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
+      })
+      .not.toBeNull()
+      .then(async () => {
+        const ids = await readHostBrowserPageIds(hostClient, worktreeId)
+        return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
+      })
+    const first = await firstPromise
+
+    let retry: CreateOutcome | null = null
+    if (!first.ok) {
+      const retryPromise = createOwnerPinnedBrowser(
+        client.page,
+        client.environmentId,
+        worktreeId,
+        fixture.url
+      )
+      await expect.poll(fixture.pendingCount, { timeout: 30_000 }).toBe(2)
+      retry = await retryPromise
+    }
+    const hostPageIds = (await readHostBrowserPageIds(hostClient, worktreeId)).filter(
+      (id) => !baselineHostPageIds.includes(id)
+    )
+
+    expect({ first, firstHostPageId, hostPageIds, retry }).toEqual({
+      first: { error: null, ok: true, pageId: firstHostPageId },
+      firstHostPageId,
+      hostPageIds: [firstHostPageId],
+      retry: null
+    })
+  } finally {
+    fixture.release()
+    await client?.dispose()
+    await fixture.close()
+  }
+})

--- a/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
+++ b/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
@@ -17,6 +17,7 @@ type HeldNavigationServer = {
   close: () => Promise<void>
   pendingCount: () => number
   release: () => void
+  sourceUrl: string
   url: string
 }
 
@@ -28,7 +29,14 @@ type CreateOutcome = {
 
 async function startHeldNavigationServer(): Promise<HeldNavigationServer> {
   const pending = new Set<ServerResponse>()
-  const server: Server = createServer((_request, response) => {
+  const server: Server = createServer((request, response) => {
+    if (request.url?.startsWith('/source')) {
+      response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+      response.end(
+        `<!doctype html><html><body style="margin:0"><a href="/hold?operation=${OPERATION_ID}" style="position:fixed;inset:0;display:block">open held page</a></body></html>`
+      )
+      return
+    }
     pending.add(response)
     response.once('close', () => pending.delete(response))
   })
@@ -58,6 +66,7 @@ async function startHeldNavigationServer(): Promise<HeldNavigationServer> {
       }),
     pendingCount: () => pending.size,
     release,
+    sourceUrl: `http://127.0.0.1:${port}/source`,
     url: `http://127.0.0.1:${port}/hold?operation=${OPERATION_ID}`
   }
 }
@@ -149,6 +158,49 @@ async function findPairedWorktreeId(
   return worktreeId
 }
 
+async function readClientBrowserPageIds(page: Page, worktreeId: string): Promise<string[]> {
+  return page.evaluate((worktreeId) => {
+    const state = window.__store?.getState()
+    return (state?.browserTabsByWorktree[worktreeId] ?? []).flatMap((workspace) =>
+      (state?.browserPagesByWorkspace[workspace.id] ?? []).map(
+        (browserPage) =>
+          state?.remoteBrowserPageHandlesByPageId[browserPage.id]?.remotePageId ?? browserPage.id
+      )
+    )
+  }, worktreeId)
+}
+
+async function findMirroredPageId(
+  page: Page,
+  worktreeId: string,
+  url: string
+): Promise<string | null> {
+  return page.evaluate(
+    ({ url, worktreeId }) => {
+      const state = window.__store?.getState()
+      for (const workspace of state?.browserTabsByWorktree[worktreeId] ?? []) {
+        const browserPage = (state?.browserPagesByWorkspace[workspace.id] ?? []).find((candidate) =>
+          candidate.url.startsWith(url)
+        )
+        if (browserPage) {
+          return browserPage.id
+        }
+      }
+      return null
+    },
+    { url, worktreeId }
+  )
+}
+
+async function openLinkFromRemotePane(page: Page): Promise<void> {
+  const frame = page.locator('[data-testid="remote-browser-frame"]:visible').first()
+  await expect(frame).toBeVisible({ timeout: 60_000 })
+  await frame.click({ button: 'right', position: { x: 60, y: 60 }, force: true })
+  const open = page.getByRole('menuitem', { name: 'Open Link In Orca Browser' })
+  await expect(open).toBeVisible({ timeout: 30_000 })
+  await open.click()
+}
+
 test('returns a headed host page identity before owner-pinned navigation can time out @headful', async ({
   electronApp,
   orcaPage,
@@ -165,6 +217,12 @@ test('returns a headed host page identity before owner-pinned navigation can tim
     const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
     const hostClient = new RuntimeClient(userDataDir, 5_000)
     client = await launchPairedElectronClient(offer, testInfo, 'STA-4231 navigation deadline')
+    const cdp = await client.page.context().newCDPSession(client.page)
+    const visibility = await cdp.send('Runtime.evaluate', {
+      expression: 'document.visibilityState',
+      returnByValue: true
+    })
+    expect(visibility.result.value).toBe('visible')
     const worktreeId = await findPairedWorktreeId(client, testRepoPath)
     const baselineHostPageIds = await readHostBrowserPageIds(hostClient, worktreeId)
     await client.page.evaluate(
@@ -207,6 +265,16 @@ test('returns a headed host page identity before owner-pinned navigation can tim
     const hostPageIds = (await readHostBrowserPageIds(hostClient, worktreeId)).filter(
       (id) => !baselineHostPageIds.includes(id)
     )
+    await expect
+      .poll(() => readClientBrowserPageIds(client!.page, worktreeId), {
+        timeout: 30_000,
+        message: 'paired client did not materialize the canonical host page'
+      })
+      .toContain(firstHostPageId)
+    await client.page.screenshot({
+      path: testInfo.outputPath('sta-4231-headed-canonical-page.png'),
+      fullPage: true
+    })
 
     expect({ first, firstHostPageId, hostPageIds, retry }).toEqual({
       first: { error: null, ok: true, pageId: firstHostPageId },
@@ -214,6 +282,84 @@ test('returns a headed host page identity before owner-pinned navigation can tim
       hostPageIds: [firstHostPageId],
       retry: null
     })
+  } finally {
+    fixture.release()
+    await client?.dispose()
+    await fixture.close()
+  }
+})
+
+test('opens the held URL through the owner-pinned remote-pane link route @headful', async ({
+  electronApp,
+  orcaPage,
+  testRepoPath
+}, testInfo: TestInfo) => {
+  test.setTimeout(300_000)
+  const fixture = await startHeldNavigationServer()
+  let client: PairedElectronClient | null = null
+  try {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+    const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+    const hostClient = new RuntimeClient(userDataDir, 5_000)
+    client = await launchPairedElectronClient(offer, testInfo, 'STA-4231 owner-pinned link route')
+    const worktreeId = await findPairedWorktreeId(client, testRepoPath)
+    await client.page.evaluate(
+      ({ environmentId, worktreeId }) => {
+        window.__store?.getState().setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+      },
+      { environmentId: client.environmentId, worktreeId }
+    )
+    await hostClient.call('browser.tabCreate', {
+      activate: true,
+      url: fixture.sourceUrl,
+      worktree: `id:${worktreeId}`
+    })
+    const sourcePageId = await expect
+      .poll(() => findMirroredPageId(client!.page, worktreeId, fixture.sourceUrl), {
+        timeout: 60_000,
+        message: 'paired client never mirrored the source browser pane'
+      })
+      .not.toBeNull()
+      .then(() => findMirroredPageId(client!.page, worktreeId, fixture.sourceUrl))
+    if (!sourcePageId) {
+      throw new Error('Source browser page disappeared')
+    }
+    await client.page.evaluate(
+      ({ pageId, worktreeId }) =>
+        window.__store?.getState().focusBrowserTabInWorktree(worktreeId, pageId, {
+          surfacePane: true
+        }),
+      { pageId: sourcePageId, worktreeId }
+    )
+    const baselineHostPageIds = await readHostBrowserPageIds(hostClient, worktreeId)
+
+    await openLinkFromRemotePane(client.page)
+    await expect.poll(fixture.pendingCount, { timeout: 30_000 }).toBe(1)
+    const createdPageId = await expect
+      .poll(async () => {
+        const ids = await readHostBrowserPageIds(hostClient, worktreeId)
+        return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
+      })
+      .not.toBeNull()
+      .then(async () => {
+        const ids = await readHostBrowserPageIds(hostClient, worktreeId)
+        return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
+      })
+    expect(createdPageId).not.toBeNull()
+    await expect
+      .poll(() => readClientBrowserPageIds(client!.page, worktreeId), {
+        timeout: 30_000,
+        message: 'link route did not materialize the canonical host page'
+      })
+      .toContain(createdPageId)
+    expect(
+      (await readHostBrowserPageIds(hostClient, worktreeId)).filter(
+        (id) => !baselineHostPageIds.includes(id)
+      )
+    ).toEqual([createdPageId])
   } finally {
     fixture.release()
     await client?.dispose()

--- a/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
+++ b/tests/e2e/paired-browser-create-navigation-deadline.spec.ts
@@ -37,6 +37,11 @@ async function startHeldNavigationServer(): Promise<HeldNavigationServer> {
       )
       return
     }
+    if (!request.url?.startsWith('/hold')) {
+      response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
+      response.end('not found')
+      return
+    }
     pending.add(response)
     response.once('close', () => pending.delete(response))
   })
@@ -244,10 +249,13 @@ test('returns a headed host page identity before owner-pinned navigation can tim
     )
     await expect.poll(fixture.pendingCount, { timeout: 30_000 }).toBe(1)
     const firstHostPageId = await expect
-      .poll(async () => {
-        const ids = await readHostBrowserPageIds(hostClient, worktreeId)
-        return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
-      })
+      .poll(
+        async () => {
+          const ids = await readHostBrowserPageIds(hostClient, worktreeId)
+          return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
+        },
+        { timeout: 30_000, message: 'host never registered the owner-pinned page' }
+      )
       .not.toBeNull()
       .then(async () => {
         const ids = await readHostBrowserPageIds(hostClient, worktreeId)
@@ -343,10 +351,13 @@ test('opens the held URL through the owner-pinned remote-pane link route @headfu
     await openLinkFromRemotePane(client.page, testInfo)
     await expect.poll(fixture.pendingCount, { timeout: 30_000 }).toBe(1)
     const createdPageId = await expect
-      .poll(async () => {
-        const ids = await readHostBrowserPageIds(hostClient, worktreeId)
-        return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
-      })
+      .poll(
+        async () => {
+          const ids = await readHostBrowserPageIds(hostClient, worktreeId)
+          return ids.find((id) => !baselineHostPageIds.includes(id)) ?? null
+        },
+        { timeout: 30_000, message: 'link route never registered a host page' }
+      )
       .not.toBeNull()
       .then(async () => {
         const ids = await readHostBrowserPageIds(hostClient, worktreeId)


### PR DESCRIPTION
## Summary
- return the canonical host page identity before slow owner-pinned navigation completes
- preallocate that identity on capable clients so an acknowledgement loss still has exact cleanup authority
- split owner-pinned creation from navigation without changing ordinary unpinned opens
- add deterministic latest-main/candidate/revert coverage plus headed and headless paired-runtime validation

Linear: STA-4231  
Originating fix: #14363 / STA-4181

## Problem and root cause
The paired client abandoned `browser.tabCreate` after 15 seconds, but the renderer-backed host could already have created a real tab and still be waiting through registration plus a navigation budget longer than the client deadline. The host owned creation truth, yet the client did not receive the canonical page ID before the deadline, so it could neither identify nor close the created tab; a user retry created a duplicate.

## Fix
- Add optional capability `browser.tab-create-known-id.v1`.
- A capable client preallocates the canonical page ID and sends it in the optional `browser.tabCreate.page` field.
- Headed renderer and offscreen backends create the page using that ID and reject duplicates before materialization.
- Owner-pinned create acknowledges after authoritative registration/identity, before slow navigation readiness.
- The client performs navigation as one separate asynchronous `browser.goto`.
- If the create acknowledgement is lost, the client closes exactly the preallocated page and confirms convergence; cleanup is scoped to the requested worktree and typed missing-page results are preserved.

No new opcode, RPC method, polling loop, retry loop, or timeout was added. Ordinary unpinned opens keep their prior create-and-navigate behavior. The final rebase ports the preload API fields into main’s modular `src/preload/api/ui-command-event-api.ts` surface.

## Deterministic reproduction and red/green/revert proof
Primary command:
```bash
SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-browser-create-navigation-deadline.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1
```

The harness launches an isolated headed Electron host and separate paired Electron client, forces the owner-pinned remote-terminal browser-link route, creates the host tab, and holds navigation beyond the former 15-second create deadline. Its independent signals are the client RPC result/canonical ID plus authoritative host and paired-client browser inventories.

- **Latest main red:** at `b19d99bd00`, both 15-second create attempts returned `runtime_timeout` with no page ID while host inventory retained two distinct pages after retry. The affected path is unchanged through this PR’s base `4221f8d429`; latest `origin/main` `25abb9368d` adds only stats-view files and does not overlap this lifecycle.
- **Candidate green:** at `a0b05d77fd`, the request returned one canonical host ID before the held navigation completed; host and client each contained exactly that one page and the retry branch was never entered.
- **Fix-disabled red:** removing only navigation-independent acknowledgement made the same oracle fail again; no ID was returned and retry left two orphan pages.

## Validation
- Headed paired Electron/CDP: direct held-navigation route plus the real remote-pane context-menu link route, **2/2 passed**.
- Headed/headless exact rollback parity: **3/3 passed** across reconciliation and capability faults.
- Focused main/renderer lifecycle suites: **1,357 passed, 1 pre-existing skip**.
- Final adversarial review run additionally passed 265 focused tests, 1,219 reliability-gate tests, prior STA-4025/STA-4063 Electron oracles, typecheck, and changed-code quality checks.
- Reliability manifest: **80/80 gates valid**.
- Cross-version wire unit coverage: **5/5 passed**; GitHub `cross-version wire compatibility` passed.
- Exact-head GitHub CI [run 31769703235](https://github.com/stablyai/orca/actions/runs/31769703235): **45 passed, 2 intentional skips, 0 failures**; PR is mergeable and clean.
- Visual proof: https://github.com/user-attachments/assets/ae5cf0d1-7219-40b0-8474-495d0ce37908

## Compatibility and resource accounting
- New clients send `page` only when the host advertises the new capability; old hosts receive the old payload and behavior.
- The field is optional and old decoders strip/ignore it safely; no stream opcode changed.
- Old clients against a new host remain supported and benefit from navigation-independent acknowledgement on the existing `waitForRegistration` path.
- Success performs one create RPC and one asynchronous goto, retains one page, and performs zero retries or cleanup calls.
- Lost acknowledgement performs one exact close and at most one confirming snapshot.
- No production timer, waiter/listener, subprocess, global scan, or unbounded collection was added; pending client placements remain capped at 128 and clear on adoption, failure, or teardown.

## Alternatives considered
- **Lengthen the 15-second deadline:** rejected because any finite deadline preserves the post-mutation ambiguity window.
- **Return identity before navigation:** selected because the host owns the canonical page and can separate durable creation from slow readiness with the smallest contract change.
- **Full two-phase operation-token protocol:** stronger general machinery, but disproportionate here once creation identity is caller-preallocated and capability-gated.
- **Cleanup only after timeout:** insufficient without a known canonical ID; exact cleanup is retained as the acknowledgement-loss backstop.

## Reviews and remaining gaps
Three OpenCode 1.18.18 reviews (lifecycle/wire/idempotency, performance/resources, topology/coverage) were clean. A fresh exact-head same-round correctness review and reproduction/merge-safety review were also **2/2 clean**, with no proven P0-P2 and no file changes. CodeRabbit’s valid E2E-proof findings were addressed in `a0b05d77fd` by rejecting incidental HTTP requests and giving inventory polls explicit bounds; the hardened headed oracle remains 2/2 green.

Unproved live gaps: physical Linux and Windows paired-server journeys, multiple simultaneous viewers, and real old/new binary pairing beyond capability/wire tests. Detached navigation rejection currently logs and can leave the deliberately created blank tab; there can also be a brief `about:blank` flash. Review noted only theoretical UUID-collision/pathological create-vs-close tails without an executable realistic counterexample.

## Relationship to STA-4150
STA-4150 is the longer-term client-hosted Electron-webview architecture. Its design explicitly calls this headed server-hosted hardening **Stage 0** for mixed-version compatibility, so it does not supersede this fix and the work is not duplicated.

## Recommendation
Ready for human review and merge. The agent will not merge this PR.




