### PR TITLE
fix(theme): match light-mode surfaces to dark's elevation ladder

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -166,7 +166,8 @@
   --secondary: #f5f5f5;
   --secondary-foreground: #171717;
   --muted: #f2f1ec;
-  --muted-foreground: #737373;
+  /* Darkened from #737373 so muted text clears 4.5:1 on the cream --muted surface. */
+  --muted-foreground: #6b6b6b;
   --accent: #f5f5f5;
   --accent-foreground: #171717;
   --destructive: #e40014;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -152,18 +152,20 @@
   --orca-security-border: #e5e5e5;
   --orca-security-input: #e5e5e5;
   --orca-security-ring: #a1a1a1;
-  --background: #fff;
-  --editor-surface: #ffffff;
+  /* Light "cream" surface ladder — mirrors dark elevation.
+     Keep in sync with src/renderer/src/lib/light-surface-tokens.ts. */
+  --background: #fdfcfa;
+  --editor-surface: #f6f4ef;
   --foreground: #0a0a0a;
-  --card: #fff;
+  --card: #fcfbf8;
   --card-foreground: #0a0a0a;
-  --popover: #fff;
+  --popover: #fcfbf8;
   --popover-foreground: #0a0a0a;
   --primary: #171717;
   --primary-foreground: #fafafa;
   --secondary: #f5f5f5;
   --secondary-foreground: #171717;
-  --muted: #f5f5f5;
+  --muted: #f2f1ec;
   --muted-foreground: #737373;
   --accent: #f5f5f5;
   --accent-foreground: #171717;
@@ -199,7 +201,7 @@
   --worktree-sidebar-accent-foreground: #171717;
   --worktree-sidebar-border: #e5e5e5;
   --worktree-sidebar-ring: #a1a1a1;
-  --sidebar: #fafafa;
+  --sidebar: #f8f7f3;
   --sidebar-foreground: #0a0a0a;
   --sidebar-primary: #171717;
   --sidebar-primary-foreground: #fafafa;

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -177,7 +177,7 @@ export function DiffSectionBody({
           language={language}
           original={section.originalContent}
           modified={section.modifiedContent}
-          theme={isDark ? 'vs-dark' : 'vs'}
+          theme={isDark ? 'vs-dark' : 'orca-light'}
           onMount={onMount}
           // Why: @monaco-editor/react can dispose models before widget teardown.
           // Keep them through unmount and dispose unattached models next tick.

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -408,7 +408,7 @@ export default function DiffViewer({
             language={language}
             original={originalContent}
             modified={modifiedContent}
-            theme={isDark ? 'vs-dark' : 'vs'}
+            theme={isDark ? 'vs-dark' : 'orca-light'}
             onMount={handleMount}
             // Why: a file can have multiple live diff tabs, so key models off tab identity (not file path) to avoid cross-tab reuse.
             // Why: Changes mode rotates only the original-side model after HEAD moves, preserving the modified side's undo stack.

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -371,7 +371,7 @@ function CodeCell({
   }, [])
 
   useEffect(() => {
-    monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')
+    monaco.editor.setTheme(isDark ? 'vs-dark' : 'orca-light')
   }, [isDark])
 
   if (!active) {
@@ -404,7 +404,7 @@ function CodeCell({
         height={editorHeight}
         defaultLanguage={cell.language}
         language={cell.language}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={isDark ? 'vs-dark' : 'orca-light'}
         value={source}
         onMount={handleMount}
         onChange={(value) => onChange(value ?? '')}

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -57,7 +57,7 @@ export default function MonacoCodeExcerpt({
   const [htmlLines, setHtmlLines] = useState<string[]>(() => lines.map(() => ''))
 
   useEffect(() => {
-    monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')
+    monaco.editor.setTheme(isDark ? 'vs-dark' : 'orca-light')
   }, [isDark])
 
   useEffect(() => {

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -84,7 +84,8 @@ export default function MonacoCodeExcerpt({
     return () => {
       cancelled = true
     }
-  }, [code, language, lines])
+    // isDark: re-colorize on theme switch — colorize() reads the global monaco theme.
+  }, [code, language, lines, isDark])
 
   return (
     <div

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -231,7 +231,7 @@ export default function MonacoEditor({
         language={language}
         // Why: defaultValue, not controlled value — Orca owns post-mount content sync; a controlled path would double setValue.
         defaultValue={content}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={isDark ? 'vs-dark' : 'orca-light'}
         onChange={contentSync.handleChange}
         onMount={handleMount}
         options={{

--- a/src/renderer/src/lib/light-surface-tokens.test.ts
+++ b/src/renderer/src/lib/light-surface-tokens.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   LIGHT_CONTENT_SURFACE_HEX,
@@ -35,13 +36,14 @@ describe('light surface tokens', () => {
     )
   })
 
-  it('keeps muted text legible on cream and the most-recessed surface (UI/secondary >= 3)', () => {
+  it('keeps muted text at AA body contrast (>= 4.5) on the cream and most-recessed surfaces', () => {
+    // Regression guard for the --muted / --muted-foreground pair (PR review #14410).
     expect(
       contrastRatio(LIGHT_MUTED_FOREGROUND_HEX, LIGHT_CONTENT_SURFACE_HEX)
-    ).toBeGreaterThanOrEqual(3)
+    ).toBeGreaterThanOrEqual(4.5)
     expect(
       contrastRatio(LIGHT_MUTED_FOREGROUND_HEX, LIGHT_SURFACE_LADDER.muted)
-    ).toBeGreaterThanOrEqual(3)
+    ).toBeGreaterThanOrEqual(4.5)
   })
 
   it('forms a monotonic white->cream ladder (each step no lighter than the last)', () => {
@@ -55,5 +57,30 @@ describe('light surface tokens', () => {
     for (let i = 1; i < order.length; i++) {
       expect(relLuminance(order[i])).toBeLessThan(relLuminance(order[i - 1]))
     }
+  })
+})
+
+describe('main.css mirrors the light token registry', () => {
+  // The TS constants above can drift from the stylesheet (CSS can't import them),
+  // so assert the first :root {} block (default light mode) uses the same values.
+  const css = readFileSync(new URL('../assets/main.css', import.meta.url), 'utf8')
+  const rootStart = css.indexOf(':root {')
+  const rootBlock = css.slice(rootStart, css.indexOf('}', rootStart))
+
+  const tokenValue = (name: string): string | null => {
+    const match = rootBlock.match(new RegExp(`(?:^|\\n)\\s*--${name}:\\s*([^;]+);`))
+    return match ? match[1].trim() : null
+  }
+
+  it.each([
+    ['background', LIGHT_SURFACE_LADDER.background],
+    ['card', LIGHT_SURFACE_LADDER.card],
+    ['popover', LIGHT_SURFACE_LADDER.card],
+    ['sidebar', LIGHT_SURFACE_LADDER.sidebar],
+    ['editor-surface', LIGHT_SURFACE_LADDER.content],
+    ['muted', LIGHT_SURFACE_LADDER.muted],
+    ['muted-foreground', LIGHT_MUTED_FOREGROUND_HEX]
+  ])('--%s in main.css matches the registry', (name, expected) => {
+    expect(tokenValue(name)).toBe(expected)
   })
 })

--- a/src/renderer/src/lib/light-surface-tokens.test.ts
+++ b/src/renderer/src/lib/light-surface-tokens.test.ts
@@ -74,6 +74,7 @@ describe('main.css mirrors the light token registry', () => {
 
   it.each([
     ['background', LIGHT_SURFACE_LADDER.background],
+    ['foreground', LIGHT_FOREGROUND_HEX],
     ['card', LIGHT_SURFACE_LADDER.card],
     ['popover', LIGHT_SURFACE_LADDER.card],
     ['sidebar', LIGHT_SURFACE_LADDER.sidebar],

--- a/src/renderer/src/lib/light-surface-tokens.test.ts
+++ b/src/renderer/src/lib/light-surface-tokens.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LIGHT_CONTENT_SURFACE_HEX,
+  LIGHT_FOREGROUND_HEX,
+  LIGHT_MUTED_FOREGROUND_HEX,
+  LIGHT_SURFACE_LADDER
+} from './light-surface-tokens'
+
+function relLuminance(hex: string): number {
+  const n = hex.replace('#', '')
+  const channel = (i: number): number => {
+    const c = Number.parseInt(n.slice(i, i + 2), 16) / 255
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4)
+}
+
+function contrastRatio(a: string, b: string): number {
+  const la = relLuminance(a)
+  const lb = relLuminance(b)
+  const hi = Math.max(la, lb)
+  const lo = Math.min(la, lb)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+describe('light surface tokens', () => {
+  it('keeps the shared content value in sync with the ladder', () => {
+    expect(LIGHT_SURFACE_LADDER.content).toBe(LIGHT_CONTENT_SURFACE_HEX)
+    expect(LIGHT_CONTENT_SURFACE_HEX).toBe('#f6f4ef')
+  })
+
+  it('keeps primary text readable on the cream content surface (AA body >= 4.5)', () => {
+    expect(contrastRatio(LIGHT_FOREGROUND_HEX, LIGHT_CONTENT_SURFACE_HEX)).toBeGreaterThanOrEqual(
+      4.5
+    )
+  })
+
+  it('keeps muted text legible on cream and the most-recessed surface (UI/secondary >= 3)', () => {
+    expect(
+      contrastRatio(LIGHT_MUTED_FOREGROUND_HEX, LIGHT_CONTENT_SURFACE_HEX)
+    ).toBeGreaterThanOrEqual(3)
+    expect(
+      contrastRatio(LIGHT_MUTED_FOREGROUND_HEX, LIGHT_SURFACE_LADDER.muted)
+    ).toBeGreaterThanOrEqual(3)
+  })
+
+  it('forms a monotonic white->cream ladder (each step no lighter than the last)', () => {
+    const order = [
+      LIGHT_SURFACE_LADDER.background,
+      LIGHT_SURFACE_LADDER.card,
+      LIGHT_SURFACE_LADDER.sidebar,
+      LIGHT_SURFACE_LADDER.content,
+      LIGHT_SURFACE_LADDER.muted
+    ]
+    for (let i = 1; i < order.length; i++) {
+      expect(relLuminance(order[i])).toBeLessThan(relLuminance(order[i - 1]))
+    }
+  })
+})

--- a/src/renderer/src/lib/light-surface-tokens.ts
+++ b/src/renderer/src/lib/light-surface-tokens.ts
@@ -1,0 +1,20 @@
+// Canonical values for the light-mode warm ("cream") surface ladder.
+// Mirrors the dark elevation ladder: chrome is the white extreme, content
+// surfaces step toward a warm off-white. `main.css` :root MUST mirror these
+// values (CSS cannot import JS); the ladder test guards the value contract.
+
+/** Editor pane, terminal, and Monaco code-area background in light mode. */
+export const LIGHT_CONTENT_SURFACE_HEX = '#f6f4ef'
+
+/** Existing light-mode foreground token values, referenced for contrast tests. */
+export const LIGHT_FOREGROUND_HEX = '#0a0a0a'
+export const LIGHT_MUTED_FOREGROUND_HEX = '#737373'
+
+/** The full light surface ladder, whitest (chrome) -> most recessed. */
+export const LIGHT_SURFACE_LADDER = {
+  background: '#fdfcfa',
+  card: '#fcfbf8',
+  sidebar: '#f8f7f3',
+  content: LIGHT_CONTENT_SURFACE_HEX,
+  muted: '#f2f1ec'
+} as const

--- a/src/renderer/src/lib/light-surface-tokens.ts
+++ b/src/renderer/src/lib/light-surface-tokens.ts
@@ -8,7 +8,7 @@ export const LIGHT_CONTENT_SURFACE_HEX = '#f6f4ef'
 
 /** Existing light-mode foreground token values, referenced for contrast tests. */
 export const LIGHT_FOREGROUND_HEX = '#0a0a0a'
-export const LIGHT_MUTED_FOREGROUND_HEX = '#737373'
+export const LIGHT_MUTED_FOREGROUND_HEX = '#6b6b6b'
 
 /** The full light surface ladder, whitest (chrome) -> most recessed. */
 export const LIGHT_SURFACE_LADDER = {

--- a/src/renderer/src/lib/monaco-orca-light-theme.test.ts
+++ b/src/renderer/src/lib/monaco-orca-light-theme.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { LIGHT_CONTENT_SURFACE_HEX } from './light-surface-tokens'
+import { ORCA_LIGHT_MONACO_THEME_NAME, orcaLightMonacoThemeData } from './monaco-orca-light-theme'
+
+describe('orca-light Monaco theme', () => {
+  it('is named orca-light', () => {
+    expect(ORCA_LIGHT_MONACO_THEME_NAME).toBe('orca-light')
+  })
+
+  it('inherits the stock light theme so syntax colors are unchanged', () => {
+    expect(orcaLightMonacoThemeData.base).toBe('vs')
+    expect(orcaLightMonacoThemeData.inherit).toBe(true)
+    expect(orcaLightMonacoThemeData.rules).toEqual([])
+  })
+
+  it('paints the editor background family on the shared cream surface', () => {
+    const cream = LIGHT_CONTENT_SURFACE_HEX
+    expect(orcaLightMonacoThemeData.colors['editor.background']).toBe(cream)
+    expect(orcaLightMonacoThemeData.colors['editorGutter.background']).toBe(cream)
+    expect(orcaLightMonacoThemeData.colors['minimap.background']).toBe(cream)
+  })
+})

--- a/src/renderer/src/lib/monaco-orca-light-theme.ts
+++ b/src/renderer/src/lib/monaco-orca-light-theme.ts
@@ -1,0 +1,20 @@
+import type { editor } from 'monaco-editor'
+import { LIGHT_CONTENT_SURFACE_HEX } from './light-surface-tokens'
+
+/** Monaco theme name registered in monaco-setup.ts and used at the editor call sites. */
+export const ORCA_LIGHT_MONACO_THEME_NAME = 'orca-light'
+
+// Why: derive from stock 'vs' with inherit:true and no custom token rules, so
+// syntax highlighting is identical to Monaco's light theme. We only repaint the
+// editor background family so the code area matches the app's cream content
+// surface instead of stock white. Keep in sync with LIGHT_CONTENT_SURFACE_HEX.
+export const orcaLightMonacoThemeData: editor.IStandaloneThemeData = {
+  base: 'vs',
+  inherit: true,
+  rules: [],
+  colors: {
+    'editor.background': LIGHT_CONTENT_SURFACE_HEX,
+    'editorGutter.background': LIGHT_CONTENT_SURFACE_HEX,
+    'minimap.background': LIGHT_CONTENT_SURFACE_HEX
+  }
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -16,6 +16,7 @@ import { installMonacoDelayerCancellationGuard } from './monaco-delayer-cancella
 import { installMonacoDiffEditorDisposalGuard } from './monaco-diff-editor-disposal'
 import { installMonacoPeekReferencesPreviewOptions } from './monaco-peek-preview-options'
 import { installMonacoContextMenuPaste } from '@/components/editor/install-monaco-context-menu-paste'
+import { ORCA_LIGHT_MONACO_THEME_NAME, orcaLightMonacoThemeData } from './monaco-orca-light-theme'
 
 globalThis.MonacoEnvironment = {
   getWorker(_workerId, label) {
@@ -78,6 +79,9 @@ registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
+// Register the app's light theme: stock `vs` syntax colors on Orca's cream
+// content surface (see monaco-orca-light-theme.ts).
+monaco.editor.defineTheme(ORCA_LIGHT_MONACO_THEME_NAME, orcaLightMonacoThemeData)
 registerJsonlLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)

--- a/src/renderer/src/lib/terminal-themes/defaults.test.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { LIGHT_CONTENT_SURFACE_HEX } from '../light-surface-tokens'
+import { DEFAULT_TERMINAL_THEMES } from './defaults'
+
+describe('default terminal themes', () => {
+  it('paints the default light terminal on the shared cream content surface', () => {
+    const light = DEFAULT_TERMINAL_THEMES['Builtin Tango Light']
+    expect(light.background).toBe(LIGHT_CONTENT_SURFACE_HEX)
+    // cursorAccent sits under the cursor block, so it must follow the background.
+    expect(light.cursorAccent).toBe(LIGHT_CONTENT_SURFACE_HEX)
+  })
+
+  it('leaves the default dark terminal untouched', () => {
+    expect(DEFAULT_TERMINAL_THEMES['Ghostty Default Style Dark'].background).toBe('#282c34')
+  })
+})

--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -1,4 +1,5 @@
 import type { TerminalThemeMap } from './types'
+import { LIGHT_CONTENT_SURFACE_HEX } from '../light-surface-tokens'
 
 export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
   // Most colors come from Ghostty. Orca raises dark selection contrast because Ghostty's
@@ -29,10 +30,10 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
   },
 
   'Builtin Tango Light': {
-    background: '#ffffff',
+    background: LIGHT_CONTENT_SURFACE_HEX,
     foreground: '#2e3434',
     cursor: '#2e3434',
-    cursorAccent: '#ffffff',
+    cursorAccent: LIGHT_CONTENT_SURFACE_HEX,
     selectionBackground: '#accef7',
     selectionForeground: '#2e3434',
     black: '#2e3436',


### PR DESCRIPTION
## Summary

Light mode gets a warm off-white ("cream") **content-surface elevation ladder** that mirrors what dark mode already has, reducing glare on the surfaces you stare at most (editor + terminal) while keeping the chrome near-white.

Dark mode deliberately steps its surfaces — the outer chrome is darkest and content panes step lighter:

| Surface | Dark | Light (before) | Light (after) |
|---|---|---|---|
| `--background` (chrome/canvas) | `#0a0a0a` | `#fff` | `#fdfcfa` |
| `--card` / `--popover` | `#171717` | `#fff` | `#fcfbf8` |
| `--sidebar` | `#171717` | `#fafafa` | `#f8f7f3` |
| `--editor-surface` | `#1e1e1e` | **`#ffffff`** | `#f6f4ef` |
| Terminal default light bg | — | `#ffffff` | `#f6f4ef` |
| Monaco code background | `vs-dark` | `vs` (`#fffffe`) | `#f6f4ef` (`orca-light`) |
| `--muted` | `#262626` | `#f5f5f5` | `#f2f1ec` |

The key point: in **dark** mode `--editor-surface` (`#1e1e1e`) is intentionally offset from `--background` (`#0a0a0a`), but in **light** mode both were `#ffffff` — the editor-pane offset the token system defines was silently lost. This PR restores that elevation/warmth parity on the light side, using one shared content value (`#f6f4ef`) across `--editor-surface`, the default light terminal, and a new custom Monaco `orca-light` theme (stock `vs` syntax colors, only the editor background repainted). The outer chrome stays at the white extreme (a ~1% warm nudge to `#fdfcfa`), and content surfaces step toward a warm off-white — a monotonic ladder mirroring dark.

No new theme preset and no theme-picker refactor: the existing default **Light** theme is adjusted in place. `System | Dark | Light` stays three options. **Dark mode is untouched.**

## Screenshots
<img width="1710" height="976" alt="setting" src="https://github.com/user-attachments/assets/2024762d-74d3-4ff0-952b-1d0adbef7bbc" />
<img width="1710" height="976" alt="terminal" src="https://github.com/user-attachments/assets/2856a827-3afc-44cc-82a1-ad40e1accc9b" />
<img width="1710" height="972" alt="editor" src="https://github.com/user-attachments/assets/1beeaa73-75ff-49cb-8c7f-62a2d05e9bb3" />



Before → after is a value change from pure white to warm off-white; the shared content surface goes `#ffffff` → `#f6f4ef` (editor + terminal + Monaco) with the chrome at `#fdfcfa`. See the table above.

## Testing

_(Run locally on the rebased branch against latest `main`.)_

- [x] `pnpm lint` — passes (exit 0).
- [x] `pnpm typecheck` — passes (all 3 tsc projects, exit 0).
- [x] `pnpm test` — 51,701 passed / 125 skipped. Two failures are **unrelated and environment-dependent**, not touched by this PR: `wsl-hook-relay-live.integration.test.ts` (a live WSL hook-relay integration test over real child stdio — times out on a non-WSL macOS box) and `tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts` (a cross-version wire e2e whose tests all skip but fails at file level locally). This PR only touches renderer CSS/theme + editor theme strings — nothing in `src/main/agent-hooks` or the wire protocol. Both are covered by CI in the proper environment.
- [x] `pnpm build:web` — CSS bundles cleanly (output contains the new tokens). Did not run the full native `electron-builder` build locally; CI covers it.
- [x] Added tests that would catch regressions: WCAG-contrast + monotonic-ladder tests for the token registry, a test pinning the default light terminal background (and asserting the dark terminal is unchanged), and a test locking the Monaco `orca-light` theme to `base: 'vs' / inherit: true / rules: []` so syntax colors provably inherit.

## AI Review Report

A whole-branch review was run with an AI coding agent (plus per-task spec+quality reviews on every commit). Main risks checked and results:

- **Dark-mode regression:** verified none — `.dark`, `vs-dark`, and `Ghostty Default Style Dark` are untouched; a test asserts the dark terminal background is unchanged.
- **"White assumption" risk:** searched for hardcoded `#fff`/`#ffffff` that would now clash on the cream. The only literal found is `export-css.ts` (the exported PDF/paper stylesheet — correctly white, not an on-screen surface). The `RichMarkdownEditor` pane renders on `bg-editor-surface`, so it inherits cream automatically.
- **Monaco scope:** only `editor.background` / `editorGutter.background` / `minimap.background` are repainted; transient `vs` widgets (suggest/hover/peek) keep their stock neutral background — a subtle hue seam, called out as an optional follow-up rather than widened here.
- **Contrast:** light `--muted-foreground` is darkened `#737373` → `#6b6b6b` so muted text clears AA body contrast (≈4.7:1) on the cream `--muted` — a review-driven fix, guarded by a regression assertion. Primary text (`#0a0a0a`) is ≈18:1.
- **Ladder coherence:** the five light values form a strictly monotonic white→cream luminance ladder (enforced by a test).

**Cross-platform:** the change is pure CSS custom-property values, a static Monaco theme-data object, and two hex values in a terminal theme map — no platform branches, no shortcuts/labels, no path or shell behavior, no Electron platform-specific code. It renders identically on macOS, Linux, and Windows and over SSH/remote (theme resolution is unchanged). Verdict: ready to merge.

## Security Audit

No security surface touched: the change introduces only static color values and a static theme object. No input handling, command execution, path handling, auth, secrets, or IPC changes; no new dependencies; the theme parser is not involved. No `url()` or network-bearing values are introduced. No follow-up needed.

## Notes

- **Dark mode unchanged.** Only the default **Light** theme surfaces change.
- **Terminal:** only the default light terminal theme (`Builtin Tango Light`) background/cursorAccent change; user-selected terminal themes and `terminalColorOverrides` are unaffected (they still win).
- **Security/privacy palette left as-is:** the `--orca-security-*` light tokens (used by the screen-privacy mode) are intentionally not changed — they keep pure white, out of scope for this default-Light adjustment.
- **Follow-up (optional):** repaint Monaco's `editorWidget` / `editorSuggestWidget` / `editorHoverWidget` / `peekViewEditor` backgrounds to the same cream for full parity on transient popups.
- **Review feedback addressed** (commits `4d29e99`, `da28e0c`): raised light `--muted-foreground` to AA body contrast on the cream `--muted`; re-colorize Monaco code excerpts on theme switch; added a test asserting `main.css` light tokens mirror the TS registry.
- No version bump (release changes are maintainer-managed).
