### PR TITLE
fix(native-chat): retire separator-glued pending sends

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -114,9 +114,8 @@ export function matchingNativeChatUserTexts(
 }
 
 /**
- * How many leading pending texts concatenate exactly to `userText`.
- * Covers rapid-send glue ("joke"+"continue" → "jokecontinue") without matching
- * unrelated prefixes ("hi" ↛ "history").
+ * How many leading pending texts concatenate exactly to `userText`, with or
+ * without one normalized whitespace separator at each send boundary.
  */
 export function countLeadingPendingTextsGluedToUserText(
   pendingTexts: readonly string[],
@@ -125,17 +124,23 @@ export function countLeadingPendingTextsGluedToUserText(
   if (pendingTexts.length === 0 || userText.length === 0) {
     return 0
   }
-  let combined = ''
+  let candidates = new Set<string>()
   for (let index = 0; index < pendingTexts.length; index += 1) {
     const piece = pendingTexts[index]
     if (!piece) {
       return 0
     }
-    combined += piece
-    if (combined === userText) {
+    const next =
+      index === 0
+        ? new Set([piece])
+        : new Set(
+            [...candidates].flatMap((candidate) => [candidate + piece, `${candidate} ${piece}`])
+          )
+    candidates = new Set([...next].filter((candidate) => userText.startsWith(candidate)))
+    if (candidates.has(userText)) {
       return index + 1
     }
-    if (!userText.startsWith(combined)) {
+    if (candidates.size === 0) {
       return 0
     }
   }

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -189,11 +189,51 @@ describe('prunePendingSends', () => {
     ).toEqual([])
   })
 
+  it('prunes optimistic sends glued with a retained whitespace separator', () => {
+    const pending = [pendingOf('p1', 'tell me a joke '), pendingOf('p2', 'continue')]
+    expect(
+      prunePendingSends(pending, [
+        userMessage('u1', 'tell me a joke continue'),
+        assistantMessage('a1', 'a joke')
+      ])
+    ).toEqual([])
+  })
+
+  it('matches mixed separated and separator-less rapid sends', () => {
+    const pending = [pendingOf('p1', 'first'), pendingOf('p2', 'second '), pendingOf('p3', 'third')]
+    expect(
+      prunePendingSends(pending, [
+        userMessage('u1', 'firstsecond third'),
+        assistantMessage('a1', 'done')
+      ])
+    ).toEqual([])
+  })
+
+  it('prunes repeated prompts represented by one separated transcript turn', () => {
+    const pending = [pendingOf('p1', 'repeat '), pendingOf('p2', 'repeat')]
+    expect(
+      prunePendingSends(pending, [
+        userMessage('u1', 'repeat repeat'),
+        assistantMessage('a1', 'done')
+      ])
+    ).toEqual([])
+  })
+
   it('does not treat an unrelated longer user turn as a glued match', () => {
     const pending = [pendingOf('p1', 'hi')]
     expect(
       prunePendingSends(pending, [
         userMessage('u1', 'history of the project'),
+        assistantMessage('a1', 'ok')
+      ])
+    ).toEqual(pending)
+  })
+
+  it('does not accept a separated glue candidate that is only a user-text prefix', () => {
+    const pending = [pendingOf('p1', 'hi'), pendingOf('p2', 'story')]
+    expect(
+      prunePendingSends(pending, [
+        userMessage('u1', 'hi story continued'),
         assistantMessage('a1', 'ok')
       ])
     ).toEqual(pending)


### PR DESCRIPTION
## ELI5

When two rapidly sent prompts become one transcript line, Native Chat should remove both temporary queued bubbles. It previously handled only prompts joined with no separator, so a retained space could leave both bubbles stuck below newer replies forever.

## What Changed

- Match glued pending sends with or without one normalized whitespace separator at each send boundary.
- Keep exact full-text matching so unrelated prefixes do not retire pending sends.
- Added coverage for retained separators, mixed separator boundaries, repeated prompts, and partial-prefix rejection.

## Why

The send path preserves the raw trailing space on the PTY, while pending-text normalization trims it. A rapid second send can therefore produce a transcript row such as tell me a joke continue, but the old matcher only tried tell me a jokecontinue. Since transcript matching is the retirement path for successful optimistic sends, both queued echoes remained pinned.

## Prior Work

#14263 addressed the same separator-glued defect, but its author closed it after determining that the broader drift they were investigating had a separate `queued_command` cause. The closing comment explicitly left #14262 open as a standalone report. This PR carries that standalone fix forward with additional mixed-boundary, repeated-prompt, and prefix-rejection coverage.

## Linked Issue

Fixes #14262

## Visual Proof

N/A — this fixes renderer reconciliation state. The deterministic string-level regression reproduces the same transcript and pending-send state without requiring a timing-dependent live agent race.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS with Node 24.18.0:

- pnpm lint — passed
- pnpm typecheck — passed
- pnpm test — passed
- pnpm build — passed
- focused pending reconciliation tests — 53 passed
- focused oxlint and oxfmt checks — passed
- git diff --check — passed

The full suite used the isolated Orca contribution environment: OpenClaw CODEX variables unset, TMPDIR=/tmp, umask 0027, and ORCA_CROSS_VERSION_BASELINE_REF=v1.4.180.

## AI Disclosure

OpenAI Codex GPT-5 was used to verify the issue against current main, implement the bounded matcher change, add regression and boundary tests, and review the diff. All commands above were run locally and the final diff was manually reviewed.

## Review

- Security: no authentication, secret handling, command execution, or permission behavior changed.
- Cross-platform: the matcher is platform-independent pure renderer string logic.
- SSH/remote: reconciliation consumes normalized transcript text identically for local and remote sessions.
- Backwards compatibility: separator-less glue and exact single-send occurrence matching retain their existing behavior.
- Performance: pending sends are capped at eight. Candidate prefixes are pruned at every boundary and exact matching remains bounded by that cache.
- Correctness boundaries: mixed separators and repeated prompts match; incomplete longer transcript prefixes do not.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why including ELI5
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered or N/A
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass or CI will cover; local preferred

All four commands were executed locally and passed.

## Author

- X / Twitter: N/A
