### PR TITLE
feat(source-control): page the git history panel to the end of history

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -29,6 +29,7 @@ import type {
   TuiAgent
 } from '../../shared/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import { readGitHistoryOptions } from '../../shared/git-history-request-options'
 import type { SshMutationExpectation } from '../../shared/ssh-types'
 import { sortDirEntries } from '../../shared/file-name-sort'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
@@ -1296,7 +1297,7 @@ export function registerFilesystemHandlers(
       _event,
       args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
     ): Promise<GitHistoryResult> => {
-      const options: GitHistoryOptions = { limit: args.limit, baseRef: args.baseRef }
+      const options: GitHistoryOptions = readGitHistoryOptions(args)
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -75,7 +75,13 @@ export const GitHistory = WorktreeSelector.extend({
   baseRef: z.string().nullable().optional(),
   // Resume point for the next page. Unknown keys are stripped here, so an option missing from this
   // schema never reaches git no matter what the client sent.
-  cursor: z.object({ anchor: FullGitObjectId, loaded: z.number().int().min(0) }).optional()
+  cursor: z
+    .object({
+      anchor: FullGitObjectId,
+      loaded: z.number().int().min(0),
+      after: FullGitObjectId
+    })
+    .optional()
 })
 
 export const GitBranchDiff = GitFilePath.extend({

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -79,12 +79,11 @@ export const GitHistory = WorktreeSelector.extend({
     .object({
       anchor: FullGitObjectId,
       loaded: z.number().int().min(0),
-      // Why: bounded so a hostile client cannot make the seam arbitrarily large; far above any
-      // real merge's parent count.
-      after: z.object({
-        id: FullGitObjectId,
-        parentIds: z.array(FullGitObjectId).max(256)
-      })
+      // Why: no length bound. This mirrors a real commit's parent list, so any cap either rejects
+      // a history git can represent or never binds — and a cap here that the shared reader does not
+      // share would reject, on this transport alone, a cursor our own backend just handed out.
+      // Every element must be a full object id, and total request size is the transport's bound.
+      after: z.object({ id: FullGitObjectId, parentIds: z.array(FullGitObjectId) })
     })
     .optional()
 })

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -72,7 +72,10 @@ export const GitCommitCompare = WorktreeSelector.extend({
 
 export const GitHistory = WorktreeSelector.extend({
   limit: z.number().int().min(1).max(200).optional(),
-  baseRef: z.string().nullable().optional()
+  baseRef: z.string().nullable().optional(),
+  // Resume point for the next page. Unknown keys are stripped here, so an option missing from this
+  // schema never reaches git no matter what the client sent.
+  cursor: z.object({ anchor: FullGitObjectId, loaded: z.number().int().min(0) }).optional()
 })
 
 export const GitBranchDiff = GitFilePath.extend({

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -79,7 +79,12 @@ export const GitHistory = WorktreeSelector.extend({
     .object({
       anchor: FullGitObjectId,
       loaded: z.number().int().min(0),
-      after: FullGitObjectId
+      // Why: bounded so a hostile client cannot make the seam arbitrarily large; far above any
+      // real merge's parent count.
+      after: z.object({
+        id: FullGitObjectId,
+        parentIds: z.array(FullGitObjectId).max(256)
+      })
     })
     .optional()
 })

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -234,7 +234,11 @@ describe('git RPC methods', () => {
       makeRequest('git.history', {
         worktree: 'id:wt-1',
         limit: 50,
-        cursor: { anchor: 'a'.repeat(40), loaded: 100, after: 'b'.repeat(40) }
+        cursor: {
+          anchor: 'a'.repeat(40),
+          loaded: 100,
+          after: { id: 'b'.repeat(40), parentIds: ['c'.repeat(40)] }
+        }
       })
     )
 
@@ -242,7 +246,11 @@ describe('git RPC methods', () => {
     expect(runtime.getRuntimeGitHistory).toHaveBeenCalledWith('id:wt-1', {
       limit: 50,
       baseRef: null,
-      cursor: { anchor: 'a'.repeat(40), loaded: 100, after: 'b'.repeat(40) }
+      cursor: {
+        anchor: 'a'.repeat(40),
+        loaded: 100,
+        after: { id: 'b'.repeat(40), parentIds: ['c'.repeat(40)] }
+      }
     })
   })
 

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -234,7 +234,7 @@ describe('git RPC methods', () => {
       makeRequest('git.history', {
         worktree: 'id:wt-1',
         limit: 50,
-        cursor: { anchor: 'a'.repeat(40), loaded: 100 }
+        cursor: { anchor: 'a'.repeat(40), loaded: 100, after: 'b'.repeat(40) }
       })
     )
 
@@ -242,7 +242,7 @@ describe('git RPC methods', () => {
     expect(runtime.getRuntimeGitHistory).toHaveBeenCalledWith('id:wt-1', {
       limit: 50,
       baseRef: null,
-      cursor: { anchor: 'a'.repeat(40), loaded: 100 }
+      cursor: { anchor: 'a'.repeat(40), loaded: 100, after: 'b'.repeat(40) }
     })
   })
 

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -3,6 +3,8 @@ import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { GIT_METHODS } from './git'
+import { GitHistory } from './git-params'
+import { readGitHistoryOptions } from '../../../../shared/git-history-request-options'
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
   return { id: 'req-1', authToken: 'tok', method, params }
@@ -252,6 +254,23 @@ describe('git RPC methods', () => {
         after: { id: 'b'.repeat(40), parentIds: ['c'.repeat(40)] }
       }
     })
+  })
+
+  // Why: the RPC schema and the shared reader validate the same cursor on different transports, so
+  // a bound on one is a cursor our own backend can hand out that only that transport rejects — the
+  // click then errors instead of degrading. An octopus merge is the seam that finds it.
+  it('accepts every cursor shape the backend can emit, on both validators', () => {
+    const parentIds = Array.from({ length: 300 }, (_, index) =>
+      index.toString(16).padStart(40, '0')
+    )
+    const cursor = {
+      anchor: 'a'.repeat(40),
+      loaded: 2,
+      after: { id: 'b'.repeat(40), parentIds }
+    }
+
+    expect(readGitHistoryOptions({ cursor }).cursor).toEqual(cursor)
+    expect(GitHistory.safeParse({ worktree: 'id:wt-1', cursor }).success).toBe(true)
   })
 
   it('routes common mutations to the runtime', async () => {

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -215,6 +215,37 @@ describe('git RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: history })
   })
 
+  // Why: the params schema strips unknown keys, so an option missing from it never reaches git —
+  // that is how paging shipped inert over the runtime RPC. Keep the cursor pinned to the schema.
+  it('forwards a paging cursor to the runtime', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitHistory: vi.fn().mockResolvedValue({
+        items: [],
+        hasIncomingChanges: false,
+        hasOutgoingChanges: false,
+        hasMore: false,
+        limit: 50
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.history', {
+        worktree: 'id:wt-1',
+        limit: 50,
+        cursor: { anchor: 'a'.repeat(40), loaded: 100 }
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.getRuntimeGitHistory).toHaveBeenCalledWith('id:wt-1', {
+      limit: 50,
+      baseRef: null,
+      cursor: { anchor: 'a'.repeat(40), loaded: 100 }
+    })
+  })
+
   it('routes common mutations to the runtime', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this table is the runtime git RPC contract; splitting it would make method coverage harder to audit. */
 import { defineMethod, type RpcMethod } from '../core'
+import { readGitHistoryOptions } from '../../../../shared/git-history-request-options'
 import type { GlobalSettings } from '../../../../shared/types'
 import type { ResolvedSourceControlAiGenerationParams } from '../../../../shared/source-control-ai'
 import {
@@ -124,10 +125,7 @@ export const GIT_METHODS: RpcMethod[] = [
     name: 'git.history',
     params: GitHistory,
     handler: async (params, { runtime }) =>
-      runtime.getRuntimeGitHistory(params.worktree, {
-        limit: params.limit,
-        baseRef: params.baseRef
-      })
+      runtime.getRuntimeGitHistory(params.worktree, readGitHistoryOptions(params))
   }),
   defineMethod({
     name: 'git.conflictOperation',

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -67,6 +67,7 @@ import {
   resolveEffectiveGitUpstream
 } from '../shared/git-effective-upstream'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
+import { readGitHistoryOptions } from '../shared/git-history-request-options'
 import { buildRelayGitEnv, buildRelayUnattendedGitEnv } from './relay-command-env'
 import {
   removeSafeUntrackedDiscardTarget,
@@ -424,10 +425,11 @@ export class GitHandler {
 
   private async history(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    return loadGitHistoryFromExecutor(this.git.bind(this), worktreePath, {
-      limit: typeof params.limit === 'number' ? params.limit : undefined,
-      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
-    })
+    return loadGitHistoryFromExecutor(
+      this.git.bind(this),
+      worktreePath,
+      readGitHistoryOptions(params)
+    )
   }
 
   private async getDiff(params: Record<string, unknown>, context?: RequestContext) {

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.expansion-persistence.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.expansion-persistence.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { GitHistoryResult } from '../../../../shared/git-history'
+import type { GitBranchChangeEntry } from '../../../../shared/types'
+import { GitHistoryPanel } from './GitHistoryPanel'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const timestamp = new Date(2026, 5, 15, 12).getTime()
+
+function commitId(index: number): string {
+  return String(index + 1).padStart(40, 'a')
+}
+
+// `offset` shifts the commit ids so a later result can drop the originally expanded commit,
+// which is what a base-ref change or branch switch does.
+function makeHistoryResult(count: number, offset = 0): GitHistoryResult {
+  const items = Array.from({ length: count }, (_, index) => {
+    const id = commitId(index + offset)
+    return {
+      id,
+      parentIds: index + 1 < count ? [commitId(index + 1 + offset)] : [],
+      subject: `Commit ${index + 1 + offset}`,
+      message: `Commit ${index + 1 + offset}`,
+      displayId: id.slice(0, 7),
+      author: 'Taylor',
+      timestamp: timestamp - index * 60_000,
+      references: []
+    }
+  })
+  return {
+    items,
+    currentRef: {
+      id: 'refs/heads/main',
+      name: 'main',
+      revision: items[0]?.id,
+      category: 'branches'
+    },
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: true,
+    limit: count
+  }
+}
+
+const fileEntries: GitBranchChangeEntry[] = [
+  { path: 'src/app.ts', status: 'modified', added: 1, removed: 0 }
+]
+
+function renderPanel(
+  result: GitHistoryResult,
+  onLoadCommitFiles: () => Promise<GitBranchChangeEntry[]>,
+  worktreeId = 'wt-a'
+): React.JSX.Element {
+  return (
+    <GitHistoryPanel
+      state={{ status: 'ready', result }}
+      worktreeId={worktreeId}
+      collapsed={false}
+      onToggle={vi.fn()}
+      onRefresh={vi.fn()}
+      onLoadMore={vi.fn()}
+      onOpenCommit={vi.fn()}
+      onLoadCommitFiles={onLoadCommitFiles}
+      onOpenCommitFile={vi.fn()}
+    />
+  )
+}
+
+function expandLabelFor(index: number): string {
+  return `Show files in commit ${commitId(index).slice(0, 7)}: Commit ${index + 1}`
+}
+
+describe('GitHistoryPanel expansion persistence', () => {
+  // Load more appends: the commits already on screen are the same commits, so collapsing them
+  // (and dropping their file lists) destroys the inspection context the action exists to extend.
+  it('keeps an expanded commit expanded, and its files cached, when Load more appends a page', async () => {
+    const onLoadCommitFiles = vi.fn(async () => fileEntries)
+    const view = render(renderPanel(makeHistoryResult(3), onLoadCommitFiles))
+
+    fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+    expect(await screen.findByText('app.ts')).toBeTruthy()
+    expect(onLoadCommitFiles).toHaveBeenCalledTimes(1)
+
+    view.rerender(renderPanel(makeHistoryResult(6), onLoadCommitFiles))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('git-history-row')).toHaveLength(6)
+    })
+    expect(screen.getByText('app.ts')).toBeTruthy()
+    expect(onLoadCommitFiles).toHaveBeenCalledTimes(1)
+  })
+
+  // The other half of the prune: state for a commit the new result dropped must not survive,
+  // so a later result that reintroduces the id refetches rather than showing a retained list.
+  it('drops expansion and cached files for a commit the new result no longer contains', async () => {
+    const onLoadCommitFiles = vi.fn(async () => fileEntries)
+    const view = render(renderPanel(makeHistoryResult(3), onLoadCommitFiles))
+
+    fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+    expect(await screen.findByText('app.ts')).toBeTruthy()
+
+    view.rerender(renderPanel(makeHistoryResult(3, 10), onLoadCommitFiles))
+
+    await waitFor(() => {
+      expect(screen.queryByText('app.ts')).toBeNull()
+    })
+
+    view.rerender(renderPanel(makeHistoryResult(3), onLoadCommitFiles))
+    fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+    expect(await screen.findByText('app.ts')).toBeTruthy()
+    expect(onLoadCommitFiles).toHaveBeenCalledTimes(2)
+  })
+
+  // Sibling worktrees of one repo share almost all history, so a commit can survive the switch.
+  // useGitHistoryCommitActions drops its commit-compare cache per worktree, so a row retained
+  // across the switch would look expanded while every file click resolved to nothing.
+  it('drops expansion and cached files when the worktree changes, even if the commit survives', async () => {
+    const onLoadCommitFiles = vi.fn(async () => fileEntries)
+    const view = render(renderPanel(makeHistoryResult(3), onLoadCommitFiles, 'wt-a'))
+
+    fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+    expect(await screen.findByText('app.ts')).toBeTruthy()
+    expect(onLoadCommitFiles).toHaveBeenCalledTimes(1)
+
+    view.rerender(renderPanel(makeHistoryResult(3), onLoadCommitFiles, 'wt-b'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('app.ts')).toBeNull()
+    })
+
+    // Re-expanding must refetch so the sibling commit-compare cache is repopulated.
+    fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+    expect(await screen.findByText('app.ts')).toBeTruthy()
+    expect(onLoadCommitFiles).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.expansion-persistence.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.expansion-persistence.test.tsx
@@ -1,11 +1,15 @@
 // @vitest-environment happy-dom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
-import type { GitHistoryResult } from '../../../../shared/git-history'
+import { GIT_HISTORY_DEFAULT_LIMIT, type GitHistoryResult } from '../../../../shared/git-history'
 import type { GitBranchChangeEntry } from '../../../../shared/types'
 import { GitHistoryPanel } from './GitHistoryPanel'
+import {
+  GIT_HISTORY_ROW_HEIGHT_PX,
+  GIT_HISTORY_VIRTUALIZE_MIN_ROWS
+} from './git-history-virtual-rows'
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -144,5 +148,177 @@ describe('GitHistoryPanel expansion persistence', () => {
     fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
     expect(await screen.findByText('app.ts')).toBeTruthy()
     expect(onLoadCommitFiles).toHaveBeenCalledTimes(2)
+  })
+
+  // Why: the virtualize threshold equals the page size, so a real first page is already over it and
+  // every Load more click by definition operates on a virtualized list. The cases above run the
+  // plain path only, which is the one production never takes.
+  describe('on the virtualized path a real page takes', () => {
+    const virtualized = GIT_HISTORY_VIRTUALIZE_MIN_ROWS + 5
+    const VIEWPORT_HEIGHT_PX = 1200
+
+    // happy-dom has no layout, so every rect is zero and the virtualizer would window to nothing.
+    // Give the scroller a viewport and the rows their height, and let the test re-fire the
+    // observers the way a browser would after content changes a row's height.
+    const observers = new Set<{ callback: ResizeObserverCallback; elements: Set<Element> }>()
+
+    function fireResizeObservers(): void {
+      for (const observer of observers) {
+        const entries = Array.from(observer.elements).map((element) => {
+          const rect = element.getBoundingClientRect()
+          const size = { blockSize: rect.height, inlineSize: rect.width }
+          return {
+            target: element,
+            contentRect: rect,
+            borderBoxSize: [size],
+            contentBoxSize: [size],
+            devicePixelContentBoxSize: [size]
+          } as unknown as ResizeObserverEntry
+        })
+        if (entries.length > 0) {
+          observer.callback(entries, observer as unknown as ResizeObserver)
+        }
+      }
+    }
+
+    beforeEach(() => {
+      observers.clear()
+      vi.stubGlobal(
+        'ResizeObserver',
+        class {
+          readonly elements = new Set<Element>()
+          constructor(readonly callback: ResizeObserverCallback) {
+            observers.add(this)
+          }
+          observe(element: Element): void {
+            this.elements.add(element)
+            fireResizeObservers()
+          }
+          unobserve(element: Element): void {
+            this.elements.delete(element)
+          }
+          disconnect(): void {
+            this.elements.clear()
+            observers.delete(this)
+          }
+        }
+      )
+      // The virtualizer sizes its viewport from offsetHeight and measures rows from the rect.
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(
+        function (this: HTMLElement) {
+          return this.classList.contains('overflow-y-auto')
+            ? VIEWPORT_HEIGHT_PX
+            : GIT_HISTORY_ROW_HEIGHT_PX
+        }
+      )
+      vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(320)
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+        function (this: Element) {
+          const expandedExtra =
+            this.classList.contains('absolute') && this.textContent?.includes('app.ts') ? 120 : 0
+          const height = this.classList.contains('overflow-y-auto')
+            ? VIEWPORT_HEIGHT_PX
+            : GIT_HISTORY_ROW_HEIGHT_PX + expandedExtra
+          return {
+            top: 0,
+            bottom: height,
+            height,
+            left: 0,
+            right: 320,
+            width: 320,
+            x: 0,
+            y: 0,
+            toJSON: () => ({})
+          } as DOMRect
+        }
+      )
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.restoreAllMocks()
+    })
+
+    // Why: assert the relationship, not the number. A threshold above the page size would leave
+    // production permanently on the unvirtualized path that the cases above already cover.
+    it('virtualizes at or before a full first page', () => {
+      expect(GIT_HISTORY_VIRTUALIZE_MIN_ROWS).toBeLessThanOrEqual(GIT_HISTORY_DEFAULT_LIMIT)
+    })
+
+    it('virtualizes once a page-sized result is on screen, and not before', () => {
+      const view = render(
+        renderPanel(
+          makeHistoryResult(3),
+          vi.fn(async () => fileEntries)
+        )
+      )
+      expect(screen.queryByTestId('git-history-virtual-list')).toBeNull()
+
+      view.rerender(
+        renderPanel(
+          makeHistoryResult(GIT_HISTORY_DEFAULT_LIMIT),
+          vi.fn(async () => fileEntries)
+        )
+      )
+      expect(screen.getByTestId('git-history-virtual-list')).toBeTruthy()
+    })
+
+    // Why: rows are absolutely positioned off an estimate that assumes one 26px line. An expanded
+    // row carries a file list and is far taller, so without measurement the rows below it are
+    // positioned on top of it.
+    it('measures an expanded row instead of leaving it at the collapsed estimate', async () => {
+      const view = render(
+        renderPanel(
+          makeHistoryResult(virtualized),
+          vi.fn(async () => fileEntries)
+        )
+      )
+      const list = screen.getByTestId('git-history-virtual-list')
+      const collapsedHeight = Number.parseFloat(list.style.height)
+      expect(collapsedHeight).toBe(virtualized * GIT_HISTORY_ROW_HEIGHT_PX)
+
+      fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+      expect(await screen.findByText('app.ts')).toBeTruthy()
+
+      fireResizeObservers()
+
+      await waitFor(() => {
+        expect(Number.parseFloat(list.style.height)).toBeGreaterThan(collapsedHeight)
+      })
+      view.unmount()
+    })
+
+    it('keeps an expanded commit expanded, and its files cached, when Load more appends a page', async () => {
+      const onLoadCommitFiles = vi.fn(async () => fileEntries)
+      const view = render(renderPanel(makeHistoryResult(virtualized), onLoadCommitFiles))
+
+      fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+      expect(await screen.findByText('app.ts')).toBeTruthy()
+      expect(onLoadCommitFiles).toHaveBeenCalledTimes(1)
+
+      view.rerender(renderPanel(makeHistoryResult(virtualized + 50), onLoadCommitFiles))
+
+      expect(screen.getByTestId('git-history-virtual-list')).toBeTruthy()
+      expect(screen.getByText('app.ts')).toBeTruthy()
+      expect(onLoadCommitFiles).toHaveBeenCalledTimes(1)
+    })
+
+    // Why: a base-ref change replaces the list, putting different commits at the same indices.
+    // State keyed by position rather than commit id would show one commit's files under another.
+    it('drops expansion when a replacing result reuses the same row positions', async () => {
+      const onLoadCommitFiles = vi.fn(async () => fileEntries)
+      const view = render(renderPanel(makeHistoryResult(virtualized), onLoadCommitFiles))
+
+      fireEvent.click(screen.getByRole('button', { name: expandLabelFor(0) }))
+      expect(await screen.findByText('app.ts')).toBeTruthy()
+
+      view.rerender(
+        renderPanel(makeHistoryResult(virtualized, virtualized + 100), onLoadCommitFiles)
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByText('app.ts')).toBeNull()
+      })
+    })
   })
 })

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -11,7 +11,9 @@ import {
   buildGitHistoryViewModels
 } from '../../../../shared/git-history-graph'
 import { GitHistoryRow } from './GitHistoryRow'
-import { GitHistoryCommitFiles, type GitHistoryCommitFilesState } from './GitHistoryCommitFiles'
+import { GitHistoryCommitFiles } from './GitHistoryCommitFiles'
+import { useGitHistoryCommitExpansion } from './useGitHistoryCommitExpansion'
+import { GitHistoryVirtualRows } from './git-history-virtual-rows'
 import {
   GitHistoryCommitContextMenu,
   type GitHistoryCommitAction
@@ -42,18 +44,23 @@ function clampGitHistoryPanelHeight(height: number): number {
 
 export function GitHistoryPanel({
   state,
+  worktreeId,
   collapsed,
   onToggle,
   onRefresh,
+  onLoadMore,
   onOpenCommit,
   onLoadCommitFiles,
   onOpenCommitFile,
   onCommitAction
 }: {
   state: GitHistoryPanelState
+  // The worktree this history belongs to; scopes the per-commit expansion/file caches.
+  worktreeId?: string
   collapsed: boolean
   onToggle: () => void
   onRefresh: () => void
+  onLoadMore?: () => void
   onOpenCommit?: (item: GitHistoryItem) => void
   onLoadCommitFiles?: (item: GitHistoryItem) => Promise<GitBranchChangeEntry[]>
   onOpenCommitFile?: (
@@ -81,65 +88,19 @@ export function GitHistoryPanel({
   }, [result])
 
   const loading = state.status === 'loading' || state.status === 'refreshing'
+  // Why: no total ceiling — paging ends when git says there is nothing older, not at a fixed depth.
+  const canLoadMore = Boolean(onLoadMore && result?.hasMore)
   const count = result?.items.length ?? 0
   const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
+  // Why: state, not a ref — the virtualizer must re-run once the scroller element attaches.
+  const [historyScrollElement, setHistoryScrollElement] = useState<HTMLDivElement | null>(null)
   const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
 
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
-  const [filesByCommit, setFilesByCommit] = useState<Record<string, GitHistoryCommitFilesState>>({})
-  // Tracks commits whose files have been loaded (or are in flight) so re-expanding
-  // never refetches; an entry is cleared on error to allow a retry.
-  const loadedCommitsRef = useRef<Set<string>>(new Set())
-
-  // A new history result can reorder or replace commits, so drop any expansion
-  // and cached file lists rather than risk showing stale files under a row.
-  useEffect(() => {
-    setExpanded(new Set())
-    setFilesByCommit({})
-    loadedCommitsRef.current = new Set()
-  }, [result])
-
-  const handleToggleExpand = useCallback(
-    (item: GitHistoryItem): void => {
-      const id = item.id
-      const willExpand = !expanded.has(id)
-      setExpanded((prev) => {
-        const next = new Set(prev)
-        if (willExpand) {
-          next.add(id)
-        } else {
-          next.delete(id)
-        }
-        return next
-      })
-      if (!willExpand || !onLoadCommitFiles || loadedCommitsRef.current.has(id)) {
-        return
-      }
-      loadedCommitsRef.current.add(id)
-      setFilesByCommit((prev) => ({ ...prev, [id]: { status: 'loading' } }))
-      onLoadCommitFiles(item)
-        .then((entries) => {
-          setFilesByCommit((prev) => ({ ...prev, [id]: { status: 'ready', entries } }))
-        })
-        .catch((error: unknown) => {
-          loadedCommitsRef.current.delete(id)
-          setFilesByCommit((prev) => ({
-            ...prev,
-            [id]: {
-              status: 'error',
-              error:
-                error instanceof Error
-                  ? error.message
-                  : translate(
-                      'auto.components.right.sidebar.GitHistoryPanel.6d1e0a7c3b',
-                      'Failed to load commit files'
-                    )
-            }
-          }))
-        })
-    },
-    [expanded, onLoadCommitFiles]
-  )
+  const { expanded, filesByCommit, toggleExpand } = useGitHistoryCommitExpansion({
+    result,
+    worktreeId,
+    onLoadCommitFiles
+  })
 
   const stopResize = useCallback((): void => {
     const session = resizeSessionRef.current
@@ -340,45 +301,71 @@ export function GitHistoryPanel({
         </div>
       )}
       {!collapsed && viewModels.length > 0 && (
-        <div className={expandedBodyClassName} style={expandedBodyStyle}>
-          {viewModels.map((viewModel) => {
-            const item = viewModel.historyItem
-            const isBoundaryNode =
-              viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
-            const canExpand =
-              !isBoundaryNode && Boolean(onLoadCommitFiles) && Boolean(onOpenCommitFile)
-            const isExpanded = canExpand && expanded.has(item.id)
-            const row = (
-              <GitHistoryRow
-                viewModel={viewModel}
-                expanded={isExpanded}
-                preserveRefIds={result?.baseRef ? [result.baseRef.id] : undefined}
-                onOpenCommit={onOpenCommit}
-                onToggleExpand={canExpand ? handleToggleExpand : undefined}
-              />
-            )
-            return (
-              <React.Fragment key={`${viewModel.kind}:${item.id}`}>
-                {onCommitAction && !isBoundaryNode ? (
-                  <ContextMenu>
-                    <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
-                    <GitHistoryCommitContextMenu item={item} onAction={onCommitAction} />
-                  </ContextMenu>
-                ) : (
-                  row
+        <div
+          ref={setHistoryScrollElement}
+          className={expandedBodyClassName}
+          style={expandedBodyStyle}
+        >
+          <GitHistoryVirtualRows
+            rows={viewModels}
+            scrollElement={historyScrollElement}
+            getRowKey={(viewModel) => `${viewModel.kind}:${viewModel.historyItem.id}`}
+            renderRow={(viewModel) => {
+              const item = viewModel.historyItem
+              const isBoundaryNode =
+                viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
+              const canExpand =
+                !isBoundaryNode && Boolean(onLoadCommitFiles) && Boolean(onOpenCommitFile)
+              const isExpanded = canExpand && expanded.has(item.id)
+              const row = (
+                <GitHistoryRow
+                  viewModel={viewModel}
+                  expanded={isExpanded}
+                  preserveRefIds={result?.baseRef ? [result.baseRef.id] : undefined}
+                  onOpenCommit={onOpenCommit}
+                  onToggleExpand={canExpand ? toggleExpand : undefined}
+                />
+              )
+              return (
+                <React.Fragment key={`${viewModel.kind}:${item.id}`}>
+                  {onCommitAction && !isBoundaryNode ? (
+                    <ContextMenu>
+                      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+                      <GitHistoryCommitContextMenu item={item} onAction={onCommitAction} />
+                    </ContextMenu>
+                  ) : (
+                    row
+                  )}
+                  {isExpanded && (
+                    <GitHistoryCommitFiles
+                      state={filesByCommit[item.id] ?? { status: 'loading' }}
+                      author={item.author}
+                      timestamp={item.timestamp}
+                      onOpenFile={(entry, event) => onOpenCommitFile?.(item, entry, event)}
+                      onOpenAll={onOpenCommit ? () => onOpenCommit(item) : undefined}
+                    />
+                  )}
+                </React.Fragment>
+              )
+            }}
+          />
+          {canLoadMore && (
+            <div className="flex justify-center px-6 py-1.5">
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="h-auto py-0.5 text-[11px] text-muted-foreground"
+                disabled={loading}
+                onClick={onLoadMore}
+              >
+                {translate(
+                  'auto.components.right.sidebar.GitHistoryPanel.loadMoreCommits',
+                  'Load more commits'
                 )}
-                {isExpanded && (
-                  <GitHistoryCommitFiles
-                    state={filesByCommit[item.id] ?? { status: 'loading' }}
-                    author={item.author}
-                    timestamp={item.timestamp}
-                    onOpenFile={(entry, event) => onOpenCommitFile?.(item, entry, event)}
-                    onOpenAll={onOpenCommit ? () => onOpenCommit(item) : undefined}
-                  />
-                )}
-              </React.Fragment>
-            )
-          })}
+              </Button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -89,7 +89,9 @@ export function GitHistoryPanel({
 
   const loading = state.status === 'loading' || state.status === 'refreshing'
   // Why: no total ceiling — paging ends when git says there is nothing older, not at a fixed depth.
-  const canLoadMore = Boolean(onLoadMore && result?.hasMore)
+  // Why: gate on the cursor too. A host too old to page still reports hasMore, and offering a
+  // button that can only re-request page one reads as a hang.
+  const canLoadMore = Boolean(onLoadMore && result?.hasMore && result?.nextCursor)
   const count = result?.items.length ?? 0
   const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
   // Why: state, not a ref — the virtualizer must re-run once the scroller element attaches.

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -195,8 +195,8 @@ import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
-import { GIT_HISTORY_DEFAULT_LIMIT } from '../../../../shared/git-history'
-import { appendGitHistoryPage, gitHistoryCursor } from './git-history-page-accumulator'
+import { GIT_HISTORY_DEFAULT_LIMIT, type GitHistoryCursor } from '../../../../shared/git-history'
+import { appendGitHistoryPage } from './git-history-page-accumulator'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import {
@@ -4953,7 +4953,7 @@ function SourceControlInner(): React.JSX.Element {
   refreshBranchCompareRef.current = refreshBranchCompare
 
   const loadGitHistoryPage = useCallback(
-    async (cursor?: string): Promise<void> => {
+    async (cursor?: GitHistoryCursor): Promise<void> => {
       if (
         !activeWorktreeId ||
         !worktreePath ||
@@ -5037,9 +5037,10 @@ function SourceControlInner(): React.JSX.Element {
   }, [loadGitHistoryPage])
 
   const loadMoreGitHistory = useCallback(async (): Promise<void> => {
-    // Why: resume from the oldest commit on screen. Reading it off the landed result rather than a
-    // requested-page counter means a failed page retries the same page instead of skipping one.
-    const cursor = gitHistoryCursor(gitHistoryState.result)
+    // Why: the cursor comes off the landed result rather than a locally counted offset, so a failed
+    // page retries the same page instead of skipping one, and a host that cannot page (older
+    // remote, no cursor echoed) simply offers nothing to load.
+    const cursor = gitHistoryState.result?.nextCursor
     if (!cursor) {
       return
     }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -195,6 +195,8 @@ import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
+import { GIT_HISTORY_DEFAULT_LIMIT } from '../../../../shared/git-history'
+import { appendGitHistoryPage, gitHistoryCursor } from './git-history-page-accumulator'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import {
@@ -4950,73 +4952,99 @@ function SourceControlInner(): React.JSX.Element {
 
   refreshBranchCompareRef.current = refreshBranchCompare
 
-  const refreshGitHistory = useCallback(async (): Promise<void> => {
-    if (
-      !activeWorktreeId ||
-      !worktreePath ||
-      isFolder ||
-      !isBranchVisible ||
-      !isGitHistoryExpanded ||
-      !isGitHistoryVisible
-    ) {
-      return
-    }
-
-    const worktreeId = activeWorktreeId
-    const requestId = gitHistoryRequestSeqRef.current + 1
-    gitHistoryRequestSeqRef.current = requestId
-    gitHistoryRequestByWorktreeRef.current[worktreeId] = requestId
-    setGitHistoryByWorktree((prev) => {
-      const previous = prev[worktreeId]
-      return {
-        ...prev,
-        [worktreeId]: previous?.result
-          ? { status: 'refreshing', result: previous.result }
-          : { status: 'loading' }
-      }
-    })
-
-    try {
-      const connectionId = getConnectionId(worktreeId) ?? undefined
-      const result = await getRuntimeGitHistory(
-        {
-          // Why: route the history read by the repo OWNER host, not the focused runtime.
-          settings: activeRepoSettings,
-          worktreeId,
-          worktreePath,
-          connectionId
-        },
-        { limit: 50, baseRef: compareBaseRef }
-      )
-      if (gitHistoryRequestByWorktreeRef.current[worktreeId] !== requestId) {
+  const loadGitHistoryPage = useCallback(
+    async (cursor?: string): Promise<void> => {
+      if (
+        !activeWorktreeId ||
+        !worktreePath ||
+        isFolder ||
+        !isBranchVisible ||
+        !isGitHistoryExpanded ||
+        !isGitHistoryVisible
+      ) {
         return
       }
-      setGitHistoryByWorktree((prev) => ({ ...prev, [worktreeId]: { status: 'ready', result } }))
-    } catch (error) {
-      if (gitHistoryRequestByWorktreeRef.current[worktreeId] !== requestId) {
-        return
-      }
-      const message = error instanceof Error ? error.message : 'Failed to load commits'
+
+      const worktreeId = activeWorktreeId
+      const requestId = gitHistoryRequestSeqRef.current + 1
+      gitHistoryRequestSeqRef.current = requestId
+      gitHistoryRequestByWorktreeRef.current[worktreeId] = requestId
       setGitHistoryByWorktree((prev) => {
         const previous = prev[worktreeId]
         return {
           ...prev,
           [worktreeId]: previous?.result
-            ? { status: 'error', result: previous.result, error: message }
-            : { status: 'error', error: message }
+            ? { status: 'refreshing', result: previous.result }
+            : { status: 'loading' }
         }
       })
+
+      try {
+        const connectionId = getConnectionId(worktreeId) ?? undefined
+        const result = await getRuntimeGitHistory(
+          {
+            // Why: route the history read by the repo OWNER host, not the focused runtime.
+            settings: activeRepoSettings,
+            worktreeId,
+            worktreePath,
+            connectionId
+          },
+          { limit: GIT_HISTORY_DEFAULT_LIMIT, baseRef: compareBaseRef, cursor }
+        )
+        if (gitHistoryRequestByWorktreeRef.current[worktreeId] !== requestId) {
+          return
+        }
+        setGitHistoryByWorktree((prev) => ({
+          ...prev,
+          // Why: fold against the state this page is landing on, not a snapshot from before the
+          // request. A refresh carries no cursor and replaces — the commits it reloads are the
+          // current truth, and a deep page taken before a rewrite may no longer be reachable.
+          [worktreeId]: {
+            status: 'ready',
+            result: cursor ? appendGitHistoryPage(prev[worktreeId]?.result, result) : result
+          }
+        }))
+      } catch (error) {
+        if (gitHistoryRequestByWorktreeRef.current[worktreeId] !== requestId) {
+          return
+        }
+        const message = error instanceof Error ? error.message : 'Failed to load commits'
+        setGitHistoryByWorktree((prev) => {
+          const previous = prev[worktreeId]
+          return {
+            ...prev,
+            [worktreeId]: previous?.result
+              ? { status: 'error', result: previous.result, error: message }
+              : { status: 'error', error: message }
+          }
+        })
+      }
+    },
+    [
+      activeRepoSettings,
+      activeWorktreeId,
+      compareBaseRef,
+      isBranchVisible,
+      isFolder,
+      isGitHistoryExpanded,
+      isGitHistoryVisible,
+      worktreePath
+    ]
+  )
+
+  const refreshGitHistory = useCallback(async (): Promise<void> => {
+    await loadGitHistoryPage()
+  }, [loadGitHistoryPage])
+
+  const loadMoreGitHistory = useCallback(async (): Promise<void> => {
+    // Why: resume from the oldest commit on screen. Reading it off the landed result rather than a
+    // requested-page counter means a failed page retries the same page instead of skipping one.
+    const cursor = gitHistoryCursor(gitHistoryState.result)
+    if (!cursor) {
+      return
     }
-  }, [
-    activeRepoSettings,
-    activeWorktreeId,
-    compareBaseRef,
-    isBranchVisible,
-    isFolder,
-    isGitHistoryExpanded,
-    isGitHistoryVisible,
-    worktreePath
-  ])
+    await loadGitHistoryPage(cursor)
+  }, [gitHistoryState, loadGitHistoryPage])
 
   const refreshGitHistoryRef = useRef(refreshGitHistory)
   refreshGitHistoryRef.current = refreshGitHistory
@@ -6299,9 +6327,11 @@ function SourceControlInner(): React.JSX.Element {
             <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
               <GitHistoryPanel
                 state={gitHistoryState}
+                worktreeId={activeWorktreeId ?? undefined}
                 collapsed={collapsedSections.has('history')}
                 onToggle={() => toggleSection('history')}
                 onRefresh={() => void refreshGitHistory()}
+                onLoadMore={() => void loadMoreGitHistory()}
                 onOpenCommit={(item) => void openHistoryCommitDiff(item)}
                 onLoadCommitFiles={loadCommitFiles}
                 onOpenCommitFile={openCommitFile}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -196,7 +196,7 @@ import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullR
 import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
 import { GIT_HISTORY_DEFAULT_LIMIT, type GitHistoryCursor } from '../../../../shared/git-history'
-import { appendGitHistoryPage } from './git-history-page-accumulator'
+import { foldGitHistoryPage } from './git-history-page-accumulator'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import {
@@ -4997,11 +4997,10 @@ function SourceControlInner(): React.JSX.Element {
         setGitHistoryByWorktree((prev) => ({
           ...prev,
           // Why: fold against the state this page is landing on, not a snapshot from before the
-          // request. A refresh carries no cursor and replaces — the commits it reloads are the
-          // current truth, and a deep page taken before a rewrite may no longer be reachable.
+          // request. Whether the page appends or replaces is the accumulator's call.
           [worktreeId]: {
             status: 'ready',
-            result: cursor ? appendGitHistoryPage(prev[worktreeId]?.result, result) : result
+            result: foldGitHistoryPage(prev[worktreeId]?.result, result, cursor)
           }
         }))
       } catch (error) {

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
@@ -8,7 +8,11 @@ function item(id: string): GitHistoryItem {
 
 const ANCHOR = 'a'.repeat(40)
 // The cursor a Load more click sends, and the anchor a page continuing that walk comes back with.
-const REQUESTED = { anchor: ANCHOR, loaded: 2, after: 'b'.repeat(40) }
+const REQUESTED = {
+  anchor: ANCHOR,
+  loaded: 2,
+  after: { id: 'b'.repeat(40), parentIds: ['c'.repeat(40)] }
+}
 
 function page(ids: string[], overrides: Partial<GitHistoryResult> = {}): GitHistoryResult {
   return {
@@ -67,12 +71,22 @@ describe('foldGitHistoryPage', () => {
 
   it('takes hasMore, the next cursor, and branch metadata from the newest page', () => {
     const merged = foldGitHistoryPage(
-      page(['a'], { mergeBase: 'old', nextCursor: { anchor: ANCHOR, loaded: 1, after: 'a' } }),
-      page(['b'], { mergeBase: 'new', nextCursor: { anchor: ANCHOR, loaded: 2, after: 'b' } }),
+      page(['a'], {
+        mergeBase: 'old',
+        nextCursor: { anchor: ANCHOR, loaded: 1, after: { id: 'a', parentIds: [] } }
+      }),
+      page(['b'], {
+        mergeBase: 'new',
+        nextCursor: { anchor: ANCHOR, loaded: 2, after: { id: 'b', parentIds: [] } }
+      }),
       REQUESTED
     )
     expect(merged.hasMore).toBe(true)
-    expect(merged.nextCursor).toEqual({ anchor: ANCHOR, loaded: 2, after: 'b' })
+    expect(merged.nextCursor).toEqual({
+      anchor: ANCHOR,
+      loaded: 2,
+      after: { id: 'b', parentIds: [] }
+    })
     expect(merged.mergeBase).toBe('new')
   })
 
@@ -81,7 +95,9 @@ describe('foldGitHistoryPage', () => {
   it('stops paging when a continuing page adds nothing new', () => {
     const merged = foldGitHistoryPage(
       page(['a', 'b']),
-      page(['a', 'b'], { nextCursor: { anchor: ANCHOR, loaded: 2, after: 'b' } }),
+      page(['a', 'b'], {
+        nextCursor: { anchor: ANCHOR, loaded: 2, after: { id: 'b', parentIds: [] } }
+      }),
       REQUESTED
     )
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b'])

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import type { GitHistoryItem, GitHistoryResult } from '../../../../shared/git-history'
-import { appendGitHistoryPage } from './git-history-page-accumulator'
+import { foldGitHistoryPage } from './git-history-page-accumulator'
 
 function item(id: string): GitHistoryItem {
   return { id, parentIds: [], subject: `commit ${id}`, message: `commit ${id}`, author: 'Ada' }
 }
 
+const ANCHOR = 'a'.repeat(40)
+// The cursor a Load more click sends, and the anchor a page continuing that walk comes back with.
+const REQUESTED = { anchor: ANCHOR, loaded: 2 }
+
 function page(ids: string[], overrides: Partial<GitHistoryResult> = {}): GitHistoryResult {
   return {
     items: ids.map(item),
+    pageAnchor: ANCHOR,
     hasIncomingChanges: false,
     hasOutgoingChanges: false,
     hasMore: true,
@@ -17,42 +22,67 @@ function page(ids: string[], overrides: Partial<GitHistoryResult> = {}): GitHist
   }
 }
 
-describe('appendGitHistoryPage', () => {
+describe('foldGitHistoryPage', () => {
   it('keeps the first page as-is', () => {
-    expect(appendGitHistoryPage(undefined, page(['a', 'b'])).items.map((i) => i.id)).toEqual([
-      'a',
-      'b'
-    ])
+    const folded = foldGitHistoryPage(undefined, page(['a', 'b']), undefined)
+    expect(folded.items.map((i) => i.id)).toEqual(['a', 'b'])
   })
 
   it('appends the next page after the commits already on screen', () => {
-    const merged = appendGitHistoryPage(page(['a', 'b']), page(['c', 'd']))
+    const merged = foldGitHistoryPage(page(['a', 'b']), page(['c', 'd']), REQUESTED)
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  // Why: a refresh reloads from HEAD. Appending it would stack today's commits under yesterday's.
+  it('replaces when no cursor was requested', () => {
+    const merged = foldGitHistoryPage(page(['a', 'b']), page(['c', 'd']), undefined)
+    expect(merged.items.map((i) => i.id)).toEqual(['c', 'd'])
+  })
+
+  // Why: an anchor killed by a rebase/amend/prune/gc is answered with a fresh page from HEAD, and
+  // the differing pageAnchor is the only thing that says so. Appending it would render an
+  // unrelated history below a dead one, children after their parents.
+  it('replaces when the page came back on a different walk than the one requested', () => {
+    const restarted = page(['x', 'y'], { pageAnchor: 'b'.repeat(40) })
+    const merged = foldGitHistoryPage(page(['a', 'b']), restarted, REQUESTED)
+    expect(merged.items.map((i) => i.id)).toEqual(['x', 'y'])
+  })
+
+  // Why: a host too old to page echoes no anchor at all, so it can never be a continuation.
+  it('replaces when the host echoes no page anchor', () => {
+    const merged = foldGitHistoryPage(
+      page(['a', 'b']),
+      page(['c', 'd'], { pageAnchor: undefined }),
+      REQUESTED
+    )
+    expect(merged.items.map((i) => i.id)).toEqual(['c', 'd'])
   })
 
   // Why: HEAD can move under the walk between pages and shift the offset, re-emitting a commit.
   // Duplicate React keys and a doubled graph row are the visible failure.
   it('drops a commit the new page repeats', () => {
-    const merged = appendGitHistoryPage(page(['a', 'b', 'c']), page(['c', 'd']))
+    const merged = foldGitHistoryPage(page(['a', 'b', 'c']), page(['c', 'd']), REQUESTED)
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
   })
 
   it('takes hasMore, the next cursor, and branch metadata from the newest page', () => {
-    const merged = appendGitHistoryPage(
-      page(['a'], { hasMore: true, mergeBase: 'old', nextCursor: { anchor: 'x', loaded: 1 } }),
-      page(['b'], { hasMore: true, mergeBase: 'new', nextCursor: { anchor: 'x', loaded: 2 } })
+    const merged = foldGitHistoryPage(
+      page(['a'], { mergeBase: 'old', nextCursor: { anchor: ANCHOR, loaded: 1 } }),
+      page(['b'], { mergeBase: 'new', nextCursor: { anchor: ANCHOR, loaded: 2 } }),
+      REQUESTED
     )
     expect(merged.hasMore).toBe(true)
-    expect(merged.nextCursor).toEqual({ anchor: 'x', loaded: 2 })
+    expect(merged.nextCursor).toEqual({ anchor: ANCHOR, loaded: 2 })
     expect(merged.mergeBase).toBe('new')
   })
 
   // Why: a host that ignores the cursor answers every page with page one. Without this the button
   // stays lit and every click re-fetches the same commits, which reads as a hang.
-  it('stops paging when a page adds nothing new', () => {
-    const merged = appendGitHistoryPage(
+  it('stops paging when a continuing page adds nothing new', () => {
+    const merged = foldGitHistoryPage(
       page(['a', 'b']),
-      page(['a', 'b'], { hasMore: true, nextCursor: { anchor: 'x', loaded: 2 } })
+      page(['a', 'b'], { nextCursor: { anchor: ANCHOR, loaded: 2 } }),
+      REQUESTED
     )
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b'])
     expect(merged.hasMore).toBe(false)
@@ -60,7 +90,7 @@ describe('appendGitHistoryPage', () => {
   })
 
   it('never loses commits already on screen when the new page is empty', () => {
-    const merged = appendGitHistoryPage(page(['a', 'b']), page([], { hasMore: false }))
+    const merged = foldGitHistoryPage(page(['a', 'b']), page([], { hasMore: false }), REQUESTED)
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b'])
     expect(merged.hasMore).toBe(false)
   })

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHistoryItem, GitHistoryResult } from '../../../../shared/git-history'
+import { appendGitHistoryPage, gitHistoryCursor } from './git-history-page-accumulator'
+
+function item(id: string): GitHistoryItem {
+  return { id, parentIds: [], subject: `commit ${id}`, message: `commit ${id}`, author: 'Ada' }
+}
+
+function page(ids: string[], overrides: Partial<GitHistoryResult> = {}): GitHistoryResult {
+  return {
+    items: ids.map(item),
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: true,
+    limit: 50,
+    ...overrides
+  }
+}
+
+describe('gitHistoryCursor', () => {
+  it('is the oldest commit on screen', () => {
+    expect(gitHistoryCursor(page(['a', 'b', 'c']))).toBe('c')
+  })
+
+  it('is undefined before anything loads', () => {
+    expect(gitHistoryCursor(undefined)).toBeUndefined()
+    expect(gitHistoryCursor(page([]))).toBeUndefined()
+  })
+})
+
+describe('appendGitHistoryPage', () => {
+  it('keeps the first page as-is', () => {
+    expect(appendGitHistoryPage(undefined, page(['a', 'b'])).items.map((i) => i.id)).toEqual([
+      'a',
+      'b'
+    ])
+  })
+
+  it('appends the next page after the commits already on screen', () => {
+    const merged = appendGitHistoryPage(page(['a', 'b']), page(['c', 'd']))
+    expect(merged.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  // Why: a cursor-anchored walk can re-emit a commit across a page boundary when topo-order
+  // interleaves parallel branches differently. Duplicate React keys and a doubled graph row are
+  // the visible failure.
+  it('drops a commit the new page repeats', () => {
+    const merged = appendGitHistoryPage(page(['a', 'b', 'c']), page(['c', 'd']))
+    expect(merged.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('takes hasMore and branch metadata from the newest page', () => {
+    const merged = appendGitHistoryPage(
+      page(['a'], { hasMore: true, mergeBase: 'old' }),
+      page(['b'], { hasMore: false, mergeBase: 'new' })
+    )
+    expect(merged.hasMore).toBe(false)
+    expect(merged.mergeBase).toBe('new')
+  })
+
+  it('never loses commits already on screen when the new page is empty', () => {
+    const merged = appendGitHistoryPage(page(['a', 'b']), page([], { hasMore: false }))
+    expect(merged.items.map((i) => i.id)).toEqual(['a', 'b'])
+    expect(merged.hasMore).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
@@ -8,12 +8,12 @@ function item(id: string): GitHistoryItem {
 
 const ANCHOR = 'a'.repeat(40)
 // The cursor a Load more click sends, and the anchor a page continuing that walk comes back with.
-const REQUESTED = { anchor: ANCHOR, loaded: 2 }
+const REQUESTED = { anchor: ANCHOR, loaded: 2, after: 'b'.repeat(40) }
 
 function page(ids: string[], overrides: Partial<GitHistoryResult> = {}): GitHistoryResult {
   return {
     items: ids.map(item),
-    pageAnchor: ANCHOR,
+    continuedCursor: true,
     hasIncomingChanges: false,
     hasOutgoingChanges: false,
     hasMore: true,
@@ -39,20 +39,20 @@ describe('foldGitHistoryPage', () => {
     expect(merged.items.map((i) => i.id)).toEqual(['c', 'd'])
   })
 
-  // Why: an anchor killed by a rebase/amend/prune/gc is answered with a fresh page from HEAD, and
-  // the differing pageAnchor is the only thing that says so. Appending it would render an
-  // unrelated history below a dead one, children after their parents.
-  it('replaces when the page came back on a different walk than the one requested', () => {
-    const restarted = page(['x', 'y'], { pageAnchor: 'b'.repeat(40) })
+  // Why: a cursor the host could not honor — dead anchor, or a walk that drifted under it — comes
+  // back as a fresh page from HEAD, and this flag is the only thing that says so. Appending it
+  // would render an unrelated history below a dead one, children after their parents.
+  it('replaces when the host could not honor the cursor', () => {
+    const restarted = page(['x', 'y'], { continuedCursor: false })
     const merged = foldGitHistoryPage(page(['a', 'b']), restarted, REQUESTED)
     expect(merged.items.map((i) => i.id)).toEqual(['x', 'y'])
   })
 
-  // Why: a host too old to page echoes no anchor at all, so it can never be a continuation.
-  it('replaces when the host echoes no page anchor', () => {
+  // Why: a host too old to page echoes nothing at all, so it can never be a continuation.
+  it('replaces when the host says nothing about the cursor', () => {
     const merged = foldGitHistoryPage(
       page(['a', 'b']),
-      page(['c', 'd'], { pageAnchor: undefined }),
+      page(['c', 'd'], { continuedCursor: undefined }),
       REQUESTED
     )
     expect(merged.items.map((i) => i.id)).toEqual(['c', 'd'])
@@ -67,12 +67,12 @@ describe('foldGitHistoryPage', () => {
 
   it('takes hasMore, the next cursor, and branch metadata from the newest page', () => {
     const merged = foldGitHistoryPage(
-      page(['a'], { mergeBase: 'old', nextCursor: { anchor: ANCHOR, loaded: 1 } }),
-      page(['b'], { mergeBase: 'new', nextCursor: { anchor: ANCHOR, loaded: 2 } }),
+      page(['a'], { mergeBase: 'old', nextCursor: { anchor: ANCHOR, loaded: 1, after: 'a' } }),
+      page(['b'], { mergeBase: 'new', nextCursor: { anchor: ANCHOR, loaded: 2, after: 'b' } }),
       REQUESTED
     )
     expect(merged.hasMore).toBe(true)
-    expect(merged.nextCursor).toEqual({ anchor: ANCHOR, loaded: 2 })
+    expect(merged.nextCursor).toEqual({ anchor: ANCHOR, loaded: 2, after: 'b' })
     expect(merged.mergeBase).toBe('new')
   })
 
@@ -81,7 +81,7 @@ describe('foldGitHistoryPage', () => {
   it('stops paging when a continuing page adds nothing new', () => {
     const merged = foldGitHistoryPage(
       page(['a', 'b']),
-      page(['a', 'b'], { nextCursor: { anchor: ANCHOR, loaded: 2 } }),
+      page(['a', 'b'], { nextCursor: { anchor: ANCHOR, loaded: 2, after: 'b' } }),
       REQUESTED
     )
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b'])

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { GitHistoryItem, GitHistoryResult } from '../../../../shared/git-history'
-import { appendGitHistoryPage, gitHistoryCursor } from './git-history-page-accumulator'
+import { appendGitHistoryPage } from './git-history-page-accumulator'
 
 function item(id: string): GitHistoryItem {
   return { id, parentIds: [], subject: `commit ${id}`, message: `commit ${id}`, author: 'Ada' }
@@ -17,17 +17,6 @@ function page(ids: string[], overrides: Partial<GitHistoryResult> = {}): GitHist
   }
 }
 
-describe('gitHistoryCursor', () => {
-  it('is the oldest commit on screen', () => {
-    expect(gitHistoryCursor(page(['a', 'b', 'c']))).toBe('c')
-  })
-
-  it('is undefined before anything loads', () => {
-    expect(gitHistoryCursor(undefined)).toBeUndefined()
-    expect(gitHistoryCursor(page([]))).toBeUndefined()
-  })
-})
-
 describe('appendGitHistoryPage', () => {
   it('keeps the first page as-is', () => {
     expect(appendGitHistoryPage(undefined, page(['a', 'b'])).items.map((i) => i.id)).toEqual([
@@ -41,21 +30,33 @@ describe('appendGitHistoryPage', () => {
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
   })
 
-  // Why: a cursor-anchored walk can re-emit a commit across a page boundary when topo-order
-  // interleaves parallel branches differently. Duplicate React keys and a doubled graph row are
-  // the visible failure.
+  // Why: HEAD can move under the walk between pages and shift the offset, re-emitting a commit.
+  // Duplicate React keys and a doubled graph row are the visible failure.
   it('drops a commit the new page repeats', () => {
     const merged = appendGitHistoryPage(page(['a', 'b', 'c']), page(['c', 'd']))
     expect(merged.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
   })
 
-  it('takes hasMore and branch metadata from the newest page', () => {
+  it('takes hasMore, the next cursor, and branch metadata from the newest page', () => {
     const merged = appendGitHistoryPage(
-      page(['a'], { hasMore: true, mergeBase: 'old' }),
-      page(['b'], { hasMore: false, mergeBase: 'new' })
+      page(['a'], { hasMore: true, mergeBase: 'old', nextCursor: { anchor: 'x', loaded: 1 } }),
+      page(['b'], { hasMore: true, mergeBase: 'new', nextCursor: { anchor: 'x', loaded: 2 } })
     )
-    expect(merged.hasMore).toBe(false)
+    expect(merged.hasMore).toBe(true)
+    expect(merged.nextCursor).toEqual({ anchor: 'x', loaded: 2 })
     expect(merged.mergeBase).toBe('new')
+  })
+
+  // Why: a host that ignores the cursor answers every page with page one. Without this the button
+  // stays lit and every click re-fetches the same commits, which reads as a hang.
+  it('stops paging when a page adds nothing new', () => {
+    const merged = appendGitHistoryPage(
+      page(['a', 'b']),
+      page(['a', 'b'], { hasMore: true, nextCursor: { anchor: 'x', loaded: 2 } })
+    )
+    expect(merged.items.map((i) => i.id)).toEqual(['a', 'b'])
+    expect(merged.hasMore).toBe(false)
+    expect(merged.nextCursor).toBeUndefined()
   })
 
   it('never loses commits already on screen when the new page is empty', () => {

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
@@ -3,10 +3,10 @@ import type { GitHistoryCursor, GitHistoryResult } from '../../../../shared/git-
 /**
  * Fold a newly fetched page onto the commits already on screen.
  *
- * Only a page that continued the walk we asked for may be appended. A refresh carries no cursor,
- * and an anchor that no longer resolves (rebase, amend, prune, gc) is answered with a fresh page
- * from HEAD — stacking either under the accumulated list would show a new history below a dead one.
- * Both replace instead, which is why the whole decision lives here rather than at the call site.
+ * Only a page that continued the cursor we sent may be appended. A refresh carries no cursor, and a
+ * cursor the host could not honor — dead anchor, or a walk that drifted under it — is answered with
+ * a fresh page from HEAD; stacking either under the accumulated list would show a new history below
+ * a dead one. Both replace instead, which is why the whole decision lives here, not at the call site.
  *
  * Page metadata (refs, merge base, incoming/outgoing, the next cursor) describes the branch and the
  * paging position rather than the page's contents, so the newest page wins.
@@ -16,7 +16,7 @@ export function foldGitHistoryPage(
   page: GitHistoryResult,
   requestedCursor: GitHistoryCursor | undefined
 ): GitHistoryResult {
-  const continued = Boolean(requestedCursor && page.pageAnchor === requestedCursor.anchor)
+  const continued = Boolean(requestedCursor && page.continuedCursor)
   if (!previous || !continued) {
     return page
   }

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
@@ -1,17 +1,10 @@
 import type { GitHistoryResult } from '../../../../shared/git-history'
 
 /**
- * Commit id to resume paging from, or undefined when nothing is loaded yet.
- */
-export function gitHistoryCursor(result: GitHistoryResult | undefined): string | undefined {
-  return result?.items.at(-1)?.id
-}
-
-/**
  * Fold a newly fetched page onto the commits already on screen.
  *
- * Page metadata (refs, merge base, incoming/outgoing) describes the branch rather than the page,
- * so the newest page wins. Items append.
+ * Page metadata (refs, merge base, incoming/outgoing, the next cursor) describes the branch and the
+ * paging position rather than the page's contents, so the newest page wins. Items append.
  */
 export function appendGitHistoryPage(
   previous: GitHistoryResult | undefined,
@@ -21,11 +14,16 @@ export function appendGitHistoryPage(
     return page
   }
 
-  // Why: topo-order can interleave parallel branches differently when the walk starts at the
-  // cursor instead of HEAD, so a commit can repeat across a page boundary. Ids are immutable, so
-  // dropping repeats here keeps React keys unique and the graph honest.
+  // Why: ids are immutable, so dropping repeats keeps React keys unique if HEAD moved under the
+  // walk between pages and shifted the offset.
   const seen = new Set(previous.items.map((item) => item.id))
   const added = page.items.filter((item) => !seen.has(item.id))
+
+  if (added.length === 0) {
+    // Why: a page that adds nothing cannot page any further — a host that ignores the cursor hands
+    // back page one forever. Stop rather than leave a "Load more" button that never moves.
+    return { ...page, items: previous.items, hasMore: false, nextCursor: undefined }
+  }
 
   return { ...page, items: [...previous.items, ...added] }
 }

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
@@ -1,16 +1,23 @@
-import type { GitHistoryResult } from '../../../../shared/git-history'
+import type { GitHistoryCursor, GitHistoryResult } from '../../../../shared/git-history'
 
 /**
  * Fold a newly fetched page onto the commits already on screen.
  *
+ * Only a page that continued the walk we asked for may be appended. A refresh carries no cursor,
+ * and an anchor that no longer resolves (rebase, amend, prune, gc) is answered with a fresh page
+ * from HEAD — stacking either under the accumulated list would show a new history below a dead one.
+ * Both replace instead, which is why the whole decision lives here rather than at the call site.
+ *
  * Page metadata (refs, merge base, incoming/outgoing, the next cursor) describes the branch and the
- * paging position rather than the page's contents, so the newest page wins. Items append.
+ * paging position rather than the page's contents, so the newest page wins.
  */
-export function appendGitHistoryPage(
+export function foldGitHistoryPage(
   previous: GitHistoryResult | undefined,
-  page: GitHistoryResult
+  page: GitHistoryResult,
+  requestedCursor: GitHistoryCursor | undefined
 ): GitHistoryResult {
-  if (!previous) {
+  const continued = Boolean(requestedCursor && page.pageAnchor === requestedCursor.anchor)
+  if (!previous || !continued) {
     return page
   }
 

--- a/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-page-accumulator.ts
@@ -1,0 +1,31 @@
+import type { GitHistoryResult } from '../../../../shared/git-history'
+
+/**
+ * Commit id to resume paging from, or undefined when nothing is loaded yet.
+ */
+export function gitHistoryCursor(result: GitHistoryResult | undefined): string | undefined {
+  return result?.items.at(-1)?.id
+}
+
+/**
+ * Fold a newly fetched page onto the commits already on screen.
+ *
+ * Page metadata (refs, merge base, incoming/outgoing) describes the branch rather than the page,
+ * so the newest page wins. Items append.
+ */
+export function appendGitHistoryPage(
+  previous: GitHistoryResult | undefined,
+  page: GitHistoryResult
+): GitHistoryResult {
+  if (!previous) {
+    return page
+  }
+
+  // Why: topo-order can interleave parallel branches differently when the walk starts at the
+  // cursor instead of HEAD, so a commit can repeat across a page boundary. Ids are immutable, so
+  // dropping repeats here keeps React keys unique and the graph honest.
+  const seen = new Set(previous.items.map((item) => item.id))
+  const added = page.items.filter((item) => !seen.has(item.id))
+
+  return { ...page, items: [...previous.items, ...added] }
+}

--- a/src/renderer/src/components/right-sidebar/git-history-virtual-rows.tsx
+++ b/src/renderer/src/components/right-sidebar/git-history-virtual-rows.tsx
@@ -1,0 +1,76 @@
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+// Why: below this count plain rows keep the DOM identical to the pre-virtualization markup, so the
+// common shallow-history case keeps exact scrollbar and flicker-free behavior. Matches the
+// threshold the file lists use for the same reason.
+export const GIT_HISTORY_VIRTUALIZE_MIN_ROWS = 50
+// Why: a collapsed commit row is one 26px line. Expanded rows carry a file list and are far
+// taller, so estimate the collapsed height and let measureElement correct the expanded ones.
+export const GIT_HISTORY_ROW_HEIGHT_PX = 26
+export const GIT_HISTORY_ROW_OVERSCAN = 8
+
+/**
+ * Windows the commit rows inside the history panel's own scroller.
+ *
+ * Unlike the file lists, this list *is* the scroll container, so there is no offset to measure
+ * against a shared scroller and no scroll margin to subtract.
+ */
+export function GitHistoryVirtualRows<TRow>({
+  rows,
+  getRowKey,
+  renderRow,
+  scrollElement
+}: {
+  rows: readonly TRow[]
+  getRowKey: (row: TRow) => string
+  renderRow: (row: TRow) => React.ReactNode
+  // Why: a state-held element, not a ref — the scroller is this component's own ancestor and is
+  // not attached when mount effects run, so a ref would leave the virtualizer unobserved.
+  scrollElement: HTMLDivElement | null
+}): React.JSX.Element {
+  const virtualize = rows.length >= GIT_HISTORY_VIRTUALIZE_MIN_ROWS
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    enabled: virtualize && scrollElement !== null,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => GIT_HISTORY_ROW_HEIGHT_PX,
+    overscan: GIT_HISTORY_ROW_OVERSCAN,
+    // Why: commit ids are immutable, so a page append carries row identity instead of remounting
+    // the window — which is what keeps an expanded row open across Load more.
+    getItemKey: (index) => {
+      const row = rows[index]
+      return row === undefined ? index : getRowKey(row)
+    }
+  })
+
+  if (!virtualize) {
+    return <>{rows.map((row) => renderRow(row))}</>
+  }
+
+  return (
+    <div
+      data-testid="git-history-virtual-list"
+      className="relative w-full"
+      style={{ height: virtualizer.getTotalSize() }}
+    >
+      {virtualizer.getVirtualItems().map((item) => {
+        const row = rows[item.index]
+        if (row === undefined) {
+          return null
+        }
+        return (
+          <div
+            key={item.key}
+            ref={virtualizer.measureElement}
+            data-index={item.index}
+            className="absolute top-0 left-0 w-full"
+            style={{ transform: `translateY(${item.start}px)` }}
+          >
+            {renderRow(row)}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/git-history-virtual-rows.tsx
+++ b/src/renderer/src/components/right-sidebar/git-history-virtual-rows.tsx
@@ -36,8 +36,10 @@ export function GitHistoryVirtualRows<TRow>({
     getScrollElement: () => scrollElement,
     estimateSize: () => GIT_HISTORY_ROW_HEIGHT_PX,
     overscan: GIT_HISTORY_ROW_OVERSCAN,
-    // Why: commit ids are immutable, so a page append carries row identity instead of remounting
-    // the window — which is what keeps an expanded row open across Load more.
+    // Why: measured row heights are cached against this key. Positions are not stable identity —
+    // a refresh or base-ref change puts different commits at the same indices, and an index key
+    // would hand a new commit the measured height of whatever expanded row used to sit there.
+    // (Expansion itself survives a page append because the panel keys that state by commit id.)
     getItemKey: (index) => {
       const row = rows[index]
       return row === undefined ? index : getRowKey(row)

--- a/src/renderer/src/components/right-sidebar/useGitHistoryCommitExpansion.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryCommitExpansion.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from 'react'
+import { translate } from '@/i18n/i18n'
+import type { GitHistoryItem, GitHistoryResult } from '../../../../shared/git-history'
+import type { GitBranchChangeEntry } from '../../../../shared/types'
+import type { GitHistoryCommitFilesState } from './GitHistoryCommitFiles'
+
+// `worktreeId` rides along with the caches so a load that completes after a worktree switch can
+// tell that its result is no longer wanted.
+type CommitExpansion = {
+  worktreeId: string | undefined
+  expanded: Set<string>
+  filesByCommit: Record<string, GitHistoryCommitFilesState>
+}
+
+type GitHistoryCommitExpansion = {
+  expanded: Set<string>
+  filesByCommit: Record<string, GitHistoryCommitFilesState>
+  toggleExpand: (item: GitHistoryItem) => void
+}
+
+function emptyExpansion(worktreeId: string | undefined): CommitExpansion {
+  return { worktreeId, expanded: new Set(), filesByCommit: {} }
+}
+
+// A commit's file list is already loaded or in flight; re-expanding must not refetch it.
+function isCommitFilesResolved(state: GitHistoryCommitFilesState | undefined): boolean {
+  return state?.status === 'loading' || state?.status === 'ready'
+}
+
+// Per-commit expansion and file-list state for the history panel. Extracted from
+// GitHistoryPanel to keep that component from growing.
+export function useGitHistoryCommitExpansion({
+  result,
+  worktreeId,
+  onLoadCommitFiles
+}: {
+  result: GitHistoryResult | undefined
+  worktreeId: string | undefined
+  onLoadCommitFiles?: (item: GitHistoryItem) => Promise<GitBranchChangeEntry[]>
+}): GitHistoryCommitExpansion {
+  const [expansion, setExpansion] = useState<CommitExpansion>(() => emptyExpansion(worktreeId))
+
+  // The commit-compare cache in useGitHistoryCommitActions is dropped whenever the worktree
+  // changes, so keep this state on the same lifetime — a row retained across the switch would
+  // still look expanded while its file clicks resolved to nothing. Reset during render rather
+  // than in an effect so the switch never paints a row that is already dead.
+  if (expansion.worktreeId !== worktreeId) {
+    setExpansion(emptyExpansion(worktreeId))
+  }
+
+  // Prune to the commits that survived the new result. Clearing wholesale would collapse every
+  // expanded row on Load more, which only appends; file lists are keyed by immutable commit id,
+  // so a surviving id cannot show stale files.
+  useEffect(() => {
+    const liveIds = new Set(result?.items.map((item) => item.id) ?? [])
+    setExpansion((prev) => {
+      const expanded = new Set([...prev.expanded].filter((id) => liveIds.has(id)))
+      const kept = Object.entries(prev.filesByCommit).filter(([id]) => liveIds.has(id))
+      if (
+        expanded.size === prev.expanded.size &&
+        kept.length === Object.keys(prev.filesByCommit).length
+      ) {
+        return prev
+      }
+      return { ...prev, expanded, filesByCommit: Object.fromEntries(kept) }
+    })
+  }, [result])
+
+  const toggleExpand = useCallback(
+    (item: GitHistoryItem): void => {
+      const id = item.id
+      const willExpand = !expansion.expanded.has(id)
+      setExpansion((prev) => {
+        const expanded = new Set(prev.expanded)
+        if (willExpand) {
+          expanded.add(id)
+        } else {
+          expanded.delete(id)
+        }
+        return { ...prev, expanded }
+      })
+      if (!willExpand || !onLoadCommitFiles || isCommitFilesResolved(expansion.filesByCommit[id])) {
+        return
+      }
+      const loadScope = expansion.worktreeId
+      // Drop a completion whose worktree has since changed: the sibling commit-compare cache is
+      // gone, so recording the files would leave rows that look loaded but cannot open.
+      const applyFiles = (state: GitHistoryCommitFilesState): void => {
+        setExpansion((prev) =>
+          prev.worktreeId !== loadScope
+            ? prev
+            : { ...prev, filesByCommit: { ...prev.filesByCommit, [id]: state } }
+        )
+      }
+      applyFiles({ status: 'loading' })
+      onLoadCommitFiles(item)
+        .then((entries) => {
+          applyFiles({ status: 'ready', entries })
+        })
+        .catch((error: unknown) => {
+          applyFiles({
+            status: 'error',
+            error:
+              error instanceof Error
+                ? error.message
+                : translate(
+                    'auto.components.right.sidebar.GitHistoryPanel.6d1e0a7c3b',
+                    'Failed to load commit files'
+                  )
+          })
+        })
+    },
+    [expansion, onLoadCommitFiles]
+  )
+
+  return { expanded: expansion.expanded, filesByCommit: expansion.filesByCommit, toggleExpand }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10842,7 +10842,8 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "error",
             "e5e81e59a6": "Resize commits",
-            "6d1e0a7c3b": "Failed to load commit files"
+            "6d1e0a7c3b": "Failed to load commit files",
+            "loadMoreCommits": "Load more commits"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "Close",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2098,12 +2098,11 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     // Why: the "add huge folder to .gitignore" flow is desktop-only; the web runtime makes no offer, so return no candidates.
     findHugeFoldersToIgnore: async () => [],
     appendGitignore: async () => false,
-    history: async ({ worktreePath, limit, baseRef }) => {
+    history: async ({ worktreePath, connectionId: _connectionId, ...options }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       return callRuntimeResult('git.history', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
-        limit,
-        baseRef
+        ...options
       })
     },
     conflictOperation: async ({ worktreePath }) => {

--- a/src/shared/git-history-cursor.test.ts
+++ b/src/shared/git-history-cursor.test.ts
@@ -222,7 +222,10 @@ describe('git history paging against a real repository', () => {
       })
     }
 
-    await run(['init', '-q', '-b', 'main', '.'])
+    // `git init -b` is Git 2.28; the project baseline is 2.25. Naming the branch through
+    // symbolic-ref works on every supported Git and ignores the user's init.defaultBranch.
+    await run(['init', '-q', '.'])
+    await run(['symbolic-ref', 'HEAD', 'refs/heads/main'])
     await commit('base')
     // A long-lived branch: both lines of history grow past a page before being merged, so a page
     // boundary necessarily lands inside one of them while the other is still unshown.

--- a/src/shared/git-history-cursor.test.ts
+++ b/src/shared/git-history-cursor.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
-import type { GitHistoryExecutor } from './git-history'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { GitHistoryCursor, GitHistoryExecutor } from './git-history'
 import { loadGitHistoryFromExecutor } from './git-history'
+
+const execFileAsync = promisify(execFile)
 
 function oid(index: number): string {
   return index.toString(16).padStart(40, '0')
@@ -11,8 +18,11 @@ function logRecord(hash: string, message: string, parents: string[]): string {
 }
 
 /**
- * Fake of a linear history of `total` commits, newest first, that honours `-n` and the starting
- * revision the way `git log` does — so a cursor request really walks from that commit's position.
+ * Fake of a linear history that honours `-n` and `--skip`.
+ *
+ * Deliberately only used for request shape and the stale-anchor degrade. A fake cannot model
+ * `--topo-order` over a DAG, and pretending it can is what let an unsound cursor look correct —
+ * the walk properties are asserted against the real git binary below.
  */
 function createWalkExecutor(
   total: number,
@@ -28,7 +38,7 @@ function createWalkExecutor(
       if (target === 'HEAD') {
         return { stdout: `${chain[0]}\n` }
       }
-      // Why: models a cursor that no longer resolves (rebased away, pruned).
+      // Why: models an anchor that no longer resolves (rebased away, pruned).
       if (target && knownOids && !knownOids.has(target)) {
         throw new Error(`unknown revision ${target}`)
       }
@@ -37,20 +47,19 @@ function createWalkExecutor(
     if (command === 'symbolic-ref') {
       return { stdout: 'main\n' }
     }
-    if (command === 'for-each-ref') {
-      return { stdout: '' }
-    }
-    if (command === 'merge-base') {
+    if (command === 'for-each-ref' || command === 'merge-base') {
       return { stdout: '' }
     }
     if (command === 'log') {
       logCalls.push(args)
       const count = Number(args.find((arg) => arg.startsWith('-n'))?.slice(2) ?? total)
+      const skip = Number(args.find((arg) => arg.startsWith('--skip='))?.slice(7) ?? 0)
       const start = args.at(-1) ?? ''
       const from = chain.indexOf(start)
-      const walk = chain.slice(from === -1 ? 0 : from, (from === -1 ? 0 : from) + count)
+      const base = (from === -1 ? 0 : from) + skip
       return {
-        stdout: walk
+        stdout: chain
+          .slice(base, base + count)
           .map((hash) =>
             logRecord(hash, `commit ${chain.indexOf(hash)}`, [chain[chain.indexOf(hash) + 1] ?? ''])
           )
@@ -64,7 +73,7 @@ function createWalkExecutor(
 }
 
 describe('git history cursor paging', () => {
-  it('walks from HEAD when no cursor is given', async () => {
+  it('walks from HEAD and offers a cursor when more remains', async () => {
     const { executor, logCalls } = createWalkExecutor(200)
 
     const result = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50 })
@@ -72,44 +81,56 @@ describe('git history cursor paging', () => {
     expect(result.items).toHaveLength(50)
     expect(result.items[0]?.id).toBe(oid(0))
     expect(result.hasMore).toBe(true)
-    // one lookahead past the page
+    expect(result.nextCursor).toEqual({ anchor: oid(0), loaded: 50 })
+    // one lookahead past the page, and no offset on the first page
     expect(logCalls[0]).toContain('-n51')
+    expect(logCalls[0]?.some((arg) => arg.startsWith('--skip='))).toBe(false)
   })
 
-  it('resumes after the cursor without repeating it', async () => {
+  it('resumes at the cursor offset without repeating the previous page', async () => {
     const { executor, logCalls } = createWalkExecutor(200)
 
-    const page = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, cursor: oid(49) })
+    const page = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      cursor: { anchor: oid(0), loaded: 50 }
+    })
 
     expect(page.items[0]?.id).toBe(oid(50))
     expect(page.items.map((item) => item.id)).not.toContain(oid(49))
     expect(page.items).toHaveLength(50)
-    // Why: the walk re-emits the cursor, so the page needs one extra beyond the lookahead.
-    expect(logCalls[0]).toContain('-n52')
-    expect(logCalls[0]?.at(-1)).toBe(oid(49))
+    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 100 })
+    expect(logCalls[0]).toContain('--skip=50')
+    // Why: the walk never re-emits an already-shown commit, so no extra lookahead is needed.
+    expect(logCalls[0]).toContain('-n51')
   })
 
   // Why: this is the property the whole design turns on — page cost must not grow with depth.
   it('asks for one page of output no matter how deep paging goes', async () => {
     const { executor, logCalls } = createWalkExecutor(1000)
 
-    for (const cursor of [oid(49), oid(299), oid(899)]) {
-      await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, cursor })
+    for (const loaded of [50, 300, 900]) {
+      await loadGitHistoryFromExecutor(executor, '/repo', {
+        limit: 50,
+        cursor: { anchor: oid(0), loaded }
+      })
     }
 
-    const requestedCounts = logCalls.map((args) =>
-      Number(args.find((arg) => arg.startsWith('-n'))?.slice(2))
-    )
-    expect(requestedCounts).toEqual([52, 52, 52])
+    expect(
+      logCalls.map((args) => Number(args.find((arg) => arg.startsWith('-n'))?.slice(2)))
+    ).toEqual([51, 51, 51])
   })
 
-  it('reports no further page at the end of history', async () => {
+  it('reports no further page, and no cursor, at the end of history', async () => {
     const { executor } = createWalkExecutor(60)
 
-    const page = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, cursor: oid(49) })
+    const page = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      cursor: { anchor: oid(0), loaded: 50 }
+    })
 
     expect(page.items).toHaveLength(10)
     expect(page.hasMore).toBe(false)
+    expect(page.nextCursor).toBeUndefined()
   })
 
   it('pages past the old 200-commit ceiling', async () => {
@@ -117,26 +138,164 @@ describe('git history cursor paging', () => {
 
     const deep = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: oid(199)
+      cursor: { anchor: oid(0), loaded: 200 }
     })
 
     expect(deep.items[0]?.id).toBe(oid(200))
     expect(deep.hasMore).toBe(true)
   })
 
-  // Why: a cursor can die under a rebase. Degrading to a fresh first page keeps the panel usable;
+  // Why: an anchor can die under a rebase. Degrading to a fresh first page keeps the panel usable;
   // passing the dead revision to `git log` would fail the whole read.
-  it('falls back to a fresh first page when the cursor no longer resolves', async () => {
+  it('falls back to a fresh first page when the anchor no longer resolves', async () => {
     const { executor, logCalls } = createWalkExecutor(200, {
-      knownOids: new Set(Array.from({ length: 200 }, (_, index) => oid(index)).slice(0, 100))
+      knownOids: new Set(Array.from({ length: 100 }, (_, index) => oid(index)))
     })
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: oid(150)
+      cursor: { anchor: oid(150), loaded: 150 }
     })
 
     expect(page.items[0]?.id).toBe(oid(0))
-    expect(logCalls[0]).toContain('-n51')
+    // Why: the offset belongs to the dead walk, so it must be dropped with it — carrying it over
+    // would skip the first 150 commits of the fresh page.
+    expect(logCalls[0]?.some((arg) => arg.startsWith('--skip='))).toBe(false)
+    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 50 })
+  })
+})
+
+/**
+ * Paging semantics against the real git binary.
+ *
+ * A commit-id cursor passes every fake above and still loses commits here: restarting the walk at
+ * the oldest row reaches only that commit's ancestors, so a merged long-lived branch drops the
+ * mainline commits above the fork point and paging stops early reporting nothing more to load.
+ */
+describe('git history paging against a real repository', () => {
+  let repoPath = ''
+  let allCommits: string[] = []
+
+  const git: GitHistoryExecutor = async (args, cwd) => {
+    const { stdout } = await execFileAsync('git', args, { cwd, maxBuffer: 8 * 1024 * 1024 })
+    return { stdout }
+  }
+
+  beforeAll(async () => {
+    repoPath = await mkdtemp(join(tmpdir(), 'orca-git-history-paging-'))
+    const run = async (args: string[]): Promise<void> => {
+      await execFileAsync('git', args, {
+        cwd: repoPath,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: 'Ada',
+          GIT_AUTHOR_EMAIL: 'ada@example.com',
+          GIT_COMMITTER_NAME: 'Ada',
+          GIT_COMMITTER_EMAIL: 'ada@example.com'
+        }
+      })
+    }
+    let tick = 0
+    // `lane` keeps each line of history on its own file so the merge below is conflict-free.
+    const commit = async (message: string, lane = 'base'): Promise<void> => {
+      tick += 1
+      await writeFile(join(repoPath, `${lane}.txt`), `${message}\n`)
+      await run(['add', '-A'])
+      const when = `2020-01-01T00:00:${String(tick % 60).padStart(2, '0')}`
+      await execFileAsync('git', ['commit', '-q', '-m', message], {
+        cwd: repoPath,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: 'Ada',
+          GIT_AUTHOR_EMAIL: 'ada@example.com',
+          GIT_COMMITTER_NAME: 'Ada',
+          GIT_COMMITTER_EMAIL: 'ada@example.com',
+          GIT_AUTHOR_DATE: when,
+          GIT_COMMITTER_DATE: when
+        }
+      })
+    }
+
+    await run(['init', '-q', '-b', 'main', '.'])
+    await commit('base')
+    // A long-lived branch: both lines of history grow past a page before being merged, so a page
+    // boundary necessarily lands inside one of them while the other is still unshown.
+    await run(['branch', 'feature'])
+    for (let index = 1; index <= 12; index += 1) {
+      await commit(`main-${index}`, 'main')
+    }
+    await run(['checkout', '-q', 'feature'])
+    for (let index = 1; index <= 12; index += 1) {
+      await commit(`feat-${index}`, 'feat')
+    }
+    await run(['checkout', '-q', 'main'])
+    await run(['merge', '-q', '--no-ff', 'feature', '-m', 'Merge feature'])
+
+    const { stdout } = await execFileAsync('git', ['rev-list', '--topo-order', 'HEAD'], {
+      cwd: repoPath
+    })
+    allCommits = stdout.trim().split('\n')
+  }, 60_000)
+
+  afterAll(async () => {
+    if (repoPath) {
+      await rm(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  async function pageThrough(limit: number): Promise<string[]> {
+    const seen: string[] = []
+    let cursor: GitHistoryCursor | undefined
+    // Bound the loop so a paging bug fails on the assertions below rather than hanging.
+    for (let page = 0; page < 50; page += 1) {
+      const result = await loadGitHistoryFromExecutor(git, repoPath, { limit, cursor })
+      seen.push(...result.items.map((item) => item.id))
+      if (!result.hasMore || !result.nextCursor) {
+        break
+      }
+      cursor = result.nextCursor
+    }
+    return seen
+  }
+
+  it('reaches every commit across a merge, in one uninterrupted topo order', async () => {
+    expect(allCommits.length).toBe(26)
+
+    const paged = await pageThrough(10)
+
+    // Why: identity, not set equality — a page boundary must neither drop a parallel line of
+    // history nor reorder one, so the paged sequence is the single-walk sequence.
+    expect(paged).toEqual(allCommits)
+  })
+
+  it('ends paging only when git has nothing older, whatever the page size', async () => {
+    for (const limit of [1, 3, 7, 25]) {
+      expect(await pageThrough(limit)).toEqual(allCommits)
+    }
+  })
+
+  it('keeps every page the same size as paging goes deeper', async () => {
+    const sizes: number[] = []
+    let cursor: GitHistoryCursor | undefined
+    for (let page = 0; page < 50; page += 1) {
+      const result = await loadGitHistoryFromExecutor(git, repoPath, { limit: 5, cursor })
+      sizes.push(result.items.length)
+      if (!result.hasMore || !result.nextCursor) {
+        break
+      }
+      cursor = result.nextCursor
+    }
+    // Why: the payload is what the SSH and relay transports cap at 1MB, so page size must not
+    // grow with depth the way re-requesting a larger window from HEAD did.
+    expect(sizes.slice(0, -1).every((size) => size === 5)).toBe(true)
+  })
+
+  it('degrades to a fresh first page when the anchor is not a known commit', async () => {
+    const result = await loadGitHistoryFromExecutor(git, repoPath, {
+      limit: 5,
+      cursor: { anchor: 'f'.repeat(40), loaded: 20 }
+    })
+
+    expect(result.items.map((item) => item.id)).toEqual(allCommits.slice(0, 5))
   })
 })

--- a/src/shared/git-history-cursor.test.ts
+++ b/src/shared/git-history-cursor.test.ts
@@ -13,6 +13,11 @@ function oid(index: number): string {
   return index.toString(16).padStart(40, '0')
 }
 
+// The fake chain is linear, so row N's only parent is row N+1.
+function seam(index: number): { id: string; parentIds: string[] } {
+  return { id: oid(index), parentIds: [oid(index + 1)] }
+}
+
 function logRecord(hash: string, message: string, parents: string[]): string {
   return `${[hash, 'Ada Lovelace', 'ada@example.com', '1700000000', '1700000000', parents.join(' '), '', message].join('\n')}\0`
 }
@@ -81,7 +86,7 @@ describe('git history cursor paging', () => {
     expect(result.items).toHaveLength(50)
     expect(result.items[0]?.id).toBe(oid(0))
     expect(result.hasMore).toBe(true)
-    expect(result.nextCursor).toEqual({ anchor: oid(0), loaded: 50, after: oid(49) })
+    expect(result.nextCursor).toEqual({ anchor: oid(0), loaded: 50, after: seam(49) })
     // one lookahead past the page, and no offset on the first page
     expect(logCalls[0]).toContain('-n51')
     expect(logCalls[0]?.some((arg) => arg.startsWith('--skip='))).toBe(false)
@@ -92,13 +97,13 @@ describe('git history cursor paging', () => {
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(0), loaded: 50, after: oid(49) }
+      cursor: { anchor: oid(0), loaded: 50, after: seam(49) }
     })
 
     expect(page.items[0]?.id).toBe(oid(50))
     expect(page.items.map((item) => item.id)).not.toContain(oid(49))
     expect(page.items).toHaveLength(50)
-    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 100, after: oid(99) })
+    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 100, after: seam(99) })
     // Why: skip stops one short of the page so the walk re-emits the seam row, and the count
     // covers that row, the page, and one lookahead.
     expect(logCalls[0]).toContain('--skip=49')
@@ -112,7 +117,7 @@ describe('git history cursor paging', () => {
     for (const loaded of [50, 300, 900]) {
       await loadGitHistoryFromExecutor(executor, '/repo', {
         limit: 50,
-        cursor: { anchor: oid(0), loaded, after: oid(loaded - 1) }
+        cursor: { anchor: oid(0), loaded, after: seam(loaded - 1) }
       })
     }
 
@@ -126,7 +131,7 @@ describe('git history cursor paging', () => {
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(0), loaded: 50, after: oid(49) }
+      cursor: { anchor: oid(0), loaded: 50, after: seam(49) }
     })
 
     expect(page.items).toHaveLength(10)
@@ -139,7 +144,7 @@ describe('git history cursor paging', () => {
 
     const deep = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(0), loaded: 200, after: oid(199) }
+      cursor: { anchor: oid(0), loaded: 200, after: seam(199) }
     })
 
     expect(deep.items[0]?.id).toBe(oid(200))
@@ -155,14 +160,14 @@ describe('git history cursor paging', () => {
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(150), loaded: 150, after: oid(149) }
+      cursor: { anchor: oid(150), loaded: 150, after: seam(149) }
     })
 
     expect(page.items[0]?.id).toBe(oid(0))
     // Why: the offset belongs to the dead walk, so it must be dropped with it — carrying it over
     // would skip the first 150 commits of the fresh page.
     expect(logCalls[0]?.some((arg) => arg.startsWith('--skip='))).toBe(false)
-    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 50, after: oid(49) })
+    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 50, after: seam(49) })
   })
 })
 
@@ -294,7 +299,7 @@ describe('git history paging against a real repository', () => {
   it('degrades to a fresh first page when the anchor is not a known commit', async () => {
     const result = await loadGitHistoryFromExecutor(git, repoPath, {
       limit: 5,
-      cursor: { anchor: 'f'.repeat(40), loaded: 20, after: 'e'.repeat(40) }
+      cursor: { anchor: 'f'.repeat(40), loaded: 20, after: { id: 'e'.repeat(40), parentIds: [] } }
     })
 
     expect(result.items.map((item) => item.id)).toEqual(allCommits.slice(0, 5))
@@ -312,6 +317,7 @@ describe('git history paging against a real repository', () => {
     expect(cursor).toBeDefined()
 
     const graftTarget = first.items[1]?.id ?? ''
+    expect(graftTarget).not.toBe(first.items.at(-1)?.id)
     const orphanParent = allCommits.at(-1) ?? ''
     await execFileAsync('git', ['replace', '--graft', graftTarget, orphanParent], { cwd: repoPath })
     try {
@@ -328,6 +334,31 @@ describe('git history paging against a real repository', () => {
       expect(drifted.items.map((item) => item.id)).toEqual(stdout.trim().split('\n'))
     } finally {
       await execFileAsync('git', ['replace', '-d', graftTarget], { cwd: repoPath })
+    }
+  })
+
+  // Why: the seam keeping its id is not enough. Grafting the seam commit itself leaves the id at
+  // the same walk offset while replacing everything below it, so an id-only check would splice the
+  // grafted chain under a row whose drawn parent edge points at a commit the list no longer holds.
+  it('restarts when the seam keeps its id but its parents were rewritten', async () => {
+    const first = await loadGitHistoryFromExecutor(git, repoPath, { limit: 5 })
+    const cursor = first.nextCursor
+    expect(cursor).toBeDefined()
+
+    const seamId = first.items.at(-1)?.id ?? ''
+    const orphanParent = allCommits.at(-1) ?? ''
+    expect(seamId).toBe(cursor?.after.id)
+    await execFileAsync('git', ['replace', '--graft', seamId, orphanParent], { cwd: repoPath })
+    try {
+      const drifted = await loadGitHistoryFromExecutor(git, repoPath, {
+        limit: 5,
+        cursor: cursor as NonNullable<typeof cursor>
+      })
+
+      // The seam is still the first row of the resumed read, so only the parent check can catch it.
+      expect(drifted.continuedCursor).toBe(false)
+    } finally {
+      await execFileAsync('git', ['replace', '-d', seamId], { cwd: repoPath })
     }
   })
 

--- a/src/shared/git-history-cursor.test.ts
+++ b/src/shared/git-history-cursor.test.ts
@@ -297,5 +297,43 @@ describe('git history paging against a real repository', () => {
     })
 
     expect(result.items.map((item) => item.id)).toEqual(allCommits.slice(0, 5))
+    // Why: the client tells a restart from a continuation by this, and only by this — without it
+    // a fresh page 1 gets appended under the commits already on screen.
+    expect(result.pageAnchor).toBe(allCommits[0])
+  })
+
+  // Why: this is what pinning the walk buys, and nothing else in the suite can see it. HEAD moving
+  // mid-paging is routine here — agents commit in terminals while the panel is open. Re-anchoring
+  // each page to the live HEAD shifts the offset under the walk, so pages silently repeat commits
+  // at the near end and drop exactly as many off the far end.
+  it('keeps later pages on the walk the first page started, when HEAD moves mid-paging', async () => {
+    const first = await loadGitHistoryFromExecutor(git, repoPath, { limit: 5 })
+    expect(first.nextCursor).toBeDefined()
+
+    await execFileAsync('git', ['commit', '-q', '--allow-empty', '-m', 'landed mid-paging'], {
+      cwd: repoPath,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'Ada',
+        GIT_AUTHOR_EMAIL: 'ada@example.com',
+        GIT_COMMITTER_NAME: 'Ada',
+        GIT_COMMITTER_EMAIL: 'ada@example.com'
+      }
+    })
+    try {
+      const seen = first.items.map((item) => item.id)
+      let cursor = first.nextCursor
+      while (cursor) {
+        const next = await loadGitHistoryFromExecutor(git, repoPath, { limit: 5, cursor })
+        expect(next.pageAnchor).toBe(cursor.anchor)
+        seen.push(...next.items.map((item) => item.id))
+        cursor = next.hasMore ? next.nextCursor : undefined
+      }
+
+      expect(new Set(seen).size).toBe(seen.length)
+      expect(seen).toEqual(allCommits)
+    } finally {
+      await execFileAsync('git', ['reset', '-q', '--hard', 'HEAD~1'], { cwd: repoPath })
+    }
   })
 })

--- a/src/shared/git-history-cursor.test.ts
+++ b/src/shared/git-history-cursor.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitHistoryExecutor } from './git-history'
+import { loadGitHistoryFromExecutor } from './git-history'
+
+function oid(index: number): string {
+  return index.toString(16).padStart(40, '0')
+}
+
+function logRecord(hash: string, message: string, parents: string[]): string {
+  return `${[hash, 'Ada Lovelace', 'ada@example.com', '1700000000', '1700000000', parents.join(' '), '', message].join('\n')}\0`
+}
+
+/**
+ * Fake of a linear history of `total` commits, newest first, that honours `-n` and the starting
+ * revision the way `git log` does — so a cursor request really walks from that commit's position.
+ */
+function createWalkExecutor(
+  total: number,
+  { knownOids }: { knownOids?: Set<string> } = {}
+): { executor: GitHistoryExecutor; logCalls: string[][] } {
+  const chain = Array.from({ length: total }, (_, index) => oid(index))
+  const logCalls: string[][] = []
+
+  const executor = vi.fn(async (args: string[]) => {
+    const command = args[0]
+    if (command === 'rev-parse') {
+      const target = args.find((arg) => arg.endsWith('^{commit}'))?.replace('^{commit}', '')
+      if (target === 'HEAD') {
+        return { stdout: `${chain[0]}\n` }
+      }
+      // Why: models a cursor that no longer resolves (rebased away, pruned).
+      if (target && knownOids && !knownOids.has(target)) {
+        throw new Error(`unknown revision ${target}`)
+      }
+      return target && chain.includes(target) ? { stdout: `${target}\n` } : { stdout: '' }
+    }
+    if (command === 'symbolic-ref') {
+      return { stdout: 'main\n' }
+    }
+    if (command === 'for-each-ref') {
+      return { stdout: '' }
+    }
+    if (command === 'merge-base') {
+      return { stdout: '' }
+    }
+    if (command === 'log') {
+      logCalls.push(args)
+      const count = Number(args.find((arg) => arg.startsWith('-n'))?.slice(2) ?? total)
+      const start = args.at(-1) ?? ''
+      const from = chain.indexOf(start)
+      const walk = chain.slice(from === -1 ? 0 : from, (from === -1 ? 0 : from) + count)
+      return {
+        stdout: walk
+          .map((hash) =>
+            logRecord(hash, `commit ${chain.indexOf(hash)}`, [chain[chain.indexOf(hash) + 1] ?? ''])
+          )
+          .join('')
+      }
+    }
+    throw new Error(`unexpected git command: ${args.join(' ')}`)
+  })
+
+  return { executor, logCalls }
+}
+
+describe('git history cursor paging', () => {
+  it('walks from HEAD when no cursor is given', async () => {
+    const { executor, logCalls } = createWalkExecutor(200)
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50 })
+
+    expect(result.items).toHaveLength(50)
+    expect(result.items[0]?.id).toBe(oid(0))
+    expect(result.hasMore).toBe(true)
+    // one lookahead past the page
+    expect(logCalls[0]).toContain('-n51')
+  })
+
+  it('resumes after the cursor without repeating it', async () => {
+    const { executor, logCalls } = createWalkExecutor(200)
+
+    const page = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, cursor: oid(49) })
+
+    expect(page.items[0]?.id).toBe(oid(50))
+    expect(page.items.map((item) => item.id)).not.toContain(oid(49))
+    expect(page.items).toHaveLength(50)
+    // Why: the walk re-emits the cursor, so the page needs one extra beyond the lookahead.
+    expect(logCalls[0]).toContain('-n52')
+    expect(logCalls[0]?.at(-1)).toBe(oid(49))
+  })
+
+  // Why: this is the property the whole design turns on — page cost must not grow with depth.
+  it('asks for one page of output no matter how deep paging goes', async () => {
+    const { executor, logCalls } = createWalkExecutor(1000)
+
+    for (const cursor of [oid(49), oid(299), oid(899)]) {
+      await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, cursor })
+    }
+
+    const requestedCounts = logCalls.map((args) =>
+      Number(args.find((arg) => arg.startsWith('-n'))?.slice(2))
+    )
+    expect(requestedCounts).toEqual([52, 52, 52])
+  })
+
+  it('reports no further page at the end of history', async () => {
+    const { executor } = createWalkExecutor(60)
+
+    const page = await loadGitHistoryFromExecutor(executor, '/repo', { limit: 50, cursor: oid(49) })
+
+    expect(page.items).toHaveLength(10)
+    expect(page.hasMore).toBe(false)
+  })
+
+  it('pages past the old 200-commit ceiling', async () => {
+    const { executor } = createWalkExecutor(1000)
+
+    const deep = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      cursor: oid(199)
+    })
+
+    expect(deep.items[0]?.id).toBe(oid(200))
+    expect(deep.hasMore).toBe(true)
+  })
+
+  // Why: a cursor can die under a rebase. Degrading to a fresh first page keeps the panel usable;
+  // passing the dead revision to `git log` would fail the whole read.
+  it('falls back to a fresh first page when the cursor no longer resolves', async () => {
+    const { executor, logCalls } = createWalkExecutor(200, {
+      knownOids: new Set(Array.from({ length: 200 }, (_, index) => oid(index)).slice(0, 100))
+    })
+
+    const page = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      cursor: oid(150)
+    })
+
+    expect(page.items[0]?.id).toBe(oid(0))
+    expect(logCalls[0]).toContain('-n51')
+  })
+})

--- a/src/shared/git-history-cursor.test.ts
+++ b/src/shared/git-history-cursor.test.ts
@@ -81,7 +81,7 @@ describe('git history cursor paging', () => {
     expect(result.items).toHaveLength(50)
     expect(result.items[0]?.id).toBe(oid(0))
     expect(result.hasMore).toBe(true)
-    expect(result.nextCursor).toEqual({ anchor: oid(0), loaded: 50 })
+    expect(result.nextCursor).toEqual({ anchor: oid(0), loaded: 50, after: oid(49) })
     // one lookahead past the page, and no offset on the first page
     expect(logCalls[0]).toContain('-n51')
     expect(logCalls[0]?.some((arg) => arg.startsWith('--skip='))).toBe(false)
@@ -92,16 +92,17 @@ describe('git history cursor paging', () => {
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(0), loaded: 50 }
+      cursor: { anchor: oid(0), loaded: 50, after: oid(49) }
     })
 
     expect(page.items[0]?.id).toBe(oid(50))
     expect(page.items.map((item) => item.id)).not.toContain(oid(49))
     expect(page.items).toHaveLength(50)
-    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 100 })
-    expect(logCalls[0]).toContain('--skip=50')
-    // Why: the walk never re-emits an already-shown commit, so no extra lookahead is needed.
-    expect(logCalls[0]).toContain('-n51')
+    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 100, after: oid(99) })
+    // Why: skip stops one short of the page so the walk re-emits the seam row, and the count
+    // covers that row, the page, and one lookahead.
+    expect(logCalls[0]).toContain('--skip=49')
+    expect(logCalls[0]).toContain('-n52')
   })
 
   // Why: this is the property the whole design turns on — page cost must not grow with depth.
@@ -111,13 +112,13 @@ describe('git history cursor paging', () => {
     for (const loaded of [50, 300, 900]) {
       await loadGitHistoryFromExecutor(executor, '/repo', {
         limit: 50,
-        cursor: { anchor: oid(0), loaded }
+        cursor: { anchor: oid(0), loaded, after: oid(loaded - 1) }
       })
     }
 
     expect(
       logCalls.map((args) => Number(args.find((arg) => arg.startsWith('-n'))?.slice(2)))
-    ).toEqual([51, 51, 51])
+    ).toEqual([52, 52, 52])
   })
 
   it('reports no further page, and no cursor, at the end of history', async () => {
@@ -125,7 +126,7 @@ describe('git history cursor paging', () => {
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(0), loaded: 50 }
+      cursor: { anchor: oid(0), loaded: 50, after: oid(49) }
     })
 
     expect(page.items).toHaveLength(10)
@@ -138,7 +139,7 @@ describe('git history cursor paging', () => {
 
     const deep = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(0), loaded: 200 }
+      cursor: { anchor: oid(0), loaded: 200, after: oid(199) }
     })
 
     expect(deep.items[0]?.id).toBe(oid(200))
@@ -154,14 +155,14 @@ describe('git history cursor paging', () => {
 
     const page = await loadGitHistoryFromExecutor(executor, '/repo', {
       limit: 50,
-      cursor: { anchor: oid(150), loaded: 150 }
+      cursor: { anchor: oid(150), loaded: 150, after: oid(149) }
     })
 
     expect(page.items[0]?.id).toBe(oid(0))
     // Why: the offset belongs to the dead walk, so it must be dropped with it — carrying it over
     // would skip the first 150 commits of the fresh page.
     expect(logCalls[0]?.some((arg) => arg.startsWith('--skip='))).toBe(false)
-    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 50 })
+    expect(page.nextCursor).toEqual({ anchor: oid(0), loaded: 50, after: oid(49) })
   })
 })
 
@@ -293,13 +294,41 @@ describe('git history paging against a real repository', () => {
   it('degrades to a fresh first page when the anchor is not a known commit', async () => {
     const result = await loadGitHistoryFromExecutor(git, repoPath, {
       limit: 5,
-      cursor: { anchor: 'f'.repeat(40), loaded: 20 }
+      cursor: { anchor: 'f'.repeat(40), loaded: 20, after: 'e'.repeat(40) }
     })
 
     expect(result.items.map((item) => item.id)).toEqual(allCommits.slice(0, 5))
     // Why: the client tells a restart from a continuation by this, and only by this — without it
     // a fresh page 1 gets appended under the commits already on screen.
-    expect(result.pageAnchor).toBe(allCommits[0])
+    expect(result.continuedCursor).toBe(false)
+  })
+
+  // Why: an anchor resolving is not proof its ancestry is unchanged. `git replace --graft` rewrites
+  // a commit's parents in place, so the same anchor can walk a different history between two page
+  // requests — and an unverified resume would splice that history in, skipping and reordering rows.
+  it('restarts rather than splicing when the walk under the anchor changed', async () => {
+    const first = await loadGitHistoryFromExecutor(git, repoPath, { limit: 5 })
+    const cursor = first.nextCursor
+    expect(cursor).toBeDefined()
+
+    const graftTarget = first.items[1]?.id ?? ''
+    const orphanParent = allCommits.at(-1) ?? ''
+    await execFileAsync('git', ['replace', '--graft', graftTarget, orphanParent], { cwd: repoPath })
+    try {
+      const drifted = await loadGitHistoryFromExecutor(git, repoPath, {
+        limit: 5,
+        cursor: cursor as NonNullable<typeof cursor>
+      })
+
+      expect(drifted.continuedCursor).toBe(false)
+      // A restart is a fresh page 1 of the walk as it now stands, which the client replaces with.
+      const { stdout } = await execFileAsync('git', ['rev-list', '--topo-order', '-n5', 'HEAD'], {
+        cwd: repoPath
+      })
+      expect(drifted.items.map((item) => item.id)).toEqual(stdout.trim().split('\n'))
+    } finally {
+      await execFileAsync('git', ['replace', '-d', graftTarget], { cwd: repoPath })
+    }
   })
 
   // Why: this is what pinning the walk buys, and nothing else in the suite can see it. HEAD moving
@@ -325,7 +354,7 @@ describe('git history paging against a real repository', () => {
       let cursor = first.nextCursor
       while (cursor) {
         const next = await loadGitHistoryFromExecutor(git, repoPath, { limit: 5, cursor })
-        expect(next.pageAnchor).toBe(cursor.anchor)
+        expect(next.continuedCursor).toBe(true)
         seen.push(...next.items.map((item) => item.id))
         cursor = next.hasMore ? next.nextCursor : undefined
       }

--- a/src/shared/git-history-graph.ts
+++ b/src/shared/git-history-graph.ts
@@ -102,6 +102,9 @@ export function buildGitHistoryViewModels(
   mergeBase?: string
 ): GitHistoryItemViewModel[] {
   let colorIndex = -1
+  // Why: parent lookup runs per merge parent per commit. Scanning the array made the whole build
+  // quadratic in the number of loaded commits, which paging now makes reachable.
+  const itemsById = new Map(historyItems.map((item) => [item.id, item]))
   const viewModels: GitHistoryItemViewModel[] = []
 
   for (const historyItem of historyItems) {
@@ -131,7 +134,7 @@ export function buildGitHistoryViewModels(
       if (index === 0) {
         colorIdentifier = getLabelColorIdentifier(historyItem, colorMap)
       } else {
-        const parent = historyItems.find((item) => item.id === historyItem.parentIds[index])
+        const parent = itemsById.get(historyItem.parentIds[index]!)
         colorIdentifier = parent ? getLabelColorIdentifier(parent, colorMap) : undefined
       }
 

--- a/src/shared/git-history-request-options.test.ts
+++ b/src/shared/git-history-request-options.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { readGitHistoryOptions } from './git-history-request-options'
 
+const SEAM = 'c'.repeat(40)
+
 describe('readGitHistoryOptions', () => {
   // Why: every transport used to spell its own whitelist out, so `cursor` reached git on none of
   // them and "Load more" silently re-served page one. This is the one place that can regress now.
@@ -9,12 +11,12 @@ describe('readGitHistoryOptions', () => {
       readGitHistoryOptions({
         limit: 25,
         baseRef: 'origin/main',
-        cursor: { anchor: 'a'.repeat(40), loaded: 50 }
+        cursor: { anchor: 'a'.repeat(40), loaded: 50, after: 'b'.repeat(40) }
       })
     ).toEqual({
       limit: 25,
       baseRef: 'origin/main',
-      cursor: { anchor: 'a'.repeat(40), loaded: 50 }
+      cursor: { anchor: 'a'.repeat(40), loaded: 50, after: 'b'.repeat(40) }
     })
   })
 
@@ -28,13 +30,18 @@ describe('readGitHistoryOptions', () => {
 
   it.each([
     ['a non-object cursor', 'abc'],
-    ['a missing anchor', { loaded: 10 }],
-    ['a blank anchor', { anchor: '   ', loaded: 10 }],
-    ['a non-string anchor', { anchor: 42, loaded: 10 }],
-    ['an abbreviated anchor', { anchor: 'abc123', loaded: 10 }],
+    ['a missing anchor', { loaded: 10, after: 'b'.repeat(40) }],
+    // Why: without the seam there is nothing to verify a resume against.
+    ['a missing seam', { anchor: 'a'.repeat(40), loaded: 10 }],
+    ['a blank anchor', { anchor: '   ', loaded: 10, after: 'b'.repeat(40) }],
+    ['a non-string anchor', { anchor: 42, loaded: 10, after: 'b'.repeat(40) }],
+    ['an abbreviated anchor', { anchor: 'abc123', loaded: 10, after: 'b'.repeat(40) }],
     // Why: the anchor is spent on a git revision argument, and requests cross a host boundary
     // (relay, paired web), so an option-shaped anchor must never reach argv.
-    ['an option-shaped anchor', { anchor: '--output=/tmp/pwned', loaded: 10 }]
+    [
+      'an option-shaped anchor',
+      { anchor: '--output=/tmp/pwned', loaded: 10, after: 'b'.repeat(40) }
+    ]
   ])('drops %s', (_label, cursor) => {
     expect(readGitHistoryOptions({ cursor }).cursor).toBeUndefined()
   })
@@ -45,16 +52,18 @@ describe('readGitHistoryOptions', () => {
     [Number.NaN, 0]
   ])('normalizes a loaded offset of %s to %s', (loaded, expected) => {
     const anchor = 'a'.repeat(40)
-    expect(readGitHistoryOptions({ cursor: { anchor, loaded } }).cursor).toEqual({
+    expect(readGitHistoryOptions({ cursor: { anchor, loaded, after: SEAM } }).cursor).toEqual({
       anchor,
+      after: SEAM,
       loaded: expected
     })
   })
 
   it('accepts a sha-256 object id', () => {
     const anchor = 'b'.repeat(64)
-    expect(readGitHistoryOptions({ cursor: { anchor, loaded: 5 } }).cursor).toEqual({
+    expect(readGitHistoryOptions({ cursor: { anchor, loaded: 5, after: SEAM } }).cursor).toEqual({
       anchor,
+      after: SEAM,
       loaded: 5
     })
   })

--- a/src/shared/git-history-request-options.test.ts
+++ b/src/shared/git-history-request-options.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readGitHistoryOptions } from './git-history-request-options'
 
-const SEAM = 'c'.repeat(40)
+const SEAM = { id: 'c'.repeat(40), parentIds: ['d'.repeat(40)] }
 
 describe('readGitHistoryOptions', () => {
   // Why: every transport used to spell its own whitelist out, so `cursor` reached git on none of
@@ -11,12 +11,12 @@ describe('readGitHistoryOptions', () => {
       readGitHistoryOptions({
         limit: 25,
         baseRef: 'origin/main',
-        cursor: { anchor: 'a'.repeat(40), loaded: 50, after: 'b'.repeat(40) }
+        cursor: { anchor: 'a'.repeat(40), loaded: 50, after: SEAM }
       })
     ).toEqual({
       limit: 25,
       baseRef: 'origin/main',
-      cursor: { anchor: 'a'.repeat(40), loaded: 50, after: 'b'.repeat(40) }
+      cursor: { anchor: 'a'.repeat(40), loaded: 50, after: SEAM }
     })
   })
 
@@ -30,18 +30,24 @@ describe('readGitHistoryOptions', () => {
 
   it.each([
     ['a non-object cursor', 'abc'],
-    ['a missing anchor', { loaded: 10, after: 'b'.repeat(40) }],
+    ['a missing anchor', { loaded: 10, after: SEAM }],
     // Why: without the seam there is nothing to verify a resume against.
     ['a missing seam', { anchor: 'a'.repeat(40), loaded: 10 }],
-    ['a blank anchor', { anchor: '   ', loaded: 10, after: 'b'.repeat(40) }],
-    ['a non-string anchor', { anchor: 42, loaded: 10, after: 'b'.repeat(40) }],
-    ['an abbreviated anchor', { anchor: 'abc123', loaded: 10, after: 'b'.repeat(40) }],
+    ['a seam with no id', { anchor: 'a'.repeat(40), loaded: 10, after: { parentIds: [] } }],
+    [
+      'a seam with an abbreviated parent',
+      { anchor: 'a'.repeat(40), loaded: 10, after: { id: 'c'.repeat(40), parentIds: ['dead'] } }
+    ],
+    [
+      'a seam whose parents are not an array',
+      { anchor: 'a'.repeat(40), loaded: 10, after: { id: 'c'.repeat(40), parentIds: 'x' } }
+    ],
+    ['a blank anchor', { anchor: '   ', loaded: 10, after: SEAM }],
+    ['a non-string anchor', { anchor: 42, loaded: 10, after: SEAM }],
+    ['an abbreviated anchor', { anchor: 'abc123', loaded: 10, after: SEAM }],
     // Why: the anchor is spent on a git revision argument, and requests cross a host boundary
     // (relay, paired web), so an option-shaped anchor must never reach argv.
-    [
-      'an option-shaped anchor',
-      { anchor: '--output=/tmp/pwned', loaded: 10, after: 'b'.repeat(40) }
-    ]
+    ['an option-shaped anchor', { anchor: '--output=/tmp/pwned', loaded: 10, after: SEAM }]
   ])('drops %s', (_label, cursor) => {
     expect(readGitHistoryOptions({ cursor }).cursor).toBeUndefined()
   })

--- a/src/shared/git-history-request-options.test.ts
+++ b/src/shared/git-history-request-options.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { readGitHistoryOptions } from './git-history-request-options'
+
+describe('readGitHistoryOptions', () => {
+  // Why: every transport used to spell its own whitelist out, so `cursor` reached git on none of
+  // them and "Load more" silently re-served page one. This is the one place that can regress now.
+  it('carries the cursor through', () => {
+    expect(
+      readGitHistoryOptions({
+        limit: 25,
+        baseRef: 'origin/main',
+        cursor: { anchor: 'a'.repeat(40), loaded: 50 }
+      })
+    ).toEqual({
+      limit: 25,
+      baseRef: 'origin/main',
+      cursor: { anchor: 'a'.repeat(40), loaded: 50 }
+    })
+  })
+
+  it('reads a first-page request', () => {
+    expect(readGitHistoryOptions({ limit: 50 })).toEqual({
+      limit: 50,
+      baseRef: null,
+      cursor: undefined
+    })
+  })
+
+  it.each([
+    ['a non-object cursor', 'abc'],
+    ['a missing anchor', { loaded: 10 }],
+    ['a blank anchor', { anchor: '   ', loaded: 10 }],
+    ['a non-string anchor', { anchor: 42, loaded: 10 }],
+    ['an abbreviated anchor', { anchor: 'abc123', loaded: 10 }],
+    // Why: the anchor is spent on a git revision argument, and requests cross a host boundary
+    // (relay, paired web), so an option-shaped anchor must never reach argv.
+    ['an option-shaped anchor', { anchor: '--output=/tmp/pwned', loaded: 10 }]
+  ])('drops %s', (_label, cursor) => {
+    expect(readGitHistoryOptions({ cursor }).cursor).toBeUndefined()
+  })
+
+  it.each([
+    [-5, 0],
+    [12.7, 12],
+    [Number.NaN, 0]
+  ])('normalizes a loaded offset of %s to %s', (loaded, expected) => {
+    const anchor = 'a'.repeat(40)
+    expect(readGitHistoryOptions({ cursor: { anchor, loaded } }).cursor).toEqual({
+      anchor,
+      loaded: expected
+    })
+  })
+
+  it('accepts a sha-256 object id', () => {
+    const anchor = 'b'.repeat(64)
+    expect(readGitHistoryOptions({ cursor: { anchor, loaded: 5 } }).cursor).toEqual({
+      anchor,
+      loaded: 5
+    })
+  })
+
+  it('ignores a non-numeric limit and a non-string baseRef', () => {
+    expect(readGitHistoryOptions({ limit: '50', baseRef: 7 })).toEqual({
+      limit: undefined,
+      baseRef: null,
+      cursor: undefined
+    })
+  })
+})

--- a/src/shared/git-history-request-options.ts
+++ b/src/shared/git-history-request-options.ts
@@ -1,4 +1,4 @@
-import type { GitHistoryCursor, GitHistoryOptions } from './git-history-types'
+import type { GitHistoryCursor, GitHistoryOptions, GitHistorySeam } from './git-history-types'
 
 /**
  * Read history options off a request that crossed a process or host boundary.
@@ -25,6 +25,24 @@ export function readGitHistoryOptions(params: {
 // rather than by blocklisting a leading dash.
 const FULL_GIT_OBJECT_ID = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/
 
+function readGitHistorySeam(value: unknown): GitHistorySeam | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  const { id, parentIds } = value as { id?: unknown; parentIds?: unknown }
+  if (typeof id !== 'string' || !FULL_GIT_OBJECT_ID.test(id) || !Array.isArray(parentIds)) {
+    return undefined
+  }
+  if (
+    !parentIds.every(
+      (parentId) => typeof parentId === 'string' && FULL_GIT_OBJECT_ID.test(parentId)
+    )
+  ) {
+    return undefined
+  }
+  return { id, parentIds: parentIds as string[] }
+}
+
 function readGitHistoryCursor(value: unknown): GitHistoryCursor | undefined {
   if (typeof value !== 'object' || value === null) {
     return undefined
@@ -36,17 +54,13 @@ function readGitHistoryCursor(value: unknown): GitHistoryCursor | undefined {
   }
   // Why: without the seam there is nothing to verify the walk against, so a cursor missing it is
   // not a cursor. Dropping it restarts at page 1 rather than resuming on an unchecked assumption.
-  if (
-    typeof anchor !== 'string' ||
-    !FULL_GIT_OBJECT_ID.test(anchor) ||
-    typeof after !== 'string' ||
-    !FULL_GIT_OBJECT_ID.test(after)
-  ) {
+  const seam = readGitHistorySeam(after)
+  if (typeof anchor !== 'string' || !FULL_GIT_OBJECT_ID.test(anchor) || !seam) {
     return undefined
   }
   return {
     anchor,
-    after,
+    after: seam,
     loaded:
       typeof loaded === 'number' && Number.isFinite(loaded) ? Math.max(0, Math.trunc(loaded)) : 0
   }

--- a/src/shared/git-history-request-options.ts
+++ b/src/shared/git-history-request-options.ts
@@ -1,0 +1,41 @@
+import type { GitHistoryCursor, GitHistoryOptions } from './git-history-types'
+
+/**
+ * Read history options off a request that crossed a process or host boundary.
+ *
+ * Every transport (Electron IPC, runtime RPC, the SSH provider, the relay, the paired web client)
+ * used to spell this whitelist out for itself, so adding `cursor` to the contract left it dropped
+ * on all of them and paging silently re-served page one. One reader means a new option reaches git
+ * everywhere or nowhere.
+ */
+export function readGitHistoryOptions(params: {
+  limit?: unknown
+  baseRef?: unknown
+  cursor?: unknown
+}): GitHistoryOptions {
+  return {
+    limit: typeof params.limit === 'number' ? params.limit : undefined,
+    baseRef: typeof params.baseRef === 'string' ? params.baseRef : null,
+    cursor: readGitHistoryCursor(params.cursor)
+  }
+}
+
+// Why: the anchor is only ever a commit id this host handed out, and it is spent on a git revision
+// argument. Requiring a full object id keeps anything option-shaped out of argv by construction
+// rather than by blocklisting a leading dash.
+const FULL_GIT_OBJECT_ID = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/
+
+function readGitHistoryCursor(value: unknown): GitHistoryCursor | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  const { anchor, loaded } = value as { anchor?: unknown; loaded?: unknown }
+  if (typeof anchor !== 'string' || !FULL_GIT_OBJECT_ID.test(anchor)) {
+    return undefined
+  }
+  return {
+    anchor,
+    loaded:
+      typeof loaded === 'number' && Number.isFinite(loaded) ? Math.max(0, Math.trunc(loaded)) : 0
+  }
+}

--- a/src/shared/git-history-request-options.ts
+++ b/src/shared/git-history-request-options.ts
@@ -29,12 +29,24 @@ function readGitHistoryCursor(value: unknown): GitHistoryCursor | undefined {
   if (typeof value !== 'object' || value === null) {
     return undefined
   }
-  const { anchor, loaded } = value as { anchor?: unknown; loaded?: unknown }
-  if (typeof anchor !== 'string' || !FULL_GIT_OBJECT_ID.test(anchor)) {
+  const { anchor, loaded, after } = value as {
+    anchor?: unknown
+    loaded?: unknown
+    after?: unknown
+  }
+  // Why: without the seam there is nothing to verify the walk against, so a cursor missing it is
+  // not a cursor. Dropping it restarts at page 1 rather than resuming on an unchecked assumption.
+  if (
+    typeof anchor !== 'string' ||
+    !FULL_GIT_OBJECT_ID.test(anchor) ||
+    typeof after !== 'string' ||
+    !FULL_GIT_OBJECT_ID.test(after)
+  ) {
     return undefined
   }
   return {
     anchor,
+    after,
     loaded:
       typeof loaded === 'number' && Number.isFinite(loaded) ? Math.max(0, Math.trunc(loaded)) : 0
   }

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -53,13 +53,27 @@ export type GitHistoryItem = {
   references?: GitHistoryItemRef[]
 }
 
+/**
+ * Resume point for the next page, produced by the read that served the previous one.
+ *
+ * `anchor` pins the walk to the commit the first page was taken from, so later pages stay a
+ * continuation of that same walk when HEAD moves mid-paging. `loaded` is how many commits of it
+ * are already on screen.
+ *
+ * An offset into a pinned walk is the only resume git supports on a DAG. A single commit id
+ * cannot serve as the cursor: restarting the walk at the oldest commit on screen reaches only
+ * that commit's ancestors, so every parallel line of history that `--topo-order` sorted after it
+ * is dropped and paging ends early with no sign anything is missing.
+ */
+export type GitHistoryCursor = {
+  anchor: string
+  loaded: number
+}
+
 export type GitHistoryOptions = {
   limit?: number
   baseRef?: string | null
-  // Commit id of the oldest item already loaded. The walk resumes from that commit's ancestors
-  // instead of HEAD, so each page costs one page of git output no matter how deep paging goes.
-  // Anchoring on a commit rather than an offset also keeps pages stitched when HEAD moves.
-  cursor?: string
+  cursor?: GitHistoryCursor
 }
 
 export type GitHistoryResult = {
@@ -72,6 +86,10 @@ export type GitHistoryResult = {
   hasOutgoingChanges: boolean
   hasMore: boolean
   limit: number
+  // Cursor to send for the next page, present only when one exists. Carrying it on the response
+  // keeps offset arithmetic out of the client, and a host too old to page simply omits it — the
+  // client then hides "Load more" instead of offering a button that re-requests page one forever.
+  nextCursor?: GitHistoryCursor
 }
 
 export type GitHistoryExecutor = (

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -86,9 +86,15 @@ export type GitHistoryResult = {
   hasOutgoingChanges: boolean
   hasMore: boolean
   limit: number
+  // The commit this page's walk actually started from. A requested anchor that no longer resolves
+  // is answered with a fresh page from HEAD, and only this says so: a client comparing it against
+  // the anchor it asked for can tell a continuation from a restart and replace rather than stack a
+  // new history under a dead one. Absent from hosts too old to page.
+  pageAnchor?: string
   // Cursor to send for the next page, present only when one exists. Carrying it on the response
   // keeps offset arithmetic out of the client, and a host too old to page simply omits it — the
   // client then hides "Load more" instead of offering a button that re-requests page one forever.
+  // Its anchor always equals `pageAnchor`; the two differ in lifetime, not value.
   nextCursor?: GitHistoryCursor
 }
 

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -108,7 +108,6 @@ export type GitHistoryResult = {
   // Cursor to send for the next page, present only when one exists. Carrying it on the response
   // keeps offset arithmetic out of the client, and a host too old to page simply omits it — the
   // client then hides "Load more" instead of offering a button that re-requests page one forever.
-  // Its anchor always equals `pageAnchor`; the two differ in lifetime, not value.
   nextCursor?: GitHistoryCursor
 }
 

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -56,6 +56,10 @@ export type GitHistoryItem = {
 export type GitHistoryOptions = {
   limit?: number
   baseRef?: string | null
+  // Commit id of the oldest item already loaded. The walk resumes from that commit's ancestors
+  // instead of HEAD, so each page costs one page of git output no matter how deep paging goes.
+  // Anchoring on a commit rather than an offset also keeps pages stitched when HEAD moves.
+  cursor?: string
 }
 
 export type GitHistoryResult = {

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -68,6 +68,12 @@ export type GitHistoryItem = {
 export type GitHistoryCursor = {
   anchor: string
   loaded: number
+  // Id of the last commit the previous page emitted. The next page re-reads that one row and
+  // continues only if the walk still leads with it: an anchor resolving does not prove its
+  // ancestry is unchanged, because replace refs and grafts rewrite what a commit's parents are
+  // without touching the commit itself. Verifying the seam is what keeps a drifted walk from
+  // being spliced into the list as though it were the next page.
+  after: string
 }
 
 export type GitHistoryOptions = {
@@ -86,11 +92,11 @@ export type GitHistoryResult = {
   hasOutgoingChanges: boolean
   hasMore: boolean
   limit: number
-  // The commit this page's walk actually started from. A requested anchor that no longer resolves
-  // is answered with a fresh page from HEAD, and only this says so: a client comparing it against
-  // the anchor it asked for can tell a continuation from a restart and replace rather than stack a
-  // new history under a dead one. Absent from hosts too old to page.
-  pageAnchor?: string
+  // Whether this page continued the cursor the request carried. A cursor is not honored when its
+  // anchor no longer resolves (rebase, amend, prune, gc) or when the walk under it drifted, and in
+  // both cases the page is a fresh first page that must replace what is on screen rather than
+  // extend it. Absent — and so never a continuation — from hosts too old to page.
+  continuedCursor?: boolean
   // Cursor to send for the next page, present only when one exists. Carrying it on the response
   // keeps offset arithmetic out of the client, and a host too old to page simply omits it — the
   // client then hides "Load more" instead of offering a button that re-requests page one forever.

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -68,12 +68,20 @@ export type GitHistoryItem = {
 export type GitHistoryCursor = {
   anchor: string
   loaded: number
-  // Id of the last commit the previous page emitted. The next page re-reads that one row and
-  // continues only if the walk still leads with it: an anchor resolving does not prove its
-  // ancestry is unchanged, because replace refs and grafts rewrite what a commit's parents are
-  // without touching the commit itself. Verifying the seam is what keeps a drifted walk from
-  // being spliced into the list as though it were the next page.
-  after: string
+  // The last row the previous page emitted. The next page re-reads that one row and continues only
+  // if the walk still produces exactly it — same commit and same parents.
+  //
+  // Both halves are load-bearing. An anchor resolving does not prove its ancestry is unchanged, and
+  // an id matching does not either: replace refs and grafts rewrite a commit's parents in place, so
+  // the seam can keep its id while everything below it becomes a different chain. Checking the
+  // parents too is what stops two walks being spliced into one list under a row whose drawn edge
+  // points at a commit the list no longer contains.
+  after: GitHistorySeam
+}
+
+export type GitHistorySeam = {
+  id: string
+  parentIds: string[]
 }
 
 export type GitHistoryOptions = {

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -8,6 +8,7 @@ import {
   GIT_HISTORY_DEFAULT_LIMIT,
   GIT_HISTORY_MAX_LIMIT,
   type GitHistoryExecutor,
+  type GitHistoryItem,
   type GitHistoryItemRef,
   type GitHistoryOptions,
   type GitHistoryResult
@@ -201,9 +202,12 @@ export async function loadGitHistoryFromExecutor(
   // dead anchor degrades to a fresh first page instead of failing the whole panel on a bad revision.
   const requestedAnchor = options.cursor?.anchor?.trim() || undefined
   const anchor = requestedAnchor ? await resolveCommit(git, cwd, requestedAnchor) : null
-  const walkTip = anchor ?? headOid
-  // Why: an unresolved anchor restarts at page 1, so its offset must go with it.
-  const skip = anchor ? Math.max(0, Math.trunc(options.cursor?.loaded ?? 0)) : 0
+  // Why: an unresolved anchor restarts at page 1, so its offset goes with it. `loaded` counts the
+  // rows already shown, and the last of those is re-read as the seam, hence -1.
+  const resume =
+    anchor && options.cursor && options.cursor.loaded > 0
+      ? { anchor, skip: Math.trunc(options.cursor.loaded) - 1, after: options.cursor.after }
+      : undefined
 
   let mergeBase: string | undefined
   if (remoteRef?.revision && currentRef.revision && remoteRef.revision !== currentRef.revision) {
@@ -215,25 +219,48 @@ export async function loadGitHistoryFromExecutor(
     }
   }
 
-  const { stdout } = await git(
-    [
-      'log',
-      `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
-      '-z',
-      '--topo-order',
-      '--decorate=full',
-      // Why: +1 tells a full page apart from the last one without a second call.
-      `-n${limit + 1}`,
-      // Why: skipping into the walk keeps every page the same size however deep paging goes, and
-      // keeps the order identical to one uninterrupted walk, so no commit is repeated or dropped.
-      ...(skip > 0 ? [`--skip=${skip}`] : []),
-      walkTip
-    ],
-    cwd
-  )
-  const parsed = parseGitHistoryLog(stdout)
+  // Why: skipping into the walk keeps every page the same size however deep paging goes, and keeps
+  // the order identical to one uninterrupted walk, so no commit is repeated or dropped. The extra
+  // row a resumed page asks for is the seam: the last row already on screen, re-read to prove the
+  // walk still leads with it. +1 beyond that tells a full page apart from the last one.
+  const readPage = async (tip: string, skip: number, extra: number): Promise<GitHistoryItem[]> => {
+    const { stdout } = await git(
+      [
+        'log',
+        `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
+        '-z',
+        '--topo-order',
+        '--decorate=full',
+        `-n${limit + 1 + extra}`,
+        ...(skip > 0 ? [`--skip=${skip}`] : []),
+        tip
+      ],
+      cwd
+    )
+    return parseGitHistoryLog(stdout)
+  }
+
+  let walkTip = resume?.anchor ?? headOid
+  let skip = resume?.skip ?? 0
+  let parsed = await readPage(walkTip, skip, resume ? 1 : 0)
+  let continuedCursor = false
+  if (resume) {
+    // Why: an anchor resolving does not prove its ancestry is unchanged — replace refs and grafts
+    // rewrite a commit's parents in place. If the walk no longer leads with the row the previous
+    // page ended on, this is a different history and splicing it on would skip and reorder commits.
+    continuedCursor = parsed[0]?.id === resume.after
+    if (continuedCursor) {
+      parsed = parsed.slice(1)
+    } else {
+      walkTip = headOid
+      skip = 0
+      parsed = await readPage(walkTip, skip, 0)
+    }
+  }
   const items = parsed.slice(0, limit)
   const hasMore = parsed.length > limit
+  // Rows of this walk now accounted for: those skipped, the seam, and this page.
+  const loaded = skip + (continuedCursor ? 1 : 0) + items.length
   const hasIncomingChanges =
     Boolean(remoteRef?.revision && mergeBase) && remoteRef?.revision !== mergeBase
   const hasOutgoingChanges =
@@ -250,7 +277,10 @@ export async function loadGitHistoryFromExecutor(
     hasOutgoingChanges,
     hasMore,
     limit,
-    pageAnchor: walkTip,
-    nextCursor: hasMore ? { anchor: walkTip, loaded: skip + items.length } : undefined
+    continuedCursor,
+    nextCursor:
+      hasMore && items.length > 0
+        ? { anchor: walkTip, loaded, after: items.at(-1)?.id ?? '' }
+        : undefined
   }
 }

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -250,6 +250,7 @@ export async function loadGitHistoryFromExecutor(
     hasOutgoingChanges,
     hasMore,
     limit,
+    pageAnchor: walkTip,
     nextCursor: hasMore ? { anchor: walkTip, loaded: skip + items.length } : undefined
   }
 }

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -194,7 +194,15 @@ export async function loadGitHistoryFromExecutor(
 
   // Why: this panel is scoped to the active workspace. Upstream and base refs
   // stay as comparison metadata so old workspaces do not list newly fetched upstream/base commits.
-  const historyRevisions = [headOid]
+  // Why: resuming from the cursor walks only its ancestors, so page N costs one page of output
+  // rather than N pages, and the walk is unaffected by commits landing on HEAD mid-paging.
+  // Why: a cursor can go stale (rebase, amend, prune, branch switch). Resolving it first means a
+  // dead cursor degrades to a fresh first page instead of failing the whole panel on a bad revision.
+  const requestedCursor = options.cursor?.trim() || undefined
+  const cursor = requestedCursor
+    ? ((await resolveCommit(git, cwd, requestedCursor)) ?? undefined)
+    : undefined
+  const historyRevisions = [cursor ?? headOid]
 
   let mergeBase: string | undefined
   if (remoteRef?.revision && currentRef.revision && remoteRef.revision !== currentRef.revision) {
@@ -213,13 +221,18 @@ export async function loadGitHistoryFromExecutor(
       '-z',
       '--topo-order',
       '--decorate=full',
-      `-n${limit + 1}`,
+      // Why: +1 detects a further page. With a cursor the walk re-emits the cursor commit
+      // itself, so one more is needed to still see a full page past it.
+      `-n${limit + (cursor ? 2 : 1)}`,
       ...historyRevisions
     ],
     cwd
   )
   const parsed = parseGitHistoryLog(stdout)
-  const items = parsed.slice(0, limit)
+  // Why: the cursor commit is already on screen. Drop it only when git actually led with it — a
+  // cursor that no longer resolves (rewritten, pruned) would otherwise silently eat a real commit.
+  const page = cursor && parsed[0]?.id === cursor ? parsed.slice(1) : parsed
+  const items = page.slice(0, limit)
   const hasIncomingChanges =
     Boolean(remoteRef?.revision && mergeBase) && remoteRef?.revision !== mergeBase
   const hasOutgoingChanges =
@@ -234,7 +247,7 @@ export async function loadGitHistoryFromExecutor(
     mergeBase,
     hasIncomingChanges,
     hasOutgoingChanges,
-    hasMore: parsed.length > limit,
+    hasMore: page.length > limit,
     limit
   }
 }

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -11,11 +11,13 @@ import {
   type GitHistoryItem,
   type GitHistoryItemRef,
   type GitHistoryOptions,
-  type GitHistoryResult
+  type GitHistoryResult,
+  type GitHistorySeam
 } from './git-history-types'
 
 export type {
   GitHistoryCursor,
+  GitHistorySeam,
   GitHistoryExecutor,
   GitHistoryGraphColorId,
   GitHistoryItem,
@@ -166,6 +168,14 @@ async function resolveNamedRef(
   return revision ? gitHistoryRefFromFullName(fullName, normalized, revision) : undefined
 }
 
+function isGitHistorySeam(row: GitHistoryItem | undefined, seam: GitHistorySeam): boolean {
+  return (
+    row?.id === seam.id &&
+    row.parentIds.length === seam.parentIds.length &&
+    row.parentIds.every((parentId, index) => parentId === seam.parentIds[index])
+  )
+}
+
 export async function loadGitHistoryFromExecutor(
   git: GitHistoryExecutor,
   cwd: string,
@@ -245,10 +255,11 @@ export async function loadGitHistoryFromExecutor(
   let parsed = await readPage(walkTip, skip, resume ? 1 : 0)
   let continuedCursor = false
   if (resume) {
-    // Why: an anchor resolving does not prove its ancestry is unchanged — replace refs and grafts
-    // rewrite a commit's parents in place. If the walk no longer leads with the row the previous
-    // page ended on, this is a different history and splicing it on would skip and reorder commits.
-    continuedCursor = parsed[0]?.id === resume.after
+    // Why: an anchor resolving does not prove its ancestry is unchanged, and neither does the seam
+    // keeping its id — replace refs and grafts rewrite a commit's parents in place. If the walk no
+    // longer produces exactly the row the previous page ended on, this is a different history and
+    // splicing it on would skip commits and leave the seam's drawn edge pointing at nothing.
+    continuedCursor = isGitHistorySeam(parsed[0], resume.after)
     if (continuedCursor) {
       parsed = parsed.slice(1)
     } else {
@@ -258,6 +269,7 @@ export async function loadGitHistoryFromExecutor(
     }
   }
   const items = parsed.slice(0, limit)
+  const seamRow = items.at(-1)
   const hasMore = parsed.length > limit
   // Rows of this walk now accounted for: those skipped, the seam, and this page.
   const loaded = skip + (continuedCursor ? 1 : 0) + items.length
@@ -280,7 +292,11 @@ export async function loadGitHistoryFromExecutor(
     continuedCursor,
     nextCursor:
       hasMore && items.length > 0
-        ? { anchor: walkTip, loaded, after: items.at(-1)?.id ?? '' }
+        ? {
+            anchor: walkTip,
+            loaded,
+            after: { id: seamRow?.id ?? '', parentIds: seamRow?.parentIds ?? [] }
+          }
         : undefined
   }
 }

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -194,9 +194,14 @@ export async function loadGitHistoryFromExecutor(
   }
 
   const { currentRef, branchName } = await resolveCurrentRef(git, cwd, headOid)
-  const [remoteRef, rawBaseRef] = await Promise.all([
+  // Why: an anchor can go stale (rebase, amend, prune, branch switch). Resolving it first means a
+  // dead anchor degrades to a fresh first page instead of failing the whole panel on a bad
+  // revision — and it rides the existing batch so paging costs no extra round trip.
+  const requestedAnchor = options.cursor?.anchor?.trim() || undefined
+  const [remoteRef, rawBaseRef, anchor] = await Promise.all([
     resolveUpstreamRef(git, cwd, branchName),
-    resolveNamedRef(git, cwd, options.baseRef)
+    resolveNamedRef(git, cwd, options.baseRef),
+    requestedAnchor ? resolveCommit(git, cwd, requestedAnchor) : Promise.resolve(null)
   ])
 
   const baseRef =
@@ -208,10 +213,6 @@ export async function loadGitHistoryFromExecutor(
   // stay as comparison metadata so old workspaces do not list newly fetched upstream/base commits.
   // Why: page by offset into a walk pinned to the cursor's anchor, so page N costs one page of
   // output rather than N pages and stays a continuation of page 1 even if HEAD moves mid-paging.
-  // Why: an anchor can go stale (rebase, amend, prune, branch switch). Resolving it first means a
-  // dead anchor degrades to a fresh first page instead of failing the whole panel on a bad revision.
-  const requestedAnchor = options.cursor?.anchor?.trim() || undefined
-  const anchor = requestedAnchor ? await resolveCommit(git, cwd, requestedAnchor) : null
   // Why: an unresolved anchor restarts at page 1, so its offset goes with it. `loaded` counts the
   // rows already shown, and the last of those is re-read as the seam, hence -1.
   const resume =

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -14,6 +14,7 @@ import {
 } from './git-history-types'
 
 export type {
+  GitHistoryCursor,
   GitHistoryExecutor,
   GitHistoryGraphColorId,
   GitHistoryItem,
@@ -194,15 +195,15 @@ export async function loadGitHistoryFromExecutor(
 
   // Why: this panel is scoped to the active workspace. Upstream and base refs
   // stay as comparison metadata so old workspaces do not list newly fetched upstream/base commits.
-  // Why: resuming from the cursor walks only its ancestors, so page N costs one page of output
-  // rather than N pages, and the walk is unaffected by commits landing on HEAD mid-paging.
-  // Why: a cursor can go stale (rebase, amend, prune, branch switch). Resolving it first means a
-  // dead cursor degrades to a fresh first page instead of failing the whole panel on a bad revision.
-  const requestedCursor = options.cursor?.trim() || undefined
-  const cursor = requestedCursor
-    ? ((await resolveCommit(git, cwd, requestedCursor)) ?? undefined)
-    : undefined
-  const historyRevisions = [cursor ?? headOid]
+  // Why: page by offset into a walk pinned to the cursor's anchor, so page N costs one page of
+  // output rather than N pages and stays a continuation of page 1 even if HEAD moves mid-paging.
+  // Why: an anchor can go stale (rebase, amend, prune, branch switch). Resolving it first means a
+  // dead anchor degrades to a fresh first page instead of failing the whole panel on a bad revision.
+  const requestedAnchor = options.cursor?.anchor?.trim() || undefined
+  const anchor = requestedAnchor ? await resolveCommit(git, cwd, requestedAnchor) : null
+  const walkTip = anchor ?? headOid
+  // Why: an unresolved anchor restarts at page 1, so its offset must go with it.
+  const skip = anchor ? Math.max(0, Math.trunc(options.cursor?.loaded ?? 0)) : 0
 
   let mergeBase: string | undefined
   if (remoteRef?.revision && currentRef.revision && remoteRef.revision !== currentRef.revision) {
@@ -221,18 +222,18 @@ export async function loadGitHistoryFromExecutor(
       '-z',
       '--topo-order',
       '--decorate=full',
-      // Why: +1 detects a further page. With a cursor the walk re-emits the cursor commit
-      // itself, so one more is needed to still see a full page past it.
-      `-n${limit + (cursor ? 2 : 1)}`,
-      ...historyRevisions
+      // Why: +1 tells a full page apart from the last one without a second call.
+      `-n${limit + 1}`,
+      // Why: skipping into the walk keeps every page the same size however deep paging goes, and
+      // keeps the order identical to one uninterrupted walk, so no commit is repeated or dropped.
+      ...(skip > 0 ? [`--skip=${skip}`] : []),
+      walkTip
     ],
     cwd
   )
   const parsed = parseGitHistoryLog(stdout)
-  // Why: the cursor commit is already on screen. Drop it only when git actually led with it — a
-  // cursor that no longer resolves (rewritten, pruned) would otherwise silently eat a real commit.
-  const page = cursor && parsed[0]?.id === cursor ? parsed.slice(1) : parsed
-  const items = page.slice(0, limit)
+  const items = parsed.slice(0, limit)
+  const hasMore = parsed.length > limit
   const hasIncomingChanges =
     Boolean(remoteRef?.revision && mergeBase) && remoteRef?.revision !== mergeBase
   const hasOutgoingChanges =
@@ -247,7 +248,8 @@ export async function loadGitHistoryFromExecutor(
     mergeBase,
     hasIncomingChanges,
     hasOutgoingChanges,
-    hasMore: page.length > limit,
-    limit
+    hasMore,
+    limit,
+    nextCursor: hasMore ? { anchor: walkTip, loaded: skip + items.length } : undefined
   }
 }


### PR DESCRIPTION
## ELI5

The Commits list in Source Control only ever loaded the newest 50 commits, so anything older was invisible. Now there's a "Load more commits" action that keeps going until you reach the very first commit — and each click costs the same small amount of work no matter how far back you are.

## What Changed

- Paging is an **offset into a walk pinned to an anchor commit**, with the seam row (its id *and* its parents) verified on every page. Anchoring keeps page N a continuation of page 1 even if HEAD moves mid-paging; verifying the seam catches the case where it isn't.
- **No total ceiling.** Paging stops when git reports nothing older, not at a fixed depth.
- Rows **virtualize above 50**, so an unbounded list stays cheap.
- Per-commit expansion state is **scoped to its worktree** and pruned to surviving commit ids, so paging never collapses an open row and a row retained across a worktree switch can't become a dead click.
- `readGitHistoryOptions` is now the single shared reader for history request options across all five transports, replacing five hand-maintained field whitelists.
- Parent lookup in the graph builder is indexed by id instead of scanning the item array.

## Why

Supersedes #14305, which solved the same issue by growing a requested limit and re-requesting `1..N+50` from HEAD each click, capped at 200. Credit to @dchaudhari7177 — their diagnosis was the useful part and is what made the right fix obvious: everything below the renderer already supported a larger window, and only the renderer was pinned. Three things made the mechanism worth replacing rather than patching:

1. **The 200 cap left #14224 half-solved.** Commit 201 and beyond stayed unreachable; the action simply disappeared.
2. **Re-requesting from HEAD grows every response.** Measured over three clicks to 200 commits: 212KB + 258KB + 313KB + 357KB = 1142KB, with the largest single response growing with depth. Cursor paging transfers 358KB total with a constant page. This matters because the SSH/relay transports set `maxPayload` to 1MB and a breach **closes the connection** rather than failing the request — a full re-request hits 1190KB raw at 801 commits. Removing the cap is only safe *because* paging is now constant-cost.
3. **Unbounded depth needs virtualization**, which the 200 cap existed to avoid needing.

A commit-id cursor was tried first and **rejected**: it cannot resume a `--topo-order` DAG walk. On a merged long-lived branch it paged 142 of 202 commits and then reported nothing older — reintroducing #14224 silently, which is worse than an honest ceiling. Hence the pinned-anchor + verified-seam design.

## Linked Issue

Fixes #14224

## Visual Proof

All 253 commits of a merge-heavy repo, fully paged, past the old 200 ceiling:

![all 253 commits](https://github.com/user-attachments/assets/293dec8c-84b0-4e9e-8714-d8c9d87c3496)

An expanded commit inside the virtualized list, with the merge-lane graph intact:

![expanded commit](https://github.com/user-attachments/assets/f9bce4b0-ee4e-4652-ab32-866b97470d40)

## Testing

Verified in the real app (macOS) against a purpose-built fixture: 253 commits, 12 real merges, 12 long-lived side branches — the DAG shape a linear fixture cannot express.

**The load-bearing check is a differential one against git itself.** Paged to the end through the UI, harvested every rendered commit id, and diffed against `git rev-list --topo-order`:

```
UI commits:    253
git rev-list:  253
duplicates:      0
silent skips:    0
order identical to git topo-order: true
```

Virtualization confirmed live: 18 DOM rows for a 6614px list. Zero console errors.

The delegated review loop separately verified paging exact against a single `rev-list` walk at every page size on three repos, including 8617 commits over 345 pages, with zero skips or duplicates.

Graph build after indexing parents, 8000 merge-heavy rows: **31.74ms → 5.35ms**, and the curve is linear rather than quadratic.

`pnpm typecheck` 0, `pnpm lint` 0, **1912/1912** tests.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not yet exercised on a live SSH/remote host or on Windows — the transport reader is covered by tests at each boundary, but a real remote run is worth doing before merge.

## Review

- **Cross-platform**: no platform-dependent code; git arguments held to the Git 2.25 baseline (there's a dedicated commit for this).
- **Remote SSH**: this is the main beneficiary — constant per-page payload keeps every message far below the 1MB cap that would otherwise close the socket.
- **Backwards compatibility**: `cursor` is a new **optional** field, which `docs/reference/remote-wire-compatibility.md` classifies as safe for mixed client/host versions. An older host ignoring it degrades to a first page rather than breaking.
- **Mobile**: untouched.
- **Performance**: covered above; a dedicated perf audit ran against this branch.

### Two costs worth stating plainly

**A refresh discards paging depth.** Refresh carries no cursor and replaces the accumulated list, because the commits it reloads are current truth and a deep page taken before a rewrite may no longer be reachable. The cost is real: someone paged 40 clicks deep who then commits is back to 50 rows and has to page again. This is a deliberate choice, not an oversight — but it is a choice, so it should be visible. Mitigating factor: every refresh trigger is event-driven (commit, remote action, worktree/base-ref change). None is a timer, so the accumulation is never wiped by polling.

**`--topo-order` without a `commit-graph` file costs a full walk of reachable history on every page** — measured 75.5ms without vs 23.7ms with, flat across pages. That is `O(total history)`, not `O(page)`, and it predates this change. But the old 200-commit cap paid it at most four times, whereas unbounded paging pays it once per click. Not actionable here, and it does not affect the constant-payload property. Worth knowing before anyone reports "history paging is slow on repo X": the first question is whether that host has a commit-graph.

